### PR TITLE
Fix form reset for uncontrolled select elements

### DIFF
--- a/fixtures/dom/src/components/fixtures/selects/index.js
+++ b/fixtures/dom/src/components/fixtures/selects/index.js
@@ -7,9 +7,21 @@ const ReactDOM = window.ReactDOM;
 class SelectFixture extends React.Component {
   state = {value: ''};
   _nestedDOMNode = null;
+  _singleFormDOMNode = null;
+  _multipleFormDOMNode = null;
 
   onChange = event => {
     this.setState({value: event.target.value});
+  };
+
+  resetSingleOptionForm = event => {
+    event.preventDefault();
+    this._singleFormDOMNode.reset();
+  };
+
+  resetMultipleOptionForm = event => {
+    event.preventDefault();
+    this._multipleFormDOMNode.reset();
   };
 
   componentDidMount() {
@@ -98,6 +110,49 @@ class SelectFixture extends React.Component {
               <option>1</option>
               <option>2</option>
             </select>
+          </div>
+        </TestCase>
+
+        <TestCase title="A single select being reset">
+          <TestCase.Steps>
+            <li>Open the select</li>
+            <li>Select "baz" or "foo"</li>
+            <li>Click the "Reset" button</li>
+          </TestCase.Steps>
+          <TestCase.ExpectedResult>
+            The select should be reset to the inital value, "bar"
+          </TestCase.ExpectedResult>
+
+          <div className="test-fixture">
+            <form ref={n => (this._singleFormDOMNode = n)}>
+              <select defaultValue="bar">
+                <option value="foo">foo</option>
+                <option value="bar">bar</option>
+                <option value="baz">baz</option>
+              </select>
+              <button onClick={this.resetSingleOptionForm}>Reset</button>
+            </form>
+          </div>
+        </TestCase>
+
+        <TestCase title="A multiple select being reset">
+          <TestCase.Steps>
+            <li>Select any combination of options</li>
+            <li>Click the "Reset" button</li>
+          </TestCase.Steps>
+          <TestCase.ExpectedResult>
+            The select should be reset to the initial values "foo" and "baz"
+          </TestCase.ExpectedResult>
+
+          <div className="test-fixture">
+            <form ref={n => (this._multipleFormDOMNode = n)}>
+              <select multiple defaultValue={['foo', 'baz']}>
+                <option value="foo">foo</option>
+                <option value="bar">bar</option>
+                <option value="baz">baz</option>
+              </select>
+              <button onClick={this.resetMultipleOptionForm}>Reset</button>
+            </form>
           </div>
         </TestCase>
       </FixtureSet>

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
@@ -76,6 +76,7 @@ function updateOptions(
   node: HTMLSelectElement,
   multiple: boolean,
   propValue: any,
+  setDefaultSelected: boolean,
 ) {
   type IndexableHTMLOptionsCollection = HTMLOptionsCollection & {
     [key: number]: HTMLOptionElement,
@@ -94,6 +95,9 @@ function updateOptions(
       if (options[i].selected !== selected) {
         options[i].selected = selected;
       }
+      if (selected && setDefaultSelected) {
+        options[i].defaultSelected = true;
+      }
     }
   } else {
     // Do not set `select.value` as exact behavior isn't consistent across all
@@ -103,6 +107,9 @@ function updateOptions(
     for (let i = 0; i < options.length; i++) {
       if (options[i].value === selectedValue) {
         options[i].selected = true;
+        if (setDefaultSelected) {
+          options[i].defaultSelected = true;
+        }
         return;
       }
       if (defaultSelected === null && !options[i].disabled) {
@@ -175,7 +182,7 @@ var ReactDOMSelect = {
     if (value != null) {
       updateOptions(node, !!props.multiple, value);
     } else if (props.defaultValue != null) {
-      updateOptions(node, !!props.multiple, props.defaultValue);
+      updateOptions(node, !!props.multiple, props.defaultValue, true);
     }
   },
 
@@ -194,7 +201,7 @@ var ReactDOMSelect = {
     } else if (wasMultiple !== !!props.multiple) {
       // For simplicity, reapply `defaultValue` if `multiple` is toggled.
       if (props.defaultValue != null) {
-        updateOptions(node, !!props.multiple, props.defaultValue);
+        updateOptions(node, !!props.multiple, props.defaultValue, true);
       } else {
         // Revert the select back to its default unselected state.
         updateOptions(node, !!props.multiple, props.multiple ? [] : '');

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberSelect.js
@@ -180,7 +180,7 @@ var ReactDOMSelect = {
     node.multiple = !!props.multiple;
     var value = props.value;
     if (value != null) {
-      updateOptions(node, !!props.multiple, value);
+      updateOptions(node, !!props.multiple, value, false);
     } else if (props.defaultValue != null) {
       updateOptions(node, !!props.multiple, props.defaultValue, true);
     }
@@ -197,14 +197,14 @@ var ReactDOMSelect = {
 
     var value = props.value;
     if (value != null) {
-      updateOptions(node, !!props.multiple, value);
+      updateOptions(node, !!props.multiple, value, false);
     } else if (wasMultiple !== !!props.multiple) {
       // For simplicity, reapply `defaultValue` if `multiple` is toggled.
       if (props.defaultValue != null) {
         updateOptions(node, !!props.multiple, props.defaultValue, true);
       } else {
         // Revert the select back to its default unselected state.
-        updateOptions(node, !!props.multiple, props.multiple ? [] : '');
+        updateOptions(node, !!props.multiple, props.multiple ? [] : '', false);
       }
     }
   },
@@ -214,7 +214,7 @@ var ReactDOMSelect = {
     var value = props.value;
 
     if (value != null) {
-      updateOptions(node, !!props.multiple, value);
+      updateOptions(node, !!props.multiple, value, false);
     }
   },
 };


### PR DESCRIPTION
Resolves https://github.com/facebook/react/issues/11010

`defaultSelected` will now be set on the select's option's elements based on the value(s) in `defaultValue`. Added a test fixture, too.