### PR TITLE
Fix the typo in the docs

### DIFF
--- a/docs/docs/lists-and-keys.md
+++ b/docs/docs/lists-and-keys.md
@@ -24,7 +24,7 @@ In React, transforming arrays into lists of [elements](/docs/rendering-elements.
 
 You can build collections of elements and [include them in JSX](/docs/introducing-jsx.html#embedding-expressions-in-jsx) using curly braces `{}`.
 
-Below, we loop through the `numbers` array using the JavaScript [`map()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) function. We return an `<li>` element for each item. Finally, we assign the resulting array of elements to `listItems`:
+Below, we loop through the `numbers` array using the JavaScript [`map()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) function. We return a `<li>` element for each item. Finally, we assign the resulting array of elements to `listItems`:
 
 ```javascript{2-4}
 const numbers = [1, 2, 3, 4, 5];


### PR DESCRIPTION
Docs: fixed the typo  `a <li> instead of an <li>`
