### PR TITLE
Find callsites that would call toString() if we pass attributes through

### DIFF
--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -126,6 +126,23 @@ var warnUnknownProperties = function(type, props, debugID) {
     var isValid = validateProperty(type, key, debugID);
     if (!isValid) {
       unknownProps.push(key);
+      var value = props[key];
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        value.toString !== Object.prototype.toString
+      ) {
+        warning(
+          false,
+          'The %s prop on <%s> is not a known property, and was given an object ' +
+            'with a custom toString() method. Remove it, or it will appear in the ' +
+            'DOM after a future React update.%s',
+          key,
+          type,
+          getStackAddendum(debugID),
+        );
+      }
     }
   }
 

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -127,16 +127,11 @@ var warnUnknownProperties = function(type, props, debugID) {
     if (!isValid) {
       unknownProps.push(key);
       var value = props[key];
-      if (
-        typeof value === 'object' &&
-        value !== null &&
-        !Array.isArray(value) &&
-        value.toString !== Object.prototype.toString
-      ) {
+      if (typeof value === 'object' && value !== null) {
         warning(
           false,
-          'The %s prop on <%s> is not a known property, and was given an object ' +
-            'with a custom toString() method. Remove it, or it will appear in the ' +
+          'The %s prop on <%s> is not a known property, and was given an object.' +
+            'Remove it, or it will appear in the ' +
             'DOM after a future React update.%s',
           key,
           type,


### PR DESCRIPTION
The downside of merging https://github.com/facebook/react/pull/10385 is that we don’t know if we have internal callsites that would break because of `toString` once we start passing attributes through. This is not a problem in open source where we’ve had a warning for a long time.

I propose we add this warning now, and let it live for a few days. Then look at the top callsites, and how many there are (and if they are benign or if calling `toString` could cause issues). 