### PR TITLE
chore(syntheticEvent): remove IE8 code

### DIFF
--- a/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
+++ b/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
@@ -12,19 +12,6 @@
 var SyntheticEvent = require('SyntheticEvent');
 
 /**
- * @interface UIEvent
- * @see http://www.w3.org/TR/DOM-Level-3-Events/
- */
-var UIEventInterface = {
-  view: function(event) {
-    return event.view;
-  },
-  detail: function(event) {
-    return event.detail || 0;
-  },
-};
-
-/**
  * @param {object} dispatchConfig Configuration used to dispatch this event.
  * @param {string} dispatchMarker Marker identifying the event target.
  * @param {object} nativeEvent Native browser event.
@@ -44,7 +31,5 @@ function SyntheticUIEvent(
     nativeEventTarget,
   );
 }
-
-SyntheticEvent.augmentClass(SyntheticUIEvent, UIEventInterface);
 
 module.exports = SyntheticUIEvent;

--- a/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
+++ b/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
@@ -11,6 +11,11 @@
 
 var SyntheticEvent = require('SyntheticEvent');
 
+var UIEventInterface = {
+  view: null,
+  detail: null,
+};
+
 /**
  * @param {object} dispatchConfig Configuration used to dispatch this event.
  * @param {string} dispatchMarker Marker identifying the event target.
@@ -31,5 +36,7 @@ function SyntheticUIEvent(
     nativeEventTarget,
   );
 }
+
+SyntheticEvent.augmentClass(SyntheticUIEvent, UIEventInterface);
 
 module.exports = SyntheticUIEvent;

--- a/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
+++ b/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
@@ -11,8 +11,6 @@
 
 var SyntheticEvent = require('SyntheticEvent');
 
-var getEventTarget = require('getEventTarget');
-
 /**
  * @interface UIEvent
  * @see http://www.w3.org/TR/DOM-Level-3-Events/

--- a/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
+++ b/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
@@ -11,9 +11,9 @@
 
 var SyntheticEvent = require('SyntheticEvent');
 
-/**		
- * @interface UIEvent		
- * @see http://www.w3.org/TR/DOM-Level-3-Events/		
+/**
+ * @interface UIEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
 var UIEventInterface = {
   view: null,

--- a/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
+++ b/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
@@ -30,12 +30,7 @@ var UIEventInterface = {
     }
 
     var doc = target.ownerDocument;
-    // TODO: Figure out why `ownerDocument` is sometimes undefined in IE8.
-    if (doc) {
-      return doc.defaultView || doc.parentWindow;
-    } else {
-      return window;
-    }
+    return doc.defaultView;
   },
   detail: function(event) {
     return event.detail || 0;

--- a/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
+++ b/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
@@ -29,8 +29,7 @@ var UIEventInterface = {
       return target;
     }
 
-    var doc = target.ownerDocument;
-    return doc.defaultView;
+    return target.ownerDocument.defaultView;
   },
   detail: function(event) {
     return event.detail || 0;

--- a/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
+++ b/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
@@ -11,6 +11,10 @@
 
 var SyntheticEvent = require('SyntheticEvent');
 
+/**		
+ * @interface UIEvent		
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/		
+ */
 var UIEventInterface = {
   view: null,
   detail: null,

--- a/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
+++ b/src/renderers/dom/shared/syntheticEvents/SyntheticUIEvent.js
@@ -19,17 +19,7 @@ var getEventTarget = require('getEventTarget');
  */
 var UIEventInterface = {
   view: function(event) {
-    if (event.view) {
-      return event.view;
-    }
-
-    var target = getEventTarget(event);
-    if (target.window === target) {
-      // target is a window object
-      return target;
-    }
-
-    return target.ownerDocument.defaultView;
+    return event.view;
   },
   detail: function(event) {
     return event.detail || 0;


### PR DESCRIPTION
Since IE8 has been deprecated for a while, I thought it might be useful to remove some IE8-only code

If this is not something you want to focus on yet, or is too much work to test, feel free to close this PR

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
6. Make sure your code lints (`npm run lint`).
7. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
8. If you haven't already, complete the CLA.
