### PR TITLE
Adjust input value detachment to avoid input validation in FireFox

### DIFF
--- a/fixtures/dom/src/components/fixtures/text-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/text-inputs/index.js
@@ -42,14 +42,23 @@ class TextInputFixtures extends React.Component {
           </p>
         </TestCase>
 
-        <TestCase title="Required Inputs" affectedBrowsers="Firefox" relatedIssues="8395">
+        <TestCase
+          title="Required Inputs"
+          affectedBrowsers="Firefox"
+          relatedIssues="8395">
           <TestCase.Steps>
             <li>View this test in Firefox</li>
           </TestCase.Steps>
 
           <TestCase.ExpectedResult>
-            <p>You should <b><i>not</i></b> see a red aura, indicating the input is invalid.</p>
-            <p>This aura looks roughly like: <input style={{boxShadow: '0 0 1px 1px red', marginLeft: 8 }} /></p>
+            You should
+            {' '}
+            <b><i>not</i></b>
+            {' '}
+            see a red aura, indicating the input is invalid.
+            <br />
+            This aura looks roughly like:
+            <input style={{boxShadow: '0 0 1px 1px red', marginLeft: 8}} />
           </TestCase.ExpectedResult>
 
           <Fixture>

--- a/fixtures/dom/src/components/fixtures/text-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/text-inputs/index.js
@@ -42,6 +42,37 @@ class TextInputFixtures extends React.Component {
           </p>
         </TestCase>
 
+        <TestCase title="Required Inputs" affectedBrowsers="Firefox" relatedIssues="8395">
+          <TestCase.Steps>
+            <li>View this test in Firefox</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            <p>You should <b><i>not</i></b> see a red aura, indicating the input is invalid.</p>
+            <p>This aura looks roughly like: <input style={{boxShadow: '0 0 1px 1px red', marginLeft: 8 }} /></p>
+          </TestCase.ExpectedResult>
+
+          <Fixture>
+            <form className="control-box">
+              <fieldset>
+                <legend>Text</legend>
+                <input required={true} />
+              </fieldset>
+              <fieldset>
+                <legend>Date</legend>
+                <input type="date" required={true} />
+              </fieldset>
+            </form>
+          </Fixture>
+
+          <p className="footnote">
+            Checking the date type is also important because of a
+            prior fix for iOS Safari that involved assigning over
+            value/defaultValue properties of the input to prevent a
+            display bug. This also triggered input validation.
+          </p>
+        </TestCase>
+
         <TestCase title="Cursor when editing email inputs">
           <TestCase.Steps>
             <li>Type "user@example.com"</li>

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
@@ -15,7 +15,7 @@ type InputWithWrapperState = HTMLInputElement & {
     initialValue: ?string,
     initialChecked: ?boolean,
     controlled: boolean,
-    detached: boolean
+    detached: boolean,
   },
 };
 

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
@@ -14,7 +14,8 @@ type InputWithWrapperState = HTMLInputElement & {
   _wrapperState: {
     initialValue: ?string,
     initialChecked: ?boolean,
-    controlled?: boolean,
+    controlled: boolean,
+    detached: boolean
   },
 };
 

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
@@ -141,7 +141,7 @@ var ReactDOMInput = {
         : props.defaultChecked,
       initialValue: props.value != null ? props.value : defaultValue,
       controlled: isControlled(props),
-      detached: false
+      detached: false,
     };
   },
 
@@ -222,8 +222,8 @@ var ReactDOMInput = {
         // Whenever setting defaultValue, ensure that the value
         // property is detatched
         if (node._wrapperState.detached === false) {
-          node.value = node.value
-          node._wrapperState.detached = true
+          node.value = node.value;
+          node._wrapperState.detached = true;
         }
 
         // In Chrome, assigning defaultValue to certain input types triggers input validation.
@@ -247,12 +247,6 @@ var ReactDOMInput = {
   postMountWrapper: function(element: Element, props: Object) {
     var node = ((element: any): InputWithWrapperState);
 
-    // Detach value from defaultValue. We won't do anything if we're working on
-    // submit or reset inputs as those values & defaultValues are linked. They
-    // are not resetable nodes so this operation doesn't matter and actually
-    // removes browser-default values (eg "Submit Query") when no value is
-    // provided.
-
     switch (props.type) {
       case 'color':
       case 'date':
@@ -263,8 +257,11 @@ var ReactDOMInput = {
       case 'week':
         // This fixes the no-show issue on iOS Safari and Android Chrome:
         // https://github.com/facebook/react/issues/7233
-        node.type = "text"
-        node.type = props.type
+        //
+        // Important: use setAttribute instead of node.type = "x" to avoid
+        // an exception in IE10/11 due to an unrecognized input type
+        node.setAttribute('type', 'text');
+        node.setAttribute('type', props.type);
         break;
       default:
         break;

--- a/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
+++ b/src/renderers/dom/fiber/wrappers/ReactDOMFiberInput.js
@@ -141,6 +141,7 @@ var ReactDOMInput = {
         : props.defaultChecked,
       initialValue: props.value != null ? props.value : defaultValue,
       controlled: isControlled(props),
+      detached: false
     };
   },
 
@@ -218,6 +219,13 @@ var ReactDOMInput = {
       }
     } else {
       if (props.value == null && props.defaultValue != null) {
+        // Whenever setting defaultValue, ensure that the value
+        // property is detatched
+        if (node._wrapperState.detached === false) {
+          node.value = node.value
+          node._wrapperState.detached = true
+        }
+
         // In Chrome, assigning defaultValue to certain input types triggers input validation.
         // For number inputs, the display value loses trailing decimal points. For email inputs,
         // Chrome raises "The specified value <x> is not a valid email address".
@@ -246,9 +254,6 @@ var ReactDOMInput = {
     // provided.
 
     switch (props.type) {
-      case 'submit':
-      case 'reset':
-        break;
       case 'color':
       case 'date':
       case 'datetime':
@@ -258,11 +263,10 @@ var ReactDOMInput = {
       case 'week':
         // This fixes the no-show issue on iOS Safari and Android Chrome:
         // https://github.com/facebook/react/issues/7233
-        node.value = '';
-        node.value = node.defaultValue;
+        node.type = "text"
+        node.type = props.type
         break;
       default:
-        node.value = node.value;
         break;
     }
 

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -1231,11 +1231,6 @@ describe('ReactDOMInput', () => {
     spyOn(document, 'createElement').and.callFake(function(type) {
       var el = originalCreateElement.apply(this, arguments);
       if (type === 'input') {
-        Object.defineProperty(el, 'type', {
-          set: function(val) {
-            log.push(`node.type = ${strify(val)}`);
-          },
-        });
         spyOn(el, 'setAttribute').and.callFake(function(name, val) {
           log.push(`node.setAttribute(${strify(name)}, ${strify(val)})`);
         });
@@ -1249,8 +1244,8 @@ describe('ReactDOMInput', () => {
     expect(log).toEqual([
       'node.setAttribute("type", "date")',
       'node.setAttribute("value", "1980-01-01")',
-      'node.type = "text"',
-      'node.type = "date"',
+      'node.setAttribute("type", "text")',
+      'node.setAttribute("type", "date")',
       'node.setAttribute("checked", "")',
       'node.setAttribute("checked", "")',
     ]);

--- a/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
+++ b/src/renderers/dom/shared/wrappers/__tests__/ReactDOMInput-test.js
@@ -1190,7 +1190,6 @@ describe('ReactDOMInput', () => {
       'set min',
       'set max',
       'set value',
-      'set value',
       'set checked',
       'set checked',
     ]);
@@ -1232,9 +1231,9 @@ describe('ReactDOMInput', () => {
     spyOn(document, 'createElement').and.callFake(function(type) {
       var el = originalCreateElement.apply(this, arguments);
       if (type === 'input') {
-        Object.defineProperty(el, 'value', {
+        Object.defineProperty(el, 'type', {
           set: function(val) {
-            log.push(`node.value = ${strify(val)}`);
+            log.push(`node.type = ${strify(val)}`);
           },
         });
         spyOn(el, 'setAttribute').and.callFake(function(name, val) {
@@ -1250,8 +1249,8 @@ describe('ReactDOMInput', () => {
     expect(log).toEqual([
       'node.setAttribute("type", "date")',
       'node.setAttribute("value", "1980-01-01")',
-      'node.value = ""',
-      'node.value = ""',
+      'node.type = "text"',
+      'node.type = "date"',
       'node.setAttribute("checked", "")',
       'node.setAttribute("checked", "")',
     ]);


### PR DESCRIPTION
Fixes #8395 

React DOM intentionally sets `value` on inputs when they are created. This prevents an issue where changes to `defaultValue` cause the `value` property to change.

This is colloquially known as "value detachment". Unfortunately, this triggers input validation, displaying a red aura in Firefox. This works around that by:

1. Only detaching if the related value is truthy.
2. Reassigning the `type` property on date/color inputs to preserve
   the iOS fix.

**Test Plan**

1. Open http://react-ff-validate.surge.sh/text-inputs
2. The **Required Inputs** test case inputs should not be invalid (no red)
3. The date input placeholders on the **All inputs** test case should display

So far, I have tested in:

**Success so far:**
Safari Desktop 11
Safari iOS 7, 8.4, 10.2, 11
Firefox 47, 56
Chrome 61
IE 10, 11
IE Edge 15