### PR TITLE
[Gatsby Docs Update] Reverted TypeKit ID

### DIFF
--- a/www/src/html.js
+++ b/www/src/html.js
@@ -59,7 +59,7 @@ export default class HTML extends Component {
             dangerouslySetInnerHTML={{__html: this.props.body}}
           />
           {this.props.postBodyComponents}
-          <script src="https://use.typekit.net/jyn3zhm.js" />
+          <script src="https://use.typekit.net/vqa1hcx.js" />
           <script
             dangerouslySetInnerHTML={{
               __html: 'try{Typekit.load({ async: true });}catch(e){}',


### PR DESCRIPTION
The `gatsby` branch is currently using my local testing TypeKit ID, which would soon break if it went to production 😝 

So I've reverted it with this PR.

We'll want to make sure `*.netlify.com` and `reactjs.org` are added as domains, though.

cc @bvaughn 
