### PR TITLE
Fix false positive SVG hydration warning for mixed case tags

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberEntry.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberEntry.js
@@ -446,7 +446,7 @@ var DOMRenderer = ReactFiberReconciler({
   ): boolean {
     return (
       instance.nodeType === ELEMENT_NODE &&
-      type === instance.nodeName.toLowerCase()
+      type.toLowerCase() === instance.nodeName.toLowerCase()
     );
   },
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js
@@ -1344,6 +1344,14 @@ describe('ReactDOMServerIntegration', () => {
         },
       );
 
+      itRenders('svg element with a mixed case name', async render => {
+        let e = await render(<svg><filter><feMorphology /></filter></svg>);
+        e = e.firstChild.firstChild;
+        expect(e.childNodes.length).toBe(0);
+        expect(e.tagName).toBe('feMorphology');
+        expect(e.namespaceURI).toBe('http://www.w3.org/2000/svg');
+      });
+
       itRenders('a math element', async render => {
         const e = await render(<math />);
         expect(e.childNodes.length).toBe(0);


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/10772.

I opted for the fix suggested by @webcarrot in https://github.com/facebook/react/issues/10772#issuecomment-334154356.

It seems like the easiest and I don’t see a realistic situation in which it wouldn’t work. I guess it could break if you rendered `<femorphology>` on the server but `<feMorphology>` on the client, but who would possibly do that?