### PR TITLE
Add legacy JSFiddle files

### DIFF
--- a/scripts/prettier/index.js
+++ b/scripts/prettier/index.js
@@ -34,7 +34,11 @@ const defaultOptions = {
 const config = {
   default: {
     patterns: ['src/**/*.js', 'www/**/*.js'],
-    ignore: ['**/third_party/**', '**/node_modules/**'],
+    ignore: [
+      '**/third_party/**',
+      '**/node_modules/**',
+      '**/jsfiddle-integration*.js',
+    ],
   },
   scripts: {
     patterns: ['scripts/**/*.js', 'fixtures/**/*.js'],

--- a/www/static/js/jsfiddle-integration-babel.js
+++ b/www/static/js/jsfiddle-integration-babel.js
@@ -1,0 +1,12 @@
+// Do not delete or move this file.
+// Many fiddles reference it so we have to keep it here.
+(function() {
+  var tag = document.querySelector(
+    'script[type="application/javascript;version=1.7"]'
+  );
+  if (!tag || tag.textContent.indexOf('window.onload=function(){') !== -1) {
+    alert('Bad JSFiddle configuration, please fork the original React JSFiddle');
+  }
+  tag.setAttribute('type', 'text/babel');
+  tag.textContent = tag.textContent.replace(/^\/\/<!\[CDATA\[/, '');
+})();

--- a/www/static/js/jsfiddle-integration.js
+++ b/www/static/js/jsfiddle-integration.js
@@ -1,0 +1,12 @@
+// Do not delete or move this file.
+// Many fiddles reference it so we have to keep it here.
+(function() {
+  var tag = document.querySelector(
+    'script[type="application/javascript;version=1.7"]'
+  );
+  if (!tag || tag.textContent.indexOf('window.onload=function(){') !== -1) {
+    alert('Bad JSFiddle configuration, please fork the original React JSFiddle');
+  }
+  tag.setAttribute('type', 'text/jsx;harmony=true');
+  tag.textContent = tag.textContent.replace(/^\/\/<!\[CDATA\[/, '');
+})();


### PR DESCRIPTION
I expect this will fix https://github.com/facebook/react/issues/11018.

Unfortunately we can't just redirect the https://fb.me shortcut URL to a new location because plenty of fiddles already reference the GH pages URL directly.