### PR TITLE
[Docs] Fix onClick button handler

### DIFF
--- a/docs/docs/refs-and-the-dom.md
+++ b/docs/docs/refs-and-the-dom.md
@@ -58,7 +58,7 @@ class CustomTextInput extends React.Component {
         <input
           type="button"
           value="Focus the text input"
-          onClick={this.focus}
+          onClick={this.focusTextInput}
         />
       </div>
     );


### PR DESCRIPTION
I found a little typo in the doc, button onClick handler should be "focusTextInput" not "focus".
