### PR TITLE
Rollup script can now extract error codes and build in a single pass

### DIFF
--- a/scripts/error-codes/replace-invariant-error-codes.js
+++ b/scripts/error-codes/replace-invariant-error-codes.js
@@ -108,7 +108,7 @@ module.exports = function(babel) {
             if (prodErrorId === undefined) {
               // The error cannot be found in the map.
               // (This case isn't expected to occur.)
-              // Even if it does, it's best to transform the invariant to a turnary,
+              // Even if it does, it's best to transform the invariant to a ternary,
               // So we don't risk executing any slow code unnecessarily
               // (eg generating an invariant message we don't actually need).
               prodInvariant = path.node.arguments[1];

--- a/scripts/error-codes/replace-invariant-error-codes.js
+++ b/scripts/error-codes/replace-invariant-error-codes.js
@@ -91,13 +91,6 @@ module.exports = function(babel) {
             var condition = node.arguments[0];
             var errorMsgLiteral = evalToString(node.arguments[1]);
 
-            var prodErrorId = errorMap[errorMsgLiteral];
-            if (prodErrorId === undefined) {
-              // The error cannot be found in the map.
-              node[SEEN_SYMBOL] = true;
-              return;
-            }
-
             var devInvariant = t.callExpression(
               node.callee,
               [
@@ -109,10 +102,22 @@ module.exports = function(babel) {
             devInvariant[SEEN_SYMBOL] = true;
 
             var localInvariantId = getProdInvariantIdentifier(path, this);
-            var prodInvariant = t.callExpression(
-              localInvariantId,
-              [t.stringLiteral(prodErrorId)].concat(node.arguments.slice(2))
-            );
+
+            var prodErrorId = errorMap[errorMsgLiteral];
+            var prodInvariant;
+            if (prodErrorId === undefined) {
+              // The error cannot be found in the map.
+              // (This case isn't expected to occur.)
+              // Even if it does, it's best to transform the invariant to a turnary,
+              // So we don't risk executing any slow code unnecessarily
+              // (eg generating an invariant message we don't actually need).
+              prodInvariant = path.node.arguments[1];
+            } else {
+              prodInvariant = t.callExpression(
+                localInvariantId,
+                [t.stringLiteral(prodErrorId)].concat(node.arguments.slice(2))
+              );
+            }
 
             prodInvariant[SEEN_SYMBOL] = true;
             path.replaceWith(

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -375,11 +375,13 @@ function getPlugins(
   modulesToStub,
   featureFlags
 ) {
+  // Extract error codes 1st so we can replace invariant messages in prod builds
+  // Without re-running the slow build script.
   const plugins = [
-    babel(updateBabelConfig(babelOpts, bundleType)),
     alias(
       Modules.getAliases(paths, bundleType, moduleType, argv['extract-errors'])
     ),
+    babel(updateBabelConfig(babelOpts, bundleType)),
   ];
 
   const replaceModules = Modules.getDefaultReplaceModules(


### PR DESCRIPTION
Relates to [this comment](https://github.com/facebook/react/pull/11260#discussion_r145565726).

Now we no longer have to run:
```bash
yarn build --extract-errors
yarn build # This second run isn't necessary anymore
```

This PR contains 2 changes:

### `scripts/rollup/build.js`

The main fix was swapping the order of error-code-extraction and replacement.

I verified this by first emptying out the contents of `error-codes.json` (`{}`) and running:
```
yarn build dom-fiber --extract-errors
```

This built the bundle _and_ extracted error codes in a single pass. I copied the resulting build artifacts to an external location and then ran `yarn build dom-fiber` a second time (after error codes had already been extracted). Then I used `diff` to compare the bundles and verify that the following files were identical:

```
packages/react-dom/cjs/react-dom.development.j
packages/react-dom/cjs/react-dom.production.min.js
packages/react-dom/umd/react-dom.development.j
packages/react-dom/umd/react-dom.production.min.js
facebook-www/ReactDOMFiber-dev.js
facebook-www/ReactDOMFiber-prod.js
```

### `scripts/error-codes/replace-invariant-error-codes.js`

I also changed this file to always convert invariants to ternaries:
```js
// Before
invariant(condition, 'error message');

// After
!condition ? invariant(false, 'error message') : void 0;
```

Regardless of whether the error message is in our error codes map. This shouldn't actually matter but...the 2nd format can be faster and so I thought I might as well do it while I was in there. (I'll revert this if anyone thinks it's overkill.)

I tested this change with AST explorer by transforming the following JavaScript:

```js
function testErrorInMap(thing: string) {
  invariant(
    thing,
    'Error in map',
  );
}

function testErrorNotInMap(thing: string) {
  invariant(
    thing,
    'Error not in map',
  );
}
```

With an error map that only contained 1 of the strings:

```js
var errorMap = {};
errorMap['Error in map'] = '1';
```

And the resulting transform looked good:
```js
var _prodInvariant = require("reactProdInvariant");

function testErrorInMap(thing: string) {
  (!string ? (__DEV__ ? invariant(false, "Error in map") : _prodInvariant("1")) : void 0);
}

function testErrorNotInMap(thing: string) {
  (!string ? (__DEV__ ? invariant(false, "Error not in map") : 'Error not in map') : void 0);
}
```