### PR TITLE
Remove bundle-collapser browserify recommendation

### DIFF
--- a/docs/docs/optimizing-performance.md
+++ b/docs/docs/optimizing-performance.md
@@ -74,17 +74,16 @@ For the most efficient Browserify production build, install a few plugins:
 
 ```
 # If you use npm
-npm install --save-dev bundle-collapser envify uglify-js uglifyify 
+npm install --save-dev envify uglify-js uglifyify 
 
 # If you use Yarn
-yarn add --dev bundle-collapser envify uglify-js uglifyify 
+yarn add --dev envify uglify-js uglifyify 
 ```
 
 To create a production build, make sure that you add these transforms **(the order matters)**:
 
 * The [`envify`](https://github.com/hughsk/envify) transform ensures the right build environment is set. Make it global (`-g`).
 * The [`uglifyify`](https://github.com/hughsk/uglifyify) transform removes development imports. Make it global too (`-g`).
-* The [`bundle-collapser`](https://github.com/substack/bundle-collapser) plugin replaces long module IDs with numbers.
 * Finally, the resulting bundle is piped to [`uglify-js`](https://github.com/mishoo/UglifyJS2) for mangling ([read why](https://github.com/hughsk/uglifyify#motivationusage)).
 
 For example:
@@ -93,7 +92,6 @@ For example:
 browserify ./index.js \
   -g [ envify --NODE_ENV production ] \
   -g uglifyify \
-  -p bundle-collapser/plugin \
   | uglifyjs --compress --mangle > ./bundle.js
 ```
 
@@ -101,6 +99,10 @@ browserify ./index.js \
 >
 >The package name is `uglify-js`, but the binary it provides is called `uglifyjs`.<br>
 >This is not a typo.
+
+>**Note:**
+>
+>[`bundle-collapser`](https://github.com/substack/bundle-collapser) may further reduce the size of your bundle but is currently removed as a recommendation due to potential resolution failures when file contents are not unique. See: [react#11049](https://github.com/facebook/react/issues/11049).
 
 Remember that you only need to do this for production builds. You shouldn't apply these plugins in development because they will hide useful React warnings, and make the builds much slower.
 

--- a/docs/docs/optimizing-performance.md
+++ b/docs/docs/optimizing-performance.md
@@ -100,10 +100,6 @@ browserify ./index.js \
 >The package name is `uglify-js`, but the binary it provides is called `uglifyjs`.<br>
 >This is not a typo.
 
->**Note:**
->
->[`bundle-collapser`](https://github.com/substack/bundle-collapser) may further reduce the size of your bundle but is currently removed as a recommendation due to potential resolution failures when file contents are not unique. See: [react#11049](https://github.com/facebook/react/issues/11049).
-
 Remember that you only need to do this for production builds. You shouldn't apply these plugins in development because they will hide useful React warnings, and make the builds much slower.
 
 ### Rollup


### PR DESCRIPTION
See: #11049 

This PR relegates the [browserify `bundle-collapser` recommendation](https://reactjs.org/docs/optimizing-performance.html#browserify) to a note. I use it all the time without any problems so it seems like a thing that's almost always nice, but since the failure in the referenced issue is pretty clear, it seems like perhaps it should be used carefully and with proper warnings.