### PR TITLE
Tweak attribute whitelist table

### DIFF
--- a/fixtures/attribute-behavior/src/App.js
+++ b/fixtures/attribute-behavior/src/App.js
@@ -22,14 +22,6 @@ const types = [
     testDisplayValue: "'a string'",
   },
   {
-    name: 'null',
-    testValue: null,
-  },
-  {
-    name: 'undefined',
-    testValue: undefined,
-  },
-  {
     name: 'empty string',
     testValue: '',
     testDisplayValue: "''",
@@ -114,6 +106,14 @@ const types = [
   {
     name: 'function',
     testValue: function f() {},
+  },
+  {
+    name: 'null',
+    testValue: null,
+  },
+  {
+    name: 'undefined',
+    testValue: undefined,
   },
 ];
 

--- a/fixtures/attribute-behavior/src/App.js
+++ b/fixtures/attribute-behavior/src/App.js
@@ -2732,7 +2732,14 @@ function CellContent(props) {
     if (rowIndex === 0) {
       return null;
     }
-    return <RowHeader>{attribute.name}</RowHeader>;
+    const hasSameBehaviorForAll = types.every(
+      type => table.get(attribute).get(type.name).hasSameBehavior
+    );
+    return (
+      <RowHeader>
+        {hasSameBehaviorForAll ? attribute.name : <b>{attribute.name}</b>}
+      </RowHeader>
+    );
   }
 
   if (rowIndex === 0) {


### PR DESCRIPTION
* Move `null` and `undefined` to the end since they're almost always the same
* Make attribute names with changes appear bold