### PR TITLE
Add a note about normalized Keycode

### DIFF
--- a/docs/docs/reference-events.md
+++ b/docs/docs/reference-events.md
@@ -148,6 +148,8 @@ boolean shiftKey
 number which
 ```
 
+React normalizes the `keyCode` into `key` for browsers that don't support `key`.
+
 * * *
 
 ### Focus Events


### PR DESCRIPTION
I forgot whether React actually did this, so I went looking into the source. Figured we should make a note of it.