### PR TITLE
Use indexOf instead of includes in RangeKeyboardFixture

### DIFF
--- a/fixtures/dom/src/components/fixtures/input-change-events/RangeKeyboardFixture.js
+++ b/fixtures/dom/src/components/fixtures/input-change-events/RangeKeyboardFixture.js
@@ -30,7 +30,9 @@ class RangeKeyboardFixture extends React.Component {
 
   handleKeydown = e => {
     // only interesting in arrow key events
-    if (![37, 38, 39, 40].includes(e.keyCode)) return;
+    if ([37, 38, 39, 40].indexOf(e.keyCode) < 0) {
+      return;
+    }
 
     this.setState(({keydownCount}) => {
       return {


### PR DESCRIPTION
Older browsers don't have `[].includes`. I thought about adding the polyfill, but indexOf is simple enough. 

This allows us to test the range input change event test fixture in IE10-11 and older Chrome/Safari/Firefox.

Fixes https://github.com/facebook/react/issues/11132