### PR TITLE
Remove allow transparency

### DIFF
--- a/fixtures/attribute-behavior/AttributeTableSnapshot.md
+++ b/fixtures/attribute-behavior/AttributeTableSnapshot.md
@@ -676,23 +676,23 @@
 ## `as` (on `<link>` inside `<div>`)
 | Test Case | Flags | Result |
 | --- | --- | --- |
-| `as=(string)`| (changed)| `"a string"` |
+| `as=(string)`| (initial)| `<empty string>` |
 | `as=(empty string)`| (initial)| `<empty string>` |
-| `as=(array with string)`| (changed)| `"string"` |
+| `as=(array with string)`| (initial)| `<empty string>` |
 | `as=(empty array)`| (initial)| `<empty string>` |
-| `as=(object)`| (changed)| `"result of toString()"` |
-| `as=(numeric string)`| (changed)| `"42"` |
-| `as=(-1)`| (changed)| `"-1"` |
-| `as=(0)`| (changed)| `"0"` |
-| `as=(integer)`| (changed)| `"1"` |
-| `as=(NaN)`| (changed, warning)| `"NaN"` |
-| `as=(float)`| (changed)| `"99.99"` |
+| `as=(object)`| (initial)| `<empty string>` |
+| `as=(numeric string)`| (initial)| `<empty string>` |
+| `as=(-1)`| (initial)| `<empty string>` |
+| `as=(0)`| (initial)| `<empty string>` |
+| `as=(integer)`| (initial)| `<empty string>` |
+| `as=(NaN)`| (initial, warning)| `<empty string>` |
+| `as=(float)`| (initial)| `<empty string>` |
 | `as=(true)`| (initial, warning)| `<empty string>` |
 | `as=(false)`| (initial, warning)| `<empty string>` |
-| `as=(string 'true')`| (changed)| `"true"` |
-| `as=(string 'false')`| (changed)| `"false"` |
-| `as=(string 'on')`| (changed)| `"on"` |
-| `as=(string 'off')`| (changed)| `"off"` |
+| `as=(string 'true')`| (initial)| `<empty string>` |
+| `as=(string 'false')`| (initial)| `<empty string>` |
+| `as=(string 'on')`| (initial)| `<empty string>` |
+| `as=(string 'off')`| (initial)| `<empty string>` |
 | `as=(symbol)`| (initial, warning)| `<empty string>` |
 | `as=(function)`| (initial, warning)| `<empty string>` |
 | `as=(null)`| (initial)| `<empty string>` |

--- a/fixtures/attribute-behavior/AttributeTableSnapshot.md
+++ b/fixtures/attribute-behavior/AttributeTableSnapshot.md
@@ -473,31 +473,6 @@
 | `allowReorder=(null)`| (initial)| `<null>` |
 | `allowReorder=(undefined)`| (initial)| `<null>` |
 
-## `allowTransparency` (on `<path>` inside `<svg>`)
-| Test Case | Flags | Result |
-| --- | --- | --- |
-| `allowTransparency=(string)`| (changed)| `"a string"` |
-| `allowTransparency=(empty string)`| (changed)| `<empty string>` |
-| `allowTransparency=(array with string)`| (changed)| `"string"` |
-| `allowTransparency=(empty array)`| (changed)| `<empty string>` |
-| `allowTransparency=(object)`| (changed)| `"result of toString()"` |
-| `allowTransparency=(numeric string)`| (changed)| `"42"` |
-| `allowTransparency=(-1)`| (changed)| `"-1"` |
-| `allowTransparency=(0)`| (changed)| `"0"` |
-| `allowTransparency=(integer)`| (changed)| `"1"` |
-| `allowTransparency=(NaN)`| (changed, warning)| `"NaN"` |
-| `allowTransparency=(float)`| (changed)| `"99.99"` |
-| `allowTransparency=(true)`| (changed)| `"true"` |
-| `allowTransparency=(false)`| (changed)| `"false"` |
-| `allowTransparency=(string 'true')`| (changed)| `"true"` |
-| `allowTransparency=(string 'false')`| (changed)| `"false"` |
-| `allowTransparency=(string 'on')`| (changed)| `"on"` |
-| `allowTransparency=(string 'off')`| (changed)| `"off"` |
-| `allowTransparency=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `allowTransparency=(function)`| (initial, warning, ssr mismatch)| `<null>` |
-| `allowTransparency=(null)`| (initial)| `<null>` |
-| `allowTransparency=(undefined)`| (initial)| `<null>` |
-
 ## `alphabetic` (on `<font-face>` inside `<svg>`)
 | Test Case | Flags | Result |
 | --- | --- | --- |
@@ -701,23 +676,23 @@
 ## `as` (on `<link>` inside `<div>`)
 | Test Case | Flags | Result |
 | --- | --- | --- |
-| `as=(string)`| (initial)| `<empty string>` |
+| `as=(string)`| (changed)| `"a string"` |
 | `as=(empty string)`| (initial)| `<empty string>` |
-| `as=(array with string)`| (initial)| `<empty string>` |
+| `as=(array with string)`| (changed)| `"string"` |
 | `as=(empty array)`| (initial)| `<empty string>` |
-| `as=(object)`| (initial)| `<empty string>` |
-| `as=(numeric string)`| (initial)| `<empty string>` |
-| `as=(-1)`| (initial)| `<empty string>` |
-| `as=(0)`| (initial)| `<empty string>` |
-| `as=(integer)`| (initial)| `<empty string>` |
-| `as=(NaN)`| (initial, warning)| `<empty string>` |
-| `as=(float)`| (initial)| `<empty string>` |
+| `as=(object)`| (changed)| `"result of toString()"` |
+| `as=(numeric string)`| (changed)| `"42"` |
+| `as=(-1)`| (changed)| `"-1"` |
+| `as=(0)`| (changed)| `"0"` |
+| `as=(integer)`| (changed)| `"1"` |
+| `as=(NaN)`| (changed, warning)| `"NaN"` |
+| `as=(float)`| (changed)| `"99.99"` |
 | `as=(true)`| (initial, warning)| `<empty string>` |
 | `as=(false)`| (initial, warning)| `<empty string>` |
-| `as=(string 'true')`| (initial)| `<empty string>` |
-| `as=(string 'false')`| (initial)| `<empty string>` |
-| `as=(string 'on')`| (initial)| `<empty string>` |
-| `as=(string 'off')`| (initial)| `<empty string>` |
+| `as=(string 'true')`| (changed)| `"true"` |
+| `as=(string 'false')`| (changed)| `"false"` |
+| `as=(string 'on')`| (changed)| `"on"` |
+| `as=(string 'off')`| (changed)| `"off"` |
 | `as=(symbol)`| (initial, warning)| `<empty string>` |
 | `as=(function)`| (initial, warning)| `<empty string>` |
 | `as=(null)`| (initial)| `<empty string>` |

--- a/fixtures/attribute-behavior/README.md
+++ b/fixtures/attribute-behavior/README.md
@@ -8,7 +8,7 @@
 
 ## Instructions
 
-`cd scripts/attribute-behavior && yarn install && yarn start`
+`cd fixtures/attribute-behavior && yarn install && yarn start`
 
 ## Interpretation
 

--- a/fixtures/attribute-behavior/src/App.js
+++ b/fixtures/attribute-behavior/src/App.js
@@ -753,9 +753,9 @@ class App extends React.Component {
 
   async componentDidMount() {
     const sources = {
-      ReactStable: 'https://unpkg.com/react@latest/dist/react.js',
-      ReactDOMStable: 'https://unpkg.com/react-dom@latest/dist/react-dom.js',
-      ReactDOMServerStable: 'https://unpkg.com/react-dom@latest/dist/react-dom-server.js',
+      ReactStable: 'https://unpkg.com/react@latest/umd/react.development.js',
+      ReactDOMStable: 'https://unpkg.com/react-dom@latest/umd/react-dom.development.js',
+      ReactDOMServerStable: 'https://unpkg.com/react-dom@latest/umd/react-dom-server.browser.development.js',
       ReactNext: '/react.development.js',
       ReactDOMNext: '/react-dom.development.js',
       ReactDOMServerNext: '/react-dom-server.browser.development.js',

--- a/fixtures/attribute-behavior/src/attributes.js
+++ b/fixtures/attribute-behavior/src/attributes.js
@@ -93,12 +93,6 @@ const attributes = [
     read: getSVGAttribute('allowReorder'),
   },
   {
-    name: 'allowTransparency',
-    containerTagName: 'svg',
-    tagName: 'path',
-    read: getSVGAttribute('allowtransparency'),
-  },
-  {
     name: 'alphabetic',
     containerTagName: 'svg',
     tagName: 'font-face',

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -26,9 +26,6 @@ var HTMLDOMPropertyConfig = {
   // name warnings.
   Properties: {
     allowFullScreen: HAS_BOOLEAN_VALUE,
-    // IE only true/false iFrame attribute
-    // https://msdn.microsoft.com/en-us/library/ms533072(v=vs.85).aspx
-    allowTransparency: HAS_STRING_BOOLEAN_VALUE,
     // specifies target context for links with `preload` type
     async: HAS_BOOLEAN_VALUE,
     // autoFocus is polyfilled/normalized by AutoFocusUtils

--- a/src/renderers/dom/shared/hooks/possibleStandardNames.js
+++ b/src/renderers/dom/shared/hooks/possibleStandardNames.js
@@ -18,7 +18,6 @@ var possibleStandardNames = {
   accesskey: 'accessKey',
   action: 'action',
   allowfullscreen: 'allowFullScreen',
-  allowtransparency: 'allowTransparency',
   alt: 'alt',
   as: 'as',
   async: 'async',


### PR DESCRIPTION
`allowtransparency` is an Internet Explorer-only attribute that controls the background transparency of an iFrame. When set to true, it respects the background color of the iFrame. When set to false, it sets the background color to that of the document.

This feature was removed in IE9. Browsers beyond this point just let you set the background of the document body to transparent, making the attribute unnecessary. 

Should some ambitious/poor developer manage to get IE7/8 to work with React 16.x, they can still use `allowtransparency="true"`, since React now supports unrecognized attributes.

**How I verified this change**

[Check out the MSDN Example on allowTransparency](http://samples.msdn.microsoft.com/workshop/samples/author/dhtml/refs/allowTransparency.htm)

**IE8 looks like this:**

<img width="655" alt="30827527-6a6687c8-a208-11e7-9c3f-e3f13f1699af" src="https://user-images.githubusercontent.com/590904/30835079-49750276-a224-11e7-8e89-9b5c6532848f.png">

**Every other browser:**

<img width="675" alt="30827538-6f3d6406-a208-11e7-973b-6883ac692272" src="https://user-images.githubusercontent.com/590904/30835094-5d492214-a224-11e7-8d68-a8c21c257ed6.png">