### PR TITLE
Default to first non-disabled option for select elements

### DIFF
--- a/fixtures/dom/src/components/IssueList.js
+++ b/fixtures/dom/src/components/IssueList.js
@@ -1,0 +1,26 @@
+const React = window.React;
+
+function csv(string) {
+  return string.split(/\s*,\s*/);
+}
+
+export default function IssueList({issues}) {
+  if (!issues) {
+    return null;
+  }
+
+  if (typeof issues === 'string') {
+    issues = csv(issues);
+  }
+
+  let links = issues.reduce((memo, issue, i) => {
+    return memo.concat(
+      i > 0 && i < issues.length ? ', ' : null,
+      <a href={'https://github.com/facebook/react/issues/' + issue} key={issue}>
+        {issue}
+      </a>
+    );
+  }, []);
+
+  return <span>{links}</span>;
+}

--- a/fixtures/dom/src/components/TestCase.js
+++ b/fixtures/dom/src/components/TestCase.js
@@ -1,7 +1,9 @@
+const React = window.React;
+
 import cn from 'classnames';
 import semver from 'semver';
-import React from 'react';
 import PropTypes from 'prop-types';
+import IssueList from './IssueList';
 import {parse} from 'query-string';
 import {semverString} from './propTypes';
 
@@ -36,6 +38,7 @@ class TestCase extends React.Component {
       resolvedIn,
       resolvedBy,
       affectedBrowsers,
+      relatedIssues,
       children,
     } = this.props;
 
@@ -93,6 +96,9 @@ class TestCase extends React.Component {
 
           {affectedBrowsers && <dt>Affected browsers: </dt>}
           {affectedBrowsers && <dd>{affectedBrowsers}</dd>}
+
+          {relatedIssues && <dt>Related Issues: </dt>}
+          {relatedIssues && <dd><IssueList issues={relatedIssues} /></dd>}
         </dl>
 
         <p className="test-case__desc">

--- a/fixtures/dom/src/components/TestCase.js
+++ b/fixtures/dom/src/components/TestCase.js
@@ -1,11 +1,11 @@
-const React = window.React;
-
 import cn from 'classnames';
 import semver from 'semver';
 import PropTypes from 'prop-types';
 import IssueList from './IssueList';
 import {parse} from 'query-string';
 import {semverString} from './propTypes';
+
+const React = window.React;
 
 const propTypes = {
   children: PropTypes.node.isRequired,

--- a/fixtures/dom/src/components/fixtures/selects/index.js
+++ b/fixtures/dom/src/components/fixtures/selects/index.js
@@ -1,6 +1,9 @@
 const React = window.React;
 const ReactDOM = window.ReactDOM;
 
+import FixtureSet from '../../FixtureSet';
+import TestCase from '../../TestCase';
+
 class SelectFixture extends React.Component {
   state = {value: ''};
   _nestedDOMNode = null;
@@ -31,35 +34,66 @@ class SelectFixture extends React.Component {
 
   render() {
     return (
-      <form>
-        <fieldset>
-          <legend>Controlled</legend>
-          <select value={this.state.value} onChange={this.onChange}>
-            <option value="">Select a color</option>
-            <option value="red">Red</option>
-            <option value="blue">Blue</option>
-            <option value="green">Green</option>
-          </select>
-          <span className="hint">Value: {this.state.value}</span>
-        </fieldset>
-        <fieldset>
-          <legend>Uncontrolled</legend>
-          <select defaultValue="">
-            <option value="">Select a color</option>
-            <option value="red">Red</option>
-            <option value="blue">Blue</option>
-            <option value="green">Green</option>
-          </select>
-          <span className="hint" />
-        </fieldset>
-        <fieldset>
-          <legend>Controlled in nested subtree</legend>
-          <div ref={node => (this._nestedDOMNode = node)} />
-          <span className="hint">
-            This should synchronize in both direction with the one above.
-          </span>
-        </fieldset>
-      </form>
+      <FixtureSet title="Selects" description="">
+        <form className="field-group">
+          <fieldset>
+            <legend>Controlled</legend>
+            <select value={this.state.value} onChange={this.onChange}>
+              <option value="">Select a color</option>
+              <option value="red">Red</option>
+              <option value="blue">Blue</option>
+              <option value="green">Green</option>
+            </select>
+            <span className="hint">Value: {this.state.value}</span>
+          </fieldset>
+          <fieldset>
+            <legend>Uncontrolled</legend>
+            <select defaultValue="">
+              <option value="">Select a color</option>
+              <option value="red">Red</option>
+              <option value="blue">Blue</option>
+              <option value="green">Green</option>
+            </select>
+          </fieldset>
+        </form>
+
+        <TestCase title="A selected disabled option" relatedIssues="2803">
+          <TestCase.Steps>
+            <li>Open the select</li>
+            <li>Select "1"</li>
+            <li>Attempt to reselect "Please select an item"</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The initial picked option should be "Please select an
+            item", however it should not be a selectable option.
+          </TestCase.ExpectedResult>
+
+          <div className="test-fixture">
+            <select defaultValue="">
+              <option value="" disabled>Please select an item</option>
+              <option>0</option>
+              <option>1</option>
+              <option>2</option>
+            </select>
+          </div>
+        </TestCase>
+
+        <TestCase title="An unselected disabled option" relatedIssues="2803">
+          <TestCase.ExpectedResult>
+            The initial picked option value should "0": the first non-disabled option.
+          </TestCase.ExpectedResult>
+
+          <div className="test-fixture">
+            <select defaultValue="">
+              <option disabled>Please select an item</option>
+              <option>0</option>
+              <option>1</option>
+              <option>2</option>
+            </select>
+          </div>
+        </TestCase>
+      </FixtureSet>
     );
   }
 }

--- a/fixtures/dom/src/components/fixtures/selects/index.js
+++ b/fixtures/dom/src/components/fixtures/selects/index.js
@@ -1,8 +1,8 @@
-const React = window.React;
-const ReactDOM = window.ReactDOM;
-
 import FixtureSet from '../../FixtureSet';
 import TestCase from '../../TestCase';
+
+const React = window.React;
+const ReactDOM = window.ReactDOM;
 
 class SelectFixture extends React.Component {
   state = {value: ''};
@@ -54,6 +54,13 @@ class SelectFixture extends React.Component {
               <option value="blue">Blue</option>
               <option value="green">Green</option>
             </select>
+          </fieldset>
+          <fieldset>
+            <legend>Controlled in nested subtree</legend>
+            <div ref={node => (this._nestedDOMNode = node)} />
+            <span className="hint">
+              This should synchronize in both direction with the "Controlled".
+            </span>
           </fieldset>
         </form>
 

--- a/fixtures/dom/src/style.css
+++ b/fixtures/dom/src/style.css
@@ -8,14 +8,12 @@ html {
   font-size: 10px;
 }
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
   font-size: 1.4rem;
   margin: 0;
   padding: 0;
-}
-
-select {
-  width: 12rem;
 }
 
 button {
@@ -24,7 +22,6 @@ button {
   padding: 5px;
 }
 
-
 .header {
   background: #222;
   box-shadow: inset 0 -1px 3px #000;
@@ -32,6 +29,10 @@ button {
   line-height: 3.2rem;
   overflow: hidden;
   padding: .8rem 1.6rem;
+}
+
+.header select {
+  width: 12rem;
 }
 
 .header__inner {
@@ -101,7 +102,8 @@ fieldset {
   overflow: hidden;
 }
 
-ul, ol {
+ul,
+ol {
   margin: 0 0 2rem 0;
 }
 
@@ -211,4 +213,8 @@ li {
   margin: 0 -15px; /* opposite of .test-case padding */
   background-color: #f4f4f4;
   border-top: 1px solid #d9d9d9;
+}
+
+.field-group {
+  overflow: hidden;
 }

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
@@ -101,14 +101,18 @@ function updateOptions(
     // Do not set `select.value` as exact behavior isn't consistent across all
     // browsers for all cases.
     let selectedValue = '' + (propValue: string);
+    let defaultSelected = null;
     for (let i = 0; i < options.length; i++) {
       if (options[i].value === selectedValue) {
         options[i].selected = true;
         return;
       }
+      if (defaultSelected === null && !options[i].disabled) {
+        defaultSelected = options[i];
+      }
     }
-    if (options.length) {
-      options[0].selected = true;
+    if (defaultSelected !== null) {
+      defaultSelected.selected = true;
     }
   }
 }

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMSelect-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMSelect-test.js
@@ -128,6 +128,22 @@ describe('ReactDOMSelect', () => {
     expect(node.value).toEqual('gorilla');
   });
 
+  it('should default to the first non-disabled option', () => {
+    var stub = (
+      <select defaultValue="">
+        <option disabled={true}>Disabled</option>
+        <option disabled={true}>Still Disabled</option>
+        <option>0</option>
+        <option disabled={true}>Also Disabled</option>
+      </select>
+    );
+    var container = document.createElement('div');
+    stub = ReactDOM.render(stub, container);
+    var node = ReactDOM.findDOMNode(stub);
+    expect(node.options[0].selected).toBe(false);
+    expect(node.options[2].selected).toBe(true);
+  });
+
   it('should allow setting `value` to __proto__', () => {
     var stub = (
       <select value="__proto__" onChange={noop}>


### PR DESCRIPTION
This fixes a regression that @nhunzaker found in https://github.com/facebook/react/pull/10142 where `select` elements were defaulting to the first `option`, regardless of whether it was disabled or not. This was not the behavior in 15.6. Copying my comment on this from Nate's PR:

>This issue stems from https://github.com/facebook/react/pull/8349 which introduced an `updateOptions` call when a `select` element is mounted.  If`updateOptions` doesn't find a matching `option` it [defaults to setting the first `option` as selected](https://github.com/facebook/react/blob/ca46c5278fe24dd9f564918d30e454033278e054/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js#L110-L112).
>
>In previous versions `updateOptions` was not called on the initial mount, so it defaulted to the standard behavior of the browser.

This brings us back in sync with the HTML spec which states:

> If the select element's display size is 1, and no option elements in the select element's list of options have their selectedness set to true, set the selectedness of the first option element in the list of options in tree order **that is not disabled**, if any, to true.

https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element


@nhunzaker I can just cherry-pick the DOM fixtures from #10142 as part of this PR if you'd like!
