### PR TITLE
[Gatsby Docs Update] Safari Mac footer fix

### DIFF
--- a/www/src/components/MarkdownPage/MarkdownPage.js
+++ b/www/src/components/MarkdownPage/MarkdownPage.js
@@ -46,7 +46,6 @@ const MarkdownPage = ({
         flex: '1 0 auto',
         position: 'relative',
         zIndex: 0,
-        overflow: 'auto', // This is required for the mobile footer layout
       }}>
       <TitleAndMetaTags
         title={`${titlePrefix}${titlePostfix}`}


### PR DESCRIPTION
`overflow: auto` from MarkdownPage.js  was causing the menu to be cropped off. (I guess safari handles the auto's overflow-y different to other browsers?)

Even though it had a comment from next to it about mobile fix, this no longer seemed to apply, as it's good in both iOS and Android without it.

cc @bvaughn 