### PR TITLE
[Gatsby Docs Update] Fix meta tags and ssr docs build

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -105,7 +105,7 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
 
       const createArticlePage = path =>
         createPage({
-          path,
+          path: path,
           component: template,
           context: {
             slug,

--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -51,7 +51,7 @@ const MarkdownPage = ({
       }}>
       <TitleAndMetaTags
         title={`${titlePrefix}${titlePostfix}`}
-        ogUrl={`${urlRoot}${location.pathname}`}
+        ogUrl={`${urlRoot}/${markdownRemark.fields.path || ''}`}
         ogDescription={ogDescription}
       />
       <div css={{flex: '1 0 auto'}}>

--- a/www/src/templates/home.js
+++ b/www/src/templates/home.js
@@ -37,7 +37,7 @@ class Home extends Component {
       <div css={{width: '100%'}}>
         <TitleAndMetaTags
           title={title}
-          ogUrl={`${urlRoot}${location.pathname}`}
+          ogUrl={`${urlRoot}/${data.markdownRemark.fields.path}`}
         />
         <header
           css={{
@@ -189,6 +189,9 @@ export const pageQuery = graphql`
       html
       frontmatter {
         title
+      }
+      fields {
+        path
       }
     }
   }

--- a/www/src/templates/home.js
+++ b/www/src/templates/home.js
@@ -30,7 +30,7 @@ class Home extends Component {
   }
 
   render() {
-    const {data, location} = this.props;
+    const {data} = this.props;
     const title = 'React - A JavaScript library for building user interfaces';
 
     return (

--- a/www/src/templates/installation.js
+++ b/www/src/templates/installation.js
@@ -157,7 +157,7 @@ class InstallationPage extends Component {
         }}>
         <TitleAndMetaTags
           title="Installation - React"
-          ogUrl={`${urlRoot}${location.pathname}`}
+          ogUrl={`${urlRoot}/${markdownRemark.fields.path || ''}`}
         />
         <div css={{flex: '1 0 auto'}}>
           <Container>
@@ -222,6 +222,9 @@ export const pageQuery = graphql`
         title
         next
         prev
+      }
+      fields {
+        path
       }
     }
   }


### PR DESCRIPTION
**what is the change?:**
Use `markdownRemark.fields.path` instead of `location.path`. We updated the graphQL query to request this info for all
pages, and then use it.

Also we had to change the syntax in `gatsby-node.js` because for some
unclear reason, the `fields` came in as `undefined` when using that
shortcut syntax.

**why make this change?:**
- `location` is undefined during the SSR phase, and we want the SSR
  build to succeed.

**test plan:**
Manual testing -
- Ran `yarn build` (!!!) and it worked
- Ran `yarn dev` and manually inspected the `head` element contents.
<img width="809" alt="screen shot 2017-09-14 at 10 46 54 am" src="https://user-images.githubusercontent.com/1114467/30407505-e20ff5be-993b-11e7-935d-0e92113ba32d.png">
<img width="636" alt="screen shot 2017-09-14 at 10 47 20 am" src="https://user-images.githubusercontent.com/1114467/30407507-e21a71a6-993b-11e7-96c8-9abb5d4c5031.png">
<img width="638" alt="screen shot 2017-09-14 at 10 47 40 am" src="https://user-images.githubusercontent.com/1114467/30407506-e212e530-993b-11e7-895a-c449ddce1cbc.png">

**issue:**
checklist on the docs site wiki;
https://github.com/bvaughn/react/wiki/Gatsby-check-list
Misc > Meta/Title tags