### PR TITLE
Bump peer deps of react to ^16.0.0

### DIFF
--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0-beta.5"
+    "react": "^16.0.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -19,7 +19,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0-beta.5"
+    "react": "^16.0.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -19,7 +19,7 @@
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {
-    "react": "^16.0.0-beta.5"
+    "react": "^16.0.0"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
Just noticed a few of the packages have the beta flag for react peer dep. Maybe okay, maybe not. 🤷‍♂️ 