### PR TITLE
Remove unused bundle flag

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -372,7 +372,6 @@ function getPlugins(
   hasteName,
   moduleType,
   manglePropertiesOnProd,
-  useFiber,
   modulesToStub
 ) {
   const plugins = [
@@ -526,7 +525,6 @@ function createBundle(bundle, bundleType) {
       bundle.hasteName,
       bundle.moduleType,
       bundle.manglePropertiesOnProd,
-      bundle.useFiber,
       bundle.modulesToStub
     ),
   })

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -293,7 +293,6 @@ const bundles = [
       'src/ReactVersion.js',
       'src/shared/**/*.js',
     ],
-    useFiber: true,
   },
 
   /******* React Native RT *******/
@@ -327,7 +326,6 @@ const bundles = [
       'src/ReactVersion.js',
       'src/shared/**/*.js',
     ],
-    useFiber: true,
   },
 
   /******* React Native CS *******/
@@ -353,7 +351,6 @@ const bundles = [
       'src/ReactVersion.js',
       'src/shared/**/*.js',
     ],
-    useFiber: true,
   },
 
   /******* React Test Renderer *******/


### PR DESCRIPTION
Verified it’s unused by running the build on these bundles. They didn’t change.