### PR TITLE
Better hashing for attribute table

### DIFF
--- a/fixtures/attribute-behavior/src/App.js
+++ b/fixtures/attribute-behavior/src/App.js
@@ -2638,8 +2638,16 @@ for (let attribute of attributes) {
   for (let type of types) {
     const result = getRenderedAttributeValues(attribute, type);
     row.set(type.name, result);
-    rowHash +=
-      result.react15.canonicalResult + '||' + result.react16.canonicalResult;
+    rowHash += [result.react15, result.react16]
+      .map(res =>
+        [
+          res.canonicalResult,
+          res.canonicalDefaultValue,
+          res.didWarn,
+          res.didError,
+        ].join('||')
+      )
+      .join('||');
   }
   table.set(attribute, row);
   if (!groupByRowPattern.get(rowHash)) {


### PR DESCRIPTION
This ensures we treat existence of errors/warnings, and default value, as part of attribute hash.