### PR TITLE
Ensure attribute table server-renders SVG inside SVG container

### DIFF
--- a/fixtures/attribute-behavior/src/App.js
+++ b/fixtures/attribute-behavior/src/App.js
@@ -2603,11 +2603,24 @@ function getRenderedAttributeValue(renderer, serverRenderer, attribute, type) {
   let hasTagMismatch = false;
   let hasUnknownElement = false;
   try {
-    const html = serverRenderer.renderToString(
-      React.createElement(tagName, props)
-    );
-    container = createContainer();
-    container.innerHTML = html;
+    if (containerTagName === 'document') {
+      const html = serverRenderer.renderToString(
+        React.createElement(tagName, props)
+      );
+      container = createContainer();
+      container.innerHTML = html;
+    } else {
+      const html = serverRenderer.renderToString(
+        React.createElement(
+          containerTagName,
+          null,
+          React.createElement(tagName, props)
+        )
+      );
+      const outerContainer = document.createElement('div');
+      outerContainer.innerHTML = html;
+      container = outerContainer.firstChild;
+    }
 
     if (
       !container.lastChild ||


### PR DESCRIPTION
This fixes an issue with things like `numOctaves` where it emitted a false positive warning for `camelCase` SVG tags because it thought we're not inside SVG mode.