### PR TITLE
Documentation : Correction of a mistake on code snippet

### DIFF
--- a/docs/docs/context.md
+++ b/docs/docs/context.md
@@ -162,8 +162,8 @@ Stateless functional components are also able to reference `context` if `context
 ```javascript
 const PropTypes = require('prop-types');
 
-const Button = ({children}, context) =>
-  <button style={{'{{'}}background: context.color}}>
+const Button = (children, context) =>
+  <button style={{background: context.color}}>
     {children}
   </button>;
 


### PR DESCRIPTION
The parameter children was wrapped with braces.
