### PR TITLE
Fix unpkg links by pointing to version 15

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -48,9 +48,9 @@
   <script src="https://unpkg.com/codemirror@5.15.2/mode/javascript/javascript.js"></script>
   <script src="https://unpkg.com/codemirror@5.15.2/mode/xml/xml.js"></script>
   <script src="https://unpkg.com/codemirror@5.15.2/mode/jsx/jsx.js"></script>
-  <script src="https://unpkg.com/prop-types/prop-types.min.js"></script>
-  <script src="https://unpkg.com/react/dist/react.min.js"></script>
-  <script src="https://unpkg.com/react-dom/dist/react-dom.min.js"></script>
+  <script src="https://unpkg.com/prop-types@15/prop-types.min.js"></script>
+  <script src="https://unpkg.com/react@15/dist/react.min.js"></script>
+  <script src="https://unpkg.com/react-dom@15/dist/react-dom.min.js"></script>
   <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>
   <script src="/react/js/live_editor.js"></script>
 </head>


### PR DESCRIPTION
When you leave out the version number, unpkg will serve from the latest version. Since these files are now in the `/umd` directory in version 16, it's best to use the version number in the unpkg URL 😅