### PR TITLE
Remove dependency on fbjs/lib/EventListener and fbjs/lib/focusNode

### DIFF
--- a/src/renderers/dom/shared/ReactBrowserEventEmitter.js
+++ b/src/renderers/dom/shared/ReactBrowserEventEmitter.js
@@ -225,7 +225,7 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
   },
 
   trapBubbledEvent: function(topLevelType, handlerBaseName, handle) {
-    return ReactDOMEventListener.trapBubbledEvent(
+    ReactDOMEventListener.trapBubbledEvent(
       topLevelType,
       handlerBaseName,
       handle,
@@ -233,7 +233,7 @@ var ReactBrowserEventEmitter = Object.assign({}, ReactEventEmitterMixin, {
   },
 
   trapCapturedEvent: function(topLevelType, handlerBaseName, handle) {
-    return ReactDOMEventListener.trapCapturedEvent(
+    ReactDOMEventListener.trapCapturedEvent(
       topLevelType,
       handlerBaseName,
       handle,

--- a/src/renderers/dom/shared/ReactDOMEventListener.js
+++ b/src/renderers/dom/shared/ReactDOMEventListener.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var EventListener = require('fbjs/lib/EventListener');
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 var ReactFiberTreeReflection = require('ReactFiberTreeReflection');
 var ReactGenericBatching = require('ReactGenericBatching');
@@ -138,12 +137,12 @@ var ReactDOMEventListener = {
    */
   trapBubbledEvent: function(topLevelType, handlerBaseName, element) {
     if (!element) {
-      return null;
+      return;
     }
-    return EventListener.listen(
-      element,
+    element.addEventListener(
       handlerBaseName,
       ReactDOMEventListener.dispatchEvent.bind(null, topLevelType),
+      false,
     );
   },
 
@@ -159,12 +158,12 @@ var ReactDOMEventListener = {
    */
   trapCapturedEvent: function(topLevelType, handlerBaseName, element) {
     if (!element) {
-      return null;
+      return;
     }
-    return EventListener.capture(
-      element,
+    element.addEventListener(
       handlerBaseName,
       ReactDOMEventListener.dispatchEvent.bind(null, topLevelType),
+      true,
     );
   },
 

--- a/src/renderers/dom/shared/ReactInputSelection.js
+++ b/src/renderers/dom/shared/ReactInputSelection.js
@@ -15,7 +15,6 @@ var ReactDOMSelection = require('ReactDOMSelection');
 var {ELEMENT_NODE} = require('HTMLNodeType');
 
 var containsNode = require('fbjs/lib/containsNode');
-var focusNode = require('fbjs/lib/focusNode');
 var getActiveElement = require('fbjs/lib/getActiveElement');
 
 function isInDocument(node) {
@@ -76,7 +75,7 @@ var ReactInputSelection = {
         }
       }
 
-      focusNode(priorFocusedElem);
+      priorFocusedElem.focus();
 
       for (let i = 0; i < ancestors.length; i++) {
         const info = ancestors[i];

--- a/src/renderers/dom/shared/__tests__/ReactBrowserEventEmitter-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactBrowserEventEmitter-test.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var EventListener;
 var EventPluginHub;
 var EventPluginRegistry;
 var React;
@@ -59,7 +58,6 @@ describe('ReactBrowserEventEmitter', () => {
   beforeEach(() => {
     jest.resetModules();
     LISTENER.mockClear();
-    EventListener = require('fbjs/lib/EventListener');
     // TODO: can we express this test with only public API?
     EventPluginHub = require('EventPluginHub');
     EventPluginRegistry = require('EventPluginRegistry');
@@ -376,43 +374,30 @@ describe('ReactBrowserEventEmitter', () => {
   });
 
   it('should listen to events only once', () => {
-    spyOn(EventListener, 'listen');
+    spyOn(document, 'addEventListener');
     ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
     ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
-    expect(EventListener.listen.calls.count()).toBe(1);
+    expect(document.addEventListener.calls.count()).toBe(1);
   });
 
   it('should work with event plugins without dependencies', () => {
-    spyOn(EventListener, 'listen');
+    spyOn(document, 'addEventListener');
 
     ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
 
-    expect(EventListener.listen.calls.argsFor(0)[1]).toBe('click');
+    expect(document.addEventListener.calls.argsFor(0)[0]).toBe('click');
   });
 
   it('should work with event plugins with dependencies', () => {
-    spyOn(EventListener, 'listen');
-    spyOn(EventListener, 'capture');
+    spyOn(document, 'addEventListener');
 
     ReactBrowserEventEmitter.listenTo(ON_CHANGE_KEY, document);
 
-    var setEventListeners = [];
-    var listenCalls = EventListener.listen.calls.allArgs();
-    var captureCalls = EventListener.capture.calls.allArgs();
-    for (var i = 0; i < listenCalls.length; i++) {
-      setEventListeners.push(listenCalls[i][1]);
-    }
-    for (i = 0; i < captureCalls.length; i++) {
-      setEventListeners.push(captureCalls[i][1]);
-    }
-
     var module = EventPluginRegistry.registrationNameModules[ON_CHANGE_KEY];
     var dependencies = module.eventTypes.change.dependencies;
-    expect(setEventListeners.length).toEqual(dependencies.length);
-
-    for (i = 0; i < setEventListeners.length; i++) {
-      expect(dependencies.indexOf(setEventListeners[i])).toBeTruthy();
-    }
+    expect(document.addEventListener.calls.count()).toEqual(
+      dependencies.length,
+    );
   });
 
   it('should bubble onTouchTap', () => {

--- a/src/renderers/dom/shared/utils/AutoFocusUtils.js
+++ b/src/renderers/dom/shared/utils/AutoFocusUtils.js
@@ -13,11 +13,9 @@
 
 var ReactDOMComponentTree = require('ReactDOMComponentTree');
 
-var focusNode = require('fbjs/lib/focusNode');
-
 var AutoFocusUtils = {
   focusDOMComponent: function() {
-    focusNode(ReactDOMComponentTree.getNodeFromInstance(this));
+    ReactDOMComponentTree.getNodeFromInstance(this).focus();
   },
 };
 


### PR DESCRIPTION
It's pretty small but still unnecessary indirection now that we don't support IE8.
See inline comments.