### PR TITLE
Minor update to portals docs "child" language

### DIFF
--- a/docs/docs/portals.md
+++ b/docs/docs/portals.md
@@ -115,8 +115,8 @@ class Parent extends React.Component {
         <p>
           Open up the browser DevTools
           to observe that the button
-          is not a child the div
-          with onClick handler.
+          is not a direct child of the div
+          with the onClick handler.
         </p>
         <Modal>
           <Child />

--- a/docs/docs/portals.md
+++ b/docs/docs/portals.md
@@ -115,7 +115,7 @@ class Parent extends React.Component {
         <p>
           Open up the browser DevTools
           to observe that the button
-          is not a direct child of the div
+          is not a child of the div
           with the onClick handler.
         </p>
         <Modal>


### PR DESCRIPTION
This commit changes the portals docs so that the language of the Parent
no longer feels like it is missing a word with "is not a child the div
with onClick handler" and replaces that with "is not a direct child of
the div with the onClick handler".

closes #10868
