### PR TITLE
Add component stack to invalid style warnings

### DIFF
--- a/packages/react-dom/src/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/ReactDOMFiberComponent.js
@@ -61,7 +61,11 @@ var HTML = '__html';
 
 var {Namespaces: {html: HTML_NAMESPACE}, getIntrinsicNamespace} = DOMNamespaces;
 
+var getStack = emptyFunction;
+
 if (__DEV__) {
+  getStack = getCurrentFiberStackAddendum;
+
   var warnedUnknownTags = {
     // Chrome is the only major browser not shipping <time>. But as of July
     // 2017 it intends to ship it due to widespread usage. We intentionally
@@ -263,7 +267,7 @@ function setInitialDOMProperties(
         }
       }
       // Relies on `updateStylesByID` not mutating `styleUpdates`.
-      CSSPropertyOperations.setValueForStyles(domElement, nextProp);
+      CSSPropertyOperations.setValueForStyles(domElement, nextProp, getStack);
     } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
       var nextHtml = nextProp ? nextProp[HTML] : undefined;
       if (nextHtml != null) {
@@ -319,7 +323,7 @@ function updateDOMProperties(
     var propKey = updatePayload[i];
     var propValue = updatePayload[i + 1];
     if (propKey === STYLE) {
-      CSSPropertyOperations.setValueForStyles(domElement, propValue);
+      CSSPropertyOperations.setValueForStyles(domElement, propValue, getStack);
     } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
       setInnerHTML(domElement, propValue);
     } else if (propKey === CHILDREN) {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -130,7 +130,7 @@ var processStyleName = memoizeStringOnly(function(styleName) {
   return hyphenateStyleName(styleName);
 });
 
-function createMarkupForStyles(styles, component) {
+function createMarkupForStyles(styles) {
   var serialized = '';
   var delimiter = '';
   for (var styleName in styles) {
@@ -141,7 +141,11 @@ function createMarkupForStyles(styles, component) {
     var styleValue = styles[styleName];
     if (__DEV__) {
       if (!isCustomProperty) {
-        warnValidStyle(styleName, styleValue, component);
+        warnValidStyle(
+          styleName,
+          styleValue,
+          () => '', // getCurrentFiberStackAddendum,
+        );
       }
     }
     if (styleValue != null) {
@@ -263,7 +267,6 @@ function createOpenTagMarkup(
   namespace,
   makeStaticMarkup,
   isRootElement,
-  instForDebug,
 ) {
   var ret = '<' + tagVerbatim;
 
@@ -276,7 +279,7 @@ function createOpenTagMarkup(
       continue;
     }
     if (propKey === STYLE) {
-      propValue = createMarkupForStyles(propValue, instForDebug);
+      propValue = createMarkupForStyles(propValue);
     }
     var markup = null;
     if (isCustomComponent(tagLowercase, props)) {
@@ -791,7 +794,6 @@ class ReactDOMServerRenderer {
       namespace,
       this.makeStaticMarkup,
       this.stack.length === 1,
-      null,
     );
     var footer = '';
     if (omittedCloseTags.hasOwnProperty(tag)) {

--- a/packages/react-dom/src/shared/CSSPropertyOperations.js
+++ b/packages/react-dom/src/shared/CSSPropertyOperations.js
@@ -57,9 +57,8 @@ var CSSPropertyOperations = {
    *
    * @param {DOMElement} node
    * @param {object} styles
-   * @param {ReactDOMComponent} component
    */
-  setValueForStyles: function(node, styles, component) {
+  setValueForStyles: function(node, styles, getStack) {
     var style = node.style;
     for (var styleName in styles) {
       if (!styles.hasOwnProperty(styleName)) {
@@ -68,7 +67,7 @@ var CSSPropertyOperations = {
       var isCustomProperty = styleName.indexOf('--') === 0;
       if (__DEV__) {
         if (!isCustomProperty) {
-          warnValidStyle(styleName, styles[styleName], component);
+          warnValidStyle(styleName, styles[styleName], getStack);
         }
       }
       var styleValue = dangerousStyleValue(

--- a/packages/react-dom/src/shared/__tests__/CSSPropertyOperations-test.js
+++ b/packages/react-dom/src/shared/__tests__/CSSPropertyOperations-test.js
@@ -13,6 +13,10 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var ReactDOMServer = require('react-dom/server');
 
+function normalizeCodeLocInfo(str) {
+  return str && str.replace(/at .+?:\d+/g, 'at **');
+}
+
 describe('CSSPropertyOperations', () => {
   it('should automatically append `px` to relevant styles', () => {
     var styles = {
@@ -91,9 +95,10 @@ describe('CSSPropertyOperations', () => {
     var root = document.createElement('div');
     ReactDOM.render(<Comp />, root);
     expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toEqual(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
       'Warning: Unsupported style property background-color. Did you mean backgroundColor?' +
-        '\n\nCheck the render method of `Comp`.',
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
     );
   });
 
@@ -116,13 +121,15 @@ describe('CSSPropertyOperations', () => {
     ReactDOM.render(<Comp style={styles} />, root);
 
     expectDev(console.error.calls.count()).toBe(2);
-    expectDev(console.error.calls.argsFor(0)[0]).toEqual(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
       'Warning: Unsupported style property -ms-transform. Did you mean msTransform?' +
-        '\n\nCheck the render method of `Comp`.',
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
     );
-    expectDev(console.error.calls.argsFor(1)[0]).toEqual(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toEqual(
       'Warning: Unsupported style property -webkit-transform. Did you mean WebkitTransform?' +
-        '\n\nCheck the render method of `Comp`.',
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
     );
   });
 
@@ -148,13 +155,17 @@ describe('CSSPropertyOperations', () => {
     ReactDOM.render(<Comp />, root);
     // msTransform is correct already and shouldn't warn
     expectDev(console.error.calls.count()).toBe(2);
-    expectDev(console.error.calls.argsFor(0)[0]).toEqual(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
       'Warning: Unsupported vendor-prefixed style property oTransform. ' +
-        'Did you mean OTransform?\n\nCheck the render method of `Comp`.',
+        'Did you mean OTransform?' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
     );
-    expectDev(console.error.calls.argsFor(1)[0]).toEqual(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toEqual(
       'Warning: Unsupported vendor-prefixed style property webkitTransform. ' +
-        'Did you mean WebkitTransform?\n\nCheck the render method of `Comp`.',
+        'Did you mean WebkitTransform?' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
     );
   });
 
@@ -180,13 +191,17 @@ describe('CSSPropertyOperations', () => {
     var root = document.createElement('div');
     ReactDOM.render(<Comp />, root);
     expectDev(console.error.calls.count()).toBe(2);
-    expectDev(console.error.calls.argsFor(0)[0]).toEqual(
-      "Warning: Style property values shouldn't contain a semicolon." +
-        '\n\nCheck the render method of `Comp`. Try "backgroundColor: blue" instead.',
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
+      "Warning: Style property values shouldn't contain a semicolon. " +
+        'Try "backgroundColor: blue" instead.' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
     );
-    expectDev(console.error.calls.argsFor(1)[0]).toEqual(
-      "Warning: Style property values shouldn't contain a semicolon." +
-        '\n\nCheck the render method of `Comp`. Try "color: red" instead.',
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toEqual(
+      "Warning: Style property values shouldn't contain a semicolon. " +
+        'Try "color: red" instead.' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
     );
   });
 
@@ -204,9 +219,10 @@ describe('CSSPropertyOperations', () => {
     ReactDOM.render(<Comp />, root);
 
     expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toEqual(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
       'Warning: `NaN` is an invalid value for the `fontSize` css style property.' +
-        '\n\nCheck the render method of `Comp`.',
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
     );
   });
 
@@ -217,11 +233,8 @@ describe('CSSPropertyOperations', () => {
       }
     }
 
-    spyOn(console, 'error');
     var root = document.createElement('div');
     ReactDOM.render(<Comp />, root);
-
-    expectDev(console.error.calls.count()).toBe(0);
   });
 
   it('should warn about style containing a Infinity value', () => {
@@ -238,9 +251,10 @@ describe('CSSPropertyOperations', () => {
     ReactDOM.render(<Comp />, root);
 
     expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toEqual(
+    expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
       'Warning: `Infinity` is an invalid value for the `fontSize` css style property.' +
-        '\n\nCheck the render method of `Comp`.',
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
     );
   });
 

--- a/packages/react-dom/src/shared/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/shared/__tests__/ReactDOMComponent-test.js
@@ -255,8 +255,11 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<span style={style} />, div);
 
       expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: `NaN` is an invalid value for the `fontSize` css style property.',
+      expectDev(
+        normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
+      ).toEqual(
+        'Warning: `NaN` is an invalid value for the `fontSize` css style property.' +
+          '\n    in span (at **)',
       );
     });
 


### PR DESCRIPTION
This is good by itself, but also moves us closer to fixing the unintenional server side dependency on reconciler modules. I took the same approach as we already do with `getStack` (e.g. like in `ReactControlledPropTypes`).

It returns an empty string on the server, but this has already been the case. So this doesn’t regress on anything.