### PR TITLE
[Gatsby] Increase the color contrast of the Meta Title when not "ondark"

### DIFF
--- a/www/src/templates/components/MetaTitle/index.js
+++ b/www/src/templates/components/MetaTitle/index.js
@@ -22,7 +22,7 @@ const MetaTitle = ({
   <div
     onClick={onClick}
     css={{
-      color: onDark ? colors.subtleOnDark : colors.subtle,
+      color: onDark ? colors.subtleOnDark : colors.dark,
       cursor: onClick ? 'pointer' : null,
       fontSize: 14,
       fontWeight: 700,


### PR DESCRIPTION
Hi,

This PR necessarily solves the problem here: https://github.com/facebook/react/issues/10929

I don't know if it's "cool", but now the contrast issue is gone.

This is my first time contributing React. And I'm so thrilled even it's a so tiny improvement. Thank you all!
