### PR TITLE
Live code editor ignores tab key for improved a11y

### DIFF
--- a/www/src/components/CodeEditor/CodeEditor.js
+++ b/www/src/components/CodeEditor/CodeEditor.js
@@ -133,7 +133,7 @@ class CodeEditor extends Component {
                   },
                 }}
                 className="gatsby-highlight">
-                <LiveEditor onChange={this._onChange} />
+                <LiveEditor onChange={this._onChange} ignoreTabKey={true} />
               </div>
             </div>
             {error &&


### PR DESCRIPTION
Resolves #10976

Note that the use of `ignoreTabKey` currently triggers a DOM warning due to `react-live` but I will follow up with an upstream fix (see FormidableLabs/react-live/pull/40).