### PR TITLE
[Gatsby Docs Update] Sidebar + article layout updates

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -27,6 +27,7 @@
     "glamor": "^2.20.40",
     "hex2rgba": "^0.0.1",
     "react-live": "^1.7.1",
+    "react-motion": "^0.5.1",
     "react-sticky": "^6.0.1",
     "remarkable": "^1.7.1",
     "slugify": "^1.2.1"

--- a/www/src/components/CodeEditor/CodeEditor.js
+++ b/www/src/components/CodeEditor/CodeEditor.js
@@ -121,6 +121,10 @@ class CodeEditor extends Component {
                   width: '100%',
                   borderRadius: '0',
                   marginTop: '0 !important',
+                  marginLeft: '0 !important',
+                  paddingLeft: '0 !important',
+                  marginRight: '0 !important',
+                  paddingRight: '0 !important',
 
                   '& pre.prism-code[contenteditable]': {
                     maxHeight: '280px !important',

--- a/www/src/components/Container/Container.js
+++ b/www/src/components/Container/Container.js
@@ -19,7 +19,7 @@ import {media} from 'theme';
  * This component wraps page content sections (eg header, footer, main).
  * It provides consistent margin and max width behavior.
  */
-const Container = ({children, isFooter}) => (
+const Container = ({children, cssProps = {}}) => (
   <div
     css={{
       paddingLeft: 20,
@@ -35,11 +35,7 @@ const Container = ({children, isFooter}) => (
         maxWidth: 1260,
       },
 
-      [media.size('sidebarFixedNarrowFooter')]: {
-        maxWidth: isFooter ? 800 : 1260,
-        paddingLeft: isFooter ? 0 : 20,
-        paddingRight: isFooter ? 0 : 20,
-      },
+      ...cssProps,
     }}>
     {children}
   </div>

--- a/www/src/components/Container/Container.js
+++ b/www/src/components/Container/Container.js
@@ -19,7 +19,7 @@ import {media} from 'theme';
  * This component wraps page content sections (eg header, footer, main).
  * It provides consistent margin and max width behavior.
  */
-const Container = ({children}) => (
+const Container = ({children, isFooter}) => (
   <div
     css={{
       paddingLeft: 20,
@@ -33,6 +33,12 @@ const Container = ({children}) => (
 
       [media.size('xxlarge')]: {
         maxWidth: 1260,
+      },
+
+      [media.size('sidebarFixedNarrowFooter')]: {
+        maxWidth: isFooter ? 800 : 1260,
+        paddingLeft: isFooter ? 0 : 20,
+        paddingRight: isFooter ? 0 : 20,
       },
     }}>
     {children}

--- a/www/src/components/LayoutFooter/Footer.js
+++ b/www/src/components/LayoutFooter/Footer.js
@@ -36,7 +36,13 @@ const Footer = () => (
         paddingTop: 10,
       },
     }}>
-    <Container isFooter={true}>
+    <Container  cssProps={{
+      [media.size('sidebarFixedNarrowFooter')]: {
+        maxWidth: 800,
+        paddingLeft: 0,
+        paddingRight: 0,
+      },
+    }}>
       <div
         css={{
           display: 'flex',

--- a/www/src/components/LayoutFooter/Footer.js
+++ b/www/src/components/LayoutFooter/Footer.js
@@ -47,10 +47,10 @@ const Footer = () => (
             paddingRight: 240,
           },
 
-          [media.between('large', 'xlargeSmaller')]: {
+          [media.between('large', 'largerSidebar')]: {
             paddingRight: 280,
           },
-          [media.between('xlargeSmaller', 'belowSidebarFixed')]: {
+          [media.between('largerSidebar', 'sidebarFixed', true)]: {
             paddingRight: 380,
           },
         }}>

--- a/www/src/components/LayoutFooter/Footer.js
+++ b/www/src/components/LayoutFooter/Footer.js
@@ -25,98 +25,132 @@ const Footer = () => (
     css={{
       backgroundColor: colors.darker,
       color: colors.white,
-      paddingTop: 50,
+      paddingTop: 10,
       paddingBottom: 50,
 
-      [media.lessThan('medium')]: {
-        paddingTop: 10,
-      },
-
-      [media.size('xxlarge')]: {
+      [media.size('sidebarFixed')]: {
         paddingTop: 80,
       },
+
+      [media.size('sidebarFixedNarrowFooter')]: {
+        paddingTop: 10,
+      },
     }}>
-    <Container>
+    <Container isFooter={true}>
       <div
         css={{
           display: 'flex',
           flexDirection: 'row',
           flexWrap: 'wrap',
+
+          [media.between('small', 'medium')]: {
+            paddingRight: 240,
+          },
+
+          [media.between('large', 'xlargeSmaller')]: {
+            paddingRight: 280,
+          },
+          [media.between('xlargeSmaller', 'belowSidebarFixed')]: {
+            paddingRight: 380,
+          },
         }}>
-        <FooterNav>
-          <MetaTitle onDark={true}>Docs</MetaTitle>
-          <FooterLink to="/docs/hello-world.html">Quick Start</FooterLink>
-          <FooterLink to="/docs/thinking-in-react.html">
-            Thinking in React
-          </FooterLink>
-          <FooterLink to="/tutorial/tutorial.html">Tutorial</FooterLink>
-          <FooterLink to="/docs/jsx-in-depth.html">Advanced Guides</FooterLink>
-        </FooterNav>
-        <FooterNav>
-          <MetaTitle onDark={true}>Community</MetaTitle>
-          <FooterLink
-            to="http://stackoverflow.com/questions/tagged/reactjs"
-            target="_blank"
-            rel="noopener">
-            Stack Overflow
-          </FooterLink>
-          <FooterLink
-            to="https://discuss.reactjs.org"
-            target="_blank"
-            rel="noopener">
-            Discussion Forum
-          </FooterLink>
-          <FooterLink
-            to="https://discord.gg/0ZcbPKXt5bZjGY5n"
-            target="_blank"
-            rel="noopener">
-            Reactiflux Chat
-          </FooterLink>
-          <FooterLink
-            to="https://www.facebook.com/react"
-            target="_blank"
-            rel="noopener">
-            Facebook
-          </FooterLink>
-          <FooterLink
-            to="https://twitter.com/reactjs"
-            target="_blank"
-            rel="noopener">
-            Twitter
-          </FooterLink>
-        </FooterNav>
-        <FooterNav>
-          <MetaTitle onDark={true}>Resources</MetaTitle>
-          <FooterLink to="/community/conferences.html">Conferences</FooterLink>
-          <FooterLink to="/community/videos.html">Videos</FooterLink>
-          <FooterLink
-            to="https://github.com/facebook/react/wiki/Examples"
-            target="_blank"
-            rel="noopener">
-            Examples
-          </FooterLink>
-          <FooterLink
-            to="https://github.com/facebook/react/wiki/Complementary-Tools"
-            target="_blank"
-            rel="noopener">
-            Complementary Tools
-          </FooterLink>
-        </FooterNav>
-        <FooterNav>
-          <MetaTitle onDark={true}>More</MetaTitle>
-          <FooterLink to="/blog.html">Blog</FooterLink>
-          <FooterLink to="https://github.com/facebook/react" target="_blank">
-            GitHub
-          </FooterLink>
-          <FooterLink
-            to="http://facebook.github.io/react-native/"
-            target="_blank">
-            React Native
-          </FooterLink>
-          <FooterLink to="/acknowledgements.html">Acknowledgements</FooterLink>
-        </FooterNav>
+        <div
+          css={{
+            flexWrap: 'wrap',
+            display: 'flex',
+
+            [media.lessThan('large')]: {
+              width: '100%',
+            },
+            [media.greaterThan('xlarge')]: {
+              width: 'calc(100% / 3 * 2)',
+              paddingLeft: 40,
+            },
+          }}>
+          <FooterNav>
+            <MetaTitle onDark={true}>Docs</MetaTitle>
+            <FooterLink to="/docs/hello-world.html">Quick Start</FooterLink>
+            <FooterLink to="/docs/thinking-in-react.html">
+              Thinking in React
+            </FooterLink>
+            <FooterLink to="/tutorial/tutorial.html">Tutorial</FooterLink>
+            <FooterLink to="/docs/jsx-in-depth.html">
+              Advanced Guides
+            </FooterLink>
+          </FooterNav>
+          <FooterNav>
+            <MetaTitle onDark={true}>Community</MetaTitle>
+            <FooterLink
+              to="http://stackoverflow.com/questions/tagged/reactjs"
+              target="_blank"
+              rel="noopener">
+              Stack Overflow
+            </FooterLink>
+            <FooterLink
+              to="https://discuss.reactjs.org"
+              target="_blank"
+              rel="noopener">
+              Discussion Forum
+            </FooterLink>
+            <FooterLink
+              to="https://discord.gg/0ZcbPKXt5bZjGY5n"
+              target="_blank"
+              rel="noopener">
+              Reactiflux Chat
+            </FooterLink>
+            <FooterLink
+              to="https://www.facebook.com/react"
+              target="_blank"
+              rel="noopener">
+              Facebook
+            </FooterLink>
+            <FooterLink
+              to="https://twitter.com/reactjs"
+              target="_blank"
+              rel="noopener">
+              Twitter
+            </FooterLink>
+          </FooterNav>
+          <FooterNav>
+            <MetaTitle onDark={true}>Resources</MetaTitle>
+            <FooterLink to="/community/conferences.html">
+              Conferences
+            </FooterLink>
+            <FooterLink to="/community/videos.html">Videos</FooterLink>
+            <FooterLink
+              to="https://github.com/facebook/react/wiki/Examples"
+              target="_blank"
+              rel="noopener">
+              Examples
+            </FooterLink>
+            <FooterLink
+              to="https://github.com/facebook/react/wiki/Complementary-Tools"
+              target="_blank"
+              rel="noopener">
+              Complementary Tools
+            </FooterLink>
+          </FooterNav>
+          <FooterNav>
+            <MetaTitle onDark={true}>More</MetaTitle>
+            <FooterLink to="/blog.html">Blog</FooterLink>
+            <FooterLink to="https://github.com/facebook/react" target="_blank">
+              GitHub
+            </FooterLink>
+            <FooterLink
+              to="http://facebook.github.io/react-native/"
+              target="_blank">
+              React Native
+            </FooterLink>
+            <FooterLink to="/acknowledgements.html">
+              Acknowledgements
+            </FooterLink>
+          </FooterNav>
+        </div>
         <section
           css={{
+            paddingTop: 40,
+            display: 'block !important', // Override 'Installation' <style> specifics
+
             [media.greaterThan('xlarge')]: {
               width: 'calc(100% / 3)',
               order: -1,

--- a/www/src/components/LayoutFooter/Footer.js
+++ b/www/src/components/LayoutFooter/Footer.js
@@ -28,6 +28,10 @@ const Footer = () => (
       paddingTop: 50,
       paddingBottom: 50,
 
+      [media.lessThan('medium')]: {
+        paddingTop: 10,
+      },
+
       [media.size('xxlarge')]: {
         paddingTop: 80,
       },
@@ -40,7 +44,7 @@ const Footer = () => (
           flexWrap: 'wrap',
         }}>
         <FooterNav>
-          <MetaTitle>Docs</MetaTitle>
+          <MetaTitle onDark={true}>Docs</MetaTitle>
           <FooterLink to="/docs/hello-world.html">Quick Start</FooterLink>
           <FooterLink to="/docs/thinking-in-react.html">
             Thinking in React
@@ -49,42 +53,57 @@ const Footer = () => (
           <FooterLink to="/docs/jsx-in-depth.html">Advanced Guides</FooterLink>
         </FooterNav>
         <FooterNav>
-          <MetaTitle>Community</MetaTitle>
+          <MetaTitle onDark={true}>Community</MetaTitle>
           <FooterLink
             to="http://stackoverflow.com/questions/tagged/reactjs"
-            target="_blank">
+            target="_blank"
+            rel="noopener">
             Stack Overflow
           </FooterLink>
-          <FooterLink to="https://discuss.reactjs.org" target="_blank">
+          <FooterLink
+            to="https://discuss.reactjs.org"
+            target="_blank"
+            rel="noopener">
             Discussion Forum
           </FooterLink>
-          <FooterLink to="https://discord.gg/0ZcbPKXt5bZjGY5n" target="_blank">
+          <FooterLink
+            to="https://discord.gg/0ZcbPKXt5bZjGY5n"
+            target="_blank"
+            rel="noopener">
             Reactiflux Chat
           </FooterLink>
-          <FooterLink to="https://www.facebook.com/react" target="_blank">
+          <FooterLink
+            to="https://www.facebook.com/react"
+            target="_blank"
+            rel="noopener">
             Facebook
           </FooterLink>
-          <FooterLink to="https://twitter.com/reactjs" target="_blank">
+          <FooterLink
+            to="https://twitter.com/reactjs"
+            target="_blank"
+            rel="noopener">
             Twitter
           </FooterLink>
         </FooterNav>
         <FooterNav>
-          <MetaTitle>Resources</MetaTitle>
+          <MetaTitle onDark={true}>Resources</MetaTitle>
           <FooterLink to="/community/conferences.html">Conferences</FooterLink>
           <FooterLink to="/community/videos.html">Videos</FooterLink>
           <FooterLink
             to="https://github.com/facebook/react/wiki/Examples"
-            target="_blank">
+            target="_blank"
+            rel="noopener">
             Examples
           </FooterLink>
           <FooterLink
             to="https://github.com/facebook/react/wiki/Complementary-Tools"
-            target="_blank">
+            target="_blank"
+            rel="noopener">
             Complementary Tools
           </FooterLink>
         </FooterNav>
         <FooterNav>
-          <MetaTitle>More</MetaTitle>
+          <MetaTitle onDark={true}>More</MetaTitle>
           <FooterLink to="/blog.html">Blog</FooterLink>
           <FooterLink to="https://github.com/facebook/react" target="_blank">
             GitHub
@@ -120,7 +139,7 @@ const Footer = () => (
           </a>
           <p
             css={{
-              color: colors.subtle,
+              color: colors.subtleOnDark,
               paddingTop: 15,
             }}>
             Copyright © 2017 Facebook Inc.

--- a/www/src/components/LayoutFooter/FooterNav.js
+++ b/www/src/components/LayoutFooter/FooterNav.js
@@ -21,14 +21,16 @@ const FooterNav = ({children, title}) => (
       flexDirection: 'column',
       alignItems: 'flex-start',
       width: '50%',
-      [media.lessThan('medium')]: {
-        paddingTop: 40,
-      },
-      [media.between('medium', 'large')]: {
+      paddingTop: 40,
+
+      [media.size('sidebarFixed')]: {
+        paddingTop: 0,
         width: '25%',
       },
-      [media.greaterThan('xlarge')]: {
-        width: 'calc(100% / 6)',
+
+      [media.size('sidebarFixedNarrowFooter')]: {
+        width: '50%',
+        paddingTop: 40,
       },
     }}>
     <div

--- a/www/src/components/LayoutFooter/FooterNav.js
+++ b/www/src/components/LayoutFooter/FooterNav.js
@@ -19,8 +19,11 @@ const FooterNav = ({children, title}) => (
     css={{
       display: 'flex',
       flexDirection: 'column',
-      alignItems: 'center',
+      alignItems: 'flex-start',
       width: '50%',
+      [media.lessThan('medium')]: {
+        paddingTop: 40,
+      },
       [media.between('medium', 'large')]: {
         width: '25%',
       },

--- a/www/src/components/LayoutHeader/Header.js
+++ b/www/src/components/LayoutHeader/Header.js
@@ -55,7 +55,7 @@ const Header = ({location}) => (
             width: 'calc(100% / 6)',
           }}
           to="/">
-          <img src={logoSvg} alt="React" height="20" />
+          <img src={logoSvg} alt="" height="20" />
           <span
             css={{
               color: colors.brand,
@@ -66,7 +66,15 @@ const Header = ({location}) => (
                 fontSize: 16,
               },
               [media.lessThan('small')]: {
-                visibility: 'hidden',
+                // Visually hidden
+                position: 'absolute',
+                overflow: 'hidden',
+                clip: 'rect(0 0 0 0)',
+                height: 1,
+                width: 1,
+                margin: -1,
+                padding: 0,
+                border: 0,
               },
             }}>
             React
@@ -79,10 +87,12 @@ const Header = ({location}) => (
             flexDirection: 'row',
             alignItems: 'stretch',
             overflowX: 'auto',
+            WebkitOverflowScrolling: 'touch',
             height: '100%',
-            width: '50%',
+            width: '60%',
             [media.size('xsmall')]: {
-              width: 'calc(100% * 2/3)',
+              flexGrow: '1',
+              width: 'auto',
             },
             [media.greaterThan('xlarge')]: {
               width: 'calc(100% / 3)',
@@ -115,7 +125,7 @@ const Header = ({location}) => (
 
         <form
           css={{
-            width: 'calc(100% / 6)',
+            width: 'calc(100% / 8)',
             display: 'flex',
             flexDirection: 'row',
             alignItems: 'center',
@@ -129,7 +139,7 @@ const Header = ({location}) => (
               width: 'calc(100% / 3)',
             },
           }}>
-          <label htmlFor="search">
+          <label htmlFor="algolia-doc-search">
             <SearchSvg />
           </label>
           <div
@@ -148,7 +158,9 @@ const Header = ({location}) => (
                 color: colors.white,
                 width: '100%',
                 fontSize: 18,
+                fontFamily: 'inherit',
                 position: 'relative',
+                marginLeft: 5,
                 ':focus': {
                   outline: 'none',
                 },
@@ -186,6 +198,7 @@ const Header = ({location}) => (
           <a
             css={{
               padding: '5px 10px',
+              marginLeft: 10,
               whiteSpace: 'nowrap',
               ...fonts.small,
             }}

--- a/www/src/components/LayoutHeader/HeaderLink.js
+++ b/www/src/components/LayoutHeader/HeaderLink.js
@@ -18,6 +18,7 @@ import {colors, media} from 'theme';
 const HeaderLink = ({isActive, title, to}) => (
   <Link css={[style, isActive && activeStyle]} to={to}>
     {title}
+    {isActive && <span css={activeAfterStyle} />}
   </Link>
 );
 
@@ -58,17 +59,18 @@ const activeStyle = {
 
   [media.greaterThan('xlarge')]: {
     position: 'relative',
+  },
+};
 
-    ':after': {
-      content: '',
-      position: 'absolute',
-      bottom: -1,
-      height: 4,
-      background: colors.brand,
-      left: 0,
-      right: 0,
-      zIndex: 1,
-    },
+const activeAfterStyle = {
+  [media.greaterThan('xlarge')]: {
+    position: 'absolute',
+    bottom: -1,
+    height: 4,
+    background: colors.brand,
+    left: 0,
+    right: 0,
+    zIndex: 1,
   },
 };
 

--- a/www/src/components/MarkdownHeader/MarkdownHeader.js
+++ b/www/src/components/MarkdownHeader/MarkdownHeader.js
@@ -14,48 +14,38 @@
 import Flex from 'components/Flex';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {colors, fonts} from 'theme';
+import {colors, fonts, media} from 'theme';
 
-const MarkdownHeader = ({path, title}) => (
+const MarkdownHeader = ({title}) => (
   <Flex type="header" halign="space-between" valign="baseline">
     <h1
       css={{
         color: colors.dark,
-        marginRight: '5%',
         marginBottom: 0,
+        marginTop: 40,
         ...fonts.header,
+
+        [media.size('medium')]: {
+          marginTop: 60,
+        },
+
+        [media.greaterThan('large')]: {
+          marginTop: 80,
+        },
+
+        [media.greaterThan('xlarge')]: {
+          textAlign: 'center',
+          maxWidth: '12em',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+        },
       }}>
       {title}
     </h1>
-    {path &&
-      <a
-        css={{
-          color: colors.subtle,
-          borderColor: colors.divider,
-          transition: 'all 0.2s ease',
-          transitionPropery: 'color, border-color',
-          whiteSpace: 'nowrap',
-
-          ':after': {
-            display: 'block',
-            content: '',
-            borderTopWidth: 1,
-            borderTopStyle: 'solid',
-          },
-
-          ':hover': {
-            color: colors.text,
-            borderColor: colors.text,
-          },
-        }}
-        href={`https://github.com/facebook/react/tree/master/docs/${path}`}>
-        Edit this page
-      </a>}
   </Flex>
 );
 
 MarkdownHeader.propTypes = {
-  path: PropTypes.string,
   title: PropTypes.string.isRequired,
 };
 

--- a/www/src/components/MarkdownHeader/MarkdownHeader.js
+++ b/www/src/components/MarkdownHeader/MarkdownHeader.js
@@ -33,7 +33,7 @@ const MarkdownHeader = ({title}) => (
           marginTop: 80,
         },
 
-        [media.greaterThan('xlarge')]: {
+        [media.greaterThan('sidebarFixed')]: {
           textAlign: 'center',
           maxWidth: '12em',
           marginLeft: 'auto',

--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -15,14 +15,13 @@ import Container from 'components/Container';
 import Flex from 'components/Flex';
 import MarkdownHeader from 'components/MarkdownHeader';
 import NavigationFooter from 'templates/components/NavigationFooter';
-import {StickyContainer} from 'react-sticky';
 import PropTypes from 'prop-types';
 import React from 'react';
 import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
 import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import findSectionForPath from 'utils/findSectionForPath';
 import toCommaSeparatedList from 'utils/toCommaSeparatedList';
-import {colors, media, sharedStyles} from 'theme';
+import {sharedStyles} from 'theme';
 import {urlRoot} from 'constants';
 
 const MarkdownPage = ({
@@ -56,15 +55,7 @@ const MarkdownPage = ({
       />
       <div css={{flex: '1 0 auto'}}>
         <Container>
-          <StickyContainer
-            css={{
-              display: 'flex',
-              [media.greaterThan('xlarge')]: {
-                maxWidth: 800,
-                marginLeft: 'auto',
-                marginRight: 'auto',
-              },
-            }}>
+          <div css={sharedStyles.articleLayout.container}>
             <Flex type="article" direction="column" grow="1" halign="stretch">
               <MarkdownHeader title={titlePrefix} />
 
@@ -84,19 +75,7 @@ const MarkdownPage = ({
                     </span>}
                 </div>}
 
-              <div
-                css={{
-                  marginTop: 40,
-                  marginBottom: 120,
-
-                  [media.between('medium', 'large')]: {
-                    marginTop: 50,
-                  },
-
-                  [media.greaterThan('xlarge')]: {
-                    marginTop: 85,
-                  },
-                }}>
+              <div css={sharedStyles.articleLayout.content}>
                 <div
                   css={[sharedStyles.markdown]}
                   dangerouslySetInnerHTML={{__html: markdownRemark.html}}
@@ -105,25 +84,7 @@ const MarkdownPage = ({
                 {markdownRemark.fields.path &&
                   <div css={{marginTop: 80}}>
                     <a
-                      css={{
-                        color: colors.subtle,
-                        borderColor: colors.divider,
-                        transition: 'all 0.2s ease',
-                        transitionPropery: 'color, border-color',
-                        whiteSpace: 'nowrap',
-
-                        ':after': {
-                          display: 'block',
-                          content: '',
-                          borderTopWidth: 1,
-                          borderTopStyle: 'solid',
-                        },
-
-                        ':hover': {
-                          color: colors.text,
-                          borderColor: colors.text,
-                        },
-                      }}
+                      css={sharedStyles.articleLayout.editLink}
                       href={`https://github.com/facebook/react/tree/master/docs/${markdownRemark.fields.path}`}>
                       Edit this page
                     </a>
@@ -131,18 +92,7 @@ const MarkdownPage = ({
               </div>
             </Flex>
 
-            <div
-              css={{
-                flex: '0 0 200px',
-                marginLeft: 'calc(9% + 40px)',
-                borderLeft: '1px solid #ececec',
-                display: 'flex',
-                flexDirection: 'column',
-
-                [media.greaterThan('xlargeSmaller')]: {
-                  flex: '0 0 300px',
-                },
-              }}>
+            <div css={sharedStyles.articleLayout.sidebar}>
               <StickyResponsiveSidebar
                 defaultActiveSection={
                   location != null
@@ -153,15 +103,16 @@ const MarkdownPage = ({
                 sectionList={sectionList}
               />
             </div>
-          </StickyContainer>
+          </div>
         </Container>
       </div>
 
       {/* TODO Read prev/next from index map, not this way */}
-      <NavigationFooter
-        next={markdownRemark.frontmatter.next}
-        prev={markdownRemark.frontmatter.prev}
-      />
+      {(markdownRemark.frontmatter.next || markdownRemark.frontmatter.prev) &&
+        <NavigationFooter
+          next={markdownRemark.frontmatter.next}
+          prev={markdownRemark.frontmatter.prev}
+        />}
     </Flex>
   );
 };

--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -22,7 +22,7 @@ import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
 import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import findSectionForPath from 'utils/findSectionForPath';
 import toCommaSeparatedList from 'utils/toCommaSeparatedList';
-import {sharedStyles} from 'theme';
+import {colors, media, sharedStyles} from 'theme';
 import {urlRoot} from 'constants';
 
 const MarkdownPage = ({
@@ -59,12 +59,14 @@ const MarkdownPage = ({
           <StickyContainer
             css={{
               display: 'flex',
+              [media.greaterThan('xlarge')]: {
+                maxWidth: 800,
+                marginLeft: 'auto',
+                marginRight: 'auto',
+              },
             }}>
             <Flex type="article" direction="column" grow="1" halign="stretch">
-              <MarkdownHeader
-                path={markdownRemark.fields.path}
-                title={titlePrefix}
-              />
+              <MarkdownHeader title={titlePrefix} />
 
               {(date || hasAuthors) &&
                 <div css={{marginTop: 15}}>
@@ -83,21 +85,63 @@ const MarkdownPage = ({
                 </div>}
 
               <div
-                css={[
-                  sharedStyles.markdown,
-                  {
-                    marginTop: 65,
-                    marginBottom: 120,
+                css={{
+                  marginTop: 40,
+                  marginBottom: 120,
+
+                  [media.between('medium', 'large')]: {
+                    marginTop: 50,
                   },
-                ]}
-                dangerouslySetInnerHTML={{__html: markdownRemark.html}}
-              />
+
+                  [media.greaterThan('xlarge')]: {
+                    marginTop: 85,
+                  },
+                }}>
+                <div
+                  css={[sharedStyles.markdown]}
+                  dangerouslySetInnerHTML={{__html: markdownRemark.html}}
+                />
+
+                {markdownRemark.fields.path &&
+                  <div css={{marginTop: 80}}>
+                    <a
+                      css={{
+                        color: colors.subtle,
+                        borderColor: colors.divider,
+                        transition: 'all 0.2s ease',
+                        transitionPropery: 'color, border-color',
+                        whiteSpace: 'nowrap',
+
+                        ':after': {
+                          display: 'block',
+                          content: '',
+                          borderTopWidth: 1,
+                          borderTopStyle: 'solid',
+                        },
+
+                        ':hover': {
+                          color: colors.text,
+                          borderColor: colors.text,
+                        },
+                      }}
+                      href={`https://github.com/facebook/react/tree/master/docs/${markdownRemark.fields.path}`}>
+                      Edit this page
+                    </a>
+                  </div>}
+              </div>
             </Flex>
 
             <div
               css={{
                 flex: '0 0 200px',
                 marginLeft: 'calc(9% + 40px)',
+                borderLeft: '1px solid #ececec',
+                display: 'flex',
+                flexDirection: 'column',
+
+                [media.greaterThan('xlargeSmaller')]: {
+                  flex: '0 0 300px',
+                },
               }}>
               <StickyResponsiveSidebar
                 defaultActiveSection={

--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -18,7 +18,7 @@ import NavigationFooter from 'templates/components/NavigationFooter';
 import {StickyContainer} from 'react-sticky';
 import PropTypes from 'prop-types';
 import React from 'react';
-import StickySidebar from 'components/StickySidebar';
+import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
 import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import findSectionForPath from 'utils/findSectionForPath';
 import toCommaSeparatedList from 'utils/toCommaSeparatedList';
@@ -99,7 +99,7 @@ const MarkdownPage = ({
                 flex: '0 0 200px',
                 marginLeft: 'calc(9% + 40px)',
               }}>
-              <StickySidebar
+              <StickyResponsiveSidebar
                 defaultActiveSection={
                   location != null
                     ? findSectionForPath(location.pathname, sectionList)

--- a/www/src/components/StickyResponsiveSidebar/ChevronSvg.js
+++ b/www/src/components/StickyResponsiveSidebar/ChevronSvg.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+*/
+
+'use strict';
+
+import React from 'react';
+
+const ChevronSvg = ({cssProps = {}}) => (
+  <svg
+    css={cssProps}
+    viewBox="0 0 926.23699 573.74994"
+    version="1.1"
+    x="0px"
+    y="0px"
+    width="10px"
+    height="10px">
+    <g transform="translate(904.92214,-879.1482)">
+      <path
+        d={`
+          m -673.67664,1221.6502 -231.2455,-231.24803 55.6165,
+          -55.627 c 30.5891,-30.59485 56.1806,-55.627 56.8701,-55.627 0.6894,
+          0 79.8637,78.60862 175.9427,174.68583 l 174.6892,174.6858 174.6892,
+          -174.6858 c 96.079,-96.07721 175.253196,-174.68583 175.942696,
+          -174.68583 0.6895,0 26.281,25.03215 56.8701,
+          55.627 l 55.6165,55.627 -231.245496,231.24803 c -127.185,127.1864
+          -231.5279,231.248 -231.873,231.248 -0.3451,0 -104.688,
+          -104.0616 -231.873,-231.248 z
+        `}
+        fill="#fff"
+      />
+    </g>
+  </svg>
+);
+
+export default ChevronSvg;

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -59,8 +59,6 @@ class StickyResponsiveSidebar extends Component {
 
   render() {
     const {defaultActiveSection, location} = this.props;
-    console.log('the defaultActiveSection is ;', defaultActiveSection);
-    console.log('this.props are ', this.props);
     const smallScreenSidebarStyles = {
       top: 0,
       left: 0,

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -108,7 +108,7 @@ class StickyResponsiveSidebar extends Component {
                   backgroundColor: '#f7f7f7',
                 },
 
-                [media.between('medium', 'belowSidebarFixed')]: {
+                [media.between('medium', 'sidebarFixed', true)]: {
                   position: 'fixed',
                   zIndex: 2,
                   height: '100%',

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -13,9 +13,33 @@
 
 import Container from 'components/Container';
 import {Component, React} from 'react';
+import isItemActive from 'utils/isItemActive';
 import {Sticky} from 'react-sticky';
 import Sidebar from 'templates/components/Sidebar';
 import {colors, media} from 'theme';
+
+// TODO: memoize to save doing O(n) on the active section items + subitems every
+// time.
+function findActiveItemTitle(location, defaultActiveSection) {
+  const {items} = defaultActiveSection;
+  for (let i = 0, len = items.length; i < len; i++) {
+    const item = items[i];
+    if (isItemActive(location, item)) {
+      return item.title;
+    } else if (item.subitems && item.subitems.length) {
+      const {subitems} = item;
+      for (let j = 0, len = subitems.length; j < len; j++) {
+        const subitem = subitems[j];
+        if (isItemActive(location, subitem)) {
+          return subitem.title;
+        }
+      }
+    }
+  }
+  // If nothing else is found, warn and default to section title
+  console.warn('No active item title found in <StickyResponsiveSidebar>');
+  return defaultActiveSection.title;
+}
 
 class StickyResponsiveSidebar extends Component {
   constructor(props, context) {
@@ -33,7 +57,9 @@ class StickyResponsiveSidebar extends Component {
   }
 
   render() {
-    const {defaultActiveSection} = this.props;
+    const {defaultActiveSection, location} = this.props;
+    console.log('the defaultActiveSection is ;', defaultActiveSection);
+    console.log('this.props are ', this.props);
     const smallScreenSidebarStyles = {
       // TODO: animate height instead of using display: none?
       // Changing height may be better a11y too
@@ -50,11 +76,10 @@ class StickyResponsiveSidebar extends Component {
       display: 'block',
     };
 
-    // TODO: use the location to find the active section item and use it's title
-    // instead
-    const activeSectionItemTitle = defaultActiveSection.title;
-
-    const bottomBarText = this.state.open ? 'Close' : activeSectionItemTitle;
+    const bottomBarText =
+      this.state.open ?
+      'Close' :
+      findActiveItemTitle(location, defaultActiveSection);
 
     return (
       <div>

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -28,7 +28,7 @@ function findActiveItemTitle(location, defaultActiveSection) {
       return item.title;
     } else if (item.subitems && item.subitems.length) {
       const {subitems} = item;
-      for (let j = 0, len = subitems.length; j < len; j++) {
+      for (let j = 0, len2 = subitems.length; j < len2; j++) {
         const subitem = subitems[j];
         if (isItemActive(location, subitem)) {
           return subitem.title;
@@ -76,10 +76,9 @@ class StickyResponsiveSidebar extends Component {
       display: 'block',
     };
 
-    const bottomBarText =
-      this.state.open ?
-      'Close' :
-      findActiveItemTitle(location, defaultActiveSection);
+    const bottomBarText = this.state.open
+      ? 'Close'
+      : findActiveItemTitle(location, defaultActiveSection);
 
     return (
       <div>

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -11,32 +11,115 @@
 
 'use strict';
 
-import React from 'react';
+import Container from 'components/Container';
+import {Component, React} from 'react';
 import {Sticky} from 'react-sticky';
 import Sidebar from 'templates/components/Sidebar';
-import {media} from 'theme';
+import {colors, media} from 'theme';
 
-const StickyResponsiveSidebar = props => (
-  <Sticky>
-    {({style}) => (
-      <div style={style}>
+class StickyResponsiveSidebar extends Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      activeSection: props.defaultActiveSection,
+      open: false,
+    };
+    this.toggleOpen = this._toggleOpen.bind(this);
+  }
+
+  _toggleOpen() {
+    this.setState({open: !this.state.open});
+  }
+
+  render() {
+    const {defaultActiveSection} = this.props;
+    const smallScreenSidebarStyles = {
+      // TODO: animate height instead of using display: none?
+      // Changing height may be better a11y too
+      display: this.state.open ? 'block' : 'none',
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+      position: 'fixed',
+      backgroundColor: colors.white,
+    };
+
+    const smallScreenBottomBarStyles = {
+      display: 'block',
+    };
+
+    // TODO: use the location to find the active section item and use it's title
+    // instead
+    const activeSectionItemTitle = defaultActiveSection.title;
+
+    const bottomBarText = this.state.open ? 'Close' : activeSectionItemTitle;
+
+    return (
+      <div>
+        <Sticky>
+          {({style}) => {
+            return (
+              <div
+                css={{
+                  [media.lessThan('small')]: smallScreenSidebarStyles,
+                  [media.greaterThan('small')]: style,
+                }}>
+                <div
+                  css={{
+                    marginTop: 60,
+
+                    [media.lessThan('small')]: {
+                      marginTop: 40,
+                    },
+
+                    [media.between('medium', 'large')]: {
+                      marginTop: 50,
+                    },
+                  }}>
+                  <Sidebar {...this.props} />
+                </div>
+              </div>
+            );
+          }}
+        </Sticky>
         <div
           css={{
-            marginTop: 60,
-
-            [media.lessThan('small')]: {
-              marginTop: 40,
-            },
-
-            [media.between('medium', 'large')]: {
-              marginTop: 50,
-            },
-          }}>
-          <Sidebar {...props} />
+            backgroundColor: colors.darker,
+            bottom: 0,
+            color: colors.brand,
+            display: 'none', // gets overriden at small screen sizes
+            left: 0,
+            cursor: 'pointer',
+            position: 'fixed',
+            right: 0,
+            width: '100%',
+            zIndex: 1,
+            [media.lessThan('small')]: smallScreenBottomBarStyles,
+          }}
+          onClick={this.toggleOpen}>
+          <Container>
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'center',
+                height: 60,
+                [media.between('medium', 'large')]: {
+                  height: 50,
+                },
+                [media.lessThan('small')]: {
+                  height: 40,
+                },
+              }}>
+              {bottomBarText}
+            </div>
+          </Container>
         </div>
       </div>
-    )}
-  </Sticky>
-);
+    );
+  }
+}
 
 export default StickyResponsiveSidebar;

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -14,7 +14,6 @@
 import Container from 'components/Container';
 import {Component, React} from 'react';
 import isItemActive from 'utils/isItemActive';
-import {Sticky} from 'react-sticky';
 import Sidebar from 'templates/components/Sidebar';
 import {colors, media} from 'theme';
 
@@ -70,6 +69,10 @@ class StickyResponsiveSidebar extends Component {
       right: 0,
       position: 'fixed',
       backgroundColor: colors.white,
+      zIndex: 2,
+      height: '100vh',
+      overflowY: 'auto',
+      WebkitOverflowScrolling: 'touch',
     };
 
     const smallScreenBottomBarStyles = {
@@ -82,32 +85,62 @@ class StickyResponsiveSidebar extends Component {
 
     return (
       <div>
-        <Sticky>
-          {({style}) => {
-            return (
-              <div
-                css={{
-                  [media.lessThan('small')]: smallScreenSidebarStyles,
-                  [media.greaterThan('small')]: style,
-                }}>
-                <div
-                  css={{
-                    marginTop: 60,
+        <div>
+          <div
+            css={{
+              [media.lessThan('small')]: smallScreenSidebarStyles,
 
-                    [media.lessThan('small')]: {
-                      marginTop: 40,
-                    },
+              [media.greaterThan('medium')]: {
+                marginRight: -999,
+                paddingRight: 999,
+                backgroundColor: '#f7f7f7',
+              },
 
-                    [media.between('medium', 'large')]: {
-                      marginTop: 50,
-                    },
-                  }}>
-                  <Sidebar {...this.props} />
-                </div>
-              </div>
-            );
-          }}
-        </Sticky>
+              [media.between('medium', 'belowSidebarFixed')]: {
+                position: 'fixed',
+                zIndex: 2,
+                height: '100%',
+              },
+
+              [media.size('small')]: {
+                height: 'calc(100vh - 40px)',
+              },
+
+              [media.between('medium', 'large')]: {
+                height: 'calc(100vh - 50px)',
+              },
+
+              [media.greaterThan('small')]: {
+                position: 'fixed',
+                zIndex: 2,
+                height: 'calc(100vh - 60px)',
+                overflowY: 'auto',
+                WebkitOverflowScrolling: 'touch',
+                marginRight: -999,
+                paddingRight: 999,
+                backgroundColor: '#f7f7f7',
+              },
+
+              [media.greaterThan('sidebarFixed')]: {
+                borderLeft: '1px solid #ececec',
+              },
+            }}>
+            <div
+              css={{
+                marginTop: 60,
+
+                [media.lessThan('small')]: {
+                  marginTop: 40,
+                },
+
+                [media.between('medium', 'large')]: {
+                  marginTop: 50,
+                },
+              }}>
+              <Sidebar {...this.props} />
+            </div>
+          </div>
+        </div>
         <div
           css={{
             backgroundColor: colors.darker,
@@ -119,7 +152,7 @@ class StickyResponsiveSidebar extends Component {
             position: 'fixed',
             right: 0,
             width: '100%',
-            zIndex: 1,
+            zIndex: 3,
             [media.lessThan('small')]: smallScreenBottomBarStyles,
           }}
           onClick={this.toggleOpen}>

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -16,6 +16,8 @@ import {Component, React} from 'react';
 import isItemActive from 'utils/isItemActive';
 import Sidebar from 'templates/components/Sidebar';
 import {colors, media} from 'theme';
+import {Motion, spring} from 'react-motion';
+import ChevronSvg from './ChevronSvg';
 
 // TODO: memoize to save doing O(n) on the active section items + subitems every
 // time.
@@ -60,9 +62,6 @@ class StickyResponsiveSidebar extends Component {
     console.log('the defaultActiveSection is ;', defaultActiveSection);
     console.log('this.props are ', this.props);
     const smallScreenSidebarStyles = {
-      // TODO: animate height instead of using display: none?
-      // Changing height may be better a11y too
-      display: this.state.open ? 'block' : 'none',
       top: 0,
       left: 0,
       bottom: 0,
@@ -73,108 +72,174 @@ class StickyResponsiveSidebar extends Component {
       height: '100vh',
       overflowY: 'auto',
       WebkitOverflowScrolling: 'touch',
+      pointerEvents: this.state.open ? 'auto' : 'none',
     };
 
     const smallScreenBottomBarStyles = {
       display: 'block',
     };
 
-    const bottomBarText = this.state.open
-      ? 'Close'
-      : findActiveItemTitle(location, defaultActiveSection);
-
     return (
-      <div>
-        <div>
-          <div
-            css={{
-              [media.lessThan('small')]: smallScreenSidebarStyles,
-
-              [media.greaterThan('medium')]: {
-                marginRight: -999,
-                paddingRight: 999,
-                backgroundColor: '#f7f7f7',
-              },
-
-              [media.between('medium', 'belowSidebarFixed')]: {
-                position: 'fixed',
-                zIndex: 2,
-                height: '100%',
-              },
-
-              [media.size('small')]: {
-                height: 'calc(100vh - 40px)',
-              },
-
-              [media.between('medium', 'large')]: {
-                height: 'calc(100vh - 50px)',
-              },
-
-              [media.greaterThan('small')]: {
-                position: 'fixed',
-                zIndex: 2,
-                height: 'calc(100vh - 60px)',
-                overflowY: 'auto',
-                WebkitOverflowScrolling: 'touch',
-                marginRight: -999,
-                paddingRight: 999,
-                backgroundColor: '#f7f7f7',
-              },
-
-              [media.greaterThan('sidebarFixed')]: {
-                borderLeft: '1px solid #ececec',
-              },
-            }}>
+      <Motion
+        defaultStyle={{
+          iconOffset: 0,
+          labelOffset: 0,
+          menuOpacity: 0,
+          menuOffset: 40,
+        }}
+        style={{
+          iconOffset: spring(this.state.open ? 7 : 0),
+          labelOffset: spring(this.state.open ? -40 : 0),
+          menuOpacity: spring(this.state.open ? 1 : 0),
+          menuOffset: spring(this.state.open ? 0 : 40),
+        }}>
+        {value => (
+          <div>
             <div
+              style={{
+                opacity: value.menuOpacity,
+              }}
               css={{
-                marginTop: 60,
+                [media.lessThan('small')]: smallScreenSidebarStyles,
 
-                [media.lessThan('small')]: {
-                  marginTop: 40,
+                [media.greaterThan('medium')]: {
+                  marginRight: -999,
+                  paddingRight: 999,
+                  backgroundColor: '#f7f7f7',
+                },
+
+                [media.between('medium', 'belowSidebarFixed')]: {
+                  position: 'fixed',
+                  zIndex: 2,
+                  height: '100%',
+                },
+
+                [media.greaterThan('small')]: {
+                  position: 'fixed',
+                  zIndex: 2,
+                  height: 'calc(100vh - 60px)',
+                  overflowY: 'auto',
+                  WebkitOverflowScrolling: 'touch',
+                  marginRight: -999,
+                  paddingRight: 999,
+                  backgroundColor: '#f7f7f7',
+                  opacity: '1 !important',
+                },
+
+                [media.size('small')]: {
+                  height: 'calc(100vh - 40px)',
                 },
 
                 [media.between('medium', 'large')]: {
-                  marginTop: 50,
+                  height: 'calc(100vh - 50px)',
+                },
+
+                [media.greaterThan('sidebarFixed')]: {
+                  borderLeft: '1px solid #ececec',
                 },
               }}>
-              <Sidebar {...this.props} />
+              <div
+                style={{
+                  transform: `translate(0px, ${value.menuOffset}px)`,
+                }}
+                css={{
+                  marginTop: 60,
+
+                  [media.lessThan('small')]: {
+                    marginTop: 40,
+                  },
+
+                  [media.between('medium', 'large')]: {
+                    marginTop: 50,
+                  },
+
+                  [media.greaterThan('small')]: {
+                    tranform: 'none !important',
+                  },
+                }}>
+                <Sidebar {...this.props} />
+              </div>
+            </div>
+            <div
+              css={{
+                backgroundColor: colors.darker,
+                bottom: 0,
+                color: colors.brand,
+                display: 'none', // gets overriden at small screen sizes
+                left: 0,
+                cursor: 'pointer',
+                position: 'fixed',
+                right: 0,
+                width: '100%',
+                zIndex: 3,
+                [media.lessThan('small')]: smallScreenBottomBarStyles,
+              }}
+              onClick={this.toggleOpen}>
+              <Container>
+                <div
+                  css={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    height: 60,
+                    [media.between('medium', 'large')]: {
+                      height: 50,
+                    },
+                    [media.lessThan('small')]: {
+                      height: 40,
+                      overflow: 'hidden',
+                      alignItems: 'flex-start',
+                    },
+                  }}>
+                  <div
+                    css={{
+                      width: 20,
+                      marginRight: 10,
+                      alignSelf: 'center',
+                      display: 'flex',
+                      flexDirection: 'column',
+                    }}>
+                    <ChevronSvg
+                      cssProps={{
+                        transform: `translate(0, ${value.iconOffset}px) rotate(180deg)`,
+                      }}
+                    />
+                    <ChevronSvg
+                      cssProps={{
+                        transform: `translate(0, ${0 - value.iconOffset}px)`,
+                      }}
+                    />
+                  </div>
+                  <div
+                    css={{
+                      flexGrow: 1,
+                    }}>
+                    <div
+                      style={{
+                        transform: `translate(0, ${value.labelOffset}px)`,
+                      }}>
+                      <div
+                        css={{
+                          height: 40,
+                          lineHeight: '40px',
+                        }}>
+                        {findActiveItemTitle(location, defaultActiveSection)}
+                      </div>
+                      <div
+                        css={{
+                          height: 40,
+                          lineHeight: '40px',
+                        }}>
+                        Close
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </Container>
             </div>
           </div>
-        </div>
-        <div
-          css={{
-            backgroundColor: colors.darker,
-            bottom: 0,
-            color: colors.brand,
-            display: 'none', // gets overriden at small screen sizes
-            left: 0,
-            cursor: 'pointer',
-            position: 'fixed',
-            right: 0,
-            width: '100%',
-            zIndex: 3,
-            [media.lessThan('small')]: smallScreenBottomBarStyles,
-          }}
-          onClick={this.toggleOpen}>
-          <Container>
-            <div
-              css={{
-                display: 'flex',
-                flexDirection: 'row',
-                alignItems: 'center',
-                height: 60,
-                [media.between('medium', 'large')]: {
-                  height: 50,
-                },
-                [media.lessThan('small')]: {
-                  height: 40,
-                },
-              }}>
-              {bottomBarText}
-            </div>
-          </Container>
-        </div>
-      </div>
+        )}
+      </Motion>
     );
   }
 }

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -16,7 +16,7 @@ import {Sticky} from 'react-sticky';
 import Sidebar from 'templates/components/Sidebar';
 import {media} from 'theme';
 
-const StickySidebar = props => (
+const StickyResponsiveSidebar = props => (
   <Sticky>
     {({style}) => (
       <div style={style}>
@@ -39,4 +39,4 @@ const StickySidebar = props => (
   </Sticky>
 );
 
-export default StickySidebar;
+export default StickyResponsiveSidebar;

--- a/www/src/components/StickyResponsiveSidebar/index.js
+++ b/www/src/components/StickyResponsiveSidebar/index.js
@@ -11,6 +11,6 @@
 
 'use strict';
 
-import StickySidebar from './StickySidebar';
+import StickyResponsiveSidebar from './StickyResponsiveSidebar';
 
-export default StickySidebar;
+export default StickyResponsiveSidebar;

--- a/www/src/css/algolia.css
+++ b/www/src/css/algolia.css
@@ -305,11 +305,14 @@
 .algolia-autocomplete .algolia-docsearch-suggestion--category-header {
   position: relative;
   display: none;
-  font-size: 1em;
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  font-weight: 700;
   background-color: #373940;
+  text-transform: uppercase;
   color: #fff;
   margin: 0;
-  padding: 0 8px;
+  padding: 5px 8px;
 }
 
 .algolia-autocomplete .algolia-docsearch-suggestion--wrapper {

--- a/www/src/pages/docs/error-decoder.html.js
+++ b/www/src/pages/docs/error-decoder.html.js
@@ -18,7 +18,7 @@ import hex2rgba from 'hex2rgba';
 import MarkdownHeader from 'components/MarkdownHeader';
 import React from 'react';
 import {StickyContainer} from 'react-sticky';
-import StickySidebar from 'components/StickySidebar';
+import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
 import {colors, sharedStyles} from 'theme';
 import findSectionForPath from 'utils/findSectionForPath';
 
@@ -81,7 +81,7 @@ const ErrorPage = ({data, location}) => (
             flex: '0 0 200px',
             marginLeft: 'calc(9% + 40px)',
           }}>
-          <StickySidebar
+          <StickyResponsiveSidebar
             defaultActiveSection={
               location != null
                 ? findSectionForPath(location.pathname, sectionList)

--- a/www/src/prism-styles.js
+++ b/www/src/prism-styles.js
@@ -19,7 +19,7 @@ const prismColors = {
   comment: '#999999',
   keyword: '#c4f1fe',
   lineHighlight: '#393d45',
-  primative: '#aa759f',
+  primative: '#c997c0',
   string: '#99c27c',
   variable: '#99c27c',
 };

--- a/www/src/templates/components/MetaTitle/index.js
+++ b/www/src/templates/components/MetaTitle/index.js
@@ -14,11 +14,17 @@
 import React from 'react';
 import {colors} from 'theme';
 
-const MetaTitle = ({children, title, cssProps = {}, onClick}) => (
+const MetaTitle = ({
+  children,
+  title,
+  cssProps = {},
+  onClick,
+  onDark = false,
+}) => (
   <div
     onClick={onClick}
     css={{
-      color: colors.subtle,
+      color: onDark ? colors.subtleOnDark : colors.subtle,
       cursor: onClick ? 'pointer' : null,
       fontSize: 14,
       fontWeight: 700,

--- a/www/src/templates/components/NavigationFooter/NavigationFooter.js
+++ b/www/src/templates/components/NavigationFooter/NavigationFooter.js
@@ -35,11 +35,11 @@ const NavigationFooter = ({next, prev}) => (
             paddingRight: 240,
           },
 
-          [media.between('large', 'xlargeSmaller')]: {
+          [media.between('large', 'largerSidebar')]: {
             paddingRight: 280,
           },
 
-          [media.between('xlargeSmaller', 'belowSidebarFixed')]: {
+          [media.between('largerSidebar', 'sidebarFixed', true)]: {
             paddingRight: 380,
           },
         }}>

--- a/www/src/templates/components/NavigationFooter/NavigationFooter.js
+++ b/www/src/templates/components/NavigationFooter/NavigationFooter.js
@@ -25,18 +25,36 @@ const NavigationFooter = ({next, prev}) => (
       color: colors.white,
       paddingTop: 50,
       paddingBottom: 50,
-      position: 'relative',
-      zIndex: 1,
     }}>
-    <Container>
-      <Flex type="ul" halign="space-between">
+    <Container isFooter={true}>
+      <Flex
+        type="ul"
+        halign="space-between"
+        css={{
+          [media.between('small', 'medium')]: {
+            paddingRight: 240,
+          },
+
+          [media.between('large', 'xlargeSmaller')]: {
+            paddingRight: 280,
+          },
+
+          [media.between('xlargeSmaller', 'belowSidebarFixed')]: {
+            paddingRight: 380,
+          },
+        }}>
         <Flex basis="50%" type="li">
           {prev &&
             <div>
               <SecondaryLabel>Previous article</SecondaryLabel>
-              <PrimaryLink to={prev}>
-                {linkToTitle(prev)}
-              </PrimaryLink>
+              <div
+                css={{
+                  paddingTop: 10,
+                }}>
+                <PrimaryLink to={prev}>
+                  {linkToTitle(prev)}
+                </PrimaryLink>
+              </div>
             </div>}
         </Flex>
         {next &&
@@ -49,9 +67,14 @@ const NavigationFooter = ({next, prev}) => (
             }}>
             <div>
               <SecondaryLabel>Next article</SecondaryLabel>
-              <PrimaryLink to={next}>
-                {linkToTitle(next)}
-              </PrimaryLink>
+              <div
+                css={{
+                  paddingTop: 10,
+                }}>
+                <PrimaryLink to={next}>
+                  {linkToTitle(next)}
+                </PrimaryLink>
+              </div>
             </div>
           </Flex>}
       </Flex>
@@ -71,12 +94,13 @@ const linkToTitle = link => link.replace(/-/g, ' ').replace('.html', '');
 const PrimaryLink = ({children, to}) => (
   <Link
     css={{
-      display: 'inline-block',
-      paddingTop: 10,
+      display: 'inline',
       textTransform: 'capitalize',
       borderColor: colors.subtle,
       transition: 'border-color 0.2s ease',
       fontSize: 30,
+      borderBottomWidth: 1,
+      borderBottomStyle: 'solid',
 
       [media.lessThan('large')]: {
         fontSize: 24,
@@ -90,16 +114,6 @@ const PrimaryLink = ({children, to}) => (
     }}
     to={to}>
     {children}
-    <span
-      css={{
-        borderTopWidth: 1,
-        borderTopStyle: 'solid',
-        borderColor: 'inherit',
-        marginBottom: -1,
-        position: 'relative',
-        display: 'block',
-      }}
-    />
   </Link>
 );
 

--- a/www/src/templates/components/NavigationFooter/NavigationFooter.js
+++ b/www/src/templates/components/NavigationFooter/NavigationFooter.js
@@ -30,7 +30,7 @@ const NavigationFooter = ({next, prev}) => (
     }}>
     <Container>
       <Flex type="ul" halign="space-between">
-        <Flex basis="50%">
+        <Flex basis="50%" type="li">
           {prev &&
             <div>
               <SecondaryLabel>Previous article</SecondaryLabel>
@@ -43,6 +43,7 @@ const NavigationFooter = ({next, prev}) => (
           <Flex
             halign="flex-end"
             basis="50%"
+            type="li"
             css={{
               textAlign: 'right',
             }}>
@@ -70,7 +71,7 @@ const linkToTitle = link => link.replace(/-/g, ' ').replace('.html', '');
 const PrimaryLink = ({children, to}) => (
   <Link
     css={{
-      display: 'block',
+      display: 'inline-block',
       paddingTop: 10,
       textTransform: 'capitalize',
       borderColor: colors.subtle,
@@ -83,22 +84,22 @@ const PrimaryLink = ({children, to}) => (
       [media.size('xsmall')]: {
         fontSize: 16,
       },
-
-      ':after': {
-        display: 'block',
-        content: '',
-        borderTopWidth: 1,
-        borderTopStyle: 'solid',
-        borderColor: 'inherit',
-        marginBottom: -1,
-        position: 'relative',
-      },
       ':hover': {
         borderColor: colors.white,
       },
     }}
     to={to}>
     {children}
+    <span
+      css={{
+        borderTopWidth: 1,
+        borderTopStyle: 'solid',
+        borderColor: 'inherit',
+        marginBottom: -1,
+        position: 'relative',
+        display: 'block',
+      }}
+    />
   </Link>
 );
 

--- a/www/src/templates/components/NavigationFooter/NavigationFooter.js
+++ b/www/src/templates/components/NavigationFooter/NavigationFooter.js
@@ -26,7 +26,13 @@ const NavigationFooter = ({next, prev}) => (
       paddingTop: 50,
       paddingBottom: 50,
     }}>
-    <Container isFooter={true}>
+    <Container cssProps={{
+      [media.size('sidebarFixedNarrowFooter')]: {
+        maxWidth: 800,
+        paddingLeft: 0,
+        paddingRight: 0,
+      },
+    }}>
       <Flex
         type="ul"
         halign="space-between"

--- a/www/src/templates/components/Sidebar/Section.js
+++ b/www/src/templates/components/Sidebar/Section.js
@@ -35,9 +35,16 @@ const Section = ({isActive, location, onClick, section}) => (
       {section.title}
     </MetaTitle>
     {isActive &&
-      <ul css={{marginBottom: 10}}>
+      <ul
+        css={{
+          marginBottom: 10,
+        }}>
         {section.items.map(item => (
-          <li key={item.id}>
+          <li
+            key={item.id}
+            css={{
+              marginTop: 5,
+            }}>
             {CreateLink(location, section, item)}
 
             {item.subitems &&
@@ -55,16 +62,17 @@ const Section = ({isActive, location, onClick, section}) => (
 );
 
 const activeLinkCss = {
-  color: colors.brand,
+  fontWeight: 'bold',
+};
 
-  ':before': {
-    content: '',
-    width: 4,
-    height: '100%',
-    borderLeft: `4px solid ${colors.brand}`,
-    marginLeft: -20,
-    paddingLeft: 16,
-  },
+const activeLinkBefore = {
+  width: 4,
+  height: 25,
+  borderLeft: `4px solid ${colors.brand}`,
+  paddingLeft: 16,
+  position: 'absolute',
+  left: 0,
+  marginTop: -3,
 };
 
 const linkCss = {
@@ -75,24 +83,23 @@ const linkCss = {
   marginTop: 5,
 
   '&:hover': {
-    color: colors.brand,
+    color: colors.subtle,
   },
 };
 
 const CreateLink = (location, section, item) => {
+  const isActive = isItemActive(location, item);
   if (item.id.includes('.html')) {
     return (
-      <Link
-        css={[linkCss, isItemActive(location, item) && activeLinkCss]}
-        to={item.id}>
+      <Link css={[linkCss, isActive && activeLinkCss]} to={item.id}>
+        {isActive && <span css={activeLinkBefore} />}
         {item.title}
       </Link>
     );
   } else if (item.forceInternal) {
     return (
-      <Link
-        css={[linkCss, isItemActive(location, item) && activeLinkCss]}
-        to={item.href}>
+      <Link css={[linkCss, isActive && activeLinkCss]} to={item.href}>
+        {isActive && <span css={activeLinkBefore} />}
         {item.title}
       </Link>
     );
@@ -120,8 +127,9 @@ const CreateLink = (location, section, item) => {
   } else {
     return (
       <Link
-        css={[linkCss, isItemActive(location, item) && activeLinkCss]}
+        css={[linkCss, isActive && activeLinkCss]}
         to={slugify(item.id, section.directory)}>
+        {isActive && <span css={activeLinkBefore} />}
         {item.title}
       </Link>
     );

--- a/www/src/templates/components/Sidebar/Section.js
+++ b/www/src/templates/components/Sidebar/Section.js
@@ -15,7 +15,7 @@ import isItemActive from 'utils/isItemActive';
 import Link from 'gatsby-link';
 import React from 'react';
 import slugify from 'utils/slugify';
-import {colors} from 'theme';
+import {colors, media} from 'theme';
 import MetaTitle from '../MetaTitle';
 
 // TODO Update isActive link as document scrolls past anchor tags
@@ -73,6 +73,10 @@ const activeLinkBefore = {
   position: 'absolute',
   left: 0,
   marginTop: -3,
+
+  [media.greaterThan('xlargeSmaller')]: {
+    left: 15,
+  },
 };
 
 const linkCss = {

--- a/www/src/templates/components/Sidebar/Section.js
+++ b/www/src/templates/components/Sidebar/Section.js
@@ -11,35 +11,15 @@
 
 'use strict';
 
+import isItemActive from 'utils/isItemActive';
 import Link from 'gatsby-link';
 import React from 'react';
 import slugify from 'utils/slugify';
 import {colors} from 'theme';
 import MetaTitle from '../MetaTitle';
 
-const toAnchor = (href = '') => {
-  const index = href.indexOf('#');
-  return index >= 0 ? href.substr(index) : '';
-};
-
 // TODO Update isActive link as document scrolls past anchor tags
 // Maybe used 'hashchange' along with 'scroll' to set/update active links
-
-// TODO Account for redirect_from URLs somehow; they currently won't match.
-
-const isItemActive = (location, item) => {
-  if (location == null) {
-    return false; // Production build of Gatsby is eval'ed in Node
-  } else if (location.hash) {
-    if (item.href) {
-      return location.hash === toAnchor(item.href);
-    }
-  } else if (item.id.includes('html')) {
-    return location.pathname.includes(item.id);
-  } else {
-    return location.pathname.includes(slugify(item.id));
-  }
-};
 
 const Section = ({isActive, location, onClick, section}) => (
   <div>

--- a/www/src/templates/components/Sidebar/Section.js
+++ b/www/src/templates/components/Sidebar/Section.js
@@ -74,7 +74,7 @@ const activeLinkBefore = {
   left: 0,
   marginTop: -3,
 
-  [media.greaterThan('xlargeSmaller')]: {
+  [media.greaterThan('largerSidebar')]: {
     left: 15,
   },
 };

--- a/www/src/templates/components/Sidebar/Sidebar.js
+++ b/www/src/templates/components/Sidebar/Sidebar.js
@@ -14,6 +14,7 @@
 import React, {Component} from 'react';
 import Flex from 'components/Flex';
 import Section from './Section';
+import {media} from 'theme';
 
 class Sidebar extends Component {
   constructor(props, context) {
@@ -35,7 +36,12 @@ class Sidebar extends Component {
         halign="stretch"
         css={{
           width: '100%',
-          paddingLeft: '1rem',
+          paddingLeft: 20,
+          position: 'relative',
+
+          [media.greaterThan('xlargeSmaller')]: {
+            paddingLeft: 40,
+          },
         }}>
         {sectionList.map((section, index) => (
           <Section

--- a/www/src/templates/components/Sidebar/Sidebar.js
+++ b/www/src/templates/components/Sidebar/Sidebar.js
@@ -39,7 +39,7 @@ class Sidebar extends Component {
           paddingLeft: 20,
           position: 'relative',
 
-          [media.greaterThan('xlargeSmaller')]: {
+          [media.greaterThan('largerSidebar')]: {
             paddingLeft: 40,
           },
         }}>

--- a/www/src/templates/home.js
+++ b/www/src/templates/home.js
@@ -98,6 +98,7 @@ class Home extends Component {
                   [media.greaterThan('xlarge')]: {
                     paddingTop: 20,
                     fontSize: 30,
+                    fontWeight: 300,
                   },
                 }}>
                 A JavaScript library for building user interfaces

--- a/www/src/templates/home.js
+++ b/www/src/templates/home.js
@@ -164,11 +164,14 @@ Home.propTypes = {
   data: PropTypes.object.isRequired,
 };
 
-const CtaItem = ({children}) => (
+const CtaItem = ({children, primary = false}) => (
   <div
     css={{
       width: '50%',
-      paddingLeft: 20,
+
+      [media.between('small', 'large')]: {
+        paddingLeft: 20,
+      },
 
       [media.greaterThan('xlarge')]: {
         paddingLeft: 40,
@@ -176,6 +179,13 @@ const CtaItem = ({children}) => (
 
       '&:first-child': {
         textAlign: 'right',
+        paddingRight: 15,
+      },
+
+      '&:nth-child(2)': {
+        [media.greaterThan('small')]: {
+          paddingLeft: 15,
+        },
       },
     }}>
     {children}
@@ -202,8 +212,25 @@ export default Home;
 // TODO This nasty CSS is required because 'docs/index.md' defines hard-coded class names.
 const markdownStyles = {
   '& .home-section': {
-    marginTop: 60,
-    marginBottom: 65,
+    marginTop: 20,
+    marginBottom: 15,
+
+    [media.greaterThan('medium')]: {
+      marginTop: 60,
+      marginBottom: 65,
+    },
+  },
+
+  '& .home-section:first-child': {
+    [media.lessThan('medium')]: {
+      marginTop: 0,
+      marginBottom: 0,
+      overflowX: 'auto',
+      paddingTop: 30,
+      WebkitOverflowScrolling: 'touch',
+      position: 'relative',
+      maskImage: 'linear-gradient(to right, transparent, white 10px, white 90%, transparent)',
+    },
   },
 
   '& .homeDivider': {
@@ -218,7 +245,8 @@ const markdownStyles = {
     flexDirection: 'row',
 
     [media.lessThan('medium')]: {
-      flexDirection: 'column',
+      display: 'block',
+      whiteSpace: 'nowrap',
     },
   },
 
@@ -230,12 +258,20 @@ const markdownStyles = {
 
     '&:first-of-type': {
       marginLeft: 0,
+
+      [media.lessThan('medium')]: {
+        marginLeft: 10,
+      },
     },
 
     [media.lessThan('medium')]: {
-      display: 'block',
-      marginTop: 40,
+      display: 'inline-block',
+      verticalAlign: 'top',
       marginLeft: 0,
+      whiteSpace: 'normal',
+      width: '75%',
+      marginRight: 20,
+      paddingBottom: 40,
 
       '&:first-of-type': {
         marginTop: 0,
@@ -244,6 +280,7 @@ const markdownStyles = {
 
     '& h3': {
       color: colors.subtle,
+      paddingTop: 0,
 
       [media.lessThan('large')]: {
         fontSize: 18,
@@ -266,7 +303,15 @@ const markdownStyles = {
   },
 
   '& .example': {
-    marginTop: 80,
+    marginTop: 40,
+
+    '&:first-child': {
+      marginTop: 0,
+    },
+
+    [media.greaterThan('xlarge')]: {
+      marginTop: 80,
+    },
   },
 };
 

--- a/www/src/templates/installation.js
+++ b/www/src/templates/installation.js
@@ -15,7 +15,6 @@ import Container from 'components/Container';
 import Flex from 'components/Flex';
 import MarkdownHeader from 'components/MarkdownHeader';
 import NavigationFooter from 'templates/components/NavigationFooter';
-import {StickyContainer} from 'react-sticky';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
@@ -161,29 +160,27 @@ class InstallationPage extends Component {
         />
         <div css={{flex: '1 0 auto'}}>
           <Container>
-            <StickyContainer
-              css={{
-                display: 'flex',
-              }}>
+            <div css={sharedStyles.articleLayout.container}>
               <Flex type="article" direction="column" grow="1" halign="stretch">
                 <MarkdownHeader title={markdownRemark.frontmatter.title} />
-                <div
-                  css={[
-                    sharedStyles.markdown,
-                    {
-                      marginTop: 65,
-                      marginBottom: 120,
-                    },
-                  ]}
-                  dangerouslySetInnerHTML={{__html: markdownRemark.html}}
-                />
+
+                <div css={sharedStyles.articleLayout.content}>
+                  <div
+                    css={[sharedStyles.markdown]}
+                    dangerouslySetInnerHTML={{__html: markdownRemark.html}}
+                  />
+                  {markdownRemark.fields.path &&
+                    <div css={{marginTop: 80}}>
+                      <a
+                        css={sharedStyles.articleLayout.editLink}
+                        href={`https://github.com/facebook/react/tree/master/docs/${markdownRemark.fields.path}`}>
+                        Edit this page
+                      </a>
+                    </div>}
+                </div>
               </Flex>
 
-              <div
-                css={{
-                  flex: '0 0 200px',
-                  marginLeft: 'calc(9% + 40px)',
-                }}>
+              <div css={sharedStyles.articleLayout.sidebar}>
                 <StickyResponsiveSidebar
                   defaultActiveSection={
                     location != null
@@ -194,15 +191,16 @@ class InstallationPage extends Component {
                   sectionList={sectionList}
                 />
               </div>
-            </StickyContainer>
+            </div>
           </Container>
         </div>
 
         {/* TODO Read prev/next from index map, not this way */}
-        <NavigationFooter
-          next={markdownRemark.frontmatter.next}
-          prev={markdownRemark.frontmatter.prev}
-        />
+        {(markdownRemark.frontmatter.next || markdownRemark.frontmatter.prev) &&
+          <NavigationFooter
+            next={markdownRemark.frontmatter.next}
+            prev={markdownRemark.frontmatter.prev}
+          />}
       </Flex>
     );
   }

--- a/www/src/templates/installation.js
+++ b/www/src/templates/installation.js
@@ -18,7 +18,7 @@ import NavigationFooter from 'templates/components/NavigationFooter';
 import {StickyContainer} from 'react-sticky';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import StickySidebar from 'components/StickySidebar';
+import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
 import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import findSectionForPath from 'utils/findSectionForPath';
 import {sharedStyles} from 'theme';
@@ -184,7 +184,7 @@ class InstallationPage extends Component {
                   flex: '0 0 200px',
                   marginLeft: 'calc(9% + 40px)',
                 }}>
-                <StickySidebar
+                <StickyResponsiveSidebar
                   defaultActiveSection={
                     location != null
                       ? findSectionForPath(location.pathname, sectionList)

--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -69,7 +69,7 @@ const media = {
   },
 
   lessThan(key: Size) {
-    return `@media (max-width: ${SIZES[key].max}px)`;
+    return `@media (max-width: ${SIZES[key].min}px)`;
   },
 
   size(key: Size) {

--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -35,17 +35,19 @@ const colors = {
   black: '#000000',
 };
 
-const SIZES = {
+let SIZES = {
   xsmall: {min: 0, max: 599},
   small: {min: 600, max: 739},
   medium: {min: 740, max: 979},
   large: {min: 980, max: 1279},
   xlarge: {min: 1280, max: 1339},
   xxlarge: {min: 1340, max: Infinity},
+};
 
-  // Tweakpoints
-  xlargeSmaller: {min: 1100, max: 1339},
-  belowSidebarFixed: {min: 740, max: 1559}, // Used for "between()"
+// Tweakpoints
+SIZES = {
+  ...SIZES,
+  largerSidebar: {min: 1100, max: SIZES.xlarge.max},
   sidebarFixed: {min: 1560, max: Infinity},
   sidebarFixedNarrowFooter: {min: 1560, max: 2000},
 };
@@ -53,11 +55,15 @@ const SIZES = {
 type Size = $Keys<typeof SIZES>;
 
 const media = {
-  between(smallKey: Size, largeKey: Size) {
-    if (SIZES[largeKey].max === Infinity) {
+  between(smallKey: Size, largeKey: Size, excludeLarge: Boolean = false) {
+    if (SIZES[largeKey].max === Infinity && !excludeLarge) {
       return `@media (min-width: ${SIZES[smallKey].min}px)`;
     } else {
-      return `@media (min-width: ${SIZES[smallKey].min}px) and (max-width: ${SIZES[largeKey].max}px)`;
+      if (excludeLarge) {
+        return `@media (min-width: ${SIZES[smallKey].min}px) and (max-width: ${SIZES[largeKey].min - 1}px)`;
+      } else {
+        return `@media (min-width: ${SIZES[smallKey].min}px) and (max-width: ${SIZES[largeKey].max}px)`;
+      }
     }
   },
 
@@ -145,7 +151,7 @@ const sharedStyles = {
         marginLeft: 80,
       },
 
-      [media.between('small', 'xlargeSmaller')]: {
+      [media.between('small', 'largerSidebar')]: {
         flex: '0 0 200px',
         marginLeft: 80,
       },
@@ -154,7 +160,7 @@ const sharedStyles = {
         marginLeft: 40,
       },
 
-      [media.greaterThan('xlargeSmaller')]: {
+      [media.greaterThan('largerSidebar')]: {
         flex: '0 0 300px',
       },
 

--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -55,11 +55,11 @@ type Size = $Keys<typeof SIZES>;
 
 const media = {
   between(smallKey: Size, largeKey: Size, excludeLarge: Boolean = false) {
-    if (SIZES[largeKey].max === Infinity && !excludeLarge) {
-      return `@media (min-width: ${SIZES[smallKey].min}px)`;
+    if (excludeLarge) {
+      return `@media (min-width: ${SIZES[smallKey].min}px) and (max-width: ${SIZES[largeKey].min - 1}px)`;
     } else {
-      if (excludeLarge) {
-        return `@media (min-width: ${SIZES[smallKey].min}px) and (max-width: ${SIZES[largeKey].min - 1}px)`;
+      if (SIZES[largeKey].max === Infinity) {
+        return `@media (min-width: ${SIZES[smallKey].min}px)`;
       } else {
         return `@media (min-width: ${SIZES[smallKey].min}px) and (max-width: ${SIZES[largeKey].max}px)`;
       }

--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -24,8 +24,10 @@ const colors = {
   darker: '#20232a', // really dark blue
   brand: '#61dafb', // electric blue
   brandLight: '#bbeffd',
+  brandOnWhite: '#10819b',
   text: '#1a1a1a', // very dark grey / black substitute
-  subtle: '#777', // light grey for text
+  subtle: '#6d6d6d', // light grey for text
+  subtleOnDark: '#999',
   divider: '#ececec', // very light grey
   note: '#ffe564', // yellow
   error: '#ff6464', // yellow
@@ -33,22 +35,12 @@ const colors = {
   black: '#000000',
 };
 
-const fonts = {
-  header: {
-    fontSize: 60,
-    lineHeight: '65px',
-    fontWeight: 700,
-  },
-  small: {
-    fontSize: 14,
-  },
-};
-
 const SIZES = {
   xsmall: {min: 0, max: 599},
   small: {min: 600, max: 739},
   medium: {min: 740, max: 979},
   large: {min: 980, max: 1279},
+  xlargeSmaller: {min: 1100, max: 1339},
   xlarge: {min: 1280, max: 1339},
   xxlarge: {min: 1340, max: Infinity},
 };
@@ -85,6 +77,22 @@ const media = {
   },
 };
 
+const fonts = {
+  header: {
+    fontSize: 60,
+    lineHeight: '65px',
+    fontWeight: 700,
+
+    [media.lessThan('medium')]: {
+      fontSize: 40,
+      lineHeight: '45px',
+    },
+  },
+  small: {
+    fontSize: 14,
+  },
+};
+
 // Shared styles are generally better as components,
 // Except when they must be used within nested CSS selectors.
 // This is the case for eg markdown content.
@@ -105,12 +113,27 @@ const sharedStyles = {
 
     '& .gatsby-highlight': {
       marginTop: 25,
+      marginLeft: -30,
+      marginRight: -30,
+      paddingLeft: 15,
+      paddingRight: 15,
     },
 
     '& a:not(.anchor):not(.gatsby-resp-image-link)': linkStyle,
 
+    '& > p:first-child': {
+      fontSize: 18,
+      lineHeight: '30px',
+      color: colors.subtle,
+
+      [media.greaterThan('xlarge')]: {
+        fontSize: 24,
+        lineHeight: '40px',
+      },
+    },
+
     '& p': {
-      marginTop: 30,
+      marginTop: 35,
       fontSize: 18,
       lineHeight: '35px',
       maxWidth: '42em',
@@ -208,17 +231,20 @@ const sharedStyles = {
     '& ol, & ul': {
       marginTop: 20,
       fontSize: 16,
-      color: colors.subtle,
+      color: colors.text,
+
+      [media.lessThan('small')]: {
+        paddingLeft: 20,
+      },
 
       '& p, & p:first-of-type': {
         fontSize: 16,
         marginTop: 0,
         lineHeight: 1.2,
-        color: colors.subtle,
       },
 
       '& li': {
-        marginTop: 10,
+        marginTop: 20,
       },
     },
 
@@ -237,11 +263,17 @@ const sharedStyles = {
     '& blockquote': {
       backgroundColor: hex2rgba('#ffe564', 0.3),
       borderLeftColor: colors.note,
-      borderLeftWidth: 5,
+      borderLeftWidth: 9,
       borderLeftStyle: 'solid',
-      padding: '20px 15px',
+      padding: '20px 45px 20px 26px',
       marginBottom: 30,
       marginTop: 20,
+      marginLeft: -30,
+      marginRight: -30,
+
+      [media.lessThan('small')]: {
+        marginLeft: -20,
+      },
 
       '& p': {
         marginTop: 15,
@@ -255,6 +287,10 @@ const sharedStyles = {
           marginTop: 0,
         },
       },
+    },
+
+    '& .gatsby-highlight + blockquote': {
+      marginTop: 40,
     },
   },
 };

--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -40,9 +40,14 @@ const SIZES = {
   small: {min: 600, max: 739},
   medium: {min: 740, max: 979},
   large: {min: 980, max: 1279},
-  xlargeSmaller: {min: 1100, max: 1339},
   xlarge: {min: 1280, max: 1339},
   xxlarge: {min: 1340, max: Infinity},
+
+  // Tweakpoints
+  xlargeSmaller: {min: 1100, max: 1339},
+  belowSidebarFixed: {min: 740, max: 1559}, // Used for "between()"
+  sidebarFixed: {min: 1560, max: Infinity},
+  sidebarFixedNarrowFooter: {min: 1560, max: 2000},
 };
 
 type Size = $Keys<typeof SIZES>;
@@ -61,7 +66,7 @@ const media = {
   },
 
   lessThan(key: Size) {
-    return `@media (max-width: ${SIZES[key].min}px)`;
+    return `@media (max-width: ${SIZES[key].min - 1}px)`;
   },
 
   size(key: Size) {
@@ -108,6 +113,75 @@ const linkStyle = {
 };
 const sharedStyles = {
   link: linkStyle,
+
+  articleLayout: {
+    container: {
+      display: 'flex',
+      minHeight: 'calc(100vh - 60px)',
+      [media.greaterThan('sidebarFixed')]: {
+        maxWidth: 800,
+        marginLeft: 'auto',
+        marginRight: 'auto',
+      },
+    },
+    content: {
+      marginTop: 40,
+      marginBottom: 120,
+
+      [media.between('medium', 'large')]: {
+        marginTop: 50,
+      },
+
+      [media.greaterThan('xlarge')]: {
+        marginTop: 85,
+      },
+    },
+    sidebar: {
+      display: 'flex',
+      flexDirection: 'column',
+
+      [media.between('small', 'sidebarFixed')]: {
+        borderLeft: '1px solid #ececec',
+        marginLeft: 80,
+      },
+
+      [media.between('small', 'xlargeSmaller')]: {
+        flex: '0 0 200px',
+        marginLeft: 80,
+      },
+
+      [media.between('small', 'medium')]: {
+        marginLeft: 40,
+      },
+
+      [media.greaterThan('xlargeSmaller')]: {
+        flex: '0 0 300px',
+      },
+
+      [media.greaterThan('sidebarFixed')]: {
+        position: 'fixed',
+        right: 0,
+        width: 300,
+        zIndex: 2,
+      },
+    },
+
+    editLink: {
+      color: colors.subtle,
+      borderColor: colors.divider,
+      transition: 'all 0.2s ease',
+      transitionPropery: 'color, border-color',
+      whiteSpace: 'nowrap',
+      borderBottomWidth: 1,
+      borderBottomStyle: 'solid',
+
+      ':hover': {
+        color: colors.text,
+        borderColor: colors.text,
+      },
+    },
+  },
+
   markdown: {
     lineHeight: '25px',
 
@@ -168,6 +242,11 @@ const sharedStyles = {
       marginBottom: -1,
       border: 'none',
       borderBottom: `1px solid ${colors.divider}`,
+      marginTop: 40,
+
+      ':first-child': {
+        marginTop: 0,
+      },
     },
 
     '& h1': {
@@ -201,6 +280,11 @@ const sharedStyles = {
       [media.greaterThan('xlarge')]: {
         fontSize: 35,
       },
+    },
+
+    '& hr + h2': {
+      borderTop: 0,
+      marginTop: 0,
     },
 
     '& h3': {
@@ -245,6 +329,10 @@ const sharedStyles = {
 
       '& li': {
         marginTop: 20,
+      },
+
+      '& li.button-newapp': {
+        marginTop: 0,
       },
     },
 

--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -24,7 +24,6 @@ const colors = {
   darker: '#20232a', // really dark blue
   brand: '#61dafb', // electric blue
   brandLight: '#bbeffd',
-  brandOnWhite: '#10819b',
   text: '#1a1a1a', // very dark grey / black substitute
   subtle: '#6d6d6d', // light grey for text
   subtleOnDark: '#999',

--- a/www/src/utils/isItemActive.js
+++ b/www/src/utils/isItemActive.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+*/
+
+'use strict';
+
+import slugify from 'utils/slugify';
+
+const toAnchor = (href = '') => {
+  const index = href.indexOf('#');
+  return index >= 0 ? href.substr(index) : '';
+};
+
+// TODO Account for redirect_from URLs somehow; they currently won't match.
+
+const isItemActive = (location, item) => {
+  if (location == null) {
+    return false; // Production build of Gatsby is eval'ed in Node
+  } else if (location.hash) {
+    if (item.href) {
+      return location.hash === toAnchor(item.href);
+    }
+  } else if (item.id.includes('html')) {
+    return location.pathname.includes(item.id);
+  } else {
+    return location.pathname.includes(slugify(item.id));
+  }
+};
+
+export default isItemActive;

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -6963,7 +6963,7 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
-raf@^3.3.0:
+raf@^3.1.0, raf@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.3.2.tgz#0c13be0b5b49b46f76d6669248d527cf2b02fe27"
   dependencies:
@@ -7050,6 +7050,14 @@ react-live@^1.7.1:
     prismjs "^1.6.0"
     prop-types "^15.5.8"
     unescape "^0.2.0"
+
+react-motion@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.1.tgz#b90631408175ab1668e173caccd66d41a44f4592"
+  dependencies:
+    performance-now "^0.2.0"
+    prop-types "^15.5.8"
+    raf "^3.1.0"
 
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"


### PR DESCRIPTION
**This supersedes #10707**

**what are the changes?:**

- Adds media queries and JS to make sidebar collapse/expand from a
sticky bottom bar on small screen sizes
- tweaks to colour contrast (checked using aXe) and some html attributes
- centralised article layout for large desktops
- created a carousel-like overflow for the marketing columns on mobile.
- moved 'Edit this page' to the bottom, as part of the new centralised layout.
- offset note and code blocks out of the grid, so there text lines up. (this was previously an issue with CodeMirror, but i think we're good now?)

**why make these changes?**

- improved accessibility score
- improved readability on large desktop 
- improved use of screen space on mobile

**test plan**
- manual testing
