### PR TITLE
Accept React attributes on custom components

### DIFF
--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -298,11 +298,15 @@ function setInitialDOMProperties(
         ensureListeningTo(rootContainerElement, propKey);
       }
     } else if (isCustomComponentTag) {
-      if ((DOMProperty.getPropertyInfo(propKey))) {
-        DOMPropertyOperations.setValueForProperty(domElement, propKey, nextProp);
-      } else {
-        DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
-      }
+      /* Suggested fix?
+       *
+       * if ((DOMProperty.getPropertyInfo(propKey))) {
+       *   DOMPropertyOperations.setValueForProperty(domElement, propKey, nextProp);
+       * } else {
+       *   DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
+       * }
+      */
+      DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
     } else if (nextProp != null) {
       // If we're updating to null or undefined, we should remove the property
       // from the DOM node instead of inadvertently setting to a string. This

--- a/src/renderers/dom/fiber/ReactDOMFiberComponent.js
+++ b/src/renderers/dom/fiber/ReactDOMFiberComponent.js
@@ -298,7 +298,11 @@ function setInitialDOMProperties(
         ensureListeningTo(rootContainerElement, propKey);
       }
     } else if (isCustomComponentTag) {
-      DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
+      if ((DOMProperty.getPropertyInfo(propKey))) {
+        DOMPropertyOperations.setValueForProperty(domElement, propKey, nextProp);
+      } else {
+        DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
+      }
     } else if (nextProp != null) {
       // If we're updating to null or undefined, we should remove the property
       // from the DOM node instead of inadvertently setting to a string. This

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -116,7 +116,7 @@ describe('DOMPropertyOperations', () => {
 
     it('should set the className to a custom component with a dash on its name', () => {
       var container = document.createElement('div');
-      ReactDOM.render(<amp-img htmlFor="haha" className="just-a-class" />, container);
+      ReactDOM.render(<amp-img className="just-a-class" />, container);
       expect(container.firstChild.getAttribute('class')).toEqual('just-a-class');
     });
   });

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -113,6 +113,12 @@ describe('DOMPropertyOperations', () => {
       ReactDOM.render(<div hidden={false} />, container);
       expect(container.firstChild.hasAttribute('hidden')).toBe(false);
     });
+
+    it('should set the className to a custom component with a dash on its name', () => {
+      var container = document.createElement('div');
+      ReactDOM.render(<amp-img htmlFor="haha" className="just-a-class" />, container);
+      expect(container.firstChild.getAttribute('class')).toEqual('just-a-class');
+    });
   });
 
   describe('value mutation method', function() {

--- a/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
+++ b/src/renderers/dom/shared/__tests__/DOMPropertyOperations-test.js
@@ -114,6 +114,12 @@ describe('DOMPropertyOperations', () => {
       expect(container.firstChild.hasAttribute('hidden')).toBe(false);
     });
 
+    it('should set the className to a custom component', () => {
+      var container = document.createElement('div');
+      ReactDOM.render(<amp className="just-a-class" />, container);
+      expect(container.firstChild.getAttribute('class')).toEqual('just-a-class');
+    });
+
     it('should set the className to a custom component with a dash on its name', () => {
       var container = document.createElement('div');
       ReactDOM.render(<amp-img className="just-a-class" />, container);


### PR DESCRIPTION
Hi there,

It seems that currently if you pass a React attribute to a custom component, it doesn't replace it with the html counterpart but just renders it as text.

For example:

```<amp-img className="my-image" />``` will render ```<amp-img classname="my-image" />```.

Apparently, that's by design, since we found that [there are tests](https://github.com/facebook/react/blob/ce8c51f8d3c26723c134e23002e7f5195f7b8c68/src/renderers/dom/shared/__tests__/ReactDOMServerIntegration-test.js#L667-L670) explicitly checking this behaviour.

Do you really think that this should work the way it is? It feels a bit strange that for custom components you would need to use `class` instead of `className`. 

(thanks @jacksbox for the pairing session 😃)

Cheers