### PR TITLE
Move loop init variable assignment

### DIFF
--- a/src/renderers/shared/shared/ReactTreeTraversal.js
+++ b/src/renderers/shared/shared/ReactTreeTraversal.js
@@ -141,11 +141,10 @@ function traverseEnterLeave(from, to, fn, argFrom, argTo) {
     pathTo.push(to);
     to = getParent(to);
   }
-  let i;
-  for (i = 0; i < pathFrom.length; i++) {
+  for (let i = 0; i < pathFrom.length; i++) {
     fn(pathFrom[i], 'bubbled', argFrom);
   }
-  for (i = pathTo.length; i-- > 0; ) {
+  for (let i = pathTo.length; i-- > 0; ) {
     fn(pathTo[i], 'captured', argTo);
   }
 }


### PR DESCRIPTION
Just a random drive-by change.

Doesn't change the logic but avoids it being `undefined`.
Maybe this can prevent a deopt because now it's always an integer.

*dogscience*