### PR TITLE
[Gatsby Docs Update] Error column fixes

### DIFF
--- a/www/src/components/CodeEditor/CodeEditor.js
+++ b/www/src/components/CodeEditor/CodeEditor.js
@@ -154,9 +154,12 @@ class CodeEditor extends Component {
                     background: colors.error,
                     color: colors.white,
                   }}>
-                  <MetaTitle cssProps={{
-                    color: colors.white,
-                  }}>Error</MetaTitle>
+                  <MetaTitle
+                    cssProps={{
+                      color: colors.white,
+                    }}>
+                    Error
+                  </MetaTitle>
                 </div>
                 <pre
                   css={{

--- a/www/src/components/CodeEditor/CodeEditor.js
+++ b/www/src/components/CodeEditor/CodeEditor.js
@@ -137,10 +137,12 @@ class CodeEditor extends Component {
             {error &&
               <div
                 css={{
-                  flex: '0 0 70%',
+                  flex: '0 0 30%',
                   overflow: 'hidden',
                   border: `1px solid ${colors.error}`,
                   borderRadius: '0 10px 10px 0',
+                  fontSize: 12,
+                  lineHeight: 1.5,
 
                   [media.lessThan('small')]: {
                     borderRadius: '0 0 10px 10px',
@@ -152,7 +154,9 @@ class CodeEditor extends Component {
                     background: colors.error,
                     color: colors.white,
                   }}>
-                  <MetaTitle>Error</MetaTitle>
+                  <MetaTitle cssProps={{
+                    color: colors.white,
+                  }}>Error</MetaTitle>
                 </div>
                 <pre
                   css={{


### PR DESCRIPTION
- Change colour of the Error title to be white, instead of the clashing grey.
- Changed width of the column, to sit well next to the 70% "Live JSX Editor" column
- Changed the font size & line height of the error column's text to look more readable

cc @bvaughn 

![screen shot 2017-09-27 at 18 17 45](https://user-images.githubusercontent.com/24449/30927533-a8c85b00-a3b0-11e7-94b2-68f6f59671c6.png)
