### PR TITLE
[Gatsby] Fix long lines of <code>

### DIFF
--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -236,6 +236,7 @@ const sharedStyles = {
       padding: '0 3px',
       fontSize: 16,
       color: colors.text,
+      wordBreak: 'break-word',
     },
 
     '& hr': {


### PR DESCRIPTION
There was an issue where mobile widths were too large, due to any long inline code.

This fixes it be adding `wordBreak: 'break-word` to break long lines of `<code>`.

cc @gaearon @bvaughn 