### PR TITLE
Docs: add link to DOM Level 3 spec for possible values of `key` prop

### DIFF
--- a/docs/docs/reference-events.md
+++ b/docs/docs/reference-events.md
@@ -148,6 +148,8 @@ boolean shiftKey
 number which
 ```
 
+The `key` property can take any of the values documented in the [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#named-key-attribute-values).
+
 * * *
 
 ### Focus Events


### PR DESCRIPTION
As someone unfamiliar with React's Synthetic Event system, it took me a lot of time to find the list of possible values for the `key` prop in keyboard events. I was expecting a numeric value since I vaguely remembered the [`keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) prop, but that's apparently deprecated now.

After several minutes of searching, I found a link in the [React v0.11 release blog post](https://reactjs.org/blog/2014/07/17/react-v0.11.html#improved-keyboard-event-normalization), so I thought this definitely should be in the docs :smile:

Let me know if you'd like the language changed or anything like that. I've completed the CLA as well :slightly_smiling_face: 
