### PR TITLE
Fix website font flicker

### DIFF
--- a/www/src/css/algolia.css
+++ b/www/src/css/algolia.css
@@ -401,7 +401,7 @@
   color: #222222;
   background-color: #EBEBEB;
   border-radius: 3px;
-  font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
 .algolia-autocomplete .algolia-docsearch-suggestion code .algolia-docsearch-suggestion--highlight {

--- a/www/src/css/reset.css
+++ b/www/src/css/reset.css
@@ -1,6 +1,6 @@
 html {
   box-sizing: border-box;
-  font-family: "proxima-nova", sans-serif;
+  font-family: sans-serif;
   font-style: normal;
   -webkit-font-smoothing: antialiased;
 }
@@ -35,5 +35,5 @@ img {
 }
 
 pre, code {
-  font-family: source-code-pro, Menlo, Consolas, "Courier New", monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }

--- a/www/src/html.js
+++ b/www/src/html.js
@@ -49,12 +49,6 @@ export default class HTML extends Component {
             content="width=device-width, initial-scale=1.0"
           />
           <link rel="icon" href="/favicon.ico" />
-          <script src="https://use.typekit.net/vqa1hcx.js" />
-          <script
-            dangerouslySetInnerHTML={{
-              __html: 'try{Typekit.load({ async: true });}catch(e){}',
-            }}
-          />
           {this.props.headComponents}
           {js}
           {css}

--- a/www/src/html.js
+++ b/www/src/html.js
@@ -49,6 +49,12 @@ export default class HTML extends Component {
             content="width=device-width, initial-scale=1.0"
           />
           <link rel="icon" href="/favicon.ico" />
+          <script src="https://use.typekit.net/vqa1hcx.js" />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: 'try{Typekit.load({ async: true });}catch(e){}',
+            }}
+          />
           {this.props.headComponents}
           {js}
           {css}
@@ -59,12 +65,6 @@ export default class HTML extends Component {
             dangerouslySetInnerHTML={{__html: this.props.body}}
           />
           {this.props.postBodyComponents}
-          <script src="https://use.typekit.net/vqa1hcx.js" />
-          <script
-            dangerouslySetInnerHTML={{
-              __html: 'try{Typekit.load({ async: true });}catch(e){}',
-            }}
-          />
         </body>
       </html>
     );


### PR DESCRIPTION
I tried moving the TypeKit tag from the bottom of the `<body>` to the `<head>` but this didn't resolve the flicker. According to [the docs](https://helpx.adobe.com/typekit/using/embed-codes.html) this is actually expected. TBH this flicker existed on the legacy site as well so I'm not sure how high-priority it is but it _is_ annoying.

So I'm now leaning towards removing TypeKit entirely and just using `sans-serif` font. Joe is going to circle back to this tomorrow and try out some other fonts that don't require using TypeKit (eg San Francisco). I think we could merge this PR for now (to remove the flicker) and then merge his later (to make things look better).

Netlify preview: https://59ce854bdf99532e00fdf5d0--reactjs.netlify.com/

cc @vjeux