### PR TITLE
Fix blog issues that resulted from migration

### DIFF
--- a/docs/_posts/2013-06-05-why-react.md
+++ b/docs/_posts/2013-06-05-why-react.md
@@ -80,7 +80,7 @@ some pretty cool things with it:
   (including IE8) and automatically use
   [event delegation](http://davidwalsh.name/event-delegate).
 
-Head on over to [facebook.github.io/react](/react) to check out what we have
+Head on over to https://reactjs.org to check out what we have
 built. Our documentation is geared towards building apps with the framework,
 but if you are interested in the nuts and bolts
 [get in touch](/support.html) with us!

--- a/docs/_posts/2013-08-05-community-roundup-6.md
+++ b/docs/_posts/2013-08-05-community-roundup-6.md
@@ -74,6 +74,6 @@ este.demos.react.todoApp = este.react.create (`/** @lends {React.ReactComponent.
 > I'm the author of "[Land of Lisp](http://landoflisp.com/)" and I love your framework. I built a somewhat similar framework a year ago [WebFUI](https://github.com/drcode/webfui) aimed at ClojureScript. My framework also uses global event delegates, a global "render" function, DOM reconciliation, etc just like react.js. (Of course these ideas all have been floating around the ether for ages, always great to see more people building on them.)
 >
 > Your implementation is more robust, and so I think the next point release of webfui will simply delegate all the "hard work" to react.js and will only focus on the areas where it adds value (enabling purely functional UI programming in clojurescript, and some other stuff related to streamlining event handling)
-<figure><a href="https://groups.google.com/forum/#!msg/reactjs/e3bYersyd64/qODfcuBR9LwJ"><img src="../img/blog/landoflisp.png"></a></figure>
+> <figure><a href="https://groups.google.com/forum/#!msg/reactjs/e3bYersyd64/qODfcuBR9LwJ"><img src="../img/blog/landoflisp.png"></a></figure>
 >
 > [Read the full post...](https://groups.google.com/forum/#!msg/reactjs/e3bYersyd64/qODfcuBR9LwJ)

--- a/docs/_posts/2013-12-23-community-roundup-12.md
+++ b/docs/_posts/2013-12-23-community-roundup-12.md
@@ -26,7 +26,7 @@ Managing the scroll position when new content is inserted is usually very tricky
 
 > We can check the scroll position before the component has updated with componentWillUpdate and scroll if necessary at componentDidUpdate
 >
-> ```
+> ```js
 > componentWillUpdate: function() {
 >   var node = this.getDOMNode();
 >   this.shouldScrollBottom =

--- a/docs/_posts/2014-01-06-community-roundup-14.md
+++ b/docs/_posts/2014-01-06-community-roundup-14.md
@@ -30,13 +30,13 @@ React is only one-piece of your web application stack. [Mark Lussier](https://gi
 
 [Selem Delul](http://selem.im) bundled the [React Tutorial](/tutorial/tutorial.html) into a rails app. This is a good example on how to get started with a rails project.
 
+> ```sh
+> git clone https://github.com/necrodome/react-rails-tutorial
+> cd react-rails-tutorial
+> bundle install
+> rake db:migrate
+> rails s
 > ```
-git clone https://github.com/necrodome/react-rails-tutorial
-cd react-rails-tutorial
-bundle install
-rake db:migrate
-rails s
-```
 > Then visit http://localhost:3000/app to see the React application that is explained in the React Tutorial. Try opening multiple tabs!
 >
 > [View on GitHub...](https://github.com/necrodome/react-rails-tutorial)

--- a/docs/_posts/2014-02-15-community-roundup-16.md
+++ b/docs/_posts/2014-02-15-community-roundup-16.md
@@ -27,14 +27,15 @@ While we're talking about tree diffing: Matt Esch ([@MatthewEsch](https://twitte
 
 
 James Padosley wrote a short post on the basics (and merits) of React: [What is React?](http://james.padolsey.com/javascript/what-is-react/)
-> What I like most about React is that it doesn't impose heady design patterns and data-modelling abstractions on me. [...] Its opinions are so minimal and its abstractions so focused on the problem of the DOM, that you can merrily slap your design choices atop.
 
+> What I like most about React is that it doesn't impose heady design patterns and data-modelling abstractions on me. [...] Its opinions are so minimal and its abstractions so focused on the problem of the DOM, that you can merrily slap your design choices atop.
+>
 > [Read the full post...](http://james.padolsey.com/javascript/what-is-react/)
 
 Taylor Lapeyre ([@taylorlapeyre](https://twitter.com/taylorlapeyre)) wrote another nice [introduction to React](http://words.taylorlapeyre.me/an-introduction-to-react).
 
 > React expects you to do the work of getting and pushing data from the server. This makes it very easy to implement React as a front end solution, since it simply expects you to hand it data. React does all the other work.
-
+>
 > [Read the full post...](http://words.taylorlapeyre.me/an-introduction-to-react)
 
 

--- a/docs/_posts/2014-02-24-community-roundup-17.md
+++ b/docs/_posts/2014-02-24-community-roundup-17.md
@@ -74,7 +74,7 @@ Dmitry Chestnykh [@dchest](https://twitter.com/dchest) wrote a [static search in
 [Martin Andert](https://github.com/martinandert) created [react-lorem-component](https://github.com/martinandert/react-lorem-component), a simple component for all your placeholding needs.
 
 ### Input with placeholder shim
-[react-input=placeholder](https://github.com/enigma-io/react-input-placeholder) by [enigma-io](https://github.com/enigma-io) is a small wrapper around React.DOM.input that shims in placeholder functionality for browsers that don't natively support it.
+[react-input-placeholder](https://github.com/enigma-io/react-input-placeholder) by [enigma-io](https://github.com/enigma-io) is a small wrapper around React.DOM.input that shims in placeholder functionality for browsers that don't natively support it.
 
 ### diContainer
 

--- a/docs/_posts/2014-03-14-community-roundup-18.md
+++ b/docs/_posts/2014-03-14-community-roundup-18.md
@@ -86,7 +86,7 @@ Jonathan Krause ([@jonykrause](https://twitter.com/jonykrause)) offers his thoug
 [Peter Hausel](http://pk11.kinja.com/) shows how to build a Wikipedia auto-complete demo based on immutable data structures (similar to [mori](https://npmjs.org/package/mori)), really taking advantage of the framework's one-way reactive data binding:
 
 > Its truly reactive design makes DOM updates finally sane and when combined with persistent data structures one can experience JavaScript development like it was never done before.
-
+>
 > [Read the full post](http://tech.kinja.com/immutable-react-1495205675)
 
 

--- a/docs/_posts/2014-10-17-community-roundup-23.md
+++ b/docs/_posts/2014-10-17-community-roundup-23.md
@@ -130,14 +130,13 @@ undo: function() {
 
 [DeLorean](https://github.com/deloreanjs/delorean) is a tiny Flux pattern implementation developed by [Fatih Kadir Akin](https://github.com/f).
 
->
-- Unidirectional data flow, it makes your app logic simpler than MVC
-- Automatically listens to data changes and keeps your data updated
-- Makes data more consistent across your whole application
-- It's framework agnostic, completely. There's no view framework dependency
-- Very small, just 4K gzipped
-- Built-in React.js integration, easy to use with Flight.js and Ractive.js and probably all others
-- Improve your UI/data consistency using rollbacks
+> - Unidirectional data flow, it makes your app logic simpler than MVC
+> - Automatically listens to data changes and keeps your data updated
+> - Makes data more consistent across your whole application
+> - It's framework agnostic, completely. There's no view framework dependency
+> - Very small, just 4K gzipped
+> - Built-in React.js integration, easy to use with Flight.js and Ractive.js and probably all others
+> - Improve your UI/data consistency using rollbacks
 
 
 ## Facebook's iOS Infrastructure

--- a/docs/_posts/2015-03-16-react-v0.13.1.md
+++ b/docs/_posts/2015-03-16-react-v0.13.1.md
@@ -33,7 +33,7 @@ We've also published version `0.13.1` of the `react` and `react-tools` packages 
 
 ### React with Add-Ons
 
-### Bug Fixes
+#### Bug Fixes
 
 * TestUtils: Don't warn about `getDOMNode` for ES6 classes
 * TestUtils: Ensure wrapped full page components (`<html>`, `<head>`, `<body>`) are treated as DOM components

--- a/docs/_posts/2015-09-14-community-roundup-27.md
+++ b/docs/_posts/2015-09-14-community-roundup-27.md
@@ -48,10 +48,6 @@ Interact with this [visual tour of Relay's architecture](http://sgwilym.github.i
 
 Sam has already launched a product that leverages Relay's data-fetching, optimistic responses, pagination, and mutations &ndash; all atop a Ruby GraphQL server: [new.comique.co](http://new.comique.co/)
 
-## Prototyping in the browser
-
-I ([steveluscher](https://github.com/steveluscher)) whipped up [a prototyping tool](https://facebook.github.io/relay/prototyping/playground.html) that you can use to hack on a schema and a React/Relay app, from the comfort of your browser. Thanks to Jimmy Jia ([taion](https://github.com/taion)) for supplying the local-only network layer, [relay-local-schema](https://github.com/relay-tools/relay-local-schema).
-
 ## Skeletons in the closet
 
 Joseph Rollins ([fortruce](https://github.com/fortruce)) created a hot-reloading, auto schema-regenerating, [Relay skeleton](https://github.com/fortruce/relay-skeleton) that you can use to get up and running quickly.
@@ -60,7 +56,7 @@ Michael Hart ([mhart](https://mhart)) built a [simple-relay-starter](https://git
 
 ## Routing around
 
-Jimmy Jia ([taion](https://github.com/taion)) and Gerald Monaco ([devknoll](https://github.com/devknoll)) have been helping lost URLs find their way to Relay apps through their work on [react-router-relay](https://github.com/relay-tools/react-router-relay). Check out Christoph Pojer's ([cpojer](https://github.com/cpojer)) [blog post](https://medium.com/@cpojer/relay-and-routing-36b5439bad9) on the topic. Jimmy completed the Relay TodoMVC example with routing, which you can check out at [taion/relay-todomvc](https://github.com/taion/relay-todomvc).
+Jimmy Jia ([taion](https://github.com/taion)) and Gerald Monaco ([devknoll](https://github.com/devknoll)) have been helping lost URLs find their way to Relay apps through their work on [react-router-relay](https://github.com/relay-tools/react-router-relay). Check out Christoph Nakazawa's ([cpojer](https://github.com/cpojer)) [blog post](https://medium.com/@cpojer/relay-and-routing-36b5439bad9) on the topic. Jimmy completed the Relay TodoMVC example with routing, which you can check out at [taion/relay-todomvc](https://github.com/taion/relay-todomvc).
 
 Chen Hung-Tu ([transedward](https://github.com/transedward)) built a chat app atop the above mentioned router, with threaded conversations and pagination. Check it out at [transedward/relay-chat](https://github.com/transedward/relay-chat).
 

--- a/docs/_posts/2015-12-16-ismounted-antipattern.md
+++ b/docs/_posts/2015-12-16-ismounted-antipattern.md
@@ -10,7 +10,7 @@ The primary use case for `isMounted()` is to avoid calling `setState()` after a 
 To avoid the error message, people often add lines like this:
 
 ```js
-if(this.isMounted()) { // This is bad.
+if (this.isMounted()) { // This is bad.
   this.setState({...});
 }
 ```

--- a/docs/_posts/2016-09-28-our-first-50000-stars.md
+++ b/docs/_posts/2016-09-28-our-first-50000-stars.md
@@ -172,8 +172,8 @@ Adam made a very insightful comment, which is now the default way we write lists
 > I think we should just treat arrays of elements as a frag. This is useful for constructs like:
 >
 > ```js
-<ul>{foo.map(function(i) { return <li>{i.data}</li>; })}</ul>
-```
+> <ul>{foo.map(function(i) { return <li>{i.data}</li>; })}</ul>
+> ```
 >
 > In this case the ul(..) will get a childList with a single child, which is itself a list.
 

--- a/www/src/theme.js
+++ b/www/src/theme.js
@@ -184,6 +184,7 @@ const sharedStyles = {
       marginTop: 25,
       marginLeft: -30,
       marginRight: -30,
+      marginBottom: 25,
       paddingLeft: 15,
       paddingRight: 15,
 
@@ -237,7 +238,7 @@ const sharedStyles = {
     '& p > code, & li > code': {
       background: hex2rgba(colors.note, 0.3),
       padding: '0 3px',
-      fontSize: 16,
+      fontSize: 'inherit',
       color: colors.text,
       wordBreak: 'break-word',
     },


### PR DESCRIPTION
The new markdown rendering engine does not parse non-plaintext stuff that is within blockquotes well (very prevalent in the community roundup posts). This PR fixes those issues, along with other stuff.

I also realized the blog images are not rendering properly and an issue has already been filed at https://github.com/gatsbyjs/gatsby/issues/2048. Changing the `<img src="...">` to `![alt](src)` syntax works for fixing most of those image issues. I'm not sure whether we should wait for this issue to be fixed in Gatsby or we can just change the syntax to the working version first. Let me know if the latter is preferred and I can submit a PR for that.