### PR TITLE
docs: Fix a typo wrt the 'swapped' fragment

### DIFF
--- a/docs/docs/addons-create-fragment.md
+++ b/docs/docs/addons-create-fragment.md
@@ -51,8 +51,8 @@ function Swapper(props) {
     });
   } else {
     children = createFragment({
-      left: props.leftChildren,
-      right: props.rightChildren
+      right: props.leftChildren,
+      left: props.rightChildren
     });
   }
   return <div>{children}</div>;


### PR DESCRIPTION
The example had the if and else clause being identical.
