### PR TITLE
Remove HTMLPropertyConfig entries for non-boolean values

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -78,19 +78,12 @@ var HTMLDOMPropertyConfig = {
     value: 0,
     // The following attributes expect boolean values. They must be in
     // the whitelist to allow boolean attribute assignment:
-    autoComplete: 0,
     // IE only true/false iFrame attribute
     // https://msdn.microsoft.com/en-us/library/ms533072(v=vs.85).aspx
     allowTransparency: 0,
     contentEditable: 0,
     draggable: 0,
     spellCheck: 0,
-    // autoCapitalize and autoCorrect are supported in Mobile Safari for
-    // keyboard hints.
-    autoCapitalize: 0,
-    autoCorrect: 0,
-    // autoSave allows WebKit/Blink to persist values of input fields on page reloads
-    autoSave: 0,
   },
   DOMAttributeNames: {
     acceptCharset: 'accept-charset',


### PR DESCRIPTION
When we originally removed attributes from the whitelist, we assumed a few attributes were string booleans, but they are not:

[**Autocomplete ("on", "off")**](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocomplete)

[**Autocapitalize ("none", "sentence", "words", ...)**](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize)

[**Autocorrect ("on", "off")**](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocorrect)

[**Autosave (string)**](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autosave)