### PR TITLE
Changed the error message displayed when a select element has props.multiple set to true and value set to null

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -796,7 +796,7 @@ describe('ReactDOMInput', () => {
     ReactTestUtils.renderIntoDocument(<input type="text" value={null} />);
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
       '`value` prop on `input` should not be null. ' +
-        'Consider using the empty string to clear the component or `undefined` ' +
+        'Consider using an empty string to clear the component or `undefined` ' +
         'for uncontrolled components.',
     );
 

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -18,6 +18,7 @@ describe('ReactDOMSelect', () => {
   var noop = function() {};
 
   beforeEach(() => {
+    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
@@ -530,6 +531,7 @@ describe('ReactDOMSelect', () => {
       <select value={null} multiple={true}><option value="test" /></select>,
     );
 
+    expectDev(console.error.calls.count()).toBe(1);
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
       '`value` prop on `select` should not be null. ' +
         'Consider using an empty array when `multiple` is ' +

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -514,12 +514,31 @@ describe('ReactDOMSelect', () => {
     );
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
       '`value` prop on `select` should not be null. ' +
-        'Consider using the empty string to clear the component or `undefined` ' +
+        'Consider using an empty string to clear the component or `undefined` ' +
         'for uncontrolled components.',
     );
 
     ReactTestUtils.renderIntoDocument(
       <select value={null}><option value="test" /></select>,
+    );
+    expectDev(console.error.calls.count()).toBe(1);
+  });
+
+  it('should warn if value is null and multiple is true', () => {
+    spyOn(console, 'error');
+    ReactTestUtils.renderIntoDocument(
+      <select value={null} multiple={true}><option value="test" /></select>,
+    );
+
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      '`value` prop on `select` should not be null. ' +
+        'Consider using an empty array when `multiple` is ' +
+        'set to `true` to clear the component or `undefined` ' +
+        'for uncontrolled components.',
+    );
+
+    ReactTestUtils.renderIntoDocument(
+      <select value={null} multiple={true}><option value="test" /></select>,
     );
     expectDev(console.error.calls.count()).toBe(1);
   });

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -357,7 +357,7 @@ describe('ReactDOMTextarea', () => {
     ReactTestUtils.renderIntoDocument(<textarea value={null} />);
     expectDev(console.error.calls.argsFor(0)[0]).toContain(
       '`value` prop on `textarea` should not be null. ' +
-        'Consider using the empty string to clear the component or `undefined` ' +
+        'Consider using an empty string to clear the component or `undefined` ' +
         'for uncontrolled components.',
     );
 

--- a/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
+++ b/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
@@ -12,10 +12,7 @@ if (__DEV__) {
   var warning = require('fbjs/lib/warning');
 }
 
-var didWarnValueNull = {
-  default: false,
-  multiple: false,
-};
+var didWarnValueNull = false;
 
 function getStackAddendum() {
   var stack = ReactDebugCurrentFrame.getStackAddendum();
@@ -27,11 +24,9 @@ function validateProperties(type, props) {
     return;
   }
 
-  var isMultipleSelect = type === 'select' && props.multiple === true;
-  var errorType = isMultipleSelect ? 'multiple' : 'default';
-  var isFirstError = !didWarnValueNull[errorType];
-
-  if (props != null && props.value === null && isFirstError) {
+  if (props != null && props.value === null && !didWarnValueNull) {
+    var isMultipleSelect = type === 'select' && !!props.multiple;
+    var errorType = isMultipleSelect ? 'multiple' : 'default';
     warning(
       false,
       '`value` prop on `%s` should not be null. ' +
@@ -43,8 +38,7 @@ function validateProperties(type, props) {
         : 'string',
       getStackAddendum(),
     );
-
-    didWarnValueNull[errorType] = true;
+    didWarnValueNull = true;
   }
 }
 

--- a/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
+++ b/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
@@ -25,20 +25,26 @@ function validateProperties(type, props) {
   }
 
   if (props != null && props.value === null && !didWarnValueNull) {
-    var isMultipleSelect = type === 'select' && !!props.multiple;
-    var errorType = isMultipleSelect ? 'multiple' : 'default';
-    warning(
-      false,
-      '`value` prop on `%s` should not be null. ' +
-        'Consider using an empty %s to clear the component or `undefined` ' +
-        'for uncontrolled components.%s',
-      type,
-      errorType === 'multiple'
-        ? 'array when `multiple` is set to `true`'
-        : 'string',
-      getStackAddendum(),
-    );
     didWarnValueNull = true;
+    if (type === 'select' && props.multiple) {
+      warning(
+        false,
+        '`value` prop on `%s` should not be null. ' +
+          'Consider using an empty array when `multiple` is set to `true` ' +
+          'to clear the component or `undefined` for uncontrolled components.%s',
+        type,
+        getStackAddendum(),
+      );
+    } else {
+      warning(
+        false,
+        '`value` prop on `%s` should not be null. ' +
+          'Consider using an empty string to clear the component or `undefined` ' +
+          'for uncontrolled components.%s',
+        type,
+        getStackAddendum(),
+      );
+    }
   }
 }
 

--- a/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
+++ b/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
@@ -12,7 +12,10 @@ if (__DEV__) {
   var warning = require('fbjs/lib/warning');
 }
 
-var didWarnValueNull = false;
+var didWarnValueNull = {
+  default: false,
+  multiple: false,
+};
 
 function getStackAddendum() {
   var stack = ReactDebugCurrentFrame.getStackAddendum();
@@ -23,17 +26,25 @@ function validateProperties(type, props) {
   if (type !== 'input' && type !== 'textarea' && type !== 'select') {
     return;
   }
-  if (props != null && props.value === null && !didWarnValueNull) {
+
+  var isMultipleSelect = type === 'select' && props.multiple === true;
+  var errorType = isMultipleSelect ? 'multiple' : 'default';
+  var isFirstError = !didWarnValueNull[errorType];
+
+  if (props != null && props.value === null && isFirstError) {
     warning(
       false,
       '`value` prop on `%s` should not be null. ' +
-        'Consider using the empty string to clear the component or `undefined` ' +
+        'Consider using an empty %s to clear the component or `undefined` ' +
         'for uncontrolled components.%s',
       type,
+      errorType === 'multiple'
+        ? 'array when `multiple` is set to `true`'
+        : 'string',
       getStackAddendum(),
     );
 
-    didWarnValueNull = true;
+    didWarnValueNull[errorType] = true;
   }
 }
 


### PR DESCRIPTION
Addresses issue #9038 

I changed the error message shown when a select element with props.multiple set to true has a value of `null` to recommend an empty array instead of an empty string. Given that "the empty string" is a common term but "the empty array" is less so, I also changed the null input value error message shown for textarea and input to use "an empty string" instead of "the empty string" and changed tests to match.
