### PR TITLE
Push host root context when bailing out on low priority

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -686,6 +686,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // TODO: Handle HostComponent tags here as well and call pushHostContext()?
     // See PR 8590 discussion for context
     switch (workInProgress.tag) {
+      case HostRoot:
+        pushHostRootContext(workInProgress);
+        break;
       case ClassComponent:
         pushContextProvider(workInProgress);
         break;


### PR DESCRIPTION
Prevents a push/pop mismatch when bailing out on HostRoots. This is currently unobservable, because HostRoots never bail out on low priority, but this does happen with prerendering.

I found this when rebasing #10624 on top of master. Submitting the fix in its own PR in to make sure I don't forget about it, in case my prerendering PR doesn't land as-is.