### PR TITLE
[Gatsby] Tightened line heights on paragraphs

### DIFF
--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -210,7 +210,7 @@ const sharedStyles = {
     '& p': {
       marginTop: 35,
       fontSize: 18,
-      lineHeight: '35px',
+      lineHeight: 1.7,
       maxWidth: '42em',
 
       '&:first-of-type': {


### PR DESCRIPTION
Tightened `line-height` on any markdown paragraphs to `1.7`, as suggested by @acdlite 

Mentioned in #10901 



