### PR TITLE
Add "art" to "react-art" peerDependencies

### DIFF
--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -25,6 +25,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
+    "art": "^0.10.1",
     "react": "^16.0.0"
   },
   "files": [


### PR DESCRIPTION
Seems like it's required in Node mode.