### PR TITLE
Misc formatting fixes

### DIFF
--- a/docs/_posts/2013-06-12-community-roundup.md
+++ b/docs/_posts/2013-06-12-community-roundup.md
@@ -12,7 +12,7 @@ It looks like [Sophie Alpert](http://sophiebits.com/) is the first person outsid
 > I just rewrote a 2000-line project in React and have now made a handful of pull requests to React. Everything about React I've seen so far seems really well thought-out and I'm proud to be the first non-FB/IG production user of React.
 >
 > The project that I rewrote in React (and am continuing to improve) is the Khan Academy question editor which content creators can use to enter questions and hints that will be presented to students:
-> <figure>[![](/react/img/blog/khan-academy-editor.png)](http://sophiebits.com/2013/06/09/using-react-to-speed-up-khan-academy.html)</figure>
+> <figure><a href="http://sophiebits.com/2013/06/09/using-react-to-speed-up-khan-academy.html"><img src="../img/blog/khan-academy-editor.png"></a></figure>
 >
 > [Read the full post...](http://sophiebits.com/2013/06/09/using-react-to-speed-up-khan-academy.html)
 

--- a/docs/_posts/2013-06-19-community-roundup-2.md
+++ b/docs/_posts/2013-06-19-community-roundup-2.md
@@ -24,7 +24,7 @@ Since the launch we have received a lot of feedback and are actively working on 
 [Danial Khosravi](https://danialk.github.io/) made a real-time chat application that interacts with the back-end using Socket.IO.
 
 > A week ago I was playing with AngularJS and [this little chat application](https://github.com/btford/angular-socket-io-im) which uses socket.io and nodejs for realtime communication. Yesterday I saw a post about ReactJS in [EchoJS](http://www.echojs.com/) and started playing with this UI library. After playing a bit with React, I decided to write and chat application using React and I used Bran Ford's Backend for server side of this little app.
-> <figure>[![](/react/img/blog/chatapp.png)](https://danialk.github.io/blog/2013/06/16/reactjs-and-socket-dot-io-chat-application/)</figure>
+> <figure><a href="https://danialk.github.io/blog/2013/06/16/reactjs-and-socket-dot-io-chat-application/"><img src="../img/blog/chatapp.png"></a></figure>
 >
 > [Read the full post...](https://danialk.github.io/blog/2013/06/16/reactjs-and-socket-dot-io-chat-application/)
 
@@ -45,7 +45,7 @@ In the same vein, [Markov Twain](https://twitter.com/markov_twain/status/3457029
 Mozilla and Google are actively working on Web Components. [Vjeux](http://blog.vjeux.com/) wrote a proof of concept that shows how to implement them using React.
 
 > Using [x-tags](http://www.x-tags.org/) from Mozilla, we can write custom tags within the DOM. This is a great opportunity to be able to write reusable components without being tied to a particular library. I wrote [x-react](https://github.com/vjeux/react-xtags/) to have them being rendered in React.
-> <figure>[![](/react/img/blog/xreact.png)](http://blog.vjeux.com/2013/javascript/custom-components-react-x-tags.html)</figure>
+> <figure><a href="http://blog.vjeux.com/2013/javascript/custom-components-react-x-tags.html"><img src="../img/blog/xreact.png"></a></figure>
 >
 > [Read the full post...](http://blog.vjeux.com/2013/javascript/custom-components-react-x-tags.html)
 
@@ -56,7 +56,7 @@ Mozilla and Google are actively working on Web Components. [Vjeux](http://blog.v
 > Developers these days are spoiled with choice when it comes to selecting an MV* framework for structuring and organizing their JavaScript web apps.
 >
 > To help solve this problem, we created TodoMVC - a project which offers the same Todo application implemented using MV* concepts in most of the popular JavaScript MV* frameworks of today.
-> <figure>[![](/react/img/blog/todomvc.png)](http://todomvc.com/labs/architecture-examples/react/)</figure>
+> <figure><a href="http://todomvc.com/labs/architecture-examples/react/"><img src="../img/blog/todomvc.png"></a></figure>
 >
 > [Read the source code...](https://github.com/tastejs/todomvc/tree/gh-pages/labs/architecture-examples/react)
 

--- a/docs/_posts/2013-06-27-community-roundup-3.md
+++ b/docs/_posts/2013-06-27-community-roundup-3.md
@@ -24,24 +24,24 @@ The highlight of this week is that an interaction-heavy app has been ported to R
 > Grunt task for compiling Facebook React's .jsx templates into .js
 >
 > ```javascript
-grunt.initConfig({
-  react: {
-    app: {
-      options: { extension: 'js' },
-      files: { 'path/to/output/dir': 'path/to/jsx/templates/dir' }
-```
+> grunt.initConfig({
+>   react: {
+>     app: {
+>       options: { extension: 'js' },
+>       files: { 'path/to/output/dir': 'path/to/jsx/templates/dir' }
+> ```
 >
 > It also works great with `grunt-browserify`!
 >
 > ```javascript
-browserify: {
-  options: {
-    transform: [ require('grunt-react').browserify ]
-  },
-  app: {
-    src: 'path/to/source/main.js',
-    dest: 'path/to/target/output.js'
-```
+> browserify: {
+>   options: {
+>     transform: [ require('grunt-react').browserify ]
+>   },
+>   app: {
+>     src: 'path/to/source/main.js',
+>     dest: 'path/to/target/output.js'
+> ```
 >
 > [Check out the project ...](https://github.com/ericclemmons/grunt-react)
 
@@ -70,14 +70,14 @@ browserify: {
 > Multiple people asked what's the story about JSX and CoffeeScript. There is no JSX pre-processor for CoffeeScript and I'm not aware of anyone working on it. Fortunately, CoffeeScript is pretty expressive and we can play around the syntax to come up with something that is usable.
 >
 > ```javascript
-{div, h3, textarea} = React.DOM
-(div {className: 'MarkdownEditor'}, [
-  (h3 {}, 'Input'),
-  (textarea {onKeyUp: @handleKeyUp, ref: 'textarea'},
-    @state.value
-  )
-])
-```
+> {div, h3, textarea} = React.DOM
+> (div {className: 'MarkdownEditor'}, [
+>   (h3 {}, 'Input'),
+>   (textarea {onKeyUp: @handleKeyUp, ref: 'textarea'},
+>     @state.value
+>   )
+> ])
+> ```
 >
 > [Read the full post...](http://blog.vjeux.com/2013/javascript/react-coffeescript.html)
 

--- a/docs/_posts/2013-06-27-community-roundup-3.md
+++ b/docs/_posts/2013-06-27-community-roundup-3.md
@@ -9,7 +9,7 @@ The highlight of this week is that an interaction-heavy app has been ported to R
 
 [Clay Allsopp](https://twitter.com/clayallsopp) successfully ported [Propeller](http://usepropeller.com/blog/posts/from-backbone-to-react/), a fairly big, interaction-heavy JavaScript app, to React.
 
-> [<img style="float: right; margin: 0 0 10px 10px;" src="/react/img/blog/propeller-logo.png" />](http://usepropeller.com/blog/posts/from-backbone-to-react/)Subviews involve a lot of easy-to-forget boilerplate that Backbone (by design) doesn't automate. Libraries like Backbone.Marionette offer more abstractions to make view nesting easier, but they're all limited by the fact that Backbone delegates how and went view-document attachment occurs to the application code.
+> [<img style="float: right; margin: 0 0 10px 10px;" src="../img/blog/propeller-logo.png" />](http://usepropeller.com/blog/posts/from-backbone-to-react/)Subviews involve a lot of easy-to-forget boilerplate that Backbone (by design) doesn't automate. Libraries like Backbone.Marionette offer more abstractions to make view nesting easier, but they're all limited by the fact that Backbone delegates how and went view-document attachment occurs to the application code.
 >
 > React, on the other hand, manages the DOM and only exposes real nodes at select points in its API. The "elements" you code in React are actually objects which wrap DOM nodes, not the actual objects which get inserted into the DOM. Internally, React converts those abstractions into actual DOMElements and fills out the document accordingly. [...]
 >

--- a/docs/_posts/2013-07-03-community-roundup-4.md
+++ b/docs/_posts/2013-07-03-community-roundup-4.md
@@ -18,7 +18,8 @@ React reconciliation process appears to be very well suited to implement a text 
 The best part is the demo of how React reconciliation process makes live editing more user-friendly.
 
 > Our renderer, post-React, is on the left. A typical math editor's preview is on the right.
-> <figure>[<img src="/react/img/blog/monkeys.gif" width="70%" />](http://bjk5.com/post/53742233351/getting-your-team-to-adopt-new-technology)</figure>
+
+[![](../img/blog/monkeys.gif)](http://bjk5.com/post/53742233351/getting-your-team-to-adopt-new-technology)
 
 ## React Snippets
 
@@ -54,4 +55,4 @@ Over the past several weeks, members of our team, [Pete Hunt](http://www.petehun
 [Tom Occhino](http://tomocchino.com/) implemented Snake in 150 lines with React.
 
 > [Check the source on GitHub](https://github.com/tomocchino/react-snake/blob/master/src/snake.js)
-> <figure>[![](/react/img/blog/snake.png)](https://tomocchino.github.io/react-snake/)</figure>
+> <figure><a href="https://tomocchino.github.io/react-snake/"><img src="../img/blog/snake.png"></a></figure>

--- a/docs/_posts/2013-08-05-community-roundup-6.md
+++ b/docs/_posts/2013-08-05-community-roundup-6.md
@@ -18,8 +18,8 @@ This is the first Community Round-up where none of the items are from Facebook/I
 > Browserify v2 transform for `text/jsx`. Basic usage is:
 >
 > ```
-% browserify -t reactify main.jsx
-```
+> % browserify -t reactify main.jsx
+> ```
 >
 > `reactify` transform activates for files with either `.jsx` extension or `/** @jsx React.DOM */` pragma as a first line for any `.js` file.
 >

--- a/docs/_posts/2013-08-05-community-roundup-6.md
+++ b/docs/_posts/2013-08-05-community-roundup-6.md
@@ -8,7 +8,7 @@ This is the first Community Round-up where none of the items are from Facebook/I
 ## React Game Tutorial
 
 [Caleb Cassel](https://twitter.com/CalebCassel) wrote a [step-by-step tutorial](https://rawgithub.com/calebcassel/react-demo/master/part1.html) about making a small game. It covers JSX, State and Events, Embedded Components and Integration with Backbone.
-<figure>[![](/react/img/blog/dog-tutorial.png)](https://rawgithub.com/calebcassel/react-demo/master/part1.html)</figure>
+<figure><a href="https://rawgithub.com/calebcassel/react-demo/master/part1.html"><img src="../img/blog/dog-tutorial.png"></a></figure>
 
 
 ## Reactify
@@ -74,6 +74,6 @@ este.demos.react.todoApp = este.react.create (`/** @lends {React.ReactComponent.
 > I'm the author of "[Land of Lisp](http://landoflisp.com/)" and I love your framework. I built a somewhat similar framework a year ago [WebFUI](https://github.com/drcode/webfui) aimed at ClojureScript. My framework also uses global event delegates, a global "render" function, DOM reconciliation, etc just like react.js. (Of course these ideas all have been floating around the ether for ages, always great to see more people building on them.)
 >
 > Your implementation is more robust, and so I think the next point release of webfui will simply delegate all the "hard work" to react.js and will only focus on the areas where it adds value (enabling purely functional UI programming in clojurescript, and some other stuff related to streamlining event handling)
-<figure>[![](/react/img/blog/landoflisp.png)](https://groups.google.com/forum/#!msg/reactjs/e3bYersyd64/qODfcuBR9LwJ)</figure>
+<figure><a href="https://groups.google.com/forum/#!msg/reactjs/e3bYersyd64/qODfcuBR9LwJ"><img src="../img/blog/landoflisp.png"></a></figure>
 >
 > [Read the full post...](https://groups.google.com/forum/#!msg/reactjs/e3bYersyd64/qODfcuBR9LwJ)

--- a/docs/_posts/2013-08-26-community-roundup-7.md
+++ b/docs/_posts/2013-08-26-community-roundup-7.md
@@ -17,7 +17,7 @@ It's been three months since we open sourced React and it is going well. Some st
 ## Wolfenstein Rendering Engine Ported to React
 
 [Pete Hunt](http://www.petehunt.net/) ported the render code of the web version of Wolfenstein 3D to React. Check out [the demo](http://www.petehunt.net/wolfenstein3D-react/wolf3d.html) and [render.js](https://github.com/petehunt/wolfenstein3D-react/blob/master/js/renderer.js#L183) file for the implementation.
-<figure>[![](/react/img/blog/wolfenstein_react.png)](http://www.petehunt.net/wolfenstein3D-react/wolf3d.html)</figure>
+<figure><a href="http://www.petehunt.net/wolfenstein3D-react/wolf3d.html"><img src="../img/blog/wolfenstein_react.png"></a></figure>
 
 
 ## React & Meteor
@@ -51,7 +51,7 @@ It's been three months since we open sourced React and it is going well. Some st
 [Jordan Walke](https://github.com/jordwalke) implemented a complete React project creator called [react-page](https://github.com/facebook/react-page/). It supports both server-side and client-side rendering, source transform and packaging JSX files using CommonJS modules, and instant reload.
 
 > Easy Application Development with React JavaScript
-> <figure>[![](/react/img/blog/react-page.png)](https://github.com/facebook/react-page/)</figure>
+> <figure><a href="https://github.com/facebook/react-page/"><img src="../img/blog/react-page.png"></a></figure>
 >
 > **Why Server Rendering?**
 >

--- a/docs/_posts/2013-09-24-community-roundup-8.md
+++ b/docs/_posts/2013-09-24-community-roundup-8.md
@@ -54,13 +54,13 @@ While this is not going to work for all the attributes since they are camelCased
 ## Markdown in React
 
 [Sophie Alpert](http://sophiebits.com/) converted [marked](https://github.com/chjj/marked), a Markdown JavaScript implementation, in React: [marked-react](https://github.com/sophiebits/marked-react). Even without using JSX, the HTML generation is now a lot cleaner. It is also safer as forgetting a call to `escape` will not introduce an XSS vulnerability.
-<figure>[![](/react/img/blog/markdown_refactor.png)](https://github.com/sophiebits/marked-react/commit/cb70c9df6542c7c34ede9efe16f9b6580692a457)</figure>
+<figure><a href="https://github.com/sophiebits/marked-react/commit/cb70c9df6542c7c34ede9efe16f9b6580692a457"><img src="../img/blog/markdown_refactor.png"></a></figure>
 
 
 ## Unite from BugBusters
 
 [Renault John Lecoultre](https://twitter.com/renajohn) wrote [Unite](https://www.bugbuster.com/), an interactive tool for analyzing code dynamically using React. It integrates with CodeMirror.
-<figure>[![](/react/img/blog/unite.png)](https://unite.bugbuster.com/)</figure>
+<figure><a href="https://unite.bugbuster.com/"><img src="../img/blog/unite.png"></a></figure>
 
 ## #reactjs IRC Logs
 

--- a/docs/_posts/2013-10-3-community-roundup-9.md
+++ b/docs/_posts/2013-10-3-community-roundup-9.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 We organized a React hackathon last week-end in the Facebook Seattle office. 50 people, grouped into 15 teams, came to hack for a day on React. It was a lot of fun and we'll probably organize more in the future.
 
-![](/react/img/blog/react-hackathon.jpg)
+![](../img/blog/react-hackathon.jpg)
 
 
 ## React Hackathon Winner
@@ -15,7 +15,7 @@ We organized a React hackathon last week-end in the Facebook Seattle office. 50 
 > The game itself is pretty simple. People join the "room" by going to [http://qu.izti.me](http://qu.izti.me/) on their device. Large displays will show a leaderboard along with the game, and small displays (such as phones) will act as personal gamepads. Users will see questions and a choice of answers. The faster you answer, the more points you earn.
 >
 > In my opinion, Socket.io and React go together like chocolate and peanut butter. The page was always an accurate representation of the game object.
-><figure>[![](/react/img/blog/quiztime.png)](http://bold-it.com/javascript/facebook-react-example/)</figure>
+><figure><a href="http://bold-it.com/javascript/facebook-react-example/"><img src="../img/blog/quiztime.png"></a></figure>
 >
 > [Read More...](http://bold-it.com/javascript/facebook-react-example/)
 
@@ -59,8 +59,8 @@ The video will be available soon on the [JSConf EU website](http://2013.jsconf.e
 > A wrapper around JSHint to allow linting of files containing JSX syntax. Accepts glob patterns. Respects your local .jshintrc file and .gitignore to filter your glob patterns.
 >
 > ```
-npm install -g jsxhint
-```
+> npm install -g jsxhint
+> ```
 >
 > [Check it out on GitHub...](https://github.com/CondeNast/JSXHint)
 
@@ -74,7 +74,7 @@ npm install -g jsxhint
 > The panel is rendered with a random panel- class on each request, and the progress bar gets a random widthX class.
 >
 > With Turbolinks alone, the entire <body> would be replaced, and transitions would not happen. In this little demo though, React adds and removes classes and text, and the attribute changes are animated with CSS transitions. The DOM is otherwise left intact.
-><figure>[![](/react/img/blog/turboreact.png)](https://turbo-react.herokuapp.com/)</figure>
+><figure><a href="https://turbo-react.herokuapp.com/"><img src="../img/blog/turboreact.png"></a></figure>
 >
 > [Check out the demo...](https://turbo-react.herokuapp.com/)
 
@@ -88,10 +88,10 @@ npm install -g jsxhint
 > Let's call it Table (to avoid any confusion what the component is about).
 >
 > ```javascript
-var Table = React.createClass({
-  /*stuff goeth here*/
-});
-```
+> var Table = React.createClass({
+>   /*stuff goeth here*/
+> });
+> ```
 >
 > You see that React components are defined using a regular JS object. Some properties and methods of the object such as render() have special meanings, the rest is upforgrabs.
 >

--- a/docs/_posts/2013-11-06-community-roundup-10.md
+++ b/docs/_posts/2013-11-06-community-roundup-10.md
@@ -47,7 +47,7 @@ The best part is that no drastic changes have been required to support all those
 > [**Read part 2 ...**](http://www.phpied.com/server-side-react-with-php-part-2/)
 >
 > Rendered markup on the server:
-> <figure>[![](/react/img/blog/react-php.png)](http://www.phpied.com/server-side-react-with-php-part-2/)</figure>
+> <figure><a href="http://www.phpied.com/server-side-react-with-php-part-2/"><img src="../img/blog/react-php.png"></a></figure>
 
 
 ## TodoMVC Benchmarks
@@ -92,7 +92,7 @@ The fact that you can control when components are rendered is a very important c
 ## Guess the filter
 
 [Connor McSheffrey](http://conr.me) implemented a small game using React. The goal is to guess which filter has been used to create the Instagram photo.
-<figure>[![](/react/img/blog/guess_filter.jpg)](http://guessthefilter.com/)</figure>
+<figure><a href="http://guessthefilter.com/"><img src="../img/blog/guess_filter.jpg"></a></figure>
 
 
 ## React vs FruitMachine

--- a/docs/_posts/2013-11-18-community-roundup-11.md
+++ b/docs/_posts/2013-11-18-community-roundup-11.md
@@ -35,7 +35,7 @@ This round-up is the proof that React has taken off from its Facebook's root: it
 [Pavan Podila](http://blog.pixelingene.com/) wrote an in-depth introduction to React on TutsPlus. This is definitively worth reading.
 
 > Within a component-tree, data should always flow down. A parent-component should set the props of a child-component to pass any data from the parent to the child. This is termed as the Owner-Owned pair. On the other hand user-events (mouse, keyboard, touches) will always bubble up from the child all the way to the root component, unless handled in between.
-<figure>[![](/react/img/blog/tutsplus.png)](http://dev.tutsplus.com/tutorials/intro-to-the-react-framework--net-35660)</figure>
+<figure><a href="http://dev.tutsplus.com/tutorials/intro-to-the-react-framework--net-35660"><img src="../img/blog/tutsplus.png"></a></figure>
 >
 > [Read the full article ...](http://dev.tutsplus.com/tutorials/intro-to-the-react-framework--net-35660)
 
@@ -51,7 +51,7 @@ This round-up is the proof that React has taken off from its Facebook's root: it
 ## Genesis Skeleton
 
 [Eric Clemmons](https://ericclemmons.github.io/) is working on a "Modern, opinionated, full-stack starter kit for rapid, streamlined application development". The version 0.4.0 has just been released and has first-class support for React.
-<figure>[![](/react/img/blog/genesis_skeleton.png)](http://genesis-skeleton.com/)</figure>
+<figure><a href="http://genesis-skeleton.com/"><img src="../img/blog/genesis_skeleton.png"></a>a></figure>
 
 
 ## AgFlow Talk
@@ -82,10 +82,10 @@ This round-up is the proof that React has taken off from its Facebook's root: it
 ## Photo Gallery
 
 [Maykel Loomans](http://miekd.com/), designer at Instagram, wrote a gallery for photos he shot using React.
-<figure>[![](/react/img/blog/xoxo2013.png)](http://photos.miekd.com/xoxo2013/)</figure>
+<figure><a href="http://photos.miekd.com/xoxo2013/"><img src="../img/blog/xoxo2013.png"></a>a></figure>
 
 
 ## Random Tweet
 
-<img src="/react/img/blog/steve_reverse.gif" style="float: right;" />
+<img src="../img/blog/steve_reverse.gif" style="float: right;" />
 <div style="width: 320px;"><blockquote class="twitter-tweet"><p>I think this reversed gif of Steve Urkel best describes my changing emotions towards the React Lib <a href="http://t.co/JoX0XqSXX3">http://t.co/JoX0XqSXX3</a></p>&mdash; Ryan Seddon (@ryanseddon) <a href="https://twitter.com/ryanseddon/statuses/398572848802852864">November 7, 2013</a></blockquote></div>

--- a/docs/_posts/2013-12-23-community-roundup-12.md
+++ b/docs/_posts/2013-12-23-community-roundup-12.md
@@ -14,7 +14,7 @@ React got featured on the front-page of Hacker News thanks to the Om library. If
 > Wait, wait, wait. What does the performance of persistent data structures have to do with the future of JavaScript MVCs?
 >
 > A whole lot.
-> <figure>[![](/react/img/blog/om-backbone.png)](https://swannodette.github.io/2013/12/17/the-future-of-javascript-mvcs/)</figure>
+> <figure><a href="https://swannodette.github.io/2013/12/17/the-future-of-javascript-mvcs/"><img src="../img/blog/om-backbone.png"></a></figure>
 >
 > [Read the full article...](https://swannodette.github.io/2013/12/17/the-future-of-javascript-mvcs/)
 
@@ -27,18 +27,18 @@ Managing the scroll position when new content is inserted is usually very tricky
 > We can check the scroll position before the component has updated with componentWillUpdate and scroll if necessary at componentDidUpdate
 >
 > ```
-componentWillUpdate: function() {
-  var node = this.getDOMNode();
-  this.shouldScrollBottom =
-    (node.scrollTop + node.offsetHeight) === node.scrollHeight;
-},
-componentDidUpdate: function() {
-  if (this.shouldScrollBottom) {
-    var node = this.getDOMNode();
-    node.scrollTop = node.scrollHeight
-  }
-},
-```
+> componentWillUpdate: function() {
+>   var node = this.getDOMNode();
+>   this.shouldScrollBottom =
+>     (node.scrollTop + node.offsetHeight) === node.scrollHeight;
+> },
+> componentDidUpdate: function() {
+>   if (this.shouldScrollBottom) {
+>     var node = this.getDOMNode();
+>     node.scrollTop = node.scrollHeight
+>   }
+> },
+> ```
 >
 > [Check out the blog article...](http://blog.vjeux.com/2013/javascript/scroll-position-with-react.html)
 
@@ -46,7 +46,7 @@ componentDidUpdate: function() {
 ## Lights Out
 
 React declarative approach is well suited to write games. [Cheng Lou](https://github.com/chenglou) wrote the famous Lights Out game in React. It's a good example of use of [TransitionGroup](/react/docs/animation.html) to implement animations.
-<figure>[![](/react/img/blog/lights-out.png)](https://chenglou.github.io/react-lights-out/)</figure>
+<figure><a href="https://chenglou.github.io/react-lights-out/"><img src="../img/blog/lights-out.png"></a></figure>
 
 [Try it out!](https://chenglou.github.io/react-lights-out/)
 
@@ -54,7 +54,7 @@ React declarative approach is well suited to write games. [Cheng Lou](https://gi
 ## Reactive Table Bookmarklet
 
 [Stoyan Stefanov](http://www.phpied.com/) wrote a bookmarklet to process tables on the internet. It adds a little "pop" button that expands to a full-screen view with sorting, editing and export to csv and json.
-<figure>[![](/react/img/blog/reactive-bookmarklet.png)](http://www.phpied.com/reactivetable-bookmarklet/)</figure>
+<figure><a href="http://www.phpied.com/reactivetable-bookmarklet/"><img src="../img/blog/reactive-bookmarklet.png"></a></figure>
 
 [Check out the blog post...](http://www.phpied.com/reactivetable-bookmarklet/)
 
@@ -91,7 +91,7 @@ hoodie new todomvc -t "hoodiehq/hoodie-react-todomvc"
 ## JSX Compiler
 
 Ever wanted to have a quick way to see what a JSX tag would be converted to? [Tim Yung](http://www.yungsters.com/) made a page for it.
-<figure>[![](/react/img/blog/jsx-compiler.png)](/react/jsx-compiler.html)</figure>
+<figure><a href="/react/jsx-compiler.html"><img src="../img/blog/jsx-compiler.png"></a></figure>
 
 [Try it out!](/react/jsx-compiler.html)
 

--- a/docs/_posts/2013-12-30-community-roundup-13.md
+++ b/docs/_posts/2013-12-30-community-roundup-13.md
@@ -94,7 +94,7 @@ var MyComponent = React.createClass({
 [David Chang](http://davidandsuzi.com/) working at [HasOffer](http://www.hasoffers.com/) wanted to speed up his Angular app and replaced Angular primitives by React at different layers. When using React naively it is 67% faster, but when combining it with angular's transclusion it is 450% slower.
 
 > Rendering this takes 803ms for 10 iterations, hovering around 35 and 55ms for each data reload (that's 67% faster). You'll notice that the first load takes a little longer than successive loads, and the second load REALLY struggles - here, it's 433ms, which is more than half of the total time!
-> <figure>[![](/react/img/blog/ngreact.png)](http://davidandsuzi.com/ngreact-react-components-in-angular/)</figure>
+> <figure><a href="http://davidandsuzi.com/ngreact-react-components-in-angular/"><img src="../img/blog/ngreact.png"></a></figure>
 >
 > [Read the full article...](http://davidandsuzi.com/ngreact-react-components-in-angular/)
 

--- a/docs/_posts/2014-01-02-react-chrome-developer-tools.md
+++ b/docs/_posts/2014-01-02-react-chrome-developer-tools.md
@@ -12,6 +12,6 @@ You will get a new tab titled "React" in your Chrome DevTools. This tab shows yo
 Selecting a Component in this tab allows you to view and edit its props and state in the panel on the right. In the breadcrumbs at the bottom, you can inspect the selected Component, the Component that created it, the Component that created that one, and so on.
 
 When you inspect a DOM element using the regular Elements tab, you can switch over to the React tab and the corresponding Component will be automatically selected. The Component will also be automatically selected if you have a breakpoint within its render phase. This allows you to step through the render tree and see how one Component affects another one.
-<figure>[![](/react/img/blog/react-dev-tools.jpg)](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi)</figure>
+<figure><a href="https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi"><img src="../img/blog/react-dev-tools.jpg"></a></figure>
 
 We hope these tools will help your team better understand your component hierarchy and track down bugs. We're very excited about this initial launch and appreciate any feedback you may have. As always, we also accept [pull requests on GitHub](https://github.com/facebook/react-devtools).

--- a/docs/_posts/2014-01-06-community-roundup-14.md
+++ b/docs/_posts/2014-01-06-community-roundup-14.md
@@ -21,7 +21,7 @@ React is only one-piece of your web application stack. [Mark Lussier](https://gi
 ## Animal Sounds
 
 [Josh Duck](http://joshduck.com/) used React in order to build a Windows 8 tablet app. This is a good example of a touch app written in React.
-<figure>[![](/react/img/blog/animal-sounds.jpg)](http://apps.microsoft.com/windows/en-us/app/baby-play-animal-sounds/9280825c-2ed9-41c0-ba38-aa9a5b890bb9)</figure>
+[![](../img/blog/animal-sounds.jpg)](http://apps.microsoft.com/windows/en-us/app/baby-play-animal-sounds/9280825c-2ed9-41c0-ba38-aa9a5b890bb9)
 
 [Download the app...](http://apps.microsoft.com/windows/en-us/app/baby-play-animal-sounds/9280825c-2ed9-41c0-ba38-aa9a5b890bb9)
 

--- a/docs/_posts/2014-02-15-community-roundup-16.md
+++ b/docs/_posts/2014-02-15-community-roundup-16.md
@@ -15,7 +15,7 @@ Got five minutes to pitch React to your coworkers? John Lynch ([@johnrlynch](htt
 
 ## React's diff algorithm
 
-React core team member Christopher Chedeau ([@vjeux](https://twitter.com/vjeux)) explores the innards of React's tree diffing algorithm in this [extensive and well-illustrated post](http://calendar.perfplanet.com/2013/diff/). <figure>[![](/react/img/blog/react-diff-tree.png)](http://calendar.perfplanet.com/2013/diff/)</figure>
+React core team member Christopher Chedeau ([@vjeux](https://twitter.com/vjeux)) explores the innards of React's tree diffing algorithm in this [extensive and well-illustrated post](http://calendar.perfplanet.com/2013/diff/). <figure>[![](../img/blog/react-diff-tree.png)](http://calendar.perfplanet.com/2013/diff/)</figure>
 
 While we're talking about tree diffing: Matt Esch ([@MatthewEsch](https://twitter.com/MatthewEsch)) created [this project](https://github.com/Matt-Esch/virtual-dom), which aims to implement the virtual DOM and a corresponding diff algorithm as separate modules.
 
@@ -67,7 +67,7 @@ Eric Florenzano ([@ericflo](https://twitter.com/ericflo)) sheds some light on wh
 > [Read the full post...](http://eflorenzano.com/blog/2014/01/23/react-finally-server-client/)
 
 ## Building a complex React component
-[Matt Harrison](http://matt-harrison.com/) walks through the process of [creating an SVG-based Resistance Calculator](http://matt-harrison.com/building-a-complex-web-component-with-facebooks-react-library/) using React. <figure>[![](/react/img/blog/resistance-calculator.png)](http://matt-harrison.com/building-a-complex-web-component-with-facebooks-react-library/)</figure>
+[Matt Harrison](http://matt-harrison.com/) walks through the process of [creating an SVG-based Resistance Calculator](http://matt-harrison.com/building-a-complex-web-component-with-facebooks-react-library/) using React. <figure>[![](../img/blog/resistance-calculator.png)](http://matt-harrison.com/building-a-complex-web-component-with-facebooks-react-library/)</figure>
 
 
 

--- a/docs/_posts/2014-02-24-community-roundup-17.md
+++ b/docs/_posts/2014-02-24-community-roundup-17.md
@@ -20,7 +20,7 @@ Sberbank, Russia's largest bank, recently switched large parts of their site to 
 ### Makona Editor
 
  John Lynch ([@johnrlynch](https://twitter.com/johnrlynch)) created Makona, a block-style document editor for the web. Blocks of different content types comprise documents, authored using plain markup. At the switch of a toggle, block contents are then rendered on the page. While not quite a WYSIWYG editor, Makona uses plain textareas for input. This makes it compatible with a wider range of platforms than traditional rich text editors.
-<figure>[![](/react/img/blog/makona-editor.png)](https://johnthethird.github.io/makona-editor/)</figure>
+[![](../img/blog/makona-editor.png)](https://johnthethird.github.io/makona-editor/)
 
 ### Create Chrome extensions using React
 React is in no way limited to just web pages. Brandon Tilley ([@BinaryMuse](https://twitter.com/BinaryMuse)) just released a detailed walk-through of [how he built his Chrome extension "Fast Tab Switcher" using React](http://brandontilley.com/2014/02/24/creating-chrome-extensions-with-react.html).
@@ -41,7 +41,7 @@ Javier Aguirre ([@javaguirre](https://twitter.com/javaguirre)) put together a si
 
 ### SVG-based graphical node editor
 [NoFlo](http://noflojs.org/) and [Meemoo](http://meemoo.org/) developer [Forresto Oliphant](http://www.forresto.com/) built an awesome SVG-based [node editor](https://forresto.github.io/prototyping/react/) in React.
- <figure>[![](/react/img/blog/react-svg-fbp.png)](https://forresto.github.io/prototyping/react/)</figure>
+ [![](../img/blog/react-svg-fbp.png)](https://forresto.github.io/prototyping/react/)
 
 
 ### Ultimate Tic-Tac-Toe Game in React

--- a/docs/_posts/2014-06-27-community-roundup-19.md
+++ b/docs/_posts/2014-06-27-community-roundup-19.md
@@ -27,7 +27,7 @@ The core concepts React themselves is something very valuable that the community
 
 And don't forget [Pete Hunt](https://github.com/petehunt)'s Wolfenstein 3D rendering engine in React ([source code](https://github.com/petehunt/wolfenstein3D-react/blob/master/js/renderer.js#L183)). While it's nearly a year old, it's still a nice demo.
 
-[![](/react/img/blog/wolfenstein_react.png)](http://www.petehunt.net/wolfenstein3D-react/wolf3d.html)
+[![](../img/blog/wolfenstein_react.png)](http://www.petehunt.net/wolfenstein3D-react/wolf3d.html)
 
 Give us a shoutout on IRC or [React Google Groups](https://groups.google.com/forum/#!forum/reactjs) if you've used React in some Interesting places.
 

--- a/docs/_posts/2014-07-28-community-roundup-20.md
+++ b/docs/_posts/2014-07-28-community-roundup-20.md
@@ -9,7 +9,7 @@ It's an exciting time for React as there are now more commits from open source c
 
 [Atom, GitHub's code editor, is now using React](http://blog.atom.io/2014/07/02/moving-atom-to-react.html) to build the editing experience. They made the move in order to improve performance. By default, React helped them eliminate unnecessary reflows, enabling them to focus on architecting the rendering pipeline in order to minimize repaints by using hardware acceleration. This is a testament to the fact that React's architecture is perfect for high performant applications.
 
-[<img src="/react/img/blog/gpu-cursor-move.gif" style="width: 100%;" />](http://blog.atom.io/2014/07/02/moving-atom-to-react.html)
+[<img src="../img/blog/gpu-cursor-move.gif" style="width: 100%;" />](http://blog.atom.io/2014/07/02/moving-atom-to-react.html)
 
 
 ## Why Does React Scale?
@@ -72,7 +72,7 @@ In related news, the next [React SF Meetup](http://www.meetup.com/ReactJS-San-Fr
 
 One of the strengths of React is that it plays nicely with other libraries. Jim Cowart proved it by writing a tutorial that explains how to write [React component adapters for KendoUI](http://www.ifandelse.com/using-reactjs-and-kendoui-together/).
 
-<figure><a href="http://www.ifandelse.com/using-reactjs-and-kendoui-together/"><img src="/react/img/blog/kendoui.png" /></a></figure>
+<figure><a href="http://www.ifandelse.com/using-reactjs-and-kendoui-together/"><img src="../img/blog/kendoui.png" /></a></figure>
 
 
 ## Acorn JSX

--- a/docs/_posts/2014-07-30-flux-actions-and-the-dispatcher.md
+++ b/docs/_posts/2014-07-30-flux-actions-and-the-dispatcher.md
@@ -23,7 +23,7 @@ Different actions are identified by a type attribute. When all of the stores rec
 
 Letting the stores update themselves eliminates many entanglements typically found in MVC applications, where cascading updates between models can lead to unstable state and make accurate testing very difficult. The objects within a Flux application are highly decoupled, and adhere very strongly to the [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter), the principle that each object within a system should know as little as possible about the other objects in the system. This results in software that is more maintainable, adaptable, testable, and easier for new engineering team members to understand.
 
-<img src="/react/img/blog/flux-diagram.png" style="width: 100%;" />
+<img src="../img/blog/flux-diagram.png" style="width: 100%;" />
 
 
 Why We Need a Dispatcher

--- a/docs/_posts/2014-08-03-community-roundup-21.md
+++ b/docs/_posts/2014-08-03-community-roundup-21.md
@@ -23,7 +23,7 @@ React.renderComponent((
 
 Areeb Malik, from Facebook, talks about his experience using React. "On paper, all those JS frameworks look promising: clean implementations, quick code design, flawless execution. But what happens when you stress test JavaScript? What happens when you throw 6 megabytes of code at it? In this talk, we'll investigate how React performs in a high stress situation, and how it has helped our team build safe code on a massive scale"
 
-[![](/react/img/blog/skills-matter.png)](https://skillsmatter.com/skillscasts/5429-going-big-with-react)
+[![](../img/blog/skills-matter.png)](https://skillsmatter.com/skillscasts/5429-going-big-with-react)
 
 <!--
 <iframe allowfullscreen="" data-progress="true" frameborder="0" height="390" id="vimeo-player" mozallowfullscreen="" src="//player.vimeo.com/video/100245392?api=1&amp;title=0" webkitallowfullscreen="" width="640"></iframe>
@@ -69,21 +69,21 @@ var App = React.createClass({
 
 Have you ever wondered how JSX was implemented? James Long wrote a very instructive blog post that explains how to [compile JSX with Sweet.js using Readtables](http://jlongster.com/Compiling-JSX-with-Sweet.js-using-Readtables).
 
-[![](/react/img/blog/sweet-jsx.png)](http://jlongster.com/Compiling-JSX-with-Sweet.js-using-Readtables)
+[![](../img/blog/sweet-jsx.png)](http://jlongster.com/Compiling-JSX-with-Sweet.js-using-Readtables)
 
 
 ## First Look: Getting Started with React
 
 [Kirill Buga](http://modernweb.com/authors/kirill-buga/) wrote an article on Modern Web explaining how [React is different from traditional MVC](http://modernweb.com/2014/07/23/getting-started-reactjs/) used by most JavaScript applications
 
-<figure><a href="http://modernweb.com/2014/07/23/getting-started-reactjs"><img src="/react/img/blog/first-look.png" /></a></figure>
+<figure><a href="http://modernweb.com/2014/07/23/getting-started-reactjs"><img src="../img/blog/first-look.png" /></a></figure>
 
 
 ## React Draggable
 
 [Matt Zabriskie](https://github.com/mzabriskie) released a [project](https://github.com/mzabriskie/react-draggable) to make your react components draggable.
 
-[![](/react/img/blog/react-draggable.png)](https://mzabriskie.github.io/react-draggable/example/)
+[![](../img/blog/react-draggable.png)](https://mzabriskie.github.io/react-draggable/example/)
 
 
 ## HTML Parser2 React

--- a/docs/_posts/2014-09-12-community-round-up-22.md
+++ b/docs/_posts/2014-09-12-community-round-up-22.md
@@ -48,7 +48,7 @@ var translated = (
 
 [Trường](http://truongtx.me/) wrote a little guide to help your [getting started using React, Browserify and Gulp](http://truongtx.me/2014/07/18/using-reactjs-with-browserify-and-gulp/).
 
-<figure><a href="http://truongtx.me/2014/07/18/using-reactjs-with-browserify-and-gulp/"><img src="/react/img/blog/react-browserify-gulp.jpg" /></a></figure>
+<figure><a href="http://truongtx.me/2014/07/18/using-reactjs-with-browserify-and-gulp/"><img src="../img/blog/react-browserify-gulp.jpg" /></a></figure>
 
 
 ## React Style
@@ -111,4 +111,4 @@ When [Kent William Innholt](http://http://kentwilliam.com/) who works at [M>Path
 To finish this round-up, Andrew Gleave made a page that displays the [Weather](https://github.com/andrewgleave/react-weather). It's great to see that React is also used for small prototypes.
 
 
-<figure><a href="https://github.com/andrewgleave/react-weather"><img src="/react/img/blog/weather.png" /></a></figure>
+<figure><a href="https://github.com/andrewgleave/react-weather"><img src="../img/blog/weather.png" /></a></figure>

--- a/docs/_posts/2014-10-17-community-roundup-23.md
+++ b/docs/_posts/2014-10-17-community-roundup-23.md
@@ -27,7 +27,7 @@ Yahoo is converting Yahoo Mail to React and Flux and in the process, they open s
 [Mikael Brassman](https://spoike.ghost.io/) wrote [Reflux](https://github.com/spoike/refluxjs), a library that implements Flux concepts. Note that it diverges significantly from the way we use Flux at Facebook. He explains [the reasons why in a blog post](https://spoike.ghost.io/deconstructing-reactjss-flux/).
 
 <center>
-<a href="https://spoike.ghost.io/deconstructing-reactjss-flux/"><img src="/react/img/blog/reflux-flux.png" width="400" /></a>
+<a href="https://spoike.ghost.io/deconstructing-reactjss-flux/"><img src="../img/blog/reflux-flux.png" width="400" /></a>
 </center>
 
 
@@ -47,7 +47,7 @@ Yahoo is converting Yahoo Mail to React and Flux and in the process, they open s
 [Kevin Dangoor](http://www.kevindangoor.com/) is converting the project tree of [Adobe's Bracket text editor](http://brackets.io/) to React and Flux. He wrote about his experience [using Flux](http://www.kevindangoor.com/2014/09/intro-to-the-new-brackets-project-tree/).
 
 <center>
-<a href="http://www.kevindangoor.com/2014/09/intro-to-the-new-brackets-project-tree/"><img src="/react/img/blog/flux-diagram.png" width="400" /></a>
+<a href="http://www.kevindangoor.com/2014/09/intro-to-the-new-brackets-project-tree/"><img src="../img/blog/flux-diagram.png" width="400" /></a>
 </center>
 
 
@@ -122,7 +122,7 @@ undo: function() {
 [Nicola Paolucci](https://github.com/durdn) from Atlassian wrote a great guide to help your getting understand [Flux step by step](https://blogs.atlassian.com/2014/08/flux-architecture-step-by-step/).
 
 <center>
-<a href="https://blogs.atlassian.com/2014/08/flux-architecture-step-by-step/"><img src="/react/img/blog/flux-chart.png" width="400" /></a>
+<a href="https://blogs.atlassian.com/2014/08/flux-architecture-step-by-step/"><img src="../img/blog/flux-chart.png" width="400" /></a>
 </center>
 
 

--- a/docs/_posts/2015-03-04-community-roundup-25.md
+++ b/docs/_posts/2015-03-04-community-roundup-25.md
@@ -44,7 +44,7 @@ A team from New Zealand called [Atomic](https://atomic.io/) is [building web and
 
 [Polarr](https://github.com/Polarrco) have rebuilt [their browser-based photo editor](http://polarrist.tumblr.com/post/111290422225/polarr-photo-editor-2-0-alpha-is-here) with React.
 
-<center><a href="http://polarrist.tumblr.com/post/111290422225/polarr-photo-editor-2-0-alpha-is-here"><img src="/react/img/blog/polarr.jpg"></a></center>
+<center><a href="http://polarrist.tumblr.com/post/111290422225/polarr-photo-editor-2-0-alpha-is-here"><img src="../img/blog/polarr.jpg"></a></center>
 
 ## It's F8!
 

--- a/docs/_posts/2015-03-19-building-the-facebook-news-feed-with-relay.md
+++ b/docs/_posts/2015-03-19-building-the-facebook-news-feed-with-relay.md
@@ -13,7 +13,7 @@ We're working hard to prepare GraphQL and Relay for public release. In the meant
 
 The diagram below shows the main parts of the Relay architecture on the client and the server:
 
-<img src="/react/img/blog/relay-components/relay-architecture.png" alt="Relay Architecture" width="650" />
+<img src="../img/blog/relay-components/relay-architecture.png" alt="Relay Architecture" width="650" />
 
 The main pieces are as follows:
 
@@ -30,7 +30,7 @@ This post will focus on **Relay components** that describe encapsulated units of
 
 To see how components work and can be composed, let's implement a basic version of the Facebook News Feed in Relay. Our application will have two components: a `<NewsFeed>` that renders a list of `<Story>` items. We'll introduce the plain React version of each component first and then convert it to a Relay component. The goal is something like the following:
 
-<img src="/react/img/blog/relay-components/sample-newsfeed.png" alt="Sample News Feed" width="360" />
+<img src="../img/blog/relay-components/sample-newsfeed.png" alt="Sample News Feed" width="360" />
 
 <br/>
 
@@ -73,7 +73,7 @@ export default Relay.createContainer(Story, {
 
 Before adding the GraphQL fragment, let's look at the component hierarchy this creates:
 
-<img src="/react/img/blog/relay-components/relay-containers.png" width="397" alt="React Container Data Flow" />
+<img src="../img/blog/relay-components/relay-containers.png" width="397" alt="React Container Data Flow" />
 
 Most props will be passed through from the container to the original component. However, Relay will return the query results for a prop whenever a fragment is defined. In this case we'll add a GraphQL fragment for `story`:
 
@@ -122,7 +122,7 @@ Relay guarantees that all data required to render a component will be available 
 
 The diagram below shows how Relay containers make data available to our React components:
 
-<img src="/react/img/blog/relay-components/relay-containers-data-flow.png" width="650" alt="Relay Container Data Flow" />
+<img src="../img/blog/relay-components/relay-containers-data-flow.png" width="650" alt="Relay Container Data Flow" />
 
 <br/>
 

--- a/docs/_posts/2015-03-30-community-roundup-26.md
+++ b/docs/_posts/2015-03-30-community-roundup-26.md
@@ -20,9 +20,7 @@ We open sourced React Native last week and the community reception blew away all
 
 If you are getting started with React Native, you should absolutely [use this tutorial](http://www.raywenderlich.com/99473/introducing-react-native-building-apps-javascript) from Colin Eberhardt. It goes through all the steps to make a reasonably complete app.
 
-<center>
-[![](/react/img/blog/property-finder.png)](http://www.raywenderlich.com/99473/introducing-react-native-building-apps-javascript)
-</center>
+[![](../img/blog/property-finder.png)](http://www.raywenderlich.com/99473/introducing-react-native-building-apps-javascript)
 
 Colin also [blogged about his experience using React Native](http://blog.scottlogic.com/2015/03/26/react-native-retrospective.html) for a few weeks and gives his thoughts on why you would or wouldn't use it.
 
@@ -38,27 +36,21 @@ Spencer Ahrens and I had the great pleasure to talk about React Native on [The C
 
 Less than 24 hours after React Native was open sourced, Simarpreet Singh built an [Hacker News reader app from scratch](https://github.com/iSimar/HackerNews-React-Native). It's unbelievable how fast he was able to pull it off!
 
-<center>
-[![](/react/img/blog/hacker-news-react-native.png)](https://github.com/iSimar/HackerNews-React-Native)
-</center>
+[![](../img/blog/hacker-news-react-native.png)](https://github.com/iSimar/HackerNews-React-Native)
 
 
 ## Parse + React
 
 There's a huge ecosystem of JavaScript modules on npm and React Native was designed to work well with the ones that don't have DOM dependencies. Parse is a great example; you can `npm install parse` on your React Native project and it'll work as is. :) We still have [a](https://github.com/facebook/react-native/issues/406) [few](https://github.com/facebook/react-native/issues/370) [issues](https://github.com/facebook/react-native/issues/316) to solve; please create an issue if your favorite library doesn't work out of the box.
 
-<center>
-[![](/react/img/blog/parse-react.jpg)](http://blog.parse.com/2015/03/25/parse-and-react-shared-chemistry/)
-</center>
+[![](../img/blog/parse-react.jpg)](http://blog.parse.com/2015/03/25/parse-and-react-shared-chemistry/)
 
 
 ## tcomb-form-native
 
 Giulio Canti is the author of the [tcomb-form library](https://github.com/gcanti/tcomb-form) for React. He already [ported it to React Native](https://github.com/gcanti/tcomb-form-native) and it looks great!
 
-<center>
-[![](/react/img/blog/tcomb-react-native.png)](https://github.com/gcanti/tcomb-form-native)
-</center>
+[![](../img/blog/tcomb-react-native.png)](https://github.com/gcanti/tcomb-form-native)
 
 
 ## Facebook Login with React Native
@@ -70,9 +62,7 @@ One of the reason we built React Native is to be able to use all the libraries i
 
 Jay Garcia spent a lot of time during the beta working on a NES music player with React Native. He wrote a blog post to share his experience and explains some code snippets.
 
-<center>
-[![](/react/img/blog/modus-create.gif)](http://moduscreate.com/react-native-has-landed/)
-</center>
+[![](../img/blog/modus-create.gif)](http://moduscreate.com/react-native-has-landed/)
 
 
 ## React Native with Babel and webpack

--- a/docs/_posts/2015-08-03-new-react-devtools-beta.md
+++ b/docs/_posts/2015-08-03-new-react-devtools-beta.md
@@ -6,7 +6,7 @@ author: [jaredly]
 We've made an entirely new version of the devtools, and we want you to try it
 out!
 
-![The full devtools gif](/react/img/blog/devtools-full.gif)
+![The full devtools gif](../img/blog/devtools-full.gif)
 
 ## Why entirely new?
 
@@ -33,7 +33,7 @@ Yeah!
 
 ### The Tree View
 
-![The new tree view of the devtools](/react/img/blog/devtools-tree-view.png)
+![The new tree view of the devtools](../img/blog/devtools-tree-view.png)
 
 - Much richer view of your props, including the contents of objects and arrays
 - Custom components are emphasized, native components are de-emphasized
@@ -52,14 +52,14 @@ Yeah!
 Select the search bar (or press "/"), and start searching for a component by
 name.
 
-![](/react/img/blog/devtools-search.gif)
+![](../img/blog/devtools-search.gif)
 
 ### The Side Pane
 
 - Now shows the `context` for a component
 - Right-click to store a prop/state value as a global variable
 
-![](/react/img/blog/devtools-side-pane.gif)
+![](../img/blog/devtools-side-pane.gif)
 
 ## How do I install it?
 

--- a/docs/_posts/2015-09-02-new-react-developer-tools.md
+++ b/docs/_posts/2015-09-02-new-react-developer-tools.md
@@ -6,7 +6,7 @@ author: [sophiebits]
 
 A month ago, we [posted a beta](/react/blog/2015/08/03/new-react-devtools-beta.html) of the new React developer tools. Today, we're releasing the first stable version of the new devtools. We're calling it version 0.14, but it's a full rewrite so we think of it more like a 2.0 release.
 
-![Video/screenshot of new devtools](/react/img/blog/devtools-full.gif)
+![Video/screenshot of new devtools](../img/blog/devtools-full.gif)
 
 It contains a handful of new features, including:
 

--- a/docs/_posts/2015-09-14-community-roundup-27.md
+++ b/docs/_posts/2015-09-14-community-roundup-27.md
@@ -1,5 +1,5 @@
 ---
-title: "Community Round-up #27 &ndash; Relay Edition"
+title: "Community Round-up #27 – Relay Edition"
 layout: post
 author: [steveluscher]
 ---

--- a/docs/_posts/2015-09-14-community-roundup-27.md
+++ b/docs/_posts/2015-09-14-community-roundup-27.md
@@ -43,7 +43,7 @@ Joe McBride ([joemcbride](https://github.com/joemcbride)) has an up-and-running 
 Interact with this [visual tour of Relay's architecture](http://sgwilym.github.io/relay-visual-learners/) by Sam Gwilym ([sgwilym](https://github.com/sgwilym)).
 
 <a href="http://sgwilym.github.io/relay-visual-learners/">
-  <img src="/react/img/blog/relay-visual-architecture-tour.png" alt="Relay for visual learners" style="max-width:100%">
+  <img src="../img/blog/relay-visual-architecture-tour.png" alt="Relay for visual learners" style="max-width:100%">
 </a>
 
 Sam has already launched a product that leverages Relay's data-fetching, optimistic responses, pagination, and mutations &ndash; all atop a Ruby GraphQL server: [new.comique.co](http://new.comique.co/)

--- a/docs/_posts/2016-02-19-new-versioning-scheme.md
+++ b/docs/_posts/2016-02-19-new-versioning-scheme.md
@@ -13,21 +13,21 @@ The core of the React API has been stable for years. Our business as well as man
 
 React isn't just a library but an ecosystem. We know that your applications and ours are not just isolated islands of code. It is a network of your own application code, your own open source components and third party libraries that all depend on React.
 
-<img src="/react/img/blog/versioning-1.png" width="403">
+<img src="../img/blog/versioning-1.png" width="403">
 
 Therefore it is important that we don't just upgrade our own codebases but that we bring our whole community with us. We take the upgrade path very seriously - for everyone.
 
-<img src="/react/img/blog/versioning-poll.png" width="596">
+<img src="../img/blog/versioning-poll.png" width="596">
 
 ## Introducing Minor Releases
 
 Ideally everyone could just depend on the latest version of React all the time.
 
-<img src="/react/img/blog/versioning-2.png" width="463">
+<img src="../img/blog/versioning-2.png" width="463">
 
 We know that in practice that is not possible. In the future, we expect more new additive APIs rather than breakage of existing ones. By moving to major revisions in the semver scheme, we can release new versions without breaking existing ones.
 
-<img src="/react/img/blog/versioning-3.png" width="503">
+<img src="../img/blog/versioning-3.png" width="503">
 
 That means that if one component needs a new API, there is no need for any of the other components to do any further work. They remain compatible.
 
@@ -47,14 +47,14 @@ Once we've reached the end of life for a particular major version, we'll release
 
 If you try to upgrade your component to 16.0.0 you might find that your application no longer works if you still have other dependencies. E.g. if Ryan's and Jed's components are only compatible with 15.x.x.
 
-<img src="/react/img/blog/versioning-4.png" width="498">
+<img src="../img/blog/versioning-4.png" width="498">
 
 Worst case, you revert back to 15.1.0 for your application. Since you'll want to use your component, you might also revert that one.
 
-<img src="/react/img/blog/versioning-5.png" width="493">
+<img src="../img/blog/versioning-5.png" width="493">
 
 Of course, Ryan and Jed think the same way. If we're not careful, we can hit a cliff where nobody upgrades. This has happened to many software project ecosystems in the past.
 
 Therefore, we're committed to making it easy for most components and libraries built on top of React to be compatible with two major versions at the same time. We will do this by introducing new APIs before completely removing the old ones, thereby avoiding those cliffs.
 
-<img src="/react/img/blog/versioning-6.png" width="493">
+<img src="../img/blog/versioning-6.png" width="493">

--- a/docs/_posts/2016-07-22-create-apps-with-no-configuration.md
+++ b/docs/_posts/2016-07-22-create-apps-with-no-configuration.md
@@ -27,22 +27,22 @@ create-react-app hello-world
 
 This will take a while as npm installs the transitive dependencies, but once it’s done, you will see a list of commands you can run in the created folder:
 
-![created folder](/react/img/blog/create-apps-with-no-configuration/created-folder.png)
+![created folder](../img/blog/create-apps-with-no-configuration/created-folder.png)
 
 ### Starting the Server
 
 Run `npm start` to launch the development server. The browser will open automatically with the created app’s URL.
 
-![compiled successfully](/react/img/blog/create-apps-with-no-configuration/compiled-successfully.png)
+![compiled successfully](../img/blog/create-apps-with-no-configuration/compiled-successfully.png)
 
 Create React App uses both webpack and Babel under the hood.
 The console output is tuned to be minimal to help you focus on the problems:
 
-![failed to compile](/react/img/blog/create-apps-with-no-configuration/failed-to-compile.png)
+![failed to compile](../img/blog/create-apps-with-no-configuration/failed-to-compile.png)
 
 ESLint is also integrated so lint warnings are displayed right in the console:
 
-![compiled with warnings](/react/img/blog/create-apps-with-no-configuration/compiled-with-warnings.png)
+![compiled with warnings](../img/blog/create-apps-with-no-configuration/compiled-with-warnings.png)
 
 We only picked a small subset of lint rules that often lead to bugs.
 
@@ -50,7 +50,7 @@ We only picked a small subset of lint rules that often lead to bugs.
 
 To build an optimized bundle, run `npm run build`:
 
-![npm run build](/react/img/blog/create-apps-with-no-configuration/npm-run-build.png)
+![npm run build](../img/blog/create-apps-with-no-configuration/npm-run-build.png)
 
 It is minified, correctly envified, and the assets include content hashes for caching.
 

--- a/docs/_posts/2016-09-28-our-first-50000-stars.md
+++ b/docs/_posts/2016-09-28-our-first-50000-stars.md
@@ -9,7 +9,7 @@ Just three and a half years ago we open sourced a little JavaScript library call
 
 In order to celebrate 50,000 GitHub stars, [Maggie Appleton](http://www.maggieappleton.com/) from [egghead.io](http://egghead.io/) has designed us a special T-shirt, which will be available for purchase from Teespring **only for a week** through Thursday, October 6. Maggie also wrote [a blog post](https://www.behance.net/gallery/43269677/Reacts-50000-Stars-Shirt) showing all the different concepts she came up with before settling on the final design.
 
-<a target="_blank" href="https://teespring.com/react-50000-stars"><img src="/react/img/blog/react-50k-tshirt.jpg" width="650" height="340" alt="React 50k Tshirt" /></a>
+<a target="_blank" href="https://teespring.com/react-50000-stars"><img src="../img/blog/react-50k-tshirt.jpg" width="650" height="340" alt="React 50k Tshirt" /></a>
 
 The T-shirts are super soft using American Apparel's tri-blend fabric; we also have kids and toddler T-shirts and baby onesies available.
 
@@ -222,7 +222,7 @@ To make this happen, React had to be decoupled from Facebook's infrastructure, s
 
 As we started to prepare for the open source launch, [Maykel Loomans](https://twitter.com/miekd), a designer on Instagram, made a mock of what the website could look like. The header ended up defining the visual identity of React: its logo and the electric blue color!
 
-<center><a target="_blank" href="/react/img/blog/react-50k-mock-full.jpg"><img src="/react/img/blog/react-50k-mock.jpg" width="400" height="410" alt="React website mock" /></a></center>
+<center><a target="_blank" href="../img/blog/react-50k-mock-full.jpg"><img src="../img/blog/react-50k-mock.jpg" width="400" height="410" alt="React website mock" /></a></center>
 
 In its earliest days, React benefited tremendously from feedback, ideas, and technical contributions of early adopters and collaborators all over the company. While it might look like an overnight success in hindsight, the story of React is actually a great example of how new ideas often need to go through several rounds of refinement, iteration, and course correction over a long period of time before reaching their full potential.
 

--- a/docs/_posts/2016-11-16-react-v15.4.0.md
+++ b/docs/_posts/2016-11-16-react-v15.4.0.md
@@ -25,7 +25,7 @@ Another thing to watch out for is that React DOM Server is now about the same si
 
 You can now visualize React components in the Chrome Timeline. This lets you see which components exactly get mounted, updated, and unmounted, how much time they take relative to each other.
 
-<center><img src="/react/img/blog/react-perf-chrome-timeline.png" width="651" height="228" alt="React components in Chrome timeline" /></center>
+<img src="../img/blog/react-perf-chrome-timeline.png" width="651" height="228" alt="React components in Chrome timeline" />
 
 To use it:
 

--- a/docs/_posts/2017-07-26-error-handling-in-react-16.md
+++ b/docs/_posts/2017-07-26-error-handling-in-react-16.md
@@ -79,11 +79,11 @@ We also encourage you to use JS error reporting services (or build your own) so 
 
 React 16 prints all errors that occurred during rendering to the console in development, even if the application accidentally swallows them. In addition to the error message and the JavaScript stack, it also provides component stack traces. Now you can see where exactly in the component tree the failure has happened:
 
-<img src="/react/img/blog/error-boundaries-stack-trace.png" alt="Component stack traces in error message" style="width: 100%;">
+<img src="../img/blog/error-boundaries-stack-trace.png" alt="Component stack traces in error message" style="width: 100%;">
 
 You can also see the filenames and line numbers in the component stack trace. This works by default in [Create React App](https://github.com/facebookincubator/create-react-app) projects:
 
-<img src="/react/img/blog/error-boundaries-stack-trace-line-numbers.png" alt="Component stack traces with line numbers in error message" style="width: 100%;">
+<img src="../img/blog/error-boundaries-stack-trace-line-numbers.png" alt="Component stack traces with line numbers in error message" style="width: 100%;">
 
 If you don’t use Create React App, you can add [this plugin](https://www.npmjs.com/package/babel-plugin-transform-react-jsx-source) manually to your Babel configuration. Note that it’s intended only for development and **must be disabled in production**.
 

--- a/docs/community/videos.it-IT.md
+++ b/docs/community/videos.it-IT.md
@@ -17,7 +17,7 @@ next: complementary-tools-it-IT.html
 ### Pensare in react - tagtree.tv
 
 Un video di [tagtree.tv](http://tagtree.tv/) che espone i principi di [Pensare in React](/react/docs/thinking-in-react.html) mentre costruisci una semplice applicazione
-<figure>[![](/react/img/docs/thinking-in-react-tagtree.png)](http://tagtree.tv/thinking-in-react)</figure>
+<figure><a href="http://tagtree.tv/thinking-in-react"><img src="../img/docs/thinking-in-react-tagtree.png"></a></figure>
 
 * * *
 
@@ -32,14 +32,14 @@ Un video di [tagtree.tv](http://tagtree.tv/) che espone i principi di [Pensare i
 ### Pensare in grande con React
 
 "Sulla carta, tutti questi framework JS sembrano promettenti: implementazioni pulite, design veloce del codice, esecuzione perfetta. Ma che succede quando metti JavaScript sotto stress? Che succede se gli dài in pasto 6 megabyte di codice? In questo talk investigheremo come si comporta React in situazioni di stress elevato, e come ha aiutato il nostro team a costruire codice sicuro ad una scala enorme."
-<figure>[![](https://i.vimeocdn.com/video/481670116_650.jpg)](https://skillsmatter.com/skillscasts/5429-going-big-with-react#video)</figure>
+<figure><a href="https://skillsmatter.com/skillscasts/5429-going-big-with-react#video"><img src="https://i.vimeocdn.com/video/481670116_650.jpg"></a></figure>
 
 * * *
 
 ### CodeWinds
 
 [Pete Hunt](http://www.petehunt.net/) ha parlato con [Jeff Barczewski](http://jeff.barczewski.com/) a proposito di React nell'Episodio 4 di CodeWinds.
-<figure>[![](/react/img/docs/codewinds-004.png)](http://codewinds.com/4)</figure>
+<figure><a href="http://codewinds.com/4"><img src="../img/docs/codewinds-004.png"></a></figure>
 
 <table width="100%"><tr><td>
 02:08 - Cos'è React e perché usarlo?<br />
@@ -72,7 +72,7 @@ Un video di [tagtree.tv](http://tagtree.tv/) che espone i principi di [Pensare i
 ### JavaScript Jabber
 
 [Pete Hunt](http://www.petehunt.net/) e [Jordan Walke](https://github.com/jordwalke) hanno parlato di React in JavaScript Jabber 73.
-<figure>[![](/react/img/docs/javascript-jabber.png)](http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content)</figure>
+<figure><a href="http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content"><img src="../img/docs/javascript-jabber.png"></a></figure>
 
 <table width="100%"><tr><td>
 01:34 – Introduzione di Pete Hunt<br />

--- a/docs/community/videos.ko-KR.md
+++ b/docs/community/videos.ko-KR.md
@@ -17,7 +17,7 @@ next: complementary-tools-ko-KR.html
 ### Thinking in react - tagtree.tv
 
 [tagtree.tv](http://tagtree.tv/)의 비디오는 간단한 어플리케이션을 구성하면서 [Thinking in React](/react/docs/thinking-in-react-ko-KR.html)의 원리들을 전달합니다.
-<figure>[![](/react/img/docs/thinking-in-react-tagtree.png)](http://tagtree.tv/thinking-in-react)</figure>
+<figure><a href="http://tagtree.tv/thinking-in-react"><img src="../img/docs/thinking-in-react-tagtree.png"></a></figure>
 
 * * *
 
@@ -40,7 +40,7 @@ next: complementary-tools-ko-KR.html
 
 CodeWinds Episode 4 에서 [Pete Hunt](http://www.petehunt.net/)와 [Jeff Barczewski](http://jeff.barczewski.com/)가 React에 대해서 이야기 합니다.
 
-<figure>[![](/react/img/docs/codewinds-004.png)](http://codewinds.com/4)</figure>
+<figure><a href="http://codewinds.com/4"><img src="../img/docs/codewinds-004.png"></a></figure>
 
 <table width="100%"><tr><td>
 02:08 - What is React and why use it?<br />
@@ -74,7 +74,7 @@ CodeWinds Episode 4 에서 [Pete Hunt](http://www.petehunt.net/)와 [Jeff Barcze
 
 JavaScript Jabber 73에서 [Pete Hunt](http://www.petehunt.net/)와 [Jordan Walke](https://github.com/jordwalke)가 React에 대해서 이야기했습니다.
 
-<figure>[![](/react/img/docs/javascript-jabber.png)](http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content)</figure>
+<figure><a href="http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content"><img src="../img/docs/javascript-jabber.png"></a></figure>
 
 <table width="100%"><tr><td>
 01:34 – Pete Hunt Introduction<br />

--- a/docs/community/videos.md
+++ b/docs/community/videos.md
@@ -88,7 +88,7 @@ Facebook engineers [Bill Fisher](https://twitter.com/fisherwebdev) and [Jing Che
 ### CodeWinds Podcast
 
 [Pete Hunt](http://www.petehunt.net/) talked with [Jeff Barczewski](http://jeff.barczewski.com/) about React in [CodeWinds Episode 4](http://codewinds.com/podcast/004.html).
-<figure>[![](/react/img/docs/codewinds-004.png)](http://codewinds.com/4)</figure>
+<figure><a href="http://codewinds.com/4"><img src="../img/docs/codewinds-004.png"></a></figure>
 
 <table width="100%">
 <tr>
@@ -136,7 +136,7 @@ Facebook engineers [Bill Fisher](https://twitter.com/fisherwebdev) and [Jing Che
 ### JavaScript Jabber Podcast
 
 [Pete Hunt](http://www.petehunt.net/) and [Jordan Walke](https://github.com/jordwalke) talked about React in [JavaScript Jabber 73](https://devchat.tv/js-jabber/073-jsj-react-with-pete-hunt-and-jordan-walke).
-<figure>[![](/react/img/docs/javascript-jabber.png)](http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content)</figure>
+<figure><a href="http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content"><img src="../img/docs/javascript-jabber.png"></a></figure>
 
 <table width="100%">
   <tr>

--- a/docs/community/videos.zh-CN.md
+++ b/docs/community/videos.zh-CN.md
@@ -17,7 +17,7 @@ next: complementary-tools-zh-CN.html
 ### Thinking in react - tagtree.tv
 
 一个 [tagtree.tv](http://tagtree.tv/) 传达 [Thinking in React](/react/docs/thinking-in-react.html) 原则的视频  在构建一个简单app时。
-<figure>[![](/react/img/docs/thinking-in-react-tagtree.png)](http://tagtree.tv/thinking-in-react)</figure>
+<figure><a href="http://tagtree.tv/thinking-in-react"><img src="../img/docs/thinking-in-react-tagtree.png"></a></figure>
 
 * * *
 
@@ -32,14 +32,14 @@ next: complementary-tools-zh-CN.html
 ### Going big with React
 
 "理论上，所有的JS框架都大有可为：干净的实现,快速的代码设计,完美的执行。但是当你压力测试时Javascript会怎样？当你丢进6MB的代码时会怎样？在这次演讲中，我们会探究React在高压环境下如何表现，以及它如何帮助我们的团队在大规模时构建安全代码。 "
-<figure>[![](https://i.vimeocdn.com/video/481670116_650.jpg)](https://skillsmatter.com/skillscasts/5429-going-big-with-react#video)</figure>
+<figure><a href="https://skillsmatter.com/skillscasts/5429-going-big-with-react#video"><img src="https://i.vimeocdn.com/video/481670116_650.jpg"></a></figure>
 
 * * *
 
 ### CodeWinds
 
 [Pete Hunt](http://www.petehunt.net/) 与 [Jeff Barczewski](http://jeff.barczewski.com/) 在 CodeWinds Episode 4 上关于 React 的谈话.
-<figure>[![](/react/img/docs/codewinds-004.png)](http://codewinds.com/4)</figure>
+<figure><a href="http://codewinds.com/4"><img src="../img/docs/codewinds-004.png"></a></figure>
 
 <table width="100%"><tr><td>
 02:08 - 什么是React，为什么我们用它?<br />
@@ -72,7 +72,7 @@ next: complementary-tools-zh-CN.html
 ### JavaScript Jabber
 
 [Pete Hunt](http://www.petehunt.net/) 和 [Jordan Walke](https://github.com/jordwalke) 在 JavaScript Jabber 73 上关于React的谈话.
-<figure>[![](/react/img/docs/javascript-jabber.png)](http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content)</figure>
+<figure><a href="http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content"><img src="../img/docs/javascript-jabber.png"></a></figure>
 
 <table width="100%"><tr><td>
 01:34 – Pete Hunt 介绍<br />

--- a/docs/contributing/implementation-notes.md
+++ b/docs/contributing/implementation-notes.md
@@ -408,7 +408,7 @@ The host internal instances need to store:
 
 If you're struggling to imagine how an internal instance tree is structured in more complex applications, [React DevTools](https://github.com/facebook/react-devtools) can give you a close approximation, as it highlights host instances with grey, and composite instances with purple:
 
- <img src="/react/img/docs/implementation-notes-tree.png" width="500" style="max-width: 100%" alt="React DevTools tree" />
+ <img src="../img/docs/implementation-notes-tree.png" width="500" style="max-width: 100%" alt="React DevTools tree" />
 
 To complete this refactoring, we will introduce a function that mounts a complete tree into a container node, just like `ReactDOM.render()`. It returns a public instance, also like `ReactDOM.render()`:
 

--- a/docs/docs/accessibility.md
+++ b/docs/docs/accessibility.md
@@ -76,7 +76,7 @@ Ensure that your web application can be fully operated with the keyboard only:
 
 Keyboard focus refers to the current element in the DOM that is selected to accept input from the keyboard. We see it everywhere as a focus outline similar to that shown in the following image:
 
-<img src="/react/img/docs/keyboard-focus.png" alt="Blue keyboard focus outline around a selected link." />
+<img src="../img/docs/keyboard-focus.png" alt="Blue keyboard focus outline around a selected link." />
 
 Only ever use CSS that removes this outline, for example by setting `outline: 0`, if you are replacing it with another focus outline implementation.
 

--- a/docs/docs/addons-perf.md
+++ b/docs/docs/addons-perf.md
@@ -93,7 +93,7 @@ Perf.printInclusive(measurements)
 
 Prints the overall time taken. If no argument's passed, defaults to all the measurements from the last recording. This prints a nicely formatted table in the console, like so:
 
-![](/react/img/docs/perf-inclusive.png)
+![](../img/docs/perf-inclusive.png)
 
 * * *
 
@@ -105,7 +105,7 @@ Perf.printExclusive(measurements)
 
 "Exclusive" times don't include the times taken to mount the components: processing props, calling `componentWillMount` and `componentDidMount`, etc.
 
-![](/react/img/docs/perf-exclusive.png)
+![](../img/docs/perf-exclusive.png)
 
 * * *
 
@@ -119,7 +119,7 @@ Perf.printWasted(measurements)
 
 "Wasted" time is spent on components that didn't actually render anything, e.g. the render stayed the same, so the DOM wasn't touched.
 
-![](/react/img/docs/perf-wasted.png)
+![](../img/docs/perf-wasted.png)
 
 * * *
 
@@ -131,7 +131,7 @@ Perf.printOperations(measurements)
 
 Prints the underlying DOM manipulations, e.g. "set innerHTML" and "remove".
 
-![](/react/img/docs/perf-dom.png)
+![](../img/docs/perf-dom.png)
 
 * * *
 

--- a/docs/docs/cross-origin-errors.md
+++ b/docs/docs/cross-origin-errors.md
@@ -24,7 +24,7 @@ When loading React (or other libraries that might throw errors) from a CDN, add 
 
 Also ensure the CDN responds with the `Access-Control-Allow-Origin: *` HTTP header:
 
-![Access-Control-Allow-Origin: *](/react/img/docs/cdn-cors-header.png)
+![Access-Control-Allow-Origin: *](../img/docs/cdn-cors-header.png)
 
 ### Webpack
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -246,7 +246,7 @@ If you serve React from a CDN, we recommend to keep the [`crossorigin`](https://
 
 We also recommend to verify that the CDN you are using sets the `Access-Control-Allow-Origin: *` HTTP header:
 
-![Access-Control-Allow-Origin: *](/react/img/docs/cdn-cors-header.png)
+![Access-Control-Allow-Origin: *](../img/docs/cdn-cors-header.png)
 
 This enables a better [error handling experience](/react/blog/2017/07/26/error-handling-in-react-16.html) in React 16 and later.
 </section>

--- a/docs/docs/lifting-state-up.md
+++ b/docs/docs/lifting-state-up.md
@@ -322,4 +322,4 @@ If something can be derived from either props or state, it probably shouldn't be
 
 When you see something wrong in the UI, you can use [React Developer Tools](https://github.com/facebook/react-devtools) to inspect the props and move up the tree until you find the component responsible for updating the state. This lets you trace the bugs to their source:
 
-<img src="/react/img/docs/react-devtools-state.gif" alt="Monitoring State in React DevTools" width="100%">
+<img src="../img/docs/react-devtools-state.gif" alt="Monitoring State in React DevTools" width="100%">

--- a/docs/docs/optimizing-performance.md
+++ b/docs/docs/optimizing-performance.md
@@ -15,11 +15,11 @@ By default, React includes many helpful warnings. These warnings are very useful
 
 If you aren't sure whether your build process is set up correctly, you can check it by installing [React Developer Tools for Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi). If you visit a site with React in production mode, the icon will have a dark background:
 
-<img src="/react/img/docs/devtools-prod.png" style="max-width:100%" alt="React DevTools on a website with production version of React">
+<img src="../img/docs/devtools-prod.png" style="max-width:100%" alt="React DevTools on a website with production version of React">
 
 If you visit a site with React in development mode, the icon will have a red background:
 
-<img src="/react/img/docs/devtools-dev.png" style="max-width:100%" alt="React DevTools on a website with development version of React">
+<img src="../img/docs/devtools-dev.png" style="max-width:100%" alt="React DevTools on a website with development version of React">
 
 It is expected that you use the development mode when working on your app, and the production mode when deploying your app to the users.
 
@@ -164,7 +164,7 @@ Remember that you only need to do this for production builds. You shouldn't appl
 
 In the **development** mode, you can visualize how components mount, update, and unmount, using the performance tools in supported browsers. For example:
 
-<center><img src="/react/img/blog/react-perf-chrome-timeline.png" style="max-width:100%" alt="React components in Chrome timeline" /></center>
+<center><img src="../img/blog/react-perf-chrome-timeline.png" style="max-width:100%" alt="React components in Chrome timeline" /></center>
 
 To do this in Chrome:
 
@@ -203,7 +203,7 @@ If you know that in some situations your component doesn't need to update, you c
 
 Here's a subtree of components. For each one, `SCU` indicates what `shouldComponentUpdate` returned, and `vDOMEq` indicates whether the rendered React elements were equivalent. Finally, the circle's color indicates whether the component had to be reconciled or not.
 
-<figure><img src="/react/img/docs/should-component-update.png" style="max-width:100%" /></figure>
+<figure><img src="../img/docs/should-component-update.png" style="max-width:100%" /></figure>
 
 Since `shouldComponentUpdate` returned `false` for the subtree rooted at C2, React did not attempt to render C2, and thus didn't even have to invoke `shouldComponentUpdate` on C4 and C5.
 

--- a/docs/docs/rendering-elements.md
+++ b/docs/docs/rendering-elements.md
@@ -88,7 +88,7 @@ React DOM compares the element and its children to the previous one, and only ap
 
 You can verify by inspecting the [last example](http://codepen.io/gaearon/pen/gwoJZk?editors=0010) with the browser tools:
 
-![DOM inspector showing granular updates](/react/img/docs/granular-dom-updates.gif)
+![DOM inspector showing granular updates](../img/docs/granular-dom-updates.gif)
 
 Even though we create an element describing the whole UI tree on every tick, only the text node whose contents has changed gets updated by React DOM.
 

--- a/docs/docs/thinking-in-react.md
+++ b/docs/docs/thinking-in-react.md
@@ -16,7 +16,7 @@ One of the many great parts of React is how it makes you think about apps as you
 
 Imagine that we already have a JSON API and a mock from our designer. The mock looks like this:
 
-![Mockup](/react/img/blog/thinking-in-react-mock.png)
+![Mockup](../img/blog/thinking-in-react-mock.png)
 
 Our JSON API returns some data that looks like this:
 
@@ -39,7 +39,7 @@ But how do you know what should be its own component? Just use the same techniqu
 
 Since you're often displaying a JSON data model to a user, you'll find that if your model was built correctly, your UI (and therefore your component structure) will map nicely. That's because UI and data models tend to adhere to the same *information architecture*, which means the work of separating your UI into components is often trivial. Just break it up into components that represent exactly one piece of your data model.
 
-![Component diagram](/react/img/blog/thinking-in-react-components.png)
+![Component diagram](../img/blog/thinking-in-react-components.png)
 
 You'll see here that we have five components in our simple app. We've italicized the data each component represents.
 

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -165,11 +165,11 @@ class Square extends React.Component {
 
 Before:
 
-![React Devtools](/react/img/tutorial/tictac-empty.png)
+![React Devtools](../img/tutorial/tictac-empty.png)
 
 After: You should see a number in each square in the rendered output.
 
-![React Devtools](/react/img/tutorial/tictac-numbers.png)
+![React Devtools](../img/tutorial/tictac-numbers.png)
 
 [View the current code.](https://codepen.io/gaearon/pen/aWWQOG?editors=0010)
 
@@ -254,7 +254,7 @@ If you click on any square, an X should show up in it.
 
 The React Devtools extension for [Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/) lets you inspect a React component tree in your browser devtools.
 
-<img src="/react/img/tutorial/devtools.png" alt="React Devtools" style="max-width: 100%">
+<img src="../img/tutorial/devtools.png" alt="React Devtools" style="max-width: 100%">
 
 It lets you inspect the props and state of any of the components in your tree.
 

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -3414,9 +3414,9 @@ gatsby-plugin-react-next@^1.0.3:
     react "16.0.0-rc.3"
     react-dom "16.0.0-rc.3"
 
-gatsby-plugin-sharp@^1.6.2, gatsby-plugin-sharp@^1.6.7:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-1.6.7.tgz#688e22dfc6f3341fcb8efebed1bae5e05ff02fd4"
+gatsby-plugin-sharp@^1.6.2, gatsby-plugin-sharp@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-1.6.8.tgz#289f11f3f54c5cdd51f78f17403b8f318fd68cfa"
   dependencies:
     async "^2.1.2"
     babel-runtime "^6.26.0"
@@ -3457,13 +3457,12 @@ gatsby-remark-copy-linked-files@^1.5.2:
     unist-util-visit "^1.1.1"
 
 gatsby-remark-images@^1.5.11:
-  version "1.5.11"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-1.5.11.tgz#6088d4903e16969bfacc097fe951569937c6cf64"
+  version "1.5.13"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-1.5.13.tgz#7e383cea60aa624e8775256702eaa57c0ea55515"
   dependencies:
     babel-runtime "^6.26.0"
     cheerio "^1.0.0-rc.2"
-    gatsby-plugin-sharp "^1.6.7"
-    image-size "^0.5.1"
+    gatsby-plugin-sharp "^1.6.8"
     is-relative-url "^2.0.0"
     lodash "^4.17.4"
     slash "^1.0.0"
@@ -3513,8 +3512,8 @@ gatsby-source-filesystem@^1.4.4:
     slash "^1.0.0"
 
 gatsby-transformer-remark@^1.7.2:
-  version "1.7.10"
-  resolved "https://registry.yarnpkg.com/gatsby-transformer-remark/-/gatsby-transformer-remark-1.7.10.tgz#0e0df5495a189b0db601ca73c48c66b70e6055be"
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-remark/-/gatsby-transformer-remark-1.7.11.tgz#799c2ac2ad1c0b9c8c9b5fbab91e766b157b0735"
   dependencies:
     babel-runtime "^6.26.0"
     bluebird "^3.5.0"


### PR DESCRIPTION
Fixed image include paths by replacing `/react/img` with `../img`:
* search: `<figure>\[!\[\]\(([^\)]+)\)\]\(([^\)]+)\)</figure>`
* replace: `<figure><a href="$2"><img src="$1"></a></figure>`

Also discovered that the remark parse does not support markdown within HTML, so I fixed that as well. This can be verified by running the following code through Markdown+Remark on [ASTExplorer](https://astexplorer.net/):
```
> <figure>[![](/react/img/blog/khan-academy-editor.png)](http://sophiebits.com/2013/06/09/using-react-to-speed-up-khan-academy.html)</figure>
```

Updated some plug-in versions to pull in a fix with the Gatsby/Sharp integration (see gatsbyjs/gatsby/pull/2205).

And fixed a few formatting issues (eg an ndash character and some code blocks within blockquotes).

Commits are atomic.