### PR TITLE
Put warnForInvalidEventListener call behind nextProp check

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -951,10 +951,10 @@ var ReactDOMFiberComponent = {
           }
         }
       } else if (registrationNameModules.hasOwnProperty(propKey)) {
-        if (__DEV__ && typeof nextProp !== 'function') {
-          warnForInvalidEventListener(propKey, nextProp);
-        }
         if (nextProp) {
+          if (__DEV__ && typeof nextProp !== 'function') {
+            warnForInvalidEventListener(propKey, nextProp);
+          }
           ensureListeningTo(rootContainerElement, propKey);
         }
       } else if (__DEV__) {


### PR DESCRIPTION
Thanks @gaearon for [pointing this out](https://github.com/facebook/react/commit/34780da5c8d702daf84a46ba436a3c580b95a3cb##commitcomment-23835350).