### PR TITLE
Fix bug with toTree on rendered array #10616

### DIFF
--- a/src/renderers/testing/ReactTestRendererFiberEntry.js
+++ b/src/renderers/testing/ReactTestRendererFiberEntry.js
@@ -296,6 +296,10 @@ function nodeAndSiblingsTrees(nodeWithSibling: ?Fiber) {
   return trees.length ? trees : null;
 }
 
+function hasSiblings(node: ?Fiber) {
+  return node && node.sibling;
+}
+
 function toTree(node: ?Fiber) {
   if (node == null) {
     return null;
@@ -309,7 +313,9 @@ function toTree(node: ?Fiber) {
         type: node.type,
         props: {...node.memoizedProps},
         instance: node.stateNode,
-        rendered: nodeAndSiblingsTrees(node.child),
+        rendered: hasSiblings(node.child)
+          ? nodeAndSiblingsTrees(node.child)
+          : toTree(node.child),
       };
     case FunctionalComponent: // 1
       return {
@@ -317,7 +323,9 @@ function toTree(node: ?Fiber) {
         type: node.type,
         props: {...node.memoizedProps},
         instance: null,
-        rendered: nodeAndSiblingsTrees(node.child),
+        rendered: hasSiblings(node.child)
+          ? nodeAndSiblingsTrees(node.child)
+          : toTree(node.child),
       };
     case HostComponent: // 5
       return {

--- a/src/renderers/testing/ReactTestRendererFiberEntry.js
+++ b/src/renderers/testing/ReactTestRendererFiberEntry.js
@@ -285,14 +285,15 @@ function toJSON(inst: Instance | TextInstance): ReactTestRendererNode {
   }
 }
 
-function nodeAndSiblingsArray(nodeWithSibling: ?Fiber) {
+function nodeAndSiblingsTrees(nodeWithSibling: ?Fiber) {
   var array = [];
   var node = nodeWithSibling;
   while (node != null) {
     array.push(node);
     node = node.sibling;
   }
-  return array;
+  const trees = array.map(toTree);
+  return trees.length ? trees : null;
 }
 
 function toTree(node: ?Fiber) {
@@ -308,7 +309,7 @@ function toTree(node: ?Fiber) {
         type: node.type,
         props: {...node.memoizedProps},
         instance: node.stateNode,
-        rendered: toTree(node.child),
+        rendered: nodeAndSiblingsTrees(node.child),
       };
     case FunctionalComponent: // 1
       return {
@@ -316,7 +317,7 @@ function toTree(node: ?Fiber) {
         type: node.type,
         props: {...node.memoizedProps},
         instance: null,
-        rendered: toTree(node.child),
+        rendered: nodeAndSiblingsTrees(node.child),
       };
     case HostComponent: // 5
       return {
@@ -324,7 +325,7 @@ function toTree(node: ?Fiber) {
         type: node.type,
         props: {...node.memoizedProps},
         instance: null, // TODO: use createNodeMock here somehow?
-        rendered: nodeAndSiblingsArray(node.child).map(toTree),
+        rendered: nodeAndSiblingsTrees(node.child),
       };
     case HostText: // 6
       return node.stateNode.text;

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -19,8 +19,12 @@ var prettyFormat = require('pretty-format');
 // with jasmine's deep equality function, and test the instances separate. We
 // also delete children props because testing them is more annoying and not
 // really important to verify.
-function cleanNode(node) {
+function cleanNodeOrArray(node) {
   if (!node) {
+    return;
+  }
+  if (Array.isArray(node)) {
+    node.forEach(cleanNodeOrArray);
     return;
   }
   if (node && node.instance) {
@@ -32,9 +36,9 @@ function cleanNode(node) {
     node.props = props;
   }
   if (Array.isArray(node.rendered)) {
-    node.rendered.forEach(cleanNode);
+    node.rendered.forEach(cleanNodeOrArray);
   } else if (typeof node.rendered === 'object') {
-    cleanNode(node.rendered);
+    cleanNodeOrArray(node.rendered);
   }
 }
 
@@ -507,7 +511,7 @@ describe('ReactTestRenderer', () => {
     var renderer = ReactTestRenderer.create(<Qoo />);
     var tree = renderer.toTree();
 
-    cleanNode(tree);
+    cleanNodeOrArray(tree);
 
     expect(prettyFormat(tree)).toEqual(
       prettyFormat({
@@ -515,13 +519,15 @@ describe('ReactTestRenderer', () => {
         type: Qoo,
         props: {},
         instance: null,
-        rendered: {
-          nodeType: 'host',
-          type: 'span',
-          props: {className: 'Qoo'},
-          instance: null,
-          rendered: ['Hello World!'],
-        },
+        rendered: [
+          {
+            nodeType: 'host',
+            type: 'span',
+            props: {className: 'Qoo'},
+            instance: null,
+            rendered: ['Hello World!'],
+          },
+        ],
       }),
     );
   });
@@ -538,7 +544,7 @@ describe('ReactTestRenderer', () => {
 
     expect(tree.instance).toBeInstanceOf(Foo);
 
-    cleanNode(tree);
+    cleanNodeOrArray(tree);
 
     expect(tree).toEqual({
       type: Foo,
@@ -547,6 +553,126 @@ describe('ReactTestRenderer', () => {
       instance: null,
       rendered: null,
     });
+  });
+
+  it('toTree() handles simple components that return arrays', () => {
+    const Foo = ({children}) => children;
+
+    const renderer = ReactTestRenderer.create(
+      <Foo>
+        <div>One</div>
+        <div>Two</div>
+      </Foo>,
+    );
+
+    var tree = renderer.toTree();
+
+    cleanNodeOrArray(tree);
+
+    expect(prettyFormat(tree)).toEqual(
+      prettyFormat({
+        type: Foo,
+        nodeType: 'component',
+        props: {},
+        instance: null,
+        rendered: [
+          {
+            instance: null,
+            nodeType: 'host',
+            props: {},
+            rendered: ['One'],
+            type: 'div',
+          },
+          {
+            instance: null,
+            nodeType: 'host',
+            props: {},
+            rendered: ['Two'],
+            type: 'div',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('toTree() handles complicated tree of fragments', () => {
+    class Foo extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    const renderer = ReactTestRenderer.create(
+      <div>
+        <Foo>
+          <div>One</div>
+          <div>Two</div>
+          <Foo>
+            <div>Three</div>
+          </Foo>
+        </Foo>
+        <div>Four</div>
+      </div>,
+    );
+
+    var tree = renderer.toTree();
+
+    cleanNodeOrArray(tree);
+
+    expect(prettyFormat(tree)).toEqual(
+      prettyFormat({
+        type: 'div',
+        instance: null,
+        nodeType: 'host',
+        props: {},
+        rendered: [
+          {
+            type: Foo,
+            nodeType: 'component',
+            props: {},
+            instance: null,
+            rendered: [
+              {
+                type: 'div',
+                nodeType: 'host',
+                props: {},
+                instance: null,
+                rendered: ['One'],
+              },
+              {
+                type: 'div',
+                nodeType: 'host',
+                props: {},
+                instance: null,
+                rendered: ['Two'],
+              },
+              {
+                type: Foo,
+                nodeType: 'component',
+                props: {},
+                instance: null,
+                rendered: [
+                  {
+                    type: 'div',
+                    nodeType: 'host',
+                    props: {},
+                    instance: null,
+                    rendered: ['Three'],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'div',
+            nodeType: 'host',
+            props: {},
+            instance: null,
+            rendered: ['Four'],
+          },
+        ],
+      }),
+    );
   });
 
   it('root instance and createNodeMock ref return the same value', () => {
@@ -600,9 +726,9 @@ describe('ReactTestRenderer', () => {
 
     // we test for the presence of instances before nulling them out
     expect(tree.instance).toBeInstanceOf(Bam);
-    expect(tree.rendered.instance).toBeInstanceOf(Bar);
+    expect(tree.rendered[0].instance).toBeInstanceOf(Bar);
 
-    cleanNode(tree);
+    cleanNodeOrArray(tree);
 
     expect(prettyFormat(tree)).toEqual(
       prettyFormat({
@@ -610,46 +736,54 @@ describe('ReactTestRenderer', () => {
         nodeType: 'component',
         props: {},
         instance: null,
-        rendered: {
-          type: Bar,
-          nodeType: 'component',
-          props: {special: true},
-          instance: null,
-          rendered: {
-            type: Foo,
+        rendered: [
+          {
+            type: Bar,
             nodeType: 'component',
-            props: {className: 'special'},
+            props: {special: true},
             instance: null,
-            rendered: {
-              type: 'div',
-              nodeType: 'host',
-              props: {className: 'Foo special'},
-              instance: null,
-              rendered: [
-                {
-                  type: 'span',
-                  nodeType: 'host',
-                  props: {className: 'Foo2'},
-                  instance: null,
-                  rendered: ['Literal'],
-                },
-                {
-                  type: Qoo,
-                  nodeType: 'component',
-                  props: {},
-                  instance: null,
-                  rendered: {
-                    type: 'span',
+            rendered: [
+              {
+                type: Foo,
+                nodeType: 'component',
+                props: {className: 'special'},
+                instance: null,
+                rendered: [
+                  {
+                    type: 'div',
                     nodeType: 'host',
-                    props: {className: 'Qoo'},
+                    props: {className: 'Foo special'},
                     instance: null,
-                    rendered: ['Hello World!'],
+                    rendered: [
+                      {
+                        type: 'span',
+                        nodeType: 'host',
+                        props: {className: 'Foo2'},
+                        instance: null,
+                        rendered: ['Literal'],
+                      },
+                      {
+                        type: Qoo,
+                        nodeType: 'component',
+                        props: {},
+                        instance: null,
+                        rendered: [
+                          {
+                            type: 'span',
+                            nodeType: 'host',
+                            props: {className: 'Qoo'},
+                            instance: null,
+                            rendered: ['Hello World!'],
+                          },
+                        ],
+                      },
+                    ],
                   },
-                },
-              ],
-            },
+                ],
+              },
+            ],
           },
-        },
+        ],
       }),
     );
   });

--- a/src/renderers/testing/__tests__/ReactTestRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactTestRenderer-test.js
@@ -519,15 +519,13 @@ describe('ReactTestRenderer', () => {
         type: Qoo,
         props: {},
         instance: null,
-        rendered: [
-          {
-            nodeType: 'host',
-            type: 'span',
-            props: {className: 'Qoo'},
-            instance: null,
-            rendered: ['Hello World!'],
-          },
-        ],
+        rendered: {
+          nodeType: 'host',
+          type: 'span',
+          props: {className: 'Qoo'},
+          instance: null,
+          rendered: ['Hello World!'],
+        },
       }),
     );
   });
@@ -651,15 +649,13 @@ describe('ReactTestRenderer', () => {
                 nodeType: 'component',
                 props: {},
                 instance: null,
-                rendered: [
-                  {
-                    type: 'div',
-                    nodeType: 'host',
-                    props: {},
-                    instance: null,
-                    rendered: ['Three'],
-                  },
-                ],
+                rendered: {
+                  type: 'div',
+                  nodeType: 'host',
+                  props: {},
+                  instance: null,
+                  rendered: ['Three'],
+                },
               },
             ],
           },
@@ -726,7 +722,7 @@ describe('ReactTestRenderer', () => {
 
     // we test for the presence of instances before nulling them out
     expect(tree.instance).toBeInstanceOf(Bam);
-    expect(tree.rendered[0].instance).toBeInstanceOf(Bar);
+    expect(tree.rendered.instance).toBeInstanceOf(Bar);
 
     cleanNodeOrArray(tree);
 
@@ -736,54 +732,46 @@ describe('ReactTestRenderer', () => {
         nodeType: 'component',
         props: {},
         instance: null,
-        rendered: [
-          {
-            type: Bar,
+        rendered: {
+          type: Bar,
+          nodeType: 'component',
+          props: {special: true},
+          instance: null,
+          rendered: {
+            type: Foo,
             nodeType: 'component',
-            props: {special: true},
+            props: {className: 'special'},
             instance: null,
-            rendered: [
-              {
-                type: Foo,
-                nodeType: 'component',
-                props: {className: 'special'},
-                instance: null,
-                rendered: [
-                  {
-                    type: 'div',
+            rendered: {
+              type: 'div',
+              nodeType: 'host',
+              props: {className: 'Foo special'},
+              instance: null,
+              rendered: [
+                {
+                  type: 'span',
+                  nodeType: 'host',
+                  props: {className: 'Foo2'},
+                  instance: null,
+                  rendered: ['Literal'],
+                },
+                {
+                  type: Qoo,
+                  nodeType: 'component',
+                  props: {},
+                  instance: null,
+                  rendered: {
+                    type: 'span',
                     nodeType: 'host',
-                    props: {className: 'Foo special'},
+                    props: {className: 'Qoo'},
                     instance: null,
-                    rendered: [
-                      {
-                        type: 'span',
-                        nodeType: 'host',
-                        props: {className: 'Foo2'},
-                        instance: null,
-                        rendered: ['Literal'],
-                      },
-                      {
-                        type: Qoo,
-                        nodeType: 'component',
-                        props: {},
-                        instance: null,
-                        rendered: [
-                          {
-                            type: 'span',
-                            nodeType: 'host',
-                            props: {className: 'Qoo'},
-                            instance: null,
-                            rendered: ['Hello World!'],
-                          },
-                        ],
-                      },
-                    ],
+                    rendered: ['Hello World!'],
                   },
-                ],
-              },
-            ],
+                },
+              ],
+            },
           },
-        ],
+        },
       }),
     );
   });


### PR DESCRIPTION
This PR addresses https://github.com/facebook/react/issues/10616.

From the snippet mentioned in the issue, the expected behavior is indeed to log the array of elements, instead of only the first element. 

In addition to that, there were some inconsistencies with the output generated by the different component types. For example, `<HostComponent>.rendered` will always be an array, while `<FunctionalComponent>.rendered` will be an object (which by the way, is what led to the issue). In order to make the response more predictable, `<Component>.rendered` will always return an array, or `null`.

Tests :white_check_mark:
Linting :white_check_mark:
Flow :white_check_mark:

