### PR TITLE
React native event type fixes

### DIFF
--- a/src/renderers/native/ReactNativeBridgeEventPlugin.js
+++ b/src/renderers/native/ReactNativeBridgeEventPlugin.js
@@ -47,7 +47,7 @@ var ReactNativeBridgeEventPlugin = {
     var directDispatchConfig = customDirectEventTypes[topLevelType];
     invariant(
       bubbleDispatchConfig || directDispatchConfig,
-      'Unsupported top level event type "%s" specified',
+      'Unsupported top level event type "%s" dispatched',
       topLevelType,
     );
     var event = SyntheticEvent.getPooled(

--- a/src/renderers/native/ReactNativeBridgeEventPlugin.js
+++ b/src/renderers/native/ReactNativeBridgeEventPlugin.js
@@ -14,6 +14,7 @@
 var EventPropagators = require('EventPropagators');
 var SyntheticEvent = require('SyntheticEvent');
 var ReactNativeEventTypes = require('ReactNativeEventTypes');
+var invariant = require('fbjs/lib/invariant');
 
 var customBubblingEventTypes = ReactNativeEventTypes.customBubblingEventTypes;
 var customDirectEventTypes = ReactNativeEventTypes.customDirectEventTypes;
@@ -44,6 +45,11 @@ var ReactNativeBridgeEventPlugin = {
   ): ?Object {
     var bubbleDispatchConfig = customBubblingEventTypes[topLevelType];
     var directDispatchConfig = customDirectEventTypes[topLevelType];
+    invariant(
+      bubbleDispatchConfig || directDispatchConfig,
+      'Unsupported top level event type "%s" specified',
+      topLevelType,
+    );
     var event = SyntheticEvent.getPooled(
       bubbleDispatchConfig || directDispatchConfig,
       targetInst,

--- a/src/renderers/native/ReactNativeEventTypes.js
+++ b/src/renderers/native/ReactNativeEventTypes.js
@@ -284,6 +284,9 @@ const IOS_DIRECT_EVENT_TYPES = {
   topShouldStartLoadWithRequest: {
     registrationName: 'onShouldStartLoadWithRequest',
   },
+  topSnapshotReady: {
+    registrationName: 'onSnapshotReady',
+  },
   topStateChange: {
     registrationName: 'onStateChange',
   },


### PR DESCRIPTION
* 5a12260: **Added invariant check for native dispatching an unsupported event type**
This prevents a case of a silent failure when native dispatches an event that JavaScript does not know how to handle.
* 633235e: **Added iOS direct event type "onSnapshotReady"**
This is used for snapshot testing. I missed it initially since I didn't gather event types from test-specific native views.

These issues were uncovered while running integration tests during a React Native fbsource sync.
* Before this fix, our snapshot tests failed due to timeouts.
* After commit 5a12260, snapshot tests failed with: _Unhandled JS Exception: Unsupported top level event type "topSnapshotReady"_
* After 633235e, snapshot tests pass.