### PR TITLE
Stop exposing DOMProperty for the www build

### DIFF
--- a/src/fb/ReactDOMFiberFBEntry.js
+++ b/src/fb/ReactDOMFiberFBEntry.js
@@ -19,8 +19,6 @@ Object.assign(
     ReactFiberTreeReflection: require('ReactFiberTreeReflection'),
     ReactDOMComponentTree: require('ReactDOMComponentTree'),
     ReactInstanceMap: require('ReactInstanceMap'),
-    // This is used for ajaxify on www:
-    DOMProperty: require('DOMProperty'),
     // These are dependencies of TapEventPlugin:
     EventPluginUtils: require('EventPluginUtils'),
     EventPropagators: require('EventPropagators'),


### PR DESCRIPTION
We don't need it anymore because we support custom attributes out of the box.
Proof: https://github.com/facebook/react/blob/12d5231c2aa60277ab22e441bc9b09b57ff3d4cc/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js#L2196-L2201