### PR TITLE
Update error codes on docs branch

### DIFF
--- a/js/errorMap.js
+++ b/js/errorMap.js
@@ -221,5 +221,14 @@ var errorMap = {
   "219": "getInspectorDataForViewTag() is not available in production",
   "220": "Container does not support insertBefore operation",
   "221": "Tried to register two views with the same name %s",
-  "222": "View config not found for name %s"
+  "222": "View config not found for name %s",
+  "223": "Trying to release an event instance  into a pool of a different type.",
+  "224": "Can't read from currently-mounting component. This error is likely caused by a bug in React. Please file an issue.",
+  "225": "Unexpected object passed to ReactTestInstance constructor (tag: %s). This is probably a bug in React.",
+  "226": "Unsupported component type %s in test renderer. This is probably a bug in React.",
+  "227": "ReactDOM was loaded before React. Make sure you load the React package before loading ReactDOM.",
+  "228": "TestUtils.Simulate expected a DOM node as the first argument but received a React element. Pass the DOM node you wish to simulate the event on instead. Note that TestUtils.Simulate will not work if you are using shallow rendering.",
+  "229": "TestUtils.Simulate expected a DOM node as the first argument but received a component instance. Pass the DOM node you wish to simulate the event on instead.",
+  "230": "_processChildContext is not available in React 16+. This likely means you have multiple copies of React and are attempting to nest a React 15 tree inside a React 16 tree using unstable_renderSubtreeIntoContainer, which isn't supported. Try to make sure you have only one copy of React (and ideally, switch to ReactDOM.unstable_createPortal).",
+  "231": "Expected `%s` listener to be a function, instead got a value of `%s` type."
 };


### PR DESCRIPTION
**what is the change?:**
This just updated the error codes on the docs.

For my future self, recording the steps it took to get here:
- On master, run `npm run build -- --extract-errors`
- Create a commit with those changes, and open a PR
  (https://github.com/facebook/react/pull/10619)
- Cherry-pick that commit onto 15-stable, and open a PR
  (https://github.com/facebook/react/pull/10621)
- Update the error codes on the `gh-pages branch` by doing the
  following based on docs
  (https://github.com/facebook/react/tree/master/docs#updating-facebookgithubioreact):
  - Set up a sister directory to `react` with `gh-pages` checked out,
    and call it `react-gh-pages`
  - In your `react` repo, with `15-stable` checked out and the
    error-codes update cherry-picked, run:
    `cd docs && bundle rake exec && bundle exec rake fetch_remotes && bundle exec rake release`
  - `cd ../react-gh-pages` and check in those changes, create a
    commit/PR
  - Manually test running the docs

**why make this change?:**
Even though this is just an RC, and not a final major release, we still
want the docs to be as up-to-date as possible.

**test plan:**
Run the docs locally and make sure things work.
![screen shot 2017-09-06 at 10 40 57 am](https://user-images.githubusercontent.com/1114467/30126463-d8e07ff0-92f0-11e7-837a-fbcc5df33aad.png)

**issue:**
https://github.com/facebook/react/issues/8854