### PR TITLE
Fix forceUpdate in shallow test renderer

### DIFF
--- a/src/renderers/testing/ReactShallowRendererEntry.js
+++ b/src/renderers/testing/ReactShallowRendererEntry.js
@@ -31,6 +31,7 @@ class ReactShallowRenderer {
     this._newState = null;
     this._rendered = null;
     this._rendering = false;
+    this._forcedUpdate = false;
     this._updater = new Updater(this);
   }
 
@@ -154,11 +155,13 @@ class ReactShallowRenderer {
 
     if (typeof this._instance.shouldComponentUpdate === 'function') {
       if (
+        this._forcedUpdate ||
         this._instance.shouldComponentUpdate(props, state, context) === false
       ) {
         this._instance.context = context;
         this._instance.props = props;
         this._instance.state = state;
+        this._forcedUpdate = false;
 
         return;
       }
@@ -188,6 +191,7 @@ class Updater {
   }
 
   enqueueForceUpdate(publicInstance, callback, callerName) {
+    this._renderer._forcedUpdate = true;
     this._renderer.render(this._renderer._element, this._renderer._context);
 
     if (typeof callback === 'function') {

--- a/src/renderers/testing/__tests__/ReactShallowRenderer-test.js
+++ b/src/renderers/testing/__tests__/ReactShallowRenderer-test.js
@@ -122,6 +122,26 @@ describe('ReactShallowRenderer', () => {
     expect(shallowRenderer.getRenderOutput()).toEqual(<div>2</div>);
   });
 
+  it('should not run shouldComponentUpdate during forced update', () => {
+    let scuCounter = 0;
+    class SimpleComponent extends React.Component {
+      shouldComponentUpdate() {
+        scuCounter++;
+      }
+      render() {
+        return <div />;
+      }
+    }
+
+    const shallowRenderer = createRenderer();
+    shallowRenderer.render(<SimpleComponent />);
+    expect(scuCounter).toEqual(0);
+
+    const instance = shallowRenderer.getMountedInstance();
+    instance.forceUpdate();
+    expect(scuCounter).toEqual(0);
+  });
+
   it('should shallow render a functional component', () => {
     function SomeComponent(props, context) {
       return (


### PR DESCRIPTION
Fixes #11236 by adding a flag during `enqueueForceUpdate` to make sure the `shouldComponentUpdate` is not being tested against.