### PR TITLE
Keep autoFocus attribute in the DOM

### DIFF
--- a/fixtures/ssr/src/components/Page.js
+++ b/fixtures/ssr/src/components/Page.js
@@ -2,6 +2,11 @@ import React, {Component} from 'react';
 
 import './Page.css';
 
+const autofocusedInputs = [
+  <input key="0" autoFocus placeholder="Has auto focus" />,
+  <input key="1" autoFocus placeholder="Has auto focus" />,
+];
+
 export default class Page extends Component {
   state = {active: false};
   handleClick = e => {
@@ -19,8 +24,15 @@ export default class Page extends Component {
           A random number: {Math.random()}
         </p>
         <p>
+          Autofocus on page load: {autofocusedInputs}
+        </p>
+        <p>
           {!this.state.active ? link : 'Thanks!'}
         </p>
+        {this.state.active &&
+          <p>
+            Autofocus on update: {autofocusedInputs}
+          </p>}
       </div>
     );
   }

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -54,6 +54,7 @@ var registrationNameModules = EventPluginRegistry.registrationNameModules;
 var DANGEROUSLY_SET_INNER_HTML = 'dangerouslySetInnerHTML';
 var SUPPRESS_CONTENT_EDITABLE_WARNING = 'suppressContentEditableWarning';
 var SUPPRESS_HYDRATION_WARNING = 'suppressHydrationWarning';
+var AUTOFOCUS = 'autoFocus';
 var CHILDREN = 'children';
 var STYLE = 'style';
 var HTML = '__html';
@@ -286,6 +287,9 @@ function setInitialDOMProperties(
       propKey === SUPPRESS_HYDRATION_WARNING
     ) {
       // Noop
+    } else if (propKey === AUTOFOCUS) {
+      // We polyfill it separately on the client during commit.
+      // We blacklist it here rather than in the property list because we emit it in SSR.
     } else if (registrationNameModules.hasOwnProperty(propKey)) {
       if (nextProp != null) {
         if (__DEV__ && typeof nextProp !== 'function') {
@@ -681,6 +685,8 @@ var ReactDOMFiberComponent = {
         propKey === SUPPRESS_HYDRATION_WARNING
       ) {
         // Noop
+      } else if (propKey === AUTOFOCUS) {
+        // Noop. It doesn't work on updates anyway.
       } else if (registrationNameModules.hasOwnProperty(propKey)) {
         // This is a special case. If any listener updates we need to ensure
         // that the "current" fiber pointer gets updated so we need a commit

--- a/src/renderers/dom/shared/DOMProperty.js
+++ b/src/renderers/dom/shared/DOMProperty.js
@@ -16,7 +16,6 @@ var invariant = require('fbjs/lib/invariant');
 var RESERVED_PROPS = {
   children: true,
   dangerouslySetInnerHTML: true,
-  autoFocus: true,
   defaultValue: true,
   defaultChecked: true,
   innerHTML: true,

--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -26,6 +26,7 @@ var HTMLDOMPropertyConfig = {
   // name warnings.
   Properties: {
     allowFullScreen: HAS_BOOLEAN_VALUE,
+    autoFocus: HAS_STRING_BOOLEAN_VALUE,
     // specifies target context for links with `preload` type
     async: HAS_BOOLEAN_VALUE,
     // autoFocus is polyfilled/normalized by AutoFocusUtils

--- a/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactServerRendering-test.js
@@ -351,6 +351,26 @@ describe('ReactDOMServer', () => {
       expect(numClicks).toEqual(2);
     });
 
+    // We have a polyfill for autoFocus on the client, but we intentionally don't
+    // want it to call focus() when hydrating because this can mess up existing
+    // focus before the JS has loaded.
+    it('should emit autofocus on the server but not focus() when hydrating', () => {
+      var element = document.createElement('div');
+      element.innerHTML = ReactDOMServer.renderToString(
+        <input autoFocus={true} />,
+      );
+      expect(element.firstChild.autofocus).toBe(true);
+
+      // It should not be called on mount.
+      element.firstChild.focus = jest.fn();
+      ReactDOM.hydrate(<input autoFocus={true} />, element);
+      expect(element.firstChild.focus).not.toHaveBeenCalled();
+
+      // Or during an update.
+      ReactDOM.render(<input autoFocus={true} />, element);
+      expect(element.firstChild.focus).not.toHaveBeenCalled();
+    });
+
     it('should throw with silly args', () => {
       expect(
         ReactDOMServer.renderToString.bind(ReactDOMServer, {x: 123}),


### PR DESCRIPTION
This is the simplest thing we could do. Changes to always emit `autofocus` into the DOM, both on the server and on the client. We still have the JS hook too, although it doesn’t run during hydration.

<s>We’ll need to also add a test verifying that the current behavior (Fiber doesn’t call JS focus on hydration) doesn’t regress. It was unintentional but we now consciously want to do it to *prevent* JS focus jumps when hydrating. I’ll work on that next.</s>

(Done.)

We could still blacklist `autoFocus` on the client, and only emit it on the server. The argument for doing that is it’s less likely to conflict with our JS hooks and matches the current behavior for non-SSR apps. The argument against it is that it’s an extra weird special case, and it will be confusing to people to see `autoFocus` only on SSR’d content.

<s>In this PR, I emit it on the client too. I haven’t decided if that’s right, and the input is welcome.</s>

I decided to always omit it on the client for extra safety.

cc @syranide @aweary @sebmarkbage