### PR TITLE
Report bad dead code elimination to React DevTools

### DIFF
--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 function checkDCE() {
+  /* global __REACT_DEVTOOLS_GLOBAL_HOOK__ */
   if (
     typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined' ||
     typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE !== 'function'

--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -1,6 +1,36 @@
 'use strict';
 
+function checkDCE() {
+  if (
+    typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined' ||
+    typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE !== 'function'
+  ) {
+    return;
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    // This branch is unreachable because this function is only called
+    // in production, but the condition is true only in development.
+    // Therefore if the branch is still here, dead code elimination wasn't
+    // properly applied.
+    // Don't change the message. React DevTools relies on it. Also make sure
+    // this message doesn't occur elsewhere in this function, or it will cause
+    // a false positive.
+    throw new Error('^_^');
+  }
+  try {
+    // Verify that the code above has been dead code eliminated (DCE'd).
+    __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(checkDCE);
+  } catch (err) {
+    // DevTools shouldn't crash React, no matter what.
+    // We should still report in case we break this code.
+    console.error(err);
+  }
+}
+
 if (process.env.NODE_ENV === 'production') {
+  // DCE check should happen before ReactDOM bundle executes so that
+  // DevTools can report bad minification during injection.
+  checkDCE();
   module.exports = require('./cjs/react-dom.production.min.js');
 } else {
   module.exports = require('./cjs/react-dom.development.js');


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/9589 (again).
We started with https://github.com/facebook/react/pull/10446, then reverted it in https://github.com/facebook/react/pull/10673 over concerns in https://github.com/facebook/react/pull/10640.

This time we don’t rely on `toString` inside ReactDOM itself. Instead we report to React DevTools if they exist, passing the function itself as an argument.

React DevTools can check for `^_^` there and both produce the “red React” and potentially even do the `setTimeout` trick to report the error to analytics.

This doesn’t have the same concerns as explained in https://github.com/facebook/react/pull/10640 because we’re not doing it for *every* user but only for React developers who visit React-powered websites which are also built with CommonJS. So it’s a smaller slice. If we suddenly can’t rely on `toString` anymore we can always cut that code from DevTools.