### PR TITLE
Add invariant check for composite components to event simulation test utils

### DIFF
--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -450,6 +450,11 @@ function makeSimulator(eventType) {
       'TestUtils.Simulate expects a component instance and not a ReactElement.' +
         'TestUtils.Simulate will not work if you are using shallow rendering.',
     );
+    invariant(
+      !ReactTestUtils.isCompositeComponent(domComponentOrNode),
+      'TestUtils.Simulate does not support a composite component instance.' +
+        'TestUtils.Simulate only works with DOM component instance or a DOM node.',
+    );
     if (ReactTestUtils.isDOMComponent(domComponentOrNode)) {
       node = findDOMNode(domComponentOrNode);
     } else if (domComponentOrNode.tagName) {

--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -447,7 +447,8 @@ function makeSimulator(eventType) {
     invariant(
       !React.isValidElement(domNode),
       'TestUtils.Simulate expected a DOM node as the first argument but received ' +
-        'a React element. Pass the DOM node you wish to simulate the event on instead.',
+        'a React element. Pass the DOM node you wish to simulate the event on instead. ' +
+        'Note that TestUtils.Simulate will not work if you are using shallow rendering.',
     );
     invariant(
       !ReactTestUtils.isCompositeComponent(domNode),

--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -437,16 +437,16 @@ var ReactTestUtils = {
 /**
  * Exports:
  *
- * - `ReactTestUtils.Simulate.click(Element)`
- * - `ReactTestUtils.Simulate.mouseMove(Element)`
- * - `ReactTestUtils.Simulate.change(Element)`
+ * - `ReactTestUtils.Simulate.click(domNode)`
+ * - `ReactTestUtils.Simulate.mouseMove(domNode)`
+ * - `ReactTestUtils.Simulate.change(domNode)`
  * - ... (All keys from event plugin `eventTypes` objects)
  */
 function makeSimulator(eventType) {
   return function(domNode, eventData) {
     invariant(
       !React.isValidElement(domNode),
-      'TestUtils.Simulate expects a component instance and not a ReactElement. ' +
+      'TestUtils.Simulate expects a DOM node and not a ReactElement. ' +
         'TestUtils.Simulate will not work if you are using shallow rendering.',
     );
     invariant(

--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -437,9 +437,9 @@ var ReactTestUtils = {
 /**
  * Exports:
  *
- * - `ReactTestUtils.Simulate.click(domNode)`
- * - `ReactTestUtils.Simulate.mouseMove(domNode)`
- * - `ReactTestUtils.Simulate.change(domNode)`
+ * - `ReactTestUtils.Simulate.click(Element)`
+ * - `ReactTestUtils.Simulate.mouseMove(Element)`
+ * - `ReactTestUtils.Simulate.change(Element)`
  * - ... (All keys from event plugin `eventTypes` objects)
  */
 function makeSimulator(eventType) {

--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -446,8 +446,8 @@ function makeSimulator(eventType) {
   return function(domNode, eventData) {
     invariant(
       !React.isValidElement(domNode),
-      'TestUtils.Simulate expects a DOM node and not a ReactElement. ' +
-        'TestUtils.Simulate will not work if you are using shallow rendering.',
+      'TestUtils.Simulate expected a DOM node as the first argument but received ' +
+        'a React element. Pass the DOM node you wish to simulate the event on instead.',
     );
     invariant(
       !ReactTestUtils.isCompositeComponent(domNode),

--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -437,45 +437,39 @@ var ReactTestUtils = {
 /**
  * Exports:
  *
- * - `ReactTestUtils.Simulate.click(Element/ReactDOMComponent)`
- * - `ReactTestUtils.Simulate.mouseMove(Element/ReactDOMComponent)`
- * - `ReactTestUtils.Simulate.change(Element/ReactDOMComponent)`
+ * - `ReactTestUtils.Simulate.click(Element)`
+ * - `ReactTestUtils.Simulate.mouseMove(Element)`
+ * - `ReactTestUtils.Simulate.change(Element)`
  * - ... (All keys from event plugin `eventTypes` objects)
  */
 function makeSimulator(eventType) {
-  return function(domComponentOrNode, eventData) {
-    var node;
+  return function(domNode, eventData) {
     invariant(
-      !React.isValidElement(domComponentOrNode),
-      'TestUtils.Simulate expects a component instance and not a ReactElement.' +
+      !React.isValidElement(domNode),
+      'TestUtils.Simulate expects a component instance and not a ReactElement. ' +
         'TestUtils.Simulate will not work if you are using shallow rendering.',
     );
     invariant(
-      !ReactTestUtils.isCompositeComponent(domComponentOrNode),
-      'TestUtils.Simulate does not support a composite component instance.' +
-        'TestUtils.Simulate only works with DOM component instance or a DOM node.',
+      !ReactTestUtils.isCompositeComponent(domNode),
+      'TestUtils.Simulate expected a DOM node as the first argument but received ' +
+        'a component instance. Pass the DOM node you wish to simulate the event on instead.',
     );
-    if (ReactTestUtils.isDOMComponent(domComponentOrNode)) {
-      node = findDOMNode(domComponentOrNode);
-    } else if (domComponentOrNode.tagName) {
-      node = domComponentOrNode;
-    }
 
     var dispatchConfig =
       EventPluginRegistry.eventNameDispatchConfigs[eventType];
 
     var fakeNativeEvent = new Event();
-    fakeNativeEvent.target = node;
+    fakeNativeEvent.target = domNode;
     fakeNativeEvent.type = eventType.toLowerCase();
 
     // We don't use SyntheticEvent.getPooled in order to not have to worry about
     // properly destroying any properties assigned from `eventData` upon release
-    var targetInst = ReactDOMComponentTree.getInstanceFromNode(node);
+    var targetInst = ReactDOMComponentTree.getInstanceFromNode(domNode);
     var event = new SyntheticEvent(
       dispatchConfig,
       targetInst,
       fakeNativeEvent,
-      node,
+      domNode,
     );
 
     // Since we aren't using pooling, always persist the event. This will make
@@ -492,7 +486,7 @@ function makeSimulator(eventType) {
     ReactDOM.unstable_batchedUpdates(function() {
       // Normally extractEvent enqueues a state restore, but we'll just always
       // do that since we we're by-passing it here.
-      ReactControlledComponent.enqueueStateRestore(node);
+      ReactControlledComponent.enqueueStateRestore(domNode);
 
       EventPluginHub.enqueueEvents(event);
       EventPluginHub.processEventQueue(true);

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -284,8 +284,8 @@ describe('ReactTestUtils', () => {
     );
 
     expect(() => ReactTestUtils.Simulate.click(instance)).toThrowError(
-      'TestUtils.Simulate does not support a composite component instance.' +
-        'TestUtils.Simulate only works with DOM component instance or a DOM node.',
+      'TestUtils.Simulate expected a DOM node as the first argument but received ' +
+        'a component instance. Pass the DOM node you wish to simulate the event on instead.',
     );
     expect(handler).not.toHaveBeenCalled();
   });

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -241,7 +241,7 @@ describe('ReactTestUtils', () => {
     );
   });
 
-  it('should throw when attempting to use ReactTestUtils.Simulate with shallow rendering', () => {
+  it('should throw when attempting to use a React element', () => {
     class SomeComponent extends React.Component {
       render() {
         return (
@@ -259,8 +259,8 @@ describe('ReactTestUtils', () => {
     );
 
     expect(() => ReactTestUtils.Simulate.click(result)).toThrowError(
-      'TestUtils.Simulate expects a DOM node and not a ReactElement. ' +
-        'TestUtils.Simulate will not work if you are using shallow rendering.',
+      'TestUtils.Simulate expected a DOM node as the first argument but received ' +
+        'a React element. Pass the DOM node you wish to simulate the event on instead.',
     );
     expect(handler).not.toHaveBeenCalled();
   });

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -234,7 +234,11 @@ describe('ReactTestUtils', () => {
         render() {
           return (
             <div>
-              <input type="text" ref="input" onChange={this.props.handleChange} />
+              <input
+                type="text"
+                ref="input"
+                onChange={this.props.handleChange}
+              />
             </div>
           );
         }

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -259,7 +259,7 @@ describe('ReactTestUtils', () => {
     );
 
     expect(() => ReactTestUtils.Simulate.click(result)).toThrowError(
-      'TestUtils.Simulate expects a component instance and not a ReactElement.' +
+      'TestUtils.Simulate expects a component instance and not a ReactElement. ' +
         'TestUtils.Simulate will not work if you are using shallow rendering.',
     );
     expect(handler).not.toHaveBeenCalled();

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -265,6 +265,31 @@ describe('ReactTestUtils', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it('should throw when attempting to use a composite component', () => {
+    class SomeComponent extends React.Component {
+      render() {
+        return (
+          <div onClick={this.props.handleClick}>
+            hello, world.
+          </div>
+        );
+      }
+    }
+
+    const handler = jasmine.createSpy('spy');
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(
+      <SomeComponent handleClick={handler} />,
+      container,
+    );
+
+    expect(() => ReactTestUtils.Simulate.click(instance)).toThrowError(
+      'TestUtils.Simulate does not support a composite component instance.' +
+        'TestUtils.Simulate only works with DOM component instance or a DOM node.',
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it('should not warn when simulating events with extra properties', () => {
     spyOn(console, 'error');
 

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -187,133 +187,6 @@ describe('ReactTestUtils', () => {
     expect(ReactTestUtils.isDOMComponent(component.refs.body)).toBe(true);
   });
 
-  it('should change the value of an input field', () => {
-    const obj = {
-      handler: function(e) {
-        e.persist();
-      },
-    };
-    spyOn(obj, 'handler').and.callThrough();
-    const container = document.createElement('div');
-    const instance = ReactDOM.render(
-      <input type="text" onChange={obj.handler} />,
-      container,
-    );
-
-    const node = ReactDOM.findDOMNode(instance);
-    node.value = 'giraffe';
-    ReactTestUtils.Simulate.change(node);
-
-    expect(obj.handler).toHaveBeenCalledWith(
-      jasmine.objectContaining({target: node}),
-    );
-  });
-
-  it('should change the value of an input field in a component', () => {
-    class SomeComponent extends React.Component {
-      render() {
-        return (
-          <div>
-            <input type="text" ref="input" onChange={this.props.handleChange} />
-          </div>
-        );
-      }
-    }
-
-    const obj = {
-      handler: function(e) {
-        e.persist();
-      },
-    };
-    spyOn(obj, 'handler').and.callThrough();
-    const container = document.createElement('div');
-    const instance = ReactDOM.render(
-      <SomeComponent handleChange={obj.handler} />,
-      container,
-    );
-
-    const node = ReactDOM.findDOMNode(instance.refs.input);
-    node.value = 'zebra';
-    ReactTestUtils.Simulate.change(node);
-
-    expect(obj.handler).toHaveBeenCalledWith(
-      jasmine.objectContaining({target: node}),
-    );
-  });
-
-  it('should throw when attempting to use a React element', () => {
-    class SomeComponent extends React.Component {
-      render() {
-        return (
-          <div onClick={this.props.handleClick}>
-            hello, world.
-          </div>
-        );
-      }
-    }
-
-    const handler = jasmine.createSpy('spy');
-    const shallowRenderer = createRenderer();
-    const result = shallowRenderer.render(
-      <SomeComponent handleClick={handler} />,
-    );
-
-    expect(() => ReactTestUtils.Simulate.click(result)).toThrowError(
-      'TestUtils.Simulate expected a DOM node as the first argument but received ' +
-        'a React element. Pass the DOM node you wish to simulate the event on instead. ' +
-        'Note that TestUtils.Simulate will not work if you are using shallow rendering.',
-    );
-    expect(handler).not.toHaveBeenCalled();
-  });
-
-  it('should throw when attempting to use a component instance', () => {
-    class SomeComponent extends React.Component {
-      render() {
-        return (
-          <div onClick={this.props.handleClick}>
-            hello, world.
-          </div>
-        );
-      }
-    }
-
-    const handler = jasmine.createSpy('spy');
-    const container = document.createElement('div');
-    const instance = ReactDOM.render(
-      <SomeComponent handleClick={handler} />,
-      container,
-    );
-
-    expect(() => ReactTestUtils.Simulate.click(instance)).toThrowError(
-      'TestUtils.Simulate expected a DOM node as the first argument but received ' +
-        'a component instance. Pass the DOM node you wish to simulate the event on instead.',
-    );
-    expect(handler).not.toHaveBeenCalled();
-  });
-
-  it('should not warn when simulating events with extra properties', () => {
-    spyOn(console, 'error');
-
-    const CLIENT_X = 100;
-
-    class Component extends React.Component {
-      handleClick = e => {
-        expect(e.clientX).toBe(CLIENT_X);
-      };
-
-      render() {
-        return <div onClick={this.handleClick} />;
-      }
-    }
-
-    const element = document.createElement('div');
-    const instance = ReactDOM.render(<Component />, element);
-    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance), {
-      clientX: CLIENT_X,
-    });
-    expectDev(console.error.calls.count()).toBe(0);
-  });
-
   it('can scry with stateless components involved', () => {
     const Stateless = () => <div><hr /></div>;
 
@@ -334,6 +207,133 @@ describe('ReactTestUtils', () => {
   });
 
   describe('Simulate', () => {
+    it('should change the value of an input field', () => {
+      const obj = {
+        handler: function(e) {
+          e.persist();
+        },
+      };
+      spyOn(obj, 'handler').and.callThrough();
+      const container = document.createElement('div');
+      const instance = ReactDOM.render(
+        <input type="text" onChange={obj.handler} />,
+        container,
+      );
+
+      const node = ReactDOM.findDOMNode(instance);
+      node.value = 'giraffe';
+      ReactTestUtils.Simulate.change(node);
+
+      expect(obj.handler).toHaveBeenCalledWith(
+        jasmine.objectContaining({target: node}),
+      );
+    });
+
+    it('should change the value of an input field in a component', () => {
+      class SomeComponent extends React.Component {
+        render() {
+          return (
+            <div>
+              <input type="text" ref="input" onChange={this.props.handleChange} />
+            </div>
+          );
+        }
+      }
+
+      const obj = {
+        handler: function(e) {
+          e.persist();
+        },
+      };
+      spyOn(obj, 'handler').and.callThrough();
+      const container = document.createElement('div');
+      const instance = ReactDOM.render(
+        <SomeComponent handleChange={obj.handler} />,
+        container,
+      );
+
+      const node = ReactDOM.findDOMNode(instance.refs.input);
+      node.value = 'zebra';
+      ReactTestUtils.Simulate.change(node);
+
+      expect(obj.handler).toHaveBeenCalledWith(
+        jasmine.objectContaining({target: node}),
+      );
+    });
+
+    it('should throw when attempting to use a React element', () => {
+      class SomeComponent extends React.Component {
+        render() {
+          return (
+            <div onClick={this.props.handleClick}>
+              hello, world.
+            </div>
+          );
+        }
+      }
+
+      const handler = jasmine.createSpy('spy');
+      const shallowRenderer = createRenderer();
+      const result = shallowRenderer.render(
+        <SomeComponent handleClick={handler} />,
+      );
+
+      expect(() => ReactTestUtils.Simulate.click(result)).toThrowError(
+        'TestUtils.Simulate expected a DOM node as the first argument but received ' +
+          'a React element. Pass the DOM node you wish to simulate the event on instead. ' +
+          'Note that TestUtils.Simulate will not work if you are using shallow rendering.',
+      );
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should throw when attempting to use a component instance', () => {
+      class SomeComponent extends React.Component {
+        render() {
+          return (
+            <div onClick={this.props.handleClick}>
+              hello, world.
+            </div>
+          );
+        }
+      }
+
+      const handler = jasmine.createSpy('spy');
+      const container = document.createElement('div');
+      const instance = ReactDOM.render(
+        <SomeComponent handleClick={handler} />,
+        container,
+      );
+
+      expect(() => ReactTestUtils.Simulate.click(instance)).toThrowError(
+        'TestUtils.Simulate expected a DOM node as the first argument but received ' +
+          'a component instance. Pass the DOM node you wish to simulate the event on instead.',
+      );
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should not warn when used with extra properties', () => {
+      spyOn(console, 'error');
+
+      const CLIENT_X = 100;
+
+      class Component extends React.Component {
+        handleClick = e => {
+          expect(e.clientX).toBe(CLIENT_X);
+        };
+
+        render() {
+          return <div onClick={this.handleClick} />;
+        }
+      }
+
+      const element = document.createElement('div');
+      const instance = ReactDOM.render(<Component />, element);
+      ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance), {
+        clientX: CLIENT_X,
+      });
+      expectDev(console.error.calls.count()).toBe(0);
+    });
+
     it('should set the type of the event', () => {
       let event;
       const stub = jest.genMockFn().mockImplementation(e => {

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -265,7 +265,7 @@ describe('ReactTestUtils', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
-  it('should throw when attempting to use a composite component', () => {
+  it('should throw when attempting to use a component instance', () => {
     class SomeComponent extends React.Component {
       render() {
         return (

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -260,7 +260,8 @@ describe('ReactTestUtils', () => {
 
     expect(() => ReactTestUtils.Simulate.click(result)).toThrowError(
       'TestUtils.Simulate expected a DOM node as the first argument but received ' +
-        'a React element. Pass the DOM node you wish to simulate the event on instead.',
+        'a React element. Pass the DOM node you wish to simulate the event on instead. ' +
+        'Note that TestUtils.Simulate will not work if you are using shallow rendering.',
     );
     expect(handler).not.toHaveBeenCalled();
   });

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -259,7 +259,7 @@ describe('ReactTestUtils', () => {
     );
 
     expect(() => ReactTestUtils.Simulate.click(result)).toThrowError(
-      'TestUtils.Simulate expects a component instance and not a ReactElement. ' +
+      'TestUtils.Simulate expects a DOM node and not a ReactElement. ' +
         'TestUtils.Simulate will not work if you are using shallow rendering.',
     );
     expect(handler).not.toHaveBeenCalled();


### PR DESCRIPTION
Per conversation from #10167, I added a test for this invariant that was mentioned in the 16 umbrella after an issue was brought up. Test event simulation should only be used with DOM nodes and DOM components.
