### PR TITLE
Fixes #9667: Updated createTextInstance to create the text node on correct document

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -159,7 +159,7 @@ function ensureListeningTo(rootContainerElement, registrationName) {
 
 function getOwnerDocumentFromRootContainer(
   rootContainerElement: Element | Document,
-) {
+): Document {
   return rootContainerElement.nodeType === DOCUMENT_NODE
     ? (rootContainerElement: any)
     : rootContainerElement.ownerDocument;

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -157,6 +157,14 @@ function ensureListeningTo(rootContainerElement, registrationName) {
   listenTo(registrationName, doc);
 }
 
+function getOwnerDocumentFromRootContainer(
+  rootContainerElement: Element | Document,
+) {
+  return rootContainerElement.nodeType === DOCUMENT_NODE
+    ? (rootContainerElement: any)
+    : rootContainerElement.ownerDocument;
+}
+
 // There are so many media events, it makes sense to just
 // maintain a list rather than create a `trapBubbledEvent` for each
 var mediaEvents = {
@@ -296,10 +304,9 @@ var ReactDOMFiberComponent = {
   ): Element {
     // We create tags in the namespace of their parent container, except HTML
     // tags get no namespace.
-    var ownerDocument: Document = rootContainerElement.nodeType ===
-      DOCUMENT_NODE
-      ? (rootContainerElement: any)
-      : rootContainerElement.ownerDocument;
+    var ownerDocument: Document = getOwnerDocumentFromRootContainer(
+      rootContainerElement,
+    );
     var domElement: Element;
     var namespaceURI = parentNamespace;
     if (namespaceURI === HTML_NAMESPACE) {
@@ -360,6 +367,12 @@ var ReactDOMFiberComponent = {
     }
 
     return domElement;
+  },
+
+  createTextNode(text: string, rootContainerElement: Element | Document): Text {
+    return getOwnerDocumentFromRootContainer(
+      rootContainerElement,
+    ).createTextNode(text);
   },
 
   setInitialProperties(

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -368,7 +368,13 @@ var DOMRenderer = ReactFiberReconciler({
       const hostContextDev = ((hostContext: any): HostContextDev);
       validateDOMNesting(null, text, null, hostContextDev.ancestorInfo);
     }
-    var textNode: TextInstance = document.createTextNode(text);
+
+    var doc = rootContainerInstance;
+    if (rootContainerInstance.nodeType !== DOCUMENT_NODE && doc.ownerDocument) {
+      doc = ((doc: any): Element).ownerDocument;
+    }
+
+    var textNode: TextInstance = ((doc: any): Document).createTextNode(text);
     precacheFiberNode(internalInstanceHandle, textNode);
     return textNode;
   },

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -46,6 +46,7 @@ var invariant = require('fbjs/lib/invariant');
 var {getChildNamespace} = DOMNamespaces;
 var {
   createElement,
+  createTextNode,
   setInitialProperties,
   diffProperties,
   updateProperties,
@@ -368,13 +369,7 @@ var DOMRenderer = ReactFiberReconciler({
       const hostContextDev = ((hostContext: any): HostContextDev);
       validateDOMNesting(null, text, null, hostContextDev.ancestorInfo);
     }
-
-    var ownerDocument: Document = rootContainerInstance.nodeType ===
-      DOCUMENT_NODE
-      ? (rootContainerInstance: any)
-      : rootContainerInstance.ownerDocument;
-
-    var textNode: TextInstance = ownerDocument.createTextNode(text);
+    var textNode: TextInstance = createTextNode(text, rootContainerInstance);
     precacheFiberNode(internalInstanceHandle, textNode);
     return textNode;
   },

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -369,12 +369,12 @@ var DOMRenderer = ReactFiberReconciler({
       validateDOMNesting(null, text, null, hostContextDev.ancestorInfo);
     }
 
-    var doc = rootContainerInstance;
-    if (rootContainerInstance.nodeType !== DOCUMENT_NODE && doc.ownerDocument) {
-      doc = ((doc: any): Element).ownerDocument;
-    }
+    var ownerDocument: Document = rootContainerInstance.nodeType ===
+      DOCUMENT_NODE
+      ? (rootContainerInstance: any)
+      : rootContainerInstance.ownerDocument;
 
-    var textNode: TextInstance = ((doc: any): Document).createTextNode(text);
+    var textNode: TextInstance = ownerDocument.createTextNode(text);
     precacheFiberNode(internalInstanceHandle, textNode);
     return textNode;
   },

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -1121,7 +1121,7 @@ describe('ReactDOMFiber', () => {
     it('should render a text component with a text DOM node on the same document as the container', () => {
       // Arrange
       // 1. Create a new document through the use of iframe
-      // 2. Set up the spy to make asserts when a text component 
+      // 2. Set up the spy to make asserts when a text component
       //    is rendered inside the iframe container
       var textContent = 'Hello world';
       var iframe = document.createElement('iframe');
@@ -1137,7 +1137,7 @@ describe('ReactDOMFiber', () => {
       var textNode;
       iframeContainer.appendChildBackup = iframeContainer.appendChild;
 
-      var appendChildSpy = spyOn(iframeContainer, 'appendChild').and.callFake(node => {
+      spyOn(iframeContainer, 'appendChild').and.callFake(node => {
         actualDocument = node.ownerDocument;
         textNode = node;
       });

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -1148,6 +1148,7 @@ describe('ReactDOMFiber', () => {
       // Assert
       expect(textNode.textContent).toBe(textContent);
       expect(actualDocument).not.toBe(document);
+      expect(actualDocument).toBe(iframeDocument);
     });
   }
 });

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -1119,7 +1119,7 @@ describe('ReactDOMFiber', () => {
       );
     });
 
-    fit('should render a text component with a text DOM node on the same document as the container', () => {
+    it('should render a text component with a text DOM node on the same document as the container', () => {
       // Arrange
       var newDocument = JSDom.jsdom('<!DOCTYPE html><html><body></body></html>');
       var newContainer = newDocument.createElement('div');

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -16,6 +16,7 @@ var ReactDOM = require('react-dom');
 var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactTestUtils = require('react-dom/test-utils');
 var PropTypes = require('prop-types');
+var JSDom = require('jsdom');
 
 describe('ReactDOMFiber', () => {
   function normalizeCodeLocInfo(str) {
@@ -1116,6 +1117,23 @@ describe('ReactDOMFiber', () => {
           'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
           'to empty a container.',
       );
+    });
+
+    fit('should render a text component with a text DOM node on the same document as the container', () => {
+      // Arrange
+      var newDocument = JSDom.jsdom('<!DOCTYPE html><html><body></body></html>');
+      var newContainer = newDocument.createElement('div');
+      var textContent = ' world ';
+      newDocument.body.appendChild(newContainer);
+
+      // Act
+      ReactDOM.render(<div><span id='pre'>hello</span>{textContent}<span>again</span></div>, newContainer);
+      
+      // Assert
+      var textNode = newDocument.getElementById('pre').nextSibling;
+      expect(textNode.textContent).toBe(textContent);
+      expect(textNode.ownerDocument).toBe(newDocument);
+      expect(textNode.ownerDocument).not.toBe(document);
     });
   }
 });

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -1134,7 +1134,6 @@ describe('ReactDOMFiber', () => {
 
       var actualDocument;
       var textNode;
-      iframeContainer.appendChildBackup = iframeContainer.appendChild;
 
       spyOn(iframeContainer, 'appendChild').and.callFake(node => {
         actualDocument = node.ownerDocument;
@@ -1146,6 +1145,7 @@ describe('ReactDOMFiber', () => {
       expect(textNode.textContent).toBe(textContent);
       expect(actualDocument).not.toBe(document);
       expect(actualDocument).toBe(iframeDocument);
+      expect(iframeContainer.appendChild).toHaveBeenCalledTimes(1);
     });
   }
 });

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -1119,7 +1119,6 @@ describe('ReactDOMFiber', () => {
     });
 
     it('should render a text component with a text DOM node on the same document as the container', () => {
-      // Arrange
       // 1. Create a new document through the use of iframe
       // 2. Set up the spy to make asserts when a text component
       //    is rendered inside the iframe container
@@ -1142,10 +1141,8 @@ describe('ReactDOMFiber', () => {
         textNode = node;
       });
 
-      // Act
       ReactDOM.render(textContent, iframeContainer);
 
-      // Assert
       expect(textNode.textContent).toBe(textContent);
       expect(actualDocument).not.toBe(document);
       expect(actualDocument).toBe(iframeDocument);

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -1121,14 +1121,19 @@ describe('ReactDOMFiber', () => {
 
     it('should render a text component with a text DOM node on the same document as the container', () => {
       // Arrange
-      var newDocument = JSDom.jsdom('<!DOCTYPE html><html><body></body></html>');
+      var newDocument = JSDom.jsdom(
+        '<!DOCTYPE html><html><body></body></html>',
+      );
       var newContainer = newDocument.createElement('div');
       var textContent = ' world ';
       newDocument.body.appendChild(newContainer);
 
       // Act
-      ReactDOM.render(<div><span id='pre'>hello</span>{textContent}<span>again</span></div>, newContainer);
-      
+      ReactDOM.render(
+        <div><span id="pre">hello</span>{textContent}<span>again</span></div>,
+        newContainer,
+      );
+
       // Assert
       var textNode = newDocument.getElementById('pre').nextSibling;
       expect(textNode.textContent).toBe(textContent);


### PR DESCRIPTION
Second try: this time update the Fiber reconciler to create the text node on the correct ownerDocument so that when it is being appendChild()'ed / insertBefore()'ed, it will succeed on IE / Edge.