### PR TITLE
[Gatsby] Pull .gatsby-highlight-code-line to container edge

### DIFF
--- a/www/src/prism-styles.js
+++ b/www/src/prism-styles.js
@@ -59,8 +59,8 @@ css.global('.gatsby-highlight + .gatsby-highlight', {
 css.global('.gatsby-highlight-code-line', {
   backgroundColor: prismColors.lineHighlight,
   display: 'block',
-  margin: '-0.125rem -1rem',
-  padding: '0.125rem 1rem',
+  margin: '-0.125rem calc(-1rem - 15px)',
+  padding: '0.125rem calc(1rem + 15px)',
 });
 
 css.global('.token.attr-name', {


### PR DESCRIPTION
Hi folks! Love the new site! 🤗  🎉 

@KyleAMathews mentioned that you currently do not pull the background of highlighted lines of code (`.gatsby-highlight-code-line`) up to the containers edge. This PR "fixes" that by taking the [horizontal padding](https://github.com/facebook/react/blob/c992261e14892f1c8e8724b7295056ea9b700f8e/www/src/theme.js#L187-L188) of `.gatsby-highlight` into account. Before/after:

![image](https://user-images.githubusercontent.com/21834/30950231-d9f9a772-a41b-11e7-8529-182f9c6bf99a.png)

![image](https://user-images.githubusercontent.com/21834/30950323-7ae1bd96-a41c-11e7-8008-75bef6424289.png)
