### PR TITLE
Removed useless typechecking

### DIFF
--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -36,7 +36,7 @@ var SUBSEPARATOR = ':';
  * @param {string} key to be escaped.
  * @return {string} the escaped key.
  */
-function escape(key: string): string {
+function escape(key) {
   var escapeRegex = /[=:]/g;
   var escaperLookup = {
     '=': '=0',


### PR DESCRIPTION
@gaearon After our dialog (https://github.com/facebook/react/pull/10227/files#r146112953) I delete this useless typechecking. I tried to add a flow to the file, but flow found 23 errors. I think I can fix these errors later, but I need help with types. Some files and functions in package React don't have typings. I can add any type, but this is a bad practice. 

Do you have a plan to add flow typechecking for all files in React package or not? 
If you have, we can talk about it and gradually add typing for all files.