### PR TITLE
Warn on missing Set/Map polyfills

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -62,22 +62,22 @@ if (__DEV__) {
   var warning = require('fbjs/lib/warning');
   var validateDOMNesting = require('validateDOMNesting');
   var {updatedAncestorInfo} = validateDOMNesting;
-}
 
-if (
-  typeof Map !== 'function' ||
-  Map.prototype == null ||
-  typeof Map.prototype.forEach !== 'function' ||
-  typeof Set !== 'function' ||
-  Set.prototype == null ||
-  typeof Set.prototype.clear !== 'function' ||
-  typeof Set.prototype.forEach !== 'function'
-) {
-  invariant(
-    false,
-    'React depends on Map and Set built-in types. Make sure that you load a ' +
-      'polyfill in older browsers. http://fb.me/react-polyfills',
-  );
+  if (
+    typeof Map !== 'function' ||
+    Map.prototype == null ||
+    typeof Map.prototype.forEach !== 'function' ||
+    typeof Set !== 'function' ||
+    Set.prototype == null ||
+    typeof Set.prototype.clear !== 'function' ||
+    typeof Set.prototype.forEach !== 'function'
+  ) {
+    warning(
+      false,
+      'React depends on Map and Set built-in types. Make sure that you load a ' +
+        'polyfill in older browsers. http://fb.me/react-polyfills',
+    );
+  }
 }
 
 require('ReactDOMClientInjection');

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -64,6 +64,22 @@ if (__DEV__) {
   var {updatedAncestorInfo} = validateDOMNesting;
 }
 
+if (
+  typeof Map !== 'function' ||
+  Map.prototype == null ||
+  typeof Map.prototype.forEach !== 'function' ||
+  typeof Set !== 'function' ||
+  Set.prototype == null ||
+  typeof Set.prototype.clear !== 'function' ||
+  typeof Set.prototype.forEach !== 'function'
+) {
+  invariant(
+    false,
+    'React depends on Map and Set built-in types. Make sure that you load a ' +
+      'polyfill in older browsers. http://fb.me/react-polyfills',
+  );
+}
+
 require('ReactDOMClientInjection');
 require('ReactDOMInjection');
 ReactControlledComponent.injection.injectFiberControlledHostComponent(

--- a/src/renderers/shared/ReactDOMFrameScheduling.js
+++ b/src/renderers/shared/ReactDOMFrameScheduling.js
@@ -25,6 +25,21 @@ import type {Deadline} from 'ReactFiberReconciler';
 var invariant = require('fbjs/lib/invariant');
 var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+
+  if (
+    ExecutionEnvironment.canUseDOM &&
+    typeof requestAnimationFrame !== 'function'
+  ) {
+    warning(
+      false,
+      'React depends on requestAnimationFrame. Make sure that you load a ' +
+        'polyfill in older browsers. http://fb.me/react-polyfills',
+    );
+  }
+}
+
 // TODO: There's no way to cancel, because Fiber doesn't atm.
 let rIC: (callback: (deadline: Deadline) => void) => number;
 
@@ -39,12 +54,6 @@ if (!ExecutionEnvironment.canUseDOM) {
     });
     return 0;
   };
-} else if (typeof requestAnimationFrame !== 'function') {
-  invariant(
-    false,
-    'React depends on requestAnimationFrame. Make sure that you load a ' +
-      'polyfill in older browsers. http://fb.me/react-polyfills',
-  );
 } else if (typeof requestIdleCallback !== 'function') {
   // Polyfill requestIdleCallback.
 

--- a/src/renderers/shared/ReactDOMFrameScheduling.js
+++ b/src/renderers/shared/ReactDOMFrameScheduling.js
@@ -43,7 +43,7 @@ if (!ExecutionEnvironment.canUseDOM) {
   invariant(
     false,
     'React depends on requestAnimationFrame. Make sure that you load a ' +
-      'polyfill in older browsers.',
+      'polyfill in older browsers. http://fb.me/react-polyfills',
   );
 } else if (typeof requestIdleCallback !== 'function') {
   // Polyfill requestIdleCallback.

--- a/src/renderers/shared/ReactDOMFrameScheduling.js
+++ b/src/renderers/shared/ReactDOMFrameScheduling.js
@@ -22,7 +22,6 @@
 
 import type {Deadline} from 'ReactFiberReconciler';
 
-var invariant = require('fbjs/lib/invariant');
 var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 
 if (__DEV__) {

--- a/src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
+++ b/src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
@@ -15,16 +15,16 @@ const ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 const describeFiber = ReactDOMFeatureFlags.useFiber ? describe : xdescribe;
 
 describeFiber('ReactDOMFrameScheduling', () => {
-  it('throws when requestAnimationFrame is not polyfilled in the browser', () => {
+  it('warns when requestAnimationFrame is not polyfilled in the browser', () => {
     const previousRAF = global.requestAnimationFrame;
     try {
       global.requestAnimationFrame = undefined;
       jest.resetModules();
-      expect(() => {
-        require('react-dom');
-      }).toThrow(
-        'React depends on requestAnimationFrame. Make sure that you load a ' +
-          'polyfill in older browsers.',
+      spyOn(console, 'error');
+      require('react-dom');
+      expect(console.error.calls.count()).toBe(1);
+      expect(console.error.calls.argsFor(0)[0]).toContain(
+        'React depends on requestAnimationFrame.',
       );
     } finally {
       global.requestAnimationFrame = previousRAF;


### PR DESCRIPTION
Adding an early check with a URL currently pointing to a gist.
We’ll move this to docs as part of 16 release.

We could do a warning instead, which would save some bytes. <s>I opted for invariant for consistency with what we do for rAFs.</s> Changed this to be a warning per feedback.

I check for specific methods we use. There’s some earlier versions of Firefox that added support gradually.