### PR TITLE
Enable opt-in to async mode

### DIFF
--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
@@ -26,18 +26,28 @@ describe('ReactDOMFiberAsync', () => {
   });
 
   if (ReactDOMFeatureFlags.useFiber) {
-    it('renders synchronously when feature flag is disabled', () => {
-      ReactDOM.render(
-        <AsyncComponent><div>Hi</div></AsyncComponent>,
-        container,
-      );
-      expect(container.textContent).toEqual('Hi');
+    describe('with feature flag disabled', () => {
+      beforeEach(() => {
+        jest.resetModules();
+        ReactFeatureFlags = require('ReactFeatureFlags');
+        container = document.createElement('div');
+        ReactFeatureFlags.enableAsyncSubtreeAPI = false;
+        ReactDOM = require('react-dom');
+      });
 
-      ReactDOM.render(
-        <AsyncComponent><div>Bye</div></AsyncComponent>,
-        container,
-      );
-      expect(container.textContent).toEqual('Bye');
+      it('renders synchronously', () => {
+        ReactDOM.render(
+          <AsyncComponent><div>Hi</div></AsyncComponent>,
+          container,
+        );
+        expect(container.textContent).toEqual('Hi');
+
+        ReactDOM.render(
+          <AsyncComponent><div>Bye</div></AsyncComponent>,
+          container,
+        );
+        expect(container.textContent).toEqual('Bye');
+      });
     });
 
     describe('with feature flag enabled', () => {

--- a/src/renderers/shared/utils/ReactFeatureFlags.js
+++ b/src/renderers/shared/utils/ReactFeatureFlags.js
@@ -14,7 +14,7 @@
 
 var ReactFeatureFlags = {
   disableNewFiberFeatures: false,
-  enableAsyncSubtreeAPI: false,
+  enableAsyncSubtreeAPI: true,
 };
 
 module.exports = ReactFeatureFlags;


### PR DESCRIPTION
When the feature flag `enableAsyncSubtreeAPI` is true, `React.unstable_AsyncComponent` creates an async subtree. When it's false, it behaves like a normal, sync React component. We use this flag at Facebook as a fail-safe so if we ship an async bug, we can set the flag to false and revert back to sync mode.

For open source, we should enable the feature flag, so people can start experimenting with async before it's stable.