### PR TITLE
Fix obscure error message when passing an invalid style value for SSR

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -360,13 +360,12 @@ describe('ReactDOMServer', () => {
     });
 
     it('should throw prop mapping error for an <iframe /> with invalid props', () => {
-      expect(
-        () => ReactDOMServer.renderToString(<iframe style="border:none;" />)
+      expect(() =>
+        ReactDOMServer.renderToString(<iframe style="border:none;" />),
       ).toThrowError(
-        'The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX.'
-      )
+        "The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + 'em'}} when using JSX.",
+      );
     });
-
   });
 
   describe('renderToStaticMarkup', () => {

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -358,6 +358,19 @@ describe('ReactDOMServer', () => {
         'Objects are not valid as a React child (found: object with keys {x})',
       );
     });
+
+    it('should not throw on <iframe /> with style attribute', () => {
+      expect(
+        () => ReactDOMServer.renderToString(<iframe style="border:none;" />)
+      ).not.toThrow();
+
+      expect(
+        ReactDOMServer.renderToString(<iframe style="border:none;" />),
+      ).toBe(
+        '<iframe src"border:none;"></iframe>',
+      );
+    });
+
   });
 
   describe('renderToStaticMarkup', () => {

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -363,8 +363,8 @@ describe('ReactDOMServer', () => {
       expect(() =>
         ReactDOMServer.renderToString(<iframe style="border:none;" />),
       ).toThrowError(
-        "The `style` prop expects a mapping from style properties to values, not " +
-        "a string. For example, style={{marginRight: spacing + 'em'}} when using JSX.",
+        'The `style` prop expects a mapping from style properties to values, not ' +
+          "a string. For example, style={{marginRight: spacing + 'em'}} when using JSX.",
       );
     });
   });

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -363,7 +363,8 @@ describe('ReactDOMServer', () => {
       expect(() =>
         ReactDOMServer.renderToString(<iframe style="border:none;" />),
       ).toThrowError(
-        "The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + 'em'}} when using JSX.",
+        "The `style` prop expects a mapping from style properties to values, not " +
+        "a string. For example, style={{marginRight: spacing + 'em'}} when using JSX.",
       );
     });
   });

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -359,16 +359,12 @@ describe('ReactDOMServer', () => {
       );
     });
 
-    it('should not throw on <iframe /> with style attribute', () => {
+    it('should throw prop mapping error for an <iframe /> with invalid props', () => {
       expect(
         () => ReactDOMServer.renderToString(<iframe style="border:none;" />)
-      ).not.toThrow();
-
-      expect(
-        ReactDOMServer.renderToString(<iframe style="border:none;" />),
-      ).toBe(
-        '<iframe src"border:none;"></iframe>',
-      );
+      ).toThrowError(
+        'The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX.'
+      )
     });
 
   });

--- a/src/renderers/shared/server/ReactPartialRenderer.js
+++ b/src/renderers/shared/server/ReactPartialRenderer.js
@@ -18,6 +18,7 @@ var DOMMarkupOperations = require('DOMMarkupOperations');
 var React = require('react');
 var ReactControlledValuePropTypes = require('ReactControlledValuePropTypes');
 
+var emptyFunction = require('fbjs/lib/emptyFunction');
 var assertValidProps = require('assertValidProps');
 var dangerousStyleValue = require('dangerousStyleValue');
 var emptyObject = require('fbjs/lib/emptyObject');
@@ -780,7 +781,7 @@ class ReactDOMServerRenderer {
       validatePropertiesInDevelopment(tag, props);
     }
 
-    assertValidProps(tag, props, () => null);
+    assertValidProps(tag, props, emptyFunction.thatReturnsNull);
 
     var out = createOpenTagMarkup(
       element.type,

--- a/src/renderers/shared/server/ReactPartialRenderer.js
+++ b/src/renderers/shared/server/ReactPartialRenderer.js
@@ -780,7 +780,7 @@ class ReactDOMServerRenderer {
       validatePropertiesInDevelopment(tag, props);
     }
 
-    assertValidProps(tag, props);
+    assertValidProps(tag, props, () => null);
 
     var out = createOpenTagMarkup(
       element.type,

--- a/src/renderers/shared/server/ReactPartialRenderer.js
+++ b/src/renderers/shared/server/ReactPartialRenderer.js
@@ -18,9 +18,9 @@ var DOMMarkupOperations = require('DOMMarkupOperations');
 var React = require('react');
 var ReactControlledValuePropTypes = require('ReactControlledValuePropTypes');
 
-var emptyFunction = require('fbjs/lib/emptyFunction');
 var assertValidProps = require('assertValidProps');
 var dangerousStyleValue = require('dangerousStyleValue');
+var emptyFunction = require('fbjs/lib/emptyFunction');
 var emptyObject = require('fbjs/lib/emptyObject');
 var escapeTextContentForBrowser = require('escapeTextContentForBrowser');
 var hyphenateStyleName = require('fbjs/lib/hyphenateStyleName');
@@ -30,6 +30,7 @@ var omittedCloseTags = require('omittedCloseTags');
 var isCustomComponent = require('isCustomComponent');
 
 var toArray = React.Children.toArray;
+var emptyFunctionThatReturnsNull = emptyFunction.thatReturnsNull;
 
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
@@ -781,7 +782,7 @@ class ReactDOMServerRenderer {
       validatePropertiesInDevelopment(tag, props);
     }
 
-    assertValidProps(tag, props, emptyFunction.thatReturnsNull);
+    assertValidProps(tag, props, emptyFunctionThatReturnsNull);
 
     var out = createOpenTagMarkup(
       element.type,


### PR DESCRIPTION
This may be a regression to add to #11065.

Adding a reduced test case for this issue by opening a PR. When trying to server render an `iframe` with an invalid `style` tag the following error is thrown:

```
~/react/ssr-test/node_modules/react-dom/cjs/react-dom-server.node.development.js:651                                                                                                                            var ownerName = getCurrentOwnerName();
                                                                                                                                                                      ^                                                                                                                                                                                                                                                                                                                                                                                                   TypeError: getCurrentOwnerName is not a function                                                                                                                                                               
at getDeclarationErrorAddendum (~/react/ssr-test/node_modules/react-dom/cjs/react-dom-server.node.development.js:651:21)                                                                                   
at assertValidProps (~/react/ssr-test/node_modules/react-dom/cjs/react-dom-server.node.development.js:675:236)                                                                                             
at ReactDOMServerRenderer.renderDOM (~/react/ssr-test/node_modules/react-dom/cjs/react-dom-server.node.development.js:2922:5)                                                                              
at ReactDOMServerRenderer.render (~/react/ssr-test/node_modules/react-dom/cjs/react-dom-server.node.development.js:2755:23)                                                                                
at ReactDOMServerRenderer.read (~/react/ssr-test/node_modules/react-dom/cjs/react-dom-server.node.development.js:2722:19)                                                                                  
at renderToString (~/react/ssr-test/node_modules/react-dom/cjs/react-dom-server.node.development.js:2980:25)                                                                                               
at Object.<anonymous> (~/react/ssr-test/src/Ssr.js:5:3)                                                                                                                                                    
at Module._compile (module.js:570:32)                                                                                                                                                                      
at loader (~/react/ssr-test/node_modules/babel-register/lib/node.js:144:5)                                                                                                                                 
at Object.require.extensions.(anonymous function) [as .js] (~/react/ssr-test/node_modules/babel-register/lib/node.js:154:7) 
```

I would expect this to throw the invalid props-style warning of:

```
The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + \'em\'}} when using JSX.
```

This can be traced back to this line here where we are missing the third argument to `assertValidProps`: https://github.com/facebook/react/blob/a276ffccd268170589a0223a855458c267cef906/src/renderers/shared/server/ReactPartialRenderer.js#L783

This file is not checked by flow which is possibly how the missed argument slipped through, though naively ading the `@flow` pragma to that file has 39 errors.

What should the fix be? (I included a commit to implement the only solution I’ve considered thus far)

* Add a `noop` third argument to `checkValidProps`? (since the only other `owner` ref in that file is explicitly set to `null` at https://github.com/facebook/react/blob/master/src/renderers/shared/server/ReactPartialRenderer.js#L57)
* alternative?