### PR TITLE
[Gatsby docs update] Enable and fix flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -6,15 +6,16 @@
 <PROJECT_ROOT>/.*/node_modules/y18n/.*
 <PROJECT_ROOT>/node_modules/chrome-devtools-frontend/.*
 <PROJECT_ROOT>/node_modules/devtools-timeline-model/.*
+<PROJECT_ROOT>/www/node_modules/.*
 <PROJECT_ROOT>/.*/__mocks__/.*
 <PROJECT_ROOT>/.*/__tests__/.*
 
 # Ignore Docs
 <PROJECT_ROOT>/docs/.*
 <PROJECT_ROOT>/.*/docs/.*
-<PROJECT_ROOT>/www/.*
 
 [include]
+./www/node_modules/hex2rgba/
 
 [libs]
 ./node_modules/fbjs/flow/lib/dev.js

--- a/flow-typed/hex2rgba.js
+++ b/flow-typed/hex2rgba.js
@@ -1,0 +1,3 @@
+declare module 'hex2rgba' {
+  declare module.exports: function;
+}

--- a/flow-typed/hex2rgba.js
+++ b/flow-typed/hex2rgba.js
@@ -1,3 +1,3 @@
 declare module 'hex2rgba' {
-  declare module.exports: function;
+  declare module.exports: (hex : string, alpha? : number) => string;
 }

--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -45,19 +45,23 @@ const fonts = {
 };
 
 const SIZES = {
-  xsmall: {max: 599},
+  xsmall: {min: 0, max: 599},
   small: {min: 600, max: 739},
   medium: {min: 740, max: 979},
   large: {min: 980, max: 1279},
   xlarge: {min: 1280, max: 1339},
-  xxlarge: {min: 1340},
+  xxlarge: {min: 1340, max: Infinity},
 };
 
 type Size = $Keys<typeof SIZES>;
 
 const media = {
   between(smallKey: Size, largeKey: Size) {
-    return `@media (min-width: ${SIZES[smallKey].min}px) and (max-width: ${SIZES[largeKey].max}px)`;
+    if (SIZES[largeKey].max === Infinity) {
+      return `@media (min-width: ${SIZES[smallKey].min}px)`;
+    } else {
+      return `@media (min-width: ${SIZES[smallKey].min}px) and (max-width: ${SIZES[largeKey].max}px)`;
+    }
   },
 
   greaterThan(key: Size) {


### PR DESCRIPTION
**what is the change?:**
- enable flow for `www` subdirectory
- ignore nested `node_modules` with flow
- allow flow to find the `hex2rgba` definition in `node_modules`
  and add a `flow-typed` libdef file. See https://github.com/facebook/flow/issues/2092
- Make types more consistent and check for corner cases in the 'theme'
  styles code.

**why make this change?:**
We want delicious types. :3

**test plan:**
`yarn flow`

**issue:**
Checklist item from wiki here; https://github.com/bvaughn/react/wiki/Gatsby-check-list
Misc > Make sure yarn flow checks the website directory and has no errors.