### PR TITLE
[Gatsby docs refactor] Make `dev` command more easily tested

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -49,7 +49,7 @@
     "url": "git+https://github.com/facebook/react.git"
   },
   "scripts": {
-    "dev": "gatsby develop",
+    "dev": "gatsby develop -H 0.0.0.0",
     "lint": "./node_modules/.bin/eslint --ext .js,.jsx --ignore-pattern public .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "develop": "gatsby develop",

--- a/www/package.json
+++ b/www/package.json
@@ -52,7 +52,7 @@
     "dev": "gatsby develop -H 0.0.0.0",
     "lint": "./node_modules/.bin/eslint --ext .js,.jsx --ignore-pattern public .",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "develop": "gatsby develop",
+    "develop": "gatsby develop -H 0.0.0.0",
     "build": "gatsby build",
     "deploy": "gatsby build --prefix-links && gh-pages -d public",
     "reset": "rimraf ./.cache"

--- a/www/package.json
+++ b/www/package.json
@@ -52,7 +52,6 @@
     "dev": "gatsby develop -H 0.0.0.0",
     "lint": "./node_modules/.bin/eslint --ext .js,.jsx --ignore-pattern public .",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "develop": "gatsby develop -H 0.0.0.0",
     "build": "gatsby build",
     "deploy": "gatsby build --prefix-links && gh-pages -d public",
     "reset": "rimraf ./.cache"


### PR DESCRIPTION
**what is the change?:**
If we want to test across different devices, we need to set the `host`
argument and tell Gatsby to listen on all ports.

**why make this change?:**
To be able to visit <my IP address>:8000 on another device and test the
docs.

**test plan:**
Manually tested