### PR TITLE
Update noop renderer to only work on a single root

### DIFF
--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalErrorHandling-test.js
@@ -543,7 +543,7 @@ describe('ReactIncrementalErrorHandling', () => {
     });
   });
 
-  it('continues work on other roots despite caught errors', () => {
+  xit('continues work on other roots despite caught errors', () => {
     class ErrorBoundary extends React.Component {
       state = {error: null};
       componentDidCatch(error) {
@@ -577,7 +577,7 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
   });
 
-  it('continues work on other roots despite uncaught errors', () => {
+  xit('continues work on other roots despite uncaught errors', () => {
     function BrokenRender(props) {
       throw new Error('Hello');
     }

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalPerf-test.js
@@ -202,7 +202,7 @@ describe('ReactDebugFiberPerf', () => {
     expect(getFlameChart()).toMatchSnapshot();
   });
 
-  it('warns on cascading renders from top-level render', () => {
+  xit('warns on cascading renders from top-level render', () => {
     class Cascading extends React.Component {
       componentDidMount() {
         ReactNoop.renderToRootWithID(<Child />, 'b');

--- a/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
+++ b/src/renderers/shared/fiber/__tests__/ReactIncrementalScheduling-test.js
@@ -31,17 +31,20 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('1')]);
   });
 
-  it('searches for work on other roots once the current root completes', () => {
-    ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
-    ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
+  xit(
+    'searches for work on other roots once the current root completes',
+    () => {
+      ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
+      ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
+      ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
 
-    ReactNoop.flush();
+      ReactNoop.flush();
 
-    expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
-    expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
-  });
+      expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
+      expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
+      expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
+    },
+  );
 
   it('schedules top-level updates in order of priority', () => {
     // Initial render.
@@ -81,7 +84,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren()).toEqual([span(5)]);
   });
 
-  it('works on deferred roots in the order they were scheduled', () => {
+  xit('works on deferred roots in the order they were scheduled', () => {
     ReactNoop.renderToRootWithID(<span prop="a:1" />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');


### PR DESCRIPTION
We're shifting toward model where renderers will schedule work per root, rather than globally across all roots. The behavior could vary greatly between different renderer implementations, so it doesn't make sense to implement this in the noop renderer, which is meant only for behavior that is the same across all renderers.