### PR TITLE
[Gatsby Docs Update] Tutorial: Clicking an anchor tag should auto-close mobile nav

### DIFF
--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -48,11 +48,16 @@ class StickyResponsiveSidebar extends Component {
     this.state = {
       open: false,
     };
-    this._toggleOpen = this._toggleOpen.bind(this);
+    this._openNavMenu = this._openNavMenu.bind(this);
+    this._closeNavMenu = this._closeNavMenu.bind(this);
   }
 
-  _toggleOpen() {
+  _openNavMenu() {
     this.setState({open: !this.state.open});
+  }
+
+  _closeNavMenu() {
+    this.setState({open: false});
   }
 
   render() {
@@ -156,7 +161,7 @@ class StickyResponsiveSidebar extends Component {
                 tranform: 'none !important',
               },
             }}>
-            <Sidebar closeParentMenu={this._toggleOpen} {...this.props} />
+            <Sidebar closeParentMenu={this._closeNavMenu} {...this.props} />
           </div>
         </div>
         <div
@@ -173,7 +178,7 @@ class StickyResponsiveSidebar extends Component {
             zIndex: 3,
             [media.lessThan('small')]: smallScreenBottomBarStyles,
           }}
-          onClick={this._toggleOpen}>
+          onClick={this._openNavMenu}>
           <Container>
             <div
               css={{

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -24,7 +24,7 @@ class StickyResponsiveSidebar extends Component {
     this.state = {
       open: false,
     };
-    this.toggleOpen = this._toggleOpen.bind(this);
+    this._toggleOpen = this._toggleOpen.bind(this);
   }
 
   _toggleOpen() {
@@ -57,6 +57,7 @@ class StickyResponsiveSidebar extends Component {
     const menuOpacity = open ? 1 : 0;
     const menuOffset = open ? 0 : 40;
 
+    // TODO: role and aria props for 'close' button?
     return (
       <div>
         <div
@@ -127,7 +128,7 @@ class StickyResponsiveSidebar extends Component {
                 tranform: 'none !important',
               },
             }}>
-            <Sidebar {...this.props} />
+            <Sidebar closeParentMenu={this._toggleOpen} {...this.props} />
           </div>
         </div>
         <div
@@ -144,7 +145,7 @@ class StickyResponsiveSidebar extends Component {
             zIndex: 3,
             [media.lessThan('small')]: smallScreenBottomBarStyles,
           }}
-          onClick={this.toggleOpen}>
+          onClick={this._toggleOpen}>
           <Container>
             <div
               css={{

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -13,9 +13,33 @@
 
 import Container from 'components/Container';
 import {Component, React} from 'react';
+import isItemActive from 'utils/isItemActive';
 import Sidebar from 'templates/components/Sidebar';
 import {colors, media} from 'theme';
 import ChevronSvg from 'templates/components/ChevronSvg';
+
+function findActiveItemTitle(location, defaultActiveSection) {
+  const {items} = defaultActiveSection;
+
+  for (let i = 0, len = items.length; i < len; i++) {
+    const item = items[i];
+    if (isItemActive(location, item)) {
+      return item.title;
+    } else if (item.subitems && item.subitems.length) {
+      const {subitems} = item;
+      for (let j = 0, len2 = subitems.length; j < len2; j++) {
+        const subitem = subitems[j];
+        if (isItemActive(location, subitem)) {
+          return subitem.title;
+        }
+      }
+    }
+  }
+
+  // If nothing else is found, warn and default to section title
+  console.warn('No active item title found in <StickyResponsiveSidebar>');
+  return defaultActiveSection.title;
+}
 
 class StickyResponsiveSidebar extends Component {
   constructor(props, context) {
@@ -32,7 +56,7 @@ class StickyResponsiveSidebar extends Component {
   }
 
   render() {
-    const {title} = this.props;
+    const {defaultActiveSection, location, title} = this.props;
     const {open} = this.state;
     const smallScreenSidebarStyles = {
       top: 0,
@@ -56,6 +80,10 @@ class StickyResponsiveSidebar extends Component {
     const labelOffset = open ? -40 : 0;
     const menuOpacity = open ? 1 : 0;
     const menuOffset = open ? 0 : 40;
+
+    const navbarLabel = defaultActiveSection != null
+      ? findActiveItemTitle(location, defaultActiveSection)
+      : title;
 
     // TODO: role and aria props for 'close' button?
     return (
@@ -197,7 +225,7 @@ class StickyResponsiveSidebar extends Component {
                       height: 40,
                       lineHeight: '40px',
                     }}>
-                    {title}
+                    {navbarLabel}
                   </div>
                   <div
                     css={{

--- a/www/src/templates/components/Sidebar/Section.js
+++ b/www/src/templates/components/Sidebar/Section.js
@@ -38,50 +38,51 @@ function Section({closeParentMenu, isActive, location, onClick, section}) {
               color: colors.text,
             },
           },
-        },
-      }}>
-      {section.title}
-      <ChevronSvg
-        cssProps={{
-          marginLeft: 7,
-          transform: isActive ? 'rotateX(180deg)' : 'rotateX(0deg)',
-          transition: 'transform 0.2s ease',
-
-          [media.lessThan('small')]: {
-            display: 'none',
-          },
         }}
-      />
-    </MetaTitle>
-    <ul
-      css={{
-        marginBottom: 10,
+      >
+        {section.title}
+        <ChevronSvg
+          cssProps={{
+            marginLeft: 7,
+            transform: isActive ? 'rotateX(180deg)' : 'rotateX(0deg)',
+            transition: 'transform 0.2s ease',
 
-        [media.greaterThan('small')]: {
-          display: isActive ? 'block' : 'none',
-        },
-      }}>
-      {section.items.map(item => (
-        <li
-          key={item.id}
-          css={{
-            marginTop: 5,
-          }}>
-          {CreateLink(location, section, item)}
+            [media.lessThan('small')]: {
+              display: 'none',
+            },
+          }}
+        />
+      </MetaTitle>
+      <ul
+        css={{
+          marginBottom: 10,
 
-          {item.subitems &&
-            <ul css={{marginLeft: 20}}>
-              {item.subitems.map(subitem => (
-                <li key={subitem.id}>
-                  {CreateLink(location, section, subitem, closeParentMenu)}
-                </li>
-              ))}
-            </ul>}
-        </li>
-      ))}
-    </ul>
-  </div>
-);
+          [media.greaterThan('small')]: {
+            display: isActive ? 'block' : 'none',
+          },
+        }}>
+        {section.items.map(item => (
+          <li
+            key={item.id}
+            css={{
+              marginTop: 5,
+            }}>
+            {CreateLink(location, section, item)}
+
+            {item.subitems &&
+              <ul css={{marginLeft: 20}}>
+                {item.subitems.map(subitem => (
+                  <li key={subitem.id}>
+                    {CreateLink(location, section, subitem, closeParentMenu)}
+                  </li>
+                ))}
+              </ul>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
 
 const activeLinkCss = {
   fontWeight: 'bold',

--- a/www/src/templates/components/Sidebar/Section.js
+++ b/www/src/templates/components/Sidebar/Section.js
@@ -23,18 +23,26 @@ import ChevronSvg from '../ChevronSvg';
 // TODO Update isActive link as document scrolls past anchor tags
 // Maybe used 'hashchange' along with 'scroll' to set/update active links
 
-const Section = ({isActive, location, onClick, section}) => (
-  <div>
-    <MetaTitle
-      onClick={onClick}
-      cssProps={{
-        marginTop: 10,
+function Section({
+  closeParentMenu,
+  isActive,
+  location,
+  onClick,
+  section,
+}) {
+  return (
+    <div>
+      <MetaTitle
+        onClick={onClick}
+        cssProps={{
+          marginTop: 10,
 
-        [media.greaterThan('small')]: {
-          color: isActive ? colors.text : colors.subtle,
+          [media.greaterThan('small')]: {
+            color: isActive ? colors.text : colors.subtle,
 
-          ':hover': {
-            color: colors.text,
+            ':hover': {
+              color: colors.text,
+            },
           },
         },
       }}>
@@ -71,7 +79,7 @@ const Section = ({isActive, location, onClick, section}) => (
             <ul css={{marginLeft: 20}}>
               {item.subitems.map(subitem => (
                 <li key={subitem.id}>
-                  {CreateLink(location, section, subitem)}
+                  {CreateLink(location, section, subitem, closeParentMenu)}
                 </li>
               ))}
             </ul>}
@@ -111,7 +119,7 @@ const linkCss = {
   },
 };
 
-const CreateLink = (location, section, item) => {
+const CreateLink = (location, section, item, closeParentMenu) => {
   const isActive = isItemActive(location, item);
   if (item.id.includes('.html')) {
     return (
@@ -121,8 +129,10 @@ const CreateLink = (location, section, item) => {
       </Link>
     );
   } else if (item.forceInternal) {
+    // We need to give the option for the parent menu to close if this link is
+    // in a pop-out menu.
     return (
-      <Link css={[linkCss, isActive && activeLinkCss]} to={item.href}>
+      <Link onClick={closeParentMenu} css={[linkCss, isActive && activeLinkCss]} to={item.href}>
         {isActive && <span css={activeLinkBefore} />}
         {item.title}
       </Link>

--- a/www/src/templates/components/Sidebar/Section.js
+++ b/www/src/templates/components/Sidebar/Section.js
@@ -23,13 +23,7 @@ import ChevronSvg from '../ChevronSvg';
 // TODO Update isActive link as document scrolls past anchor tags
 // Maybe used 'hashchange' along with 'scroll' to set/update active links
 
-function Section({
-  closeParentMenu,
-  isActive,
-  location,
-  onClick,
-  section,
-}) {
+function Section({closeParentMenu, isActive, location, onClick, section}) {
   return (
     <div>
       <MetaTitle
@@ -132,7 +126,10 @@ const CreateLink = (location, section, item, closeParentMenu) => {
     // We need to give the option for the parent menu to close if this link is
     // in a pop-out menu.
     return (
-      <Link onClick={closeParentMenu} css={[linkCss, isActive && activeLinkCss]} to={item.href}>
+      <Link
+        onClick={closeParentMenu}
+        css={[linkCss, isActive && activeLinkCss]}
+        to={item.href}>
         {isActive && <span css={activeLinkBefore} />}
         {item.title}
       </Link>

--- a/www/src/templates/components/Sidebar/Section.js
+++ b/www/src/templates/components/Sidebar/Section.js
@@ -38,8 +38,7 @@ function Section({closeParentMenu, isActive, location, onClick, section}) {
               color: colors.text,
             },
           },
-        }}
-      >
+        }}>
         {section.title}
         <ChevronSvg
           cssProps={{

--- a/www/src/templates/components/Sidebar/Sidebar.js
+++ b/www/src/templates/components/Sidebar/Sidebar.js
@@ -26,7 +26,7 @@ class Sidebar extends Component {
   }
 
   render() {
-    const {location, sectionList} = this.props;
+    const {closeParentMenu, location, sectionList} = this.props;
     const {activeSection} = this.state;
 
     return (
@@ -49,6 +49,7 @@ class Sidebar extends Component {
         }}>
         {sectionList.map((section, index) => (
           <Section
+            closeParentMenu={closeParentMenu}
             isActive={activeSection === section || sectionList.length === 1}
             key={index}
             location={location}


### PR DESCRIPTION
**what is the change?:**

*Edit:* 
Also fixes the issue where the section listed on the tutorial page was not correct. I can go into more detail if needed.

---
We create a prop to close the mobile nav and then pass it all the way
down through to the links for the tutorial page -
```
<StickyResponsiveSidebar> -> sends down handler to close mobile nav
V
<Sidebar>
V
<Section>
V
<GatsbyLink> -> receives onClick to close mobile nav
```

**why make this change?:**
So that the menu doesn't stay open after people click a link :)

We considered listening to 'onhashchange' and ran into two problems;
- React doesn't support listening to `onhashchange` on DOMComponents,
  and I'm not sure that would work anyway
- When listening to `window.onhashchange` it didn't seem to fire
- Better to pass something down than to add another global event
  listener imo

**test plan:**
Manual testing
AND I ran `yarn build`

![bottom_nav_open_close](https://user-images.githubusercontent.com/1114467/30671401-8c6f7a8c-9e1b-11e7-8d4a-65c2bc241c99.gif)

**issue:**
Checklist item on this wiki;
https://github.com/bvaughn/react/wiki/Gatsby-check-list
Sidebar Component > Tutorial: Clicking an anchor tag should auto-close mobile nav
