### PR TITLE
[Gatsby docs update] add title and meta tags, initial version

### DIFF
--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -13,22 +13,21 @@
 
 import Container from 'components/Container';
 import Flex from 'components/Flex';
-import Helmet from 'react-helmet';
 import MarkdownHeader from 'components/MarkdownHeader';
 import NavigationFooter from 'templates/components/NavigationFooter';
 import {StickyContainer} from 'react-sticky';
 import PropTypes from 'prop-types';
 import React from 'react';
 import StickySidebar from 'components/StickySidebar';
+import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import findSectionForPath from 'utils/findSectionForPath';
 import toCommaSeparatedList from 'utils/toCommaSeparatedList';
 import {sharedStyles} from 'theme';
 
-// TODO Use 'react-helmet' to set metadata
-
 const MarkdownPage = ({
   authors,
   date,
+  ogDescription,
   location,
   markdownRemark,
   sectionList,
@@ -49,7 +48,11 @@ const MarkdownPage = ({
         position: 'relative',
         zIndex: 0,
       }}>
-      <Helmet title={`${titlePrefix}${titlePostfix}`} />
+      <TitleAndMetaTags
+        title={`${titlePrefix}${titlePostfix}`}
+        ogUrl={location.pathname}
+        ogDescription={ogDescription}
+      />
       <div css={{flex: '1 0 auto'}}>
         <Container>
           <StickyContainer
@@ -59,7 +62,7 @@ const MarkdownPage = ({
             <Flex type="article" direction="column" grow="1" halign="stretch">
               <MarkdownHeader
                 path={markdownRemark.fields.path}
-                title={markdownRemark.frontmatter.title}
+                title={titlePrefix}
               />
 
               {(date || hasAuthors) &&

--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -13,6 +13,7 @@
 
 import Container from 'components/Container';
 import Flex from 'components/Flex';
+import Helmet from 'react-helmet';
 import MarkdownHeader from 'components/MarkdownHeader';
 import NavigationFooter from 'templates/components/NavigationFooter';
 import {StickyContainer} from 'react-sticky';
@@ -31,8 +32,10 @@ const MarkdownPage = ({
   location,
   markdownRemark,
   sectionList,
+  titlePostfix,
 }) => {
   const hasAuthors = authors.length > 0;
+  const titlePrefix = markdownRemark.frontmatter.title;
 
   return (
     <Flex
@@ -46,6 +49,7 @@ const MarkdownPage = ({
         position: 'relative',
         zIndex: 0,
       }}>
+      <Helmet title={`${titlePrefix}${titlePostfix}`} />
       <div css={{flex: '1 0 auto'}}>
         <Container>
           <StickyContainer

--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -32,10 +32,10 @@ const MarkdownPage = ({
   location,
   markdownRemark,
   sectionList,
-  titlePostfix,
+  titlePostfix = '',
 }) => {
   const hasAuthors = authors.length > 0;
-  const titlePrefix = markdownRemark.frontmatter.title;
+  const titlePrefix = markdownRemark.frontmatter.title || '';
 
   return (
     <Flex

--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -23,6 +23,7 @@ import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import findSectionForPath from 'utils/findSectionForPath';
 import toCommaSeparatedList from 'utils/toCommaSeparatedList';
 import {sharedStyles} from 'theme';
+import {urlRoot} from 'constants';
 
 const MarkdownPage = ({
   authors,
@@ -50,7 +51,7 @@ const MarkdownPage = ({
       }}>
       <TitleAndMetaTags
         title={`${titlePrefix}${titlePostfix}`}
-        ogUrl={location.pathname}
+        ogUrl={`${urlRoot}${location.pathname}`}
         ogDescription={ogDescription}
       />
       <div css={{flex: '1 0 auto'}}>

--- a/www/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/www/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -22,11 +22,15 @@ const TitleAndMetaTags = ({title, ogDescription, ogUrl}) => {
     <Helmet title={title}>
       <meta property="og:title" content={title} />
       <meta property="og:type" content="website" />
-      {ogUrl &&
-      <meta property="og:url" content={ogUrl} />
-      }
-      <meta property="og:image" content="https://facebook.github.io/react/img/logo_og.png" />
-      <meta property="og:description" content={ogDescription || defaultDescription} />
+      {ogUrl && <meta property="og:url" content={ogUrl} />}
+      <meta
+        property="og:image"
+        content="https://facebook.github.io/react/img/logo_og.png"
+      />
+      <meta
+        property="og:description"
+        content={ogDescription || defaultDescription}
+      />
       <meta property="fb:app_id" content="623268441017527" />
     </Helmet>
   );

--- a/www/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/www/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -17,7 +17,6 @@ import React from 'react';
 const defaultDescription = 'A JavaScript library for building user interfaces';
 
 const TitleAndMetaTags = ({title, ogDescription, ogUrl}) => {
-  // TODO: get the og:url passed in
   return (
     <Helmet title={title}>
       <meta property="og:title" content={title} />

--- a/www/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/www/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+*/
+
+'use strict';
+
+import Helmet from 'react-helmet';
+import React from 'react';
+
+const defaultDescription = 'A JavaScript library for building user interfaces';
+
+const TitleAndMetaTags = ({title, ogDescription, ogUrl}) => {
+  // TODO: get the og:url passed in
+  return (
+    <Helmet title={title}>
+      <meta property="og:title" content={title} />
+      <meta property="og:type" content="website" />
+      {ogUrl &&
+      <meta property="og:url" content={ogUrl} />
+      }
+      <meta property="og:image" content="https://facebook.github.io/react/img/logo_og.png" />
+      <meta property="og:description" content={ogDescription || defaultDescription} />
+      <meta property="fb:app_id" content="623268441017527" />
+    </Helmet>
+  );
+};
+
+export default TitleAndMetaTags;

--- a/www/src/components/TitleAndMetaTags/index.js
+++ b/www/src/components/TitleAndMetaTags/index.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+*/
+
+'use strict';
+
+import TitleAndMetaTags from './TitleAndMetaTags';
+
+export default TitleAndMetaTags;

--- a/www/src/constants.js
+++ b/www/src/constants.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ * @flow
+*/
+
+'use strict';
+
+/**
+ * Variables shared by multiple components.
+ */
+
+export default {
+  // NOTE: We can't just use `location.toString()` because when we are rendering
+  // the SSR part in node.js we won't have a proper location.
+  // TODO: update this once we move to https://react.com
+  urlRoot: 'https://facebook.github.io/react',
+};

--- a/www/src/constants.js
+++ b/www/src/constants.js
@@ -19,6 +19,5 @@
 export default {
   // NOTE: We can't just use `location.toString()` because when we are rendering
   // the SSR part in node.js we won't have a proper location.
-  // TODO: update this once we move to https://react.com
-  urlRoot: 'https://facebook.github.io/react',
+  urlRoot: 'https://reactjs.org',
 };

--- a/www/src/templates/blog.js
+++ b/www/src/templates/blog.js
@@ -36,6 +36,7 @@ const Blog = ({data, location}) => (
     authors={data.markdownRemark.frontmatter.author}
     date={data.markdownRemark.fields.date}
     location={location}
+    ogDescription={data.markdownRemark.excerpt}
     markdownRemark={data.markdownRemark}
     sectionList={toSectionList(data.allMarkdownRemark)}
     titlePostfix=' - React Blog'
@@ -51,6 +52,7 @@ export const pageQuery = graphql`
   query TemplateBlogMarkdown($slug: String!) {
     markdownRemark(fields: { slug: { eq: $slug } }) {
       html
+      excerpt(pruneLength: 500)
       frontmatter {
         title
         next

--- a/www/src/templates/blog.js
+++ b/www/src/templates/blog.js
@@ -39,7 +39,7 @@ const Blog = ({data, location}) => (
     ogDescription={data.markdownRemark.excerpt}
     markdownRemark={data.markdownRemark}
     sectionList={toSectionList(data.allMarkdownRemark)}
-    titlePostfix=' - React Blog'
+    titlePostfix=" - React Blog"
   />
 );
 

--- a/www/src/templates/blog.js
+++ b/www/src/templates/blog.js
@@ -38,6 +38,7 @@ const Blog = ({data, location}) => (
     location={location}
     markdownRemark={data.markdownRemark}
     sectionList={toSectionList(data.allMarkdownRemark)}
+    titlePostfix=' - React Blog'
   />
 );
 

--- a/www/src/templates/community.js
+++ b/www/src/templates/community.js
@@ -26,7 +26,7 @@ const Community = ({data, location}) => (
     location={location}
     markdownRemark={data.markdownRemark}
     sectionList={sectionList}
-    titlePostfix=' - React'
+    titlePostfix=" - React"
   />
 );
 

--- a/www/src/templates/community.js
+++ b/www/src/templates/community.js
@@ -26,6 +26,7 @@ const Community = ({data, location}) => (
     location={location}
     markdownRemark={data.markdownRemark}
     sectionList={sectionList}
+    titlePostfix=' - React'
   />
 );
 

--- a/www/src/templates/docs.js
+++ b/www/src/templates/docs.js
@@ -35,6 +35,7 @@ const Docs = ({data, location}) => (
     location={location}
     markdownRemark={data.markdownRemark}
     sectionList={sectionList}
+    titlePostfix=' - React'
   />
 );
 

--- a/www/src/templates/docs.js
+++ b/www/src/templates/docs.js
@@ -35,7 +35,7 @@ const Docs = ({data, location}) => (
     location={location}
     markdownRemark={data.markdownRemark}
     sectionList={sectionList}
-    titlePostfix=' - React'
+    titlePostfix=" - React"
   />
 );
 

--- a/www/src/templates/home.js
+++ b/www/src/templates/home.js
@@ -14,10 +14,10 @@
 import ButtonLink from './components/ButtonLink';
 import Container from 'components/Container';
 import Flex from 'components/Flex';
-import Helmet from 'react-helmet';
 import mountCodeExample from 'utils/mountCodeExample';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
+import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import {colors, media, sharedStyles} from 'theme';
 
 class Home extends Component {
@@ -29,11 +29,16 @@ class Home extends Component {
   }
 
   render() {
-    const {data} = this.props;
+    const {data, location} = this.props;
+    const title =
+      'React - A JavaScript library for building user interfaces';
 
     return (
       <div css={{width: '100%'}}>
-        <Helmet title='React - A JavaScript library for building user interfaces' />
+        <TitleAndMetaTags
+          title={title}
+          ogUrl={location.pathname}
+        />
         <header
           css={{
             backgroundColor: colors.dark,

--- a/www/src/templates/home.js
+++ b/www/src/templates/home.js
@@ -19,6 +19,8 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import {colors, media, sharedStyles} from 'theme';
+import {urlRoot} from 'constants';
+
 
 class Home extends Component {
   componentDidMount() {
@@ -37,7 +39,7 @@ class Home extends Component {
       <div css={{width: '100%'}}>
         <TitleAndMetaTags
           title={title}
-          ogUrl={location.pathname}
+          ogUrl={`${urlRoot}${location.pathname}`}
         />
         <header
           css={{

--- a/www/src/templates/home.js
+++ b/www/src/templates/home.js
@@ -14,6 +14,7 @@
 import ButtonLink from './components/ButtonLink';
 import Container from 'components/Container';
 import Flex from 'components/Flex';
+import Helmet from 'react-helmet';
 import mountCodeExample from 'utils/mountCodeExample';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
@@ -32,6 +33,7 @@ class Home extends Component {
 
     return (
       <div css={{width: '100%'}}>
+        <Helmet title='React - A JavaScript library for building user interfaces' />
         <header
           css={{
             backgroundColor: colors.dark,

--- a/www/src/templates/home.js
+++ b/www/src/templates/home.js
@@ -21,7 +21,6 @@ import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import {colors, media, sharedStyles} from 'theme';
 import {urlRoot} from 'constants';
 
-
 class Home extends Component {
   componentDidMount() {
     mountCodeExample('helloExample', HELLO_COMPONENT);
@@ -32,8 +31,7 @@ class Home extends Component {
 
   render() {
     const {data, location} = this.props;
-    const title =
-      'React - A JavaScript library for building user interfaces';
+    const title = 'React - A JavaScript library for building user interfaces';
 
     return (
       <div css={{width: '100%'}}>

--- a/www/src/templates/installation.js
+++ b/www/src/templates/installation.js
@@ -149,7 +149,7 @@ class InstallationPage extends Component {
           zIndex: 0,
         }}>
         <TitleAndMetaTags
-          title='Installation - React'
+          title="Installation - React"
           ogUrl={`${urlRoot}${location.pathname}`}
         />
         <div css={{flex: '1 0 auto'}}>

--- a/www/src/templates/installation.js
+++ b/www/src/templates/installation.js
@@ -13,6 +13,7 @@
 
 import Container from 'components/Container';
 import Flex from 'components/Flex';
+import Helmet from 'react-helmet';
 import MarkdownHeader from 'components/MarkdownHeader';
 import NavigationFooter from 'templates/components/NavigationFooter';
 import {StickyContainer} from 'react-sticky';
@@ -146,6 +147,7 @@ class InstallationPage extends Component {
           position: 'relative',
           zIndex: 0,
         }}>
+        <Helmet title='Installation - React' />
         <div css={{flex: '1 0 auto'}}>
           <Container>
             <StickyContainer

--- a/www/src/templates/installation.js
+++ b/www/src/templates/installation.js
@@ -22,6 +22,7 @@ import StickySidebar from 'components/StickySidebar';
 import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import findSectionForPath from 'utils/findSectionForPath';
 import {sharedStyles} from 'theme';
+import {urlRoot} from 'constants';
 
 import sectionListA from '../../../docs/_data/nav_docs.yml';
 import sectionListB from '../../../docs/_data/nav_contributing.yml';
@@ -149,7 +150,7 @@ class InstallationPage extends Component {
         }}>
         <TitleAndMetaTags
           title='Installation - React'
-          ogUrl={location.pathname}
+          ogUrl={`${urlRoot}${location.pathname}`}
         />
         <div css={{flex: '1 0 auto'}}>
           <Container>

--- a/www/src/templates/installation.js
+++ b/www/src/templates/installation.js
@@ -13,13 +13,13 @@
 
 import Container from 'components/Container';
 import Flex from 'components/Flex';
-import Helmet from 'react-helmet';
 import MarkdownHeader from 'components/MarkdownHeader';
 import NavigationFooter from 'templates/components/NavigationFooter';
 import {StickyContainer} from 'react-sticky';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import StickySidebar from 'components/StickySidebar';
+import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import findSectionForPath from 'utils/findSectionForPath';
 import {sharedStyles} from 'theme';
 
@@ -147,7 +147,10 @@ class InstallationPage extends Component {
           position: 'relative',
           zIndex: 0,
         }}>
-        <Helmet title='Installation - React' />
+        <TitleAndMetaTags
+          title='Installation - React'
+          ogUrl={location.pathname}
+        />
         <div css={{flex: '1 0 auto'}}>
           <Container>
             <StickyContainer

--- a/www/src/templates/tutorial.js
+++ b/www/src/templates/tutorial.js
@@ -22,6 +22,7 @@ const Tutorial = ({data, location}) => (
     location={location}
     markdownRemark={data.markdownRemark}
     sectionList={sectionList}
+    titlePostfix=' - React'
   />
 );
 

--- a/www/src/templates/tutorial.js
+++ b/www/src/templates/tutorial.js
@@ -22,7 +22,7 @@ const Tutorial = ({data, location}) => (
     location={location}
     markdownRemark={data.markdownRemark}
     sectionList={sectionList}
-    titlePostfix=' - React'
+    titlePostfix=" - React"
   />
 );
 


### PR DESCRIPTION
Add initial version of meta og tags to header using react-helmet

**what is the change?:**
Adds the same 'meta' tags from the old docs site to the new docs site.
Some details;
- some tags were the same for all docs pages afaik so I hard-coded those
  into a reusable component
- the 'og:url' tag is not quite right yet, but follow-up diffs can fix
  it.
- In the old docs each blog post had a description that was the first
  paragraph. That seemed complex to do here - we have access to an
  'excerpt' param in GraphQL and can set the truncation length, but
  can't specify that we want the first paragraph.
  Another option for the excerpt is to grab the HTML, get the first 'p'
  element content, and sanitize it, but that seemed more complex.

**why make this change?:**
We want metadata - the delicious cream center of each webpage :)

**test plan:**
Manual testing

This is not quite finished so I didn't test super thoroughly

**issue:**
Checklist item from Gatsby wiki;
https://github.com/bvaughn/react/wiki/Gatsby-check-list
Misc > Make sure helmet title and metadata is working correctly