### PR TITLE
Remove "const" in uncompiled code

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -8,8 +8,8 @@ function testMinificationUsedDCE() {
   try {
     // use scoped variable for our initial test, in case
     // 'top-level' mangling is not enabled.
-    const source = testMinificationUsedDCE.toString();
-    const longVariableName = true;
+    var source = testMinificationUsedDCE.toString();
+    var longVariableName = true;
     if (longVariableName && source.match(/longVariableName/g).length === 3) {
       // We are not minified.
       // This might be a Node environment where DCE is not expected anyway.


### PR DESCRIPTION
Test Plan: All fixtures/packaging iframes display correctly on Chrome 38.0.2125.0 from https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Mac/290001/; previously several were blank with "Use of const in strict mode" errors logged to the console.