### PR TITLE
Ensure all external links have consistent behavior

### DIFF
--- a/docs/_data/nav_community.yml
+++ b/docs/_data/nav_community.yml
@@ -6,9 +6,9 @@
       title: Conferences
     - id: videos
       title: Videos
-    - id: complementary-tools
-      title: Complementary Tools
-      href: https://github.com/facebook/react/wiki/Complementary-Tools
     - id: examples
       title: Examples
       href: https://github.com/facebook/react/wiki/Examples
+    - id: complementary-tools
+      title: Complementary Tools
+      href: https://github.com/facebook/react/wiki/Complementary-Tools

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ id: home
       <h3>A Component Using External Plugins</h3>
       <p>
         React is flexible and provides hooks that allow you to interface with
-        other libraries and frameworks. This example uses **remarkable**, an
+        other libraries and frameworks. This example uses <strong>remarkable</strong>, an
         external Markdown library, to convert the textarea's value in real time.
       </p>
       <div id="markdownExample"></div>

--- a/www/src/components/ErrorDecoder/ErrorDecoder.js
+++ b/www/src/components/ErrorDecoder/ErrorDecoder.js
@@ -29,7 +29,9 @@ function urlify(str) {
   for (let i = 0; i < segments.length; i++) {
     if (i % 2 === 1) {
       segments[i] = (
-        <a key={i} target="_blank" href={segments[i]}>{segments[i]}</a>
+        <a key={i} target="_blank" rel="noopener" href={segments[i]}>
+          {segments[i]}
+        </a>
       );
     }
   }

--- a/www/src/components/LayoutFooter/ExternalFooterLink.js
+++ b/www/src/components/LayoutFooter/ExternalFooterLink.js
@@ -13,7 +13,7 @@ import React from 'react';
 import {colors} from 'theme';
 import ExternalLinkSvg from 'templates/components/ExternalLinkSvg';
 
-const ExternalFooterLink = ({children, href, target}) => (
+const ExternalFooterLink = ({children, href, target, rel}) => (
   <a
     css={{
       lineHeight: 2,
@@ -22,7 +22,8 @@ const ExternalFooterLink = ({children, href, target}) => (
       },
     }}
     href={href}
-    target={target}>
+    target={target}
+    rel={rel}>
     {children}
     <ExternalLinkSvg
       cssProps={{

--- a/www/src/components/LayoutFooter/Footer.js
+++ b/www/src/components/LayoutFooter/Footer.js
@@ -130,12 +130,14 @@ const Footer = ({layoutHasSidebar = false}) => (
             <FooterLink to="/blog/">Blog</FooterLink>
             <ExternalFooterLink
               href="https://github.com/facebook/react"
-              target="_blank">
+              target="_blank"
+              rel="noopener">
               GitHub
             </ExternalFooterLink>
             <ExternalFooterLink
               href="http://facebook.github.io/react-native/"
-              target="_blank">
+              target="_blank"
+              rel="noopener">
               React Native
             </ExternalFooterLink>
             <FooterLink to="/acknowledgements.html">
@@ -162,7 +164,10 @@ const Footer = ({layoutHasSidebar = false}) => (
               paddingTop: 40,
             },
           }}>
-          <a href="https://code.facebook.com/projects/" target="_blank">
+          <a
+            href="https://code.facebook.com/projects/"
+            target="_blank"
+            rel="noopener">
             <img
               alt="Facebook Open Source"
               css={{

--- a/www/src/components/LayoutHeader/Header.js
+++ b/www/src/components/LayoutHeader/Header.js
@@ -217,7 +217,9 @@ const Header = ({location}) => (
               whiteSpace: 'nowrap',
               ...fonts.small,
             }}
-            href="https://github.com/facebook/react/releases">
+            href="https://github.com/facebook/react/releases"
+            target="_blank"
+            rel="noopener">
             v{version}
           </a>
           <a
@@ -230,7 +232,9 @@ const Header = ({location}) => (
                 color: colors.brand,
               },
             }}
-            href="https://github.com/facebook/react/">
+            href="https://github.com/facebook/react/"
+            target="_blank"
+            rel="noopener">
             GitHub
             <ExternalLinkSvg
               cssProps={{

--- a/www/src/utils/createLink.js
+++ b/www/src/utils/createLink.js
@@ -32,7 +32,7 @@ const createLinkBlog = ({item, location, section}) => {
 const createLinkCommunity = ({item, location, section}) => {
   if (item.href) {
     return (
-      <a css={[linkCss]} href={item.href}>
+      <a css={[linkCss]} href={item.href} target="_blank" rel="noopener">
         {item.title}
         <ExternalLinkSvg
           cssProps={{
@@ -44,13 +44,12 @@ const createLinkCommunity = ({item, location, section}) => {
         />
       </a>
     );
-  } else {
-    return createLinkDocs({
-      item,
-      location,
-      section,
-    });
   }
+  return createLinkDocs({
+    item,
+    location,
+    section,
+  });
 };
 
 const createLinkDocs = ({item, location, section}) => {

--- a/www/src/utils/sectionList.js
+++ b/www/src/utils/sectionList.js
@@ -17,21 +17,21 @@ import navDocs from '../../../docs/_data/nav_docs.yml';
 import navTutorial from '../../../docs/_data/nav_tutorial.yml';
 
 const sectionListDocs = navDocs
-  .map(item => {
-    item.directory = 'docs';
-    return item;
-  })
+  .map(item => ({
+    ...item,
+    directory: 'docs',
+  }))
   .concat(
-    navContributing.map(item => {
-      item.directory = 'contributing';
-      return item;
-    }),
+    navContributing.map(item => ({
+      ...item,
+      directory: 'contributing',
+    })),
   );
 
-const sectionListCommunity = navCommunity.map(item => {
-  item.directory = 'community';
-  return item;
-});
+const sectionListCommunity = navCommunity.map(item => ({
+  ...item,
+  directory: 'community',
+}));
 
 export {
   sectionListCommunity,


### PR DESCRIPTION
The new docs site looks great! I did an audit of the links on the entire site and found some issues. This PR attempts to address them:

- The `<ExternalFooterLink>` component was not making use of the `rel` prop passed in. Hence links created by `<ExternalFooterLink>` component could have `target="_blank"` and subjected to the `window.opener` security vulnerabililty. I have made `<ExternalFooterLink>` use the `rel` prop.
- Some links with `target="_blank"` don't have the `rel="noopener"` attribute.
- Reorder the `sectionListCommunity` links on the [Community Resources page](https://reactjs.org/community/support.html) to match the footer.
- Some of the links that have the external icon / render the `<ExternalLinkSvg>` component do not open in new tabs. I made the behavior consistent by adding `target="_blank"` and `rel="noopener"` to them. If this is intended, let me know and I'll revert.

Other minor stuff:

- `**remarkable**` on the homepage of the "A Component Using External Plugins" section was left as markdown. Changed it to `<strong>` as the line "JSX is optional and not required to use in the React" in the "A Simple Component" section is also rendered using `<strong>`.

Some questions/suggestions I have:

- Some of the links in the templates of the `docs` directory face the issues mentioned above but they are no longer in use. Should they be fixed as well?
- I think `target="_blank"` and `rel="noopener"` should be part of an `<ExternalLink>` component so that all external links on the new docs site can use it without having those two props be repeated so many times like inside `LayoutFooter/Footer.js`. I can do a site-wide refactor for this if there's interest.