### PR TITLE
[Gatsby docs update] menu overlay padding bottom

### DIFF
--- a/www/src/templates/components/Sidebar/Sidebar.js
+++ b/www/src/templates/components/Sidebar/Sidebar.js
@@ -42,7 +42,7 @@ class Sidebar extends Component {
           },
 
           [media.lessThan('small')]: {
-            paddingBottom: 50,
+            paddingBottom: 100,
           },
         }}>
         {sectionList.map((section, index) => (


### PR DESCRIPTION
Increase the padding a bit to allow for when the toolbar is visible on iOS. 