### PR TITLE
[fiber-debugger] Fix the debugger to match changes to Fiber

### DIFF
--- a/fixtures/fiber-debugger/src/App.js
+++ b/fixtures/fiber-debugger/src/App.js
@@ -41,8 +41,6 @@ class App extends Component {
         sibling: true,
         return: false,
         fx: false,
-        progressedChild: false,
-        progressedDel: false,
       },
     };
   }

--- a/fixtures/fiber-debugger/src/Fibers.js
+++ b/fixtures/fiber-debugger/src/Fibers.js
@@ -314,7 +314,7 @@ export default function Fibers({fibers, show, ...rest}) {
                       </span>,
                       <br key="br" />,
                     ]}
-                    {fiber.progressedPriority !== 0 && [
+                    {fiber.progressedPriority && [
                       `Finished: ${formatPriority(fiber.progressedPriority)}`,
                       <br key="br" />,
                     ]}

--- a/fixtures/fiber-debugger/src/Fibers.js
+++ b/fixtures/fiber-debugger/src/Fibers.js
@@ -163,8 +163,6 @@ const strokes = {
   sibling: 'darkgreen',
   return: 'red',
   fx: 'purple',
-  progressedChild: 'cyan',
-  progressedDel: 'brown',
 };
 
 function Edge(props) {
@@ -242,12 +240,10 @@ function formatPriority(priority) {
     case 2:
       return 'task';
     case 3:
-      return 'animation';
-    case 4:
       return 'hi-pri work';
-    case 5:
+    case 4:
       return 'lo-pri work';
-    case 6:
+    case 5:
       return 'offscreen work';
     default:
       throw new Error('Unknown priority.');
@@ -302,20 +298,9 @@ export default function Fibers({fibers, show, ...rest}) {
               {fibers.currentIDs.indexOf(fiber.id) === -1
                 ? <small>
                     {fiber.pendingWorkPriority !== 0 && [
-                      <span
-                        style={{
-                          fontWeight: fiber.pendingWorkPriority <=
-                            fiber.progressedPriority
-                            ? 'bold'
-                            : 'normal',
-                        }}
-                        key="span">
+                      <span key="span">
                         Needs: {formatPriority(fiber.pendingWorkPriority)}
                       </span>,
-                      <br key="br" />,
-                    ]}
-                    {fiber.progressedPriority && [
-                      `Finished: ${formatPriority(fiber.progressedPriority)}`,
                       <br key="br" />,
                     ]}
                     {fiber.memoizedProps !== null &&
@@ -323,7 +308,7 @@ export default function Fibers({fibers, show, ...rest}) {
                       fiber.memoizedProps === fiber.pendingProps
                         ? 'Can reuse memoized.'
                         : 'Cannot reuse memoized.',
-                      <br />,
+                      <br key="br" />,
                     ]}
                   </small>
                 : <small>
@@ -340,16 +325,6 @@ export default function Fibers({fibers, show, ...rest}) {
               weight={1000}
               key={`${fiber.id}-${fiber.child}-child`}>
               child
-            </Edge>,
-          fiber.progressedChild &&
-            show.progressedChild &&
-            <Edge
-              source={fiber.id}
-              target={fiber.progressedChild}
-              kind="progressedChild"
-              weight={1000}
-              key={`${fiber.id}-${fiber.progressedChild}-pChild`}>
-              pChild
             </Edge>,
           fiber.sibling &&
             show.sibling &&
@@ -400,26 +375,6 @@ export default function Fibers({fibers, show, ...rest}) {
               weight={100}
               key={`${fiber.id}-${fiber.lastEffect}-lastEffect`}>
               lastFx
-            </Edge>,
-          fiber.progressedFirstDeletion &&
-            show.progressedDel &&
-            <Edge
-              source={fiber.id}
-              target={fiber.progressedFirstDeletion}
-              kind="progressedDel"
-              weight={100}
-              key={`${fiber.id}-${fiber.progressedFirstDeletion}-pFD`}>
-              pFDel
-            </Edge>,
-          fiber.progressedLastDeletion &&
-            show.progressedDel &&
-            <Edge
-              source={fiber.id}
-              target={fiber.progressedLastDeletion}
-              kind="progressedDel"
-              weight={100}
-              key={`${fiber.id}-${fiber.progressedLastDeletion}-pLD`}>
-              pLDel
             </Edge>,
           fiber.alternate &&
             show.alt &&

--- a/fixtures/fiber-debugger/src/describeFibers.js
+++ b/fixtures/fiber-debugger/src/describeFibers.js
@@ -63,9 +63,6 @@ export default function describeFibers(rootFiber, workInProgress) {
       nextEffect: acknowledgeFiber(fiber.nextEffect),
       firstEffect: acknowledgeFiber(fiber.firstEffect),
       lastEffect: acknowledgeFiber(fiber.lastEffect),
-      progressedChild: acknowledgeFiber(fiber.progressedChild),
-      progressedFirstDeletion: acknowledgeFiber(fiber.progressedFirstDeletion),
-      progressedLastDeletion: acknowledgeFiber(fiber.progressedLastDeletion),
       alternate: acknowledgeFiber(fiber.alternate),
     });
     return id;


### PR DESCRIPTION
[`formatPriority`](https://github.com/facebook/react/blob/master/fixtures/fiber-debugger/src/Fibers.js#L253) was throwing "Unknown priority." when `fiber.progressedPriority` is undefined (which happens as soon as you run the app).

```
Uncaught Error: Unknown priority.
    at formatPriority (Fibers.js:253)
    at Fibers.js:317
    at Array.map (<anonymous>)
    at Fibers (Fibers.js:282)
    at mountIndeterminateComponent (react-dom.development.js:9774)
    at beginWork (react-dom.development.js:9972)
    at performUnitOfWork (react-dom.development.js:11932)
    at workLoop (react-dom.development.js:12042)
    at HTMLUnknownElement.callCallback (react-dom.development.js:1304)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:1343)
```