### PR TITLE
Update build scripts to put RN-RT files in the right places

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -20,6 +20,7 @@ const sizes = require('./plugins/sizes-plugin');
 const Stats = require('./stats');
 const syncReactDom = require('./sync').syncReactDom;
 const syncReactNative = require('./sync').syncReactNative;
+const syncReactNativeRT = require('./sync').syncReactNativeRT;
 const Packaging = require('./packaging');
 const Header = require('./header');
 const closure = require('rollup-plugin-closure-compiler-js');
@@ -168,7 +169,12 @@ function handleRollupWarnings(warning) {
 function updateBundleConfig(config, filename, format, bundleType, hasteName) {
   return Object.assign({}, config, {
     banner: getBanner(bundleType, hasteName, filename),
-    dest: Packaging.getPackageDestination(config, bundleType, filename),
+    dest: Packaging.getPackageDestination(
+      config,
+      bundleType,
+      filename,
+      hasteName
+    ),
     footer: getFooter(bundleType),
     format,
     interop: false,
@@ -503,6 +509,7 @@ rimraf('build', () => {
   const tasks = [
     Packaging.createFacebookWWWBuild,
     Packaging.createReactNativeBuild,
+    Packaging.createReactNativeRTBuild,
   ];
   for (const bundle of Bundles.bundles) {
     tasks.push(
@@ -519,6 +526,9 @@ rimraf('build', () => {
   if (syncFbsource) {
     tasks.push(() =>
       syncReactNative(join('build', 'react-native'), syncFbsource)
+    );
+    tasks.push(() =>
+      syncReactNativeRT(join('build', 'react-native-rt'), syncFbsource)
     );
   } else if (syncWww) {
     tasks.push(() => syncReactDom(join('build', 'facebook-www'), syncWww));

--- a/scripts/rollup/sync.js
+++ b/scripts/rollup/sync.js
@@ -7,6 +7,7 @@ const resolvePath = require('./utils').resolvePath;
 const DEFAULT_FB_SOURCE_PATH = '~/fbsource/';
 const DEFAULT_WWW_PATH = '~/www/';
 const RELATIVE_RN_PATH = 'xplat/js/react-native-github/Libraries/Renderer/';
+const RELATIVE_RN_RT_PATH = 'xplat/js/RKJSModules/Libraries/RT/downstream/';
 const RELATIVE_WWW_PATH = 'html/shared/react/';
 
 function doSync(buildPath, destPath) {
@@ -46,7 +47,22 @@ function syncReactNative(buildPath, fbSourcePath) {
   return doSync(buildPath, destPath);
 }
 
+function syncReactNativeRT(buildPath, fbSourcePath) {
+  fbSourcePath = typeof fbSourcePath === 'string'
+    ? fbSourcePath
+    : DEFAULT_FB_SOURCE_PATH;
+
+  if (fbSourcePath.charAt(fbSourcePath.length - 1) !== '/') {
+    fbSourcePath += '/';
+  }
+
+  const destPath = resolvePath(fbSourcePath + RELATIVE_RN_RT_PATH);
+
+  return doSync(buildPath, destPath);
+}
+
 module.exports = {
   syncReactDom,
   syncReactNative,
+  syncReactNativeRT,
 };


### PR DESCRIPTION
Contents of `build` folder after `yarn build -- --type=RN` includes:
```
.
├── react-native
│   ├── ReactNativeFiber-dev.js
│   ├── ReactNativeFiber-prod.js
│   └── shims
│       ├── NativeMethodsMixin.js
│       ├── ReactDebugTool.js
│       ├── ReactGlobalSharedState.js
│       ├── ReactNative.js
│       ├── ReactNativeBridgeEventPlugin.js
│       ├── ReactNativeComponentTree.js
│       ├── ReactNativePropRegistry.js
│       ├── ReactNativeTypes.js
│       ├── ReactPerf.js
│       ├── ReactTypes.js
│       ├── TouchHistoryMath.js
│       ├── createReactNativeComponentClass.js
│       └── takeSnapshot.js
└── react-native-rt
    ├── ReactNativeRTFiber-dev.js
    ├── ReactNativeRTFiber-prod.js
    └── shims
        └── ReactNativeRTTypes.js
```