### PR TITLE
Update DOM warning wording and link

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMAttribute-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMAttribute-test.js
@@ -112,9 +112,9 @@ describe('ReactDOM unknown attribute', () => {
 
       testUnknownAttributeRemoval(Symbol('foo'));
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid prop `unknown` on <div> tag. Either remove this ' +
-          'prop from the element, or pass a string or number value to keep it ' +
-          'in the DOM. For details, see https://fb.me/react-unknown-prop\n' +
+        'Warning: Invalid value for prop `unknown` on <div> tag. Either remove it ' +
+          'from the element, or pass a string or number value to keep it ' +
+          'in the DOM. For details, see https://fb.me/react-attribute-behavior\n' +
           '    in div (at **)',
       );
       expectDev(console.error.calls.count()).toBe(1);
@@ -125,10 +125,10 @@ describe('ReactDOM unknown attribute', () => {
 
       testUnknownAttributeRemoval(function someFunction() {});
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid prop `unknown` on <div> tag. Either remove this ' +
-          'prop from the element, or pass a string or number value to ' +
+        'Warning: Invalid value for prop `unknown` on <div> tag. Either remove ' +
+          'it from the element, or pass a string or number value to ' +
           'keep it in the DOM. For details, see ' +
-          'https://fb.me/react-unknown-prop\n' +
+          'https://fb.me/react-attribute-behavior\n' +
           '    in div (at **)',
       );
       expectDev(console.error.calls.count()).toBe(1);

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -174,7 +174,7 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<div onDblClick={() => {}} />, container);
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown event handler property `onDblClick`. Did you mean `onDoubleClick`?\n    in div (at **)',
+        'Warning: Invalid event handler property `onDblClick`. Did you mean `onDoubleClick`?\n    in div (at **)',
       );
     });
 
@@ -233,7 +233,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.getAttribute('CHILDREN')).toBe('5');
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown DOM property `CHILDREN`. Did you mean `children`?\n    in div (at **)',
+        'Warning: Invalid DOM property `CHILDREN`. Did you mean `children`?\n    in div (at **)',
       );
     });
 
@@ -1729,10 +1729,10 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<input type="text" onclick="1" />);
       expectDev(console.error.calls.count()).toBe(2);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-        'Warning: Unknown event handler property `onclick`. Did you mean ' +
+        'Warning: Invalid event handler property `onclick`. Did you mean ' +
           '`onClick`?\n    in input (at **)',
       );
     });
@@ -1743,10 +1743,10 @@ describe('ReactDOMComponent', () => {
       ReactDOMServer.renderToString(<input type="text" onclick="1" />);
       expectDev(console.error.calls.count()).toBe(2);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-        'Warning: Unknown event handler property `onclick`. Did you mean ' +
+        'Warning: Invalid event handler property `onclick`. Did you mean ' +
           '`onClick`?\n    in input (at **)',
       );
     });
@@ -1761,7 +1761,7 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<div class="paladin" />, container);
       expectDev(console.error.calls.count()).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Unknown DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
     });
 
@@ -1939,11 +1939,11 @@ describe('ReactDOMComponent', () => {
       expectDev(console.error.calls.count()).toBe(2);
 
       expectDev(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Unknown DOM property `for`. Did you mean `htmlFor`?\n    in label',
+        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
 
       expectDev(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: Unknown DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
+        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
     });
 
@@ -1960,11 +1960,11 @@ describe('ReactDOMComponent', () => {
       expectDev(console.error.calls.count()).toBe(2);
 
       expectDev(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Unknown DOM property `for`. Did you mean `htmlFor`?\n    in label',
+        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
 
       expectDev(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: Unknown DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
+        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
     });
   });
@@ -2002,7 +2002,7 @@ describe('ReactDOMComponent', () => {
       expect(el.className).toBe('test');
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Unknown DOM property `class`. Did you mean `className`?',
+        'Warning: Invalid DOM property `class`. Did you mean `className`?',
       );
     });
 
@@ -2014,7 +2014,7 @@ describe('ReactDOMComponent', () => {
       expect(el.className).toBe('test');
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Unknown DOM property `cLASS`. Did you mean `className`?',
+        'Warning: Invalid DOM property `cLASS`. Did you mean `className`?',
       );
     });
 
@@ -2029,7 +2029,7 @@ describe('ReactDOMComponent', () => {
       expect(text.hasAttribute('arabic-form')).toBe(true);
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Unknown DOM property `arabic-form`. Did you mean `arabicForm`?',
+        'Warning: Invalid DOM property `arabic-form`. Did you mean `arabicForm`?',
       );
     });
 
@@ -2198,7 +2198,7 @@ describe('ReactDOMComponent', () => {
       expect(el.getAttribute('size')).toBe('30');
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Unknown DOM property `SiZe`. Did you mean `size`?',
+        'Warning: Invalid DOM property `SiZe`. Did you mean `size`?',
       );
     });
   });
@@ -2313,7 +2313,7 @@ describe('ReactDOMComponent', () => {
 
         expectDev(console.error.calls.count()).toBe(1);
         expectDev(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Unknown DOM property `x-height`. Did you mean `xHeight`',
+          'Warning: Invalid DOM property `x-height`. Did you mean `xHeight`',
         );
       });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -148,9 +148,9 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<div foo={() => {}} />, container);
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid prop `foo` on <div> tag. Either remove this prop ' +
+        'Warning: Invalid value for prop `foo` on <div> tag. Either remove it ' +
           'from the element, or pass a string or number value to keep ' +
-          'it in the DOM. For details, see https://fb.me/react-unknown-prop' +
+          'it in the DOM. For details, see https://fb.me/react-attribute-behavior' +
           '\n    in div (at **)',
       );
     });
@@ -161,9 +161,9 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<div foo={() => {}} baz={() => {}} />, container);
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid props `foo`, `baz` on <div> tag. Either remove these ' +
-          'props from the element, or pass a string or number value to keep ' +
-          'them in the DOM. For details, see https://fb.me/react-unknown-prop' +
+        'Warning: Invalid values for props `foo`, `baz` on <div> tag. Either remove ' +
+          'them from the element, or pass a string or number value to keep ' +
+          'them in the DOM. For details, see https://fb.me/react-attribute-behavior' +
           '\n    in div (at **)',
       );
     });
@@ -233,7 +233,7 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.getAttribute('CHILDREN')).toBe('5');
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid DOM property `CHILDREN`. Did you mean `children`?\n    in div (at **)',
+        'Warning: Unknown DOM property `CHILDREN`. Did you mean `children`?\n    in div (at **)',
       );
     });
 
@@ -1729,7 +1729,7 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<input type="text" onclick="1" />);
       expectDev(console.error.calls.count()).toBe(2);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Warning: Unknown DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
         'Warning: Unknown event handler property `onclick`. Did you mean ' +
@@ -1743,7 +1743,7 @@ describe('ReactDOMComponent', () => {
       ReactDOMServer.renderToString(<input type="text" onclick="1" />);
       expectDev(console.error.calls.count()).toBe(2);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Warning: Unknown DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
         'Warning: Unknown event handler property `onclick`. Did you mean ' +
@@ -1761,7 +1761,7 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<div class="paladin" />, container);
       expectDev(console.error.calls.count()).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Warning: Unknown DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
     });
 
@@ -1939,11 +1939,11 @@ describe('ReactDOMComponent', () => {
       expectDev(console.error.calls.count()).toBe(2);
 
       expectDev(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
+        'Warning: Unknown DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
 
       expectDev(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
+        'Warning: Unknown DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
     });
 
@@ -1960,11 +1960,11 @@ describe('ReactDOMComponent', () => {
       expectDev(console.error.calls.count()).toBe(2);
 
       expectDev(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
+        'Warning: Unknown DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
 
       expectDev(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
+        'Warning: Unknown DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
     });
   });
@@ -2002,7 +2002,7 @@ describe('ReactDOMComponent', () => {
       expect(el.className).toBe('test');
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?',
+        'Warning: Unknown DOM property `class`. Did you mean `className`?',
       );
     });
 
@@ -2014,7 +2014,7 @@ describe('ReactDOMComponent', () => {
       expect(el.className).toBe('test');
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid DOM property `cLASS`. Did you mean `className`?',
+        'Warning: Unknown DOM property `cLASS`. Did you mean `className`?',
       );
     });
 
@@ -2029,7 +2029,7 @@ describe('ReactDOMComponent', () => {
       expect(text.hasAttribute('arabic-form')).toBe(true);
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid DOM property `arabic-form`. Did you mean `arabicForm`?',
+        'Warning: Unknown DOM property `arabic-form`. Did you mean `arabicForm`?',
       );
     });
 
@@ -2115,7 +2115,7 @@ describe('ReactDOMComponent', () => {
       expect(el.hasAttribute('whatever')).toBe(false);
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid prop `whatever` on <div> tag',
+        'Warning: Invalid value for prop `whatever` on <div> tag',
       );
     });
 
@@ -2186,7 +2186,7 @@ describe('ReactDOMComponent', () => {
       expect(el.hasAttribute('whatever')).toBe(false);
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid prop `whatever` on <div> tag.',
+        'Warning: Invalid value for prop `whatever` on <div> tag.',
       );
     });
 
@@ -2198,7 +2198,7 @@ describe('ReactDOMComponent', () => {
       expect(el.getAttribute('size')).toBe('30');
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid DOM property `SiZe`. Did you mean `size`?',
+        'Warning: Unknown DOM property `SiZe`. Did you mean `size`?',
       );
     });
   });
@@ -2313,7 +2313,7 @@ describe('ReactDOMComponent', () => {
 
         expectDev(console.error.calls.count()).toBe(1);
         expectDev(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid DOM property `x-height`. Did you mean `xHeight`',
+          'Warning: Unknown DOM property `x-height`. Did you mean `xHeight`',
         );
       });
 

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -73,7 +73,7 @@ if (__DEV__) {
     if (registrationName != null) {
       warning(
         false,
-        'Unknown event handler property `%s`. Did you mean `%s`?%s',
+        'Invalid event handler property `%s`. Did you mean `%s`?%s',
         name,
         registrationName,
         getStackAddendum(debugID),
@@ -166,7 +166,7 @@ if (__DEV__) {
       if (standardName !== name) {
         warning(
           false,
-          'Unknown DOM property `%s`. Did you mean `%s`?%s',
+          'Invalid DOM property `%s`. Did you mean `%s`?%s',
           name,
           standardName,
           getStackAddendum(debugID),

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -166,7 +166,7 @@ if (__DEV__) {
       if (standardName !== name) {
         warning(
           false,
-          'Invalid DOM property `%s`. Did you mean `%s`?%s',
+          'Unknown DOM property `%s`. Did you mean `%s`?%s',
           name,
           standardName,
           getStackAddendum(debugID),
@@ -234,9 +234,9 @@ var warnUnknownProperties = function(type, props, debugID) {
   if (unknownProps.length === 1) {
     warning(
       false,
-      'Invalid prop %s on <%s> tag. Either remove this prop from the element, ' +
+      'Invalid value for prop %s on <%s> tag. Either remove it from the element, ' +
         'or pass a string or number value to keep it in the DOM. ' +
-        'For details, see https://fb.me/react-unknown-prop%s',
+        'For details, see https://fb.me/react-attribute-behavior%s',
       unknownPropString,
       type,
       getStackAddendum(debugID),
@@ -244,9 +244,9 @@ var warnUnknownProperties = function(type, props, debugID) {
   } else if (unknownProps.length > 1) {
     warning(
       false,
-      'Invalid props %s on <%s> tag. Either remove these props from the element, ' +
+      'Invalid values for props %s on <%s> tag. Either remove them from the element, ' +
         'or pass a string or number value to keep them in the DOM. ' +
-        'For details, see https://fb.me/react-unknown-prop%s',
+        'For details, see https://fb.me/react-attribute-behavior%s',
       unknownPropString,
       type,
       getStackAddendum(debugID),


### PR DESCRIPTION
I think we should get it in before 16.

It updates the link from the warning to point to the DOM blog post. We can then change it to docs once they're in place. The link that is in the code now points to the old behavior, and we can't change it because we want 15 to still point to it.

It also updates the wording to make it correct. The wording we have now is more about the old behavior (prop being invalid) rather than new one (value itself being invalid).

<s>One final minor change is that I now use `Invalid` when I talk about values, and `Unknown` when I talk about names. Not saying it's the greatest scheme ever but IMO it's better than the arbitrary distinction we have now (almost all say `Unknown` but one says `Invalid` for no specific reason).</s>

After discussion, I changed it to consistently using `Invalid` when talking about misspellings, and `Unknown` in other cases. I thought about using `Misspelled` but that isn't very fair to `class`. Maybe we can add a separate message for `class` later and point people to an HTML -> JSX compiler?

This only changes strings.