### PR TITLE
Fix production crash

### DIFF
--- a/packages/react-dom/src/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/ReactDOMFiberComponent.js
@@ -61,7 +61,7 @@ var HTML = '__html';
 
 var {Namespaces: {html: HTML_NAMESPACE}, getIntrinsicNamespace} = DOMNamespaces;
 
-var getStack = emptyFunction.thatReturnsArgument('');
+var getStack = emptyFunction.thatReturns('');
 
 if (__DEV__) {
   getStack = getCurrentFiberStackAddendum;

--- a/packages/react-dom/src/__tests__/ReactDOMProduction-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMProduction-test.js
@@ -211,6 +211,28 @@ describe('ReactDOMProduction', () => {
     );
   });
 
+  // Regression test verifying that trying to access (missing) component stack doesn't crash.
+  it('should throw on children for void elements', () => {
+    const errorCode = 137;
+    const container = document.createElement('div');
+    expect(() =>
+      ReactDOM.render(<input>children</input>, container),
+    ).toThrowError(
+      `Minified React error #${errorCode}; visit ` +
+        `http://facebook.github.io/react/docs/error-decoder.html?invariant=${errorCode}&args[]=input&args[]=` +
+        ' for the full message or use the non-minified dev environment' +
+        ' for full errors and additional helpful warnings.',
+    );
+    expect(() =>
+      ReactDOMServer.renderToString(<input>children</input>, container),
+    ).toThrowError(
+      `Minified React error #${errorCode}; visit ` +
+        `http://facebook.github.io/react/docs/error-decoder.html?invariant=${errorCode}&args[]=input&args[]=` +
+        ' for the full message or use the non-minified dev environment' +
+        ' for full errors and additional helpful warnings.',
+    );
+  });
+
   it('should not crash with devtools installed', () => {
     try {
       global.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -30,7 +30,7 @@ var omittedCloseTags = require('omittedCloseTags');
 var isCustomComponent = require('isCustomComponent');
 
 var toArray = React.Children.toArray;
-var getStackAddendum = emptyFunction.thatReturnsArgument('');
+var getStackAddendum = emptyFunction.thatReturns('');
 
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');

--- a/packages/react-dom/src/shared/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/shared/__tests__/ReactDOMComponent-test.js
@@ -953,7 +953,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should warn against children for void elements', () => {
+    it('should throw on children for void elements', () => {
       const container = document.createElement('div');
       let caughtErr;
       try {
@@ -969,7 +969,7 @@ describe('ReactDOMComponent', () => {
       );
     });
 
-    it('should warn against dangerouslySetInnerHTML for void elements', () => {
+    it('should throw on dangerouslySetInnerHTML for void elements', () => {
       const container = document.createElement('div');
       let caughtErr;
       try {


### PR DESCRIPTION
Fixes an embarrassing production crash I introduced in https://github.com/facebook/react/pull/11284. I misunderstood what this `fbjs` function does.

Verified this fixes it by trying the rebuilt bundle on FB.com in production mode.
Also by newly added regression test (which fails on master).