### PR TITLE
Don't call componentDidUpdate() in shallow renderer

### DIFF
--- a/src/renderers/testing/ReactShallowRendererEntry.js
+++ b/src/renderers/testing/ReactShallowRendererEntry.js
@@ -136,12 +136,8 @@ class ReactShallowRenderer {
     }
 
     this._rendered = this._instance.render();
-
-    // Calling cDU might lead to problems with host component references.
-    // Since our components aren't really mounted, refs won't be available.
-    // if (typeof this._instance.componentDidMount === 'function') {
-    //   this._instance.componentDidMount();
-    // }
+    // Intentionally do not call componentDidMount()
+    // because DOM refs are not available.
   }
 
   _updateClassComponent(props, context) {
@@ -179,6 +175,8 @@ class ReactShallowRenderer {
     this._instance.state = state;
 
     this._rendered = this._instance.render();
+    // Intentionally do not call componentDidUpdate()
+    // because DOM refs are not available.
   }
 }
 

--- a/src/renderers/testing/ReactShallowRendererEntry.js
+++ b/src/renderers/testing/ReactShallowRendererEntry.js
@@ -180,14 +180,6 @@ class ReactShallowRenderer {
     this._instance.state = state;
 
     this._rendered = this._instance.render();
-
-    // The 15.x shallow renderer triggered cDU for setState() calls only.
-    if (
-      oldState !== state &&
-      typeof this._instance.componentDidUpdate === 'function'
-    ) {
-      this._instance.componentDidUpdate(oldProps, oldState);
-    }
   }
 }
 

--- a/src/renderers/testing/ReactShallowRendererEntry.js
+++ b/src/renderers/testing/ReactShallowRendererEntry.js
@@ -146,7 +146,6 @@ class ReactShallowRenderer {
 
   _updateClassComponent(props, context) {
     const oldProps = this._instance.props;
-    const oldState = this._instance.state;
 
     if (
       oldProps !== props &&

--- a/src/renderers/testing/__tests__/ReactShallowRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactShallowRenderer-test.js
@@ -51,12 +51,7 @@ describe('ReactShallowRenderer', () => {
     const instance = shallowRenderer.getMountedInstance();
     instance.setState({});
 
-    // The previous shallow renderer triggered cDU for setState() calls.
-    expect(logs).toEqual([
-      'shouldComponentUpdate',
-      'componentWillUpdate',
-      'componentDidUpdate',
-    ]);
+    expect(logs).toEqual(['shouldComponentUpdate', 'componentWillUpdate']);
 
     logs.splice(0);
 
@@ -407,7 +402,7 @@ describe('ReactShallowRenderer', () => {
       updatedState,
       updatedContext,
     ]);
-    expect(componentDidUpdateParams).toEqual([initialProp, initialState]);
+    expect(componentDidUpdateParams).toEqual([]);
   });
 
   it('can shallowly render components with ref as function', () => {


### PR DESCRIPTION
We did this for initial compatibility with Stack, but this behavior seems undesirable because it's inconsistent with `componentDidMount`.

Past discussion in https://github.com/facebook/react/pull/9426#discussion_r112013921 seems to uncover Enzyme depends on it. Can we verify this is the case? I ran Jest internally and did not see issues caused by this change. Since Enzyme needs to adapt to other 16 changes, we might as well make this one.