### PR TITLE
Remove View.propTypes RN deprecation workaround

### DIFF
--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -213,16 +213,7 @@ function validatePropTypes(element) {
     return;
   }
   var name = componentClass.displayName || componentClass.name;
-
-  // ReactNative `View.propTypes` have been deprecated in favor of `ViewPropTypes`.
-  // In their place a temporary getter has been added with a deprecated warning message.
-  // Avoid triggering that warning during validation using the temporary workaround,
-  // __propTypesSecretDontUseThesePlease.
-  // TODO (bvaughn) Revert this particular change any time after April 1 ReactNative tag.
-  var propTypes = typeof componentClass.__propTypesSecretDontUseThesePlease ===
-    'object'
-    ? componentClass.__propTypesSecretDontUseThesePlease
-    : componentClass.propTypes;
+  var propTypes = componentClass.propTypes;
 
   if (propTypes) {
     currentlyValidatingElement = element;


### PR DESCRIPTION
Looks like we don't need it anymore?
Based on

>Revert this particular change any time after April 1 ReactNative tag.

I haven't actually tested.