### PR TITLE
Use lower case for HTML attributes

### DIFF
--- a/src/renderers/dom/shared/DOMMarkupOperations.js
+++ b/src/renderers/dom/shared/DOMMarkupOperations.js
@@ -10,12 +10,15 @@
 'use strict';
 
 var DOMProperty = require('DOMProperty');
+var {Namespaces} = require('DOMNamespaces');
 
 var quoteAttributeValueForBrowser = require('quoteAttributeValueForBrowser');
 
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
 }
+
+var HTML_NAMESPACE = Namespaces.html;
 
 // isAttributeNameSafe() is currently duplicated in DOMPropertyOperations.
 // TODO: Find a better place for this.
@@ -85,13 +88,16 @@ var DOMMarkupOperations = {
    * @param {*} value
    * @return {?string} Markup string, or null if the property was invalid.
    */
-  createMarkupForProperty: function(name, value) {
+  createMarkupForProperty: function(name, value, namespace) {
     var propertyInfo = DOMProperty.getPropertyInfo(name);
     if (propertyInfo) {
       if (shouldIgnoreValue(propertyInfo, value)) {
         return '';
       }
       var attributeName = propertyInfo.attributeName;
+      if (namespace === HTML_NAMESPACE) {
+        attributeName = attributeName.toLowerCase();
+      }
       if (
         propertyInfo.hasBooleanValue ||
         (propertyInfo.hasOverloadedBooleanValue && value === true)
@@ -106,6 +112,9 @@ var DOMMarkupOperations = {
     } else if (DOMProperty.shouldSetAttribute(name, value)) {
       if (value == null) {
         return '';
+      }
+      if (namespace === HTML_NAMESPACE) {
+        name = name.toLowerCase();
       }
       return name + '=' + quoteAttributeValueForBrowser(value);
     }

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -701,4 +701,27 @@ describe('ReactDOMServer', () => {
       'tabindex=',
     );
   });
+
+  it('keeps tracks of attribute case sensitivity based on the namespace', () => {
+    const html = ReactDOMServer.renderToString(
+      <div itemProp="name">
+        <svg textRendering="optimizeLegibility" baseProfile="full">
+          <foreignObject externalResourcesRequired={true} tabIndex="1">
+            <img srcSet="wow" />
+            <svg viewBox="0 0 0 0" />
+          </foreignObject>
+        </svg>
+        <input minLength="10" />
+      </div>,
+    );
+    // SVG is case sensitive
+    expect(html).toContain('text-rendering=');
+    expect(html).toContain('baseProfile=');
+    expect(html).toContain('tabindex=');
+    expect(html).toContain('viewBox=');
+    // HTML is not, but people expect lowercase output
+    expect(html).toContain('itemprop=');
+    expect(html).toContain('srcset=');
+    expect(html).toContain('minlength=');
+  });
 });

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -695,4 +695,10 @@ describe('ReactDOMServer', () => {
         'HTML tags in React.',
     );
   });
+
+  it('uses lowercase tags in HTML output', () => {
+    expect(ReactDOMServer.renderToString(<div tabIndex="-1" />)).toContain(
+      'tabindex=',
+    );
+  });
 });

--- a/src/renderers/shared/server/ReactPartialRenderer.js
+++ b/src/renderers/shared/server/ReactPartialRenderer.js
@@ -284,7 +284,11 @@ function createOpenTagMarkup(
         );
       }
     } else {
-      markup = DOMMarkupOperations.createMarkupForProperty(propKey, propValue);
+      markup = DOMMarkupOperations.createMarkupForProperty(
+        propKey,
+        propValue,
+        namespace,
+      );
     }
     if (markup) {
       ret += ' ' + markup;


### PR DESCRIPTION
It doesn't really matter because HTML is case insensitive but people prefer it.
Fixes https://github.com/facebook/react/issues/10863.