### PR TITLE
Fix a dead link to algorithm paper

### DIFF
--- a/docs/docs/reconciliation.md
+++ b/docs/docs/reconciliation.md
@@ -10,7 +10,7 @@ React provides a declarative API so that you don't have to worry about exactly w
 
 When you use React, at a single point in time you can think of the `render()` function as creating a tree of React elements. On the next state or props update, that `render()` function will return a different tree of React elements. React then needs to figure out how to efficiently update the UI to match the most recent tree.
 
-There are some generic solutions to this algorithmic problem of generating the minimum number of operations to transform one tree into another. However, the [state of the art algorithms](http://grfia.dlsi.ua.es/ml/algorithms/references/editsurvey_bille.pdf) have a complexity in the order of O(n<sup>3</sup>) where n is the number of elements in the tree.
+There are some generic solutions to this algorithmic problem of generating the minimum number of operations to transform one tree into another. However, the [state of the art algorithms](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.100.2577&rep=rep1&type=pdf) have a complexity in the order of O(n<sup>3</sup>) where n is the number of elements in the tree.
 
 If we used this in React, displaying 1000 elements would require in the order of one billion comparisons. This is far too expensive. Instead, React implements a heuristic O(n) algorithm based on two assumptions:
 


### PR DESCRIPTION
The link to the algorithm describing how to efficiently transform one tree into another tree was broken. A working link to the paper was added.