### PR TITLE
[Gatsby] Add a stopgap fix for Safari indentation issue

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -11,6 +11,7 @@
     "gatsby/react-dom": "16.0.0"
   },
   "dependencies": {
+    "@gaearon/react-live": "1.7.1-with-safari-fix",
     "array-from": "^2.1.1",
     "gatsby": "^1.9.9",
     "gatsby-link": "^1.6.9",
@@ -32,7 +33,6 @@
     "gatsby-transformer-sharp": "^1.6.1",
     "glamor": "^2.20.40",
     "hex2rgba": "^0.0.1",
-    "react-live": "^1.7.1",
     "remarkable": "^1.7.1",
     "slugify": "^1.2.1",
     "string.prototype.includes": "^1.0.0",

--- a/www/src/components/CodeEditor/CodeEditor.js
+++ b/www/src/components/CodeEditor/CodeEditor.js
@@ -12,7 +12,9 @@
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 import Remarkable from 'remarkable';
-import {LiveProvider, LiveEditor} from 'react-live';
+// TODO: switch back to the upstream version of react-live
+// once https://github.com/FormidableLabs/react-live/issues/37 is fixed.
+import {LiveProvider, LiveEditor} from '@gaearon/react-live';
 import {colors, media} from 'theme';
 import MetaTitle from 'templates/components/MetaTitle';
 

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"@gaearon/react-live@1.7.1-with-safari-fix":
+  version "1.7.1-with-safari-fix"
+  resolved "https://registry.yarnpkg.com/@gaearon/react-live/-/react-live-1.7.1-with-safari-fix.tgz#fef25ce045749b24c79f6475562530726e507876"
+  dependencies:
+    buble "^0.15.2"
+    core-js "^2.4.1"
+    dom-iterator "^0.3.0"
+    prismjs "^1.6.0"
+    prop-types "^15.5.8"
+    unescape "^0.2.0"
+
 "@types/node@^6.0.46":
   version "6.0.79"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.79.tgz#5efe7d4a6d8c453c7e9eaf55d931f4a22fac5169"
@@ -7365,17 +7376,6 @@ react-hot-loader@^3.0.0-beta.6:
     react-proxy "^3.0.0-alpha.0"
     redbox-react "^1.3.6"
     source-map "^0.4.4"
-
-react-live@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/react-live/-/react-live-1.7.1.tgz#a4fc7a4d23c2596cf7d4ed10f62dca9a02915e26"
-  dependencies:
-    buble "^0.15.2"
-    core-js "^2.4.1"
-    dom-iterator "^0.3.0"
-    prismjs "^1.6.0"
-    prop-types "^15.5.8"
-    unescape "^0.2.0"
 
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"


### PR DESCRIPTION
Works around https://github.com/FormidableLabs/react-live/issues/37.

The tab button still works confusingly there but it's a known issue.

cc @philpl