### PR TITLE
Updating param flow type definition

### DIFF
--- a/src/renderers/native/ReactNativeEventEmitter.js
+++ b/src/renderers/native/ReactNativeEventEmitter.js
@@ -100,7 +100,7 @@ var ReactNativeEventEmitter = {
   _receiveRootNodeIDEvent: function(
     rootNodeID: number,
     topLevelType: string,
-    nativeEventParam: Object,
+    nativeEventParam: ?Object,
   ) {
     var nativeEvent = nativeEventParam || EMPTY_NATIVE_EVENT;
     var inst = ReactNativeComponentTree.getInstanceFromNode(rootNodeID);


### PR DESCRIPTION
This is a follow up PR of https://github.com/facebook/react/pull/10530

Updating the flow param type since we have this check:

```javascript
var nativeEvent = nativeEventParam || EMPTY_NATIVE_EVENT;
```

