### PR TITLE
[Not for commit] Demonstrate async bug

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -1517,7 +1517,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     }
 
-    if (expirationTime === Sync && (isCommitting || isBatchingUpdates)) {
+    if (expirationTime === Sync && (isPerformingWork || isBatchingUpdates)) {
       // If we're in a batch, or in the commit phase, downgrade sync to task
       return Task;
     }


### PR DESCRIPTION
During a recent sync to Facebook's internal repo, we encountered a bug introduced by https://github.com/facebook/react/pull/10426 and fixed by https://github.com/facebook/react/pull/11187.

Even though the bug is fixed in the latest master, we decided to investigate the root cause of the bug to protect against future regressions.

Thanks to some debugging by @trueadm and @gaearon, I think I have a good sense of what caused the bug. I wasn't able to figure out a test case that reproduces the original error in the old commit, but I'm reasonably confident that it's related to how we calculate the expiration time of an incoming update.

Updates that occur during the commit phase (`componentDidUpdate`) should receive task priority, so that they are flushed in the next batch.

Updates that occur during the render phase (like `componentWillReceiveProps`) should receive the same expiration time as whatever is currently rendering, so that they are flushed in the current batch. If we're rendering sync work, then the update should have sync expiration. It should *not* be downgraded to task. Otherwise, won't be rendered until the next batch, which could lead to an infinite loop of updates.

In the commit that introduced this bug, this check is incorrect:

https://github.com/facebook/react/blob/3019210df2b486416ed94d7b9becffaf254e81c4/src/renderers/shared/fiber/ReactFiberScheduler.js#L1544-L1549

It should be checking `isCommitting`, not `isPerforming` work, because we don't want to downgrade if we're in the render phase, only the commit phase.

Even though this is wrong, it didn't manifest as a bug in our units tests because of other code that happened to mask it in most cases.

https://github.com/facebook/react/pull/11187 removed the incidental complexity that was masking the bug. While working on that PR, I discovered the error and corrected that check:

https://github.com/facebook/react/blob/0c5a455ecb33041f973e9770e8d8dc5fccfcf484/src/renderers/shared/fiber/ReactFiberScheduler.js#L1520-L1523

This PR demonstrates that if you change that line back from `isCommitting` to `isPerformingWork`, it causes several unit test failures.