### PR TITLE
Share Object.assign polyfill between UMD builds

### DIFF
--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -87,7 +87,7 @@ function createModuleMap(paths, extractErrors, bundleType) {
   return moduleMap;
 }
 
-function getNodeModules(bundleType) {
+function getNodeModules(bundleType, isRenderer) {
   // rather than adding the rollup node resolve plugin,
   // we can instead deal with the only node module that is used
   // for UMD bundles - object-assign
@@ -95,7 +95,11 @@ function getNodeModules(bundleType) {
     case UMD_DEV:
     case UMD_PROD:
       return {
-        'object-assign': resolve('./node_modules/object-assign/index.js'),
+        // Bundle object-assign once in the isomorphic React, and then use
+        // that from the renderer UMD. Avoids bundling it in both UMDs.
+        'object-assign': isRenderer
+          ? resolve('./scripts/rollup/shims/rollup/assign.js')
+          : resolve('./node_modules/object-assign/index.js'),
         // include the ART package modules directly by aliasing them from node_modules
         'art/modes/current': resolve('./node_modules/art/modes/current.js'),
         'art/modes/fast-noSideEffects': resolve(
@@ -286,7 +290,7 @@ function getAliases(paths, bundleType, isRenderer, extractErrors) {
       bundleType
     ),
     getInternalModules(),
-    getNodeModules(bundleType),
+    getNodeModules(bundleType, isRenderer),
     getFbjsModuleAliases(bundleType)
   );
 }

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -1,36 +1,36 @@
 {
   "bundleSizes": {
     "react.development.js (UMD_DEV)": {
-      "size": 66238,
-      "gzip": 16739
+      "size": 66336,
+      "gzip": 16788
     },
     "react.production.min.js (UMD_PROD)": {
-      "size": 6707,
-      "gzip": 2801
+      "size": 6716,
+      "gzip": 2804
     },
     "react.development.js (NODE_DEV)": {
-      "size": 56692,
-      "gzip": 14483
+      "size": 56799,
+      "gzip": 14530
     },
     "react.production.min.js (NODE_PROD)": {
-      "size": 5730,
-      "gzip": 2416
+      "size": 5739,
+      "gzip": 2421
     },
     "React-dev.js (FB_DEV)": {
-      "size": 53533,
-      "gzip": 13666
+      "size": 53683,
+      "gzip": 13731
     },
     "React-prod.js (FB_PROD)": {
-      "size": 25034,
-      "gzip": 6707
+      "size": 25188,
+      "gzip": 6767
     },
     "react-dom.development.js (UMD_DEV)": {
-      "size": 649654,
-      "gzip": 149173
+      "size": 647720,
+      "gzip": 148505
     },
     "react-dom.production.min.js (UMD_PROD)": {
-      "size": 103686,
-      "gzip": 32364
+      "size": 102839,
+      "gzip": 32049
     },
     "react-dom.development.js (NODE_DEV)": {
       "size": 608523,
@@ -81,12 +81,12 @@
       "gzip": 15742
     },
     "react-dom-server.browser.development.js (UMD_DEV)": {
-      "size": 136901,
-      "gzip": 34895
+      "size": 134937,
+      "gzip": 34221
     },
     "react-dom-server.browser.production.min.js (UMD_PROD)": {
-      "size": 15917,
-      "gzip": 6199
+      "size": 15077,
+      "gzip": 5914
     },
     "react-dom-server.browser.development.js (NODE_DEV)": {
       "size": 105249,
@@ -113,12 +113,12 @@
       "gzip": 6238
     },
     "react-art.development.js (UMD_DEV)": {
-      "size": 372313,
-      "gzip": 82691
+      "size": 370239,
+      "gzip": 81901
     },
     "react-art.production.min.js (UMD_PROD)": {
-      "size": 83447,
-      "gzip": 25837
+      "size": 82583,
+      "gzip": 25472
     },
     "react-art.development.js (NODE_DEV)": {
       "size": 293850,

--- a/scripts/rollup/shims/rollup/assign.js
+++ b/scripts/rollup/shims/rollup/assign.js
@@ -1,0 +1,4 @@
+var ReactInternals = require('react')
+  .__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+module.exports = ReactInternals.assign;

--- a/src/isomorphic/ReactEntry.js
+++ b/src/isomorphic/ReactEntry.js
@@ -52,6 +52,8 @@ var React = {
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     ReactCurrentOwner: require('ReactCurrentOwner'),
+    // Used by renderers to avoid bundling object-assign twice in UMD bundles:
+    assign: require('object-assign'),
   },
 };
 


### PR DESCRIPTION
This wins back 0.3k post min/gzip which we lost due to adding license headers 😛 We can later share more utilities like this, since currently it's suboptimal that some `fbjs` things are duplicated. This only affects UMD builds.

How I verified it works:

* Fixtures work (but they were broken between changing the bundling logic and adding an export)
* The combined size has decreased
* The diff makes sense (https://gist.github.com/gaearon/75431ad02d69a08e95aef6fba2645244), most of it is renaming `index` to `assign` though (since Rollup gives it a different name now)

It only affects UMD builds and doesn’t affect any other builds.
This is not global shared state, it's just manual deduplication.