### PR TITLE
Move click handler outside PureComponent render

### DIFF
--- a/docs/docs/optimizing-performance.md
+++ b/docs/docs/optimizing-performance.md
@@ -253,13 +253,18 @@ class CounterButton extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {count: 1};
+    this.handleClick = this.handleClick.bind(this);
+  }
+  
+  handleClick() {
+    this.setState(state => ({count: state.count + 1}));
   }
 
   render() {
     return (
       <button
         color={this.props.color}
-        onClick={() => this.setState(state => ({count: state.count + 1}))}>
+        onClick={this.handleClick}>
         Count: {this.state.count}
       </button>
     );


### PR DESCRIPTION
If I understand correctly, won't this cause a re-render every time since we're creating a new function inside the render method? Moving it outside to prevent this.
