### PR TITLE
Fix for createHTMLDocument API specific to IE11

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -132,7 +132,8 @@ if (__DEV__) {
   // can be used for comparison.
   var normalizeHTML = function(parent: Element, html: string) {
     if (!testDocument) {
-      testDocument = document.implementation.createHTMLDocument(""); // title is not optional in IE11
+      // The title argument is required in IE11 so we pass an empty string.
+      testDocument = document.implementation.createHTMLDocument('');
     }
     var testElement = parent.namespaceURI === HTML_NAMESPACE
       ? testDocument.createElement(parent.tagName)

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -132,7 +132,7 @@ if (__DEV__) {
   // can be used for comparison.
   var normalizeHTML = function(parent: Element, html: string) {
     if (!testDocument) {
-      testDocument = document.implementation.createHTMLDocument();
+      testDocument = document.implementation.createHTMLDocument(""); // title is not optional in IE11
     }
     var testElement = parent.namespaceURI === HTML_NAMESPACE
       ? testDocument.createElement(parent.tagName)


### PR DESCRIPTION
The createHTMLDocument API title parameter is not optional in IE while other browsers don't care IE11 will throw if an argument is not passed. This only impacts react.dom.development not react.dom.production.

Fixes issue #10865 

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
6. Make sure your code lints (`npm run lint`).
7. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
8. If you haven't already, complete the CLA.
