### PR TITLE
Release script no longer auto-updates peerDependencies react version

### DIFF
--- a/scripts/release/build-commands/update-package-versions.js
+++ b/scripts/release/build-commands/update-package-versions.js
@@ -20,7 +20,7 @@ const update = async ({cwd, dry, version}) => {
     await writeJson(packagePath, rootPackage, {spaces: 2});
 
     // Update ReactVersion source file
-    const reactVersionPath = join(cwd, 'packages/shared/src/ReactVersion.js');
+    const reactVersionPath = join(cwd, 'packages/shared/ReactVersion.js');
     const reactVersion = readFileSync(reactVersionPath, 'utf8').replace(
       /module\.exports = '[^']+';/,
       `module.exports = '${version}';`
@@ -39,6 +39,16 @@ const update = async ({cwd, dry, version}) => {
         json.version = `0.${semver.minor(json.version) + 1}.0`;
       } else {
         json.version = version;
+      }
+
+      if (project !== 'react') {
+        const peerVersion = json.peerDependencies.react.replace('^', '');
+
+        // Release engineers can manually update minor and bugfix versions,
+        // But we should ensure that major versions always match.
+        if (semver.major(version) !== semver.major(peerVersion)) {
+          json.peerDependencies.react = `^${semver.major(version)}.0.0`;
+        }
       }
 
       await writeJson(path, json, {spaces: 2});

--- a/scripts/release/build-commands/update-package-versions.js
+++ b/scripts/release/build-commands/update-package-versions.js
@@ -41,9 +41,6 @@ const update = async ({cwd, dry, version}) => {
         json.version = version;
       }
 
-      if (project !== 'react') {
-        json.peerDependencies.react = `^${version}`;
-      }
       await writeJson(path, json, {spaces: 2});
     };
     await Promise.all(projects.map(updateProjectPackage));


### PR DESCRIPTION
After some discussion, the team has decided not to automatically increment the `react` version specified by project `peerDependencies` when we release minor updates. This PR removes that logic from the release script.

(Going forward, we'll have to rely on Flow to notify us of upcoming changes and manually update the dependency before running the release script.)

Resolves #11278