### PR TITLE
[Gatsby Docs Update] Overlay toggle button

### DIFF
--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -101,7 +101,6 @@ const MarkdownPage = ({
                 )}
                 location={location}
                 sectionList={sectionList}
-                title={titlePrefix}
               />
             </div>
           </div>

--- a/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/www/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -32,7 +32,6 @@ class StickyResponsiveSidebar extends Component {
   }
 
   render() {
-    const {title} = this.props;
     const {open} = this.state;
     const smallScreenSidebarStyles = {
       top: 0,
@@ -49,11 +48,10 @@ class StickyResponsiveSidebar extends Component {
     };
 
     const smallScreenBottomBarStyles = {
-      display: 'block',
+      display: 'inline-block',
     };
 
-    const iconOffset = open ? 7 : 0;
-    const labelOffset = open ? -40 : 0;
+    const iconOffset = open ? 8 : -4;
     const menuOpacity = open ? 1 : 0;
     const menuOffset = open ? 0 : 40;
 
@@ -133,15 +131,16 @@ class StickyResponsiveSidebar extends Component {
         <div
           css={{
             backgroundColor: colors.darker,
-            bottom: 0,
+            bottom: 44, // iOS Safari's inert "bottom 44px"
             color: colors.brand,
             display: 'none', // gets overriden at small screen sizes
-            left: 0,
             cursor: 'pointer',
             position: 'fixed',
-            right: 0,
-            width: '100%',
+            right: 20,
             zIndex: 3,
+            borderRadius: '50%',
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+            boxShadow: '0 0 20px rgba(0, 0, 0, 0.3)',
             [media.lessThan('small')]: smallScreenBottomBarStyles,
           }}
           onClick={this.toggleOpen}>
@@ -156,7 +155,7 @@ class StickyResponsiveSidebar extends Component {
                   height: 50,
                 },
                 [media.lessThan('small')]: {
-                  height: 40,
+                  height: 60,
                   overflow: 'hidden',
                   alignItems: 'flex-start',
                 },
@@ -164,48 +163,26 @@ class StickyResponsiveSidebar extends Component {
               <div
                 css={{
                   width: 20,
-                  marginRight: 10,
+                  height: 20,
                   alignSelf: 'center',
                   display: 'flex',
                   flexDirection: 'column',
+                  color: colors.brand,
                 }}>
                 <ChevronSvg
+                  size={15}
                   cssProps={{
-                    transform: `translate(0, ${iconOffset}px) rotate(180deg)`,
-                    transition: 'transform 0.5s ease',
+                    transform: `translate(2px, ${iconOffset}px) rotate(180deg)`,
+                    transition: 'transform 0.2s ease',
                   }}
                 />
                 <ChevronSvg
+                  size={15}
                   cssProps={{
-                    transform: `translate(0, ${0 - iconOffset}px)`,
-                    transition: 'transform 0.5s ease',
+                    transform: `translate(2px, ${0 - iconOffset}px)`,
+                    transition: 'transform 0.2s ease',
                   }}
                 />
-              </div>
-              <div
-                css={{
-                  flexGrow: 1,
-                }}>
-                <div
-                  style={{
-                    transform: `translate(0, ${labelOffset}px)`,
-                    transition: 'transform 0.5s ease',
-                  }}>
-                  <div
-                    css={{
-                      height: 40,
-                      lineHeight: '40px',
-                    }}>
-                    {title}
-                  </div>
-                  <div
-                    css={{
-                      height: 40,
-                      lineHeight: '40px',
-                    }}>
-                    Close
-                  </div>
-                </div>
               </div>
             </div>
           </Container>

--- a/www/src/templates/components/ChevronSvg/index.js
+++ b/www/src/templates/components/ChevronSvg/index.js
@@ -13,15 +13,15 @@
 
 import React from 'react';
 
-const ChevronSvg = ({cssProps = {}}) => (
+const ChevronSvg = ({size = 10, cssProps = {}}) => (
   <svg
     css={cssProps}
     viewBox="0 0 926.23699 573.74994"
     version="1.1"
     x="0px"
     y="0px"
-    width="10px"
-    height="10px">
+    width={size}
+    height={size}>
     <g transform="translate(904.92214,-879.1482)">
       <path
         d={`


### PR DESCRIPTION
- Currently, if you have iOS Safari in "full-height" mode, and you tap the overlay toggle button, it doesn't actually do anything except turn off the full-height mode. This is because it's inside of Safari's 44px inert area. 
- So this is a simplified overlay toggle button (just the icon) that's raised 44px, so it's out of the inert area.
- The text has been removed because, when 44px higher, it's a bit of an intrusive button on longer titles. Feels obvious enough without a label, I think.

**preview**

![toggle-btn](https://user-images.githubusercontent.com/24449/30777697-8125a88c-a0b8-11e7-96cb-4b93f67d2b65.gif)

cc @bvaughn @flarnie 

