### PR TITLE
Update ReactCoroutine-test to only use public API

### DIFF
--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -20,6 +20,7 @@
 import type {Fiber} from 'ReactFiber';
 import type {UpdateQueue} from 'ReactFiberUpdateQueue';
 
+var ReactCoroutine = require('ReactCoroutine');
 var ReactFeatureFlags = require('ReactFeatureFlags');
 var ReactFiberInstrumentation = require('ReactFiberInstrumentation');
 var ReactFiberReconciler = require('react-reconciler');
@@ -451,6 +452,10 @@ var ReactNoop = {
   unbatchedUpdates: NoopRenderer.unbatchedUpdates,
 
   flushSync: NoopRenderer.flushSync,
+
+  createCoroutine: ReactCoroutine.createCoroutine,
+
+  createYield: ReactCoroutine.createYield,
 
   // Logs the current state of the tree.
   dumpTree(rootID: string = DEFAULT_ROOT_ID) {

--- a/packages/react-reconciler/src/__tests__/ReactCoroutine-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactCoroutine-test.js
@@ -11,15 +11,12 @@
 
 var React;
 var ReactNoop;
-var ReactCoroutine;
 
 describe('ReactCoroutine', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
-    // TODO: can we express this test with only public API?
-    ReactCoroutine = require('ReactCoroutine');
   });
 
   function div(...children) {
@@ -43,7 +40,7 @@ describe('ReactCoroutine', () => {
     // yielding. E.g. Continuation.yieldType = 123;
     function Child({bar}) {
       ops.push(['Child', bar]);
-      return ReactCoroutine.createYield({
+      return ReactNoop.createYield({
         props: {
           bar: bar,
         },
@@ -67,11 +64,7 @@ describe('ReactCoroutine', () => {
     // yielding. E.g. Parent.handler = HandleYields;
     function Parent(props) {
       ops.push('Parent');
-      return ReactCoroutine.createCoroutine(
-        props.children,
-        HandleYields,
-        props,
-      );
+      return ReactNoop.createCoroutine(props.children, HandleYields, props);
     }
 
     function App() {
@@ -104,7 +97,7 @@ describe('ReactCoroutine', () => {
     }
 
     function Child({bar}) {
-      return ReactCoroutine.createYield({
+      return ReactNoop.createYield({
         props: {
           bar: bar,
         },
@@ -123,11 +116,7 @@ describe('ReactCoroutine', () => {
     }
 
     function Parent(props) {
-      return ReactCoroutine.createCoroutine(
-        props.children,
-        HandleYields,
-        props,
-      );
+      return ReactNoop.createCoroutine(props.children, HandleYields, props);
     }
 
     function App(props) {
@@ -163,7 +152,7 @@ describe('ReactCoroutine', () => {
     class Child extends React.Component {
       render() {
         ops.push('Child');
-        return ReactCoroutine.createYield(Continuation);
+        return ReactNoop.createYield(Continuation);
       }
       componentWillUnmount() {
         ops.push('Unmount Child');
@@ -180,7 +169,7 @@ describe('ReactCoroutine', () => {
     class Parent extends React.Component {
       render() {
         ops.push('Parent');
-        return ReactCoroutine.createCoroutine(
+        return ReactNoop.createCoroutine(
           this.props.children,
           HandleYields,
           this.props,
@@ -215,12 +204,12 @@ describe('ReactCoroutine', () => {
       state = {value: 5};
       render() {
         instances[this.props.id] = this;
-        return ReactCoroutine.createYield(this.state.value);
+        return ReactNoop.createYield(this.state.value);
       }
     }
 
     function App(props) {
-      return ReactCoroutine.createCoroutine(
+      return ReactNoop.createCoroutine(
         [
           <Counter key="a" id="a" />,
           <Counter key="b" id="b" />,


### PR DESCRIPTION
In this case, these tests are currently testing apis that haven't been exposed
publicly yet, so there isn't currently an actually public api to be used.

For now, expose `createCoroutine` and `createYield` through `ReactNoop`
renderer, which is already used for testing (as per @gaearon's suggestion).
When these apis are exposed publicly, these tests can be updated using that api.

Part of #11299