### PR TITLE
[Gatsby] Consistent capitalization for homepage call to action

### DIFF
--- a/www/src/templates/home.js
+++ b/www/src/templates/home.js
@@ -117,7 +117,7 @@ class Home extends Component {
                 </CtaItem>
                 <CtaItem>
                   <ButtonLink to="/tutorial/tutorial.html" type="secondary">
-                    Take the tutorial
+                    Take the Tutorial
                   </ButtonLink>
                 </CtaItem>
               </Flex>
@@ -148,7 +148,7 @@ class Home extends Component {
               </CtaItem>
               <CtaItem>
                 <ButtonLink to="/tutorial/tutorial.html" type="secondary">
-                  Take the tutorial
+                  Take the Tutorial
                 </ButtonLink>
               </CtaItem>
             </Flex>


### PR DESCRIPTION
Not feeling super strong about this, but the difference was a bit jarring.

<img width="402" alt="screen shot 2017-09-27 at 7 36 06 pm" src="https://user-images.githubusercontent.com/810438/30930936-244b944a-a3bb-11e7-9dcb-fe93359e3155.png">
