### PR TITLE
Remove implicit casts of Fiber to bool

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -63,7 +63,7 @@ var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
 var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
 
 function getDeclarationErrorAddendum() {
-  if (ReactCurrentOwner.current) {
+  if (ReactCurrentOwner.current !== null) {
     var name = getComponentName(ReactCurrentOwner.current);
     if (name) {
       return '\n\nCheck the render method of `' + name + '`.';

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -574,7 +574,7 @@ function renderSubtreeIntoContainer(
     const isRootRenderedBySomeReact = !!container._reactRootContainer;
     const rootEl = getReactRootElementInContainer(container);
     const hasNonRootReactChild = !!(rootEl &&
-      ReactDOMComponentTree.getInstanceFromNode(rootEl));
+      ReactDOMComponentTree.getInstanceFromNode(rootEl) !== null);
 
     warning(
       !hasNonRootReactChild || isRootRenderedBySomeReact,
@@ -695,7 +695,7 @@ var ReactDOMFiber = {
       if (__DEV__) {
         const rootEl = getReactRootElementInContainer(container);
         const renderedByDifferentReact =
-          rootEl && !ReactDOMComponentTree.getInstanceFromNode(rootEl);
+          rootEl && ReactDOMComponentTree.getInstanceFromNode(rootEl) === null;
         warning(
           !renderedByDifferentReact,
           "unmountComponentAtNode(): The node you're attempting to unmount " +
@@ -716,7 +716,7 @@ var ReactDOMFiber = {
       if (__DEV__) {
         const rootEl = getReactRootElementInContainer(container);
         const hasNonRootReactChild = !!(rootEl &&
-          ReactDOMComponentTree.getInstanceFromNode(rootEl));
+          ReactDOMComponentTree.getInstanceFromNode(rootEl) !== null);
 
         // Check if the container itself is a React root node.
         const isContainerReactRoot =

--- a/src/renderers/dom/shared/ReactDOMComponentTree.js
+++ b/src/renderers/dom/shared/ReactDOMComponentTree.js
@@ -126,25 +126,26 @@ function precacheChildNodes(inst, node) {
  * ReactDOMTextComponent instance ancestor.
  */
 function getClosestInstanceFromNode(node) {
-  if (node[internalInstanceKey]) {
-    return node[internalInstanceKey];
+  let inst = node[internalInstanceKey];
+  if (inst !== undefined) {
+    return inst;
   }
 
   // Walk up the tree until we find an ancestor whose instance we have cached.
   var parents = [];
-  while (!node[internalInstanceKey]) {
+  do {
     parents.push(node);
     if (node.parentNode) {
       node = node.parentNode;
+      inst = node[internalInstanceKey];
     } else {
       // Top of the tree. This node must not be part of a React tree (or is
       // unmounted, potentially).
       return null;
     }
-  }
+  } while (inst === undefined);
 
   var closest;
-  var inst = node[internalInstanceKey];
   if (inst.tag === HostComponent || inst.tag === HostText) {
     // In Fiber, this will always be the deepest root.
     return inst;
@@ -165,7 +166,7 @@ function getClosestInstanceFromNode(node) {
  */
 function getInstanceFromNode(node) {
   var inst = node[internalInstanceKey];
-  if (inst) {
+  if (inst !== undefined) {
     if (inst.tag === HostComponent || inst.tag === HostText) {
       return inst;
     } else if (inst._hostNode === node) {

--- a/src/renderers/dom/shared/ReactDOMEventListener.js
+++ b/src/renderers/dom/shared/ReactDOMEventListener.js
@@ -87,12 +87,12 @@ function handleTopLevelImpl(bookKeeping) {
   // inconsistencies with ReactMount's node cache. See #1105.
   var ancestor = targetInst;
   do {
-    if (!ancestor) {
+    if (ancestor === null) {
       bookKeeping.ancestors.push(ancestor);
       break;
     }
     var root = findRootContainerNode(ancestor);
-    if (!root) {
+    if (root === null) {
       break;
     }
     bookKeeping.ancestors.push(ancestor);

--- a/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/ChangeEventPlugin.js
@@ -268,7 +268,7 @@ var ChangeEventPlugin = {
     nativeEvent,
     nativeEventTarget,
   ) {
-    var targetNode = targetInst
+    var targetNode = targetInst !== null
       ? ReactDOMComponentTree.getNodeFromInstance(targetInst)
       : window;
 
@@ -288,7 +288,7 @@ var ChangeEventPlugin = {
 
     if (getTargetInstFunc) {
       var inst = getTargetInstFunc(topLevelType, targetInst);
-      if (inst) {
+      if (inst != null) {
         var event = createAndAccumulateChangeEvent(
           inst,
           nativeEvent,

--- a/src/renderers/dom/shared/eventPlugins/SelectEventPlugin.js
+++ b/src/renderers/dom/shared/eventPlugins/SelectEventPlugin.js
@@ -160,7 +160,7 @@ var SelectEventPlugin = {
       return null;
     }
 
-    var targetNode = targetInst
+    var targetNode = targetInst !== null
       ? ReactDOMComponentTree.getNodeFromInstance(targetInst)
       : window;
 

--- a/src/renderers/dom/shared/findDOMNode.js
+++ b/src/renderers/dom/shared/findDOMNode.js
@@ -62,7 +62,7 @@ const findDOMNode = function(
   }
 
   var inst = ReactInstanceMap.get(componentOrElement);
-  if (inst) {
+  if (inst !== undefined) {
     if (typeof inst.tag === 'number') {
       return findFiber(inst);
     } else {

--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -94,13 +94,10 @@ function findAllInRenderedStackTreeInternal(inst, test) {
 }
 
 function findAllInRenderedFiberTreeInternal(fiber, test) {
-  if (!fiber) {
-    return [];
-  }
   var currentParent = ReactFiberTreeReflection.findCurrentFiberUsingSlowPath(
     fiber,
   );
-  if (!currentParent) {
+  if (currentParent === null) {
     return [];
   }
   let node = currentParent;
@@ -117,7 +114,7 @@ function findAllInRenderedFiberTreeInternal(fiber, test) {
         ret.push(publicInst);
       }
     }
-    if (node.child) {
+    if (node.child !== null) {
       node.child.return = node;
       node = node.child;
       continue;
@@ -125,8 +122,8 @@ function findAllInRenderedFiberTreeInternal(fiber, test) {
     if (node === currentParent) {
       return ret;
     }
-    while (!node.sibling) {
-      if (!node.return || node.return === currentParent) {
+    while (node.sibling === null) {
+      if (node.return === null || node.return === currentParent) {
         return ret;
       }
       node = node.return;

--- a/src/renderers/native/findNodeHandle.js
+++ b/src/renderers/native/findNodeHandle.js
@@ -87,7 +87,7 @@ function findNodeHandle(componentOrHandle: any): any {
   // TODO (balpert): Wrap iOS native components in a composite wrapper, then
   // ReactInstanceMap.get here will always succeed for mounted components
   var internalInstance: Fiber = ReactInstanceMap.get(component);
-  if (internalInstance) {
+  if (internalInstance !== undefined) {
     return ReactNativeFiberRenderer.findHostInstance(internalInstance);
   } else {
     if (component) {

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -291,7 +291,7 @@ var ReactNoop = {
       return component;
     }
     const inst = ReactInstanceMap.get(component);
-    return inst ? NoopRenderer.findHostInstance(inst) : null;
+    return inst !== undefined ? NoopRenderer.findHostInstance(inst) : null;
   },
 
   flushDeferredPri(timeout: number = Infinity): Array<mixed> {

--- a/src/renderers/shared/fiber/ReactChildFiber.js
+++ b/src/renderers/shared/fiber/ReactChildFiber.js
@@ -121,28 +121,20 @@ function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<*> {
 function coerceRef(current: Fiber | null, element: ReactElement) {
   let mixedRef = element.ref;
   if (mixedRef !== null && typeof mixedRef !== 'function') {
-    if (element._owner) {
-      const owner: ?(Fiber | ReactInstance) = (element._owner: any);
+    const owner: ?(Fiber | ReactInstance) = (element._owner: any);
+    if (owner != null) {
       let inst;
-      if (owner) {
-        if (typeof owner.tag === 'number') {
-          const ownerFiber = ((owner: any): Fiber);
-          invariant(
-            ownerFiber.tag === ClassComponent,
-            'Stateless function components cannot have refs.',
-          );
-          inst = ownerFiber.stateNode;
-        } else {
-          // Stack
-          inst = (owner: any).getPublicInstance();
-        }
+      if (typeof owner.tag === 'number') {
+        const ownerFiber = ((owner: any): Fiber);
+        invariant(
+          ownerFiber.tag === ClassComponent,
+          'Stateless function components cannot have refs.',
+        );
+        inst = ownerFiber.stateNode;
+      } else {
+        // Stack
+        inst = (owner: any).getPublicInstance();
       }
-      invariant(
-        inst,
-        'Missing owner for string ref %s. This error is likely caused by a ' +
-          'bug in React. Please file an issue.',
-        mixedRef,
-      );
       const stringRef = '' + mixedRef;
       // Check if previous string ref matches new string ref
       if (
@@ -875,7 +867,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
           newChildren[newIdx],
           priority,
         );
-        if (!newFiber) {
+        if (newFiber === null) {
           continue;
         }
         lastPlacedIndex = placeChild(newFiber, lastPlacedIndex, newIdx);
@@ -902,7 +894,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         newChildren[newIdx],
         priority,
       );
-      if (newFiber) {
+      if (newFiber !== null) {
         if (shouldTrackSideEffects) {
           if (newFiber.alternate !== null) {
             // The new fiber is a work in progress, but if there exists a
@@ -1007,13 +999,13 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
         // unfortunate because it triggers the slow path all the time. We need
         // a better way to communicate whether this was a miss or null,
         // boolean, undefined, etc.
-        if (!oldFiber) {
+        if (oldFiber === null) {
           oldFiber = nextOldFiber;
         }
         break;
       }
       if (shouldTrackSideEffects) {
-        if (oldFiber && newFiber.alternate === null) {
+        if (oldFiber !== null && newFiber.alternate === null) {
           // We matched the slot, but we didn't reuse the existing fiber, so we
           // need to delete the existing child.
           deleteChild(returnFiber, oldFiber);

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -351,7 +351,7 @@ function createFiberFromElementType(
   type: mixed,
   key: null | string,
   internalContextTag: TypeOfInternalContext,
-  debugOwner: null | Fiber | ReactInstance,
+  debugOwner: ?(Fiber | ReactInstance),
 ): Fiber {
   let fiber;
   if (typeof type === 'function') {
@@ -387,7 +387,9 @@ function createFiberFromElementType(
           ' You likely forgot to export your component from the file ' +
           "it's defined in.";
       }
-      const ownerName = debugOwner ? getComponentName(debugOwner) : null;
+      const ownerName = debugOwner != null
+        ? getComponentName(debugOwner)
+        : null;
       if (ownerName) {
         info += '\n\nCheck the render method of `' + ownerName + '`.';
       }

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -177,7 +177,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   function markRef(current: Fiber | null, workInProgress: Fiber) {
     const ref = workInProgress.ref;
-    if (ref !== null && (!current || current.ref !== ref)) {
+    if (ref !== null && (current === null || current.ref !== ref)) {
       // Schedule a Ref effect
       workInProgress.effectTag |= Ref;
     }

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -385,7 +385,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // itself will be GC:ed when the parent updates the next time.
     current.return = null;
     current.child = null;
-    if (current.alternate) {
+    if (current.alternate !== null) {
       current.alternate.child = null;
       current.alternate.return = null;
     }

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -85,7 +85,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   function appendAllYields(yields: Array<mixed>, workInProgress: Fiber) {
     let node = workInProgress.stateNode;
-    if (node) {
+    if (node !== null) {
       node.return = workInProgress;
     }
     while (node !== null) {

--- a/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/src/renderers/shared/fiber/ReactFiberContext.js
@@ -303,7 +303,7 @@ exports.findCurrentUnmaskedContext = function(fiber: Fiber): Object {
     }
     const parent = node.return;
     invariant(
-      parent,
+      parent !== null,
       'Found unexpected detached subtree parent. ' +
         'This error is likely caused by a bug in React. Please file an issue.',
     );

--- a/src/renderers/shared/fiber/ReactFiberHydrationContext.js
+++ b/src/renderers/shared/fiber/ReactFiberHydrationContext.js
@@ -295,7 +295,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     popToNextHostParent(fiber);
-    nextHydratableInstance = hydrationParentFiber
+    nextHydratableInstance = hydrationParentFiber !== null
       ? getNextHydratableSibling(fiber.stateNode)
       : null;
     return true;

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -293,7 +293,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       container: OpaqueRoot,
     ): React$Component<any, any> | PI | null {
       const containerFiber = container.current;
-      if (!containerFiber.child) {
+      if (containerFiber.child === null) {
         return null;
       }
       switch (containerFiber.child.tag) {

--- a/src/renderers/shared/fiber/ReactFiberTreeReflection.js
+++ b/src/renderers/shared/fiber/ReactFiberTreeReflection.js
@@ -40,7 +40,7 @@ var UNMOUNTED = 3;
 
 function isFiberMountedImpl(fiber: Fiber): number {
   let node = fiber;
-  if (!fiber.alternate) {
+  if (fiber.alternate === null) {
     // If there is no alternate, this might be a new tree that isn't inserted
     // yet. If it is, then it will have a pending insertion effect on it.
     if ((node.effectTag & Placement) !== NoEffect) {
@@ -89,8 +89,8 @@ exports.isMounted = function(component: React$Component<any, any>): boolean {
     }
   }
 
-  var fiber: ?Fiber = ReactInstanceMap.get(component);
-  if (!fiber) {
+  var fiber: Fiber | void = ReactInstanceMap.get(component);
+  if (fiber === undefined) {
     return false;
   }
   return isFiberMountedImpl(fiber) === MOUNTED;
@@ -105,7 +105,7 @@ function assertIsMounted(fiber) {
 
 function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
   let alternate = fiber.alternate;
-  if (!alternate) {
+  if (alternate === null) {
     // If there is no alternate, then we only need to check if it is mounted.
     const state = isFiberMountedImpl(fiber);
     invariant(
@@ -124,8 +124,8 @@ function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
   let b = alternate;
   while (true) {
     let parentA = a.return;
-    let parentB = parentA ? parentA.alternate : null;
-    if (!parentA || !parentB) {
+    let parentB = parentA !== null ? parentA.alternate : null;
+    if (parentA === null || parentB === null) {
       // We're at the root.
       break;
     }
@@ -135,7 +135,7 @@ function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
     // priority: the bailed out fiber's child reuses the current child.
     if (parentA.child === parentB.child) {
       let child = parentA.child;
-      while (child) {
+      while (child !== null) {
         if (child === a) {
           // We've determined that A is the current branch.
           assertIsMounted(parentA);
@@ -168,7 +168,7 @@ function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
       // Search parent A's child set
       let didFindChild = false;
       let child = parentA.child;
-      while (child) {
+      while (child !== null) {
         if (child === a) {
           didFindChild = true;
           a = parentA;
@@ -186,7 +186,7 @@ function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
       if (!didFindChild) {
         // Search parent B's child set
         child = parentB.child;
-        while (child) {
+        while (child !== null) {
           if (child === a) {
             didFindChild = true;
             a = parentB;
@@ -232,7 +232,7 @@ exports.findCurrentFiberUsingSlowPath = findCurrentFiberUsingSlowPath;
 
 exports.findCurrentHostFiber = function(parent: Fiber): Fiber | null {
   const currentParent = findCurrentFiberUsingSlowPath(parent);
-  if (!currentParent) {
+  if (currentParent === null) {
     return null;
   }
 
@@ -241,7 +241,7 @@ exports.findCurrentHostFiber = function(parent: Fiber): Fiber | null {
   while (true) {
     if (node.tag === HostComponent || node.tag === HostText) {
       return node;
-    } else if (node.child) {
+    } else if (node.child !== null) {
       node.child.return = node;
       node = node.child;
       continue;
@@ -249,8 +249,8 @@ exports.findCurrentHostFiber = function(parent: Fiber): Fiber | null {
     if (node === currentParent) {
       return null;
     }
-    while (!node.sibling) {
-      if (!node.return || node.return === currentParent) {
+    while (node.sibling === null) {
+      if (node.return === null || node.return === currentParent) {
         return null;
       }
       node = node.return;
@@ -267,7 +267,7 @@ exports.findCurrentHostFiberWithNoPortals = function(
   parent: Fiber,
 ): Fiber | null {
   const currentParent = findCurrentFiberUsingSlowPath(parent);
-  if (!currentParent) {
+  if (currentParent === null) {
     return null;
   }
 
@@ -276,7 +276,7 @@ exports.findCurrentHostFiberWithNoPortals = function(
   while (true) {
     if (node.tag === HostComponent || node.tag === HostText) {
       return node;
-    } else if (node.child && node.tag !== HostPortal) {
+    } else if (node.child !== null && node.tag !== HostPortal) {
       node.child.return = node;
       node = node.child;
       continue;
@@ -284,8 +284,8 @@ exports.findCurrentHostFiberWithNoPortals = function(
     if (node === currentParent) {
       return null;
     }
-    while (!node.sibling) {
-      if (!node.return || node.return === currentParent) {
+    while (node.sibling === null) {
+      if (node.return === null || node.return === currentParent) {
         return null;
       }
       node = node.return;

--- a/src/renderers/shared/shared/ReactTreeTraversal.js
+++ b/src/renderers/shared/shared/ReactTreeTraversal.js
@@ -26,9 +26,8 @@ function getParent(inst) {
       // host node but that wouldn't work for React Native and doesn't let us
       // do the portal feature.
     } while (inst && inst.tag !== HostComponent);
-    if (inst) {
-      return inst;
-    }
+    // Possibly null.
+    return inst;
   }
   return null;
 }
@@ -117,7 +116,9 @@ function traverseTwoPhase(inst, fn, arg) {
  * "entered" or "left" that element.
  */
 function traverseEnterLeave(from, to, fn, argFrom, argTo) {
-  var common = from && to ? getLowestCommonAncestor(from, to) : null;
+  var common = from !== null && to !== null
+    ? getLowestCommonAncestor(from, to)
+    : null;
   var pathFrom = [];
   while (from && from !== common) {
     pathFrom.push(from);

--- a/src/renderers/shared/shared/event/EventPluginUtils.js
+++ b/src/renderers/shared/shared/event/EventPluginUtils.js
@@ -67,12 +67,12 @@ if (__DEV__) {
     var listenersIsArr = Array.isArray(dispatchListeners);
     var listenersLen = listenersIsArr
       ? dispatchListeners.length
-      : dispatchListeners ? 1 : 0;
+      : dispatchListeners != null ? 1 : 0;
 
     var instancesIsArr = Array.isArray(dispatchInstances);
     var instancesLen = instancesIsArr
       ? dispatchInstances.length
-      : dispatchInstances ? 1 : 0;
+      : dispatchInstances != null ? 1 : 0;
 
     warning(
       instancesIsArr === listenersIsArr && instancesLen === listenersLen,
@@ -152,7 +152,7 @@ function executeDispatchesInOrderStopAtTrueImpl(event) {
         return dispatchInstances[i];
       }
     }
-  } else if (dispatchListeners) {
+  } else if (dispatchListeners != null) {
     if (dispatchListeners(event, dispatchInstances)) {
       return dispatchInstances;
     }

--- a/src/renderers/shared/shared/event/ReactControlledComponent.js
+++ b/src/renderers/shared/shared/event/ReactControlledComponent.js
@@ -34,7 +34,7 @@ function restoreStateOfTarget(target) {
   // We perform this translation at the end of the event loop so that we
   // always receive the correct fiber here
   var internalInstance = EventPluginUtils.getInstanceFromNode(target);
-  if (!internalInstance) {
+  if (internalInstance === null) {
     // Unmounted
     return;
   }

--- a/src/renderers/shared/shared/event/eventPlugins/ResponderEventPlugin.js
+++ b/src/renderers/shared/shared/event/eventPlugins/ResponderEventPlugin.js
@@ -355,7 +355,7 @@ function setResponderAndExtractTransfer(
     shouldSetEvent.constructor.release(shouldSetEvent);
   }
 
-  if (!wantsResponderInst || wantsResponderInst === responderInst) {
+  if (wantsResponderInst === null || wantsResponderInst === responderInst) {
     return null;
   }
   var extracted;

--- a/src/shared/ReactFiberComponentTreeHook.js
+++ b/src/shared/ReactFiberComponentTreeHook.js
@@ -34,7 +34,7 @@ function describeFiber(fiber: Fiber): string {
       var source = fiber._debugSource;
       var name = getComponentName(fiber);
       var ownerName = null;
-      if (owner) {
+      if (owner != null) {
         ownerName = getComponentName(owner);
       }
       return describeComponentFrame(name, source, ownerName);


### PR DESCRIPTION
In a couple places I used `==` weak equals -- particularly, element._owner (either null from ReactCurrentOwner, or undefined if it's not present at all), event._dispatchInstances from event system where typing is sloppier, and ChangeEventPlugin which mixes null/undefined. Everywhere else I did strict and believe that it's safe.

Methodology: run tests with this patch and fix all errors.

```diff
diff --git a/scripts/jest/environment.js b/scripts/jest/environment.js
index 71323d7de..96e52aac7 100644
--- a/scripts/jest/environment.js
+++ b/scripts/jest/environment.js
@@ -15,3 +15,15 @@ global.requestIdleCallback = function(callback) {
     });
   });
 };
+
+eval(
+  `
+global.checkBool = function(x) {
+  if (typeof x === 'object' && x !== null && 'stateNode' in x) {
+    //console.log('xyz', new Error().stack);
+    throw new Error('Cast of Fiber to bool detected');
+  }
+  return x;
+};
+`
+);
diff --git a/scripts/jest/preprocessor.js b/scripts/jest/preprocessor.js
index 7727b1b2d..022f6d08c 100644
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -53,6 +53,39 @@ var babelOptions = {
     // into ReactART builds that include JSX.
     // TODO: I have not verified that this actually works.
     require.resolve('babel-plugin-transform-react-jsx-source'),
+    function(babel) {
+      const {types: t} = babel;
+
+      return {
+        name: 'check-bool', // not required
+        visitor: {
+          Conditional(path) {
+            path.node.test = t.CallExpression(t.identifier('checkBool'), [
+              path.node.test,
+            ]);
+          },
+          UnaryExpression(path) {
+            if (path.node.operator === '!') {
+              path.node.argument = t.CallExpression(t.identifier('checkBool'), [
+                path.node.argument,
+              ]);
+            }
+          },
+          BinaryExpression(path) {
+            if (path.node.operator === '||' || path.node.operator === '&&') {
+              path.node.left = t.CallExpression(t.identifier('checkBool'), [
+                path.node.left,
+              ]);
+              path.node.right = t.CallExpression(t.identifier('checkBool'), [
+                path.node.right,
+              ]);
+            }
+          },
+        },
+      };
+    },
   ],
   retainLines: true,
 };
```