### PR TITLE
[Documentation] Add reference to onInvalid form event

### DIFF
--- a/docs/docs/reference-events.md
+++ b/docs/docs/reference-events.md
@@ -173,7 +173,7 @@ DOMEventTarget relatedTarget
 Event names:
 
 ```
-onChange onInput onSubmit
+onChange onInput onInvalid onSubmit
 ```
 
 For more information about the onChange event, see [Forms](/react/docs/forms.html).


### PR DESCRIPTION
This pull adds the `onInvalid` event to the list of "Form Events" on the "SyntheticEvent" docs page (https://facebook.github.io/react/docs/events.html#form-events).

This event was added in [v15](https://facebook.github.io/react/blog/2016/04/07/react-v15.html) in the PR https://github.com/facebook/react/pull/5187.

Closes #10553 