### PR TITLE
Better messaging for componentDidCatch cross-origin errors

### DIFF
--- a/src/renderers/shared/utils/ReactErrorUtils.js
+++ b/src/renderers/shared/utils/ReactErrorUtils.js
@@ -247,14 +247,8 @@ if (__DEV__) {
         } else if (isCrossOriginError) {
           error = new Error(
             "A cross-origin error was thrown. React doesn't have access to " +
-              'the actual error because it catches errors using a global ' +
-              'error handler, in order to preserve the "Pause on exceptions" ' +
-              'behavior of the DevTools. This is only an issue in DEV-mode; ' +
-              'in production, React uses a normal try-catch statement.\n\n' +
-              'If you are using React from a CDN, ensure that the <script> tag ' +
-              'has a `crossorigin` attribute, and that it is served with the ' +
-              '`Access-Control-Allow-Origin: *` HTTP header. ' +
-              'See https://fb.me/react-cdn-crossorigin',
+              'the actual error object in development. ' +
+              'See https://fb.me/react-crossorigin-error for more information.',
           );
         }
         ReactErrorUtils._hasCaughtError = true;


### PR DESCRIPTION
The prior message was a bit wordy and didn't cover all cases (like the one we discovered while researching #10441).

We can use the new URL to explain background info on the DEV-mode technique we're using _in addition to_ common fixes (eg `crossorigin` attribute for CDN scripts and Webpack `devtools` settings). Putting this information behind a link will allow us to more easily edit it in the future as common causes for this issue change.

Resolves #10441

**Note** I have not yet setup the `fb.me/react-crossorigin-error` shortcut or written the content that will live there. It's been a long day and I'm taking off. Technically we can merge this at any time (to unblock the RC) and just follow-up with the link soon. Or I'll add it on Monday if we're not in a hurry. 😄 