### PR TITLE
Fix typo in createReactClassIntegration-test.js

### DIFF
--- a/src/isomorphic/classic/__tests__/createReactClassIntegration-test.js
+++ b/src/isomorphic/classic/__tests__/createReactClassIntegration-test.js
@@ -105,7 +105,7 @@ describe('create-react-class-integration', () => {
     );
   });
 
-  it('should warn when mispelling shouldComponentUpdate', () => {
+  it('should warn when misspelling shouldComponentUpdate', () => {
     spyOn(console, 'error');
 
     createReactClass({
@@ -140,7 +140,7 @@ describe('create-react-class-integration', () => {
     );
   });
 
-  it('should warn when mispelling componentWillReceiveProps', () => {
+  it('should warn when misspelling componentWillReceiveProps', () => {
     spyOn(console, 'error');
     createReactClass({
       componentWillRecieveProps: function() {


### PR DESCRIPTION
Small fix:

Fix typo in createReactClassIntegration-test.js. "mispelling" is a misspelling of "misspelling".
