### PR TITLE
Garbage collection

### DIFF
--- a/fixtures/fiber-triangle/index.html
+++ b/fixtures/fiber-triangle/index.html
@@ -76,51 +76,54 @@
         }
       }
 
-      function SierpinskiTriangle({ x, y, s, children }) {
-        if (s <= targetSize) {
-          return (
-            <Dot
-              x={x - (targetSize / 2)}
-              y={y - (targetSize / 2)}
-              size={targetSize}
-              text={children}
-            />
+      class SierpinskiTriangle extends React.Component {
+        shouldComponentUpdate(nextProps) {
+          var o = this.props;
+          var n = nextProps;
+          return !(
+            o.x === n.x &&
+            o.y === n.y &&
+            o.s === n.s &&
+            o.children === n.children
           );
-          return r;
         }
-        var newSize = s / 2;
-        var slowDown = true;
-        if (slowDown) {
-          var e = performance.now() + 0.8;
-          while (performance.now() < e) {
-            // Artificially long execution time.
+        render() {
+          let {x, y, s, children} = this.props;
+          if (s <= targetSize) {
+            return (
+              <Dot
+                x={x - (targetSize / 2)}
+                y={y - (targetSize / 2)}
+                size={targetSize}
+                text={children}
+              />
+            );
+            return r;
           }
+          var newSize = s / 2;
+          var slowDown = true;
+          if (slowDown) {
+            var e = performance.now() + 0.8;
+            while (performance.now() < e) {
+              // Artificially long execution time.
+            }
+          }
+
+          s /= 2;
+
+          return [
+            <SierpinskiTriangle x={x} y={y - (s / 2)} s={s}>
+              {children}
+            </SierpinskiTriangle>,
+            <SierpinskiTriangle x={x - s} y={y + (s / 2)} s={s}>
+              {children}
+            </SierpinskiTriangle>,
+            <SierpinskiTriangle x={x + s} y={y + (s / 2)} s={s}>
+              {children}
+            </SierpinskiTriangle>,
+          ];
         }
-
-        s /= 2;
-
-        return [
-          <SierpinskiTriangle x={x} y={y - (s / 2)} s={s}>
-            {children}
-          </SierpinskiTriangle>,
-          <SierpinskiTriangle x={x - s} y={y + (s / 2)} s={s}>
-            {children}
-          </SierpinskiTriangle>,
-          <SierpinskiTriangle x={x + s} y={y + (s / 2)} s={s}>
-            {children}
-          </SierpinskiTriangle>,
-        ];
       }
-      SierpinskiTriangle.shouldComponentUpdate = function(oldProps, newProps) {
-        var o = oldProps;
-        var n = newProps;
-        return !(
-          o.x === n.x &&
-          o.y === n.y &&
-          o.s === n.s &&
-          o.children === n.children
-        );
-      };
 
       class ExampleApplication extends React.Component {
         constructor() {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "glob-stream": "^6.1.0",
     "gzip-js": "~0.3.2",
     "gzip-size": "^3.0.0",
+    "jasmine-check": "^1.0.0-rc.0",
     "jest": "20.1.0-delta.1",
     "jest-config": "20.1.0-delta.1",
     "jest-jasmine2": "20.1.0-delta.1",

--- a/scripts/jest/test-framework-setup.js
+++ b/scripts/jest/test-framework-setup.js
@@ -68,4 +68,6 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
     return expectation;
   };
   global.expectDev = expectDev;
+
+  require('jasmine-check').install();
 }

--- a/src/renderers/art/ReactARTFiberEntry.js
+++ b/src/renderers/art/ReactARTFiberEntry.js
@@ -532,10 +532,7 @@ const ARTRenderer = ReactFiberReconciler({
     );
   },
 
-  now(): number {
-    // TODO: Enable expiration by implementing this method.
-    return 0;
-  },
+  now: ReactDOMFrameScheduling.now,
 
   useSyncScheduling: true,
 });

--- a/src/renderers/art/ReactARTFiberEntry.js
+++ b/src/renderers/art/ReactARTFiberEntry.js
@@ -532,6 +532,11 @@ const ARTRenderer = ReactFiberReconciler({
     );
   },
 
+  now(): number {
+    // TODO: Enable expiration by implementing this method.
+    return 0;
+  },
+
   useSyncScheduling: true,
 });
 

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -21,7 +21,6 @@ var ReactDOMFiberOption = require('ReactDOMFiberOption');
 var ReactDOMFiberSelect = require('ReactDOMFiberSelect');
 var ReactDOMFiberTextarea = require('ReactDOMFiberTextarea');
 var {getCurrentFiberOwnerName} = require('ReactDebugCurrentFiber');
-var {DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE} = require('HTMLNodeType');
 
 var assertValidProps = require('assertValidProps');
 var emptyFunction = require('fbjs/lib/emptyFunction');
@@ -148,24 +147,6 @@ if (__DEV__) {
   };
 }
 
-function ensureListeningTo(rootContainerElement, registrationName) {
-  var isDocumentOrFragment =
-    rootContainerElement.nodeType === DOCUMENT_NODE ||
-    rootContainerElement.nodeType === DOCUMENT_FRAGMENT_NODE;
-  var doc = isDocumentOrFragment
-    ? rootContainerElement
-    : rootContainerElement.ownerDocument;
-  listenTo(registrationName, doc);
-}
-
-function getOwnerDocumentFromRootContainer(
-  rootContainerElement: Element | Document,
-): Document {
-  return rootContainerElement.nodeType === DOCUMENT_NODE
-    ? (rootContainerElement: any)
-    : rootContainerElement.ownerDocument;
-}
-
 // There are so many media events, it makes sense to just
 // maintain a list rather than create a `trapBubbledEvent` for each
 var mediaEvents = {
@@ -209,7 +190,7 @@ function trapClickOnNonInteractiveElement(node: HTMLElement) {
 
 function setInitialDOMProperties(
   domElement: Element,
-  rootContainerElement: Element | Document,
+  ownerDocument: Document,
   nextProps: Object,
   isCustomComponentTag: boolean,
 ): void {
@@ -246,7 +227,7 @@ function setInitialDOMProperties(
         if (__DEV__ && typeof nextProp !== 'function') {
           warnForInvalidEventListener(propKey, nextProp);
         }
-        ensureListeningTo(rootContainerElement, propKey);
+        listenTo(propKey, ownerDocument);
       }
     } else if (isCustomComponentTag) {
       DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
@@ -300,14 +281,12 @@ var ReactDOMFiberComponent = {
   createElement(
     type: *,
     props: Object,
-    rootContainerElement: Element | Document,
+    ownerDocument: Document,
     parentNamespace: string,
   ): Element {
     // We create tags in the namespace of their parent container, except HTML
     // tags get no namespace.
-    var ownerDocument: Document = getOwnerDocumentFromRootContainer(
-      rootContainerElement,
-    );
+
     var domElement: Element;
     var namespaceURI = parentNamespace;
     if (namespaceURI === HTML_NAMESPACE) {
@@ -370,17 +349,15 @@ var ReactDOMFiberComponent = {
     return domElement;
   },
 
-  createTextNode(text: string, rootContainerElement: Element | Document): Text {
-    return getOwnerDocumentFromRootContainer(
-      rootContainerElement,
-    ).createTextNode(text);
+  createTextNode(text: string, ownerDocument: Document): Text {
+    return ownerDocument.createTextNode(text);
   },
 
   setInitialProperties(
     domElement: Element,
     tag: string,
     rawProps: Object,
-    rootContainerElement: Element | Document,
+    ownerDocument: Document,
   ): void {
     var isCustomComponentTag = isCustomComponent(tag, rawProps);
     if (__DEV__) {
@@ -475,7 +452,7 @@ var ReactDOMFiberComponent = {
         );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
-        ensureListeningTo(rootContainerElement, 'onChange');
+        listenTo('onChange', ownerDocument);
         break;
       case 'option':
         ReactDOMFiberOption.validateProps(domElement, rawProps);
@@ -491,7 +468,7 @@ var ReactDOMFiberComponent = {
         );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
-        ensureListeningTo(rootContainerElement, 'onChange');
+        listenTo('onChange', ownerDocument);
         break;
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
@@ -503,7 +480,7 @@ var ReactDOMFiberComponent = {
         );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
-        ensureListeningTo(rootContainerElement, 'onChange');
+        listenTo('onChange', ownerDocument);
         break;
       default:
         props = rawProps;
@@ -513,7 +490,7 @@ var ReactDOMFiberComponent = {
 
     setInitialDOMProperties(
       domElement,
-      rootContainerElement,
+      ownerDocument,
       props,
       isCustomComponentTag,
     );
@@ -552,7 +529,7 @@ var ReactDOMFiberComponent = {
     tag: string,
     lastRawProps: Object,
     nextRawProps: Object,
-    rootContainerElement: Element | Document,
+    ownerDocument: Document,
   ): null | Array<mixed> {
     if (__DEV__) {
       validatePropertiesInDevelopment(tag, nextRawProps);
@@ -724,7 +701,7 @@ var ReactDOMFiberComponent = {
           if (__DEV__ && typeof nextProp !== 'function') {
             warnForInvalidEventListener(propKey, nextProp);
           }
-          ensureListeningTo(rootContainerElement, propKey);
+          listenTo(propKey, ownerDocument);
         }
         if (!updatePayload && lastProp !== nextProp) {
           // This is a special case. If any listener updates we need to ensure
@@ -791,7 +768,7 @@ var ReactDOMFiberComponent = {
     tag: string,
     rawProps: Object,
     parentNamespace: string,
-    rootContainerElement: Element | Document,
+    ownerDocument: Document,
   ): null | Array<mixed> {
     if (__DEV__) {
       var isCustomComponentTag = isCustomComponent(tag, rawProps);
@@ -878,7 +855,7 @@ var ReactDOMFiberComponent = {
         );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
-        ensureListeningTo(rootContainerElement, 'onChange');
+        listenTo('onChange', ownerDocument);
         break;
       case 'option':
         ReactDOMFiberOption.validateProps(domElement, rawProps);
@@ -892,7 +869,7 @@ var ReactDOMFiberComponent = {
         );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
-        ensureListeningTo(rootContainerElement, 'onChange');
+        listenTo('onChange', ownerDocument);
         break;
       case 'textarea':
         ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
@@ -903,7 +880,7 @@ var ReactDOMFiberComponent = {
         );
         // For controlled components we always need to ensure we're listening
         // to onChange. Even if there is no listener.
-        ensureListeningTo(rootContainerElement, 'onChange');
+        listenTo('onChange', ownerDocument);
         break;
     }
 
@@ -970,7 +947,7 @@ var ReactDOMFiberComponent = {
           if (__DEV__ && typeof nextProp !== 'function') {
             warnForInvalidEventListener(propKey, nextProp);
           }
-          ensureListeningTo(rootContainerElement, propKey);
+          listenTo(propKey, ownerDocument);
         }
       } else if (__DEV__) {
         // Validate that the properties correspond to their expected values.

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -159,6 +159,22 @@ function shouldAutoFocusHostComponent(type: string, props: Props): boolean {
   return false;
 }
 
+// TODO: Better polyfill
+let now;
+if (
+  typeof window !== 'undefined' &&
+  window.performance &&
+  typeof window.performance.now === 'function'
+) {
+  now = function() {
+    return performance.now();
+  };
+} else {
+  now = function() {
+    return Date.now();
+  };
+}
+
 var DOMRenderer = ReactFiberReconciler({
   getRootHostContext(rootContainerInstance: Container): HostContext {
     let type;
@@ -433,6 +449,8 @@ var DOMRenderer = ReactFiberReconciler({
       container.removeChild(child);
     }
   },
+
+  now: now,
 
   canHydrateInstance(
     instance: Instance | TextInstance,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -160,20 +160,20 @@ function shouldAutoFocusHostComponent(type: string, props: Props): boolean {
 }
 
 // TODO: Better polyfill
-// let now;
-// if (
-//   typeof window !== 'undefined' &&
-//   window.performance &&
-//   typeof window.performance.now === 'function'
-// ) {
-//   now = function() {
-//     return performance.now();
-//   };
-// } else {
-//   now = function() {
-//     return Date.now();
-//   };
-// }
+let now;
+if (
+  typeof window !== 'undefined' &&
+  window.performance &&
+  typeof window.performance.now === 'function'
+) {
+  now = function() {
+    return performance.now();
+  };
+} else {
+  now = function() {
+    return Date.now();
+  };
+}
 
 var DOMRenderer = ReactFiberReconciler({
   getRootHostContext(rootContainerInstance: Container): HostContext {
@@ -452,7 +452,8 @@ var DOMRenderer = ReactFiberReconciler({
 
   now() {
     // TODO: Use performance.now to enable expiration
-    return 0;
+    // return 0;
+    return now();
   },
 
   canHydrateInstance(

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -159,22 +159,6 @@ function shouldAutoFocusHostComponent(type: string, props: Props): boolean {
   return false;
 }
 
-// TODO: Better polyfill
-let now;
-if (
-  typeof window !== 'undefined' &&
-  window.performance &&
-  typeof window.performance.now === 'function'
-) {
-  now = function() {
-    return performance.now();
-  };
-} else {
-  now = function() {
-    return Date.now();
-  };
-}
-
 var DOMRenderer = ReactFiberReconciler({
   getRootHostContext(rootContainerInstance: Container): HostContext {
     let type;
@@ -450,7 +434,7 @@ var DOMRenderer = ReactFiberReconciler({
     }
   },
 
-  now,
+  now: ReactDOMFrameScheduling.now,
 
   canHydrateInstance(
     instance: Instance | TextInstance,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -740,7 +740,7 @@ type PublicRoot = {
 
 function PublicRootNode(
   container: DOMContainer | (() => DOMContainer),
-  namespace: ?string,
+  namespace?: string,
 ) {
   if (typeof container === 'function') {
     if (typeof namespace !== 'string') {
@@ -788,7 +788,7 @@ PublicRootNode.prototype.unmount = function(callback) {
 var ReactDOMFiber = {
   unstable_createRoot(
     container: DOMContainer | (() => DOMContainer),
-    namespace: ?string,
+    namespace?: string,
   ): PublicRoot {
     return new PublicRootNode(container, namespace);
   },

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -160,20 +160,20 @@ function shouldAutoFocusHostComponent(type: string, props: Props): boolean {
 }
 
 // TODO: Better polyfill
-let now;
-if (
-  typeof window !== 'undefined' &&
-  window.performance &&
-  typeof window.performance.now === 'function'
-) {
-  now = function() {
-    return performance.now();
-  };
-} else {
-  now = function() {
-    return Date.now();
-  };
-}
+// let now;
+// if (
+//   typeof window !== 'undefined' &&
+//   window.performance &&
+//   typeof window.performance.now === 'function'
+// ) {
+//   now = function() {
+//     return performance.now();
+//   };
+// } else {
+//   now = function() {
+//     return Date.now();
+//   };
+// }
 
 var DOMRenderer = ReactFiberReconciler({
   getRootHostContext(rootContainerInstance: Container): HostContext {
@@ -450,7 +450,10 @@ var DOMRenderer = ReactFiberReconciler({
     }
   },
 
-  now: now,
+  now() {
+    // TODO: Use performance.now to enable expiration
+    return 0;
+  },
 
   canHydrateInstance(
     instance: Instance | TextInstance,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -786,7 +786,7 @@ PublicRootNode.prototype.unmount = function(callback) {
 };
 
 var ReactDOMFiber = {
-  unstable_create(
+  unstable_createRoot(
     container: DOMContainer | (() => DOMContainer),
     namespace: ?string,
   ): PublicRoot {

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -450,11 +450,7 @@ var DOMRenderer = ReactFiberReconciler({
     }
   },
 
-  now() {
-    // TODO: Use performance.now to enable expiration
-    // return 0;
-    return now();
-  },
+  now,
 
   canHydrateInstance(
     instance: Instance | TextInstance,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -732,7 +732,7 @@ function createPortal(
 type PublicRoot = {
   render(children: ReactNodeList, callback: ?() => mixed): void,
   prerender(children: ReactNodeList): Work,
-  unmount(callback: ?() => mixed): Work,
+  unmount(callback: ?() => mixed): void,
 
   _reactRootContainer: *,
   _getComponent: () => DOMContainer,

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {Work} from 'ReactFiberReconciler';
 import type {ReactNodeList} from 'ReactTypes';
 
 require('checkReact');
@@ -728,7 +729,64 @@ function createPortal(
   return ReactPortal.createPortal(children, container, null, key);
 }
 
+type PublicRoot = {
+  render(children: ReactNodeList, callback: () => mixed): Work,
+  prerender(children: ReactNodeList, callback: () => mixed): Work,
+  unmount(callback: () => mixed): Work,
+
+  _reactRootContainer: *,
+  _getComponent: () => DOMContainer,
+};
+
+function PublicRootNode(
+  container: DOMContainer | (() => DOMContainer),
+  namespace: ?string,
+) {
+  if (typeof container === 'function') {
+    if (typeof namespace !== 'string') {
+      // Default to HTML namespace
+      namespace = DOMNamespaces.html;
+    }
+    this._reactRootContainer = DOMRenderer.createContainer(namespace);
+    this._getComponent = container;
+  } else {
+    // Assume this is a DOM container
+    const domContainer: DOMContainer = (container: any);
+    this._reactRootContainer = DOMRenderer.createContainer(domContainer);
+    this._getComponent = function() {
+      return domContainer;
+    };
+  }
+}
+PublicRootNode.prototype.render = function(
+  children: ReactNodeList,
+  callback: () => mixed,
+): Work {
+  return DOMRenderer.updateContainer(
+    children,
+    this._reactRootContainer,
+    null,
+    callback,
+  );
+};
+PublicRootNode.prototype.prerender = function() {};
+PublicRootNode.prototype.unmount = function() {
+  return DOMRenderer.updateContainer(
+    null,
+    this._reactRootContainer,
+    null,
+    null,
+  );
+};
+
 var ReactDOMFiber = {
+  unstable_create(
+    container: DOMContainer | (() => DOMContainer),
+    namespace: ?string,
+  ): PublicRoot {
+    return new PublicRootNode(container, namespace);
+  },
+
   createPortal,
 
   findDOMNode(

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -89,17 +89,20 @@ ReactControlledComponent.injection.injectFiberControlledHostComponent(
 
 type DOMContainer =
   | (Element & {
-    _reactRootContainer: ?Object,
+    _reactRootContainer?: Object | null,
   })
   | (Document & {
-    _reactRootContainer: ?Object,
+    _reactRootContainer?: Object | null,
   });
 
-type Container =
-  | Element
-  | Document
-  // If the DOM container is lazily provided, the container is the namespace uri
-  | string;
+type LazyContainer = {
+  namespace: string,
+  ownerDocument: Document,
+  getContainer: () => Element | DOMContainer,
+  _reactRootContainer?: Object | null,
+};
+
+type Container = DOMContainer | LazyContainer;
 
 type Props = {
   autoFocus?: boolean,
@@ -119,10 +122,15 @@ type HostContext = HostContextDev | HostContextProd;
 let eventsEnabled: ?boolean = null;
 let selectionInformation: ?mixed = null;
 
+function isLazyContainer(container: Container): boolean {
+  return typeof (container: any).getContainer === 'function';
+}
+
 function getOwnerDocument(container: Container): Document {
   let ownerDocument;
-  if (typeof container === 'string') {
-    ownerDocument = document;
+  if (isLazyContainer(container)) {
+    const lazyContainer: LazyContainer = (container: any);
+    ownerDocument = lazyContainer.ownerDocument;
   } else if (container.nodeType === DOCUMENT_NODE) {
     ownerDocument = (container: any);
   } else {
@@ -131,14 +139,17 @@ function getOwnerDocument(container: Container): Document {
   return ownerDocument;
 }
 
-function ensureDOMContainer(container: Container): Element | Document {
+function ensureDOMContainer(container: Container): DOMContainer {
+  if (!isLazyContainer(container)) {
+    return ((container: any): DOMContainer);
+  }
+  const lazyContainer: LazyContainer = (container: any);
+  const domContainer = lazyContainer.getContainer();
   invariant(
-    typeof container !== 'string',
-    // TODO: Better error message. Probably should have errored already, when
-    // validating the result of getContainer.
+    container !== null && container !== undefined,
+    // TODO: Better error message.
     'Container should have resolved by now',
   );
-  const domContainer: Element | Document = (container: any);
   return domContainer;
 }
 
@@ -192,8 +203,9 @@ var DOMRenderer = ReactFiberReconciler({
   getRootHostContext(rootContainerInstance: Container): HostContext {
     let type;
     let namespace;
-    if (typeof rootContainerInstance === 'string') {
-      namespace = rootContainerInstance;
+
+    if (isLazyContainer(rootContainerInstance)) {
+      namespace = ((rootContainerInstance: any): LazyContainer).namespace;
       if (__DEV__) {
         return {namespace, ancestorInfo: null};
       }
@@ -735,28 +747,21 @@ type PublicRoot = {
   unmount(callback: ?() => mixed): void,
 
   _reactRootContainer: *,
-  _getComponent: () => DOMContainer,
 };
 
-function PublicRootNode(
-  container: DOMContainer | (() => DOMContainer),
+type RootOptions = {
+  hydrate?: boolean,
+};
+
+type LazyRootOptions = {
   namespace?: string,
-) {
-  if (typeof container === 'function') {
-    if (typeof namespace !== 'string') {
-      // Default to HTML namespace
-      namespace = DOMNamespaces.html;
-    }
-    this._reactRootContainer = DOMRenderer.createContainer(namespace);
-    this._getComponent = container;
-  } else {
-    // Assume this is a DOM container
-    const domContainer: DOMContainer = (container: any);
-    this._reactRootContainer = DOMRenderer.createContainer(domContainer);
-    this._getComponent = function() {
-      return domContainer;
-    };
-  }
+  ownerDocument?: Document,
+};
+
+function PublicRootNode(container: Container, hydrate: boolean) {
+  const root = DOMRenderer.createContainer(container);
+  root.hydrate = hydrate;
+  this._reactRootContainer = root;
 }
 PublicRootNode.prototype.render = function(
   children: ReactNodeList,
@@ -787,10 +792,38 @@ PublicRootNode.prototype.unmount = function(callback) {
 
 var ReactDOMFiber = {
   unstable_createRoot(
-    container: DOMContainer | (() => DOMContainer),
-    namespace?: string,
+    container: DOMContainer,
+    options?: RootOptions,
   ): PublicRoot {
-    return new PublicRootNode(container, namespace);
+    let hydrate = false;
+    if (options != null && options.hydrate !== undefined) {
+      hydrate = options.hydrate;
+    }
+    return new PublicRootNode(container, hydrate);
+  },
+
+  unstable_createLazyRoot(
+    getContainer: () => DOMContainer,
+    options?: LazyRootOptions,
+  ): PublicRoot {
+    // Default to HTML namespace
+    let namespace = DOMNamespaces.html;
+    // Default to global document
+    let ownerDocument = document;
+    if (options != null) {
+      if (options.namespace != null) {
+        namespace = options.namespace;
+      }
+      if (options.ownerDocument != null) {
+        ownerDocument = options.ownerDocument;
+      }
+    }
+    const container = {
+      getContainer,
+      namespace,
+      ownerDocument,
+    };
+    return new PublicRootNode(container, false);
   },
 
   createPortal,

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiber-test.js
@@ -1142,7 +1142,7 @@ describe('ReactDOMFiber', () => {
     expect(iframeContainer.appendChild).toHaveBeenCalledTimes(1);
   });
 
-  it('should mount into a document fragment', () => {
+  fit('should mount into a document fragment', () => {
     var fragment = document.createDocumentFragment();
     ReactDOM.render(<div>foo</div>, fragment);
     expect(container.innerHTML).toBe('');

--- a/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
+++ b/src/renderers/dom/fiber/__tests__/ReactDOMFiberAsync-test.js
@@ -284,8 +284,8 @@ describe('ReactDOMFiberAsync', () => {
 
       // Flush the async updates
       jest.runAllTimers();
-      expect(container.textContent).toEqual('BCAD');
-      expect(ops).toEqual(['BC', 'BCAD']);
+      expect(container.textContent).toEqual('ABCD');
+      expect(ops).toEqual(['BC', 'ABCD']);
     });
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
@@ -56,6 +56,18 @@ describe('ReactDOMAsyncRoot', () => {
 
       jest.runAllTimers();
     });
+
+    it('resolves `then` callback synchronously if update is sync', () => {
+      const container = document.createElement('div');
+      const root = ReactDOM.unstable_createRoot(container);
+      const work = root.prerender(<div>Hi</div>);
+      work.then(() => {
+        work.commit();
+        expect(container.textContent).toEqual('Hi');
+      });
+      // `then` should have synchronously resolved
+      expect(container.textContent).toEqual('Hi');
+    });
   } else {
     it('does not apply to stack');
   }

--- a/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let ReactFeatureFlags;
+
+describe('ReactDOMAsyncMount', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactFeatureFlags = require('ReactFeatureFlags');
+    ReactFeatureFlags.enableAsyncSubtreeAPI = true;
+  });
+
+  it('works in easy mode', () => {
+    const container = document.createElement('div');
+    const root = ReactDOM.unstable_create(container);
+    root.render(<div>Foo</div>);
+    expect(container.textContent).toEqual('Foo');
+    root.render(<div>Bar</div>);
+    expect(container.textContent).toEqual('Bar');
+    root.unmount();
+    expect(container.textContent).toEqual('');
+  });
+
+  it('can pass callback to render', () => {
+    const container = document.createElement('div');
+    const root = ReactDOM.unstable_create(container);
+    let called = false;
+    root.render(<div>Foo</div>, () => {
+      called = true;
+    });
+    expect(container.textContent).toEqual('Foo');
+    expect(called).toBe(true);
+  });
+
+  it('can await result of render method', async () => {
+    const container = document.createElement('div');
+    const root = ReactDOM.unstable_create(container);
+    await root.render(<div>Foo</div>);
+    expect(container.textContent).toEqual('Foo');
+  });
+
+  it('can defer commit using prerender', async () => {
+    const Async = React.unstable_AsyncComponent;
+    const container = document.createElement('div');
+    const root = ReactDOM.unstable_create(container);
+    const work = root.prerender(<Async>Foo</Async>);
+
+    // Hasn't updated yet
+    expect(container.textContent).toEqual('');
+
+    await work;
+
+    // Tree has completed, but still hasn't updated yet
+    expect(container.textContent).toEqual('');
+
+    // Synchronsouly update DOM
+    work.commit();
+    expect(container.textContent).toEqual('Foo');
+  });
+});

--- a/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMAsyncRoot-test.js
@@ -28,7 +28,7 @@ describe('ReactDOMAsyncRoot', () => {
   if (ReactDOMFeatureFlags.useFiber) {
     it('works in easy mode', () => {
       const container = document.createElement('div');
-      const root = ReactDOM.unstable_create(container);
+      const root = ReactDOM.unstable_createRoot(container);
       root.render(<div>Foo</div>);
       expect(container.textContent).toEqual('Foo');
       root.render(<div>Bar</div>);
@@ -40,7 +40,7 @@ describe('ReactDOMAsyncRoot', () => {
     it('can defer commit using prerender', () => {
       const Async = React.unstable_AsyncComponent;
       const container = document.createElement('div');
-      const root = ReactDOM.unstable_create(container);
+      const root = ReactDOM.unstable_createRoot(container);
       const work = root.prerender(<Async>Foo</Async>);
 
       // Hasn't updated yet

--- a/src/renderers/native-rt/ReactNativeRTFiberRenderer.js
+++ b/src/renderers/native-rt/ReactNativeRTFiberRenderer.js
@@ -181,6 +181,11 @@ const NativeRTRenderer = ReactFiberReconciler({
   },
 
   useSyncScheduling: true,
+
+  now(): number {
+    // TODO: Enable expiration by implementing this method.
+    return 0;
+  },
 });
 
 module.exports = NativeRTRenderer;

--- a/src/renderers/native/ReactNativeFiberRenderer.js
+++ b/src/renderers/native/ReactNativeFiberRenderer.js
@@ -377,6 +377,11 @@ const NativeRenderer = ReactFiberReconciler({
   },
 
   useSyncScheduling: true,
+
+  now(): number {
+    // TODO: Enable expiration by implementing this method.
+    return 0;
+  },
 });
 
 module.exports = NativeRenderer;

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -284,7 +284,7 @@ var ReactNoop = {
     }
   },
 
-  create(rootID: string) {
+  createRoot(rootID: string) {
     rootID = typeof rootID === 'string' ? rootID : DEFAULT_ROOT_ID;
     invariant(
       !roots.has(rootID),

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -403,7 +403,7 @@ var ReactNoop = {
       logHostInstances(container.children, depth + 1);
     }
 
-    function logUpdateQueue(updateQueue: UpdateQueue, depth) {
+    function logUpdateQueue(updateQueue: UpdateQueue<mixed>, depth) {
       log('  '.repeat(depth + 1) + 'QUEUED UPDATES');
       const firstUpdate = updateQueue.first;
       if (!firstUpdate) {

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -405,7 +405,7 @@ var ReactNoop = {
         '  '.repeat(depth + 1) + '~',
         firstUpdate && firstUpdate.partialState,
         firstUpdate.callback ? 'with callback' : '',
-        '[' + firstUpdate.priorityLevel + ']',
+        '[' + firstUpdate.expirationTime + ']',
       );
       var next;
       while ((next = firstUpdate.next)) {
@@ -413,7 +413,7 @@ var ReactNoop = {
           '  '.repeat(depth + 1) + '~',
           next.partialState,
           next.callback ? 'with callback' : '',
-          '[' + firstUpdate.priorityLevel + ']',
+          '[' + firstUpdate.expirationTime + ']',
         );
       }
     }
@@ -423,7 +423,7 @@ var ReactNoop = {
         '  '.repeat(depth) +
           '- ' +
           (fiber.type ? fiber.type.name || fiber.type : '[root]'),
-        '[' + fiber.pendingWorkPriority + (fiber.pendingProps ? '*' : '') + ']',
+        '[' + fiber.expirationTime + (fiber.pendingProps ? '*' : '') + ']',
       );
       if (fiber.updateQueue) {
         logUpdateQueue(fiber.updateQueue, depth);

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -296,8 +296,17 @@ var ReactNoop = {
     const root = NoopRenderer.createContainer(container);
     roots.set(rootID, root);
     return {
+      render(children: any) {
+        const work = NoopRenderer.updateRoot(children, root, null);
+        work.then(() => work.commit());
+      },
       prerender(children: any) {
         return NoopRenderer.updateRoot(children, root, null);
+      },
+      unmount() {
+        roots.delete(rootID);
+        const work = NoopRenderer.updateRoot(null, root, null);
+        work.then(() => work.commit());
       },
       getChildren() {
         return ReactNoop.getChildren(rootID);

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -201,6 +201,11 @@ var NoopRenderer = ReactFiberReconciler({
   prepareForCommit(): void {},
 
   resetAfterCommit(): void {},
+
+  now(): number {
+    // TODO: Add an API to advance time.
+    return 0;
+  },
 });
 
 var rootContainers = new Map();

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -83,6 +83,8 @@ function removeChild(
   parentInstance.children.splice(index, 1);
 }
 
+let elapsedTimeInMs = 0;
+
 var NoopRenderer = ReactFiberReconciler({
   getRootHostContext() {
     if (failInBeginPhase) {
@@ -203,8 +205,7 @@ var NoopRenderer = ReactFiberReconciler({
   resetAfterCommit(): void {},
 
   now(): number {
-    // TODO: Add an API to advance time.
-    return 0;
+    return elapsedTimeInMs;
   },
 });
 
@@ -339,6 +340,14 @@ var ReactNoop = {
       }
     }
     expect(actual).toEqual(expected);
+  },
+
+  expire(ms: number): void {
+    elapsedTimeInMs += ms;
+  },
+
+  flushExpired(): Array<mixed> {
+    return ReactNoop.flushUnitsOfWork(0);
   },
 
   yield(value: mixed) {

--- a/src/renderers/noop/ReactNoopEntry.js
+++ b/src/renderers/noop/ReactNoopEntry.js
@@ -24,6 +24,7 @@ var ReactFiberInstrumentation = require('ReactFiberInstrumentation');
 var ReactFiberReconciler = require('ReactFiberReconciler');
 var ReactInstanceMap = require('ReactInstanceMap');
 var emptyObject = require('fbjs/lib/emptyObject');
+var invariant = require('fbjs/lib/invariant');
 
 var expect = require('jest-matchers');
 
@@ -281,6 +282,27 @@ var ReactNoop = {
         rootContainers.delete(rootID);
       });
     }
+  },
+
+  create(rootID: string) {
+    rootID = typeof rootID === 'string' ? rootID : DEFAULT_ROOT_ID;
+    invariant(
+      !roots.has(rootID),
+      'Root with id %s already exists. Choose a different id.',
+      rootID,
+    );
+    const container = {rootID: rootID, children: []};
+    rootContainers.set(rootID, container);
+    const root = NoopRenderer.createContainer(container);
+    roots.set(rootID, root);
+    return {
+      prerender(children: any) {
+        return NoopRenderer.updateRoot(children, root, null);
+      },
+      getChildren() {
+        return ReactNoop.getChildren(rootID);
+      },
+    };
   },
 
   findInstance(

--- a/src/renderers/shared/ReactDOMFrameScheduling.js
+++ b/src/renderers/shared/ReactDOMFrameScheduling.js
@@ -37,6 +37,13 @@ if (__DEV__) {
   }
 }
 
+let now: () => number;
+if (typeof performance === 'object' && typeof performance.now === 'function') {
+  now = performance.now.bind(performance);
+} else {
+  now = Date.now;
+}
+
 // TODO: There's no way to cancel, because Fiber doesn't atm.
 let rIC: (callback: (deadline: Deadline) => void) => number;
 
@@ -68,17 +75,11 @@ if (!ExecutionEnvironment.canUseDOM) {
   var activeFrameTime = 33;
 
   var frameDeadlineObject = {
-    timeRemaining: typeof performance === 'object' &&
-      typeof performance.now === 'function'
-      ? function() {
-          // We assume that if we have a performance timer that the rAF callback
-          // gets a performance timer value. Not sure if this is always true.
-          return frameDeadline - performance.now();
-        }
-      : function() {
-          // As a fallback we use Date.now.
-          return frameDeadline - Date.now();
-        },
+    timeRemaining() {
+      // We assume that if we have a performance timer that the rAF callback
+      // gets a performance timer value. Not sure if this is always true.
+      return frameDeadline - now();
+    },
   };
 
   // We use the postMessage trick to defer idle work until after the repaint.
@@ -153,4 +154,5 @@ if (!ExecutionEnvironment.canUseDOM) {
   rIC = requestIdleCallback;
 }
 
+exports.now = now;
 exports.rIC = rIC;

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -112,7 +112,7 @@ export type Fiber = {|
   memoizedProps: any, // The props used to create the output.
 
   // A queue of state updates and callbacks.
-  updateQueue: UpdateQueue | null,
+  updateQueue: UpdateQueue<any> | null,
 
   // The state used to create the output
   memoizedState: any,

--- a/src/renderers/shared/fiber/ReactFiber.js
+++ b/src/renderers/shared/fiber/ReactFiber.js
@@ -21,6 +21,7 @@ import type {TypeOfWork} from 'ReactTypeOfWork';
 import type {TypeOfInternalContext} from 'ReactTypeOfInternalContext';
 import type {TypeOfSideEffect} from 'ReactTypeOfSideEffect';
 import type {PriorityLevel} from 'ReactPriorityLevel';
+import type {ExpirationTime} from 'ReactFiberExpirationTime';
 import type {UpdateQueue} from 'ReactFiberUpdateQueue';
 
 var {
@@ -36,6 +37,8 @@ var {
 } = require('ReactTypeOfWork');
 
 var {NoWork} = require('ReactPriorityLevel');
+
+var {Done} = require('ReactFiberExpirationTime');
 
 var {NoContext} = require('ReactTypeOfInternalContext');
 
@@ -134,8 +137,9 @@ export type Fiber = {|
   firstEffect: Fiber | null,
   lastEffect: Fiber | null,
 
-  // This will be used to quickly determine if a subtree has no pending changes.
-  pendingWorkPriority: PriorityLevel,
+  // Represents a time in the future by which this work should be completed.
+  // This is also used to quickly determine if a subtree has no pending changes.
+  expirationTime: ExpirationTime,
 
   // This is a pooled version of a Fiber. Every fiber that gets updated will
   // eventually have a pair. There are cases when we can clean up pairs to save
@@ -189,7 +193,7 @@ function FiberNode(
   this.firstEffect = null;
   this.lastEffect = null;
 
-  this.pendingWorkPriority = NoWork;
+  this.expirationTime = Done;
 
   this.alternate = null;
 
@@ -233,7 +237,7 @@ function shouldConstruct(Component) {
 // This is used to create an alternate fiber to do work on.
 exports.createWorkInProgress = function(
   current: Fiber,
-  renderPriority: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   let workInProgress = current.alternate;
   if (workInProgress === null) {
@@ -270,7 +274,7 @@ exports.createWorkInProgress = function(
     workInProgress.lastEffect = null;
   }
 
-  workInProgress.pendingWorkPriority = renderPriority;
+  workInProgress.expirationTime = expirationTime;
 
   workInProgress.child = current.child;
   workInProgress.memoizedProps = current.memoizedProps;
@@ -296,7 +300,7 @@ exports.createHostRootFiber = function(): Fiber {
 exports.createFiberFromElement = function(
   element: ReactElement,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   let owner = null;
   if (__DEV__) {
@@ -310,7 +314,7 @@ exports.createFiberFromElement = function(
     owner,
   );
   fiber.pendingProps = element.props;
-  fiber.pendingWorkPriority = priorityLevel;
+  fiber.expirationTime = expirationTime;
 
   if (__DEV__) {
     fiber._debugSource = element._source;
@@ -323,24 +327,24 @@ exports.createFiberFromElement = function(
 exports.createFiberFromFragment = function(
   elements: ReactFragment,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   // TODO: Consider supporting keyed fragments. Technically, we accidentally
   // support that in the existing React.
   const fiber = createFiber(Fragment, null, internalContextTag);
   fiber.pendingProps = elements;
-  fiber.pendingWorkPriority = priorityLevel;
+  fiber.expirationTime = expirationTime;
   return fiber;
 };
 
 exports.createFiberFromText = function(
   content: string,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   const fiber = createFiber(HostText, null, internalContextTag);
   fiber.pendingProps = content;
-  fiber.pendingWorkPriority = priorityLevel;
+  fiber.expirationTime = expirationTime;
   return fiber;
 };
 
@@ -411,7 +415,7 @@ exports.createFiberFromHostInstanceForDeletion = function(): Fiber {
 exports.createFiberFromCoroutine = function(
   coroutine: ReactCoroutine,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   const fiber = createFiber(
     CoroutineComponent,
@@ -420,27 +424,28 @@ exports.createFiberFromCoroutine = function(
   );
   fiber.type = coroutine.handler;
   fiber.pendingProps = coroutine;
-  fiber.pendingWorkPriority = priorityLevel;
+  fiber.expirationTime = expirationTime;
   return fiber;
 };
 
 exports.createFiberFromYield = function(
   yieldNode: ReactYield,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   const fiber = createFiber(YieldComponent, null, internalContextTag);
+  fiber.expirationTime = expirationTime;
   return fiber;
 };
 
 exports.createFiberFromPortal = function(
   portal: ReactPortal,
   internalContextTag: TypeOfInternalContext,
-  priorityLevel: PriorityLevel,
+  expirationTime: ExpirationTime,
 ): Fiber {
   const fiber = createFiber(HostPortal, portal.key, internalContextTag);
   fiber.pendingProps = portal.children || [];
-  fiber.pendingWorkPriority = priorityLevel;
+  fiber.expirationTime = expirationTime;
   fiber.stateNode = {
     containerInfo: portal.containerInfo,
     implementation: portal.implementation,

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -350,7 +350,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress,
         updateQueue,
         null,
-        prevState,
         null,
         renderExpirationTime,
       );
@@ -360,7 +359,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         resetHydrationState();
         return bailoutOnAlreadyFinishedWork(current, workInProgress);
       }
-      const element = state.element;
+      const element = state !== null ? state.element : null;
       if (
         root.hydrate &&
         (current === null || current.child === null) &&

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -48,7 +48,7 @@ var {
   YieldComponent,
   Fragment,
 } = ReactTypeOfWork;
-var {NoWork, OffscreenPriority} = require('ReactPriorityLevel');
+var {Done, Never} = require('ReactFiberExpirationTime');
 var {
   PerformedWork,
   Placement,
@@ -72,9 +72,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext: HostContext<C, CX>,
   hydrationContext: HydrationContext<C, CX>,
-  scheduleUpdate: (fiber: Fiber, priorityLevel: PriorityLevel) => void,
-  getPriorityContext: (fiber: Fiber, forceAsync: boolean) => PriorityLevel,
+  scheduleUpdate: (fiber: Fiber, expirationTime: ExpirationTime) => void,
+  getPriorityContext: (
+    fiber: Fiber,
+    forceAsync: boolean,
+  ) => PriorityLevel | null,
   recalculateCurrentTime: () => ExpirationTime,
+  getExpirationTimeForPriority: (
+    currentTime: ExpirationTime,
+    priorityLevel: PriorityLevel | null,
+  ) => ExpirationTime,
 ) {
   const {
     shouldSetTextContent,
@@ -102,23 +109,24 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     memoizeProps,
     memoizeState,
     recalculateCurrentTime,
+    getExpirationTimeForPriority,
   );
 
+  // TODO: Remove this and use reconcileChildrenAtExpirationTime directly.
   function reconcileChildren(current, workInProgress, nextChildren) {
-    const priorityLevel = workInProgress.pendingWorkPriority;
-    reconcileChildrenAtPriority(
+    reconcileChildrenAtExpirationTime(
       current,
       workInProgress,
       nextChildren,
-      priorityLevel,
+      workInProgress.expirationTime,
     );
   }
 
-  function reconcileChildrenAtPriority(
+  function reconcileChildrenAtExpirationTime(
     current,
     workInProgress,
     nextChildren,
-    priorityLevel,
+    renderExpirationTime,
   ) {
     if (current === null) {
       // If this is a fresh new component that hasn't been rendered yet, we
@@ -129,7 +137,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress,
         workInProgress.child,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     } else if (current.child === workInProgress.child) {
       // If the current child is the same as the work in progress, it means that
@@ -142,7 +150,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress,
         workInProgress.child,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     } else {
       // If, on the other hand, it is already using a clone, that means we've
@@ -152,7 +160,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress,
         workInProgress.child,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     }
   }
@@ -226,7 +234,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function updateClassComponent(
     current: Fiber | null,
     workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
+    renderExpirationTime: ExpirationTime,
   ) {
     // Push context providers early to prevent context stack mismatches.
     // During mounting we don't know the child context yet as the instance doesn't exist.
@@ -238,18 +246,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       if (!workInProgress.stateNode) {
         // In the initial pass we might need to construct the instance.
         constructClassInstance(workInProgress, workInProgress.pendingProps);
-        mountClassInstance(workInProgress, priorityLevel);
+        mountClassInstance(workInProgress, renderExpirationTime);
         shouldUpdate = true;
       } else {
         invariant(false, 'Resuming work not yet implemented.');
         // In a resume, we'll already have an instance we can reuse.
-        // shouldUpdate = resumeMountClassInstance(workInProgress, priorityLevel);
+        // shouldUpdate = resumeMountClassInstance(workInProgress, renderExpirationTime);
       }
     } else {
       shouldUpdate = updateClassInstance(
         current,
         workInProgress,
-        priorityLevel,
+        renderExpirationTime,
       );
     }
     return finishClassComponent(
@@ -321,7 +329,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     pushHostContainer(workInProgress, root.containerInfo);
   }
 
-  function updateHostRoot(current, workInProgress, priorityLevel) {
+  function updateHostRoot(current, workInProgress, renderExpirationTime) {
+    const root = (workInProgress.stateNode: FiberRoot);
     pushHostRootContext(workInProgress);
     const updateQueue = workInProgress.updateQueue;
     if (updateQueue !== null) {
@@ -333,11 +342,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         null,
         prevState,
         null,
-        priorityLevel,
+        renderExpirationTime,
       );
       if (prevState === state) {
         // If the state is the same as before, that's a bailout because we had
-        // no work matching this priority.
+        // no work that expires at this time.
         resetHydrationState();
         return bailoutOnAlreadyFinishedWork(current, workInProgress);
       }
@@ -364,7 +373,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           workInProgress,
           workInProgress.child,
           element,
-          priorityLevel,
+          renderExpirationTime,
         );
       } else {
         // Otherwise reset hydration state in case we aborted and resumed another
@@ -380,7 +389,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     return bailoutOnAlreadyFinishedWork(current, workInProgress);
   }
 
-  function updateHostComponent(current, workInProgress, renderPriority) {
+  function updateHostComponent(current, workInProgress, renderExpirationTime) {
     pushHostContext(workInProgress);
 
     if (current === null) {
@@ -426,13 +435,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     // Check the host config to see if the children are offscreen/hidden.
     if (
-      renderPriority !== OffscreenPriority &&
+      renderExpirationTime !== Never &&
       !useSyncScheduling &&
       shouldDeprioritizeSubtree(type, nextProps)
     ) {
       // Down-prioritize the children.
-      workInProgress.pendingWorkPriority = OffscreenPriority;
-      // Bailout and come back to this fiber later at OffscreenPriority.
+      workInProgress.expirationTime = Never;
+      // Bailout and come back to this fiber later.
       return null;
     }
 
@@ -455,7 +464,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     return null;
   }
 
-  function mountIndeterminateComponent(current, workInProgress, priorityLevel) {
+  function mountIndeterminateComponent(
+    current,
+    workInProgress,
+    renderExpirationTime,
+  ) {
     invariant(
       current === null,
       'An indeterminate component should never have mounted. This error is ' +
@@ -490,7 +503,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // We will invalidate the child context in finishClassComponent() right after rendering.
       const hasContext = pushContextProvider(workInProgress);
       adoptClassInstance(workInProgress, value);
-      mountClassInstance(workInProgress, priorityLevel);
+      mountClassInstance(workInProgress, renderExpirationTime);
       return finishClassComponent(current, workInProgress, true, hasContext);
     } else {
       // Proceed under the assumption that this is a functional component
@@ -535,7 +548,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function updateCoroutineComponent(current, workInProgress) {
+  function updateCoroutineComponent(
+    current,
+    workInProgress,
+    renderExpirationTime,
+  ) {
     var nextCoroutine = (workInProgress.pendingProps: null | ReactCoroutine);
     if (hasContextChanged()) {
       // Normally we can bail out on props equality but if context has changed
@@ -559,30 +576,29 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     const nextChildren = nextCoroutine.children;
-    const priorityLevel = workInProgress.pendingWorkPriority;
 
-    // The following is a fork of reconcileChildrenAtPriority but using
+    // The following is a fork of reconcileChildrenAtExpirationTime but using
     // stateNode to store the child.
     if (current === null) {
       workInProgress.stateNode = mountChildFibersInPlace(
         workInProgress,
         workInProgress.stateNode,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     } else if (current.child === workInProgress.child) {
       workInProgress.stateNode = reconcileChildFibers(
         workInProgress,
         workInProgress.stateNode,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     } else {
       workInProgress.stateNode = reconcileChildFibersInPlace(
         workInProgress,
         workInProgress.stateNode,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
     }
 
@@ -592,9 +608,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     return workInProgress.stateNode;
   }
 
-  function updatePortalComponent(current, workInProgress) {
+  function updatePortalComponent(
+    current,
+    workInProgress,
+    renderExpirationTime,
+  ) {
     pushHostContainer(workInProgress, workInProgress.stateNode.containerInfo);
-    const priorityLevel = workInProgress.pendingWorkPriority;
     let nextChildren = workInProgress.pendingProps;
     if (hasContextChanged()) {
       // Normally we can bail out on props equality but if context has changed
@@ -624,7 +643,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress,
         workInProgress.child,
         nextChildren,
-        priorityLevel,
+        renderExpirationTime,
       );
       memoizeProps(workInProgress, nextChildren);
     } else {
@@ -719,11 +738,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function beginWork(
     current: Fiber | null,
     workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
+    renderExpirationTime: ExpirationTime,
   ): Fiber | null {
     if (
-      workInProgress.pendingWorkPriority === NoWork ||
-      workInProgress.pendingWorkPriority > priorityLevel
+      workInProgress.expirationTime === Done ||
+      workInProgress.expirationTime > renderExpirationTime
     ) {
       return bailoutOnLowPriority(current, workInProgress);
     }
@@ -733,16 +752,24 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         return mountIndeterminateComponent(
           current,
           workInProgress,
-          priorityLevel,
+          renderExpirationTime,
         );
       case FunctionalComponent:
         return updateFunctionalComponent(current, workInProgress);
       case ClassComponent:
-        return updateClassComponent(current, workInProgress, priorityLevel);
+        return updateClassComponent(
+          current,
+          workInProgress,
+          renderExpirationTime,
+        );
       case HostRoot:
-        return updateHostRoot(current, workInProgress, priorityLevel);
+        return updateHostRoot(current, workInProgress, renderExpirationTime);
       case HostComponent:
-        return updateHostComponent(current, workInProgress, priorityLevel);
+        return updateHostComponent(
+          current,
+          workInProgress,
+          renderExpirationTime,
+        );
       case HostText:
         return updateHostText(current, workInProgress);
       case CoroutineHandlerPhase:
@@ -750,13 +777,21 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress.tag = CoroutineComponent;
       // Intentionally fall through since this is now the same.
       case CoroutineComponent:
-        return updateCoroutineComponent(current, workInProgress);
+        return updateCoroutineComponent(
+          current,
+          workInProgress,
+          renderExpirationTime,
+        );
       case YieldComponent:
         // A yield component is just a placeholder, we can just run through the
         // next one immediately.
         return null;
       case HostPortal:
-        return updatePortalComponent(current, workInProgress);
+        return updatePortalComponent(
+          current,
+          workInProgress,
+          renderExpirationTime,
+        );
       case Fragment:
         return updateFragment(current, workInProgress);
       default:
@@ -771,7 +806,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function beginFailedWork(
     current: Fiber | null,
     workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
+    renderExpirationTime: ExpirationTime,
   ) {
     // Push context providers here to avoid a push/pop context mismatch.
     switch (workInProgress.tag) {
@@ -804,8 +839,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     if (
-      workInProgress.pendingWorkPriority === NoWork ||
-      workInProgress.pendingWorkPriority > priorityLevel
+      workInProgress.expirationTime === Done ||
+      workInProgress.expirationTime > renderExpirationTime
     ) {
       return bailoutOnLowPriority(current, workInProgress);
     }
@@ -817,11 +852,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     // Unmount the current children as if the component rendered null
     const nextChildren = null;
-    reconcileChildrenAtPriority(
+    reconcileChildrenAtExpirationTime(
       current,
       workInProgress,
       nextChildren,
-      priorityLevel,
+      renderExpirationTime,
     );
 
     if (workInProgress.tag === ClassComponent) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -17,6 +17,7 @@ import type {HydrationContext} from 'ReactFiberHydrationContext';
 import type {FiberRoot} from 'ReactFiberRoot';
 import type {HostConfig} from 'ReactFiberReconciler';
 import type {PriorityLevel} from 'ReactPriorityLevel';
+import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 var {
   mountChildFibersInPlace,
@@ -73,6 +74,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   hydrationContext: HydrationContext<C, CX>,
   scheduleUpdate: (fiber: Fiber, priorityLevel: PriorityLevel) => void,
   getPriorityContext: (fiber: Fiber, forceAsync: boolean) => PriorityLevel,
+  recalculateCurrentTime: () => ExpirationTime,
 ) {
   const {
     shouldSetTextContent,
@@ -99,6 +101,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     getPriorityContext,
     memoizeProps,
     memoizeState,
+    recalculateCurrentTime,
   );
 
   function reconcileChildren(current, workInProgress, nextChildren) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -362,6 +362,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
       const element = state.element;
       if (
+        root.hydrate &&
         (current === null || current.child === null) &&
         enterHydrationState(workInProgress)
       ) {

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -330,7 +330,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function updateHostRoot(current, workInProgress, renderExpirationTime) {
+    const root = (workInProgress.stateNode: FiberRoot);
     pushHostRootContext(workInProgress);
+    if (root.completedAt === renderExpirationTime) {
+      // The root is already complete. Bail out and commit.
+      // TODO: This is a limited version of resuming that only applies to
+      // the root, to account for the pathological case where a completed
+      // root must be completely restarted before it can commit. Once we
+      // implement resuming for real, this special branch shouldn't
+      // be neccessary.
+      return null;
+    }
+
     const updateQueue = workInProgress.updateQueue;
     if (updateQueue !== null) {
       const prevState = workInProgress.memoizedState;

--- a/src/renderers/shared/fiber/ReactFiberBeginWork.js
+++ b/src/renderers/shared/fiber/ReactFiberBeginWork.js
@@ -330,7 +330,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function updateHostRoot(current, workInProgress, renderExpirationTime) {
-    const root = (workInProgress.stateNode: FiberRoot);
     pushHostRootContext(workInProgress);
     const updateQueue = workInProgress.updateQueue;
     if (updateQueue !== null) {

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -78,11 +78,18 @@ if (__DEV__) {
 }
 
 module.exports = function(
-  scheduleUpdate: (fiber: Fiber, priorityLevel: PriorityLevel) => void,
-  getPriorityContext: (fiber: Fiber, forceAsync: boolean) => PriorityLevel,
+  scheduleUpdate: (fiber: Fiber, expirationTime: ExpirationTime) => void,
+  getPriorityContext: (
+    fiber: Fiber,
+    forceAsync: boolean,
+  ) => PriorityLevel | null,
   memoizeProps: (workInProgress: Fiber, props: any) => void,
   memoizeState: (workInProgress: Fiber, state: any) => void,
   recalculateCurrentTime: () => ExpirationTime,
+  getExpirationTimeForPriority: (
+    currentTime: ExpirationTime,
+    priorityLevel: PriorityLevel | null,
+  ) => ExpirationTime,
 ) {
   // Class component state updater
   const updater = {
@@ -91,34 +98,66 @@ module.exports = function(
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
       const currentTime = recalculateCurrentTime();
+      const expirationTime = getExpirationTimeForPriority(
+        currentTime,
+        priorityLevel,
+      );
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'setState');
       }
-      addUpdate(fiber, partialState, callback, priorityLevel, currentTime);
-      scheduleUpdate(fiber, priorityLevel);
+      addUpdate(
+        fiber,
+        partialState,
+        callback,
+        priorityLevel,
+        expirationTime,
+        currentTime,
+      );
+      scheduleUpdate(fiber, expirationTime);
     },
     enqueueReplaceState(instance, state, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
       const currentTime = recalculateCurrentTime();
+      const expirationTime = getExpirationTimeForPriority(
+        currentTime,
+        priorityLevel,
+      );
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'replaceState');
       }
-      addReplaceUpdate(fiber, state, callback, priorityLevel, currentTime);
-      scheduleUpdate(fiber, priorityLevel);
+      addReplaceUpdate(
+        fiber,
+        state,
+        callback,
+        priorityLevel,
+        expirationTime,
+        currentTime,
+      );
+      scheduleUpdate(fiber, expirationTime);
     },
     enqueueForceUpdate(instance, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
       const currentTime = recalculateCurrentTime();
+      const expirationTime = getExpirationTimeForPriority(
+        currentTime,
+        priorityLevel,
+      );
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'forceUpdate');
       }
-      addForceUpdate(fiber, callback, priorityLevel, currentTime);
-      scheduleUpdate(fiber, priorityLevel);
+      addForceUpdate(
+        fiber,
+        callback,
+        priorityLevel,
+        expirationTime,
+        currentTime,
+      );
+      scheduleUpdate(fiber, expirationTime);
     },
   };
 
@@ -388,7 +427,7 @@ module.exports = function(
   // Invokes the mount life-cycles on a previously never rendered instance.
   function mountClassInstance(
     workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
+    renderExpirationTime: ExpirationTime,
   ): void {
     const current = workInProgress.alternate;
 
@@ -435,7 +474,7 @@ module.exports = function(
           instance,
           state,
           props,
-          priorityLevel,
+          renderExpirationTime,
         );
       }
     }
@@ -553,7 +592,7 @@ module.exports = function(
   function updateClassInstance(
     current: Fiber,
     workInProgress: Fiber,
-    priorityLevel: PriorityLevel,
+    renderExpirationTime: ExpirationTime,
   ): boolean {
     const instance = workInProgress.stateNode;
     resetInputPointers(workInProgress, instance);
@@ -602,7 +641,7 @@ module.exports = function(
         instance,
         oldState,
         newProps,
-        priorityLevel,
+        renderExpirationTime,
       );
     } else {
       newState = oldState;

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -12,6 +12,7 @@
 
 import type {Fiber} from 'ReactFiber';
 import type {PriorityLevel} from 'ReactPriorityLevel';
+import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 var {Update} = require('ReactTypeOfSideEffect');
 
@@ -81,6 +82,7 @@ module.exports = function(
   getPriorityContext: (fiber: Fiber, forceAsync: boolean) => PriorityLevel,
   memoizeProps: (workInProgress: Fiber, props: any) => void,
   memoizeState: (workInProgress: Fiber, state: any) => void,
+  recalculateCurrentTime: () => ExpirationTime,
 ) {
   // Class component state updater
   const updater = {
@@ -88,31 +90,34 @@ module.exports = function(
     enqueueSetState(instance, partialState, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
+      const currentTime = recalculateCurrentTime();
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'setState');
       }
-      addUpdate(fiber, partialState, callback, priorityLevel);
+      addUpdate(fiber, partialState, callback, priorityLevel, currentTime);
       scheduleUpdate(fiber, priorityLevel);
     },
     enqueueReplaceState(instance, state, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
+      const currentTime = recalculateCurrentTime();
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'replaceState');
       }
-      addReplaceUpdate(fiber, state, callback, priorityLevel);
+      addReplaceUpdate(fiber, state, callback, priorityLevel, currentTime);
       scheduleUpdate(fiber, priorityLevel);
     },
     enqueueForceUpdate(instance, callback) {
       const fiber = ReactInstanceMap.get(instance);
       const priorityLevel = getPriorityContext(fiber, false);
+      const currentTime = recalculateCurrentTime();
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'forceUpdate');
       }
-      addForceUpdate(fiber, callback, priorityLevel);
+      addForceUpdate(fiber, callback, priorityLevel, currentTime);
       scheduleUpdate(fiber, priorityLevel);
     },
   };

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -26,9 +26,7 @@ var {
   isContextConsumer,
 } = require('ReactFiberContext');
 var {
-  addUpdate,
-  addReplaceUpdate,
-  addForceUpdate,
+  insertUpdateIntoFiber,
   beginUpdateQueue,
 } = require('ReactFiberUpdateQueue');
 var {hasContextChanged} = require('ReactFiberContext');
@@ -106,14 +104,17 @@ module.exports = function(
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'setState');
       }
-      addUpdate(
-        fiber,
-        partialState,
-        callback,
+      const update = {
         priorityLevel,
         expirationTime,
-        currentTime,
-      );
+        partialState,
+        callback,
+        isReplace: false,
+        isForced: false,
+        isTopLevelUnmount: false,
+        next: null,
+      };
+      insertUpdateIntoFiber(fiber, update, currentTime);
       scheduleUpdate(fiber, expirationTime);
     },
     enqueueReplaceState(instance, state, callback) {
@@ -128,14 +129,17 @@ module.exports = function(
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'replaceState');
       }
-      addReplaceUpdate(
-        fiber,
-        state,
-        callback,
+      const update = {
         priorityLevel,
         expirationTime,
-        currentTime,
-      );
+        partialState: state,
+        callback,
+        isReplace: true,
+        isForced: false,
+        isTopLevelUnmount: false,
+        next: null,
+      };
+      insertUpdateIntoFiber(fiber, update, currentTime);
       scheduleUpdate(fiber, expirationTime);
     },
     enqueueForceUpdate(instance, callback) {
@@ -150,13 +154,17 @@ module.exports = function(
       if (__DEV__) {
         warnOnInvalidCallback(callback, 'forceUpdate');
       }
-      addForceUpdate(
-        fiber,
-        callback,
+      const update = {
         priorityLevel,
         expirationTime,
-        currentTime,
-      );
+        partialState: null,
+        callback,
+        isReplace: false,
+        isForced: true,
+        isTopLevelUnmount: false,
+        next: null,
+      };
+      insertUpdateIntoFiber(fiber, update, currentTime);
       scheduleUpdate(fiber, expirationTime);
     },
   };

--- a/src/renderers/shared/fiber/ReactFiberClassComponent.js
+++ b/src/renderers/shared/fiber/ReactFiberClassComponent.js
@@ -111,7 +111,7 @@ module.exports = function(
         callback,
         isReplace: false,
         isForced: false,
-        isTopLevelUnmount: false,
+        nextCallback: null,
         next: null,
       };
       insertUpdateIntoFiber(fiber, update, currentTime);
@@ -136,7 +136,7 @@ module.exports = function(
         callback,
         isReplace: true,
         isForced: false,
-        isTopLevelUnmount: false,
+        nextCallback: null,
         next: null,
       };
       insertUpdateIntoFiber(fiber, update, currentTime);
@@ -161,7 +161,7 @@ module.exports = function(
         callback,
         isReplace: false,
         isForced: true,
-        isTopLevelUnmount: false,
+        nextCallback: null,
         next: null,
       };
       insertUpdateIntoFiber(fiber, update, currentTime);
@@ -456,7 +456,7 @@ module.exports = function(
     const unmaskedContext = getUnmaskedContext(workInProgress);
 
     instance.props = props;
-    instance.state = state;
+    instance.state = workInProgress.memoizedState = state;
     instance.refs = emptyObject;
     instance.context = getMaskedContext(workInProgress, unmaskedContext);
 
@@ -480,7 +480,6 @@ module.exports = function(
           workInProgress,
           updateQueue,
           instance,
-          state,
           props,
           renderExpirationTime,
         );
@@ -647,7 +646,6 @@ module.exports = function(
         workInProgress,
         workInProgress.updateQueue,
         instance,
-        oldState,
         newProps,
         renderExpirationTime,
       );

--- a/src/renderers/shared/fiber/ReactFiberCommitWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCommitWork.js
@@ -22,7 +22,6 @@ var {
   HostPortal,
   CoroutineComponent,
 } = ReactTypeOfWork;
-var {commitCallbacks} = require('ReactFiberUpdateQueue');
 var {onCommitUnmount} = require('ReactFiberDevToolsHook');
 var {
   invokeGuardedCallback,
@@ -488,6 +487,19 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
+  function commitCallbacks(callbackList, context) {
+    for (let i = 0; i < callbackList.length; i++) {
+      const callback = callbackList[i];
+      invariant(
+        typeof callback === 'function',
+        'Invalid argument passed as callback. Expected a function. Instead ' +
+          'received: %s',
+        callback,
+      );
+      callback.call(context);
+    }
+  }
+
   function commitLifeCycles(current: Fiber | null, finishedWork: Fiber): void {
     switch (finishedWork.tag) {
       case ClassComponent: {
@@ -521,15 +533,27 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           finishedWork.effectTag & Callback &&
           finishedWork.updateQueue !== null
         ) {
-          commitCallbacks(finishedWork, finishedWork.updateQueue, instance);
+          const updateQueue = finishedWork.updateQueue;
+          if (updateQueue.callbackList !== null) {
+            // Set the list to null to make sure they don't get called more than once.
+            const callbackList = updateQueue.callbackList;
+            updateQueue.callbackList = null;
+            commitCallbacks(callbackList, instance);
+          }
         }
         return;
       }
       case HostRoot: {
         const updateQueue = finishedWork.updateQueue;
-        if (updateQueue !== null) {
-          const instance = finishedWork.child && finishedWork.child.stateNode;
-          commitCallbacks(finishedWork, updateQueue, instance);
+        if (updateQueue !== null && updateQueue.callbackList !== null) {
+          // Set the list to null to make sure they don't get called more
+          // than once.
+          const callbackList = updateQueue.callbackList;
+          updateQueue.callbackList = null;
+          const instance = finishedWork.child !== null
+            ? finishedWork.child.stateNode
+            : null;
+          commitCallbacks(callbackList, instance);
         }
         return;
       }

--- a/src/renderers/shared/fiber/ReactFiberExpirationTime.js
+++ b/src/renderers/shared/fiber/ReactFiberExpirationTime.js
@@ -28,13 +28,15 @@ export type ExpirationTime = number;
 const Done = 0;
 exports.Done = Done;
 
+const MAGIC_NUMBER_OFFSET = 2;
+
 const Never = Infinity;
 exports.Never = Infinity;
 
 // 1 unit of expiration time represents 10ms.
 function msToExpirationTime(ms: number): ExpirationTime {
-  // Always add 1 so that we don't clash with the magic number for Done.
-  return Math.round(ms / 10) + 1;
+  // Always add an offset so that we don't clash with the magic number for Done.
+  return Math.round(ms / 10) + MAGIC_NUMBER_OFFSET;
 }
 exports.msToExpirationTime = msToExpirationTime;
 
@@ -56,7 +58,7 @@ function priorityToExpirationTime(
       return Done;
     case SynchronousPriority:
       // Return a number lower than the current time, but higher than Done.
-      return 1;
+      return MAGIC_NUMBER_OFFSET - 1;
     case TaskPriority:
       // Return the current time, so that this work completes in this batch.
       return currentTime;
@@ -69,6 +71,7 @@ function priorityToExpirationTime(
     case OffscreenPriority:
       return Never;
     default:
+      console.log(priorityLevel);
       invariant(
         false,
         'Switch statement should be exhuastive. ' +
@@ -102,3 +105,11 @@ function expirationTimeToPriorityLevel(
   return LowPriority;
 }
 exports.expirationTimeToPriorityLevel = expirationTimeToPriorityLevel;
+
+function earlierExpirationTime(
+  t1: ExpirationTime,
+  t2: ExpirationTime,
+): ExpirationTime {
+  return t1 !== Done && (t2 === Done || t2 > t1) ? t1 : t2;
+}
+exports.earlierExpirationTime = earlierExpirationTime;

--- a/src/renderers/shared/fiber/ReactFiberExpirationTime.js
+++ b/src/renderers/shared/fiber/ReactFiberExpirationTime.js
@@ -30,6 +30,7 @@ const Sync = 1;
 const Task = 2;
 const Never = Infinity;
 
+const UNIT_SIZE = 10;
 const MAGIC_NUMBER_OFFSET = 10;
 
 exports.Done = Done;
@@ -38,12 +39,23 @@ exports.Never = Infinity;
 // 1 unit of expiration time represents 10ms.
 function msToExpirationTime(ms: number): ExpirationTime {
   // Always add an offset so that we don't clash with the magic number for Done.
-  return Math.round(ms / 10) + MAGIC_NUMBER_OFFSET;
+  return Math.round(ms / UNIT_SIZE) + MAGIC_NUMBER_OFFSET;
 }
 exports.msToExpirationTime = msToExpirationTime;
 
-function ceiling(time: ExpirationTime, precision: number): ExpirationTime {
-  return Math.ceil(Math.ceil(time * precision) / precision);
+function ceiling(num: number, precision: number): number {
+  return Math.ceil(Math.ceil(num * precision) / precision);
+}
+
+function bucket(
+  currentTime: ExpirationTime,
+  expirationInMs: number,
+  precisionInMs: number,
+): ExpirationTime {
+  return ceiling(
+    currentTime + expirationInMs / UNIT_SIZE,
+    precisionInMs / UNIT_SIZE,
+  );
 }
 
 // Given the current clock time and a priority level, returns an expiration time
@@ -62,12 +74,14 @@ function priorityToExpirationTime(
       return Sync;
     case TaskPriority:
       return Task;
-    case HighPriority:
+    case HighPriority: {
       // Should complete within ~100ms. 120ms max.
-      return msToExpirationTime(ceiling(100, 20));
-    case LowPriority:
+      return bucket(currentTime, 100, 20);
+    }
+    case LowPriority: {
       // Should complete within ~1000ms. 1200ms max.
-      return msToExpirationTime(ceiling(1000, 200));
+      return bucket(currentTime, 1000, 200);
+    }
     case OffscreenPriority:
       return Never;
     default:

--- a/src/renderers/shared/fiber/ReactFiberExpirationTime.js
+++ b/src/renderers/shared/fiber/ReactFiberExpirationTime.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @providesModule ReactFiberExpirationTime
+ * @flow
+ */
+
+'use strict';
+
+import type {PriorityLevel} from 'ReactPriorityLevel';
+const {
+  NoWork,
+  SynchronousPriority,
+  TaskPriority,
+  HighPriority,
+  LowPriority,
+  OffscreenPriority,
+} = require('ReactPriorityLevel');
+
+const invariant = require('fbjs/lib/invariant');
+
+// TODO: Use an opaque type once ESLint et al support the syntax
+export type ExpirationTime = number;
+
+const Done = 0;
+exports.Done = Done;
+
+const Never = Infinity;
+exports.Never = Infinity;
+
+// 1 unit of expiration time represents 10ms.
+function msToExpirationTime(ms: number): ExpirationTime {
+  // Always add 1 so that we don't clash with the magic number for Done.
+  return Math.round(ms / 10) + 1;
+}
+exports.msToExpirationTime = msToExpirationTime;
+
+function ceiling(time: ExpirationTime, precision: number): ExpirationTime {
+  return Math.ceil(Math.ceil(time * precision) / precision);
+}
+
+// Given the current clock time and a priority level, returns an expiration time
+// that represents a point in the future by which some work should complete.
+// The lower the priority, the further out the expiration time. We use rounding
+// to batch like updates together. The further out the expiration time, the
+// more we want to batch, so we use a larger precision when rounding.
+function priorityToExpirationTime(
+  currentTime: ExpirationTime,
+  priorityLevel: PriorityLevel,
+): ExpirationTime {
+  switch (priorityLevel) {
+    case NoWork:
+      return Done;
+    case SynchronousPriority:
+      // Return a number lower than the current time, but higher than Done.
+      return 1;
+    case TaskPriority:
+      // Return the current time, so that this work completes in this batch.
+      return currentTime;
+    case HighPriority:
+      // Should complete within ~100ms. 120ms max.
+      return msToExpirationTime(ceiling(100, 20));
+    case LowPriority:
+      // Should complete within ~1000ms. 1200ms max.
+      return msToExpirationTime(ceiling(1000, 200));
+    case OffscreenPriority:
+      return Never;
+    default:
+      invariant(
+        false,
+        'Switch statement should be exhuastive. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
+  }
+}
+exports.priorityToExpirationTime = priorityToExpirationTime;
+
+// Given the current clock time and an expiration time, returns the
+// corresponding priority level. The more time has advanced, the higher the
+// priority level.
+function expirationTimeToPriorityLevel(
+  currentTime: ExpirationTime,
+  expirationTime: ExpirationTime,
+): PriorityLevel {
+  // First check for magic values
+  if (expirationTime === Done) {
+    return NoWork;
+  }
+  if (expirationTime === Never) {
+    return OffscreenPriority;
+  }
+  if (expirationTime < currentTime) {
+    return SynchronousPriority;
+  }
+  if (expirationTime === currentTime) {
+    return TaskPriority;
+  }
+  // TODO: We don't currently distinguish between high and low priority.
+  return LowPriority;
+}
+exports.expirationTimeToPriorityLevel = expirationTimeToPriorityLevel;

--- a/src/renderers/shared/fiber/ReactFiberExpirationTime.js
+++ b/src/renderers/shared/fiber/ReactFiberExpirationTime.js
@@ -121,11 +121,3 @@ function expirationTimeToPriorityLevel(
   return LowPriority;
 }
 exports.expirationTimeToPriorityLevel = expirationTimeToPriorityLevel;
-
-function earlierExpirationTime(
-  t1: ExpirationTime,
-  t2: ExpirationTime,
-): ExpirationTime {
-  return t1 !== Done && (t2 === Done || t2 > t1) ? t1 : t2;
-}
-exports.earlierExpirationTime = earlierExpirationTime;

--- a/src/renderers/shared/fiber/ReactFiberGarbageCollection.js
+++ b/src/renderers/shared/fiber/ReactFiberGarbageCollection.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @providesModule ReactFiberGarbageCollection
+ * @flow
+ */
+
+'use strict';
+
+const {ClassComponent} = require('ReactTypeOfWork');
+const {PreparedWork, NeedsCleanUp} = require('ReactTypeOfSideEffect');
+
+function markForCleanUp(workInProgress: Fiber) {
+  // Mark that this fiber prepared work that needs to be cleaned-up.
+  workInProgress.effectTag |= PreparedWork;
+
+  // Mark that the parents contain work that needs to be cleaned-up.
+  let node = workInProgress;
+  do {
+    node.effectTag |= NeedsCleanUp;
+    node = node.return;
+  } while (node !== null && !(node.effectTag & NeedsCleanUp));
+}
+exports.markForCleanUp = markForCleanUp;
+
+function dropTree(workInProgress: Fiber) {
+  const rootOfDroppedTree = workInProgress;
+  let previous = null;
+  let next = rootOfDroppedTree;
+  while (next !== null) {
+    previous = next;
+    next = beginCleanUp(previous);
+    if (next === null) {
+      next = completeCleanUp(rootOfDroppedTree, previous);
+    }
+  }
+}
+exports.dropTree = dropTree;
+
+function beginCleanUp(workInProgress: Fiber): Fiber | null {
+  if (!(workInProgress.effectTag & NeedsCleanUp)) {
+    // This tree does not have any work to be cleaned up. Bail out.
+    return null;
+  }
+
+  if (workInProgress.tag === ClassComponent) {
+    const instance = workInProgress.stateNode;
+    if (workInProgress.alternate === null) {
+      if (typeof instance.unstable_abortMount === 'function') {
+        instance.unstable_abortMount();
+      }
+    } else if (workInProgress.effectTag & PreparedWork) {
+      if (typeof instance.unstable_abortUpdate === 'function') {
+        instance.unstable_abortUpdate();
+      }
+    }
+  }
+
+  workInProgress.effectTag &= ~PreparedWork;
+
+  // Continue on the child;
+  const current = workInProgress.alternate;
+  if (current !== null && current.child === workInProgress.child) {
+    return null;
+  }
+  return workInProgress.child;
+}
+
+function completeCleanUp(
+  rootOfDroppedTree: Fiber,
+  workInProgress: Fiber,
+): Fiber | null {
+  let node = workInProgress;
+  // Stop once we reach the root of the dropped tree
+  while (node !== null && node !== rootOfDroppedTree) {
+    if (node.sibling !== null) {
+      // Clean-up the sibling next.
+      return node.sibling;
+    }
+    // Finished this set of children. Go back to the parent.
+    node = node.return;
+  }
+  return null;
+}

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -350,7 +350,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       return;
     }
     processUpdateQueue(blockers, null, null, null, expirationTime);
-    expireWork(expirationTime);
+    expireWork(root, expirationTime);
   };
   WorkNode.prototype.then = function(callback) {
     const root = this._reactRootContainer;

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -202,6 +202,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   var {
     scheduleUpdate,
     getPriorityContext,
+    getExpirationTimeForPriority,
     recalculateCurrentTime,
     batchedUpdates,
     unbatchedUpdates,
@@ -241,6 +242,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       (element.type.prototype: any).unstable_isAsyncReactComponent === true;
     const priorityLevel = getPriorityContext(current, forceAsync);
     const currentTime = recalculateCurrentTime();
+    const expirationTime = getExpirationTimeForPriority(
+      currentTime,
+      priorityLevel,
+    );
     const nextState = {element};
     callback = callback === undefined ? null : callback;
     if (__DEV__) {
@@ -251,8 +256,15 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         callback,
       );
     }
-    addTopLevelUpdate(current, nextState, callback, priorityLevel, currentTime);
-    scheduleUpdate(current, priorityLevel);
+    addTopLevelUpdate(
+      current,
+      nextState,
+      callback,
+      priorityLevel,
+      expirationTime,
+      currentTime,
+    );
+    scheduleUpdate(current, expirationTime);
   }
 
   return {

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -121,6 +121,8 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
   prepareForCommit(): void,
   resetAfterCommit(): void,
 
+  now(): number,
+
   // Optional hydration
   canHydrateInstance?: (instance: I | TI, type: T, props: P) => boolean,
   canHydrateTextInstance?: (instance: I | TI, text: string) => boolean,
@@ -200,6 +202,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   var {
     scheduleUpdate,
     getPriorityContext,
+    recalculateCurrentTime,
     batchedUpdates,
     unbatchedUpdates,
     flushSync,
@@ -237,6 +240,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       element.type.prototype != null &&
       (element.type.prototype: any).unstable_isAsyncReactComponent === true;
     const priorityLevel = getPriorityContext(current, forceAsync);
+    const currentTime = recalculateCurrentTime();
     const nextState = {element};
     callback = callback === undefined ? null : callback;
     if (__DEV__) {
@@ -247,7 +251,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         callback,
       );
     }
-    addTopLevelUpdate(current, nextState, callback, priorityLevel);
+    addTopLevelUpdate(current, nextState, callback, priorityLevel, currentTime);
     scheduleUpdate(current, priorityLevel);
   }
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -20,7 +20,9 @@ var ReactFeatureFlags = require('ReactFeatureFlags');
 
 var {
   insertUpdateIntoFiber,
+  insertUpdateIntoQueue,
   createUpdateQueue,
+  processUpdateQueue,
 } = require('ReactFiberUpdateQueue');
 
 var {
@@ -57,7 +59,7 @@ type Awaitable<T> = {
   then(resolve: (result: T) => mixed): void,
 };
 
-type Work = Awaitable<void> & {
+export type Work = Awaitable<void> & {
   commit(): void,
 
   _reactRootContainer: *,
@@ -173,12 +175,17 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
 
 export type Reconciler<C, I, TI> = {
   createContainer(containerInfo: C): OpaqueRoot,
+  updateRoot(
+    element: ReactNodeList,
+    container: OpaqueRoot,
+    parentComponent: ?React$Component<any, any>,
+  ): Work,
   updateContainer(
     element: ReactNodeList,
     container: OpaqueRoot,
     parentComponent: ?React$Component<any, any>,
     callback: ?Function,
-  ): Work,
+  ): void,
   batchedUpdates<A>(fn: () => A): A,
   unbatchedUpdates<A>(fn: () => A): A,
   flushSync<A>(fn: () => A): A,
@@ -220,6 +227,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     getPriorityContext,
     getExpirationTimeForPriority,
     recalculateCurrentTime,
+    expireWork,
     batchedUpdates,
     unbatchedUpdates,
     flushSync,
@@ -227,8 +235,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   } = ReactFiberScheduler(config);
 
   function scheduleTopLevelUpdate(
-    current: Fiber,
+    root: FiberRoot,
     element: ReactNodeList,
+    currentTime: ExpirationTime,
+    isPrerender: boolean,
     callback: ?Function,
   ): ExpirationTime {
     if (__DEV__) {
@@ -247,6 +257,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     }
 
+    const current = root.current;
+
     // Check if the top-level element is an async wrapper component. If so, treat
     // updates to the root as async. This is a bit weird but lets us avoid a separate
     // `renderAsync` API.
@@ -257,7 +269,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       element.type.prototype != null &&
       (element.type.prototype: any).unstable_isAsyncReactComponent === true;
     const priorityLevel = getPriorityContext(current, forceAsync);
-    const currentTime = recalculateCurrentTime();
     const expirationTime = getExpirationTimeForPriority(
       currentTime,
       priorityLevel,
@@ -305,6 +316,24 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     }
 
+    if (isPrerender) {
+      // Block the root from committing at this expiration time.
+      if (root.blockers === null) {
+        root.blockers = createUpdateQueue();
+      }
+      const blockUpdate = {
+        priorityLevel: null,
+        expirationTime,
+        partialState: nextState,
+        callback: null,
+        isReplace: false,
+        isForced: false,
+        isTopLevelUnmount: false,
+        next: null,
+      };
+      insertUpdateIntoQueue(root.blockers, blockUpdate, currentTime);
+    }
+
     scheduleUpdate(current, expirationTime);
     return expirationTime;
   }
@@ -313,13 +342,38 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     this._reactRootContainer = root;
     this._expirationTime = expirationTime;
   }
-  WorkNode.prototype.commit = function() {};
-  WorkNode.prototype.then = function(resolve) {
-    // const fiber = this._reactRootContainer.current;
-    // const expirationTime = this._expirationTime;
-    // const currentTime = recalculateCurrentTime();
-    // addCallback(fiber, resolve, null, expirationTime, currentTime);
-    // scheduleUpdate(fiber, expirationTime);
+  WorkNode.prototype.commit = function() {
+    const root = this._reactRootContainer;
+    const expirationTime = this._expirationTime;
+    const blockers = root.blockers;
+    if (blockers === null) {
+      return;
+    }
+    processUpdateQueue(blockers, null, null, null, expirationTime);
+    expireWork(expirationTime);
+  };
+  WorkNode.prototype.then = function(callback) {
+    const root = this._reactRootContainer;
+    const expirationTime = this._expirationTime;
+
+    // Add callback to queue of callbacks on the root. It will be called once
+    // the root completes at the corresponding expiration time.
+    const update = {
+      priorityLevel: null,
+      expirationTime,
+      partialState: null,
+      callback,
+      isReplace: false,
+      isForced: false,
+      isTopLevelUnmount: false,
+      next: null,
+    };
+    const currentTime = recalculateCurrentTime();
+    if (root.completionCallbacks === null) {
+      root.completionCallbacks = createUpdateQueue();
+    }
+    insertUpdateIntoQueue(root.completionCallbacks, update, currentTime);
+    scheduleUpdate(root.current, expirationTime);
   };
 
   return {
@@ -331,8 +385,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       element: ReactNodeList,
       container: OpaqueRoot,
       parentComponent: ?React$Component<any, any>,
-      didComplete: ?Function,
-    ) {
+    ): Work {
       const current = container.current;
 
       if (__DEV__) {
@@ -354,14 +407,19 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         container.pendingContext = context;
       }
 
-      const expirationTime = scheduleTopLevelUpdate(current, element);
+      const currentTime = recalculateCurrentTime();
+      const expirationTime = scheduleTopLevelUpdate(
+        container,
+        element,
+        currentTime,
+        true,
+        null,
+      );
 
       let completionCallbacks = container.completionCallbacks;
       if (completionCallbacks === null) {
         completionCallbacks = createUpdateQueue();
       }
-
-      // TODO: Add didComplete to root's completionCallbacks
 
       return new WorkNode(container, expirationTime);
     },
@@ -371,7 +429,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       container: OpaqueRoot,
       parentComponent: ?React$Component<any, any>,
       callback: ?Function,
-    ): Work {
+    ): void {
       // TODO: If this is a nested container, this won't be the root.
       const current = container.current;
 
@@ -394,7 +452,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         container.pendingContext = context;
       }
 
-      scheduleTopLevelUpdate(current, element, callback);
+      const currentTime = recalculateCurrentTime();
+      scheduleTopLevelUpdate(container, element, currentTime, false, callback);
     },
 
     batchedUpdates,

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -12,7 +12,6 @@
 
 import type {Fiber} from 'ReactFiber';
 import type {FiberRoot} from 'ReactFiberRoot';
-import type {PriorityLevel} from 'ReactPriorityLevel';
 import type {ExpirationTime} from 'ReactFiberExpirationTime';
 import type {ReactNodeList} from 'ReactTypes';
 
@@ -224,6 +223,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   var {
     scheduleUpdate,
+    scheduleCompletionCallback,
     getPriorityContext,
     getExpirationTimeForPriority,
     recalculateCurrentTime,
@@ -321,7 +321,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       if (root.blockers === null) {
         root.blockers = createUpdateQueue();
       }
-      const blockUpdate = {
+      const block = {
         priorityLevel: null,
         expirationTime,
         partialState: null,
@@ -331,7 +331,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         isTopLevelUnmount: false,
         next: null,
       };
-      insertUpdateIntoQueue(root.blockers, blockUpdate, currentTime);
+      insertUpdateIntoQueue(root.blockers, block, currentTime);
     }
 
     scheduleUpdate(current, expirationTime);
@@ -355,25 +355,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   WorkNode.prototype.then = function(callback) {
     const root = this._reactRootContainer;
     const expirationTime = this._expirationTime;
-
-    // Add callback to queue of callbacks on the root. It will be called once
-    // the root completes at the corresponding expiration time.
-    const update = {
-      priorityLevel: null,
-      expirationTime,
-      partialState: null,
-      callback,
-      isReplace: false,
-      isForced: false,
-      isTopLevelUnmount: false,
-      next: null,
-    };
-    const currentTime = recalculateCurrentTime();
-    if (root.completionCallbacks === null) {
-      root.completionCallbacks = createUpdateQueue();
-    }
-    insertUpdateIntoQueue(root.completionCallbacks, update, currentTime);
-    scheduleUpdate(root.current, expirationTime);
+    scheduleCompletionCallback(root, callback, expirationTime);
   };
 
   return {

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -12,11 +12,16 @@
 
 import type {Fiber} from 'ReactFiber';
 import type {FiberRoot} from 'ReactFiberRoot';
+import type {PriorityLevel} from 'ReactPriorityLevel';
+import type {ExpirationTime} from 'ReactFiberExpirationTime';
 import type {ReactNodeList} from 'ReactTypes';
 
 var ReactFeatureFlags = require('ReactFeatureFlags');
 
-var {addTopLevelUpdate} = require('ReactFiberUpdateQueue');
+var {
+  insertUpdateIntoFiber,
+  createUpdateQueue,
+} = require('ReactFiberUpdateQueue');
 
 var {
   findCurrentUnmaskedContext,
@@ -47,6 +52,17 @@ export type Deadline = {
 
 type OpaqueHandle = Fiber;
 type OpaqueRoot = FiberRoot;
+
+type Awaitable<T> = {
+  then(resolve: (result: T) => mixed): void,
+};
+
+type Work = Awaitable<void> & {
+  commit(): void,
+
+  _reactRootContainer: *,
+  _expirationTime: ExpirationTime,
+};
 
 export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
   getRootHostContext(rootContainerInstance: C): CX,
@@ -162,7 +178,7 @@ export type Reconciler<C, I, TI> = {
     container: OpaqueRoot,
     parentComponent: ?React$Component<any, any>,
     callback: ?Function,
-  ): void,
+  ): Work,
   batchedUpdates<A>(fn: () => A): A,
   unbatchedUpdates<A>(fn: () => A): A,
   flushSync<A>(fn: () => A): A,
@@ -214,7 +230,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     current: Fiber,
     element: ReactNodeList,
     callback: ?Function,
-  ) {
+  ): ExpirationTime {
     if (__DEV__) {
       if (
         ReactDebugCurrentFiber.phase === 'render' &&
@@ -256,20 +272,98 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         callback,
       );
     }
-    addTopLevelUpdate(
-      current,
-      nextState,
-      callback,
+    const isTopLevelUnmount = nextState.element === null;
+    const update = {
       priorityLevel,
       expirationTime,
-      currentTime,
-    );
+      partialState: nextState,
+      callback,
+      isReplace: false,
+      isForced: false,
+      isTopLevelUnmount,
+      next: null,
+    };
+    const update2 = insertUpdateIntoFiber(current, update, currentTime);
+
+    if (isTopLevelUnmount) {
+      // TODO: Redesign the top-level mount/update/unmount API to avoid this
+      // special case.
+      const queue1 = current.updateQueue;
+      const queue2 = current.alternate !== null
+        ? current.alternate.updateQueue
+        : null;
+
+      // Drop all updates that are lower-priority, so that the tree is not
+      // remounted. We need to do this for both queues.
+      if (queue1 !== null && update.next !== null) {
+        update.next = null;
+        queue1.last = update;
+      }
+      if (queue2 !== null && update2 !== null && update2.next !== null) {
+        update2.next = null;
+        queue2.last = update;
+      }
+    }
+
     scheduleUpdate(current, expirationTime);
+    return expirationTime;
   }
+
+  function WorkNode(root: OpaqueRoot, expirationTime: ExpirationTime) {
+    this._reactRootContainer = root;
+    this._expirationTime = expirationTime;
+  }
+  WorkNode.prototype.commit = function() {};
+  WorkNode.prototype.then = function(resolve) {
+    // const fiber = this._reactRootContainer.current;
+    // const expirationTime = this._expirationTime;
+    // const currentTime = recalculateCurrentTime();
+    // addCallback(fiber, resolve, null, expirationTime, currentTime);
+    // scheduleUpdate(fiber, expirationTime);
+  };
 
   return {
     createContainer(containerInfo: C): OpaqueRoot {
       return createFiberRoot(containerInfo);
+    },
+
+    updateRoot(
+      element: ReactNodeList,
+      container: OpaqueRoot,
+      parentComponent: ?React$Component<any, any>,
+      didComplete: ?Function,
+    ) {
+      const current = container.current;
+
+      if (__DEV__) {
+        if (ReactFiberInstrumentation.debugTool) {
+          if (current.alternate === null) {
+            ReactFiberInstrumentation.debugTool.onMountContainer(container);
+          } else if (element === null) {
+            ReactFiberInstrumentation.debugTool.onUnmountContainer(container);
+          } else {
+            ReactFiberInstrumentation.debugTool.onUpdateContainer(container);
+          }
+        }
+      }
+
+      const context = getContextForSubtree(parentComponent);
+      if (container.context === null) {
+        container.context = context;
+      } else {
+        container.pendingContext = context;
+      }
+
+      const expirationTime = scheduleTopLevelUpdate(current, element);
+
+      let completionCallbacks = container.completionCallbacks;
+      if (completionCallbacks === null) {
+        completionCallbacks = createUpdateQueue();
+      }
+
+      // TODO: Add didComplete to root's completionCallbacks
+
+      return new WorkNode(container, expirationTime);
     },
 
     updateContainer(
@@ -277,7 +371,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       container: OpaqueRoot,
       parentComponent: ?React$Component<any, any>,
       callback: ?Function,
-    ): void {
+    ): Work {
       // TODO: If this is a nested container, this won't be the root.
       const current = container.current;
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -324,7 +324,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       const blockUpdate = {
         priorityLevel: null,
         expirationTime,
-        partialState: nextState,
+        partialState: null,
         callback: null,
         isReplace: false,
         isForced: false,

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -11,8 +11,10 @@
 'use strict';
 
 import type {Fiber} from 'ReactFiber';
+import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 const {createHostRootFiber} = require('ReactFiber');
+const {Done} = require('ReactFiberExpirationTime');
 
 export type FiberRoot = {
   // Any additional information from the host associated with this root.
@@ -21,11 +23,23 @@ export type FiberRoot = {
   current: Fiber,
   // Determines if this root has already been added to the schedule for work.
   isScheduled: boolean,
+  // The time at which this root completed.
+  completedAt: ExpirationTime,
   // The work schedule is a linked list.
   nextScheduledRoot: FiberRoot | null,
   // Top context object, used by renderSubtreeIntoContainer
   context: Object | null,
   pendingContext: Object | null,
+};
+
+// Indicates whether the root is blocked from committing at a particular
+// expiration time.
+exports.isRootBlocked = function(
+  root: FiberRoot,
+  time: ExpirationTime,
+): boolean {
+  // TODO: Implementation
+  return false;
 };
 
 exports.createFiberRoot = function(containerInfo: any): FiberRoot {
@@ -36,6 +50,7 @@ exports.createFiberRoot = function(containerInfo: any): FiberRoot {
     current: uninitializedFiber,
     containerInfo: containerInfo,
     isScheduled: false,
+    completedAt: Done,
     nextScheduledRoot: null,
     context: null,
     pendingContext: null,

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {Fiber} from 'ReactFiber';
+import type {UpdateQueue} from 'ReactFiberUpdateQueue';
 import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 const {createHostRootFiber} = require('ReactFiber');
@@ -25,6 +26,9 @@ export type FiberRoot = {
   isScheduled: boolean,
   // The time at which this root completed.
   completedAt: ExpirationTime,
+  // A queue of callbacks that fire once their corresponding expiration time
+  // has completed. Only fired once.
+  completionCallbacks: UpdateQueue,
   // The work schedule is a linked list.
   nextScheduledRoot: FiberRoot | null,
   // Top context object, used by renderSubtreeIntoContainer
@@ -51,6 +55,7 @@ exports.createFiberRoot = function(containerInfo: any): FiberRoot {
     containerInfo: containerInfo,
     isScheduled: false,
     completedAt: Done,
+    completionCallbacks: null,
     nextScheduledRoot: null,
     context: null,
     pendingContext: null,

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -34,6 +34,9 @@ export type FiberRoot = {
   // A queue of callbacks that fire once their corresponding expiration time
   // has completed. Only fired once.
   completionCallbacks: UpdateQueue<null> | null,
+  // When set, indicates that all work in this tree with this time or earlier
+  // should be flushed by the end of the batch, as if it has task priority.
+  forceExpire: null | ExpirationTime,
   // The work schedule is a linked list.
   nextScheduledRoot: FiberRoot | null,
   // Top context object, used by renderSubtreeIntoContainer
@@ -64,6 +67,7 @@ exports.createFiberRoot = function(containerInfo: any): FiberRoot {
     completedAt: Done,
     blockers: null,
     completionCallbacks: null,
+    forceExpire: null,
     nextScheduledRoot: null,
     context: null,
     pendingContext: null,

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -16,6 +16,7 @@ import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 const {createHostRootFiber} = require('ReactFiber');
 const {getUpdateQueueExpirationTime} = require('ReactFiberUpdateQueue');
+
 const {Done} = require('ReactFiberExpirationTime');
 
 export type FiberRoot = {

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -42,6 +42,8 @@ export type FiberRoot = {
   // Top context object, used by renderSubtreeIntoContainer
   context: Object | null,
   pendingContext: Object | null,
+  // Determines if we should attempt to hydrate on the initial mount
+  hydrate: boolean,
 };
 
 exports.isRootBlocked = function(
@@ -71,6 +73,7 @@ exports.createFiberRoot = function(containerInfo: any): FiberRoot {
     nextScheduledRoot: null,
     context: null,
     pendingContext: null,
+    hydrate: true,
   };
   uninitializedFiber.stateNode = root;
   return root;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -991,7 +991,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       nextRenderExpirationTime,
     );
 
-    loop: while (
+    while (
       shouldContinueWorking(minPriorityLevel, nextPriorityLevel, deadline)
     ) {
       if (nextRenderExpirationTime <= mostRecentCurrentTime) {

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -67,7 +67,6 @@ var {
   Done,
   Never,
   msToExpirationTime,
-  earlierExpirationTime,
   priorityToExpirationTime,
   expirationTimeToPriorityLevel,
 } = require('ReactFiberExpirationTime');
@@ -608,10 +607,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     // Bubble up the earliest expiration time.
     let child = workInProgress.child;
     while (child !== null) {
-      newExpirationTime = earlierExpirationTime(
-        newExpirationTime,
-        child.expirationTime,
-      );
+      if (
+        child.expirationTime !== Done &&
+        (newExpirationTime === Done || newExpirationTime > child.expirationTime)
+      ) {
+        newExpirationTime = child.expirationTime;
+      }
       child = child.sibling;
     }
     workInProgress.expirationTime = newExpirationTime;

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -52,6 +52,7 @@ var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 var getComponentName = require('getComponentName');
 
 var {createWorkInProgress} = require('ReactFiber');
+var {isRootBlocked} = require('ReactFiberRoot');
 var {onCommitRoot} = require('ReactFiberDevToolsHook');
 
 var {
@@ -260,10 +261,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function resetNextUnitOfWork() {
-    // Clear out roots with no more work on them, or if they have uncaught errors
+    // Clear out roots with no more work on them
     while (
       nextScheduledRoot !== null &&
-      nextScheduledRoot.current.expirationTime === Done
+      nextScheduledRoot.current.expirationTime === Done &&
+      nextScheduledRoot.completedAt === Done
     ) {
       // Unschedule this root.
       nextScheduledRoot.isScheduled = false;
@@ -287,10 +289,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     let earliestExpirationRoot = null;
     let earliestExpirationTime = Done;
     while (root !== null) {
+      let rootExpirationTime = shouldWorkOnRoot(root);
       if (
-        root.current.expirationTime !== Done &&
+        rootExpirationTime !== Done &&
         (earliestExpirationTime === Done ||
-          earliestExpirationTime > root.current.expirationTime)
+          earliestExpirationTime > rootExpirationTime)
       ) {
         earliestExpirationTime = root.current.expirationTime;
         earliestExpirationRoot = root;
@@ -307,10 +310,26 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // unfortunately this is it.
       resetContextStack();
 
-      nextUnitOfWork = createWorkInProgress(
-        earliestExpirationRoot.current,
-        earliestExpirationTime,
-      );
+      if (earliestExpirationRoot.completedAt === nextRenderExpirationTime) {
+        // If the root is already complete, reuse the existing work-in-progress.
+        // TODO: This is a limited version of resuming that only applies to
+        // the root, to account for the pathological case where a completed
+        // root must be completely restarted before it can commit. Once we
+        // implement resuming for real, this special branch shouldn't
+        // be neccessary.
+        nextUnitOfWork = earliestExpirationRoot.current.alternate;
+        invariant(
+          nextUnitOfWork !== null,
+          'Expected a completed root to have a work-in-progress. This error ' +
+            'is likely caused by a bug in React. Please file an issue.',
+        );
+      } else {
+        earliestExpirationRoot.completedAt = Done;
+        nextUnitOfWork = createWorkInProgress(
+          earliestExpirationRoot.current,
+          earliestExpirationTime,
+        );
+      }
       if (earliestExpirationRoot !== nextRenderedTree) {
         // We've switched trees. Reset the nested update counter.
         nestedUpdateCount = 0;
@@ -323,6 +342,37 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     nextUnitOfWork = null;
     nextRenderedTree = null;
     return;
+  }
+
+  // Indicates whether the root should be worked on. Not the same as whether a
+  // root has work, because work could be blocked.
+  function shouldWorkOnRoot(root: FiberRoot): ExpirationTime {
+    const completedAt = root.completedAt;
+    const expirationTime = root.current.expirationTime;
+
+    if (expirationTime === Done) {
+      // There's no work in this tree.
+      return Done;
+    }
+
+    if (completedAt !== Done) {
+      // The root completed but was blocked from committing.
+
+      if (expirationTime < completedAt) {
+        // We have work that expires earlier than the completed root. Regardless
+        // of whether the root is blocked, we should work on it.
+        return expirationTime;
+      }
+
+      // There have been no higher priority updates since we completed the root.
+      // If it's still blocked, return Done, as if it has no more work. If it's
+      // no longer blocked, return the time at which it completed so that we
+      // can commit it.
+      const isBlocked = isRootBlocked(root, expirationTime);
+      return isBlocked ? Done : completedAt;
+    }
+
+    return expirationTime;
   }
 
   function commitAllHostEffects() {
@@ -449,6 +499,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         'related to the return field. This error is likely caused by a bug ' +
         'in React. Please file an issue.',
     );
+
+    root.completedAt = Done;
 
     if (nextRenderExpirationTime <= mostRecentCurrentTime) {
       // Keep track of the number of iterations to prevent an infinite
@@ -705,7 +757,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         // We've reached the root. Mark the root as pending commit. Depending
         // on how much time we have left, we'll either commit it now or in
         // the next frame.
-        pendingCommit = workInProgress;
+        const root = workInProgress.stateNode;
+        if (isRootBlocked(root, nextRenderExpirationTime)) {
+          root.completedAt = workInProgress.expirationTime = nextRenderExpirationTime;
+        } else {
+          pendingCommit = workInProgress;
+        }
         return null;
       }
     }

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -75,7 +75,7 @@ var {
 var {AsyncUpdates} = require('ReactTypeOfInternalContext');
 
 var {
-  PerformedWork,
+  InsigificantBits,
   Placement,
   Update,
   PlacementAndUpdate,
@@ -459,7 +459,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // possible bitmap value, we remove the secondary effects from the
       // effect tag and switch on that value.
       let primaryEffectTag =
-        effectTag & ~(Callback | Err | ContentReset | Ref | PerformedWork);
+        effectTag & ~(Callback | Err | ContentReset | Ref | InsigificantBits);
       switch (primaryEffectTag) {
         case Placement: {
           commitPlacement(nextEffect);
@@ -572,7 +572,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     ReactCurrentOwner.current = null;
 
     let firstEffect;
-    if (finishedWork.effectTag > PerformedWork) {
+    if (finishedWork.effectTag > InsigificantBits) {
       // A fiber's effect list consists only of its children, not itself. So if
       // the root has an effect, we need to add it to the end of the list. The
       // resulting list is the set that would belong to the root's parent, if
@@ -787,9 +787,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         // reusing children we'll schedule this effect onto itself since we're
         // at the end.
         const effectTag = workInProgress.effectTag;
-        // Skip both NoWork and PerformedWork tags when creating the effect list.
-        // PerformedWork effect is read by React DevTools but shouldn't be committed.
-        if (effectTag > PerformedWork) {
+        // Skip insigificant effect fields
+        if (effectTag > InsigificantBits) {
           if (returnFiber.lastEffect !== null) {
             returnFiber.lastEffect.nextEffect = workInProgress;
           } else {

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -223,9 +223,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   let nextUnitOfWork: Fiber | null = null;
   // The time at which we're currently rendering work.
   let nextRenderExpirationTime: ExpirationTime = Done;
-  // If not null, all work up to and including this time should be
-  // flushed before the end of the current batch.
-  let forceExpire: ExpirationTime | null = null;
 
   // The next fiber with an effect that we're currently committing.
   let nextEffect: Fiber | null = null;
@@ -305,7 +302,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         (earliestExpirationTime === Done ||
           earliestExpirationTime > rootExpirationTime)
       ) {
-        earliestExpirationTime = root.current.expirationTime;
+        earliestExpirationTime = rootExpirationTime;
         earliestExpirationRoot = root;
       }
       // We didn't find anything to do in this root, so let's try the next one.
@@ -1723,25 +1720,30 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function recalculateCurrentTime(): ExpirationTime {
-    if (forceExpire !== null) {
-      return forceExpire;
+    if (nextRenderedTree !== null) {
+      // Check if the current root is being force expired.
+      const forceExpire = nextRenderedTree.forceExpire;
+      if (forceExpire !== null) {
+        // Override the current time with the `forceExpire` time. This has the
+        // effect of expiring all work up to and including that time.
+        mostRecentCurrentTime = forceExpire;
+        return forceExpire;
+      }
     }
     mostRecentCurrentTime = msToExpirationTime(now());
     return mostRecentCurrentTime;
   }
 
-  function expireWork(expirationTime: ExpirationTime): void {
+  function expireWork(root: FiberRoot, expirationTime: ExpirationTime): void {
     invariant(
       !isPerformingWork,
       'Cannot commit while already performing work.',
     );
-    // Override the current time with the given time. This has the effect of
-    // expiring all work up to and including that time.
-    forceExpire = mostRecentCurrentTime = expirationTime;
+    root.forceExpire = expirationTime;
     try {
       performWork(TaskPriority, null);
     } finally {
-      forceExpire = null;
+      root.forceExpire = null;
       recalculateCurrentTime();
     }
   }

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -51,7 +51,7 @@ var ReactFiberHydrationContext = require('ReactFiberHydrationContext');
 var {ReactCurrentOwner} = require('ReactGlobalSharedState');
 var getComponentName = require('getComponentName');
 
-var {createWorkInProgress, largerPriority} = require('ReactFiber');
+var {createWorkInProgress} = require('ReactFiber');
 var {onCommitRoot} = require('ReactFiberDevToolsHook');
 
 var {
@@ -63,7 +63,14 @@ var {
   OffscreenPriority,
 } = require('ReactPriorityLevel');
 
-var {msToExpirationTime} = require('ReactFiberExpirationTime');
+var {
+  Done,
+  Never,
+  msToExpirationTime,
+  earlierExpirationTime,
+  priorityToExpirationTime,
+  expirationTimeToPriorityLevel,
+} = require('ReactFiberExpirationTime');
 
 var {AsyncUpdates} = require('ReactTypeOfInternalContext');
 
@@ -86,7 +93,7 @@ var {
   ClassComponent,
 } = require('ReactTypeOfWork');
 
-var {getUpdatePriority} = require('ReactFiberUpdateQueue');
+var {getUpdateExpirationTime} = require('ReactFiberUpdateQueue');
 
 var {resetContext} = require('ReactFiberContext');
 
@@ -164,6 +171,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     scheduleUpdate,
     getPriorityContext,
     recalculateCurrentTime,
+    getExpirationTimeForPriority,
   );
   const {completeWork} = ReactFiberCompleteWork(
     config,
@@ -187,12 +195,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   } = config;
 
   // Represents the current time in ms.
-  let currentTime: ExpirationTime = msToExpirationTime(now());
+  let mostRecentCurrentTime: ExpirationTime = msToExpirationTime(now());
 
   // The priority level to use when scheduling an update. We use NoWork to
   // represent the default priority.
-  // TODO: Should we change this to an array instead of using the call stack?
-  // Might be less confusing.
   let priorityContext: PriorityLevel = NoWork;
 
   // Keeps track of whether we're currently in a work loop.
@@ -210,7 +216,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   // The next work in progress fiber that we're currently working on.
   let nextUnitOfWork: Fiber | null = null;
-  let nextPriorityLevel: PriorityLevel = NoWork;
+  // The time at which we're currently rendering work.
+  let nextRenderExpirationTime: ExpirationTime = Done;
 
   // The next fiber with an effect that we're currently committing.
   let nextEffect: Fiber | null = null;
@@ -253,14 +260,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     resetHostContainer();
   }
 
-  // resetNextUnitOfWork mutates the current priority context. It is reset after
-  // after the workLoop exits, so never call resetNextUnitOfWork from outside
-  // the work loop.
   function resetNextUnitOfWork() {
     // Clear out roots with no more work on them, or if they have uncaught errors
     while (
       nextScheduledRoot !== null &&
-      nextScheduledRoot.current.pendingWorkPriority === NoWork
+      nextScheduledRoot.current.expirationTime === Done
     ) {
       // Unschedule this root.
       nextScheduledRoot.isScheduled = false;
@@ -272,7 +276,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       if (nextScheduledRoot === lastScheduledRoot) {
         nextScheduledRoot = null;
         lastScheduledRoot = null;
-        nextPriorityLevel = NoWork;
+        nextRenderExpirationTime = Done;
         return null;
       }
       // Continue with the next root.
@@ -281,22 +285,22 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     let root = nextScheduledRoot;
-    let highestPriorityRoot = null;
-    let highestPriorityLevel = NoWork;
+    let earliestExpirationRoot = null;
+    let earliestExpirationTime = Done;
     while (root !== null) {
       if (
-        root.current.pendingWorkPriority !== NoWork &&
-        (highestPriorityLevel === NoWork ||
-          highestPriorityLevel > root.current.pendingWorkPriority)
+        root.current.expirationTime !== Done &&
+        (earliestExpirationTime === Done ||
+          earliestExpirationTime > root.current.expirationTime)
       ) {
-        highestPriorityLevel = root.current.pendingWorkPriority;
-        highestPriorityRoot = root;
+        earliestExpirationTime = root.current.expirationTime;
+        earliestExpirationRoot = root;
       }
       // We didn't find anything to do in this root, so let's try the next one.
       root = root.nextScheduledRoot;
     }
-    if (highestPriorityRoot !== null) {
-      nextPriorityLevel = highestPriorityLevel;
+    if (earliestExpirationRoot !== null) {
+      nextRenderExpirationTime = earliestExpirationTime;
       // Before we start any new work, let's make sure that we have a fresh
       // stack to work from.
       // TODO: This call is buried a bit too deep. It would be nice to have
@@ -305,18 +309,18 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       resetContextStack();
 
       nextUnitOfWork = createWorkInProgress(
-        highestPriorityRoot.current,
-        highestPriorityLevel,
+        earliestExpirationRoot.current,
+        earliestExpirationTime,
       );
-      if (highestPriorityRoot !== nextRenderedTree) {
+      if (earliestExpirationRoot !== nextRenderedTree) {
         // We've switched trees. Reset the nested update counter.
         nestedUpdateCount = 0;
-        nextRenderedTree = highestPriorityRoot;
+        nextRenderedTree = earliestExpirationRoot;
       }
       return;
     }
 
-    nextPriorityLevel = NoWork;
+    nextRenderExpirationTime = Done;
     nextUnitOfWork = null;
     nextRenderedTree = null;
     return;
@@ -394,7 +398,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     while (nextEffect !== null) {
       const effectTag = nextEffect.effectTag;
 
-      // Use Task priority for lifecycle updates
       if (effectTag & (Update | Callback)) {
         if (__DEV__) {
           recordEffect();
@@ -448,10 +451,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         'in React. Please file an issue.',
     );
 
-    if (
-      nextPriorityLevel === SynchronousPriority ||
-      nextPriorityLevel === TaskPriority
-    ) {
+    if (nextRenderExpirationTime <= mostRecentCurrentTime) {
       // Keep track of the number of iterations to prevent an infinite
       // update loop.
       nestedUpdateCount++;
@@ -585,35 +585,36 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       commitPhaseBoundaries = null;
     }
 
-    // This tree is done. Reset the unit of work pointer to the next highest
-    // priority root. If there's no more work left, the pointer is set to null.
+    // This tree is done. Reset the unit of work pointer to the root that
+    // expires soonest. If there's no work left, the pointer is set to null.
     resetNextUnitOfWork();
   }
 
-  function resetWorkPriority(
+  function resetExpirationTime(
     workInProgress: Fiber,
-    renderPriority: PriorityLevel,
+    renderTime: ExpirationTime,
   ) {
-    if (
-      workInProgress.pendingWorkPriority !== NoWork &&
-      workInProgress.pendingWorkPriority > renderPriority
-    ) {
-      // This was a down-prioritization. Don't bubble priority from children.
+    if (renderTime !== Never && workInProgress.expirationTime === Never) {
+      // The children of this component are hidden. Don't bubble their
+      // expiration times.
       return;
     }
 
-    // Check for pending update priority.
-    let newPriority = getUpdatePriority(workInProgress);
+    // Check for pending updates.
+    let newExpirationTime = getUpdateExpirationTime(workInProgress);
 
     // TODO: Coroutines need to visit stateNode
 
+    // Bubble up the earliest expiration time.
     let child = workInProgress.child;
     while (child !== null) {
-      // Ensure that remaining work priority bubbles up.
-      newPriority = largerPriority(newPriority, child.pendingWorkPriority);
+      newExpirationTime = earlierExpirationTime(
+        newExpirationTime,
+        child.expirationTime,
+      );
       child = child.sibling;
     }
-    workInProgress.pendingWorkPriority = newPriority;
+    workInProgress.expirationTime = newExpirationTime;
   }
 
   function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
@@ -626,7 +627,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       if (__DEV__) {
         ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
       }
-      const next = completeWork(current, workInProgress, nextPriorityLevel);
+      const next = completeWork(
+        current,
+        workInProgress,
+        nextRenderExpirationTime,
+      );
       if (__DEV__) {
         ReactDebugCurrentFiber.resetCurrentFiber();
       }
@@ -634,7 +639,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       const returnFiber = workInProgress.return;
       const siblingFiber = workInProgress.sibling;
 
-      resetWorkPriority(workInProgress, nextPriorityLevel);
+      resetExpirationTime(workInProgress, nextRenderExpirationTime);
 
       if (next !== null) {
         if (__DEV__) {
@@ -722,7 +727,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       startWorkTimer(workInProgress);
       ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
     }
-    let next = beginWork(current, workInProgress, nextPriorityLevel);
+    let next = beginWork(current, workInProgress, nextRenderExpirationTime);
     if (__DEV__) {
       ReactDebugCurrentFiber.resetCurrentFiber();
     }
@@ -752,7 +757,11 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       startWorkTimer(workInProgress);
       ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
     }
-    let next = beginFailedWork(current, workInProgress, nextPriorityLevel);
+    let next = beginFailedWork(
+      current,
+      workInProgress,
+      nextRenderExpirationTime,
+    );
     if (__DEV__) {
       ReactDebugCurrentFiber.resetCurrentFiber();
     }
@@ -787,7 +796,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     if (
       capturedErrors !== null &&
       capturedErrors.size > 0 &&
-      nextPriorityLevel === TaskPriority
+      nextRenderExpirationTime !== Done &&
+      nextRenderExpirationTime <= mostRecentCurrentTime
     ) {
       while (nextUnitOfWork !== null) {
         if (hasCapturedError(nextUnitOfWork)) {
@@ -803,14 +813,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
               'a bug in React. Please file an issue.',
           );
           // We just completed a root. Commit it now.
-          priorityContext = TaskPriority;
           commitAllWork(pendingCommit);
-          priorityContext = nextPriorityLevel;
-
           if (
             capturedErrors === null ||
             capturedErrors.size === 0 ||
-            nextPriorityLevel !== TaskPriority
+            nextRenderExpirationTime === Done ||
+            nextRenderExpirationTime > mostRecentCurrentTime
           ) {
             // There are no more unhandled errors. We can exit this special
             // work loop. If there's still additional work, we'll perform it
@@ -824,28 +832,26 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function workLoop(
-    minPriorityLevel: PriorityLevel,
+    minExpirationTime: ExpirationTime,
     deadline: Deadline | null,
   ) {
     if (pendingCommit !== null) {
-      priorityContext = TaskPriority;
       commitAllWork(pendingCommit);
       handleCommitPhaseErrors();
     } else if (nextUnitOfWork === null) {
       resetNextUnitOfWork();
     }
 
-    if (nextPriorityLevel === NoWork || nextPriorityLevel > minPriorityLevel) {
+    if (
+      nextRenderExpirationTime === Done ||
+      nextRenderExpirationTime > minExpirationTime
+    ) {
       return;
     }
 
-    // During the render phase, updates should have the same priority at which
-    // we're rendering.
-    priorityContext = nextPriorityLevel;
-
     loop: do {
-      if (nextPriorityLevel <= TaskPriority) {
-        // Flush all synchronous and task work.
+      if (nextRenderExpirationTime <= mostRecentCurrentTime) {
+        // Flush all expired work.
         while (nextUnitOfWork !== null) {
           nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
           if (nextUnitOfWork === null) {
@@ -855,24 +861,22 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
                 'a bug in React. Please file an issue.',
             );
             // We just completed a root. Commit it now.
-            priorityContext = TaskPriority;
             commitAllWork(pendingCommit);
-            priorityContext = nextPriorityLevel;
             // Clear any errors that were scheduled during the commit phase.
             handleCommitPhaseErrors();
-            // The priority level may have changed. Check again.
+            // The render time may have changed. Check again.
             if (
-              nextPriorityLevel === NoWork ||
-              nextPriorityLevel > minPriorityLevel ||
-              nextPriorityLevel > TaskPriority
+              nextRenderExpirationTime === Done ||
+              nextRenderExpirationTime > minExpirationTime ||
+              nextRenderExpirationTime > mostRecentCurrentTime
             ) {
-              // The priority level does not match.
+              // We've completed all the expired work.
               break;
             }
           }
         }
       } else if (deadline !== null) {
-        // Flush asynchronous work until the deadline expires.
+        // Flush asynchronous work until the deadline runs out of time.
         while (nextUnitOfWork !== null && !deadlineHasExpired) {
           if (deadline.timeRemaining() > timeHeuristicForUnitOfWork) {
             nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
@@ -889,18 +893,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
               // We just completed a root. If we have time, commit it now.
               // Otherwise, we'll commit it in the next frame.
               if (deadline.timeRemaining() > timeHeuristicForUnitOfWork) {
-                priorityContext = TaskPriority;
                 commitAllWork(pendingCommit);
-                priorityContext = nextPriorityLevel;
                 // Clear any errors that were scheduled during the commit phase.
                 handleCommitPhaseErrors();
-                // The priority level may have changed. Check again.
+                // The render time may have changed. Check again.
                 if (
-                  nextPriorityLevel === NoWork ||
-                  nextPriorityLevel > minPriorityLevel ||
-                  nextPriorityLevel < HighPriority
+                  nextRenderExpirationTime === Done ||
+                  nextRenderExpirationTime > minExpirationTime ||
+                  nextRenderExpirationTime <= mostRecentCurrentTime
                 ) {
-                  // The priority level does not match.
+                  // We've completed all the async work.
                   break;
                 }
               } else {
@@ -915,12 +917,16 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
       // There might be work left. Depending on the priority, we should
       // either perform it now or schedule a callback to perform it later.
-      switch (nextPriorityLevel) {
+      const currentTime = recalculateCurrentTime();
+      switch (expirationTimeToPriorityLevel(
+        currentTime,
+        nextRenderExpirationTime,
+      )) {
         case SynchronousPriority:
         case TaskPriority:
           // We have remaining synchronous or task work. Keep performing it,
           // regardless of whether we're inside a callback.
-          if (nextPriorityLevel <= minPriorityLevel) {
+          if (nextRenderExpirationTime <= minExpirationTime) {
             continue loop;
           }
           break loop;
@@ -934,7 +940,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
             break loop;
           }
           // We are inside a callback.
-          if (!deadlineHasExpired && nextPriorityLevel <= minPriorityLevel) {
+          if (
+            !deadlineHasExpired &&
+            nextRenderExpirationTime <= minExpirationTime
+          ) {
             // We still have time. Keep working.
             continue loop;
           }
@@ -956,7 +965,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function performWorkCatchBlock(
     failedWork: Fiber,
     boundary: Fiber,
-    minPriorityLevel: PriorityLevel,
+    minExpirationTime: ExpirationTime,
     deadline: Deadline | null,
   ) {
     // We're going to restart the error boundary that captured the error.
@@ -972,7 +981,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     nextUnitOfWork = performFailedUnitOfWork(boundary);
 
     // Continue working.
-    workLoop(minPriorityLevel, deadline);
+    workLoop(minExpirationTime, deadline);
   }
 
   function performWork(
@@ -990,21 +999,32 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     );
     isPerformingWork = true;
 
-    // The priority context changes during the render phase. We'll need to
-    // reset it at the end.
+    // Updates that occur during the commit phase should have task priority
+    // by default. (Render phase updates are special; getPriorityContext
+    // accounts for their behavior.)
     const previousPriorityContext = priorityContext;
+    priorityContext = TaskPriority;
+
+    // Read the current time from the host environment.
+    const currentTime = recalculateCurrentTime();
+    const minExpirationTime = priorityToExpirationTime(
+      currentTime,
+      minPriorityLevel,
+    );
+
+    nestedUpdateCount = 0;
 
     let didError = false;
     let error = null;
     if (__DEV__) {
-      invokeGuardedCallback(null, workLoop, null, minPriorityLevel, deadline);
+      invokeGuardedCallback(null, workLoop, null, minExpirationTime, deadline);
       if (hasCaughtError()) {
         didError = true;
         error = clearCaughtError();
       }
     } else {
       try {
-        workLoop(minPriorityLevel, deadline);
+        workLoop(minExpirationTime, deadline);
       } catch (e) {
         didError = true;
         error = e;
@@ -1051,7 +1071,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           null,
           failedWork,
           boundary,
-          minPriorityLevel,
+          minExpirationTime,
           deadline,
         );
         if (hasCaughtError()) {
@@ -1064,7 +1084,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           performWorkCatchBlock(
             failedWork,
             boundary,
-            minPriorityLevel,
+            minExpirationTime,
             deadline,
           );
           error = null;
@@ -1078,18 +1098,20 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       break;
     }
 
-    // Reset the priority context to its previous value.
-    priorityContext = previousPriorityContext;
-
     // If we're inside a callback, set this to false, since we just flushed it.
     if (deadline !== null) {
       isCallbackScheduled = false;
     }
     // If there's remaining async work, make sure we schedule another callback.
-    if (nextPriorityLevel > TaskPriority && !isCallbackScheduled) {
+    if (
+      nextRenderExpirationTime > mostRecentCurrentTime &&
+      !isCallbackScheduled
+    ) {
       scheduleDeferredCallback(performDeferredWork);
       isCallbackScheduled = true;
     }
+
+    priorityContext = previousPriorityContext;
 
     const errorToThrow = firstUncaughtError;
 
@@ -1355,8 +1377,8 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function scheduleRoot(root: FiberRoot, priorityLevel: PriorityLevel) {
-    if (priorityLevel === NoWork) {
+  function scheduleRoot(root: FiberRoot, expirationTime: ExpirationTime) {
+    if (expirationTime === Done) {
       return;
     }
 
@@ -1374,13 +1396,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function scheduleUpdate(fiber: Fiber, priorityLevel: PriorityLevel) {
-    return scheduleUpdateImpl(fiber, priorityLevel, false);
+  function scheduleUpdate(fiber: Fiber, expirationTime: ExpirationTime) {
+    return scheduleUpdateImpl(fiber, expirationTime, false);
   }
 
   function scheduleUpdateImpl(
     fiber: Fiber,
-    priorityLevel: PriorityLevel,
+    expirationTime: ExpirationTime,
     isErrorRecovery: boolean,
   ) {
     if (__DEV__) {
@@ -1398,7 +1420,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       );
     }
 
-    if (!isPerformingWork && priorityLevel <= nextPriorityLevel) {
+    if (!isPerformingWork && expirationTime <= nextRenderExpirationTime) {
       // We must reset the current unit of work pointer so that we restart the
       // search from the root during the next tick, in case there is now higher
       // priority work somewhere earlier than before.
@@ -1415,59 +1437,58 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     let node = fiber;
     let shouldContinue = true;
     while (node !== null && shouldContinue) {
-      // Walk the parent path to the root and update each node's priority. Once
-      // we reach a node whose priority matches (and whose alternate's priority
-      // matches) we can exit safely knowing that the rest of the path is correct.
+      // Walk the parent path to the root and update each node's expiration
+      // time. Once we reach a node whose expiration matches (and whose
+      // alternate's expiration matches) we can exit safely knowing that the
+      // rest of the path is correct.
       shouldContinue = false;
       if (
-        node.pendingWorkPriority === NoWork ||
-        node.pendingWorkPriority > priorityLevel
+        node.expirationTime === Done ||
+        node.expirationTime > expirationTime
       ) {
-        // Priority did not match. Update and keep going.
+        // Expiration time did not match. Update and keep going.
         shouldContinue = true;
-        node.pendingWorkPriority = priorityLevel;
+        node.expirationTime = expirationTime;
       }
       if (node.alternate !== null) {
         if (
-          node.alternate.pendingWorkPriority === NoWork ||
-          node.alternate.pendingWorkPriority > priorityLevel
+          node.alternate.expirationTime === Done ||
+          node.alternate.expirationTime > expirationTime
         ) {
-          // Priority did not match. Update and keep going.
+          // Expiration time did not match. Update and keep going.
           shouldContinue = true;
-          node.alternate.pendingWorkPriority = priorityLevel;
+          node.alternate.expirationTime = expirationTime;
         }
       }
       if (node.return === null) {
         if (node.tag === HostRoot) {
           const root: FiberRoot = (node.stateNode: any);
-          scheduleRoot(root, priorityLevel);
+          scheduleRoot(root, expirationTime);
           if (!isPerformingWork) {
-            switch (priorityLevel) {
-              case SynchronousPriority:
-                // Perform this update now.
-                if (isUnbatchingUpdates) {
-                  // We're inside unbatchedUpdates, which is inside either
-                  // batchedUpdates or a lifecycle. We should only flush
-                  // synchronous work, not task work.
-                  performWork(SynchronousPriority, null);
-                } else {
-                  // Flush both synchronous and task work.
-                  performWork(TaskPriority, null);
-                }
-                break;
-              case TaskPriority:
-                invariant(
-                  isBatchingUpdates,
-                  'Task updates can only be scheduled as a nested update or ' +
-                    'inside batchedUpdates.',
-                );
-                break;
-              default:
-                // Schedule a callback to perform the work later.
-                if (!isCallbackScheduled) {
-                  scheduleDeferredCallback(performDeferredWork);
-                  isCallbackScheduled = true;
-                }
+            if (expirationTime < mostRecentCurrentTime) {
+              // This update is synchronous. Perform it now.
+              if (isUnbatchingUpdates) {
+                // We're inside unbatchedUpdates, which is inside either
+                // batchedUpdates or a lifecycle. We should only flush
+                // synchronous work, not task work.
+                performWork(SynchronousPriority, null);
+              } else {
+                // Flush both synchronous and task work.
+                performWork(TaskPriority, null);
+              }
+            } else if (expirationTime === mostRecentCurrentTime) {
+              invariant(
+                isBatchingUpdates,
+                'Task updates can only be scheduled as a nested update or ' +
+                  'inside batchedUpdates. This error is likely caused by a ' +
+                  'bug in React. Please file an issue.',
+              );
+            } else {
+              // This update is async. Schedule a callback.
+              if (!isCallbackScheduled) {
+                scheduleDeferredCallback(performDeferredWork);
+                isCallbackScheduled = true;
+              }
             }
           }
         } else {
@@ -1486,7 +1507,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   function getPriorityContext(
     fiber: Fiber,
     forceAsync: boolean,
-  ): PriorityLevel {
+  ): PriorityLevel | null {
+    if (isPerformingWork && !isCommitting) {
+      // Updates during the render phase should expire at the same time as
+      // the work that is being rendered. Return null to indicate.
+      return null;
+    }
+
     let priorityLevel = priorityContext;
     if (priorityLevel === NoWork) {
       if (
@@ -1511,13 +1538,29 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     return priorityLevel;
   }
 
+  function getExpirationTimeForPriority(
+    currentTime: ExpirationTime,
+    priorityLevel: PriorityLevel | null,
+  ): ExpirationTime {
+    if (priorityLevel === null) {
+      // A priorityLevel of null indicates that this update should expire at
+      // the same time as whatever is currently being rendered.
+      return nextRenderExpirationTime;
+    }
+    return priorityToExpirationTime(currentTime, priorityLevel);
+  }
+
   function scheduleErrorRecovery(fiber: Fiber) {
-    scheduleUpdateImpl(fiber, TaskPriority, true);
+    scheduleUpdateImpl(
+      fiber,
+      priorityToExpirationTime(mostRecentCurrentTime, TaskPriority),
+      true,
+    );
   }
 
   function recalculateCurrentTime(): ExpirationTime {
-    currentTime = msToExpirationTime(now());
-    return currentTime;
+    mostRecentCurrentTime = msToExpirationTime(now());
+    return mostRecentCurrentTime;
   }
 
   function batchedUpdates<A, R>(fn: (a: A) => R, a: A): R {
@@ -1583,6 +1626,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     scheduleUpdate: scheduleUpdate,
     getPriorityContext: getPriorityContext,
     recalculateCurrentTime: recalculateCurrentTime,
+    getExpirationTimeForPriority: getExpirationTimeForPriority,
     batchedUpdates: batchedUpdates,
     unbatchedUpdates: unbatchedUpdates,
     flushSync: flushSync,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -96,6 +96,8 @@ var {
 var {
   getUpdateExpirationTime,
   processUpdateQueue,
+  createUpdateQueue,
+  insertUpdateIntoQueue,
 } = require('ReactFiberUpdateQueue');
 
 var {resetContext} = require('ReactFiberContext');
@@ -367,11 +369,26 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
     if (completedAt !== Done) {
       // The root completed but was blocked from committing.
-
       if (expirationTime < completedAt) {
-        // We have work that expires earlier than the completed root. Regardless
-        // of whether the root is blocked, we should work on it.
+        // We have work that expires earlier than the completed root.
         return expirationTime;
+      }
+
+      // If the expiration time of the pending work is equal to the time at
+      // which we completed the work-in-progress, it's possible additional
+      // work was scheduled that happens to fall within the same expiration
+      // bucket. We need to check the work-in-progress fiber.
+      if (expirationTime === completedAt) {
+        const workInProgress = root.current.alternate;
+        if (
+          workInProgress !== null &&
+          (workInProgress.expirationTime !== Done &&
+            workInProgress.expirationTime <= expirationTime)
+        ) {
+          // We have more work. Restart the completed tree.
+          root.completedAt = Done;
+          return expirationTime;
+        }
       }
 
       // There have been no higher priority updates since we completed the root.
@@ -801,7 +818,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         if (isRootBlocked(root, nextRenderExpirationTime)) {
           // The root is blocked from committing. Mark it as complete so we
           // know we can commit it later without starting new work.
-          root.completedAt = workInProgress.expirationTime = nextRenderExpirationTime;
+          root.completedAt = nextRenderExpirationTime;
         } else {
           // The root is not blocked, so we can commit it now.
           pendingCommit = workInProgress;
@@ -1618,6 +1635,37 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
+  function scheduleCompletionCallback(
+    root: FiberRoot,
+    callback: () => mixed,
+    expirationTime: ExpirationTime,
+  ) {
+    // Add callback to queue of callbacks on the root. It will be called once
+    // the root completes at the corresponding expiration time.
+    const update = {
+      priorityLevel: null,
+      expirationTime,
+      partialState: null,
+      callback,
+      isReplace: false,
+      isForced: false,
+      isTopLevelUnmount: false,
+      next: null,
+    };
+    const currentTime = recalculateCurrentTime();
+    if (root.completionCallbacks === null) {
+      root.completionCallbacks = createUpdateQueue();
+    }
+    insertUpdateIntoQueue(root.completionCallbacks, update, currentTime);
+    if (expirationTime === root.completedAt) {
+      // The tree already completed at this expiration time. Resolve the
+      // callback synchronously.
+      performWork(TaskPriority, null);
+    } else {
+      scheduleUpdate(root.current, expirationTime);
+    }
+  }
+
   function getPriorityContext(
     fiber: Fiber,
     forceAsync: boolean,
@@ -1757,6 +1805,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
 
   return {
     scheduleUpdate: scheduleUpdate,
+    scheduleCompletionCallback: scheduleCompletionCallback,
     getPriorityContext: getPriorityContext,
     recalculateCurrentTime: recalculateCurrentTime,
     getExpirationTimeForPriority: getExpirationTimeForPriority,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -396,33 +396,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       // no longer blocked, return the time at which it completed so that we
       // can commit it.
       if (isRootBlocked(root, completedAt)) {
-        // Process pending completion callbacks so that they are called at
-        // the end of the current batch.
-        const completionCallbacks = root.completionCallbacks;
-        if (completionCallbacks !== null) {
-          processUpdateQueue(
-            completionCallbacks,
-            null,
-            null,
-            null,
-            completedAt,
-          );
-          const callbackList = completionCallbacks.callbackList;
-          if (callbackList !== null) {
-            // Add new callbacks to list of completion callbacks
-            if (rootCompletionCallbackList === null) {
-              rootCompletionCallbackList = callbackList;
-            } else {
-              for (let i = 0; i < callbackList.length; i++) {
-                rootCompletionCallbackList.push(callbackList[i]);
-              }
-            }
-            completionCallbacks.callbackList = null;
-            if (completionCallbacks.first === null) {
-              root.completionCallbacks = null;
-            }
-          }
-        }
+        // We usually process completion callbacks right after a root is
+        // completed. But this root already completed, and it's possible that
+        // we received new completion callbacks since then.
+        processCompletionCallbacks(root, completedAt);
         return Done;
       }
 
@@ -430,6 +407,33 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
 
     return expirationTime;
+  }
+
+  function processCompletionCallbacks(
+    root: FiberRoot,
+    completedAt: ExpirationTime,
+  ) {
+    // Process pending completion callbacks so that they are called at
+    // the end of the current batch.
+    const completionCallbacks = root.completionCallbacks;
+    if (completionCallbacks !== null) {
+      processUpdateQueue(completionCallbacks, null, null, null, completedAt);
+      const callbackList = completionCallbacks.callbackList;
+      if (callbackList !== null) {
+        // Add new callbacks to list of completion callbacks
+        if (rootCompletionCallbackList === null) {
+          rootCompletionCallbackList = callbackList;
+        } else {
+          for (let i = 0; i < callbackList.length; i++) {
+            rootCompletionCallbackList.push(callbackList[i]);
+          }
+        }
+        completionCallbacks.callbackList = null;
+        if (completionCallbacks.first === null) {
+          root.completionCallbacks = null;
+        }
+      }
+    }
   }
 
   function commitAllHostEffects() {
@@ -823,6 +827,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           // The root is not blocked, so we can commit it now.
           pendingCommit = workInProgress;
         }
+        processCompletionCallbacks(root, nextRenderExpirationTime);
         return null;
       }
     }
@@ -1607,12 +1612,9 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
                 }
                 break;
               case TaskPriority:
-                invariant(
-                  isBatchingUpdates,
-                  'Task updates can only be scheduled as a nested update or ' +
-                    'inside batchedUpdates. This error is likely caused by a ' +
-                    'bug in React. Please file an issue.',
-                );
+                if (!isPerformingWork && !isBatchingUpdates) {
+                  performWork(TaskPriority, null);
+                }
                 break;
               default:
                 // This update is async. Schedule a callback.

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -20,7 +20,6 @@ const {Done} = require('ReactFiberExpirationTime');
 
 const {ClassComponent, HostRoot} = require('ReactTypeOfWork');
 
-const invariant = require('fbjs/lib/invariant');
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
 }
@@ -95,7 +94,7 @@ function cloneUpdate(update: Update): Update {
 
 const COALESCENCE_THRESHOLD: ExpirationTime = 10;
 
-function insertUpdateIntoQueue(
+function insertUpdateIntoPosition(
   queue: UpdateQueue,
   update: Update,
   insertAfter: Update | null,
@@ -110,6 +109,8 @@ function insertUpdateIntoQueue(
     // could lead to starvation, so we stop coalescing once the time until the
     // expiration time reaches a certain threshold.
     if (
+      // Only coalesce if a priority level is specified
+      update.priorityLevel !== null &&
       insertAfter !== null &&
       insertAfter.priorityLevel === update.priorityLevel
     ) {
@@ -207,7 +208,7 @@ function ensureUpdateQueues(fiber: Fiber) {
 // we shouldn't make a copy.
 //
 // If the update is cloned, it returns the cloned update.
-function insertUpdate(
+function insertUpdateIntoFiber(
   fiber: Fiber,
   update: Update,
   currentTime: ExpirationTime,
@@ -238,7 +239,7 @@ function insertUpdate(
 
   if (queue2 === null) {
     // If there's no alternate queue, there's nothing else to do but insert.
-    insertUpdateIntoQueue(
+    insertUpdateIntoPosition(
       queue1,
       update,
       insertAfter1,
@@ -256,7 +257,7 @@ function insertUpdate(
 
   // Now we can insert into the first queue. This must come after finding both
   // insertion positions because it mutates the list.
-  insertUpdateIntoQueue(
+  insertUpdateIntoPosition(
     queue1,
     update,
     insertAfter1,
@@ -285,7 +286,7 @@ function insertUpdate(
     // The insertion positions are different, so we need to clone the update and
     // insert the clone into the alternate queue.
     const update2 = cloneUpdate(update);
-    insertUpdateIntoQueue(
+    insertUpdateIntoPosition(
       queue2,
       update2,
       insertAfter2,
@@ -295,71 +296,24 @@ function insertUpdate(
     return update2;
   }
 }
+exports.insertUpdateIntoFiber = insertUpdateIntoFiber;
 
-function addUpdate(
-  fiber: Fiber,
-  partialState: PartialState<any, any> | null,
-  callback: mixed,
-  priorityLevel: PriorityLevel | null,
-  expirationTime: ExpirationTime,
+function insertUpdateIntoQueue(
+  queue: UpdateQueue,
+  update: Update,
   currentTime: ExpirationTime,
-): void {
-  const update = {
-    priorityLevel,
-    expirationTime,
-    partialState,
-    callback,
-    isReplace: false,
-    isForced: false,
-    isTopLevelUnmount: false,
-    next: null,
-  };
-  insertUpdate(fiber, update, currentTime);
+) {
+  const insertAfter = findInsertionPosition(queue, update);
+  const insertBefore = insertAfter !== null ? insertAfter.next : null;
+  insertUpdateIntoPosition(
+    queue,
+    update,
+    insertAfter,
+    insertBefore,
+    currentTime,
+  );
 }
-exports.addUpdate = addUpdate;
-
-function addReplaceUpdate(
-  fiber: Fiber,
-  state: any | null,
-  callback: Callback | null,
-  priorityLevel: PriorityLevel | null,
-  expirationTime: ExpirationTime,
-  currentTime: ExpirationTime,
-): void {
-  const update = {
-    priorityLevel,
-    expirationTime,
-    partialState: state,
-    callback,
-    isReplace: true,
-    isForced: false,
-    isTopLevelUnmount: false,
-    next: null,
-  };
-  insertUpdate(fiber, update, currentTime);
-}
-exports.addReplaceUpdate = addReplaceUpdate;
-
-function addForceUpdate(
-  fiber: Fiber,
-  callback: Callback | null,
-  priorityLevel: PriorityLevel | null,
-  expirationTime: ExpirationTime,
-  currentTime: ExpirationTime,
-): void {
-  const update = {
-    priorityLevel,
-    expirationTime,
-    partialState: null,
-    callback,
-    isReplace: false,
-    isForced: true,
-    isTopLevelUnmount: false,
-    next: null,
-  };
-  insertUpdate(fiber, update, currentTime);
-}
-exports.addForceUpdate = addForceUpdate;
+exports.insertUpdateIntoQueue = insertUpdateIntoQueue;
 
 function getUpdateExpirationTime(fiber: Fiber): ExpirationTime {
   const updateQueue = fiber.updateQueue;
@@ -373,48 +327,6 @@ function getUpdateExpirationTime(fiber: Fiber): ExpirationTime {
 }
 exports.getUpdateExpirationTime = getUpdateExpirationTime;
 
-function addTopLevelUpdate(
-  fiber: Fiber,
-  partialState: PartialState<any, any>,
-  callback: Callback | null,
-  priorityLevel: PriorityLevel | null,
-  expirationTime: ExpirationTime,
-  currentTime: ExpirationTime,
-): void {
-  const isTopLevelUnmount = partialState.element === null;
-
-  const update = {
-    priorityLevel,
-    expirationTime,
-    partialState,
-    callback,
-    isReplace: false,
-    isForced: false,
-    isTopLevelUnmount,
-    next: null,
-  };
-  const update2 = insertUpdate(fiber, update, currentTime);
-
-  if (isTopLevelUnmount) {
-    // TODO: Redesign the top-level mount/update/unmount API to avoid this
-    // special case.
-    const queue1 = _queue1;
-    const queue2 = _queue2;
-
-    // Drop all updates that are lower-priority, so that the tree is not
-    // remounted. We need to do this for both queues.
-    if (queue1 !== null && update.next !== null) {
-      update.next = null;
-      queue1.last = update;
-    }
-    if (queue2 !== null && update2 !== null && update2.next !== null) {
-      update2.next = null;
-      queue2.last = update;
-    }
-  }
-}
-exports.addTopLevelUpdate = addTopLevelUpdate;
-
 function getStateFromUpdate(update, instance, prevState, props) {
   const partialState = update.partialState;
   if (typeof partialState === 'function') {
@@ -425,28 +337,13 @@ function getStateFromUpdate(update, instance, prevState, props) {
   }
 }
 
-function beginUpdateQueue(
-  current: Fiber | null,
-  workInProgress: Fiber,
+function processUpdateQueue(
   queue: UpdateQueue,
-  instance: any,
-  prevState: any,
-  props: any,
+  instance: mixed,
+  prevState: Object,
+  props: mixed,
   renderExpirationTime: ExpirationTime,
-): any {
-  if (current !== null && current.updateQueue === queue) {
-    // We need to create a work-in-progress queue, by cloning the current queue.
-    const currentQueue = queue;
-    queue = workInProgress.updateQueue = {
-      first: currentQueue.first,
-      last: currentQueue.last,
-      // These fields are no longer valid because they were already committed.
-      // Reset them.
-      callbackList: null,
-      hasForceUpdate: false,
-    };
-  }
-
+): mixed {
   if (__DEV__) {
     // Set this flag so we can warn if setState is called inside the update
     // function of another setState.
@@ -497,18 +394,12 @@ function beginUpdateQueue(
     ) {
       callbackList = callbackList !== null ? callbackList : [];
       callbackList.push(update.callback);
-      workInProgress.effectTag |= CallbackEffect;
     }
     update = update.next;
   }
 
   queue.callbackList = callbackList;
   queue.hasForceUpdate = hasForceUpdate;
-
-  if (queue.first === null && callbackList === null && !hasForceUpdate) {
-    // The queue is empty and there are no callbacks. We can reset it.
-    workInProgress.updateQueue = null;
-  }
 
   if (__DEV__) {
     // No longer processing.
@@ -517,30 +408,49 @@ function beginUpdateQueue(
 
   return state;
 }
-exports.beginUpdateQueue = beginUpdateQueue;
+exports.insertUpdateIntoQueue = insertUpdateIntoQueue;
 
-function commitCallbacks(
-  finishedWork: Fiber,
+function beginUpdateQueue(
+  current: Fiber | null,
+  workInProgress: Fiber,
   queue: UpdateQueue,
-  context: mixed,
-) {
-  const callbackList = queue.callbackList;
-  if (callbackList === null) {
-    return;
+  instance: any,
+  prevState: any,
+  props: any,
+  renderExpirationTime: ExpirationTime,
+): any {
+  if (current !== null && current.updateQueue === queue) {
+    // We need to create a work-in-progress queue, by cloning the current queue.
+    const currentQueue = queue;
+    queue = workInProgress.updateQueue = {
+      first: currentQueue.first,
+      last: currentQueue.last,
+      // These fields are no longer valid because they were already committed.
+      // Reset them.
+      callbackList: null,
+      hasForceUpdate: false,
+    };
   }
 
-  // Set the list to null to make sure they don't get called more than once.
-  queue.callbackList = null;
+  const state = processUpdateQueue(
+    queue,
+    instance,
+    prevState,
+    props,
+    renderExpirationTime,
+  );
 
-  for (let i = 0; i < callbackList.length; i++) {
-    const callback = callbackList[i];
-    invariant(
-      typeof callback === 'function',
-      'Invalid argument passed as callback. Expected a function. Instead ' +
-        'received: %s',
-      callback,
-    );
-    callback.call(context);
+  const updatedQueue = workInProgress.updateQueue;
+  if (updatedQueue !== null) {
+    const callbackList = updatedQueue.callbackList;
+    if (callbackList !== null) {
+      workInProgress.effectTag |= CallbackEffect;
+    } else if (updatedQueue.first === null && !updatedQueue.hasForceUpdate) {
+      // The queue is empty. We can reset it.
+      workInProgress.updateQueue = null;
+    }
   }
+
+  return state;
 }
-exports.commitCallbacks = commitCallbacks;
+exports.beginUpdateQueue = beginUpdateQueue;

--- a/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
+++ b/src/renderers/shared/fiber/ReactFiberUpdateQueue.js
@@ -37,8 +37,8 @@ export type Update<State> = {
   callback: Callback | null,
   isReplace: boolean,
   isForced: boolean,
-  isTopLevelUnmount: boolean,
   next: Update<State> | null,
+  nextCallback: Update<State> | null,
 };
 
 // Singly linked-list of updates. When an update is scheduled, it is added to
@@ -53,24 +53,32 @@ export type Update<State> = {
 //
 // When the tree is committed, the work-in-progress becomes the current.
 export type UpdateQueue<State> = {
+  // A processed update is not removed from the queue if there are any
+  // unprocessed updates that came before it. In that case, we need to keep
+  // track of the base state, which represents the base state of the first
+  // unprocessed update, which is the same as the first update in the list.
+  baseState: State | null,
+  // For the same reason, we keep track of the remaining expiration time.
+  expirationTime: ExpirationTime,
   first: Update<State> | null,
   last: Update<State> | null,
+  firstCallback: Update<State> | null,
+  lastCallback: Update<State> | null,
   hasForceUpdate: boolean,
-  callbackList: null | Array<Callback>,
 
   // Dev only
   isProcessing?: boolean,
 };
 
-let _queue1;
-let _queue2;
-
-function createUpdateQueue<State>(): UpdateQueue<State> {
+function createUpdateQueue<State>(baseState: State): UpdateQueue<State> {
   const queue: UpdateQueue<State> = {
+    baseState,
+    expirationTime: Done,
     first: null,
     last: null,
+    firstCallback: null,
+    lastCallback: null,
     hasForceUpdate: false,
-    callbackList: null,
   };
   if (__DEV__) {
     queue.isProcessing = false;
@@ -79,147 +87,90 @@ function createUpdateQueue<State>(): UpdateQueue<State> {
 }
 exports.createUpdateQueue = createUpdateQueue;
 
-function cloneUpdate<State>(update: Update<State>): Update<State> {
-  return {
-    priorityLevel: update.priorityLevel,
-    expirationTime: update.expirationTime,
-    partialState: update.partialState,
-    callback: update.callback,
-    isReplace: update.isReplace,
-    isForced: update.isForced,
-    isTopLevelUnmount: update.isTopLevelUnmount,
-    next: null,
-  };
-}
-
 const COALESCENCE_THRESHOLD: ExpirationTime = 10;
 
-function insertUpdateIntoPosition<State>(
+function insertUpdateIntoQueue<State>(
   queue: UpdateQueue<State>,
   update: Update<State>,
-  insertAfter: Update<State> | null,
-  insertBefore: Update<State> | null,
   currentTime: ExpirationTime,
 ) {
-  if (insertAfter !== null) {
-    insertAfter.next = update;
-    // If we receive multiple updates to the same fiber at the same priority
-    // level, we coalesce them by assigning the same expiration time, so that
-    // they all flush at the same time. Because this causes an interruption, it
-    // could lead to starvation, so we stop coalescing once the time until the
-    // expiration time reaches a certain threshold.
+  if (queue.last === null) {
+    // Queue is empty
+    queue.first = queue.last = update;
     if (
-      // Only coalesce if a priority level is specified
-      update.priorityLevel !== null &&
-      insertAfter !== null &&
-      insertAfter.priorityLevel === update.priorityLevel
+      queue.expirationTime === Done ||
+      queue.expirationTime > update.expirationTime
     ) {
-      const coalescedTime = insertAfter.expirationTime;
+      queue.expirationTime = update.expirationTime;
+    }
+    return;
+  }
+
+  // If the priority is not null, see if there are other pending updates with
+  // the same priority. If so, we may need to coalesce them into the same
+  // expiration bucket.
+  const priorityLevel = update.priorityLevel;
+  if (priorityLevel !== null) {
+    let coalescentUpdate = null;
+    if (queue.last.priorityLevel === priorityLevel) {
+      // Fast path where the last update has the same priority.
+      coalescentUpdate = queue.last;
+    } else {
+      // Scan the list for the last update with the same priority.
+      let node = queue.first;
+      while (node !== null) {
+        if (node.priorityLevel === priorityLevel) {
+          coalescentUpdate = node;
+        }
+        node = node.next;
+      }
+    }
+    if (coalescentUpdate !== null) {
+      const coalescedTime = coalescentUpdate.expirationTime;
+      // If the remaining time is greater than the threshold, add the new
+      // update to the same expiration bucket.
       if (coalescedTime - currentTime > COALESCENCE_THRESHOLD) {
         update.expirationTime = coalescedTime;
       }
     }
-  } else {
-    // This is the first item in the queue.
-    update.next = queue.first;
-    queue.first = update;
   }
 
-  if (insertBefore !== null) {
-    update.next = insertBefore;
-  } else {
-    // This is the last item in the queue.
-    queue.last = update;
+  // Append the update to the end of the list.
+  queue.last.next = update;
+  queue.last = update;
+  if (
+    queue.expirationTime === Done ||
+    queue.expirationTime > update.expirationTime
+  ) {
+    queue.expirationTime = update.expirationTime;
   }
 }
+exports.insertUpdateIntoQueue = insertUpdateIntoQueue;
 
-// Returns the update after which the incoming update should be inserted into
-// the queue, or null if it should be inserted at beginning.
-function findInsertionPosition<State>(
-  queue: UpdateQueue<State>,
+function insertUpdateIntoFiber<State>(
+  fiber: Fiber,
   update: Update<State>,
-): Update<State> | null {
-  const expirationTime = update.expirationTime;
-  let insertAfter = null;
-  let insertBefore = null;
-  if (queue.last !== null && queue.last.expirationTime <= expirationTime) {
-    // Fast path for the common case where the update should be inserted at
-    // the end of the queue.
-    insertAfter = queue.last;
-  } else {
-    insertBefore = queue.first;
-    while (
-      insertBefore !== null &&
-      insertBefore.expirationTime <= expirationTime
-    ) {
-      insertAfter = insertBefore;
-      insertBefore = insertBefore.next;
-    }
-  }
-  return insertAfter;
-}
-
-function ensureUpdateQueues(fiber: Fiber) {
+  currentTime: ExpirationTime,
+) {
+  // We'll have at least one and at most two distinct update queues.
   const alternateFiber = fiber.alternate;
-
   let queue1 = fiber.updateQueue;
   if (queue1 === null) {
-    queue1 = fiber.updateQueue = createUpdateQueue();
+    queue1 = fiber.updateQueue = createUpdateQueue(fiber.memoizedState);
   }
 
   let queue2;
   if (alternateFiber !== null) {
     queue2 = alternateFiber.updateQueue;
     if (queue2 === null) {
-      queue2 = alternateFiber.updateQueue = createUpdateQueue();
+      queue2 = alternateFiber.updateQueue = createUpdateQueue(
+        alternateFiber.memoizedState,
+      );
     }
   } else {
     queue2 = null;
   }
-
-  _queue1 = queue1;
-  // Return null if there is no alternate queue, or if its queue is the same.
-  _queue2 = queue2 !== queue1 ? queue2 : null;
-}
-
-// The work-in-progress queue is a subset of the current queue (if it exists).
-// We need to insert the incoming update into both lists. However, it's possible
-// that the correct position in one list will be different from the position in
-// the other. Consider the following case:
-//
-//     Current:             3-5-6
-//     Work-in-progress:        6
-//
-// Then we receive an update with priority 4 and insert it into each list:
-//
-//     Current:             3-4-5-6
-//     Work-in-progress:        4-6
-//
-// In the current queue, the new update's `next` pointer points to the update
-// with priority 5. But in the work-in-progress queue, the pointer points to the
-// update with priority 6. Because these two queues share the same persistent
-// data structure, this won't do. (This can only happen when the incoming update
-// has higher priority than all the updates in the work-in-progress queue.)
-//
-// To solve this, in the case where the incoming update needs to be inserted
-// into two different positions, we'll make a clone of the update and insert
-// each copy into a separate queue. This forks the list while maintaining a
-// persistent structure, because the update that is added to the work-in-progress
-// is always added to the front of the list.
-//
-// However, if incoming update is inserted into the same position of both lists,
-// we shouldn't make a copy.
-//
-// If the update is cloned, it returns the cloned update.
-function insertUpdateIntoFiber<State>(
-  fiber: Fiber,
-  update: Update<State>,
-  currentTime: ExpirationTime,
-): Update<State> | null {
-  // We'll have at least one and at most two distinct update queues.
-  ensureUpdateQueues(fiber);
-  const queue1 = _queue1;
-  const queue2 = _queue2;
+  queue2 = queue2 !== queue1 ? queue2 : null;
 
   // Warn if an update is scheduled from inside an updater function.
   if (__DEV__) {
@@ -234,96 +185,34 @@ function insertUpdateIntoFiber<State>(
     }
   }
 
-  // Find the insertion position in the first queue.
-  const insertAfter1 = findInsertionPosition(queue1, update);
-  const insertBefore1 = insertAfter1 !== null
-    ? insertAfter1.next
-    : queue1.first;
-
+  // If there's only one queue, add the update to that queue and exit.
   if (queue2 === null) {
-    // If there's no alternate queue, there's nothing else to do but insert.
-    insertUpdateIntoPosition(
-      queue1,
-      update,
-      insertAfter1,
-      insertBefore1,
-      currentTime,
-    );
-    return null;
+    insertUpdateIntoQueue(queue1, update, currentTime);
+    return;
   }
 
-  // If there is an alternate queue, find the insertion position.
-  const insertAfter2 = findInsertionPosition(queue2, update);
-  const insertBefore2 = insertAfter2 !== null
-    ? insertAfter2.next
-    : queue2.first;
-
-  // Now we can insert into the first queue. This must come after finding both
-  // insertion positions because it mutates the list.
-  insertUpdateIntoPosition(
-    queue1,
-    update,
-    insertAfter1,
-    insertBefore1,
-    currentTime,
-  );
-
-  // See if the insertion positions are equal. Be careful to only compare
-  // non-null values.
-  if (
-    (insertBefore1 === insertBefore2 && insertBefore1 !== null) ||
-    (insertAfter1 === insertAfter2 && insertAfter1 !== null)
-  ) {
-    // The insertion positions are the same, so when we inserted into the first
-    // queue, it also inserted into the alternate. All we need to do is update
-    // the alternate queue's `first` and `last` pointers, in case they
-    // have changed.
-    if (insertAfter2 === null) {
-      queue2.first = update;
-    }
-    if (insertBefore2 === null) {
-      queue2.last = null;
-    }
-    return null;
-  } else {
-    // The insertion positions are different, so we need to clone the update and
-    // insert the clone into the alternate queue.
-    const update2 = cloneUpdate(update);
-    insertUpdateIntoPosition(
-      queue2,
-      update2,
-      insertAfter2,
-      insertBefore2,
-      currentTime,
-    );
-    return update2;
+  // If either queue is empty, we need to add to both queues.
+  if (queue1.last === null || queue2.last === null) {
+    insertUpdateIntoQueue(queue1, update, currentTime);
+    insertUpdateIntoQueue(queue2, update, currentTime);
+    return;
   }
+
+  // If both lists are not empty, the last update is the same for both lists
+  // because of structural sharing. So, we should only append to one of
+  // the lists.
+  insertUpdateIntoQueue(queue1, update, currentTime);
+  // But we still need to update the `last` pointer of queue2.
+  queue2.last = update;
 }
 exports.insertUpdateIntoFiber = insertUpdateIntoFiber;
 
-function insertUpdateIntoQueue<State>(
-  queue: UpdateQueue<State>,
-  update: Update<State>,
-  currentTime: ExpirationTime,
-) {
-  const insertAfter = findInsertionPosition(queue, update);
-  const insertBefore = insertAfter !== null ? insertAfter.next : null;
-  insertUpdateIntoPosition(
-    queue,
-    update,
-    insertAfter,
-    insertBefore,
-    currentTime,
-  );
-}
-exports.insertUpdateIntoQueue = insertUpdateIntoQueue;
-
 function getUpdateExpirationTime(fiber: Fiber): ExpirationTime {
-  const updateQueue = fiber.updateQueue;
-  if (updateQueue === null) {
+  if (fiber.tag !== ClassComponent && fiber.tag !== HostRoot) {
     return Done;
   }
-  if (fiber.tag !== ClassComponent && fiber.tag !== HostRoot) {
+  const updateQueue = fiber.updateQueue;
+  if (updateQueue === null) {
     return Done;
   }
   return getUpdateQueueExpirationTime(updateQueue);
@@ -333,7 +222,7 @@ exports.getUpdateExpirationTime = getUpdateExpirationTime;
 function getUpdateQueueExpirationTime<State>(
   updateQueue: UpdateQueue<State>,
 ): ExpirationTime {
-  return updateQueue.first !== null ? updateQueue.first.expirationTime : Done;
+  return updateQueue.expirationTime;
 }
 exports.getUpdateQueueExpirationTime = getUpdateQueueExpirationTime;
 
@@ -351,34 +240,59 @@ function getStateFromUpdate(update, instance, prevState, props) {
 function processUpdateQueue<State>(
   queue: UpdateQueue<State>,
   instance: mixed,
-  prevState: State,
   props: mixed,
   renderExpirationTime: ExpirationTime,
-): State {
+): State | null {
   if (__DEV__) {
     // Set this flag so we can warn if setState is called inside the update
     // function of another setState.
     queue.isProcessing = true;
   }
 
-  // Calculate these using the the existing values as a base.
-  let callbackList = queue.callbackList;
-  let hasForceUpdate = queue.hasForceUpdate;
+  // Reset the remaining expiration time. If we skip over any updates, we'll
+  // increase this accordingly.
+  queue.expirationTime = Done;
 
-  // Applies updates with matching priority to the previous state to create
-  // a new state object.
-  let state = prevState;
+  let state = queue.baseState;
   let dontMutatePrevState = true;
   let update = queue.first;
-  while (update !== null && update.expirationTime <= renderExpirationTime) {
-    // Remove each update from the queue right before it is processed. That way
-    // if setState is called from inside an updater function, the new update
-    // will be inserted in the correct position.
-    queue.first = update.next;
-    if (queue.first === null) {
-      queue.last = null;
+  let didSkip = false;
+  while (update !== null) {
+    const updateExpirationTime = update.expirationTime;
+    if (
+      updateExpirationTime === Done ||
+      updateExpirationTime > renderExpirationTime
+    ) {
+      // This update does not have sufficient priority. Skip it.
+      const remainingExpirationTime = queue.expirationTime;
+      if (
+        remainingExpirationTime === Done ||
+        remainingExpirationTime > updateExpirationTime
+      ) {
+        // Update the remaining expiration time.
+        queue.expirationTime = updateExpirationTime;
+      }
+      if (!didSkip) {
+        didSkip = true;
+        queue.baseState = state;
+      }
+      // Continue to the next update.
+      update = update.next;
+      continue;
     }
 
+    // This update does have sufficient priority.
+
+    // If no previous updates were skipped, drop this update from the queue by
+    // advancing the head of the list.
+    if (!didSkip) {
+      queue.first = update.next;
+      if (queue.first === null) {
+        queue.last = null;
+      }
+    }
+
+    // Process the update
     let partialState;
     if (update.isReplace) {
       state = getStateFromUpdate(update, instance, state, props);
@@ -396,22 +310,23 @@ function processUpdateQueue<State>(
       }
     }
     if (update.isForced) {
-      hasForceUpdate = true;
+      queue.hasForceUpdate = true;
     }
-    // Second condition ignores top-level unmount callbacks if they are not the
-    // last update in the queue, since a subsequent update will cause a remount.
-    if (
-      update.callback !== null &&
-      !(update.isTopLevelUnmount && update.next !== null)
-    ) {
-      callbackList = callbackList !== null ? callbackList : [];
-      callbackList.push(update.callback);
+    if (update.callback !== null) {
+      // Append to list of callbacks.
+      if (queue.lastCallback === null) {
+        queue.lastCallback = queue.firstCallback = update;
+      } else {
+        queue.lastCallback.nextCallback = update;
+        queue.lastCallback = update;
+      }
     }
     update = update.next;
   }
-
-  queue.callbackList = callbackList;
-  queue.hasForceUpdate = hasForceUpdate;
+  if (!didSkip) {
+    didSkip = true;
+    queue.baseState = state;
+  }
 
   if (__DEV__) {
     // No longer processing.
@@ -427,19 +342,21 @@ function beginUpdateQueue<State>(
   workInProgress: Fiber,
   queue: UpdateQueue<State>,
   instance: any,
-  prevState: any,
   props: any,
   renderExpirationTime: ExpirationTime,
-): State {
+): State | null {
   if (current !== null && current.updateQueue === queue) {
     // We need to create a work-in-progress queue, by cloning the current queue.
     const currentQueue = queue;
     queue = workInProgress.updateQueue = {
+      baseState: currentQueue.baseState,
+      expirationTime: currentQueue.expirationTime,
       first: currentQueue.first,
       last: currentQueue.last,
       // These fields are no longer valid because they were already committed.
       // Reset them.
-      callbackList: null,
+      firstCallback: null,
+      lastCallback: null,
       hasForceUpdate: false,
     };
   }
@@ -447,15 +364,13 @@ function beginUpdateQueue<State>(
   const state = processUpdateQueue(
     queue,
     instance,
-    prevState,
     props,
     renderExpirationTime,
   );
 
   const updatedQueue = workInProgress.updateQueue;
   if (updatedQueue !== null) {
-    const callbackList = updatedQueue.callbackList;
-    if (callbackList !== null) {
+    if (updatedQueue.lastCallback !== null) {
       workInProgress.effectTag |= CallbackEffect;
     } else if (updatedQueue.first === null && !updatedQueue.hasForceUpdate) {
       // The queue is empty. We can reset it.

--- a/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
+++ b/src/renderers/shared/fiber/ReactTypeOfSideEffect.js
@@ -13,16 +13,26 @@
 export type TypeOfSideEffect = number;
 
 module.exports = {
-  // Don't change these two values:
-  NoEffect: 0, //           0b00000000
-  PerformedWork: 1, //      0b00000001
-  // You can change the rest (and add more).
-  Placement: 2, //          0b00000010
-  Update: 4, //             0b00000100
-  PlacementAndUpdate: 6, // 0b00000110
-  Deletion: 8, //           0b00001000
-  ContentReset: 16, //      0b00010000
-  Callback: 32, //          0b00100000
-  Err: 64, //               0b01000000
-  Ref: 128, //              0b10000000
+  NoEffect: 0, //            0b0000000000
+
+  // Read by the React DevTools. Don't change!
+  PerformedWork: 1, //       0b0000000001
+  // Indicates the work completed and needs to be garbage collected. This needs
+  // to be its own field so we can tell when work is completed multiple times.
+  PreparedWork: 2, //        0b0000000010
+  // Indicates the subtree contains work that needs to be garbage collected.
+  NeedsCleanUp: 4, //        0b0000000100
+
+  // The preceding fields should be disregarded when adding work to the effect
+  // list. Only add to effect list if effectTag > InsigificantBits
+  InsigificantBits: 7, //    0b0000000111
+
+  Placement: 8, //           0b0000001000
+  Update: 16, //             0b0000010000
+  PlacementAndUpdate: 24, // 0b0000011000
+  Deletion: 32, //           0b0000100000
+  ContentReset: 64, //       0b0001000000
+  Callback: 128, //          0b0010000000
+  Err: 256, //               0b0100000000
+  Ref: 512, //               0b1000000000
 };

--- a/src/renderers/shared/fiber/__tests__/ReactDeterministicUpdates-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactDeterministicUpdates-test.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactNoop;
+
+describe('ReactDeterministicUpdates', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactNoop = require('ReactNoopEntry');
+  });
+
+  const HIGH_PRI_UPDATE = 'HIGH_PRI_UPDATE';
+  const LOW_PRI_UPDATE = 'LOW_PRI_UPDATE';
+  const EXPIRE = 'EXPIRE';
+
+  const genAction = gen.oneOf([
+    {type: HIGH_PRI_UPDATE},
+    {type: LOW_PRI_UPDATE},
+    gen.object({type: EXPIRE, payload: gen.intWithin(0, 50)}),
+  ]);
+
+  check.it(
+    'terminal value is the same regardless of priority',
+    {times: 20},
+    gen.array(genAction, {size: 5}),
+    (actions, id) => {
+      class Log extends React.Component {
+        state = {log: []};
+        render() {
+          return null;
+        }
+      }
+
+      let instance;
+      const root = ReactNoop.createRoot();
+      root.render(<Log ref={inst => (instance = inst)} />);
+      ReactNoop.flush();
+
+      // Schedule updates at different priorities. Assert that they are
+      // processed in insertion order.
+      function updateLog(value) {
+        // Append value to the log. The log represents the order in which
+        // updates were processed.
+        return state => ({log: [...state.log, value]});
+      }
+
+      function checkLog(log) {
+        let previous;
+        for (let i = 0; i < log.length; i++) {
+          const current = log[i];
+          if (typeof current !== 'number') {
+            throw new Error('Expected a number.');
+          }
+          if (previous !== undefined) {
+            if (current < previous) {
+              throw new Error('Updates were flushed out of order');
+            }
+          }
+          previous = current;
+        }
+      }
+
+      try {
+        var updateCounter = 0;
+        var expectedTerminalLog = [];
+        for (var i = 0; i < actions.length; i++) {
+          var action = actions[i];
+          ReactNoop.flushSync(() => {
+            switch (action.type) {
+              case HIGH_PRI_UPDATE:
+                instance.setState(updateLog(++updateCounter));
+                expectedTerminalLog.push(updateCounter);
+                break;
+              case LOW_PRI_UPDATE:
+                ReactNoop.deferredUpdates(() => {
+                  instance.setState(updateLog(++updateCounter));
+                });
+                expectedTerminalLog.push(updateCounter);
+                break;
+              case EXPIRE:
+                ReactNoop.expire(action.payload);
+                break;
+              default:
+                throw new Error('Switch statement should be exhaustive.');
+            }
+          });
+          checkLog(instance.state.log);
+        }
+        ReactNoop.flush();
+        // The final state is deterministic
+        expect(instance.state.log).toEqual(expectedTerminalLog);
+      } finally {
+        root.unmount();
+        ReactNoop.flush();
+      }
+    },
+  );
+});

--- a/src/renderers/shared/fiber/__tests__/ReactExpiration-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactExpiration-test.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+var React;
+var ReactNoop;
+
+describe('ReactExpiration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+  });
+
+  function span(prop) {
+    return {type: 'span', children: [], prop};
+  }
+
+  it('increases priority of updates as time progresses', () => {
+    ReactNoop.render(<span prop="done" />);
+
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Nothing has expired yet because time hasn't advanced.
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance by 300ms, not enough to expire the low pri update.
+    ReactNoop.expire(300);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance by another second. Now the update should expire and flush.
+    ReactNoop.expire(1000);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span('done')]);
+  });
+
+  it('coalesces updates to the same component', () => {
+    const foos = [];
+    class Foo extends React.Component {
+      constructor() {
+        super();
+        this.state = {step: 0};
+        foos.push(this);
+      }
+      render() {
+        return <span prop={this.state.step} />;
+      }
+    }
+
+    ReactNoop.render([<Foo key="A" />, <Foo key="B" />]);
+    ReactNoop.flush();
+    const [a, b] = foos;
+
+    a.setState({step: 1});
+
+    // Advance time by 500ms.
+    ReactNoop.expire(500);
+
+    // Update A again. This update should coalesce with the previous update.
+    a.setState({step: 2});
+    // Update B. This is the first update, so it has nothing to coalesce with.
+    b.setState({step: 1});
+
+    // Advance time. This should be enough to flush both updates to A, but not
+    // the update to B. If only the first update to A flushes, but not the
+    // second, then it wasn't coalesced properly.
+    ReactNoop.expire(500);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span(2), span(0)]);
+
+    // Now expire the update to B.
+    ReactNoop.expire(500);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span(2), span(1)]);
+  });
+
+  it('stops coalescing after a certain threshold', () => {
+    let instance;
+    class Foo extends React.Component {
+      state = {step: 0};
+      render() {
+        instance = this;
+        return <span prop={this.state.step} />;
+      }
+    }
+
+    ReactNoop.render(<Foo />);
+    ReactNoop.flush();
+
+    instance.setState({step: 1});
+
+    // Advance time by 500 ms.
+    ReactNoop.expire(500);
+
+    // Update again. This update should coalesce with the previous update.
+    instance.setState({step: 2});
+
+    // Advance time by 480ms. Not enough to expire the updates.
+    ReactNoop.expire(480);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span(0)]);
+
+    // Update again. This update should NOT be coalesced, because the
+    // previous updates have almost expired.
+    instance.setState({step: 3});
+
+    // Advance time. This should expire the first two updates,
+    // but not the third.
+    ReactNoop.expire(500);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span(2)]);
+
+    // Now expire the remaining update.
+    ReactNoop.expire(1000);
+    ReactNoop.flushExpired();
+    expect(ReactNoop.getChildren()).toEqual([span(3)]);
+  });
+});

--- a/src/renderers/shared/fiber/__tests__/ReactFiberGarbageCollection-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactFiberGarbageCollection-test.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactNoop;
+
+describe('ReactFiberGarbageCollection', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+  });
+
+  it('cleans up dropped fibers', () => {
+    class Foo extends React.Component {
+      unstable_prepareMount() {
+        ReactNoop.yield(`${this.props.label} completed`);
+      }
+      unstable_abortMount() {
+        ReactNoop.yield(`${this.props.label} dropped`);
+      }
+      componentWillUnmount() {
+        ReactNoop.yield(`${this.props.label} unmounted`);
+      }
+      componentDidMount() {
+        ReactNoop.yield(`${this.props.label} mounted`);
+      }
+      render() {
+        ReactNoop.yield(`${this.props.label} began`);
+        return this.props.children || null;
+      }
+    }
+
+    function Bar(props) {
+      return props.children;
+    }
+
+    function App() {
+      return (
+        <Bar>
+          <Foo label="a">
+            <Bar><Foo label="b" /></Bar>
+            <Foo label="c" />
+          </Foo>
+          <Bar><Foo label="d" /></Bar>
+        </Bar>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    root.render(<App />);
+
+    // Complete some of the fibers, but don't mount them
+    ReactNoop.flushThrough([
+      'a began',
+      'b began',
+      'b completed',
+      'c began',
+      'c completed',
+      'a completed',
+    ]);
+
+    // Unmount the whole tree
+    root.render(null);
+
+    // a, b, and c should have been dropped. But not d, because it
+    // didn't complete.
+    expect(ReactNoop.flush()).toEqual(['a dropped', 'b dropped', 'c dropped']);
+
+    // Render the app again, but this time mount the whole tree.
+    root.render(<App />);
+    ReactNoop.flush();
+    // Unmount the app. a, b, c, and d should be unmounted, not dropped.
+    root.render(null);
+    expect(ReactNoop.flush()).toEqual([
+      'a unmounted',
+      'b unmounted',
+      'c unmounted',
+      'd unmounted',
+    ]);
+  });
+
+  it('drops in-progress updates on deletion', () => {
+    class Foo extends React.Component {
+      unstable_prepareMount() {
+        ReactNoop.yield('prepare mount');
+      }
+      unstable_prepareUpdate() {
+        ReactNoop.yield('prepare update');
+      }
+      unstable_abortMount() {
+        ReactNoop.yield('drop mount');
+      }
+      unstable_abortUpdate() {
+        ReactNoop.yield('drop update');
+      }
+      componentDidMount() {
+        ReactNoop.yield('did mount');
+      }
+      componentDidUpdate() {
+        ReactNoop.yield('did update');
+      }
+      componentWillUnmount() {
+        ReactNoop.yield('did unmount');
+      }
+      render() {
+        ReactNoop.yield('render');
+        return null;
+      }
+    }
+
+    const root = ReactNoop.createRoot();
+    // Mount the tree
+    root.render([<Foo key="1" />, <span key="2" />]);
+    ReactNoop.flush();
+
+    // Start an update
+    root.render([<Foo key="1" />, <span key="2" />]);
+    ReactNoop.flushThrough(['render', 'prepare update']);
+
+    // Unmount the tree. Both the mount and the update should be cleaned up.
+    root.render(null);
+    expect(ReactNoop.flush()).toEqual(['drop update', 'did unmount']);
+  });
+});

--- a/src/renderers/shared/fiber/__tests__/ReactFiberHostContext-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactFiberHostContext-test.js
@@ -46,6 +46,9 @@ describe('ReactFiberHostContext', () => {
       appendChildToContainer: function() {
         return null;
       },
+      now: function() {
+        return 0;
+      },
       useSyncScheduling: true,
     });
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalRoot-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalRoot-test.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactNoop;
+
+describe('ReactIncrementalRoot', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+  });
+
+  function span(prop) {
+    return {type: 'span', children: [], prop};
+  }
+
+  it('prerenders roots', () => {
+    const root = ReactNoop.create();
+    const work = root.prerender(<span prop="A" />);
+    expect(root.getChildren()).toEqual([]);
+    work.commit();
+    expect(root.getChildren()).toEqual([span('A')]);
+  });
+
+  it('resolves `then` callback synchronously if tree is already completed', () => {
+    const root = ReactNoop.create();
+    const work = root.prerender(<span prop="A" />);
+    ReactNoop.flush();
+    let wasCalled = false;
+    work.then(() => {
+      wasCalled = true;
+    });
+    expect(wasCalled).toBe(true);
+  });
+
+  it('does not restart a completed tree if there were no additional updates', () => {
+    let ops = [];
+    function Foo(props) {
+      ops.push('Foo');
+      return <span prop={props.children} />;
+    }
+    const root = ReactNoop.create();
+    const work = root.prerender(<Foo>Hi</Foo>);
+
+    ReactNoop.flush();
+    expect(ops).toEqual(['Foo']);
+    expect(root.getChildren([]));
+
+    work.then(() => {
+      ops.push('Root completed');
+      work.commit();
+      ops.push('Root committed');
+    });
+
+    expect(ops).toEqual([
+      'Foo',
+      'Root completed',
+      // Should not re-render Foo
+      'Root committed',
+    ]);
+    expect(root.getChildren([span('Hi')]));
+  });
+
+  it('works on a blocked tree if the expiration time is less than or equal to the blocked update', () => {
+    let ops = [];
+    function Foo(props) {
+      ops.push('Foo: ' + props.children);
+      return <span prop={props.children} />;
+    }
+    const root = ReactNoop.create();
+    root.prerender(<Foo>A</Foo>);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Foo: A']);
+    expect(root.getChildren()).toEqual([]);
+
+    // workA and workB have the same expiration time
+    root.prerender(<Foo>B</Foo>);
+    ReactNoop.flush();
+
+    // Should have re-rendered the root, even though it's blocked
+    // from committing.
+    expect(ops).toEqual(['Foo: A', 'Foo: B']);
+    expect(root.getChildren()).toEqual([]);
+  });
+
+  it(
+    'does not work on on a blocked tree if the expiration time is greater than the blocked update',
+  );
+});

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalRoot-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalRoot-test.js
@@ -24,7 +24,7 @@ describe('ReactIncrementalRoot', () => {
   }
 
   it('prerenders roots', () => {
-    const root = ReactNoop.create();
+    const root = ReactNoop.createRoot();
     const work = root.prerender(<span prop="A" />);
     expect(root.getChildren()).toEqual([]);
     work.commit();
@@ -32,7 +32,7 @@ describe('ReactIncrementalRoot', () => {
   });
 
   it('resolves `then` callback synchronously if tree is already completed', () => {
-    const root = ReactNoop.create();
+    const root = ReactNoop.createRoot();
     const work = root.prerender(<span prop="A" />);
     ReactNoop.flush();
     let wasCalled = false;
@@ -48,7 +48,7 @@ describe('ReactIncrementalRoot', () => {
       ops.push('Foo');
       return <span prop={props.children} />;
     }
-    const root = ReactNoop.create();
+    const root = ReactNoop.createRoot();
     const work = root.prerender(<Foo>Hi</Foo>);
 
     ReactNoop.flush();
@@ -76,7 +76,7 @@ describe('ReactIncrementalRoot', () => {
       ops.push('Foo: ' + props.children);
       return <span prop={props.children} />;
     }
-    const root = ReactNoop.create();
+    const root = ReactNoop.createRoot();
     root.prerender(<Foo>A</Foo>);
     ReactNoop.flush();
 

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -57,11 +57,13 @@ describe('ReactIncrementalScheduling', () => {
         ReactNoop.render(<span prop={4} />);
       });
     });
+    // The sync updates flush first.
+    expect(ReactNoop.getChildren()).toEqual([span(4)]);
 
-    // The low pri update should be flushed last, even though it was scheduled
-    // before the sync updates.
+    // The terminal value should be the last update that was scheduled,
+    // regardless of priority. In this case, that's the last sync update.
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span(5)]);
+    expect(ReactNoop.getChildren()).toEqual([span(4)]);
   });
 
   it('schedules top-level updates with same priority in order of insertion', () => {

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
@@ -54,6 +54,14 @@ describe('ReactIncrementalTriangle', () => {
     };
   }
 
+  const EXPIRE = 'EXPIRE';
+  function expire(ms) {
+    return {
+      type: EXPIRE,
+      ms,
+    };
+  }
+
   function TriangleSimulator() {
     let triangles = [];
     let leafTriangles = [];
@@ -212,6 +220,9 @@ describe('ReactIncrementalTriangle', () => {
                 targetTriangle.activate();
               }
               break;
+            case EXPIRE:
+              ReactNoop.expire(action.ms);
+              break;
             default:
               break;
           }
@@ -251,7 +262,7 @@ describe('ReactIncrementalTriangle', () => {
     }
 
     function randomAction() {
-      switch (randomInteger(0, 4)) {
+      switch (randomInteger(0, 5)) {
         case 0:
           return flush(randomInteger(0, totalTriangles * 1.5));
         case 1:
@@ -260,6 +271,8 @@ describe('ReactIncrementalTriangle', () => {
           return interrupt();
         case 3:
           return toggle(randomInteger(0, totalChildren));
+        case 4:
+          return expire(randomInteger(0, 1500));
         default:
           throw new Error('Switch statement should be exhaustive');
       }
@@ -289,6 +302,9 @@ describe('ReactIncrementalTriangle', () => {
             break;
           case TOGGLE:
             result += `toggle(${action.childIndex})`;
+            break;
+          case EXPIRE:
+            result += `expire(${action.ms})`;
             break;
           default:
             throw new Error('Switch statement should be exhaustive');

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalTriangle-test.js
@@ -244,6 +244,7 @@ describe('ReactIncrementalTriangle', () => {
     simulate(step(1), toggle(0), flush(2), step(2), toggle(0));
     simulate(step(1), flush(3), toggle(0), step(0));
     simulate(step(1), flush(3), toggle(18), step(0));
+    simulate(interrupt(), step(6), step(7), toggle(6), interrupt());
   });
 
   it('fuzz tester', () => {

--- a/src/renderers/testing/ReactTestRendererFiberEntry.js
+++ b/src/renderers/testing/ReactTestRendererFiberEntry.js
@@ -247,6 +247,11 @@ var TestRenderer = ReactFiberReconciler({
   useSyncScheduling: true,
 
   getPublicInstance,
+
+  now(): number {
+    // Test renderer does not use expiration
+    return 0;
+  },
 });
 
 var defaultTestOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,6 +2614,12 @@ istanbul-reports@^1.1.1:
   dependencies:
     handlebars "^4.0.3"
 
+jasmine-check@^1.0.0-rc.0:
+  version "1.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/jasmine-check/-/jasmine-check-1.0.0-rc.0.tgz#117728c150078ecf211986c5f164275b71e937a4"
+  dependencies:
+    testcheck "^1.0.0-rc"
+
 jest-changed-files@20.1.0-delta.1:
   version "20.1.0-delta.1"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-20.1.0-delta.1.tgz#912f8eff09c79b28fc7b66513f0ad505f1b378d5"
@@ -4315,6 +4321,10 @@ test-exclude@^4.0.3:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+testcheck@^1.0.0-rc:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/testcheck/-/testcheck-1.0.0-rc.2.tgz#11356a25b84575efe0b0857451e85b5fa74ee4e4"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Adds lifecycle methods that are invoked during the complete phase. These can be used to prepare external resources, like subscriptions, before work is committed.

Corresponding lifecycle methods are invoked if work is dropped without committing. Otherwise, the normal commit phase lifecycles (`componentDidMount`, `componentDidUpdate`) are called.

In theory, the same underlying mechanism could be used to create and destroy persistent Yoga views in React Native without leaking memory.

The complete phase lifecycles are:
- `unstable_prepareMount`
- `unstable_prepareUpdate`

The garbage collection lifecycles are:
- `unstable_abortMount`
- `unstable_abortUpdate`

To avoid memory leaks, every call of a "prepare" lifecycle must have either a corresponding commit phase lifecycle or a corresponding "abort" lifecycle.

TODO:
- [ ] Dropped trees don't need to be garbage collected immediately. Defer by scheduling a callback. Requires refactoring to give `createWorkInProgress` access to the scheduler.

Based on top of my other open async PRs. Relevant work starts with the commit titled "Garbage collection."