### PR TITLE
Ignore CR/LF differences when warning about markup mismatch

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -125,7 +125,7 @@ if (__DEV__) {
       clientValue,
     );
     const normalizedServerValue = normalizeMarkupForTextOrAttribute(
-      clientValue,
+      serverValue,
     );
     if (normalizedServerValue === normalizedClientValue) {
       return;

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -60,12 +60,15 @@ var HTML = '__html';
 var {Namespaces: {html: HTML_NAMESPACE}, getIntrinsicNamespace} = DOMNamespaces;
 
 var NORMALIZE_NEWLINES_REGEX = /\r\n?/g;
-function isServerTextDifferentFromClientText(
-  serverText: string,
+function isServerMarkupDifferentFromClient(
+  serverText: ?string,
   clientText: string,
 ): boolean {
   if (serverText === clientText) {
     return false;
+  }
+  if (serverText === null || typeof serverText === 'undefined') {
+    return true;
   }
   // HTML parsing normalizes CR and CRLF to LF.
   // https://www.w3.org/TR/html5/single-page.html#preprocessing-the-input-stream
@@ -974,7 +977,7 @@ var ReactDOMFiberComponent = {
         // TODO: Warn if there is more than a single textNode as a child.
         // TODO: Should we use domElement.firstChild.nodeValue to compare?
         if (typeof nextProp === 'string') {
-          const isDifferent = isServerTextDifferentFromClientText(
+          const isDifferent = isServerMarkupDifferentFromClient(
             domElement.textContent,
             nextProp,
           );
@@ -1028,7 +1031,11 @@ var ReactDOMFiberComponent = {
             nextProp,
           );
           serverValue = domElement.getAttribute('style');
-          if (expectedStyle !== serverValue) {
+          const isDifferent = isServerMarkupDifferentFromClient(
+            serverValue,
+            expectedStyle,
+          );
+          if (isDifferent) {
             warnForPropDifference(propKey, serverValue, expectedStyle);
           }
         } else if (isCustomComponentTag) {
@@ -1039,8 +1046,11 @@ var ReactDOMFiberComponent = {
             propKey,
             nextProp,
           );
-
-          if (nextProp !== serverValue) {
+          const isDifferent = isServerMarkupDifferentFromClient(
+            serverValue,
+            nextProp,
+          );
+          if (isDifferent) {
             warnForPropDifference(propKey, serverValue, nextProp);
           }
         } else if (DOMProperty.shouldSetAttribute(propKey, nextProp)) {
@@ -1071,7 +1081,11 @@ var ReactDOMFiberComponent = {
             );
           }
 
-          if (nextProp !== serverValue) {
+          const isDifferent = isServerMarkupDifferentFromClient(
+            serverValue,
+            nextProp,
+          );
+          if (isDifferent) {
             warnForPropDifference(propKey, serverValue, nextProp);
           }
         }
@@ -1119,7 +1133,7 @@ var ReactDOMFiberComponent = {
   },
 
   diffHydratedText(textNode: Text, text: string): boolean {
-    const isDifferent = isServerTextDifferentFromClientText(
+    const isDifferent = isServerMarkupDifferentFromClient(
       textNode.nodeValue,
       text,
     );

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -77,11 +77,12 @@ if (__DEV__) {
   };
 
   // HTML parsing normalizes CR and CRLF to LF.
+  // It also can turn \u0000 into \uFFFD inside attributes.
   // https://www.w3.org/TR/html5/single-page.html#preprocessing-the-input-stream
   // If we have a mismatch, it might be caused by that.
   // We won't be patching up in this case as that matches our past behavior.
   var NORMALIZE_NEWLINES_REGEX = /\r\n?/g;
-  var NORMALIZE_NULL_REGEX = /\u0000/g;
+  var NORMALIZE_NULL_AND_REPLACEMENT_REGEX = /\u0000|\uFFFD/g;
 
   var normalizeMarkupForTextOrAttribute = function(markup: mixed): string {
     const markupString = typeof markup === 'string'
@@ -89,7 +90,7 @@ if (__DEV__) {
       : '' + (markup: any);
     return markupString
       .replace(NORMALIZE_NEWLINES_REGEX, '\n')
-      .replace(NORMALIZE_NULL_REGEX, '');
+      .replace(NORMALIZE_NULL_AND_REPLACEMENT_REGEX, '');
   };
 
   var warnForTextDifference = function(

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -81,6 +81,16 @@ if (__DEV__) {
   // If we have a mismatch, it might be caused by that.
   // We won't be patching up in this case as that matches our past behavior.
   var NORMALIZE_NEWLINES_REGEX = /\r\n?/g;
+  var NORMALIZE_NULL_REGEX = /\u0000/g;
+
+  var normalizeMarkupForTextOrAttribute = function(markup: mixed): string {
+    const markupString = typeof markup === 'string'
+      ? markup
+      : '' + (markup: any);
+    return markupString
+      .replace(NORMALIZE_NEWLINES_REGEX, '\n')
+      .replace(NORMALIZE_NULL_REGEX, '');
+  };
 
   var warnForTextDifference = function(
     serverText: string,
@@ -89,21 +99,17 @@ if (__DEV__) {
     if (didWarnInvalidHydration) {
       return;
     }
-    if (typeof clientText === 'string') {
-      const normalizedClientText = clientText.replace(
-        NORMALIZE_NEWLINES_REGEX,
-        '\n',
-      );
-      if (serverText === normalizedClientText) {
-        return;
-      }
+    const normalizedClientText = normalizeMarkupForTextOrAttribute(clientText);
+    const normalizedServerText = normalizeMarkupForTextOrAttribute(serverText);
+    if (normalizedServerText === normalizedClientText) {
+      return;
     }
     didWarnInvalidHydration = true;
     warning(
       false,
       'Text content did not match. Server: "%s" Client: "%s"',
-      serverText,
-      clientText,
+      normalizedServerText,
+      normalizedClientText,
     );
   };
 
@@ -115,22 +121,22 @@ if (__DEV__) {
     if (didWarnInvalidHydration) {
       return;
     }
-    if (typeof clientValue === 'string') {
-      const normalizedClientValue = clientValue.replace(
-        NORMALIZE_NEWLINES_REGEX,
-        '\n',
-      );
-      if (serverValue === normalizedClientValue) {
-        return;
-      }
+    const normalizedClientValue = normalizeMarkupForTextOrAttribute(
+      clientValue,
+    );
+    const normalizedServerValue = normalizeMarkupForTextOrAttribute(
+      clientValue,
+    );
+    if (normalizedServerValue === normalizedClientValue) {
+      return;
     }
     didWarnInvalidHydration = true;
     warning(
       false,
       'Prop `%s` did not match. Server: %s Client: %s',
       propName,
-      JSON.stringify(serverValue),
-      JSON.stringify(clientValue),
+      JSON.stringify(normalizedServerValue),
+      JSON.stringify(normalizedClientValue),
     );
   };
 

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -80,7 +80,7 @@ if (__DEV__) {
   // It also can turn \u0000 into \uFFFD inside attributes.
   // https://www.w3.org/TR/html5/single-page.html#preprocessing-the-input-stream
   // If we have a mismatch, it might be caused by that.
-  // We won't be patching up in this case as that matches our past behavior.
+  // We will still patch up in this case but not fire the warning.
   var NORMALIZE_NEWLINES_REGEX = /\r\n?/g;
   var NORMALIZE_NULL_AND_REPLACEMENT_REGEX = /\u0000|\uFFFD/g;
 

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -82,16 +82,21 @@ if (__DEV__) {
   // We won't be patching up in this case as that matches our past behavior.
   var NORMALIZE_NEWLINES_REGEX = /\r\n?/g;
 
-  var warnForTextDifference = function(serverText: string, clientText: string) {
+  var warnForTextDifference = function(
+    serverText: string,
+    clientText: string | number,
+  ) {
     if (didWarnInvalidHydration) {
       return;
     }
-    const normalizedClientText = clientText.replace(
-      NORMALIZE_NEWLINES_REGEX,
-      '\n',
-    );
-    if (serverText === normalizedClientText) {
-      return;
+    if (typeof clientText === 'string') {
+      const normalizedClientText = clientText.replace(
+        NORMALIZE_NEWLINES_REGEX,
+        '\n',
+      );
+      if (serverText === normalizedClientText) {
+        return;
+      }
     }
     didWarnInvalidHydration = true;
     warning(

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -76,8 +76,21 @@ if (__DEV__) {
     validateUnknownProperties(type, props);
   };
 
+  // HTML parsing normalizes CR and CRLF to LF.
+  // https://www.w3.org/TR/html5/single-page.html#preprocessing-the-input-stream
+  // If we have a mismatch, it might be caused by that.
+  // We won't be patching up in this case as that matches our past behavior.
+  var NORMALIZE_NEWLINES_REGEX = /\r\n?/g;
+
   var warnForTextDifference = function(serverText: string, clientText: string) {
     if (didWarnInvalidHydration) {
+      return;
+    }
+    const normalizedClientText = clientText.replace(
+      NORMALIZE_NEWLINES_REGEX,
+      '\n',
+    );
+    if (serverText === normalizedClientText) {
       return;
     }
     didWarnInvalidHydration = true;
@@ -96,6 +109,15 @@ if (__DEV__) {
   ) {
     if (didWarnInvalidHydration) {
       return;
+    }
+    if (typeof clientValue === 'string') {
+      const normalizedClientValue = clientValue.replace(
+        NORMALIZE_NEWLINES_REGEX,
+        '\n',
+      );
+      if (serverValue === normalizedClientValue) {
+        return;
+      }
     }
     didWarnInvalidHydration = true;
     warning(

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -1566,15 +1566,6 @@ describe('ReactDOMServerIntegration', () => {
           }
         },
       );
-
-      // TODO: this fails because the suite always fails when __html is just text.
-      // I don't know if it's a bug or a mistake in the test code yet.s
-
-      // itRenders('an element with dangerouslySetInnerHTML with carriage returns', async render => {
-      //   const e = await render(<div dangerouslySetInnerHTML={{ __html: 'foo\rbar\r\nbaz\nqux' }} />);
-      //   // Even client doesn't have CRs because it sets .innerHTML which converts to LF.
-      //   expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\nbar\nbaz\nqux');
-      // });
     });
 
     describe('components that throw errors', function() {

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -1117,52 +1117,6 @@ describe('ReactDOMServerIntegration', () => {
           expectTextNode(e.childNodes[1], 'bar');
         }
       });
-
-      describe('with carriage returns', () => {
-        // HTML parsing normalizes CR and CRLF to LF.
-        // https://www.w3.org/TR/html5/single-page.html#preprocessing-the-input-stream
-        // If we have a mismatch, it might be caused by that (and should not be reported).
-        // We won't be patching up in this case as that matches our past behavior.
-
-        itRenders('a div with one text CR child', async render => {
-          const e = await render(<div>{'foo\rbar\r\nbaz\nqux'}</div>);
-          if (
-            render === serverRender ||
-            render === clientRenderOnServerString ||
-            render === streamRender
-          ) {
-            expect(e.childNodes.length).toBe(1);
-            // Both CR and CRLF are replaced with LF.
-            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\nbar\nbaz\nqux');
-          } else {
-            expect(e.childNodes.length).toBe(1);
-            // Client rendering leaves CRs as they are.
-            // TODO: verify that it doesn't cause any observable difference.
-            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\rbar\r\nbaz\nqux');
-          }
-        });
-
-        itRenders('a div with two text CR children', async render => {
-          const e = await render(<div>{'foo\rbar'}{'\r\nbaz\nqux'}</div>);
-          if (
-            render === serverRender ||
-            render === clientRenderOnServerString ||
-            render === streamRender
-          ) {
-            // Both CR and CRLF are replaced with LF.
-            // We have three nodes because there is a comment between them.
-            expect(e.childNodes.length).toBe(3);
-            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\nbar');
-            expectNode(e.childNodes[2], TEXT_NODE_TYPE, '\nbaz\nqux');
-          } else {
-            expect(e.childNodes.length).toBe(2);
-            // Client rendering leaves CRs as they are.
-            // TODO: verify that it doesn't cause any observable difference.
-            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\rbar');
-            expectNode(e.childNodes[1], TEXT_NODE_TYPE, '\r\nbaz\nqux');
-          }
-        });
-      });
     });
 
     describe('number children', function() {
@@ -1545,6 +1499,59 @@ describe('ReactDOMServerIntegration', () => {
           expectTextNode(e.childNodes[1], '<span>Text2&quot;</span>');
         }
       });
+    });
+
+    describe('carriage return', () => {
+
+      // HTML parsing normalizes CR and CRLF to LF.
+      // https://www.w3.org/TR/html5/single-page.html#preprocessing-the-input-stream
+      // If we have a mismatch, it might be caused by that (and should not be reported).
+      // We won't be patching up in this case as that matches our past behavior.
+
+      itRenders(
+        'an element with one text child with carriage returns',
+        async render => {
+          const e = await render(<div>{'foo\rbar\r\nbaz\nqux'}</div>);
+          if (
+            render === serverRender ||
+            render === clientRenderOnServerString ||
+            render === streamRender
+          ) {
+            expect(e.childNodes.length).toBe(1);
+            // Both CR and CRLF are replaced with LF.
+            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\nbar\nbaz\nqux');
+          } else {
+            expect(e.childNodes.length).toBe(1);
+            // Client rendering leaves CRs as they are.
+            // TODO: verify that it doesn't cause any observable difference.
+            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\rbar\r\nbaz\nqux');
+          }
+        },
+      );
+
+      itRenders(
+        'an element with two text children with carriage returns',
+        async render => {
+          const e = await render(<div>{'foo\rbar'}{'\r\nbaz\nqux'}</div>);
+          if (
+            render === serverRender ||
+            render === clientRenderOnServerString ||
+            render === streamRender
+          ) {
+            // Both CR and CRLF are replaced with LF.
+            // We have three nodes because there is a comment between them.
+            expect(e.childNodes.length).toBe(3);
+            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\nbar');
+            expectNode(e.childNodes[2], TEXT_NODE_TYPE, '\nbaz\nqux');
+          } else {
+            expect(e.childNodes.length).toBe(2);
+            // Client rendering leaves CRs as they are.
+            // TODO: verify that it doesn't cause any observable difference.
+            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\rbar');
+            expectNode(e.childNodes[1], TEXT_NODE_TYPE, '\r\nbaz\nqux');
+          }
+        },
+      );
     });
 
     describe('components that throw errors', function() {

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -1502,7 +1502,6 @@ describe('ReactDOMServerIntegration', () => {
     });
 
     describe('carriage return', () => {
-
       // HTML parsing normalizes CR and CRLF to LF.
       // https://www.w3.org/TR/html5/single-page.html#preprocessing-the-input-stream
       // If we have a mismatch, it might be caused by that (and should not be reported).
@@ -1549,6 +1548,24 @@ describe('ReactDOMServerIntegration', () => {
             // TODO: verify that it doesn't cause any observable difference.
             expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\rbar');
             expectNode(e.childNodes[1], TEXT_NODE_TYPE, '\r\nbaz\nqux');
+          }
+        },
+      );
+
+      itRenders(
+        'an element with an attribute value with carriage returns',
+        async render => {
+          const e = await render(<a title={'foo\rbar\r\nbaz\nqux'} />);
+          if (
+            render === serverRender ||
+            render === clientRenderOnServerString ||
+            render === streamRender
+          ) {
+            // Both CR and CRLF are replaced with LF.
+            expect(e.title).toBe('foo\nbar\nbaz\nqux');
+          } else {
+            // Client rendering leaves CRs as they are.
+            expect(e.title).toBe('foo\rbar\r\nbaz\nqux');
           }
         },
       );

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -1117,6 +1117,52 @@ describe('ReactDOMServerIntegration', () => {
           expectTextNode(e.childNodes[1], 'bar');
         }
       });
+
+      describe('with carriage returns', () => {
+        // HTML parsing normalizes CR and CRLF to LF.
+        // https://www.w3.org/TR/html5/single-page.html#preprocessing-the-input-stream
+        // If we have a mismatch, it might be caused by that (and should not be reported).
+        // We won't be patching up in this case as that matches our past behavior.
+
+        itRenders('a div with one text CR child', async render => {
+          const e = await render(<div>{'foo\rbar\r\nbaz\nqux'}</div>);
+          if (
+            render === serverRender ||
+            render === clientRenderOnServerString ||
+            render === streamRender
+          ) {
+            expect(e.childNodes.length).toBe(1);
+            // Both CR and CRLF are replaced with LF.
+            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\nbar\nbaz\nqux');
+          } else {
+            expect(e.childNodes.length).toBe(1);
+            // Client rendering leaves CRs as they are.
+            // TODO: verify that it doesn't cause any observable difference.
+            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\rbar\r\nbaz\nqux');
+          }
+        });
+
+        itRenders('a div with two text CR children', async render => {
+          const e = await render(<div>{'foo\rbar'}{'\r\nbaz\nqux'}</div>);
+          if (
+            render === serverRender ||
+            render === clientRenderOnServerString ||
+            render === streamRender
+          ) {
+            // Both CR and CRLF are replaced with LF.
+            // We have three nodes because there is a comment between them.
+            expect(e.childNodes.length).toBe(3);
+            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\nbar');
+            expectNode(e.childNodes[2], TEXT_NODE_TYPE, '\nbaz\nqux');
+          } else {
+            expect(e.childNodes.length).toBe(2);
+            // Client rendering leaves CRs as they are.
+            // TODO: verify that it doesn't cause any observable difference.
+            expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\rbar');
+            expectNode(e.childNodes[1], TEXT_NODE_TYPE, '\r\nbaz\nqux');
+          }
+        });
+      });
     });
 
     describe('number children', function() {

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -1569,6 +1569,16 @@ describe('ReactDOMServerIntegration', () => {
           }
         },
       );
+
+      // TODO: this fails because the suite always fails when __html is just text.
+      // I don't know if it's a bug or a mistake in the test code yet.s
+
+      // itRenders('an element with dangerouslySetInnerHTML with carriage returns', async render => {
+      //   const e = await render(<div dangerouslySetInnerHTML={{ __html: 'foo\rbar\r\nbaz\nqux' }} />);
+      //   // Both CR and CRLF are replaced with LF.
+      //   // It happens on the client too because it uses the .innerHTML code path node.
+      //   expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\nbar\nbaz\nqux');
+      // });
     });
 
     describe('components that throw errors', function() {


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/11103.

According to [the spec](https://www.w3.org/TR/html5/single-page.html#preprocessing-the-input-stream), HTML parser turns `\r\n` or lone `\r` into `\n`.

Since we compare JS app string (which might have `\r`) with the representation parsed from HTML (which can't), we have a false positive text mismatch warning.

I am solving this by adding a second check. It's only activated when we have a mismatch, so it only penalizes users with mismatching markup, or users with `\r` in content.

<s>I opted **not** to patch up the markup when the only difference is `\r` normalization. This is because we never did that before, and nobody complained. So it's probably unobservable to the user anyway (even though it's observable from the DOM—you can't have `\r` by setting `innerHTML` or parsing, but you can if you `createTextNode`s with it directly).</s>

<s>An alternative could be to always normalize `\r` when creating text nodes (and patch up markup if we encounter it). This would also make the behavior consistent between `innerHTML` and `createTextNode` path on the client side.</s>

<s>It seems like we can always do the latter if we want to, but the former is an unobtrusive fix that can be applied now.</s>

Updated it to just ignore the warning, but still patch up. Production logic doesn't change now.

Later updated to normalize both server and client values before emitting the warning. I started stripping both null and "replacement" character (browser sometimes turns null into it) since that's the only other corner case I know.