### PR TITLE
Custom attribute follow up

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMInvalidARIAHook-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMInvalidARIAHook-test.js
@@ -59,8 +59,8 @@ describe('ReactDOMInvalidARIAHook', () => {
       mountComponent({'aria-hasPopup': 'true'});
       expectDev(console.error.calls.count()).toBe(1);
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Unknown ARIA attribute aria-hasPopup. ' +
-          'Did you mean aria-haspopup?',
+        'Warning: Unknown ARIA attribute `aria-hasPopup`. ' +
+          'Did you mean `aria-haspopup`?',
       );
     });
 
@@ -70,8 +70,8 @@ describe('ReactDOMInvalidARIAHook', () => {
       mountComponent({ariaHasPopup: 'true'});
       expectDev(console.error.calls.count()).toBe(1);
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid ARIA attribute ariaHasPopup. ' +
-          'Did you mean aria-haspopup?',
+        'Warning: Invalid ARIA attribute `ariaHasPopup`. ' +
+          'Did you mean `aria-haspopup`?',
       );
     });
 
@@ -81,7 +81,7 @@ describe('ReactDOMInvalidARIAHook', () => {
       mountComponent({ariaSomethingInvalid: 'true'});
       expectDev(console.error.calls.count()).toBe(1);
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid ARIA attribute ariaSomethingInvalid. ARIA ' +
+        'Warning: Invalid ARIA attribute `ariaSomethingInvalid`. ARIA ' +
           'attributes follow the pattern aria-* and must be lowercase.',
       );
     });

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -613,19 +613,22 @@ describe('ReactDOMServerIntegration', () => {
         expect(e.hasAttribute('className')).toBe(false);
       });
 
-      itRenders('no badly cased className with a warning', async render => {
+      itRenders('badly cased className with a warning', async render => {
         const e = await render(<div classname="test" />, 1);
         expect(e.hasAttribute('class')).toBe(false);
         expect(e.hasAttribute('classname')).toBe(true);
       });
 
-      itRenders('className prop when given the alias', async render => {
-        const e = await render(<div class="test" />, 1);
-        expect(e.className).toBe('test');
-      });
+      itRenders(
+        'className prop when given the alias with a warning',
+        async render => {
+          const e = await render(<div class="test" />, 1);
+          expect(e.className).toBe('test');
+        },
+      );
 
       itRenders(
-        'no className prop when given a badly cased alias',
+        'className prop when given a badly cased alias',
         async render => {
           const e = await render(<div cLASs="test" />, 1);
           expect(e.className).toBe('test');
@@ -1310,7 +1313,7 @@ describe('ReactDOMServerIntegration', () => {
         );
       });
 
-      itRenders('no svg child element with a badly cased', async render => {
+      itRenders('svg child element with a badly cased alias', async render => {
         let e = await render(
           <svg><image xlinkhref="http://i.imgur.com/w7GCRPb.png" /></svg>,
           1,

--- a/src/renderers/dom/shared/hooks/ReactDOMInvalidARIAHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMInvalidARIAHook.js
@@ -57,7 +57,7 @@ function validateProperty(tagName, name, debugID) {
     if (correctName == null) {
       warning(
         false,
-        'Invalid ARIA attribute %s. ARIA attributes follow the pattern aria-* and must be lowercase.%s',
+        'Invalid ARIA attribute `%s`. ARIA attributes follow the pattern aria-* and must be lowercase.%s',
         name,
         getStackAddendum(debugID),
       );
@@ -68,7 +68,7 @@ function validateProperty(tagName, name, debugID) {
     if (name !== correctName) {
       warning(
         false,
-        'Invalid ARIA attribute %s. Did you mean %s?%s',
+        'Invalid ARIA attribute `%s`. Did you mean `%s`?%s',
         name,
         correctName,
         getStackAddendum(debugID),
@@ -94,7 +94,7 @@ function validateProperty(tagName, name, debugID) {
     if (name !== standardName) {
       warning(
         false,
-        'Unknown ARIA attribute %s. Did you mean %s?%s',
+        'Unknown ARIA attribute `%s`. Did you mean `%s`?%s',
         name,
         standardName,
         getStackAddendum(debugID),


### PR DESCRIPTION
Follow up from #10385. 

- Adds backticks around props in `ReactDOMInvalidARIAHook`. This is consistent with `ReactUnknownDOMPropertyHook`
- Fixes test names in server integration tests to reflect the change in behavior of custom attributes