### PR TITLE
Fixes example in Web Components docs

### DIFF
--- a/docs/docs/web-components.md
+++ b/docs/docs/web-components.md
@@ -42,7 +42,7 @@ function BrickFlipbox() {
 ## Using React in your Web Components
 
 ```javascript
-class XSearch {
+class XSearch extends HTMLElement {
   connectedCallback() {
     const mountPoint = document.createElement('span');
     this.attachShadow({ mode: 'open' }).appendChild(mountPoint);

--- a/docs/docs/web-components.md
+++ b/docs/docs/web-components.md
@@ -41,6 +41,8 @@ function BrickFlipbox() {
 
 ## Using React in your Web Components
 
+Similarly, you can call `ReactDOM.render()` from inside a web component:
+
 ```javascript
 class XSearch extends HTMLElement {
   connectedCallback() {
@@ -54,3 +56,7 @@ class XSearch extends HTMLElement {
 }
 customElements.define('x-search', XSearch);
 ```
+
+>Note:
+>
+>This code will **not** work if compiled with Babel [due to an intentional limitation in the specification](https://github.com/w3c/webcomponents/issues/587). It will only work if you use the `class` syntax directly in the browser without compiling the code first.


### PR DESCRIPTION
In the example, it was missing `extends HTMLElement` as the super class for the class component.

Example of this working:

https://jsfiddle.net/vana3xgf/