### PR TITLE
Remove Stack (part 2, safe: dead branches in tests)

### DIFF
--- a/src/isomorphic/children/__tests__/ReactChildren-test.js
+++ b/src/isomorphic/children/__tests__/ReactChildren-test.js
@@ -9,8 +9,6 @@
 
 'use strict';
 
-const ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-
 describe('ReactChildren', () => {
   var React;
   var ReactTestUtils;
@@ -878,52 +876,50 @@ describe('ReactChildren', () => {
     );
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    describe('with fragments enabled', () => {
-      it('warns for keys for arrays of elements in a fragment', () => {
-        spyOn(console, 'error');
-        class ComponentReturningArray extends React.Component {
-          render() {
-            return [<div />, <div />];
-          }
+  describe('with fragments enabled', () => {
+    it('warns for keys for arrays of elements in a fragment', () => {
+      spyOn(console, 'error');
+      class ComponentReturningArray extends React.Component {
+        render() {
+          return [<div />, <div />];
         }
+      }
 
-        ReactTestUtils.renderIntoDocument(<ComponentReturningArray />);
+      ReactTestUtils.renderIntoDocument(<ComponentReturningArray />);
 
-        expectDev(console.error.calls.count()).toBe(1);
-        expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: ' +
-            'Each child in an array or iterator should have a unique "key" prop.' +
-            ' See https://fb.me/react-warning-keys for more information.' +
-            '\n    in ComponentReturningArray (at **)',
-        );
-      });
-
-      it('does not warn when there are keys on  elements in a fragment', () => {
-        spyOn(console, 'error');
-        class ComponentReturningArray extends React.Component {
-          render() {
-            return [<div key="foo" />, <div key="bar" />];
-          }
-        }
-
-        ReactTestUtils.renderIntoDocument(<ComponentReturningArray />);
-
-        expectDev(console.error.calls.count()).toBe(0);
-      });
-
-      it('warns for keys for arrays at the top level', () => {
-        spyOn(console, 'error');
-
-        ReactTestUtils.renderIntoDocument([<div />, <div />]);
-
-        expectDev(console.error.calls.count()).toBe(1);
-        expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: ' +
-            'Each child in an array or iterator should have a unique "key" prop.' +
-            ' See https://fb.me/react-warning-keys for more information.',
-        );
-      });
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+        'Warning: ' +
+          'Each child in an array or iterator should have a unique "key" prop.' +
+          ' See https://fb.me/react-warning-keys for more information.' +
+          '\n    in ComponentReturningArray (at **)',
+      );
     });
-  }
+
+    it('does not warn when there are keys on  elements in a fragment', () => {
+      spyOn(console, 'error');
+      class ComponentReturningArray extends React.Component {
+        render() {
+          return [<div key="foo" />, <div key="bar" />];
+        }
+      }
+
+      ReactTestUtils.renderIntoDocument(<ComponentReturningArray />);
+
+      expectDev(console.error.calls.count()).toBe(0);
+    });
+
+    it('warns for keys for arrays at the top level', () => {
+      spyOn(console, 'error');
+
+      ReactTestUtils.renderIntoDocument([<div />, <div />]);
+
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+        'Warning: ' +
+          'Each child in an array or iterator should have a unique "key" prop.' +
+          ' See https://fb.me/react-warning-keys for more information.',
+      );
+    });
+  });
 });

--- a/src/isomorphic/classic/element/__tests__/ReactElement-test.js
+++ b/src/isomorphic/classic/element/__tests__/ReactElement-test.js
@@ -12,7 +12,6 @@
 var React;
 var ReactDOM;
 var ReactTestUtils;
-var ReactDOMFeatureFlags;
 
 describe('ReactElement', () => {
   var ComponentClass;
@@ -29,7 +28,6 @@ describe('ReactElement', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactTestUtils = require('react-dom/test-utils');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     // NOTE: We're explicitly not using JSX here. This is intended to test
     // classic JS without JSX.
     ComponentClass = class extends React.Component {
@@ -235,12 +233,7 @@ describe('ReactElement', () => {
     var instance = ReactTestUtils.renderIntoDocument(
       React.createElement(Wrapper),
     );
-
-    if (ReactDOMFeatureFlags.useFiber) {
-      expect(element._owner.stateNode).toBe(instance);
-    } else {
-      expect(element._owner.getPublicInstance()).toBe(instance);
-    }
+    expect(element._owner.stateNode).toBe(instance);
   });
 
   it('merges an additional argument onto the children prop', () => {

--- a/src/renderers/__tests__/EventPluginHub-test.js
+++ b/src/renderers/__tests__/EventPluginHub-test.js
@@ -14,13 +14,11 @@ jest.mock('isEventSupported');
 describe('EventPluginHub', () => {
   var React;
   var ReactTestUtils;
-  var ReactDOMFeatureFlags;
 
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
     ReactTestUtils = require('react-dom/test-utils');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
   });
 
   it('should prevent non-function listeners, at dispatch', () => {
@@ -33,14 +31,10 @@ describe('EventPluginHub', () => {
     }).toThrowError(
       'Expected `onClick` listener to be a function, instead got a value of `string` type.',
     );
-    if (ReactDOMFeatureFlags.useFiber) {
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Expected `onClick` listener to be a function, instead got a value of `string` type.',
-      );
-    } else {
-      expectDev(console.error.calls.count()).toBe(0);
-    }
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'Expected `onClick` listener to be a function, instead got a value of `string` type.',
+    );
   });
 
   it('should not prevent null listeners, at dispatch', () => {

--- a/src/renderers/__tests__/ReactComponentTreeHook-test.js
+++ b/src/renderers/__tests__/ReactComponentTreeHook-test.js
@@ -9,13 +9,9 @@
 
 'use strict';
 
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-var describeStack = ReactDOMFeatureFlags.useFiber ? describe.skip : describe;
-
-describe('ReactComponentTreeHook', () => {
+describe.skip('ReactComponentTreeHook', () => {
   var React;
   var ReactDOM;
-  var ReactDOMServer;
   var ReactInstanceMap;
   var ReactComponentTreeHook;
   var ReactDebugCurrentFiber;
@@ -26,7 +22,6 @@ describe('ReactComponentTreeHook', () => {
 
     React = require('react');
     ReactDOM = require('react-dom');
-    ReactDOMServer = require('react-dom/server');
     ReactInstanceMap = require('ReactInstanceMap');
     ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
     ReactComponentTreeHook = require('ReactComponentTreeHook');
@@ -37,9 +32,8 @@ describe('ReactComponentTreeHook', () => {
   describe('stack addenda', () => {
     it('gets created', () => {
       function getAddendum(element) {
-        var addendum = ReactDOMFeatureFlags.useFiber
-          ? ReactDebugCurrentFiber.getCurrentFiberStackAddendum() || ''
-          : ReactComponentTreeHook.getCurrentStackAddendum();
+        var addendum =
+          ReactDebugCurrentFiber.getCurrentFiberStackAddendum() || '';
         return addendum.replace(/\(at .+?:\d+\)/g, '(at **)');
       }
 
@@ -107,68 +101,6 @@ describe('ReactComponentTreeHook', () => {
       // Make sure owner is fetched for the top element too.
       // expectDev(getAddendum(rOwnedByQ)).toBe('\n    in R (created by Q)');
     });
-
-    // These are features and regression tests that only affect
-    // the Stack implementation of the stack addendum.
-    if (!ReactDOMFeatureFlags.useFiber) {
-      it('can be retrieved by ID', () => {
-        function getAddendum(id) {
-          var addendum = ReactComponentTreeHook.getStackAddendumByID(id);
-          return addendum.replace(/\(at .+?:\d+\)/g, '(at **)');
-        }
-
-        class Q extends React.Component {
-          render() {
-            return null;
-          }
-        }
-
-        var q = ReactDOM.render(<Q />, document.createElement('div'));
-        expectDev(getAddendum(ReactInstanceMap.get(q)._debugID)).toBe(
-          '\n    in Q (at **)',
-        );
-
-        spyOn(console, 'error');
-        getAddendum(-17);
-        expectDev(console.error.calls.count()).toBe(1);
-        expectDev(console.error.calls.argsFor(0)[0]).toBe(
-          'Warning: ReactComponentTreeHook: Missing React element for ' +
-            'debugID -17 when building stack',
-        );
-      });
-
-      it('is created during mounting', () => {
-        // https://github.com/facebook/react/issues/7187
-        var el = document.createElement('div');
-        var portalEl = document.createElement('div');
-        class Foo extends React.Component {
-          componentWillMount() {
-            ReactDOM.render(<div />, portalEl);
-          }
-          render() {
-            return <div><div /></div>;
-          }
-        }
-        ReactDOM.render(<Foo />, el);
-      });
-
-      it('is created when calling renderToString during render', () => {
-        // https://github.com/facebook/react/issues/7190
-        var el = document.createElement('div');
-        class Foo extends React.Component {
-          render() {
-            return (
-              <div>
-                <div>
-                  {ReactDOMServer.renderToString(<div />)}
-                </div>
-              </div>
-            );
-          }
-        }
-        ReactDOM.render(<Foo />, el);
-      });
-    }
   });
 
   // The rest of this file is not relevant for Fiber.
@@ -227,7 +159,7 @@ describe('ReactComponentTreeHook', () => {
     expectWrapperTreeToEqual(null);
   }
 
-  describeStack('mount', () => {
+  describe('mount', () => {
     it('uses displayName or Unknown for classic components', () => {
       class Foo extends React.Component {
         render() {
@@ -699,7 +631,7 @@ describe('ReactComponentTreeHook', () => {
     });
   });
 
-  describeStack('update', () => {
+  describe('update', () => {
     describe('host component', () => {
       it('updates text of a single text child', () => {
         var elementBefore = <div>Hi.</div>;
@@ -1919,7 +1851,7 @@ describe('ReactComponentTreeHook', () => {
     });
   });
 
-  describeStack('misc', () => {
+  describe('misc', () => {
     it('tracks owner correctly', () => {
       class Foo extends React.Component {
         render() {
@@ -2089,7 +2021,7 @@ describe('ReactComponentTreeHook', () => {
     });
   });
 
-  describeStack('in environment without Map, Set and Array.from', () => {
+  describe('in environment without Map, Set and Array.from', () => {
     var realMap;
     var realSet;
     var realArrayFrom;
@@ -2107,7 +2039,6 @@ describe('ReactComponentTreeHook', () => {
 
       React = require('react');
       ReactDOM = require('react-dom');
-      ReactDOMServer = require('react-dom/server');
       ReactInstanceMap = require('ReactInstanceMap');
       ReactComponentTreeHook = require('ReactComponentTreeHook');
       ReactComponentTreeTestUtils = require('ReactComponentTreeTestUtils');

--- a/src/renderers/__tests__/ReactCompositeComponent-test.js
+++ b/src/renderers/__tests__/ReactCompositeComponent-test.js
@@ -13,7 +13,6 @@ var ChildUpdates;
 var MorphingComponent;
 var React;
 var ReactDOM;
-var ReactDOMFeatureFlags;
 var ReactDOMServer;
 var ReactCurrentOwner;
 var ReactTestUtils;
@@ -26,7 +25,6 @@ describe('ReactCompositeComponent', () => {
     jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactDOMServer = require('react-dom/server');
     ReactCurrentOwner = require('react')
       .__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner;
@@ -123,25 +121,19 @@ describe('ReactCompositeComponent', () => {
     var container = document.createElement('div');
     container.innerHTML = markup;
     ReactDOM.render(<Parent />, container);
-    if (ReactDOMFeatureFlags.useFiber) {
-      expectDev(console.warn.calls.count()).toBe(1);
-      expectDev(console.warn.calls.argsFor(0)[0]).toContain(
-        'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
-          'will stop working in React v17. Replace the ReactDOM.render() call ' +
-          'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
-      );
-    } else {
-      expectDev(console.warn.calls.count()).toBe(0);
-    }
+    expectDev(console.warn.calls.count()).toBe(1);
+    expectDev(console.warn.calls.argsFor(0)[0]).toContain(
+      'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
+        'will stop working in React v17. Replace the ReactDOM.render() call ' +
+        'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+    );
 
     // New explicit API
     console.warn.calls.reset();
-    if (ReactDOMFeatureFlags.useFiber) {
-      container = document.createElement('div');
-      container.innerHTML = markup;
-      ReactDOM.hydrate(<Parent />, container);
-      expectDev(console.warn.calls.count()).toBe(0);
-    }
+    container = document.createElement('div');
+    container.innerHTML = markup;
+    ReactDOM.hydrate(<Parent />, container);
+    expectDev(console.warn.calls.count()).toBe(0);
   });
 
   it('should react to state changes from callbacks', () => {

--- a/src/renderers/__tests__/ReactEmptyComponent-test.js
+++ b/src/renderers/__tests__/ReactEmptyComponent-test.js
@@ -14,8 +14,6 @@ var ReactDOM;
 var ReactTestUtils;
 var TogglingComponent;
 
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-
 var log;
 
 describe('ReactEmptyComponent', () => {
@@ -69,20 +67,18 @@ describe('ReactEmptyComponent', () => {
     expect(container2.children.length).toBe(0);
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    it('should still throw when rendering to undefined', () => {
-      class Component extends React.Component {
-        render() {}
-      }
+  it('should still throw when rendering to undefined', () => {
+    class Component extends React.Component {
+      render() {}
+    }
 
-      expect(function() {
-        ReactTestUtils.renderIntoDocument(<Component />);
-      }).toThrowError(
-        'Component(...): Nothing was returned from render. This usually means a return statement is missing. ' +
-          'Or, to render nothing, return null.',
-      );
-    });
-  }
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(<Component />);
+    }).toThrowError(
+      'Component(...): Nothing was returned from render. This usually means a return statement is missing. ' +
+        'Or, to render nothing, return null.',
+    );
+  });
 
   it('should be able to switch between rendering null and a normal tag', () => {
     var instance1 = (
@@ -233,15 +229,8 @@ describe('ReactEmptyComponent', () => {
 
   it('can render null at the top level', () => {
     var div = document.createElement('div');
-    if (ReactDOMFeatureFlags.useFiber) {
-      ReactDOM.render(null, div);
-      expect(div.innerHTML).toBe('');
-    } else {
-      // Stack does not implement this.
-      expect(function() {
-        ReactDOM.render(null, div);
-      }).toThrowError('ReactDOM.render(): Invalid component element.');
-    }
+    ReactDOM.render(null, div);
+    expect(div.innerHTML).toBe('');
   });
 
   it('does not break when updating during mount', () => {
@@ -293,21 +282,11 @@ describe('ReactEmptyComponent', () => {
 
     ReactDOM.render(<Empty />, container);
     var noscript1 = container.firstChild;
-    if (ReactDOMFeatureFlags.useFiber) {
-      expect(noscript1).toBe(null);
-    } else {
-      expect(noscript1.nodeName).toBe('#comment');
-    }
+    expect(noscript1).toBe(null);
 
     // This update shouldn't create a DOM node
     ReactDOM.render(<Empty />, container);
     var noscript2 = container.firstChild;
-    if (ReactDOMFeatureFlags.useFiber) {
-      expect(noscript1).toBe(null);
-    } else {
-      expect(noscript2.nodeName).toBe('#comment');
-    }
-
-    expect(noscript1).toBe(noscript2);
+    expect(noscript2).toBe(null);
   });
 });

--- a/src/renderers/__tests__/ReactErrorBoundaries-test.js
+++ b/src/renderers/__tests__/ReactErrorBoundaries-test.js
@@ -9,8 +9,6 @@
 
 'use strict';
 
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-
 var PropTypes;
 var React;
 var ReactDOM;
@@ -399,12 +397,7 @@ describe('ReactErrorBoundaries', () => {
         log.push('NoopErrorBoundary componentWillUnmount');
       }
       componentDidCatch() {
-        if (ReactDOMFeatureFlags.useFiber) {
-          log.push('NoopErrorBoundary componentDidCatch');
-        } else {
-          // In Stack, not calling setState() is treated as a rethrow.
-          log.push('NoopErrorBoundary componentDidCatch [*]');
-        }
+        log.push('NoopErrorBoundary componentDidCatch');
       }
     };
 
@@ -507,14 +500,9 @@ describe('ReactErrorBoundaries', () => {
         log.push('RetryErrorBoundary componentWillUnmount');
       }
       componentDidCatch(error) {
-        if (ReactDOMFeatureFlags.useFiber) {
-          log.push('RetryErrorBoundary componentDidCatch [!]');
-          // In Fiber, calling setState() (and failing) is treated as a rethrow.
-          this.setState({});
-        } else {
-          log.push('RetryErrorBoundary componentDidCatch [*]');
-          // In Stack, not calling setState() is treated as a rethrow.
-        }
+        log.push('RetryErrorBoundary componentDidCatch [!]');
+        // In Fiber, calling setState() (and failing) is treated as a rethrow.
+        this.setState({});
       }
     };
 
@@ -639,22 +627,13 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Fiber mounts with null children before capturing error
-            'ErrorBoundary componentDidMount',
-            // Catch and render an error message
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            // Catch and render an error message
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidMount',
-          ]),
+      // Fiber mounts with null children before capturing error
+      'ErrorBoundary componentDidMount',
+      // Catch and render an error message
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -676,22 +655,13 @@ describe('ReactErrorBoundaries', () => {
       'ErrorBoundary componentWillMount',
       'ErrorBoundary render success',
       'BrokenConstructor constructor [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Fiber mounts with null children before capturing error
-            'ErrorBoundary componentDidMount',
-            // Catch and render an error message
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            // Catch and render an error message
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidMount',
-          ]),
+      // Fiber mounts with null children before capturing error
+      'ErrorBoundary componentDidMount',
+      // Catch and render an error message
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -714,20 +684,11 @@ describe('ReactErrorBoundaries', () => {
       'ErrorBoundary render success',
       'BrokenComponentWillMount constructor',
       'BrokenComponentWillMount componentWillMount [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            'ErrorBoundary componentDidMount',
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            // Catch and render an error message
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidMount',
-          ]),
+      'ErrorBoundary componentDidMount',
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -806,29 +767,15 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            'ErrorBoundary componentDidMount',
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorMessage constructor',
-            'ErrorMessage componentWillMount',
-            'ErrorMessage render',
-            'ErrorMessage componentDidMount',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            // Handle the error:
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary render error',
-            // Mount the error message:
-            'ErrorMessage constructor',
-            'ErrorMessage componentWillMount',
-            'ErrorMessage render',
-            'ErrorMessage componentDidMount',
-            'ErrorBoundary componentDidMount',
-          ]),
+      'ErrorBoundary componentDidMount',
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorMessage constructor',
+      'ErrorMessage componentWillMount',
+      'ErrorMessage render',
+      'ErrorMessage componentDidMount',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -860,39 +807,22 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // In Fiber, failed error boundaries render null before attempting to recover
-            'RetryErrorBoundary componentDidMount',
-            'RetryErrorBoundary componentDidCatch [!]',
-            'ErrorBoundary componentDidMount',
-            // Retry
-            'RetryErrorBoundary render',
-            'BrokenRender constructor',
-            'BrokenRender componentWillMount',
-            'BrokenRender render [!]',
-            // This time, the error propagates to the higher boundary
-            'RetryErrorBoundary componentWillUnmount',
-            'ErrorBoundary componentDidCatch',
-            // Render the error
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            // The first error boundary catches the error.
-            // However, it doesn't adjust its state so next render will also fail.
-            'RetryErrorBoundary componentDidCatch [*]',
-            'RetryErrorBoundary render',
-            'BrokenRender constructor',
-            'BrokenRender componentWillMount',
-            'BrokenRender render [!]',
-            // This time, the error propagates to the higher boundary
-            'ErrorBoundary componentDidCatch',
-            // Render the error
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidMount',
-          ]),
+      // In Fiber, failed error boundaries render null before attempting to recover
+      'RetryErrorBoundary componentDidMount',
+      'RetryErrorBoundary componentDidCatch [!]',
+      'ErrorBoundary componentDidMount',
+      // Retry
+      'RetryErrorBoundary render',
+      'BrokenRender constructor',
+      'BrokenRender componentWillMount',
+      'BrokenRender render [!]',
+      // This time, the error propagates to the higher boundary
+      'RetryErrorBoundary componentWillUnmount',
+      'ErrorBoundary componentDidCatch',
+      // Render the error
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -916,20 +846,11 @@ describe('ReactErrorBoundaries', () => {
       'BrokenComponentWillMountErrorBoundary constructor',
       'BrokenComponentWillMountErrorBoundary componentWillMount [!]',
       // The error propagates to the higher boundary
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            'ErrorBoundary componentDidMount',
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            'ErrorBoundary componentDidCatch',
-            // Render the error
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidMount',
-          ]),
+      'ErrorBoundary componentDidMount',
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -960,31 +881,19 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender render [!]',
       // The first error boundary catches the error
       // It adjusts state but throws displaying the message
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Finish mounting with null children
-            'BrokenRenderErrorBoundary componentDidMount',
-            // Attempt to handle the error
-            'BrokenRenderErrorBoundary componentDidCatch',
-            'ErrorBoundary componentDidMount',
-            'BrokenRenderErrorBoundary render error [!]',
-            // Boundary fails with new error, propagate to next boundary
-            'BrokenRenderErrorBoundary componentWillUnmount',
-            // Attempt to handle the error again
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            'BrokenRenderErrorBoundary componentDidCatch',
-            'BrokenRenderErrorBoundary render error [!]',
-            // The error propagates to the higher boundary
-            'ErrorBoundary componentDidCatch',
-            // Render the error
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidMount',
-          ]),
+      // Finish mounting with null children
+      'BrokenRenderErrorBoundary componentDidMount',
+      // Attempt to handle the error
+      'BrokenRenderErrorBoundary componentDidCatch',
+      'ErrorBoundary componentDidMount',
+      'BrokenRenderErrorBoundary render error [!]',
+      // Boundary fails with new error, propagate to next boundary
+      'BrokenRenderErrorBoundary componentWillUnmount',
+      // Attempt to handle the error again
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -1015,23 +924,14 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Finish mounting with null children
-            'ErrorBoundary componentDidMount',
-            // Handle the error
-            'ErrorBoundary componentDidCatch',
-            // Render the error message
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            'ErrorBoundary componentDidCatch',
-            // Render the error message
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidMount',
-          ]),
+      // Finish mounting with null children
+      'ErrorBoundary componentDidMount',
+      // Handle the error
+      'ErrorBoundary componentDidCatch',
+      // Render the error message
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -1064,28 +964,15 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
       // Handle error:
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Finish mounting with null children
-            'ErrorBoundary componentDidMount',
-            // Handle the error
-            'ErrorBoundary componentDidCatch',
-            // Render the error message
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'Error message ref is set to [object HTMLDivElement]',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            'ErrorBoundary componentDidCatch',
-            // Stack reconciler resets ref on update, as it doesn't know ref was never set.
-            // This is unnecessary, and Fiber doesn't do it:
-            'Child ref is set to null',
-            'ErrorBoundary render error',
-            // Ref to error message should get set:
-            'Error message ref is set to [object HTMLDivElement]',
-            'ErrorBoundary componentDidMount',
-          ]),
+      // Finish mounting with null children
+      'ErrorBoundary componentDidMount',
+      // Handle the error
+      'ErrorBoundary componentDidCatch',
+      // Render the error message
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'Error message ref is set to [object HTMLDivElement]',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -1149,26 +1036,15 @@ describe('ReactErrorBoundaries', () => {
       'Normal2 render',
       // BrokenConstructor will abort rendering:
       'BrokenConstructor constructor [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Finish updating with null children
-            'Normal componentWillUnmount',
-            'ErrorBoundary componentDidUpdate',
-            // Handle the error
-            'ErrorBoundary componentDidCatch',
-            // Render the error message
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            'ErrorBoundary componentDidCatch',
-            // Stack unmounts first, then renders:
-            'Normal componentWillUnmount',
-            'ErrorBoundary render error',
-            // Normal2 does not get lifefycle because it was never mounted
-            'ErrorBoundary componentDidUpdate',
-          ]),
+      // Finish updating with null children
+      'Normal componentWillUnmount',
+      'ErrorBoundary componentDidUpdate',
+      // Handle the error
+      'ErrorBoundary componentDidCatch',
+      // Render the error message
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -1209,26 +1085,15 @@ describe('ReactErrorBoundaries', () => {
       // BrokenComponentWillMount will abort rendering:
       'BrokenComponentWillMount constructor',
       'BrokenComponentWillMount componentWillMount [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Finish updating with null children
-            'Normal componentWillUnmount',
-            'ErrorBoundary componentDidUpdate',
-            // Handle the error
-            'ErrorBoundary componentDidCatch',
-            // Render the error message
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            'ErrorBoundary componentDidCatch',
-            // Stack unmounts first, then renders:
-            'Normal componentWillUnmount',
-            'ErrorBoundary render error',
-            // Normal2 does not get lifefycle because it was never mounted
-            'ErrorBoundary componentDidUpdate',
-          ]),
+      // Finish updating with null children
+      'Normal componentWillUnmount',
+      'ErrorBoundary componentDidUpdate',
+      // Handle the error
+      'ErrorBoundary componentDidCatch',
+      // Render the error message
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -1264,26 +1129,15 @@ describe('ReactErrorBoundaries', () => {
       'Normal render',
       // BrokenComponentWillReceiveProps will abort rendering:
       'BrokenComponentWillReceiveProps componentWillReceiveProps [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Finish updating with null children
-            'Normal componentWillUnmount',
-            'BrokenComponentWillReceiveProps componentWillUnmount',
-            'ErrorBoundary componentDidUpdate',
-            // Handle the error
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            'ErrorBoundary componentDidCatch',
-            // Stack unmounts first, then renders:
-            'Normal componentWillUnmount',
-            'BrokenComponentWillReceiveProps componentWillUnmount',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]),
+      // Finish updating with null children
+      'Normal componentWillUnmount',
+      'BrokenComponentWillReceiveProps componentWillUnmount',
+      'ErrorBoundary componentDidUpdate',
+      // Handle the error
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -1320,26 +1174,15 @@ describe('ReactErrorBoundaries', () => {
       // BrokenComponentWillUpdate will abort rendering:
       'BrokenComponentWillUpdate componentWillReceiveProps',
       'BrokenComponentWillUpdate componentWillUpdate [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Finish updating with null children
-            'Normal componentWillUnmount',
-            'BrokenComponentWillUpdate componentWillUnmount',
-            'ErrorBoundary componentDidUpdate',
-            // Handle the error
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            'ErrorBoundary componentDidCatch',
-            // Stack unmounts first, then renders:
-            'Normal componentWillUnmount',
-            'BrokenComponentWillUpdate componentWillUnmount',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]),
+      // Finish updating with null children
+      'Normal componentWillUnmount',
+      'BrokenComponentWillUpdate componentWillUnmount',
+      'ErrorBoundary componentDidUpdate',
+      // Handle the error
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -1381,25 +1224,14 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Finish updating with null children
-            'Normal componentWillUnmount',
-            'ErrorBoundary componentDidUpdate',
-            // Handle the error
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            'ErrorBoundary componentDidCatch',
-            // Stack unmounts first, then renders:
-            'Normal componentWillUnmount',
-            'ErrorBoundary render error',
-            // Normal2 does not get lifefycle because it was never mounted
-            'ErrorBoundary componentDidUpdate',
-          ]),
+      // Finish updating with null children
+      'Normal componentWillUnmount',
+      'ErrorBoundary componentDidUpdate',
+      // Handle the error
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -1451,22 +1283,13 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Finish updating with null children
-            'Child1 ref is set to null',
-            'ErrorBoundary componentDidUpdate',
-            // Handle the error
-            'ErrorBoundary componentDidCatch',
-            'ErrorBoundary componentWillUpdate',
-            'ErrorBoundary render error',
-          ]
-        : [
-            'ErrorBoundary componentDidCatch',
-            // Stack resets ref first, renders later
-            'Child1 ref is set to null',
-            'ErrorBoundary render error',
-          ]),
+      // Finish updating with null children
+      'Child1 ref is set to null',
+      'ErrorBoundary componentDidUpdate',
+      // Handle the error
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
       'Error message ref is set to [object HTMLDivElement]',
       // Child2 ref is never set because its mounting aborted
       'ErrorBoundary componentDidUpdate',
@@ -1509,35 +1332,22 @@ describe('ReactErrorBoundaries', () => {
       'BrokenComponentWillUnmount render',
       // Unmounting throws:
       'BrokenComponentWillUnmount componentWillUnmount [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Fiber proceeds with lifecycles despite errors
-            'Normal componentWillUnmount',
-            // The components have updated in this phase
-            'BrokenComponentWillUnmount componentDidUpdate',
-            'ErrorBoundary componentDidUpdate',
-            // Now that commit phase is done, Fiber unmounts the boundary's children
-            'BrokenComponentWillUnmount componentWillUnmount [!]',
-            'ErrorBoundary componentDidCatch',
-            // The initial render was aborted, so
-            // Fiber retries from the root.
-            'ErrorBoundary componentWillUpdate',
-            // Render an error now (stack will do it later)
-            'ErrorBoundary render error',
-            // Attempt to unmount previous child:
-            // Done
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            // Stack will handle error immediately
-            'ErrorBoundary componentDidCatch',
-            // Attempt to unmount previous children:
-            'BrokenComponentWillUnmount componentWillUnmount [!]',
-            'Normal componentWillUnmount',
-            // Render an error now (Fiber will do it earlier)
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]),
+      // Fiber proceeds with lifecycles despite errors
+      'Normal componentWillUnmount',
+      // The components have updated in this phase
+      'BrokenComponentWillUnmount componentDidUpdate',
+      'ErrorBoundary componentDidUpdate',
+      // Now that commit phase is done, Fiber unmounts the boundary's children
+      'BrokenComponentWillUnmount componentWillUnmount [!]',
+      'ErrorBoundary componentDidCatch',
+      // The initial render was aborted, so
+      // Fiber retries from the root.
+      'ErrorBoundary componentWillUpdate',
+      // Render an error now (stack will do it later)
+      'ErrorBoundary render error',
+      // Attempt to unmount previous child:
+      // Done
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -1580,33 +1390,21 @@ describe('ReactErrorBoundaries', () => {
       'BrokenComponentWillUnmount render',
       // Unmounting throws:
       'BrokenComponentWillUnmount componentWillUnmount [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Fiber proceeds with lifecycles despite errors
-            'BrokenComponentWillUnmount componentDidUpdate',
-            'Normal componentDidUpdate',
-            'ErrorBoundary componentDidUpdate',
-            'Normal componentWillUnmount',
-            'BrokenComponentWillUnmount componentWillUnmount [!]',
-            // Now that commit phase is done, Fiber handles errors
-            'ErrorBoundary componentDidCatch',
-            // The initial render was aborted, so
-            // Fiber retries from the root.
-            'ErrorBoundary componentWillUpdate',
-            // Render an error now (stack will do it later)
-            'ErrorBoundary render error',
-            // Done
-            'ErrorBoundary componentDidUpdate',
-          ]
-        : [
-            'ErrorBoundary componentDidCatch',
-            // Attempt to unmount previous children:
-            'Normal componentWillUnmount',
-            'BrokenComponentWillUnmount componentWillUnmount [!]',
-            // Stack calls lifecycles first, then renders.
-            'ErrorBoundary render error',
-            'ErrorBoundary componentDidUpdate',
-          ]),
+      // Fiber proceeds with lifecycles despite errors
+      'BrokenComponentWillUnmount componentDidUpdate',
+      'Normal componentDidUpdate',
+      'ErrorBoundary componentDidUpdate',
+      'Normal componentWillUnmount',
+      'BrokenComponentWillUnmount componentWillUnmount [!]',
+      // Now that commit phase is done, Fiber handles errors
+      'ErrorBoundary componentDidCatch',
+      // The initial render was aborted, so
+      // Fiber retries from the root.
+      'ErrorBoundary componentWillUpdate',
+      // Render an error now (stack will do it later)
+      'ErrorBoundary render error',
+      // Done
+      'ErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -1660,31 +1458,19 @@ describe('ReactErrorBoundaries', () => {
       'InnerErrorBoundary render success',
       // Try unmounting child
       'BrokenComponentWillUnmount componentWillUnmount [!]',
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            // Fiber proceeds with lifecycles despite errors
-            // Inner and outer boundaries have updated in this phase
-            'InnerErrorBoundary componentDidUpdate',
-            'OuterErrorBoundary componentDidUpdate',
-            // Now that commit phase is done, Fiber handles errors
-            // Only inner boundary receives the error:
-            'InnerErrorBoundary componentDidCatch',
-            'InnerErrorBoundary componentWillUpdate',
-            // Render an error now
-            'InnerErrorBoundary render error',
-            // In Fiber, this was a local update to the
-            // inner boundary so only its hook fires
-            'InnerErrorBoundary componentDidUpdate',
-          ]
-        : [
-            // Stack will handle error immediately
-            'InnerErrorBoundary componentDidCatch',
-            'InnerErrorBoundary render error',
-            // In stack, this was a part of the update to the
-            // outer boundary so both lifecycles fire
-            'InnerErrorBoundary componentDidUpdate',
-            'OuterErrorBoundary componentDidUpdate',
-          ]),
+      // Fiber proceeds with lifecycles despite errors
+      // Inner and outer boundaries have updated in this phase
+      'InnerErrorBoundary componentDidUpdate',
+      'OuterErrorBoundary componentDidUpdate',
+      // Now that commit phase is done, Fiber handles errors
+      // Only inner boundary receives the error:
+      'InnerErrorBoundary componentDidCatch',
+      'InnerErrorBoundary componentWillUpdate',
+      // Render an error now
+      'InnerErrorBoundary render error',
+      // In Fiber, this was a local update to the
+      // inner boundary so only its hook fires
+      'InnerErrorBoundary componentDidUpdate',
     ]);
 
     log.length = 0;
@@ -1856,374 +1642,371 @@ describe('ReactErrorBoundaries', () => {
     expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
   });
 
-  // The tests below implement new features in Fiber.
-  if (ReactDOMFeatureFlags.useFiber) {
-    it('catches errors originating downstream', () => {
-      var fail = false;
-      class Stateful extends React.Component {
-        state = {shouldThrow: false};
+  it('catches errors originating downstream', () => {
+    var fail = false;
+    class Stateful extends React.Component {
+      state = {shouldThrow: false};
 
-        render() {
-          if (fail) {
-            log.push('Stateful render [!]');
-            throw new Error('Hello');
-          }
-          return <div>{this.props.children}</div>;
+      render() {
+        if (fail) {
+          log.push('Stateful render [!]');
+          throw new Error('Hello');
         }
+        return <div>{this.props.children}</div>;
       }
+    }
 
-      var statefulInst;
-      var container = document.createElement('div');
-      ReactDOM.render(
-        <ErrorBoundary>
-          <Stateful ref={inst => (statefulInst = inst)} />
-        </ErrorBoundary>,
-        container,
-      );
+    var statefulInst;
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary>
+        <Stateful ref={inst => (statefulInst = inst)} />
+      </ErrorBoundary>,
+      container,
+    );
 
-      log.length = 0;
-      expect(() => {
-        fail = true;
-        statefulInst.forceUpdate();
-      }).not.toThrow();
+    log.length = 0;
+    expect(() => {
+      fail = true;
+      statefulInst.forceUpdate();
+    }).not.toThrow();
 
-      expect(log).toEqual([
-        'Stateful render [!]',
-        'ErrorBoundary componentDidCatch',
-        'ErrorBoundary componentWillUpdate',
-        'ErrorBoundary render error',
-        'ErrorBoundary componentDidUpdate',
-      ]);
+    expect(log).toEqual([
+      'Stateful render [!]',
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
+    ]);
 
-      log.length = 0;
-      ReactDOM.unmountComponentAtNode(container);
-      expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
-    });
+    log.length = 0;
+    ReactDOM.unmountComponentAtNode(container);
+    expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
+  });
 
-    it('catches errors in componentDidMount', () => {
-      var container = document.createElement('div');
-      ReactDOM.render(
-        <ErrorBoundary>
-          <BrokenComponentWillUnmount>
-            <Normal />
-          </BrokenComponentWillUnmount>
-          <BrokenComponentDidMount />
-          <Normal logName="LastChild" />
-        </ErrorBoundary>,
-        container,
-      );
-      expect(log).toEqual([
-        'ErrorBoundary constructor',
-        'ErrorBoundary componentWillMount',
-        'ErrorBoundary render success',
-        'BrokenComponentWillUnmount constructor',
-        'BrokenComponentWillUnmount componentWillMount',
-        'BrokenComponentWillUnmount render',
-        'Normal constructor',
-        'Normal componentWillMount',
-        'Normal render',
-        'BrokenComponentDidMount constructor',
-        'BrokenComponentDidMount componentWillMount',
-        'BrokenComponentDidMount render',
-        'LastChild constructor',
-        'LastChild componentWillMount',
-        'LastChild render',
-        // Start flushing didMount queue
-        'Normal componentDidMount',
-        'BrokenComponentWillUnmount componentDidMount',
-        'BrokenComponentDidMount componentDidMount [!]',
-        // Continue despite the error
-        'LastChild componentDidMount',
-        'ErrorBoundary componentDidMount',
-        // Now we are ready to handle the error
-        // Safely unmount every child
-        'BrokenComponentWillUnmount componentWillUnmount [!]',
-        // Continue unmounting safely despite any errors
-        'Normal componentWillUnmount',
-        'BrokenComponentDidMount componentWillUnmount',
-        'LastChild componentWillUnmount',
-        // Handle the error
-        'ErrorBoundary componentDidCatch',
-        'ErrorBoundary componentWillUpdate',
-        'ErrorBoundary render error',
-        // The update has finished
-        'ErrorBoundary componentDidUpdate',
-      ]);
+  it('catches errors in componentDidMount', () => {
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary>
+        <BrokenComponentWillUnmount>
+          <Normal />
+        </BrokenComponentWillUnmount>
+        <BrokenComponentDidMount />
+        <Normal logName="LastChild" />
+      </ErrorBoundary>,
+      container,
+    );
+    expect(log).toEqual([
+      'ErrorBoundary constructor',
+      'ErrorBoundary componentWillMount',
+      'ErrorBoundary render success',
+      'BrokenComponentWillUnmount constructor',
+      'BrokenComponentWillUnmount componentWillMount',
+      'BrokenComponentWillUnmount render',
+      'Normal constructor',
+      'Normal componentWillMount',
+      'Normal render',
+      'BrokenComponentDidMount constructor',
+      'BrokenComponentDidMount componentWillMount',
+      'BrokenComponentDidMount render',
+      'LastChild constructor',
+      'LastChild componentWillMount',
+      'LastChild render',
+      // Start flushing didMount queue
+      'Normal componentDidMount',
+      'BrokenComponentWillUnmount componentDidMount',
+      'BrokenComponentDidMount componentDidMount [!]',
+      // Continue despite the error
+      'LastChild componentDidMount',
+      'ErrorBoundary componentDidMount',
+      // Now we are ready to handle the error
+      // Safely unmount every child
+      'BrokenComponentWillUnmount componentWillUnmount [!]',
+      // Continue unmounting safely despite any errors
+      'Normal componentWillUnmount',
+      'BrokenComponentDidMount componentWillUnmount',
+      'LastChild componentWillUnmount',
+      // Handle the error
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      // The update has finished
+      'ErrorBoundary componentDidUpdate',
+    ]);
 
-      log.length = 0;
-      ReactDOM.unmountComponentAtNode(container);
-      expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
-    });
+    log.length = 0;
+    ReactDOM.unmountComponentAtNode(container);
+    expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
+  });
 
-    it('catches errors in componentDidUpdate', () => {
-      var container = document.createElement('div');
-      ReactDOM.render(
-        <ErrorBoundary>
-          <BrokenComponentDidUpdate />
-        </ErrorBoundary>,
-        container,
-      );
+  it('catches errors in componentDidUpdate', () => {
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary>
+        <BrokenComponentDidUpdate />
+      </ErrorBoundary>,
+      container,
+    );
 
-      log.length = 0;
-      ReactDOM.render(
-        <ErrorBoundary>
-          <BrokenComponentDidUpdate />
-        </ErrorBoundary>,
-        container,
-      );
-      expect(log).toEqual([
-        'ErrorBoundary componentWillReceiveProps',
-        'ErrorBoundary componentWillUpdate',
-        'ErrorBoundary render success',
-        'BrokenComponentDidUpdate componentWillReceiveProps',
-        'BrokenComponentDidUpdate componentWillUpdate',
-        'BrokenComponentDidUpdate render',
-        // All lifecycles run
-        'BrokenComponentDidUpdate componentDidUpdate [!]',
-        'ErrorBoundary componentDidUpdate',
-        'BrokenComponentDidUpdate componentWillUnmount',
-        // Then, error is handled
-        'ErrorBoundary componentDidCatch',
-        'ErrorBoundary componentWillUpdate',
-        'ErrorBoundary render error',
-        'ErrorBoundary componentDidUpdate',
-      ]);
+    log.length = 0;
+    ReactDOM.render(
+      <ErrorBoundary>
+        <BrokenComponentDidUpdate />
+      </ErrorBoundary>,
+      container,
+    );
+    expect(log).toEqual([
+      'ErrorBoundary componentWillReceiveProps',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render success',
+      'BrokenComponentDidUpdate componentWillReceiveProps',
+      'BrokenComponentDidUpdate componentWillUpdate',
+      'BrokenComponentDidUpdate render',
+      // All lifecycles run
+      'BrokenComponentDidUpdate componentDidUpdate [!]',
+      'ErrorBoundary componentDidUpdate',
+      'BrokenComponentDidUpdate componentWillUnmount',
+      // Then, error is handled
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
+    ]);
 
-      log.length = 0;
-      ReactDOM.unmountComponentAtNode(container);
-      expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
-    });
+    log.length = 0;
+    ReactDOM.unmountComponentAtNode(container);
+    expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
+  });
 
-    it('propagates errors inside boundary during componentDidMount', () => {
-      var container = document.createElement('div');
-      ReactDOM.render(
-        <ErrorBoundary>
-          <BrokenComponentDidMountErrorBoundary
-            renderError={error => (
-              <div>
-                We should never catch our own error: {error.message}.
-              </div>
-            )}
-          />
-        </ErrorBoundary>,
-        container,
-      );
-      expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
-      expect(log).toEqual([
-        'ErrorBoundary constructor',
-        'ErrorBoundary componentWillMount',
-        'ErrorBoundary render success',
-        'BrokenComponentDidMountErrorBoundary constructor',
-        'BrokenComponentDidMountErrorBoundary componentWillMount',
-        'BrokenComponentDidMountErrorBoundary render success',
-        'BrokenComponentDidMountErrorBoundary componentDidMount [!]',
-        // Fiber proceeds with the hooks
-        'ErrorBoundary componentDidMount',
-        'BrokenComponentDidMountErrorBoundary componentWillUnmount',
-        // The error propagates to the higher boundary
-        'ErrorBoundary componentDidCatch',
-        // Fiber retries from the root
-        'ErrorBoundary componentWillUpdate',
-        'ErrorBoundary render error',
-        'ErrorBoundary componentDidUpdate',
-      ]);
+  it('propagates errors inside boundary during componentDidMount', () => {
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary>
+        <BrokenComponentDidMountErrorBoundary
+          renderError={error => (
+            <div>
+              We should never catch our own error: {error.message}.
+            </div>
+          )}
+        />
+      </ErrorBoundary>,
+      container,
+    );
+    expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
+    expect(log).toEqual([
+      'ErrorBoundary constructor',
+      'ErrorBoundary componentWillMount',
+      'ErrorBoundary render success',
+      'BrokenComponentDidMountErrorBoundary constructor',
+      'BrokenComponentDidMountErrorBoundary componentWillMount',
+      'BrokenComponentDidMountErrorBoundary render success',
+      'BrokenComponentDidMountErrorBoundary componentDidMount [!]',
+      // Fiber proceeds with the hooks
+      'ErrorBoundary componentDidMount',
+      'BrokenComponentDidMountErrorBoundary componentWillUnmount',
+      // The error propagates to the higher boundary
+      'ErrorBoundary componentDidCatch',
+      // Fiber retries from the root
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
+    ]);
 
-      log.length = 0;
-      ReactDOM.unmountComponentAtNode(container);
-      expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
-    });
+    log.length = 0;
+    ReactDOM.unmountComponentAtNode(container);
+    expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
+  });
 
-    it('lets different boundaries catch their own first errors', () => {
-      function renderUnmountError(error) {
-        return <div>Caught an unmounting error: {error.message}.</div>;
+  it('lets different boundaries catch their own first errors', () => {
+    function renderUnmountError(error) {
+      return <div>Caught an unmounting error: {error.message}.</div>;
+    }
+    function renderUpdateError(error) {
+      return <div>Caught an updating error: {error.message}.</div>;
+    }
+
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary logName="OuterErrorBoundary">
+        <ErrorBoundary
+          logName="InnerUnmountBoundary"
+          renderError={renderUnmountError}>
+          <BrokenComponentWillUnmount errorText="E1" />
+          <BrokenComponentWillUnmount errorText="E2" />
+        </ErrorBoundary>
+        <ErrorBoundary
+          logName="InnerUpdateBoundary"
+          renderError={renderUpdateError}>
+          <BrokenComponentDidUpdate errorText="E3" />
+          <BrokenComponentDidUpdate errorText="E4" />
+        </ErrorBoundary>
+      </ErrorBoundary>,
+      container,
+    );
+
+    log.length = 0;
+    ReactDOM.render(
+      <ErrorBoundary logName="OuterErrorBoundary">
+        <ErrorBoundary
+          logName="InnerUnmountBoundary"
+          renderError={renderUnmountError}
+        />
+        <ErrorBoundary
+          logName="InnerUpdateBoundary"
+          renderError={renderUpdateError}>
+          <BrokenComponentDidUpdate errorText="E3" />
+          <BrokenComponentDidUpdate errorText="E4" />
+        </ErrorBoundary>
+      </ErrorBoundary>,
+      container,
+    );
+
+    expect(container.firstChild.textContent).toBe(
+      'Caught an unmounting error: E1.' + 'Caught an updating error: E3.',
+    );
+    expect(log).toEqual([
+      // Begin update phase
+      'OuterErrorBoundary componentWillReceiveProps',
+      'OuterErrorBoundary componentWillUpdate',
+      'OuterErrorBoundary render success',
+      'InnerUnmountBoundary componentWillReceiveProps',
+      'InnerUnmountBoundary componentWillUpdate',
+      'InnerUnmountBoundary render success',
+      'InnerUpdateBoundary componentWillReceiveProps',
+      'InnerUpdateBoundary componentWillUpdate',
+      'InnerUpdateBoundary render success',
+      // First come the updates
+      'BrokenComponentDidUpdate componentWillReceiveProps',
+      'BrokenComponentDidUpdate componentWillUpdate',
+      'BrokenComponentDidUpdate render',
+      'BrokenComponentDidUpdate componentWillReceiveProps',
+      'BrokenComponentDidUpdate componentWillUpdate',
+      'BrokenComponentDidUpdate render',
+      // We're in commit phase now, deleting
+      'BrokenComponentWillUnmount componentWillUnmount [!]',
+      'BrokenComponentWillUnmount componentWillUnmount [!]',
+      // Continue despite errors, handle them after commit is done
+      'InnerUnmountBoundary componentDidUpdate',
+      // We're still in commit phase, now calling update lifecycles
+      'BrokenComponentDidUpdate componentDidUpdate [!]',
+      // Again, continue despite errors, we'll handle them later
+      'BrokenComponentDidUpdate componentDidUpdate [!]',
+      'InnerUpdateBoundary componentDidUpdate',
+      'OuterErrorBoundary componentDidUpdate',
+      // After the commit phase, attempt to recover from any errors that
+      // were captured
+      'BrokenComponentDidUpdate componentWillUnmount',
+      'BrokenComponentDidUpdate componentWillUnmount',
+      'InnerUnmountBoundary componentDidCatch',
+      'InnerUpdateBoundary componentDidCatch',
+      'InnerUnmountBoundary componentWillUpdate',
+      'InnerUnmountBoundary render error',
+      'InnerUpdateBoundary componentWillUpdate',
+      'InnerUpdateBoundary render error',
+      'InnerUnmountBoundary componentDidUpdate',
+      'InnerUpdateBoundary componentDidUpdate',
+    ]);
+
+    log.length = 0;
+    ReactDOM.unmountComponentAtNode(container);
+    expect(log).toEqual([
+      'OuterErrorBoundary componentWillUnmount',
+      'InnerUnmountBoundary componentWillUnmount',
+      'InnerUpdateBoundary componentWillUnmount',
+    ]);
+  });
+
+  it('discards a bad root if the root component fails', () => {
+    spyOn(console, 'error');
+
+    const X = null;
+    const Y = undefined;
+    let err1;
+    let err2;
+
+    try {
+      let container = document.createElement('div');
+      ReactDOM.render(<X />, container);
+    } catch (err) {
+      err1 = err;
+    }
+    try {
+      let container = document.createElement('div');
+      ReactDOM.render(<Y />, container);
+    } catch (err) {
+      err2 = err;
+    }
+
+    expect(err1.message).toMatch(/got: null/);
+    expect(err2.message).toMatch(/got: undefined/);
+  });
+
+  it('renders empty output if error boundary does not handle the error', () => {
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <div>
+        Sibling
+        <NoopErrorBoundary>
+          <BrokenRender />
+        </NoopErrorBoundary>
+      </div>,
+      container,
+    );
+    expect(container.firstChild.textContent).toBe('Sibling');
+    expect(log).toEqual([
+      'NoopErrorBoundary constructor',
+      'NoopErrorBoundary componentWillMount',
+      'NoopErrorBoundary render',
+      'BrokenRender constructor',
+      'BrokenRender componentWillMount',
+      'BrokenRender render [!]',
+      // In Fiber, noop error boundaries render null
+      'NoopErrorBoundary componentDidMount',
+      'NoopErrorBoundary componentDidCatch',
+      // Nothing happens.
+    ]);
+
+    log.length = 0;
+    ReactDOM.unmountComponentAtNode(container);
+    expect(log).toEqual(['NoopErrorBoundary componentWillUnmount']);
+  });
+
+  it('passes first error when two errors happen in commit', () => {
+    const errors = [];
+    let caughtError;
+    class Parent extends React.Component {
+      render() {
+        return <Child />;
       }
-      function renderUpdateError(error) {
-        return <div>Caught an updating error: {error.message}.</div>;
+      componentDidMount() {
+        errors.push('parent sad');
+        throw new Error('parent sad');
       }
-
-      var container = document.createElement('div');
-      ReactDOM.render(
-        <ErrorBoundary logName="OuterErrorBoundary">
-          <ErrorBoundary
-            logName="InnerUnmountBoundary"
-            renderError={renderUnmountError}>
-            <BrokenComponentWillUnmount errorText="E1" />
-            <BrokenComponentWillUnmount errorText="E2" />
-          </ErrorBoundary>
-          <ErrorBoundary
-            logName="InnerUpdateBoundary"
-            renderError={renderUpdateError}>
-            <BrokenComponentDidUpdate errorText="E3" />
-            <BrokenComponentDidUpdate errorText="E4" />
-          </ErrorBoundary>
-        </ErrorBoundary>,
-        container,
-      );
-
-      log.length = 0;
-      ReactDOM.render(
-        <ErrorBoundary logName="OuterErrorBoundary">
-          <ErrorBoundary
-            logName="InnerUnmountBoundary"
-            renderError={renderUnmountError}
-          />
-          <ErrorBoundary
-            logName="InnerUpdateBoundary"
-            renderError={renderUpdateError}>
-            <BrokenComponentDidUpdate errorText="E3" />
-            <BrokenComponentDidUpdate errorText="E4" />
-          </ErrorBoundary>
-        </ErrorBoundary>,
-        container,
-      );
-
-      expect(container.firstChild.textContent).toBe(
-        'Caught an unmounting error: E1.' + 'Caught an updating error: E3.',
-      );
-      expect(log).toEqual([
-        // Begin update phase
-        'OuterErrorBoundary componentWillReceiveProps',
-        'OuterErrorBoundary componentWillUpdate',
-        'OuterErrorBoundary render success',
-        'InnerUnmountBoundary componentWillReceiveProps',
-        'InnerUnmountBoundary componentWillUpdate',
-        'InnerUnmountBoundary render success',
-        'InnerUpdateBoundary componentWillReceiveProps',
-        'InnerUpdateBoundary componentWillUpdate',
-        'InnerUpdateBoundary render success',
-        // First come the updates
-        'BrokenComponentDidUpdate componentWillReceiveProps',
-        'BrokenComponentDidUpdate componentWillUpdate',
-        'BrokenComponentDidUpdate render',
-        'BrokenComponentDidUpdate componentWillReceiveProps',
-        'BrokenComponentDidUpdate componentWillUpdate',
-        'BrokenComponentDidUpdate render',
-        // We're in commit phase now, deleting
-        'BrokenComponentWillUnmount componentWillUnmount [!]',
-        'BrokenComponentWillUnmount componentWillUnmount [!]',
-        // Continue despite errors, handle them after commit is done
-        'InnerUnmountBoundary componentDidUpdate',
-        // We're still in commit phase, now calling update lifecycles
-        'BrokenComponentDidUpdate componentDidUpdate [!]',
-        // Again, continue despite errors, we'll handle them later
-        'BrokenComponentDidUpdate componentDidUpdate [!]',
-        'InnerUpdateBoundary componentDidUpdate',
-        'OuterErrorBoundary componentDidUpdate',
-        // After the commit phase, attempt to recover from any errors that
-        // were captured
-        'BrokenComponentDidUpdate componentWillUnmount',
-        'BrokenComponentDidUpdate componentWillUnmount',
-        'InnerUnmountBoundary componentDidCatch',
-        'InnerUpdateBoundary componentDidCatch',
-        'InnerUnmountBoundary componentWillUpdate',
-        'InnerUnmountBoundary render error',
-        'InnerUpdateBoundary componentWillUpdate',
-        'InnerUpdateBoundary render error',
-        'InnerUnmountBoundary componentDidUpdate',
-        'InnerUpdateBoundary componentDidUpdate',
-      ]);
-
-      log.length = 0;
-      ReactDOM.unmountComponentAtNode(container);
-      expect(log).toEqual([
-        'OuterErrorBoundary componentWillUnmount',
-        'InnerUnmountBoundary componentWillUnmount',
-        'InnerUpdateBoundary componentWillUnmount',
-      ]);
-    });
-
-    it('discards a bad root if the root component fails', () => {
-      spyOn(console, 'error');
-
-      const X = null;
-      const Y = undefined;
-      let err1;
-      let err2;
-
-      try {
-        let container = document.createElement('div');
-        ReactDOM.render(<X />, container);
-      } catch (err) {
-        err1 = err;
+    }
+    class Child extends React.Component {
+      render() {
+        return <div />;
       }
-      try {
-        let container = document.createElement('div');
-        ReactDOM.render(<Y />, container);
-      } catch (err) {
-        err2 = err;
+      componentDidMount() {
+        errors.push('child sad');
+        throw new Error('child sad');
       }
+    }
 
-      expect(err1.message).toMatch(/got: null/);
-      expect(err2.message).toMatch(/got: undefined/);
-    });
-
-    it('renders empty output if error boundary does not handle the error', () => {
-      var container = document.createElement('div');
-      ReactDOM.render(
-        <div>
-          Sibling
-          <NoopErrorBoundary>
-            <BrokenRender />
-          </NoopErrorBoundary>
-        </div>,
-        container,
-      );
-      expect(container.firstChild.textContent).toBe('Sibling');
-      expect(log).toEqual([
-        'NoopErrorBoundary constructor',
-        'NoopErrorBoundary componentWillMount',
-        'NoopErrorBoundary render',
-        'BrokenRender constructor',
-        'BrokenRender componentWillMount',
-        'BrokenRender render [!]',
-        // In Fiber, noop error boundaries render null
-        'NoopErrorBoundary componentDidMount',
-        'NoopErrorBoundary componentDidCatch',
-        // Nothing happens.
-      ]);
-
-      log.length = 0;
-      ReactDOM.unmountComponentAtNode(container);
-      expect(log).toEqual(['NoopErrorBoundary componentWillUnmount']);
-    });
-
-    it('passes first error when two errors happen in commit', () => {
-      const errors = [];
-      let caughtError;
-      class Parent extends React.Component {
-        render() {
-          return <Child />;
-        }
-        componentDidMount() {
-          errors.push('parent sad');
-          throw new Error('parent sad');
-        }
+    var container = document.createElement('div');
+    try {
+      // Here, we test the behavior where there is no error boundary and we
+      // delegate to the host root.
+      ReactDOM.render(<Parent />, container);
+    } catch (e) {
+      if (e.message !== 'parent sad' && e.message !== 'child sad') {
+        throw e;
       }
-      class Child extends React.Component {
-        render() {
-          return <div />;
-        }
-        componentDidMount() {
-          errors.push('child sad');
-          throw new Error('child sad');
-        }
-      }
+      caughtError = e;
+    }
 
-      var container = document.createElement('div');
-      try {
-        // Here, we test the behavior where there is no error boundary and we
-        // delegate to the host root.
-        ReactDOM.render(<Parent />, container);
-      } catch (e) {
-        if (e.message !== 'parent sad' && e.message !== 'child sad') {
-          throw e;
-        }
-        caughtError = e;
-      }
-
-      expect(errors).toEqual(['child sad', 'parent sad']);
-      // Error should be the first thrown
-      expect(caughtError.message).toBe('child sad');
-    });
-  }
+    expect(errors).toEqual(['child sad', 'parent sad']);
+    // Error should be the first thrown
+    expect(caughtError.message).toBe('child sad');
+  });
 });

--- a/src/renderers/__tests__/ReactHostOperationHistoryHook-test.js
+++ b/src/renderers/__tests__/ReactHostOperationHistoryHook-test.js
@@ -9,12 +9,9 @@
 
 'use strict';
 
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-var describeStack = ReactDOMFeatureFlags.useFiber ? describe.skip : describe;
-
 // This is only used by ReactPerf which is currently not supported on Fiber.
 // Use browser timeline integration instead.
-describeStack('ReactHostOperationHistoryHook', () => {
+describe.skip('ReactHostOperationHistoryHook', () => {
   var React;
   var ReactPerf;
   var ReactDOM;

--- a/src/renderers/__tests__/ReactMultiChild-test.js
+++ b/src/renderers/__tests__/ReactMultiChild-test.js
@@ -16,13 +16,11 @@ describe('ReactMultiChild', () => {
 
   var React;
   var ReactDOM;
-  var ReactDOMFeatureFlags;
 
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
   });
 
   describe('reconciliation', () => {
@@ -280,8 +278,7 @@ describe('ReactMultiChild', () => {
       'Warning: Using Maps as children is unsupported and will likely yield ' +
         'unexpected results. Convert it to a sequence/iterable of keyed ' +
         'ReactElements instead.\n' +
-        // Fiber gives a slightly better stack with the nearest host components
-        (ReactDOMFeatureFlags.useFiber ? '    in div (at **)\n' : '') +
+        '    in div (at **)\n' +
         '    in Parent (at **)',
     );
   });
@@ -368,23 +365,12 @@ describe('ReactMultiChild', () => {
       'oneA componentDidMount',
       'twoA componentDidMount',
 
-      ...(ReactDOMFeatureFlags.useFiber
-        ? [
-            'oneB componentWillMount',
-            'oneB render',
-            'twoB componentWillMount',
-            'twoB render',
-            'oneA componentWillUnmount',
-            'twoA componentWillUnmount',
-          ]
-        : [
-            'oneB componentWillMount',
-            'oneB render',
-            'oneA componentWillUnmount',
-            'twoB componentWillMount',
-            'twoB render',
-            'twoA componentWillUnmount',
-          ]),
+      'oneB componentWillMount',
+      'oneB render',
+      'twoB componentWillMount',
+      'twoB render',
+      'oneA componentWillUnmount',
+      'twoA componentWillUnmount',
 
       'oneB componentDidMount',
       'twoB componentDidMount',

--- a/src/renderers/__tests__/ReactMultiChildText-test.js
+++ b/src/renderers/__tests__/ReactMultiChildText-test.js
@@ -11,7 +11,6 @@
 
 var React = require('react');
 var ReactDOM = require('react-dom');
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactTestUtils = require('react-dom/test-utils');
 
 // Helpers
@@ -48,43 +47,16 @@ var expectChildren = function(container, children) {
       expect(textNode.data).toBe('' + children);
     }
   } else {
-    var openingCommentNode;
-    var closingCommentNode;
     var mountIndex = 0;
 
     for (var i = 0; i < children.length; i++) {
       var child = children[i];
 
       if (typeof child === 'string') {
-        if (ReactDOMFeatureFlags.useFiber) {
-          textNode = outerNode.childNodes[mountIndex];
-          expect(textNode.nodeType).toBe(3);
-          expect(textNode.data).toBe('' + child);
-          mountIndex++;
-        } else {
-          openingCommentNode = outerNode.childNodes[mountIndex];
-
-          expect(openingCommentNode.nodeType).toBe(8);
-          expect(openingCommentNode.nodeValue).toMatch(/ react-text: [0-9]+ /);
-
-          if (child === '') {
-            textNode = null;
-            closingCommentNode = openingCommentNode.nextSibling;
-            mountIndex += 2;
-          } else {
-            textNode = openingCommentNode.nextSibling;
-            closingCommentNode = textNode.nextSibling;
-            mountIndex += 3;
-          }
-
-          if (textNode) {
-            expect(textNode.nodeType).toBe(3);
-            expect(textNode.data).toBe('' + child);
-          }
-
-          expect(closingCommentNode.nodeType).toBe(8);
-          expect(closingCommentNode.nodeValue).toBe(' /react-text ');
-        }
+        textNode = outerNode.childNodes[mountIndex];
+        expect(textNode.nodeType).toBe(3);
+        expect(textNode.data).toBe('' + child);
+        mountIndex++;
       } else {
         var elementDOMNode = outerNode.childNodes[mountIndex];
         expect(elementDOMNode.tagName).toBe('DIV');
@@ -189,20 +161,14 @@ describe('ReactMultiChildText', () => {
       [true, <div>{1.2}{''}{<div />}{'foo'}</div>, true, 1.2], [<div />, '1.2'],
       ['', 'foo', <div>{true}{<div />}{1.2}{''}</div>, 'foo'], ['', 'foo', <div />, 'foo'],
     ]);
-    if (ReactDOMFeatureFlags.useFiber) {
-      expectDev(console.error.calls.count()).toBe(2);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Each child in an array or iterator should have a unique "key" prop.',
-      );
-      expectDev(console.error.calls.argsFor(1)[0]).toContain(
-        'Warning: Each child in an array or iterator should have a unique "key" prop.',
-      );
-    } else {
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Each child in an array or iterator should have a unique "key" prop.',
-      );
-    }
+
+    expectDev(console.error.calls.count()).toBe(2);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'Warning: Each child in an array or iterator should have a unique "key" prop.',
+    );
+    expectDev(console.error.calls.argsFor(1)[0]).toContain(
+      'Warning: Each child in an array or iterator should have a unique "key" prop.',
+    );
   });
 
   it('should throw if rendering both HTML and children', () => {

--- a/src/renderers/__tests__/ReactPerf-test.js
+++ b/src/renderers/__tests__/ReactPerf-test.js
@@ -9,12 +9,9 @@
 
 'use strict';
 
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-var describeStack = ReactDOMFeatureFlags.useFiber ? describe.skip : describe;
-
 // ReactPerf is currently not supported on Fiber.
 // Use browser timeline integration instead.
-describeStack('ReactPerf', () => {
+describe.skip('ReactPerf', () => {
   var React;
   var ReactDOM;
   var ReactPerf;

--- a/src/renderers/__tests__/ReactStatelessComponent-test.js
+++ b/src/renderers/__tests__/ReactStatelessComponent-test.js
@@ -14,8 +14,6 @@ var React;
 var ReactDOM;
 var ReactTestUtils;
 
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-
 function StatelessComponent(props) {
   return <div>{props.name}</div>;
 }
@@ -118,54 +116,22 @@ describe('ReactStatelessComponent', () => {
 
     ReactDOM.render(<StatelessComponentWithChildContext name="A" />, container);
 
-    // Stack and Fiber differ in terms of they show warnings
-    if (ReactDOMFeatureFlags.useFiber) {
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'StatelessComponentWithChildContext(...): childContextTypes cannot ' +
-          'be defined on a functional component.',
-      );
-    } else {
-      expectDev(console.error.calls.count()).toBe(2);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'StatelessComponentWithChildContext(...): childContextTypes cannot ' +
-          'be defined on a functional component.',
-      );
-      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-        'Warning: StatelessComponentWithChildContext.childContextTypes is specified ' +
-          'but there is no getChildContext() method on the instance. You can either ' +
-          'define getChildContext() on StatelessComponentWithChildContext or remove ' +
-          'childContextTypes from it.',
-      );
-    }
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'StatelessComponentWithChildContext(...): childContextTypes cannot ' +
+        'be defined on a functional component.',
+    );
   });
 
-  if (!ReactDOMFeatureFlags.useFiber) {
-    // Stack doesn't support fragments
-    it('should throw when stateless component returns array', () => {
-      function NotAComponent() {
-        return [<div />, <div />];
-      }
-      expect(function() {
-        ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
-      }).toThrowError(
-        'NotAComponent(...): A valid React element (or null) must be returned. ' +
-          'You may have returned undefined, an array or some other invalid object.',
-      );
-    });
-  }
-
-  if (ReactDOMFeatureFlags.useFiber) {
-    it('should throw when stateless component returns undefined', () => {
-      function NotAComponent() {}
-      expect(function() {
-        ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
-      }).toThrowError(
-        'NotAComponent(...): Nothing was returned from render. ' +
-          'This usually means a return statement is missing. Or, to render nothing, return null.',
-      );
-    });
-  }
+  it('should throw when stateless component returns undefined', () => {
+    function NotAComponent() {}
+    expect(function() {
+      ReactTestUtils.renderIntoDocument(<div><NotAComponent /></div>);
+    }).toThrowError(
+      'NotAComponent(...): Nothing was returned from render. ' +
+        'This usually means a return statement is missing. Or, to render nothing, return null.',
+    );
+  });
 
   it('should throw on string refs in pure functions', () => {
     function Child() {

--- a/src/renderers/__tests__/ReactUpdates-test.js
+++ b/src/renderers/__tests__/ReactUpdates-test.js
@@ -12,13 +12,11 @@
 var React;
 var ReactDOM;
 var ReactTestUtils;
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 
 describe('ReactUpdates', () => {
   beforeEach(() => {
     React = require('react');
     ReactDOM = require('react-dom');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactTestUtils = require('react-dom/test-utils');
   });
 
@@ -519,9 +517,7 @@ describe('ReactUpdates', () => {
       render() {
         var portal = null;
         // If we're using Fiber, we use Portals instead to achieve this.
-        if (ReactDOMFeatureFlags.useFiber) {
-          portal = ReactDOM.createPortal(<B ref={n => (b = n)} />, bContainer);
-        }
+        portal = ReactDOM.createPortal(<B ref={n => (b = n)} />, bContainer);
         return <div>A{this.state.x}{portal}</div>;
       }
     }
@@ -535,10 +531,6 @@ describe('ReactUpdates', () => {
     }
 
     a = ReactTestUtils.renderIntoDocument(<A />);
-    if (!ReactDOMFeatureFlags.useFiber) {
-      ReactDOM.render(<B ref={n => (b = n)} />, bContainer);
-    }
-
     ReactDOM.unstable_batchedUpdates(function() {
       a.setState({x: 1});
       b.setState({x: 1});
@@ -1178,35 +1170,33 @@ describe('ReactUpdates', () => {
     }).toThrow('Maximum');
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    it('does not fall into an infinite error loop', () => {
-      function BadRender() {
-        throw new Error('error');
-      }
+  it('does not fall into an infinite error loop', () => {
+    function BadRender() {
+      throw new Error('error');
+    }
 
-      class ErrorBoundary extends React.Component {
-        componentDidCatch() {
-          this.props.parent.remount();
-        }
-        render() {
-          return <BadRender />;
-        }
+    class ErrorBoundary extends React.Component {
+      componentDidCatch() {
+        this.props.parent.remount();
       }
-
-      class NonTerminating extends React.Component {
-        state = {step: 0};
-        remount() {
-          this.setState(state => ({step: state.step + 1}));
-        }
-        render() {
-          return <ErrorBoundary key={this.state.step} parent={this} />;
-        }
+      render() {
+        return <BadRender />;
       }
+    }
 
-      const container = document.createElement('div');
-      expect(() => {
-        ReactDOM.render(<NonTerminating />, container);
-      }).toThrow('Maximum');
-    });
-  }
+    class NonTerminating extends React.Component {
+      state = {step: 0};
+      remount() {
+        this.setState(state => ({step: state.step + 1}));
+      }
+      render() {
+        return <ErrorBoundary key={this.state.step} parent={this} />;
+      }
+    }
+
+    const container = document.createElement('div');
+    expect(() => {
+      ReactDOM.render(<NonTerminating />, container);
+    }).toThrow('Maximum');
+  });
 });

--- a/src/renderers/__tests__/multiple-copies-of-react-test.js
+++ b/src/renderers/__tests__/multiple-copies-of-react-test.js
@@ -10,7 +10,6 @@
 'use strict';
 
 let React = require('react');
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactTestUtils = require('react-dom/test-utils');
 
 class TextWithStringRef extends React.Component {
@@ -27,23 +26,12 @@ class TextWithStringRef extends React.Component {
 
 describe('when different React version is used with string ref', () => {
   it('throws the "Refs must have owner" warning', () => {
-    if (ReactDOMFeatureFlags.useFiber) {
-      expect(() => {
-        ReactTestUtils.renderIntoDocument(<TextWithStringRef />);
-      }).toThrow(
-        'Element ref was specified as a string (foo) but no owner was set.' +
-          ' You may have multiple copies of React loaded. (details: ' +
-          'https://fb.me/react-refs-must-have-owner).',
-      );
-    } else {
-      expect(() => {
-        ReactTestUtils.renderIntoDocument(<TextWithStringRef />);
-      }).toThrow(
-        'Only a ReactOwner can have refs. You might be adding a ref to a ' +
-          "component that was not created inside a component's `render` " +
-          'method, or you have multiple copies of React loaded ' +
-          '(details: https://fb.me/react-refs-must-have-owner)',
-      );
-    }
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(<TextWithStringRef />);
+    }).toThrow(
+      'Element ref was specified as a string (foo) but no owner was set.' +
+        ' You may have multiple copies of React loaded. (details: ' +
+        'https://fb.me/react-refs-must-have-owner).',
+    );
   });
 });

--- a/src/renderers/__tests__/refs-test.js
+++ b/src/renderers/__tests__/refs-test.js
@@ -10,7 +10,6 @@
 'use strict';
 
 var React = require('react');
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactTestUtils = require('react-dom/test-utils');
 
 /**
@@ -348,40 +347,38 @@ describe('root level refs', () => {
     expect(ref).toHaveBeenCalledTimes(2);
     expect(ref.mock.calls[1][0]).toBe(null);
 
-    if (ReactDOMFeatureFlags.useFiber) {
-      // fragment
-      inst = null;
-      ref = jest.fn(value => (inst = value));
-      var divInst = null;
-      var ref2 = jest.fn(value => (divInst = value));
-      result = ReactDOM.render(
-        [<Comp ref={ref} key="a" />, 5, <div ref={ref2} key="b">Hello</div>],
-        container,
-      );
+    // fragment
+    inst = null;
+    ref = jest.fn(value => (inst = value));
+    var divInst = null;
+    var ref2 = jest.fn(value => (divInst = value));
+    result = ReactDOM.render(
+      [<Comp ref={ref} key="a" />, 5, <div ref={ref2} key="b">Hello</div>],
+      container,
+    );
 
-      // first call should be `Comp`
-      expect(ref).toHaveBeenCalledTimes(1);
-      expect(ref.mock.calls[0][0]).toBeInstanceOf(Comp);
-      expect(result).toBe(ref.mock.calls[0][0]);
+    // first call should be `Comp`
+    expect(ref).toHaveBeenCalledTimes(1);
+    expect(ref.mock.calls[0][0]).toBeInstanceOf(Comp);
+    expect(result).toBe(ref.mock.calls[0][0]);
 
-      expect(ref2).toHaveBeenCalledTimes(1);
-      expect(divInst).toBeInstanceOf(HTMLDivElement);
-      expect(result).not.toBe(divInst);
+    expect(ref2).toHaveBeenCalledTimes(1);
+    expect(divInst).toBeInstanceOf(HTMLDivElement);
+    expect(result).not.toBe(divInst);
 
-      ReactDOM.unmountComponentAtNode(container);
-      expect(ref).toHaveBeenCalledTimes(2);
-      expect(ref.mock.calls[1][0]).toBe(null);
-      expect(ref2).toHaveBeenCalledTimes(2);
-      expect(ref2.mock.calls[1][0]).toBe(null);
+    ReactDOM.unmountComponentAtNode(container);
+    expect(ref).toHaveBeenCalledTimes(2);
+    expect(ref.mock.calls[1][0]).toBe(null);
+    expect(ref2).toHaveBeenCalledTimes(2);
+    expect(ref2.mock.calls[1][0]).toBe(null);
 
-      // null
-      result = ReactDOM.render(null, container);
-      expect(result).toBe(null);
+    // null
+    result = ReactDOM.render(null, container);
+    expect(result).toBe(null);
 
-      // primitives
-      result = ReactDOM.render(5, container);
-      expect(result).toBeInstanceOf(Text);
-    }
+    // primitives
+    result = ReactDOM.render(5, container);
+    expect(result).toBeInstanceOf(Text);
   });
 });
 
@@ -397,28 +394,6 @@ describe('creating element with ref in constructor', () => {
     }
   }
 
-  var devErrorMessage =
-    'addComponentAsRefTo(...): Only a ReactOwner can have refs. You might ' +
-    "be adding a ref to a component that was not created inside a component's " +
-    '`render` method, or you have multiple copies of React loaded ' +
-    '(details: https://fb.me/react-refs-must-have-owner).';
-
-  var prodErrorMessage =
-    'Minified React error #119; visit ' +
-    'http://facebook.github.io/react/docs/error-decoder.html?invariant=119 for the full message ' +
-    'or use the non-minified dev environment for full errors and additional helpful warnings.';
-
-  var fiberDevErrorMessage =
-    'Element ref was specified as a string (p) but no owner was ' +
-    'set. You may have multiple copies of React loaded. ' +
-    '(details: https://fb.me/react-refs-must-have-owner).';
-
-  var fiberProdErrorMessage =
-    'Minified React error #149; visit ' +
-    'http://facebook.github.io/react/docs/error-decoder.html?invariant=149&args[]=p ' +
-    'for the full message or use the non-minified dev environment for full errors and additional ' +
-    'helpful warnings.';
-
   it('throws an error when __DEV__ = true', () => {
     ReactTestUtils = require('react-dom/test-utils');
 
@@ -429,7 +404,9 @@ describe('creating element with ref in constructor', () => {
       expect(function() {
         ReactTestUtils.renderIntoDocument(<RefTest />);
       }).toThrowError(
-        ReactDOMFeatureFlags.useFiber ? fiberDevErrorMessage : devErrorMessage,
+        'Element ref was specified as a string (p) but no owner was ' +
+          'set. You may have multiple copies of React loaded. ' +
+          '(details: https://fb.me/react-refs-must-have-owner).',
       );
     } finally {
       __DEV__ = originalDev;
@@ -446,9 +423,10 @@ describe('creating element with ref in constructor', () => {
       expect(function() {
         ReactTestUtils.renderIntoDocument(<RefTest />);
       }).toThrowError(
-        ReactDOMFeatureFlags.useFiber
-          ? fiberProdErrorMessage
-          : prodErrorMessage,
+        'Minified React error #149; visit ' +
+          'http://facebook.github.io/react/docs/error-decoder.html?invariant=149&args[]=p ' +
+          'for the full message or use the non-minified dev environment for full errors and additional ' +
+          'helpful warnings.',
       );
     } finally {
       __DEV__ = originalDev;

--- a/src/renderers/dom/__tests__/ReactDOMProduction-test.js
+++ b/src/renderers/dom/__tests__/ReactDOMProduction-test.js
@@ -9,8 +9,6 @@
 'use strict';
 
 describe('ReactDOMProduction', () => {
-  var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-
   var React;
   var ReactDOM;
   var ReactDOMServer;
@@ -195,7 +193,7 @@ describe('ReactDOMProduction', () => {
   });
 
   it('should throw with an error code in production', () => {
-    const errorCode = ReactDOMFeatureFlags.useFiber ? 152 : 109;
+    const errorCode = 152;
     expect(function() {
       class Component extends React.Component {
         render() {
@@ -235,57 +233,55 @@ describe('ReactDOMProduction', () => {
     }
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    // This test is originally from ReactDOMFiber-test but we replicate it here
-    // to avoid production-only regressions because of host context differences
-    // in dev and prod.
-    it('should keep track of namespace across portals in production', () => {
-      var svgEls, htmlEls;
-      var expectSVG = {ref: el => svgEls.push(el)};
-      var expectHTML = {ref: el => htmlEls.push(el)};
-      var usePortal = function(tree) {
-        return ReactDOM.createPortal(tree, document.createElement('div'));
-      };
-      var assertNamespacesMatch = function(tree) {
-        var container = document.createElement('div');
-        svgEls = [];
-        htmlEls = [];
-        ReactDOM.render(tree, container);
-        svgEls.forEach(el => {
-          expect(el.namespaceURI).toBe('http://www.w3.org/2000/svg');
-        });
-        htmlEls.forEach(el => {
-          expect(el.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
-        });
-        ReactDOM.unmountComponentAtNode(container);
-        expect(container.innerHTML).toBe('');
-      };
+  // This test is originally from ReactDOMFiber-test but we replicate it here
+  // to avoid production-only regressions because of host context differences
+  // in dev and prod.
+  it('should keep track of namespace across portals in production', () => {
+    var svgEls, htmlEls;
+    var expectSVG = {ref: el => svgEls.push(el)};
+    var expectHTML = {ref: el => htmlEls.push(el)};
+    var usePortal = function(tree) {
+      return ReactDOM.createPortal(tree, document.createElement('div'));
+    };
+    var assertNamespacesMatch = function(tree) {
+      var container = document.createElement('div');
+      svgEls = [];
+      htmlEls = [];
+      ReactDOM.render(tree, container);
+      svgEls.forEach(el => {
+        expect(el.namespaceURI).toBe('http://www.w3.org/2000/svg');
+      });
+      htmlEls.forEach(el => {
+        expect(el.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+      });
+      ReactDOM.unmountComponentAtNode(container);
+      expect(container.innerHTML).toBe('');
+    };
 
-      assertNamespacesMatch(
-        <div {...expectHTML}>
-          <svg {...expectSVG}>
-            <foreignObject {...expectSVG}>
-              <p {...expectHTML} />
-              {usePortal(
+    assertNamespacesMatch(
+      <div {...expectHTML}>
+        <svg {...expectSVG}>
+          <foreignObject {...expectSVG}>
+            <p {...expectHTML} />
+            {usePortal(
+              <svg {...expectSVG}>
+                <image {...expectSVG} />
                 <svg {...expectSVG}>
                   <image {...expectSVG} />
-                  <svg {...expectSVG}>
-                    <image {...expectSVG} />
-                    <foreignObject {...expectSVG}>
-                      <p {...expectHTML} />
-                    </foreignObject>
-                    {usePortal(<p {...expectHTML} />)}
-                  </svg>
-                  <image {...expectSVG} />
-                </svg>,
-              )}
-              <p {...expectHTML} />
-            </foreignObject>
-            <image {...expectSVG} />
-          </svg>
-          <p {...expectHTML} />
-        </div>,
-      );
-    });
-  }
+                  <foreignObject {...expectSVG}>
+                    <p {...expectHTML} />
+                  </foreignObject>
+                  {usePortal(<p {...expectHTML} />)}
+                </svg>
+                <image {...expectSVG} />
+              </svg>,
+            )}
+            <p {...expectHTML} />
+          </foreignObject>
+          <image {...expectSVG} />
+        </svg>
+        <p {...expectHTML} />
+      </div>,
+    );
+  });
 });

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -11,7 +11,6 @@
 
 var React = require('react');
 var ReactDOM = require('react-dom');
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactTestUtils = require('react-dom/test-utils');
 var PropTypes = require('prop-types');
 
@@ -74,1076 +73,1072 @@ describe('ReactDOMFiber', () => {
     expect(called).toEqual(true);
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    it('should render a component returning strings directly from render', () => {
-      const Text = ({value}) => value;
+  it('should render a component returning strings directly from render', () => {
+    const Text = ({value}) => value;
 
-      ReactDOM.render(<Text value="foo" />, container);
-      expect(container.textContent).toEqual('foo');
-    });
+    ReactDOM.render(<Text value="foo" />, container);
+    expect(container.textContent).toEqual('foo');
+  });
 
-    it('should render a component returning numbers directly from render', () => {
-      const Text = ({value}) => value;
+  it('should render a component returning numbers directly from render', () => {
+    const Text = ({value}) => value;
 
-      ReactDOM.render(<Text value={10} />, container);
+    ReactDOM.render(<Text value={10} />, container);
 
-      expect(container.textContent).toEqual('10');
-    });
+    expect(container.textContent).toEqual('10');
+  });
 
-    it('finds the DOM Text node of a string child', () => {
-      class Text extends React.Component {
-        render() {
-          return this.props.value;
-        }
+  it('finds the DOM Text node of a string child', () => {
+    class Text extends React.Component {
+      render() {
+        return this.props.value;
       }
+    }
 
-      let instance = null;
-      ReactDOM.render(
-        <Text value="foo" ref={ref => (instance = ref)} />,
-        container,
-      );
+    let instance = null;
+    ReactDOM.render(
+      <Text value="foo" ref={ref => (instance = ref)} />,
+      container,
+    );
 
-      const textNode = ReactDOM.findDOMNode(instance);
-      expect(textNode).toBe(container.firstChild);
-      expect(textNode.nodeType).toBe(3);
-      expect(textNode.nodeValue).toBe('foo');
+    const textNode = ReactDOM.findDOMNode(instance);
+    expect(textNode).toBe(container.firstChild);
+    expect(textNode.nodeType).toBe(3);
+    expect(textNode.nodeValue).toBe('foo');
+  });
+
+  it('finds the first child when a component returns a fragment', () => {
+    class Fragment extends React.Component {
+      render() {
+        return [<div key="a" />, <span key="b" />];
+      }
+    }
+
+    let instance = null;
+    ReactDOM.render(<Fragment ref={ref => (instance = ref)} />, container);
+
+    expect(container.childNodes.length).toBe(2);
+
+    const firstNode = ReactDOM.findDOMNode(instance);
+    expect(firstNode).toBe(container.firstChild);
+    expect(firstNode.tagName).toBe('DIV');
+  });
+
+  it('finds the first child even when fragment is nested', () => {
+    class Wrapper extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    class Fragment extends React.Component {
+      render() {
+        return [<Wrapper key="a"><div /></Wrapper>, <span key="b" />];
+      }
+    }
+
+    let instance = null;
+    ReactDOM.render(<Fragment ref={ref => (instance = ref)} />, container);
+
+    expect(container.childNodes.length).toBe(2);
+
+    const firstNode = ReactDOM.findDOMNode(instance);
+    expect(firstNode).toBe(container.firstChild);
+    expect(firstNode.tagName).toBe('DIV');
+  });
+
+  it('finds the first child even when first child renders null', () => {
+    class NullComponent extends React.Component {
+      render() {
+        return null;
+      }
+    }
+
+    class Fragment extends React.Component {
+      render() {
+        return [<NullComponent key="a" />, <div key="b" />, <span key="c" />];
+      }
+    }
+
+    let instance = null;
+    ReactDOM.render(<Fragment ref={ref => (instance = ref)} />, container);
+
+    expect(container.childNodes.length).toBe(2);
+
+    const firstNode = ReactDOM.findDOMNode(instance);
+    expect(firstNode).toBe(container.firstChild);
+    expect(firstNode.tagName).toBe('DIV');
+  });
+
+  var svgEls, htmlEls, mathEls;
+  var expectSVG = {ref: el => svgEls.push(el)};
+  var expectHTML = {ref: el => htmlEls.push(el)};
+  var expectMath = {ref: el => mathEls.push(el)};
+
+  var usePortal = function(tree) {
+    return ReactDOM.createPortal(tree, document.createElement('div'));
+  };
+
+  var assertNamespacesMatch = function(tree) {
+    container = document.createElement('div');
+    svgEls = [];
+    htmlEls = [];
+    mathEls = [];
+
+    ReactDOM.render(tree, container);
+    svgEls.forEach(el => {
+      expect(el.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    });
+    htmlEls.forEach(el => {
+      expect(el.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+    });
+    mathEls.forEach(el => {
+      expect(el.namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
     });
 
-    it('finds the first child when a component returns a fragment', () => {
-      class Fragment extends React.Component {
-        render() {
-          return [<div key="a" />, <span key="b" />];
-        }
+    ReactDOM.unmountComponentAtNode(container);
+    expect(container.innerHTML).toBe('');
+  };
+
+  it('should render one portal', () => {
+    var portalContainer = document.createElement('div');
+
+    ReactDOM.render(
+      <div>
+        {ReactDOM.createPortal(<div>portal</div>, portalContainer)}
+      </div>,
+      container,
+    );
+    expect(portalContainer.innerHTML).toBe('<div>portal</div>');
+    expect(container.innerHTML).toBe('<div></div>');
+
+    ReactDOM.unmountComponentAtNode(container);
+    expect(portalContainer.innerHTML).toBe('');
+    expect(container.innerHTML).toBe('');
+  });
+
+  // TODO: remove in React 17
+  it('should support unstable_createPortal alias', () => {
+    var portalContainer = document.createElement('div');
+
+    ReactDOM.render(
+      <div>
+        {ReactDOM.unstable_createPortal(<div>portal</div>, portalContainer)}
+      </div>,
+      container,
+    );
+    expect(portalContainer.innerHTML).toBe('<div>portal</div>');
+    expect(container.innerHTML).toBe('<div></div>');
+
+    ReactDOM.unmountComponentAtNode(container);
+    expect(portalContainer.innerHTML).toBe('');
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('should render many portals', () => {
+    var portalContainer1 = document.createElement('div');
+    var portalContainer2 = document.createElement('div');
+
+    var ops = [];
+    class Child extends React.Component {
+      componentDidMount() {
+        ops.push(`${this.props.name} componentDidMount`);
       }
-
-      let instance = null;
-      ReactDOM.render(<Fragment ref={ref => (instance = ref)} />, container);
-
-      expect(container.childNodes.length).toBe(2);
-
-      const firstNode = ReactDOM.findDOMNode(instance);
-      expect(firstNode).toBe(container.firstChild);
-      expect(firstNode.tagName).toBe('DIV');
-    });
-
-    it('finds the first child even when fragment is nested', () => {
-      class Wrapper extends React.Component {
-        render() {
-          return this.props.children;
-        }
+      componentDidUpdate() {
+        ops.push(`${this.props.name} componentDidUpdate`);
       }
-
-      class Fragment extends React.Component {
-        render() {
-          return [<Wrapper key="a"><div /></Wrapper>, <span key="b" />];
-        }
+      componentWillUnmount() {
+        ops.push(`${this.props.name} componentWillUnmount`);
       }
-
-      let instance = null;
-      ReactDOM.render(<Fragment ref={ref => (instance = ref)} />, container);
-
-      expect(container.childNodes.length).toBe(2);
-
-      const firstNode = ReactDOM.findDOMNode(instance);
-      expect(firstNode).toBe(container.firstChild);
-      expect(firstNode.tagName).toBe('DIV');
-    });
-
-    it('finds the first child even when first child renders null', () => {
-      class NullComponent extends React.Component {
-        render() {
-          return null;
-        }
+      render() {
+        return <div>{this.props.name}</div>;
       }
+    }
 
-      class Fragment extends React.Component {
-        render() {
-          return [<NullComponent key="a" />, <div key="b" />, <span key="c" />];
-        }
+    class Parent extends React.Component {
+      componentDidMount() {
+        ops.push(`Parent:${this.props.step} componentDidMount`);
       }
-
-      let instance = null;
-      ReactDOM.render(<Fragment ref={ref => (instance = ref)} />, container);
-
-      expect(container.childNodes.length).toBe(2);
-
-      const firstNode = ReactDOM.findDOMNode(instance);
-      expect(firstNode).toBe(container.firstChild);
-      expect(firstNode.tagName).toBe('DIV');
-    });
-  }
-
-  if (ReactDOMFeatureFlags.useFiber) {
-    var svgEls, htmlEls, mathEls;
-    var expectSVG = {ref: el => svgEls.push(el)};
-    var expectHTML = {ref: el => htmlEls.push(el)};
-    var expectMath = {ref: el => mathEls.push(el)};
-
-    var usePortal = function(tree) {
-      return ReactDOM.createPortal(tree, document.createElement('div'));
-    };
-
-    var assertNamespacesMatch = function(tree) {
-      container = document.createElement('div');
-      svgEls = [];
-      htmlEls = [];
-      mathEls = [];
-
-      ReactDOM.render(tree, container);
-      svgEls.forEach(el => {
-        expect(el.namespaceURI).toBe('http://www.w3.org/2000/svg');
-      });
-      htmlEls.forEach(el => {
-        expect(el.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
-      });
-      mathEls.forEach(el => {
-        expect(el.namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
-      });
-
-      ReactDOM.unmountComponentAtNode(container);
-      expect(container.innerHTML).toBe('');
-    };
-
-    it('should render one portal', () => {
-      var portalContainer = document.createElement('div');
-
-      ReactDOM.render(
-        <div>
-          {ReactDOM.createPortal(<div>portal</div>, portalContainer)}
-        </div>,
-        container,
-      );
-      expect(portalContainer.innerHTML).toBe('<div>portal</div>');
-      expect(container.innerHTML).toBe('<div></div>');
-
-      ReactDOM.unmountComponentAtNode(container);
-      expect(portalContainer.innerHTML).toBe('');
-      expect(container.innerHTML).toBe('');
-    });
-
-    // TODO: remove in React 17
-    it('should support unstable_createPortal alias', () => {
-      var portalContainer = document.createElement('div');
-
-      ReactDOM.render(
-        <div>
-          {ReactDOM.unstable_createPortal(<div>portal</div>, portalContainer)}
-        </div>,
-        container,
-      );
-      expect(portalContainer.innerHTML).toBe('<div>portal</div>');
-      expect(container.innerHTML).toBe('<div></div>');
-
-      ReactDOM.unmountComponentAtNode(container);
-      expect(portalContainer.innerHTML).toBe('');
-      expect(container.innerHTML).toBe('');
-    });
-
-    it('should render many portals', () => {
-      var portalContainer1 = document.createElement('div');
-      var portalContainer2 = document.createElement('div');
-
-      var ops = [];
-      class Child extends React.Component {
-        componentDidMount() {
-          ops.push(`${this.props.name} componentDidMount`);
-        }
-        componentDidUpdate() {
-          ops.push(`${this.props.name} componentDidUpdate`);
-        }
-        componentWillUnmount() {
-          ops.push(`${this.props.name} componentWillUnmount`);
-        }
-        render() {
-          return <div>{this.props.name}</div>;
-        }
+      componentDidUpdate() {
+        ops.push(`Parent:${this.props.step} componentDidUpdate`);
       }
-
-      class Parent extends React.Component {
-        componentDidMount() {
-          ops.push(`Parent:${this.props.step} componentDidMount`);
-        }
-        componentDidUpdate() {
-          ops.push(`Parent:${this.props.step} componentDidUpdate`);
-        }
-        componentWillUnmount() {
-          ops.push(`Parent:${this.props.step} componentWillUnmount`);
-        }
-        render() {
-          const {step} = this.props;
-          return [
-            <Child key="a" name={`normal[0]:${step}`} />,
-            ReactDOM.createPortal(
-              <Child key="b" name={`portal1[0]:${step}`} />,
-              portalContainer1,
-            ),
-            <Child key="c" name={`normal[1]:${step}`} />,
-            ReactDOM.createPortal(
-              [
-                <Child key="d" name={`portal2[0]:${step}`} />,
-                <Child key="e" name={`portal2[1]:${step}`} />,
-              ],
-              portalContainer2,
-            ),
-          ];
-        }
+      componentWillUnmount() {
+        ops.push(`Parent:${this.props.step} componentWillUnmount`);
       }
-
-      ReactDOM.render(<Parent step="a" />, container);
-      expect(portalContainer1.innerHTML).toBe('<div>portal1[0]:a</div>');
-      expect(portalContainer2.innerHTML).toBe(
-        '<div>portal2[0]:a</div><div>portal2[1]:a</div>',
-      );
-      expect(container.innerHTML).toBe(
-        '<div>normal[0]:a</div><div>normal[1]:a</div>',
-      );
-      expect(ops).toEqual([
-        'normal[0]:a componentDidMount',
-        'portal1[0]:a componentDidMount',
-        'normal[1]:a componentDidMount',
-        'portal2[0]:a componentDidMount',
-        'portal2[1]:a componentDidMount',
-        'Parent:a componentDidMount',
-      ]);
-
-      ops.length = 0;
-      ReactDOM.render(<Parent step="b" />, container);
-      expect(portalContainer1.innerHTML).toBe('<div>portal1[0]:b</div>');
-      expect(portalContainer2.innerHTML).toBe(
-        '<div>portal2[0]:b</div><div>portal2[1]:b</div>',
-      );
-      expect(container.innerHTML).toBe(
-        '<div>normal[0]:b</div><div>normal[1]:b</div>',
-      );
-      expect(ops).toEqual([
-        'normal[0]:b componentDidUpdate',
-        'portal1[0]:b componentDidUpdate',
-        'normal[1]:b componentDidUpdate',
-        'portal2[0]:b componentDidUpdate',
-        'portal2[1]:b componentDidUpdate',
-        'Parent:b componentDidUpdate',
-      ]);
-
-      ops.length = 0;
-      ReactDOM.unmountComponentAtNode(container);
-      expect(portalContainer1.innerHTML).toBe('');
-      expect(portalContainer2.innerHTML).toBe('');
-      expect(container.innerHTML).toBe('');
-      expect(ops).toEqual([
-        'Parent:b componentWillUnmount',
-        'normal[0]:b componentWillUnmount',
-        'portal1[0]:b componentWillUnmount',
-        'normal[1]:b componentWillUnmount',
-        'portal2[0]:b componentWillUnmount',
-        'portal2[1]:b componentWillUnmount',
-      ]);
-    });
-
-    it('should render nested portals', () => {
-      var portalContainer1 = document.createElement('div');
-      var portalContainer2 = document.createElement('div');
-      var portalContainer3 = document.createElement('div');
-
-      ReactDOM.render(
-        [
-          <div key="a">normal[0]</div>,
+      render() {
+        const {step} = this.props;
+        return [
+          <Child key="a" name={`normal[0]:${step}`} />,
           ReactDOM.createPortal(
-            [
-              <div key="b">portal1[0]</div>,
-              ReactDOM.createPortal(
-                <div key="c">portal2[0]</div>,
-                portalContainer2,
-              ),
-              ReactDOM.createPortal(
-                <div key="d">portal3[0]</div>,
-                portalContainer3,
-              ),
-              <div key="e">portal1[1]</div>,
-            ],
+            <Child key="b" name={`portal1[0]:${step}`} />,
             portalContainer1,
           ),
-          <div key="f">normal[1]</div>,
-        ],
-        container,
-      );
-      expect(portalContainer1.innerHTML).toBe(
-        '<div>portal1[0]</div><div>portal1[1]</div>',
-      );
-      expect(portalContainer2.innerHTML).toBe('<div>portal2[0]</div>');
-      expect(portalContainer3.innerHTML).toBe('<div>portal3[0]</div>');
-      expect(container.innerHTML).toBe(
-        '<div>normal[0]</div><div>normal[1]</div>',
-      );
+          <Child key="c" name={`normal[1]:${step}`} />,
+          ReactDOM.createPortal(
+            [
+              <Child key="d" name={`portal2[0]:${step}`} />,
+              <Child key="e" name={`portal2[1]:${step}`} />,
+            ],
+            portalContainer2,
+          ),
+        ];
+      }
+    }
 
-      ReactDOM.unmountComponentAtNode(container);
-      expect(portalContainer1.innerHTML).toBe('');
-      expect(portalContainer2.innerHTML).toBe('');
-      expect(portalContainer3.innerHTML).toBe('');
-      expect(container.innerHTML).toBe('');
-    });
+    ReactDOM.render(<Parent step="a" />, container);
+    expect(portalContainer1.innerHTML).toBe('<div>portal1[0]:a</div>');
+    expect(portalContainer2.innerHTML).toBe(
+      '<div>portal2[0]:a</div><div>portal2[1]:a</div>',
+    );
+    expect(container.innerHTML).toBe(
+      '<div>normal[0]:a</div><div>normal[1]:a</div>',
+    );
+    expect(ops).toEqual([
+      'normal[0]:a componentDidMount',
+      'portal1[0]:a componentDidMount',
+      'normal[1]:a componentDidMount',
+      'portal2[0]:a componentDidMount',
+      'portal2[1]:a componentDidMount',
+      'Parent:a componentDidMount',
+    ]);
 
-    it('should reconcile portal children', () => {
-      var portalContainer = document.createElement('div');
+    ops.length = 0;
+    ReactDOM.render(<Parent step="b" />, container);
+    expect(portalContainer1.innerHTML).toBe('<div>portal1[0]:b</div>');
+    expect(portalContainer2.innerHTML).toBe(
+      '<div>portal2[0]:b</div><div>portal2[1]:b</div>',
+    );
+    expect(container.innerHTML).toBe(
+      '<div>normal[0]:b</div><div>normal[1]:b</div>',
+    );
+    expect(ops).toEqual([
+      'normal[0]:b componentDidUpdate',
+      'portal1[0]:b componentDidUpdate',
+      'normal[1]:b componentDidUpdate',
+      'portal2[0]:b componentDidUpdate',
+      'portal2[1]:b componentDidUpdate',
+      'Parent:b componentDidUpdate',
+    ]);
 
-      ReactDOM.render(
-        <div>
-          {ReactDOM.createPortal(<div>portal:1</div>, portalContainer)}
-        </div>,
-        container,
-      );
-      expect(portalContainer.innerHTML).toBe('<div>portal:1</div>');
-      expect(container.innerHTML).toBe('<div></div>');
+    ops.length = 0;
+    ReactDOM.unmountComponentAtNode(container);
+    expect(portalContainer1.innerHTML).toBe('');
+    expect(portalContainer2.innerHTML).toBe('');
+    expect(container.innerHTML).toBe('');
+    expect(ops).toEqual([
+      'Parent:b componentWillUnmount',
+      'normal[0]:b componentWillUnmount',
+      'portal1[0]:b componentWillUnmount',
+      'normal[1]:b componentWillUnmount',
+      'portal2[0]:b componentWillUnmount',
+      'portal2[1]:b componentWillUnmount',
+    ]);
+  });
 
-      ReactDOM.render(
-        <div>
-          {ReactDOM.createPortal(<div>portal:2</div>, portalContainer)}
-        </div>,
-        container,
-      );
-      expect(portalContainer.innerHTML).toBe('<div>portal:2</div>');
-      expect(container.innerHTML).toBe('<div></div>');
+  it('should render nested portals', () => {
+    var portalContainer1 = document.createElement('div');
+    var portalContainer2 = document.createElement('div');
+    var portalContainer3 = document.createElement('div');
 
-      ReactDOM.render(
-        <div>
-          {ReactDOM.createPortal(<p>portal:3</p>, portalContainer)}
-        </div>,
-        container,
-      );
-      expect(portalContainer.innerHTML).toBe('<p>portal:3</p>');
-      expect(container.innerHTML).toBe('<div></div>');
+    ReactDOM.render(
+      [
+        <div key="a">normal[0]</div>,
+        ReactDOM.createPortal(
+          [
+            <div key="b">portal1[0]</div>,
+            ReactDOM.createPortal(
+              <div key="c">portal2[0]</div>,
+              portalContainer2,
+            ),
+            ReactDOM.createPortal(
+              <div key="d">portal3[0]</div>,
+              portalContainer3,
+            ),
+            <div key="e">portal1[1]</div>,
+          ],
+          portalContainer1,
+        ),
+        <div key="f">normal[1]</div>,
+      ],
+      container,
+    );
+    expect(portalContainer1.innerHTML).toBe(
+      '<div>portal1[0]</div><div>portal1[1]</div>',
+    );
+    expect(portalContainer2.innerHTML).toBe('<div>portal2[0]</div>');
+    expect(portalContainer3.innerHTML).toBe('<div>portal3[0]</div>');
+    expect(container.innerHTML).toBe(
+      '<div>normal[0]</div><div>normal[1]</div>',
+    );
 
-      ReactDOM.render(
-        <div>
-          {ReactDOM.createPortal(['Hi', 'Bye'], portalContainer)}
-        </div>,
-        container,
-      );
-      expect(portalContainer.innerHTML).toBe('HiBye');
-      expect(container.innerHTML).toBe('<div></div>');
+    ReactDOM.unmountComponentAtNode(container);
+    expect(portalContainer1.innerHTML).toBe('');
+    expect(portalContainer2.innerHTML).toBe('');
+    expect(portalContainer3.innerHTML).toBe('');
+    expect(container.innerHTML).toBe('');
+  });
 
-      ReactDOM.render(
-        <div>
-          {ReactDOM.createPortal(['Bye', 'Hi'], portalContainer)}
-        </div>,
-        container,
-      );
-      expect(portalContainer.innerHTML).toBe('ByeHi');
-      expect(container.innerHTML).toBe('<div></div>');
+  it('should reconcile portal children', () => {
+    var portalContainer = document.createElement('div');
 
-      ReactDOM.render(
-        <div>
-          {ReactDOM.createPortal(null, portalContainer)}
-        </div>,
-        container,
-      );
-      expect(portalContainer.innerHTML).toBe('');
-      expect(container.innerHTML).toBe('<div></div>');
-    });
+    ReactDOM.render(
+      <div>
+        {ReactDOM.createPortal(<div>portal:1</div>, portalContainer)}
+      </div>,
+      container,
+    );
+    expect(portalContainer.innerHTML).toBe('<div>portal:1</div>');
+    expect(container.innerHTML).toBe('<div></div>');
 
-    it('should keep track of namespace across portals (simple)', () => {
-      assertNamespacesMatch(
-        <svg {...expectSVG}>
-          <image {...expectSVG} />
-          {usePortal(<div {...expectHTML} />)}
-          <image {...expectSVG} />
-        </svg>,
-      );
-      assertNamespacesMatch(
+    ReactDOM.render(
+      <div>
+        {ReactDOM.createPortal(<div>portal:2</div>, portalContainer)}
+      </div>,
+      container,
+    );
+    expect(portalContainer.innerHTML).toBe('<div>portal:2</div>');
+    expect(container.innerHTML).toBe('<div></div>');
+
+    ReactDOM.render(
+      <div>
+        {ReactDOM.createPortal(<p>portal:3</p>, portalContainer)}
+      </div>,
+      container,
+    );
+    expect(portalContainer.innerHTML).toBe('<p>portal:3</p>');
+    expect(container.innerHTML).toBe('<div></div>');
+
+    ReactDOM.render(
+      <div>
+        {ReactDOM.createPortal(['Hi', 'Bye'], portalContainer)}
+      </div>,
+      container,
+    );
+    expect(portalContainer.innerHTML).toBe('HiBye');
+    expect(container.innerHTML).toBe('<div></div>');
+
+    ReactDOM.render(
+      <div>
+        {ReactDOM.createPortal(['Bye', 'Hi'], portalContainer)}
+      </div>,
+      container,
+    );
+    expect(portalContainer.innerHTML).toBe('ByeHi');
+    expect(container.innerHTML).toBe('<div></div>');
+
+    ReactDOM.render(
+      <div>
+        {ReactDOM.createPortal(null, portalContainer)}
+      </div>,
+      container,
+    );
+    expect(portalContainer.innerHTML).toBe('');
+    expect(container.innerHTML).toBe('<div></div>');
+  });
+
+  it('should keep track of namespace across portals (simple)', () => {
+    assertNamespacesMatch(
+      <svg {...expectSVG}>
+        <image {...expectSVG} />
+        {usePortal(<div {...expectHTML} />)}
+        <image {...expectSVG} />
+      </svg>,
+    );
+    assertNamespacesMatch(
+      <math {...expectMath}>
+        <mi {...expectMath} />
+        {usePortal(<div {...expectHTML} />)}
+        <mi {...expectMath} />
+      </math>,
+    );
+    assertNamespacesMatch(
+      <div {...expectHTML}>
+        <p {...expectHTML} />
+        {usePortal(
+          <svg {...expectSVG}>
+            <image {...expectSVG} />
+          </svg>,
+        )}
+        <p {...expectHTML} />
+      </div>,
+    );
+  });
+
+  it('should keep track of namespace across portals (medium)', () => {
+    assertNamespacesMatch(
+      <svg {...expectSVG}>
+        <image {...expectSVG} />
+        {usePortal(<div {...expectHTML} />)}
+        <image {...expectSVG} />
+        {usePortal(<div {...expectHTML} />)}
+        <image {...expectSVG} />
+      </svg>,
+    );
+    assertNamespacesMatch(
+      <div {...expectHTML}>
         <math {...expectMath}>
           <mi {...expectMath} />
-          {usePortal(<div {...expectHTML} />)}
-          <mi {...expectMath} />
-        </math>,
-      );
-      assertNamespacesMatch(
-        <div {...expectHTML}>
-          <p {...expectHTML} />
           {usePortal(
             <svg {...expectSVG}>
               <image {...expectSVG} />
             </svg>,
           )}
-          <p {...expectHTML} />
-        </div>,
-      );
-    });
-
-    it('should keep track of namespace across portals (medium)', () => {
-      assertNamespacesMatch(
-        <svg {...expectSVG}>
-          <image {...expectSVG} />
-          {usePortal(<div {...expectHTML} />)}
-          <image {...expectSVG} />
-          {usePortal(<div {...expectHTML} />)}
-          <image {...expectSVG} />
-        </svg>,
-      );
-      assertNamespacesMatch(
-        <div {...expectHTML}>
-          <math {...expectMath}>
-            <mi {...expectMath} />
-            {usePortal(
-              <svg {...expectSVG}>
-                <image {...expectSVG} />
-              </svg>,
-            )}
-          </math>
-          <p {...expectHTML} />
-        </div>,
-      );
-      assertNamespacesMatch(
-        <math {...expectMath}>
-          <mi {...expectMath} />
-          {usePortal(
-            <svg {...expectSVG}>
-              <image {...expectSVG} />
-              <foreignObject {...expectSVG}>
-                <p {...expectHTML} />
-                <math {...expectMath}>
-                  <mi {...expectMath} />
-                </math>
-                <p {...expectHTML} />
-              </foreignObject>
-              <image {...expectSVG} />
-            </svg>,
-          )}
-          <mi {...expectMath} />
-        </math>,
-      );
-      assertNamespacesMatch(
-        <div {...expectHTML}>
-          {usePortal(
-            <svg {...expectSVG}>
-              {usePortal(<div {...expectHTML} />)}
-              <image {...expectSVG} />
-            </svg>,
-          )}
-          <p {...expectHTML} />
-        </div>,
-      );
-      assertNamespacesMatch(
-        <svg {...expectSVG}>
-          <svg {...expectSVG}>
-            {usePortal(<div {...expectHTML} />)}
-            <image {...expectSVG} />
-          </svg>
-          <image {...expectSVG} />
-        </svg>,
-      );
-    });
-
-    it('should keep track of namespace across portals (complex)', () => {
-      assertNamespacesMatch(
-        <div {...expectHTML}>
-          {usePortal(
-            <svg {...expectSVG}>
-              <image {...expectSVG} />
-            </svg>,
-          )}
-          <p {...expectHTML} />
+        </math>
+        <p {...expectHTML} />
+      </div>,
+    );
+    assertNamespacesMatch(
+      <math {...expectMath}>
+        <mi {...expectMath} />
+        {usePortal(
           <svg {...expectSVG}>
             <image {...expectSVG} />
-          </svg>
-          <svg {...expectSVG}>
-            <svg {...expectSVG}>
-              <image {...expectSVG} />
-            </svg>
-            <image {...expectSVG} />
-          </svg>
-          <p {...expectHTML} />
-        </div>,
-      );
-      assertNamespacesMatch(
-        <div {...expectHTML}>
-          <svg {...expectSVG}>
-            <svg {...expectSVG}>
-              <image {...expectSVG} />
-              {usePortal(
-                <svg {...expectSVG}>
-                  <image {...expectSVG} />
-                  <svg {...expectSVG}>
-                    <image {...expectSVG} />
-                  </svg>
-                  <image {...expectSVG} />
-                </svg>,
-              )}
-              <image {...expectSVG} />
-              <foreignObject {...expectSVG}>
-                <p {...expectHTML} />
-                {usePortal(<p {...expectHTML} />)}
-                <p {...expectHTML} />
-              </foreignObject>
-            </svg>
-            <image {...expectSVG} />
-          </svg>
-          <p {...expectHTML} />
-        </div>,
-      );
-      assertNamespacesMatch(
-        <div {...expectHTML}>
-          <svg {...expectSVG}>
             <foreignObject {...expectSVG}>
               <p {...expectHTML} />
-              {usePortal(
-                <svg {...expectSVG}>
-                  <image {...expectSVG} />
-                  <svg {...expectSVG}>
-                    <image {...expectSVG} />
-                    <foreignObject {...expectSVG}>
-                      <p {...expectHTML} />
-                    </foreignObject>
-                    {usePortal(<p {...expectHTML} />)}
-                  </svg>
-                  <image {...expectSVG} />
-                </svg>,
-              )}
+              <math {...expectMath}>
+                <mi {...expectMath} />
+              </math>
               <p {...expectHTML} />
             </foreignObject>
             <image {...expectSVG} />
-          </svg>
-          <p {...expectHTML} />
-        </div>,
-      );
-    });
-
-    it('should unwind namespaces on uncaught errors', () => {
-      function BrokenRender() {
-        throw new Error('Hello');
-      }
-
-      expect(() => {
-        assertNamespacesMatch(
-          <svg {...expectSVG}>
-            <BrokenRender />
           </svg>,
-        );
-      }).toThrow('Hello');
-      assertNamespacesMatch(<div {...expectHTML} />);
-    });
+        )}
+        <mi {...expectMath} />
+      </math>,
+    );
+    assertNamespacesMatch(
+      <div {...expectHTML}>
+        {usePortal(
+          <svg {...expectSVG}>
+            {usePortal(<div {...expectHTML} />)}
+            <image {...expectSVG} />
+          </svg>,
+        )}
+        <p {...expectHTML} />
+      </div>,
+    );
+    assertNamespacesMatch(
+      <svg {...expectSVG}>
+        <svg {...expectSVG}>
+          {usePortal(<div {...expectHTML} />)}
+          <image {...expectSVG} />
+        </svg>
+        <image {...expectSVG} />
+      </svg>,
+    );
+  });
 
-    it('should unwind namespaces on caught errors', () => {
-      function BrokenRender() {
-        throw new Error('Hello');
-      }
-
-      class ErrorBoundary extends React.Component {
-        state = {error: null};
-        componentDidCatch(error) {
-          this.setState({error});
-        }
-        render() {
-          if (this.state.error) {
-            return <p {...expectHTML} />;
-          }
-          return this.props.children;
-        }
-      }
-
-      assertNamespacesMatch(
+  it('should keep track of namespace across portals (complex)', () => {
+    assertNamespacesMatch(
+      <div {...expectHTML}>
+        {usePortal(
+          <svg {...expectSVG}>
+            <image {...expectSVG} />
+          </svg>,
+        )}
+        <p {...expectHTML} />
+        <svg {...expectSVG}>
+          <image {...expectSVG} />
+        </svg>
+        <svg {...expectSVG}>
+          <svg {...expectSVG}>
+            <image {...expectSVG} />
+          </svg>
+          <image {...expectSVG} />
+        </svg>
+        <p {...expectHTML} />
+      </div>,
+    );
+    assertNamespacesMatch(
+      <div {...expectHTML}>
+        <svg {...expectSVG}>
+          <svg {...expectSVG}>
+            <image {...expectSVG} />
+            {usePortal(
+              <svg {...expectSVG}>
+                <image {...expectSVG} />
+                <svg {...expectSVG}>
+                  <image {...expectSVG} />
+                </svg>
+                <image {...expectSVG} />
+              </svg>,
+            )}
+            <image {...expectSVG} />
+            <foreignObject {...expectSVG}>
+              <p {...expectHTML} />
+              {usePortal(<p {...expectHTML} />)}
+              <p {...expectHTML} />
+            </foreignObject>
+          </svg>
+          <image {...expectSVG} />
+        </svg>
+        <p {...expectHTML} />
+      </div>,
+    );
+    assertNamespacesMatch(
+      <div {...expectHTML}>
         <svg {...expectSVG}>
           <foreignObject {...expectSVG}>
-            <ErrorBoundary>
-              <math {...expectMath}>
-                <BrokenRender />
-              </math>
-            </ErrorBoundary>
+            <p {...expectHTML} />
+            {usePortal(
+              <svg {...expectSVG}>
+                <image {...expectSVG} />
+                <svg {...expectSVG}>
+                  <image {...expectSVG} />
+                  <foreignObject {...expectSVG}>
+                    <p {...expectHTML} />
+                  </foreignObject>
+                  {usePortal(<p {...expectHTML} />)}
+                </svg>
+                <image {...expectSVG} />
+              </svg>,
+            )}
+            <p {...expectHTML} />
           </foreignObject>
           <image {...expectSVG} />
-        </svg>,
-      );
-      assertNamespacesMatch(<div {...expectHTML} />);
-    });
+        </svg>
+        <p {...expectHTML} />
+      </div>,
+    );
+  });
 
-    it('should unwind namespaces on caught errors in a portal', () => {
-      function BrokenRender() {
-        throw new Error('Hello');
-      }
+  it('should unwind namespaces on uncaught errors', () => {
+    function BrokenRender() {
+      throw new Error('Hello');
+    }
 
-      class ErrorBoundary extends React.Component {
-        state = {error: null};
-        componentDidCatch(error) {
-          this.setState({error});
-        }
-        render() {
-          if (this.state.error) {
-            return <image {...expectSVG} />;
-          }
-          return this.props.children;
-        }
-      }
-
+    expect(() => {
       assertNamespacesMatch(
         <svg {...expectSVG}>
-          <ErrorBoundary>
-            {usePortal(
-              <div {...expectHTML}>
-                <math {...expectMath}>
-                  <BrokenRender />)
-                </math>
-              </div>,
-            )}
-          </ErrorBoundary>
-          {usePortal(<div {...expectHTML} />)}
+          <BrokenRender />
         </svg>,
       );
-    });
+    }).toThrow('Hello');
+    assertNamespacesMatch(<div {...expectHTML} />);
+  });
 
-    it('should pass portal context when rendering subtree elsewhere', () => {
-      var portalContainer = document.createElement('div');
+  it('should unwind namespaces on caught errors', () => {
+    function BrokenRender() {
+      throw new Error('Hello');
+    }
 
-      class Component extends React.Component {
-        static contextTypes = {
-          foo: PropTypes.string.isRequired,
-        };
-
-        render() {
-          return <div>{this.context.foo}</div>;
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
+      }
+      render() {
+        if (this.state.error) {
+          return <p {...expectHTML} />;
         }
+        return this.props.children;
+      }
+    }
+
+    assertNamespacesMatch(
+      <svg {...expectSVG}>
+        <foreignObject {...expectSVG}>
+          <ErrorBoundary>
+            <math {...expectMath}>
+              <BrokenRender />
+            </math>
+          </ErrorBoundary>
+        </foreignObject>
+        <image {...expectSVG} />
+      </svg>,
+    );
+    assertNamespacesMatch(<div {...expectHTML} />);
+  });
+
+  it('should unwind namespaces on caught errors in a portal', () => {
+    function BrokenRender() {
+      throw new Error('Hello');
+    }
+
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
+      }
+      render() {
+        if (this.state.error) {
+          return <image {...expectSVG} />;
+        }
+        return this.props.children;
+      }
+    }
+
+    assertNamespacesMatch(
+      <svg {...expectSVG}>
+        <ErrorBoundary>
+          {usePortal(
+            <div {...expectHTML}>
+              <math {...expectMath}>
+                <BrokenRender />)
+              </math>
+            </div>,
+          )}
+        </ErrorBoundary>
+        {usePortal(<div {...expectHTML} />)}
+      </svg>,
+    );
+  });
+
+  it('should pass portal context when rendering subtree elsewhere', () => {
+    var portalContainer = document.createElement('div');
+
+    class Component extends React.Component {
+      static contextTypes = {
+        foo: PropTypes.string.isRequired,
+      };
+
+      render() {
+        return <div>{this.context.foo}</div>;
+      }
+    }
+
+    class Parent extends React.Component {
+      static childContextTypes = {
+        foo: PropTypes.string.isRequired,
+      };
+
+      getChildContext() {
+        return {
+          foo: 'bar',
+        };
       }
 
-      class Parent extends React.Component {
-        static childContextTypes = {
-          foo: PropTypes.string.isRequired,
+      render() {
+        return ReactDOM.createPortal(<Component />, portalContainer);
+      }
+    }
+
+    ReactDOM.render(<Parent />, container);
+    expect(container.innerHTML).toBe('');
+    expect(portalContainer.innerHTML).toBe('<div>bar</div>');
+  });
+
+  it('should update portal context if it changes due to setState', () => {
+    var portalContainer = document.createElement('div');
+
+    class Component extends React.Component {
+      static contextTypes = {
+        foo: PropTypes.string.isRequired,
+        getFoo: PropTypes.func.isRequired,
+      };
+
+      render() {
+        return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
+      }
+    }
+
+    class Parent extends React.Component {
+      static childContextTypes = {
+        foo: PropTypes.string.isRequired,
+        getFoo: PropTypes.func.isRequired,
+      };
+
+      state = {
+        bar: 'initial',
+      };
+
+      getChildContext() {
+        return {
+          foo: this.state.bar,
+          getFoo: () => this.state.bar,
         };
-
-        getChildContext() {
-          return {
-            foo: 'bar',
-          };
-        }
-
-        render() {
-          return ReactDOM.createPortal(<Component />, portalContainer);
-        }
       }
 
-      ReactDOM.render(<Parent />, container);
-      expect(container.innerHTML).toBe('');
-      expect(portalContainer.innerHTML).toBe('<div>bar</div>');
-    });
+      render() {
+        return ReactDOM.createPortal(<Component />, portalContainer);
+      }
+    }
 
-    it('should update portal context if it changes due to setState', () => {
-      var portalContainer = document.createElement('div');
+    var instance = ReactDOM.render(<Parent />, container);
+    expect(portalContainer.innerHTML).toBe('<div>initial-initial</div>');
+    expect(container.innerHTML).toBe('');
+    instance.setState({bar: 'changed'});
+    expect(portalContainer.innerHTML).toBe('<div>changed-changed</div>');
+    expect(container.innerHTML).toBe('');
+  });
 
-      class Component extends React.Component {
-        static contextTypes = {
-          foo: PropTypes.string.isRequired,
-          getFoo: PropTypes.func.isRequired,
+  it('should update portal context if it changes due to re-render', () => {
+    var portalContainer = document.createElement('div');
+
+    class Component extends React.Component {
+      static contextTypes = {
+        foo: PropTypes.string.isRequired,
+        getFoo: PropTypes.func.isRequired,
+      };
+
+      render() {
+        return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
+      }
+    }
+
+    class Parent extends React.Component {
+      static childContextTypes = {
+        foo: PropTypes.string.isRequired,
+        getFoo: PropTypes.func.isRequired,
+      };
+
+      getChildContext() {
+        return {
+          foo: this.props.bar,
+          getFoo: () => this.props.bar,
         };
-
-        render() {
-          return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
-        }
       }
 
-      class Parent extends React.Component {
-        static childContextTypes = {
-          foo: PropTypes.string.isRequired,
-          getFoo: PropTypes.func.isRequired,
-        };
-
-        state = {
-          bar: 'initial',
-        };
-
-        getChildContext() {
-          return {
-            foo: this.state.bar,
-            getFoo: () => this.state.bar,
-          };
-        }
-
-        render() {
-          return ReactDOM.createPortal(<Component />, portalContainer);
-        }
+      render() {
+        return ReactDOM.createPortal(<Component />, portalContainer);
       }
+    }
 
-      var instance = ReactDOM.render(<Parent />, container);
-      expect(portalContainer.innerHTML).toBe('<div>initial-initial</div>');
-      expect(container.innerHTML).toBe('');
-      instance.setState({bar: 'changed'});
-      expect(portalContainer.innerHTML).toBe('<div>changed-changed</div>');
-      expect(container.innerHTML).toBe('');
-    });
+    ReactDOM.render(<Parent bar="initial" />, container);
+    expect(portalContainer.innerHTML).toBe('<div>initial-initial</div>');
+    expect(container.innerHTML).toBe('');
+    ReactDOM.render(<Parent bar="changed" />, container);
+    expect(portalContainer.innerHTML).toBe('<div>changed-changed</div>');
+    expect(container.innerHTML).toBe('');
+  });
 
-    it('should update portal context if it changes due to re-render', () => {
-      var portalContainer = document.createElement('div');
-
-      class Component extends React.Component {
-        static contextTypes = {
-          foo: PropTypes.string.isRequired,
-          getFoo: PropTypes.func.isRequired,
-        };
-
-        render() {
-          return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
-        }
+  it('findDOMNode should find dom element after expanding a fragment', () => {
+    class MyNode extends React.Component {
+      render() {
+        return !this.props.flag
+          ? [<div key="a" />]
+          : [<span key="b" />, <div key="a" />];
       }
+    }
 
-      class Parent extends React.Component {
-        static childContextTypes = {
-          foo: PropTypes.string.isRequired,
-          getFoo: PropTypes.func.isRequired,
-        };
+    var myNodeA = ReactDOM.render(<MyNode />, container);
+    var a = ReactDOM.findDOMNode(myNodeA);
+    expect(a.tagName).toBe('DIV');
 
-        getChildContext() {
-          return {
-            foo: this.props.bar,
-            getFoo: () => this.props.bar,
-          };
-        }
+    var myNodeB = ReactDOM.render(<MyNode flag={true} />, container);
+    expect(myNodeA === myNodeB).toBe(true);
 
-        render() {
-          return ReactDOM.createPortal(<Component />, portalContainer);
-        }
+    var b = ReactDOM.findDOMNode(myNodeB);
+    expect(b.tagName).toBe('SPAN');
+  });
+
+  it('should bubble events from the portal to the parent', () => {
+    var portalContainer = document.createElement('div');
+
+    var ops = [];
+    var portal = null;
+
+    ReactDOM.render(
+      <div onClick={() => ops.push('parent clicked')}>
+        {ReactDOM.createPortal(
+          <div
+            onClick={() => ops.push('portal clicked')}
+            ref={n => (portal = n)}>
+            portal
+          </div>,
+          portalContainer,
+        )}
+      </div>,
+      container,
+    );
+
+    expect(portal.tagName).toBe('DIV');
+
+    var fakeNativeEvent = {};
+    ReactTestUtils.simulateNativeEventOnNode(
+      'topClick',
+      portal,
+      fakeNativeEvent,
+    );
+
+    expect(ops).toEqual(['portal clicked', 'parent clicked']);
+  });
+
+  it('should not onMouseLeave when staying in the portal', () => {
+    var portalContainer = document.createElement('div');
+
+    var ops = [];
+    var firstTarget = null;
+    var secondTarget = null;
+    var thirdTarget = null;
+
+    function simulateMouseMove(from, to) {
+      if (from) {
+        ReactTestUtils.simulateNativeEventOnNode('topMouseOut', from, {
+          target: from,
+          relatedTarget: to,
+        });
       }
-
-      ReactDOM.render(<Parent bar="initial" />, container);
-      expect(portalContainer.innerHTML).toBe('<div>initial-initial</div>');
-      expect(container.innerHTML).toBe('');
-      ReactDOM.render(<Parent bar="changed" />, container);
-      expect(portalContainer.innerHTML).toBe('<div>changed-changed</div>');
-      expect(container.innerHTML).toBe('');
-    });
-
-    it('findDOMNode should find dom element after expanding a fragment', () => {
-      class MyNode extends React.Component {
-        render() {
-          return !this.props.flag
-            ? [<div key="a" />]
-            : [<span key="b" />, <div key="a" />];
-        }
+      if (to) {
+        ReactTestUtils.simulateNativeEventOnNode('topMouseOver', to, {
+          target: to,
+          relatedTarget: from,
+        });
       }
+    }
 
-      var myNodeA = ReactDOM.render(<MyNode />, container);
-      var a = ReactDOM.findDOMNode(myNodeA);
-      expect(a.tagName).toBe('DIV');
-
-      var myNodeB = ReactDOM.render(<MyNode flag={true} />, container);
-      expect(myNodeA === myNodeB).toBe(true);
-
-      var b = ReactDOM.findDOMNode(myNodeB);
-      expect(b.tagName).toBe('SPAN');
-    });
-
-    it('should bubble events from the portal to the parent', () => {
-      var portalContainer = document.createElement('div');
-
-      var ops = [];
-      var portal = null;
-
-      ReactDOM.render(
-        <div onClick={() => ops.push('parent clicked')}>
+    ReactDOM.render(
+      <div>
+        <div
+          onMouseEnter={() => ops.push('enter parent')}
+          onMouseLeave={() => ops.push('leave parent')}>
+          <div ref={n => (firstTarget = n)} />
           {ReactDOM.createPortal(
             <div
-              onClick={() => ops.push('portal clicked')}
-              ref={n => (portal = n)}>
+              onMouseEnter={() => ops.push('enter portal')}
+              onMouseLeave={() => ops.push('leave portal')}
+              ref={n => (secondTarget = n)}>
               portal
             </div>,
             portalContainer,
           )}
-        </div>,
-        container,
-      );
+        </div>
+        <div ref={n => (thirdTarget = n)} />
+      </div>,
+      container,
+    );
 
-      expect(portal.tagName).toBe('DIV');
+    simulateMouseMove(null, firstTarget);
+    expect(ops).toEqual(['enter parent']);
 
+    ops = [];
+
+    simulateMouseMove(firstTarget, secondTarget);
+    expect(ops).toEqual([
+      // Parent did not invoke leave because we're still inside the portal.
+      'enter portal',
+    ]);
+
+    ops = [];
+
+    simulateMouseMove(secondTarget, thirdTarget);
+    expect(ops).toEqual([
+      'leave portal',
+      'leave parent', // Only when we leave the portal does onMouseLeave fire.
+    ]);
+  });
+
+  it('should throw on bad createPortal argument', () => {
+    expect(() => {
+      ReactDOM.createPortal(<div>portal</div>, null);
+    }).toThrow('Target container is not a DOM element.');
+    expect(() => {
+      ReactDOM.createPortal(<div>portal</div>, document.createTextNode('hi'));
+    }).toThrow('Target container is not a DOM element.');
+  });
+
+  it('should warn for non-functional event listeners', () => {
+    spyOn(console, 'error');
+    class Example extends React.Component {
+      render() {
+        return <div onClick="woops" />;
+      }
+    }
+    ReactDOM.render(<Example />, container);
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(
+      normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
+    ).toContain(
+      'Expected `onClick` listener to be a function, instead got a value of `string` type.\n' +
+        '    in div (at **)\n' +
+        '    in Example (at **)',
+    );
+  });
+
+  it('should not update event handlers until commit', () => {
+    let ops = [];
+    const handlerA = () => ops.push('A');
+    const handlerB = () => ops.push('B');
+
+    class Example extends React.Component {
+      state = {flip: false, count: 0};
+      flip() {
+        this.setState({flip: true, count: this.state.count + 1});
+      }
+      tick() {
+        this.setState({count: this.state.count + 1});
+      }
+      render() {
+        const useB = !this.props.forceA && this.state.flip;
+        return <div onClick={useB ? handlerB : handlerA} />;
+      }
+    }
+
+    class Click extends React.Component {
+      constructor() {
+        super();
+        click(node);
+      }
+      render() {
+        return null;
+      }
+    }
+
+    let inst;
+    ReactDOM.render([<Example key="a" ref={n => (inst = n)} />], container);
+    const node = container.firstChild;
+    expect(node.tagName).toEqual('DIV');
+
+    function click(target) {
       var fakeNativeEvent = {};
       ReactTestUtils.simulateNativeEventOnNode(
         'topClick',
-        portal,
+        target,
         fakeNativeEvent,
       );
+    }
 
-      expect(ops).toEqual(['portal clicked', 'parent clicked']);
-    });
+    click(node);
 
-    it('should not onMouseLeave when staying in the portal', () => {
-      var portalContainer = document.createElement('div');
+    expect(ops).toEqual(['A']);
+    ops = [];
 
-      var ops = [];
-      var firstTarget = null;
-      var secondTarget = null;
-      var thirdTarget = null;
+    // Render with the other event handler.
+    inst.flip();
 
-      function simulateMouseMove(from, to) {
-        if (from) {
-          ReactTestUtils.simulateNativeEventOnNode('topMouseOut', from, {
-            target: from,
-            relatedTarget: to,
-          });
-        }
-        if (to) {
-          ReactTestUtils.simulateNativeEventOnNode('topMouseOver', to, {
-            target: to,
-            relatedTarget: from,
-          });
-        }
-      }
+    click(node);
 
-      ReactDOM.render(
-        <div>
-          <div
-            onMouseEnter={() => ops.push('enter parent')}
-            onMouseLeave={() => ops.push('leave parent')}>
-            <div ref={n => (firstTarget = n)} />
-            {ReactDOM.createPortal(
-              <div
-                onMouseEnter={() => ops.push('enter portal')}
-                onMouseLeave={() => ops.push('leave portal')}
-                ref={n => (secondTarget = n)}>
-                portal
-              </div>,
-              portalContainer,
-            )}
-          </div>
-          <div ref={n => (thirdTarget = n)} />
-        </div>,
-        container,
-      );
+    expect(ops).toEqual(['B']);
+    ops = [];
 
-      simulateMouseMove(null, firstTarget);
-      expect(ops).toEqual(['enter parent']);
+    // Rerender without changing any props.
+    inst.tick();
 
-      ops = [];
+    click(node);
 
-      simulateMouseMove(firstTarget, secondTarget);
-      expect(ops).toEqual([
-        // Parent did not invoke leave because we're still inside the portal.
-        'enter portal',
-      ]);
+    expect(ops).toEqual(['B']);
+    ops = [];
 
-      ops = [];
+    // Render a flip back to the A handler. The second component invokes the
+    // click handler during render to simulate a click during an aborted
+    // render. I use this hack because at current time we don't have a way to
+    // test aborted ReactDOM renders.
+    ReactDOM.render(
+      [<Example key="a" forceA={true} />, <Click key="b" />],
+      container,
+    );
 
-      simulateMouseMove(secondTarget, thirdTarget);
-      expect(ops).toEqual([
-        'leave portal',
-        'leave parent', // Only when we leave the portal does onMouseLeave fire.
-      ]);
-    });
+    // Because the new click handler has not yet committed, we should still
+    // invoke B.
+    expect(ops).toEqual(['B']);
+    ops = [];
 
-    it('should throw on bad createPortal argument', () => {
-      expect(() => {
-        ReactDOM.createPortal(<div>portal</div>, null);
-      }).toThrow('Target container is not a DOM element.');
-      expect(() => {
-        ReactDOM.createPortal(<div>portal</div>, document.createTextNode('hi'));
-      }).toThrow('Target container is not a DOM element.');
-    });
+    // Any click that happens after commit, should invoke A.
+    click(node);
+    expect(ops).toEqual(['A']);
+  });
 
-    it('should warn for non-functional event listeners', () => {
-      spyOn(console, 'error');
-      class Example extends React.Component {
-        render() {
-          return <div onClick="woops" />;
-        }
-      }
-      ReactDOM.render(<Example />, container);
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(
-        normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
-      ).toContain(
-        'Expected `onClick` listener to be a function, instead got a value of `string` type.\n' +
-          '    in div (at **)\n' +
-          '    in Example (at **)',
-      );
-    });
+  it('should not crash encountering low-priority tree', () => {
+    ReactDOM.render(
+      <div hidden={true}>
+        <div />
+      </div>,
+      container,
+    );
+  });
 
-    it('should not update event handlers until commit', () => {
-      let ops = [];
-      const handlerA = () => ops.push('A');
-      const handlerB = () => ops.push('B');
+  it('should not warn when rendering into an empty container', () => {
+    spyOn(console, 'error');
+    ReactDOM.render(<div>foo</div>, container);
+    expect(container.innerHTML).toBe('<div>foo</div>');
+    ReactDOM.render(null, container);
+    expect(container.innerHTML).toBe('');
+    expectDev(console.error.calls.count()).toBe(0);
+    ReactDOM.render(<div>bar</div>, container);
+    expect(container.innerHTML).toBe('<div>bar</div>');
+    expectDev(console.error.calls.count()).toBe(0);
+  });
 
-      class Example extends React.Component {
-        state = {flip: false, count: 0};
-        flip() {
-          this.setState({flip: true, count: this.state.count + 1});
-        }
-        tick() {
-          this.setState({count: this.state.count + 1});
-        }
-        render() {
-          const useB = !this.props.forceA && this.state.flip;
-          return <div onClick={useB ? handlerB : handlerA} />;
-        }
-      }
-
-      class Click extends React.Component {
-        constructor() {
-          super();
-          click(node);
-        }
-        render() {
-          return null;
-        }
-      }
-
-      let inst;
-      ReactDOM.render([<Example key="a" ref={n => (inst = n)} />], container);
-      const node = container.firstChild;
-      expect(node.tagName).toEqual('DIV');
-
-      function click(target) {
-        var fakeNativeEvent = {};
-        ReactTestUtils.simulateNativeEventOnNode(
-          'topClick',
-          target,
-          fakeNativeEvent,
-        );
-      }
-
-      click(node);
-
-      expect(ops).toEqual(['A']);
-      ops = [];
-
-      // Render with the other event handler.
-      inst.flip();
-
-      click(node);
-
-      expect(ops).toEqual(['B']);
-      ops = [];
-
-      // Rerender without changing any props.
-      inst.tick();
-
-      click(node);
-
-      expect(ops).toEqual(['B']);
-      ops = [];
-
-      // Render a flip back to the A handler. The second component invokes the
-      // click handler during render to simulate a click during an aborted
-      // render. I use this hack because at current time we don't have a way to
-      // test aborted ReactDOM renders.
-      ReactDOM.render(
-        [<Example key="a" forceA={true} />, <Click key="b" />],
-        container,
-      );
-
-      // Because the new click handler has not yet committed, we should still
-      // invoke B.
-      expect(ops).toEqual(['B']);
-      ops = [];
-
-      // Any click that happens after commit, should invoke A.
-      click(node);
-      expect(ops).toEqual(['A']);
-    });
-
-    it('should not crash encountering low-priority tree', () => {
-      ReactDOM.render(
-        <div hidden={true}>
-          <div />
-        </div>,
-        container,
-      );
-    });
-
-    it('should not warn when rendering into an empty container', () => {
-      spyOn(console, 'error');
-      ReactDOM.render(<div>foo</div>, container);
-      expect(container.innerHTML).toBe('<div>foo</div>');
-      ReactDOM.render(null, container);
-      expect(container.innerHTML).toBe('');
-      expectDev(console.error.calls.count()).toBe(0);
-      ReactDOM.render(<div>bar</div>, container);
-      expect(container.innerHTML).toBe('<div>bar</div>');
-      expectDev(console.error.calls.count()).toBe(0);
-    });
-
-    it('should warn when replacing a container which was manually updated outside of React', () => {
-      spyOn(console, 'error');
-      // when not messing with the DOM outside of React
-      ReactDOM.render(<div key="1">foo</div>, container);
-      ReactDOM.render(<div key="1">bar</div>, container);
-      expect(container.innerHTML).toBe('<div>bar</div>');
-      // then we mess with the DOM before an update
-      // we know this will error - that is expected right now
-      // It's an error of type 'NotFoundError' with no message
-      expect(() => {
-        container.innerHTML = '<div>MEOW.</div>';
-        ReactDOM.render(<div key="2">baz</div>, container);
-      }).toThrowError();
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'render(...): ' +
-          'It looks like the React-rendered content of this container was ' +
-          'removed without using React. This is not supported and will ' +
-          'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
-          'to empty a container.',
-      );
-    });
-
-    it('should warn when doing an update to a container manually updated outside of React', () => {
-      spyOn(console, 'error');
-      // when not messing with the DOM outside of React
-      ReactDOM.render(<div>foo</div>, container);
-      ReactDOM.render(<div>bar</div>, container);
-      expect(container.innerHTML).toBe('<div>bar</div>');
-      // then we mess with the DOM before an update
+  it('should warn when replacing a container which was manually updated outside of React', () => {
+    spyOn(console, 'error');
+    // when not messing with the DOM outside of React
+    ReactDOM.render(<div key="1">foo</div>, container);
+    ReactDOM.render(<div key="1">bar</div>, container);
+    expect(container.innerHTML).toBe('<div>bar</div>');
+    // then we mess with the DOM before an update
+    // we know this will error - that is expected right now
+    // It's an error of type 'NotFoundError' with no message
+    expect(() => {
       container.innerHTML = '<div>MEOW.</div>';
-      ReactDOM.render(<div>baz</div>, container);
-      // silently fails to update
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'render(...): ' +
-          'It looks like the React-rendered content of this container was ' +
-          'removed without using React. This is not supported and will ' +
-          'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
-          'to empty a container.',
-      );
+      ReactDOM.render(<div key="2">baz</div>, container);
+    }).toThrowError();
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'render(...): ' +
+        'It looks like the React-rendered content of this container was ' +
+        'removed without using React. This is not supported and will ' +
+        'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
+        'to empty a container.',
+    );
+  });
+
+  it('should warn when doing an update to a container manually updated outside of React', () => {
+    spyOn(console, 'error');
+    // when not messing with the DOM outside of React
+    ReactDOM.render(<div>foo</div>, container);
+    ReactDOM.render(<div>bar</div>, container);
+    expect(container.innerHTML).toBe('<div>bar</div>');
+    // then we mess with the DOM before an update
+    container.innerHTML = '<div>MEOW.</div>';
+    ReactDOM.render(<div>baz</div>, container);
+    // silently fails to update
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'render(...): ' +
+        'It looks like the React-rendered content of this container was ' +
+        'removed without using React. This is not supported and will ' +
+        'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
+        'to empty a container.',
+    );
+  });
+
+  it('should warn when doing an update to a container manually cleared outside of React', () => {
+    spyOn(console, 'error');
+    // when not messing with the DOM outside of React
+    ReactDOM.render(<div>foo</div>, container);
+    ReactDOM.render(<div>bar</div>, container);
+    expect(container.innerHTML).toBe('<div>bar</div>');
+    // then we mess with the DOM before an update
+    container.innerHTML = '';
+    ReactDOM.render(<div>baz</div>, container);
+    // silently fails to update
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'render(...): ' +
+        'It looks like the React-rendered content of this container was ' +
+        'removed without using React. This is not supported and will ' +
+        'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
+        'to empty a container.',
+    );
+  });
+
+  it('should render a text component with a text DOM node on the same document as the container', () => {
+    // 1. Create a new document through the use of iframe
+    // 2. Set up the spy to make asserts when a text component
+    //    is rendered inside the iframe container
+    var textContent = 'Hello world';
+    var iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    var iframeDocument = iframe.contentDocument;
+    iframeDocument.write(
+      '<!DOCTYPE html><html><head></head><body><div></div></body></html>',
+    );
+    iframeDocument.close();
+    var iframeContainer = iframeDocument.body.firstChild;
+
+    var actualDocument;
+    var textNode;
+
+    spyOn(iframeContainer, 'appendChild').and.callFake(node => {
+      actualDocument = node.ownerDocument;
+      textNode = node;
     });
 
-    it('should warn when doing an update to a container manually cleared outside of React', () => {
-      spyOn(console, 'error');
-      // when not messing with the DOM outside of React
-      ReactDOM.render(<div>foo</div>, container);
-      ReactDOM.render(<div>bar</div>, container);
-      expect(container.innerHTML).toBe('<div>bar</div>');
-      // then we mess with the DOM before an update
-      container.innerHTML = '';
-      ReactDOM.render(<div>baz</div>, container);
-      // silently fails to update
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'render(...): ' +
-          'It looks like the React-rendered content of this container was ' +
-          'removed without using React. This is not supported and will ' +
-          'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
-          'to empty a container.',
-      );
-    });
+    ReactDOM.render(textContent, iframeContainer);
 
-    it('should render a text component with a text DOM node on the same document as the container', () => {
-      // 1. Create a new document through the use of iframe
-      // 2. Set up the spy to make asserts when a text component
-      //    is rendered inside the iframe container
-      var textContent = 'Hello world';
-      var iframe = document.createElement('iframe');
-      document.body.appendChild(iframe);
-      var iframeDocument = iframe.contentDocument;
-      iframeDocument.write(
-        '<!DOCTYPE html><html><head></head><body><div></div></body></html>',
-      );
-      iframeDocument.close();
-      var iframeContainer = iframeDocument.body.firstChild;
-
-      var actualDocument;
-      var textNode;
-
-      spyOn(iframeContainer, 'appendChild').and.callFake(node => {
-        actualDocument = node.ownerDocument;
-        textNode = node;
-      });
-
-      ReactDOM.render(textContent, iframeContainer);
-
-      expect(textNode.textContent).toBe(textContent);
-      expect(actualDocument).not.toBe(document);
-      expect(actualDocument).toBe(iframeDocument);
-      expect(iframeContainer.appendChild).toHaveBeenCalledTimes(1);
-    });
-  }
+    expect(textNode.textContent).toBe(textContent);
+    expect(actualDocument).not.toBe(document);
+    expect(actualDocument).toBe(iframeDocument);
+    expect(iframeContainer.appendChild).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
@@ -1,5 +1,4 @@
 var React = require('react');
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactFeatureFlags = require('ReactFeatureFlags');
 
 var ReactDOM;
@@ -25,270 +24,268 @@ describe('ReactDOMFiberAsync', () => {
     expect(ops).toEqual(['Hi', 'Bye']);
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    describe('with feature flag disabled', () => {
-      beforeEach(() => {
-        jest.resetModules();
-        ReactFeatureFlags = require('ReactFeatureFlags');
-        container = document.createElement('div');
-        ReactFeatureFlags.enableAsyncSubtreeAPI = false;
-        ReactDOM = require('react-dom');
-      });
-
-      it('renders synchronously', () => {
-        ReactDOM.render(
-          <AsyncComponent><div>Hi</div></AsyncComponent>,
-          container,
-        );
-        expect(container.textContent).toEqual('Hi');
-
-        ReactDOM.render(
-          <AsyncComponent><div>Bye</div></AsyncComponent>,
-          container,
-        );
-        expect(container.textContent).toEqual('Bye');
-      });
+  describe('with feature flag disabled', () => {
+    beforeEach(() => {
+      jest.resetModules();
+      ReactFeatureFlags = require('ReactFeatureFlags');
+      container = document.createElement('div');
+      ReactFeatureFlags.enableAsyncSubtreeAPI = false;
+      ReactDOM = require('react-dom');
     });
 
-    describe('with feature flag enabled', () => {
-      beforeEach(() => {
-        jest.resetModules();
-        ReactFeatureFlags = require('ReactFeatureFlags');
-        container = document.createElement('div');
-        ReactFeatureFlags.enableAsyncSubtreeAPI = true;
-        ReactDOM = require('react-dom');
-      });
+    it('renders synchronously', () => {
+      ReactDOM.render(
+        <AsyncComponent><div>Hi</div></AsyncComponent>,
+        container,
+      );
+      expect(container.textContent).toEqual('Hi');
 
-      it('AsyncComponent at the root makes the entire tree async', () => {
-        ReactDOM.render(
-          <AsyncComponent><div>Hi</div></AsyncComponent>,
-          container,
-        );
-        expect(container.textContent).toEqual('');
-        jest.runAllTimers();
-        expect(container.textContent).toEqual('Hi');
+      ReactDOM.render(
+        <AsyncComponent><div>Bye</div></AsyncComponent>,
+        container,
+      );
+      expect(container.textContent).toEqual('Bye');
+    });
+  });
 
-        ReactDOM.render(
-          <AsyncComponent><div>Bye</div></AsyncComponent>,
-          container,
-        );
-        expect(container.textContent).toEqual('Hi');
-        jest.runAllTimers();
-        expect(container.textContent).toEqual('Bye');
-      });
+  describe('with feature flag enabled', () => {
+    beforeEach(() => {
+      jest.resetModules();
+      ReactFeatureFlags = require('ReactFeatureFlags');
+      container = document.createElement('div');
+      ReactFeatureFlags.enableAsyncSubtreeAPI = true;
+      ReactDOM = require('react-dom');
+    });
 
-      it('updates inside an async tree are async by default', () => {
-        let instance;
-        class Component extends React.Component {
-          state = {step: 0};
-          render() {
-            instance = this;
-            return <div>{this.state.step}</div>;
-          }
+    it('AsyncComponent at the root makes the entire tree async', () => {
+      ReactDOM.render(
+        <AsyncComponent><div>Hi</div></AsyncComponent>,
+        container,
+      );
+      expect(container.textContent).toEqual('');
+      jest.runAllTimers();
+      expect(container.textContent).toEqual('Hi');
+
+      ReactDOM.render(
+        <AsyncComponent><div>Bye</div></AsyncComponent>,
+        container,
+      );
+      expect(container.textContent).toEqual('Hi');
+      jest.runAllTimers();
+      expect(container.textContent).toEqual('Bye');
+    });
+
+    it('updates inside an async tree are async by default', () => {
+      let instance;
+      class Component extends React.Component {
+        state = {step: 0};
+        render() {
+          instance = this;
+          return <div>{this.state.step}</div>;
         }
+      }
 
-        ReactDOM.render(
-          <AsyncComponent><Component /></AsyncComponent>,
-          container,
-        );
-        expect(container.textContent).toEqual('');
-        jest.runAllTimers();
-        expect(container.textContent).toEqual('0');
+      ReactDOM.render(
+        <AsyncComponent><Component /></AsyncComponent>,
+        container,
+      );
+      expect(container.textContent).toEqual('');
+      jest.runAllTimers();
+      expect(container.textContent).toEqual('0');
 
-        instance.setState({step: 1});
-        expect(container.textContent).toEqual('0');
-        jest.runAllTimers();
-        expect(container.textContent).toEqual('1');
-      });
+      instance.setState({step: 1});
+      expect(container.textContent).toEqual('0');
+      jest.runAllTimers();
+      expect(container.textContent).toEqual('1');
+    });
 
-      it('AsyncComponent creates an async subtree', () => {
-        let instance;
-        class Component extends React.unstable_AsyncComponent {
-          state = {step: 0};
-          render() {
-            instance = this;
-            return <div>{this.state.step}</div>;
-          }
+    it('AsyncComponent creates an async subtree', () => {
+      let instance;
+      class Component extends React.unstable_AsyncComponent {
+        state = {step: 0};
+        render() {
+          instance = this;
+          return <div>{this.state.step}</div>;
         }
+      }
 
-        ReactDOM.render(<div><Component /></div>, container);
-        jest.runAllTimers();
+      ReactDOM.render(<div><Component /></div>, container);
+      jest.runAllTimers();
 
-        instance.setState({step: 1});
-        expect(container.textContent).toEqual('0');
-        jest.runAllTimers();
-        expect(container.textContent).toEqual('1');
-      });
+      instance.setState({step: 1});
+      expect(container.textContent).toEqual('0');
+      jest.runAllTimers();
+      expect(container.textContent).toEqual('1');
+    });
 
-      it('updates inside an async subtree are async by default', () => {
-        class Component extends React.unstable_AsyncComponent {
-          render() {
-            return <Child />;
-          }
+    it('updates inside an async subtree are async by default', () => {
+      class Component extends React.unstable_AsyncComponent {
+        render() {
+          return <Child />;
         }
+      }
 
-        let instance;
-        class Child extends React.Component {
-          state = {step: 0};
-          render() {
-            instance = this;
-            return <div>{this.state.step}</div>;
-          }
+      let instance;
+      class Child extends React.Component {
+        state = {step: 0};
+        render() {
+          instance = this;
+          return <div>{this.state.step}</div>;
         }
+      }
 
-        ReactDOM.render(<div><Component /></div>, container);
-        jest.runAllTimers();
+      ReactDOM.render(<div><Component /></div>, container);
+      jest.runAllTimers();
 
-        instance.setState({step: 1});
-        expect(container.textContent).toEqual('0');
-        jest.runAllTimers();
-        expect(container.textContent).toEqual('1');
-      });
+      instance.setState({step: 1});
+      expect(container.textContent).toEqual('0');
+      jest.runAllTimers();
+      expect(container.textContent).toEqual('1');
+    });
 
-      it('flushSync batches sync updates and flushes them at the end of the batch', () => {
-        let ops = [];
-        let instance;
+    it('flushSync batches sync updates and flushes them at the end of the batch', () => {
+      let ops = [];
+      let instance;
 
-        class Component extends React.Component {
-          state = {text: ''};
-          push(val) {
-            this.setState(state => ({text: state.text + val}));
-          }
-          componentDidUpdate() {
-            ops.push(this.state.text);
-          }
-          render() {
-            instance = this;
-            return <span>{this.state.text}</span>;
-          }
+      class Component extends React.Component {
+        state = {text: ''};
+        push(val) {
+          this.setState(state => ({text: state.text + val}));
         }
+        componentDidUpdate() {
+          ops.push(this.state.text);
+        }
+        render() {
+          instance = this;
+          return <span>{this.state.text}</span>;
+        }
+      }
 
-        ReactDOM.render(<Component />, container);
+      ReactDOM.render(<Component />, container);
 
-        instance.push('A');
-        expect(ops).toEqual(['A']);
+      instance.push('A');
+      expect(ops).toEqual(['A']);
+      expect(container.textContent).toEqual('A');
+
+      ReactDOM.flushSync(() => {
+        instance.push('B');
+        instance.push('C');
+        // Not flushed yet
         expect(container.textContent).toEqual('A');
+        expect(ops).toEqual(['A']);
+      });
+      expect(container.textContent).toEqual('ABC');
+      expect(ops).toEqual(['A', 'ABC']);
+      instance.push('D');
+      expect(container.textContent).toEqual('ABCD');
+      expect(ops).toEqual(['A', 'ABC', 'ABCD']);
+    });
+
+    it('flushSync flushes updates even if nested inside another flushSync', () => {
+      let ops = [];
+      let instance;
+
+      class Component extends React.Component {
+        state = {text: ''};
+        push(val) {
+          this.setState(state => ({text: state.text + val}));
+        }
+        componentDidUpdate() {
+          ops.push(this.state.text);
+        }
+        render() {
+          instance = this;
+          return <span>{this.state.text}</span>;
+        }
+      }
+
+      ReactDOM.render(<Component />, container);
+
+      instance.push('A');
+      expect(ops).toEqual(['A']);
+      expect(container.textContent).toEqual('A');
+
+      ReactDOM.flushSync(() => {
+        instance.push('B');
+        instance.push('C');
+        // Not flushed yet
+        expect(container.textContent).toEqual('A');
+        expect(ops).toEqual(['A']);
 
         ReactDOM.flushSync(() => {
-          instance.push('B');
-          instance.push('C');
-          // Not flushed yet
-          expect(container.textContent).toEqual('A');
-          expect(ops).toEqual(['A']);
+          instance.push('D');
         });
-        expect(container.textContent).toEqual('ABC');
-        expect(ops).toEqual(['A', 'ABC']);
-        instance.push('D');
-        expect(container.textContent).toEqual('ABCD');
-        expect(ops).toEqual(['A', 'ABC', 'ABCD']);
-      });
-
-      it('flushSync flushes updates even if nested inside another flushSync', () => {
-        let ops = [];
-        let instance;
-
-        class Component extends React.Component {
-          state = {text: ''};
-          push(val) {
-            this.setState(state => ({text: state.text + val}));
-          }
-          componentDidUpdate() {
-            ops.push(this.state.text);
-          }
-          render() {
-            instance = this;
-            return <span>{this.state.text}</span>;
-          }
-        }
-
-        ReactDOM.render(<Component />, container);
-
-        instance.push('A');
-        expect(ops).toEqual(['A']);
-        expect(container.textContent).toEqual('A');
-
-        ReactDOM.flushSync(() => {
-          instance.push('B');
-          instance.push('C');
-          // Not flushed yet
-          expect(container.textContent).toEqual('A');
-          expect(ops).toEqual(['A']);
-
-          ReactDOM.flushSync(() => {
-            instance.push('D');
-          });
-          // The nested flushSync caused everything to flush.
-          expect(container.textContent).toEqual('ABCD');
-          expect(ops).toEqual(['A', 'ABCD']);
-        });
+        // The nested flushSync caused everything to flush.
         expect(container.textContent).toEqual('ABCD');
         expect(ops).toEqual(['A', 'ABCD']);
       });
-
-      it('flushSync throws if already performing work', () => {
-        class Component extends React.Component {
-          componentDidUpdate() {
-            ReactDOM.flushSync(() => {});
-          }
-          render() {
-            return null;
-          }
-        }
-
-        // Initial mount
-        ReactDOM.render(<Component />, container);
-        // Update
-        expect(() => ReactDOM.render(<Component />, container)).toThrow(
-          'flushSync was called from inside a lifecycle method',
-        );
-      });
-
-      it('flushSync flushes updates before end of the tick', () => {
-        let ops = [];
-        let instance;
-
-        class Component extends React.unstable_AsyncComponent {
-          state = {text: ''};
-          push(val) {
-            this.setState(state => ({text: state.text + val}));
-          }
-          componentDidUpdate() {
-            ops.push(this.state.text);
-          }
-          render() {
-            instance = this;
-            return <span>{this.state.text}</span>;
-          }
-        }
-
-        ReactDOM.render(<Component />, container);
-        jest.runAllTimers();
-
-        // Updates are async by default
-        instance.push('A');
-        expect(ops).toEqual([]);
-        expect(container.textContent).toEqual('');
-
-        ReactDOM.flushSync(() => {
-          instance.push('B');
-          instance.push('C');
-          // Not flushed yet
-          expect(container.textContent).toEqual('');
-          expect(ops).toEqual([]);
-        });
-        // Only the active updates have flushed
-        expect(container.textContent).toEqual('BC');
-        expect(ops).toEqual(['BC']);
-
-        instance.push('D');
-        expect(container.textContent).toEqual('BC');
-        expect(ops).toEqual(['BC']);
-
-        // Flush the async updates
-        jest.runAllTimers();
-        expect(container.textContent).toEqual('BCAD');
-        expect(ops).toEqual(['BC', 'BCAD']);
-      });
+      expect(container.textContent).toEqual('ABCD');
+      expect(ops).toEqual(['A', 'ABCD']);
     });
-  }
+
+    it('flushSync throws if already performing work', () => {
+      class Component extends React.Component {
+        componentDidUpdate() {
+          ReactDOM.flushSync(() => {});
+        }
+        render() {
+          return null;
+        }
+      }
+
+      // Initial mount
+      ReactDOM.render(<Component />, container);
+      // Update
+      expect(() => ReactDOM.render(<Component />, container)).toThrow(
+        'flushSync was called from inside a lifecycle method',
+      );
+    });
+
+    it('flushSync flushes updates before end of the tick', () => {
+      let ops = [];
+      let instance;
+
+      class Component extends React.unstable_AsyncComponent {
+        state = {text: ''};
+        push(val) {
+          this.setState(state => ({text: state.text + val}));
+        }
+        componentDidUpdate() {
+          ops.push(this.state.text);
+        }
+        render() {
+          instance = this;
+          return <span>{this.state.text}</span>;
+        }
+      }
+
+      ReactDOM.render(<Component />, container);
+      jest.runAllTimers();
+
+      // Updates are async by default
+      instance.push('A');
+      expect(ops).toEqual([]);
+      expect(container.textContent).toEqual('');
+
+      ReactDOM.flushSync(() => {
+        instance.push('B');
+        instance.push('C');
+        // Not flushed yet
+        expect(container.textContent).toEqual('');
+        expect(ops).toEqual([]);
+      });
+      // Only the active updates have flushed
+      expect(container.textContent).toEqual('BC');
+      expect(ops).toEqual(['BC']);
+
+      instance.push('D');
+      expect(container.textContent).toEqual('BC');
+      expect(ops).toEqual(['BC']);
+
+      // Flush the async updates
+      jest.runAllTimers();
+      expect(container.textContent).toEqual('BCAD');
+      expect(ops).toEqual(['BC', 'BCAD']);
+    });
+  });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponentTree-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponentTree-test.js
@@ -9,8 +9,6 @@
 
 'use strict';
 
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-
 describe('ReactDOMComponentTree', () => {
   var React;
   var ReactDOM;
@@ -21,11 +19,7 @@ describe('ReactDOMComponentTree', () => {
     var container = document.createElement('div');
     // Force server-rendering path:
     container.innerHTML = ReactDOMServer.renderToString(elt);
-    if (ReactDOMFeatureFlags.useFiber) {
-      return ReactDOM.hydrate(elt, container);
-    } else {
-      return ReactDOM.render(elt, container);
-    }
+    return ReactDOM.hydrate(elt, container);
   }
 
   function getTypeOf(instance) {

--- a/src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
@@ -12,7 +12,6 @@
 var React;
 var ReactDOM;
 var ReactDOMServer;
-var ReactDOMFeatureFlags;
 
 // In standard React, TextComponent keeps track of different Text templates
 // using comments. However, in React Fiber, those comments are not outputted due
@@ -28,7 +27,6 @@ describe('ReactDOMTextComponent', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
   });
 
   it('updates a mounted text component in place', () => {
@@ -117,11 +115,7 @@ describe('ReactDOMTextComponent', () => {
     var reactEl = <div>{'foo'}{'bar'}{'baz'}</div>;
     el.innerHTML = ReactDOMServer.renderToString(reactEl);
 
-    if (ReactDOMFeatureFlags.useFiber) {
-      ReactDOM.hydrate(reactEl, el);
-    } else {
-      ReactDOM.render(reactEl, el);
-    }
+    ReactDOM.hydrate(reactEl, el);
     expect(el.textContent).toBe('foobarbaz');
 
     ReactDOM.unmountComponentAtNode(el);
@@ -129,11 +123,7 @@ describe('ReactDOMTextComponent', () => {
     reactEl = <div>{''}{''}{''}</div>;
     el.innerHTML = ReactDOMServer.renderToString(reactEl);
 
-    if (ReactDOMFeatureFlags.useFiber) {
-      ReactDOM.hydrate(reactEl, el);
-    } else {
-      ReactDOM.render(reactEl, el);
-    }
+    ReactDOM.hydrate(reactEl, el);
     expect(el.textContent).toBe('');
   });
 

--- a/src/renderers/dom/shared/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactMount-test.js
@@ -9,7 +9,6 @@
 
 'use strict';
 
-const ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 const {COMMENT_NODE} = require('HTMLNodeType');
 
 const invariant = require('invariant');
@@ -66,24 +65,22 @@ describe('ReactMount', () => {
     });
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    it('warns when given a factory', () => {
-      spyOn(console, 'error');
-      class Component extends React.Component {
-        render() {
-          return <div />;
-        }
+  it('warns when given a factory', () => {
+    spyOn(console, 'error');
+    class Component extends React.Component {
+      render() {
+        return <div />;
       }
+    }
 
-      ReactTestUtils.renderIntoDocument(Component);
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Functions are not valid as a React child. ' +
-          'This may happen if you return a Component instead of <Component /> from render. ' +
-          'Or maybe you meant to call this function rather than return it.',
-      );
-    });
-  }
+    ReactTestUtils.renderIntoDocument(Component);
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'Functions are not valid as a React child. ' +
+        'This may happen if you return a Component instead of <Component /> from render. ' +
+        'Or maybe you meant to call this function rather than return it.',
+    );
+  });
 
   it('should render different components in same root', () => {
     var container = document.createElement('container');
@@ -144,21 +141,11 @@ describe('ReactMount', () => {
     container.innerHTML = ReactDOMServer.renderToString(<div />) + ' ';
 
     spyOn(console, 'error');
-    if (ReactDOMFeatureFlags.useFiber) {
-      ReactDOM.hydrate(<div />, container);
-    } else {
-      ReactDOM.render(<div />, container);
-    }
+    ReactDOM.hydrate(<div />, container);
     expectDev(console.error.calls.count()).toBe(1);
-    if (ReactDOMFeatureFlags.useFiber) {
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Did not expect server HTML to contain the text node " " in <container>.',
-      );
-    } else {
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Target node has markup rendered by React, but there are unrelated nodes as well.',
-      );
-    }
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'Did not expect server HTML to contain the text node " " in <container>.',
+    );
   });
 
   it('should warn if mounting into right padded rendered markup', () => {
@@ -166,21 +153,11 @@ describe('ReactMount', () => {
     container.innerHTML = ' ' + ReactDOMServer.renderToString(<div />);
 
     spyOn(console, 'error');
-    if (ReactDOMFeatureFlags.useFiber) {
-      ReactDOM.hydrate(<div />, container);
-    } else {
-      ReactDOM.render(<div />, container);
-    }
+    ReactDOM.hydrate(<div />, container);
     expectDev(console.error.calls.count()).toBe(1);
-    if (ReactDOMFeatureFlags.useFiber) {
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Did not expect server HTML to contain the text node " " in <container>.',
-      );
-    } else {
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Target node has markup rendered by React, but there are unrelated nodes as well.',
-      );
-    }
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'Did not expect server HTML to contain the text node " " in <container>.',
+    );
   });
 
   it('should not warn if mounting into non-empty node', () => {
@@ -213,29 +190,15 @@ describe('ReactMount', () => {
     div.innerHTML = markup;
 
     spyOn(console, 'error');
-    if (ReactDOMFeatureFlags.useFiber) {
-      ReactDOM.hydrate(
-        <div>This markup contains an nbsp entity: &nbsp; client text</div>,
-        div,
-      );
-    } else {
-      ReactDOM.render(
-        <div>This markup contains an nbsp entity: &nbsp; client text</div>,
-        div,
-      );
-    }
+    ReactDOM.hydrate(
+      <div>This markup contains an nbsp entity: &nbsp; client text</div>,
+      div,
+    );
     expectDev(console.error.calls.count()).toBe(1);
-    if (ReactDOMFeatureFlags.useFiber) {
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Server: "This markup contains an nbsp entity:   server text" ' +
-          'Client: "This markup contains an nbsp entity:   client text"',
-      );
-    } else {
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        ' (client) nbsp entity: &nbsp; client text</div>\n' +
-          ' (server) nbsp entity: &nbsp; server text</div>',
-      );
-    }
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'Server: "This markup contains an nbsp entity:   server text" ' +
+        'Client: "This markup contains an nbsp entity:   client text"',
+    );
   });
 
   if (WebComponents !== undefined) {
@@ -388,41 +351,39 @@ describe('ReactMount', () => {
     expect(container2.textContent).toEqual('a!');
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    describe('mount point is a comment node', () => {
-      let containerDiv;
-      let mountPoint;
+  describe('mount point is a comment node', () => {
+    let containerDiv;
+    let mountPoint;
 
-      beforeEach(() => {
-        containerDiv = document.createElement('div');
-        containerDiv.innerHTML = 'A<!-- react-mount-point-unstable -->B';
-        mountPoint = containerDiv.childNodes[1];
-        invariant(mountPoint.nodeType === COMMENT_NODE, 'Expected comment');
-      });
-
-      it('renders at a comment node', () => {
-        function Char(props) {
-          return props.children;
-        }
-        function list(chars) {
-          return chars.split('').map(c => <Char key={c}>{c}</Char>);
-        }
-
-        ReactDOM.render(list('aeiou'), mountPoint);
-        expect(containerDiv.innerHTML).toBe(
-          'Aaeiou<!-- react-mount-point-unstable -->B',
-        );
-
-        ReactDOM.render(list('yea'), mountPoint);
-        expect(containerDiv.innerHTML).toBe(
-          'Ayea<!-- react-mount-point-unstable -->B',
-        );
-
-        ReactDOM.render(list(''), mountPoint);
-        expect(containerDiv.innerHTML).toBe(
-          'A<!-- react-mount-point-unstable -->B',
-        );
-      });
+    beforeEach(() => {
+      containerDiv = document.createElement('div');
+      containerDiv.innerHTML = 'A<!-- react-mount-point-unstable -->B';
+      mountPoint = containerDiv.childNodes[1];
+      invariant(mountPoint.nodeType === COMMENT_NODE, 'Expected comment');
     });
-  }
+
+    it('renders at a comment node', () => {
+      function Char(props) {
+        return props.children;
+      }
+      function list(chars) {
+        return chars.split('').map(c => <Char key={c}>{c}</Char>);
+      }
+
+      ReactDOM.render(list('aeiou'), mountPoint);
+      expect(containerDiv.innerHTML).toBe(
+        'Aaeiou<!-- react-mount-point-unstable -->B',
+      );
+
+      ReactDOM.render(list('yea'), mountPoint);
+      expect(containerDiv.innerHTML).toBe(
+        'Ayea<!-- react-mount-point-unstable -->B',
+      );
+
+      ReactDOM.render(list(''), mountPoint);
+      expect(containerDiv.innerHTML).toBe(
+        'A<!-- react-mount-point-unstable -->B',
+      );
+    });
+  });
 });

--- a/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
@@ -15,15 +15,6 @@ var ReactDOMServer;
 
 var getTestDocument;
 
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-
-var UNMOUNT_INVARIANT_MESSAGE =
-  '<html> tried to unmount. ' +
-  'Because of cross-browser quirks it is impossible to unmount some ' +
-  'top-level components (eg <html>, <head>, and <body>) reliably and ' +
-  'efficiently. To fix this, have a single top-level component that ' +
-  'never unmounts render these elements.';
-
 describe('rendering React components at document', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -36,16 +27,12 @@ describe('rendering React components at document', () => {
 
   describe('with old implicit hydration API', () => {
     function expectDeprecationWarningWithFiber() {
-      if (ReactDOMFeatureFlags.useFiber) {
-        expectDev(console.warn.calls.count()).toBe(1);
-        expectDev(console.warn.calls.argsFor(0)[0]).toContain(
-          'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
-            'will stop working in React v17. Replace the ReactDOM.render() call ' +
-            'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
-        );
-      } else {
-        expectDev(console.warn.calls.count()).toBe(0);
-      }
+      expectDev(console.warn.calls.count()).toBe(1);
+      expectDev(console.warn.calls.argsFor(0)[0]).toContain(
+        'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
+          'will stop working in React v17. Replace the ReactDOM.render() call ' +
+          'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+      );
     }
 
     it('should be able to adopt server markup', () => {
@@ -101,17 +88,9 @@ describe('rendering React components at document', () => {
       ReactDOM.render(<Root />, testDocument);
       expect(testDocument.body.innerHTML).toBe('Hello world');
 
-      if (ReactDOMFeatureFlags.useFiber) {
-        // In Fiber this actually works. It might not be a good idea though.
-        ReactDOM.unmountComponentAtNode(testDocument);
-        expect(testDocument.firstChild).toBe(null);
-      } else {
-        expect(function() {
-          ReactDOM.unmountComponentAtNode(testDocument);
-        }).toThrowError(UNMOUNT_INVARIANT_MESSAGE);
-
-        expect(testDocument.body.innerHTML).toBe('Hello world');
-      }
+      // In Fiber this actually works. It might not be a good idea though.
+      ReactDOM.unmountComponentAtNode(testDocument);
+      expect(testDocument.firstChild).toBe(null);
 
       expectDeprecationWarningWithFiber();
     });
@@ -152,23 +131,12 @@ describe('rendering React components at document', () => {
       var testDocument = getTestDocument(markup);
 
       ReactDOM.render(<Component />, testDocument);
-
       expect(testDocument.body.innerHTML).toBe('Hello world');
 
-      // Reactive update
-      if (ReactDOMFeatureFlags.useFiber) {
-        // This works but is probably a bad idea.
-        ReactDOM.render(<Component2 />, testDocument);
+      // This works but is probably a bad idea.
+      ReactDOM.render(<Component2 />, testDocument);
 
-        expect(testDocument.body.innerHTML).toBe('Goodbye world');
-      } else {
-        expect(function() {
-          ReactDOM.render(<Component2 />, testDocument);
-        }).toThrowError(UNMOUNT_INVARIANT_MESSAGE);
-
-        expect(testDocument.body.innerHTML).toBe('Hello world');
-      }
-
+      expect(testDocument.body.innerHTML).toBe('Goodbye world');
       expectDeprecationWarningWithFiber();
     });
 
@@ -231,38 +199,20 @@ describe('rendering React components at document', () => {
       );
       var testDocument = getTestDocument(markup);
 
-      if (ReactDOMFeatureFlags.useFiber) {
-        spyOn(console, 'warn');
-        spyOn(console, 'error');
-        ReactDOM.render(<Component text="Hello world" />, testDocument);
-        expect(testDocument.body.innerHTML).toBe('Hello world');
-        expectDev(console.warn.calls.count()).toBe(1);
-        expectDev(console.warn.calls.argsFor(0)[0]).toContain(
-          'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
-            'will stop working in React v17. Replace the ReactDOM.render() call ' +
-            'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
-        );
-        expectDev(console.error.calls.count()).toBe(1);
-        expectDev(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Text content did not match.',
-        );
-      } else {
-        expect(function() {
-          // Notice the text is different!
-          ReactDOM.render(<Component text="Hello world" />, testDocument);
-        }).toThrowError(
-          "You're trying to render a component to the document using " +
-            'server rendering but the checksum was invalid. This usually ' +
-            'means you rendered a different component type or props on ' +
-            'the client from the one on the server, or your render() methods ' +
-            'are impure. React cannot handle this case due to cross-browser ' +
-            'quirks by rendering at the document root. You should look for ' +
-            'environment dependent code in your components and ensure ' +
-            'the props are the same client and server side:\n' +
-            ' (client) dy data-reactid="4">Hello world</body></\n' +
-            ' (server) dy data-reactid="4">Goodbye world</body>',
-        );
-      }
+      spyOn(console, 'warn');
+      spyOn(console, 'error');
+      ReactDOM.render(<Component text="Hello world" />, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+      expectDev(console.warn.calls.count()).toBe(1);
+      expectDev(console.warn.calls.argsFor(0)[0]).toContain(
+        'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
+          'will stop working in React v17. Replace the ReactDOM.render() call ' +
+          'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+      );
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Warning: Text content did not match.',
+      );
     });
 
     it('should throw on full document render w/ no markup', () => {
@@ -283,19 +233,8 @@ describe('rendering React components at document', () => {
         }
       }
 
-      if (ReactDOMFeatureFlags.useFiber) {
-        ReactDOM.render(<Component text="Hello world" />, testDocument);
-        expect(testDocument.body.innerHTML).toBe('Hello world');
-      } else {
-        expect(function() {
-          ReactDOM.render(<Component />, testDocument);
-        }).toThrowError(
-          "You're trying to render a component to the document but you didn't " +
-            "use server rendering. We can't do this without using server " +
-            'rendering due to cross-browser quirks. See ' +
-            'ReactDOMServer.renderToString() for server rendering.',
-        );
-      }
+      ReactDOM.render(<Component text="Hello world" />, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello world');
       // We don't expect a warning about new hydration API here because
       // we aren't sure if the user meant to hydrate or replace the document.
       // We would see a warning if the document had React-rendered HTML in it.
@@ -323,221 +262,219 @@ describe('rendering React components at document', () => {
     });
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    describe('with new explicit hydration API', () => {
-      it('should be able to adopt server markup', () => {
-        class Root extends React.Component {
-          render() {
-            return (
-              <html>
-                <head>
-                  <title>Hello World</title>
-                </head>
-                <body>
-                  {'Hello ' + this.props.hello}
-                </body>
-              </html>
-            );
-          }
+  describe('with new explicit hydration API', () => {
+    it('should be able to adopt server markup', () => {
+      class Root extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                {'Hello ' + this.props.hello}
+              </body>
+            </html>
+          );
         }
+      }
 
-        var markup = ReactDOMServer.renderToString(<Root hello="world" />);
-        var testDocument = getTestDocument(markup);
-        var body = testDocument.body;
+      var markup = ReactDOMServer.renderToString(<Root hello="world" />);
+      var testDocument = getTestDocument(markup);
+      var body = testDocument.body;
 
-        ReactDOM.hydrate(<Root hello="world" />, testDocument);
-        expect(testDocument.body.innerHTML).toBe('Hello world');
+      ReactDOM.hydrate(<Root hello="world" />, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello world');
 
-        ReactDOM.hydrate(<Root hello="moon" />, testDocument);
-        expect(testDocument.body.innerHTML).toBe('Hello moon');
+      ReactDOM.hydrate(<Root hello="moon" />, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello moon');
 
-        expect(body === testDocument.body).toBe(true);
-      });
-
-      it('should not be able to unmount component from document node', () => {
-        class Root extends React.Component {
-          render() {
-            return (
-              <html>
-                <head>
-                  <title>Hello World</title>
-                </head>
-                <body>
-                  Hello world
-                </body>
-              </html>
-            );
-          }
-        }
-
-        var markup = ReactDOMServer.renderToString(<Root />);
-        var testDocument = getTestDocument(markup);
-        ReactDOM.hydrate(<Root />, testDocument);
-        expect(testDocument.body.innerHTML).toBe('Hello world');
-
-        // In Fiber this actually works. It might not be a good idea though.
-        ReactDOM.unmountComponentAtNode(testDocument);
-        expect(testDocument.firstChild).toBe(null);
-      });
-
-      it('should not be able to switch root constructors', () => {
-        class Component extends React.Component {
-          render() {
-            return (
-              <html>
-                <head>
-                  <title>Hello World</title>
-                </head>
-                <body>
-                  Hello world
-                </body>
-              </html>
-            );
-          }
-        }
-
-        class Component2 extends React.Component {
-          render() {
-            return (
-              <html>
-                <head>
-                  <title>Hello World</title>
-                </head>
-                <body>
-                  Goodbye world
-                </body>
-              </html>
-            );
-          }
-        }
-
-        var markup = ReactDOMServer.renderToString(<Component />);
-        var testDocument = getTestDocument(markup);
-
-        ReactDOM.hydrate(<Component />, testDocument);
-
-        expect(testDocument.body.innerHTML).toBe('Hello world');
-
-        // This works but is probably a bad idea.
-        ReactDOM.hydrate(<Component2 />, testDocument);
-
-        expect(testDocument.body.innerHTML).toBe('Goodbye world');
-      });
-
-      it('should be able to mount into document', () => {
-        class Component extends React.Component {
-          render() {
-            return (
-              <html>
-                <head>
-                  <title>Hello World</title>
-                </head>
-                <body>
-                  {this.props.text}
-                </body>
-              </html>
-            );
-          }
-        }
-
-        var markup = ReactDOMServer.renderToString(
-          <Component text="Hello world" />,
-        );
-        var testDocument = getTestDocument(markup);
-
-        ReactDOM.hydrate(<Component text="Hello world" />, testDocument);
-
-        expect(testDocument.body.innerHTML).toBe('Hello world');
-      });
-
-      it('renders over an existing text child without throwing', () => {
-        spyOn(console, 'error');
-        const container = document.createElement('div');
-        container.textContent = 'potato';
-        ReactDOM.hydrate(<div>parsnip</div>, container);
-        expect(container.textContent).toBe('parsnip');
-        expectDev(console.error.calls.count()).toBe(1);
-        expectDev(console.error.calls.argsFor(0)[0]).toContain(
-          'Did not expect server HTML to contain the text node "potato" in <div>.',
-        );
-      });
-
-      it('should give helpful errors on state desync', () => {
-        class Component extends React.Component {
-          render() {
-            return (
-              <html>
-                <head>
-                  <title>Hello World</title>
-                </head>
-                <body>
-                  {this.props.text}
-                </body>
-              </html>
-            );
-          }
-        }
-
-        var markup = ReactDOMServer.renderToString(
-          <Component text="Goodbye world" />,
-        );
-        var testDocument = getTestDocument(markup);
-
-        spyOn(console, 'error');
-        ReactDOM.hydrate(<Component text="Hello world" />, testDocument);
-        expect(testDocument.body.innerHTML).toBe('Hello world');
-        expectDev(console.error.calls.count()).toBe(1);
-        expectDev(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Text content did not match.',
-        );
-      });
-
-      it('should render w/ no markup to full document', () => {
-        spyOn(console, 'error');
-        var testDocument = getTestDocument();
-
-        class Component extends React.Component {
-          render() {
-            return (
-              <html>
-                <head>
-                  <title>Hello World</title>
-                </head>
-                <body>
-                  {this.props.text}
-                </body>
-              </html>
-            );
-          }
-        }
-
-        ReactDOM.hydrate(<Component text="Hello world" />, testDocument);
-        expect(testDocument.body.innerHTML).toBe('Hello world');
-        expectDev(console.error.calls.count()).toBe(1);
-        expectDev(console.error.calls.argsFor(0)[0]).toContain(
-          // getTestDocument() has an extra <meta> that we didn't render.
-          'Did not expect server HTML to contain a <meta> in <head>.',
-        );
-      });
-
-      it('supports findDOMNode on full-page components', () => {
-        var tree = (
-          <html>
-            <head>
-              <title>Hello World</title>
-            </head>
-            <body>
-              Hello world
-            </body>
-          </html>
-        );
-
-        var markup = ReactDOMServer.renderToString(tree);
-        var testDocument = getTestDocument(markup);
-        var component = ReactDOM.hydrate(tree, testDocument);
-        expect(testDocument.body.innerHTML).toBe('Hello world');
-        expect(ReactDOM.findDOMNode(component).tagName).toBe('HTML');
-      });
+      expect(body === testDocument.body).toBe(true);
     });
-  }
+
+    it('should not be able to unmount component from document node', () => {
+      class Root extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                Hello world
+              </body>
+            </html>
+          );
+        }
+      }
+
+      var markup = ReactDOMServer.renderToString(<Root />);
+      var testDocument = getTestDocument(markup);
+      ReactDOM.hydrate(<Root />, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+
+      // In Fiber this actually works. It might not be a good idea though.
+      ReactDOM.unmountComponentAtNode(testDocument);
+      expect(testDocument.firstChild).toBe(null);
+    });
+
+    it('should not be able to switch root constructors', () => {
+      class Component extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                Hello world
+              </body>
+            </html>
+          );
+        }
+      }
+
+      class Component2 extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                Goodbye world
+              </body>
+            </html>
+          );
+        }
+      }
+
+      var markup = ReactDOMServer.renderToString(<Component />);
+      var testDocument = getTestDocument(markup);
+
+      ReactDOM.hydrate(<Component />, testDocument);
+
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+
+      // This works but is probably a bad idea.
+      ReactDOM.hydrate(<Component2 />, testDocument);
+
+      expect(testDocument.body.innerHTML).toBe('Goodbye world');
+    });
+
+    it('should be able to mount into document', () => {
+      class Component extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                {this.props.text}
+              </body>
+            </html>
+          );
+        }
+      }
+
+      var markup = ReactDOMServer.renderToString(
+        <Component text="Hello world" />,
+      );
+      var testDocument = getTestDocument(markup);
+
+      ReactDOM.hydrate(<Component text="Hello world" />, testDocument);
+
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+    });
+
+    it('renders over an existing text child without throwing', () => {
+      spyOn(console, 'error');
+      const container = document.createElement('div');
+      container.textContent = 'potato';
+      ReactDOM.hydrate(<div>parsnip</div>, container);
+      expect(container.textContent).toBe('parsnip');
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Did not expect server HTML to contain the text node "potato" in <div>.',
+      );
+    });
+
+    it('should give helpful errors on state desync', () => {
+      class Component extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                {this.props.text}
+              </body>
+            </html>
+          );
+        }
+      }
+
+      var markup = ReactDOMServer.renderToString(
+        <Component text="Goodbye world" />,
+      );
+      var testDocument = getTestDocument(markup);
+
+      spyOn(console, 'error');
+      ReactDOM.hydrate(<Component text="Hello world" />, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Warning: Text content did not match.',
+      );
+    });
+
+    it('should render w/ no markup to full document', () => {
+      spyOn(console, 'error');
+      var testDocument = getTestDocument();
+
+      class Component extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>
+                {this.props.text}
+              </body>
+            </html>
+          );
+        }
+      }
+
+      ReactDOM.hydrate(<Component text="Hello world" />, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        // getTestDocument() has an extra <meta> that we didn't render.
+        'Did not expect server HTML to contain a <meta> in <head>.',
+      );
+    });
+
+    it('supports findDOMNode on full-page components', () => {
+      var tree = (
+        <html>
+          <head>
+            <title>Hello World</title>
+          </head>
+          <body>
+            Hello world
+          </body>
+        </html>
+      );
+
+      var markup = ReactDOMServer.renderToString(tree);
+      var testDocument = getTestDocument(markup);
+      var component = ReactDOM.hydrate(tree, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+      expect(ReactDOM.findDOMNode(component).tagName).toBe('HTML');
+    });
+  });
 });

--- a/src/renderers/dom/shared/__tests__/ReactServerRenderingBrowser-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRenderingBrowser-test.js
@@ -13,8 +13,6 @@ var React;
 var ReactDOMServer;
 var ReactDOMServerBrowser;
 
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-
 describe('ReactServerRenderingBrowser', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -53,18 +51,16 @@ describe('ReactServerRenderingBrowser', () => {
     );
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    it('throws meaningfully for server-only APIs', () => {
-      expect(() => ReactDOMServerBrowser.renderToNodeStream(<div />)).toThrow(
-        'ReactDOMServer.renderToNodeStream(): The streaming API is not available ' +
-          'in the browser. Use ReactDOMServer.renderToString() instead.',
-      );
-      expect(() =>
-        ReactDOMServerBrowser.renderToStaticNodeStream(<div />),
-      ).toThrow(
-        'ReactDOMServer.renderToStaticNodeStream(): The streaming API is not available ' +
-          'in the browser. Use ReactDOMServer.renderToStaticMarkup() instead.',
-      );
-    });
-  }
+  it('throws meaningfully for server-only APIs', () => {
+    expect(() => ReactDOMServerBrowser.renderToNodeStream(<div />)).toThrow(
+      'ReactDOMServer.renderToNodeStream(): The streaming API is not available ' +
+        'in the browser. Use ReactDOMServer.renderToString() instead.',
+    );
+    expect(() =>
+      ReactDOMServerBrowser.renderToStaticNodeStream(<div />),
+    ).toThrow(
+      'ReactDOMServer.renderToStaticNodeStream(): The streaming API is not available ' +
+        'in the browser. Use ReactDOMServer.renderToStaticMarkup() instead.',
+    );
+  });
 });

--- a/src/renderers/dom/shared/__tests__/renderSubtreeIntoContainer-test.js
+++ b/src/renderers/dom/shared/__tests__/renderSubtreeIntoContainer-test.js
@@ -12,7 +12,6 @@
 var React = require('react');
 var PropTypes = require('prop-types');
 var ReactDOM = require('react-dom');
-var ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
 var ReactTestUtils = require('react-dom/test-utils');
 var renderSubtreeIntoContainer = require('react-dom')
   .unstable_renderSubtreeIntoContainer;
@@ -299,26 +298,24 @@ describe('renderSubtreeIntoContainer', () => {
     expect(portal2.textContent).toBe('foo');
   });
 
-  if (ReactDOMFeatureFlags.useFiber) {
-    it('fails gracefully when mixing React 15 and 16', () => {
-      class C extends React.Component {
-        render() {
-          return <div />;
-        }
+  it('fails gracefully when mixing React 15 and 16', () => {
+    class C extends React.Component {
+      render() {
+        return <div />;
       }
-      const c = ReactDOM.render(<C />, document.createElement('div'));
-      // React 15 calls this:
-      // https://github.com/facebook/react/blob/77b71fc3c4/src/renderers/dom/client/ReactMount.js#L478-L479
-      expect(() => {
-        c._reactInternalInstance._processChildContext({});
-      }).toThrow(
-        '_processChildContext is not available in React 16+. This likely ' +
-          'means you have multiple copies of React and are attempting to nest ' +
-          'a React 15 tree inside a React 16 tree using ' +
-          "unstable_renderSubtreeIntoContainer, which isn't supported. Try to " +
-          'make sure you have only one copy of React (and ideally, switch to ' +
-          'ReactDOM.createPortal).',
-      );
-    });
-  }
+    }
+    const c = ReactDOM.render(<C />, document.createElement('div'));
+    // React 15 calls this:
+    // https://github.com/facebook/react/blob/77b71fc3c4/src/renderers/dom/client/ReactMount.js#L478-L479
+    expect(() => {
+      c._reactInternalInstance._processChildContext({});
+    }).toThrow(
+      '_processChildContext is not available in React 16+. This likely ' +
+        'means you have multiple copies of React and are attempting to nest ' +
+        'a React 15 tree inside a React 16 tree using ' +
+        "unstable_renderSubtreeIntoContainer, which isn't supported. Try to " +
+        'make sure you have only one copy of React (and ideally, switch to ' +
+        'ReactDOM.createPortal).',
+    );
+  });
 });

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -15,7 +15,6 @@ describe('ReactDOMInput', () => {
   var React;
   var ReactDOM;
   var ReactDOMServer;
-  var ReactDOMFeatureFlags;
   var ReactTestUtils;
   var inputValueTracking;
 
@@ -35,7 +34,6 @@ describe('ReactDOMInput', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactTestUtils = require('react-dom/test-utils');
     // TODO: can we express this test with only public API?
     inputValueTracking = require('inputValueTracking');
@@ -1187,7 +1185,6 @@ describe('ReactDOMInput', () => {
       <input value="0" type="range" min="0" max="100" step="1" />,
     );
     expect(log).toEqual([
-      ...(ReactDOMFeatureFlags.useFiber ? [] : ['set data-reactroot']),
       'set type',
       'set step',
       'set min',
@@ -1251,9 +1248,6 @@ describe('ReactDOMInput', () => {
       <input type="date" defaultValue="1980-01-01" />,
     );
     expect(log).toEqual([
-      ...(ReactDOMFeatureFlags.useFiber
-        ? []
-        : ['node.setAttribute("data-reactroot", "")']),
       'node.setAttribute("type", "date")',
       'node.setAttribute("value", "1980-01-01")',
       'node.value = ""',

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMOption-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMOption-test.js
@@ -16,13 +16,11 @@ describe('ReactDOMOption', () => {
 
   var React;
   var ReactDOM;
-  var ReactDOMFeatureFlags;
   var ReactTestUtils;
 
   beforeEach(() => {
     React = require('react');
     ReactDOM = require('react-dom');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
     ReactTestUtils = require('react-dom/test-utils');
   });
 
@@ -45,11 +43,9 @@ describe('ReactDOMOption', () => {
     expectDev(
       normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
     ).toContain(
-      ReactDOMFeatureFlags.useFiber
-        ? '<div> cannot appear as a child of <option>.\n' +
-            '    in div (at **)\n' +
-            '    in option (at **)'
-        : 'Only strings and numbers are supported as <option> children.',
+      '<div> cannot appear as a child of <option>.\n' +
+        '    in div (at **)\n' +
+        '    in option (at **)',
     );
   });
 

--- a/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
+++ b/src/renderers/dom/test/__tests__/ReactTestUtils-test.js
@@ -12,7 +12,6 @@
 let createRenderer;
 let React;
 let ReactDOM;
-let ReactDOMFeatureFlags;
 let ReactDOMServer;
 let ReactTestUtils;
 
@@ -23,7 +22,6 @@ describe('ReactTestUtils', () => {
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
     ReactTestUtils = require('react-dom/test-utils');
-    ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
   });
 
   it('can scryRenderedDOMComponentsWithClass with TextComponent', () => {
@@ -173,9 +171,7 @@ describe('ReactTestUtils', () => {
 
     const markup = ReactDOMServer.renderToString(<Root />);
     const testDocument = getTestDocument(markup);
-    const component = ReactDOMFeatureFlags.useFiber
-      ? ReactDOM.hydrate(<Root />, testDocument)
-      : ReactDOM.render(<Root />, testDocument);
+    const component = ReactDOM.hydrate(<Root />, testDocument);
 
     expect(component.refs.html.tagName).toBe('HTML');
     expect(component.refs.head.tagName).toBe('HEAD');

--- a/src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
+++ b/src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
@@ -9,10 +9,7 @@
 
 'use strict';
 
-const ReactDOMFeatureFlags = require('ReactDOMFeatureFlags');
-const describeFiber = ReactDOMFeatureFlags.useFiber ? describe : xdescribe;
-
-describeFiber('ReactDOMFrameScheduling', () => {
+describe('ReactDOMFrameScheduling', () => {
   it('warns when requestAnimationFrame is not polyfilled in the browser', () => {
     const previousRAF = global.requestAnimationFrame;
     try {


### PR DESCRIPTION
Builds on #10794.
New commit is dde565f.

Best diff view is without the whitespace: https://github.com/facebook/react/pull/10796/commits/dde565f?w=1

This removes all `useFiber` checks in the tests, assuming `true`. Technically there are no more references to `ReactDOMFeatureFlags.useFiber`, but I didn’t delete it just to make sure the build is 100% the same for extra safety.

This is safe to merge because it only touches the tests.
I verified the build folder content is identical to master (just like #10794).

```
	modified:   src/isomorphic/children/__tests__/ReactChildren-test.js
	modified:   src/isomorphic/classic/element/__tests__/ReactElement-test.js
	modified:   src/renderers/__tests__/EventPluginHub-test.js
	modified:   src/renderers/__tests__/ReactComponent-test.js
	modified:   src/renderers/__tests__/ReactComponentTreeHook-test.js
	modified:   src/renderers/__tests__/ReactCompositeComponent-test.js
	modified:   src/renderers/__tests__/ReactCompositeComponentState-test.js
	modified:   src/renderers/__tests__/ReactEmptyComponent-test.js
	modified:   src/renderers/__tests__/ReactErrorBoundaries-test.js
	modified:   src/renderers/__tests__/ReactHostOperationHistoryHook-test.js
	modified:   src/renderers/__tests__/ReactMultiChild-test.js
	modified:   src/renderers/__tests__/ReactMultiChildText-test.js
	modified:   src/renderers/__tests__/ReactPerf-test.js
	modified:   src/renderers/__tests__/ReactStatelessComponent-test.js
	modified:   src/renderers/__tests__/ReactUpdates-test.js
	modified:   src/renderers/__tests__/multiple-copies-of-react-test.js
	modified:   src/renderers/__tests__/refs-test.js
	modified:   src/renderers/dom/__tests__/ReactDOMProduction-test.js
	modified:   src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
	modified:   src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
	modified:   src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
	modified:   src/renderers/dom/shared/__tests__/ReactDOMComponentTree-test.js
	modified:   src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
	modified:   src/renderers/dom/shared/__tests__/ReactDOMTextComponent-test.js
	modified:   src/renderers/dom/shared/__tests__/ReactMount-test.js
	modified:   src/renderers/dom/shared/__tests__/ReactRenderDocument-test.js
	modified:   src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
	modified:   src/renderers/dom/shared/__tests__/ReactServerRenderingBrowser-test.js
	modified:   src/renderers/dom/shared/__tests__/renderSubtreeIntoContainer-test.js
	modified:   src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
	modified:   src/renderers/dom/shared/wrappers/__tests__/ReactDOMOption-test.js
	modified:   src/renderers/dom/test/__tests__/ReactTestUtils-test.js
	modified:   src/renderers/shared/__tests__/ReactDOMFrameScheduling-test.js
```

The next step is in https://github.com/facebook/react/pull/10797.