### PR TITLE
Fix author in latest blog post

### DIFF
--- a/docs/_data/authors.yml
+++ b/docs/_data/authors.yml
@@ -49,6 +49,9 @@ LoukaN:
 matthewjohnston4:
   name: Matthew Johnston
   url: https://github.com/matthewathome
+nhunzaker:
+  name: Nathan Hunzaker
+  url: https://github.com/nhunzaker
 petehunt:
   name: Pete Hunt
   url: https://twitter.com/floydophone


### PR DESCRIPTION
Fix this so that @nhunzaker gets his name up there for real (will want to cherry-pick back to master but the blog post isn't there either so I'll let y'all handle that). I took a best guess at URL you might want to link to but obviously pick one you want.