### PR TITLE
Update import instruction for TypeScript/rollup

### DIFF
--- a/docs/docs/reference-react.md
+++ b/docs/docs/reference-react.md
@@ -14,7 +14,7 @@ redirect_from:
   - "docs/glossary.html"
 ---
 
-`React` is the entry point to the React library. If you load React from a `<script>` tag, these top-level APIs are available on the `React` global. If you use ES6 with npm, you can write `import React from 'react'`. If you use ES5 with npm, you can write `var React = require('react')`.
+`React` is the entry point to the React library. If you load React from a `<script>` tag, these top-level APIs are available on the `React` global. If you use ES6 with npm, you can write `import * as React from 'react'`. If you use ES5 with npm, you can write `var React = require('react')`.
 
 ## Overview
 


### PR DESCRIPTION
Using `import React from 'react'` without the wildcard import will cause TypeScript to attempt to use `React.default` and other ES2015 module aware bundler to look for the default export.