### PR TITLE
Prettier formats gatsby-node file as well

### DIFF
--- a/scripts/prettier/index.js
+++ b/scripts/prettier/index.js
@@ -34,7 +34,7 @@ const defaultOptions = {
 const config = {
   default: {
     patterns: ['src/**/*.js', 'www/**/*.js'],
-    ignore: ['**/third_party/**', '**/node_modules/**', 'www/gatsby-node.js'],
+    ignore: ['**/third_party/**', '**/node_modules/**'],
   },
   scripts: {
     patterns: ['scripts/**/*.js', 'fixtures/**/*.js'],

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -12,7 +12,7 @@
 const {resolve} = require('path');
 const webpack = require('webpack');
 
-exports.modifyWebpackConfig = ({ config, stage }) => {
+exports.modifyWebpackConfig = ({config, stage}) => {
   // See https://github.com/FormidableLabs/react-live/issues/5
   config.plugin('ignore', () => new webpack.IgnorePlugin(/^(xor|props)$/));
 
@@ -35,7 +35,8 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
   const homeTemplate = resolve('./src/templates/home.js');
   const installationTemplate = resolve('./src/templates/installation.js');
 
-  const allMarkdown = await graphql(`
+  const allMarkdown = await graphql(
+    `
     {
       allMarkdownRemark(limit: 1000) {
         edges {
@@ -48,7 +49,8 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
         }
       }
     }
-  `);
+  `,
+  );
 
   if (allMarkdown.errors) {
     console.error(allMarkdown.errors);
@@ -75,11 +77,9 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
           slug,
         },
       });
-
     } else if (slug === 'docs/error-decoder.html') {
       // No-op so far as markdown templates go.
       // Error codes are managed by a page (which gets created automatically).
-
     } else if (
       slug.includes('blog/') ||
       slug.includes('community/') ||
@@ -92,10 +92,7 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
         template = blogTemplate;
       } else if (slug.includes('community/')) {
         template = communityTemplate;
-      } else if (
-        slug.includes('contributing/') ||
-        slug.includes('docs/')
-      ) {
+      } else if (slug.includes('contributing/') || slug.includes('docs/')) {
         template = docsTemplate;
       } else if (slug.includes('tutorial/')) {
         template = tutorialTemplate;
@@ -125,13 +122,14 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
             fromPath: `/${fromPath}`,
             redirectInBrowser: true,
             toPath: `/${slug}`,
-          })
+          }),
         );
       }
     }
   });
 
-  const newestBlogEntry = await graphql(`
+  const newestBlogEntry = await graphql(
+    `
     {
       allMarkdownRemark(
         limit: 1,
@@ -147,7 +145,8 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
         }
       }
     }
-  `);
+  `,
+  );
   const newestBlogNode = newestBlogEntry.data.allMarkdownRemark.edges[0].node;
 
   // Blog landing page should always show the most recent blog entry.
@@ -202,7 +201,7 @@ exports.onCreateNode = ({node, boundActionCreators, getNode}) => {
         // This should (probably) only happen for the index.md,
         // But let's log it in case it happens for other files also.
         console.warn(
-          `Warning: No slug found for "${relativePath}". Falling back to default "${slug}".`
+          `Warning: No slug found for "${relativePath}". Falling back to default "${slug}".`,
         );
       }
 
@@ -230,8 +229,8 @@ exports.onCreateNode = ({node, boundActionCreators, getNode}) => {
   }
 };
 
-exports.onCreatePage = async ({ page, boundActionCreators }) => {
-  const { createPage } = boundActionCreators;
+exports.onCreatePage = async ({page, boundActionCreators}) => {
+  const {createPage} = boundActionCreators;
 
   return new Promise(resolvePromise => {
     // page.matchPath is a special key that's used for matching pages only on the client.


### PR DESCRIPTION
I believe I excluded this file originally b'c of a trailing comma issue that caused trouble with earlier versions of Node. If we pin to a newer version anyway (for async/await support) then this is no longer necessary and it would be reasonable to format this file also.