### PR TITLE
Add focus helper to range test, update button styles

### DIFF
--- a/fixtures/dom/src/components/fixtures/input-change-events/RangeKeyboardFixture.js
+++ b/fixtures/dom/src/components/fixtures/input-change-events/RangeKeyboardFixture.js
@@ -52,11 +52,16 @@ class RangeKeyboardFixture extends React.Component {
 
     return (
       <Fixture>
-        <input
-          type="range"
-          ref={r => (this.input = r)}
-          onChange={this.handleChange}
-        />
+        <div>
+          <input
+            type="range"
+            ref={r => (this.input = r)}
+            onChange={this.handleChange}
+          />
+          <button onClick={() => this.input.focus()}>
+            Focus Knob
+          </button>
+        </div>
         {' '}
 
         <p style={{color}}>

--- a/fixtures/dom/src/style.css
+++ b/fixtures/dom/src/style.css
@@ -17,9 +17,13 @@ body {
 }
 
 button {
+  background: white;
+  border-radius: 2px;
+  border: 1px solid rgba(0, 0, 0, 0.24);
+  cursor: pointer;
+  font-size: 16px;
   margin: 10px;
-  font-size: 18px;
-  padding: 5px;
+  padding: 6px 8px;
 }
 
 .header {


### PR DESCRIPTION
When testing range input change events, clicking the knob would cause it to move if the click region wasn't precisely on the center of the knob.

This is annoying! This commit adds a button to focus the range input knob and takes a small pass at styling buttons.

A label would work here too, however it does not generate a focus ring in all browsers.

![focus](https://user-images.githubusercontent.com/590904/31277171-aaafe0dc-aa6d-11e7-95a7-21d58023ea8d.gif)


