### PR TITLE
Upsell React DevTools in 16

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -812,11 +812,12 @@ if (__DEV__) {
       var showFileUrlMessage = window.location.protocol.indexOf('http') === -1;
       console.info(
         '%cDownload the React DevTools ' +
-          (showFileUrlMessage
-            ? 'and use an HTTP server (instead of a file: URL) '
-            : '') +
           'for a better development experience: ' +
-          'https://fb.me/react-devtools',
+          'https://fb.me/react-devtools' +
+          (showFileUrlMessage
+            ? '\nYou might need to use a local HTTP server (instead of file://): ' +
+                'https://fb.me/react-devtools-faq'
+            : ''),
         'font-weight:bold',
       );
     }

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -15,6 +15,7 @@
 import type {Fiber} from 'ReactFiber';
 import type {ReactNodeList} from 'ReactTypes';
 
+var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 var ReactBrowserEventEmitter = require('ReactBrowserEventEmitter');
 var ReactControlledComponent = require('ReactControlledComponent');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
@@ -788,14 +789,38 @@ var ReactDOMFiber = {
   },
 };
 
-if (typeof injectInternals === 'function') {
-  injectInternals({
-    findFiberByHostInstance: ReactDOMComponentTree.getClosestInstanceFromNode,
-    findHostInstanceByFiber: DOMRenderer.findHostInstance,
-    // This is an enum because we may add more (e.g. profiler build)
-    bundleType: __DEV__ ? 1 : 0,
-    version: ReactVersion,
-  });
+const foundDevTools = injectInternals({
+  findFiberByHostInstance: ReactDOMComponentTree.getClosestInstanceFromNode,
+  findHostInstanceByFiber: DOMRenderer.findHostInstance,
+  // This is an enum because we may add more (e.g. profiler build)
+  bundleType: __DEV__ ? 1 : 0,
+  version: ReactVersion,
+});
+
+if (__DEV__) {
+  if (
+    !foundDevTools &&
+    ExecutionEnvironment.canUseDOM &&
+    window.top === window.self
+  ) {
+    // If we're in Chrome or Firefox, provide a download link if not installed.
+    if (
+      (navigator.userAgent.indexOf('Chrome') > -1 &&
+        navigator.userAgent.indexOf('Edge') === -1) ||
+      navigator.userAgent.indexOf('Firefox') > -1
+    ) {
+      var showFileUrlMessage = window.location.protocol.indexOf('http') === -1;
+      console.info(
+        '%cDownload the React DevTools ' +
+          (showFileUrlMessage
+            ? 'and use an HTTP server (instead of a file: URL) '
+            : '') +
+          'for a better development experience: ' +
+          'https://fb.me/react-devtools',
+        'font-weight:bold',
+      );
+    }
+  }
 }
 
 module.exports = ReactDOMFiber;

--- a/src/renderers/native/ReactNativeFiberEntry.js
+++ b/src/renderers/native/ReactNativeFiberEntry.js
@@ -116,15 +116,13 @@ if (__DEV__) {
   );
 }
 
-if (typeof injectInternals === 'function') {
-  injectInternals({
-    findFiberByHostInstance: ReactNativeComponentTree.getClosestInstanceFromNode,
-    findHostInstanceByFiber: ReactNativeFiberRenderer.findHostInstance,
-    getInspectorDataForViewTag: ReactNativeFiberInspector.getInspectorDataForViewTag,
-    // This is an enum because we may add more (e.g. profiler build)
-    bundleType: __DEV__ ? 1 : 0,
-    version: ReactVersion,
-  });
-}
+injectInternals({
+  findFiberByHostInstance: ReactNativeComponentTree.getClosestInstanceFromNode,
+  findHostInstanceByFiber: ReactNativeFiberRenderer.findHostInstance,
+  getInspectorDataForViewTag: ReactNativeFiberInspector.getInspectorDataForViewTag,
+  // This is an enum because we may add more (e.g. profiler build)
+  bundleType: __DEV__ ? 1 : 0,
+  version: ReactVersion,
+});
 
 module.exports = ReactNativeFiber;

--- a/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
+++ b/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
@@ -22,53 +22,65 @@ if (__DEV__) {
 }
 
 let rendererID = null;
-let injectInternals = null;
-let onCommitRoot = null;
-let onCommitUnmount = null;
-if (
-  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' &&
-  __REACT_DEVTOOLS_GLOBAL_HOOK__.supportsFiber
-) {
-  let {
-    inject,
-    onCommitFiberRoot,
-    onCommitFiberUnmount,
-  } = __REACT_DEVTOOLS_GLOBAL_HOOK__;
 
-  injectInternals = function(internals: Object) {
+function injectInternals(internals: Object): boolean {
+  if (__DEV__) {
+    warning(rendererID == null, 'Cannot inject into DevTools twice.');
+  }
+  if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+    // No DevTools
+    return false;
+  }
+  if (!__REACT_DEVTOOLS_GLOBAL_HOOK__.supportsFiber) {
     if (__DEV__) {
-      warning(rendererID == null, 'Cannot inject into DevTools twice.');
+      warning(
+        false,
+        'The installed version of React DevTools is too old and will not work ' +
+          'with the current version of React. Please update React DevTools. ' +
+          'https://fb.me/react-devtools#installation',
+      );
     }
-    rendererID = inject(internals);
-  };
+    // DevTools exists, even though it doesn't support Fiber.
+    return true;
+  }
+  try {
+    rendererID = __REACT_DEVTOOLS_GLOBAL_HOOK__.inject(internals);
+  } catch (err) {
+    // Catch all errors because it is unsafe to throw during initialization.
+    if (__DEV__) {
+      warning(false, 'React DevTools encountered an error: %s.', err);
+    }
+  }
+  // DevTools exists
+  return true;
+}
 
-  onCommitRoot = function(root: FiberRoot) {
-    if (rendererID == null) {
-      return;
+function onCommitRoot(root: FiberRoot) {
+  if (rendererID == null) {
+    return;
+  }
+  try {
+    __REACT_DEVTOOLS_GLOBAL_HOOK__.onCommitFiberRoot(rendererID, root);
+  } catch (err) {
+    // Catch all errors because it is unsafe to throw in the commit phase.
+    if (__DEV__) {
+      warning(false, 'React DevTools encountered an error: %s', err);
     }
-    try {
-      onCommitFiberRoot(rendererID, root);
-    } catch (err) {
-      // Catch all errors because it is unsafe to throw in the commit phase.
-      if (__DEV__) {
-        warning(false, 'React DevTools encountered an error: %s', err);
-      }
-    }
-  };
+  }
+}
 
-  onCommitUnmount = function(fiber: Fiber) {
-    if (rendererID == null) {
-      return;
+function onCommitUnmount(fiber: Fiber) {
+  if (rendererID == null) {
+    return;
+  }
+  try {
+    __REACT_DEVTOOLS_GLOBAL_HOOK__.onCommitFiberUnmount(rendererID, fiber);
+  } catch (err) {
+    // Catch all errors because it is unsafe to throw in the commit phase.
+    if (__DEV__) {
+      warning(false, 'React DevTools encountered an error: %s', err);
     }
-    try {
-      onCommitFiberUnmount(rendererID, fiber);
-    } catch (err) {
-      // Catch all errors because it is unsafe to throw in the commit phase.
-      if (__DEV__) {
-        warning(false, 'React DevTools encountered an error: %s', err);
-      }
-    }
-  };
+  }
 }
 
 exports.injectInternals = injectInternals;

--- a/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
+++ b/src/renderers/shared/fiber/ReactFiberDevToolsHook.js
@@ -37,7 +37,7 @@ function injectInternals(internals: Object): boolean {
         false,
         'The installed version of React DevTools is too old and will not work ' +
           'with the current version of React. Please update React DevTools. ' +
-          'https://fb.me/react-devtools#installation',
+          'https://fb.me/react-devtools',
       );
     }
     // DevTools exists, even though it doesn't support Fiber.
@@ -56,7 +56,10 @@ function injectInternals(internals: Object): boolean {
 }
 
 function onCommitRoot(root: FiberRoot) {
-  if (rendererID == null) {
+  if (
+    typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined' ||
+    rendererID == null
+  ) {
     return;
   }
   try {
@@ -70,7 +73,10 @@ function onCommitRoot(root: FiberRoot) {
 }
 
 function onCommitUnmount(fiber: Fiber) {
-  if (rendererID == null) {
+  if (
+    typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined' ||
+    rendererID == null
+  ) {
     return;
   }
   try {


### PR DESCRIPTION
This is based on [existing code](https://github.com/facebook/react/blob/81706eeb7a51c1cea7fd8e66733a4f4618155ef5/src/renderers/dom/ReactDOMStackEntry.js#L84-L108) that didn’t make it into the DOM Fiber bundle before.

A few things are different.

* I refactored `ReactFiberDevToolsHook` because conditional exports were confusing. Instead we always export everything, and `injectInternals` will not do anything if DevTools don’t exist.
* `injectInternals` now catches errors inside the hook injection. Seems less fragile.
* We now show a message if you use a version of DevTools incompatible with Fiber.
* The upsell message now uses `console.info` over `console.debug` because Chrome started muting `console.debug` by default. This message is aimed at new users, and they won’t know to toggle the filters.
* I also added bold formatting to it via `%c` since both Chrome and Firefox support it (FF [supports it](https://bugzilla.mozilla.org/show_bug.cgi?id=823097) since version 31). Otherwise it's too easy to miss in Chrome.
* I removed [this check](https://github.com/facebook/react/blob/81706eeb7a51c1cea7fd8e66733a4f4618155ef5/src/renderers/dom/ReactDOMStackEntry.js#L98) because Firefox now also has issues with `file://` URLs so we should show the same message to FF users.

Old version message (verified by installing an old version):

<img width="503" alt="screen shot 2017-08-02 at 12 26 53" src="https://user-images.githubusercontent.com/810438/28872166-e7df9a4a-777f-11e7-943e-98dd099fe900.png">

Upsell messages:

<img width="503" alt="screen shot 2017-08-02 at 12 30 08" src="https://user-images.githubusercontent.com/810438/28872172-f0cc860e-777f-11e7-82e7-14e7d173d335.png">
<img width="694" alt="screen shot 2017-08-02 at 12 30 20" src="https://user-images.githubusercontent.com/810438/28872173-f0d14afe-777f-11e7-99ab-ee291829e766.png">

Extension still works:

<img width="364" alt="screen shot 2017-08-02 at 12 42 31" src="https://user-images.githubusercontent.com/810438/28872248-4659afe8-7780-11e7-9246-a97a975fba45.png">
<img width="374" alt="screen shot 2017-08-02 at 12 43 47" src="https://user-images.githubusercontent.com/810438/28872249-46615298-7780-11e7-8c58-a0184713035d.png">

Also verified the message doesn’t appear for production builds or in Node.

<img width="817" alt="screen shot 2017-08-02 at 12 46 23" src="https://user-images.githubusercontent.com/810438/28872339-a265c9fc-7780-11e7-9fc9-c3a7d49f5046.png">
