### PR TITLE
Reset effectTag to NoEffect instead of NoWork

### DIFF
--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -265,7 +265,7 @@ exports.createWorkInProgress = function(
   } else {
     // We already have an alternate.
     // Reset the effect tag.
-    workInProgress.effectTag = NoWork;
+    workInProgress.effectTag = NoEffect;
 
     // The effect list is no longer valid.
     workInProgress.nextEffect = null;


### PR DESCRIPTION
Just a small typo fix. There are currently no problems because `NoEffect` and `NoWork` are both `0`, but that can change in the future.