### PR TITLE
[Gatsby Docs Update] Normalized font weights

### DIFF
--- a/www/src/pages/blog/all.html.js
+++ b/www/src/pages/blog/all.html.js
@@ -51,7 +51,7 @@ const AllBlogPosts = ({data}) => (
                   fontSize: 24,
                   color: colors.dark,
                   lineHeight: 1.3,
-                  fontWeight: 600,
+                  fontWeight: 700,
                 }}>
                 <Link
                   css={{

--- a/www/src/prism-styles.js
+++ b/www/src/prism-styles.js
@@ -137,11 +137,11 @@ css.global(
 );
 
 css.global('.token.important', {
-  fontWeight: 'normal',
+  fontWeight: 400,
 });
 
 css.global('.token.bold', {
-  fontWeight: 'bold',
+  fontWeight: 700,
 });
 css.global('.token.italic', {
   fontStyle: 'italic',

--- a/www/src/templates/components/ButtonLink/ButtonLink.js
+++ b/www/src/templates/components/ButtonLink/ButtonLink.js
@@ -61,7 +61,7 @@ const style = {
 const primaryStyle = {
   backgroundColor: colors.brand,
   color: colors.black,
-  fontWeight: 100,
+  fontWeight: 300,
   padding: '10px 25px',
   whiteSpace: 'nowrap',
   transition: 'background-color 0.2s ease-out',

--- a/www/src/templates/home.js
+++ b/www/src/templates/home.js
@@ -289,7 +289,7 @@ const markdownStyles = {
 
       [media.greaterThan('xlarge')]: {
         fontSize: 24,
-        fontWeight: 500,
+        fontWeight: 400,
       },
     },
 

--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -373,7 +373,7 @@ const sharedStyles = {
         marginTop: 15,
 
         '&:first-of-type': {
-          fontWeight: 'bold',
+          fontWeight: 700,
           marginTop: 0,
         },
 

--- a/www/src/utils/createLink.js
+++ b/www/src/utils/createLink.js
@@ -81,7 +81,7 @@ const createLinkTutorial = ({item, location, onLinkClick, section}) => {
 };
 
 const activeLinkCss = {
-  fontWeight: 'bold',
+  fontWeight: 700,
 };
 
 const activeLinkBefore = {


### PR DESCRIPTION
I've normalized the font weights for (A) speed, (B) consistency, and (C) compatibility with the production TypeKit code.

We're now down to just 300, 400 and 700 weights. 

cc @bvaughn 