### PR TITLE
Add <svg tabIndex> to the attribute table

### DIFF
--- a/fixtures/attribute-behavior/AttributeTableSnapshot.md
+++ b/fixtures/attribute-behavior/AttributeTableSnapshot.md
@@ -10773,6 +10773,31 @@
 | `tabIndex=(null)`| (initial)| `<number: -1>` |
 | `tabIndex=(undefined)`| (initial)| `<number: -1>` |
 
+## `tabIndex` (on `<svg>` inside `<div>`)
+| Test Case | Flags | Result |
+| --- | --- | --- |
+| `tabIndex=(string)`| (initial)| `<number: -1>` |
+| `tabIndex=(empty string)`| (initial)| `<number: -1>` |
+| `tabIndex=(array with string)`| (initial)| `<number: -1>` |
+| `tabIndex=(empty array)`| (initial)| `<number: -1>` |
+| `tabIndex=(object)`| (initial)| `<number: -1>` |
+| `tabIndex=(numeric string)`| (initial, ssr mismatch)| `<number: -1>` |
+| `tabIndex=(-1)`| (initial)| `<number: -1>` |
+| `tabIndex=(0)`| (initial, ssr mismatch)| `<number: -1>` |
+| `tabIndex=(integer)`| (initial, ssr mismatch)| `<number: -1>` |
+| `tabIndex=(NaN)`| (initial, warning)| `<number: -1>` |
+| `tabIndex=(float)`| (initial, ssr mismatch)| `<number: -1>` |
+| `tabIndex=(true)`| (initial, warning)| `<number: -1>` |
+| `tabIndex=(false)`| (initial, warning)| `<number: -1>` |
+| `tabIndex=(string 'true')`| (initial)| `<number: -1>` |
+| `tabIndex=(string 'false')`| (initial)| `<number: -1>` |
+| `tabIndex=(string 'on')`| (initial)| `<number: -1>` |
+| `tabIndex=(string 'off')`| (initial)| `<number: -1>` |
+| `tabIndex=(symbol)`| (initial, warning)| `<number: -1>` |
+| `tabIndex=(function)`| (initial, warning)| `<number: -1>` |
+| `tabIndex=(null)`| (initial)| `<number: -1>` |
+| `tabIndex=(undefined)`| (initial)| `<number: -1>` |
+
 ## `tableValues` (on `<feFuncA>` inside `<svg>`)
 | Test Case | Flags | Result |
 | --- | --- | --- |

--- a/fixtures/attribute-behavior/src/attributes.js
+++ b/fixtures/attribute-behavior/src/attributes.js
@@ -1859,6 +1859,11 @@ const attributes = [
   },
   {name: 'tabIndex'},
   {
+    name: 'tabIndex',
+    read: getSVGProperty('tabIndex'),
+    tagName: 'svg',
+  },
+  {
     name: 'tableValues',
     read: getSVGProperty('tableValues'),
     containerTagName: 'svg',


### PR DESCRIPTION
This adds it to prevent future regressions to https://github.com/facebook/react/issues/10987.

We can see the behavior is wrong by comparing the SVG and non-SVG versions:

<img width="642" alt="screen shot 2017-10-02 at 18 41 53" src="https://user-images.githubusercontent.com/810438/31091084-b1427cf8-a7a1-11e7-8e9c-ffaae80d49cd.png">
