### PR TITLE
Add comment for renderToStringImpl parameter

### DIFF
--- a/src/renderers/dom/stack/server/ReactServerRendering.js
+++ b/src/renderers/dom/stack/server/ReactServerRendering.js
@@ -27,6 +27,7 @@ var pendingTransactions = 0;
 
 /**
  * @param {ReactElement} element
+ * @param {boolean} makeStaticMarkup
  * @return {string} the HTML markup
  */
 function renderToStringImpl(element, makeStaticMarkup) {


### PR DESCRIPTION
Small addition - Added a comment for the second parameter to `renderToStringImpl`
