### PR TITLE
Add "prop-types" to dependencies of "react-test-renderer"

### DIFF
--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -16,7 +16,8 @@
   "homepage": "https://reactjs.org/",
   "dependencies": {
     "fbjs": "^0.8.16",
-    "object-assign": "^4.1.1"
+    "object-assign": "^4.1.1",
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": "^16.0.0"


### PR DESCRIPTION
They are [imported](https://github.com/facebook/react/blob/4ceb5a4aa064ef6253bf0fb12adf38d68d8ecdb5/packages/react-test-renderer/src/ReactShallowRenderer.js#L11) by the shallow renderer but not specified.