### PR TITLE
[Website] Add titles and labels to iframes and images on Community pages

### DIFF
--- a/docs/community/conferences.md
+++ b/docs/community/conferences.md
@@ -96,7 +96,7 @@ January 28 & 29 in Facebook HQ, CA
 
 [Website](http://conf2015.reactjs.org/) - [Schedule](http://conf2015.reactjs.org/schedule.html) - [Videos](https://www.youtube.com/playlist?list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr)
 
-<iframe width="650" height="315" src="//www.youtube-nocookie.com/embed/KVZ-P-ZI6W4?list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr" frameborder="0" allowfullscreen></iframe>
+<iframe title="React.js Conf 2015 Keynote" width="650" height="315" src="//www.youtube-nocookie.com/embed/KVZ-P-ZI6W4?list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr" frameborder="0" allowfullscreen></iframe>
 
 ### ReactEurope 2015
 July 2 & 3 in Paris, France

--- a/docs/community/videos.md
+++ b/docs/community/videos.md
@@ -11,84 +11,84 @@ redirect_from: "docs/videos.html"
 
 [Tom Occhino](http://tomocchino.com/) and [Jordan Walke](https://github.com/jordwalke) introduce React at Facebook Seattle.
 
-<iframe width="650" height="366" src="https://www.youtube-nocookie.com/embed/XxVg_s8xAms" frameborder="0" allowfullscreen></iframe>
+<iframe title="Tom Occhino and Jordan Walke introduce React at Facebook Seattle" width="650" height="366" src="https://www.youtube-nocookie.com/embed/XxVg_s8xAms" frameborder="0" allowfullscreen></iframe>
 
 ### Introducing React Native
 
 [Tom Occhino](https://twitter.com/tomocchino) reviews the past and present of React in 2015, and teases where it's going next.
 
-<iframe width="650" height="366" src="https://www.youtube-nocookie.com/embed/KVZ-P-ZI6W4?list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr" frameborder="0" allowfullscreen></iframe>
+<iframe title="React.js Conf 2015 Keynote - Introducing React Native" width="650" height="366" src="https://www.youtube-nocookie.com/embed/KVZ-P-ZI6W4?list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr" frameborder="0" allowfullscreen></iframe>
 
 ### Rethinking Web App Development at Facebook
 
 Delivering reliable, high-performance web experiences at Facebook's scale has required us to challenge some long-held assumptions about software development. Watch this Facebook F8 2014 talk to learn how we abandoned the traditional MVC paradigm in favor of a more functional application architecture.
 
-<iframe width="650" height="366" src="https://www.youtube-nocookie.com/embed/nYkdrAPrdcw" frameborder="0" allowfullscreen></iframe>
+<iframe title="Hacker Way: Rethinking Web App Development at Facebook" width="650" height="366" src="https://www.youtube-nocookie.com/embed/nYkdrAPrdcw" frameborder="0" allowfullscreen></iframe>
 
 ### Secrets of the Virtual DOM
 
 [Pete Hunt](http://www.petehunt.net/) at Mountain West JavaScript 2014 discusses why a virtual DOM was built for React, how it compares to other systems, and its relevance to the future of browser technologies.
 
-<iframe width="650" height="366" src="https://www.youtube-nocookie.com/embed/h3KksH8gfcQ" frameborder="0" allowfullscreen></iframe>
+<iframe title="Mountain West JavaScript 2014 - Be Predictable, Not Correct. by Pete Hunt" width="650" height="366" src="https://www.youtube-nocookie.com/embed/h3KksH8gfcQ" frameborder="0" allowfullscreen></iframe>
 
 ### Rethinking Best Practices
 
 [Pete Hunt](http://www.petehunt.net/)'s talk at JSConf EU 2013 covers three topics: throwing out the notion of templates and building views with JavaScript, “re-rendering” your entire application when your data changes, and a lightweight implementation of the DOM and events.
 
-<iframe width="650" height="366" src="https://www.youtube-nocookie.com/embed/x7cQ3mrcKaY" frameborder="0" allowfullscreen></iframe>
+<iframe title="Pete Hunt: React: Rethinking Best Practices - JSConf EU 2013" width="650" height="366" src="https://www.youtube-nocookie.com/embed/x7cQ3mrcKaY" frameborder="0" allowfullscreen></iframe>
 
 
 ### High performance functional DOM programming
 
 Tech Talk by [Pete Hunt](http://www.petehunt.net/) at Meteor DevShop 11.
 
-<iframe width="650" height="366" src="https://www.youtube-nocookie.com/embed/qqVbr_LaCIo" frameborder="0" allowfullscreen></iframe>
+<iframe title="Pete Hunt: High performance functional programming with React and Meteor" width="650" height="366" src="https://www.youtube-nocookie.com/embed/qqVbr_LaCIo" frameborder="0" allowfullscreen></iframe>
 
 
 ### Developing User Interfaces With React
 
 [Steven Luscher](https://github.com/steveluscher) at Super VanJS 2013.
 
-<iframe width="650" height="366" src="https://www.youtube-nocookie.com/embed/1OeXsL5mr4g" frameborder="0" allowfullscreen></iframe>
+<iframe title="SuperVanJS 2013: Steven Luscher - Developing User Interfaces with Facebook's React" width="650" height="366" src="https://www.youtube-nocookie.com/embed/1OeXsL5mr4g" frameborder="0" allowfullscreen></iframe>
 
 
 ### Introduction to React
 
 [Stoyan Stefanov](http://www.phpied.com/) at LAWebSpeed meetup.
 
-<iframe width="650" height="366" src="https://www.youtube-nocookie.com/embed/SMMRJif5QW0" frameborder="0" allowfullscreen></iframe>
+<iframe title="Joe Dev on Tech - Stoyan Stefanov - Introduction to React" width="650" height="366" src="https://www.youtube-nocookie.com/embed/SMMRJif5QW0" frameborder="0" allowfullscreen></iframe>
 
 ### Going big with React
 
 Areeb Malik investigates how React performs in a high stress situation, and how it helped his team build safe code on a massive scale.
 
-[![](https://i.vimeocdn.com/video/481670116_650.jpg)](https://skillsmatter.com/skillscasts/5429-going-big-with-react#video)
+[![going big with React](https://i.vimeocdn.com/video/481670116_650.jpg)](https://skillsmatter.com/skillscasts/5429-going-big-with-react#video)
 
 ### Backbone + React + Middleman Screencast
 
 This screencast shows how to integrate Backbone with React using [Backbone-React-Component](https://github.com/magalhas/backbone-react-component).
 
-<iframe width="650" height="488" src="https://www.youtube-nocookie.com/embed/iul1fWHVU6A" frameborder="0" allowfullscreen></iframe>
+<iframe title="Backbone React Component with Middleman" width="650" height="488" src="https://www.youtube-nocookie.com/embed/iul1fWHVU6A" frameborder="0" allowfullscreen></iframe>
 
 ### React, or how to make life simpler
 
 Tech talk by [Alexander Solovyov](http://solovyov.net/) at FrontEnd Dev Conf '14 (Russian).
 
-<iframe width="650" height="366" src="https://www.youtube-nocookie.com/embed/YJNUK0EA_Jo" frameborder="0" allowfullscreen></iframe>
+<iframe title="Tech talk by Alexander Solovyov at FrontEnd Dev Conf ‘14 (Russian)." width="650" height="366" src="https://www.youtube-nocookie.com/embed/YJNUK0EA_Jo" frameborder="0" allowfullscreen></iframe>
 
 
 ### React and Flux: Building Applications with a Unidirectional Data Flow
 
 Facebook engineers [Bill Fisher](https://twitter.com/fisherwebdev) and [Jing Chen](https://twitter.com/jingc) talk about Flux and React at Forward JS 2014, and how using an application architecture with a unidirectional data flow cleans up a lot of their code.
 
-<iframe width="650" height="366" src="https://www.youtube-nocookie.com/embed/i__969noyAM" frameborder="0" allowfullscreen></iframe>
+<iframe title="React and Flux: Building Applications with a Unidirectional Data Flow" width="650" height="366" src="https://www.youtube-nocookie.com/embed/i__969noyAM" frameborder="0" allowfullscreen></iframe>
 
 > [Slides and sample code](https://github.com/zertosh/ssr-demo-kit)
 
 ### CodeWinds Podcast
 
 [Pete Hunt](http://www.petehunt.net/) talked with [Jeff Barczewski](http://jeff.barczewski.com/) about React in [CodeWinds Episode 4](http://codewinds.com/podcast/004.html).
-<figure><a href="http://codewinds.com/4"><img src="../img/docs/codewinds-004.png"></a></figure>
+<figure><a aria-label="link to play Codewinds Podcast episode 4" href="http://codewinds.com/4"><img alt="Pete Hunt talked with Jeff Barczewski about React in Codewinds Episode 4" src="../img/docs/codewinds-004.png"></a></figure>
 
 <table width="100%">
 <tr>
@@ -136,7 +136,7 @@ Facebook engineers [Bill Fisher](https://twitter.com/fisherwebdev) and [Jing Che
 ### JavaScript Jabber Podcast
 
 [Pete Hunt](http://www.petehunt.net/) and [Jordan Walke](https://github.com/jordwalke) talked about React in [JavaScript Jabber 73](https://devchat.tv/js-jabber/073-jsj-react-with-pete-hunt-and-jordan-walke).
-<figure><a href="http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content"><img src="../img/docs/javascript-jabber.png"></a></figure>
+<figure><a aria-label="link to play JavaScript Jabber Podcast episode 73" href="http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content"><img alt="Pete Hunt and Jordan Walke talk about React in JavaScript Jabber 73" src="../img/docs/javascript-jabber.png"></a></figure>
 
 <table width="100%">
   <tr>

--- a/docs/community/videos.md
+++ b/docs/community/videos.md
@@ -88,7 +88,7 @@ Facebook engineers [Bill Fisher](https://twitter.com/fisherwebdev) and [Jing Che
 ### CodeWinds Podcast
 
 [Pete Hunt](http://www.petehunt.net/) talked with [Jeff Barczewski](http://jeff.barczewski.com/) about React in [CodeWinds Episode 4](http://codewinds.com/podcast/004.html).
-<figure><a aria-label="link to play Codewinds Podcast episode 4" href="http://codewinds.com/4"><img alt="Pete Hunt talked with Jeff Barczewski about React in Codewinds Episode 4" src="../img/docs/codewinds-004.png"></a></figure>
+<figure><a aria-label="link to play Codewinds Podcast episode 4" href="http://codewinds.com/4"><img src="../img/docs/codewinds-004.png"></a></figure>
 
 <table width="100%">
 <tr>
@@ -136,7 +136,7 @@ Facebook engineers [Bill Fisher](https://twitter.com/fisherwebdev) and [Jing Che
 ### JavaScript Jabber Podcast
 
 [Pete Hunt](http://www.petehunt.net/) and [Jordan Walke](https://github.com/jordwalke) talked about React in [JavaScript Jabber 73](https://devchat.tv/js-jabber/073-jsj-react-with-pete-hunt-and-jordan-walke).
-<figure><a aria-label="link to play JavaScript Jabber Podcast episode 73" href="http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content"><img alt="Pete Hunt and Jordan Walke talk about React in JavaScript Jabber 73" src="../img/docs/javascript-jabber.png"></a></figure>
+<figure><a aria-label="link to play JavaScript Jabber Podcast episode 73" href="http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/#content"><img src="../img/docs/javascript-jabber.png"></a></figure>
 
 <table width="100%">
   <tr>


### PR DESCRIPTION
**what is the change?:**
- add titles to all iframes
- add alt tags to images
- add `aria-label` to some links which only have images as contents.

**why make this change?:**
Based on warnings thrown by aXe a11y audit of those pages

**test plan:**
Manual testing

**issue:**
None