### PR TITLE
Update authors for v16

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,34 +1,60 @@
 839 <8398a7@gmail.com>
+Aaron Ackerman <theron17@gmail.com>
+Aaron Cannon <cannona@fireantproductions.com>
 Aaron Franks <aaron.franks@gmail.com>
 Aaron Gelter <aaron.gelter@harman.com>
+Abhay Nikam <nikam.abhay1@gmail.com>
+Abhishek Soni <abhisheksoni2720@gmail.com>
+Adam <gadtfly@users.noreply.github.com>
 Adam Bloomston <adam@glitterfram.es>
 Adam Krebs <amk528@cs.nyu.edu>
 Adam Mark <adammark75@gmail.com>
 Adam Solove <asolove@gmail.com>
+Adam Stankiewicz <sheerun@sher.pl>
 Adam Timberlake <adam.timberlake@gmail.com>
 Adam Zapletal <adamzap@gmail.com>
+Addy Osmani <addyosmani@gmail.com>
+Adrian Sieber <mail@adriansieber.com>
+Aesop Wolf <aesopwolf@users.noreply.github.com>
 Ahmad Wali Sidiqi <wali-s@users.noreply.github.com>
 Alan Plum <me@pluma.io>
 Alan Souza <alansouzati@gmail.com>
 Alan deLevie <adelevie@gmail.com>
 Alastair Hole <afhole@gmail.com>
+Alex <itaieps+github@fastmail.fm>
 Alex <ultrafez@users.noreply.github.com>
+Alex Babkov <alex.babkov@rexsoftware.com.au>
+Alex Baumgertner <alex.baumgertner@gmail.com>
 Alex Boatwright <drdelambre@gmail.com>
 Alex Boyd <alex@opengroove.org>
 Alex Dajani <xelad1@gmail.com>
+Alex Jacobs <lex.jacobs@gmail.com>
+Alex Katopodis <akatopo@users.noreply.github.com>
 Alex Lopatin <alex@alexlopatin.com>
 Alex Mykyta <dancingwithcows@gmail.com>
 Alex Pien <alexpien@gmail.com>
 Alex Smith <iqwz@ya.ru>
 Alex Zelenskiy <azelenskiy@fb.com>
+Alex Zherdev <alex.zherdev@gmail.com>
+Alexander <alexander.chisler@gmail.com>
+Alexander <alx.safari@gmail.com>
 Alexander Shtuchkin <ashtuchkin@gmail.com>
 Alexander Solovyov <alexander@solovyov.net>
 Alexander Tseung <alextsg@gmail.com>
 Alexandre Gaudencio <shahor@shahor.fr>
+Alexandre Kirszenberg <a.kirszenberg@gmail.com>
 Alexey Raspopov <avenger7x13@gmail.com>
 Alexey Shamrin <shamrin@gmail.com>
+Ali Taheri Moghaddar <ali.taheri.m@gmail.com>
 Ali Ukani <ali.ukani@gmail.com>
+Alireza Mostafizi <ar.mostafizi@gmail.com>
+Almero Steyn <almero.steyn@gmail.com>
+Amanvir Sangha <amanvir@users.noreply.github.com>
+Amjad Masad <amjad.masad@gmail.com>
+Anastasia A <sacret@nm.ru>
+Andre Giron <agiron123@gmail.com>
 Andre Z Sanchez <andrezacsanchez@gmail.com>
+Andreas Möller <am@localheinz.com>
 Andreas Savvides <asavvides@twitter.com>
 Andreas Svensson <andreas@syranide.com>
 Andres Kalle <mjomble@gmail.com>
@@ -37,31 +63,51 @@ Andrew Clark <acdlite@me.com>
 Andrew Cobby <cobbweb@users.noreply.github.com>
 Andrew Davey <andrew@equin.co.uk>
 Andrew Henderson <andrew.m.henderson@gmail.com>
+Andrew Imm <aimm22@gmail.com>
 Andrew Kulakov <avk@8xx8.ru>
+Andrew Lo <andrew.lo@rangle.io>
+Andrew Poliakov <pavlin99th@me.com>
 Andrew Rasmussen <andras@fb.com>
+Andrew Rota <rota.andrew@gmail.com>
 Andrew Sokolov <asokolov@atlassian.com>
 Andrew Zich <azich@fb.com>
+Andrey Marchenko <tom910ru@gmail.com>
+Andrey Okonetchnikov <okonet@users.noreply.github.com>
 Andrey Popp <8mayday@gmail.com>
+Andrey Safronov <a.safronov87@gmail.com>
+Andy Edwards <jedwards@fastmail.com>
+Ankeet Maini <ankeet.maini@gmail.com>
 Anthony van der Hoorn <anthony.vanderhoorn@gmail.com>
 Anto Aravinth <anto.aravinth.cse@gmail.com>
 Antonio Ruberto <anto.ruberto@gmail.com>
 Antti Ahti <antti.ahti@gmail.com>
+António Nuno Monteiro <anmonteiro@gmail.com>
 Anuj Tomar <ankuto@gmail.com>
+Anuja Ware <anuja@joshsoftware.com>
 AoDev <AoDev@users.noreply.github.com>
 April Arcus <april.arcus@gmail.com>
 Areeb Malik <areeb.malik91@gmail.com>
 Aria Buckles <aria@khanacademy.org>
 Aria Stewart <aredridel@dinhe.net>
 Arian Faurtosh <arian@icloud.com>
+Arni Fannar <arnifa@gmail.com>
+Arshabh Kumar Agarwal <arshabh.agarwal.it@gmail.com>
 Artem Nezvigin <artem@artnez.com>
+Arthur Gunn <arthur@gunn.co.nz>
+Ashish <ashishgupta.3197@gmail.com>
 Austin Wright <aaa@bzfx.net>
+Avinash Kondeti <avi.kondeti@gmail.com>
 Ayman Osman <aymano.osman@gmail.com>
+B.Orlov <bgnorlov@gmail.com>
+BDav24 <BDav24@users.noreply.github.com>
+BEAUDRU Manuel <beaudru.manuel@gmail.com>
 Baraa Hamodi <bhamodi@uwaterloo.ca>
 Bartosz Kaszubowski <gosimek@gmail.com>
 Basarat Ali Syed <basaratali@gmail.com>
 Battaile Fauber <battaile@gmail.com>
 Beau Smith <beau@beausmith.com>
 Ben Anderson <banderson@constantcontact.com>
+Ben Berman <ben.m.berman@gmail.com>
 Ben Brooks <ben@benbrooks.net>
 Ben Foxall <benfoxall@gmail.com>
 Ben Halpern <bendhalpern@gmail.com>
@@ -69,48 +115,70 @@ Ben Jaffe <jaffe.ben@gmail.com>
 Ben Moss <ben@mossity.com>
 Ben Newman <bn@cs.stanford.edu>
 Ben Ripkens <bripkens.dev@gmail.com>
+Benedikt Meurer <benedikt.meurer@googlemail.com>
 Benjamin Keen <ben.keen@gmail.com>
 Benjamin Leiken <benleiken@gmail.com>
 Benjamin Woodruff <github@benjam.info>
 Benjy Cui <benjytrys@gmail.com>
+Benoit Girard <b56girard@gmail.com>
+Benton Rochester <bentonrochester@gmail.com>
+Bernard Lin <bernardlin12@gmail.com>
 Bill Blanchard <bill@plumbdev.com>
 Bill Fisher <fisherwebdev@gmail.com>
+Billy Shih <me@billyshih.com>
 Blaine Hatab <jbhatab@gmail.com>
 Blaine Kasten <blainekasten@gmail.com>
 Bob Eagan <bob@synapsestudios.com>
 Bob Ralian <bob.ralian@gmail.com>
 Bob Renwick <bob.renwick@gmail.com>
 Bobby <puppybytes@gmail.com>
+Bogdan Chadkin <trysound@yandex.ru>
 Bojan Mihelac <bmihelac@mihelac.org>
+Boris Yankov <borisyankov@gmail.com>
+Brad Vogel <bradavogel@gmail.com>
+Bradford <brad.lamson@gmail.com>
 Bradley Spaulding <brad.spaulding@gmail.com>
 Brandon Bloom <brandon@brandonbloom.name>
+Brandon Dail <aweary@users.noreply.github.com>
 Brandon Tilley <brandon@brandontilley.com>
 Brenard Cubacub <bcbcb@users.noreply.github.com>
+Brent Vatne <brentvatne@gmail.com>
 Brian Cooke <bri@bricooke.com>
+Brian Emil Hartz <brianhartz@gmail.com>
 Brian Holt <btholt@gmail.com>
 Brian Hsu <brianhsu@Brians-MacBook-Pro.local>
 Brian Kim <briankimpossible@gmail.com>
 Brian Kung <brian@callmekung.com>
 Brian Reavis <brian@thirdroute.com>
 Brian Rue <brian@rollbar.com>
+Brian Vaughn <brian.david.vaughn@gmail.com>
+Bruce Harris <bharris845@gmail.com>
+Bruno Heridet <delapouite@gmail.com>
 Bruno Škvorc <bruno@skvorc.me>
+Bryan Braun <bbraun7@gmail.com>
+CT Wu <wu.chingting@gmail.com>
 Cam Song <neosoyn@gmail.com>
 Cam Spiers <camspiers@gmail.com>
 Cameron Chamberlain <git@camjc.com>
 Cameron Matheson <cameron@instructure.com>
+Carolina Powers <carolinapoloni@gmail.com>
 Carter Chung <carterchung@users.noreply.github.com>
 Cassus Adam Banko <banko.adam@gmail.com>
 Cat Chen <catchen@fb.com>
 Cedric Sohrauer <cedric.sohrauer@infopark.de>
 Cesar William Alvarenga <cesarwbr@gmail.com>
+Chad Fawcett <me@chadf.ca>
 Changsoon Bok <winmain@gmail.com>
 Charles Marsh <charlie@khanacademy.org>
+Charlie Garcia <cgarcia@intellisys.com.do>
 Chase Adams <realchaseadams@gmail.com>
 Cheng Lou <chenglou92@gmail.com>
 Chitharanjan Das <das.chitharanjan@gmail.com>
+Chris <thisguychris@users.noreply.github.com>
 Chris Bolin <bolin.chris@gmail.com>
 Chris Grovers <chrisgrovers@users.noreply.github.com>
 Chris Ha <chriskevinha@gmail.com>
+Chris Pearce <hello@chrispearce.me>
 Chris Rebert <github@rebertia.com>
 Chris Sciolla <csciolla1@gmail.com>
 Christian Alfoni <christianalfoni@gmail.com>
@@ -118,35 +186,58 @@ Christian Oliff <christianoliff@yahoo.com>
 Christian Roman <chroman16@gmail.com>
 Christoffer Sawicki <christoffer.sawicki@gmail.com>
 Christoph Pojer <christoph.pojer@gmail.com>
+Christophe Hurpeau <christophe@hurpeau.com>
 Christopher Monsanto <chris@monsan.to>
+Claudio Brandolino <cbrandolino@gmail.com>
 Clay Allsopp <clay.allsopp@gmail.com>
+Clay Miller <clay@smockle.com>
+Clement Hoang <clement.hoang24@gmail.com>
+CodinCat <a55951234@gmail.com>
+Cody Reichert <codyreichert@gmail.com>
+Colin Wren <colinwren@users.noreply.github.com>
 Connor McSheffrey <c@conr.me>
 Conor Hastings <hastings.conorm@gmail.com>
+Constantin Gavrilete <cgav@users.noreply.github.com>
 Cory House <housecor@gmail.com>
 Cotton Hou <himcotton@gmail.com>
 Craig Akimoto <strawbrary@users.noreply.github.com>
 Cristovao Verstraeten <cristovao@apleasantview.com>
+DQNEO <dqneoo@gmail.com>
+Dai Nguyen <dainguyenhuu@users.noreply.github.com>
+Damian Nicholson <damian.nicholson21@gmail.com>
 Damien Pellier <dpellier@leadformance.com>
+Damien Soulard <iDams@users.noreply.github.com>
 Dan Abramov <dan.abramov@gmail.com>
 Dan Fox <iamdanfox@gmail.com>
 Dan Schafer <dschafer@fb.com>
+DanZeuss <danvc@zeuss.com>
 Daniel Carlsson <daniel.carlsson.1987@gmail.com>
 Daniel Cousens <dcousens@users.noreply.github.com>
 Daniel Friesen <daniel@nadir-seen-fire.com>
 Daniel Gasienica <daniel@gasienica.ch>
 Daniel Hejl <daniel.hejl@hotmail.com>
 Daniel Hejl <hejldaniel@gmail.com>
+Daniel Liburd <daniel.liburd@gmail.com>
 Daniel Lo Nigro <daniel@dan.cx>
 Daniel Mané <danmane@gmail.com>
 Daniel Miladinov <dmiladinov@wingspan.com>
 Daniel Rodgers-Pryor <djrodgerspryor@gmail.com>
+Daniel Rosenwasser <DanielRosenwasser@users.noreply.github.com>
+Daniel Rotter <daniel.rotter@gmail.com>
 Daniel Schonfeld <daniel@schonfeld.org>
+Daniela Borges <alunassertiva@gmail.com>
+Danilo Vitoriano <vitoriano08@gmail.com>
 Danny Ben-David <dannybd@fb.com>
+Danny Hurlburt <dhurlburtusa@users.noreply.github.com>
 Darcy <smadad@me.com>
 Daryl Lau <daryl@weak.io>
 Darío Javier Cravero <dario@uxtemple.com>
 Dave Galbraith <dave@jut.io>
+Dave Lunny <d@velunny.com>
+Dave Voyles <Dnvoyles@gmail.com>
+David Aurelio <dev@david-aurelio.com>
 David Baker <djbaker2@gmail.com>
+David Beitey <david@davidjb.com>
 David Ed Mellum <david@edmellum.com>
 David Goldberg <gberg1@users.noreply.github.com>
 David Granado <davidjgranado@gmail.com>
@@ -158,65 +249,126 @@ David Mininger <dmininger@gmail.com>
 David Neubauer <davidneub@gmail.com>
 David Percy <davetp425@gmail.com>
 Dean Shi <dnshi@users.noreply.github.com>
+Denis Laxalde <denis@laxalde.org>
+Denis Pismenny <dpismenny@users.noreply.github.com>
 Denis Sokolov <denis@sokolov.cc>
 Deniss Jacenko <deniss.jacenko+github@gmail.com>
 Dennis Johnson <djohnson@rallydev.com>
+Desmond Brand <dmnd@desmondbrand.com>
+Devedse <2350015+devedse@users.noreply.github.com>
+Devinsuit <r.poryvaev@hotmail.com>
 Devon Blandin <dblandin@gmail.com>
 Devon Harvey <devonharvey@gmail.com>
+Dheeraj Kumar <a.dheeraj.kumar@gmail.com>
+Dhyey Thakore <dhyey35@gmail.com>
+Diego Muracciole <diegomuracciole@gmail.com>
+Dima Beznos <beznos.d@gmail.com>
+Dimzel Sobolev <disobolev@icloud.com>
+Dmitri Zaitsev <dmitri14@gmail.com>
 Dmitrii Abramov <dmitrii@rheia.us>
+Dmitriy Kubyshkin <grassator@gmail.com>
 Dmitriy Rozhkov <dmitriy.rozhkov@xing.com>
 Dmitry Blues <dmitri.blyus@gmail.com>
 Dmitry Mazuro <dmitry.mazuro@icloud.com>
+Dmitry Zhuravlev-Nevsky <dmitry.nevsky@gmail.com>
 Domenico Matteo <matteo.domenico@gmail.com>
+Dominic Gannaway <dg@domgan.com>
 Don Abrams <donabrams@gmail.com>
 Dongsheng Liu <bellanchor@gmail.com>
+Duke Pham <dookpham@gmail.com>
 Dustan Kasten <dustan.kasten@gmail.com>
 Dustin Getz <dgetz@wingspan.com>
 Dylan Harrington <dylanharrington@gmail.com>
+Dylan Kirby <djkirby@users.noreply.github.com>
+Edgar (Algebr) <edgar.factorial@gmail.com>
+Eduard <ghinea.eduard@yahoo.com>
 Eduardo Garcia <emumaniacx@gmail.com>
 Edvin Erikson <edvin@rocketblast.com>
 Elaine Fang <elainefang@Elaines-MacBook-Pro.local>
+Eli White <github@eli-white.com>
 Enguerran <engcolson@gmail.com>
+Eoin Hennessy <eoin.hennessy@gmail.com>
+Eric Churchill <eric.churchill2@gmail.com>
 Eric Clemmons <eric@smarterspam.com>
+Eric Douglas <eric.douglas.mail@gmail.com>
 Eric Eastwood <contact@ericeastwood.com>
+Eric Elliott <support@paralleldrive.com>
 Eric Florenzano <floguy@gmail.com>
+Eric Matthys <ericmatthys@gmail.com>
+Eric Nakagawa <ericnakagawa@gmail.com>
 Eric O'Connell <eric.oconnell@idealist.org>
+Eric Pitcher <ericpitcher@live.com>
+Eric Sakmar <eric.sakmar@gmail.com>
 Eric Schoffstall <contra@wearefractal.com>
 Erik Harper <eharper@mixpo.com>
+Erik Hellman <iam@erikhellman.com>
 Espen Hovlandsdal <rexxars@gmail.com>
+Esteban <elas7@users.noreply.github.com>
+Eugene <elforastero@ya.ru>
+EugeneGarbuzov <ridaim@yandex.ru>
 Evan Coonrod <evan@paloalto.com>
+Evan Jacobs <evan@yaycmyk.com>
+Evan Scott <glitterbyte@gmail.com>
 Evan Vosberg <evanvosberg@urban.to>
 Fabio M. Costa <fabiomcosta@gmail.com>
+Fabrizio Castellarin <f.castellarin@gmail.com>
+Faheel Ahmad <faheel@live.in>
+Fatih <frontsideair@users.noreply.github.com>
 Federico Rampazzo <frampone@gmail.com>
 Felipe Oliveira Carvalho <felipekde@gmail.com>
 Felix Gnass <fgnass@gmail.com>
 Felix Kling <felix.kling@gmx.net>
+Fernando Alex Helwanger <fhelwanger@gmail.com>
 Fernando Correia <fernando@servicero.com>
+Fernando Montoya <montogeek@gmail.com>
+Filip Hoško <filiphosko@gmail.com>
+Filip Spiridonov <filip.spiridonov@gmail.com>
+Flarnie Marchan <flarnie@users.noreply.github.com>
+Fokke Zandbergen <mail@fokkezb.nl>
+Frank Yan <fryn@users.noreply.github.com>
 Frankie Bagnardi <f.bagnardi@gmail.com>
+François Chalifour <francoischalifour@users.noreply.github.com>
 François-Xavier Bois <fxbois@gmail.com>
+Fraser Haer <fraser.haer@hotmail.com>
 Fred Zhao <fredz@fb.com>
 Freddy Rangel <frederick.rangel@gmail.com>
 Fyodor Ivanishchev <cbrwizard@gmail.com>
 G Scott Olson <gscottolson@gmail.com>
 G. Kay Lee <balancetraveller+github@gmail.com>
 Gabe Levi <gabelevi@gmail.com>
+Gabriel Lett Viviani <gm.lett@gmail.com>
 Gajus Kuizinas <g.kuizinas@anuary.com>
+Gant Laborde <gantman@gmail.com>
 Gareth Nicholson <gareth.nic@gmail.com>
+Garmash Nikolay <garmash.nikolay@gmail.com>
 Garren Smith <garren.smith@gmail.com>
+Garrett McCullough <gwmccull@yahoo.com>
 Gavin McQuistin <gavin@kickfiredesign.com>
+Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>
 Geert Pasteels <geert.pasteels@gmail.com>
 Geert-Jan Brits <gbrits@gmail.com>
 George A Sisco III <george.sisco@gmail.com>
 Georgii Dolzhykov <thorn.mailbox@gmail.com>
+Gert Hengeveld <info@ghengeveld.nl>
+Giamir Buoncristiani <giamir@thoughtworks.com>
+Gil Chen-Zion <gilchenzion@users.noreply.github.com>
 Gilbert <gilbertbgarza@gmail.com>
+Giorgio Polvara <polvara@gmail.com>
+Giuseppe <ggurgone@gmail.com>
 Glen Mailer <glenjamin@gmail.com>
 Grant Timmerman <granttimmerman@gmail.com>
 Greg Hurrell <glh@fb.com>
+Greg Palmer <g-palmer@users.noreply.github.com>
 Greg Perkins <gregrperkins@fb.com>
 Greg Roodt <groodt@gmail.com>
 Gregory <g.marcilhacy@gmail.com>
+Grgur Grisogono <grguru@gmail.com>
+Griffin Michl <griffinmichl@gmail.com>
 Guangqiang Dong <gqdong@fb.com>
 Guido Bouman <m@guido.vc>
+Guilherme Oenning <me@goenning.net>
+Guilherme Ruiz <guiiruiz@hotmail.com>
+Guillaume Claret <guillaume@ouicar.fr>
 Harry Hull <harry.hull1@gmail.com>
 Harry Marr <harry.marr@gmail.com>
 Harry Moreno <morenoh149@gmail.com>
@@ -224,40 +376,57 @@ Harshad Sabne <harshadsabne@users.noreply.github.com>
 Hekar Khani <hekark@gmail.com>
 Hendrik Swanepoel <hendrik.swanepoel@gmail.com>
 Henrik Nyh <henrik@nyh.se>
+Henry Harris <henrythomasharris@gmail.com>
 Henry Wong <henryw4k@gmail.com>
 Henry Zhu <hi@henryzoo.com>
 Hideo Matsumoto <hideo-m@pekeq.com>
+Hikaru Suido <hikaru.suido@gmail.com>
+Hiroyuki Wada <wadahiro@gmail.com>
 Hou Chia <kchia87@gmail.com>
 Huang-Wei Chang <chang.huangwei.01@gmail.com>
 Hugo Agbonon <hugo@agbonon.fr>
 Hugo Jobling <me@thisishugo.com>
 Hyeock Kwon <doublus@gmail.com>
+Héctor Ramos <hramos@users.noreply.github.com>
 Héliton Nordt <hnordt@hnordt.com>
 Ian Obermiller <ian@obermillers.com>
+Ian Sutherland <ian@iansutherland.ca>
 Ignacio Carbajo <icarbajop@gmail.com>
 Igor Scekic <igorscekic2@gmail.com>
+Ike Peters <ikedpeters21@gmail.com>
 Ilia Pavlenkov <dortonway@gmail.com>
+Ilya Gelman <ilyagelman@ilyagelman.com>
 Ilya Shuklin <ilya.shuklin@gmail.com>
 Ilyá Belsky <gelias.gbelsky@gmail.com>
 Ingvar Stepanyan <me@rreverser.com>
 Irae Carvalho <irae@irae.pro.br>
 Isaac Salier-Hellendag <isaac@fb.com>
+Islam Sharabash <islam.sharabash@gmail.com>
 Iurii Kucherov <yuyokk@gmail.com>
+Ivan <15101126742@163.com>
 Ivan Kozik <ivan@ludios.org>
 Ivan Krechetov <ikr@ikr.su>
 Ivan Vergiliev <ivan.vergiliev@gmail.com>
+Ivan Zotov <ivanzotov@gmail.com>
 J. Andrew Brassington <jabbrass@zoho.com>
 J. Renée Beach <splendidnoise@gmail.com>
 JD Isaacks <jd@jisaacks.com>
 JJ Weber <jj.weber@gmail.com>
 JW <JW00000@gmail.com>
+Jack <jack@jackmarchant.com>
+Jack Cross <jackjocross@gmail.com>
+Jack Ford <jford8820@gmail.com>
 Jack Zhang <jzhang31191@gmail.com>
 Jackie Wung <jacquelinewung@gmail.com>
+Jackson Huang <jackson888888@gmail.com>
 Jacob Gable <jacob.gable@gmail.com>
 Jacob Greenleaf <jake@imgur.com>
+Jacob Lamont <cob@jacoblamont.com>
+Jae Hun Lee <jaehlee11@gmail.com>
 Jae Hun Ro <jhr24@duke.edu>
 Jaeho Lee <me@jaeholee.org>
 Jaime Mingo <j.mingov@3boll.com>
+Jake Boone <jakeboone02@gmail.com>
 Jake Worth <jakeworth82@gmail.com>
 Jakub Malinowski <jakubmal@gmail.com>
 James <james@mystrata.com>
@@ -276,15 +445,22 @@ Jamison Dance <jergason@gmail.com>
 Jan Hancic <jan.hancic@gmail.com>
 Jan Kassens <jan@kassens.net>
 Jan Raasch <jan@janraasch.com>
+Jan Schär <jscissr@gmail.com>
+Jane Manchun Wong <wongmjane@icloud.com>
 Jared Forsyth <jared@jaredforsyth.com>
+Jared Fox <jalexanderfox@gmail.com>
+Jarrod Mosen <jarrod.mosen@me.com>
 Jason <usaman2010us@gmail.com>
 Jason Bonta <jbonta@gmail.com>
+Jason Grlicky <jgrlicky@gmail.com>
 Jason Ly <jason.ly@gmail.com>
 Jason Miller <aidenn0@geocities.com>
 Jason Quense <monastic.panic@gmail.com>
 Jason Trill <jason@jasontrill.com>
 Jason Webster <jason@metalabdesign.com>
 Jay Jaeho Lee <jay@spoqa.com>
+Jay Phelps <hello@jayphelps.com>
+Jayen Ashar <jayenashar@users.noreply.github.com>
 Jean Lauliac <lauliacj@gmail.com>
 Jed Watson <jed.watson@me.com>
 Jeff Barczewski <jeff.barczewski@gmail.com>
@@ -295,28 +471,38 @@ Jeff Kolesky <github@kolesky.com>
 Jeff Morrison <jeff@anafx.com>
 Jeff Welch <whatthejeff@gmail.com>
 Jeffrey Lin <lin.jeffrey@gmail.com>
+Jeffrey Wan <jeffrey.wan@blueapron.com>
+Jen Wong <jenjwong@gmail.com>
 Jeremy Fairbank <elpapapollo@gmail.com>
+Jess Telford <jess+github@jes.st>
 Jesse Skinner <jesse@thefutureoftheweb.com>
 Jignesh Kakadiya <jigneshhk1992@gmail.com>
 Jim OBrien <jimobrien930@gmail.com>
 Jim Sproch <jsproch@fb.com>
+Jiminikiz <jiminikiz@users.noreply.github.com>
 Jimmy Jea <jimjea@gmail.com>
 Jing Chen <jingc@fb.com>
 Jinwoo Oh <arkist@gmail.com>
 Jinxiu Lee <lee.jinxiu@gmail.com>
+Jirat Ki <saakyz@gmail.com>
 Jiyeon Seo <zzzeons@gmail.com>
 Jody McIntyre <scjody@modernduck.com>
 Joe Critchley <joecritch@gmail.com>
 Joe Stein <joeaarons@gmail.com>
 Joel Auterson <joel.auterson@googlemail.com>
+Joel Denning <joeldenning@gmail.com>
+Joel Sequeira <joelseq96@gmail.com>
+Johan Tinglöf <karljohantinglof@gmail.com>
 Johannes Baiter <johannes.baiter@gmail.com>
 Johannes Emerich <johannes@emerich.de>
 Johannes Lumpe <johannes@johanneslumpe.de>
 John Heroy <johnheroy@users.noreply.github.com>
+John Longanecker <johnlonganecker@gmail.com>
 John Ryan <tjfryan@fb.com>
 John Watson <jwatson@fb.com>
 John-David Dalton <john.david.dalton@gmail.com>
 Jon Beebe <jon.beebe@daveramsey.com>
+Jon Bretman <jon.bretman@gmail.com>
 Jon Chester <jonchester@fb.com>
 Jon Hester <jon.d.hester@gmail.com>
 Jon Madison <jon@tfftech.com>
@@ -333,6 +519,7 @@ Joseph Nudell <joenudell@gmail.com>
 Joseph Savona <joesavona@fb.com>
 Josh Bassett <josh.bassett@gmail.com>
 Josh Duck <josh@fb.com>
+Josh Hunt <josh@trtr.co>
 Josh Perez <josh.perez@airbnb.com>
 Josh Yudaken <yud@instagram.com>
 Joshua Evans <joshua.evans@quantified.co>
@@ -340,46 +527,67 @@ Joshua Go <joshuago@gmail.com>
 Joshua Goldberg <jsgoldberg90@gmail.com>
 Joshua Ma <me@joshma.com>
 João Valente <filipevalente@gmail.com>
+Juan <juan@juansoto.me>
 Juan Serrano <germ13@users.noreply.github.com>
 Julen Ruiz Aizpuru <julenx@gmail.com>
 Julian Viereck <julian.viereck@gmail.com>
 Julien Bordellier <git@julienbordellier.com>
 Julio Lopez <ljuliom@gmail.com>
+Jun Kim <i2r.jun@gmail.com>
 Jun Wu <quark@lihdd.net>
 Juraj Dudak <jdudak@fb.com>
 Justas Brazauskas <brazauskasjustas@gmail.com>
+Justin <abigsmall@users.noreply.github.com>
+Justin Grant <justingrant@users.noreply.github.com>
 Justin Jaffray <justinjaffray@khanacademy.org>
 Justin Robison <jrobison151@gmail.com>
 Justin Woo <moomoowoo@gmail.com>
+KB <karol.borkowski@syzygy.pl>
 Kale <krydrogen@gmail.com>
 Kamron Batman <kamronbatman@users.noreply.github.com>
+Karl Horky <karl.horky@gmail.com>
 Karl Mikkelsen <karl@kingkarl.com>
 Karpich Dmitry <karpich@gollard.ru>
+Karthik Balakrishnan <karthikb351@gmail.com>
+Karthik Chintapalli <karthik.chintapalli@gmail.com>
+Kateryna <k.porshnieva@gmail.com>
+Kaylee Knowles <kayleeknowles42@gmail.com>
+KeicaM <zawiasam@users.noreply.github.com>
 Keito Uchiyama <projects@keito.me>
 Ken Powers <ken@kenpowers.net>
+Kenneth Chau <kenotron@users.noreply.github.com>
 Kent C. Dodds <kent@doddsfamily.us>
 Kevin Cheng <09chengk@gmail.com>
 Kevin Coughlin <kevintcoughlin@gmail.com>
 Kevin Huang <huang.kev@gmail.com>
+Kevin Lacker <kevin@parse.com>
 Kevin Lau <thekevlau@gmail.com>
+Kevin Lin <kevinslin8@gmail.com>
 Kevin Old <kevin@kevinold.com>
 Kevin Robinson <krobinson@twitter.com>
+Kevin Suttle <kevin@suttle.email>
 Kewei Jiang <jkewei328@hotmail.com>
+Keyan Zhang <root@keyanzhang.com>
 Kier Borromeo <seraphipod@gmail.com>
+Kiho · Cham <monkindey@163.com>
 KimCoding <jeokrang@hanmail.net>
 Kirk Steven Hansen <hanski07@kirk-hansens-macbook.local>
 Kit Randel <kit@nocturne.net.nz>
+Kite <ixkaito@gmail.com>
 Kohei TAKATA <kt.koheitakata@gmail.com>
 Koo Youngmin <youngmin@youngminz.kr>
 Krystian Karczewski <karcz.k@gmail.com>
 Kunal Mehta <k.mehta@berkeley.edu>
+Kurt Furbush <kurtfurbush@gmail.com>
 Kurt Ruppel <me@kurtruppel.com>
+Kurt Weiberth <kweiberth@users.noreply.github.com>
 Kyle Kelley <rgbkrk@gmail.com>
 Kyle Mathews <mathews.kyle@gmail.com>
 Laurence Rowe <l@lrowe.co.uk>
 Laurent Etiemble <laurent.etiemble@monobjc.net>
 Lee Byron <lee@leebyron.com>
 Lee Jaeyoung <jaeyoung@monodiary.net>
+Lee Sanghyeon <yongdamsh@gmail.com>
 Lei <tendant@gmail.com>
 Leland Richardson <leland.m.richardson@gmail.com>
 Leon Fedotov <LeonFedotov@users.noreply.github.com>
@@ -387,36 +595,61 @@ Leon Yip <lyip1992@users.noreply.github.com>
 Leonardo YongUk Kim <dalinaum@gmail.com>
 Levi Buzolic <levibuzolic@gmail.com>
 Levi McCallum <levi@levimccallum.com>
+Lewis Blackwood <lewis.blackwood@gmail.com>
+Liangzhen Zhu <zhudx6512@163.com>
 Lily <qvang.j@gmail.com>
+Linus Unnebäck <linus@folkdatorn.se>
+Lipis <lipiridis@gmail.com>
+Liz <feministy@users.noreply.github.com>
 Logan Allen <loganfynne@gmail.com>
 Lovisa Svallingson <lovisasvallingson@gmail.com>
+Lucas <AgtLucas@users.noreply.github.com>
 Ludovico Fischer <livrerie@gmail.com>
 Luigy Leon <luichi.19@gmail.com>
+Luke Belliveau <luke.belliveau@gmail.com>
 Luke Horvat <lukehorvat@gmail.com>
+Lutz Rosema <terabaud@gmail.com>
+MICHAEL JACKSON <mjijackson@gmail.com>
 MIKAMI Yoshiyuki <yoshuki@saikyoline.jp>
+Maciej Kasprzyk <kapustka.maciek@gmail.com>
 Maher Beg <maherbeg@gmail.com>
+Maksim Shastsel <max.shastik@yandex.ru>
 Manas <prometheansacrifice@gmail.com>
+Marcelo Alves <selfmadecelo@gmail.com>
 Marcin K. <katzoo@github.mail>
 Marcin Kwiatkowski <marcin.kwiatkowski@hotmail.com>
+Marcin Mazurek <marcin@mazurek.pro>
 Marcin Szczepanski <marcins@gmail.com>
+Marcio Puga <marciopuga@gmail.com>
+Marcos Ojeda <subliminal@gmail.com>
+Marcy Sutton <holla@marcysutton.com>
 Mariano Desanze <protronm@gmail.com>
+Mario Souto <mariosouto@outlook.com>
+Marius Skaar Ludvigsen <marius.ludvigsen@gmail.com>
 Marjan <marjan.georgiev@gmail.com>
 Mark Anderson <undernewmanagement@users.noreply.github.com>
 Mark Funk <mfunk86@gmail.com>
 Mark Hintz <markohintz@gmail.com>
 Mark IJbema <markijbema@gmail.com>
 Mark Murphy <murphy.mark@live.ca>
+Mark Pedrotti <pedrottimark@gmail.com>
+Mark Penner <mnpenner@users.noreply.github.com>
 Mark Richardson <echo@fb.com>
 Mark Rushakoff <mark@influxdb.com>
 Mark Sun <sunmark14@gmail.com>
+Marks Polakovs <marks@markspolakovs.me>
 Marlon Landaverde <milanlandaverde@gmail.com>
+Marshall Bowers <elliott.codes@gmail.com>
 Marshall Roch <mroch@fb.com>
 Martin Andert <mandert@gmail.com>
+Martin Hochel <hochelmartin@gmail.com>
 Martin Hujer <mhujer@gmail.com>
 Martin Jul <martin@mjul.com>
 Martin Konicek <mkonicek@fb.com>
 Martin Mihaylov <martomi@users.noreply.github.com>
+Martin V <ndresx@gmail.com>
 Masaki KOBAYASHI <makky.4d6b.3f5@gmail.com>
+Mateusz Burzyński <mateuszburzynski@gmail.com>
 Mathieu M-Gosselin <mathieumg@gmail.com>
 Mathieu Savy <savy.mathieu@gmail.com>
 Matias Singers <mail@matiassingers.com>
@@ -434,74 +667,113 @@ Matthew Johnston <matthewjohnston4@outlook.com>
 Matthew King <mking@users.noreply.github.com>
 Matthew Looi <looi.matthew@gmail.com>
 Matthew Miner <matthew@matthewminer.com>
+Matthew Shotton <matthew.shotton@bbc.co.uk>
 Matthias Le Brun <mlbli@me.com>
 Matti Nelimarkka <matti.nelimarkka@hiit.fi>
 Mattijs Kneppers <mattijs@arttech.nl>
+Max Donchenko <wereya2@yandex.ru>
 Max F. Albrecht <1@178.is>
 Max Heiber <max.heiber@gmail.com>
 Max Stoiber <contact@mstoiber.com>
 Maxi Ferreira <charca@gmail.com>
 Maxim Abramchuk <MaximAbramchuck@gmail.com>
+Maxwel D'souza <maxellusionist@gmail.com>
 Merrick Christensen <merrick.christensen@gmail.com>
 Mert Kahyaoğlu <mertkahyaoglu93@gmail.com>
 Michael Chan <mijoch@gmail.com>
+Michael Jackson <mjijackson@gmail.com>
 Michael McDermott <michael@mgmcdermott.com>
+Michael O'Brien <mcobrien@users.noreply.github.com>
 Michael Randers-Pehrson <michael.rp@gmail.com>
 Michael Ridgway <mridgway@yahoo-inc.com>
+Michael Sinov <sihaelov@gmail.com>
+Michael Terry <michael@michaelterry.org>
 Michael Warner <MichaelJWarner@hotmail.com>
 Michael Wiencek <mwtuea@gmail.com>
 Michael Ziwisky <mikezx@gmail.com>
 Michal Srb <xixixao@seznam.cz>
+Michał Ordon <designorant@users.noreply.github.com>
+Michał Pierzchała <thymikee@gmail.com>
+Michele Bertoli <MicheleBertoli@users.noreply.github.com>
 Michelle Todd <himichelletodd@gmail.com>
+Michiya <mhibino@users.noreply.github.com>
 Mihai Parparita <mihai.parparita@gmail.com>
 Mike D Pilsbury <mike.pilsbury@gmail.com>
 Mike Groseclose <mike.groseclose@gmail.com>
 Mike Nordick <mnordick>
+Mikhail Osher <yo@miraage.io>
 Mikolaj Dadela <mikolaj.dadela@hgv-online.de>
 Miles Johnson <mileswjohnson@gmail.com>
+Miller Medeiros <miller@millermedeiros.com>
 Minwe LUO <minwe@yunshipei.com>
+Minwei Xu <faceswilliam@gmail.com>
 Miorel Palii <miorel@fb.com>
+Mitchel Humpherys <mitch.special@gmail.com>
+Mitermayer Reis <mitermayer.reis@gmail.com>
+Moacir Rosa <paulomoacir.junior@gmail.com>
+Mojtaba Dashtinejad <mojtaba@gmail.com>
 Morhaus <alexandre.kirszenberg@gmail.com>
 Moshe Kolodny <kolodny.github@gmail.com>
 Mouad Debbar <mdebbar@fb.com>
 Murad <rogozhnikoff@users.noreply.github.com>
 Murray M. Moss <murray@mmoss.name>
+Murtaza Haveliwala <murtaza.sh@gmail.com>
+NE-SmallTown <ne_smalltown@163.com>
 Nadeesha Cabral <nadeesha.cabral@gmail.com>
 Naman Goel <naman34@gmail.com>
+Nate <nchristensen@deseretdigital.com>
 Nate Hunzaker <nate.hunzaker@gmail.com>
 Nate Lee <nathaniel.jy.lee88@gmail.com>
+Nate Norberg <natenorberg@gmail.com>
+Nathan Hardy <nhardy@users.noreply.github.com>
 Nathan Smith <NogsMPLS@users.noreply.github.com>
 Nathan White <nw@nwhite.net>
 Nee <944316342@qq.com>
+Neo <nihgwu@live.com>
 Neri Marschik <marschik_neri@cyberagent.co.jp>
+NestorTejero <webeafix@gmail.com>
 Nguyen Truong Duy <truongduy134@yahoo.com>
 Nicholas Bergson-Shilcock <me@nicholasbs.net>
 Nicholas Clawson <nickclaw@users.noreply.github.com>
 Nick Balestra <nickbalestra@users.noreply.github.com>
 Nick Fitzgerald <fitzgen@gmail.com>
 Nick Gavalas <njg57@cornell.edu>
+Nick Kasten <kastencode@gmail.com>
 Nick Merwin <nick@lemurheavy.com>
 Nick Presta <nick@nickpresta.ca>
 Nick Raienko <enaqxx@gmail.com>
 Nick Thompson <ncthom91@gmail.com>
 Nick Williams <WickyNilliams@users.noreply.github.com>
+Nik Nyby <nnyby@columbia.edu>
+Nikita Lebedev <bloomber111@gmail.com>
 Niklas Boström <nbostrom@gmail.com>
+Nikoloz Buligini <nbuligini11@gmail.com>
+Nima Jahanshahi <nbjahan@gmail.com>
 Ning Xia <ning-github@users.noreply.github.com>
 Niole Nelson <niolenelson@gmail.com>
+Nolan Lawson <nolan@nolanlawson.com>
+Nuno Campos <nuno@crowdprocess.com>
+OJ Kwon <kwon.ohjoong@gmail.com>
 Oiva Eskola <oiva.eskola@gmail.com>
 Oleg <o.yanchinskiy@gmail.com>
 Oleksii Markhovskyi <olexiy.markhovsky@gmail.com>
 Oliver Zeigermann <oliver.zeigermann@gmail.com>
 Olivier Tassinari <Olivier.tassinari@gmail.com>
+Omid Hezaveh <omidfi@users.noreply.github.com>
+Oscar Bolmsten <oscar-b@users.noreply.github.com>
+Oskari Mantere <osku.mantere@gmail.com>
 Owen Coutts <owenc@fb.com>
 Pablo Lacerda de Miranda <pablolm@yahoo-inc.com>
 Paolo Moretti <moretti@users.noreply.github.com>
 Pascal Hartig <passy@twitter.com>
 Patrick <info@telepark.de>
+Patrick Finnigan <patrick.k.finnigan@gmail.com>
 Patrick Laughlin <patrick@laughl.info>
 Patrick Stapleton <github@gdi2290.com>
 Paul Benigeri <me@benigeri.com>
 Paul Harper <benekastah@gmail.com>
+Paul Kehrer <paul.l.kehrer@gmail.com>
+Paul Manta <paulmanta@users.noreply.github.com>
 Paul O’Shannessy <paul@oshannessy.com>
 Paul Seiffert <paul.seiffert@gmail.com>
 Paul Shen <paul@mnml0.com>
@@ -511,56 +783,107 @@ Peter Blazejewicz <peter.blazejewicz@gmail.com>
 Peter Cottle <pcottle@fb.com>
 Peter Jaros <peter.a.jaros@gmail.com>
 Peter Newnham <peter.newnham@appsbroker.com>
+Peter Ruibal <ruibalp@gmail.com>
 Petri Lehtinen <petri@digip.org>
 Petri Lievonen <plievone@cc.hut.fi>
+Phil Quinn <philquinn90@gmail.com>
+Phil Rajchgot <tophil@outlook.com>
+Philip Jackson <p-jackson@live.com>
+Philipp Spieß <hello@philippspiess.com>
+Pieter De Baets <pieter.debaets@gmail.com>
 Pieter Vanderwerff <me@pieter.io>
+Piotr Czajkowski <czajkowski.piotr@gmail.com>
+Piper Chester <piperchester@gmail.com>
+Pontus Abrahamsson <info@wdlinkoping.se>
 Pouja Nikray <poujanik@gmail.com>
 Prathamesh Sonpatki <csonpatki@gmail.com>
 Prayag Verma <prayag.verma@gmail.com>
 Preston Parry <ClimbsRocks@users.noreply.github.com>
+Qin Junwen <kjj10@163.com>
+RSG <Radi123@users.noreply.github.com>
+Rachel D. Cartwright <stormchica@gmail.com>
 Rafael <rafael.garcia@clever.com>
+Rafael Angeline <me@rafaelangeline.com>
 Rafal Dittwald <rafal.dittwald@gmail.com>
+Ragnar Þór Valgeirsson <ragnar.valgeirsson@gmail.com>
+Rahul Gupta <rahulgupta4@practo.com>
 Rainer Oviir <roviir@gmail.com>
+Raito Bezarius <masterancpp@gmail.com>
 Rajat Sehgal <rajatsehgal1988@gmail.com>
 Rajiv Tirumalareddy <rajivtreddy@gmail.com>
 Ram Kaniyur <quadrupleslap@users.noreply.github.com>
 Randall Randall <randall@randallsquared.com>
 Ray <ray@tomo.im>
+Ray Dai <exiadbq@gmail.com>
 Raymond Ha <raymond@shraymonks.com>
 Reed Loden <reed@reedloden.com>
 Remko Tronçon <git@el-tramo.be>
+Ricardo <ddrjm@users.noreply.github.com>
+Rich Harris <richard.a.harris@gmail.com>
+Richard <riscarrott@googlemail.com>
 Richard D. Worth <rdworth@gmail.com>
 Richard Feldman <richard.t.feldman@gmail.com>
 Richard Kho <hello@richardkho.com>
 Richard Littauer <richard.littauer@gmail.com>
 Richard Livesey <Livesey7@hotmail.co.uk>
+Richard Maisano <rickmaisano@gmail.com>
+Richard Roncancio <batusai513@msn.com>
 Richard Wood <rwoodnz@gmail.com>
+Richie Thomas <rickthomas1980@gmail.com>
 Rick Beerendonk <rick@beerendonk.com>
 Rick Ford <rickfordrick@gmail.com>
 Riley Tomasek <riley.tomasek@gmail.com>
 Rob Arnold <robarnold@cs.cmu.edu>
 Robert Binna <rbinna@gmail.com>
+Robert Chang <cht8687@gmail.com>
+Robert Haritonov <r@rhr.me>
+Robert Kielty <rob.kielty@gmail.com>
 Robert Knight <robert.knight@mendeley.com>
+Robert Martin <rmartin@rmart.in>
 Robert Sedovsek <robert.sedovsek@gmail.com>
 Robin Berjon <robin@berjon.com>
 Robin Frischmann <robin@rofrischmann.de>
+Robin Ricard <ricard.robin@gmail.com>
+Roderick Hsiao <roderickhsiao@users.noreply.github.com>
+Rodrigo Pombo <pombopombopombo@gmail.com>
+Rohan Nair <rohan@objectiveiq.com>
+Roman Liutikov <roman01la@romanliutikov.com>
+Roman Matusevich <roma.matusevich@gmail.com>
 Roman Pominov <rpominov+github@gmail.com>
 Roman Vanesyan <roman.vanesyan@gmail.com>
+Rui Araújo <ruka.araujo@gmail.com>
 Russ <russwirtz@gmail.com>
+Ryan Lahfa <masterancpp@gmail.com>
 Ryan Seddon <seddon.ryan@gmail.com>
+Ryo Shibayama <j02521@gmail.com>
 Sahat Yalkabov <sakhat@gmail.com>
 Saif Hakim <saif@benchling.com>
 Saiichi Hashimoto <saiichihashimoto@gmail.com>
+Sakina Crocker <sakinac@gmail.com>
+Sam Balana <sam.balana@ardentacademy.com>
 Sam Beveridge <sbeveridge@saltstack.com>
 Sam Saccone <samccone@gmail.com>
 Sam Selikoff <sam.selikoff@gmail.com>
+Samer Buna <samerbuna@users.noreply.github.com>
+Samuel <savepointsam@gmail.com>
+Samuel Hapák <samuel.hapak@gmail.com>
+Samuel Reed <samuel.trace.reed@gmail.com>
+Samuel Scheiderich <samsch@users.noreply.github.com>
 Samy Al Zahrani <samy@sadeem.net>
 Sander Spies <sandermail@gmail.com>
+Sasha Aickin <xander76@yahoo.com>
+Sassan Haradji <sassanh@gmail.com>
+Satoshi Nakajima <satoshi.nakajima@gmail.com>
+Scott <scottdomes@gmail.com>
 Scott Burch <scott@bulldoginfo.com>
 Scott Feeney <scott@oceanbase.org>
+Sean Gransee <sean.gransee@gmail.com>
 Sean Kinsey <oyvind@fb.com>
+Sean Smith <sean.smith.2009@gmail.com>
+Seba <sebaest77@gmail.com>
 Sebastian Markbåge <sebastian@calyptus.eu>
 Sebastian McKenzie <sebmck@gmail.com>
+Senin Roman <Rastopyr@gmail.com>
 Seoh Char <devthewild@gmail.com>
 Sercan Eraslan <sercan.eraslan@sahibinden.com>
 Serg <undrdog@yandex.ru>
@@ -575,34 +898,62 @@ Shinnosuke Watanabe <snnskwtnb@gmail.com>
 Shogun Sea <shogunsea08@gmail.com>
 Shota Kubota <kubosho@users.noreply.github.com>
 Shripad K <assortmentofsorts@gmail.com>
+Shubheksha Jalan <jshubheksha@gmail.com>
+Shuhei Kagawa <shuhei.kagawa@gmail.com>
 Sibi <psibi2000@gmail.com>
 Simen Bekkhus <sbekkhus91@gmail.com>
 Simon Højberg <r.hackr@gmail.com>
 Simon Welsh <simon@simon.geek.nz>
 Simone Vittori <hello@simonewebdesign.it>
+Skasi <skasski@gmx.at>
+Snowmanzzz(Zhengzhong Zhao) <zhengzhongzhao@gmail.com>
 Soichiro Kawamura <mail@w-st.com>
+Soo Jae Hwang <misoguy1985@gmail.com>
+Sophia <szensius@gmail.com>
 Sophia Westwood <sophia@quip.com>
 Sophie Alpert <git@sophiebits.com>
 Sota Ohara <ohrst.18@gmail.com>
+Spen Taylor <spen_@hotmail.co.uk>
+Spencer Ahrens <sahrens@users.noreply.github.com>
 Spencer Handley <spencerhandley@gmail.com>
+Sriram Thiagarajan <sri.sjc@gmail.com>
 Stefan Dombrowski <sdo451@gmail.com>
+Stephen John Sorensen <spudly@users.noreply.github.com>
 Stephen Murphy <smurphy3@apple.com>
+Stephie <Stephie@users.noreply.github.com>
 Sterling Cobb <sterlingcobb@gmail.com>
 Steve Baker <_steve_@outlook.com>
+Steve Mao <maochenyan@gmail.com>
 Steven Luscher <react@steveluscher.com>
+Steven Syrek <sjsyrek@users.noreply.github.com>
 Steven Vachon <contact@svachon.com>
+Stolenkid <stolen.kid7@gmail.com>
 Stoyan Stefanov <ssttoo@ymail.com>
+Stuart Harris <stuart.harris@red-badger.com>
+SunHuawei <stonesun@aliyun.com>
 Sundeep Malladi <sundeep.malladi@gmail.com>
+Sung Won Cho <mikeswcho@gmail.com>
 Sunny Juneja <me@sunnyjuneja.com>
+Sunny Ripert <sunny@sunfox.org>
+Superlaziness <shemyakin@me.com>
 Sven Helmberger <fforw@gmx.de>
 Sverre Johansen <sverre.johansen@gmail.com>
+Swaroop SM <swaroop.striker@gmail.com>
 Sébastien Lorber <lorber.sebastien@gmail.com>
 Sławomir Laskowski <laskowski.box@gmail.com>
+Taegon Kim <gonom9@gmail.com>
 Taeho Kim <dittos@gmail.com>
+Taehwan, No <taehwanno.dev@gmail.com>
+Tanase Hagi <TanaseHagi@users.noreply.github.com>
+Tanner <devtanc@gmail.com>
 Tay Yang Shun <tay.yang.shun@gmail.com>
 Ted Kim <ted@vcnc.co.kr>
+TedPowers <TedPowers@users.noreply.github.com>
 Tengfei Guo <terryr3rd@yeah.net>
 Teodor Szente <teodor98sz@gmail.com>
+Tetsuharu OHZEKI <saneyuki.s.snyk@gmail.com>
+Tetsuya Hasegawa <tetsuya.chicago@gmail.com>
+Thibaut Rizzi <zoom@rhizom.fr>
 Thomas Aylott <oblivious@subtlegradient.com>
 Thomas Boyt <thomas.boyt@venmo.com>
 Thomas Broadley <buriedunderbooks@hotmail.com>
@@ -611,6 +962,7 @@ Thomas Röggla <t.roggla@cwi.nl>
 Thomas Shaddox <thomas@heyzap.com>
 Thomas Shafer <thomasjshafer@gmail.com>
 ThomasCrvsr <crevoisier.thomas@gmail.com>
+Tiago Fernandez <tiago.fernandez@gmail.com>
 Tienchai Wirojsaksaree <tienchai@fb.com>
 Tim Routowicz <troutowicz@gmail.com>
 Tim Schaub <tschaub@users.noreply.github.com>
@@ -618,79 +970,162 @@ Timothy Yung <yungsters@gmail.com>
 Timur Carpeev <timuric@users.noreply.github.com>
 Tobias Reiss <tag+github@basecode.de>
 Tom Duncalf <tom@tomduncalf.com>
+Tom Gasson <tom.gasson@arup.com>
 Tom Haggie <thaggie@gmail.com>
 Tom Hauburger <thauburger@gmail.com>
 Tom MacWright <tom@macwright.org>
 Tom Occhino <tomocchino@gmail.com>
 Tomasz Kołodziejski <tkolodziejski@gmail.com>
 Tomoya Suzuki <tmysz.dev@gmail.com>
+Tomáš Hromada <Gyfis@seznam.cz>
+Tony Rossi <tony@iamrossi.com>
 Tony Spiro <tspiro@tonyspiro.com>
 Toru Kobayashi <koba0004@gmail.com>
+Trevor Smith <trevorlynnsmith@gmail.com>
 Trinh Hoang Nhu <trinhhoangnhu@gmail.com>
+Troy DeMonbreun <github@troyd.net>
 Tsung Hung <thung@me.com>
 Tyler Brock <tyler.brock@gmail.com>
+Tyler Buchea <tyler@buchea.com>
+Tyler Deitz <tylerdeitz@gmail.com>
+Ujjwal Ojha <ojhaujjwal@users.noreply.github.com>
+Uladzimir Havenchyk <uladzimir@toptal.com>
+Usman <syedusmanajmal@gmail.com>
 Ustin Zarubin <ustin.zarubin@campusbellhops.com>
 Vadim Chernysh <chernysh.vadim@gmail.com>
+Valentin Shergin <valentin@shergin.com>
+Van der Auwermeulen Grégoire <gregoirevandera@gmail.com>
+Varayut Lerdkanlayanawat <l.varayut@gmail.com>
+Varun Bhuvanendran <varunbhuvanendran@users.noreply.github.com>
 Varun Rau <varunrau@gmail.com>
 Vasiliy Loginevskiy <Yeti.or@gmail.com>
+Vedat Mahir YILMAZ <mahir@vedatmahir.com>
+Veljko Tornjanski <tornjanski.veljko@gmail.com>
+Vesa Laakso <laakso.vesa@gmail.com>
 Victor Alvarez <v.alvarez312@gmail.com>
 Victor Homyakov <vkhomyackov@gmail.com>
 Victor Koenders <victor.koenders@gmail.com>
+Victoria Quirante <victoria.quirante@gmail.com>
+Vikash Agrawal <vikashagrawal1990@gmail.com>
 Ville Immonen <ville.immonen@iki.fi>
 Vincent Riemer <vincentriemer@gmail.com>
 Vincent Siao <vincent@asana.com>
+Vincent Taing <taing.vincent@gmail.com>
 Vipul A M <vipulnsward@gmail.com>
+Vitaliy Potapov <noginsk@rambler.ru>
 Vitaly Kramskikh <vkramskikh@gmail.com>
 Vitor Balocco <vitorbal@gmail.com>
 Vjeux <vjeuxx@gmail.com>
+Vladimir Kovpak <cn007b@gmail.com>
+Vladimir Tikunov <vtikunov@yandex.ru>
 Volkan Unsal <spocksplanet@gmail.com>
 Wander Wang <wander.wang@ismole.com>
 Wayne Larsen <wayne@larsen.st>
+Weizenlol <winliveweiz@gmail.com>
+Whien <sal95610@gmail.com>
 WickyNilliams <WickyNilliams@MBA>
+Will Myers <will@usebutton.com>
+William Hoffmann <whoffpen@gmail.com>
 Wincent Colaiuta <win@wincent.com>
 Wout Mertens <Wout.Mertens@gmail.com>
 Xavier Morel <xmo-odoo@users.noreply.github.com>
 XuefengWu <benewu@gmail.com>
 Yakov Dalinchuk <murashki@users.noreply.github.com>
+Yan Li <mangakjd@gmail.com>
 Yasar icli <hello@yasaricli.com>
+Yaxian <yaxian.gu@gmail.com>
 YouBao Nong <noyobo@gmail.com>
 Yuichi Hagio <yhagio87@gmail.com>
+Yura Chuchola <smhfanda@gmail.com>
 Yuriy Dybskiy <yuriy@dybskiy.com>
+Yusong Liu <lysnku@gmail.com>
 Yutaka Nakajima <nakazye@gmail.com>
 Yuval Dekel <thedekel@fb.com>
+Zac Braddy <zacharybraddy@gmail.com>
+Zac Smith <billyzacsmith@gmail.com>
 Zach Bruggeman <mail@bruggie.com>
 Zach Ramaekers <zramaekers@gmail.com>
 Zacharias <zachasme@users.noreply.github.com>
 Zeke Sikelianos <zeke@sikelianos.com>
 Zhangjd <zhang.jd@qq.com>
 adraeth <jerzy.mirecki@gmail.com>
+ankitml <ankitml@gmail.com>
 arush <arush@ilovebrands.net>
+bel3atar <bel3atar@aol.com>
 brafdlog <brafdlog@gmail.com>
+brillout <brillout@users.noreply.github.com>
 chen <kikyous@163.com>
+chocolateboy <chocolate@cpan.org>
+cjshawMIT <cjshaw@mit.edu>
 clariroid <clarinette.uranus@gmail.com>
 claudiopro <claudio.procida@gmail.com>
+cloudy1 <mohaned@cloudypedia.com>
+comerc <comerc@users.noreply.github.com>
 cutbko <kutsenko.eugene@hotmail.com>
 davidxi <davidgraycn@gmail.com>
+dfrownfelter <davidrfrownfelter@gmail.com>
+djskinner <skinner@destiny-denied.co.uk>
 dongmeng.ldm <dongmeng.ldm@alibaba-inc.com>
+everdimension <everdimension@gmail.com>
+gillchristian <gillchristiang@gmail.com>
+gitanupam <anupamjain@gmail.com>
+guoyong yi <451417726@qq.com>
+hanumanthan <hanu.sas@gmail.com>
+hao.huang <hao.huang@aliyun.com>
+hjmoss <hjmoss@users.noreply.github.com>
+hkal <hkal@users.noreply.github.com>
 iamchenxin <iamchenxin@gmail.com>
 iamdoron <doronpagot@gmail.com>
 iawia002 <z2d@jifangcheng.com>
 imagentleman <imagentlemail@gmail.com>
+imjanghyuk <im.janghyuk@gmail.com>
+inkinworld <inkinworld@live.com>
+jaaberg <aaberg89@gmail.com>
+jddxf <740531372@qq.com>
+jinmmd <jinmmd@gmail.com>
 koh-taka <koh-taka@users.noreply.github.com>
 kohashi85 <hako584@gmail.com>
+ksvitkovsky <ksvitkovsky@yandex.ru>
 laiso <laiso@lai.so>
+lamo2k123 <lamo2k123@gmail.com>
 leeyoungalias <leeyoungalias@qq.com>
 li.li <li.li@ele.me>
+lucas <lucas.aragno157@gmail.com>
 maxprafferty <maxprafferty@gmail.com>
+mdogadailo <m.dogadailo@gmail.com>
+mfijas <michal.fijas@gmail.com>
+mguidotto <j8.matteo@gmail.com>
+mondaychen <monday.chen@gmail.com>
+najisawas <naji_sawas@gmx.com>
+neeldeep <neeldeep@users.noreply.github.com>
+newvlad <vladdr@live.com>
+nhducit <nhducit@users.noreply.github.com>
+ogom <ogom@outlook.com>
+pingan1927 <pengsencai1986@gmail.com>
 rgarifullin <ringarifullin@gmail.com>
+saiyagg <saiyagg@gmail.com>
+scloudyy <onecloud.shen@gmail.com>
+segmentationfaulter <segmentationfaulter@users.noreply.github.com>
+shifengchen <shifengchen10@gmail.com>
 songawee <dennis@songawee.com>
+starkch <chp.sitark@autodesk.com>
 sugarshin <shinsugar@gmail.com>
+tokikuch <msmania@users.noreply.github.com>
+ventuno <ventuno@users.noreply.github.com>
+wacii <w.a.cunningham.ii@gmail.com>
 wali-s <ahmad3y2k@hotmail.com>
+walrusfruitcake <walrusfruitcake@users.noreply.github.com>
 yiminghe <yiminghe@gmail.com>
 youmoo <youmoolee@gmail.com>
+yuntao.qyt <yuntao.qyt@alibaba-inc.com>
+z.ky <zky829@users.noreply.github.com>
 zhangjg <jinguozhang@qq.com>
+zhangs <zhangtreefish@yahoo.com>
+zombieJ <smith3816@gmail.com>
 zwhitchcox <zwhitchcox@gmail.com>
 Árni Hermann Reynisson <arnihr@gmail.com>
 元彦 <yuanyan@users.noreply.github.com>
 凌恒 <jiakun.dujk@alibaba-inc.com>
 张敏 <cookfront@gmail.com>
+王晓勇 <Plortinus@gmail.com>
+龙海燕 <1250766229@qq.com>

--- a/docs/_data/acknowledgements.yml
+++ b/docs/_data/acknowledgements.yml
@@ -1,35 +1,59 @@
 ---
 - - '839'
+  - Aaron Ackerman
+  - Aaron Cannon
   - Aaron Franks
   - Aaron Gelter
+  - Abhay Nikam
+  - Abhishek Soni
+  - Adam
   - Adam Bloomston
   - Adam Krebs
   - Adam Mark
   - Adam Solove
+  - Adam Stankiewicz
   - Adam Timberlake
   - Adam Zapletal
+  - Addy Osmani
+  - Adrian Sieber
+  - Aesop Wolf
   - Ahmad Wali Sidiqi
   - Alan Plum
   - Alan Souza
   - Alan deLevie
   - Alastair Hole
   - Alex
+  - Alex Babkov
+  - Alex Baumgertner
   - Alex Boatwright
   - Alex Boyd
   - Alex Dajani
+  - Alex Jacobs
+  - Alex Katopodis
   - Alex Lopatin
   - Alex Mykyta
   - Alex Pien
   - Alex Smith
   - Alex Zelenskiy
+  - Alex Zherdev
+  - Alexander
   - Alexander Shtuchkin
   - Alexander Solovyov
   - Alexander Tseung
   - Alexandre Gaudencio
+  - Alexandre Kirszenberg
   - Alexey Raspopov
   - Alexey Shamrin
+  - Ali Taheri Moghaddar
   - Ali Ukani
+  - Alireza Mostafizi
+  - Almero Steyn
+  - Amanvir Sangha
+  - Amjad Masad
+  - Anastasia A
+  - Andre Giron
   - Andre Z Sanchez
+  - Andreas Möller
   - Andreas Savvides
   - Andreas Svensson
   - Andres Kalle
@@ -38,31 +62,51 @@
   - Andrew Cobby
   - Andrew Davey
   - Andrew Henderson
+  - Andrew Imm
   - Andrew Kulakov
+  - Andrew Lo
+  - Andrew Poliakov
   - Andrew Rasmussen
+  - Andrew Rota
   - Andrew Sokolov
   - Andrew Zich
+  - Andrey Marchenko
+  - Andrey Okonetchnikov
   - Andrey Popp
+  - Andrey Safronov
+  - Andy Edwards
+  - Ankeet Maini
   - Anthony van der Hoorn
   - Anto Aravinth
   - Antonio Ruberto
   - Antti Ahti
+  - António Nuno Monteiro
   - Anuj Tomar
+  - Anuja Ware
   - AoDev
   - April Arcus
   - Areeb Malik
   - Aria Buckles
   - Aria Stewart
   - Arian Faurtosh
+  - Arni Fannar
+  - Arshabh Kumar Agarwal
   - Artem Nezvigin
+  - Arthur Gunn
+  - Ashish
   - Austin Wright
+  - Avinash Kondeti
   - Ayman Osman
+  - B.Orlov
+  - BDav24
+  - BEAUDRU Manuel
   - Baraa Hamodi
   - Bartosz Kaszubowski
   - Basarat Ali Syed
   - Battaile Fauber
   - Beau Smith
   - Ben Anderson
+  - Ben Berman
   - Ben Brooks
   - Ben Foxall
   - Ben Halpern
@@ -70,48 +114,70 @@
   - Ben Moss
   - Ben Newman
   - Ben Ripkens
+  - Benedikt Meurer
   - Benjamin Keen
   - Benjamin Leiken
   - Benjamin Woodruff
   - Benjy Cui
+  - Benoit Girard
+  - Benton Rochester
+  - Bernard Lin
   - Bill Blanchard
   - Bill Fisher
+  - Billy Shih
   - Blaine Hatab
   - Blaine Kasten
   - Bob Eagan
   - Bob Ralian
   - Bob Renwick
   - Bobby
+  - Bogdan Chadkin
   - Bojan Mihelac
+  - Boris Yankov
+  - Brad Vogel
+  - Bradford
   - Bradley Spaulding
   - Brandon Bloom
+  - Brandon Dail
   - Brandon Tilley
   - Brenard Cubacub
+  - Brent Vatne
   - Brian Cooke
+  - Brian Emil Hartz
   - Brian Holt
   - Brian Hsu
   - Brian Kim
   - Brian Kung
   - Brian Reavis
   - Brian Rue
+  - Brian Vaughn
+  - Bruce Harris
+  - Bruno Heridet
   - Bruno Škvorc
+  - Bryan Braun
+  - CT Wu
   - Cam Song
   - Cam Spiers
   - Cameron Chamberlain
   - Cameron Matheson
+  - Carolina Powers
   - Carter Chung
   - Cassus Adam Banko
   - Cat Chen
   - Cedric Sohrauer
   - Cesar William Alvarenga
+  - Chad Fawcett
   - Changsoon Bok
   - Charles Marsh
+  - Charlie Garcia
   - Chase Adams
   - Cheng Lou
   - Chitharanjan Das
+  - Chris
   - Chris Bolin
   - Chris Grovers
   - Chris Ha
+  - Chris Pearce
   - Chris Rebert
   - Chris Sciolla
   - Christian Alfoni
@@ -119,35 +185,58 @@
   - Christian Roman
   - Christoffer Sawicki
   - Christoph Pojer
+  - Christophe Hurpeau
   - Christopher Monsanto
+  - Claudio Brandolino
   - Clay Allsopp
+  - Clay Miller
+  - Clement Hoang
+  - CodinCat
+  - Cody Reichert
+  - Colin Wren
   - Connor McSheffrey
   - Conor Hastings
+  - Constantin Gavrilete
   - Cory House
   - Cotton Hou
   - Craig Akimoto
   - Cristovao Verstraeten
+  - DQNEO
+  - Dai Nguyen
+  - Damian Nicholson
   - Damien Pellier
+  - Damien Soulard
   - Dan Abramov
   - Dan Fox
   - Dan Schafer
+  - DanZeuss
   - Daniel Carlsson
   - Daniel Cousens
   - Daniel Friesen
   - Daniel Gasienica
   - Daniel Hejl
   - Daniel Hejl
+  - Daniel Liburd
   - Daniel Lo Nigro
   - Daniel Mané
   - Daniel Miladinov
   - Daniel Rodgers-Pryor
+  - Daniel Rosenwasser
+  - Daniel Rotter
   - Daniel Schonfeld
+  - Daniela Borges
+  - Danilo Vitoriano
   - Danny Ben-David
+  - Danny Hurlburt
   - Darcy
   - Daryl Lau
   - Darío Javier Cravero
   - Dave Galbraith
+  - Dave Lunny
+  - Dave Voyles
+  - David Aurelio
   - David Baker
+  - David Beitey
   - David Ed Mellum
   - David Goldberg
   - David Granado
@@ -159,65 +248,126 @@
   - David Neubauer
   - David Percy
   - Dean Shi
+  - Denis Laxalde
+  - Denis Pismenny
   - Denis Sokolov
   - Deniss Jacenko
   - Dennis Johnson
+  - Desmond Brand
+  - Devedse
+  - Devinsuit
   - Devon Blandin
   - Devon Harvey
+  - Dheeraj Kumar
+  - Dhyey Thakore
+  - Diego Muracciole
+  - Dima Beznos
+  - Dimzel Sobolev
+  - Dmitri Zaitsev
   - Dmitrii Abramov
+  - Dmitriy Kubyshkin
   - Dmitriy Rozhkov
   - Dmitry Blues
   - Dmitry Mazuro
+  - Dmitry Zhuravlev-Nevsky
   - Domenico Matteo
+  - Dominic Gannaway
   - Don Abrams
   - Dongsheng Liu
+  - Duke Pham
   - Dustan Kasten
   - Dustin Getz
   - Dylan Harrington
+  - Dylan Kirby
+  - Edgar (Algebr)
+  - Eduard
   - Eduardo Garcia
   - Edvin Erikson
   - Elaine Fang
+  - Eli White
   - Enguerran
+  - Eoin Hennessy
+  - Eric Churchill
   - Eric Clemmons
+  - Eric Douglas
   - Eric Eastwood
+  - Eric Elliott
   - Eric Florenzano
+  - Eric Matthys
+  - Eric Nakagawa
   - Eric O'Connell
+  - Eric Pitcher
+  - Eric Sakmar
   - Eric Schoffstall
   - Erik Harper
+  - Erik Hellman
   - Espen Hovlandsdal
+  - Esteban
+  - Eugene
+  - EugeneGarbuzov
   - Evan Coonrod
+  - Evan Jacobs
+  - Evan Scott
   - Evan Vosberg
   - Fabio M. Costa
+  - Fabrizio Castellarin
+  - Faheel Ahmad
+  - Fatih
   - Federico Rampazzo
   - Felipe Oliveira Carvalho
   - Felix Gnass
   - Felix Kling
+  - Fernando Alex Helwanger
   - Fernando Correia
+  - Fernando Montoya
+  - Filip Hoško
+  - Filip Spiridonov
+  - Flarnie Marchan
+  - Fokke Zandbergen
+  - Frank Yan
   - Frankie Bagnardi
+  - François Chalifour
   - François-Xavier Bois
+  - Fraser Haer
   - Fred Zhao
   - Freddy Rangel
   - Fyodor Ivanishchev
   - G Scott Olson
   - G. Kay Lee
   - Gabe Levi
+  - Gabriel Lett Viviani
   - Gajus Kuizinas
+  - Gant Laborde
   - Gareth Nicholson
+  - Garmash Nikolay
   - Garren Smith
+  - Garrett McCullough
   - Gavin McQuistin
+  - Gaëtan Renaudeau
   - Geert Pasteels
   - Geert-Jan Brits
   - George A Sisco III
   - Georgii Dolzhykov
+  - Gert Hengeveld
+  - Giamir Buoncristiani
+  - Gil Chen-Zion
   - Gilbert
+  - Giorgio Polvara
+  - Giuseppe
   - Glen Mailer
   - Grant Timmerman
   - Greg Hurrell
+  - Greg Palmer
   - Greg Perkins
   - Greg Roodt
   - Gregory
+  - Grgur Grisogono
+  - Griffin Michl
   - Guangqiang Dong
   - Guido Bouman
+  - Guilherme Oenning
+  - Guilherme Ruiz
+  - Guillaume Claret
   - Harry Hull
   - Harry Marr
   - Harry Moreno
@@ -225,40 +375,57 @@
   - Hekar Khani
   - Hendrik Swanepoel
   - Henrik Nyh
+- - Henry Harris
   - Henry Wong
   - Henry Zhu
   - Hideo Matsumoto
+  - Hikaru Suido
+  - Hiroyuki Wada
   - Hou Chia
   - Huang-Wei Chang
-- - Hugo Agbonon
+  - Hugo Agbonon
   - Hugo Jobling
   - Hyeock Kwon
+  - Héctor Ramos
   - Héliton Nordt
   - Ian Obermiller
+  - Ian Sutherland
   - Ignacio Carbajo
   - Igor Scekic
+  - Ike Peters
   - Ilia Pavlenkov
+  - Ilya Gelman
   - Ilya Shuklin
   - Ilyá Belsky
   - Ingvar Stepanyan
   - Irae Carvalho
   - Isaac Salier-Hellendag
+  - Islam Sharabash
   - Iurii Kucherov
+  - Ivan
   - Ivan Kozik
   - Ivan Krechetov
   - Ivan Vergiliev
+  - Ivan Zotov
   - J. Andrew Brassington
   - J. Renée Beach
   - JD Isaacks
   - JJ Weber
   - JW
+  - Jack
+  - Jack Cross
+  - Jack Ford
   - Jack Zhang
   - Jackie Wung
+  - Jackson Huang
   - Jacob Gable
   - Jacob Greenleaf
+  - Jacob Lamont
+  - Jae Hun Lee
   - Jae Hun Ro
   - Jaeho Lee
   - Jaime Mingo
+  - Jake Boone
   - Jake Worth
   - Jakub Malinowski
   - James
@@ -277,15 +444,22 @@
   - Jan Hancic
   - Jan Kassens
   - Jan Raasch
+  - Jan Schär
+  - Jane Manchun Wong
   - Jared Forsyth
+  - Jared Fox
+  - Jarrod Mosen
   - Jason
   - Jason Bonta
+  - Jason Grlicky
   - Jason Ly
   - Jason Miller
   - Jason Quense
   - Jason Trill
   - Jason Webster
   - Jay Jaeho Lee
+  - Jay Phelps
+  - Jayen Ashar
   - Jean Lauliac
   - Jed Watson
   - Jeff Barczewski
@@ -296,28 +470,38 @@
   - Jeff Morrison
   - Jeff Welch
   - Jeffrey Lin
+  - Jeffrey Wan
+  - Jen Wong
   - Jeremy Fairbank
+  - Jess Telford
   - Jesse Skinner
   - Jignesh Kakadiya
   - Jim OBrien
   - Jim Sproch
+  - Jiminikiz
   - Jimmy Jea
   - Jing Chen
   - Jinwoo Oh
   - Jinxiu Lee
+  - Jirat Ki
   - Jiyeon Seo
   - Jody McIntyre
   - Joe Critchley
   - Joe Stein
   - Joel Auterson
+  - Joel Denning
+  - Joel Sequeira
+  - Johan Tinglöf
   - Johannes Baiter
   - Johannes Emerich
   - Johannes Lumpe
   - John Heroy
+  - John Longanecker
   - John Ryan
   - John Watson
   - John-David Dalton
   - Jon Beebe
+  - Jon Bretman
   - Jon Chester
   - Jon Hester
   - Jon Madison
@@ -334,6 +518,7 @@
   - Joseph Savona
   - Josh Bassett
   - Josh Duck
+  - Josh Hunt
   - Josh Perez
   - Josh Yudaken
   - Joshua Evans
@@ -341,46 +526,67 @@
   - Joshua Goldberg
   - Joshua Ma
   - João Valente
+  - Juan
   - Juan Serrano
   - Julen Ruiz Aizpuru
   - Julian Viereck
   - Julien Bordellier
   - Julio Lopez
+  - Jun Kim
   - Jun Wu
   - Juraj Dudak
   - Justas Brazauskas
+  - Justin
+  - Justin Grant
   - Justin Jaffray
   - Justin Robison
   - Justin Woo
+  - KB
   - Kale
   - Kamron Batman
+  - Karl Horky
   - Karl Mikkelsen
   - Karpich Dmitry
+  - Karthik Balakrishnan
+  - Karthik Chintapalli
+  - Kateryna
+  - Kaylee Knowles
+  - KeicaM
   - Keito Uchiyama
   - Ken Powers
+  - Kenneth Chau
   - Kent C. Dodds
   - Kevin Cheng
   - Kevin Coughlin
   - Kevin Huang
+  - Kevin Lacker
   - Kevin Lau
+  - Kevin Lin
   - Kevin Old
   - Kevin Robinson
+  - Kevin Suttle
   - Kewei Jiang
+  - Keyan Zhang
   - Kier Borromeo
+  - Kiho · Cham
   - KimCoding
   - Kirk Steven Hansen
   - Kit Randel
+  - Kite
   - Kohei TAKATA
   - Koo Youngmin
   - Krystian Karczewski
   - Kunal Mehta
+  - Kurt Furbush
   - Kurt Ruppel
+  - Kurt Weiberth
   - Kyle Kelley
   - Kyle Mathews
   - Laurence Rowe
   - Laurent Etiemble
   - Lee Byron
   - Lee Jaeyoung
+  - Lee Sanghyeon
   - Lei
   - Leland Richardson
   - Leon Fedotov
@@ -388,36 +594,61 @@
   - Leonardo YongUk Kim
   - Levi Buzolic
   - Levi McCallum
+  - Lewis Blackwood
+  - Liangzhen Zhu
   - Lily
+  - Linus Unnebäck
+  - Lipis
+  - Liz
   - Logan Allen
   - Lovisa Svallingson
+  - Lucas
   - Ludovico Fischer
   - Luigy Leon
+  - Luke Belliveau
   - Luke Horvat
+  - Lutz Rosema
+  - MICHAEL JACKSON
   - MIKAMI Yoshiyuki
+  - Maciej Kasprzyk
   - Maher Beg
+  - Maksim Shastsel
   - Manas
+  - Marcelo Alves
   - Marcin K.
   - Marcin Kwiatkowski
+  - Marcin Mazurek
   - Marcin Szczepanski
+  - Marcio Puga
+  - Marcos Ojeda
+  - Marcy Sutton
   - Mariano Desanze
+  - Mario Souto
+  - Marius Skaar Ludvigsen
   - Marjan
   - Mark Anderson
   - Mark Funk
   - Mark Hintz
   - Mark IJbema
   - Mark Murphy
+  - Mark Pedrotti
+  - Mark Penner
   - Mark Richardson
   - Mark Rushakoff
   - Mark Sun
+  - Marks Polakovs
   - Marlon Landaverde
+  - Marshall Bowers
   - Marshall Roch
   - Martin Andert
+  - Martin Hochel
   - Martin Hujer
   - Martin Jul
   - Martin Konicek
   - Martin Mihaylov
+  - Martin V
   - Masaki KOBAYASHI
+  - Mateusz Burzyński
   - Mathieu M-Gosselin
   - Mathieu Savy
   - Matias Singers
@@ -435,74 +666,113 @@
   - Matthew King
   - Matthew Looi
   - Matthew Miner
+  - Matthew Shotton
   - Matthias Le Brun
   - Matti Nelimarkka
   - Mattijs Kneppers
+  - Max Donchenko
   - Max F. Albrecht
   - Max Heiber
   - Max Stoiber
   - Maxi Ferreira
   - Maxim Abramchuk
+  - Maxwel D'souza
   - Merrick Christensen
   - Mert Kahyaoğlu
   - Michael Chan
+  - Michael Jackson
   - Michael McDermott
+  - Michael O'Brien
   - Michael Randers-Pehrson
   - Michael Ridgway
+  - Michael Sinov
+  - Michael Terry
   - Michael Warner
   - Michael Wiencek
   - Michael Ziwisky
   - Michal Srb
+  - Michał Ordon
+  - Michał Pierzchała
+  - Michele Bertoli
   - Michelle Todd
+  - Michiya
   - Mihai Parparita
   - Mike D Pilsbury
   - Mike Groseclose
   - Mike Nordick
+  - Mikhail Osher
   - Mikolaj Dadela
   - Miles Johnson
+  - Miller Medeiros
   - Minwe LUO
+  - Minwei Xu
   - Miorel Palii
-- - Morhaus
+  - Mitchel Humpherys
+  - Mitermayer Reis
+  - Moacir Rosa
+  - Mojtaba Dashtinejad
+  - Morhaus
   - Moshe Kolodny
   - Mouad Debbar
   - Murad
   - Murray M. Moss
+  - Murtaza Haveliwala
+  - NE-SmallTown
   - Nadeesha Cabral
   - Naman Goel
+  - Nate
   - Nate Hunzaker
   - Nate Lee
+  - Nate Norberg
+  - Nathan Hardy
   - Nathan Smith
   - Nathan White
   - Nee
+  - Neo
   - Neri Marschik
+  - NestorTejero
   - Nguyen Truong Duy
   - Nicholas Bergson-Shilcock
   - Nicholas Clawson
   - Nick Balestra
   - Nick Fitzgerald
   - Nick Gavalas
+  - Nick Kasten
   - Nick Merwin
   - Nick Presta
   - Nick Raienko
   - Nick Thompson
   - Nick Williams
+  - Nik Nyby
+  - Nikita Lebedev
   - Niklas Boström
+  - Nikoloz Buligini
+  - Nima Jahanshahi
   - Ning Xia
   - Niole Nelson
+  - Nolan Lawson
+  - Nuno Campos
+- - OJ Kwon
   - Oiva Eskola
   - Oleg
   - Oleksii Markhovskyi
   - Oliver Zeigermann
   - Olivier Tassinari
+  - Omid Hezaveh
+  - Oscar Bolmsten
+  - Oskari Mantere
   - Owen Coutts
   - Pablo Lacerda de Miranda
   - Paolo Moretti
   - Pascal Hartig
   - Patrick
+  - Patrick Finnigan
   - Patrick Laughlin
   - Patrick Stapleton
   - Paul Benigeri
   - Paul Harper
+  - Paul Kehrer
+  - Paul Manta
   - Paul O’Shannessy
   - Paul Seiffert
   - Paul Shen
@@ -512,56 +782,107 @@
   - Peter Cottle
   - Peter Jaros
   - Peter Newnham
+  - Peter Ruibal
   - Petri Lehtinen
   - Petri Lievonen
+  - Phil Quinn
+  - Phil Rajchgot
+  - Philip Jackson
+  - Philipp Spieß
+  - Pieter De Baets
   - Pieter Vanderwerff
+  - Piotr Czajkowski
+  - Piper Chester
+  - Pontus Abrahamsson
   - Pouja Nikray
   - Prathamesh Sonpatki
   - Prayag Verma
   - Preston Parry
+  - Qin Junwen
+  - RSG
+  - Rachel D. Cartwright
   - Rafael
+  - Rafael Angeline
   - Rafal Dittwald
+  - Ragnar Þór Valgeirsson
+  - Rahul Gupta
   - Rainer Oviir
+  - Raito Bezarius
   - Rajat Sehgal
   - Rajiv Tirumalareddy
   - Ram Kaniyur
   - Randall Randall
   - Ray
+  - Ray Dai
   - Raymond Ha
   - Reed Loden
   - Remko Tronçon
+  - Ricardo
+  - Rich Harris
+  - Richard
   - Richard D. Worth
   - Richard Feldman
   - Richard Kho
   - Richard Littauer
   - Richard Livesey
+  - Richard Maisano
+  - Richard Roncancio
   - Richard Wood
+  - Richie Thomas
   - Rick Beerendonk
   - Rick Ford
   - Riley Tomasek
   - Rob Arnold
   - Robert Binna
+  - Robert Chang
+  - Robert Haritonov
+  - Robert Kielty
   - Robert Knight
+  - Robert Martin
   - Robert Sedovsek
   - Robin Berjon
   - Robin Frischmann
+  - Robin Ricard
+  - Roderick Hsiao
+  - Rodrigo Pombo
+  - Rohan Nair
+  - Roman Liutikov
+  - Roman Matusevich
   - Roman Pominov
   - Roman Vanesyan
+  - Rui Araújo
   - Russ
+  - Ryan Lahfa
   - Ryan Seddon
+  - Ryo Shibayama
   - Sahat Yalkabov
   - Saif Hakim
   - Saiichi Hashimoto
+  - Sakina Crocker
+  - Sam Balana
   - Sam Beveridge
   - Sam Saccone
   - Sam Selikoff
+  - Samer Buna
+  - Samuel
+  - Samuel Hapák
+  - Samuel Reed
+  - Samuel Scheiderich
   - Samy Al Zahrani
   - Sander Spies
+  - Sasha Aickin
+  - Sassan Haradji
+  - Satoshi Nakajima
+  - Scott
   - Scott Burch
   - Scott Feeney
+  - Sean Gransee
   - Sean Kinsey
+  - Sean Smith
+  - Seba
   - Sebastian Markbåge
   - Sebastian McKenzie
+  - Senin Roman
   - Seoh Char
   - Sercan Eraslan
   - Serg
@@ -576,34 +897,62 @@
   - Shogun Sea
   - Shota Kubota
   - Shripad K
+  - Shubheksha Jalan
+  - Shuhei Kagawa
   - Sibi
   - Simen Bekkhus
   - Simon Højberg
   - Simon Welsh
   - Simone Vittori
+  - Skasi
+  - Snowmanzzz(Zhengzhong Zhao)
   - Soichiro Kawamura
+  - Soo Jae Hwang
+  - Sophia
   - Sophia Westwood
   - Sophie Alpert
   - Sota Ohara
+  - Spen Taylor
+  - Spencer Ahrens
   - Spencer Handley
+  - Sriram Thiagarajan
   - Stefan Dombrowski
+  - Stephen John Sorensen
   - Stephen Murphy
+  - Stephie
   - Sterling Cobb
   - Steve Baker
+  - Steve Mao
   - Steven Luscher
+  - Steven Syrek
   - Steven Vachon
+  - Stolenkid
   - Stoyan Stefanov
+  - Stuart Harris
+  - SunHuawei
   - Sundeep Malladi
+  - Sung Won Cho
   - Sunny Juneja
+  - Sunny Ripert
+  - Superlaziness
   - Sven Helmberger
   - Sverre Johansen
+  - Swaroop SM
   - Sébastien Lorber
   - Sławomir Laskowski
+  - Taegon Kim
   - Taeho Kim
+  - Taehwan, No
+  - Tanase Hagi
+  - Tanner
   - Tay Yang Shun
   - Ted Kim
+  - TedPowers
   - Tengfei Guo
   - Teodor Szente
+  - Tetsuharu OHZEKI
+  - Tetsuya Hasegawa
+  - Thibaut Rizzi
   - Thomas Aylott
   - Thomas Boyt
   - Thomas Broadley
@@ -612,6 +961,7 @@
   - Thomas Shaddox
   - Thomas Shafer
   - ThomasCrvsr
+  - Tiago Fernandez
   - Tienchai Wirojsaksaree
   - Tim Routowicz
   - Tim Schaub
@@ -619,79 +969,162 @@
   - Timur Carpeev
   - Tobias Reiss
   - Tom Duncalf
+  - Tom Gasson
   - Tom Haggie
   - Tom Hauburger
   - Tom MacWright
   - Tom Occhino
   - Tomasz Kołodziejski
   - Tomoya Suzuki
+  - Tomáš Hromada
+  - Tony Rossi
   - Tony Spiro
   - Toru Kobayashi
+  - Trevor Smith
   - Trinh Hoang Nhu
+  - Troy DeMonbreun
   - Tsung Hung
   - Tyler Brock
+  - Tyler Buchea
+  - Tyler Deitz
+  - Ujjwal Ojha
+  - Uladzimir Havenchyk
+  - Usman
   - Ustin Zarubin
   - Vadim Chernysh
+  - Valentin Shergin
+  - Van der Auwermeulen Grégoire
+  - Varayut Lerdkanlayanawat
+  - Varun Bhuvanendran
   - Varun Rau
   - Vasiliy Loginevskiy
+  - Vedat Mahir YILMAZ
+  - Veljko Tornjanski
+  - Vesa Laakso
   - Victor Alvarez
   - Victor Homyakov
   - Victor Koenders
+  - Victoria Quirante
+  - Vikash Agrawal
   - Ville Immonen
   - Vincent Riemer
   - Vincent Siao
+  - Vincent Taing
   - Vipul A M
+  - Vitaliy Potapov
   - Vitaly Kramskikh
   - Vitor Balocco
   - Vjeux
+  - Vladimir Kovpak
+  - Vladimir Tikunov
   - Volkan Unsal
   - Wander Wang
   - Wayne Larsen
+  - Weizenlol
+  - Whien
   - WickyNilliams
+  - Will Myers
+  - William Hoffmann
   - Wincent Colaiuta
   - Wout Mertens
   - Xavier Morel
   - XuefengWu
   - Yakov Dalinchuk
+  - Yan Li
   - Yasar icli
+  - Yaxian
   - YouBao Nong
   - Yuichi Hagio
+  - Yura Chuchola
   - Yuriy Dybskiy
+  - Yusong Liu
   - Yutaka Nakajima
   - Yuval Dekel
+  - Zac Braddy
+  - Zac Smith
   - Zach Bruggeman
   - Zach Ramaekers
   - Zacharias
   - Zeke Sikelianos
   - Zhangjd
   - adraeth
+  - ankitml
   - arush
+  - bel3atar
   - brafdlog
+  - brillout
   - chen
+  - chocolateboy
+  - cjshawMIT
   - clariroid
   - claudiopro
+  - cloudy1
+  - comerc
   - cutbko
   - davidxi
+  - dfrownfelter
+  - djskinner
   - dongmeng.ldm
+  - everdimension
+  - gillchristian
+  - gitanupam
+  - guoyong yi
+  - hanumanthan
+  - hao.huang
+  - hjmoss
+  - hkal
   - iamchenxin
   - iamdoron
   - iawia002
   - imagentleman
+  - imjanghyuk
+  - inkinworld
+  - jaaberg
+  - jddxf
+  - jinmmd
   - koh-taka
   - kohashi85
+  - ksvitkovsky
   - laiso
+  - lamo2k123
   - leeyoungalias
   - li.li
+  - lucas
   - maxprafferty
+  - mdogadailo
+  - mfijas
+  - mguidotto
+  - mondaychen
+  - najisawas
+  - neeldeep
+  - newvlad
+  - nhducit
+  - ogom
+  - pingan1927
   - rgarifullin
+  - saiyagg
+  - scloudyy
+  - segmentationfaulter
+  - shifengchen
   - songawee
+  - starkch
   - sugarshin
+  - tokikuch
+  - ventuno
+  - wacii
   - wali-s
+  - walrusfruitcake
   - yiminghe
   - youmoo
+  - yuntao.qyt
+  - z.ky
   - zhangjg
+  - zhangs
+  - zombieJ
   - zwhitchcox
   - "Árni Hermann Reynisson"
   - "元彦"
   - "凌恒"
   - "张敏"
+  - "王晓勇"
+  - "龙海燕"


### PR DESCRIPTION
To update the AUTHORS file, I ran the script and then removed duplicate names. To decide which email to go with, I first favoured ones existing in the file, then picked the address with the most commits associated with it.