### PR TITLE
Add --sync-www flag to build script

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -18,6 +18,7 @@ const Bundles = require('./bundles');
 const propertyMangleWhitelist = require('./mangle').propertyMangleWhitelist;
 const sizes = require('./plugins/sizes-plugin');
 const Stats = require('./stats');
+const syncReactDom = require('./sync').syncReactDom;
 const syncReactNative = require('./sync').syncReactNative;
 const Packaging = require('./packaging');
 const Header = require('./header');
@@ -40,6 +41,7 @@ const requestedBundleNames = (argv._[0] || '')
   .split(',')
   .map(type => type.toLowerCase());
 const syncFbsource = argv['sync-fbsource'];
+const syncWww = argv['sync-www'];
 
 // used for when we property mangle with uglify/gcc
 const mangleRegex = new RegExp(
@@ -514,6 +516,8 @@ rimraf('build', () => {
     tasks.push(() =>
       syncReactNative(join('build', 'react-native'), syncFbsource)
     );
+  } else if (syncWww) {
+    tasks.push(() => syncReactDom(join('build', 'facebook-www'), syncWww));
   }
   // rather than run concurently, opt to run them serially
   // this helps improve console/warning/error output

--- a/scripts/rollup/sync.js
+++ b/scripts/rollup/sync.js
@@ -5,7 +5,32 @@ const chalk = require('chalk');
 const resolvePath = require('./utils').resolvePath;
 
 const DEFAULT_FB_SOURCE_PATH = '~/fbsource/';
+const DEFAULT_WWW_PATH = '~/www/';
 const RELATIVE_RN_PATH = 'xplat/js/react-native-github/Libraries/Renderer/';
+const RELATIVE_WWW_PATH = 'html/shared/react/';
+
+function doSync(buildPath, destPath) {
+  console.log(`${chalk.bgYellow.black(' SYNCING ')} React to ${destPath}`);
+
+  const promise = asyncCopyTo(buildPath, destPath);
+  promise.then(() => {
+    console.log(`${chalk.bgGreen.black(' SYNCED ')} React to ${destPath}`);
+  });
+
+  return promise;
+}
+
+function syncReactDom(buildPath, wwwPath) {
+  wwwPath = typeof wwwPath === 'string' ? wwwPath : DEFAULT_WWW_PATH;
+
+  if (wwwPath.charAt(wwwPath.length - 1) !== '/') {
+    wwwPath += '/';
+  }
+
+  const destPath = resolvePath(wwwPath + RELATIVE_WWW_PATH);
+
+  return doSync(buildPath, destPath);
+}
 
 function syncReactNative(buildPath, fbSourcePath) {
   fbSourcePath = typeof fbSourcePath === 'string'
@@ -18,20 +43,10 @@ function syncReactNative(buildPath, fbSourcePath) {
 
   const destPath = resolvePath(fbSourcePath + RELATIVE_RN_PATH);
 
-  console.log(
-    `${chalk.bgYellow.black(' SYNCING ')} ReactNative to ${destPath}`
-  );
-
-  const promise = asyncCopyTo(buildPath, destPath);
-  promise.then(() => {
-    console.log(
-      `${chalk.bgGreen.black(' SYNCED ')} ReactNative to ${destPath}`
-    );
-  });
-
-  return promise;
+  return doSync(buildPath, destPath);
 }
 
 module.exports = {
-  syncReactNative: syncReactNative,
+  syncReactDom,
+  syncReactNative,
 };


### PR DESCRIPTION
This is convenient for iterating on React/ReactDOM and testing changes in www. It's similar to the `--sync-fbsource` flag that I added a few weeks back for React Native.

```sh
yarn build -- dom --sync-www # defaults to ~/www
yarn build -- dom --sync-www=/path/to/www
```