### PR TITLE
Upgrade flow-bin to 0.53.1

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -39,4 +39,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [version]
-^0.52.0
+^0.53.1

--- a/flow/environment.js
+++ b/flow/environment.js
@@ -14,7 +14,3 @@
 declare var __REACT_DEVTOOLS_GLOBAL_HOOK__: any; /*?{
   inject: ?((stuff: Object) => void)
 };*/
-
-// temporary patches for React.Component and React.Element
-declare var ReactComponent: typeof React$Component;
-declare var ReactElement: typeof React$Element;

--- a/flow/react-native-host-hooks.js
+++ b/flow/react-native-host-hooks.js
@@ -83,5 +83,5 @@ declare module 'UIManager' {
   ) : Promise<any>;
 }
 declare module 'View' {
-  declare var exports : typeof ReactComponent;
+  declare var exports : typeof React$Component;
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fbjs": "^0.8.9",
     "fbjs-scripts": "^0.6.0",
     "filesize": "^3.5.6",
-    "flow-bin": "^0.52.0",
+    "flow-bin": "^0.53.1",
     "git-branch": "^0.3.0",
     "glob": "^6.0.4",
     "glob-stream": "^6.1.0",

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -546,7 +546,7 @@ ReactGenericBatching.injection.injectFiberBatchedUpdates(
 var warnedAboutHydrateAPI = false;
 
 function renderSubtreeIntoContainer(
-  parentComponent: ?ReactComponent<any, any, any>,
+  parentComponent: ?React$Component<any, any>,
   children: ReactNodeList,
   container: DOMContainer,
   forceHydrate: boolean,
@@ -650,7 +650,7 @@ function renderSubtreeIntoContainer(
 
 var ReactDOMFiber = {
   hydrate(
-    element: ReactElement<any>,
+    element: React$Element<any>,
     container: DOMContainer,
     callback: ?Function,
   ) {
@@ -659,7 +659,7 @@ var ReactDOMFiber = {
   },
 
   render(
-    element: ReactElement<any>,
+    element: React$Element<any>,
     container: DOMContainer,
     callback: ?Function,
   ) {
@@ -705,8 +705,8 @@ var ReactDOMFiber = {
   },
 
   unstable_renderSubtreeIntoContainer(
-    parentComponent: ReactComponent<any, any, any>,
-    element: ReactElement<any>,
+    parentComponent: React$Component<any, any>,
+    element: React$Element<any>,
     containerNode: DOMContainer,
     callback: ?Function,
   ) {

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -649,11 +649,7 @@ function renderSubtreeIntoContainer(
 }
 
 var ReactDOMFiber = {
-  hydrate(
-    element: React$Element<any>,
-    container: DOMContainer,
-    callback: ?Function,
-  ) {
+  hydrate(element: React$Node, container: DOMContainer, callback: ?Function) {
     // TODO: throw or warn if we couldn't hydrate?
     return renderSubtreeIntoContainer(null, element, container, true, callback);
   },

--- a/src/renderers/dom/shared/findDOMNode.js
+++ b/src/renderers/dom/shared/findDOMNode.js
@@ -29,7 +29,7 @@ let findStack = function(arg) {
 };
 
 const findDOMNode = function(
-  componentOrElement: Element | ?ReactComponent<any, any, any>,
+  componentOrElement: Element | ?React$Component<any, any>,
 ): null | Element | Text {
   if (__DEV__) {
     var owner = (ReactCurrentOwner.current: any);

--- a/src/renderers/dom/stack/server/ReactServerUpdateQueue.js
+++ b/src/renderers/dom/stack/server/ReactServerUpdateQueue.js
@@ -19,7 +19,7 @@ var warning = require('fbjs/lib/warning');
 import type {Transaction} from 'Transaction';
 
 function warnNoop(
-  publicInstance: ReactComponent<any, any, any>,
+  publicInstance: React$Component<any, any>,
   callerName: string,
 ) {
   if (__DEV__) {
@@ -58,7 +58,7 @@ class ReactServerUpdateQueue {
    * @protected
    * @final
    */
-  isMounted(publicInstance: ReactComponent<any, any, any>): boolean {
+  isMounted(publicInstance: React$Component<any, any>): boolean {
     return false;
   }
 
@@ -78,7 +78,7 @@ class ReactServerUpdateQueue {
    * @internal
    */
   enqueueForceUpdate(
-    publicInstance: ReactComponent<any, any, any>,
+    publicInstance: React$Component<any, any>,
     callback?: Function,
     callerName?: string,
   ) {
@@ -103,7 +103,7 @@ class ReactServerUpdateQueue {
    * @internal
    */
   enqueueReplaceState(
-    publicInstance: ReactComponent<any, any, any>,
+    publicInstance: React$Component<any, any>,
     completeState: Object | Function,
     callback?: Function,
     callerName?: string,
@@ -131,7 +131,7 @@ class ReactServerUpdateQueue {
    * @internal
    */
   enqueueSetState(
-    publicInstance: ReactComponent<any, any, any>,
+    publicInstance: React$Component<any, any>,
     partialState: Object | Function,
     callback?: Function,
     callerName?: string,

--- a/src/renderers/native/ReactNativeComponent.js
+++ b/src/renderers/native/ReactNativeComponent.js
@@ -45,7 +45,7 @@ import type {
  * @abstract
  */
 class ReactNativeComponent<DefaultProps, Props, State>
-  extends React.Component<DefaultProps, Props, State> {
+  extends React.Component<Props, State> {
   static defaultProps: $Abstract<DefaultProps>;
   props: Props;
   state: $Abstract<State>;

--- a/src/renderers/native/ReactNativeFiberEntry.js
+++ b/src/renderers/native/ReactNativeFiberEntry.js
@@ -48,7 +48,7 @@ const ReactNativeFiber: ReactNativeType = {
 
   findNodeHandle: findNumericNodeHandle,
 
-  render(element: ReactElement<any>, containerTag: any, callback: ?Function) {
+  render(element: React$Element<any>, containerTag: any, callback: ?Function) {
     let root = roots.get(containerTag);
 
     if (!root) {

--- a/src/renderers/native/ReactNativeTypes.js
+++ b/src/renderers/native/ReactNativeTypes.js
@@ -11,8 +11,6 @@
  */
 'use strict';
 
-import type React from 'react';
-
 export type MeasureOnSuccessCallback = (
   x: number,
   y: number,
@@ -78,7 +76,7 @@ export type ReactNativeType = {
   NativeComponent: any,
   findNodeHandle(componentOrHandle: any): ?number,
   render(
-    element: React.Element<any>,
+    element: React$Element<any>,
     containerTag: any,
     callback: ?Function,
   ): any,

--- a/src/renderers/native/takeSnapshot.js
+++ b/src/renderers/native/takeSnapshot.js
@@ -33,7 +33,7 @@ const findNumericNodeHandle = require('findNumericNodeHandle');
  * @platform ios
  */
 function takeSnapshot(
-  view?: 'window' | ReactElement<any> | number,
+  view?: 'window' | React$Element<any> | number,
   options?: {
     width?: number,
     height?: number,

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -251,12 +251,12 @@ var ReactNoop = {
   },
 
   // Shortcut for testing a single root
-  render(element: ReactElement<any>, callback: ?Function) {
+  render(element: React$Element<any>, callback: ?Function) {
     ReactNoop.renderToRootWithID(element, DEFAULT_ROOT_ID, callback);
   },
 
   renderToRootWithID(
-    element: ReactElement<any>,
+    element: React$Element<any>,
     rootID: string,
     callback: ?Function,
   ) {
@@ -281,7 +281,7 @@ var ReactNoop = {
   },
 
   findInstance(
-    componentOrElement: Element | ?ReactComponent<any, any, any>,
+    componentOrElement: Element | ?React$Component<any, any>,
   ): null | Instance | TextInstance {
     if (componentOrElement == null) {
       return null;

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -160,7 +160,7 @@ export type Reconciler<C, I, TI> = {
   updateContainer(
     element: ReactNodeList,
     container: OpaqueRoot,
-    parentComponent: ?ReactComponent<any, any, any>,
+    parentComponent: ?React$Component<any, any>,
     callback: ?Function,
   ): void,
   performWithPriority(priorityLevel: PriorityLevel, fn: Function): void,
@@ -172,7 +172,7 @@ export type Reconciler<C, I, TI> = {
   // Used to extract the return value from the initial render. Legacy API.
   getPublicRootInstance(
     container: OpaqueRoot,
-  ): ReactComponent<any, any, any> | TI | I | null,
+  ): React$Component<any, any> | TI | I | null,
 
   // Use for findDOMNode/findHostNode. Legacy API.
   findHostInstance(component: Fiber): I | TI | null,
@@ -256,7 +256,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     updateContainer(
       element: ReactNodeList,
       container: OpaqueRoot,
-      parentComponent: ?ReactComponent<any, any, any>,
+      parentComponent: ?React$Component<any, any>,
       callback: ?Function,
     ): void {
       // TODO: If this is a nested container, this won't be the root.
@@ -296,7 +296,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     getPublicRootInstance(
       container: OpaqueRoot,
-    ): ReactComponent<any, any, any> | PI | null {
+    ): React$Component<any, any> | PI | null {
       const containerFiber = container.current;
       if (!containerFiber.child) {
         return null;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -111,7 +111,9 @@ if (__DEV__) {
     stopCommitLifeCyclesTimer,
   } = require('ReactDebugFiberPerf');
 
-  var warnAboutUpdateOnUnmounted = function(instance: React$ComponentType<any>) {
+  var warnAboutUpdateOnUnmounted = function(
+    instance: React$ComponentType<any>,
+  ) {
     const ctor = instance.constructor;
     warning(
       false,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -111,7 +111,7 @@ if (__DEV__) {
     stopCommitLifeCyclesTimer,
   } = require('ReactDebugFiberPerf');
 
-  var warnAboutUpdateOnUnmounted = function(instance: ReactClass<any>) {
+  var warnAboutUpdateOnUnmounted = function(instance: React$ComponentType<any>) {
     const ctor = instance.constructor;
     warning(
       false,
@@ -123,7 +123,7 @@ if (__DEV__) {
     );
   };
 
-  var warnAboutInvalidUpdates = function(instance: ReactClass<any>) {
+  var warnAboutInvalidUpdates = function(instance: React$ComponentType<any>) {
     switch (ReactDebugCurrentFiber.phase) {
       case 'getChildContext':
         warning(

--- a/src/renderers/shared/fiber/ReactFiberTreeReflection.js
+++ b/src/renderers/shared/fiber/ReactFiberTreeReflection.js
@@ -71,7 +71,7 @@ exports.isFiberMounted = function(fiber: Fiber): boolean {
 };
 
 exports.isMounted = function(
-  component: ReactComponent<any, any, any>,
+  component: React$Component<any, any>,
 ): boolean {
   if (__DEV__) {
     const owner = (ReactCurrentOwner.current: any);

--- a/src/renderers/shared/fiber/ReactFiberTreeReflection.js
+++ b/src/renderers/shared/fiber/ReactFiberTreeReflection.js
@@ -70,9 +70,7 @@ exports.isFiberMounted = function(fiber: Fiber): boolean {
   return isFiberMountedImpl(fiber) === MOUNTED;
 };
 
-exports.isMounted = function(
-  component: React$Component<any, any>,
-): boolean {
+exports.isMounted = function(component: React$Component<any, any>): boolean {
   if (__DEV__) {
     const owner = (ReactCurrentOwner.current: any);
     if (owner !== null && owner.tag === ClassComponent) {

--- a/src/renderers/shared/fiber/isomorphic/ReactTypes.js
+++ b/src/renderers/shared/fiber/isomorphic/ReactTypes.js
@@ -13,16 +13,16 @@
 'use strict';
 
 export type ReactNode =
-  | ReactElement<any>
+  | React$Element<any>
   | ReactCoroutine
   | ReactYield
   | ReactPortal
   | ReactText
   | ReactFragment;
 
-export type ReactFragment = ReactEmpty | Iterable<ReactNode>;
+export type ReactFragment = ReactEmpty | Iterable<React$Node>;
 
-export type ReactNodeList = ReactEmpty | ReactNode;
+export type ReactNodeList = ReactEmpty | React$Node;
 
 export type ReactText = string | number;
 

--- a/src/renderers/shared/shared/event/ReactSyntheticEventType.js
+++ b/src/renderers/shared/shared/event/ReactSyntheticEventType.js
@@ -33,4 +33,4 @@ export type ReactSyntheticEvent = {
     nativeTarget: Event,
     nativeEventTarget: EventTarget,
   ) => ReactSyntheticEvent,
-} & SyntheticEvent;
+} & SyntheticEvent<>;

--- a/src/renderers/shared/shared/getContextForSubtree.js
+++ b/src/renderers/shared/shared/getContextForSubtree.js
@@ -20,7 +20,7 @@ let getContextFiber = function(arg) {
 };
 
 function getContextForSubtree(
-  parentComponent: ?ReactComponent<any, any, any>,
+  parentComponent: ?React$Component<any, any>,
 ): Object {
   if (!parentComponent) {
     return emptyObject;

--- a/src/renderers/shared/stack/reconciler/ReactNodeTypes.js
+++ b/src/renderers/shared/stack/reconciler/ReactNodeTypes.js
@@ -23,7 +23,7 @@ var ReactNodeTypes = {
   COMPOSITE: 1,
   EMPTY: 2,
 
-  getType: function(node: ReactElement<any>): ReactNodeType {
+  getType: function(node: React.Element<any>): ReactNodeType {
     if (node === null || node === false) {
       return ReactNodeTypes.EMPTY;
     } else if (React.isValidElement(node)) {

--- a/src/renderers/shared/stack/reconciler/ReactNodeTypes.js
+++ b/src/renderers/shared/stack/reconciler/ReactNodeTypes.js
@@ -23,7 +23,7 @@ var ReactNodeTypes = {
   COMPOSITE: 1,
   EMPTY: 2,
 
-  getType: function(node: React.Element<any>): ReactNodeType {
+  getType: function(node: React$Element<any>): ReactNodeType {
     if (node === null || node === false) {
       return ReactNodeTypes.EMPTY;
     } else if (React.isValidElement(node)) {

--- a/src/renderers/shared/stack/reconciler/flattenStackChildren.js
+++ b/src/renderers/shared/stack/reconciler/flattenStackChildren.js
@@ -43,7 +43,7 @@ if (
  */
 function flattenSingleChildIntoContext(
   traverseContext: mixed,
-  child: ReactElement<any>,
+  child: React$Element<any>,
   name: string,
   selfDebugID?: number,
 ): void {
@@ -82,9 +82,9 @@ function flattenSingleChildIntoContext(
  * @return {!object} flattened children keyed by name.
  */
 function flattenStackChildren(
-  children: ReactElement<any>,
+  children: React$Element<any>,
   selfDebugID?: number,
-): ?{[name: string]: ReactElement<any>} {
+): ?{[name: string]: React$Element<any>} {
   if (children == null) {
     return children;
   }

--- a/src/renderers/testing/ReactTestRendererFiberEntry.js
+++ b/src/renderers/testing/ReactTestRendererFiberEntry.js
@@ -32,7 +32,7 @@ import type {Fiber} from 'ReactFiber';
 import type {FiberRoot} from 'ReactFiberRoot';
 
 type TestRendererOptions = {
-  createNodeMock: (element: ReactElement<any>) => any,
+  createNodeMock: (element: React$Element<any>) => any,
 };
 
 type ReactTestRendererJSON = {|
@@ -551,7 +551,7 @@ function propsMatch(props: Object, filter: Object): boolean {
 }
 
 var ReactTestRendererFiber = {
-  create(element: ReactElement<any>, options: TestRendererOptions) {
+  create(element: React$Element<any>, options: TestRendererOptions) {
     var createNodeMock = defaultTestOptions.createNodeMock;
     if (options && typeof options.createNodeMock === 'function') {
       createNodeMock = options.createNodeMock;
@@ -586,7 +586,7 @@ var ReactTestRendererFiber = {
         }
         return toTree(root.current);
       },
-      update(newElement: ReactElement<any>) {
+      update(newElement: React$Element<any>) {
         if (root == null || root.current == null) {
           return;
         }

--- a/src/shared/ReactElementType.js
+++ b/src/shared/ReactElementType.js
@@ -29,7 +29,7 @@ export type ReactElement = {
   _store: {
     validated: boolean,
   },
-  _self: ReactElement,
+  _self: React$Element<any>,
   _shadowChildren: any,
   _source: Source,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,9 +1853,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.52.0:
-  version "0.52.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.52.0.tgz#b6d9abe8bcd1ee5c62df386451a4e2553cadc3a3"
+flow-bin@^0.53.1:
+  version "0.53.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.53.1.tgz#9b22b63a23c99763ae533ebbab07f88c88c97d84"
 
 flow-parser@0.43.0:
   version "0.43.0"


### PR DESCRIPTION
This keeps Flow versions in-sync between GitHub and fbsource. I noticed a Flow incompatibility between these 2 versions when syncing React Native this morning.

Commits are atomic to simplify the review process.

Resources:
* [Flow 53 release blog](https://medium.com/flow-type/even-better-support-for-react-in-flow-25b0a3485627)
* [Flow React type definitions](https://github.com/facebook/flow/blob/v0.53.1/lib/react.js)
* [`flow-upgrade` utility](https://yarnpkg.com/en/package/flow-upgrade)
* [Flow React type reference](https://flow.org/en/docs/react/types/)