### PR TITLE
Wrap warning() calls in a DEV check for RN_* builds too

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -123,6 +123,8 @@ function updateBabelConfig(babelOpts, bundleType) {
   switch (bundleType) {
     case FB_DEV:
     case FB_PROD:
+    case RN_DEV:
+    case RN_PROD:
       return Object.assign({}, babelOpts, {
         plugins: babelOpts.plugins.concat([
           // Wrap warning() calls in a __DEV__ check so they are stripped from production.

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -144,14 +144,16 @@ function validateExplicitKey(element, parentType) {
   }
 
   currentlyValidatingElement = element;
-  warning(
-    false,
-    'Each child in an array or iterator should have a unique "key" prop.' +
-      '%s%s See https://fb.me/react-warning-keys for more information.%s',
-    currentComponentErrorInfo,
-    childOwner,
-    getStackAddendum(),
-  );
+  if (__DEV__) {
+    warning(
+      false,
+      'Each child in an array or iterator should have a unique "key" prop.' +
+        '%s%s See https://fb.me/react-warning-keys for more information.%s',
+      currentComponentErrorInfo,
+      childOwner,
+      getStackAddendum(),
+    );
+  }
   currentlyValidatingElement = null;
 }
 

--- a/src/renderers/dom/stack/client/ReactDOMComponent.js
+++ b/src/renderers/dom/stack/client/ReactDOMComponent.js
@@ -42,8 +42,11 @@ var memoizeStringOnly = require('fbjs/lib/memoizeStringOnly');
 var omittedCloseTags = require('omittedCloseTags');
 var validateDOMNesting = require('validateDOMNesting');
 var voidElementTags = require('voidElementTags');
-var warning = require('fbjs/lib/warning');
 var warnValidStyle = require('warnValidStyle');
+
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+}
 
 var didWarnShadyDOM = false;
 

--- a/src/renderers/native/ReactNativeBridgeEventPlugin.js
+++ b/src/renderers/native/ReactNativeBridgeEventPlugin.js
@@ -15,25 +15,19 @@ var EventPropagators = require('EventPropagators');
 var SyntheticEvent = require('SyntheticEvent');
 var UIManager = require('UIManager');
 
-var warning = require('fbjs/lib/warning');
-
 var customBubblingEventTypes = UIManager.customBubblingEventTypes;
 var customDirectEventTypes = UIManager.customDirectEventTypes;
 
-var allTypesByEventName = {};
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
 
-for (var bubblingTypeName in customBubblingEventTypes) {
-  allTypesByEventName[bubblingTypeName] =
-    customBubblingEventTypes[bubblingTypeName];
-}
-
-for (var directTypeName in customDirectEventTypes) {
-  warning(
-    !customBubblingEventTypes[directTypeName],
-    'Event cannot be both direct and bubbling: %s',
-    directTypeName,
-  );
-  allTypesByEventName[directTypeName] = customDirectEventTypes[directTypeName];
+  for (var directTypeName in customDirectEventTypes) {
+    warning(
+      !customBubblingEventTypes[directTypeName],
+      'Event cannot be both direct and bubbling: %s',
+      directTypeName,
+    );
+  }
 }
 
 var ReactNativeBridgeEventPlugin = {

--- a/src/renderers/native/ReactNativeEventEmitter.js
+++ b/src/renderers/native/ReactNativeEventEmitter.js
@@ -18,7 +18,9 @@ var ReactNativeComponentTree = require('ReactNativeComponentTree');
 var ReactNativeTagHandles = require('ReactNativeTagHandles');
 var ReactGenericBatching = require('ReactGenericBatching');
 
-var warning = require('fbjs/lib/warning');
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+}
 
 /**
  * Version of `ReactBrowserEventEmitter` that works on the receiving side of a

--- a/src/renderers/native/findNodeHandle.js
+++ b/src/renderers/native/findNodeHandle.js
@@ -18,7 +18,10 @@ var ReactNativeFiberRenderer = require('ReactNativeFiberRenderer');
 var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 
 var invariant = require('fbjs/lib/invariant');
-var warning = require('fbjs/lib/warning');
+
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+}
 
 import type {Fiber} from 'ReactFiber';
 import type {ReactInstance} from 'ReactInstanceType';

--- a/src/renderers/shared/shared/event/eventPlugins/ResponderTouchHistoryStore.js
+++ b/src/renderers/shared/shared/event/eventPlugins/ResponderTouchHistoryStore.js
@@ -104,13 +104,15 @@ function resetTouchRecord(touchRecord: TouchRecord, touch: Touch): void {
 
 function getTouchIdentifier({identifier}: Touch): number {
   invariant(identifier != null, 'Touch object is missing identifier.');
-  warning(
-    identifier <= MAX_TOUCH_BANK,
-    'Touch identifier %s is greater than maximum supported %s which causes ' +
-      'performance issues backfilling array locations for all of the indices.',
-    identifier,
-    MAX_TOUCH_BANK,
-  );
+  if (__DEV__) {
+    warning(
+      identifier <= MAX_TOUCH_BANK,
+      'Touch identifier %s is greater than maximum supported %s which causes ' +
+        'performance issues backfilling array locations for all of the indices.',
+      identifier,
+      MAX_TOUCH_BANK,
+    );
+  }
   return identifier;
 }
 

--- a/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactChildReconciler.js
@@ -17,7 +17,10 @@ var ReactReconciler = require('ReactReconciler');
 var instantiateReactComponent = require('instantiateReactComponent');
 var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
 var traverseStackChildren = require('traverseStackChildren');
-var warning = require('fbjs/lib/warning');
+
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+}
 
 var ReactComponentTreeHook;
 

--- a/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
+++ b/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js
@@ -24,6 +24,7 @@ var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 if (__DEV__) {
   var {ReactDebugCurrentFrame} = require('ReactGlobalSharedState');
   var ReactDebugCurrentStack = require('ReactDebugCurrentStack');
+  var warning = require('fbjs/lib/warning');
   var warningAboutMissingGetChildContext = {};
 }
 
@@ -32,7 +33,6 @@ var emptyObject = require('fbjs/lib/emptyObject');
 var invariant = require('fbjs/lib/invariant');
 var shallowEqual = require('fbjs/lib/shallowEqual');
 var shouldUpdateReactComponent = require('shouldUpdateReactComponent');
-var warning = require('fbjs/lib/warning');
 
 function StatelessComponent(Component) {}
 StatelessComponent.prototype.render = function() {

--- a/src/renderers/shared/stack/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactReconciler.js
@@ -14,7 +14,9 @@
 var ReactRef = require('ReactRef');
 var ReactInstrumentation = require('ReactInstrumentation');
 
-var warning = require('fbjs/lib/warning');
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+}
 
 /**
  * Helper to call ReactRef.attachRefs with this composite component, split out
@@ -187,16 +189,18 @@ var ReactReconciler = {
     updateBatchNumber,
   ) {
     if (internalInstance._updateBatchNumber !== updateBatchNumber) {
-      // The component's enqueued batch number should always be the current
-      // batch or the following one.
-      warning(
-        internalInstance._updateBatchNumber == null ||
-          internalInstance._updateBatchNumber === updateBatchNumber + 1,
-        'performUpdateIfNecessary: Unexpected batch number (current %s, ' +
-          'pending %s)',
-        updateBatchNumber,
-        internalInstance._updateBatchNumber,
-      );
+      if (__DEV__) {
+        // The component's enqueued batch number should always be the current
+        // batch or the following one.
+        warning(
+          internalInstance._updateBatchNumber == null ||
+            internalInstance._updateBatchNumber === updateBatchNumber + 1,
+          'performUpdateIfNecessary: Unexpected batch number (current %s, ' +
+            'pending %s)',
+          updateBatchNumber,
+          internalInstance._updateBatchNumber,
+        );
+      }
       return;
     }
     if (__DEV__) {

--- a/src/renderers/shared/stack/reconciler/flattenStackChildren.js
+++ b/src/renderers/shared/stack/reconciler/flattenStackChildren.js
@@ -14,7 +14,10 @@
 
 var KeyEscapeUtils = require('KeyEscapeUtils');
 var traverseStackChildren = require('traverseStackChildren');
-var warning = require('fbjs/lib/warning');
+
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+}
 
 var ReactComponentTreeHook;
 

--- a/src/renderers/shared/stack/reconciler/instantiateReactComponent.js
+++ b/src/renderers/shared/stack/reconciler/instantiateReactComponent.js
@@ -16,7 +16,10 @@ var ReactEmptyComponent = require('ReactEmptyComponent');
 var ReactHostComponent = require('ReactHostComponent');
 
 var invariant = require('fbjs/lib/invariant');
-var warning = require('fbjs/lib/warning');
+
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+}
 
 var nextDebugID = 1;
 

--- a/src/renderers/shared/stack/reconciler/traverseStackChildren.js
+++ b/src/renderers/shared/stack/reconciler/traverseStackChildren.js
@@ -13,7 +13,6 @@
 
 var invariant = require('fbjs/lib/invariant');
 var KeyEscapeUtils = require('KeyEscapeUtils');
-var warning = require('fbjs/lib/warning');
 
 var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
 var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
@@ -24,6 +23,7 @@ var REACT_ELEMENT_TYPE =
   0xeac7;
 
 if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
   var {
     getCurrentStackAddendum,
   } = require('ReactGlobalSharedState').ReactComponentTreeHook;


### PR DESCRIPTION
Building on the work done in #10361-
* This PR fixes an errant `warning` left in the React Native build by auto-wrapping all calls to `warning` in an if-DEV check.
* I also wrapped several `warning` imports and a call or two in `__DEV__` checks in the source just by looking at which ones were removed from the prod bundle after adding this check.
* I also removed a useless variable (`allTypesByEventName`) and loop from `src/renderers/native/ReactNativeBridgeEventPlugin`.

Before and after diffs below.

### build/react-native/ReactNativeStack-prod.js
```diff
14c14
< var invariant = require("fbjs/lib/invariant"), React = require("react"), emptyObject = require("fbjs/lib/emptyObject"), warning = require("fbjs/lib/warning"), UIManager = require("UIManager");
---
> var invariant = require("fbjs/lib/invariant"), React = require("react"), emptyObject = require("fbjs/lib/emptyObject"), UIManager = require("UIManager");
192,193c192
<         if (internalInstance._updateBatchNumber !== updateBatchNumber) return void warning(null == internalInstance._updateBatchNumber || internalInstance._updateBatchNumber === updateBatchNumber + 1, "performUpdateIfNecessary: Unexpected batch number (current %s, " + "pending %s)", updateBatchNumber, internalInstance._updateBatchNumber);
<         internalInstance.performUpdateIfNecessary(transaction);
---
>         internalInstance._updateBatchNumber === updateBatchNumber && internalInstance.performUpdateIfNecessary(transaction);
1309,1316c1308
< var customBubblingEventTypes = UIManager.customBubblingEventTypes, customDirectEventTypes = UIManager.customDirectEventTypes, allTypesByEventName = {};
< 
< for (var bubblingTypeName in customBubblingEventTypes) allTypesByEventName[bubblingTypeName] = customBubblingEventTypes[bubblingTypeName];
< 
< for (var directTypeName in customDirectEventTypes) warning(!customBubblingEventTypes[directTypeName], "Event cannot be both direct and bubbling: %s", directTypeName), 
< allTypesByEventName[directTypeName] = customDirectEventTypes[directTypeName];
< 
< var ReactNativeBridgeEventPlugin = {
---
> var customBubblingEventTypes = UIManager.customBubblingEventTypes, customDirectEventTypes = UIManager.customDirectEventTypes, ReactNativeBridgeEventPlugin = {
1456c1448
< var ResponderSyntheticEvent_1 = ResponderSyntheticEvent, isEndish$2 = EventPluginUtils_1.isEndish, isMoveish$2 = EventPluginUtils_1.isMoveish, isStartish$2 = EventPluginUtils_1.isStartish, warning$7, MAX_TOUCH_BANK = 20, touchBank = [], touchHistory = {
---
> var ResponderSyntheticEvent_1 = ResponderSyntheticEvent, isEndish$2 = EventPluginUtils_1.isEndish, isMoveish$2 = EventPluginUtils_1.isMoveish, isStartish$2 = EventPluginUtils_1.isStartish, MAX_TOUCH_BANK = 20, touchBank = [], touchHistory = {
1492,1493c1484
<     return invariant(null != identifier, "Touch object is missing identifier."), warning$7(identifier <= MAX_TOUCH_BANK, "Touch identifier %s is greater than maximum supported %s which causes " + "performance issues backfilling array locations for all of the indices.", identifier, MAX_TOUCH_BANK), 
<     identifier;
---
>     return invariant(null != identifier, "Touch object is missing identifier."), identifier;
```

### build/react-native/ReactNativeFiber-prod.js
```diff
16,20c16
< require("deepFreezeAndThrowOnMutationInDev");
< 
< var warning = require("fbjs/lib/warning");
< 
< require("InitializeCore");
---
> require("deepFreezeAndThrowOnMutationInDev"), require("InitializeCore");
1748c1744
< }, warning$11, onCommitFiberRoot = null, onCommitFiberUnmount = null, hasLoggedError = !1;
---
> }, onCommitFiberRoot = null, onCommitFiberUnmount = null, hasLoggedError = !1;
1755c1751
<             1 || hasLoggedError || (hasLoggedError = !0, warning$11(!1, "React DevTools encountered an error: %s", err));
---
>             1 || hasLoggedError || (hasLoggedError = !0);
3259,3266c3255
< var customBubblingEventTypes = UIManager.customBubblingEventTypes, customDirectEventTypes = UIManager.customDirectEventTypes, allTypesByEventName = {};
< 
< for (var bubblingTypeName in customBubblingEventTypes) allTypesByEventName[bubblingTypeName] = customBubblingEventTypes[bubblingTypeName];
< 
< for (var directTypeName in customDirectEventTypes) warning(!customBubblingEventTypes[directTypeName], "Event cannot be both direct and bubbling: %s", directTypeName), 
< allTypesByEventName[directTypeName] = customDirectEventTypes[directTypeName];
< 
< var ReactNativeBridgeEventPlugin = {
---
> var customBubblingEventTypes = UIManager.customBubblingEventTypes, customDirectEventTypes = UIManager.customDirectEventTypes, ReactNativeBridgeEventPlugin = {
3340c3329
< var ResponderSyntheticEvent_1 = ResponderSyntheticEvent, isEndish$2 = EventPluginUtils_1.isEndish, isMoveish$2 = EventPluginUtils_1.isMoveish, isStartish$2 = EventPluginUtils_1.isStartish, warning$15, MAX_TOUCH_BANK = 20, touchBank = [], touchHistory = {
---
> var ResponderSyntheticEvent_1 = ResponderSyntheticEvent, isEndish$2 = EventPluginUtils_1.isEndish, isMoveish$2 = EventPluginUtils_1.isMoveish, isStartish$2 = EventPluginUtils_1.isStartish, MAX_TOUCH_BANK = 20, touchBank = [], touchHistory = {
3376,3377c3365
<     return invariant(null != identifier, "Touch object is missing identifier."), warning$15(identifier <= MAX_TOUCH_BANK, "Touch identifier %s is greater than maximum supported %s which causes " + "performance issues backfilling array locations for all of the indices.", identifier, MAX_TOUCH_BANK), 
<     identifier;
---
>     return invariant(null != identifier, "Touch object is missing identifier."), identifier;
```

### build/react-native/ReactNativeStack-dev.js
``` diff
15c15
<     var invariant = require("fbjs/lib/invariant"), React = require("react"), warning = require("fbjs/lib/warning"), ExecutionEnvironment = require("fbjs/lib/ExecutionEnvironment"), performanceNow = require("fbjs/lib/performanceNow"), emptyObject = require("fbjs/lib/emptyObject"), UIManager = require("UIManager"), checkPropTypes = require("prop-types/checkPropTypes"), shallowEqual = require("fbjs/lib/shallowEqual");
---
>     var invariant = require("fbjs/lib/invariant"), React = require("react"), require$$0 = require("fbjs/lib/warning"), ExecutionEnvironment = require("fbjs/lib/ExecutionEnvironment"), performanceNow = require("fbjs/lib/performanceNow"), emptyObject = require("fbjs/lib/emptyObject"), UIManager = require("UIManager"), checkPropTypes = require("prop-types/checkPropTypes"), shallowEqual = require("fbjs/lib/shallowEqual");
59,60c59,60
<     }, ReactNativeComponentTree_1 = ReactNativeComponentTree, ReactInvalidSetStateWarningHook = {}, warning$2 = warning, processingChildContext = !1, warnInvalidSetState = function() {
<         warning$2(!processingChildContext, "setState(...): Cannot call setState() inside getChildContext()");
---
>     }, ReactNativeComponentTree_1 = ReactNativeComponentTree, ReactInvalidSetStateWarningHook = {}, warning$1 = require$$0, processingChildContext = !1, warnInvalidSetState = function() {
>         warning$1(!processingChildContext, "setState(...): Cannot call setState() inside getChildContext()");
92c92
<     var ReactGlobalSharedState_1 = ReactGlobalSharedState, ReactComponentTreeHook = ReactGlobalSharedState_1.ReactComponentTreeHook, warning$1 = warning, ReactDebugTool$1 = null, hooks = [], didHookThrowForEvent = {}, callHook = function(event, fn, context, arg1, arg2, arg3, arg4, arg5) {
---
>     var ReactGlobalSharedState_1 = ReactGlobalSharedState, ReactComponentTreeHook = ReactGlobalSharedState_1.ReactComponentTreeHook, warning = require$$0, ReactDebugTool$1 = null, hooks = [], didHookThrowForEvent = {}, callHook = function(event, fn, context, arg1, arg2, arg3, arg4, arg5) {
96c96
<             warning$1(didHookThrowForEvent[event], "Exception thrown by hook while handling %s: %s", event, e + "\n" + e.stack), 
---
>             warning(didHookThrowForEvent[event], "Exception thrown by hook while handling %s: %s", event, e + "\n" + e.stack), 
133c133
<         arguments.length > 1 && void 0 !== arguments[1] && arguments[1] && 0 === debugID || debugID || warning$1(!1, "ReactDebugTool: debugID may not be empty.");
---
>         arguments.length > 1 && void 0 !== arguments[1] && arguments[1] && 0 === debugID || debugID || warning(!1, "ReactDebugTool: debugID may not be empty.");
135c135
<         0 !== currentFlushNesting && (currentTimerType && !lifeCycleTimerHasWarned && (warning$1(!1, "There is an internal error in the React performance measurement code." + "\n\nDid not expect %s timer to start while %s timer is still in " + "progress for %s instance.", timerType, currentTimerType || "no", debugID === currentTimerDebugID ? "the same" : "another"), 
---
>         0 !== currentFlushNesting && (currentTimerType && !lifeCycleTimerHasWarned && (warning(!1, "There is an internal error in the React performance measurement code." + "\n\nDid not expect %s timer to start while %s timer is still in " + "progress for %s instance.", timerType, currentTimerType || "no", debugID === currentTimerDebugID ? "the same" : "another"), 
139c139
<         0 !== currentFlushNesting && (currentTimerType === timerType || lifeCycleTimerHasWarned || (warning$1(!1, "There is an internal error in the React performance measurement code. " + "We did not expect %s timer to stop while %s timer is still in " + "progress for %s instance. Please report this as a bug in React.", timerType, currentTimerType || "no", debugID === currentTimerDebugID ? "the same" : "another"), 
---
>         0 !== currentFlushNesting && (currentTimerType === timerType || lifeCycleTimerHasWarned || (warning(!1, "There is an internal error in the React performance measurement code. " + "We did not expect %s timer to stop while %s timer is still in " + "progress for %s instance. Please report this as a bug in React.", timerType, currentTimerType || "no", debugID === currentTimerDebugID ? "the same" : "another"), 
314c314
<     }, ReactRef = {}, ReactCompositeComponentTypes = ReactCompositeComponentTypes$1, _require = ReactGlobalSharedState_1, ReactComponentTreeHook$1 = _require.ReactComponentTreeHook, warning$4 = warning, warnedAboutStatelessRefs = {};
---
>     }, ReactRef = {}, ReactCompositeComponentTypes = ReactCompositeComponentTypes$1, _require = ReactGlobalSharedState_1, ReactComponentTreeHook$1 = _require.ReactComponentTreeHook, warning$3 = require$$0, warnedAboutStatelessRefs = {};
322c322
<             warning$4(!1, "Stateless function components cannot be given refs. " + "Attempts to access this ref will fail.%s%s", info, ReactComponentTreeHook$1.getStackAddendumByID(component._debugID)));
---
>             warning$3(!1, "Stateless function components cannot be given refs. " + "Attempts to access this ref will fail.%s%s", info, ReactComponentTreeHook$1.getStackAddendumByID(component._debugID)));
347c347
<     var ReactRef_1 = ReactRef;
---
>     var ReactRef_1 = ReactRef, warning$2 = require$$0;
378c378
<             if (internalInstance._updateBatchNumber !== updateBatchNumber) return void warning(null == internalInstance._updateBatchNumber || internalInstance._updateBatchNumber === updateBatchNumber + 1, "performUpdateIfNecessary: Unexpected batch number (current %s, " + "pending %s)", updateBatchNumber, internalInstance._updateBatchNumber);
---
>             if (internalInstance._updateBatchNumber !== updateBatchNumber) return void warning$2(null == internalInstance._updateBatchNumber || internalInstance._updateBatchNumber === updateBatchNumber + 1, "performUpdateIfNecessary: Unexpected batch number (current %s, " + "pending %s)", updateBatchNumber, internalInstance._updateBatchNumber);
565,566c565,566
<     }, ReactUpdates_1 = ReactUpdates, ReactCurrentOwner = ReactGlobalSharedState_1.ReactCurrentOwner, warning$5 = warning, warnOnInvalidCallback = function(callback, callerName) {
<         warning$5(null === callback || "function" == typeof callback, "%s(...): Expected the last optional `callback` argument to be a " + "function. Instead received: %s.", callerName, "" + callback);
---
>     }, ReactUpdates_1 = ReactUpdates, ReactCurrentOwner = ReactGlobalSharedState_1.ReactCurrentOwner, warning$4 = require$$0, warnOnInvalidCallback = function(callback, callerName) {
>         warning$4(null === callback || "function" == typeof callback, "%s(...): Expected the last optional `callback` argument to be a " + "function. Instead received: %s.", callerName, "" + callback);
575c575
<             return warning$5(!1, "Can only update a mounted or mounting component. This usually means " + "you called setState, replaceState, or forceUpdate on an unmounted " + "component. This is a no-op.\n\nPlease check the code for the " + "%s component.", ctor && (ctor.displayName || ctor.name) || "ReactClass"), 
---
>             return warning$4(!1, "Can only update a mounted or mounting component. This usually means " + "you called setState, replaceState, or forceUpdate on an unmounted " + "component. This is a no-op.\n\nPlease check the code for the " + "%s component.", ctor && (ctor.displayName || ctor.name) || "ReactClass"), 
578c578
<         return warning$5(null == ReactCurrentOwner.current, "Cannot update during an existing state transition (such as within " + "`render` or another component's constructor). Render methods should " + "be a pure function of props and state; constructor side-effects are " + "an anti-pattern, but can be moved to `componentWillMount`."), 
---
>         return warning$4(null == ReactCurrentOwner.current, "Cannot update during an existing state transition (such as within " + "`render` or another component's constructor). Render methods should " + "be a pure function of props and state; constructor side-effects are " + "an anti-pattern, but can be moved to `componentWillMount`."), 
584c584
<             null !== owner && (warning$5(owner._warnedAboutRefsInRender, "%s is accessing isMounted inside its render() function. " + "render() should be a pure function of props and state. It should " + "never access something that requires stale data from the previous " + "render, such as refs. Move this logic to componentDidMount and " + "componentDidUpdate instead.", owner.getName() || "A component"), 
---
>             null !== owner && (warning$4(owner._warnedAboutRefsInRender, "%s is accessing isMounted inside its render() function. " + "render() should be a pure function of props and state. It should " + "never access something that requires stale data from the previous " + "render, such as refs. Move this logic to componentDidMount and " + "componentDidUpdate instead.", owner.getName() || "A component"), 
607c607
<             ReactInstrumentation.debugTool.onSetState(), warning$5(null != partialState, "setState(...): You passed an undefined or null state object; " + "instead, use forceUpdate().");
---
>             ReactInstrumentation.debugTool.onSetState(), warning$4(null != partialState, "setState(...): You passed an undefined or null state object; " + "instead, use forceUpdate().");
719c719
<     var shouldUpdateReactComponent_1 = shouldUpdateReactComponent, ReactCurrentOwner$1 = ReactGlobalSharedState_1.ReactCurrentOwner, _require2 = ReactGlobalSharedState_1, ReactDebugCurrentFrame = _require2.ReactDebugCurrentFrame, ReactDebugCurrentStack = ReactDebugCurrentStack_1, warningAboutMissingGetChildContext = {};
---
>     var shouldUpdateReactComponent_1 = shouldUpdateReactComponent, ReactCurrentOwner$1 = ReactGlobalSharedState_1.ReactCurrentOwner, _require2 = ReactGlobalSharedState_1, ReactDebugCurrentFrame = _require2.ReactDebugCurrentFrame, ReactDebugCurrentStack = ReactDebugCurrentStack_1, warning$6 = require$$0, warningAboutMissingGetChildContext = {};
754c754
<             warning(!Component.childContextTypes, "%s(...): childContextTypes cannot be defined on a functional component.", Component.displayName || Component.name || "Component"), 
---
>             warning$6(!Component.childContextTypes, "%s(...): childContextTypes cannot be defined on a functional component.", Component.displayName || Component.name || "Component"), 
757c757
<             null == inst.render && warning(!1, "%s(...): No `render` method found on the returned component " + "instance: you may have forgotten to define `render`.", Component.displayName || Component.name || "Component");
---
>             null == inst.render && warning$6(!1, "%s(...): No `render` method found on the returned component " + "instance: you may have forgotten to define `render`.", Component.displayName || Component.name || "Component");
759c759
<             warning(void 0 === inst.props || !propsMutated, "%s(...): When calling super() in `%s`, make sure to pass " + "up the same props that your component's constructor was passed.", componentName, componentName), 
---
>             warning$6(void 0 === inst.props || !propsMutated, "%s(...): When calling super() in `%s`, make sure to pass " + "up the same props that your component's constructor was passed.", componentName, componentName), 
762,770c762,770
<             warning(!inst.getInitialState || inst.getInitialState.isReactClassApproved || inst.state, "getInitialState was defined on %s, a plain JavaScript class. " + "This is only supported for classes created using React.createClass. " + "Did you mean to define a state property instead?", this.getName() || "a component"), 
<             warning(!inst.getDefaultProps || inst.getDefaultProps.isReactClassApproved, "getDefaultProps was defined on %s, a plain JavaScript class. " + "This is only supported for classes created using React.createClass. " + "Use a static property to define defaultProps instead.", this.getName() || "a component"), 
<             warning(!inst.propTypes, "propTypes was defined as an instance property on %s. Use a static " + "property to define propTypes instead.", this.getName() || "a component"), 
<             warning(!inst.contextTypes, "contextTypes was defined as an instance property on %s. Use a " + "static property to define contextTypes instead.", this.getName() || "a component"), 
<             warning("function" != typeof inst.componentShouldUpdate, "%s has a method called " + "componentShouldUpdate(). Did you mean shouldComponentUpdate()? " + "The name is phrased as a question because the function is " + "expected to return a value.", this.getName() || "A component"), 
<             warning("function" != typeof inst.componentDidUnmount, "%s has a method called " + "componentDidUnmount(). But there is no such lifecycle method. " + "Did you mean componentWillUnmount()?", this.getName() || "A component"), 
<             warning("function" != typeof inst.componentWillRecieveProps, "%s has a method called " + "componentWillRecieveProps(). Did you mean componentWillReceiveProps()?", this.getName() || "A component"), 
<             isPureComponent(Component) && void 0 !== inst.shouldComponentUpdate && warning(!1, "%s has a method called shouldComponentUpdate(). " + "shouldComponentUpdate should not be used when extending React.PureComponent. " + "Please extend React.Component if shouldComponentUpdate is used.", this.getName() || "A pure component"), 
<             warning(!inst.defaultProps, "Setting defaultProps as an instance property on %s is not supported and will be ignored." + " Instead, define defaultProps as a static property on %s.", this.getName() || "a component", this.getName() || "a component");
---
>             warning$6(!inst.getInitialState || inst.getInitialState.isReactClassApproved || inst.state, "getInitialState was defined on %s, a plain JavaScript class. " + "This is only supported for classes created using React.createClass. " + "Did you mean to define a state property instead?", this.getName() || "a component"), 
>             warning$6(!inst.getDefaultProps || inst.getDefaultProps.isReactClassApproved, "getDefaultProps was defined on %s, a plain JavaScript class. " + "This is only supported for classes created using React.createClass. " + "Use a static property to define defaultProps instead.", this.getName() || "a component"), 
>             warning$6(!inst.propTypes, "propTypes was defined as an instance property on %s. Use a static " + "property to define propTypes instead.", this.getName() || "a component"), 
>             warning$6(!inst.contextTypes, "contextTypes was defined as an instance property on %s. Use a " + "static property to define contextTypes instead.", this.getName() || "a component"), 
>             warning$6("function" != typeof inst.componentShouldUpdate, "%s has a method called " + "componentShouldUpdate(). Did you mean shouldComponentUpdate()? " + "The name is phrased as a question because the function is " + "expected to return a value.", this.getName() || "A component"), 
>             warning$6("function" != typeof inst.componentDidUnmount, "%s has a method called " + "componentDidUnmount(). But there is no such lifecycle method. " + "Did you mean componentWillUnmount()?", this.getName() || "A component"), 
>             warning$6("function" != typeof inst.componentWillRecieveProps, "%s has a method called " + "componentWillRecieveProps(). Did you mean componentWillReceiveProps()?", this.getName() || "A component"), 
>             isPureComponent(Component) && void 0 !== inst.shouldComponentUpdate && warning$6(!1, "%s has a method called shouldComponentUpdate(). " + "shouldComponentUpdate should not be used when extending React.PureComponent. " + "Please extend React.Component if shouldComponentUpdate is used.", this.getName() || "A pure component"), 
>             warning$6(!inst.defaultProps, "Setting defaultProps as an instance property on %s is not supported and will be ignored." + " Instead, define defaultProps as a static property on %s.", this.getName() || "a component", this.getName() || "a component");
883c883
<             warning(!Component.childContextTypes, "%s.childContextTypes is specified but there is no getChildContext() method " + "on the instance. You can either define getChildContext() on %s or remove " + "childContextTypes from it.", componentName, componentName)), 
---
>             warning$6(!Component.childContextTypes, "%s.childContextTypes is specified but there is no getChildContext() method " + "on the instance. You can either define getChildContext() on %s or remove " + "childContextTypes from it.", componentName, componentName)), 
915c915
<                 warning(!1, "%s.componentWillReceiveProps(): Assigning directly to " + "this.state is deprecated (except inside a component's " + "constructor). Use setState instead.", this.getName() || "ReactCompositeComponent"));
---
>                 warning$6(!1, "%s.componentWillReceiveProps(): Assigning directly to " + "this.state is deprecated (except inside a component's " + "constructor). Use setState instead.", this.getName() || "ReactCompositeComponent"));
926c926
<             if (warning(void 0 !== shouldUpdate, "%s.shouldComponentUpdate(): Returned undefined instead of a " + "boolean value. Make sure to return true or false.", this.getName() || "ReactCompositeComponent"), 
---
>             if (warning$6(void 0 !== shouldUpdate, "%s.shouldComponentUpdate(): Returned undefined instead of a " + "boolean value. Make sure to return true or false.", this.getName() || "ReactCompositeComponent"), 
1054c1054
<     }, ReactHostComponent_1 = ReactHostComponent, nextDebugID = 1, ReactCompositeComponentWrapper = function(element) {
---
>     }, ReactHostComponent_1 = ReactHostComponent, warning$5 = require$$0, nextDebugID = 1, ReactCompositeComponentWrapper = function(element) {
1079c1079
<         return warning("function" == typeof instance.mountComponent && "function" == typeof instance.receiveComponent && "function" == typeof instance.getHostNode && "function" == typeof instance.unmountComponent, "Only React Components can be mounted."), 
---
>         return warning$5("function" == typeof instance.mountComponent && "function" == typeof instance.receiveComponent && "function" == typeof instance.getHostNode && "function" == typeof instance.unmountComponent, "Only React Components can be mounted."), 
1086c1086
<     var instantiateReactComponent_1 = instantiateReactComponent, DevOnlyStubShim = null, ReactNativeFeatureFlags = require("ReactNativeFeatureFlags"), ReactCurrentOwner$2 = ReactGlobalSharedState_1.ReactCurrentOwner, injectedFindNode = ReactNativeFeatureFlags.useFiber ? function(fiber) {
---
>     var instantiateReactComponent_1 = instantiateReactComponent, DevOnlyStubShim = null, ReactNativeFeatureFlags = require("ReactNativeFeatureFlags"), ReactCurrentOwner$2 = ReactGlobalSharedState_1.ReactCurrentOwner, warning$7 = require$$0, injectedFindNode = ReactNativeFeatureFlags.useFiber ? function(fiber) {
1093c1093
<         if (null !== owner && (warning(owner._warnedAboutRefsInRender, "%s is accessing findNodeHandle inside its render(). " + "render() should be a pure function of props and state. It should " + "never access something that requires stale data from the previous " + "render, such as refs. Move this logic to componentDidMount and " + "componentDidUpdate instead.", owner.getName() || "A component"), 
---
>         if (null !== owner && (warning$7(owner._warnedAboutRefsInRender, "%s is accessing findNodeHandle inside its render(). " + "render() should be a pure function of props and state. It should " + "never access something that requires stale data from the previous " + "render, such as refs. Move this logic to componentDidMount and " + "componentDidUpdate instead.", owner.getName() || "A component"), 
1275c1275
<     }, EventPluginRegistry_1 = EventPluginRegistry, warning$6 = warning, injection = {
---
>     }, EventPluginRegistry_1 = EventPluginRegistry, warning$8 = require$$0, injection = {
1277c1277
<             ComponentTree = Injected, warning$6(Injected && Injected.getNodeFromInstance && Injected.getInstanceFromNode, "EventPluginUtils.injection.injectComponentTree(...): Injected " + "module is missing getNodeFromInstance or getInstanceFromNode.");
---
>             ComponentTree = Injected, warning$8(Injected && Injected.getNodeFromInstance && Injected.getInstanceFromNode, "EventPluginUtils.injection.injectComponentTree(...): Injected " + "module is missing getNodeFromInstance or getInstanceFromNode.");
1292c1292
<         warning$6(instancesIsArr === listenersIsArr && instancesLen === listenersLen, "EventPluginUtils: Invalid `event`.");
---
>         warning$8(instancesIsArr === listenersIsArr && instancesLen === listenersLen, "EventPluginUtils: Invalid `event`.");
1477c1477
<     }, getListener = EventPluginHub_1.getListener, warning$7 = warning;
---
>     }, getListener = EventPluginHub_1.getListener, warning$10 = require$$0;
1483c1483
<         warning$7(inst, "Dispatching inst must not be null");
---
>         warning$10(inst, "Dispatching inst must not be null");
1524c1524
<     }, EventPropagators_1 = EventPropagators, didWarnForAddedNewProperty = !1, isProxySupported = "function" == typeof Proxy, EVENT_POOL_SIZE = 10, warning$8 = warning, shouldBeReleasedProperties = [ "dispatchConfig", "_targetInst", "nativeEvent", "isDefaultPrevented", "isPropagationStopped", "_dispatchListeners", "_dispatchInstances" ], EventInterface = {
---
>     }, EventPropagators_1 = EventPropagators, didWarnForAddedNewProperty = !1, isProxySupported = "function" == typeof Proxy, EVENT_POOL_SIZE = 10, warning$11 = require$$0, shouldBeReleasedProperties = [ "dispatchConfig", "_targetInst", "nativeEvent", "isDefaultPrevented", "isPropagationStopped", "_dispatchListeners", "_dispatchInstances" ], EventInterface = {
1588c1588
<                     return "isPersistent" === prop || target.constructor.Interface.hasOwnProperty(prop) || -1 !== shouldBeReleasedProperties.indexOf(prop) || (warning$8(didWarnForAddedNewProperty || target.isPersistent(), "This synthetic event is reused for performance reasons. If you're " + "seeing this, you're adding a new property in the synthetic event object. " + "The property is never released. See " + "https://fb.me/react-event-pooling for more information."), 
---
>                     return "isPersistent" === prop || target.constructor.Interface.hasOwnProperty(prop) || -1 !== shouldBeReleasedProperties.indexOf(prop) || (warning$11(didWarnForAddedNewProperty || target.isPersistent(), "This synthetic event is reused for performance reasons. If you're " + "seeing this, you're adding a new property in the synthetic event object. " + "The property is never released. See " + "https://fb.me/react-event-pooling for more information."), 
1611c1611
<             warning$8(!1, "This synthetic event is reused for performance reasons. If you're seeing this, " + "you're %s `%s` on a released/nullified synthetic event. %s. " + "If you must keep the original synthetic event around, use event.persist(). " + "See https://fb.me/react-event-pooling for more information.", action, propName, result);
---
>             warning$11(!1, "This synthetic event is reused for performance reasons. If you're seeing this, " + "you're %s `%s` on a released/nullified synthetic event. %s. " + "If you must keep the original synthetic event around, use event.persist(). " + "See https://fb.me/react-event-pooling for more information.", action, propName, result);
1631,1634c1631,1632
<     var customBubblingEventTypes = UIManager.customBubblingEventTypes, customDirectEventTypes = UIManager.customDirectEventTypes, allTypesByEventName = {};
<     for (var bubblingTypeName in customBubblingEventTypes) allTypesByEventName[bubblingTypeName] = customBubblingEventTypes[bubblingTypeName];
<     for (var directTypeName in customDirectEventTypes) warning(!customBubblingEventTypes[directTypeName], "Event cannot be both direct and bubbling: %s", directTypeName), 
<     allTypesByEventName[directTypeName] = customDirectEventTypes[directTypeName];
---
>     var warning$9 = require$$0, customBubblingEventTypes = UIManager.customBubblingEventTypes, customDirectEventTypes = UIManager.customDirectEventTypes;
>     for (var directTypeName in customDirectEventTypes) warning$9(!customBubblingEventTypes[directTypeName], "Event cannot be both direct and bubbling: %s", directTypeName);
1712c1710
<     }, ReactGenericBatching_1 = ReactGenericBatching, EMPTY_NATIVE_EVENT = {}, touchSubsequence = function(touches, indices) {
---
>     }, ReactGenericBatching_1 = ReactGenericBatching, warning$12 = require$$0, EMPTY_NATIVE_EVENT = {}, touchSubsequence = function(touches, indices) {
1743c1741
<                 null !== target && void 0 !== target && (target < ReactNativeTagHandles_1.tagsStartAt ? warning(!1, "A view is reporting that a touch occurred on tag zero.") : rootNodeID = target), 
---
>                 null !== target && void 0 !== target && (target < ReactNativeTagHandles_1.tagsStartAt ? warning$12(!1, "A view is reporting that a touch occurred on tag zero.") : rootNodeID = target), 
1763c1761
<     var ResponderSyntheticEvent_1 = ResponderSyntheticEvent, isEndish$2 = EventPluginUtils_1.isEndish, isMoveish$2 = EventPluginUtils_1.isMoveish, isStartish$2 = EventPluginUtils_1.isStartish, warning$9 = warning, MAX_TOUCH_BANK = 20, touchBank = [], touchHistory = {
---
>     var ResponderSyntheticEvent_1 = ResponderSyntheticEvent, isEndish$2 = EventPluginUtils_1.isEndish, isMoveish$2 = EventPluginUtils_1.isMoveish, isStartish$2 = EventPluginUtils_1.isStartish, warning$13 = require$$0, MAX_TOUCH_BANK = 20, touchBank = [], touchHistory = {
1795c1793
<         return invariant(null != identifier, "Touch object is missing identifier."), warning$9(identifier <= MAX_TOUCH_BANK, "Touch identifier %s is greater than maximum supported %s which causes " + "performance issues backfilling array locations for all of the indices.", identifier, MAX_TOUCH_BANK), 
---
>         return invariant(null != identifier, "Touch object is missing identifier."), warning$13(identifier <= MAX_TOUCH_BANK, "Touch identifier %s is greater than maximum supported %s which causes " + "performance issues backfilling array locations for all of the indices.", identifier, MAX_TOUCH_BANK), 
1843c1841
<                 warning$9(null != activeRecord && activeRecord.touchActive, "Cannot find single active touch.");
---
>                 warning$13(null != activeRecord && activeRecord.touchActive, "Cannot find single active touch.");
2473c2471
<     }, KeyEscapeUtils_1 = KeyEscapeUtils, ITERATOR_SYMBOL = "function" == typeof Symbol && Symbol.iterator, FAUX_ITERATOR_SYMBOL = "@@iterator", REACT_ELEMENT_TYPE = "function" == typeof Symbol && Symbol.for && Symbol.for("react.element") || 60103, getCurrentStackAddendum$1 = ReactGlobalSharedState_1.ReactComponentTreeHook.getCurrentStackAddendum, SEPARATOR = ".", SUBSEPARATOR = ":", didWarnAboutMaps = !1;
---
>     }, KeyEscapeUtils_1 = KeyEscapeUtils, ITERATOR_SYMBOL = "function" == typeof Symbol && Symbol.iterator, FAUX_ITERATOR_SYMBOL = "@@iterator", REACT_ELEMENT_TYPE = "function" == typeof Symbol && Symbol.for && Symbol.for("react.element") || 60103, warning$15 = require$$0, getCurrentStackAddendum$1 = ReactGlobalSharedState_1.ReactComponentTreeHook.getCurrentStackAddendum, SEPARATOR = ".", SUBSEPARATOR = ":", didWarnAboutMaps = !1;
2486c2484
<                 iteratorFn === children.entries && (warning(didWarnAboutMaps, "Using Maps as children is unsupported and will likely yield " + "unexpected results. Convert it to a sequence/iterable of keyed " + "ReactElements instead.%s", getCurrentStackAddendum$1()), 
---
>                 iteratorFn === children.entries && (warning$15(didWarnAboutMaps, "Using Maps as children is unsupported and will likely yield " + "unexpected results. Convert it to a sequence/iterable of keyed " + "ReactElements instead.%s", getCurrentStackAddendum$1()), 
2502c2500
<     var ReactComponentTreeHook$3, traverseStackChildren_1 = traverseStackChildren;
---
>     var ReactComponentTreeHook$3, traverseStackChildren_1 = traverseStackChildren, warning$14 = require$$0;
2507c2505
<         keyUnique || warning(!1, "flattenChildren(...): " + "Encountered two children with the same key, `%s`. " + "Keys should be unique so that components maintain their identity " + "across updates. Non-unique keys may cause children to be " + "duplicated and/or omitted — the behavior is unsupported and " + "could change in a future version.%s", KeyEscapeUtils_1.unescapeInDev(name), ReactComponentTreeHook$3.getStackAddendumByID(selfDebugID)), 
---
>         keyUnique || warning$14(!1, "flattenChildren(...): " + "Encountered two children with the same key, `%s`. " + "Keys should be unique so that components maintain their identity " + "across updates. Non-unique keys may cause children to be " + "duplicated and/or omitted — the behavior is unsupported and " + "could change in a future version.%s", KeyEscapeUtils_1.unescapeInDev(name), ReactComponentTreeHook$3.getStackAddendumByID(selfDebugID)), 
2543c2541
<     }, ReactChildReconciler_1 = ReactChildReconciler;
---
>     }, ReactChildReconciler_1 = ReactChildReconciler, warning$16 = require$$0;
2549c2547
<             keyUnique || warning(!1, "flattenChildren(...): Encountered two children with the same key, " + "`%s`. " + "Keys should be unique so that components maintain their identity " + "across updates. Non-unique keys may cause children to be " + "duplicated and/or omitted — the behavior is unsupported and " + "could change in a future version.%s", KeyEscapeUtils_1.unescapeInDev(name), ReactComponentTreeHook$4.getStackAddendumByID(selfDebugID)), 
---
>             keyUnique || warning$16(!1, "flattenChildren(...): Encountered two children with the same key, " + "`%s`. " + "Keys should be unique so that components maintain their identity " + "across updates. Non-unique keys may cause children to be " + "duplicated and/or omitted — the behavior is unsupported and " + "could change in a future version.%s", KeyEscapeUtils_1.unescapeInDev(name), ReactComponentTreeHook$4.getStackAddendumByID(selfDebugID)), 
```

### build/react-native/ReactNativeFiber-dev.js
``` diff
3221c3221
<     }, ReactVersion = "16.0.0-beta.5", ReactNativeFeatureFlags = require("ReactNativeFeatureFlags"), ReactCurrentOwner$3 = ReactGlobalSharedState_1.ReactCurrentOwner, injectedFindNode = ReactNativeFeatureFlags.useFiber ? function(fiber) {
---
>     }, ReactVersion = "16.0.0-beta.5", ReactNativeFeatureFlags = require("ReactNativeFeatureFlags"), ReactCurrentOwner$3 = ReactGlobalSharedState_1.ReactCurrentOwner, warning$11 = require$$0, injectedFindNode = ReactNativeFeatureFlags.useFiber ? function(fiber) {
3228c3228
<         if (null !== owner && (require$$0(owner._warnedAboutRefsInRender, "%s is accessing findNodeHandle inside its render(). " + "render() should be a pure function of props and state. It should " + "never access something that requires stale data from the previous " + "render, such as refs. Move this logic to componentDidMount and " + "componentDidUpdate instead.", owner.getName() || "A component"), 
---
>         if (null !== owner && (warning$11(owner._warnedAboutRefsInRender, "%s is accessing findNodeHandle inside its render(). " + "render() should be a pure function of props and state. It should " + "never access something that requires stale data from the previous " + "render, such as refs. Move this logic to componentDidMount and " + "componentDidUpdate instead.", owner.getName() || "A component"), 
3423c3423
<     }, getListener = EventPluginHub_1.getListener, warning$11 = require$$0;
---
>     }, getListener = EventPluginHub_1.getListener, warning$13 = require$$0;
3429c3429
<         warning$11(inst, "Dispatching inst must not be null");
---
>         warning$13(inst, "Dispatching inst must not be null");
3470c3470
<     }, EventPropagators_1 = EventPropagators, didWarnForAddedNewProperty = !1, isProxySupported = "function" == typeof Proxy, EVENT_POOL_SIZE = 10, warning$12 = require$$0, shouldBeReleasedProperties = [ "dispatchConfig", "_targetInst", "nativeEvent", "isDefaultPrevented", "isPropagationStopped", "_dispatchListeners", "_dispatchInstances" ], EventInterface = {
---
>     }, EventPropagators_1 = EventPropagators, didWarnForAddedNewProperty = !1, isProxySupported = "function" == typeof Proxy, EVENT_POOL_SIZE = 10, warning$14 = require$$0, shouldBeReleasedProperties = [ "dispatchConfig", "_targetInst", "nativeEvent", "isDefaultPrevented", "isPropagationStopped", "_dispatchListeners", "_dispatchInstances" ], EventInterface = {
3534c3534
<                     return "isPersistent" === prop || target.constructor.Interface.hasOwnProperty(prop) || -1 !== shouldBeReleasedProperties.indexOf(prop) || (warning$12(didWarnForAddedNewProperty || target.isPersistent(), "This synthetic event is reused for performance reasons. If you're " + "seeing this, you're adding a new property in the synthetic event object. " + "The property is never released. See " + "https://fb.me/react-event-pooling for more information."), 
---
>                     return "isPersistent" === prop || target.constructor.Interface.hasOwnProperty(prop) || -1 !== shouldBeReleasedProperties.indexOf(prop) || (warning$14(didWarnForAddedNewProperty || target.isPersistent(), "This synthetic event is reused for performance reasons. If you're " + "seeing this, you're adding a new property in the synthetic event object. " + "The property is never released. See " + "https://fb.me/react-event-pooling for more information."), 
3557c3557
<             warning$12(!1, "This synthetic event is reused for performance reasons. If you're seeing this, " + "you're %s `%s` on a released/nullified synthetic event. %s. " + "If you must keep the original synthetic event around, use event.persist(). " + "See https://fb.me/react-event-pooling for more information.", action, propName, result);
---
>             warning$14(!1, "This synthetic event is reused for performance reasons. If you're seeing this, " + "you're %s `%s` on a released/nullified synthetic event. %s. " + "If you must keep the original synthetic event around, use event.persist(). " + "See https://fb.me/react-event-pooling for more information.", action, propName, result);
3577,3580c3577,3578
<     var customBubblingEventTypes = UIManager.customBubblingEventTypes, customDirectEventTypes = UIManager.customDirectEventTypes, allTypesByEventName = {};
<     for (var bubblingTypeName in customBubblingEventTypes) allTypesByEventName[bubblingTypeName] = customBubblingEventTypes[bubblingTypeName];
<     for (var directTypeName in customDirectEventTypes) require$$0(!customBubblingEventTypes[directTypeName], "Event cannot be both direct and bubbling: %s", directTypeName), 
<     allTypesByEventName[directTypeName] = customDirectEventTypes[directTypeName];
---
>     var warning$12 = require$$0, customBubblingEventTypes = UIManager.customBubblingEventTypes, customDirectEventTypes = UIManager.customDirectEventTypes;
>     for (var directTypeName in customDirectEventTypes) warning$12(!customBubblingEventTypes[directTypeName], "Event cannot be both direct and bubbling: %s", directTypeName);
3599c3597
<     }, ReactEventEmitterMixin_1 = ReactEventEmitterMixin, EMPTY_NATIVE_EVENT = {}, touchSubsequence = function(touches, indices) {
---
>     }, ReactEventEmitterMixin_1 = ReactEventEmitterMixin, warning$15 = require$$0, EMPTY_NATIVE_EVENT = {}, touchSubsequence = function(touches, indices) {
3630c3628
<                 null !== target && void 0 !== target && (target < ReactNativeTagHandles_1.tagsStartAt ? require$$0(!1, "A view is reporting that a touch occurred on tag zero.") : rootNodeID = target), 
---
>                 null !== target && void 0 !== target && (target < ReactNativeTagHandles_1.tagsStartAt ? warning$15(!1, "A view is reporting that a touch occurred on tag zero.") : rootNodeID = target), 
3650c3648
<     var ResponderSyntheticEvent_1 = ResponderSyntheticEvent, isEndish$2 = EventPluginUtils_1.isEndish, isMoveish$2 = EventPluginUtils_1.isMoveish, isStartish$2 = EventPluginUtils_1.isStartish, warning$13 = require$$0, MAX_TOUCH_BANK = 20, touchBank = [], touchHistory = {
---
>     var ResponderSyntheticEvent_1 = ResponderSyntheticEvent, isEndish$2 = EventPluginUtils_1.isEndish, isMoveish$2 = EventPluginUtils_1.isMoveish, isStartish$2 = EventPluginUtils_1.isStartish, warning$16 = require$$0, MAX_TOUCH_BANK = 20, touchBank = [], touchHistory = {
3682c3680
<         return invariant(null != identifier, "Touch object is missing identifier."), warning$13(identifier <= MAX_TOUCH_BANK, "Touch identifier %s is greater than maximum supported %s which causes " + "performance issues backfilling array locations for all of the indices.", identifier, MAX_TOUCH_BANK), 
---
>         return invariant(null != identifier, "Touch object is missing identifier."), warning$16(identifier <= MAX_TOUCH_BANK, "Touch identifier %s is greater than maximum supported %s which causes " + "performance issues backfilling array locations for all of the indices.", identifier, MAX_TOUCH_BANK), 
3730c3728
<                 warning$13(null != activeRecord && activeRecord.touchActive, "Cannot find single active touch.");
---
>                 warning$16(null != activeRecord && activeRecord.touchActive, "Cannot find single active touch.");
4036,4037c4034,4035
<     var takeSnapshot_1 = takeSnapshot, ReactInvalidSetStateWarningHook = {}, warning$15 = require$$0, processingChildContext = !1, warnInvalidSetState = function() {
<         warning$15(!processingChildContext, "setState(...): Cannot call setState() inside getChildContext()");
---
>     var takeSnapshot_1 = takeSnapshot, ReactInvalidSetStateWarningHook = {}, warning$18 = require$$0, processingChildContext = !1, warnInvalidSetState = function() {
>         warning$18(!processingChildContext, "setState(...): Cannot call setState() inside getChildContext()");
4062c4060
<     var ReactHostOperationHistoryHook_1 = ReactHostOperationHistoryHook, ReactComponentTreeHook = ReactGlobalSharedState_1.ReactComponentTreeHook, warning$14 = require$$0, ReactDebugTool = null, hooks = [], didHookThrowForEvent = {}, callHook = function(event, fn, context, arg1, arg2, arg3, arg4, arg5) {
---
>     var ReactHostOperationHistoryHook_1 = ReactHostOperationHistoryHook, ReactComponentTreeHook = ReactGlobalSharedState_1.ReactComponentTreeHook, warning$17 = require$$0, ReactDebugTool = null, hooks = [], didHookThrowForEvent = {}, callHook = function(event, fn, context, arg1, arg2, arg3, arg4, arg5) {
4066c4064
<             warning$14(didHookThrowForEvent[event], "Exception thrown by hook while handling %s: %s", event, e + "\n" + e.stack), 
---
>             warning$17(didHookThrowForEvent[event], "Exception thrown by hook while handling %s: %s", event, e + "\n" + e.stack), 
4103c4101
<         arguments.length > 1 && void 0 !== arguments[1] && arguments[1] && 0 === debugID || debugID || warning$14(!1, "ReactDebugTool: debugID may not be empty.");
---
>         arguments.length > 1 && void 0 !== arguments[1] && arguments[1] && 0 === debugID || debugID || warning$17(!1, "ReactDebugTool: debugID may not be empty.");
4105c4103
<         0 !== currentFlushNesting && (currentTimerType && !lifeCycleTimerHasWarned && (warning$14(!1, "There is an internal error in the React performance measurement code." + "\n\nDid not expect %s timer to start while %s timer is still in " + "progress for %s instance.", timerType, currentTimerType || "no", debugID === currentTimerDebugID ? "the same" : "another"), 
---
>         0 !== currentFlushNesting && (currentTimerType && !lifeCycleTimerHasWarned && (warning$17(!1, "There is an internal error in the React performance measurement code." + "\n\nDid not expect %s timer to start while %s timer is still in " + "progress for %s instance.", timerType, currentTimerType || "no", debugID === currentTimerDebugID ? "the same" : "another"), 
4109c4107
<         0 !== currentFlushNesting && (currentTimerType === timerType || lifeCycleTimerHasWarned || (warning$14(!1, "There is an internal error in the React performance measurement code. " + "We did not expect %s timer to stop while %s timer is still in " + "progress for %s instance. Please report this as a bug in React.", timerType, currentTimerType || "no", debugID === currentTimerDebugID ? "the same" : "another"), 
---
>         0 !== currentFlushNesting && (currentTimerType === timerType || lifeCycleTimerHasWarned || (warning$17(!1, "There is an internal error in the React performance measurement code. " + "We did not expect %s timer to stop while %s timer is still in " + "progress for %s instance. Please report this as a bug in React.", timerType, currentTimerType || "no", debugID === currentTimerDebugID ? "the same" : "another"), 
```