### PR TITLE
Added :componentStackFrames property to error info object

### DIFF
--- a/fixtures/dom/src/components/fixtures/error-handling/index.js
+++ b/fixtures/dom/src/components/fixtures/error-handling/index.js
@@ -15,9 +15,10 @@ class ErrorBoundary extends React.Component {
     shouldThrow: false,
     didThrow: false,
     error: null,
+    info: null,
   };
-  componentDidCatch(error) {
-    this.setState({error, didThrow: true});
+  componentDidCatch(error, info) {
+    this.setState({error, info, didThrow: true});
   }
   triggerError = () => {
     this.setState({
@@ -26,11 +27,21 @@ class ErrorBoundary extends React.Component {
   };
   render() {
     if (this.state.didThrow) {
-      if (this.state.error) {
-        return <p>Captured an error: {this.state.error.message}</p>;
-      } else {
-        return <p>Captured an error: {'' + this.state.error}</p>;
-      }
+      const errorSummary = this.state.error
+        ? <p>Captured an error: {this.state.error.message}</p>
+        : <p>Captured an error: {'' + this.state.error}</p>;
+
+      return (
+        <div>
+          {errorSummary}
+          <details>
+            <summary>Error info</summary>
+            <pre className="error-info">
+              {JSON.stringify(this.state.info, null, 2)}
+            </pre>
+          </details>
+        </div>
+      );
     }
     if (this.state.shouldThrow) {
       return <BadRender doThrow={this.props.doThrow} />;

--- a/fixtures/dom/src/style.css
+++ b/fixtures/dom/src/style.css
@@ -24,6 +24,9 @@ button {
   padding: 5px;
 }
 
+details {
+  margin: 1rem 0;
+}
 
 .header {
   background: #222;
@@ -211,4 +214,14 @@ li {
   margin: 0 -15px; /* opposite of .test-case padding */
   background-color: #f4f4f4;
   border-top: 1px solid #d9d9d9;
+}
+
+.error-info {
+  white-space: pre-wrap;
+  font-size: 12px;
+  max-height: 200px;
+  overflow: auto;
+  background: #eee;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
 }

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -17,10 +17,12 @@ import type {FiberRoot} from 'ReactFiberRoot';
 import type {HostConfig, Deadline} from 'ReactFiberReconciler';
 import type {PriorityLevel} from 'ReactPriorityLevel';
 import type {HydrationContext} from 'ReactFiberHydrationContext';
+import type {StackFrame} from 'ReactFiberComponentTreeHook';
 
 export type CapturedError = {
   componentName: ?string,
   componentStack: string,
+  componentStackFrames: Array<StackFrame>,
   error: mixed,
   errorBoundary: ?Object,
   errorBoundaryFound: boolean,
@@ -30,12 +32,14 @@ export type CapturedError = {
 
 export type HandleErrorInfo = {
   componentStack: string,
+  componentStackFrames: Array<StackFrame>,
 };
 
 var {popContextProvider} = require('ReactFiberContext');
 const {reset} = require('ReactFiberStack');
 var {
   getStackAddendumByWorkInProgressFiber,
+  getStackFramesByWorkInProgressFiber,
 } = require('ReactFiberComponentTreeHook');
 var {logCapturedError} = require('ReactFiberErrorLogger');
 var {
@@ -1181,6 +1185,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // The risk is that the return path from this Fiber may not be accurate.
       // That risk is acceptable given the benefit of providing users more context.
       const componentStack = getStackAddendumByWorkInProgressFiber(failedWork);
+      const componentStackFrames = getStackFramesByWorkInProgressFiber(
+        failedWork,
+      );
       const componentName = getComponentName(failedWork);
 
       // Add to the collection of captured errors. This is stored as a global
@@ -1194,6 +1201,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       const capturedError = {
         componentName,
         componentStack,
+        componentStackFrames,
         error,
         errorBoundary: errorBoundaryFound ? boundary.stateNode : null,
         errorBoundaryFound,
@@ -1279,6 +1287,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
         const info: HandleErrorInfo = {
           componentStack: capturedError.componentStack,
+          componentStackFrames: capturedError.componentStackFrames,
         };
 
         // Allow the boundary to handle the error, usually by scheduling

--- a/src/shared/ReactFiberComponentTreeHook.js
+++ b/src/shared/ReactFiberComponentTreeHook.js
@@ -27,7 +27,6 @@ import type {Fiber} from 'ReactFiber';
 
 export type StackFrame = {
   name: string | null,
-  ownerName: string | null,
   source: Source | null,
 };
 
@@ -38,19 +37,15 @@ function createStackFrame(fiber: Fiber): StackFrame {
     case ClassComponent:
     case HostComponent:
       const name = getComponentName(fiber);
-      const owner = fiber._debugOwner;
-      const ownerName = owner != null ? getComponentName(owner) : null;
       const source = fiber._debugSource;
 
       return {
         name,
-        ownerName,
         source: source != null ? source : null,
       };
     default:
       return {
         name: null,
-        ownerName: null,
         source: null,
       };
   }

--- a/src/shared/ReactFiberComponentTreeHook.js
+++ b/src/shared/ReactFiberComponentTreeHook.js
@@ -22,7 +22,39 @@ var {
 var describeComponentFrame = require('describeComponentFrame');
 var getComponentName = require('getComponentName');
 
+import type {Source} from 'ReactElementType';
 import type {Fiber} from 'ReactFiber';
+
+export type StackFrame = {
+  name: string | null,
+  ownerName: string | null,
+  source: Source | null,
+};
+
+function createStackFrame(fiber: Fiber): StackFrame {
+  switch (fiber.tag) {
+    case IndeterminateComponent:
+    case FunctionalComponent:
+    case ClassComponent:
+    case HostComponent:
+      const name = getComponentName(fiber);
+      const owner = fiber._debugOwner;
+      const ownerName = owner != null ? getComponentName(owner) : null;
+      const source = fiber._debugSource;
+
+      return {
+        name,
+        ownerName,
+        source: source != null ? source : null,
+      };
+    default:
+      return {
+        name: null,
+        ownerName: null,
+        source: null,
+      };
+  }
+}
 
 function describeFiber(fiber: Fiber): string {
   switch (fiber.tag) {
@@ -30,10 +62,10 @@ function describeFiber(fiber: Fiber): string {
     case FunctionalComponent:
     case ClassComponent:
     case HostComponent:
-      var owner = fiber._debugOwner;
-      var source = fiber._debugSource;
-      var name = getComponentName(fiber);
-      var ownerName = null;
+      const owner = fiber._debugOwner;
+      const source = fiber._debugSource;
+      const name = getComponentName(fiber);
+      let ownerName = null;
       if (owner) {
         ownerName = getComponentName(owner);
       }
@@ -47,8 +79,8 @@ function describeFiber(fiber: Fiber): string {
 // only during begin or complete phase. Do not call it under any other
 // circumstances.
 function getStackAddendumByWorkInProgressFiber(workInProgress: Fiber): string {
-  var info = '';
-  var node = workInProgress;
+  let info = '';
+  let node = workInProgress;
   do {
     info += describeFiber(node);
     // Otherwise this return pointer might point to the wrong tree:
@@ -57,6 +89,23 @@ function getStackAddendumByWorkInProgressFiber(workInProgress: Fiber): string {
   return info;
 }
 
+// This function can only be called with a work-in-progress fiber and
+// only during begin or complete phase. Do not call it under any other
+// circumstances.
+function getStackFramesByWorkInProgressFiber(
+  workInProgress: Fiber,
+): Array<StackFrame> {
+  const stackFrames = [];
+  let node = workInProgress;
+  do {
+    stackFrames.push(createStackFrame(node));
+    // Otherwise this return pointer might point to the wrong tree:
+    node = node.return;
+  } while (node);
+  return stackFrames;
+}
+
 module.exports = {
   getStackAddendumByWorkInProgressFiber,
+  getStackFramesByWorkInProgressFiber,
 };


### PR DESCRIPTION
We pass a `componentStack` (string) property to the injected error dialog and the `componentDidCatch` lifecycle method. This string is pre-formatted string to match the `error.stack` string for logging convenience. However this approach requires parsing in order to do anything beyond basic logging.

This PR adds a new `componentStackFrames` property to both of the above methods. It is loosely based on the [TC39 error stack strawman](https://esdiscuss.org/topic/error-stack-strawman). This new property looks like this:

```js
type Source = {
  fileName: string,
  lineNumber: number,
};

type StackFrame = {
  name: string | null,
  source: Source | null,
};
 
// callStackFrames is an Array<StackFrame>
```

In addition to adding basic tests for this property, I've also updated our fixtures to expose it:
![screen shot 2017-08-17 at 5 17 48 pm](https://user-images.githubusercontent.com/29597/29439149-8f40cb14-8370-11e7-910b-81b3cab5f91b.png)

Resolves #10461