### PR TITLE
API for prerendering a top-level update and deferring the commit

### DIFF
--- a/src/renderers/dom/shared/__tests__/ReactDOMRoot-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMRoot-test.js
@@ -78,4 +78,24 @@ describe('ReactDOMRoot', () => {
     work.commit();
     expect(container.textContent).toEqual('Hi');
   });
+
+  it("does not restart a blocked root that wasn't updated", () => {
+    let ops = [];
+    function Foo(props) {
+      ops.push('Foo');
+      return props.children;
+    }
+    const root = ReactDOM.createRoot(container);
+    const work = root.prerender(<Foo>Hi</Foo>);
+    expect(ops).toEqual(['Foo']);
+    // Hasn't updated yet
+    expect(container.textContent).toEqual('');
+
+    ops = [];
+
+    // Flush work. Shouldn't re-render Foo.
+    work.commit();
+    expect(ops).toEqual([]);
+    expect(container.textContent).toEqual('Hi');
+  });
 });

--- a/src/renderers/dom/shared/__tests__/ReactDOMRoot-test.js
+++ b/src/renderers/dom/shared/__tests__/ReactDOMRoot-test.js
@@ -68,4 +68,14 @@ describe('ReactDOMRoot', () => {
     root.render(<div><span>d</span><span>c</span></div>);
     expect(container.textContent).toEqual('abdc');
   });
+
+  it('can defer commit using prerender', () => {
+    const root = ReactDOM.createRoot(container);
+    const work = root.prerender(<div>Hi</div>);
+    // Hasn't updated yet
+    expect(container.textContent).toEqual('');
+    // Flush work
+    work.commit();
+    expect(container.textContent).toEqual('Hi');
+  });
 });

--- a/src/renderers/shared/fiber/ReactFiberCompleteWork.js
+++ b/src/renderers/shared/fiber/ReactFiberCompleteWork.js
@@ -48,6 +48,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CX, PL>,
   hostContext: HostContext<C, CX>,
   hydrationContext: HydrationContext<C, CX>,
+  blockCurrentlyRenderingWork: () => void,
 ) {
   const {
     createInstance,
@@ -218,6 +219,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           // This resets the hacky state to fix isMounted before committing.
           // TODO: Delete this when we delete isMounted and findDOMNode.
           workInProgress.effectTag &= ~Placement;
+        }
+
+        const memoizedState = workInProgress.memoizedState;
+        if (memoizedState !== null && memoizedState.isBlocked) {
+          // Root is blocked by a top-level update.
+          blockCurrentlyRenderingWork();
         }
         return null;
       }

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -26,6 +26,8 @@ export type FiberRoot = {
   // Determines if this root was blocked from committing.
   isBlocked: boolean,
   // The time at which this root completed.
+  // TODO: Remove once we add back resuming.
+  completedAt: ExpirationTime,
   forceExpire: ExpirationTime,
   // The work schedule is a linked list.
   nextScheduledRoot: FiberRoot | null,
@@ -48,6 +50,7 @@ exports.createFiberRoot = function(
     containerInfo: containerInfo,
     isScheduled: false,
     isBlocked: false,
+    completedAt: NoWork,
     forceExpire: NoWork,
     nextScheduledRoot: null,
     context: null,

--- a/src/renderers/shared/fiber/ReactFiberRoot.js
+++ b/src/renderers/shared/fiber/ReactFiberRoot.js
@@ -11,8 +11,10 @@
 'use strict';
 
 import type {Fiber} from 'ReactFiber';
+import type {ExpirationTime} from 'ReactFiberExpirationTime';
 
 const {createHostRootFiber} = require('ReactFiber');
+const {NoWork} = require('ReactFiberExpirationTime');
 
 export type FiberRoot = {
   // Any additional information from the host associated with this root.
@@ -21,6 +23,10 @@ export type FiberRoot = {
   current: Fiber,
   // Determines if this root has already been added to the schedule for work.
   isScheduled: boolean,
+  // Determines if this root was blocked from committing.
+  isBlocked: boolean,
+  // The time at which this root completed.
+  forceExpire: ExpirationTime,
   // The work schedule is a linked list.
   nextScheduledRoot: FiberRoot | null,
   // Top context object, used by renderSubtreeIntoContainer
@@ -41,6 +47,8 @@ exports.createFiberRoot = function(
     current: uninitializedFiber,
     containerInfo: containerInfo,
     isScheduled: false,
+    isBlocked: false,
+    forceExpire: NoWork,
     nextScheduledRoot: null,
     context: null,
     pendingContext: null,

--- a/src/renderers/shared/fiber/ReactFiberScheduler.js
+++ b/src/renderers/shared/fiber/ReactFiberScheduler.js
@@ -172,6 +172,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     config,
     hostContext,
     hydrationContext,
+    blockCurrentlyRenderingRoot,
   );
   const {
     commitResetTextContent,
@@ -216,6 +217,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   let nextUnitOfWork: Fiber | null = null;
   // The time at which we're currently rendering work.
   let nextRenderExpirationTime: ExpirationTime = NoWork;
+  // The root that we're currently working on.
+  let nextRenderedTree: FiberRoot | null = null;
+  // Whether the root we're currently working on is blocked from committing.
+  let nextCommitIsBlocked: boolean = false;
 
   // The next fiber with an effect that we're currently committing.
   let nextEffect: Fiber | null = null;
@@ -248,7 +253,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   // Use these to prevent an infinite loop of nested updates
   const NESTED_UPDATE_LIMIT = 1000;
   let nestedUpdateCount: number = 0;
-  let nextRenderedTree: FiberRoot | null = null;
 
   function resetContextStack() {
     // Reset the stack
@@ -286,13 +290,17 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     let earliestExpirationRoot = null;
     let earliestExpirationTime = NoWork;
     while (root !== null) {
-      if (
-        root.current.expirationTime !== NoWork &&
-        (earliestExpirationTime === NoWork ||
-          earliestExpirationTime > root.current.expirationTime)
-      ) {
-        earliestExpirationTime = root.current.expirationTime;
-        earliestExpirationRoot = root;
+      if (root.isBlocked) {
+        // TODO: Process completion callbacks
+      } else {
+        if (
+          root.current.expirationTime !== NoWork &&
+          (earliestExpirationTime === NoWork ||
+            earliestExpirationTime > root.current.expirationTime)
+        ) {
+          earliestExpirationTime = root.current.expirationTime;
+          earliestExpirationRoot = root;
+        }
       }
       // We didn't find anything to do in this root, so let's try the next one.
       root = root.nextScheduledRoot;
@@ -315,13 +323,19 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         nestedUpdateCount = 0;
         nextRenderedTree = earliestExpirationRoot;
       }
+      nextCommitIsBlocked = false;
       return;
     }
 
     nextRenderExpirationTime = NoWork;
     nextUnitOfWork = null;
     nextRenderedTree = null;
+    nextCommitIsBlocked = false;
     return;
+  }
+
+  function blockCurrentlyRenderingRoot() {
+    nextCommitIsBlocked = true;
   }
 
   function commitAllHostEffects() {
@@ -702,10 +716,13 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         workInProgress = returnFiber;
         continue;
       } else {
-        // We've reached the root. Mark the root as pending commit. Depending
-        // on how much time we have left, we'll either commit it now or in
-        // the next frame.
-        pendingCommit = workInProgress;
+        // We've reached the root.
+        const root: FiberRoot = workInProgress.stateNode;
+        if (nextCommitIsBlocked) {
+          root.isBlocked = true;
+        } else {
+          pendingCommit = workInProgress;
+        }
         return null;
       }
     }
@@ -808,13 +825,10 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
         }
         if (nextUnitOfWork === null) {
-          invariant(
-            pendingCommit !== null,
-            'Should have a pending commit. This error is likely caused by ' +
-              'a bug in React. Please file an issue.',
-          );
-          // We just completed a root. Commit it now.
-          commitAllWork(pendingCommit);
+          if (pendingCommit !== null) {
+            // We just completed a root. Commit it now.
+            commitAllWork(pendingCommit);
+          }
           if (
             capturedErrors === null ||
             capturedErrors.size === 0 ||
@@ -856,15 +870,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
         while (nextUnitOfWork !== null) {
           nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
           if (nextUnitOfWork === null) {
-            invariant(
-              pendingCommit !== null,
-              'Should have a pending commit. This error is likely caused by ' +
-                'a bug in React. Please file an issue.',
-            );
-            // We just completed a root. Commit it now.
-            commitAllWork(pendingCommit);
-            // Clear any errors that were scheduled during the commit phase.
-            handleCommitPhaseErrors();
+            if (pendingCommit !== null) {
+              // We just completed a root. Commit it now.
+              commitAllWork(pendingCommit);
+              // Clear any errors that were scheduled during the commit phase.
+              handleCommitPhaseErrors();
+            }
             // The render time may have changed. Check again.
             if (
               nextRenderExpirationTime === NoWork ||
@@ -886,28 +897,26 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
             // omit either of the checks in the following condition, but we need
             // both to satisfy Flow.
             if (nextUnitOfWork === null) {
-              invariant(
-                pendingCommit !== null,
-                'Should have a pending commit. This error is likely caused by ' +
-                  'a bug in React. Please file an issue.',
-              );
-              // We just completed a root. If we have time, commit it now.
-              // Otherwise, we'll commit it in the next frame.
-              if (deadline.timeRemaining() > timeHeuristicForUnitOfWork) {
-                commitAllWork(pendingCommit);
-                // Clear any errors that were scheduled during the commit phase.
-                handleCommitPhaseErrors();
-                // The render time may have changed. Check again.
-                if (
-                  nextRenderExpirationTime === NoWork ||
-                  nextRenderExpirationTime > minExpirationTime ||
-                  nextRenderExpirationTime <= mostRecentCurrentTime
-                ) {
-                  // We've completed all the async work.
-                  break;
+              if (pendingCommit !== null) {
+                // We just completed a root. If we have time, commit it now.
+                // Otherwise, we'll commit it in the next frame.
+                if (deadline.timeRemaining() > timeHeuristicForUnitOfWork) {
+                  commitAllWork(pendingCommit);
+                  // Clear any errors that were scheduled during the
+                  // commit phase.
+                  handleCommitPhaseErrors();
+                } else {
+                  deadlineHasExpired = true;
                 }
-              } else {
-                deadlineHasExpired = true;
+              }
+              // The render time may have changed. Check again.
+              if (
+                nextRenderExpirationTime === NoWork ||
+                nextRenderExpirationTime > minExpirationTime ||
+                nextRenderExpirationTime <= mostRecentCurrentTime
+              ) {
+                // We've completed all the async work.
+                break;
               }
             }
           } else {
@@ -1354,25 +1363,6 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     }
   }
 
-  function scheduleRoot(root: FiberRoot, expirationTime: ExpirationTime) {
-    if (expirationTime === NoWork) {
-      return;
-    }
-
-    if (!root.isScheduled) {
-      root.isScheduled = true;
-      if (lastScheduledRoot) {
-        // Schedule ourselves to the end.
-        lastScheduledRoot.nextScheduledRoot = root;
-        lastScheduledRoot = root;
-      } else {
-        // We're the only work scheduled.
-        nextScheduledRoot = root;
-        lastScheduledRoot = root;
-      }
-    }
-  }
-
   function computeAsyncExpiration() {
     // Given the current clock time, returns an expiration time. We use rounding
     // to batch like updates together.
@@ -1461,17 +1451,12 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     let node = fiber;
     let shouldContinue = true;
     while (node !== null && shouldContinue) {
-      // Walk the parent path to the root and update each node's expiration
-      // time. Once we reach a node whose expiration matches (and whose
-      // alternate's expiration matches) we can exit safely knowing that the
-      // rest of the path is correct.
-      shouldContinue = false;
+      // Walk the parent path to the root and update each node's
+      // expiration time.
       if (
         node.expirationTime === NoWork ||
         node.expirationTime > expirationTime
       ) {
-        // Expiration time did not match. Update and keep going.
-        shouldContinue = true;
         node.expirationTime = expirationTime;
       }
       if (node.alternate !== null) {
@@ -1479,15 +1464,29 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
           node.alternate.expirationTime === NoWork ||
           node.alternate.expirationTime > expirationTime
         ) {
-          // Expiration time did not match. Update and keep going.
-          shouldContinue = true;
           node.alternate.expirationTime = expirationTime;
         }
       }
       if (node.return === null) {
         if (node.tag === HostRoot) {
           const root: FiberRoot = (node.stateNode: any);
-          scheduleRoot(root, expirationTime);
+
+          // Set this to false in case the root has been unblocked.
+          root.isBlocked = false;
+
+          if (!root.isScheduled) {
+            root.isScheduled = true;
+            if (lastScheduledRoot) {
+              // Schedule ourselves to the end.
+              lastScheduledRoot.nextScheduledRoot = root;
+              lastScheduledRoot = root;
+            } else {
+              // We're the only work scheduled.
+              nextScheduledRoot = root;
+              lastScheduledRoot = root;
+            }
+          }
+
           if (!isPerformingWork) {
             switch (expirationTime) {
               case Sync:
@@ -1535,10 +1534,35 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
   }
 
   function recalculateCurrentTime(): ExpirationTime {
+    if (nextRenderedTree !== null) {
+      // Check if the current root is being force expired.
+      const forceExpire = nextRenderedTree.forceExpire;
+      if (forceExpire !== NoWork) {
+        // Override the current time with the `forceExpire` time. This has the
+        // effect of expiring all work up to and including that time.
+        mostRecentCurrentTime = forceExpire;
+        return forceExpire;
+      }
+    }
     // Subtract initial time so it fits inside 32bits
     const ms = now() - startTime;
     mostRecentCurrentTime = msToExpirationTime(ms);
     return mostRecentCurrentTime;
+  }
+
+  function expireWork(root: FiberRoot, expirationTime: ExpirationTime): void {
+    invariant(
+      !isPerformingWork,
+      'Cannot commit while already performing work.',
+    );
+    root.forceExpire = expirationTime;
+    root.isBlocked = false;
+    try {
+      performWork(expirationTime, null);
+    } finally {
+      root.forceExpire = NoWork;
+      recalculateCurrentTime();
+    }
   }
 
   function batchedUpdates<A, R>(fn: (a: A) => R, a: A): R {
@@ -1604,6 +1628,7 @@ module.exports = function<T, P, I, TI, PI, C, CX, PL>(
     computeAsyncExpiration: computeAsyncExpiration,
     computeExpirationForFiber: computeExpirationForFiber,
     scheduleWork: scheduleWork,
+    expireWork: expireWork,
     batchedUpdates: batchedUpdates,
     unbatchedUpdates: unbatchedUpdates,
     flushSync: flushSync,


### PR DESCRIPTION
Adds the ability to start rendering work without flushing the changes to the screen, by blocking the commit phase. This can be used to coordinate React's commit phase with other async work.

- `root.prerender` schedules an update and returns a work object.
- `work.commit` unblocks the commit phase and flushes the remaining
  work synchronously.

(Not yet implemented is `work.then`, which schedules a callback that fires once the work has completed. To keep these PRs focused, I'll do this in a follow-up.)