### PR TITLE
Stop exposing shallow renderer from TestUtils

### DIFF
--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -49,12 +49,12 @@
       "gzip": 94276
     },
     "react-dom-test-utils.development.js (NODE_DEV)": {
-      "size": 53750,
-      "gzip": 13493
+      "size": 44954,
+      "gzip": 11677
     },
     "ReactTestUtils-dev.js (FB_DEV)": {
-      "size": 53159,
-      "gzip": 13402
+      "size": 44385,
+      "gzip": 11593
     },
     "react-dom-unstable-native-dependencies.development.js (UMD_DEV)": {
       "size": 88140,

--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -16,7 +16,6 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var ReactFiberTreeReflection = require('ReactFiberTreeReflection');
 var ReactInstanceMap = require('ReactInstanceMap');
-var ReactShallowRenderer = require('ReactShallowRendererEntry'); // TODO (bvaughn) Remove this import before 16.0.0
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var SyntheticEvent = require('SyntheticEvent');
 
@@ -43,20 +42,6 @@ var {
   HostComponent,
   HostText,
 } = ReactTypeOfWork;
-
-// TODO (bvaughn) Remove this warning before 16.0.0
-// It's only being added for temporary deprecation notice in RN.
-let warnedAboutShallowRenderer = false;
-function createRendererWithWarning() {
-  warning(
-    warnedAboutShallowRenderer,
-    'Shallow renderer has been moved to react-test-renderer/shallow. ' +
-      'Update references to remove this warning. ' +
-      'TestUtils.createRenderer will be removed completely in React 16.',
-  );
-  warnedAboutShallowRenderer = true;
-  return new ReactShallowRenderer();
-}
 
 function Event(suffix) {}
 
@@ -425,10 +410,6 @@ var ReactTestUtils = {
       touches: [{pageX: x, pageY: y}],
     };
   },
-
-  // TODO (bvaughn) Remove this warning accessor before 16.0.0.
-  // It's only being added for temporary deprecation notice in RN.
-  createRenderer: createRendererWithWarning,
 
   Simulate: null,
   SimulateNative: {},

--- a/src/renderers/dom/test/ReactTestUtilsEntry.js
+++ b/src/renderers/dom/test/ReactTestUtilsEntry.js
@@ -21,10 +21,6 @@ var SyntheticEvent = require('SyntheticEvent');
 
 var invariant = require('fbjs/lib/invariant');
 
-if (__DEV__) {
-  var warning = require('fbjs/lib/warning');
-}
-
 var {findDOMNode} = ReactDOM;
 var {
   EventPluginHub,


### PR DESCRIPTION
We intended to remove this export in React 16, but forgot to do it in RC.

It clearly warns about being removed in 16 though so it's not too bad.