### PR TITLE
Fix "null" instead of the component stack in a warning

### DIFF
--- a/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
+++ b/src/renderers/shared/fiber/ReactDebugCurrentFiber.js
@@ -55,9 +55,13 @@ function resetCurrentFiber() {
   ReactDebugCurrentFiber.phase = null;
 }
 
-function setCurrentFiber(fiber: Fiber | null, phase: LifeCyclePhase | null) {
+function setCurrentFiber(fiber: Fiber) {
   ReactDebugCurrentFrame.getCurrentStack = getCurrentFiberStackAddendum;
   ReactDebugCurrentFiber.current = fiber;
+  ReactDebugCurrentFiber.phase = null;
+}
+
+function setCurrentPhase(phase: LifeCyclePhase | null) {
   ReactDebugCurrentFiber.phase = phase;
 }
 
@@ -66,6 +70,7 @@ var ReactDebugCurrentFiber = {
   phase: (null: LifeCyclePhase | null),
   resetCurrentFiber,
   setCurrentFiber,
+  setCurrentPhase,
   getCurrentFiberOwnerName,
   getCurrentFiberStackAddendum,
 };

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -725,10 +725,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       return bailoutOnLowPriority(current, workInProgress);
     }
 
-    if (__DEV__) {
-      ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
-    }
-
     switch (workInProgress.tag) {
       case IndeterminateComponent:
         return mountIndeterminateComponent(

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -207,9 +207,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     if (__DEV__) {
       ReactCurrentOwner.current = workInProgress;
-      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, 'render');
+      ReactDebugCurrentFiber.setCurrentPhase('render');
       nextChildren = fn(nextProps, context);
-      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, null);
+      ReactDebugCurrentFiber.setCurrentPhase(null);
     } else {
       nextChildren = fn(nextProps, context);
     }
@@ -281,9 +281,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     ReactCurrentOwner.current = workInProgress;
     let nextChildren;
     if (__DEV__) {
-      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, 'render');
+      ReactDebugCurrentFiber.setCurrentPhase('render');
       nextChildren = instance.render();
-      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, null);
+      ReactDebugCurrentFiber.setCurrentPhase(null);
     } else {
       nextChildren = instance.render();
     }
@@ -726,7 +726,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     if (__DEV__) {
-      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, null);
+      ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
     }
 
     switch (workInProgress.tag) {

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -188,7 +188,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     renderPriority: PriorityLevel,
   ): Fiber | null {
     if (__DEV__) {
-      ReactDebugCurrentFiber.setCurrentFiber(workInProgress, null);
+      ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
     }
 
     // Get the latest props.

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -42,10 +42,6 @@ var {
 var {Placement, Ref, Update} = ReactTypeOfSideEffect;
 var {OffscreenPriority} = ReactPriorityLevel;
 
-if (__DEV__) {
-  var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
-}
-
 var invariant = require('fbjs/lib/invariant');
 
 module.exports = function<T, P, I, TI, PI, C, CX, PL>(
@@ -187,10 +183,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     workInProgress: Fiber,
     renderPriority: PriorityLevel,
   ): Fiber | null {
-    if (__DEV__) {
-      ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
-    }
-
     // Get the latest props.
     let newProps = workInProgress.pendingProps;
     if (newProps === null) {

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -181,7 +181,7 @@ export type Reconciler<C, I, TI> = {
 getContextForSubtree._injectFiber(function(fiber: Fiber) {
   const parentContext = findCurrentUnmaskedContext(fiber);
   return isContextProvider(fiber)
-    ? processChildContext(fiber, parentContext, false)
+    ? processChildContext(fiber, parentContext)
     : parentContext;
 });
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -317,7 +317,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function commitAllHostEffects() {
     while (nextEffect !== null) {
       if (__DEV__) {
-        ReactDebugCurrentFiber.setCurrentFiber(nextEffect, null);
+        ReactDebugCurrentFiber.setCurrentFiber(nextEffect);
         recordEffect();
       }
 

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -615,7 +615,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // means that we don't need an additional field on the work in
       // progress.
       const current = workInProgress.alternate;
+      if (__DEV__) {
+        ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
+      }
       const next = completeWork(current, workInProgress, nextPriorityLevel);
+      if (__DEV__) {
+        ReactDebugCurrentFiber.resetCurrentFiber();
+      }
 
       const returnFiber = workInProgress.return;
       const siblingFiber = workInProgress.sibling;
@@ -706,8 +712,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // See if beginning this work spawns more work.
     if (__DEV__) {
       startWorkTimer(workInProgress);
+      ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
     }
     let next = beginWork(current, workInProgress, nextPriorityLevel);
+    if (__DEV__) {
+      ReactDebugCurrentFiber.resetCurrentFiber();
+    }
     if (__DEV__ && ReactFiberInstrumentation.debugTool) {
       ReactFiberInstrumentation.debugTool.onBeginWork(workInProgress);
     }
@@ -718,9 +728,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     ReactCurrentOwner.current = null;
-    if (__DEV__) {
-      ReactDebugCurrentFiber.resetCurrentFiber();
-    }
 
     return next;
   }
@@ -735,8 +742,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // See if beginning this work spawns more work.
     if (__DEV__) {
       startWorkTimer(workInProgress);
+      ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
     }
     let next = beginFailedWork(current, workInProgress, nextPriorityLevel);
+    if (__DEV__) {
+      ReactDebugCurrentFiber.resetCurrentFiber();
+    }
     if (__DEV__ && ReactFiberInstrumentation.debugTool) {
       ReactFiberInstrumentation.debugTool.onBeginWork(workInProgress);
     }
@@ -747,9 +758,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     ReactCurrentOwner.current = null;
-    if (__DEV__) {
-      ReactDebugCurrentFiber.resetCurrentFiber();
-    }
 
     return next;
   }


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/10831.

(Note: the warning itself is still legit. This just fixes it to print the component stack instead of `null` in some cases.)

See individual commit messages for more info on what we did wrong and why this helps.