### PR TITLE
Fix "/blog/" redirect (and markdown redirects)

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -151,10 +151,7 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
   // Blog landing page should always show the most recent blog entry.
   createRedirect({
     fromPath: '/blog/',
-    toPath: newestBlogNode.fields.slug,
-  });
-  createRedirect({
-    fromPath: '/blog',
+    redirectInBrowser: true,
     toPath: newestBlogNode.fields.slug,
   });
 };

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -116,15 +116,19 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
       createArticlePage(slug);
 
       // Register redirects as well if the markdown specifies them.
-      // TODO Once Gatsby has a built-in solution for redirects, switch to it.
-      // https://github.com/gatsbyjs/gatsby/pull/1068
       if (edge.node.fields.redirect) {
-        const redirect = JSON.parse(edge.node.fields.redirect);
-        if (Array.isArray(redirect)) {
-          redirect.forEach(createArticlePage);
-        } else {
-          createArticlePage(redirect);
+        let redirect = JSON.parse(edge.node.fields.redirect);
+        if (!Array.isArray(redirect)) {
+          redirect = [redirect];
         }
+
+        redirect.forEach(fromPath =>
+          createRedirect({
+            fromPath: `/${fromPath}`,
+            redirectInBrowser: true,
+            toPath: `/${slug}`,
+          })
+        );
       }
     }
   });

--- a/www/src/components/LayoutFooter/Footer.js
+++ b/www/src/components/LayoutFooter/Footer.js
@@ -128,7 +128,7 @@ const Footer = ({layoutHasSidebar = false}) => (
           </FooterNav>
           <FooterNav layoutHasSidebar={layoutHasSidebar}>
             <MetaTitle onDark={true}>More</MetaTitle>
-            <FooterLink to="/blog">Blog</FooterLink>
+            <FooterLink to="/blog/">Blog</FooterLink>
             <FooterLink to="https://github.com/facebook/react" target="_blank">
               GitHub
             </FooterLink>

--- a/www/src/components/LayoutHeader/Header.js
+++ b/www/src/components/LayoutHeader/Header.js
@@ -12,7 +12,7 @@
 'use strict';
 
 import Container from 'components/Container';
-import HeaderLink from './HeaderLink';
+import {HeaderAnchor, HeaderLink} from './HeaderLink';
 import Link from 'gatsby-link';
 import React from 'react';
 import {colors, fonts, media} from 'theme';
@@ -128,7 +128,7 @@ const Header = ({location}) => (
             title="Community"
             to="/community/support.html"
           />
-          <HeaderLink
+          <HeaderAnchor
             isActive={location.pathname.includes('/blog')}
             title="Blog"
             to="/blog"

--- a/www/src/components/LayoutHeader/Header.js
+++ b/www/src/components/LayoutHeader/Header.js
@@ -12,7 +12,7 @@
 'use strict';
 
 import Container from 'components/Container';
-import {HeaderAnchor, HeaderLink} from './HeaderLink';
+import HeaderLink from './HeaderLink';
 import Link from 'gatsby-link';
 import React from 'react';
 import {colors, fonts, media} from 'theme';
@@ -128,10 +128,10 @@ const Header = ({location}) => (
             title="Community"
             to="/community/support.html"
           />
-          <HeaderAnchor
+          <HeaderLink
             isActive={location.pathname.includes('/blog')}
             title="Blog"
-            to="/blog"
+            to="/blog/"
           />
         </nav>
 

--- a/www/src/components/LayoutHeader/HeaderLink.js
+++ b/www/src/components/LayoutHeader/HeaderLink.js
@@ -15,6 +15,16 @@ import Link from 'gatsby-link';
 import React from 'react';
 import {colors, media} from 'theme';
 
+// TODO (bvaughn) Remove this component once Gatsby #2227 has been released
+// In the meanwhile it is required in order for the header "Blog" redirect to work
+// https://github.com/gatsbyjs/gatsby/pull/2227
+const HeaderAnchor = ({isActive, title, to}) => (
+  <a css={[style, isActive && activeStyle]} href={to}>
+    {title}
+    {isActive && <span css={activeAfterStyle} />}
+  </a>
+);
+
 const HeaderLink = ({isActive, title, to}) => (
   <Link css={[style, isActive && activeStyle]} to={to}>
     {title}
@@ -74,4 +84,4 @@ const activeAfterStyle = {
   },
 };
 
-export default HeaderLink;
+export {HeaderAnchor, HeaderLink};

--- a/www/src/components/LayoutHeader/HeaderLink.js
+++ b/www/src/components/LayoutHeader/HeaderLink.js
@@ -15,16 +15,6 @@ import Link from 'gatsby-link';
 import React from 'react';
 import {colors, media} from 'theme';
 
-// TODO (bvaughn) Remove this component once Gatsby #2227 has been released
-// In the meanwhile it is required in order for the header "Blog" redirect to work
-// https://github.com/gatsbyjs/gatsby/pull/2227
-const HeaderAnchor = ({isActive, title, to}) => (
-  <a css={[style, isActive && activeStyle]} href={to}>
-    {title}
-    {isActive && <span css={activeAfterStyle} />}
-  </a>
-);
-
 const HeaderLink = ({isActive, title, to}) => (
   <Link css={[style, isActive && activeStyle]} to={to}>
     {title}
@@ -84,4 +74,4 @@ const activeAfterStyle = {
   },
 };
 
-export {HeaderAnchor, HeaderLink};
+export default HeaderLink;


### PR DESCRIPTION
Now that gatsbyjs/gatsby/pull/2227 has been released and I've found a work-around for gatsbyjs/gatsby/issues/2225 (see [here](https://github.com/gatsbyjs/gatsby/issues/2225#issuecomment-332014115)) this PR fixes redirects.

URLs I spot-tested:
* /blog/ -> /blog/2017/09/08/dom-attributes-in-react-16.html
* /docs/videos.html -> /community/videos.html
* /docs/animation-ja-JP.html -> /docs/animation.html