### PR TITLE
Add a note about deprecating react-addons-perf

### DIFF
--- a/docs/docs/addons-perf.md
+++ b/docs/docs/addons-perf.md
@@ -8,7 +8,7 @@ category: Add-Ons
 
 > Note:
 >
-> `react-addons-perf` is no longer supported in v16. Please use Chrome Performance Tab instead: [Learn more about it](https://facebook.github.io/react/docs/optimizing-performance.html#profiling-components-with-the-chrome-performance-tab).
+> As of React 16, `react-addons-perf` is not supported. Please use [your browser's profiling tools](/react/docs/optimizing-performance.html#profiling-components-with-the-chrome-performance-tab) to get insight into which components re-render.
 
 **Importing**
 

--- a/docs/docs/addons-perf.md
+++ b/docs/docs/addons-perf.md
@@ -6,6 +6,10 @@ layout: docs
 category: Add-Ons
 ---
 
+> Note:
+>
+> `react-addons-perf` is no longer supported in v16. Please use Chrome Performance Tab instead: [Learn more about it](https://facebook.github.io/react/docs/optimizing-performance.html#profiling-components-with-the-chrome-performance-tab).
+
 **Importing**
 
 ```javascript


### PR DESCRIPTION
`react-addons-perf` is no longer in React v16. This documentation is not linked from anywhere but we can get the page from Google search like the word "react performance".

Should I keep the documentation and add a deprecated warning?