### PR TITLE
Fix false positive <noscript> rehydration text difference warning in React 16

### DIFF
--- a/fixtures/ssr/src/components/Chrome.js
+++ b/fixtures/ssr/src/components/Chrome.js
@@ -15,6 +15,11 @@ export default class Chrome extends Component {
           <title>{this.props.title}</title>
         </head>
         <body>
+          <noscript
+            dangerouslySetInnerHTML={{
+              __html: `<b>Enable JavaScript to run this app.</b>`,
+            }}
+          />
           {this.props.children}
           <script
             dangerouslySetInnerHTML={{

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -164,17 +164,16 @@ if (__DEV__) {
     );
   };
 
-  var testDocument;
   // Parse the HTML and read it back to normalize the HTML string so that it
   // can be used for comparison.
   var normalizeHTML = function(parent: Element, html: string) {
-    if (!testDocument) {
-      // The title argument is required in IE11 so we pass an empty string.
-      testDocument = document.implementation.createHTMLDocument('');
-    }
+    // We could have created a separate document here to avoid
+    // re-initializing custom elements if they exist. But this breaks
+    // how <noscript> is being handled. So we use the same document.
+    // See the discussion in https://github.com/facebook/react/pull/11157.
     var testElement = parent.namespaceURI === HTML_NAMESPACE
-      ? testDocument.createElement(parent.tagName)
-      : testDocument.createElementNS(
+      ? parent.ownerDocument.createElement(parent.tagName)
+      : parent.ownerDocument.createElementNS(
           (parent.namespaceURI: any),
           parent.tagName,
         );

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -179,6 +179,19 @@ if (__DEV__) {
           parent.tagName,
         );
     testElement.innerHTML = html;
+
+    if (parent.tagName === 'NOSCRIPT') {
+      // <noscript> content is parsed as text, but only if the browser parses it
+      // together with <noscript> tag itself. So we have to wrap it once more.
+      var wrapperElement = document.createElement('div');
+      wrapperElement.innerHTML = '<noscript>' + html + '</noscript>';
+      var noscriptElement = wrapperElement.firstElementChild;
+      // Make Flow happy (but it'll always be there).
+      if (noscriptElement !== null && typeof noscriptElement !== 'undefined') {
+        return noscriptElement.innerHTML;
+      }
+    }
+
     return testElement.innerHTML;
   };
 }

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -179,19 +179,6 @@ if (__DEV__) {
           parent.tagName,
         );
     testElement.innerHTML = html;
-
-    if (parent.tagName === 'NOSCRIPT') {
-      // <noscript> content is parsed as text, but only if the browser parses it
-      // together with <noscript> tag itself. So we have to wrap it once more.
-      var wrapperElement = document.createElement('div');
-      wrapperElement.innerHTML = '<noscript>' + html + '</noscript>';
-      var noscriptElement = wrapperElement.firstElementChild;
-      // Make Flow happy (but it'll always be there).
-      if (noscriptElement !== null && typeof noscriptElement !== 'undefined') {
-        return noscriptElement.innerHTML;
-      }
-    }
-
     return testElement.innerHTML;
   };
 }


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/10993.

It doesn’t seem like jsdom reproduces the original issue (?!) so instead I added a `<noscript>` into our SSR fixture. I verified the warning appears without the fix, and disappears after the fix.

The `<noscript>` tag is special because the browser parses it as text content when scripting is enabled. However, the way we normalized HTML did not reproduce the same behavior faithfully because we didn’t include the `<noscript>` tag itself into that HTML. Therefore, it didn’t switch the parsing mode to treat its content as text.

The fix adds a special case for `<noscript>` to wrap it an extra time. I decided to special-case it because it seemed more solid than always wrapping (which is not always possible to do one level, e.g. `tr > td` case).