### PR TITLE
Expose ReactCoroutine on __SECRET as unstable API

### DIFF
--- a/packages/react-reconciler/index.js
+++ b/packages/react-reconciler/index.js
@@ -17,3 +17,6 @@ export type {
 } from './src/ReactFiberReconciler';
 
 module.exports = require('./src/ReactFiberReconciler');
+module.exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = {
+  ReactCoroutine: require('./src/ReactCoroutine'),
+};


### PR DESCRIPTION
Opening PR for the sake of discussion after talking to @gaearon. 

I've wanted to experiment with ReactCoroutine for awhile. I can copy the code into another project to try it out and I will, but Dan brought up adding it to `__SECRET...` so here's a PR

