### PR TITLE
[CS] Clone container instead of new root concept

### DIFF
--- a/src/renderers/native-cs/ReactNativeCSFiberEntry.js
+++ b/src/renderers/native-cs/ReactNativeCSFiberEntry.js
@@ -175,13 +175,25 @@ const ReactNativeCSFiberRenderer = ReactFiberReconciler({
       return 0;
     },
 
-    createRootInstance(
-      rootContainerInstance: Container,
-      hostContext: {},
-    ): Instance {
-      return 123;
+    cloneContainer(container: Container, keepChildren: boolean): Container {
+      return 0;
     },
-    commitRootInstance(rootInstance: Instance): void {},
+    tryToReuseContainer(
+      container: Container,
+      keepChildren: boolean,
+    ): Container {
+      return 0;
+    },
+
+    appendInititalChildToContainer(
+      container: Container,
+      child: Instance | TextInstance,
+    ): void {},
+
+    completeContainer(
+      oldContainer: Container,
+      newContainer: Container,
+    ): void {},
   },
 });
 

--- a/src/renderers/shared/fiber/ReactFiberReconciler.js
+++ b/src/renderers/shared/fiber/ReactFiberReconciler.js
@@ -100,7 +100,7 @@ export type HostConfig<T, P, I, TI, PI, C, CX, PL> = {
   +hydration?: HydrationHostConfig<T, P, I, TI, C, CX, PL>,
 
   +mutation?: MutableUpdatesHostConfig<T, P, I, TI, C, PL>,
-  +persistence?: PersistentUpdatesHostConfig<T, P, I, C, CX, PL>,
+  +persistence?: PersistentUpdatesHostConfig<T, P, I, TI, C, PL>,
 };
 
 type MutableUpdatesHostConfig<T, P, I, TI, C, PL> = {
@@ -132,7 +132,7 @@ type MutableUpdatesHostConfig<T, P, I, TI, C, PL> = {
   removeChildFromContainer(container: C, child: I | TI): void,
 };
 
-type PersistentUpdatesHostConfig<T, P, I, C, CX, PL> = {
+type PersistentUpdatesHostConfig<T, P, I, TI, C, PL> = {
   cloneInstance(
     instance: I,
     updatePayload: PL,
@@ -152,8 +152,12 @@ type PersistentUpdatesHostConfig<T, P, I, C, CX, PL> = {
     keepChildren: boolean,
   ): I,
 
-  createRootInstance(rootContainerInstance: C, hostContext: CX): I,
-  commitRootInstance(rootInstance: I): void,
+  cloneContainer(container: C, keepChildren: boolean): C,
+  tryToReuseContainer(container: C, keepChildren: boolean): C,
+
+  appendInititalChildToContainer(container: C, child: I | TI): void,
+
+  completeContainer(oldContainer: C, newContainer: C): void,
 };
 
 type HydrationHostConfig<T, P, I, TI, C, CX, PL> = {


### PR DESCRIPTION
The extra "root" concept is kind of unnecessary. Instead of having a mutable container even in the persistent mode, I'll instead make the container be immutable too and be cloned. Then the "commit" just becomes swapping the previous container for the new one.

I might have to implement this in a hacky way since we currently can't have two different host containers, since the HostRoot stateNode slot is occupied by FiberRoot.