### PR TITLE
[Gatsby docs update] minor fixes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,9 +37,7 @@ id: home
       <p>
         <strong>JSX is optional and not required to use React.</strong>
         Try the
-        <a href="http://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&code_lz=MYGwhgzhAEASCmIQHsCy8pgOb2vAHgC7wB2AJjAErxjCEB0AwsgLYAOyJph0A3gFABIAE6ky8YQAoAlHyEj4hAK7CS0ADxkAlgDcAfAiTI-hABZaI9NsORtLJMC3gBfdQHpt-gNxDn_P_zUtIQAIgDyqPSi5BKS6oYo6Jg40A5OALwARCHwOlokmdBuegA00CzISiSEAHLI4tJeQA&debug=false&circleciRepo=&evaluate=false&lineWrap=false&presets=react&prettier=true&targets=&version=6.26.0">
-        Babel REPL
-        </a>
+        <a href="http://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&code_lz=MYGwhgzhAEASCmIQHsCy8pgOb2vAHgC7wB2AJjAErxjCEB0AwsgLYAOyJph0A3gFABIAE6ky8YQAoAlHyEj4hAK7CS0ADxkAlgDcAfAiTI-hABZaI9NsORtLJMC3gBfdQHpt-gNxDn_P_zUtIQAIgDyqPSi5BKS6oYo6Jg40A5OALwARCHwOlokmdBuegA00CzISiSEAHLI4tJeQA&debug=false&circleciRepo=&evaluate=false&lineWrap=false&presets=react&prettier=true&targets=&version=6.26.0">Babel REPL</a>
         to see the raw JavaScript code produced by the JSX compilation step.
       </p>
       <div id="helloExample"></div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,14 @@ id: home
         JSX. Input data that is passed into the component can be accessed by
         `render()` via `this.props`.
       </p>
+      <p>
+        <strong>JSX is optional and not required to use React.</strong>
+        Try the
+        <a href="http://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&code_lz=MYGwhgzhAEASCmIQHsCy8pgOb2vAHgC7wB2AJjAErxjCEB0AwsgLYAOyJph0A3gFABIAE6ky8YQAoAlHyEj4hAK7CS0ADxkAlgDcAfAiTI-hABZaI9NsORtLJMC3gBfdQHpt-gNxDn_P_zUtIQAIgDyqPSi5BKS6oYo6Jg40A5OALwARCHwOlokmdBuegA00CzISiSEAHLI4tJeQA&debug=false&circleciRepo=&evaluate=false&lineWrap=false&presets=react&prettier=true&targets=&version=6.26.0">
+        Babel REPL
+        </a>
+        to see the raw JavaScript code produced by the JSX compilation step.
+      </p>
       <div id="helloExample"></div>
     </div>
     <div class="example">

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,11 +34,6 @@ id: home
         JSX. Input data that is passed into the component can be accessed by
         `render()` via `this.props`.
       </p>
-      <p>
-        <strong>JSX is optional and not required to use React.</strong> Try
-        clicking on "Compiled JS" to see the raw JavaScript code produced by
-        the JSX compiler.
-      </p>
       <div id="helloExample"></div>
     </div>
     <div class="example">

--- a/www/src/templates/installation.js
+++ b/www/src/templates/installation.js
@@ -80,10 +80,10 @@ function display(type, value) {
 }
 
 var foundHash = false;
-function selectTabForHashLink() {
+function selectTabForHashLink(location) {
   var hashLinks = document.querySelectorAll('a.anchor');
   for (var i = 0; i < hashLinks.length && !foundHash; ++i) {
-    if (hashLinks[i].hash === window.location.hash) {
+    if (location && (hashLinks[i].hash === location.hash)) {
       var parent = hashLinks[i].parentElement;
       while (parent) {
         if (parent.tagName === 'SECTION') {
@@ -107,7 +107,7 @@ function selectTabForHashLink() {
   }
 }
 
-// HACK Expose toggle functions global for markup-deifned event handlers.
+// HACK Expose toggle functions global for markup-defined event handlers.
 // Don't acceess the 'window' object without checking first though,
 // Because it would break the (Node only) Gatsby build step.
 if (typeof window !== 'undefined') {
@@ -117,15 +117,22 @@ if (typeof window !== 'undefined') {
 
 class InstallationPage extends Component {
   componentDidMount() {
+    const location = this.props.location;
     // If we are coming to the page with a hash in it (i.e. from a search, for example), try to get
     // us as close as possible to the correct platform and dev os using the hashtag and section walk up.
-    if (
-      this.props.location.hash !== '' &&
-      this.props.location.hash !== 'content'
-    ) {
+    if (location && location.hash !== '' && location.hash !== 'content') {
       // content is default
       // Hash links are added a bit later so we wait for them.
-      this.props.addEventListener('DOMContentLoaded', selectTabForHashLink);
+      // HACK we don't have a window object if/when Gatsby executes this in node
+      if (
+        typeof window !== 'undefined'
+        && typeof window.addEventListener === 'function'
+      ) {
+        window.addEventListener(
+          'DOMContentLoaded',
+          selectTabForHashLink.bind(null, location),
+        );
+      }
     }
     display('target', 'fiddle');
   }

--- a/www/src/templates/installation.js
+++ b/www/src/templates/installation.js
@@ -83,7 +83,7 @@ var foundHash = false;
 function selectTabForHashLink(location) {
   var hashLinks = document.querySelectorAll('a.anchor');
   for (var i = 0; i < hashLinks.length && !foundHash; ++i) {
-    if (location && (hashLinks[i].hash === location.hash)) {
+    if (location && hashLinks[i].hash === location.hash) {
       var parent = hashLinks[i].parentElement;
       while (parent) {
         if (parent.tagName === 'SECTION') {
@@ -125,8 +125,8 @@ class InstallationPage extends Component {
       // Hash links are added a bit later so we wait for them.
       // HACK we don't have a window object if/when Gatsby executes this in node
       if (
-        typeof window !== 'undefined'
-        && typeof window.addEventListener === 'function'
+        typeof window !== 'undefined' &&
+        typeof window.addEventListener === 'function'
       ) {
         window.addEventListener(
           'DOMContentLoaded',


### PR DESCRIPTION
Fixes a couple of minor things:
 - a copy correction on the home page
 - removes/guards uses of 'window' in the hacky JS for the 'installation' docs page

See individual commit messages for more info/context.