### PR TITLE
Cased data attributes should properly diff on server hydration

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -928,8 +928,10 @@ var ReactDOMFiberComponent = {
       var extraAttributeNames: Set<string> = new Set();
       var attributes = domElement.attributes;
       for (var i = 0; i < attributes.length; i++) {
-        // TODO: Do we need to lower case this to get case insensitive matches?
-        var name = attributes[i].name;
+        // Downcase to work around IE Edge, which reports some SVG attributes
+        // in all-caps. See:
+        // https://github.com/facebook/react/pull/10394#issuecomment-320523369
+        var name = attributes[i].name.toLowerCase();
         switch (name) {
           // Built-in attributes are whitelisted
           // TODO: Once these are gone from the server renderer, we don't need

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -1024,7 +1024,7 @@ var ReactDOMFiberComponent = {
           DOMProperty.isCustomAttribute(propKey)
         ) {
           // $FlowFixMe - Should be inferred as not undefined.
-          extraAttributeNames.delete(propKey);
+          extraAttributeNames.delete(propKey.toLowerCase());
           serverValue = DOMPropertyOperations.getValueForAttribute(
             domElement,
             propKey,

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -624,6 +624,12 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<div className={null} />);
         expect(e.hasAttribute('className')).toBe(false);
       });
+
+      itRenders('no lower case classname', async render => {
+        const e = await render(<div classname="test" />, 1);
+        expect(e.hasAttribute('className')).toBe(false);
+        expect(e.hasAttribute('class')).toBe(false);
+      });
     });
 
     describe('htmlFor property', function() {

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -789,6 +789,11 @@ describe('ReactDOMServerIntegration', () => {
         expect(e.getAttribute('data-foo')).toBe('bar');
       });
 
+      itRenders('unknown data- attributes with casing', async render => {
+        const e = await render(<div data-myAttribute="test" />, 0);
+        expect(e.getAttribute('data-myAttribute')).toBe('test');
+      });
+
       itRenders('no unknown data- attributes with null value', async render => {
         const e = await render(<div data-foo={null} />);
         expect(e.hasAttribute('data-foo')).toBe(false);


### PR DESCRIPTION
@gaearon noticed this in my custom attribute PR (https://github.com/facebook/react/pull/7311#issuecomment-320454976)

Attribute names are reported back from the DOM as lower case. If a cased data attribute is given, the diffing process gets tripped up because a propKey of `data-myAttribute` reports back as `data-myattribute`. This results in an error along the lines of:

```
We expected 0 warning(s), but saw 1 warning(s).
We saw these warnings:
Warning: Extra attributes from the server: data-myattribute
```

The diffing process compares the component props to [a list of attributes directly from the DOM element](https://github.com/facebook/react/blob/master/src/renderers/dom/fiber/ReactDOMFiberComponent.js#L929-L932). The DOM list always has lower case names. The React property object uses whatever was given to the component. So there's an inconsistency between the `data-myAttribute` React prop, and the `data-myattribute` from the DOM.

This isn't a problem for attributes in the whitelist. When properties are injected into `DOMProperties.properties`,  React adds an `attributeName` that is the lower case version of the React prop key name. This attribute name is what gets removed from the list of diffed props. 

Also it looks like cased data attributes are technically supported in React 15.6.1:
https://jsfiddle.net/84v837e9/185/

The casing goes away when the attribute is put into the DOM.