### PR TITLE
Refactor ensureUpdateQueues to avoid returning a tuple

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -163,19 +163,14 @@ function findInsertionPosition(queue, update): Update | null {
 function ensureUpdateQueues(fiber: Fiber) {
   const alternateFiber = fiber.alternate;
 
-  let queue1 = fiber.updateQueue;
-  if (queue1 === null) {
-    queue1 = fiber.updateQueue = createUpdateQueue();
+  if (fiber.updateQueue === null) {
+    fiber.updateQueue = createUpdateQueue();
   }
 
-  let queue2;
   if (alternateFiber !== null) {
-    queue2 = alternateFiber.updateQueue;
-    if (queue2 === null) {
-      queue2 = alternateFiber.updateQueue = createUpdateQueue();
+    if (alternateFiber.updateQueue === null) {
+      alternateFiber.updateQueue = createUpdateQueue();
     }
-  } else {
-    queue2 = null;
   }
 }
 
@@ -369,9 +364,7 @@ function addTopLevelUpdate(
     // TODO: Redesign the top-level mount/update/unmount API to avoid this
     // special case.
     const queue1: UpdateQueue | null = fiber.updateQueue;
-    const queue2: UpdateQueue | null = fiber.alternate &&
-      fiber.alternate.updateQueue !== queue1
-      ? fiber.alternate.updateQueue
+    const queue2: UpdateQueue | null = fiber.alternate ? fiber.alternate.updateQueue
       : null;
 
     // Drop all updates that are lower-priority, so that the tree is not

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -160,7 +160,7 @@ function findInsertionPosition(queue, update): Update | null {
   return insertAfter;
 }
 
-function ensureUpdateQueues(fiber: Fiber): [UpdateQueue, UpdateQueue | null] {
+function ensureUpdateQueues(fiber: Fiber) {
   const alternateFiber = fiber.alternate;
 
   let queue1 = fiber.updateQueue;
@@ -177,13 +177,6 @@ function ensureUpdateQueues(fiber: Fiber): [UpdateQueue, UpdateQueue | null] {
   } else {
     queue2 = null;
   }
-
-  // TODO: Refactor to avoid returning a tuple.
-  return [
-    queue1,
-    // Return null if there is no alternate queue, or if its queue is the same.
-    queue2 !== queue1 ? queue2 : null,
-  ];
 }
 
 // The work-in-progress queue is a subset of the current queue (if it exists).
@@ -217,7 +210,12 @@ function ensureUpdateQueues(fiber: Fiber): [UpdateQueue, UpdateQueue | null] {
 // If the update is cloned, it returns the cloned update.
 function insertUpdate(fiber: Fiber, update: Update): Update | null {
   // We'll have at least one and at most two distinct update queues.
-  const [queue1, queue2] = ensureUpdateQueues(fiber);
+  ensureUpdateQueues(fiber);
+  const queue1: UpdateQueue = (fiber.updateQueue: any);
+  const queue2: UpdateQueue | null = fiber.alternate &&
+    fiber.alternate.updateQueue !== queue1
+    ? fiber.alternate.updateQueue
+    : null;
 
   // Warn if an update is scheduled from inside an updater function.
   if (__DEV__) {
@@ -356,7 +354,7 @@ function addTopLevelUpdate(
 ): void {
   const isTopLevelUnmount = partialState.element === null;
 
-  const update = {
+  const update: Update = {
     priorityLevel,
     partialState,
     callback,
@@ -370,7 +368,11 @@ function addTopLevelUpdate(
   if (isTopLevelUnmount) {
     // TODO: Redesign the top-level mount/update/unmount API to avoid this
     // special case.
-    const [queue1, queue2] = ensureUpdateQueues(fiber);
+    const queue1: UpdateQueue | null = fiber.updateQueue;
+    const queue2: UpdateQueue | null = fiber.alternate &&
+      fiber.alternate.updateQueue !== queue1
+      ? fiber.alternate.updateQueue
+      : null;
 
     // Drop all updates that are lower-priority, so that the tree is not
     // remounted. We need to do this for both queues.

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -364,7 +364,8 @@ function addTopLevelUpdate(
     // TODO: Redesign the top-level mount/update/unmount API to avoid this
     // special case.
     const queue1: UpdateQueue | null = fiber.updateQueue;
-    const queue2: UpdateQueue | null = fiber.alternate ? fiber.alternate.updateQueue
+    const queue2: UpdateQueue | null = fiber.alternate
+      ? fiber.alternate.updateQueue
       : null;
 
     // Drop all updates that are lower-priority, so that the tree is not


### PR DESCRIPTION
Refactor `ensureUpdateQueues` and `insertUpdate` & `addTopLevelUpdate`.
Use `queue` & `alternateQueue` instead of `queue1` & `queue2`.