### PR TITLE
Update to latest allowed versions of `fbjs` and `prop-types`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1781,8 +1781,8 @@ fbjs-scripts@^0.6.0:
     through2 "^2.0.0"
 
 fbjs@^0.8.9:
-  version "0.8.12"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -3576,10 +3576,11 @@ promise@^7.1.1:
     asap "~2.0.3"
 
 prop-types@^15.5.8:
-  version "15.5.8"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
     fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 prr@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
**what is the change?:**
Updates to the latest allowed versions for two dependencies.

`yarn upgrade 'fbjs@^0.8.9'`
and
`yarn upgrade 'prop-types@^15.5.8'`

**why make this change?:**
Prepping for the 16.0 RC, we want to have a reproducible build that is
as close as possible to what new users will get when installing React.

**test plan:**
`yarn && yarn build && yarn test`

**issue:**
https://github.com/facebook/react/issues/10623