### PR TITLE
Fix createPortal link in API docs

### DIFF
--- a/docs/docs/reference-react-dom.md
+++ b/docs/docs/reference-react-dom.md
@@ -16,7 +16,7 @@ The `react-dom` package provides DOM-specific methods that can be used at the to
 - [`hydrate()`](#hydrate)
 - [`unmountComponentAtNode()`](#unmountcomponentatnode)
 - [`findDOMNode()`](#finddomnode)
-- [`createPortal()`](#createPortal)
+- [`createPortal()`](#createportal)
 
 ### Browser Support
 


### PR DESCRIPTION
The anchor name is lower case
