### PR TITLE
Fix incorrect calculation of onMouseEnter/Leave component path

### DIFF
--- a/src/renderers/dom/shared/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
+++ b/src/renderers/dom/shared/eventPlugins/__tests__/EnterLeaveEventPlugin-test.js
@@ -13,6 +13,7 @@ var EnterLeaveEventPlugin;
 var React;
 var ReactDOM;
 var ReactDOMComponentTree;
+var ReactTestUtils;
 
 describe('EnterLeaveEventPlugin', () => {
   beforeEach(() => {
@@ -20,6 +21,7 @@ describe('EnterLeaveEventPlugin', () => {
 
     React = require('react');
     ReactDOM = require('react-dom');
+    ReactTestUtils = require('react-dom/test-utils');
     // TODO: can we express this test with only public API?
     ReactDOMComponentTree = require('ReactDOMComponentTree');
     EnterLeaveEventPlugin = require('EnterLeaveEventPlugin');
@@ -57,5 +59,39 @@ describe('EnterLeaveEventPlugin', () => {
     expect(leave.relatedTarget).toBe(div);
     expect(enter.target).toBe(div);
     expect(enter.relatedTarget).toBe(iframe.contentWindow);
+  });
+
+  // Regression test for https://github.com/facebook/react/issues/10906.
+  it('should find the common parent after updates', () => {
+    let parentEnterCalls = 0;
+    let childEnterCalls = 0;
+    let parent = null;
+    class Parent extends React.Component {
+      render() {
+        return (
+          <div
+            onMouseEnter={() => parentEnterCalls++}
+            ref={node => (parent = node)}>
+            {this.props.showChild &&
+              <div onMouseEnter={() => childEnterCalls++} />}
+          </div>
+        );
+      }
+    }
+
+    const div = document.createElement('div');
+    ReactDOM.render(<Parent />, div);
+    // The issue only reproduced on insertion during the first update.
+    ReactDOM.render(<Parent showChild={true} />, div);
+
+    // Enter from parent into the child.
+    ReactTestUtils.simulateNativeEventOnNode('topMouseOut', parent, {
+      target: parent,
+      relatedTarget: parent.firstChild,
+    });
+
+    // Entering a child should fire on the child, not on the parent.
+    expect(childEnterCalls).toBe(1);
+    expect(parentEnterCalls).toBe(0);
   });
 });

--- a/src/renderers/shared/shared/ReactTreeTraversal.js
+++ b/src/renderers/shared/shared/ReactTreeTraversal.js
@@ -112,12 +112,24 @@ function traverseTwoPhase(inst, fn, arg) {
 function traverseEnterLeave(from, to, fn, argFrom, argTo) {
   var common = from && to ? getLowestCommonAncestor(from, to) : null;
   var pathFrom = [];
-  while (from && from !== common) {
+  while (true) {
+    if (!from) {
+      break;
+    }
+    if (from === common) {
+      break;
+    }
     pathFrom.push(from);
     from = getParent(from);
   }
   var pathTo = [];
-  while (to && to !== common) {
+  while (true) {
+    if (!to) {
+      break;
+    }
+    if (to === common) {
+      break;
+    }
     pathTo.push(to);
     to = getParent(to);
   }

--- a/src/renderers/shared/shared/ReactTreeTraversal.js
+++ b/src/renderers/shared/shared/ReactTreeTraversal.js
@@ -119,6 +119,10 @@ function traverseEnterLeave(from, to, fn, argFrom, argTo) {
     if (from === common) {
       break;
     }
+    const alternate = from.alternate;
+    if (alternate !== null && alternate === common) {
+      break;
+    }
     pathFrom.push(from);
     from = getParent(from);
   }
@@ -128,6 +132,10 @@ function traverseEnterLeave(from, to, fn, argFrom, argTo) {
       break;
     }
     if (to === common) {
+      break;
+    }
+    const alternate = to.alternate;
+    if (alternate !== null && alternate === common) {
       break;
     }
     pathTo.push(to);

--- a/src/renderers/shared/shared/ReactTreeTraversal.js
+++ b/src/renderers/shared/shared/ReactTreeTraversal.js
@@ -110,8 +110,8 @@ function traverseTwoPhase(inst, fn, arg) {
  * "entered" or "left" that element.
  */
 function traverseEnterLeave(from, to, fn, argFrom, argTo) {
-  var common = from && to ? getLowestCommonAncestor(from, to) : null;
-  var pathFrom = [];
+  const common = from && to ? getLowestCommonAncestor(from, to) : null;
+  const pathFrom = [];
   while (true) {
     if (!from) {
       break;
@@ -122,7 +122,7 @@ function traverseEnterLeave(from, to, fn, argFrom, argTo) {
     pathFrom.push(from);
     from = getParent(from);
   }
-  var pathTo = [];
+  const pathTo = [];
   while (true) {
     if (!to) {
       break;
@@ -133,7 +133,7 @@ function traverseEnterLeave(from, to, fn, argFrom, argTo) {
     pathTo.push(to);
     to = getParent(to);
   }
-  var i;
+  let i;
   for (i = 0; i < pathFrom.length; i++) {
     fn(pathFrom[i], 'bubbled', argFrom);
   }


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/10906 and https://github.com/facebook/react/issues/11152.
We forgot to compare alternates so in some cases, the from/to path was calculated incorrectly.

See individual commits. The first one adds a test, the last one fixes the bug. The ones in the middle prepare the code to look readable after the bugfix.

I verified both https://github.com/facebook/react/issues/10906 and https://github.com/facebook/react/issues/11152 reproduced before, but no longer reproduce after the bugfix.