### PR TITLE
 Throw better error when rendering into parentless commentNode 

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -174,7 +174,7 @@ var DOMRenderer = ReactFiberReconciler({
       }
       default: {
         const container: any = nodeType === COMMENT_NODE
-          ? rootContainerInstance.parentNode
+          ? rootContainerInstance.parentNode || rootContainerInstance
           : rootContainerInstance;
         const ownNamespace = container.namespaceURI || null;
         type = container.tagName;

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -172,12 +172,21 @@ var DOMRenderer = ReactFiberReconciler({
         namespace = root ? root.namespaceURI : getChildNamespace(null, '');
         break;
       }
-      default: {
-        const container: any = nodeType === COMMENT_NODE
-          ? rootContainerInstance.parentNode || rootContainerInstance
-          : rootContainerInstance;
+      case COMMENT_NODE: {
+        invariant(
+          rootContainerInstance.parentNode != null, // match null & undefined
+          'The commentNode which you are rendering into must have a parent.',
+        );
+        const container: any =
+          rootContainerInstance.parentNode || rootContainerInstance;
         const ownNamespace = container.namespaceURI || null;
         type = container.tagName;
+        namespace = getChildNamespace(ownNamespace, type);
+        break;
+      }
+      default: {
+        const ownNamespace = rootContainerInstance.namespaceURI || null;
+        type = rootContainerInstance.tagName;
         namespace = getChildNamespace(ownNamespace, type);
         break;
       }

--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -174,7 +174,7 @@ var DOMRenderer = ReactFiberReconciler({
       }
       case COMMENT_NODE: {
         invariant(
-          rootContainerInstance.parentNode != null, // match null & undefined
+          rootContainerInstance.parentNode !== null,
           'The commentNode which you are rendering into must have a parent.',
         );
         const container: any =

--- a/src/renderers/dom/shared/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactMount-test.js
@@ -352,4 +352,27 @@ describe('ReactMount', () => {
       );
     });
   });
+
+  describe('mount point is a comment node with no parent', () => {
+    let containerDiv;
+    let mountPoint;
+
+    beforeEach(() => {
+      mountPoint = document.createComment('react-mount-point-unstable');
+      invariant(mountPoint.nodeType === COMMENT_NODE, 'Expected comment');
+    });
+
+    fit('renders at a comment node', () => {
+      function Char(props) {
+        return props.children;
+      }
+      function list(chars) {
+        return chars.split('').map(c => <Char key={c}>{c}</Char>);
+      }
+
+      expect(() => {
+        ReactDOM.render(list('aeiou'), mountPoint);
+      }).not.toThrow();
+    });
+  });
 });

--- a/src/renderers/dom/shared/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactMount-test.js
@@ -358,11 +358,11 @@ describe('ReactMount', () => {
     let mountPoint;
 
     beforeEach(() => {
-      mountPoint = document.createComment('react-mount-point-unstable');
+      mountPoint = document.createComment(' react-mount-point-unstable ');
       invariant(mountPoint.nodeType === COMMENT_NODE, 'Expected comment');
     });
 
-    fit('renders at a comment node', () => {
+    it('throws an informative error', () => {
       function Char(props) {
         return props.children;
       }
@@ -372,7 +372,10 @@ describe('ReactMount', () => {
 
       expect(() => {
         ReactDOM.render(list('aeiou'), mountPoint);
-      }).not.toThrow();
+      })
+      .toThrowError(
+        /The commentNode which you are rendering into must have a parent/
+      );
     });
   });
 });

--- a/src/renderers/dom/shared/__tests__/ReactMount-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactMount-test.js
@@ -372,9 +372,8 @@ describe('ReactMount', () => {
 
       expect(() => {
         ReactDOM.render(list('aeiou'), mountPoint);
-      })
-      .toThrowError(
-        /The commentNode which you are rendering into must have a parent/
+      }).toThrowError(
+        /The commentNode which you are rendering into must have a parent/,
       );
     });
   });


### PR DESCRIPTION
We have come across a use case where React renders into a comment node
with no parent, and this code assumes that there is always a parent node
for a comment node.

**what is the change?:**
- Instead of trying to succeed somehow when rendering into a commentNode
  which has no parent, we should throw an informative error.
- Changes the test to check for the informative error
- Also updates the test to use a valid commentNode; previously the test
  was failing because apparently you need the commentNode to have the
  text ' react-mount-point-unstable ' and not just
  'react-mount-point-unstable'.

**why make this change?:**
To debug and mitigate effect of bug reported in https://our.intern.facebook.com/intern/tasks/?t=22198152

**test plan:**
`yarn test src/renderers/dom/shared/__tests__/ReactMount-test.js`

**issue:**
See internal task https://our.intern.facebook.com/intern/tasks/?t=22198152