### PR TITLE
Add React.Children.find method

### DIFF
--- a/src/isomorphic/ReactEntry.js
+++ b/src/isomorphic/ReactEntry.js
@@ -33,6 +33,7 @@ var React = {
     forEach: ReactChildren.forEach,
     count: ReactChildren.count,
     toArray: ReactChildren.toArray,
+    find: ReactChildren.find,
     only: onlyChild,
   },
 

--- a/src/isomorphic/children/__tests__/ReactChildren-test.js
+++ b/src/isomorphic/children/__tests__/ReactChildren-test.js
@@ -922,4 +922,73 @@ describe('ReactChildren', () => {
       );
     });
   });
+
+  it('should find children', () => {
+    expect(
+      React.Children.find(undefined, () => {
+        return true;
+      }),
+    ).toEqual(null);
+    expect(
+      React.Children.find(null, () => {
+        return true;
+      }),
+    ).toEqual(null);
+
+    const child0 = <div id="123" />;
+
+    expect(React.Children.find(child0, elem => elem.props.id === '123')).toBe(
+      child0,
+    );
+    expect(React.Children.find(child0, elem => elem.props.id === '125')).toBe(
+      null,
+    );
+
+    const child1 = null;
+    const child2 = <div id="456" />;
+    const child3 = <div id="789" />;
+
+    var instance = (
+      <div>
+        {child0}
+        {child1}
+        {child2}
+        {child3}
+      </div>
+    );
+    var children = instance.props.children;
+
+    expect(
+      React.Children.find(children, elem => elem && elem.props.id === '123'),
+    ).toBe(child0);
+    expect(React.Children.find(children, elem => elem === null)).toBe(child1);
+    expect(
+      React.Children.find(children, elem => elem && elem.props.id === '456'),
+    ).toBe(child2);
+    expect(
+      React.Children.find(children, elem => elem && elem.props.id === '789'),
+    ).toBe(child3);
+
+    const cb0 = jasmine
+      .createSpy()
+      .and.callFake(elem => elem && elem.props.id === '123');
+    React.Children.find(children, cb0);
+    expect(cb0.calls.count()).toBe(1);
+
+    const cb1 = jasmine.createSpy().and.callFake(elem => elem === null);
+    React.Children.find(children, cb1);
+    expect(cb1.calls.count()).toBe(2);
+
+    const cb2 = jasmine
+      .createSpy()
+      .and.callFake(elem => elem && elem.props.id === '456');
+    React.Children.find(children, cb2);
+    expect(cb2.calls.count()).toBe(3);
+
+    const cb3 = jasmine
+      .createSpy()
+      .and.callFake(elem => elem && elem.props.id === '789');
+    React.Children.find(children, cb3);
+    expect(cb3.calls.count()).toBe(4);
+  });
 });


### PR DESCRIPTION
Related to #9834 

This is my first contribution to this repo, so let me know if I'm missing anything. I'm not sure where/how the documentation is generated, so I only added doc-style comments to the added function, but I can work on it too if it's in a different place.

~I'm not satisfied yet with the code duplication (from the `traverseAllChildrenImpl`), so I'm going to try and add a `testFunc` argument to `traverseAllChildrenImpl`, so that React.Children.find reuses it. Any feedback is appreciated.~

I've reused `traverseAllChildrenImpl` to minimize code duplication. The trade-off is that now that function is a bit more complex, with all the if/else branches from the "isFinding" mode, and that it returns either a number or the child, depending on the mode. Let me know if code duplication is preferred instead (or another solution).
