### PR TITLE
fix(examples/todo): don't submit empty values

### DIFF
--- a/docs/_js/examples/todo.js
+++ b/docs/_js/examples/todo.js
@@ -26,6 +26,9 @@ class TodoApp extends React.Component {
 
   handleSubmit(e) {
     e.preventDefault();
+    if (!this.state.text.length) {
+      return;
+    }
     var newItem = {
       text: this.state.text,
       id: Date.now()


### PR DESCRIPTION
This PR fixes a problem in the live example on the homepage which we can submit empty todo items:

<img src="https://user-images.githubusercontent.com/5158436/31038629-cb4577aa-a584-11e7-86b1-9dc047fb375f.png" width="250px" />

