### PR TITLE
Add exception for 16.alpha when loading React in DOM Fixtures

### DIFF
--- a/fixtures/dom/src/react-loader.js
+++ b/fixtures/dom/src/react-loader.js
@@ -42,7 +42,9 @@ export default function loadReact() {
   let version = query.version || 'local';
 
   if (version !== 'local') {
-    if (parseInt(version, 10) >= 16) {
+    // The file structure was updated in 16. This wasn't the case for alphas.
+    // Load the old module location for anything less than 16 RC
+    if (parseInt(version, 10) >= 16 && version.indexOf('alpha') < 0) {
       REACT_PATH =
         'https://unpkg.com/react@' + version + '/umd/react.development.js';
       DOM_PATH =


### PR DESCRIPTION
The file structure was updated in 16. This wasn't the case for alphas. We need to load the old module location for anything less than 16 RC.

Follow up from https://github.com/facebook/react/issues/11132#issuecomment-335757661

![screen shot 2017-10-11 at 7 21 49 pm](https://user-images.githubusercontent.com/590904/31471922-7468987a-aeb9-11e7-9211-e6dfc68d3ce3.png)

🎉 