### PR TITLE
Update Reference-readme to remove React.DOM

### DIFF
--- a/docs/docs/reference-react.md
+++ b/docs/docs/reference-react.md
@@ -90,8 +90,6 @@ React.createElement(
 
 Create and return a new [React element](/docs/rendering-elements.html) of the given type. The type argument can be either a tag name string (such as `'div'` or `'span'`), or a [React component](/docs/components-and-props.html) type (a class or a function).
 
-Convenience wrappers around `React.createElement()` for DOM components are provided by `React.DOM`. For example, `React.DOM.a(...)` is a convenience wrapper for `React.createElement('a', ...)`. They are considered legacy, and we encourage you to either use JSX or use `React.createElement()` directly instead.
-
 Code written with [JSX](/docs/introducing-jsx.html) will be converted to use `React.createElement()`. You will not typically invoke `React.createElement()` directly if you are using JSX. See [React Without JSX](/docs/react-without-jsx.html) to learn more.
 
 * * *


### PR DESCRIPTION
`React.DOM` is now Undefined in React 16 so `React.DOM.div` or `React.DOM.button` are no longer possible.
