### PR TITLE
Clear previous children when SVG node doesn't have innerHTML

### DIFF
--- a/src/renderers/dom/shared/setInnerHTML.js
+++ b/src/renderers/dom/shared/setInnerHTML.js
@@ -31,6 +31,9 @@ var setInnerHTML = createMicrosoftUnsafeLocalFunction(function(node, html) {
       reusableSVGContainer || document.createElement('div');
     reusableSVGContainer.innerHTML = '<svg>' + html + '</svg>';
     var svgNode = reusableSVGContainer.firstChild;
+    while (node.firstChild) {
+      node.removeChild(node.firstChild);
+    }
     while (svgNode.firstChild) {
       node.appendChild(svgNode.firstChild);
     }

--- a/src/renderers/dom/shared/utils/__tests__/setInnerHTML-test.js
+++ b/src/renderers/dom/shared/utils/__tests__/setInnerHTML-test.js
@@ -34,16 +34,6 @@ describe('setInnerHTML', () => {
         has: (target, prop) => {
           return prop === 'innerHTML' ? false : prop in target;
         },
-        get: (target, prop) => {
-          if (prop === 'appendChild') {
-            return function(child) {
-              child.parentElement.removeChild(child);
-              return target.appendChild(child);
-            };
-          } else {
-            return target[prop];
-          }
-        },
       });
 
       spyOn(node, 'appendChild').and.callThrough();

--- a/src/renderers/dom/shared/utils/__tests__/setInnerHTML-test.js
+++ b/src/renderers/dom/shared/utils/__tests__/setInnerHTML-test.js
@@ -24,17 +24,35 @@ describe('setInnerHTML', () => {
   });
 
   describe('when the node does not have an innerHTML property', () => {
-    // Disabled. JSDOM doesn't seem to remove nodes when using appendChild to
-    // move existing nodes.
-    xit('sets innerHTML on it', () => {
+    var node;
+    var nodeProxy;
+    beforeEach(() => {
       // Create a mock node that looks like an SVG in IE (without innerHTML)
-      var node = {
-        namespaceURI: Namespaces.svg,
-        appendChild: jasmine.createSpy(),
-      };
+      node = document.createElementNS(Namespaces.svg, 'svg');
 
+      nodeProxy = new Proxy(node, {
+        has: (target, prop) => {
+          return prop === 'innerHTML' ? false : prop in target;
+        },
+        get: (target, prop) => {
+          if (prop === 'appendChild') {
+            return function(child) {
+              child.parentElement.removeChild(child);
+              return target.appendChild(child);
+            };
+          } else {
+            return target[prop];
+          }
+        },
+      });
+
+      spyOn(node, 'appendChild').and.callThrough();
+      spyOn(node, 'removeChild').and.callThrough();
+    });
+
+    it('sets innerHTML on it', () => {
       var html = '<circle></circle><rect></rect>';
-      setInnerHTML(node, html);
+      setInnerHTML(nodeProxy, html);
 
       expect(node.appendChild.calls.argsFor(0)[0].outerHTML).toBe(
         '<circle></circle>',
@@ -42,6 +60,19 @@ describe('setInnerHTML', () => {
       expect(node.appendChild.calls.argsFor(1)[0].outerHTML).toBe(
         '<rect></rect>',
       );
+    });
+
+    it('clears previous children', () => {
+      var firstHtml = '<rect></rect>';
+      var secondHtml = '<circle></circle>';
+      setInnerHTML(nodeProxy, firstHtml);
+
+      setInnerHTML(nodeProxy, secondHtml);
+
+      expect(node.removeChild.calls.argsFor(0)[0].outerHTML).toBe(
+        '<rect></rect>',
+      );
+      expect(node.innerHTML).toBe('<circle></circle>');
     });
   });
 });


### PR DESCRIPTION
Fixes #10013 

I also fixed the UT, but they only work in node 6+ (using Proxy).
I saw that node 4-5 are still supported as development environments, so if this upgrade is not possible right now I'll revert them.
Couldn't get the tests to work otherwise 😞 