### PR TITLE
Add note to 'unreleased' CHANGELOG about deprecating Bower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### All Packages
 
 * Fix an accidental extra global variable in the UMD builds. ([@gaearon](https://github.com/gaearon) in [#10935](https://github.com/facebook/react/pull/10935))
+* Deprecate use of Bower for accessing React packages. We will no longer be using Bower. ([@bvaughn](https://github.com/bvaughn) in [#11223](https://github.com/facebook/react/pull/11223))
 
 ### React DOM
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
     Click to see more.
   </summary>
 
+### Discontinuing Bower Releases
+
+Starting with 16.1.0, we will no longer be publishing new releases on Bower. You can continue using Bower for old releases, or point your Bower configs to the [React UMD builds hosted on unpkg](https://reactjs.org/docs/installation.html#using-a-cdn) that mirror npm releases and will continue to be updated.
+
 ### All Packages
 
 * Fix an accidental extra global variable in the UMD builds. ([@gaearon](https://github.com/gaearon) in [#10935](https://github.com/facebook/react/pull/10935))
@@ -36,11 +40,6 @@
 
 * Fix multiple `setState()` calls in `componentWillMount()` in shallow renderer. ([@Hypnosphi](https://github.com/Hypnosphi) in [#11167](https://github.com/facebook/react/pull/11167))
 * Add back support for running in production mode. ([@gaearon](https://github.com/gaearon) in [#11112](https://github.com/facebook/react/pull/11112))
-
-
-### Discontinuing Bower Releases
-
-Starting with 16.1.0, we will no longer be publishing new releases on Bower. You can continue using Bower for old releases, or point your Bower configs to the [React UMD builds hosted on unpkg](https://reactjs.org/docs/installation.html#using-a-cdn) that mirror npm releases and will continue to be updated.
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 ### All Packages
 
 * Fix an accidental extra global variable in the UMD builds. ([@gaearon](https://github.com/gaearon) in [#10935](https://github.com/facebook/react/pull/10935))
-* Deprecate use of Bower for accessing React packages. We will no longer be using Bower. ([@bvaughn](https://github.com/bvaughn) in [#11223](https://github.com/facebook/react/pull/11223))
 
 ### React DOM
 
@@ -37,6 +36,11 @@
 
 * Fix multiple `setState()` calls in `componentWillMount()` in shallow renderer. ([@Hypnosphi](https://github.com/Hypnosphi) in [#11167](https://github.com/facebook/react/pull/11167))
 * Add back support for running in production mode. ([@gaearon](https://github.com/gaearon) in [#11112](https://github.com/facebook/react/pull/11112))
+
+
+### Discontinuing Bower Releases
+
+Starting with 16.1.0, we will no longer be publishing new releases on Bower. You can continue using Bower for old releases, or point your Bower configs to the [React UMD builds hosted on unpkg](https://reactjs.org/docs/installation.html#using-a-cdn) that mirror npm releases and will continue to be updated.
 
 </details>
 


### PR DESCRIPTION
**what is the change?:**
We will no longer release new versions of React to Bower, and we should
announce that as part of our CHANGELOG.

**why make this change?:**
We decided on this as a team.

**test plan:**
Visual inspection and spell check. :)

**issue:**
Just follow-up for https://github.com/facebook/react/pull/11223