### PR TITLE
Remove tests in ReactDOMComponent-test depending on internal API

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -829,12 +829,6 @@ describe('ReactDOMComponent', () => {
 
   describe('mountComponent', () => {
     var mountComponent;
-    var getValueTracker = (node: HTMLInputElement | HTMLTextAreaElement) => {
-      return Object.getOwnPropertyDescriptor(
-        node.constructor.prototype,
-        'value',
-      ).get;
-    };
 
     beforeEach(() => {
       mountComponent = function(props) {
@@ -1154,37 +1148,47 @@ describe('ReactDOMComponent', () => {
         <input type="text" defaultValue="foo" />,
         container,
       );
-      var getTrackedValue = getValueTracker(inst);
-      expect(getTrackedValue.call(inst)).toEqual('foo');
+
+      var getValueTracker = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      ).get;
+
+      expect(getValueTracker.call(inst)).toEqual('foo');
 
       inst.defaultValue = 'new foo';
-      expect(getTrackedValue.call(inst)).not.toEqual('new foo');
-      expect(getTrackedValue.call(inst)).toEqual('foo');
+      expect(getValueTracker.call(inst)).not.toEqual('new foo');
+      expect(getValueTracker.call(inst)).toEqual('foo');
 
       inst.value = 'bar';
-      expect(getTrackedValue.call(inst)).toEqual('bar');
+      expect(getValueTracker.call(inst)).toEqual('bar');
 
       // even if the value changes to empty string, should not return to defaultValue
       inst.value = '';
-      expect(getTrackedValue.call(inst)).toEqual('');
+      expect(getValueTracker.call(inst)).toEqual('');
     });
 
     it('should track textarea values', () => {
       var container = document.createElement('div');
       var inst = ReactDOM.render(<textarea defaultValue="foo" />, container);
-      var getTrackedValue = getValueTracker(inst);
-      expect(getTrackedValue.call(inst)).toEqual('foo');
+
+      var getValueTracker = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        'value',
+      ).get;
+
+      expect(getValueTracker.call(inst)).toEqual('foo');
 
       inst.defaultValue = 'new foo';
-      expect(getTrackedValue.call(inst)).not.toEqual('new foo');
-      expect(getTrackedValue.call(inst)).toEqual('foo');
+      expect(getValueTracker.call(inst)).not.toEqual('new foo');
+      expect(getValueTracker.call(inst)).toEqual('foo');
 
       inst.value = 'bar';
-      expect(getTrackedValue.call(inst)).toEqual('bar');
+      expect(getValueTracker.call(inst)).toEqual('bar');
 
       // even if the value changes to empty string, should not return to defaultValue
       inst.value = '';
-      expect(getTrackedValue.call(inst)).toEqual('');
+      expect(getValueTracker.call(inst)).toEqual('');
     });
 
     it('should throw for children on void elements', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -15,12 +15,26 @@ describe('ReactDOMComponent', () => {
   var ReactDOM;
   var ReactDOMServer;
 
+  var getInputValueTracker;
+  var getTextAreaValueTracker;
+
   function normalizeCodeLocInfo(str) {
     return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
   }
 
   beforeEach(() => {
     jest.resetModules();
+
+    getInputValueTracker = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    ).get;
+
+    getTextAreaValueTracker = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'value',
+    ).get;
+
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
@@ -1149,46 +1163,14 @@ describe('ReactDOMComponent', () => {
         container,
       );
 
-      var getValueTracker = Object.getOwnPropertyDescriptor(
-        HTMLInputElement.prototype,
-        'value',
-      ).get;
-
-      expect(getValueTracker.call(inst)).toEqual('foo');
-
-      inst.defaultValue = 'new foo';
-      expect(getValueTracker.call(inst)).not.toEqual('new foo');
-      expect(getValueTracker.call(inst)).toEqual('foo');
-
-      inst.value = 'bar';
-      expect(getValueTracker.call(inst)).toEqual('bar');
-
-      // even if the value changes to empty string, should not return to defaultValue
-      inst.value = '';
-      expect(getValueTracker.call(inst)).toEqual('');
+      expect(getInputValueTracker.call(inst)).toEqual('foo');
     });
 
     it('should track textarea values', () => {
       var container = document.createElement('div');
       var inst = ReactDOM.render(<textarea defaultValue="foo" />, container);
 
-      var getValueTracker = Object.getOwnPropertyDescriptor(
-        HTMLTextAreaElement.prototype,
-        'value',
-      ).get;
-
-      expect(getValueTracker.call(inst)).toEqual('foo');
-
-      inst.defaultValue = 'new foo';
-      expect(getValueTracker.call(inst)).not.toEqual('new foo');
-      expect(getValueTracker.call(inst)).toEqual('foo');
-
-      inst.value = 'bar';
-      expect(getValueTracker.call(inst)).toEqual('bar');
-
-      // even if the value changes to empty string, should not return to defaultValue
-      inst.value = '';
-      expect(getValueTracker.call(inst)).toEqual('');
+      expect(getTextAreaValueTracker.call(inst)).toEqual('foo');
     });
 
     it('should throw for children on void elements', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -843,7 +843,7 @@ describe('ReactDOMComponent', () => {
         get: () => {
           return descriptor.get.call(this);
         },
-        set: (value) => {
+        set: value => {
           currentValue = '' + value;
           descriptor.set.call(this, value);
         },

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -15,26 +15,12 @@ describe('ReactDOMComponent', () => {
   var ReactDOM;
   var ReactDOMServer;
 
-  var getInputValueTracker;
-  var getTextAreaValueTracker;
-
   function normalizeCodeLocInfo(str) {
     return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
   }
 
   beforeEach(() => {
     jest.resetModules();
-
-    getInputValueTracker = Object.getOwnPropertyDescriptor(
-      HTMLInputElement.prototype,
-      'value',
-    ).get;
-
-    getTextAreaValueTracker = Object.getOwnPropertyDescriptor(
-      HTMLTextAreaElement.prototype,
-      'value',
-    ).get;
-
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
@@ -1154,23 +1140,6 @@ describe('ReactDOMComponent', () => {
           "not a string. For example, style={{marginRight: spacing + 'em'}} " +
           'when using JSX.',
       );
-    });
-
-    it('should track input values', () => {
-      var container = document.createElement('div');
-      var inst = ReactDOM.render(
-        <input type="text" defaultValue="foo" />,
-        container,
-      );
-
-      expect(getInputValueTracker.call(inst)).toEqual('foo');
-    });
-
-    it('should track textarea values', () => {
-      var container = document.createElement('div');
-      var inst = ReactDOM.render(<textarea defaultValue="foo" />, container);
-
-      expect(getTextAreaValueTracker.call(inst)).toEqual('foo');
     });
 
     it('should throw for children on void elements', () => {


### PR DESCRIPTION
Removed `inputValueTracking` dependency in `ReactDOMComponent-test` based on list in #11299. I took this approach based on #11309 review. Please let me know if this is not the way we should test it.
