### PR TITLE
Make sure all class constructors in the docs call super with props

### DIFF
--- a/docs/_posts/2015-01-27-react-v0.13.0-beta-1.md
+++ b/docs/_posts/2015-01-27-react-v0.13.0-beta-1.md
@@ -89,8 +89,8 @@ Therefore we decided not to have this built-in into React's class model. You can
 
 ```javascript
 class Counter extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.tick = this.tick.bind(this);
   }
   tick() {

--- a/docs/docs/higher-order-components.md
+++ b/docs/docs/higher-order-components.md
@@ -30,8 +30,8 @@ For example, say you have a `CommentList` component that subscribes to an extern
 
 ```js
 class CommentList extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.handleChange = this.handleChange.bind(this);
     this.state = {
       // "DataSource" is some global data source

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -200,8 +200,8 @@ First, add a constructor to the class to initialize the state:
 
 ```javascript{2-7}
 class Square extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       value: null,
     };
@@ -228,8 +228,8 @@ Now the `<button>` tag looks like this:
 
 ```javascript{10-12}
 class Square extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       value: null,
     };
@@ -282,8 +282,8 @@ Pulling state upwards like this is common when refactoring React components, so 
 
 ```javascript{2-7}
 class Board extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       squares: Array(9).fill(null),
     };
@@ -399,8 +399,8 @@ Try clicking a square – you should get an error because we haven't defined `ha
 
 ```javascript{9-13}
 class Board extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       squares: Array(9).fill(null),
     };
@@ -528,8 +528,8 @@ Let's default the first move to be by 'X'. Modify our starting state in our Boar
 
 ```javascript{6}
 class Board extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       squares: Array(9).fill(null),
       xIsNext: true,
@@ -564,8 +564,8 @@ After these changes you should have this Board component:
 
 ```javascript{6,11-16,29}
 class Board extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       squares: Array(9).fill(null),
       xIsNext: true,
@@ -715,8 +715,8 @@ First, set up the initial state for Game by adding a constructor to it:
 
 ```javascript{2-10}
 class Game extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       history: [{
         squares: Array(9).fill(null),
@@ -1006,8 +1006,8 @@ First, add `stepNumber: 0` to the initial state in Game's `constructor`:
 
 ```js{8}
 class Game extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       history: [{
         squares: Array(9).fill(null),


### PR DESCRIPTION
Frankly I'm not sure whether it is strictly necessary to do "always call the base constructor with props", but it is mentioned [here](https://reactjs.org/docs/state-and-lifecycle.html#adding-local-state-to-a-class) so I think this should be enforced in the documentation at the very least.

Some of the test fixtures in `/src` have components which do not call the `super()` with `props` as well. I can make a PR to fix those if you like.

Also, I understand that the docs page is undergoing migration at the moment. If I should be making doc changes in the new repo or hold off further changes until the migration is complete, do let me know.