### PR TITLE
Fix FB isomorphic build

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -369,6 +369,25 @@ const bundles = [
   },
 ];
 
+// Based on deep-freeze by substack (public domain)
+function deepFreeze(o) {
+  Object.freeze(o);
+  Object.getOwnPropertyNames(o).forEach(function(prop) {
+    if (
+      o.hasOwnProperty(prop) &&
+      o[prop] !== null &&
+      (typeof o[prop] === 'object' || typeof o[prop] === 'function') &&
+      !Object.isFrozen(o[prop])
+    ) {
+      deepFreeze(o[prop]);
+    }
+  });
+  return o;
+}
+
+// Don't accidentally mutate config as part of the build
+deepFreeze(bundles);
+
 module.exports = {
   bundleTypes,
   bundles,

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -374,7 +374,6 @@ function deepFreeze(o) {
   Object.freeze(o);
   Object.getOwnPropertyNames(o).forEach(function(prop) {
     if (
-      o.hasOwnProperty(prop) &&
       o[prop] !== null &&
       (typeof o[prop] === 'object' || typeof o[prop] === 'function') &&
       !Object.isFrozen(o[prop])

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -143,7 +143,7 @@ function getExternalModules(externals, bundleType, isRenderer) {
   // this means having a require("name-of-external-module") at
   // the top of the bundle. for UMD bundles this means having
   // both a require and a global check for them
-  let externalModules = externals;
+  let externalModules = externals.slice();
 
   switch (bundleType) {
     case UMD_DEV:

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -158,7 +158,6 @@ function getExternalModules(externals, bundleType, isRenderer) {
     case RN_PROD:
       fbjsModules.forEach(module => externalModules.push(module));
       externalModules.push('object-assign');
-
       if (isRenderer) {
         externalModules.push('react');
       }
@@ -166,6 +165,7 @@ function getExternalModules(externals, bundleType, isRenderer) {
     case FB_DEV:
     case FB_PROD:
       fbjsModules.forEach(module => externalModules.push(module));
+      externalModules.push('object-assign');
       externalModules.push('ReactCurrentOwner');
       externalModules.push('lowPriorityWarning');
       if (isRenderer) {


### PR DESCRIPTION
`yarn build` worked but `yarn build -- --type=FB` failed.

I tracked it down to a mutation in the bundle config. Since NODE builds ran just before FB, the newly added `object-assign` external was already there and `yarn build` worked even though it was still missing in FB configuration.

This deep freezes the config, removes the mutation, and explicitly adds `object-assign` as an external for FB builds. (We’ll need to set up an internal www `node_modules/object-assign` shim that just points it at our `Object.assign` polyfill or even `Object.assign` itself since our polyfill is global.)

I want to note that technically that `object-assign` import ends up unused in the FB bundle. It was a hack to remove UMD duplication. But it doesn’t harm to keep it IMO. Better than forking the entry point again.