### PR TITLE
 Deduplication of warning messages in nested updates (#11081)

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -34,6 +34,7 @@ if (__DEV__) {
   var ReactFiberInstrumentation = require('ReactFiberInstrumentation');
   var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
   var getComponentName = require('getComponentName');
+  var didWarnAboutNestedUpdates = false;
 }
 
 var {
@@ -214,8 +215,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     if (__DEV__) {
       if (
         ReactDebugCurrentFiber.phase === 'render' &&
-        ReactDebugCurrentFiber.current !== null
+        ReactDebugCurrentFiber.current !== null &&
+        !didWarnAboutNestedUpdates
       ) {
+        didWarnAboutNestedUpdates = true;
         warning(
           false,
           'Render methods should be a pure function of props and state; ' +

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -109,6 +109,8 @@ if (__DEV__) {
     stopCommitLifeCyclesTimer,
   } = require('ReactDebugFiberPerf');
 
+  var didWarnAboutStateTransition = false;
+
   var warnAboutUpdateOnUnmounted = function(
     instance: React$ComponentType<any>,
   ) {
@@ -132,6 +134,10 @@ if (__DEV__) {
         );
         break;
       case 'render':
+        if (didWarnAboutStateTransition) {
+          return;
+        }
+        didWarnAboutStateTransition = true;
         warning(
           false,
           'Cannot update during an existing state transition (such as within ' +


### PR DESCRIPTION
@gaearon I have added flags for preventing duplication of both the warning messages so they print only once now.
But I noticed that the error related to 'Maximum update depth exceeded .... ' was going in infinite loop. Not sure if its an issue or I am missing something. 
