### PR TITLE
Added component stack to contentEditable warning

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1130,7 +1130,7 @@ describe('ReactDOMComponent', () => {
         'Warning: A component is `contentEditable` and contains `children` ' +
           'managed by React. It is now your responsibility to guarantee that ' +
           'none of those nodes are unexpectedly modified or duplicated. This ' +
-          'is probably not intentional.\n    in div (at **)'
+          'is probably not intentional.\n    in div (at **)',
       );
     });
 

--- a/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMComponent-test.js
@@ -1126,7 +1126,12 @@ describe('ReactDOMComponent', () => {
       spyOn(console, 'error');
       mountComponent({contentEditable: true, children: ''});
       expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain('contentEditable');
+      expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
+        'Warning: A component is `contentEditable` and contains `children` ' +
+          'managed by React. It is now your responsibility to guarantee that ' +
+          'none of those nodes are unexpectedly modified or duplicated. This ' +
+          'is probably not intentional.\n    in div (at **)'
+      );
     });
 
     it('should respect suppressContentEditableWarning', () => {

--- a/src/renderers/dom/shared/utils/assertValidProps.js
+++ b/src/renderers/dom/shared/utils/assertValidProps.js
@@ -66,11 +66,11 @@ function assertValidProps(
       props.suppressContentEditableWarning ||
         !props.contentEditable ||
         props.children == null,
-        'A component is `contentEditable` and contains `children` managed by ' +
-          'React. It is now your responsibility to guarantee that none of ' +
-          'those nodes are unexpectedly modified or duplicated. This is ' +
-          'probably not intentional.%s',
-        getCurrentFiberStackAddendum() || '',
+      'A component is `contentEditable` and contains `children` managed by ' +
+        'React. It is now your responsibility to guarantee that none of ' +
+        'those nodes are unexpectedly modified or duplicated. This is ' +
+        'probably not intentional.%s',
+      getCurrentFiberStackAddendum() || '',
     );
   }
   invariant(

--- a/src/renderers/dom/shared/utils/assertValidProps.js
+++ b/src/renderers/dom/shared/utils/assertValidProps.js
@@ -13,6 +13,7 @@ var invariant = require('fbjs/lib/invariant');
 var voidElementTags = require('voidElementTags');
 
 if (__DEV__) {
+  var {getCurrentFiberStackAddendum} = require('ReactDebugCurrentFiber');
   var warning = require('fbjs/lib/warning');
 }
 
@@ -65,10 +66,11 @@ function assertValidProps(
       props.suppressContentEditableWarning ||
         !props.contentEditable ||
         props.children == null,
-      'A component is `contentEditable` and contains `children` managed by ' +
-        'React. It is now your responsibility to guarantee that none of ' +
-        'those nodes are unexpectedly modified or duplicated. This is ' +
-        'probably not intentional.',
+        'A component is `contentEditable` and contains `children` managed by ' +
+          'React. It is now your responsibility to guarantee that none of ' +
+          'those nodes are unexpectedly modified or duplicated. This is ' +
+          'probably not intentional.%s',
+        getCurrentFiberStackAddendum() || '',
     );
   }
   invariant(


### PR DESCRIPTION
In ref to #8497 I've added the componentStack to the contentEditable warning message. Update test suite and all tests pass. Closes #8497

This is a new PR after I failed on this previous one https://github.com/facebook/react/pull/11138