### PR TITLE
Remove Task priority

### DIFF
--- a/packages/react-reconciler/src/ReactFiberExpirationTime.js
+++ b/packages/react-reconciler/src/ReactFiberExpirationTime.js
@@ -14,14 +14,12 @@ export type ExpirationTime = number;
 
 const NoWork = 0;
 const Sync = 1;
-const Task = 2;
 const Never = 2147483647; // Max int32: Math.pow(2, 31) - 1
 
 const UNIT_SIZE = 10;
-const MAGIC_NUMBER_OFFSET = 3;
+const MAGIC_NUMBER_OFFSET = 2;
 
 exports.Sync = Sync;
-exports.Task = Task;
 exports.NoWork = NoWork;
 exports.Never = Never;
 

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -22,10 +22,6 @@ export type FiberRoot = {
   pendingChildren: any,
   // The currently active root fiber. This is the mutable root of the tree.
   current: Fiber,
-  // Whether this root is part of the root schedule. Different than whether it
-  // has remaining expiration time, because we don't remove roots from the
-  // schedule until the next time we search for work.
-  isScheduled: boolean,
   // Remaining expiration time on this root.
   remainingExpirationTime: ExpirationTime,
   // Determines if this root can be committed.
@@ -55,7 +51,6 @@ exports.createFiberRoot = function(
     current: uninitializedFiber,
     containerInfo: containerInfo,
     pendingChildren: null,
-    isScheduled: false,
     remainingExpirationTime: NoWork,
     isReadyForCommit: false,
     finishedWork: null,

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -30,8 +30,6 @@ export type FiberRoot = {
   remainingExpirationTime: ExpirationTime,
   // Determines if this root can be committed.
   isReadyForCommit: boolean,
-  // Used for unbatchedUpdates
-  isUnbatched: boolean,
   // A finished work-in-progress HostRoot that's ready to be committed.
   // TODO: The reason this is separate from isReadyForCommit is because the
   // FiberRoot concept will likely be lifted out of the reconciler and into
@@ -60,7 +58,6 @@ exports.createFiberRoot = function(
     isScheduled: false,
     remainingExpirationTime: NoWork,
     isReadyForCommit: false,
-    isUnbatched: false,
     finishedWork: null,
     context: null,
     pendingContext: null,

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -22,10 +22,16 @@ export type FiberRoot = {
   pendingChildren: any,
   // The currently active root fiber. This is the mutable root of the tree.
   current: Fiber,
+  // Whether this root is part of the root schedule. Different than whether it
+  // has remaining expiration time, because we don't remove roots from the
+  // schedule until the next time we search for work.
+  isScheduled: boolean,
   // Remaining expiration time on this root.
   remainingExpirationTime: ExpirationTime,
   // Determines if this root can be committed.
   isReadyForCommit: boolean,
+  // Used for unbatchedUpdates
+  isUnbatched: boolean,
   // A finished work-in-progress HostRoot that's ready to be committed.
   // TODO: The reason this is separate from isReadyForCommit is because the
   // FiberRoot concept will likely be lifted out of the reconciler and into
@@ -51,8 +57,10 @@ exports.createFiberRoot = function(
     current: uninitializedFiber,
     containerInfo: containerInfo,
     pendingChildren: null,
+    isScheduled: false,
     remainingExpirationTime: NoWork,
     isReadyForCommit: false,
+    isUnbatched: false,
     finishedWork: null,
     context: null,
     pendingContext: null,


### PR DESCRIPTION
The concept of Task priority was originally added as a way to avoid reentrancy. Sync priority is for work that flushes synchronously, and Task is for work that flushes at the end of the event loop.

But it turns out that in most cases, it's simpler to model Task and Sync as the same priority level. For example, it's never correct to flush Sync work from the update queue without flushing Task. Doing so can lead to infinite update loops.

And using a separate priority level is not necessary to avoid reentrancy. We already track when work is being rendered, and exit before entering the render cycle again. That alone is sufficient.

This commit removes Task priority from the codebase. Now we use the same level for both truly synchronous work and work that is deferred until the end of the event loop.

This also enables us to remove DOM-specific legacy cases from the  reconciler and lift them to the renderer.