### PR TITLE
New API for top-level updates

### DIFF
--- a/fixtures/fiber-triangle/index.html
+++ b/fixtures/fiber-triangle/index.html
@@ -76,51 +76,54 @@
         }
       }
 
-      function SierpinskiTriangle({ x, y, s, children }) {
-        if (s <= targetSize) {
-          return (
-            <Dot
-              x={x - (targetSize / 2)}
-              y={y - (targetSize / 2)}
-              size={targetSize}
-              text={children}
-            />
+      class SierpinskiTriangle extends React.Component {
+        shouldComponentUpdate(nextProps) {
+          var o = this.props;
+          var n = nextProps;
+          return !(
+            o.x === n.x &&
+            o.y === n.y &&
+            o.s === n.s &&
+            o.children === n.children
           );
-          return r;
         }
-        var newSize = s / 2;
-        var slowDown = true;
-        if (slowDown) {
-          var e = performance.now() + 0.8;
-          while (performance.now() < e) {
-            // Artificially long execution time.
+        render() {
+          let {x, y, s, children} = this.props;
+          if (s <= targetSize) {
+            return (
+              <Dot
+                x={x - (targetSize / 2)}
+                y={y - (targetSize / 2)}
+                size={targetSize}
+                text={children}
+              />
+            );
+            return r;
           }
+          var newSize = s / 2;
+          var slowDown = true;
+          if (slowDown) {
+            var e = performance.now() + 0.8;
+            while (performance.now() < e) {
+              // Artificially long execution time.
+            }
+          }
+
+          s /= 2;
+
+          return [
+            <SierpinskiTriangle x={x} y={y - (s / 2)} s={s}>
+              {children}
+            </SierpinskiTriangle>,
+            <SierpinskiTriangle x={x - s} y={y + (s / 2)} s={s}>
+              {children}
+            </SierpinskiTriangle>,
+            <SierpinskiTriangle x={x + s} y={y + (s / 2)} s={s}>
+              {children}
+            </SierpinskiTriangle>,
+          ];
         }
-
-        s /= 2;
-
-        return [
-          <SierpinskiTriangle x={x} y={y - (s / 2)} s={s}>
-            {children}
-          </SierpinskiTriangle>,
-          <SierpinskiTriangle x={x - s} y={y + (s / 2)} s={s}>
-            {children}
-          </SierpinskiTriangle>,
-          <SierpinskiTriangle x={x + s} y={y + (s / 2)} s={s}>
-            {children}
-          </SierpinskiTriangle>,
-        ];
       }
-      SierpinskiTriangle.shouldComponentUpdate = function(oldProps, newProps) {
-        var o = oldProps;
-        var n = newProps;
-        return !(
-          o.x === n.x &&
-          o.y === n.y &&
-          o.s === n.s &&
-          o.children === n.children
-        );
-      };
 
       class ExampleApplication extends React.Component {
         constructor() {

--- a/src/renderers/art/ReactARTFiberEntry.js
+++ b/src/renderers/art/ReactARTFiberEntry.js
@@ -532,10 +532,7 @@ const ARTRenderer = ReactFiberReconciler({
     );
   },
 
-  now(): number {
-    // TODO: Enable expiration by implementing this method.
-    return 0;
-  },
+  now: ReactDOMFrameScheduling.now,
 
   useSyncScheduling: true,
 });

--- a/src/renderers/art/ReactARTFiberEntry.js
+++ b/src/renderers/art/ReactARTFiberEntry.js
@@ -532,6 +532,11 @@ const ARTRenderer = ReactFiberReconciler({
     );
   },
 
+  now(): number {
+    // TODO: Enable expiration by implementing this method.
+    return 0;
+  },
+
   useSyncScheduling: true,
 });
 

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -163,20 +163,20 @@ function shouldAutoFocusHostComponent(type: string, props: Props): boolean {
 }
 
 // TODO: Better polyfill
-let now;
-if (
-  typeof window !== 'undefined' &&
-  window.performance &&
-  typeof window.performance.now === 'function'
-) {
-  now = function() {
-    return performance.now();
-  };
-} else {
-  now = function() {
-    return Date.now();
-  };
-}
+// let now;
+// if (
+//   typeof window !== 'undefined' &&
+//   window.performance &&
+//   typeof window.performance.now === 'function'
+// ) {
+//   now = function() {
+//     return performance.now();
+//   };
+// } else {
+//   now = function() {
+//     return Date.now();
+//   };
+// }
 
 var DOMRenderer = ReactFiberReconciler({
   getRootHostContext(rootContainerInstance: Container): HostContext {
@@ -453,7 +453,10 @@ var DOMRenderer = ReactFiberReconciler({
     }
   },
 
-  now: now,
+  now() {
+    // TODO: Use performance.now to enable expiration
+    return 0;
+  },
 
   canHydrateInstance(
     instance: Instance | TextInstance,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -453,11 +453,7 @@ var DOMRenderer = ReactFiberReconciler({
     }
   },
 
-  now() {
-    // TODO: Use performance.now to enable expiration
-    // return 0;
-    return now();
-  },
+  now,
 
   canHydrateInstance(
     instance: Instance | TextInstance,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -802,7 +802,7 @@ function createPortal(
 type PublicRoot = {
   render(children: ReactNodeList, callback: ?() => mixed): void,
   prerender(children: ReactNodeList): Work,
-  unmount(callback: ?() => mixed): Work,
+  unmount(callback: ?() => mixed): void,
 
   _reactRootContainer: *,
   _getComponent: () => DOMContainer,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -162,22 +162,6 @@ function shouldAutoFocusHostComponent(type: string, props: Props): boolean {
   return false;
 }
 
-// TODO: Better polyfill
-let now;
-if (
-  typeof window !== 'undefined' &&
-  window.performance &&
-  typeof window.performance.now === 'function'
-) {
-  now = function() {
-    return performance.now();
-  };
-} else {
-  now = function() {
-    return Date.now();
-  };
-}
-
 var DOMRenderer = ReactFiberReconciler({
   getRootHostContext(rootContainerInstance: Container): HostContext {
     let type;
@@ -453,7 +437,7 @@ var DOMRenderer = ReactFiberReconciler({
     }
   },
 
-  now,
+  now: ReactDOMFrameScheduling.now,
 
   canHydrateInstance(
     instance: Instance | TextInstance,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -810,7 +810,7 @@ type PublicRoot = {
 
 function PublicRootNode(
   container: DOMContainer | (() => DOMContainer),
-  namespace: ?string,
+  namespace?: string,
 ) {
   if (typeof container === 'function') {
     if (typeof namespace !== 'string') {
@@ -858,7 +858,7 @@ PublicRootNode.prototype.unmount = function(callback) {
 var ReactDOMFiber = {
   unstable_createRoot(
     container: DOMContainer | (() => DOMContainer),
-    namespace: ?string,
+    namespace?: string,
   ): PublicRoot {
     return new PublicRootNode(container, namespace);
   },

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -163,20 +163,20 @@ function shouldAutoFocusHostComponent(type: string, props: Props): boolean {
 }
 
 // TODO: Better polyfill
-// let now;
-// if (
-//   typeof window !== 'undefined' &&
-//   window.performance &&
-//   typeof window.performance.now === 'function'
-// ) {
-//   now = function() {
-//     return performance.now();
-//   };
-// } else {
-//   now = function() {
-//     return Date.now();
-//   };
-// }
+let now;
+if (
+  typeof window !== 'undefined' &&
+  window.performance &&
+  typeof window.performance.now === 'function'
+) {
+  now = function() {
+    return performance.now();
+  };
+} else {
+  now = function() {
+    return Date.now();
+  };
+}
 
 var DOMRenderer = ReactFiberReconciler({
   getRootHostContext(rootContainerInstance: Container): HostContext {
@@ -455,7 +455,8 @@ var DOMRenderer = ReactFiberReconciler({
 
   now() {
     // TODO: Use performance.now to enable expiration
-    return 0;
+    // return 0;
+    return now();
   },
 
   canHydrateInstance(

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -800,9 +800,9 @@ function createPortal(
 }
 
 type PublicRoot = {
-  render(children: ReactNodeList, callback: () => mixed): Work,
-  prerender(children: ReactNodeList, callback: () => mixed): Work,
-  unmount(callback: () => mixed): Work,
+  render(children: ReactNodeList, callback: ?() => mixed): void,
+  prerender(children: ReactNodeList): Work,
+  unmount(callback: ?() => mixed): Work,
 
   _reactRootContainer: *,
   _getComponent: () => DOMContainer,
@@ -830,23 +830,29 @@ function PublicRootNode(
 }
 PublicRootNode.prototype.render = function(
   children: ReactNodeList,
-  callback: () => mixed,
-): Work {
-  return DOMRenderer.updateContainer(
-    children,
-    this._reactRootContainer,
-    null,
-    callback,
-  );
+  callback: ?() => mixed,
+): void {
+  const work = DOMRenderer.updateRoot(children, this._reactRootContainer, null);
+  callback = callback === undefined ? null : callback;
+  work.then(() => {
+    work.commit();
+    if (callback !== null) {
+      (callback: any)();
+    }
+  });
 };
-PublicRootNode.prototype.prerender = function() {};
-PublicRootNode.prototype.unmount = function() {
-  return DOMRenderer.updateContainer(
-    null,
-    this._reactRootContainer,
-    null,
-    null,
-  );
+PublicRootNode.prototype.prerender = function(children: ReactNodeList): Work {
+  return DOMRenderer.updateRoot(children, this._reactRootContainer, null);
+};
+PublicRootNode.prototype.unmount = function(callback) {
+  const work = DOMRenderer.updateRoot(null, this._reactRootContainer, null);
+  callback = callback === undefined ? null : callback;
+  work.then(() => {
+    work.commit();
+    if (callback !== null) {
+      (callback: any)();
+    }
+  });
 };
 
 var ReactDOMFiber = {

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -162,6 +162,22 @@ function shouldAutoFocusHostComponent(type: string, props: Props): boolean {
   return false;
 }
 
+// TODO: Better polyfill
+let now;
+if (
+  typeof window !== 'undefined' &&
+  window.performance &&
+  typeof window.performance.now === 'function'
+) {
+  now = function() {
+    return performance.now();
+  };
+} else {
+  now = function() {
+    return Date.now();
+  };
+}
+
 var DOMRenderer = ReactFiberReconciler({
   getRootHostContext(rootContainerInstance: Container): HostContext {
     let type;
@@ -436,6 +452,8 @@ var DOMRenderer = ReactFiberReconciler({
       container.removeChild(child);
     }
   },
+
+  now: now,
 
   canHydrateInstance(
     instance: Instance | TextInstance,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -856,7 +856,7 @@ PublicRootNode.prototype.unmount = function(callback) {
 };
 
 var ReactDOMFiber = {
-  unstable_create(
+  unstable_createRoot(
     container: DOMContainer | (() => DOMContainer),
     namespace: ?string,
   ): PublicRoot {

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -1142,7 +1142,7 @@ describe('ReactDOMFiber', () => {
     expect(iframeContainer.appendChild).toHaveBeenCalledTimes(1);
   });
 
-  it('should mount into a document fragment', () => {
+  fit('should mount into a document fragment', () => {
     var fragment = document.createDocumentFragment();
     ReactDOM.render(<div>foo</div>, fragment);
     expect(container.innerHTML).toBe('');

--- a/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
@@ -56,6 +56,18 @@ describe('ReactDOMAsyncRoot', () => {
 
       jest.runAllTimers();
     });
+
+    it('resolves `then` callback synchronously if update is sync', () => {
+      const container = document.createElement('div');
+      const root = ReactDOM.unstable_createRoot(container);
+      const work = root.prerender(<div>Hi</div>);
+      work.then(() => {
+        work.commit();
+        expect(container.textContent).toEqual('Hi');
+      });
+      // `then` should have synchronously resolved
+      expect(container.textContent).toEqual('Hi');
+    });
   } else {
     it('does not apply to stack');
   }

--- a/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let ReactFeatureFlags;
+
+describe('ReactDOMAsyncMount', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactFeatureFlags = require('ReactFeatureFlags');
+    ReactFeatureFlags.enableAsyncSubtreeAPI = true;
+  });
+
+  it('works in easy mode', () => {
+    const container = document.createElement('div');
+    const root = ReactDOM.unstable_create(container);
+    root.render(<div>Foo</div>);
+    expect(container.textContent).toEqual('Foo');
+    root.render(<div>Bar</div>);
+    expect(container.textContent).toEqual('Bar');
+    root.unmount();
+    expect(container.textContent).toEqual('');
+  });
+
+  it('can pass callback to render', () => {
+    const container = document.createElement('div');
+    const root = ReactDOM.unstable_create(container);
+    let called = false;
+    root.render(<div>Foo</div>, () => {
+      called = true;
+    });
+    expect(container.textContent).toEqual('Foo');
+    expect(called).toBe(true);
+  });
+
+  it('can await result of render method', async () => {
+    const container = document.createElement('div');
+    const root = ReactDOM.unstable_create(container);
+    await root.render(<div>Foo</div>);
+    expect(container.textContent).toEqual('Foo');
+  });
+
+  it('can defer commit using prerender', async () => {
+    const Async = React.unstable_AsyncComponent;
+    const container = document.createElement('div');
+    const root = ReactDOM.unstable_create(container);
+    const work = root.prerender(<Async>Foo</Async>);
+
+    // Hasn't updated yet
+    expect(container.textContent).toEqual('');
+
+    await work;
+
+    // Tree has completed, but still hasn't updated yet
+    expect(container.textContent).toEqual('');
+
+    // Synchronsouly update DOM
+    work.commit();
+    expect(container.textContent).toEqual('Foo');
+  });
+});

--- a/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
@@ -28,7 +28,7 @@ describe('ReactDOMAsyncRoot', () => {
   if (ReactDOMFeatureFlags.useFiber) {
     it('works in easy mode', () => {
       const container = document.createElement('div');
-      const root = ReactDOM.unstable_create(container);
+      const root = ReactDOM.unstable_createRoot(container);
       root.render(<div>Foo</div>);
       expect(container.textContent).toEqual('Foo');
       root.render(<div>Bar</div>);
@@ -40,7 +40,7 @@ describe('ReactDOMAsyncRoot', () => {
     it('can defer commit using prerender', () => {
       const Async = React.unstable_AsyncComponent;
       const container = document.createElement('div');
-      const root = ReactDOM.unstable_create(container);
+      const root = ReactDOM.unstable_createRoot(container);
       const work = root.prerender(<Async>Foo</Async>);
 
       // Hasn't updated yet

--- a/src/renderers/native-rt/ReactNativeRTFiberRenderer.js
+++ b/src/renderers/native-rt/ReactNativeRTFiberRenderer.js
@@ -227,6 +227,11 @@ const NativeRTRenderer = ReactFiberReconciler({
   },
 
   useSyncScheduling: true,
+
+  now(): number {
+    // TODO: Enable expiration by implementing this method.
+    return 0;
+  },
 });
 
 module.exports = NativeRTRenderer;

--- a/src/renderers/native/ReactNativeFiberRenderer.js
+++ b/src/renderers/native/ReactNativeFiberRenderer.js
@@ -377,6 +377,11 @@ const NativeRenderer = ReactFiberReconciler({
   },
 
   useSyncScheduling: true,
+
+  now(): number {
+    // TODO: Enable expiration by implementing this method.
+    return 0;
+  },
 });
 
 module.exports = NativeRenderer;

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -284,7 +284,7 @@ var ReactNoop = {
     }
   },
 
-  create(rootID: string) {
+  createRoot(rootID: string) {
     rootID = typeof rootID === 'string' ? rootID : DEFAULT_ROOT_ID;
     invariant(
       !roots.has(rootID),

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -403,7 +403,7 @@ var ReactNoop = {
       logHostInstances(container.children, depth + 1);
     }
 
-    function logUpdateQueue(updateQueue: UpdateQueue, depth) {
+    function logUpdateQueue(updateQueue: UpdateQueue<mixed>, depth) {
       log('  '.repeat(depth + 1) + 'QUEUED UPDATES');
       const firstUpdate = updateQueue.first;
       if (!firstUpdate) {

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -405,7 +405,7 @@ var ReactNoop = {
         '  '.repeat(depth + 1) + '~',
         firstUpdate && firstUpdate.partialState,
         firstUpdate.callback ? 'with callback' : '',
-        '[' + firstUpdate.priorityLevel + ']',
+        '[' + firstUpdate.expirationTime + ']',
       );
       var next;
       while ((next = firstUpdate.next)) {
@@ -413,7 +413,7 @@ var ReactNoop = {
           '  '.repeat(depth + 1) + '~',
           next.partialState,
           next.callback ? 'with callback' : '',
-          '[' + firstUpdate.priorityLevel + ']',
+          '[' + firstUpdate.expirationTime + ']',
         );
       }
     }
@@ -423,7 +423,7 @@ var ReactNoop = {
         '  '.repeat(depth) +
           '- ' +
           (fiber.type ? fiber.type.name || fiber.type : '[root]'),
-        '[' + fiber.pendingWorkPriority + (fiber.pendingProps ? '*' : '') + ']',
+        '[' + fiber.expirationTime + (fiber.pendingProps ? '*' : '') + ']',
       );
       if (fiber.updateQueue) {
         logUpdateQueue(fiber.updateQueue, depth);

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -201,6 +201,11 @@ var NoopRenderer = ReactFiberReconciler({
   prepareForCommit(): void {},
 
   resetAfterCommit(): void {},
+
+  now(): number {
+    // TODO: Add an API to advance time.
+    return 0;
+  },
 });
 
 var rootContainers = new Map();

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -83,6 +83,8 @@ function removeChild(
   parentInstance.children.splice(index, 1);
 }
 
+let elapsedTimeInMs = 0;
+
 var NoopRenderer = ReactFiberReconciler({
   getRootHostContext() {
     if (failInBeginPhase) {
@@ -203,8 +205,7 @@ var NoopRenderer = ReactFiberReconciler({
   resetAfterCommit(): void {},
 
   now(): number {
-    // TODO: Add an API to advance time.
-    return 0;
+    return elapsedTimeInMs;
   },
 });
 
@@ -339,6 +340,14 @@ var ReactNoop = {
       }
     }
     expect(actual).toEqual(expected);
+  },
+
+  expire(ms: number): void {
+    elapsedTimeInMs += ms;
+  },
+
+  flushExpired(): Array<mixed> {
+    return ReactNoop.flushUnitsOfWork(0);
   },
 
   yield(value: mixed) {

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -24,6 +24,7 @@ var ReactFiberInstrumentation = require('ReactFiberInstrumentation');
 var ReactFiberReconciler = require('ReactFiberReconciler');
 var ReactInstanceMap = require('ReactInstanceMap');
 var emptyObject = require('fbjs/lib/emptyObject');
+var invariant = require('fbjs/lib/invariant');
 
 var expect = require('jest-matchers');
 
@@ -281,6 +282,27 @@ var ReactNoop = {
         rootContainers.delete(rootID);
       });
     }
+  },
+
+  create(rootID: string) {
+    rootID = typeof rootID === 'string' ? rootID : DEFAULT_ROOT_ID;
+    invariant(
+      !roots.has(rootID),
+      'Root with id %s already exists. Choose a different id.',
+      rootID,
+    );
+    const container = {rootID: rootID, children: []};
+    rootContainers.set(rootID, container);
+    const root = NoopRenderer.createContainer(container);
+    roots.set(rootID, root);
+    return {
+      prerender(children: any) {
+        return NoopRenderer.updateRoot(children, root, null);
+      },
+      getChildren() {
+        return ReactNoop.getChildren(rootID);
+      },
+    };
   },
 
   findInstance(

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -112,7 +112,7 @@ export type Fiber = {|
   memoizedProps: any, // The props used to create the output.
 
   // A queue of state updates and callbacks.
-  updateQueue: UpdateQueue | null,
+  updateQueue: UpdateQueue<any> | null,
 
   // The state used to create the output
   memoizedState: any,

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -21,6 +21,7 @@ import type {TypeOfWork} from 'ReactTypeOfWork';
 import type {TypeOfInternalContext} from 'ReactTypeOfInternalContext';
 import type {TypeOfSideEffect} from 'ReactTypeOfSideEffect';
 import type {PriorityLevel} from 'ReactPriorityLevel';
+import type {ExpirationTime} from 'ReactFiberExpirationTime';
 import type {UpdateQueue} from 'ReactFiberUpdateQueue';
 
 var {
@@ -36,6 +37,8 @@ var {
 } = require('ReactTypeOfWork');
 
 var {NoWork} = require('ReactPriorityLevel');
+
+var {Done} = require('ReactFiberExpirationTime');
 
 var {NoContext} = require('ReactTypeOfInternalContext');
 
@@ -134,8 +137,9 @@ export type Fiber = {|
   firstEffect: Fiber | null,
   lastEffect: Fiber | null,
 
-  // This will be used to quickly determine if a subtree has no pending changes.
-  pendingWorkPriority: PriorityLevel,
+  // Represents a time in the future by which this work should be completed.
+  // This is also used to quickly determine if a subtree has no pending changes.
+  expirationTime: ExpirationTime,
 
   // This is a pooled version of a Fiber. Every fiber that gets updated will
   // eventually have a pair. There are cases when we can clean up pairs to save
@@ -189,7 +193,7 @@ function FiberNode(
   this.firstEffect = null;
   this.lastEffect = null;
 
-  this.pendingWorkPriority = NoWork;
+  this.expirationTime = Done;
 
   this.alternate = null;
 
@@ -233,7 +237,7 @@ function shouldConstruct(Component) {
 // This is used to create an alternate fiber to do work on.
 exports.createWorkInProgress = function(
   current: Fiber,
-  renderPriority: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   let workInProgress = current.alternate;
   if (workInProgress === null) {
@@ -270,7 +274,7 @@ exports.createWorkInProgress = function(
     workInProgress.lastEffect = null;
   }
 
-  workInProgress.pendingWorkPriority = renderPriority;
+  workInProgress.expirationTime = expirationTime;
 
   workInProgress.child = current.child;
   workInProgress.memoizedProps = current.memoizedProps;
@@ -296,7 +300,7 @@ exports.createHostRootFiber = function(): Fiber {
 exports.createFiberFromElement = function(
   element: ReactElement,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   let owner = null;
   if (__DEV__) {
@@ -310,7 +314,7 @@ exports.createFiberFromElement = function(
     owner,
   );
   fiber.pendingProps = element.props;
-  fiber.pendingWorkPriority = priorityLevel;
+  fiber.expirationTime = expirationTime;
 
   if (__DEV__) {
     fiber._debugSource = element._source;
@@ -323,24 +327,24 @@ exports.createFiberFromElement = function(
 exports.createFiberFromFragment = function(
   elements: ReactFragment,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   // TODO: Consider supporting keyed fragments. Technically, we accidentally
   // support that in the existing React.
   const fiber = createFiber(Fragment, null, internalContextTag);
   fiber.pendingProps = elements;
-  fiber.pendingWorkPriority = priorityLevel;
+  fiber.expirationTime = expirationTime;
   return fiber;
 };
 
 exports.createFiberFromText = function(
   content: string,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   const fiber = createFiber(HostText, null, internalContextTag);
   fiber.pendingProps = content;
-  fiber.pendingWorkPriority = priorityLevel;
+  fiber.expirationTime = expirationTime;
   return fiber;
 };
 
@@ -411,7 +415,7 @@ exports.createFiberFromHostInstanceForDeletion = function(): Fiber {
 exports.createFiberFromCoroutine = function(
   coroutine: ReactCoroutine,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   const fiber = createFiber(
     CoroutineComponent,
@@ -420,27 +424,28 @@ exports.createFiberFromCoroutine = function(
   );
   fiber.type = coroutine.handler;
   fiber.pendingProps = coroutine;
-  fiber.pendingWorkPriority = priorityLevel;
+  fiber.expirationTime = expirationTime;
   return fiber;
 };
 
 exports.createFiberFromYield = function(
   yieldNode: ReactYield,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   const fiber = createFiber(YieldComponent, null, internalContextTag);
+  fiber.expirationTime = expirationTime;
   return fiber;
 };
 
 exports.createFiberFromPortal = function(
   portal: ReactPortal,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   const fiber = createFiber(HostPortal, portal.key, internalContextTag);
   fiber.pendingProps = portal.children || [];
-  fiber.pendingWorkPriority = priorityLevel;
+  fiber.expirationTime = expirationTime;
   fiber.stateNode = {
     containerInfo: portal.containerInfo,
     implementation: portal.implementation,

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -36,9 +36,9 @@ var {
   Fragment,
 } = require('ReactTypeOfWork');
 
-var {NoWork} = require('ReactPriorityLevel');
+var {NoWork: NoWorkPriority} = require('ReactPriorityLevel');
 
-var {Done} = require('ReactFiberExpirationTime');
+var {NoWork} = require('ReactFiberExpirationTime');
 
 var {NoContext} = require('ReactTypeOfInternalContext');
 
@@ -193,7 +193,7 @@ function FiberNode(
   this.firstEffect = null;
   this.lastEffect = null;
 
-  this.expirationTime = Done;
+  this.expirationTime = NoWork;
 
   this.alternate = null;
 
@@ -457,5 +457,5 @@ exports.largerPriority = function(
   p1: PriorityLevel,
   p2: PriorityLevel,
 ): PriorityLevel {
-  return p1 !== NoWork && (p2 === NoWork || p2 > p1) ? p1 : p2;
+  return p1 !== NoWorkPriority && (p2 === NoWorkPriority || p2 > p1) ? p1 : p2;
 };

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -48,7 +48,7 @@ var {
   YieldComponent,
   Fragment,
 } = ReactTypeOfWork;
-var {NoWork, OffscreenPriority} = require('ReactPriorityLevel');
+var {Done, Never} = require('ReactFiberExpirationTime');
 var {
   PerformedWork,
   Placement,
@@ -72,9 +72,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext: HostContext<C, CX>,
   hydrationContext: HydrationContext<C, CX>,
-  scheduleUpdate: (fiber: Fiber, priorityLevel: PriorityLevel) => void,
-  getPriorityContext: (fiber: Fiber, forceAsync: boolean) => PriorityLevel,
+  scheduleUpdate: (fiber: Fiber, expirationTime: ExpirationTime) => void,
+  getPriorityContext: (
+    fiber: Fiber,
+    forceAsync: boolean,
+  ) => PriorityLevel | null,
   recalculateCurrentTime: () => ExpirationTime,
+  getExpirationTimeForPriority: (
+    currentTime: ExpirationTime,
+    priorityLevel: PriorityLevel | null,
+  ) => ExpirationTime,
 ) {
   const {
     shouldSetTextContent,
@@ -102,23 +109,24 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     memoizeProps,
     memoizeState,
     recalculateCurrentTime,
+    getExpirationTimeForPriority,
   );
 
+  // TODO: Remove this and use reconcileChildrenAtExpirationTime directly.
   function reconcileChildren(current, workInProgress, nextChildren) {
-    const priorityLevel = workInProgress.pendingWorkPriority;
-    reconcileChildrenAtPriority(
+    reconcileChildrenAtExpirationTime(
       current,
       workInProgress,
       nextChildren,
-      priorityLevel,
+      workInProgress.expirationTime,
     );
   }
 
-  function reconcileChildrenAtPriority(
+  function reconcileChildrenAtExpirationTime(
     current,
     workInProgress,
     nextChildren,
-    priorityLevel,
+    renderExpirationTime,
   ) {
     if (current === null) {
       // If this is a fresh new component that hasn't been rendered yet, we
@@ -129,7 +137,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress,
         workInProgress.child,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     } else if (current.child === workInProgress.child) {
       // If the current child is the same as the work in progress, it means that
@@ -142,7 +150,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress,
         workInProgress.child,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     } else {
       // If, on the other hand, it is already using a clone, that means we've
@@ -152,7 +160,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress,
         workInProgress.child,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     }
   }
@@ -226,7 +234,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function updateClassComponent(
     current: Fiber | null,
     workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
+    renderExpirationTime: ExpirationTime,
   ) {
     // Push context providers early to prevent context stack mismatches.
     // During mounting we don't know the child context yet as the instance doesn't exist.
@@ -238,18 +246,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       if (!workInProgress.stateNode) {
         // In the initial pass we might need to construct the instance.
         constructClassInstance(workInProgress, workInProgress.pendingProps);
-        mountClassInstance(workInProgress, priorityLevel);
+        mountClassInstance(workInProgress, renderExpirationTime);
         shouldUpdate = true;
       } else {
         invariant(false, 'Resuming work not yet implemented.');
         // In a resume, we'll already have an instance we can reuse.
-        // shouldUpdate = resumeMountClassInstance(workInProgress, priorityLevel);
+        // shouldUpdate = resumeMountClassInstance(workInProgress, renderExpirationTime);
       }
     } else {
       shouldUpdate = updateClassInstance(
         current,
         workInProgress,
-        priorityLevel,
+        renderExpirationTime,
       );
     }
     return finishClassComponent(
@@ -321,7 +329,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     pushHostContainer(workInProgress, root.containerInfo);
   }
 
-  function updateHostRoot(current, workInProgress, priorityLevel) {
+  function updateHostRoot(current, workInProgress, renderExpirationTime) {
+    const root = (workInProgress.stateNode: FiberRoot);
     pushHostRootContext(workInProgress);
     const updateQueue = workInProgress.updateQueue;
     if (updateQueue !== null) {
@@ -333,11 +342,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         null,
         prevState,
         null,
-        priorityLevel,
+        renderExpirationTime,
       );
       if (prevState === state) {
         // If the state is the same as before, that's a bailout because we had
-        // no work matching this priority.
+        // no work that expires at this time.
         resetHydrationState();
         return bailoutOnAlreadyFinishedWork(current, workInProgress);
       }
@@ -364,7 +373,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           workInProgress,
           workInProgress.child,
           element,
-          priorityLevel,
+          renderExpirationTime,
         );
       } else {
         // Otherwise reset hydration state in case we aborted and resumed another
@@ -380,7 +389,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     return bailoutOnAlreadyFinishedWork(current, workInProgress);
   }
 
-  function updateHostComponent(current, workInProgress, renderPriority) {
+  function updateHostComponent(current, workInProgress, renderExpirationTime) {
     pushHostContext(workInProgress);
 
     if (current === null) {
@@ -426,13 +435,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     // Check the host config to see if the children are offscreen/hidden.
     if (
-      renderPriority !== OffscreenPriority &&
+      renderExpirationTime !== Never &&
       !useSyncScheduling &&
       shouldDeprioritizeSubtree(type, nextProps)
     ) {
       // Down-prioritize the children.
-      workInProgress.pendingWorkPriority = OffscreenPriority;
-      // Bailout and come back to this fiber later at OffscreenPriority.
+      workInProgress.expirationTime = Never;
+      // Bailout and come back to this fiber later.
       return null;
     }
 
@@ -455,7 +464,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     return null;
   }
 
-  function mountIndeterminateComponent(current, workInProgress, priorityLevel) {
+  function mountIndeterminateComponent(
+    current,
+    workInProgress,
+    renderExpirationTime,
+  ) {
     invariant(
       current === null,
       'An indeterminate component should never have mounted. This error is ' +
@@ -490,7 +503,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // We will invalidate the child context in finishClassComponent() right after rendering.
       const hasContext = pushContextProvider(workInProgress);
       adoptClassInstance(workInProgress, value);
-      mountClassInstance(workInProgress, priorityLevel);
+      mountClassInstance(workInProgress, renderExpirationTime);
       return finishClassComponent(current, workInProgress, true, hasContext);
     } else {
       // Proceed under the assumption that this is a functional component
@@ -535,7 +548,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function updateCoroutineComponent(current, workInProgress) {
+  function updateCoroutineComponent(
+    current,
+    workInProgress,
+    renderExpirationTime,
+  ) {
     var nextCoroutine = (workInProgress.pendingProps: null | ReactCoroutine);
     if (hasContextChanged()) {
       // Normally we can bail out on props equality but if context has changed
@@ -559,30 +576,29 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     const nextChildren = nextCoroutine.children;
-    const priorityLevel = workInProgress.pendingWorkPriority;
 
-    // The following is a fork of reconcileChildrenAtPriority but using
+    // The following is a fork of reconcileChildrenAtExpirationTime but using
     // stateNode to store the child.
     if (current === null) {
       workInProgress.stateNode = mountChildFibersInPlace(
         workInProgress,
         workInProgress.stateNode,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     } else if (current.child === workInProgress.child) {
       workInProgress.stateNode = reconcileChildFibers(
         workInProgress,
         workInProgress.stateNode,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     } else {
       workInProgress.stateNode = reconcileChildFibersInPlace(
         workInProgress,
         workInProgress.stateNode,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     }
 
@@ -592,9 +608,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     return workInProgress.stateNode;
   }
 
-  function updatePortalComponent(current, workInProgress) {
+  function updatePortalComponent(
+    current,
+    workInProgress,
+    renderExpirationTime,
+  ) {
     pushHostContainer(workInProgress, workInProgress.stateNode.containerInfo);
-    const priorityLevel = workInProgress.pendingWorkPriority;
     let nextChildren = workInProgress.pendingProps;
     if (hasContextChanged()) {
       // Normally we can bail out on props equality but if context has changed
@@ -624,7 +643,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress,
         workInProgress.child,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
       memoizeProps(workInProgress, nextChildren);
     } else {
@@ -719,11 +738,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function beginWork(
     current: Fiber | null,
     workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
+    renderExpirationTime: ExpirationTime,
   ): Fiber | null {
     if (
-      workInProgress.pendingWorkPriority === NoWork ||
-      workInProgress.pendingWorkPriority > priorityLevel
+      workInProgress.expirationTime === Done ||
+      workInProgress.expirationTime > renderExpirationTime
     ) {
       return bailoutOnLowPriority(current, workInProgress);
     }
@@ -733,16 +752,24 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         return mountIndeterminateComponent(
           current,
           workInProgress,
-          priorityLevel,
+          renderExpirationTime,
         );
       case FunctionalComponent:
         return updateFunctionalComponent(current, workInProgress);
       case ClassComponent:
-        return updateClassComponent(current, workInProgress, priorityLevel);
+        return updateClassComponent(
+          current,
+          workInProgress,
+          renderExpirationTime,
+        );
       case HostRoot:
-        return updateHostRoot(current, workInProgress, priorityLevel);
+        return updateHostRoot(current, workInProgress, renderExpirationTime);
       case HostComponent:
-        return updateHostComponent(current, workInProgress, priorityLevel);
+        return updateHostComponent(
+          current,
+          workInProgress,
+          renderExpirationTime,
+        );
       case HostText:
         return updateHostText(current, workInProgress);
       case CoroutineHandlerPhase:
@@ -750,13 +777,21 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress.tag = CoroutineComponent;
       // Intentionally fall through since this is now the same.
       case CoroutineComponent:
-        return updateCoroutineComponent(current, workInProgress);
+        return updateCoroutineComponent(
+          current,
+          workInProgress,
+          renderExpirationTime,
+        );
       case YieldComponent:
         // A yield component is just a placeholder, we can just run through the
         // next one immediately.
         return null;
       case HostPortal:
-        return updatePortalComponent(current, workInProgress);
+        return updatePortalComponent(
+          current,
+          workInProgress,
+          renderExpirationTime,
+        );
       case Fragment:
         return updateFragment(current, workInProgress);
       default:
@@ -771,7 +806,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function beginFailedWork(
     current: Fiber | null,
     workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
+    renderExpirationTime: ExpirationTime,
   ) {
     // Push context providers here to avoid a push/pop context mismatch.
     switch (workInProgress.tag) {
@@ -804,8 +839,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     if (
-      workInProgress.pendingWorkPriority === NoWork ||
-      workInProgress.pendingWorkPriority > priorityLevel
+      workInProgress.expirationTime === Done ||
+      workInProgress.expirationTime > renderExpirationTime
     ) {
       return bailoutOnLowPriority(current, workInProgress);
     }
@@ -817,11 +852,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     // Unmount the current children as if the component rendered null
     const nextChildren = null;
-    reconcileChildrenAtPriority(
+    reconcileChildrenAtExpirationTime(
       current,
       workInProgress,
       nextChildren,
-      priorityLevel,
+      renderExpirationTime,
     );
 
     if (workInProgress.tag === ClassComponent) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -48,7 +48,7 @@ var {
   YieldComponent,
   Fragment,
 } = ReactTypeOfWork;
-var {Done, Never} = require('ReactFiberExpirationTime');
+var {NoWork, Never} = require('ReactFiberExpirationTime');
 var {
   PerformedWork,
   Placement,
@@ -330,7 +330,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function updateHostRoot(current, workInProgress, renderExpirationTime) {
-    const root = (workInProgress.stateNode: FiberRoot);
     pushHostRootContext(workInProgress);
     const updateQueue = workInProgress.updateQueue;
     if (updateQueue !== null) {
@@ -741,7 +740,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     renderExpirationTime: ExpirationTime,
   ): Fiber | null {
     if (
-      workInProgress.expirationTime === Done ||
+      workInProgress.expirationTime === NoWork ||
       workInProgress.expirationTime > renderExpirationTime
     ) {
       return bailoutOnLowPriority(current, workInProgress);
@@ -839,7 +838,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     if (
-      workInProgress.expirationTime === Done ||
+      workInProgress.expirationTime === NoWork ||
       workInProgress.expirationTime > renderExpirationTime
     ) {
       return bailoutOnLowPriority(current, workInProgress);

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -17,6 +17,7 @@ import type {HydrationContext} from 'ReactFiberHydrationContext';
 import type {FiberRoot} from 'ReactFiberRoot';
 import type {HostConfig} from 'ReactFiberReconciler';
 import type {PriorityLevel} from 'ReactPriorityLevel';
+import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 var {
   mountChildFibersInPlace,
@@ -73,6 +74,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   hydrationContext: HydrationContext<C, CX>,
   scheduleUpdate: (fiber: Fiber, priorityLevel: PriorityLevel) => void,
   getPriorityContext: (fiber: Fiber, forceAsync: boolean) => PriorityLevel,
+  recalculateCurrentTime: () => ExpirationTime,
 ) {
   const {
     shouldSetTextContent,
@@ -99,6 +101,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     getPriorityContext,
     memoizeProps,
     memoizeState,
+    recalculateCurrentTime,
   );
 
   function reconcileChildren(current, workInProgress, nextChildren) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -362,6 +362,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
       const element = state.element;
       if (
+        root.hydrate &&
         (current === null || current.child === null) &&
         enterHydrationState(workInProgress)
       ) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -330,7 +330,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function updateHostRoot(current, workInProgress, renderExpirationTime) {
+    const root = (workInProgress.stateNode: FiberRoot);
     pushHostRootContext(workInProgress);
+    if (root.completedAt === renderExpirationTime) {
+      // The root is already complete. Bail out and commit.
+      // TODO: This is a limited version of resuming that only applies to
+      // the root, to account for the pathological case where a completed
+      // root must be completely restarted before it can commit. Once we
+      // implement resuming for real, this special branch shouldn't
+      // be neccessary.
+      return null;
+    }
+
     const updateQueue = workInProgress.updateQueue;
     if (updateQueue !== null) {
       const prevState = workInProgress.memoizedState;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -16,7 +16,6 @@ import type {HostContext} from 'ReactFiberHostContext';
 import type {HydrationContext} from 'ReactFiberHydrationContext';
 import type {FiberRoot} from 'ReactFiberRoot';
 import type {HostConfig} from 'ReactFiberReconciler';
-import type {PriorityLevel} from 'ReactPriorityLevel';
 import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 var {
@@ -72,16 +71,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext: HostContext<C, CX>,
   hydrationContext: HydrationContext<C, CX>,
-  scheduleUpdate: (fiber: Fiber, expirationTime: ExpirationTime) => void,
-  getPriorityContext: (
+  scheduleUpdate: (
     fiber: Fiber,
-    forceAsync: boolean,
-  ) => PriorityLevel | null,
-  recalculateCurrentTime: () => ExpirationTime,
-  getExpirationTimeForPriority: (
-    currentTime: ExpirationTime,
-    priorityLevel: PriorityLevel | null,
-  ) => ExpirationTime,
+    partialState: mixed,
+    callback: (() => mixed) | null,
+    isReplace: boolean,
+    isForced: boolean,
+  ) => void,
 ) {
   const {
     shouldSetTextContent,
@@ -103,14 +99,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     mountClassInstance,
     // resumeMountClassInstance,
     updateClassInstance,
-  } = ReactFiberClassComponent(
-    scheduleUpdate,
-    getPriorityContext,
-    memoizeProps,
-    memoizeState,
-    recalculateCurrentTime,
-    getExpirationTimeForPriority,
-  );
+  } = ReactFiberClassComponent(scheduleUpdate, memoizeProps, memoizeState);
 
   // TODO: Remove this and use reconcileChildrenAtExpirationTime directly.
   function reconcileChildren(current, workInProgress, nextChildren) {

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -78,11 +78,18 @@ if (__DEV__) {
 }
 
 module.exports = function(
-  scheduleUpdate: (fiber: Fiber, priorityLevel: PriorityLevel) => void,
-  getPriorityContext: (fiber: Fiber, forceAsync: boolean) => PriorityLevel,
+  scheduleUpdate: (fiber: Fiber, expirationTime: ExpirationTime) => void,
+  getPriorityContext: (
+    fiber: Fiber,
+    forceAsync: boolean,
+  ) => PriorityLevel | null,
   memoizeProps: (workInProgress: Fiber, props: any) => void,
   memoizeState: (workInProgress: Fiber, state: any) => void,
   recalculateCurrentTime: () => ExpirationTime,
+  getExpirationTimeForPriority: (
+    currentTime: ExpirationTime,
+    priorityLevel: PriorityLevel | null,
+  ) => ExpirationTime,
 ) {
   // Class component state updater
   const updater = {
@@ -91,34 +98,66 @@ module.exports = function(
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
       const currentTime = recalculateCurrentTime();
+      const expirationTime = getExpirationTimeForPriority(
+        currentTime,
+        priorityLevel,
+      );
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'setState');
       }
-      addUpdate(fiber, partialState, callback, priorityLevel, currentTime);
-      scheduleUpdate(fiber, priorityLevel);
+      addUpdate(
+        fiber,
+        partialState,
+        callback,
+        priorityLevel,
+        expirationTime,
+        currentTime,
+      );
+      scheduleUpdate(fiber, expirationTime);
     },
     enqueueReplaceState(instance, state, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
       const currentTime = recalculateCurrentTime();
+      const expirationTime = getExpirationTimeForPriority(
+        currentTime,
+        priorityLevel,
+      );
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'replaceState');
       }
-      addReplaceUpdate(fiber, state, callback, priorityLevel, currentTime);
-      scheduleUpdate(fiber, priorityLevel);
+      addReplaceUpdate(
+        fiber,
+        state,
+        callback,
+        priorityLevel,
+        expirationTime,
+        currentTime,
+      );
+      scheduleUpdate(fiber, expirationTime);
     },
     enqueueForceUpdate(instance, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
       const currentTime = recalculateCurrentTime();
+      const expirationTime = getExpirationTimeForPriority(
+        currentTime,
+        priorityLevel,
+      );
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'forceUpdate');
       }
-      addForceUpdate(fiber, callback, priorityLevel, currentTime);
-      scheduleUpdate(fiber, priorityLevel);
+      addForceUpdate(
+        fiber,
+        callback,
+        priorityLevel,
+        expirationTime,
+        currentTime,
+      );
+      scheduleUpdate(fiber, expirationTime);
     },
   };
 
@@ -388,7 +427,7 @@ module.exports = function(
   // Invokes the mount life-cycles on a previously never rendered instance.
   function mountClassInstance(
     workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
+    renderExpirationTime: ExpirationTime,
   ): void {
     const current = workInProgress.alternate;
 
@@ -435,7 +474,7 @@ module.exports = function(
           instance,
           state,
           props,
-          priorityLevel,
+          renderExpirationTime,
         );
       }
     }
@@ -553,7 +592,7 @@ module.exports = function(
   function updateClassInstance(
     current: Fiber,
     workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
+    renderExpirationTime: ExpirationTime,
   ): boolean {
     const instance = workInProgress.stateNode;
     resetInputPointers(workInProgress, instance);
@@ -602,7 +641,7 @@ module.exports = function(
         instance,
         oldState,
         newProps,
-        priorityLevel,
+        renderExpirationTime,
       );
     } else {
       newState = oldState;

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -12,6 +12,7 @@
 
 import type {Fiber} from 'ReactFiber';
 import type {PriorityLevel} from 'ReactPriorityLevel';
+import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 var {Update} = require('ReactTypeOfSideEffect');
 
@@ -81,6 +82,7 @@ module.exports = function(
   getPriorityContext: (fiber: Fiber, forceAsync: boolean) => PriorityLevel,
   memoizeProps: (workInProgress: Fiber, props: any) => void,
   memoizeState: (workInProgress: Fiber, state: any) => void,
+  recalculateCurrentTime: () => ExpirationTime,
 ) {
   // Class component state updater
   const updater = {
@@ -88,31 +90,34 @@ module.exports = function(
     enqueueSetState(instance, partialState, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
+      const currentTime = recalculateCurrentTime();
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'setState');
       }
-      addUpdate(fiber, partialState, callback, priorityLevel);
+      addUpdate(fiber, partialState, callback, priorityLevel, currentTime);
       scheduleUpdate(fiber, priorityLevel);
     },
     enqueueReplaceState(instance, state, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
+      const currentTime = recalculateCurrentTime();
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'replaceState');
       }
-      addReplaceUpdate(fiber, state, callback, priorityLevel);
+      addReplaceUpdate(fiber, state, callback, priorityLevel, currentTime);
       scheduleUpdate(fiber, priorityLevel);
     },
     enqueueForceUpdate(instance, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
+      const currentTime = recalculateCurrentTime();
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'forceUpdate');
       }
-      addForceUpdate(fiber, callback, priorityLevel);
+      addForceUpdate(fiber, callback, priorityLevel, currentTime);
       scheduleUpdate(fiber, priorityLevel);
     },
   };

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -26,9 +26,7 @@ var {
   isContextConsumer,
 } = require('ReactFiberContext');
 var {
-  addUpdate,
-  addReplaceUpdate,
-  addForceUpdate,
+  insertUpdateIntoFiber,
   beginUpdateQueue,
 } = require('ReactFiberUpdateQueue');
 var {hasContextChanged} = require('ReactFiberContext');
@@ -106,14 +104,17 @@ module.exports = function(
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'setState');
       }
-      addUpdate(
-        fiber,
-        partialState,
-        callback,
+      const update = {
         priorityLevel,
         expirationTime,
-        currentTime,
-      );
+        partialState,
+        callback,
+        isReplace: false,
+        isForced: false,
+        isTopLevelUnmount: false,
+        next: null,
+      };
+      insertUpdateIntoFiber(fiber, update, currentTime);
       scheduleUpdate(fiber, expirationTime);
     },
     enqueueReplaceState(instance, state, callback) {
@@ -128,14 +129,17 @@ module.exports = function(
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'replaceState');
       }
-      addReplaceUpdate(
-        fiber,
-        state,
-        callback,
+      const update = {
         priorityLevel,
         expirationTime,
-        currentTime,
-      );
+        partialState: state,
+        callback,
+        isReplace: true,
+        isForced: false,
+        isTopLevelUnmount: false,
+        next: null,
+      };
+      insertUpdateIntoFiber(fiber, update, currentTime);
       scheduleUpdate(fiber, expirationTime);
     },
     enqueueForceUpdate(instance, callback) {
@@ -150,13 +154,17 @@ module.exports = function(
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'forceUpdate');
       }
-      addForceUpdate(
-        fiber,
-        callback,
+      const update = {
         priorityLevel,
         expirationTime,
-        currentTime,
-      );
+        partialState: null,
+        callback,
+        isReplace: false,
+        isForced: true,
+        isTopLevelUnmount: false,
+        next: null,
+      };
+      insertUpdateIntoFiber(fiber, update, currentTime);
       scheduleUpdate(fiber, expirationTime);
     },
   };

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -22,7 +22,6 @@ var {
   HostPortal,
   CoroutineComponent,
 } = ReactTypeOfWork;
-var {commitCallbacks} = require('ReactFiberUpdateQueue');
 var {onCommitUnmount} = require('ReactFiberDevToolsHook');
 var {
   invokeGuardedCallback,
@@ -488,6 +487,19 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
+  function commitCallbacks(callbackList, context) {
+    for (let i = 0; i < callbackList.length; i++) {
+      const callback = callbackList[i];
+      invariant(
+        typeof callback === 'function',
+        'Invalid argument passed as callback. Expected a function. Instead ' +
+          'received: %s',
+        callback,
+      );
+      callback.call(context);
+    }
+  }
+
   function commitLifeCycles(current: Fiber | null, finishedWork: Fiber): void {
     switch (finishedWork.tag) {
       case ClassComponent: {
@@ -521,15 +533,27 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           finishedWork.effectTag & Callback &&
           finishedWork.updateQueue !== null
         ) {
-          commitCallbacks(finishedWork, finishedWork.updateQueue, instance);
+          const updateQueue = finishedWork.updateQueue;
+          if (updateQueue.callbackList !== null) {
+            // Set the list to null to make sure they don't get called more than once.
+            const callbackList = updateQueue.callbackList;
+            updateQueue.callbackList = null;
+            commitCallbacks(callbackList, instance);
+          }
         }
         return;
       }
       case HostRoot: {
         const updateQueue = finishedWork.updateQueue;
-        if (updateQueue !== null) {
-          const instance = finishedWork.child && finishedWork.child.stateNode;
-          commitCallbacks(finishedWork, updateQueue, instance);
+        if (updateQueue !== null && updateQueue.callbackList !== null) {
+          // Set the list to null to make sure they don't get called more
+          // than once.
+          const callbackList = updateQueue.callbackList;
+          updateQueue.callbackList = null;
+          const instance = finishedWork.child !== null
+            ? finishedWork.child.stateNode
+            : null;
+          commitCallbacks(callbackList, instance);
         }
         return;
       }

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -18,6 +18,7 @@ import type {HydrationContext} from 'ReactFiberHydrationContext';
 import type {FiberRoot} from 'ReactFiberRoot';
 import type {HostConfig} from 'ReactFiberReconciler';
 
+var {topLevelBlockedAt} = require('ReactFiberRoot');
 var {reconcileChildFibers} = require('ReactChildFiber');
 var {
   popContextProvider,
@@ -40,7 +41,7 @@ var {
   Fragment,
 } = ReactTypeOfWork;
 var {Placement, Ref, Update} = ReactTypeOfSideEffect;
-var {Never} = ReactFiberExpirationTime;
+var {NoWork, Never} = ReactFiberExpirationTime;
 
 var invariant = require('fbjs/lib/invariant');
 
@@ -219,6 +220,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           // TODO: Delete this when we delete isMounted and findDOMNode.
           workInProgress.effectTag &= ~Placement;
         }
+
+        // Check if the root is blocked by a top-level update.
+        const blockedAt = topLevelBlockedAt(fiberRoot);
+        fiberRoot.isBlocked =
+          blockedAt !== NoWork && blockedAt <= renderExpirationTime;
         return null;
       }
       case HostComponent: {

--- a/src/renderers/shared/fiber/ReactFiberExpirationTime.js
+++ b/src/renderers/shared/fiber/ReactFiberExpirationTime.js
@@ -12,7 +12,7 @@
 
 import type {PriorityLevel} from 'ReactPriorityLevel';
 const {
-  NoWork,
+  NoWork: NoWorkPriority,
   SynchronousPriority,
   TaskPriority,
   HighPriority,
@@ -25,26 +25,27 @@ const invariant = require('fbjs/lib/invariant');
 // TODO: Use an opaque type once ESLint et al support the syntax
 export type ExpirationTime = number;
 
-const Done = 0;
+const NoWork = 0;
 const Sync = 1;
 const Task = 2;
-const Never = Number.MAX_SAFE_INTEGER;
+const Never = Math.pow(2, 31) - 1; // Max int32
 
 const UNIT_SIZE = 10;
 const MAGIC_NUMBER_OFFSET = 10;
 
-exports.Done = Done;
+exports.NoWork = NoWork;
 exports.Never = Never;
 
 // 1 unit of expiration time represents 10ms.
 function msToExpirationTime(ms: number): ExpirationTime {
-  // Always add an offset so that we don't clash with the magic number for Done.
-  return Math.round(ms / UNIT_SIZE) + MAGIC_NUMBER_OFFSET;
+  // Always add an offset so that we don't clash with the magic number for NoWork.
+  return ((ms / UNIT_SIZE) | 0) + MAGIC_NUMBER_OFFSET;
 }
 exports.msToExpirationTime = msToExpirationTime;
 
 function ceiling(num: number, precision: number): number {
-  return Math.ceil(Math.ceil(num * precision) / precision);
+  // return Math.ceil(Math.ceil(num * precision) / precision);
+  return (((((num * precision) | 0) + 1) | 0) + 1) / precision;
 }
 
 function bucket(
@@ -69,7 +70,7 @@ function priorityToExpirationTime(
 ): ExpirationTime {
   switch (priorityLevel) {
     case NoWork:
-      return Done;
+      return NoWorkPriority;
     case SynchronousPriority:
       return Sync;
     case TaskPriority:
@@ -103,7 +104,7 @@ function expirationTimeToPriorityLevel(
 ): PriorityLevel {
   // First check for magic values
   switch (expirationTime) {
-    case Done:
+    case NoWorkPriority:
       return NoWork;
     case Sync:
       return SynchronousPriority;

--- a/src/renderers/shared/fiber/ReactFiberExpirationTime.js
+++ b/src/renderers/shared/fiber/ReactFiberExpirationTime.js
@@ -28,13 +28,15 @@ export type ExpirationTime = number;
 const Done = 0;
 exports.Done = Done;
 
+const MAGIC_NUMBER_OFFSET = 2;
+
 const Never = Number.MAX_SAFE_INTEGER;
 exports.Never = Never;
 
 // 1 unit of expiration time represents 10ms.
 function msToExpirationTime(ms: number): ExpirationTime {
-  // Always add 1 so that we don't clash with the magic number for Done.
-  return Math.round(ms / 10) + 1;
+  // Always add an offset so that we don't clash with the magic number for Done.
+  return Math.round(ms / 10) + MAGIC_NUMBER_OFFSET;
 }
 exports.msToExpirationTime = msToExpirationTime;
 
@@ -56,7 +58,7 @@ function priorityToExpirationTime(
       return Done;
     case SynchronousPriority:
       // Return a number lower than the current time, but higher than Done.
-      return 1;
+      return MAGIC_NUMBER_OFFSET - 1;
     case TaskPriority:
       // Return the current time, so that this work completes in this batch.
       return currentTime;
@@ -69,6 +71,7 @@ function priorityToExpirationTime(
     case OffscreenPriority:
       return Never;
     default:
+      console.log(priorityLevel);
       invariant(
         false,
         'Switch statement should be exhuastive. ' +
@@ -102,3 +105,11 @@ function expirationTimeToPriorityLevel(
   return LowPriority;
 }
 exports.expirationTimeToPriorityLevel = expirationTimeToPriorityLevel;
+
+function earlierExpirationTime(
+  t1: ExpirationTime,
+  t2: ExpirationTime,
+): ExpirationTime {
+  return t1 !== Done && (t2 === Done || t2 > t1) ? t1 : t2;
+}
+exports.earlierExpirationTime = earlierExpirationTime;

--- a/src/renderers/shared/fiber/ReactFiberExpirationTime.js
+++ b/src/renderers/shared/fiber/ReactFiberExpirationTime.js
@@ -121,11 +121,3 @@ function expirationTimeToPriorityLevel(
   return LowPriority;
 }
 exports.expirationTimeToPriorityLevel = expirationTimeToPriorityLevel;
-
-function earlierExpirationTime(
-  t1: ExpirationTime,
-  t2: ExpirationTime,
-): ExpirationTime {
-  return t1 !== Done && (t2 === Done || t2 > t1) ? t1 : t2;
-}
-exports.earlierExpirationTime = earlierExpirationTime;

--- a/src/renderers/shared/fiber/ReactFiberExpirationTime.js
+++ b/src/renderers/shared/fiber/ReactFiberExpirationTime.js
@@ -26,11 +26,13 @@ const invariant = require('fbjs/lib/invariant');
 export type ExpirationTime = number;
 
 const Done = 0;
-exports.Done = Done;
-
-const MAGIC_NUMBER_OFFSET = 2;
-
+const Sync = 1;
+const Task = 2;
 const Never = Number.MAX_SAFE_INTEGER;
+
+const MAGIC_NUMBER_OFFSET = 10;
+
+exports.Done = Done;
 exports.Never = Never;
 
 // 1 unit of expiration time represents 10ms.
@@ -57,11 +59,9 @@ function priorityToExpirationTime(
     case NoWork:
       return Done;
     case SynchronousPriority:
-      // Return a number lower than the current time, but higher than Done.
-      return MAGIC_NUMBER_OFFSET - 1;
+      return Sync;
     case TaskPriority:
-      // Return the current time, so that this work completes in this batch.
-      return currentTime;
+      return Task;
     case HighPriority:
       // Should complete within ~100ms. 120ms max.
       return msToExpirationTime(ceiling(100, 20));
@@ -71,7 +71,6 @@ function priorityToExpirationTime(
     case OffscreenPriority:
       return Never;
     default:
-      console.log(priorityLevel);
       invariant(
         false,
         'Switch statement should be exhuastive. ' +
@@ -89,16 +88,19 @@ function expirationTimeToPriorityLevel(
   expirationTime: ExpirationTime,
 ): PriorityLevel {
   // First check for magic values
-  if (expirationTime === Done) {
-    return NoWork;
+  switch (expirationTime) {
+    case Done:
+      return NoWork;
+    case Sync:
+      return SynchronousPriority;
+    case Task:
+      return TaskPriority;
+    case Never:
+      return OffscreenPriority;
+    default:
+      break;
   }
-  if (expirationTime === Never) {
-    return OffscreenPriority;
-  }
-  if (expirationTime < currentTime) {
-    return SynchronousPriority;
-  }
-  if (expirationTime === currentTime) {
+  if (expirationTime <= currentTime) {
     return TaskPriority;
   }
   // TODO: We don't currently distinguish between high and low priority.

--- a/src/renderers/shared/fiber/ReactFiberExpirationTime.js
+++ b/src/renderers/shared/fiber/ReactFiberExpirationTime.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @providesModule ReactFiberExpirationTime
+ * @flow
+ */
+
+'use strict';
+
+import type {PriorityLevel} from 'ReactPriorityLevel';
+const {
+  NoWork,
+  SynchronousPriority,
+  TaskPriority,
+  HighPriority,
+  LowPriority,
+  OffscreenPriority,
+} = require('ReactPriorityLevel');
+
+const invariant = require('fbjs/lib/invariant');
+
+// TODO: Use an opaque type once ESLint et al support the syntax
+export type ExpirationTime = number;
+
+const Done = 0;
+exports.Done = Done;
+
+const Never = Number.MAX_SAFE_INTEGER;
+exports.Never = Never;
+
+// 1 unit of expiration time represents 10ms.
+function msToExpirationTime(ms: number): ExpirationTime {
+  // Always add 1 so that we don't clash with the magic number for Done.
+  return Math.round(ms / 10) + 1;
+}
+exports.msToExpirationTime = msToExpirationTime;
+
+function ceiling(time: ExpirationTime, precision: number): ExpirationTime {
+  return Math.ceil(Math.ceil(time * precision) / precision);
+}
+
+// Given the current clock time and a priority level, returns an expiration time
+// that represents a point in the future by which some work should complete.
+// The lower the priority, the further out the expiration time. We use rounding
+// to batch like updates together. The further out the expiration time, the
+// more we want to batch, so we use a larger precision when rounding.
+function priorityToExpirationTime(
+  currentTime: ExpirationTime,
+  priorityLevel: PriorityLevel,
+): ExpirationTime {
+  switch (priorityLevel) {
+    case NoWork:
+      return Done;
+    case SynchronousPriority:
+      // Return a number lower than the current time, but higher than Done.
+      return 1;
+    case TaskPriority:
+      // Return the current time, so that this work completes in this batch.
+      return currentTime;
+    case HighPriority:
+      // Should complete within ~100ms. 120ms max.
+      return msToExpirationTime(ceiling(100, 20));
+    case LowPriority:
+      // Should complete within ~1000ms. 1200ms max.
+      return msToExpirationTime(ceiling(1000, 200));
+    case OffscreenPriority:
+      return Never;
+    default:
+      invariant(
+        false,
+        'Switch statement should be exhuastive. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
+  }
+}
+exports.priorityToExpirationTime = priorityToExpirationTime;
+
+// Given the current clock time and an expiration time, returns the
+// corresponding priority level. The more time has advanced, the higher the
+// priority level.
+function expirationTimeToPriorityLevel(
+  currentTime: ExpirationTime,
+  expirationTime: ExpirationTime,
+): PriorityLevel {
+  // First check for magic values
+  if (expirationTime === Done) {
+    return NoWork;
+  }
+  if (expirationTime === Never) {
+    return OffscreenPriority;
+  }
+  if (expirationTime < currentTime) {
+    return SynchronousPriority;
+  }
+  if (expirationTime === currentTime) {
+    return TaskPriority;
+  }
+  // TODO: We don't currently distinguish between high and low priority.
+  return LowPriority;
+}
+exports.expirationTimeToPriorityLevel = expirationTimeToPriorityLevel;

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -122,6 +122,8 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
   prepareForCommit(): void,
   resetAfterCommit(): void,
 
+  now(): number,
+
   // Optional hydration
   canHydrateInstance?: (instance: I | TI, type: T, props: P) => boolean,
   canHydrateTextInstance?: (instance: I | TI, text: string) => boolean,
@@ -235,6 +237,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   var {
     scheduleUpdate,
     getPriorityContext,
+    recalculateCurrentTime,
     batchedUpdates,
     unbatchedUpdates,
     flushSync,
@@ -274,6 +277,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       element.type.prototype != null &&
       (element.type.prototype: any).unstable_isAsyncReactComponent === true;
     const priorityLevel = getPriorityContext(current, forceAsync);
+    const currentTime = recalculateCurrentTime();
     const nextState = {element};
     callback = callback === undefined ? null : callback;
     if (__DEV__) {
@@ -284,7 +288,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         callback,
       );
     }
-    addTopLevelUpdate(current, nextState, callback, priorityLevel);
+    addTopLevelUpdate(current, nextState, callback, priorityLevel, currentTime);
     scheduleUpdate(current, priorityLevel);
   }
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -361,7 +361,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       const blockUpdate = {
         priorityLevel: null,
         expirationTime,
-        partialState: nextState,
+        partialState: null,
         callback: null,
         isReplace: false,
         isForced: false,

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -237,6 +237,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   var {
     scheduleUpdate,
     getPriorityContext,
+    getExpirationTimeForPriority,
     recalculateCurrentTime,
     batchedUpdates,
     unbatchedUpdates,
@@ -278,6 +279,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       (element.type.prototype: any).unstable_isAsyncReactComponent === true;
     const priorityLevel = getPriorityContext(current, forceAsync);
     const currentTime = recalculateCurrentTime();
+    const expirationTime = getExpirationTimeForPriority(
+      currentTime,
+      priorityLevel,
+    );
     const nextState = {element};
     callback = callback === undefined ? null : callback;
     if (__DEV__) {
@@ -288,8 +293,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         callback,
       );
     }
-    addTopLevelUpdate(current, nextState, callback, priorityLevel, currentTime);
-    scheduleUpdate(current, priorityLevel);
+    addTopLevelUpdate(
+      current,
+      nextState,
+      callback,
+      priorityLevel,
+      expirationTime,
+      currentTime,
+    );
+    scheduleUpdate(current, expirationTime);
   }
 
   return {

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -257,7 +257,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   var {getPublicInstance} = config;
 
   var {
-    scheduleUpdate,
+    scheduleWork,
     scheduleCompletionCallback,
     getPriorityContext,
     getExpirationTimeForPriority,
@@ -371,7 +371,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       insertUpdateIntoQueue(root.blockers, block, currentTime);
     }
 
-    scheduleUpdate(current, expirationTime);
+    scheduleWork(current, expirationTime);
     return expirationTime;
   }
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -355,8 +355,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     if (isPrerender) {
       // Block the root from committing at this expiration time.
-      if (root.blockers === null) {
-        root.blockers = createUpdateQueue();
+      if (root.topLevelBlockers === null) {
+        root.topLevelBlockers = createUpdateQueue();
       }
       const block = {
         priorityLevel: null,
@@ -368,7 +368,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         isTopLevelUnmount: false,
         next: null,
       };
-      insertUpdateIntoQueue(root.blockers, block, currentTime);
+      insertUpdateIntoQueue(root.topLevelBlockers, block, currentTime);
     }
 
     scheduleWork(current, expirationTime);
@@ -382,11 +382,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   WorkNode.prototype.commit = function() {
     const root = this._reactRootContainer;
     const expirationTime = this._expirationTime;
-    const blockers = root.blockers;
-    if (blockers === null) {
+    const topLevelBlockers = root.topLevelBlockers;
+    if (topLevelBlockers === null) {
       return;
     }
-    processUpdateQueue(blockers, null, null, null, expirationTime);
+    processUpdateQueue(topLevelBlockers, null, null, null, expirationTime);
     expireWork(root, expirationTime);
   };
   WorkNode.prototype.then = function(callback) {

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -387,7 +387,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       return;
     }
     processUpdateQueue(blockers, null, null, null, expirationTime);
-    expireWork(expirationTime);
+    expireWork(root, expirationTime);
   };
   WorkNode.prototype.then = function(callback) {
     const root = this._reactRootContainer;

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -20,7 +20,9 @@ var ReactFeatureFlags = require('ReactFeatureFlags');
 
 var {
   insertUpdateIntoFiber,
+  insertUpdateIntoQueue,
   createUpdateQueue,
+  processUpdateQueue,
 } = require('ReactFiberUpdateQueue');
 
 var {
@@ -58,7 +60,7 @@ type Awaitable<T> = {
   then(resolve: (result: T) => mixed): void,
 };
 
-type Work = Awaitable<void> & {
+export type Work = Awaitable<void> & {
   commit(): void,
 
   _reactRootContainer: *,
@@ -208,12 +210,17 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
 
 export type Reconciler<C, I, TI> = {
   createContainer(containerInfo: C): OpaqueRoot,
+  updateRoot(
+    element: ReactNodeList,
+    container: OpaqueRoot,
+    parentComponent: ?React$Component<any, any>,
+  ): Work,
   updateContainer(
     element: ReactNodeList,
     container: OpaqueRoot,
     parentComponent: ?React$Component<any, any>,
     callback: ?Function,
-  ): Work,
+  ): void,
   batchedUpdates<A>(fn: () => A): A,
   unbatchedUpdates<A>(fn: () => A): A,
   flushSync<A>(fn: () => A): A,
@@ -255,6 +262,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     getPriorityContext,
     getExpirationTimeForPriority,
     recalculateCurrentTime,
+    expireWork,
     batchedUpdates,
     unbatchedUpdates,
     flushSync,
@@ -262,8 +270,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   } = ReactFiberScheduler(config);
 
   function scheduleTopLevelUpdate(
-    current: Fiber,
+    root: FiberRoot,
     element: ReactNodeList,
+    currentTime: ExpirationTime,
+    isPrerender: boolean,
     callback: ?Function,
   ): ExpirationTime {
     if (__DEV__) {
@@ -284,6 +294,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     }
 
+    const current = root.current;
+
     // Check if the top-level element is an async wrapper component. If so, treat
     // updates to the root as async. This is a bit weird but lets us avoid a separate
     // `renderAsync` API.
@@ -294,7 +306,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       element.type.prototype != null &&
       (element.type.prototype: any).unstable_isAsyncReactComponent === true;
     const priorityLevel = getPriorityContext(current, forceAsync);
-    const currentTime = recalculateCurrentTime();
     const expirationTime = getExpirationTimeForPriority(
       currentTime,
       priorityLevel,
@@ -342,6 +353,24 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     }
 
+    if (isPrerender) {
+      // Block the root from committing at this expiration time.
+      if (root.blockers === null) {
+        root.blockers = createUpdateQueue();
+      }
+      const blockUpdate = {
+        priorityLevel: null,
+        expirationTime,
+        partialState: nextState,
+        callback: null,
+        isReplace: false,
+        isForced: false,
+        isTopLevelUnmount: false,
+        next: null,
+      };
+      insertUpdateIntoQueue(root.blockers, blockUpdate, currentTime);
+    }
+
     scheduleUpdate(current, expirationTime);
     return expirationTime;
   }
@@ -350,13 +379,38 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     this._reactRootContainer = root;
     this._expirationTime = expirationTime;
   }
-  WorkNode.prototype.commit = function() {};
-  WorkNode.prototype.then = function(resolve) {
-    // const fiber = this._reactRootContainer.current;
-    // const expirationTime = this._expirationTime;
-    // const currentTime = recalculateCurrentTime();
-    // addCallback(fiber, resolve, null, expirationTime, currentTime);
-    // scheduleUpdate(fiber, expirationTime);
+  WorkNode.prototype.commit = function() {
+    const root = this._reactRootContainer;
+    const expirationTime = this._expirationTime;
+    const blockers = root.blockers;
+    if (blockers === null) {
+      return;
+    }
+    processUpdateQueue(blockers, null, null, null, expirationTime);
+    expireWork(expirationTime);
+  };
+  WorkNode.prototype.then = function(callback) {
+    const root = this._reactRootContainer;
+    const expirationTime = this._expirationTime;
+
+    // Add callback to queue of callbacks on the root. It will be called once
+    // the root completes at the corresponding expiration time.
+    const update = {
+      priorityLevel: null,
+      expirationTime,
+      partialState: null,
+      callback,
+      isReplace: false,
+      isForced: false,
+      isTopLevelUnmount: false,
+      next: null,
+    };
+    const currentTime = recalculateCurrentTime();
+    if (root.completionCallbacks === null) {
+      root.completionCallbacks = createUpdateQueue();
+    }
+    insertUpdateIntoQueue(root.completionCallbacks, update, currentTime);
+    scheduleUpdate(root.current, expirationTime);
   };
 
   return {
@@ -368,8 +422,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       element: ReactNodeList,
       container: OpaqueRoot,
       parentComponent: ?React$Component<any, any>,
-      didComplete: ?Function,
-    ) {
+    ): Work {
       const current = container.current;
 
       if (__DEV__) {
@@ -391,14 +444,19 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         container.pendingContext = context;
       }
 
-      const expirationTime = scheduleTopLevelUpdate(current, element);
+      const currentTime = recalculateCurrentTime();
+      const expirationTime = scheduleTopLevelUpdate(
+        container,
+        element,
+        currentTime,
+        true,
+        null,
+      );
 
       let completionCallbacks = container.completionCallbacks;
       if (completionCallbacks === null) {
         completionCallbacks = createUpdateQueue();
       }
-
-      // TODO: Add didComplete to root's completionCallbacks
 
       return new WorkNode(container, expirationTime);
     },
@@ -408,7 +466,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       container: OpaqueRoot,
       parentComponent: ?React$Component<any, any>,
       callback: ?Function,
-    ): Work {
+    ): void {
       // TODO: If this is a nested container, this won't be the root.
       const current = container.current;
 
@@ -431,7 +489,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         container.pendingContext = context;
       }
 
-      scheduleTopLevelUpdate(current, element, callback);
+      const currentTime = recalculateCurrentTime();
+      scheduleTopLevelUpdate(container, element, currentTime, false, callback);
     },
 
     batchedUpdates,

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -41,6 +41,8 @@ export type FiberRoot = {
   // Top context object, used by renderSubtreeIntoContainer
   context: Object | null,
   pendingContext: Object | null,
+  // Determines if we should attempt to hydrate on the initial mount
+  hydrate: boolean,
 };
 
 exports.isRootBlocked = function(
@@ -70,6 +72,7 @@ exports.createFiberRoot = function(containerInfo: any): FiberRoot {
     nextScheduledRoot: null,
     context: null,
     pendingContext: null,
+    hydrate: true,
   };
   uninitializedFiber.stateNode = root;
   return root;

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {Fiber} from 'ReactFiber';
+import type {UpdateQueue} from 'ReactFiberUpdateQueue';
 import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 const {createHostRootFiber} = require('ReactFiber');
@@ -25,6 +26,9 @@ export type FiberRoot = {
   isScheduled: boolean,
   // The time at which this root completed.
   completedAt: ExpirationTime,
+  // A queue of callbacks that fire once their corresponding expiration time
+  // has completed. Only fired once.
+  completionCallbacks: UpdateQueue,
   // The work schedule is a linked list.
   nextScheduledRoot: FiberRoot | null,
   // Top context object, used by renderSubtreeIntoContainer
@@ -51,6 +55,7 @@ exports.createFiberRoot = function(containerInfo: any): FiberRoot {
     containerInfo: containerInfo,
     isScheduled: false,
     completedAt: NoWork,
+    completionCallbacks: null,
     nextScheduledRoot: null,
     context: null,
     pendingContext: null,

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -33,6 +33,9 @@ export type FiberRoot = {
   // A queue of callbacks that fire once their corresponding expiration time
   // has completed. Only fired once.
   completionCallbacks: UpdateQueue<null> | null,
+  // When set, indicates that all work in this tree with this time or earlier
+  // should be flushed by the end of the batch, as if it has task priority.
+  forceExpire: null | ExpirationTime,
   // The work schedule is a linked list.
   nextScheduledRoot: FiberRoot | null,
   // Top context object, used by renderSubtreeIntoContainer
@@ -63,6 +66,7 @@ exports.createFiberRoot = function(containerInfo: any): FiberRoot {
     completedAt: NoWork,
     blockers: null,
     completionCallbacks: null,
+    forceExpire: null,
     nextScheduledRoot: null,
     context: null,
     pendingContext: null,

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -15,6 +15,7 @@ import type {UpdateQueue} from 'ReactFiberUpdateQueue';
 import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 const {createHostRootFiber} = require('ReactFiber');
+const {getUpdateQueueExpirationTime} = require('ReactFiberUpdateQueue');
 const {NoWork} = require('ReactFiberExpirationTime');
 
 export type FiberRoot = {
@@ -26,9 +27,12 @@ export type FiberRoot = {
   isScheduled: boolean,
   // The time at which this root completed.
   completedAt: ExpirationTime,
+  // A queue that represents times at which this root is blocked
+  // from committing.
+  blockers: UpdateQueue<null> | null,
   // A queue of callbacks that fire once their corresponding expiration time
   // has completed. Only fired once.
-  completionCallbacks: UpdateQueue,
+  completionCallbacks: UpdateQueue<null> | null,
   // The work schedule is a linked list.
   nextScheduledRoot: FiberRoot | null,
   // Top context object, used by renderSubtreeIntoContainer
@@ -36,14 +40,16 @@ export type FiberRoot = {
   pendingContext: Object | null,
 };
 
-// Indicates whether the root is blocked from committing at a particular
-// expiration time.
 exports.isRootBlocked = function(
   root: FiberRoot,
-  time: ExpirationTime,
-): boolean {
-  // TODO: Implementation
-  return false;
+  expirationTime: ExpirationTime,
+) {
+  const blockers = root.blockers;
+  if (blockers === null) {
+    return false;
+  }
+  const blockedAt = getUpdateQueueExpirationTime(blockers);
+  return blockedAt !== NoWork && blockedAt <= expirationTime;
 };
 
 exports.createFiberRoot = function(containerInfo: any): FiberRoot {
@@ -55,6 +61,7 @@ exports.createFiberRoot = function(containerInfo: any): FiberRoot {
     containerInfo: containerInfo,
     isScheduled: false,
     completedAt: NoWork,
+    blockers: null,
     completionCallbacks: null,
     nextScheduledRoot: null,
     context: null,

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -11,8 +11,10 @@
 'use strict';
 
 import type {Fiber} from 'ReactFiber';
+import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 const {createHostRootFiber} = require('ReactFiber');
+const {NoWork} = require('ReactFiberExpirationTime');
 
 export type FiberRoot = {
   // Any additional information from the host associated with this root.
@@ -21,11 +23,23 @@ export type FiberRoot = {
   current: Fiber,
   // Determines if this root has already been added to the schedule for work.
   isScheduled: boolean,
+  // The time at which this root completed.
+  completedAt: ExpirationTime,
   // The work schedule is a linked list.
   nextScheduledRoot: FiberRoot | null,
   // Top context object, used by renderSubtreeIntoContainer
   context: Object | null,
   pendingContext: Object | null,
+};
+
+// Indicates whether the root is blocked from committing at a particular
+// expiration time.
+exports.isRootBlocked = function(
+  root: FiberRoot,
+  time: ExpirationTime,
+): boolean {
+  // TODO: Implementation
+  return false;
 };
 
 exports.createFiberRoot = function(containerInfo: any): FiberRoot {
@@ -36,6 +50,7 @@ exports.createFiberRoot = function(containerInfo: any): FiberRoot {
     current: uninitializedFiber,
     containerInfo: containerInfo,
     isScheduled: false,
+    completedAt: NoWork,
     nextScheduledRoot: null,
     context: null,
     pendingContext: null,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -67,7 +67,6 @@ var {
   Done,
   Never,
   msToExpirationTime,
-  earlierExpirationTime,
   priorityToExpirationTime,
   expirationTimeToPriorityLevel,
 } = require('ReactFiberExpirationTime');
@@ -614,10 +613,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // Bubble up the earliest expiration time.
     let child = workInProgress.child;
     while (child !== null) {
-      newExpirationTime = earlierExpirationTime(
-        newExpirationTime,
-        child.expirationTime,
-      );
+      if (
+        child.expirationTime !== Done &&
+        (newExpirationTime === Done || newExpirationTime > child.expirationTime)
+      ) {
+        newExpirationTime = child.expirationTime;
+      }
       child = child.sibling;
     }
     workInProgress.expirationTime = newExpirationTime;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -1013,7 +1013,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     // Read the current time from the host environment.
     const currentTime = recalculateCurrentTime();
-    const minExpirationTime = priorityToExpirationTime(
+    const minExpirationTime = getExpirationTimeForPriority(
       currentTime,
       minPriorityLevel,
     );
@@ -1471,30 +1471,36 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           const root: FiberRoot = (node.stateNode: any);
           scheduleRoot(root, expirationTime);
           if (!isPerformingWork) {
-            if (expirationTime < mostRecentCurrentTime) {
-              // This update is synchronous. Perform it now.
-              if (isUnbatchingUpdates) {
-                // We're inside unbatchedUpdates, which is inside either
-                // batchedUpdates or a lifecycle. We should only flush
-                // synchronous work, not task work.
-                performWork(SynchronousPriority, null);
-              } else {
-                // Flush both synchronous and task work.
-                performWork(TaskPriority, null);
-              }
-            } else if (expirationTime === mostRecentCurrentTime) {
-              invariant(
-                isBatchingUpdates,
-                'Task updates can only be scheduled as a nested update or ' +
-                  'inside batchedUpdates. This error is likely caused by a ' +
-                  'bug in React. Please file an issue.',
-              );
-            } else {
-              // This update is async. Schedule a callback.
-              if (!isCallbackScheduled) {
-                scheduleDeferredCallback(performDeferredWork);
-                isCallbackScheduled = true;
-              }
+            const priorityLevel = expirationTimeToPriorityLevel(
+              mostRecentCurrentTime,
+              expirationTime,
+            );
+            switch (priorityLevel) {
+              case SynchronousPriority:
+                if (isUnbatchingUpdates) {
+                  // We're inside unbatchedUpdates, which is inside either
+                  // batchedUpdates or a lifecycle. We should only flush
+                  // synchronous work, not task work.
+                  performWork(SynchronousPriority, null);
+                } else {
+                  // Flush both synchronous and task work.
+                  performWork(TaskPriority, null);
+                }
+                break;
+              case TaskPriority:
+                invariant(
+                  isBatchingUpdates,
+                  'Task updates can only be scheduled as a nested update or ' +
+                    'inside batchedUpdates. This error is likely caused by a ' +
+                    'bug in React. Please file an issue.',
+                );
+                break;
+              default:
+                // This update is async. Schedule a callback.
+                if (!isCallbackScheduled) {
+                  scheduleDeferredCallback(performDeferredWork);
+                  isCallbackScheduled = true;
+                }
             }
           }
         } else {
@@ -1557,11 +1563,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function scheduleErrorRecovery(fiber: Fiber) {
-    scheduleUpdateImpl(
-      fiber,
-      priorityToExpirationTime(mostRecentCurrentTime, TaskPriority),
-      true,
+    const taskTime = getExpirationTimeForPriority(
+      mostRecentCurrentTime,
+      TaskPriority,
     );
+    scheduleUpdateImpl(fiber, taskTime, true);
   }
 
   function recalculateCurrentTime(): ExpirationTime {

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -998,7 +998,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       nextRenderExpirationTime,
     );
 
-    loop: while (
+    while (
       shouldContinueWorking(minPriorityLevel, nextPriorityLevel, deadline)
     ) {
       if (nextRenderExpirationTime <= mostRecentCurrentTime) {

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -15,6 +15,7 @@ import type {FiberRoot} from 'ReactFiberRoot';
 import type {HostConfig, Deadline} from 'ReactFiberReconciler';
 import type {PriorityLevel} from 'ReactPriorityLevel';
 import type {HydrationContext} from 'ReactFiberHydrationContext';
+import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 export type CapturedError = {
   componentName: ?string,
@@ -61,6 +62,8 @@ var {
   LowPriority,
   OffscreenPriority,
 } = require('ReactPriorityLevel');
+
+var {msToExpirationTime} = require('ReactFiberExpirationTime');
 
 var {AsyncUpdates} = require('ReactTypeOfInternalContext');
 
@@ -166,6 +169,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     hydrationContext,
     scheduleUpdate,
     getPriorityContext,
+    recalculateCurrentTime,
   );
   const {completeWork} = ReactFiberCompleteWork(
     config,
@@ -181,11 +185,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     commitDetachRef,
   } = ReactFiberCommitWork(config, captureError);
   const {
+    now,
     scheduleDeferredCallback,
     useSyncScheduling,
     prepareForCommit,
     resetAfterCommit,
   } = config;
+
+  // Represents the current time in ms.
+  let currentTime: ExpirationTime = msToExpirationTime(now());
 
   // The priority level to use when scheduling an update. We use NoWork to
   // represent the default priority.
@@ -1513,6 +1521,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     scheduleUpdateImpl(fiber, TaskPriority, true);
   }
 
+  function recalculateCurrentTime(): ExpirationTime {
+    currentTime = msToExpirationTime(now());
+    return currentTime;
+  }
+
   function batchedUpdates<A, R>(fn: (a: A) => R, a: A): R {
     const previousIsBatchingUpdates = isBatchingUpdates;
     isBatchingUpdates = true;
@@ -1575,6 +1588,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   return {
     scheduleUpdate: scheduleUpdate,
     getPriorityContext: getPriorityContext,
+    recalculateCurrentTime: recalculateCurrentTime,
     batchedUpdates: batchedUpdates,
     unbatchedUpdates: unbatchedUpdates,
     flushSync: flushSync,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -92,7 +92,10 @@ var {
   ClassComponent,
 } = require('ReactTypeOfWork');
 
-var {getUpdateExpirationTime} = require('ReactFiberUpdateQueue');
+var {
+  getUpdateExpirationTime,
+  processUpdateQueue,
+} = require('ReactFiberUpdateQueue');
 
 var {resetContext} = require('ReactFiberContext');
 
@@ -224,11 +227,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   let nextUnitOfWork: Fiber | null = null;
   // The time at which we're currently rendering work.
   let nextRenderExpirationTime: ExpirationTime = NoWork;
+  // If not null, all work up to and including this time should be
+  // flushed before the end of the current batch.
+  let forceExpire: ExpirationTime | null = null;
 
   // The next fiber with an effect that we're currently committing.
   let nextEffect: Fiber | null = null;
 
   let pendingCommit: Fiber | null = null;
+
+  let rootCompletionCallbackList: Array<() => mixed> | null = null;
 
   // Linked list of roots with scheduled work on them.
   let nextScheduledRoot: FiberRoot | null = null;
@@ -352,6 +360,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   // Indicates whether the root should be worked on. Not the same as whether a
   // root has work, because work could be blocked.
+  // TODO: Find a better name for this function. It also schedules completion
+  // callbacks, if a root is blocked.
   function shouldWorkOnRoot(root: FiberRoot): ExpirationTime {
     const completedAt = root.completedAt;
     const expirationTime = root.current.expirationTime;
@@ -374,8 +384,38 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // If it's still blocked, return NoWork, as if it has no more work. If it's
       // no longer blocked, return the time at which it completed so that we
       // can commit it.
-      const isBlocked = isRootBlocked(root, expirationTime);
-      return isBlocked ? NoWork : completedAt;
+      if (isRootBlocked(root, completedAt)) {
+        // Process pending completion callbacks so that they are called at
+        // the end of the current batch.
+        const completionCallbacks = root.completionCallbacks;
+        if (completionCallbacks !== null) {
+          processUpdateQueue(
+            completionCallbacks,
+            null,
+            null,
+            null,
+            completedAt,
+          );
+          const callbackList = completionCallbacks.callbackList;
+          if (callbackList !== null) {
+            // Add new callbacks to list of completion callbacks
+            if (rootCompletionCallbackList === null) {
+              rootCompletionCallbackList = callbackList;
+            } else {
+              for (let i = 0; i < callbackList.length; i++) {
+                rootCompletionCallbackList.push(callbackList[i]);
+              }
+            }
+            completionCallbacks.callbackList = null;
+            if (completionCallbacks.first === null) {
+              root.completionCallbacks = null;
+            }
+          }
+        }
+        return NoWork;
+      }
+
+      return completedAt;
     }
 
     return expirationTime;
@@ -761,13 +801,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress = returnFiber;
         continue;
       } else {
-        // We've reached the root. Mark the root as pending commit. Depending
-        // on how much time we have left, we'll either commit it now or in
-        // the next frame.
         const root = workInProgress.stateNode;
+        // We've reached the root. Mark the root as complete. Depending on how
+        // much time we have left, we'll either commit it now or in the
+        // next frame.
         if (isRootBlocked(root, nextRenderExpirationTime)) {
+          // The root is blocked from committing. Mark it as complete so we
+          // know we can commit it later without starting new work.
           root.completedAt = workInProgress.expirationTime = nextRenderExpirationTime;
         } else {
+          // The root is not blocked, so we can commit it now.
           pendingCommit = workInProgress;
         }
         return null;
@@ -872,13 +915,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
         }
         if (nextUnitOfWork === null) {
-          invariant(
-            pendingCommit !== null,
-            'Should have a pending commit. This error is likely caused by ' +
-              'a bug in React. Please file an issue.',
-          );
-          // We just completed a root. Commit it now.
-          commitAllWork(pendingCommit);
+          if (pendingCommit !== null) {
+            // We just completed a root. Commit it now.
+            commitAllWork(pendingCommit);
+          } else {
+            resetNextUnitOfWork();
+          }
           if (
             capturedErrors === null ||
             capturedErrors.size === 0 ||
@@ -896,8 +938,52 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
+  function shouldContinueWorking(
+    minPriorityLevel: PriorityLevel,
+    nextPriorityLevel: PriorityLevel,
+    deadline: Deadline | null,
+  ): boolean {
+    // There might be work left. Depending on the priority, we should
+    // either perform it now or schedule a callback to perform it later.
+    switch (nextPriorityLevel) {
+      case SynchronousPriority:
+      case TaskPriority:
+        // We have remaining synchronous or task work. Keep performing it,
+        // regardless of whether we're inside a callback.
+        if (nextPriorityLevel <= minPriorityLevel) {
+          return true;
+        }
+        return false;
+      case HighPriority:
+      case LowPriority:
+      case OffscreenPriority:
+        // We have remaining async work.
+        if (deadline === null) {
+          // We're not inside a callback. Exit and perform the work during
+          // the next callback.
+          return false;
+        }
+        // We are inside a callback.
+        if (!deadlineHasExpired && nextPriorityLevel <= minPriorityLevel) {
+          // We still have time. Keep working.
+          return true;
+        }
+        // We've run out of time. Exit.
+        return false;
+      case NoWork:
+        // No work left. We can exit.
+        return false;
+      default:
+        invariant(
+          false,
+          'Switch statement should be exhuastive. ' +
+            'This error is likely caused by a bug in React. Please file an issue.',
+        );
+    }
+  }
+
   function workLoop(
-    minExpirationTime: ExpirationTime,
+    minPriorityLevel: PriorityLevel,
     deadline: Deadline | null,
   ) {
     if (pendingCommit !== null) {
@@ -907,33 +993,36 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       resetNextUnitOfWork();
     }
 
-    if (
-      nextRenderExpirationTime === NoWork ||
-      nextRenderExpirationTime > minExpirationTime
-    ) {
-      return;
-    }
+    let nextPriorityLevel = expirationTimeToPriorityLevel(
+      recalculateCurrentTime(),
+      nextRenderExpirationTime,
+    );
 
-    loop: do {
+    loop: while (
+      shouldContinueWorking(minPriorityLevel, nextPriorityLevel, deadline)
+    ) {
       if (nextRenderExpirationTime <= mostRecentCurrentTime) {
         // Flush all expired work.
         while (nextUnitOfWork !== null) {
           nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
           if (nextUnitOfWork === null) {
-            invariant(
-              pendingCommit !== null,
-              'Should have a pending commit. This error is likely caused by ' +
-                'a bug in React. Please file an issue.',
-            );
-            // We just completed a root. Commit it now.
-            commitAllWork(pendingCommit);
-            // Clear any errors that were scheduled during the commit phase.
-            handleCommitPhaseErrors();
+            if (pendingCommit !== null) {
+              // We just completed a root. Commit it now.
+              commitAllWork(pendingCommit);
+              // Clear any errors that were scheduled during the commit phase.
+              handleCommitPhaseErrors();
+            } else {
+              resetNextUnitOfWork();
+            }
             // The render time may have changed. Check again.
+            nextPriorityLevel = expirationTimeToPriorityLevel(
+              recalculateCurrentTime(),
+              nextRenderExpirationTime,
+            );
             if (
-              nextRenderExpirationTime === NoWork ||
-              nextRenderExpirationTime > minExpirationTime ||
-              nextRenderExpirationTime > mostRecentCurrentTime
+              nextPriorityLevel === NoWork ||
+              nextPriorityLevel > minPriorityLevel ||
+              nextPriorityLevel > TaskPriority
             ) {
               // We've completed all the expired work.
               break;
@@ -950,22 +1039,24 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
             // omit either of the checks in the following condition, but we need
             // both to satisfy Flow.
             if (nextUnitOfWork === null) {
-              invariant(
-                pendingCommit !== null,
-                'Should have a pending commit. This error is likely caused by ' +
-                  'a bug in React. Please file an issue.',
-              );
-              // We just completed a root. If we have time, commit it now.
-              // Otherwise, we'll commit it in the next frame.
               if (deadline.timeRemaining() > timeHeuristicForUnitOfWork) {
-                commitAllWork(pendingCommit);
-                // Clear any errors that were scheduled during the commit phase.
-                handleCommitPhaseErrors();
+                if (pendingCommit !== null) {
+                  // We just completed a root. Commit it now.
+                  commitAllWork(pendingCommit);
+                  // Clear any errors that were scheduled during the commit phase.
+                  handleCommitPhaseErrors();
+                } else {
+                  resetNextUnitOfWork();
+                }
                 // The render time may have changed. Check again.
+                nextPriorityLevel = expirationTimeToPriorityLevel(
+                  recalculateCurrentTime(),
+                  nextRenderExpirationTime,
+                );
                 if (
-                  nextRenderExpirationTime === NoWork ||
-                  nextRenderExpirationTime > minExpirationTime ||
-                  nextRenderExpirationTime <= mostRecentCurrentTime
+                  nextPriorityLevel === NoWork ||
+                  nextPriorityLevel > minPriorityLevel ||
+                  nextPriorityLevel <= TaskPriority
                 ) {
                   // We've completed all the async work.
                   break;
@@ -979,58 +1070,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           }
         }
       }
-
-      // There might be work left. Depending on the priority, we should
-      // either perform it now or schedule a callback to perform it later.
-      const currentTime = recalculateCurrentTime();
-      switch (expirationTimeToPriorityLevel(
-        currentTime,
-        nextRenderExpirationTime,
-      )) {
-        case SynchronousPriority:
-        case TaskPriority:
-          // We have remaining synchronous or task work. Keep performing it,
-          // regardless of whether we're inside a callback.
-          if (nextRenderExpirationTime <= minExpirationTime) {
-            continue loop;
-          }
-          break loop;
-        case HighPriority:
-        case LowPriority:
-        case OffscreenPriority:
-          // We have remaining async work.
-          if (deadline === null) {
-            // We're not inside a callback. Exit and perform the work during
-            // the next callback.
-            break loop;
-          }
-          // We are inside a callback.
-          if (
-            !deadlineHasExpired &&
-            nextRenderExpirationTime <= minExpirationTime
-          ) {
-            // We still have time. Keep working.
-            continue loop;
-          }
-          // We've run out of time. Exit.
-          break loop;
-        case NoWork:
-          // No work left. We can exit.
-          break loop;
-        default:
-          invariant(
-            false,
-            'Switch statement should be exhuastive. ' +
-              'This error is likely caused by a bug in React. Please file an issue.',
-          );
-      }
-    } while (true);
+    }
   }
 
   function performWorkCatchBlock(
     failedWork: Fiber,
     boundary: Fiber,
-    minExpirationTime: ExpirationTime,
+    minPriorityLevel: PriorityLevel,
     deadline: Deadline | null,
   ) {
     // We're going to restart the error boundary that captured the error.
@@ -1046,7 +1092,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     nextUnitOfWork = performFailedUnitOfWork(boundary);
 
     // Continue working.
-    workLoop(minExpirationTime, deadline);
+    workLoop(minPriorityLevel, deadline);
   }
 
   function performWork(
@@ -1064,32 +1110,27 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     );
     isPerformingWork = true;
 
+    rootCompletionCallbackList = null;
+
     // Updates that occur during the commit phase should have task priority
     // by default. (Render phase updates are special; getPriorityContext
     // accounts for their behavior.)
     const previousPriorityContext = priorityContext;
     priorityContext = TaskPriority;
 
-    // Read the current time from the host environment.
-    const currentTime = recalculateCurrentTime();
-    const minExpirationTime = getExpirationTimeForPriority(
-      currentTime,
-      minPriorityLevel,
-    );
-
     nestedUpdateCount = 0;
 
     let didError = false;
     let error = null;
     if (__DEV__) {
-      invokeGuardedCallback(null, workLoop, null, minExpirationTime, deadline);
+      invokeGuardedCallback(null, workLoop, null, minPriorityLevel, deadline);
       if (hasCaughtError()) {
         didError = true;
         error = clearCaughtError();
       }
     } else {
       try {
-        workLoop(minExpirationTime, deadline);
+        workLoop(minPriorityLevel, deadline);
       } catch (e) {
         didError = true;
         error = e;
@@ -1136,7 +1177,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           null,
           failedWork,
           boundary,
-          minExpirationTime,
+          minPriorityLevel,
           deadline,
         );
         if (hasCaughtError()) {
@@ -1149,7 +1190,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           performWorkCatchBlock(
             failedWork,
             boundary,
-            minExpirationTime,
+            minPriorityLevel,
             deadline,
           );
           error = null;
@@ -1197,6 +1238,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // It's safe to throw any unhandled errors.
     if (errorToThrow !== null) {
       throw errorToThrow;
+    }
+
+    // Call completion callbacks. These callbacks may call performWork. This
+    // is the one place where recursion is allowed.
+    if (rootCompletionCallbackList !== null) {
+      const list = rootCompletionCallbackList;
+      for (let i = 0; i < list.length; i++) {
+        list[i]();
+      }
     }
   }
 
@@ -1630,10 +1680,29 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function recalculateCurrentTime(): ExpirationTime {
+    if (forceExpire !== null) {
+      return forceExpire;
+    }
     // Subtract initial time so it fits inside 32bits
     const ms = now() - startTime;
     mostRecentCurrentTime = msToExpirationTime(ms);
     return mostRecentCurrentTime;
+  }
+
+  function expireWork(expirationTime: ExpirationTime): void {
+    invariant(
+      !isPerformingWork,
+      'Cannot commit while already performing work.',
+    );
+    // Override the current time with the given time. This has the effect of
+    // expiring all work up to and including that time.
+    forceExpire = mostRecentCurrentTime = expirationTime;
+    try {
+      performWork(TaskPriority, null);
+    } finally {
+      forceExpire = null;
+      recalculateCurrentTime();
+    }
   }
 
   function batchedUpdates<A, R>(fn: (a: A) => R, a: A): R {
@@ -1700,6 +1769,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     getPriorityContext: getPriorityContext,
     recalculateCurrentTime: recalculateCurrentTime,
     getExpirationTimeForPriority: getExpirationTimeForPriority,
+    expireWork: expireWork,
     batchedUpdates: batchedUpdates,
     unbatchedUpdates: unbatchedUpdates,
     flushSync: flushSync,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -52,7 +52,6 @@ var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 var getComponentName = require('getComponentName');
 
 var {createWorkInProgress} = require('ReactFiber');
-var {isRootBlocked} = require('ReactFiberRoot');
 var {onCommitRoot} = require('ReactFiberDevToolsHook');
 
 var {
@@ -335,12 +334,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
             'is likely caused by a bug in React. Please file an issue.',
         );
       } else {
-        earliestExpirationRoot.completedAt = NoWork;
         nextUnitOfWork = createWorkInProgress(
           earliestExpirationRoot.current,
           earliestExpirationTime,
         );
       }
+
+      earliestExpirationRoot.completedAt = NoWork;
+      earliestExpirationRoot.isBlocked = false;
+
       if (earliestExpirationRoot !== nextRenderedTree) {
         // We've switched trees. Reset the nested update counter.
         nestedUpdateCount = 0;
@@ -360,53 +362,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   // TODO: Find a better name for this function. It also schedules completion
   // callbacks, if a root is blocked.
   function shouldWorkOnRoot(root: FiberRoot): ExpirationTime {
-    const completedAt = root.completedAt;
     const expirationTime = root.current.expirationTime;
-
     if (expirationTime === NoWork) {
       // There's no work in this tree.
       return NoWork;
     }
-
-    if (completedAt !== NoWork) {
-      // The root completed but was blocked from committing.
-      if (expirationTime < completedAt) {
-        // We have work that expires earlier than the completed root.
-        return expirationTime;
-      }
-
-      // If the expiration time of the pending work is equal to the time at
-      // which we completed the work-in-progress, it's possible additional
-      // work was scheduled that happens to fall within the same expiration
-      // bucket. We need to check the work-in-progress fiber.
-      if (expirationTime === completedAt) {
-        const workInProgress = root.current.alternate;
-        if (
-          workInProgress !== null &&
-          (workInProgress.expirationTime !== NoWork &&
-            workInProgress.expirationTime <= expirationTime)
-        ) {
-          // We have more work. Restart the completed tree.
-          root.completedAt = NoWork;
-          return expirationTime;
-        }
-      }
-
-      // There have been no higher priority updates since we completed the root.
-      // If it's still blocked, return NoWork, as if it has no more work. If it's
-      // no longer blocked, return the time at which it completed so that we
-      // can commit it.
-      if (isRootBlocked(root, completedAt)) {
-        // We usually process completion callbacks right after a root is
-        // completed. But this root already completed, and it's possible that
-        // we received new completion callbacks since then.
-        processCompletionCallbacks(root, completedAt);
-        return NoWork;
-      }
-
-      return completedAt;
+    if (root.isBlocked) {
+      // We usually process completion callbacks right after a root is
+      // completed. But this root already completed, and it's possible that
+      // we received new completion callbacks since then.
+      processCompletionCallbacks(root, root.completedAt);
+      return NoWork;
     }
-
     return expirationTime;
   }
 
@@ -817,16 +784,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress = returnFiber;
         continue;
       } else {
+        // We've reached the root. Mark it as complete.
         const root = workInProgress.stateNode;
-        // We've reached the root. Mark the root as complete. Depending on how
-        // much time we have left, we'll either commit it now or in the
-        // next frame.
-        if (isRootBlocked(root, nextRenderExpirationTime)) {
-          // The root is blocked from committing. Mark it as complete so we
-          // know we can commit it later without starting new work.
-          root.completedAt = nextRenderExpirationTime;
-        } else {
-          // The root is not blocked, so we can commit it now.
+        root.completedAt = nextRenderExpirationTime;
+        // If the root isn't blocked, it's ready to commit. If it is blocked,
+        // we'll come back to it later.
+        if (!root.isBlocked) {
           pendingCommit = workInProgress;
         }
         processCompletionCallbacks(root, nextRenderExpirationTime);
@@ -1509,25 +1472,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function scheduleRoot(root: FiberRoot, expirationTime: ExpirationTime) {
-    if (expirationTime === NoWork) {
-      return;
-    }
-
-    if (!root.isScheduled) {
-      root.isScheduled = true;
-      if (lastScheduledRoot) {
-        // Schedule ourselves to the end.
-        lastScheduledRoot.nextScheduledRoot = root;
-        lastScheduledRoot = root;
-      } else {
-        // We're the only work scheduled.
-        nextScheduledRoot = root;
-        lastScheduledRoot = root;
-      }
-    }
-  }
-
   function scheduleUpdate(
     fiber: Fiber,
     partialState: mixed,
@@ -1549,6 +1493,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       isReplace,
       isForced,
       nextCallback: null,
+      isTopLevelUnmount: false,
       next: null,
     };
     insertUpdateIntoFiber(fiber, update, currentTime);
@@ -1594,19 +1539,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     let node = fiber;
-    let shouldContinue = true;
-    while (node !== null && shouldContinue) {
-      // Walk the parent path to the root and update each node's expiration
-      // time. Once we reach a node whose expiration matches (and whose
-      // alternate's expiration matches) we can exit safely knowing that the
-      // rest of the path is correct.
-      shouldContinue = false;
+    while (node !== null) {
       if (
         node.expirationTime === NoWork ||
         node.expirationTime > expirationTime
       ) {
-        // Expiration time did not match. Update and keep going.
-        shouldContinue = true;
         node.expirationTime = expirationTime;
       }
       if (node.alternate !== null) {
@@ -1614,15 +1551,33 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           node.alternate.expirationTime === NoWork ||
           node.alternate.expirationTime > expirationTime
         ) {
-          // Expiration time did not match. Update and keep going.
-          shouldContinue = true;
           node.alternate.expirationTime = expirationTime;
         }
       }
       if (node.return === null) {
         if (node.tag === HostRoot) {
           const root: FiberRoot = (node.stateNode: any);
-          scheduleRoot(root, expirationTime);
+
+          // Add the root to the work schedule.
+          if (expirationTime !== NoWork) {
+            root.isBlocked = false;
+            if (!root.isScheduled) {
+              root.isScheduled = true;
+              if (lastScheduledRoot) {
+                // Schedule ourselves to the end.
+                lastScheduledRoot.nextScheduledRoot = root;
+                lastScheduledRoot = root;
+              } else {
+                // We're the only work scheduled.
+                nextScheduledRoot = root;
+                lastScheduledRoot = root;
+              }
+            }
+          }
+
+          // If we're not current performing work, we need to either start
+          // working now (if the update is synchronous) or schedule a callback
+          // to perform work later.
           if (!isPerformingWork) {
             const priorityLevel = expirationTimeToPriorityLevel(
               mostRecentCurrentTime,
@@ -1774,6 +1729,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       'Cannot commit while already performing work.',
     );
     root.forceExpire = expirationTime;
+    root.isBlocked = false;
     try {
       performWork(TaskPriority, null);
     } finally {

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -229,9 +229,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   let nextUnitOfWork: Fiber | null = null;
   // The time at which we're currently rendering work.
   let nextRenderExpirationTime: ExpirationTime = NoWork;
-  // If not null, all work up to and including this time should be
-  // flushed before the end of the current batch.
-  let forceExpire: ExpirationTime | null = null;
 
   // The next fiber with an effect that we're currently committing.
   let nextEffect: Fiber | null = null;
@@ -311,7 +308,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         (earliestExpirationTime === NoWork ||
           earliestExpirationTime > rootExpirationTime)
       ) {
-        earliestExpirationTime = root.current.expirationTime;
+        earliestExpirationTime = rootExpirationTime;
         earliestExpirationRoot = root;
       }
       // We didn't find anything to do in this root, so let's try the next one.
@@ -1730,8 +1727,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function recalculateCurrentTime(): ExpirationTime {
-    if (forceExpire !== null) {
-      return forceExpire;
+    if (nextRenderedTree !== null) {
+      // Check if the current root is being force expired.
+      const forceExpire = nextRenderedTree.forceExpire;
+      if (forceExpire !== null) {
+        // Override the current time with the `forceExpire` time. This has the
+        // effect of expiring all work up to and including that time.
+        mostRecentCurrentTime = forceExpire;
+        return forceExpire;
+      }
     }
     // Subtract initial time so it fits inside 32bits
     const ms = now() - startTime;
@@ -1739,18 +1743,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     return mostRecentCurrentTime;
   }
 
-  function expireWork(expirationTime: ExpirationTime): void {
+  function expireWork(root: FiberRoot, expirationTime: ExpirationTime): void {
     invariant(
       !isPerformingWork,
       'Cannot commit while already performing work.',
     );
-    // Override the current time with the given time. This has the effect of
-    // expiring all work up to and including that time.
-    forceExpire = mostRecentCurrentTime = expirationTime;
+    root.forceExpire = expirationTime;
     try {
       performWork(TaskPriority, null);
     } finally {
-      forceExpire = null;
+      root.forceExpire = null;
       recalculateCurrentTime();
     }
   }

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -16,7 +16,7 @@ import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 const {Callback: CallbackEffect} = require('ReactTypeOfSideEffect');
 
-const {Done} = require('ReactFiberExpirationTime');
+const {NoWork} = require('ReactFiberExpirationTime');
 
 const {ClassComponent, HostRoot} = require('ReactTypeOfWork');
 
@@ -364,12 +364,12 @@ exports.addForceUpdate = addForceUpdate;
 function getUpdateExpirationTime(fiber: Fiber): ExpirationTime {
   const updateQueue = fiber.updateQueue;
   if (updateQueue === null) {
-    return Done;
+    return NoWork;
   }
   if (fiber.tag !== ClassComponent && fiber.tag !== HostRoot) {
-    return Done;
+    return NoWork;
   }
-  return updateQueue.first !== null ? updateQueue.first.expirationTime : Done;
+  return updateQueue.first !== null ? updateQueue.first.expirationTime : NoWork;
 }
 exports.getUpdateExpirationTime = getUpdateExpirationTime;
 

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -31,15 +31,15 @@ type PartialState<State, Props> =
 // Callbacks are not validated until invocation
 type Callback = mixed;
 
-export type Update = {
+export type Update<State> = {
   priorityLevel: PriorityLevel | null,
   expirationTime: ExpirationTime,
-  partialState: PartialState<any, any>,
+  partialState: PartialState<State, any>,
   callback: Callback | null,
   isReplace: boolean,
   isForced: boolean,
   isTopLevelUnmount: boolean,
-  next: Update | null,
+  next: Update<State> | null,
 };
 
 // Singly linked-list of updates. When an update is scheduled, it is added to
@@ -53,9 +53,9 @@ export type Update = {
 // The work-in-progress queue is always a subset of the current queue.
 //
 // When the tree is committed, the work-in-progress becomes the current.
-export type UpdateQueue = {
-  first: Update | null,
-  last: Update | null,
+export type UpdateQueue<State> = {
+  first: Update<State> | null,
+  last: Update<State> | null,
   hasForceUpdate: boolean,
   callbackList: null | Array<Callback>,
 
@@ -66,7 +66,7 @@ export type UpdateQueue = {
 let _queue1;
 let _queue2;
 
-function createUpdateQueue(): UpdateQueue {
+function createUpdateQueue<State>(): UpdateQueue<State> {
   const queue: UpdateQueue = {
     first: null,
     last: null,
@@ -78,8 +78,9 @@ function createUpdateQueue(): UpdateQueue {
   }
   return queue;
 }
+exports.createUpdateQueue = createUpdateQueue;
 
-function cloneUpdate(update: Update): Update {
+function cloneUpdate(update: Update<State>): Update<State> {
   return {
     priorityLevel: update.priorityLevel,
     expirationTime: update.expirationTime,
@@ -95,10 +96,10 @@ function cloneUpdate(update: Update): Update {
 const COALESCENCE_THRESHOLD: ExpirationTime = 10;
 
 function insertUpdateIntoPosition(
-  queue: UpdateQueue,
-  update: Update,
-  insertAfter: Update | null,
-  insertBefore: Update | null,
+  queue: UpdateQueue<State>,
+  update: Update<State>,
+  insertAfter: Update<State> | null,
+  insertBefore: Update<State> | null,
   currentTime: ExpirationTime,
 ) {
   if (insertAfter !== null) {
@@ -135,7 +136,10 @@ function insertUpdateIntoPosition(
 
 // Returns the update after which the incoming update should be inserted into
 // the queue, or null if it should be inserted at beginning.
-function findInsertionPosition(queue, update): Update | null {
+function findInsertionPosition(
+  queue: UpdateQueue<State>,
+  update: Update<State>,
+): Update<State> | null {
   const expirationTime = update.expirationTime;
   let insertAfter = null;
   let insertBefore = null;
@@ -210,9 +214,9 @@ function ensureUpdateQueues(fiber: Fiber) {
 // If the update is cloned, it returns the cloned update.
 function insertUpdateIntoFiber(
   fiber: Fiber,
-  update: Update,
+  update: Update<State>,
   currentTime: ExpirationTime,
-): Update | null {
+): Update<State> | null {
   // We'll have at least one and at most two distinct update queues.
   ensureUpdateQueues(fiber);
   const queue1 = _queue1;
@@ -300,7 +304,7 @@ exports.insertUpdateIntoFiber = insertUpdateIntoFiber;
 
 function insertUpdateIntoQueue(
   queue: UpdateQueue,
-  update: Update,
+  update: Update<State>,
   currentTime: ExpirationTime,
 ) {
   const insertAfter = findInsertionPosition(queue, update);
@@ -323,9 +327,16 @@ function getUpdateExpirationTime(fiber: Fiber): ExpirationTime {
   if (fiber.tag !== ClassComponent && fiber.tag !== HostRoot) {
     return NoWork;
   }
-  return updateQueue.first !== null ? updateQueue.first.expirationTime : NoWork;
+  return getUpdateQueueExpirationTime(updateQueue);
 }
 exports.getUpdateExpirationTime = getUpdateExpirationTime;
+
+function getUpdateQueueExpirationTime<State>(
+  updateQueue: UpdateQueue<State>,
+): ExpirationTime {
+  return updateQueue.first !== null ? updateQueue.first.expirationTime : NoWork;
+}
+exports.getUpdateQueueExpirationTime = getUpdateQueueExpirationTime;
 
 function getStateFromUpdate(update, instance, prevState, props) {
   const partialState = update.partialState;
@@ -338,12 +349,12 @@ function getStateFromUpdate(update, instance, prevState, props) {
 }
 
 function processUpdateQueue(
-  queue: UpdateQueue,
+  queue: UpdateQueue<State>,
   instance: mixed,
-  prevState: Object,
+  prevState: State,
   props: mixed,
   renderExpirationTime: ExpirationTime,
-): mixed {
+): State {
   if (__DEV__) {
     // Set this flag so we can warn if setState is called inside the update
     // function of another setState.
@@ -408,17 +419,17 @@ function processUpdateQueue(
 
   return state;
 }
-exports.insertUpdateIntoQueue = insertUpdateIntoQueue;
+exports.processUpdateQueue = processUpdateQueue;
 
 function beginUpdateQueue(
   current: Fiber | null,
   workInProgress: Fiber,
-  queue: UpdateQueue,
+  queue: UpdateQueue<State>,
   instance: any,
   prevState: any,
   props: any,
   renderExpirationTime: ExpirationTime,
-): any {
+): State {
   if (current !== null && current.updateQueue === queue) {
     // We need to create a work-in-progress queue, by cloning the current queue.
     const currentQueue = queue;

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -20,7 +20,6 @@ const {NoWork} = require('ReactFiberExpirationTime');
 
 const {ClassComponent, HostRoot} = require('ReactTypeOfWork');
 
-const invariant = require('fbjs/lib/invariant');
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
 }
@@ -95,7 +94,7 @@ function cloneUpdate(update: Update): Update {
 
 const COALESCENCE_THRESHOLD: ExpirationTime = 10;
 
-function insertUpdateIntoQueue(
+function insertUpdateIntoPosition(
   queue: UpdateQueue,
   update: Update,
   insertAfter: Update | null,
@@ -110,6 +109,8 @@ function insertUpdateIntoQueue(
     // could lead to starvation, so we stop coalescing once the time until the
     // expiration time reaches a certain threshold.
     if (
+      // Only coalesce if a priority level is specified
+      update.priorityLevel !== null &&
       insertAfter !== null &&
       insertAfter.priorityLevel === update.priorityLevel
     ) {
@@ -207,7 +208,7 @@ function ensureUpdateQueues(fiber: Fiber) {
 // we shouldn't make a copy.
 //
 // If the update is cloned, it returns the cloned update.
-function insertUpdate(
+function insertUpdateIntoFiber(
   fiber: Fiber,
   update: Update,
   currentTime: ExpirationTime,
@@ -238,7 +239,7 @@ function insertUpdate(
 
   if (queue2 === null) {
     // If there's no alternate queue, there's nothing else to do but insert.
-    insertUpdateIntoQueue(
+    insertUpdateIntoPosition(
       queue1,
       update,
       insertAfter1,
@@ -256,7 +257,7 @@ function insertUpdate(
 
   // Now we can insert into the first queue. This must come after finding both
   // insertion positions because it mutates the list.
-  insertUpdateIntoQueue(
+  insertUpdateIntoPosition(
     queue1,
     update,
     insertAfter1,
@@ -285,7 +286,7 @@ function insertUpdate(
     // The insertion positions are different, so we need to clone the update and
     // insert the clone into the alternate queue.
     const update2 = cloneUpdate(update);
-    insertUpdateIntoQueue(
+    insertUpdateIntoPosition(
       queue2,
       update2,
       insertAfter2,
@@ -295,71 +296,24 @@ function insertUpdate(
     return update2;
   }
 }
+exports.insertUpdateIntoFiber = insertUpdateIntoFiber;
 
-function addUpdate(
-  fiber: Fiber,
-  partialState: PartialState<any, any> | null,
-  callback: mixed,
-  priorityLevel: PriorityLevel | null,
-  expirationTime: ExpirationTime,
+function insertUpdateIntoQueue(
+  queue: UpdateQueue,
+  update: Update,
   currentTime: ExpirationTime,
-): void {
-  const update = {
-    priorityLevel,
-    expirationTime,
-    partialState,
-    callback,
-    isReplace: false,
-    isForced: false,
-    isTopLevelUnmount: false,
-    next: null,
-  };
-  insertUpdate(fiber, update, currentTime);
+) {
+  const insertAfter = findInsertionPosition(queue, update);
+  const insertBefore = insertAfter !== null ? insertAfter.next : null;
+  insertUpdateIntoPosition(
+    queue,
+    update,
+    insertAfter,
+    insertBefore,
+    currentTime,
+  );
 }
-exports.addUpdate = addUpdate;
-
-function addReplaceUpdate(
-  fiber: Fiber,
-  state: any | null,
-  callback: Callback | null,
-  priorityLevel: PriorityLevel | null,
-  expirationTime: ExpirationTime,
-  currentTime: ExpirationTime,
-): void {
-  const update = {
-    priorityLevel,
-    expirationTime,
-    partialState: state,
-    callback,
-    isReplace: true,
-    isForced: false,
-    isTopLevelUnmount: false,
-    next: null,
-  };
-  insertUpdate(fiber, update, currentTime);
-}
-exports.addReplaceUpdate = addReplaceUpdate;
-
-function addForceUpdate(
-  fiber: Fiber,
-  callback: Callback | null,
-  priorityLevel: PriorityLevel | null,
-  expirationTime: ExpirationTime,
-  currentTime: ExpirationTime,
-): void {
-  const update = {
-    priorityLevel,
-    expirationTime,
-    partialState: null,
-    callback,
-    isReplace: false,
-    isForced: true,
-    isTopLevelUnmount: false,
-    next: null,
-  };
-  insertUpdate(fiber, update, currentTime);
-}
-exports.addForceUpdate = addForceUpdate;
+exports.insertUpdateIntoQueue = insertUpdateIntoQueue;
 
 function getUpdateExpirationTime(fiber: Fiber): ExpirationTime {
   const updateQueue = fiber.updateQueue;
@@ -373,48 +327,6 @@ function getUpdateExpirationTime(fiber: Fiber): ExpirationTime {
 }
 exports.getUpdateExpirationTime = getUpdateExpirationTime;
 
-function addTopLevelUpdate(
-  fiber: Fiber,
-  partialState: PartialState<any, any>,
-  callback: Callback | null,
-  priorityLevel: PriorityLevel | null,
-  expirationTime: ExpirationTime,
-  currentTime: ExpirationTime,
-): void {
-  const isTopLevelUnmount = partialState.element === null;
-
-  const update = {
-    priorityLevel,
-    expirationTime,
-    partialState,
-    callback,
-    isReplace: false,
-    isForced: false,
-    isTopLevelUnmount,
-    next: null,
-  };
-  const update2 = insertUpdate(fiber, update, currentTime);
-
-  if (isTopLevelUnmount) {
-    // TODO: Redesign the top-level mount/update/unmount API to avoid this
-    // special case.
-    const queue1 = _queue1;
-    const queue2 = _queue2;
-
-    // Drop all updates that are lower-priority, so that the tree is not
-    // remounted. We need to do this for both queues.
-    if (queue1 !== null && update.next !== null) {
-      update.next = null;
-      queue1.last = update;
-    }
-    if (queue2 !== null && update2 !== null && update2.next !== null) {
-      update2.next = null;
-      queue2.last = update;
-    }
-  }
-}
-exports.addTopLevelUpdate = addTopLevelUpdate;
-
 function getStateFromUpdate(update, instance, prevState, props) {
   const partialState = update.partialState;
   if (typeof partialState === 'function') {
@@ -425,28 +337,13 @@ function getStateFromUpdate(update, instance, prevState, props) {
   }
 }
 
-function beginUpdateQueue(
-  current: Fiber | null,
-  workInProgress: Fiber,
+function processUpdateQueue(
   queue: UpdateQueue,
-  instance: any,
-  prevState: any,
-  props: any,
+  instance: mixed,
+  prevState: Object,
+  props: mixed,
   renderExpirationTime: ExpirationTime,
-): any {
-  if (current !== null && current.updateQueue === queue) {
-    // We need to create a work-in-progress queue, by cloning the current queue.
-    const currentQueue = queue;
-    queue = workInProgress.updateQueue = {
-      first: currentQueue.first,
-      last: currentQueue.last,
-      // These fields are no longer valid because they were already committed.
-      // Reset them.
-      callbackList: null,
-      hasForceUpdate: false,
-    };
-  }
-
+): mixed {
   if (__DEV__) {
     // Set this flag so we can warn if setState is called inside the update
     // function of another setState.
@@ -497,18 +394,12 @@ function beginUpdateQueue(
     ) {
       callbackList = callbackList !== null ? callbackList : [];
       callbackList.push(update.callback);
-      workInProgress.effectTag |= CallbackEffect;
     }
     update = update.next;
   }
 
   queue.callbackList = callbackList;
   queue.hasForceUpdate = hasForceUpdate;
-
-  if (queue.first === null && callbackList === null && !hasForceUpdate) {
-    // The queue is empty and there are no callbacks. We can reset it.
-    workInProgress.updateQueue = null;
-  }
 
   if (__DEV__) {
     // No longer processing.
@@ -517,30 +408,49 @@ function beginUpdateQueue(
 
   return state;
 }
-exports.beginUpdateQueue = beginUpdateQueue;
+exports.insertUpdateIntoQueue = insertUpdateIntoQueue;
 
-function commitCallbacks(
-  finishedWork: Fiber,
+function beginUpdateQueue(
+  current: Fiber | null,
+  workInProgress: Fiber,
   queue: UpdateQueue,
-  context: mixed,
-) {
-  const callbackList = queue.callbackList;
-  if (callbackList === null) {
-    return;
+  instance: any,
+  prevState: any,
+  props: any,
+  renderExpirationTime: ExpirationTime,
+): any {
+  if (current !== null && current.updateQueue === queue) {
+    // We need to create a work-in-progress queue, by cloning the current queue.
+    const currentQueue = queue;
+    queue = workInProgress.updateQueue = {
+      first: currentQueue.first,
+      last: currentQueue.last,
+      // These fields are no longer valid because they were already committed.
+      // Reset them.
+      callbackList: null,
+      hasForceUpdate: false,
+    };
   }
 
-  // Set the list to null to make sure they don't get called more than once.
-  queue.callbackList = null;
+  const state = processUpdateQueue(
+    queue,
+    instance,
+    prevState,
+    props,
+    renderExpirationTime,
+  );
 
-  for (let i = 0; i < callbackList.length; i++) {
-    const callback = callbackList[i];
-    invariant(
-      typeof callback === 'function',
-      'Invalid argument passed as callback. Expected a function. Instead ' +
-        'received: %s',
-      callback,
-    );
-    callback.call(context);
+  const updatedQueue = workInProgress.updateQueue;
+  if (updatedQueue !== null) {
+    const callbackList = updatedQueue.callbackList;
+    if (callbackList !== null) {
+      workInProgress.effectTag |= CallbackEffect;
+    } else if (updatedQueue.first === null && !updatedQueue.hasForceUpdate) {
+      // The queue is empty. We can reset it.
+      workInProgress.updateQueue = null;
+    }
   }
+
+  return state;
 }
-exports.commitCallbacks = commitCallbacks;
+exports.beginUpdateQueue = beginUpdateQueue;

--- a/src/renderers/shared/fiber/__tests__/ReactExpiration-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactExpiration-test.js
@@ -71,7 +71,7 @@ describe('ReactExpiration', () => {
     // Advance time. This should be enough to flush both updates to A, but not
     // the update to B. If only the first update to A flushes, but not the
     // second, then it wasn't coalesced properly.
-    ReactNoop.expire(500);
+    ReactNoop.expire(600);
     ReactNoop.flushExpired();
     expect(ReactNoop.getChildren()).toEqual([span(2), span(0)]);
 

--- a/src/renderers/shared/fiber/__tests__/ReactExpiration-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactExpiration-test.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+var React;
+var ReactNoop;
+
+describe('ReactExpiration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+  });
+
+  function span(prop) {
+    return {type: 'span', children: [], prop};
+  }
+
+  it('increases priority of updates as time progresses', () => {
+    ReactNoop.render(<span prop="done" />);
+
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Nothing has expired yet because time hasn't advanced.
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance by 300ms, not enough to expire the low pri update.
+    ReactNoop.expire(300);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance by another second. Now the update should expire and flush.
+    ReactNoop.expire(1000);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span('done')]);
+  });
+
+  it('coalesces updates to the same component', () => {
+    const foos = [];
+    class Foo extends React.Component {
+      constructor() {
+        super();
+        this.state = {step: 0};
+        foos.push(this);
+      }
+      render() {
+        return <span prop={this.state.step} />;
+      }
+    }
+
+    ReactNoop.render([<Foo key="A" />, <Foo key="B" />]);
+    ReactNoop.flush();
+    const [a, b] = foos;
+
+    a.setState({step: 1});
+
+    // Advance time by 500ms.
+    ReactNoop.expire(500);
+
+    // Update A again. This update should coalesce with the previous update.
+    a.setState({step: 2});
+    // Update B. This is the first update, so it has nothing to coalesce with.
+    b.setState({step: 1});
+
+    // Advance time. This should be enough to flush both updates to A, but not
+    // the update to B. If only the first update to A flushes, but not the
+    // second, then it wasn't coalesced properly.
+    ReactNoop.expire(500);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span(2), span(0)]);
+
+    // Now expire the update to B.
+    ReactNoop.expire(500);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span(2), span(1)]);
+  });
+
+  it('stops coalescing after a certain threshold', () => {
+    let instance;
+    class Foo extends React.Component {
+      state = {step: 0};
+      render() {
+        instance = this;
+        return <span prop={this.state.step} />;
+      }
+    }
+
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+
+    instance.setState({step: 1});
+
+    // Advance time by 500 ms.
+    ReactNoop.expire(500);
+
+    // Update again. This update should coalesce with the previous update.
+    instance.setState({step: 2});
+
+    // Advance time by 480ms. Not enough to expire the updates.
+    ReactNoop.expire(480);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span(0)]);
+
+    // Update again. This update should NOT be coalesced, because the
+    // previous updates have almost expired.
+    instance.setState({step: 3});
+
+    // Advance time. This should expire the first two updates,
+    // but not the third.
+    ReactNoop.expire(500);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span(2)]);
+
+    // Now expire the remaining update.
+    ReactNoop.expire(1000);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span(3)]);
+  });
+});

--- a/src/renderers/shared/fiber/__tests__/ReactFiberHostContext-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactFiberHostContext-test.js
@@ -46,6 +46,9 @@ describe('ReactFiberHostContext', () => {
       appendChildToContainer: function() {
         return null;
       },
+      now: function() {
+        return 0;
+      },
       useSyncScheduling: true,
     });
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalRoot-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalRoot-test.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactNoop;
+
+describe('ReactIncrementalRoot', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+  });
+
+  function span(prop) {
+    return {type: 'span', children: [], prop};
+  }
+
+  it('prerenders roots', () => {
+    const root = ReactNoop.create();
+    const work = root.prerender(<span prop="A" />);
+    expect(root.getChildren()).toEqual([]);
+    work.commit();
+    expect(root.getChildren()).toEqual([span('A')]);
+  });
+
+  it('resolves `then` callback synchronously if tree is already completed', () => {
+    const root = ReactNoop.create();
+    const work = root.prerender(<span prop="A" />);
+    ReactNoop.flush();
+    let wasCalled = false;
+    work.then(() => {
+      wasCalled = true;
+    });
+    expect(wasCalled).toBe(true);
+  });
+
+  it('does not restart a completed tree if there were no additional updates', () => {
+    let ops = [];
+    function Foo(props) {
+      ops.push('Foo');
+      return <span prop={props.children} />;
+    }
+    const root = ReactNoop.create();
+    const work = root.prerender(<Foo>Hi</Foo>);
+
+    ReactNoop.flush();
+    expect(ops).toEqual(['Foo']);
+    expect(root.getChildren([]));
+
+    work.then(() => {
+      ops.push('Root completed');
+      work.commit();
+      ops.push('Root committed');
+    });
+
+    expect(ops).toEqual([
+      'Foo',
+      'Root completed',
+      // Should not re-render Foo
+      'Root committed',
+    ]);
+    expect(root.getChildren([span('Hi')]));
+  });
+
+  it('works on a blocked tree if the expiration time is less than or equal to the blocked update', () => {
+    let ops = [];
+    function Foo(props) {
+      ops.push('Foo: ' + props.children);
+      return <span prop={props.children} />;
+    }
+    const root = ReactNoop.create();
+    root.prerender(<Foo>A</Foo>);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Foo: A']);
+    expect(root.getChildren()).toEqual([]);
+
+    // workA and workB have the same expiration time
+    root.prerender(<Foo>B</Foo>);
+    ReactNoop.flush();
+
+    // Should have re-rendered the root, even though it's blocked
+    // from committing.
+    expect(ops).toEqual(['Foo: A', 'Foo: B']);
+    expect(root.getChildren()).toEqual([]);
+  });
+
+  it(
+    'does not work on on a blocked tree if the expiration time is greater than the blocked update',
+  );
+});

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalRoot-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalRoot-test.js
@@ -24,7 +24,7 @@ describe('ReactIncrementalRoot', () => {
   }
 
   it('prerenders roots', () => {
-    const root = ReactNoop.create();
+    const root = ReactNoop.createRoot();
     const work = root.prerender(<span prop="A" />);
     expect(root.getChildren()).toEqual([]);
     work.commit();
@@ -32,7 +32,7 @@ describe('ReactIncrementalRoot', () => {
   });
 
   it('resolves `then` callback synchronously if tree is already completed', () => {
-    const root = ReactNoop.create();
+    const root = ReactNoop.createRoot();
     const work = root.prerender(<span prop="A" />);
     ReactNoop.flush();
     let wasCalled = false;
@@ -48,7 +48,7 @@ describe('ReactIncrementalRoot', () => {
       ops.push('Foo');
       return <span prop={props.children} />;
     }
-    const root = ReactNoop.create();
+    const root = ReactNoop.createRoot();
     const work = root.prerender(<Foo>Hi</Foo>);
 
     ReactNoop.flush();
@@ -76,7 +76,7 @@ describe('ReactIncrementalRoot', () => {
       ops.push('Foo: ' + props.children);
       return <span prop={props.children} />;
     }
-    const root = ReactNoop.create();
+    const root = ReactNoop.createRoot();
     root.prerender(<Foo>A</Foo>);
     ReactNoop.flush();
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
@@ -54,6 +54,14 @@ describe('ReactIncrementalTriangle', () => {
     };
   }
 
+  const EXPIRE = 'EXPIRE';
+  function expire(ms) {
+    return {
+      type: EXPIRE,
+      ms,
+    };
+  }
+
   function TriangleSimulator() {
     let triangles = [];
     let leafTriangles = [];
@@ -212,6 +220,9 @@ describe('ReactIncrementalTriangle', () => {
                 targetTriangle.activate();
               }
               break;
+            case EXPIRE:
+              ReactNoop.expire(action.ms);
+              break;
             default:
               break;
           }
@@ -251,7 +262,7 @@ describe('ReactIncrementalTriangle', () => {
     }
 
     function randomAction() {
-      switch (randomInteger(0, 4)) {
+      switch (randomInteger(0, 5)) {
         case 0:
           return flush(randomInteger(0, totalTriangles * 1.5));
         case 1:
@@ -260,6 +271,8 @@ describe('ReactIncrementalTriangle', () => {
           return interrupt();
         case 3:
           return toggle(randomInteger(0, totalChildren));
+        case 4:
+          return expire(randomInteger(0, 1500));
         default:
           throw new Error('Switch statement should be exhaustive');
       }
@@ -289,6 +302,9 @@ describe('ReactIncrementalTriangle', () => {
             break;
           case TOGGLE:
             result += `toggle(${action.childIndex})`;
+            break;
+          case EXPIRE:
+            result += `expire(${action.ms})`;
             break;
           default:
             throw new Error('Switch statement should be exhaustive');

--- a/src/renderers/testing/ReactTestRendererFiberEntry.js
+++ b/src/renderers/testing/ReactTestRendererFiberEntry.js
@@ -247,6 +247,11 @@ var TestRenderer = ReactFiberReconciler({
   useSyncScheduling: true,
 
   getPublicInstance,
+
+  now(): number {
+    // Test renderer does not use expiration
+    return 0;
+  },
 });
 
 var defaultTestOptions = {


### PR DESCRIPTION
Introduces an additional, new API for performing top-level updates in React DOM:

```js
// Existing API
ReactDOM.render(<App foo="A" />, container); // mount
ReactDOM.render(<App foo="B" />, container); // update
ReactDOM.unmountComponentAtNode(container); // unmount


// New API
const root = ReactDOM.unstable_createRoot(container);

// Simple
root.render(<App foo="A" />); // mount
root.render(<App foo="B" />); // update
root.unmount(); // unmount

// With pre-rendering
const work = root.prerender(<App foo="C" />); // Begin rendering but don't flush yet.
await work; // Wait for work to complete. Still don't flush yet.
work.commit(); // Synchronously flush changes

// Start prerendering before container is available
let container;
const root = ReactDOM.unstable_createRoot(function getContainer() {
  return container;
});
root.prerender(<App foo="A" />); // Begin rendering but don't flush yet.
container = await promiseForContainer;
work.commit(); // Synchronously flush remaining work
```

(Will fill in with more details later regarding motivations and use cases.)

I had thought we might be able to implement the existing API (`ReactDOM.render`) on top of the new API, but the semantics of the `.then` callback are sufficiently different that I don't think it's possible without a breaking change.

Work-in-progress:

- [x] `ReactDOM.unstable_createRoot` that returns a public root instance. Replaces hidden `_reactRootContainer` field.
- [x] Work type that represents a top-level update. Has `then` and `commit` methods.
- [x] `work.commit()` synchronously flushes all remaining work.
- [x] Pre-rendering in one tree should not block updates in a separate tree.
- [x] Completion callbacks (`.then`) resolve synchronously if tree is already complete
- [x] Committing one tree should not flush updates in a separate tree.
- [x] Figure out how hydration fits into this.
- [x] Lazy containers
  - [x] Namespace parameter
  - [x] Owner document parameter
- [x] Things that are "done" but need tests to confirm
  - [x] Rendering before DOM container is available

Depends on expiration times PR https://github.com/facebook/react/pull/10426