### PR TITLE
Revert "Use the virtual target for change events to avoid restoring controlled state on the real target (#10444)"

### DIFF
--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -43,28 +43,16 @@ var eventTypes = {
   },
 };
 
-function shouldUseChangeEvent(elem) {
-  var nodeName = elem.nodeName && elem.nodeName.toLowerCase();
-  return (
-    nodeName === 'select' || (nodeName === 'input' && elem.type === 'file')
-  );
-}
-
-function createAndAccumulateChangeEvent(
-  inst,
-  nativeEvent,
-  nativeEventTarget,
-  virtualTarget,
-) {
+function createAndAccumulateChangeEvent(inst, nativeEvent, target) {
   var event = SyntheticEvent.getPooled(
     eventTypes.change,
     inst,
     nativeEvent,
-    nativeEventTarget,
+    target,
   );
   event.type = 'change';
   // Flag this event loop as needing state restore.
-  ReactControlledComponent.enqueueStateRestore(virtualTarget);
+  ReactControlledComponent.enqueueStateRestore(target);
   EventPropagators.accumulateTwoPhaseDispatches(event);
   return event;
 }
@@ -305,7 +293,6 @@ var ChangeEventPlugin = {
           inst,
           nativeEvent,
           nativeEventTarget,
-          targetNode,
         );
         return event;
       }


### PR DESCRIPTION
This reverts the meaningful (src, non-test) part of commit 3bc64327f01a2c9fd1529934ebf4a484c55d7e94 since we've reverted the commit it depended on in 18083a8a7305483e219592914ef52729907a4368. I don't fully understand the negative implications of leaving this unreverted but it sounds like consensus is that it's safer to revert.

I left the new fixture and verified it works correctly in Chrome 62 Mac, as well as the jest tests passing.