### PR TITLE
[website] a11y fixes

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -27,10 +27,10 @@ React is flexible and can be used in a variety of projects. You can create new a
        top: 1px;
        padding: 10px;
        margin: 0px 2px 0px 2px;
-       border: 1px solid #05A5D1;
+       border: 1px solid #046E8B;
        border-bottom-color: transparent;
        border-radius: 3px 3px 0px 0px;
-       color: #05A5D1;
+       color: #046E8B;
        background-color: transparent;
        font-size: 0.99em;
        cursor: pointer;
@@ -45,7 +45,7 @@ React is flexible and can be used in a variety of projects. You can create new a
       display: inline-block;
       list-style-type: none;
       margin: 0;
-      border-bottom: 1px solid #05A5D1;
+      border-bottom: 1px solid #046E8B;
       cursor: default;
     }
     @media screen and (max-width: 960px) {
@@ -53,7 +53,7 @@ React is flexible and can be used in a variety of projects. You can create new a
       .toggler li:first-child,
       .toggler li:last-child {
         display: block;
-        border-bottom-color: #05A5D1;
+        border-bottom-color: #046E8B;
         border-radius: 3px;
         margin: 2px 0px 2px 0px;
       }
@@ -64,13 +64,13 @@ React is flexible and can be used in a variety of projects. You can create new a
     .display-target-fiddle .toggler .button-fiddle:focus,
     .display-target-newapp .toggler .button-newapp:focus,
     .display-target-existingapp .toggler .button-existingapp:focus {
-      background-color: #046E8B;
+      border: solid 1px #61dafb;;
       color: white;
     }
     .display-target-fiddle .toggler .button-fiddle,
     .display-target-newapp .toggler .button-newapp,
     .display-target-existingapp .toggler .button-existingapp {
-      background-color: #05A5D1;
+      background-color: #046E8B;
       color: white;
     }
     section {

--- a/www/src/components/LayoutHeader/Header.js
+++ b/www/src/components/LayoutHeader/Header.js
@@ -194,6 +194,7 @@ const Header = ({location}) => (
             id="algolia-doc-search"
             type="search"
             placeholder="Search docs"
+            aria-label="Search docs"
           />
         </form>
 


### PR DESCRIPTION
**what is the change?:**
- adds 'aria-label' to search input
- increase contrast of 'installation' page tabs

**details/why:**
We needed an 'aria-label';
There was no label on this input, and screen readers might not have been
able to identify it's purpose.
[The `placeholder` doesn't count as a label.](http://a11yproject.com/posts/placeholder-input-elements/)

We needed more contrast;
Without sufficient contrast, some users may not be able to read the text on the
tabs.
Changed the dark blue used for the text/background of the tabs on the
'installation' page to a slightly darker blue, which we were already
using for the 'focus' style of the tabs. It looked a bit weird before,
imo, when the 'focus' was darker.

Now the 'focus' style just lightens the border to the new signature
blue.

We plan to refactor this page and remove the tabs soon, so not too
worried about making this fix perfect.

**test plan:**
Manual testing - loaded the pages and things look, and ran aXe a11y audit, no
more warnings about these two issues. :)

<img width="1237" alt="screen shot 2017-09-28 at 11 02 03 am" src="https://user-images.githubusercontent.com/1114467/30983056-21b63a0e-a43e-11e7-80f9-eb86151a52d8.png">
