### PR TITLE
[Gatsby Docs Update] Syntax highlight changes

### DIFF
--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -22,3 +22,4 @@ In addition, we're grateful to
  - [Christopher Aue](http://christopheraue.net/) for letting us use the [reactjs.com](http://reactjs.com/) domain name and the [@reactjs](https://twitter.com/reactjs) username on Twitter.
  - [ProjectMoon](https://github.com/ProjectMoon) for letting us use the [flux](https://www.npmjs.com/package/flux) package name on npm.
  - Shane Anderson for allowing us to use the [react](https://github.com/react) org on GitHub.
+ - [Dmitri Voronianski](https://github.com/voronianski) for letting us use the [Oceanic Next](https://labs.voronianski.com/oceanic-next-color-scheme/) color scheme on this website.

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -53,6 +53,7 @@ module.exports = {
             },
           },
           'gatsby-remark-autolink-headers',
+          'gatsby-remark-use-jsx',
           {
             resolve: `gatsby-remark-prismjs`,
             options: {

--- a/www/package.json
+++ b/www/package.json
@@ -34,7 +34,8 @@
     "remarkable": "^1.7.1",
     "slugify": "^1.2.1",
     "string.prototype.includes": "^1.0.0",
-    "string.prototype.repeat": "^0.2.0"
+    "string.prototype.repeat": "^0.2.0",
+    "unist-util-visit": "^1.1.3"
   },
   "devDependencies": {
     "gh-pages": "^1.0.0",

--- a/www/plugins/gatsby-remark-use-jsx/index.js
+++ b/www/plugins/gatsby-remark-use-jsx/index.js
@@ -1,0 +1,22 @@
+const visit = require('unist-util-visit');
+
+// Always treat JS blocks as JSX.
+// TODO: maybe we can just change it in Markdown in the future?
+module.exports = ({markdownAST}) => {
+  visit(markdownAST, `code`, node => {
+    if (typeof node.lang !== 'string') {
+      return;
+    }
+    if (node.lang.indexOf('jsx') === 0) {
+      // Already JSX (with optional line range).
+      return;
+    }
+    // Turn JS into JSX, preserving the optional line range.
+    if (node.lang.indexOf('js') === 0) {
+      node.lang = 'jsx' + node.lang.substring('js'.length);
+    }
+    if (node.lang.indexOf('javascript') === 0) {
+      node.lang = 'jsx' + node.lang.substring('javascript'.length);
+    }
+ })
+};

--- a/www/plugins/gatsby-remark-use-jsx/index.js
+++ b/www/plugins/gatsby-remark-use-jsx/index.js
@@ -18,5 +18,5 @@ module.exports = ({markdownAST}) => {
     if (node.lang.indexOf('javascript') === 0) {
       node.lang = 'jsx' + node.lang.substring('javascript'.length);
     }
- })
+  });
 };

--- a/www/plugins/gatsby-remark-use-jsx/package.json
+++ b/www/plugins/gatsby-remark-use-jsx/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "gatsby-remark-use-jsx",
+  "version": "0.0.1"
+}

--- a/www/src/css/reset.css
+++ b/www/src/css/reset.css
@@ -34,6 +34,6 @@ img {
   vertical-align: top;
 }
 
-pre {
+pre, code {
   font-family: source-code-pro, Menlo, Consolas, "Courier New", monospace;
 }

--- a/www/src/pages/acknowledgements.html.js
+++ b/www/src/pages/acknowledgements.html.js
@@ -81,6 +81,13 @@ const Acknowlegements = ({data, location}) => (
               {' '}
               org on GitHub.
             </li>
+            <li>
+              <a href="https://github.com/voronianski">Dmitri Voronianski</a> for letting us use the
+              {' '}
+              <a href="https://labs.voronianski.com/oceanic-next-color-scheme/">Oceanic Next</a>
+              {' '}
+              color scheme on this website.
+            </li>
           </ul>
         </div>
       </div>

--- a/www/src/pages/acknowledgements.html.js
+++ b/www/src/pages/acknowledgements.html.js
@@ -82,9 +82,13 @@ const Acknowlegements = ({data, location}) => (
               org on GitHub.
             </li>
             <li>
-              <a href="https://github.com/voronianski">Dmitri Voronianski</a> for letting us use the
+              <a href="https://github.com/voronianski">Dmitri Voronianski</a>
               {' '}
-              <a href="https://labs.voronianski.com/oceanic-next-color-scheme/">Oceanic Next</a>
+              for letting us use the
+              {' '}
+              <a href="https://labs.voronianski.com/oceanic-next-color-scheme/">
+                Oceanic Next
+              </a>
               {' '}
               color scheme on this website.
             </li>

--- a/www/src/prism-styles.js
+++ b/www/src/prism-styles.js
@@ -94,24 +94,19 @@ css.global(
 
 css.global(`.token.boolean`, {
   color: prismColors.boolean,
-})
+});
 
-css.global(
-  `.token.tag`,
-  {
-    color: prismColors.tag,
-  },
-);
+css.global(`.token.tag`, {
+  color: prismColors.tag,
+});
 
-css.global(`.token.string`,
-  {
-    color: prismColors.string,
-  },
-);
+css.global(`.token.string`, {
+  color: prismColors.string,
+});
 
 css.global(`.token.punctuation`, {
   color: prismColors.punctuation,
-})
+});
 
 css.global(
   `

--- a/www/src/prism-styles.js
+++ b/www/src/prism-styles.js
@@ -13,13 +13,20 @@ import {css} from 'glamor';
 import {colors} from 'theme';
 
 const prismColors = {
-  char: '#61dafb',
+  char: '#D8DEE9',
   comment: '#999999',
-  keyword: '#c4f1fe',
+  keyword: '#c5a5c5',
   lineHighlight: '#393d45',
-  primative: '#c997c0',
-  string: '#99c27c',
-  variable: '#99c27c',
+  primitive: '#5a9bcf',
+  string: '#8dc891',
+  variable: '#d7deea',
+  boolean: '#ff8b50',
+  punctuation: '#5FB3B3',
+  tag: '#fc929e',
+  function: '#79b6f2',
+  className: '#FAC863',
+  method: '#6699CC',
+  operator: '#fc929e',
 };
 
 css.global('.gatsby-highlight', {
@@ -57,7 +64,7 @@ css.global('.gatsby-highlight-code-line', {
 });
 
 css.global('.token.attr-name', {
-  color: colors.white,
+  color: prismColors.keyword,
 });
 
 css.global(
@@ -75,38 +82,51 @@ css.global(
 css.global(
   `
 .token.property,
-.token.boolean,
 .token.number,
 .token.function-name,
 .token.constant,
 .token.symbol,
 .token.deleted`,
   {
-    color: prismColors.primative,
+    color: prismColors.primitive,
   },
 );
 
+css.global(`.token.boolean`, {
+  color: prismColors.boolean,
+})
+
 css.global(
-  `
-.token.punctuation,
-.token.tag,
-.token.string`,
+  `.token.tag`,
+  {
+    color: prismColors.tag,
+  },
+);
+
+css.global(`.token.string`,
   {
     color: prismColors.string,
   },
 );
 
+css.global(`.token.punctuation`, {
+  color: prismColors.punctuation,
+})
+
 css.global(
   `
 .token.selector,
 .token.char,
-.token.function,
 .token.builtin,
 .token.inserted`,
   {
     color: prismColors.char,
   },
 );
+
+css.global(`.token.function`, {
+  color: prismColors.function,
+});
 
 css.global(
   `
@@ -120,7 +140,7 @@ css.global(
 );
 
 css.global('.token.attr-value', {
-  color: prismColors.comment,
+  color: prismColors.string,
 });
 
 css.global('.token.keyword', {
@@ -132,7 +152,7 @@ css.global(
 .token.atrule,
 .token.class-name`,
   {
-    color: prismColors.char,
+    color: prismColors.className,
   },
 );
 

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -9179,7 +9179,7 @@ unist-util-visit-children@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-1.1.1.tgz#eba63b371116231181068837118b6e6e10ec8844"
 
-unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.1.1:
+unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.1.1, unist-util-visit@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.1.3.tgz#ec268e731b9d277a79a5b5aa0643990e405d600b"
 


### PR DESCRIPTION
- I've tweaked a few colours to closer match Oceanic Next.
- I've converted all markdown docs files to use "jsx" code blocks instead of "js" to correctly highlight JSX tags

cc @bvaughn @gaearon 

![screen shot 2017-09-27 at 16 20 33](https://user-images.githubusercontent.com/24449/30922032-e1356ff2-a39f-11e7-8dc0-81bd86552306.png)
![screen shot 2017-09-27 at 16 20 41](https://user-images.githubusercontent.com/24449/30922031-e12f19a4-a39f-11e7-91d8-8da5d2ae3082.png)
