### PR TITLE
[Gatsby Docs Update] Horizontal overflow on mobile

### DIFF
--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -188,6 +188,12 @@ const sharedStyles = {
       marginRight: -30,
       paddingLeft: 15,
       paddingRight: 15,
+
+      [media.lessThan('small')]: {
+        marginLeft: -20,
+        marginRight: -20,
+        borderRadius: 0,
+      },
     },
 
     '& a:not(.anchor):not(.gatsby-resp-image-link)': linkStyle,
@@ -358,6 +364,7 @@ const sharedStyles = {
 
       [media.lessThan('small')]: {
         marginLeft: -20,
+        marginRight: -20,
       },
 
       '& p': {


### PR DESCRIPTION
**issue**

- mobile devices (both iOS and Android) would overflow horizontally on any docs pages where a code block or note was present.

**what's included?**

- a fix for the above issue, by reducing the negative margin on code blocks and notes
- removed code blocks border radius, to improve the appearance
- _tested on iOS 11 and Android 8_

**note**

- a previous PR had a "fix" for this using `overflowX: hidden`, which caused an awful scrolling regression. this is much cleaner anyway!

_before_ (this whilst the page has been horizontally scrolled to reveal the right-hand side)

<img width="622" alt="before" src="https://user-images.githubusercontent.com/24449/30776209-648e3752-a09a-11e7-8743-7c191bb2fd55.png">

_after_

<img width="556" alt="after" src="https://user-images.githubusercontent.com/24449/30776208-648df21a-a09a-11e7-99ce-50ba54283321.png">


cc @bvaughn @flarnie 