### PR TITLE
Remove undocumented TestUtils methods

### DIFF
--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -197,38 +197,6 @@ var ReactTestUtils = {
     return constructor === type;
   },
 
-  // TODO: deprecate? It's undocumented and unused.
-  isCompositeComponentElement: function(inst) {
-    if (!React.isValidElement(inst)) {
-      return false;
-    }
-    // We check the prototype of the type that will get mounted, not the
-    // instance itself. This is a future proof way of duck typing.
-    var prototype = inst.type.prototype;
-    return (
-      typeof prototype.render === 'function' &&
-      typeof prototype.setState === 'function'
-    );
-  },
-
-  // TODO: deprecate? It's undocumented and unused.
-  isCompositeComponentElementWithType: function(inst, type) {
-    var internalInstance = ReactInstanceMap.get(inst);
-    var constructor = internalInstance._currentElement.type;
-
-    return !!(ReactTestUtils.isCompositeComponentElement(inst) &&
-      constructor === type);
-  },
-
-  // TODO: deprecate? It's undocumented and unused.
-  getRenderedChildOfCompositeComponent: function(inst) {
-    if (!ReactTestUtils.isCompositeComponent(inst)) {
-      return null;
-    }
-    var internalInstance = ReactInstanceMap.get(inst);
-    return internalInstance._renderedComponent.getPublicInstance();
-  },
-
   findAllInRenderedTree: function(inst, test) {
     if (!inst) {
       return [];


### PR DESCRIPTION
These methods are not documented. Internally there's just one match of `isCompositeComponentElement` which is trivial to inline. The other two methods are not used internally, and have been broken in all 16 betas and RCs.

Enzyme technically imports them but doesn’t use. They don’t want to remove them until we remove them (https://github.com/airbnb/enzyme/pull/1023). So let’s just remove before 16.