### PR TITLE
Adding Crowdin config file to master repo

### DIFF
--- a/docs/crowdin.yaml
+++ b/docs/crowdin.yaml
@@ -1,0 +1,61 @@
+project_identifier_env: CROWDIN_REACT_PROJECT_ID
+api_key_env: CROWDIN_REACT_API_KEY
+base_path: "./"
+preserve_hierarchy: true
+
+files:
+  -
+    source: '/docs/*.md'
+    translation: '/docs/i18n/%locale%/%original_file_name%'
+    languages_mapping: &anchor
+      locale:
+        'af': 'af'
+        'ar': 'ar'
+        'bs-BA': 'bs-BA'
+        'ca': 'ca'
+        'cs': 'cs'
+        'da': 'da'
+        'de': 'de'
+        'el': 'el'
+        'es-ES': 'es-ES'
+        'fa': 'fa-IR'
+        'fi': 'fi'
+        'fr': 'fr'
+        'he': 'he'
+        'hu': 'hu'
+        'id': 'id-ID'
+        'it': 'it'
+        'ja': 'ja'
+        'ko': 'ko'
+        'mr': 'mr-IN'
+        'nl': 'nl'
+        'no': 'no-NO'
+        'pl': 'pl'
+        'pt-BR': 'pt-BR'
+        'pt-PT': 'pt-PT'
+        'ro': 'ro'
+        'ru': 'ru'
+        'sk': 'sk-SK'
+        'sr': 'sr'
+        'sv-SE': 'sv-SE'
+        'tr': 'tr'
+        'uk': 'uk'
+        'vi': 'vi'
+        'zh-CN': 'zh-Hans'
+        'zh-TW': 'zh-Hant'
+  -
+    source: '/tutorial/*.md'
+    translation: '/tutorial/%locale%/%original_file_name%'
+    languages_mapping: *anchor
+  -
+    source: '/community/*.md'
+    translation: '/community/%locale%/%original_file_name%'
+    languages_mapping: *anchor
+  -
+    source: '/contributing/*.md'
+    translation: '/contributing/%locale%/%original_file_name%'
+    languages_mapping: *anchor
+  -
+    source: '/_data/*.yml'
+    translation: '/_data/%locale%/%original_file_name%'
+    languages_mapping: *anchor

--- a/docs/crowdin.yaml
+++ b/docs/crowdin.yaml
@@ -84,6 +84,18 @@ files:
     translation: '/%locale%/index.md'
     languages_mapping: *anchor
   -
+    source: '/README.md'
+    translation: '/%locale%/README.md'
+    languages_mapping: *anchor
+  -
+    source: '/acknowledgements.md'
+    translation: '/%locale%/acknowledgements.md'
+    languages_mapping: *anchor
+  -
+    source: '/404.md'
+    translation: '/%locale%/404.md'
+    languages_mapping: *anchor
+  -
     source: '/jsx-compiler.md'
     translation: '/%locale%/jsx-compiler.md'
     languages_mapping: *anchor

--- a/docs/crowdin.yaml
+++ b/docs/crowdin.yaml
@@ -72,6 +72,9 @@ files:
     source: '/_data/*.yml'
     translation: '/_data/%locale%/%original_file_name%'
     languages_mapping: *anchor
+    ignore:
+      - '/_data/acknowledgements.yml'
+      - '/_data/authors.md'
   -
     source: '/warnings/*.md'
     translation: '/warnings/%locale%/%original_file_name%'

--- a/docs/crowdin.yaml
+++ b/docs/crowdin.yaml
@@ -50,6 +50,19 @@ files:
   -
     source: '/community/*.md'
     translation: '/community/%locale%/%original_file_name%'
+    ignore:
+      - '/community/complementary-tools.it-IT.md'
+      - '/community/complementary-tools.ko-KR.md'
+      - '/community/complementary-tools.zh-CN.md'
+      - '/community/conferences.it-IT.md'
+      - '/community/conferences.ko-KR.md'
+      - '/community/conferences.zh-CN.md'
+      - '/community/examples.it-IT.md'
+      - '/community/examples.ko-KR.md'
+      - '/community/examples.zh-CN.md'
+      - '/community/videos.it-IT.md'
+      - '/community/videos.ko-KR.md'
+      - '/community/videos.zh-CN.md'
     languages_mapping: *anchor
   -
     source: '/contributing/*.md'
@@ -58,4 +71,16 @@ files:
   -
     source: '/_data/*.yml'
     translation: '/_data/%locale%/%original_file_name%'
+    languages_mapping: *anchor
+  -
+    source: '/warnings/*.md'
+    translation: '/warnings/%locale%/%original_file_name%'
+    languages_mapping: *anchor
+  -
+    source: '/index.md'
+    translation: '/%locale%/index.md'
+    languages_mapping: *anchor
+  -
+    source: '/jsx-compiler.md'
+    translation: '/%locale%/jsx-compiler.md'
     languages_mapping: *anchor


### PR DESCRIPTION
This adds the base Crowdin config file for localization using the currently existing docs website layout. It will be adjusted over time to include shared strings (navigation, footers, etc) as localization progresses.