### PR TITLE
Use the virtual target for change events to avoid restoring controlled state on the real target

### DIFF
--- a/fixtures/dom/src/components/fixtures/selects/index.js
+++ b/fixtures/dom/src/components/fixtures/selects/index.js
@@ -1,10 +1,34 @@
 const React = window.React;
+const ReactDOM = window.ReactDOM;
 
 class SelectFixture extends React.Component {
   state = {value: ''};
+  _nestedDOMNode = null;
+
   onChange = event => {
     this.setState({value: event.target.value});
   };
+
+  componentDidMount() {
+    this._renderNestedSelect();
+  }
+
+  componentDidUpdate() {
+    this._renderNestedSelect();
+  }
+
+  _renderNestedSelect() {
+    ReactDOM.render(
+      <select value={this.state.value} onChange={this.onChange}>
+        <option value="">Select a color</option>
+        <option value="red">Red</option>
+        <option value="blue">Blue</option>
+        <option value="green">Green</option>
+      </select>,
+      this._nestedDOMNode
+    )
+  }
+
   render() {
     return (
       <form>
@@ -24,8 +48,14 @@ class SelectFixture extends React.Component {
             <option value="">Select a color</option>
             <option value="red">Red</option>
             <option value="blue">Blue</option>
-            <option value="gree">Green</option>
+            <option value="green">Green</option>
           </select>
+          <span className="hint"></span>
+        </fieldset>
+        <fieldset>
+          <legend>Controlled in nested subtree</legend>
+          <div ref={node => this._nestedDOMNode = node} />
+          <span className="hint">This should synchronize in both direction with the one above.</span>
         </fieldset>
       </form>
     );

--- a/fixtures/dom/src/components/fixtures/selects/index.js
+++ b/fixtures/dom/src/components/fixtures/selects/index.js
@@ -26,7 +26,7 @@ class SelectFixture extends React.Component {
         <option value="green">Green</option>
       </select>,
       this._nestedDOMNode
-    )
+    );
   }
 
   render() {
@@ -50,12 +50,14 @@ class SelectFixture extends React.Component {
             <option value="blue">Blue</option>
             <option value="green">Green</option>
           </select>
-          <span className="hint"></span>
+          <span className="hint" />
         </fieldset>
         <fieldset>
           <legend>Controlled in nested subtree</legend>
-          <div ref={node => this._nestedDOMNode = node} />
-          <span className="hint">This should synchronize in both direction with the one above.</span>
+          <div ref={node => (this._nestedDOMNode = node)} />
+          <span className="hint">
+            This should synchronize in both direction with the one above.
+          </span>
         </fieldset>
       </form>
     );

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -47,16 +47,21 @@ function shouldUseChangeEvent(elem) {
   );
 }
 
-function createAndAccumulateChangeEvent(inst, nativeEvent, target) {
+function createAndAccumulateChangeEvent(
+  inst,
+  nativeEvent,
+  nativeEventTarget,
+  virtualTarget,
+) {
   var event = SyntheticEvent.getPooled(
     eventTypes.change,
     inst,
     nativeEvent,
-    target,
+    nativeEventTarget,
   );
   event.type = 'change';
   // Flag this event loop as needing state restore.
-  ReactControlledComponent.enqueueStateRestore(target);
+  ReactControlledComponent.enqueueStateRestore(virtualTarget);
   EventPropagators.accumulateTwoPhaseDispatches(event);
   return event;
 }
@@ -174,6 +179,7 @@ var ChangeEventPlugin = {
         var event = createAndAccumulateChangeEvent(
           inst,
           nativeEvent,
+          nativeEventTarget,
           targetNode,
         );
         return event;

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -174,7 +174,7 @@ var ChangeEventPlugin = {
         var event = createAndAccumulateChangeEvent(
           inst,
           nativeEvent,
-          nativeEventTarget,
+          targetNode,
         );
         return event;
       }

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMSelect-test.js
@@ -589,4 +589,69 @@ describe('ReactDOMSelect', () => {
     expect(node.options[1].selected).toBe(true); // b
     expect(node.options[2].selected).toBe(false); // c
   });
+
+  it('should allow controlling `value` in a nested render', () => {
+
+    var selectNode;
+
+    class Parent extends React.Component {
+      state = {
+        value: 'giraffe',
+      };
+
+      componentDidMount() {
+        this._renderNested();
+      }
+
+      componentDidUpdate() {
+        this._renderNested();
+      }
+
+      _handleChange(event) {
+        this.setState({ value: event.target.value });
+      }
+
+      _renderNested() {
+        ReactDOM.render(
+          <select
+            onChange={this._handleChange.bind(this)}
+            ref={n => selectNode = n}
+            value={this.state.value}>
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+            <option value="gorilla">A gorilla!</option>
+          </select>,
+          this._nestingContainer
+        );
+      }
+
+      render() {
+        return <div ref={n => this._nestingContainer = n} />;
+      }
+    }
+
+    var container = document.createElement('div');
+
+    document.body.appendChild(container);
+
+    ReactDOM.render(<Parent />, container);
+
+    expect(selectNode.value).toBe('giraffe');
+
+    selectNode.value = 'gorilla';
+
+    var nativeEvent = document.createEvent('Event');
+    nativeEvent.initEvent('input', true, true);
+    selectNode.dispatchEvent(nativeEvent);
+
+    expect(selectNode.value).toEqual('gorilla');
+
+    var nativeEvent = document.createEvent('Event');
+    nativeEvent.initEvent('change', true, true);
+    selectNode.dispatchEvent(nativeEvent);
+
+    expect(selectNode.value).toEqual('gorilla');
+
+    document.body.removeChild(container);
+  });
 });

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMSelect-test.js
@@ -591,7 +591,6 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should allow controlling `value` in a nested render', () => {
-
     var selectNode;
 
     class Parent extends React.Component {
@@ -608,25 +607,25 @@ describe('ReactDOMSelect', () => {
       }
 
       _handleChange(event) {
-        this.setState({ value: event.target.value });
+        this.setState({value: event.target.value});
       }
 
       _renderNested() {
         ReactDOM.render(
           <select
             onChange={this._handleChange.bind(this)}
-            ref={n => selectNode = n}
+            ref={n => (selectNode = n)}
             value={this.state.value}>
             <option value="monkey">A monkey!</option>
             <option value="giraffe">A giraffe!</option>
             <option value="gorilla">A gorilla!</option>
           </select>,
-          this._nestingContainer
+          this._nestingContainer,
         );
       }
 
       render() {
-        return <div ref={n => this._nestingContainer = n} />;
+        return <div ref={n => (this._nestingContainer = n)} />;
       }
     }
 
@@ -640,13 +639,13 @@ describe('ReactDOMSelect', () => {
 
     selectNode.value = 'gorilla';
 
-    var nativeEvent = document.createEvent('Event');
+    let nativeEvent = document.createEvent('Event');
     nativeEvent.initEvent('input', true, true);
     selectNode.dispatchEvent(nativeEvent);
 
     expect(selectNode.value).toEqual('gorilla');
 
-    var nativeEvent = document.createEvent('Event');
+    nativeEvent = document.createEvent('Event');
     nativeEvent.initEvent('change', true, true);
     selectNode.dispatchEvent(nativeEvent);
 


### PR DESCRIPTION
Fixes #10420

The problem is that we try to restore the controlled value after the `oninput` event. So we've restored it to its previous value by the time we fire `onChange`. So the controlling component doesn't have a chance to update it.

This ensures that we "restore controlled state" on the wrapper instead of the real target - which is a noop.