### PR TITLE
remove note about license for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,5 +62,3 @@ To help you get your feet wet and get you familiar with our contribution process
 React is [MIT licensed](./LICENSE).
 
 React documentation is [Creative Commons licensed](./LICENSE-docs).
-
-Examples provided in this repository and in the documentation are [separately licensed](./LICENSE-examples).


### PR DESCRIPTION
removing the old mention of license for examples. since there is no examples in the repository and also because the license for them was deleted [here](https://github.com/facebook/react/pull/10890)
