### PR TITLE
Update docs to reflect support for form onReset

### DIFF
--- a/docs/_js/examples/todo.js
+++ b/docs/_js/examples/todo.js
@@ -3,8 +3,10 @@ class TodoApp extends React.Component {
   constructor(props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
+    this.handleReset = this.handleReset.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
-    this.state = {items: [], text: ''};
+    this.originalValues = {items: [], text: ''};
+    this.state = this.originalValues;
   }
 
   render() {
@@ -12,9 +14,10 @@ class TodoApp extends React.Component {
       <div>
         <h3>TODO</h3>
         <TodoList items={this.state.items} />
-        <form onSubmit={this.handleSubmit}>
+        <form onSubmit={this.handleSubmit} onReset={this.handleReset}>
           <input onChange={this.handleChange} value={this.state.text} />
-          <button>{'Add #' + (this.state.items.length + 1)}</button>
+          <button>{'Add #' + (this.state.items.length + 1)}</button><br />
+          <button type="reset">Reset</button>
         </form>
       </div>
     );
@@ -22,6 +25,13 @@ class TodoApp extends React.Component {
 
   handleChange(e) {
     this.setState({text: e.target.value});
+  }
+
+  handleReset(e) {
+    e.preventDefault();
+    this.setState(() => (
+      this.originalValues
+    ));
   }
 
   handleSubmit(e) {

--- a/docs/docs/reference-events.md
+++ b/docs/docs/reference-events.md
@@ -173,7 +173,7 @@ DOMEventTarget relatedTarget
 Event names:
 
 ```
-onChange onInput onSubmit
+onChange onInput onReset onSubmit
 ```
 
 For more information about the onChange event, see [Forms](/react/docs/forms.html).

--- a/src/renderers/dom/shared/__tests__/ReactDOM-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOM-test.js
@@ -18,6 +18,7 @@ var ReactTestUtils = require('react-dom/test-utils');
 describe('ReactDOM', () => {
   // TODO: uncomment this test once we can run in phantom, which
   // supports real submit events.
+  // TODO: also add tests for the events onChange, onInput, and onReset
   /*
   it('should bubble onSubmit', function() {
     var count = 0;


### PR DESCRIPTION
This is a small change to the docs to reflect the fact that `onReset` can be handled by [Form Events](https://facebook.github.io/react/docs/events.html#form-events)
