### PR TITLE
Markdown fixes on "DOM Attributes in React 16" post

### DIFF
--- a/docs/_posts/2017-09-08-dom-attributes-in-react-16.md
+++ b/docs/_posts/2017-09-08-dom-attributes-in-react-16.md
@@ -12,7 +12,7 @@ In the past, React used to ignore unknown DOM attributes. If you wrote JSX with 
 
 would render an empty div to the DOM with React 15:
 
-````js
+```js
 // React 15 output:
 <div />
 ```
@@ -105,7 +105,7 @@ We've made a few other changes to make the behavior more predictable and help en
 Below is a detailed list of them.
 
 * **Unknown attributes with string, number, and object values:**  
-  
+
     ```js
     <div mycustomattribute="value" />
     <div mycustomattribute={42} />
@@ -118,7 +118,7 @@ Below is a detailed list of them.
     *Note: attributes starting with `on` are not passed through as an exception because this could become a potential security hole.*
 
 * **Known attributes with a different canonical React name:**  
-  
+
     ```js
     <div tabindex="-1" />
     <div class="hi" />


### PR DESCRIPTION
Noticed a syntax issue on this post which causes a rendering issue within Gatsby. This should fix it.