### PR TITLE
Correct logo URL

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -23,7 +23,7 @@
   <meta property="og:title" content="{{ title }}">
   <meta property="og:type" content="{{ type }}">
   <meta property="og:url" content="https://reactjs.org/{{ page.url }}">
-  <meta property="og:image" content="https://reactjs.org/img/logo_og.png">
+  <meta property="og:image" content="https://reactjs.org/logo-og.png">
   <meta property="og:description" content="{{ description }}">
   <meta property="fb:app_id" content="623268441017527">
 


### PR DESCRIPTION
Correct URL for logo. The old URL shows "Page Not Found"