### PR TITLE
Removed test utils dependency on test renderer from bundle config

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -118,7 +118,6 @@ const bundles = [
       'prop-types/checkPropTypes',
       'react',
       'react-dom',
-      'react-test-renderer', // TODO (bvaughn) Remove this dependency before 16.0.0
     ],
     fbEntry: 'src/renderers/dom/test/ReactTestUtilsEntry',
     hasteName: 'ReactTestUtils',
@@ -129,7 +128,6 @@ const bundles = [
     paths: [
       'src/renderers/dom/test/**/*.js',
       'src/renderers/shared/**/*.js',
-      'src/renderers/testing/**/*.js', // TODO (bvaughn) Remove this dependency before 16.0.0
 
       'src/ReactVersion.js',
       'src/shared/**/*.js',


### PR DESCRIPTION
For react 15.4 and below, the shallow renderer was exposed via:
```js
import { createRenderer } from 'react-addons-test-utils';
```

For 15.5 and later, it's exposed via:
```js
import { createRenderer } from 'react-test-renderer/shallow';
```

For a little time, prior to the 16.0 release, we exposed it in both places (along with a deprecation warning). The backwards-compatible route, and warning, were removed in commit 43dae74 _but_ we missed the associated dependency in the Rollup bundle config.

This commit cleans that up too. Verified by running `yarn build -- test` locally without any build errors.