### PR TITLE
[Gatsby] Installation tabs design

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -27,13 +27,16 @@ React is flexible and can be used in a variety of projects. You can create new a
        top: 1px;
        padding: 10px;
        margin: 0px 2px 0px 2px;
-       border: 1px solid #046E8B;
        border-bottom-color: transparent;
        border-radius: 3px 3px 0px 0px;
-       color: #046E8B;
+       color: #373940;
        background-color: transparent;
        font-size: 0.99em;
        cursor: pointer;
+       opacity: 0.5;
+    }
+    .toggler li:active {
+      opacity: 1;
     }
     .toggler li:first-child {
       margin-left: 0;
@@ -45,33 +48,30 @@ React is flexible and can be used in a variety of projects. You can create new a
       display: inline-block;
       list-style-type: none;
       margin: 0;
-      border-bottom: 1px solid #046E8B;
+      border-bottom: 1px solid #ececec;
       cursor: default;
+      margin: 0 -15px;
+      padding: 0 15px;
     }
     @media screen and (max-width: 960px) {
       .toggler li,
       .toggler li:first-child,
       .toggler li:last-child {
         display: block;
-        border-bottom-color: #046E8B;
         border-radius: 3px;
         margin: 2px 0px 2px 0px;
-      }
-      .toggler ul {
-        border-bottom: 0;
       }
     }
     .display-target-fiddle .toggler .button-fiddle:focus,
     .display-target-newapp .toggler .button-newapp:focus,
     .display-target-existingapp .toggler .button-existingapp:focus {
-      border: solid 1px #61dafb;;
-      color: white;
+      opacity: 1;
     }
     .display-target-fiddle .toggler .button-fiddle,
     .display-target-newapp .toggler .button-newapp,
     .display-target-existingapp .toggler .button-existingapp {
-      background-color: #046E8B;
-      color: white;
+      opacity: 1;
+      font-weight: 700;
     }
     section {
       display: none;


### PR DESCRIPTION
I've updated the design of the Installation, as they were untreated since the previous design. The idea here was to simplify them to make them more obvious.

cc @gaearon 

<img width="1440" alt="installation-tabs" src="https://user-images.githubusercontent.com/24449/31045643-3cd6e7ae-a5e0-11e7-8ba9-ae2371a6f1af.png">
