### PR TITLE
Update JSFiddle templates for React 16

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 **What is the current behavior?**
 
-**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem via https://jsfiddle.net or similar (template: https://jsfiddle.net/ebsrpraL/).**
+**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem via https://jsfiddle.net or similar (template for React 16: https://jsfiddle.net/Luktwrdm/, template for React 15: https://jsfiddle.net/hmbg7e9w/).**
 
 **What is the expected behavior?**
 


### PR DESCRIPTION
These were broken after 16 was tagged as `latest` on npm 😬 . This fixes that problem, and also adds two template options: one for React 16 and one for React 15. I figure we should provide both for now since there's still a lot of 15.x users.