### PR TITLE
 Add production bundles for Test and Shallow renderers

### DIFF
--- a/packages/react-dom/test-utils.js
+++ b/packages/react-dom/test-utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  throw Error('test-utils is not available in production mode.');
+  module.exports = require('./cjs/react-dom-test-utils.production.min.js');
 } else {
-  module.exports = require('./cjs/react-dom-test-utils.development');
+  module.exports = require('./cjs/react-dom-test-utils.development.js');
 }

--- a/packages/react-test-renderer/index.js
+++ b/packages/react-test-renderer/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  throw Error('test renderer is not available in production mode.');
+  module.exports = require('./cjs/react-test-renderer.production.min.js');
 } else {
-  module.exports = require('./cjs/react-test-renderer.development');
+  module.exports = require('./cjs/react-test-renderer.development.js');
 }

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -26,7 +26,6 @@
     "README.md",
     "index.js",
     "shallow.js",
-    "stack.js",
     "cjs/"
   ]
 }

--- a/packages/react-test-renderer/shallow.js
+++ b/packages/react-test-renderer/shallow.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  throw Error('shallow renderer is not available in production mode.');
+  module.exports = require('./cjs/react-test-renderer-shallow.production.min.js');
 } else {
-  module.exports = require('./cjs/react-test-renderer-shallow.development');
+  module.exports = require('./cjs/react-test-renderer-shallow.development.js');
 }

--- a/packages/react-test-renderer/stack.js
+++ b/packages/react-test-renderer/stack.js
@@ -1,7 +1,0 @@
-'use strict';
-
-if (process.env.NODE_ENV === 'production') {
-  throw Error('test renderer is not available in production mode.');
-} else {
-  module.exports = require('./cjs/react-test-renderer-stack.development');
-}

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -93,7 +93,7 @@ const bundles = [
   },
   {
     babelOpts: babelOptsReact,
-    bundleTypes: [FB_DEV, NODE_DEV],
+    bundleTypes: [FB_DEV, NODE_DEV, NODE_PROD],
     config: {
       destDir: 'build/',
       globals: {

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -325,7 +325,7 @@ const bundles = [
   /******* React Test Renderer *******/
   {
     babelOpts: babelOptsReact,
-    bundleTypes: [FB_DEV, NODE_DEV],
+    bundleTypes: [FB_DEV, NODE_DEV, NODE_PROD],
     config: {
       destDir: 'build/',
       moduleName: 'ReactTestRenderer',
@@ -350,7 +350,7 @@ const bundles = [
   },
   {
     babelOpts: babelOptsReact,
-    bundleTypes: [FB_DEV, NODE_DEV],
+    bundleTypes: [FB_DEV, NODE_DEV, NODE_PROD],
     config: {
       destDir: 'build/',
       moduleName: 'ReactShallowRenderer',

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -203,6 +203,10 @@
     "react-test-renderer-shallow.production.min.js (NODE_PROD)": {
       "size": 4508,
       "gzip": 1637
+    },
+    "react-dom-test-utils.production.min.js (NODE_PROD)": {
+      "size": 11608,
+      "gzip": 4241
     }
   }
 }

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -195,6 +195,14 @@
     "ReactNativeRTFiber-prod.js (RN_PROD)": {
       "size": 167912,
       "gzip": 28774
+    },
+    "react-test-renderer.production.min.js (NODE_PROD)": {
+      "size": 53838,
+      "gzip": 16625
+    },
+    "react-test-renderer-shallow.production.min.js (NODE_PROD)": {
+      "size": 4508,
+      "gzip": 1637
     }
   }
 }


### PR DESCRIPTION
Per discussion in https://github.com/facebook/react/issues/10938, adds bundles for production versions of test and shallow renderer.

Tested by building and running Node REPL with `production` env and doing a basic sanity check.