### PR TITLE
Deterministic updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "glob-stream": "^6.1.0",
     "gzip-js": "~0.3.2",
     "gzip-size": "^3.0.0",
+    "jasmine-check": "^1.0.0-rc.0",
     "jest": "20.1.0-delta.1",
     "jest-config": "20.1.0-delta.1",
     "jest-jasmine2": "20.1.0-delta.1",

--- a/scripts/jest/test-framework-setup.js
+++ b/scripts/jest/test-framework-setup.js
@@ -68,4 +68,6 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
     return expectation;
   };
   global.expectDev = expectDev;
+
+  require('jasmine-check').install();
 }

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
@@ -284,8 +284,8 @@ describe('ReactDOMFiberAsync', () => {
 
       // Flush the async updates
       jest.runAllTimers();
-      expect(container.textContent).toEqual('BCAD');
-      expect(ops).toEqual(['BC', 'BCAD']);
+      expect(container.textContent).toEqual('ABCD');
+      expect(ops).toEqual(['BC', 'ABCD']);
     });
   });
 });

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -405,7 +405,7 @@ var ReactNoop = {
       logHostInstances(container.children, depth + 1);
     }
 
-    function logUpdateQueue(updateQueue: UpdateQueue, depth) {
+    function logUpdateQueue(updateQueue: UpdateQueue<mixed>, depth) {
       log('  '.repeat(depth + 1) + 'QUEUED UPDATES');
       const firstUpdate = updateQueue.first;
       if (!firstUpdate) {

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -109,7 +109,7 @@ export type Fiber = {|
   memoizedProps: any, // The props used to create the output.
 
   // A queue of state updates and callbacks.
-  updateQueue: UpdateQueue | null,
+  updateQueue: UpdateQueue<mixed> | null,
 
   // The state used to create the output
   memoizedState: any,

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -109,7 +109,7 @@ export type Fiber = {|
   memoizedProps: any, // The props used to create the output.
 
   // A queue of state updates and callbacks.
-  updateQueue: UpdateQueue<mixed> | null,
+  updateQueue: UpdateQueue<any> | null,
 
   // The state used to create the output
   memoizedState: any,

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -71,8 +71,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext: HostContext<C, CX>,
   hydrationContext: HydrationContext<C, CX>,
-  scheduleUpdate: (fiber: Fiber, expirationTime: ExpirationTime) => void,
-  getExpirationTime: (fiber: Fiber, forceAsync: boolean) => ExpirationTime,
+  scheduleUpdate: (
+    fiber: Fiber,
+    partialState: mixed,
+    callback: (() => mixed) | null,
+    isReplace: boolean,
+    isForced: boolean,
+  ) => void,
 ) {
   const {
     shouldSetTextContent,
@@ -94,12 +99,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     mountClassInstance,
     // resumeMountClassInstance,
     updateClassInstance,
-  } = ReactFiberClassComponent(
-    scheduleUpdate,
-    getExpirationTime,
-    memoizeProps,
-    memoizeState,
-  );
+  } = ReactFiberClassComponent(scheduleUpdate, memoizeProps, memoizeState);
 
   // TODO: Remove this and use reconcileChildrenAtExpirationTime directly.
   function reconcileChildren(current, workInProgress, nextChildren) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -71,13 +71,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext: HostContext<C, CX>,
   hydrationContext: HydrationContext<C, CX>,
-  scheduleUpdate: (
-    fiber: Fiber,
-    partialState: mixed,
-    callback: (() => mixed) | null,
-    isReplace: boolean,
-    isForced: boolean,
-  ) => void,
+  scheduleWork: (fiber: Fiber, expirationTime: ExpirationTime) => void,
+  createUpdateExpirationForFiber: (fiber: Fiber) => ExpirationTime,
 ) {
   const {
     shouldSetTextContent,
@@ -99,7 +94,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     mountClassInstance,
     // resumeMountClassInstance,
     updateClassInstance,
-  } = ReactFiberClassComponent(scheduleUpdate, memoizeProps, memoizeState);
+  } = ReactFiberClassComponent(
+    scheduleWork,
+    createUpdateExpirationForFiber,
+    memoizeProps,
+    memoizeState,
+  );
 
   // TODO: Remove this and use reconcileChildrenAtExpirationTime directly.
   function reconcileChildren(current, workInProgress, nextChildren) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -337,7 +337,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         resetHydrationState();
         return bailoutOnAlreadyFinishedWork(current, workInProgress);
       }
-      const element = state !== null ? state.element : null;
+      const element = state.element;
       if (
         (current === null || current.child === null) &&
         enterHydrationState(workInProgress)

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -24,7 +24,7 @@ var {
   reconcileChildFibersInPlace,
   cloneChildFibers,
 } = require('ReactChildFiber');
-var {beginUpdateQueue} = require('ReactFiberUpdateQueue');
+var {processUpdateQueue} = require('ReactFiberUpdateQueue');
 var ReactTypeOfWork = require('ReactTypeOfWork');
 var {
   getMaskedContext,
@@ -323,7 +323,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     const updateQueue = workInProgress.updateQueue;
     if (updateQueue !== null) {
       const prevState = workInProgress.memoizedState;
-      const state = beginUpdateQueue(
+      const state = processUpdateQueue(
         current,
         workInProgress,
         updateQueue,
@@ -719,7 +719,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function memoizeState(workInProgress: Fiber, nextState: any) {
     workInProgress.memoizedState = nextState;
     // Don't reset the updateQueue, in case there are pending updates. Resetting
-    // is handled by beginUpdateQueue.
+    // is handled by processUpdateQueue.
   }
 
   function beginWork(

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -72,7 +72,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   hostContext: HostContext<C, CX>,
   hydrationContext: HydrationContext<C, CX>,
   scheduleWork: (fiber: Fiber, expirationTime: ExpirationTime) => void,
-  createUpdateExpirationForFiber: (fiber: Fiber) => ExpirationTime,
+  computeExpirationForFiber: (fiber: Fiber) => ExpirationTime,
 ) {
   const {
     shouldSetTextContent,
@@ -96,7 +96,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     updateClassInstance,
   } = ReactFiberClassComponent(
     scheduleWork,
-    createUpdateExpirationForFiber,
+    computeExpirationForFiber,
     memoizeProps,
     memoizeState,
   );

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -328,7 +328,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress,
         updateQueue,
         null,
-        prevState,
         null,
         renderExpirationTime,
       );
@@ -338,7 +337,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         resetHydrationState();
         return bailoutOnAlreadyFinishedWork(current, workInProgress);
       }
-      const element = state.element;
+      const element = state !== null ? state.element : null;
       if (
         (current === null || current.child === null) &&
         enterHydrationState(workInProgress)

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -76,7 +76,7 @@ if (__DEV__) {
 
 module.exports = function(
   scheduleWork: (fiber: Fiber, expirationTime: ExpirationTime) => void,
-  createUpdateExpirationForFiber: (fiber: Fiber) => ExpirationTime,
+  computeExpirationForFiber: (fiber: Fiber) => ExpirationTime,
   memoizeProps: (workInProgress: Fiber, props: any) => void,
   memoizeState: (workInProgress: Fiber, state: any) => void,
 ) {
@@ -89,7 +89,7 @@ module.exports = function(
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'setState');
       }
-      const expirationTime = createUpdateExpirationForFiber(fiber);
+      const expirationTime = computeExpirationForFiber(fiber);
       const update = {
         expirationTime,
         partialState,
@@ -108,7 +108,7 @@ module.exports = function(
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'replaceState');
       }
-      const expirationTime = createUpdateExpirationForFiber(fiber);
+      const expirationTime = computeExpirationForFiber(fiber);
       const update = {
         expirationTime,
         partialState: state,
@@ -127,7 +127,7 @@ module.exports = function(
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'forceUpdate');
       }
-      const expirationTime = createUpdateExpirationForFiber(fiber);
+      const expirationTime = computeExpirationForFiber(fiber);
       const update = {
         expirationTime,
         partialState: null,

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -26,7 +26,7 @@ var {
 } = require('ReactFiberContext');
 var {
   insertUpdateIntoFiber,
-  beginUpdateQueue,
+  processUpdateQueue,
 } = require('ReactFiberUpdateQueue');
 var {hasContextChanged} = require('ReactFiberContext');
 var {isMounted} = require('ReactFiberTreeReflection');
@@ -448,7 +448,7 @@ module.exports = function(
       // process them now.
       const updateQueue = workInProgress.updateQueue;
       if (updateQueue !== null) {
-        instance.state = beginUpdateQueue(
+        instance.state = processUpdateQueue(
           current,
           workInProgress,
           updateQueue,
@@ -505,7 +505,7 @@ module.exports = function(
   //   // Process the update queue before calling shouldComponentUpdate
   //   const updateQueue = workInProgress.updateQueue;
   //   if (updateQueue !== null) {
-  //     newState = beginUpdateQueue(
+  //     newState = processUpdateQueue(
   //       workInProgress,
   //       updateQueue,
   //       instance,
@@ -548,7 +548,7 @@ module.exports = function(
   //     // componentWillMount may have called setState. Process the update queue.
   //     const newUpdateQueue = workInProgress.updateQueue;
   //     if (newUpdateQueue !== null) {
-  //       newState = beginUpdateQueue(
+  //       newState = processUpdateQueue(
   //         workInProgress,
   //         newUpdateQueue,
   //         instance,
@@ -614,7 +614,7 @@ module.exports = function(
     // TODO: Previous state can be null.
     let newState;
     if (workInProgress.updateQueue !== null) {
-      newState = beginUpdateQueue(
+      newState = processUpdateQueue(
         current,
         workInProgress,
         workInProgress.updateQueue,

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -24,12 +24,7 @@ var {
   getUnmaskedContext,
   isContextConsumer,
 } = require('ReactFiberContext');
-var {
-  addUpdate,
-  addReplaceUpdate,
-  addForceUpdate,
-  beginUpdateQueue,
-} = require('ReactFiberUpdateQueue');
+var {beginUpdateQueue} = require('ReactFiberUpdateQueue');
 var {hasContextChanged} = require('ReactFiberContext');
 var {isMounted} = require('ReactFiberTreeReflection');
 var ReactInstanceMap = require('ReactInstanceMap');
@@ -77,8 +72,13 @@ if (__DEV__) {
 }
 
 module.exports = function(
-  scheduleUpdate: (fiber: Fiber, expirationTime: ExpirationTime) => void,
-  getExpirationTime: (fiber: Fiber, forceAsync: boolean) => ExpirationTime,
+  scheduleUpdate: (
+    fiber: Fiber,
+    partialState: mixed,
+    callback: (() => mixed) | null,
+    isReplace: boolean,
+    isForced: boolean,
+  ) => void,
   memoizeProps: (workInProgress: Fiber, props: any) => void,
   memoizeState: (workInProgress: Fiber, state: any) => void,
 ) {
@@ -87,33 +87,27 @@ module.exports = function(
     isMounted,
     enqueueSetState(instance, partialState, callback) {
       const fiber = ReactInstanceMap.get(instance);
-      const expirationTime = getExpirationTime(fiber, false);
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'setState');
       }
-      addUpdate(fiber, partialState, callback, expirationTime);
-      scheduleUpdate(fiber, expirationTime);
+      scheduleUpdate(fiber, partialState, callback, false, false);
     },
     enqueueReplaceState(instance, state, callback) {
       const fiber = ReactInstanceMap.get(instance);
-      const expirationTime = getExpirationTime(fiber, false);
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'replaceState');
       }
-      addReplaceUpdate(fiber, state, callback, expirationTime);
-      scheduleUpdate(fiber, expirationTime);
+      scheduleUpdate(fiber, state, callback, true, false);
     },
     enqueueForceUpdate(instance, callback) {
       const fiber = ReactInstanceMap.get(instance);
-      const expirationTime = getExpirationTime(fiber, false);
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'forceUpdate');
       }
-      addForceUpdate(fiber, callback, expirationTime);
-      scheduleUpdate(fiber, expirationTime);
+      scheduleUpdate(fiber, null, callback, false, true);
     },
   };
 

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -398,7 +398,7 @@ module.exports = function(
     const unmaskedContext = getUnmaskedContext(workInProgress);
 
     instance.props = props;
-    instance.state = state;
+    instance.state = workInProgress.memoizedState = state;
     instance.refs = emptyObject;
     instance.context = getMaskedContext(workInProgress, unmaskedContext);
 
@@ -422,7 +422,6 @@ module.exports = function(
           workInProgress,
           updateQueue,
           instance,
-          state,
           props,
           renderExpirationTime,
         );
@@ -589,7 +588,6 @@ module.exports = function(
         workInProgress,
         workInProgress.updateQueue,
         instance,
-        oldState,
         newProps,
         renderExpirationTime,
       );

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -29,12 +29,7 @@ var {
   clearCaughtError,
 } = require('ReactErrorUtils');
 
-var {
-  Placement,
-  Update,
-  Callback,
-  ContentReset,
-} = require('ReactTypeOfSideEffect');
+var {Placement, Update, ContentReset} = require('ReactTypeOfSideEffect');
 
 var invariant = require('fbjs/lib/invariant');
 
@@ -102,9 +97,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function commitCallbacks(callbackList, context) {
-    for (let i = 0; i < callbackList.length; i++) {
-      const callback = callbackList[i];
+  function commitCallbacks(updateQueue, context) {
+    let callbackNode = updateQueue.firstCallback;
+    // Reset the callback list before calling them in case something throws.
+    updateQueue.firstCallback = updateQueue.lastCallback = null;
+
+    while (callbackNode !== null) {
+      const callback = callbackNode.callback;
+      // Remove this callback from the update object in case it's still part
+      // of the queue, so that we don't call it again.
+      callbackNode.callback = null;
       invariant(
         typeof callback === 'function',
         'Invalid argument passed as callback. Expected a function. Instead ' +
@@ -112,6 +114,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         callback,
       );
       callback.call(context);
+      const nextCallback = callbackNode.nextCallback;
+      callbackNode.nextCallback = null;
+      callbackNode = nextCallback;
     }
   }
 
@@ -144,31 +149,19 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
             }
           }
         }
-        if (
-          finishedWork.effectTag & Callback &&
-          finishedWork.updateQueue !== null
-        ) {
-          const updateQueue = finishedWork.updateQueue;
-          if (updateQueue.callbackList !== null) {
-            // Set the list to null to make sure they don't get called more than once.
-            const callbackList = updateQueue.callbackList;
-            updateQueue.callbackList = null;
-            commitCallbacks(callbackList, instance);
-          }
+        const updateQueue = finishedWork.updateQueue;
+        if (updateQueue !== null) {
+          commitCallbacks(updateQueue, instance);
         }
         return;
       }
       case HostRoot: {
         const updateQueue = finishedWork.updateQueue;
-        if (updateQueue !== null && updateQueue.callbackList !== null) {
-          // Set the list to null to make sure they don't get called more
-          // than once.
-          const callbackList = updateQueue.callbackList;
-          updateQueue.callbackList = null;
+        if (updateQueue !== null) {
           const instance = finishedWork.child !== null
             ? finishedWork.child.stateNode
             : null;
-          commitCallbacks(callbackList, instance);
+          commitCallbacks(updateQueue, instance);
         }
         return;
       }

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -22,6 +22,7 @@ var {
   HostPortal,
   CoroutineComponent,
 } = ReactTypeOfWork;
+var {commitCallbacks} = require('ReactFiberUpdateQueue');
 var {onCommitUnmount} = require('ReactFiberDevToolsHook');
 var {
   invokeGuardedCallback,
@@ -94,29 +95,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           captureError(current, refError);
         }
       }
-    }
-  }
-
-  function commitCallbacks(updateQueue, context) {
-    let callbackNode = updateQueue.firstCallback;
-    // Reset the callback list before calling them in case something throws.
-    updateQueue.firstCallback = updateQueue.lastCallback = null;
-
-    while (callbackNode !== null) {
-      const callback = callbackNode.callback;
-      // Remove this callback from the update object in case it's still part
-      // of the queue, so that we don't call it again.
-      callbackNode.callback = null;
-      invariant(
-        typeof callback === 'function',
-        'Invalid argument passed as callback. Expected a function. Instead ' +
-          'received: %s',
-        callback,
-      );
-      callback.call(context);
-      const nextCallback = callbackNode.nextCallback;
-      callbackNode.nextCallback = null;
-      callbackNode = nextCallback;
     }
   }
 

--- a/src/renderers/shared/fiber/ReactFiberExpirationTime.js
+++ b/src/renderers/shared/fiber/ReactFiberExpirationTime.js
@@ -34,7 +34,7 @@ function msToExpirationTime(ms: number): ExpirationTime {
 exports.msToExpirationTime = msToExpirationTime;
 
 function ceiling(num: number, precision: number): number {
-  return (((((num * precision) | 0) + 1) / precision) | 0) + 1;
+  return (((num / precision) | 0) + 1) * precision;
 }
 
 function bucket(

--- a/src/renderers/shared/fiber/ReactFiberExpirationTime.js
+++ b/src/renderers/shared/fiber/ReactFiberExpirationTime.js
@@ -37,24 +37,17 @@ function ceiling(num: number, precision: number): number {
   return (((num / precision) | 0) + 1) * precision;
 }
 
-function bucket(
+function computeExpirationBucket(
   currentTime: ExpirationTime,
   expirationInMs: number,
-  precisionInMs: number,
+  bucketSizeMs: number,
 ): ExpirationTime {
   return ceiling(
     currentTime + expirationInMs / UNIT_SIZE,
-    precisionInMs / UNIT_SIZE,
+    bucketSizeMs / UNIT_SIZE,
   );
 }
-
-// Given the current clock time, returns an expiration time. We use rounding
-// to batch like updates together.
-function asyncExpirationTime(currentTime: ExpirationTime) {
-  // Should complete within ~1000ms. 1200ms max.
-  return bucket(currentTime, 1000, 200);
-}
-exports.asyncExpirationTime = asyncExpirationTime;
+exports.computeExpirationBucket = computeExpirationBucket;
 
 // Given the current clock time and an expiration time, returns the
 // relative expiration time. Possible values include NoWork, Sync, Task, and

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -14,10 +14,6 @@ import type {Fiber} from 'ReactFiber';
 import type {FiberRoot} from 'ReactFiberRoot';
 import type {ReactNodeList} from 'ReactTypes';
 
-var ReactFeatureFlags = require('ReactFeatureFlags');
-
-var {insertUpdateIntoFiber} = require('ReactFiberUpdateQueue');
-
 var {
   findCurrentUnmaskedContext,
   isContextProvider,
@@ -265,8 +261,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   var {getPublicInstance} = config;
 
   var {
-    scheduleWork,
-    getExpirationTime,
+    scheduleUpdate,
     batchedUpdates,
     unbatchedUpdates,
     flushSync,
@@ -296,17 +291,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     }
 
-    // Check if the top-level element is an async wrapper component. If so, treat
-    // updates to the root as async. This is a bit weird but lets us avoid a separate
-    // `renderAsync` API.
-    const forceAsync =
-      ReactFeatureFlags.enableAsyncSubtreeAPI &&
-      element != null &&
-      element.type != null &&
-      element.type.prototype != null &&
-      (element.type.prototype: any).unstable_isAsyncReactComponent === true;
-    const expirationTime = getExpirationTime(current, forceAsync);
-    const nextState = {element};
     callback = callback === undefined ? null : callback;
     if (__DEV__) {
       warning(
@@ -316,17 +300,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         callback,
       );
     }
-    const update = {
-      expirationTime,
-      partialState: nextState,
-      callback,
-      isReplace: false,
-      isForced: false,
-      nextCallback: null,
-      next: null,
-    };
-    insertUpdateIntoFiber(current, update);
-    scheduleWork(current, expirationTime);
+    const state = {element};
+    scheduleUpdate(current, state, callback, false, false);
   }
 
   return {

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -316,38 +316,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         callback,
       );
     }
-    const isTopLevelUnmount = nextState.element === null;
     const update = {
       expirationTime,
       partialState: nextState,
       callback,
       isReplace: false,
       isForced: false,
-      isTopLevelUnmount,
+      nextCallback: null,
       next: null,
     };
-    const update2 = insertUpdateIntoFiber(current, update);
-
-    if (isTopLevelUnmount) {
-      // TODO: Redesign the top-level mount/update/unmount API to avoid this
-      // special case.
-      const queue1 = current.updateQueue;
-      const queue2 = current.alternate !== null
-        ? current.alternate.updateQueue
-        : null;
-
-      // Drop all updates that are lower-priority, so that the tree is not
-      // remounted. We need to do this for both queues.
-      if (queue1 !== null && update.next !== null) {
-        update.next = null;
-        queue1.last = update;
-      }
-      if (queue2 !== null && update2 !== null && update2.next !== null) {
-        update2.next = null;
-        queue2.last = update;
-      }
-    }
-
+    insertUpdateIntoFiber(current, update);
     scheduleWork(current, expirationTime);
   }
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -24,7 +24,6 @@ var {createFiberRoot} = require('ReactFiberRoot');
 var ReactFiberScheduler = require('ReactFiberScheduler');
 var ReactInstanceMap = require('ReactInstanceMap');
 var {HostComponent} = require('ReactTypeOfWork');
-var {asyncExpirationTime} = require('ReactFiberExpirationTime');
 var {insertUpdateIntoFiber} = require('ReactFiberUpdateQueue');
 var emptyObject = require('fbjs/lib/emptyObject');
 
@@ -264,8 +263,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   var {getPublicInstance} = config;
 
   var {
-    createUpdateExpirationForFiber,
-    recalculateCurrentTime,
+    computeAsyncExpiration,
+    computeExpirationForFiber,
     scheduleWork,
     batchedUpdates,
     unbatchedUpdates,
@@ -317,10 +316,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       element.type.prototype != null &&
       (element.type.prototype: any).unstable_isAsyncReactComponent === true
     ) {
-      const currentTime = recalculateCurrentTime();
-      expirationTime = asyncExpirationTime(currentTime);
+      expirationTime = computeAsyncExpiration();
     } else {
-      expirationTime = createUpdateExpirationForFiber(current);
+      expirationTime = computeExpirationForFiber(current);
     }
 
     const update = {

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -183,7 +183,7 @@ function getStateFromUpdate(update, instance, prevState, props) {
   }
 }
 
-function beginUpdateQueue<State>(
+function processUpdateQueue<State>(
   current: Fiber | null,
   workInProgress: Fiber,
   queue: UpdateQueue<State>,
@@ -305,7 +305,7 @@ function beginUpdateQueue<State>(
 
   return state;
 }
-exports.beginUpdateQueue = beginUpdateQueue;
+exports.processUpdateQueue = processUpdateQueue;
 
 function commitCallbacks<State>(queue: UpdateQueue<State>, context: any) {
   const callbackList = queue.callbackList;

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -30,14 +30,14 @@ type PartialState<State, Props> =
 // Callbacks are not validated until invocation
 type Callback = mixed;
 
-export type Update = {
+export type Update<State> = {
   expirationTime: ExpirationTime,
   partialState: PartialState<any, any>,
   callback: Callback | null,
   isReplace: boolean,
   isForced: boolean,
-  isTopLevelUnmount: boolean,
-  next: Update | null,
+  next: Update<State> | null,
+  nextCallback: Update<State> | null,
 };
 
 // Singly linked-list of updates. When an update is scheduled, it is added to
@@ -51,25 +51,33 @@ export type Update = {
 // The work-in-progress queue is always a subset of the current queue.
 //
 // When the tree is committed, the work-in-progress becomes the current.
-export type UpdateQueue = {
-  first: Update | null,
-  last: Update | null,
+export type UpdateQueue<State> = {
+  // A processed update is not removed from the queue if there are any
+  // unprocessed updates that came before it. In that case, we need to keep
+  // track of the base state, which represents the base state of the first
+  // unprocessed update, which is the same as the first update in the list.
+  baseState: State | null,
+  // For the same reason, we keep track of the remaining expiration time.
+  expirationTime: ExpirationTime,
+  first: Update<State> | null,
+  last: Update<State> | null,
+  firstCallback: Update<State> | null,
+  lastCallback: Update<State> | null,
   hasForceUpdate: boolean,
-  callbackList: null | Array<Callback>,
 
   // Dev only
   isProcessing?: boolean,
 };
 
-let _queue1;
-let _queue2;
-
-function createUpdateQueue(): UpdateQueue {
-  const queue: UpdateQueue = {
+function createUpdateQueue<State>(baseState: State): UpdateQueue<State> {
+  const queue: UpdateQueue<State> = {
+    baseState,
+    expirationTime: NoWork,
     first: null,
     last: null,
+    firstCallback: null,
+    lastCallback: null,
     hasForceUpdate: false,
-    callbackList: null,
   };
   if (__DEV__) {
     queue.isProcessing = false;
@@ -77,120 +85,47 @@ function createUpdateQueue(): UpdateQueue {
   return queue;
 }
 
-function cloneUpdate(update: Update): Update {
-  return {
-    expirationTime: update.expirationTime,
-    partialState: update.partialState,
-    callback: update.callback,
-    isReplace: update.isReplace,
-    isForced: update.isForced,
-    isTopLevelUnmount: update.isTopLevelUnmount,
-    next: null,
-  };
-}
-
-function insertUpdateIntoPosition(
-  queue: UpdateQueue,
-  update: Update,
-  insertAfter: Update | null,
-  insertBefore: Update | null,
+function insertUpdateIntoQueue<State>(
+  queue: UpdateQueue<State>,
+  update: Update<State>,
 ) {
-  if (insertAfter !== null) {
-    insertAfter.next = update;
+  // Append the update to the end of the list.
+  if (queue.last === null) {
+    // Queue is empty
+    queue.first = queue.last = update;
   } else {
-    // This is the first item in the queue.
-    update.next = queue.first;
-    queue.first = update;
-  }
-
-  if (insertBefore !== null) {
-    update.next = insertBefore;
-  } else {
-    // This is the last item in the queue.
+    queue.last.next = update;
     queue.last = update;
   }
-}
-
-// Returns the update after which the incoming update should be inserted into
-// the queue, or null if it should be inserted at beginning.
-function findInsertionPosition(queue, update): Update | null {
-  const expirationTime = update.expirationTime;
-  let insertAfter = null;
-  let insertBefore = null;
-  if (queue.last !== null && queue.last.expirationTime <= expirationTime) {
-    // Fast path for the common case where the update should be inserted at
-    // the end of the queue.
-    insertAfter = queue.last;
-  } else {
-    insertBefore = queue.first;
-    while (
-      insertBefore !== null &&
-      insertBefore.expirationTime <= expirationTime
-    ) {
-      insertAfter = insertBefore;
-      insertBefore = insertBefore.next;
-    }
+  if (
+    queue.expirationTime === NoWork ||
+    queue.expirationTime > update.expirationTime
+  ) {
+    queue.expirationTime = update.expirationTime;
   }
-  return insertAfter;
 }
+exports.insertUpdateIntoQueue = insertUpdateIntoQueue;
 
-function ensureUpdateQueues(fiber: Fiber) {
+function insertUpdateIntoFiber<State>(fiber: Fiber, update: Update<State>) {
+  // We'll have at least one and at most two distinct update queues.
   const alternateFiber = fiber.alternate;
-
   let queue1 = fiber.updateQueue;
   if (queue1 === null) {
-    queue1 = fiber.updateQueue = createUpdateQueue();
+    queue1 = fiber.updateQueue = createUpdateQueue(fiber.memoizedState);
   }
 
   let queue2;
   if (alternateFiber !== null) {
     queue2 = alternateFiber.updateQueue;
     if (queue2 === null) {
-      queue2 = alternateFiber.updateQueue = createUpdateQueue();
+      queue2 = alternateFiber.updateQueue = createUpdateQueue(
+        alternateFiber.memoizedState,
+      );
     }
   } else {
     queue2 = null;
   }
-
-  _queue1 = queue1;
-  // Return null if there is no alternate queue, or if its queue is the same.
-  _queue2 = queue2 !== queue1 ? queue2 : null;
-}
-
-// The work-in-progress queue is a subset of the current queue (if it exists).
-// We need to insert the incoming update into both lists. However, it's possible
-// that the correct position in one list will be different from the position in
-// the other. Consider the following case:
-//
-//     Current:             3-5-6
-//     Work-in-progress:        6
-//
-// Then we receive an update with priority 4 and insert it into each list:
-//
-//     Current:             3-4-5-6
-//     Work-in-progress:        4-6
-//
-// In the current queue, the new update's `next` pointer points to the update
-// with priority 5. But in the work-in-progress queue, the pointer points to the
-// update with priority 6. Because these two queues share the same persistent
-// data structure, this won't do. (This can only happen when the incoming update
-// has higher priority than all the updates in the work-in-progress queue.)
-//
-// To solve this, in the case where the incoming update needs to be inserted
-// into two different positions, we'll make a clone of the update and insert
-// each copy into a separate queue. This forks the list while maintaining a
-// persistent structure, because the update that is added to the work-in-progress
-// is always added to the front of the list.
-//
-// However, if incoming update is inserted into the same position of both lists,
-// we shouldn't make a copy.
-//
-// If the update is cloned, it returns the cloned update.
-function insertUpdateIntoFiber(fiber: Fiber, update: Update): Update | null {
-  // We'll have at least one and at most two distinct update queues.
-  ensureUpdateQueues(fiber);
-  const queue1 = _queue1;
-  const queue2 = _queue2;
+  queue2 = queue2 !== queue1 ? queue2 : null;
 
   // Warn if an update is scheduled from inside an updater function.
   if (__DEV__) {
@@ -205,64 +140,37 @@ function insertUpdateIntoFiber(fiber: Fiber, update: Update): Update | null {
     }
   }
 
-  // Find the insertion position in the first queue.
-  const insertAfter1 = findInsertionPosition(queue1, update);
-  const insertBefore1 = insertAfter1 !== null
-    ? insertAfter1.next
-    : queue1.first;
-
+  // If there's only one queue, add the update to that queue and exit.
   if (queue2 === null) {
-    // If there's no alternate queue, there's nothing else to do but insert.
-    insertUpdateIntoPosition(queue1, update, insertAfter1, insertBefore1);
-    return null;
+    insertUpdateIntoQueue(queue1, update);
+    return;
   }
 
-  // If there is an alternate queue, find the insertion position.
-  const insertAfter2 = findInsertionPosition(queue2, update);
-  const insertBefore2 = insertAfter2 !== null
-    ? insertAfter2.next
-    : queue2.first;
-
-  // Now we can insert into the first queue. This must come after finding both
-  // insertion positions because it mutates the list.
-  insertUpdateIntoPosition(queue1, update, insertAfter1, insertBefore1);
-
-  // See if the insertion positions are equal. Be careful to only compare
-  // non-null values.
-  if (
-    (insertBefore1 === insertBefore2 && insertBefore1 !== null) ||
-    (insertAfter1 === insertAfter2 && insertAfter1 !== null)
-  ) {
-    // The insertion positions are the same, so when we inserted into the first
-    // queue, it also inserted into the alternate. All we need to do is update
-    // the alternate queue's `first` and `last` pointers, in case they
-    // have changed.
-    if (insertAfter2 === null) {
-      queue2.first = update;
-    }
-    if (insertBefore2 === null) {
-      queue2.last = null;
-    }
-    return null;
-  } else {
-    // The insertion positions are different, so we need to clone the update and
-    // insert the clone into the alternate queue.
-    const update2 = cloneUpdate(update);
-    insertUpdateIntoPosition(queue2, update2, insertAfter2, insertBefore2);
-    return update2;
+  // If either queue is empty, we need to add to both queues.
+  if (queue1.last === null || queue2.last === null) {
+    insertUpdateIntoQueue(queue1, update);
+    insertUpdateIntoQueue(queue2, update);
+    return;
   }
+
+  // If both lists are not empty, the last update is the same for both lists
+  // because of structural sharing. So, we should only append to one of
+  // the lists.
+  insertUpdateIntoQueue(queue1, update);
+  // But we still need to update the `last` pointer of queue2.
+  queue2.last = update;
 }
 exports.insertUpdateIntoFiber = insertUpdateIntoFiber;
 
 function getUpdateExpirationTime(fiber: Fiber): ExpirationTime {
+  if (fiber.tag !== ClassComponent && fiber.tag !== HostRoot) {
+    return NoWork;
+  }
   const updateQueue = fiber.updateQueue;
   if (updateQueue === null) {
     return NoWork;
   }
-  if (fiber.tag !== ClassComponent && fiber.tag !== HostRoot) {
-    return NoWork;
-  }
-  return updateQueue.first !== null ? updateQueue.first.expirationTime : NoWork;
+  return updateQueue.expirationTime;
 }
 exports.getUpdateExpirationTime = getUpdateExpirationTime;
 
@@ -276,12 +184,11 @@ function getStateFromUpdate(update, instance, prevState, props) {
   }
 }
 
-function beginUpdateQueue(
+function beginUpdateQueue<State>(
   current: Fiber | null,
   workInProgress: Fiber,
-  queue: UpdateQueue,
+  queue: UpdateQueue<State>,
   instance: any,
-  prevState: any,
   props: any,
   renderExpirationTime: ExpirationTime,
 ): any {
@@ -289,11 +196,14 @@ function beginUpdateQueue(
     // We need to create a work-in-progress queue, by cloning the current queue.
     const currentQueue = queue;
     queue = workInProgress.updateQueue = {
+      baseState: currentQueue.baseState,
+      expirationTime: currentQueue.expirationTime,
       first: currentQueue.first,
       last: currentQueue.last,
       // These fields are no longer valid because they were already committed.
       // Reset them.
-      callbackList: null,
+      firstCallback: null,
+      lastCallback: null,
       hasForceUpdate: false,
     };
   }
@@ -304,24 +214,50 @@ function beginUpdateQueue(
     queue.isProcessing = true;
   }
 
-  // Calculate these using the the existing values as a base.
-  let callbackList = queue.callbackList;
-  let hasForceUpdate = queue.hasForceUpdate;
+  // Reset the remaining expiration time. If we skip over any updates, we'll
+  // increase this accordingly.
+  queue.expirationTime = NoWork;
 
-  // Applies updates with matching priority to the previous state to create
-  // a new state object.
-  let state = prevState;
+  let state = queue.baseState;
   let dontMutatePrevState = true;
   let update = queue.first;
-  while (update !== null && update.expirationTime <= renderExpirationTime) {
-    // Remove each update from the queue right before it is processed. That way
-    // if setState is called from inside an updater function, the new update
-    // will be inserted in the correct position.
-    queue.first = update.next;
-    if (queue.first === null) {
-      queue.last = null;
+  let didSkip = false;
+  while (update !== null) {
+    const updateExpirationTime = update.expirationTime;
+    if (
+      updateExpirationTime === NoWork ||
+      updateExpirationTime > renderExpirationTime
+    ) {
+      // This update does not have sufficient priority. Skip it.
+      const remainingExpirationTime = queue.expirationTime;
+      if (
+        remainingExpirationTime === NoWork ||
+        remainingExpirationTime > updateExpirationTime
+      ) {
+        // Update the remaining expiration time.
+        queue.expirationTime = updateExpirationTime;
+      }
+      if (!didSkip) {
+        didSkip = true;
+        queue.baseState = state;
+      }
+      // Continue to the next update.
+      update = update.next;
+      continue;
     }
 
+    // This update does have sufficient priority.
+
+    // If no previous updates were skipped, drop this update from the queue by
+    // advancing the head of the list.
+    if (!didSkip) {
+      queue.first = update.next;
+      if (queue.first === null) {
+        queue.last = null;
+      }
+    }
+
+    // Process the update
     let partialState;
     if (update.isReplace) {
       state = getStateFromUpdate(update, instance, state, props);
@@ -330,6 +266,7 @@ function beginUpdateQueue(
       partialState = getStateFromUpdate(update, instance, state, props);
       if (partialState) {
         if (dontMutatePrevState) {
+          // $FlowFixMe: Idk how to type this properly.
           state = Object.assign({}, state, partialState);
         } else {
           state = Object.assign(state, partialState);
@@ -338,29 +275,31 @@ function beginUpdateQueue(
       }
     }
     if (update.isForced) {
-      hasForceUpdate = true;
+      queue.hasForceUpdate = true;
     }
-    // Second condition ignores top-level unmount callbacks if they are not the
-    // last update in the queue, since a subsequent update will cause a remount.
-    if (
-      update.callback !== null &&
-      !(update.isTopLevelUnmount && update.next !== null)
-    ) {
-      callbackList = callbackList !== null ? callbackList : [];
-      callbackList.push(update.callback);
+    if (update.callback !== null) {
+      // Append to list of callbacks.
+      if (queue.lastCallback === null) {
+        queue.lastCallback = queue.firstCallback = update;
+      } else {
+        queue.lastCallback.nextCallback = update;
+        queue.lastCallback = update;
+      }
     }
     update = update.next;
   }
 
-  if (callbackList !== null) {
+  if (queue.lastCallback !== null) {
     workInProgress.effectTag |= CallbackEffect;
-  } else if (queue.first === null && !hasForceUpdate) {
+  } else if (queue.first === null && !queue.hasForceUpdate) {
     // The queue is empty. We can reset it.
     workInProgress.updateQueue = null;
   }
 
-  queue.callbackList = callbackList;
-  queue.hasForceUpdate = hasForceUpdate;
+  if (!didSkip) {
+    didSkip = true;
+    queue.baseState = state;
+  }
 
   if (__DEV__) {
     // No longer processing.

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -222,10 +222,7 @@ function processUpdateQueue<State>(
   let didSkip = false;
   while (update !== null) {
     const updateExpirationTime = update.expirationTime;
-    if (
-      updateExpirationTime === NoWork ||
-      updateExpirationTime > renderExpirationTime
-    ) {
+    if (updateExpirationTime > renderExpirationTime) {
       // This update does not have sufficient priority. Skip it.
       const remainingExpirationTime = queue.expirationTime;
       if (

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -19,7 +19,7 @@ const {NoWork} = require('ReactFiberExpirationTime');
 
 const {ClassComponent, HostRoot} = require('ReactTypeOfWork');
 
-const invariant = require('invariant');
+const invariant = require('fbjs/lib/invariant');
 
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
@@ -57,7 +57,7 @@ export type UpdateQueue<State> = {
   // unprocessed updates that came before it. In that case, we need to keep
   // track of the base state, which represents the base state of the first
   // unprocessed update, which is the same as the first update in the list.
-  baseState: State | null,
+  baseState: State,
   // For the same reason, we keep track of the remaining expiration time.
   expirationTime: ExpirationTime,
   first: Update<State> | null,
@@ -87,7 +87,7 @@ function createUpdateQueue<State>(baseState: State): UpdateQueue<State> {
 function insertUpdateIntoQueue<State>(
   queue: UpdateQueue<State>,
   update: Update<State>,
-) {
+): void {
   // Append the update to the end of the list.
   if (queue.last === null) {
     // Queue is empty
@@ -105,7 +105,10 @@ function insertUpdateIntoQueue<State>(
 }
 exports.insertUpdateIntoQueue = insertUpdateIntoQueue;
 
-function insertUpdateIntoFiber<State>(fiber: Fiber, update: Update<State>) {
+function insertUpdateIntoFiber<State>(
+  fiber: Fiber,
+  update: Update<State>,
+): void {
   // We'll have at least one and at most two distinct update queues.
   const alternateFiber = fiber.alternate;
   let queue1 = fiber.updateQueue;
@@ -190,7 +193,7 @@ function processUpdateQueue<State>(
   instance: any,
   props: any,
   renderExpirationTime: ExpirationTime,
-): any {
+): State {
   if (current !== null && current.updateQueue === queue) {
     // We need to create a work-in-progress queue, by cloning the current queue.
     const currentQueue = queue;

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -57,11 +57,13 @@ describe('ReactIncrementalScheduling', () => {
         ReactNoop.render(<span prop={4} />);
       });
     });
+    // The sync updates flush first.
+    expect(ReactNoop.getChildren()).toEqual([span(4)]);
 
-    // The low pri update should be flushed last, even though it was scheduled
-    // before the sync updates.
+    // The terminal value should be the last update that was scheduled,
+    // regardless of priority. In this case, that's the last sync update.
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span(5)]);
+    expect(ReactNoop.getChildren()).toEqual([span(4)]);
   });
 
   it('schedules top-level updates with same priority in order of insertion', () => {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
@@ -246,6 +246,7 @@ describe('ReactIncrementalTriangle', () => {
     simulate(step(1), flush(3), toggle(18), step(0));
     simulate(step(4), flush(52), expire(1476), flush(17), step(0));
     simulate(interrupt(), toggle(10), step(2), expire(990), flush(46));
+    simulate(interrupt(), step(6), step(7), toggle(6), interrupt());
   });
 
   it('fuzz tester', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,6 +2614,12 @@ istanbul-reports@^1.1.1:
   dependencies:
     handlebars "^4.0.3"
 
+jasmine-check@^1.0.0-rc.0:
+  version "1.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/jasmine-check/-/jasmine-check-1.0.0-rc.0.tgz#117728c150078ecf211986c5f164275b71e937a4"
+  dependencies:
+    testcheck "^1.0.0-rc"
+
 jest-changed-files@20.1.0-delta.1:
   version "20.1.0-delta.1"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-20.1.0-delta.1.tgz#912f8eff09c79b28fc7b66513f0ad505f1b378d5"
@@ -4315,6 +4321,10 @@ test-exclude@^4.0.3:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+testcheck@^1.0.0-rc:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/testcheck/-/testcheck-1.0.0-rc.2.tgz#11356a25b84575efe0b0857451e85b5fa74ee4e4"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
High priority updates typically require less work to render than low priority ones. It's beneficial to flush those first, in their own batch, before working on more expensive low priority ones. We do this even if a high priority is scheduled after a low priority one.

However, we don't want this reordering of updates to affect the terminal state. State should be deterministic: once all work has been flushed, the final state should be the same regardless of how they were scheduled.

To get both properties, we store updates on the queue in insertion order instead of priority order (always append). Then, when processing the queue, we skip over updates with insufficient priority. Instead of removing updates from the queue right after processing them, we only remove them if there are no unprocessed updates before it in the list.

This means that updates may be processed more than once.

As a bonus, the new implementation is simpler and requires less code.

To avoid conflicts, this works off my expiration times (#10426) and prerendering (#10624) PRs.