### PR TITLE
maybe proactively redirect some doc site issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,8 @@
 **Do you want to request a *feature* or report a *bug*?**
 
+Note that the documentation and source code for reactjs.org lives in a different repository: https://github.com/reactjs/reactjs.org. 
+If your issue is regarding the documentation website please open the issue at https://github.com/reactjs/reactjs.org/issues/new.
+
 **What is the current behavior?**
 
 **If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem via https://jsfiddle.net or similar (template for React 16: https://jsfiddle.net/Luktwrdm/, template for React 15: https://jsfiddle.net/hmbg7e9w/).**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,9 @@
-**Do you want to request a *feature* or report a *bug*?**
+<!--
+  Note: if the issue is about documentation or the website, please file it at:
+  https://github.com/reactjs/reactjs.org/issues/new
+-->
 
-Note that the documentation and source code for reactjs.org lives in a different repository: https://github.com/reactjs/reactjs.org. 
-If your issue is regarding the documentation website please open the issue at https://github.com/reactjs/reactjs.org/issues/new.
+**Do you want to request a *feature* or report a *bug*?**
 
 **What is the current behavior?**
 


### PR DESCRIPTION
Not sure how often new issue creators read this, but this may help proactively guide the handful of docs issues that have been coming through over to the docs site.