### PR TITLE
Fix typo on docs for React 16

### DIFF
--- a/docs/_posts/2017-09-26-react-v16.0.md
+++ b/docs/_posts/2017-09-26-react-v16.0.md
@@ -83,7 +83,7 @@ Despite all these additions, React 16 is actually **smaller** compared to 15.6.1
 
 That amounts to a combined **32% size decrease compared to the previous version (30% post-gzip)**.
 
-The size difference is partly attributable to a change in packaging. React now uses [Rollup](https://rollupjs.org/) to create flat bundles for each of its different target formats, resulting in both size and runtime performance wins. The flat bundle format also means that React's impact on bundle size is roughly consistent regardless of how your ship your app, whether it's with Webpack, Browserify, the pre-built UMD bundles, or any other system.
+The size difference is partly attributable to a change in packaging. React now uses [Rollup](https://rollupjs.org/) to create flat bundles for each of its different target formats, resulting in both size and runtime performance wins. The flat bundle format also means that React's impact on bundle size is roughly consistent regardless of how you ship your app, whether it's with Webpack, Browserify, the pre-built UMD bundles, or any other system.
 
 ### MIT licensed
 


### PR DESCRIPTION
While reading the doc for React 16, I have found a typo that I fixed in this PR.