### PR TITLE
Compile spread to Object.assign calls

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
   "plugins": [
     "transform-class-properties",
     "syntax-trailing-function-commas",
-    "transform-object-rest-spread",
+    ["transform-object-rest-spread", { "useBuiltIns": true }],
     "transform-es2015-template-literals",
     "transform-es2015-literals",
     "transform-es2015-arrow-functions",


### PR DESCRIPTION
Noticed Rollup was complaining about `_extends` helper repeating.

But we don’t need it. Instead let’s emit `Object.assign` calls.
Diff of build folder: https://gist.github.com/gaearon/50e2b020a6d7d549e2c7b0273f01016e.

FB and RN bundles now get plain `Object.assign()`, UMD and CJS bundles keep using the polyfill.