### PR TITLE
[docs] Prevent using variable from outer scope

### DIFF
--- a/docs/docs/integrating-with-other-libraries.md
+++ b/docs/docs/integrating-with-other-libraries.md
@@ -416,7 +416,7 @@ const BackboneNameInput = connectToBackboneModel(NameInput);
 
 function Example(props) {
   function handleChange(e) {
-    model.set('firstName', e.target.value);
+    props.model.set('firstName', e.target.value);
   }
 
   return (


### PR DESCRIPTION
Small fix that prevents leaking a variable to the outer scope. If you modify initial code sample in the following manner you will get Uncaught ReferenceError:
```js
function Example(props) {
  function handleChange(e) {
    model.set('firstName', e.target.value);
  }

  return (
    <BackboneNameInput
      model={props.model}
      handleChange={handleChange}
    />
  );
}

ReactDOM.render(
  <Example model={new Backbone.Model({ firstName: 'Frodo' })} />,
  document.getElementById('root')
);
```
Demo of the bug: https://codepen.io/wa-Nadoo/pen/EwyyqE?editors=0010
Fixed code sample: https://codepen.io/wa-Nadoo/pen/PJzGPq?editors=0010
