### PR TITLE
Remove IE8 property expansion workaround

### DIFF
--- a/src/renderers/dom/shared/CSSProperty.js
+++ b/src/renderers/dom/shared/CSSProperty.js
@@ -84,71 +84,8 @@ Object.keys(isUnitlessNumber).forEach(function(prop) {
   });
 });
 
-/**
- * Most style properties can be unset by doing .style[prop] = '' but IE8
- * doesn't like doing that with shorthand properties so for the properties that
- * IE8 breaks on, which are listed here, we instead unset each of the
- * individual properties. See http://bugs.jquery.com/ticket/12385.
- * The 4-value 'clock' properties like margin, padding, border-width seem to
- * behave without any problems. Curiously, list-style works too without any
- * special prodding.
- */
-var shorthandPropertyExpansions = {
-  background: {
-    backgroundAttachment: true,
-    backgroundColor: true,
-    backgroundImage: true,
-    backgroundPositionX: true,
-    backgroundPositionY: true,
-    backgroundRepeat: true,
-  },
-  backgroundPosition: {
-    backgroundPositionX: true,
-    backgroundPositionY: true,
-  },
-  border: {
-    borderWidth: true,
-    borderStyle: true,
-    borderColor: true,
-  },
-  borderBottom: {
-    borderBottomWidth: true,
-    borderBottomStyle: true,
-    borderBottomColor: true,
-  },
-  borderLeft: {
-    borderLeftWidth: true,
-    borderLeftStyle: true,
-    borderLeftColor: true,
-  },
-  borderRight: {
-    borderRightWidth: true,
-    borderRightStyle: true,
-    borderRightColor: true,
-  },
-  borderTop: {
-    borderTopWidth: true,
-    borderTopStyle: true,
-    borderTopColor: true,
-  },
-  font: {
-    fontStyle: true,
-    fontVariant: true,
-    fontWeight: true,
-    fontSize: true,
-    lineHeight: true,
-    fontFamily: true,
-  },
-  outline: {
-    outlineWidth: true,
-    outlineStyle: true,
-    outlineColor: true,
-  },
-};
-
 var CSSProperty = {
   isUnitlessNumber: isUnitlessNumber,
-  shorthandPropertyExpansions: shorthandPropertyExpansions,
 };
 
 module.exports = CSSProperty;

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -21,17 +21,6 @@ if (__DEV__) {
   var warnValidStyle = require('warnValidStyle');
 }
 
-var hasShorthandPropertyBug = false;
-if (ExecutionEnvironment.canUseDOM) {
-  var tempStyle = document.createElement('div').style;
-  try {
-    // IE8 throws "Invalid argument." if resetting shorthand style properties.
-    tempStyle.font = '';
-  } catch (e) {
-    hasShorthandPropertyBug = true;
-  }
-}
-
 /**
  * Operations for dealing with CSS properties.
  */
@@ -100,18 +89,7 @@ var CSSPropertyOperations = {
       } else if (styleValue) {
         style[styleName] = styleValue;
       } else {
-        var expansion =
-          hasShorthandPropertyBug &&
-          CSSProperty.shorthandPropertyExpansions[styleName];
-        if (expansion) {
-          // Shorthand property that IE8 won't like unsetting, so unset each
-          // component to placate it
-          for (var individualStyleName in expansion) {
-            style[individualStyleName] = '';
-          }
-        } else {
-          style[styleName] = '';
-        }
+        style[styleName] = '';
       }
     }
   },

--- a/src/renderers/dom/shared/CSSPropertyOperations.js
+++ b/src/renderers/dom/shared/CSSPropertyOperations.js
@@ -11,9 +11,6 @@
 
 'use strict';
 
-var CSSProperty = require('CSSProperty');
-var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
-
 var dangerousStyleValue = require('dangerousStyleValue');
 
 if (__DEV__) {


### PR DESCRIPTION
We don’t support it anymore.
Just need to verify IE9 is not affected. 