### PR TITLE
Allow custom attribute named `on` to be passed on to elements

### DIFF
--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -206,7 +206,7 @@ var DOMProperty = {
     if (
       (name[0] === 'o' || name[0] === 'O') &&
       (name[1] === 'n' || name[1] === 'N') &&
-      name.toLowerCase() !== 'on'
+      name.length > 2
     ) {
       return false;
     }

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -205,7 +205,8 @@ var DOMProperty = {
     }
     if (
       (name[0] === 'o' || name[0] === 'O') &&
-      (name[1] === 'n' || name[1] === 'N')
+      (name[1] === 'n' || name[1] === 'N') &&
+      name.toLowerCase() !== 'on'
     ) {
       return false;
     }

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -198,6 +198,13 @@ describe('ReactDOMComponent', () => {
       );
     });
 
+    it('should not warn if property `on` is passed on a custom component', () => {
+      spyOn(console, 'error');
+      var container = document.createElement('div');
+      ReactDOM.render(<amp-image on="tap" />, container);
+      expectDev(console.error.calls.count()).toBe(0);
+    });
+
     it('should warn for unknown function event handlers', () => {
       spyOn(console, 'error');
       var container = document.createElement('div');

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -198,13 +198,6 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should not warn if property `on` is passed on a custom component', () => {
-      spyOn(console, 'error');
-      var container = document.createElement('div');
-      ReactDOM.render(<amp-image on="tap" />, container);
-      expectDev(console.error.calls.count()).toBe(0);
-    });
-
     it('should warn for unknown function event handlers', () => {
       spyOn(console, 'error');
       var container = document.createElement('div');

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -991,6 +991,11 @@ describe('ReactDOMServerIntegration', () => {
       );
       expect(e.getAttribute('onunknownevent')).toBe(null);
     });
+
+    itRenders('custom attribute named `on`', async render => {
+      const e = await render(<div on="tap:do-something" />);
+      expect(e.getAttribute('on')).toEqual('tap:do-something');
+    });
   });
 
   describe('elements and children', function() {

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -70,7 +70,7 @@ if (__DEV__) {
       return true;
     }
 
-    if (lowerCasedName.indexOf('on') === 0) {
+    if (lowerCasedName.indexOf('on') === 0 && lowerCasedName !== 'on') {
       warning(
         false,
         'Unknown event handler property `%s`. It will be ignored.%s',

--- a/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+++ b/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
@@ -70,7 +70,7 @@ if (__DEV__) {
       return true;
     }
 
-    if (lowerCasedName.indexOf('on') === 0 && lowerCasedName !== 'on') {
+    if (lowerCasedName.indexOf('on') === 0 && lowerCasedName.length > 2) {
       warning(
         false,
         'Unknown event handler property `%s`. It will be ignored.%s',


### PR DESCRIPTION
Hi there,

It seems that currently is not possible to pass a custom property named `on` on custom components.

We would like to render AMP pages on the server, in which you define the event handlers like so: `<amp-image on="tap:do-something" />`.

In order to do so, I made the check a bit more specific, to allow the property to be passed if it's just named `on`.

Even though the tests are passing, please let me know if that would be the right approach.

Thanks,
Georgios