### PR TITLE
Adding the correct argument name to documentation tag

### DIFF
--- a/src/isomorphic/modern/class/ReactNoopUpdateQueue.js
+++ b/src/isomorphic/modern/class/ReactNoopUpdateQueue.js
@@ -58,7 +58,7 @@ var ReactNoopUpdateQueue = {
    *
    * @param {ReactClass} publicInstance The instance that should rerender.
    * @param {?function} callback Called after component is updated.
-   * @param {?string} Name of the calling function in the public API.
+   * @param {?string} callerName name of the calling function in the public API.
    * @internal
    */
   enqueueForceUpdate: function(publicInstance, callback, callerName) {
@@ -75,7 +75,7 @@ var ReactNoopUpdateQueue = {
    * @param {ReactClass} publicInstance The instance that should rerender.
    * @param {object} completeState Next state.
    * @param {?function} callback Called after component is updated.
-   * @param {?string} Name of the calling function in the public API.
+   * @param {?string} callerName name of the calling function in the public API.
    * @internal
    */
   enqueueReplaceState: function(

--- a/src/renderers/dom/shared/eventPlugins/BeforeInputEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/BeforeInputEventPlugin.js
@@ -273,7 +273,7 @@ function extractCompositionEvent(
 }
 
 /**
- * @param {string} topLevelType Record from `BrowserEventConstants`.
+ * @param {TopLevelTypes} topLevelType Record from `BrowserEventConstants`.
  * @param {object} nativeEvent Native browser event.
  * @return {?string} The string corresponding to this `beforeInput` event.
  */

--- a/src/renderers/dom/stack/client/ReactMount.js
+++ b/src/renderers/dom/stack/client/ReactMount.js
@@ -85,7 +85,7 @@ function internalGetID(node) {
 /**
  * Mounts this component and inserts it into the DOM.
  *
- * @param {ReactComponent} componentInstance The instance to mount.
+ * @param {ReactComponent} wrapperInstance The instance to mount.
  * @param {DOMElement} container DOM element to mount into.
  * @param {ReactReconcileTransaction} transaction
  * @param {boolean} shouldReuseMarkup If true, do not insert markup

--- a/src/renderers/dom/stack/server/ReactServerUpdateQueue.js
+++ b/src/renderers/dom/stack/server/ReactServerUpdateQueue.js
@@ -74,7 +74,7 @@ class ReactServerUpdateQueue {
    *
    * @param {ReactClass} publicInstance The instance that should rerender.
    * @param {?function} callback Called after component is updated.
-   * @param {?string} Name of the calling function in the public API.
+   * @param {?string} callerName Name of the calling function in the public API.
    * @internal
    */
   enqueueForceUpdate(

--- a/src/renderers/shared/stack/reconciler/ReactReconciler.js
+++ b/src/renderers/shared/stack/reconciler/ReactReconciler.js
@@ -32,8 +32,8 @@ var ReactReconciler = {
    *
    * @param {ReactComponent} internalInstance
    * @param {ReactReconcileTransaction|ReactServerRenderingTransaction} transaction
-   * @param {?object} the containing host component instance
-   * @param {?object} info about the host container
+   * @param {?object} hostParent the containing host component instance
+   * @param {?object} hostContainerInfo info about the host container
    * @return {?string} Rendered markup to be inserted into the DOM.
    * @final
    * @internal

--- a/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
+++ b/src/renderers/shared/stack/reconciler/ReactUpdateQueue.js
@@ -123,7 +123,7 @@ var ReactUpdateQueue = {
    *
    * @param {ReactClass} publicInstance The instance that should rerender.
    * @param {?function} callback Called after component is updated.
-   * @param {?string} Name of the calling function in the public API.
+   * @param {?string} callerName Name of the calling function in the public API.
    * @internal
    */
   enqueueForceUpdate: function(publicInstance, callback, callerName) {


### PR DESCRIPTION
Minor nits on documentation tags to make sure the function param names are matching the documentation tag param name