### PR TITLE
 Deduplicated many warnings (#11140)

### DIFF
--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -221,6 +221,10 @@ describe('ReactComponentLifeCycle', () => {
         'unmounted component. This is a no-op.\n\nPlease check the code for the ' +
         'StatefulComponent component.',
     );
+
+    // Check deduplication
+    ReactTestUtils.renderIntoDocument(<StatefulComponent />);
+    expectDev(console.error.calls.count()).toBe(1);
   });
 
   it('should correctly determine if a component is mounted', () => {

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -374,6 +374,11 @@ describe('ReactCompositeComponent', () => {
     expect(instance).toBe(instance2);
     expect(renderedState).toBe(1);
     expect(instance2.state.value).toBe(1);
+
+    // Test deduplication
+    ReactDOM.unmountComponentAtNode(container);
+    ReactDOM.render(<Component prop={123} />, container);
+    expectDev(console.error.calls.count()).toBe(1);
   });
 
   it('should warn about `setState` in getChildContext', () => {
@@ -407,6 +412,11 @@ describe('ReactCompositeComponent', () => {
     expectDev(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: setState(...): Cannot call setState() inside getChildContext()',
     );
+
+    // Test deduplication
+    ReactDOM.unmountComponentAtNode(container);
+    ReactDOM.render(<Component />, container);
+    expectDev(console.error.calls.count()).toBe(1);
   });
 
   it('should cleanup even if render() fatals', () => {

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -252,6 +252,9 @@ describe('ReactCompositeComponent', () => {
         'component. This is a no-op.\n\nPlease check the code for the ' +
         'Component component.',
     );
+
+    instance.forceUpdate();
+    expectDev(console.error.calls.count()).toBe(1);
   });
 
   it('should warn about `setState` on unmounted components', () => {

--- a/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
@@ -421,6 +421,10 @@ describe('ReactCompositeComponent-state', () => {
         "this.state is deprecated (except inside a component's constructor). " +
         'Use setState instead.',
     );
+
+    // Check deduplication
+    ReactDOM.render(<Test />, container);
+    expect(console.error.calls.count()).toEqual(1);
   });
 
   it('should treat assigning to this.state inside cWM as a replaceState, with a warning', () => {

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -656,8 +656,11 @@ describe('ReactDOMServer', () => {
         ' This usually means you called setState() outside componentWillMount() on the server.' +
         ' This is a no-op.\n\nPlease check the code for the Foo component.',
     );
+
     var markup = ReactDOMServer.renderToStaticMarkup(<Foo />);
     expect(markup).toBe('<div>hello</div>');
+    jest.runOnlyPendingTimers();
+    expectDev(console.error.calls.count()).toBe(1);
   });
 
   it('warns with a no-op when an async forceUpdate is triggered', () => {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -72,6 +72,7 @@ if (__DEV__) {
   var {ReactDebugCurrentFrame} = require('shared/ReactGlobalSharedState');
   var currentDebugStack = null;
   var currentDebugElementStack = null;
+  var didWarnAboutNoopUpdateForComponent = {};
   var setCurrentDebugStack = function(stack: Array<Frame>) {
     var frame: Frame = stack[stack.length - 1];
     currentDebugElementStack = ((frame: any): FrameDev).debugElementStack;
@@ -175,6 +176,13 @@ function warnNoop(
 ) {
   if (__DEV__) {
     var constructor = publicInstance.constructor;
+    const componentName =
+      (constructor && getComponentName(constructor)) || 'ReactClass';
+    const warningKey = `${callerName}_${componentName}`;
+    if (didWarnAboutNoopUpdateForComponent[warningKey]) {
+      return;
+    }
+
     warning(
       false,
       '%s(...): Can only update a mounting component. ' +
@@ -182,8 +190,9 @@ function warnNoop(
         'This is a no-op.\n\nPlease check the code for the %s component.',
       callerName,
       callerName,
-      (constructor && getComponentName(constructor)) || 'ReactClass',
+      componentName,
     );
+    didWarnAboutNoopUpdateForComponent[warningKey] = true;
   }
 }
 

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -72,7 +72,6 @@ if (__DEV__) {
   var {ReactDebugCurrentFrame} = require('shared/ReactGlobalSharedState');
   var currentDebugStack = null;
   var currentDebugElementStack = null;
-  var didWarnAboutNoopUpdateForComponent = {};
   var setCurrentDebugStack = function(stack: Array<Frame>) {
     var frame: Frame = stack[stack.length - 1];
     currentDebugElementStack = ((frame: any): FrameDev).debugElementStack;
@@ -113,6 +112,7 @@ var didWarnDefaultChecked = false;
 var didWarnDefaultSelectValue = false;
 var didWarnDefaultTextareaValue = false;
 var didWarnInvalidOptionChildren = false;
+var didWarnAboutNoopUpdateForComponent = {};
 var valuePropNames = ['value', 'defaultValue'];
 var newlineEatingTags = {
   listing: true,
@@ -178,7 +178,7 @@ function warnNoop(
     var constructor = publicInstance.constructor;
     const componentName =
       (constructor && getComponentName(constructor)) || 'ReactClass';
-    const warningKey = `${callerName}_${componentName}`;
+    const warningKey = `${componentName}.${callerName}`;
     if (didWarnAboutNoopUpdateForComponent[warningKey]) {
       return;
     }

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -41,6 +41,7 @@ if (__DEV__) {
   var warning = require('fbjs/lib/warning');
 
   var {startPhaseTimer, stopPhaseTimer} = require('./ReactDebugFiberPerf');
+  var didWarnAboutStateAssignmentForComponent = {};
 
   var warnOnInvalidCallback = function(callback: mixed, callerName: string) {
     warning(
@@ -393,13 +394,17 @@ module.exports = function(
 
     if (instance.state !== oldState) {
       if (__DEV__) {
-        warning(
-          false,
-          '%s.componentWillReceiveProps(): Assigning directly to ' +
-            "this.state is deprecated (except inside a component's " +
-            'constructor). Use setState instead.',
-          getComponentName(workInProgress),
-        );
+        const componentName = getComponentName(workInProgress) || 'Component';
+        if (!didWarnAboutStateAssignmentForComponent[componentName]) {
+          warning(
+            false,
+            '%s.componentWillReceiveProps(): Assigning directly to ' +
+              "this.state is deprecated (except inside a component's " +
+              'constructor). Use setState instead.',
+            componentName,
+          );
+          didWarnAboutStateAssignmentForComponent[componentName] = true;
+        }
       }
       updater.enqueueReplaceState(instance, instance.state, null);
     }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -109,7 +109,6 @@ if (__DEV__) {
     if (didWarnStateUpdateForUnmountedComponent[componentName]) {
       return;
     }
-
     warning(
       false,
       'Can only update a mounted or mounting ' +

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -120,7 +120,7 @@ if (__DEV__) {
     didWarnStateUpdateForUnmountedComponent[componentName] = true;
   };
 
-  var warnAboutInvalidUpdates = function(instance: React$ComponentType<any>) {
+  var warnAboutInvalidUpdates = function(instance: React$Component<any>) {
     switch (ReactDebugCurrentFiber.phase) {
       case 'getChildContext':
         if (didWarnSetStateChildContext) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -101,34 +101,42 @@ if (__DEV__) {
   } = require('./ReactDebugFiberPerf');
 
   var didWarnAboutStateTransition = false;
+  var didWarnSetStateChildContext = false;
+  var didWarnStateUpdateForUnmountedComponent = {};
 
-  var warnAboutUpdateOnUnmounted = function(
-    instance: React$ComponentType<any>,
-  ) {
-    const ctor = instance.constructor;
+  var warnAboutUpdateOnUnmounted = function(fiber: Fiber) {
+    const componentName = getComponentName(fiber) || 'ReactClass';
+    if (didWarnStateUpdateForUnmountedComponent[componentName]) {
+      return;
+    }
+
     warning(
       false,
-      'Can only update a mounted or mounting component. This usually means ' +
-        'you called setState, replaceState, or forceUpdate on an unmounted ' +
-        'component. This is a no-op.\n\nPlease check the code for the ' +
-        '%s component.',
-      (ctor && (ctor.displayName || ctor.name)) || 'ReactClass',
+      'Can only update a mounted or mounting ' +
+        'component. This usually means you called setState, replaceState, ' +
+        'or forceUpdate on an unmounted component. This is a no-op.\n\nPlease ' +
+        'check the code for the %s component.',
+      componentName,
     );
+    didWarnStateUpdateForUnmountedComponent[componentName] = true;
   };
 
   var warnAboutInvalidUpdates = function(instance: React$ComponentType<any>) {
     switch (ReactDebugCurrentFiber.phase) {
       case 'getChildContext':
+        if (didWarnSetStateChildContext) {
+          return;
+        }
         warning(
           false,
           'setState(...): Cannot call setState() inside getChildContext()',
         );
+        didWarnSetStateChildContext = true;
         break;
       case 'render':
         if (didWarnAboutStateTransition) {
           return;
         }
-        didWarnAboutStateTransition = true;
         warning(
           false,
           'Cannot update during an existing state transition (such as within ' +
@@ -136,6 +144,7 @@ if (__DEV__) {
             'be a pure function of props and state; constructor side-effects are ' +
             'an anti-pattern, but can be moved to `componentWillMount`.',
         );
+        didWarnAboutStateTransition = true;
         break;
     }
   };
@@ -1229,7 +1238,7 @@ module.exports = function<T, P, I, TI, PI, C, CC, CX, PL>(
         } else {
           if (__DEV__) {
             if (!isErrorRecovery && fiber.tag === ClassComponent) {
-              warnAboutUpdateOnUnmounted(fiber.stateNode);
+              warnAboutUpdateOnUnmounted(fiber);
             }
           }
           return;

--- a/packages/react-reconciler/src/ReactFiberUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberUpdateQueue.js
@@ -20,6 +20,7 @@ const {NoWork} = require('./ReactFiberExpirationTime');
 
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
+  var didWarnUpdateInsideUpdate = false;
 }
 
 type PartialState<State, Props> =
@@ -132,7 +133,10 @@ function insertUpdateIntoFiber<State>(
 
   // Warn if an update is scheduled from inside an updater function.
   if (__DEV__) {
-    if (queue1.isProcessing || (queue2 !== null && queue2.isProcessing)) {
+    if (
+      (queue1.isProcessing || (queue2 !== null && queue2.isProcessing)) &&
+      !didWarnUpdateInsideUpdate
+    ) {
       warning(
         false,
         'An update (setState, replaceState, or forceUpdate) was scheduled ' +
@@ -140,6 +144,7 @@ function insertUpdateIntoFiber<State>(
           'with zero side-effects. Consider using componentDidUpdate or a ' +
           'callback.',
       );
+      didWarnUpdateInsideUpdate = true;
     }
   }
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -341,6 +341,19 @@ describe('ReactIncrementalUpdates', () => {
     expect(instance.state).toEqual({a: 'a', b: 'b'});
 
     expectDev(console.error.calls.count()).toBe(1);
-    console.error.calls.reset();
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'An update (setState, replaceState, or forceUpdate) was scheduled ' +
+        'from inside an update function. Update functions should be pure, ' +
+        'with zero side-effects. Consider using componentDidUpdate or a ' +
+        'callback.',
+    );
+
+    // Test deduplication
+    instance.setState(function a() {
+      this.setState({a: 'a'});
+      return {b: 'b'};
+    });
+    ReactNoop.flush();
+    expectDev(console.error.calls.count()).toBe(1);
   });
 });

--- a/packages/react/src/ReactNoopUpdateQueue.js
+++ b/packages/react/src/ReactNoopUpdateQueue.js
@@ -18,7 +18,7 @@ function warnNoop(publicInstance, callerName) {
     const componentName =
       (constructor && (constructor.displayName || constructor.name)) ||
       'ReactClass';
-    const warningKey = `${callerName}_${componentName}`;
+    const warningKey = `${componentName}.${callerName}`;
     if (didWarnStateUpdateForUnmountedComponent[warningKey]) {
       return;
     }

--- a/packages/react/src/ReactNoopUpdateQueue.js
+++ b/packages/react/src/ReactNoopUpdateQueue.js
@@ -9,11 +9,19 @@
 
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
+  var didWarnStateUpdateForUnmountedComponent = {};
 }
 
 function warnNoop(publicInstance, callerName) {
   if (__DEV__) {
     var constructor = publicInstance.constructor;
+    const componentName =
+      (constructor && (constructor.displayName || constructor.name)) ||
+      'ReactClass';
+    const warningKey = `${callerName}_${componentName}`;
+    if (didWarnStateUpdateForUnmountedComponent[warningKey]) {
+      return;
+    }
     warning(
       false,
       '%s(...): Can only update a mounted or mounting component. ' +
@@ -21,9 +29,9 @@ function warnNoop(publicInstance, callerName) {
         'This is a no-op.\n\nPlease check the code for the %s component.',
       callerName,
       callerName,
-      (constructor && (constructor.displayName || constructor.name)) ||
-        'ReactClass',
+      componentName,
     );
+    didWarnStateUpdateForUnmountedComponent[warningKey] = true;
   }
 }
 


### PR DESCRIPTION
  Deduplicated the following warnings:

1.  Can only update a mounted or mounting component.
    This usually means you called setState, replaceState,
    or forceUpdate on an unmounted component. This is a no-op

2.  %s.componentWillReceiveProps(): Assigning directly to
    this.state is deprecated (except inside a component's
    constructor). Use setState instead.'

3.  An update (setState, replaceState, or forceUpdate) was scheduled
    from inside an update function. Update functions should be pure,
    with zero side-effects. Consider using componentDidUpdate or a
    callback.

4.  setState(...): Cannot call setState() inside getChildContext()

@gaearon  Let me know if it looks ok to you