### PR TITLE
Docs: shallowRenderer does not call cDM and cDU

### DIFF
--- a/docs/docs/addons-shallow-renderer.md
+++ b/docs/docs/addons-shallow-renderer.md
@@ -47,7 +47,7 @@ expect(result.props.children).toEqual([
 ]);
 ```
 
-Shallow testing currently has some limitations, namely not supporting refs.
+Shallow testing currently has some limitations, namely not supporting refs and not calling `componentDidMount()` and `componentDidUpdate()`.
 
 > Note:
 >


### PR DESCRIPTION
I think this is a limitation that should be documented.

Correctly, this PR is for v16 because shallowRenderer calls `componentDidUpdate` when updates with `setstate` in v15.