### PR TITLE
docs: Update ref syntax

### DIFF
--- a/docs/docs/addons-test-utils.md
+++ b/docs/docs/addons-test-utils.md
@@ -66,16 +66,16 @@ Simulate an event dispatch on a DOM node with optional `eventData` event data.
 **Clicking an element**
 
 ```javascript
-// <button ref="button">...</button>
-const node = this.refs.button;
+// <button ref={(button) => { this.button = button; }}>...</button>
+const node = this.button;
 ReactTestUtils.Simulate.click(node);
 ```
 
 **Changing the value of an input field and then pressing ENTER.**
 
 ```javascript
-// <input ref="input" />
-const node = this.refs.input;
+// <input ref={(input) => { this.input = input; }} />
+const node = this.input;
 node.value = 'giraffe';
 ReactTestUtils.Simulate.change(node);
 ReactTestUtils.Simulate.keyDown(node, {key: "Enter", keyCode: 13, which: 13});


### PR DESCRIPTION
Using `ref="button"`, as the docs currently state, yields an error: `TypeError: Cannot read property 'tagName' of undefined`

I've updated this to the new syntax as described in https://facebook.github.io/react/docs/refs-and-the-dom.html, and it's now working.