### PR TITLE
Gatsby markdown cleanup

### DIFF
--- a/docs/_posts/2013-06-02-jsfiddle-integration.md
+++ b/docs/_posts/2013-06-02-jsfiddle-integration.md
@@ -7,4 +7,3 @@ author: [vjeux]
 
 
 <blockquote class="twitter-tweet" align="center"><p>React (by Facebook) is now available on JSFiddle. <a href="http://t.co/wNQf9JPv5u" title="http://facebook.github.io/react/">facebook.github.io/react/</a></p>&mdash; JSFiddle (@jsfiddle) <a href="https://twitter.com/jsfiddle/status/341114115781177344">June 2, 2013</a></blockquote>
-<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/docs/_posts/2013-09-24-community-roundup-8.md
+++ b/docs/_posts/2013-09-24-community-roundup-8.md
@@ -29,8 +29,6 @@ We've also reached a point where there are too many questions for us to handle d
 While this is not going to work for all the attributes since they are camelCased in React, this is a pretty cool trick.
 
 <div style="margin-left: 74px;"><blockquote class="twitter-tweet"><p>Turn any DOM element into a React.js function: JSXTransformer.transform(&quot;/** <a href="https://twitter.com/jsx">@jsx</a> React.DOM */&quot; + element.innerHTML).code</p>&mdash; Ross Allen (@ssorallen) <a href="https://twitter.com/ssorallen/statuses/377105575441489920">September 9, 2013</a></blockquote></div>
-<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-
 
 ## Remarkable React
 

--- a/docs/_posts/2014-11-25-community-roundup-24.md
+++ b/docs/_posts/2014-11-25-community-roundup-24.md
@@ -95,5 +95,3 @@ We're counting down the days until [React.js Conf](http://conf.reactjs.com) at F
     <blockquote class="twitter-tweet" lang="en"><p>If anyone in Sydney is curious about <a href="https://twitter.com/reactjs">@reactjs</a>, I&#39;m presenting at <a href="https://twitter.com/sydjs">@sydjs</a> tonight on how to use it and why it is the future. <a href="https://twitter.com/hashtag/javascript?src=hash">#javascript</a></p>&mdash; Jed Watson (@JedWatson) <a href="https://twitter.com/JedWatson/status/534943557568565248">November 19, 2014</a></blockquote>
   </div>
 </div>
-
-<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/docs/_posts/2015-02-18-react-conf-roundup-2015.md
+++ b/docs/_posts/2015-02-18-react-conf-roundup-2015.md
@@ -262,7 +262,6 @@ And, in case you missed a session, you can borrow **Michael Chan’s** [drawings
     <blockquote class="twitter-tweet" lang="en"><p>I really love the community shout outs by <a href="https://twitter.com/Vjeux">@vjeux</a> between talks at <a href="https://twitter.com/hashtag/reactjsconf?src=hash">#reactjsconf</a>!</p>&mdash; Andrew Rota (@AndrewRota) <a href="https://twitter.com/AndrewRota/status/560927339522297856">January 29, 2015</a></blockquote>
   </div>
 </div>
-<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 **All proceeds from React.js Conf 2015 were donated to the wonderful programs at [code.org](http://code.org)**. These programs aim to increase access to the field of computer science by underrepresented members of our community. Watch this video to learn more.
 

--- a/docs/_posts/2016-07-22-create-apps-with-no-configuration.md
+++ b/docs/_posts/2016-07-22-create-apps-with-no-configuration.md
@@ -130,7 +130,6 @@ Combining these tools requires some experience with each of them. Even so, it is
 Many of those tools are plugin platforms and don’t directly acknowledge each other’s existence. They leave it up to the users to wire them together. The tools mature and change independently, and tutorials quickly get out of date.
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Marc was almost ready to implement his &quot;hello world&quot; React app <a href="https://t.co/ptdg4yteF1">pic.twitter.com/ptdg4yteF1</a></p>&mdash; Thomas Fuchs (@thomasfuchs) <a href="https://twitter.com/thomasfuchs/status/708675139253174273">March 12, 2016</a></blockquote>
-<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 This doesn’t mean those tools aren’t great. To many of us, they have become indispensable, and we very much appreciate the effort of their maintainers. They already have too much on their plates to worry about the state of the React ecosystem.
 

--- a/docs/_posts/2017-09-26-react-v16.0.md
+++ b/docs/_posts/2017-09-26-react-v16.0.md
@@ -100,7 +100,6 @@ Perhaps the most exciting area we're working on is **async rendering**—a strat
 This demo provides an early peek at the types of problems async rendering can solve:
 
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Ever wonder what &quot;async rendering&quot; means? Here&#39;s a demo of how to coordinate an async React tree with non-React work <a href="https://t.co/3snoahB3uV">https://t.co/3snoahB3uV</a> <a href="https://t.co/egQ988gBjR">pic.twitter.com/egQ988gBjR</a></p>&mdash; Andrew Clark (@acdlite) <a href="https://twitter.com/acdlite/status/909926793536094209">September 18, 2017</a></blockquote>
-<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 *Tip: Pay attention to the spinning black square.*
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,9 +73,4 @@ id: home
       <div id="markdownExample"></div>
     </div>
   </div>
-  <script src="https://unpkg.com/remarkable@1.7.1/dist/remarkable.min.js"></script>
-  <script src="/react/js/examples/hello.js"></script>
-  <script src="/react/js/examples/timer.js"></script>
-  <script src="/react/js/examples/todo.js"></script>
-  <script src="/react/js/examples/markdown.js"></script>
 </section>

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -21,6 +21,7 @@ module.exports = {
     'gatsby-plugin-netlify',
     'gatsby-plugin-glamor',
     'gatsby-plugin-react-next',
+    'gatsby-plugin-twitter',
     {
       resolve: 'gatsby-plugin-nprogress',
       options: {

--- a/www/package.json
+++ b/www/package.json
@@ -23,6 +23,7 @@
     "gatsby-plugin-react-helmet": "^1.0.3",
     "gatsby-plugin-react-next": "^1.0.3",
     "gatsby-plugin-sharp": "^1.6.2",
+    "gatsby-plugin-twitter": "^1.0.10",
     "gatsby-remark-autolink-headers": "^1.4.4",
     "gatsby-remark-copy-linked-files": "^1.5.2",
     "gatsby-remark-images": "^1.5.11",

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -3625,6 +3625,12 @@ gatsby-plugin-sharp@^1.6.2, gatsby-plugin-sharp@^1.6.8:
     progress "^1.1.8"
     sharp "^0.17.3"
 
+gatsby-plugin-twitter@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-twitter/-/gatsby-plugin-twitter-1.0.10.tgz#cac183238442779ddbbc54fb04622c114907af17"
+  dependencies:
+    babel-runtime "^6.26.0"
+
 gatsby-react-router-scroll@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-1.0.1.tgz#2e0132807273e544f05bed016645b6e2dfe08c48"


### PR DESCRIPTION
* Removed unnecessary `<script>` tags from `index.md`
* Added [`gatsby-plugin-twitter`](https://www.gatsbyjs.org/packages/gatsby-plugin-twitter/) (rather than embedding `<script>` tags in markdown) to auto-load Twitter JS for embedded tweets whenever a blog post with an embedded tweet is loaded.

#### Screenshot of [/blog/2013/06/02/jsfiddle-integration.html](https://59cd37b3a6188f07e19012b1--reactjs.netlify.com/blog/2013/06/02/jsfiddle-integration.html)
<img width="617" alt="screen shot 2017-09-28 at 10 58 38 am" src="https://user-images.githubusercontent.com/29597/30982367-03952afa-a43c-11e7-8c72-0d14be0bacd8.png">
