### PR TITLE
Reset instance vars before calling commit phase lifecycles

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -66,6 +66,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   if (__DEV__) {
     var callComponentWillUnmountWithTimerInDev = function(current, instance) {
       startPhaseTimer(current, 'componentWillUnmount');
+      instance.props = current.memoizedProps;
+      instance.state = current.memoizedState;
       instance.componentWillUnmount();
       stopPhaseTimer();
     };
@@ -87,6 +89,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     } else {
       try {
+        instance.props = current.memoizedProps;
+        instance.state = current.memoizedState;
         instance.componentWillUnmount();
       } catch (unmountError) {
         captureError(current, unmountError);
@@ -495,6 +499,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
             if (__DEV__) {
               startPhaseTimer(finishedWork, 'componentDidMount');
             }
+            instance.props = finishedWork.memoizedProps;
+            instance.state = finishedWork.memoizedState;
             instance.componentDidMount();
             if (__DEV__) {
               stopPhaseTimer();
@@ -505,6 +511,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
             if (__DEV__) {
               startPhaseTimer(finishedWork, 'componentDidUpdate');
             }
+            instance.props = finishedWork.memoizedProps;
+            instance.state = finishedWork.memoizedState;
             instance.componentDidUpdate(prevProps, prevState);
             if (__DEV__) {
               stopPhaseTimer();


### PR DESCRIPTION
Fixes an issue where if a component throws, its instance variables are not reset before `componentWillUnmount` is called. See https://jsfiddle.net/m3pL3yaj/ for an illustration.

To protect against issues like this, we should always set `this.props` and `this.state` right before calling a lifecycle method, as if they were explicit arguments.