### PR TITLE
Added gatsby-plugin-nprogress for slow-loading pages (eg Blog)

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -21,7 +21,12 @@ module.exports = {
     'gatsby-plugin-netlify',
     'gatsby-plugin-glamor',
     'gatsby-plugin-react-next',
-    'gatsby-plugin-nprogress',
+    {
+      resolve: 'gatsby-plugin-nprogress',
+      options: {
+        color: '#61dafb',
+      },
+    },
     {
       resolve: 'gatsby-source-filesystem',
       options: {

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -21,8 +21,9 @@ module.exports = {
     'gatsby-plugin-netlify',
     'gatsby-plugin-glamor',
     'gatsby-plugin-react-next',
+    'gatsby-plugin-nprogress',
     {
-      resolve: `gatsby-source-filesystem`,
+      resolve: 'gatsby-source-filesystem',
       options: {
         path: `${__dirname}/src/pages`,
         name: 'pages',
@@ -30,19 +31,19 @@ module.exports = {
     },
     {
       /* Docs, Tutorial, Community, and Blog section content comes from here. */
-      resolve: `gatsby-source-filesystem`,
+      resolve: 'gatsby-source-filesystem',
       options: {
-        name: `packages`,
+        name: 'packages',
         path: `${__dirname}/../docs/`,
       },
     },
     {
-      resolve: `gatsby-transformer-remark`,
+      resolve: 'gatsby-transformer-remark',
       options: {
         plugins: [
           'gatsby-remark-responsive-iframe',
           {
-            resolve: `gatsby-remark-images`,
+            resolve: 'gatsby-remark-images',
             options: {
               maxWidth: 840,
             },
@@ -50,7 +51,7 @@ module.exports = {
           'gatsby-remark-autolink-headers',
           'gatsby-remark-use-jsx',
           {
-            resolve: `gatsby-remark-prismjs`,
+            resolve: 'gatsby-remark-prismjs',
             options: {
               classPrefix: 'gatsby-code-',
             },
@@ -60,14 +61,14 @@ module.exports = {
         ],
       },
     },
-    `gatsby-transformer-sharp`,
-    `gatsby-plugin-sharp`,
+    'gatsby-transformer-sharp',
+    'gatsby-plugin-sharp',
     {
-      resolve: `gatsby-plugin-google-analytics`,
+      resolve: 'gatsby-plugin-google-analytics',
       options: {
-        trackingId: `UA-41298772-1`,
+        trackingId: 'UA-41298772-1',
       },
     },
-    `gatsby-plugin-react-helmet`,
+    'gatsby-plugin-react-helmet',
   ],
 };

--- a/www/package.json
+++ b/www/package.json
@@ -19,6 +19,7 @@
     "gatsby-plugin-google-analytics": "^1.0.4",
     "gatsby-plugin-manifest": "^1.0.4",
     "gatsby-plugin-netlify": "^1.0.4",
+    "gatsby-plugin-nprogress": "^1.0.7",
     "gatsby-plugin-react-helmet": "^1.0.3",
     "gatsby-plugin-react-next": "^1.0.3",
     "gatsby-plugin-sharp": "^1.6.2",

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -3588,6 +3588,13 @@ gatsby-plugin-netlify@^1.0.4:
     lodash "^4.17.4"
     webpack-assets-manifest "^1.0.0"
 
+gatsby-plugin-nprogress@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-nprogress/-/gatsby-plugin-nprogress-1.0.7.tgz#36cf18776d22c282d3355d32b8c212afdf1a2907"
+  dependencies:
+    babel-runtime "^6.26.0"
+    nprogress "^0.2.0"
+
 gatsby-plugin-react-helmet@^1.0.3:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-1.0.6.tgz#32431fbfd072b05453080ed304142f4747868848"
@@ -6159,6 +6166,10 @@ npmlog@^4.0.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
+
+nprogress@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/nprogress/-/nprogress-0.2.0.tgz#cb8f34c53213d895723fcbab907e9422adbcafb1"
 
 nth-check@^1.0.1, nth-check@~1.0.1:
   version "1.0.1"

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -3735,8 +3735,8 @@ gatsby-transformer-sharp@^1.6.1:
     image-size "^0.6.0"
 
 gatsby@^1.9.9:
-  version "1.9.45"
-  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-1.9.45.tgz#3ac9d238fcf4abb7276689b8dd91b06bc98617c6"
+  version "1.9.49"
+  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-1.9.49.tgz#ff934a985493e731ada7e81ec77b17dd474e3e61"
   dependencies:
     async "^2.1.2"
     babel-code-frame "^6.22.0"


### PR DESCRIPTION
Adds the [`gatsby-plugin-nprogress` plugin](https://www.gatsbyjs.org/packages/gatsby-plugin-nprogress/) (which displays the [npgoress](ricostacruz.com/nprogress/) loading bar if a page takes longer than a second to load.)

This might fix the nit you mentioned, @gaearon. Let's see how it looks when Netlify adds a preview link. (Kyle also recommended this plug-in a time or two. Gatsby uses it on its own website.)