### PR TITLE
Sync setStates inside willUpdate and didUpdate should flush at same time

### DIFF
--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -1494,7 +1494,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       if (isCommitting) {
         // Updates that occur during the commit phase should have task priority
         // by default.
-        expirationTime = Task;
+        expirationTime = Sync;
       } else {
         // Updates during the render phase should expire at the same time as
         // the work that is being rendered.
@@ -1517,7 +1517,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
       }
     }
 
-    if (expirationTime === Sync && (isCommitting || isBatchingUpdates)) {
+    if (
+      expirationTime === Sync &&
+      (isBatchingUpdates || (isUnbatchingUpdates && isCommitting))
+    ) {
       // If we're in a batch, or in the commit phase, downgrade sync to task
       return Task;
     }


### PR DESCRIPTION
In sync mode, we downgrade sync priority work to task work when we're in the commit phase, but not in the render phase. That means if you schedule updates in both phases, the render phase update will flush first, and the commit phase update will flush after that. What should really happen is that both updates flush at the same time.

To solve this, updates in the commit phase are now given sync priority. The distinction between task and sync really only exists to account for a historical quirk in the behavior of top-level mounts. (Refer to the test case titled "initial mount is sync inside batchedUpdates".)

Ideally, there would only be one priority for both sync and task. This gets us closer to that model, while still accounting for top-level mounts.