### PR TITLE
[Gatsby Docs Update] Menu overlay: scrolling fixes

### DIFF
--- a/www/src/components/LayoutFooter/Footer.js
+++ b/www/src/components/LayoutFooter/Footer.js
@@ -18,13 +18,14 @@ import {colors, media} from 'theme';
 
 import ossLogoPng from 'images/oss_logo.png';
 
-const Footer = ({layoutHasSidebar = false}) => (
+const Footer = ({layoutHasSidebar = false, isVisible = true}) => (
   <footer
     css={{
       backgroundColor: colors.darker,
       color: colors.white,
       paddingTop: 10,
       paddingBottom: 50,
+      display: isVisible === false ? 'none' : null,
 
       [media.size('sidebarFixed')]: {
         paddingTop: 40,

--- a/www/src/components/LayoutHeader/Header.js
+++ b/www/src/components/LayoutHeader/Header.js
@@ -32,8 +32,8 @@ const Header = ({location, isVisible = true}) => (
       width: '100%',
       top: 0,
       left: 0,
-      maxHeight: isVisible === false ? '0px' : '100px',
-      transition: 'max-height 0.2s ease',
+      transform: `translate(0, ${isVisible === false ? '-100%' : '0'})`,
+      transition: 'transform 0.6s ease',
       overflow: 'hidden',
     }}>
     <Container>

--- a/www/src/components/LayoutHeader/Header.js
+++ b/www/src/components/LayoutHeader/Header.js
@@ -22,7 +22,7 @@ import logoSvg from 'icons/logo.svg';
 // This is how the previous Jekyll site determined version though.
 const {version} = require('../../../../package.json');
 
-const Header = ({location}) => (
+const Header = ({location, isVisible = true}) => (
   <header
     css={{
       backgroundColor: colors.darker,
@@ -32,6 +32,9 @@ const Header = ({location}) => (
       width: '100%',
       top: 0,
       left: 0,
+      maxHeight: isVisible === false ? '0px' : '100px',
+      transition: 'max-height 0.2s ease',
+      overflow: 'hidden',
     }}>
     <Container>
       <div

--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -19,104 +19,148 @@ import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
 import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import findSectionForPath from 'utils/findSectionForPath';
 import toCommaSeparatedList from 'utils/toCommaSeparatedList';
-import {sharedStyles} from 'theme';
+import {media, sharedStyles} from 'theme';
 import {urlRoot} from 'constants';
 
-const MarkdownPage = ({
-  authors,
-  createLink,
-  date,
-  ogDescription,
-  location,
-  markdownRemark,
-  sectionList,
-  titlePostfix = '',
-}) => {
-  const hasAuthors = authors.length > 0;
-  const titlePrefix = markdownRemark.frontmatter.title || '';
+class MarkdownPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.toggleMenuOverlay = this.toggleMenuOverlay.bind(this);
+    this.handleWindowResize = this.handleWindowResize.bind(this);
+    this.state = {
+      isMenuOverlayOpen: false,
+    };
+  }
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.isMenuOverlayOpen && !prevState.isMenuOverlayOpen) {
+      // Menu has been opened
+      window.addEventListener('resize', this.handleWindowResize);
+    }
+  }
+  handleWindowResize() {
+    const mediaQuery = media.greaterThan('small').replace('@media ', '');
+    if (window.matchMedia(mediaQuery).matches) {
+      // If the screen has been resized >= 'small'
+      this.toggleMenuOverlay(false);
+    }
+  }
+  toggleMenuOverlay(willOpen) {
+    this.setState(
+      {
+        isMenuOverlayOpen: willOpen,
+      },
+      () => {
+        this.context.onMenuOverlayToggle(this.state.isMenuOverlayOpen);
+      },
+    );
+  }
+  handleTouchMove(evt) {
+    // Prevent anything else from being touched when the menu overlay is open, to avoid touch scrolling issues
+    if (this.state.isMenuOverlayOpen) {
+      evt.preventDefault();
+    }
+  }
+  render() {
+    const {
+      authors,
+      createLink,
+      date,
+      ogDescription,
+      location,
+      markdownRemark,
+      sectionList,
+      titlePostfix = '',
+    } = this.props;
+    const hasAuthors = authors.length > 0;
+    const titlePrefix = markdownRemark.frontmatter.title || '';
 
-  return (
-    <Flex
-      direction="column"
-      grow="1"
-      shrink="0"
-      halign="stretch"
-      css={{
-        width: '100%',
-        flex: '1 0 auto',
-        position: 'relative',
-        zIndex: 0,
-        overflow: 'auto', // This is required for the mobile footer layout
-      }}>
-      <TitleAndMetaTags
-        title={`${titlePrefix}${titlePostfix}`}
-        ogUrl={`${urlRoot}/${markdownRemark.fields.path || ''}`}
-        ogDescription={ogDescription}
-      />
-      <div css={{flex: '1 0 auto'}}>
-        <Container>
-          <div css={sharedStyles.articleLayout.container}>
-            <Flex type="article" direction="column" grow="1" halign="stretch">
-              <MarkdownHeader title={titlePrefix} />
+    return (
+      <Flex
+        direction="column"
+        grow="1"
+        shrink="0"
+        halign="stretch"
+        css={{
+          width: '100%',
+          flex: '1 0 auto',
+          position: 'relative',
+          zIndex: 0,
+          overflow: 'auto', // This is required for the mobile footer layout
+        }}
+        onTouchMove={this.handleTouchMove}>
+        <TitleAndMetaTags
+          title={`${titlePrefix}${titlePostfix}`}
+          ogUrl={`${urlRoot}/${markdownRemark.fields.path || ''}`}
+          ogDescription={ogDescription}
+        />
+        <div css={{flex: '1 0 auto'}}>
+          <Container>
+            <div css={sharedStyles.articleLayout.container}>
+              <Flex type="article" direction="column" grow="1" halign="stretch">
+                <MarkdownHeader title={titlePrefix} />
 
-              {(date || hasAuthors) &&
-                <div css={{marginTop: 15}}>
-                  {date}{' '}
-                  {hasAuthors &&
-                    <span>
-                      by {toCommaSeparatedList(authors, author => (
-                        <a
-                          css={sharedStyles.link}
-                          href={author.frontmatter.url}
-                          key={author.frontmatter.name}>
-                          {author.frontmatter.name}
-                        </a>
-                      ))}
-                    </span>}
-                </div>}
-
-              <div css={sharedStyles.articleLayout.content}>
-                <div
-                  css={[sharedStyles.markdown]}
-                  dangerouslySetInnerHTML={{__html: markdownRemark.html}}
-                />
-
-                {markdownRemark.fields.path &&
-                  <div css={{marginTop: 80}}>
-                    <a
-                      css={sharedStyles.articleLayout.editLink}
-                      href={`https://github.com/facebook/react/tree/master/docs/${markdownRemark.fields.path}`}>
-                      Edit this page
-                    </a>
+                {(date || hasAuthors) &&
+                  <div css={{marginTop: 15}}>
+                    {date}{' '}
+                    {hasAuthors &&
+                      <span>
+                        by{' '}
+                        {toCommaSeparatedList(authors, author => (
+                          <a
+                            css={sharedStyles.link}
+                            href={author.frontmatter.url}
+                            key={author.frontmatter.name}>
+                            {author.frontmatter.name}
+                          </a>
+                        ))}
+                      </span>}
                   </div>}
+
+                <div css={sharedStyles.articleLayout.content}>
+                  <div
+                    css={[sharedStyles.markdown]}
+                    dangerouslySetInnerHTML={{__html: markdownRemark.html}}
+                  />
+
+                  {markdownRemark.fields.path &&
+                    <div css={{marginTop: 80}}>
+                      <a
+                        css={sharedStyles.articleLayout.editLink}
+                        href={`https://github.com/facebook/react/tree/master/docs/${markdownRemark.fields.path}`}>
+                        Edit this page
+                      </a>
+                    </div>}
+                </div>
+              </Flex>
+
+              <div css={sharedStyles.articleLayout.sidebar}>
+                <StickyResponsiveSidebar
+                  createLink={createLink}
+                  defaultActiveSection={findSectionForPath(
+                    location.pathname,
+                    sectionList,
+                  )}
+                  location={location}
+                  onRequestToggle={this.toggleMenuOverlay}
+                  open={this.state.isMenuOverlayOpen}
+                  sectionList={sectionList}
+                />
               </div>
-            </Flex>
-
-            <div css={sharedStyles.articleLayout.sidebar}>
-              <StickyResponsiveSidebar
-                createLink={createLink}
-                defaultActiveSection={findSectionForPath(
-                  location.pathname,
-                  sectionList,
-                )}
-                location={location}
-                sectionList={sectionList}
-              />
             </div>
-          </div>
-        </Container>
-      </div>
+          </Container>
+        </div>
 
-      {/* TODO Read prev/next from index map, not this way */}
-      {(markdownRemark.frontmatter.next || markdownRemark.frontmatter.prev) &&
-        <NavigationFooter
-          location={location}
-          next={markdownRemark.frontmatter.next}
-          prev={markdownRemark.frontmatter.prev}
-        />}
-    </Flex>
-  );
-};
+        {/* TODO Read prev/next from index map, not this way */}
+        {(markdownRemark.frontmatter.next || markdownRemark.frontmatter.prev) &&
+          <NavigationFooter
+            location={location}
+            next={markdownRemark.frontmatter.next}
+            prev={markdownRemark.frontmatter.prev}
+          />}
+      </Flex>
+    );
+  }
+}
 
 MarkdownPage.defaultProps = {
   authors: [],
@@ -130,6 +174,10 @@ MarkdownPage.propTypes = {
   location: PropTypes.object.isRequired,
   markdownRemark: PropTypes.object.isRequired,
   sectionList: PropTypes.array.isRequired,
+};
+
+MarkdownPage.contextTypes = {
+  onMenuOverlayToggle: PropTypes.func.isRequired,
 };
 
 export default MarkdownPage;

--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -12,6 +12,7 @@
 import Container from 'components/Container';
 import Flex from 'components/Flex';
 import MarkdownHeader from 'components/MarkdownHeader';
+import MenuOverlayContainer from 'components/MenuOverlayContainer';
 import NavigationFooter from 'templates/components/NavigationFooter';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -19,148 +20,117 @@ import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
 import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import findSectionForPath from 'utils/findSectionForPath';
 import toCommaSeparatedList from 'utils/toCommaSeparatedList';
-import {media, sharedStyles} from 'theme';
+import {sharedStyles} from 'theme';
 import {urlRoot} from 'constants';
 
-class MarkdownPage extends React.Component {
-  constructor(props) {
-    super(props);
-    this.toggleMenuOverlay = this.toggleMenuOverlay.bind(this);
-    this.handleWindowResize = this.handleWindowResize.bind(this);
-    this.state = {
-      isMenuOverlayOpen: false,
-    };
-  }
-  componentDidUpdate(prevProps, prevState) {
-    if (this.state.isMenuOverlayOpen && !prevState.isMenuOverlayOpen) {
-      // Menu has been opened
-      window.addEventListener('resize', this.handleWindowResize);
-    }
-  }
-  handleWindowResize() {
-    const mediaQuery = media.greaterThan('small').replace('@media ', '');
-    if (window.matchMedia(mediaQuery).matches) {
-      // If the screen has been resized >= 'small'
-      this.toggleMenuOverlay(false);
-    }
-  }
-  toggleMenuOverlay(willOpen) {
-    this.setState(
-      {
-        isMenuOverlayOpen: willOpen,
-      },
-      () => {
-        this.context.onMenuOverlayToggle(this.state.isMenuOverlayOpen);
-      },
-    );
-  }
-  handleTouchMove(evt) {
-    // Prevent anything else from being touched when the menu overlay is open, to avoid touch scrolling issues
-    if (this.state.isMenuOverlayOpen) {
-      evt.preventDefault();
-    }
-  }
-  render() {
-    const {
-      authors,
-      createLink,
-      date,
-      ogDescription,
-      location,
-      markdownRemark,
-      sectionList,
-      titlePostfix = '',
-    } = this.props;
-    const hasAuthors = authors.length > 0;
-    const titlePrefix = markdownRemark.frontmatter.title || '';
+const MarkdownPage = ({
+  authors,
+  createLink,
+  date,
+  ogDescription,
+  location,
+  markdownRemark,
+  sectionList,
+  titlePostfix = '',
+}) => {
+  const hasAuthors = authors.length > 0;
+  const titlePrefix = markdownRemark.frontmatter.title || '';
 
-    return (
-      <Flex
-        direction="column"
-        grow="1"
-        shrink="0"
-        halign="stretch"
-        css={{
-          width: '100%',
-          flex: '1 0 auto',
-          position: 'relative',
-          zIndex: 0,
-          overflow: 'auto', // This is required for the mobile footer layout
-        }}
-        onTouchMove={this.handleTouchMove}>
-        <TitleAndMetaTags
-          title={`${titlePrefix}${titlePostfix}`}
-          ogUrl={`${urlRoot}/${markdownRemark.fields.path || ''}`}
-          ogDescription={ogDescription}
-        />
-        <div css={{flex: '1 0 auto'}}>
-          <Container>
-            <div css={sharedStyles.articleLayout.container}>
-              <Flex type="article" direction="column" grow="1" halign="stretch">
-                <MarkdownHeader title={titlePrefix} />
+  return (
+    <MenuOverlayContainer>
+      {({toggleMenuOverlay, open: isMenuOverlayOpen, preventTouches}) => (
+        <Flex
+          direction="column"
+          grow="1"
+          shrink="0"
+          halign="stretch"
+          css={{
+            width: '100%',
+            flex: '1 0 auto',
+            position: 'relative',
+            zIndex: 0,
+            overflow: 'auto', // This is required for the mobile footer layout
+          }}
+          onTouchMove={preventTouches}>
+          <TitleAndMetaTags
+            title={`${titlePrefix}${titlePostfix}`}
+            ogUrl={`${urlRoot}/${markdownRemark.fields.path || ''}`}
+            ogDescription={ogDescription}
+          />
+          <div css={{flex: '1 0 auto'}}>
+            <Container>
+              <div css={sharedStyles.articleLayout.container}>
+                <Flex
+                  type="article"
+                  direction="column"
+                  grow="1"
+                  halign="stretch">
+                  <MarkdownHeader title={titlePrefix} />
 
-                {(date || hasAuthors) &&
-                  <div css={{marginTop: 15}}>
-                    {date}{' '}
-                    {hasAuthors &&
-                      <span>
-                        by{' '}
-                        {toCommaSeparatedList(authors, author => (
-                          <a
-                            css={sharedStyles.link}
-                            href={author.frontmatter.url}
-                            key={author.frontmatter.name}>
-                            {author.frontmatter.name}
-                          </a>
-                        ))}
-                      </span>}
-                  </div>}
-
-                <div css={sharedStyles.articleLayout.content}>
-                  <div
-                    css={[sharedStyles.markdown]}
-                    dangerouslySetInnerHTML={{__html: markdownRemark.html}}
-                  />
-
-                  {markdownRemark.fields.path &&
-                    <div css={{marginTop: 80}}>
-                      <a
-                        css={sharedStyles.articleLayout.editLink}
-                        href={`https://github.com/facebook/react/tree/master/docs/${markdownRemark.fields.path}`}>
-                        Edit this page
-                      </a>
+                  {(date || hasAuthors) &&
+                    <div css={{marginTop: 15}}>
+                      {date}{' '}
+                      {hasAuthors &&
+                        <span>
+                          by{' '}
+                          {toCommaSeparatedList(authors, author => (
+                            <a
+                              css={sharedStyles.link}
+                              href={author.frontmatter.url}
+                              key={author.frontmatter.name}>
+                              {author.frontmatter.name}
+                            </a>
+                          ))}
+                        </span>}
                     </div>}
+
+                  <div css={sharedStyles.articleLayout.content}>
+                    <div
+                      css={[sharedStyles.markdown]}
+                      dangerouslySetInnerHTML={{__html: markdownRemark.html}}
+                    />
+
+                    {markdownRemark.fields.path &&
+                      <div css={{marginTop: 80}}>
+                        <a
+                          css={sharedStyles.articleLayout.editLink}
+                          href={`https://github.com/facebook/react/tree/master/docs/${markdownRemark.fields.path}`}>
+                          Edit this page
+                        </a>
+                      </div>}
+                  </div>
+                </Flex>
+
+                <div css={sharedStyles.articleLayout.sidebar}>
+                  <StickyResponsiveSidebar
+                    createLink={createLink}
+                    defaultActiveSection={findSectionForPath(
+                      location.pathname,
+                      sectionList,
+                    )}
+                    location={location}
+                    onRequestToggle={toggleMenuOverlay}
+                    open={isMenuOverlayOpen}
+                    sectionList={sectionList}
+                  />
                 </div>
-              </Flex>
-
-              <div css={sharedStyles.articleLayout.sidebar}>
-                <StickyResponsiveSidebar
-                  createLink={createLink}
-                  defaultActiveSection={findSectionForPath(
-                    location.pathname,
-                    sectionList,
-                  )}
-                  location={location}
-                  onRequestToggle={this.toggleMenuOverlay}
-                  open={this.state.isMenuOverlayOpen}
-                  sectionList={sectionList}
-                />
               </div>
-            </div>
-          </Container>
-        </div>
+            </Container>
+          </div>
 
-        {/* TODO Read prev/next from index map, not this way */}
-        {(markdownRemark.frontmatter.next || markdownRemark.frontmatter.prev) &&
-          <NavigationFooter
-            location={location}
-            next={markdownRemark.frontmatter.next}
-            prev={markdownRemark.frontmatter.prev}
-          />}
-      </Flex>
-    );
-  }
-}
+          {/* TODO Read prev/next from index map, not this way */}
+          {(markdownRemark.frontmatter.next ||
+            markdownRemark.frontmatter.prev) &&
+            <NavigationFooter
+              location={location}
+              next={markdownRemark.frontmatter.next}
+              prev={markdownRemark.frontmatter.prev}
+            />}
+        </Flex>
+      )}
+    </MenuOverlayContainer>
+  );
+};
 
 MarkdownPage.defaultProps = {
   authors: [],
@@ -174,10 +144,6 @@ MarkdownPage.propTypes = {
   location: PropTypes.object.isRequired,
   markdownRemark: PropTypes.object.isRequired,
   sectionList: PropTypes.array.isRequired,
-};
-
-MarkdownPage.contextTypes = {
-  onMenuOverlayToggle: PropTypes.func.isRequired,
 };
 
 export default MarkdownPage;

--- a/www/src/components/MenuOverlayContainer/MenuOverlayContainer.js
+++ b/www/src/components/MenuOverlayContainer/MenuOverlayContainer.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+*/
+
+'use strict';
+
+import {Component} from 'react';
+import PropTypes from 'prop-types';
+import {media} from 'theme';
+
+class MenuOverlayContainer extends Component {
+  constructor(props) {
+    super(props);
+    this.toggleMenuOverlay = this.toggleMenuOverlay.bind(this);
+    this.handleWindowResize = this.handleWindowResize.bind(this);
+    this.handleTouchMove = this.handleTouchMove.bind(this);
+    this.state = {
+      open: false,
+    };
+  }
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.open) {
+      window.addEventListener('resize', this.handleWindowResize);
+    } else {
+      window.removeEventListener('resize', this.handleWindowResize);
+    }
+  }
+
+  componentWillUnmount() {
+    this.context.onMenuOverlayToggle(false);
+    window.removeEventListener('resize', this.handleWindowResize);
+  }
+
+  handleWindowResize() {
+    const mediaQuery = media.greaterThan('small').replace('@media ', '');
+    if (window.matchMedia(mediaQuery).matches) {
+      // If the screen has been resized >= 'small'
+      this.toggleMenuOverlay(false);
+    }
+  }
+
+  toggleMenuOverlay(willOpen) {
+    this.setState(
+      {
+        open: willOpen,
+      },
+      () => {
+        this.context.onMenuOverlayToggle(this.state.open);
+      },
+    );
+  }
+
+  handleTouchMove(evt) {
+    // Prevent anything else from being touched when the menu overlay is open
+    // to avoid touch scrolling issues
+    if (this.state.open) {
+      evt.preventDefault();
+    }
+  }
+  render() {
+    return this.props.children({
+      open: this.state.open,
+      toggleMenuOverlay: this.toggleMenuOverlay,
+      preventTouches: this.handleTouchMove,
+    });
+  }
+}
+
+MenuOverlayContainer.contextTypes = {
+  onMenuOverlayToggle: PropTypes.func.isRequired,
+};
+
+export default MenuOverlayContainer;

--- a/www/src/components/MenuOverlayContainer/index.js
+++ b/www/src/components/MenuOverlayContainer/index.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+*/
+
+'use strict';
+
+import MenuOverlayContainer from './MenuOverlayContainer';
+
+export default MenuOverlayContainer;

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -11,6 +11,7 @@
 
 import Container from 'components/Container';
 import {Component, React} from 'react';
+import PropTypes from 'prop-types';
 import Sidebar from 'templates/components/Sidebar';
 import {colors, media} from 'theme';
 import ChevronSvg from 'templates/components/ChevronSvg';
@@ -18,19 +19,36 @@ import ChevronSvg from 'templates/components/ChevronSvg';
 class StickyResponsiveSidebar extends Component {
   constructor(props, context) {
     super(props, context);
-
-    this.state = {
-      open: false,
-    };
     this.toggleOpen = this._toggleOpen.bind(this);
   }
 
   _toggleOpen() {
-    this.setState({open: !this.state.open});
+    this.props.onRequestToggle(!this.props.open);
+  }
+
+  handleMenuTouchMove(evt) {
+    // Prevent evt.preventDefault in <MarkdownPage />
+    evt.stopPropagation();
+  }
+
+  handleMenuTouchStart(evt) {
+    // Prevent "overscrolling"
+    // http://blog.christoffer.online/2015-06-10-six-things-i-learnt-about-ios-rubberband-overflow-scrolling/
+    const element = evt.currentTarget;
+    const top = element.scrollTop;
+    const totalScroll = element.scrollHeight;
+    const currentScroll = top + element.offsetHeight;
+
+    if (top === 0) {
+      element.scrollTop = 1;
+    } else if (currentScroll === totalScroll) {
+      element.scrollTop = top - 1;
+    }
   }
 
   render() {
-    const {open} = this.state;
+    const {open} = this.props;
+
     const smallScreenSidebarStyles = {
       top: 0,
       left: 0,
@@ -56,6 +74,8 @@ class StickyResponsiveSidebar extends Component {
     return (
       <div>
         <div
+          onTouchMove={this.handleMenuTouchMove}
+          onTouchStart={this.handleMenuTouchStart}
           style={{
             opacity: menuOpacity,
             transition: 'opacity 0.5s ease',
@@ -103,6 +123,10 @@ class StickyResponsiveSidebar extends Component {
             style={{
               transform: `translate(0px, ${menuOffset}px)`,
               transition: 'transform 0.5s ease',
+              paddingBottom: 100,
+              [media.greaterThan('small')]: {
+                paddingBottom: 40,
+              },
             }}
             css={{
               marginTop: 60,
@@ -189,5 +213,15 @@ class StickyResponsiveSidebar extends Component {
     );
   }
 }
+
+StickyResponsiveSidebar.propTypes = {
+  onRequestToggle: PropTypes.func,
+  open: PropTypes.func,
+};
+
+StickyResponsiveSidebar.defaultProps = {
+  onRequestToggle: () => null,
+  open: false,
+};
 
 export default StickyResponsiveSidebar;

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -120,19 +120,13 @@ class StickyResponsiveSidebar extends Component {
             },
           }}>
           <div
-            style={{
-              transform: `translate(0px, ${menuOffset}px)`,
-              transition: 'transform 0.5s ease',
-              paddingBottom: 100,
-              [media.greaterThan('small')]: {
-                paddingBottom: 40,
-              },
-            }}
             css={{
               marginTop: 60,
 
               [media.size('xsmall')]: {
                 marginTop: 40,
+                transform: `translate(0px, ${menuOffset}px)`,
+                transition: 'transform 0.5s ease',
               },
 
               [media.between('small', 'medium')]: {
@@ -145,6 +139,7 @@ class StickyResponsiveSidebar extends Component {
 
               [media.greaterThan('small')]: {
                 tranform: 'none !important',
+                paddingBottom: 40,
               },
             }}>
             <Sidebar {...this.props} />
@@ -216,7 +211,7 @@ class StickyResponsiveSidebar extends Component {
 
 StickyResponsiveSidebar.propTypes = {
   onRequestToggle: PropTypes.func,
-  open: PropTypes.func,
+  open: PropTypes.bool,
 };
 
 StickyResponsiveSidebar.defaultProps = {

--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -86,8 +86,7 @@ class Template extends Component {
               marginTop: 50,
             },
             [media.lessThan('medium')]: {
-              marginTop: this.state.showHeaderAndFooter ? 40 : 0,
-              transition: 'margin-top 0.2s ease',
+              marginTop: 40,
             },
           }}>
           {children()}

--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -10,6 +10,7 @@
 'use strict';
 
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Flex from 'components/Flex';
 import Footer from 'components/LayoutFooter';
 import Header from 'components/LayoutHeader';
@@ -22,6 +23,20 @@ import 'css/reset.css';
 import 'css/algolia.css';
 
 class Template extends Component {
+  constructor(props) {
+    super(props);
+    this.handleMenuOverlayToggle = this.handleMenuOverlayToggle.bind(this);
+    this.state = {
+      showHeaderAndFooter: true,
+    };
+  }
+
+  getChildContext() {
+    return {
+      onMenuOverlayToggle: this.handleMenuOverlayToggle,
+    };
+  }
+
   componentDidMount() {
     // Initialize Algolia search.
     // TODO Is this expensive? Should it be deferred until a user is about to search?
@@ -30,6 +45,12 @@ class Template extends Component {
       apiKey: '36221914cce388c46d0420343e0bb32e',
       indexName: 'react',
       inputSelector: '#algolia-doc-search',
+    });
+  }
+
+  handleMenuOverlayToggle(isOpen) {
+    this.setState({
+      showHeaderAndFooter: !isOpen,
     });
   }
 
@@ -49,7 +70,10 @@ class Template extends Component {
           flexDirection: 'column',
           minHeight: 'calc(100vh - 40px)',
         }}>
-        <Header location={location} />
+        <Header
+          location={location}
+          isVisible={this.state.showHeaderAndFooter}
+        />
         <Flex
           direction="column"
           shrink="0"
@@ -62,15 +86,23 @@ class Template extends Component {
               marginTop: 50,
             },
             [media.lessThan('medium')]: {
-              marginTop: 40,
+              marginTop: this.state.showHeaderAndFooter ? 40 : 0,
+              transition: 'margin-top 0.2s ease',
             },
           }}>
           {children()}
         </Flex>
-        <Footer layoutHasSidebar={layoutHasSidebar} />
+        <Footer
+          layoutHasSidebar={layoutHasSidebar}
+          isVisible={this.state.showHeaderAndFooter}
+        />
       </div>
     );
   }
 }
+
+Template.childContextTypes = {
+  onMenuOverlayToggle: PropTypes.func,
+};
 
 export default Template;

--- a/www/src/pages/docs/error-decoder.html.js
+++ b/www/src/pages/docs/error-decoder.html.js
@@ -14,6 +14,7 @@ import ErrorDecoder from 'components/ErrorDecoder';
 import Flex from 'components/Flex';
 import hex2rgba from 'hex2rgba';
 import MarkdownHeader from 'components/MarkdownHeader';
+import MenuOverlayContainer from 'components/MenuOverlayContainer';
 import React from 'react';
 import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
 import {colors, sharedStyles} from 'theme';
@@ -22,74 +23,81 @@ import findSectionForPath from 'utils/findSectionForPath';
 import {sectionListDocs} from 'utils/sectionList';
 
 const ErrorPage = ({data, location}) => (
-  <Flex
-    direction="column"
-    grow="1"
-    shrink="0"
-    halign="stretch"
-    css={{
-      width: '100%',
-      flex: '1 0 auto',
-      position: 'relative',
-      zIndex: 0,
-    }}>
-    <Container>
-      <div css={sharedStyles.articleLayout.container}>
+  <MenuOverlayContainer>
+    {({open: isMenuOverlayOpen, toggleMenuOverlay, preventTouches}) => (
+      <Flex
+        direction="column"
+        grow="1"
+        shrink="0"
+        halign="stretch"
+        css={{
+          width: '100%',
+          flex: '1 0 auto',
+          position: 'relative',
+          zIndex: 0,
+        }}
+        onTouchMove={preventTouches}>
+        <Container>
+          <div css={sharedStyles.articleLayout.container}>
 
-        <Flex
-          type="article"
-          direction="column"
-          grow="1"
-          halign="stretch"
-          css={{
-            minHeight: 'calc(100vh - 40px)',
-          }}>
-          <MarkdownHeader
-            path={data.markdownRemark.fields.path}
-            title={data.markdownRemark.frontmatter.title}
-          />
+            <Flex
+              type="article"
+              direction="column"
+              grow="1"
+              halign="stretch"
+              css={{
+                minHeight: 'calc(100vh - 40px)',
+              }}>
+              <MarkdownHeader
+                path={data.markdownRemark.fields.path}
+                title={data.markdownRemark.frontmatter.title}
+              />
 
-          <div css={sharedStyles.articleLayout.content}>
-            <div
-              css={sharedStyles.markdown}
-              dangerouslySetInnerHTML={{__html: data.markdownRemark.html}}
-            />
-            <div
-              css={[
-                sharedStyles.markdown,
-                {
-                  marginTop: 30,
-                  '& code': {
-                    display: 'block',
-                    marginTop: 30,
-                    padding: '1rem',
-                    borderRadius: '0.5rem',
-                    backgroundColor: hex2rgba(colors.error, 0.1),
-                    color: colors.error,
-                  },
-                },
-              ]}>
-              <ErrorDecoder location={location} />
+              <div css={sharedStyles.articleLayout.content}>
+                <div
+                  css={sharedStyles.markdown}
+                  dangerouslySetInnerHTML={{__html: data.markdownRemark.html}}
+                />
+                <div
+                  css={[
+                    sharedStyles.markdown,
+                    {
+                      marginTop: 30,
+                      '& code': {
+                        display: 'block',
+                        marginTop: 30,
+                        padding: '1rem',
+                        borderRadius: '0.5rem',
+                        backgroundColor: hex2rgba(colors.error, 0.1),
+                        color: colors.error,
+                      },
+                    },
+                  ]}>
+                  <ErrorDecoder location={location} />
+                </div>
+              </div>
+            </Flex>
+
+            <div css={sharedStyles.articleLayout.sidebar}>
+              <StickyResponsiveSidebar
+                createLink={createLinkDocs}
+                defaultActiveSection={findSectionForPath(
+                  location.pathname,
+                  sectionListDocs,
+                )}
+                location={location}
+                sectionList={sectionListDocs}
+                title={data.markdownRemark.frontmatter.title}
+                open={isMenuOverlayOpen}
+                onRequestToggle={toggleMenuOverlay}
+              />
             </div>
+
           </div>
-        </Flex>
-
-        <div css={sharedStyles.articleLayout.sidebar}>
-          <StickyResponsiveSidebar
-            createLink={createLinkDocs}
-            defaultActiveSection={findSectionForPath(
-              location.pathname,
-              sectionListDocs,
-            )}
-            location={location}
-            sectionList={sectionListDocs}
-            title={data.markdownRemark.frontmatter.title}
-          />
-        </div>
-
-      </div>
-    </Container>
-  </Flex>
+        </Container>
+      </Flex>
+    )}
+  </MenuOverlayContainer>
 );
 
 // eslint-disable-next-line no-undef

--- a/www/src/templates/components/NavigationFooter/NavigationFooter.js
+++ b/www/src/templates/components/NavigationFooter/NavigationFooter.js
@@ -16,23 +16,23 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {colors, fonts, media} from 'theme';
 
-const NavigationFooter = ({next, prev, location}) => {
-  return (
-    <div
-      css={{
-        background: colors.dark,
-        color: colors.white,
-        paddingTop: 50,
-        paddingBottom: 50,
-      }}>
-      <Container>
-        <Flex
-          type="ul"
-          halign="space-between"
-          css={{
-            [media.between('small', 'medium')]: {
-              paddingRight: 240,
-            },
+const NavigationFooter = ({next, prev, location, isVisible = true}) => (
+  <div
+    css={{
+      background: colors.dark,
+      color: colors.white,
+      paddingTop: 50,
+      paddingBottom: 50,
+      display: isVisible === false ? 'none' : null,
+    }}>
+    <Container>
+      <Flex
+        type="ul"
+        halign="space-between"
+        css={{
+          [media.between('small', 'medium')]: {
+            paddingRight: 240,
+          },
 
             [media.between('large', 'largerSidebar')]: {
               paddingRight: 280,

--- a/www/src/templates/components/NavigationFooter/NavigationFooter.js
+++ b/www/src/templates/components/NavigationFooter/NavigationFooter.js
@@ -34,53 +34,52 @@ const NavigationFooter = ({next, prev, location, isVisible = true}) => (
             paddingRight: 240,
           },
 
-            [media.between('large', 'largerSidebar')]: {
-              paddingRight: 280,
-            },
+          [media.between('large', 'largerSidebar')]: {
+            paddingRight: 280,
+          },
 
-            [media.between('largerSidebar', 'sidebarFixed', true)]: {
-              paddingRight: 380,
-            },
-          }}>
-          <Flex basis="50%" type="li">
-            {prev &&
-              <div>
-                <SecondaryLabel>Previous article</SecondaryLabel>
-                <div
-                  css={{
-                    paddingTop: 10,
-                  }}>
-                  <PrimaryLink location={location} to={prev}>
-                    {linkToTitle(prev)}
-                  </PrimaryLink>
-                </div>
-              </div>}
-          </Flex>
-          {next &&
-            <Flex
-              halign="flex-end"
-              basis="50%"
-              type="li"
-              css={{
-                textAlign: 'right',
-              }}>
-              <div>
-                <SecondaryLabel>Next article</SecondaryLabel>
-                <div
-                  css={{
-                    paddingTop: 10,
-                  }}>
-                  <PrimaryLink location={location} to={next}>
-                    {linkToTitle(next)}
-                  </PrimaryLink>
-                </div>
+          [media.between('largerSidebar', 'sidebarFixed', true)]: {
+            paddingRight: 380,
+          },
+        }}>
+        <Flex basis="50%" type="li">
+          {prev &&
+            <div>
+              <SecondaryLabel>Previous article</SecondaryLabel>
+              <div
+                css={{
+                  paddingTop: 10,
+                }}>
+                <PrimaryLink location={location} to={prev}>
+                  {linkToTitle(prev)}
+                </PrimaryLink>
               </div>
-            </Flex>}
+            </div>}
         </Flex>
-      </Container>
-    </div>
-  );
-};
+        {next &&
+          <Flex
+            halign="flex-end"
+            basis="50%"
+            type="li"
+            css={{
+              textAlign: 'right',
+            }}>
+            <div>
+              <SecondaryLabel>Next article</SecondaryLabel>
+              <div
+                css={{
+                  paddingTop: 10,
+                }}>
+                <PrimaryLink location={location} to={next}>
+                  {linkToTitle(next)}
+                </PrimaryLink>
+              </div>
+            </div>
+          </Flex>}
+      </Flex>
+    </Container>
+  </div>
+);
 
 NavigationFooter.propTypes = {
   next: PropTypes.string,

--- a/www/src/templates/components/Sidebar/Sidebar.js
+++ b/www/src/templates/components/Sidebar/Sidebar.js
@@ -42,7 +42,7 @@ class Sidebar extends Component {
           },
 
           [media.lessThan('small')]: {
-            paddingBottom: 50,
+            paddingBottom: 100,
           },
         }}>
         {sectionList.map((section, index) => (

--- a/www/src/templates/installation.js
+++ b/www/src/templates/installation.js
@@ -12,6 +12,7 @@
 import Container from 'components/Container';
 import Flex from 'components/Flex';
 import MarkdownHeader from 'components/MarkdownHeader';
+import MenuOverlayContainer from 'components/MenuOverlayContainer';
 import NavigationFooter from 'templates/components/NavigationFooter';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
@@ -128,67 +129,79 @@ class InstallationPage extends Component {
     const {markdownRemark} = data;
 
     return (
-      <Flex
-        direction="column"
-        grow="1"
-        shrink="0"
-        halign="stretch"
-        css={{
-          width: '100%',
-          flex: '1 0 auto',
-          position: 'relative',
-          zIndex: 0,
-        }}>
-        <TitleAndMetaTags
-          title="Installation - React"
-          ogUrl={`${urlRoot}/${markdownRemark.fields.path || ''}`}
-        />
-        <div css={{flex: '1 0 auto'}}>
-          <Container>
-            <div css={sharedStyles.articleLayout.container}>
-              <Flex type="article" direction="column" grow="1" halign="stretch">
-                <MarkdownHeader title={markdownRemark.frontmatter.title} />
+      <MenuOverlayContainer>
+        {({open: isMenuOverlayOpen, toggleMenuOverlay, preventTouches}) => (
+          <Flex
+            direction="column"
+            grow="1"
+            shrink="0"
+            halign="stretch"
+            css={{
+              width: '100%',
+              flex: '1 0 auto',
+              position: 'relative',
+              zIndex: 0,
+            }}
+            onTouchMove={preventTouches}>
+            <TitleAndMetaTags
+              title="Installation - React"
+              ogUrl={`${urlRoot}/${markdownRemark.fields.path || ''}`}
+            />
+            <div css={{flex: '1 0 auto'}}>
+              <Container>
+                <div css={sharedStyles.articleLayout.container}>
+                  <Flex
+                    type="article"
+                    direction="column"
+                    grow="1"
+                    halign="stretch">
+                    <MarkdownHeader title={markdownRemark.frontmatter.title} />
 
-                <div css={sharedStyles.articleLayout.content}>
-                  <div
-                    css={[sharedStyles.markdown]}
-                    dangerouslySetInnerHTML={{__html: markdownRemark.html}}
-                  />
-                  {markdownRemark.fields.path &&
-                    <div css={{marginTop: 80}}>
-                      <a
-                        css={sharedStyles.articleLayout.editLink}
-                        href={`https://github.com/facebook/react/tree/master/docs/${markdownRemark.fields.path}`}>
-                        Edit this page
-                      </a>
-                    </div>}
+                    <div css={sharedStyles.articleLayout.content}>
+                      <div
+                        css={[sharedStyles.markdown]}
+                        dangerouslySetInnerHTML={{__html: markdownRemark.html}}
+                      />
+                      {markdownRemark.fields.path &&
+                        <div css={{marginTop: 80}}>
+                          <a
+                            css={sharedStyles.articleLayout.editLink}
+                            href={`https://github.com/facebook/react/tree/master/docs/${markdownRemark.fields.path}`}>
+                            Edit this page
+                          </a>
+                        </div>}
+                    </div>
+                  </Flex>
+
+                  <div css={sharedStyles.articleLayout.sidebar}>
+                    <StickyResponsiveSidebar
+                      createLink={createLinkDocs}
+                      defaultActiveSection={findSectionForPath(
+                        location.pathname,
+                        sectionListDocs,
+                      )}
+                      location={location}
+                      sectionList={sectionListDocs}
+                      title="Installation"
+                      open={isMenuOverlayOpen}
+                      onRequestToggle={toggleMenuOverlay}
+                    />
+                  </div>
                 </div>
-              </Flex>
-
-              <div css={sharedStyles.articleLayout.sidebar}>
-                <StickyResponsiveSidebar
-                  createLink={createLinkDocs}
-                  defaultActiveSection={findSectionForPath(
-                    location.pathname,
-                    sectionListDocs,
-                  )}
-                  location={location}
-                  sectionList={sectionListDocs}
-                  title="Installation"
-                />
-              </div>
+              </Container>
             </div>
-          </Container>
-        </div>
 
-        {/* TODO Read prev/next from index map, not this way */}
-        {(markdownRemark.frontmatter.next || markdownRemark.frontmatter.prev) &&
-          <NavigationFooter
-            location={location}
-            next={markdownRemark.frontmatter.next}
-            prev={markdownRemark.frontmatter.prev}
-          />}
-      </Flex>
+            {/* TODO Read prev/next from index map, not this way */}
+            {(markdownRemark.frontmatter.next ||
+              markdownRemark.frontmatter.prev) &&
+              <NavigationFooter
+                location={location}
+                next={markdownRemark.frontmatter.next}
+                prev={markdownRemark.frontmatter.prev}
+              />}
+          </Flex>
+        )}
+      </MenuOverlayContainer>
     );
   }
 }


### PR DESCRIPTION
**issues**

- when scrolling within the menu overlay, the background would capture the touch event instead, and you'd be scrolling the main content rather than the overlay's scrollbar. this would happy fairly randomly.
- a similar issue would happen if you scrolled to the top or bottom of the overlay (A.k.A. "overscroll")

_here's a demonstration of what was happening_

![ezgif-1-0be83948b1](https://user-images.githubusercontent.com/24449/30777375-08e4f4d8-a0b1-11e7-9482-98e3ce404fd9.gif)

**what's included**

- fixes for the both, by using `evt.preventDefault()` on the main content within the docs, and then taking care of the header and footer by hiding them. (The header actually animates away, whereas the footer can never be seen, so that isn't applicable.).
- "overscroll" has been taken care of with a fix inspired by this (http://blog.christoffer.online/2015-06-10-six-things-i-learnt-about-ios-rubberband-overflow-scrolling/). (more idiomatic to React though)

_screencast preview of the fixes:_

https://cl.ly/1f0T2G452239

cc @bvaughn @flarnie 

