### PR TITLE
Add renderer id to react-devtools injection

### DIFF
--- a/src/renderers/dom/ReactDOMStackEntry.js
+++ b/src/renderers/dom/ReactDOMStackEntry.js
@@ -79,6 +79,7 @@ if (
     },
     Mount: ReactMount,
     Reconciler: ReactReconciler,
+    id: 'react-dom',
   });
 }
 

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -813,6 +813,7 @@ const foundDevTools = injectInternals({
   // This is an enum because we may add more (e.g. profiler build)
   bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,
+  id: 'react-dom',
 });
 
 if (__DEV__) {


### PR DESCRIPTION
Helps to resolve `react-devtools` [700](https://github.com/facebook/react-devtools/issues/700) — reporting multiple `react-dom` copies.

I added `id` argument to detect `react-dom` without code-guessing.