### PR TITLE
Update react summit Nigeria title

### DIFF
--- a/docs/community/conferences.md
+++ b/docs/community/conferences.md
@@ -54,7 +54,7 @@ October 13 in Stockholm, Sweden
 
 [Website](https://statejs.com/)
 
-### Second React Summit - NG 2017
+### React Summit 2017
 October 21 in Lagos, Nigeria
 
 [Website](https://reactsummit2017.splashthat.com/) - [Twitter](https://twitter.com/DevCircleLagos/) - [Facebook](https://www.facebook.com/groups/DevCLagos/)


### PR DESCRIPTION
Being that we plan on holding another React Summit next year, the organizing body have decided to change the title to "React Summit 2017" so that only the year would be changed for the next summit.