### PR TITLE
Make "art" a dependency of "react-art"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "packages/*"
   ],
   "devDependencies": {
+    "art": "^0.10.1",
     "async": "^1.5.0",
     "babel-cli": "^6.6.5",
     "babel-core": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "packages/*"
   ],
   "devDependencies": {
-    "art": "^0.10.1",
     "async": "^1.5.0",
     "babel-cli": "^6.6.5",
     "babel-core": "^6.0.0",

--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://reactjs.org/",
   "dependencies": {
+    "art": "^0.10.1",
     "create-react-class": "^15.6.2",
     "fbjs": "^0.8.16",
     "loose-envify": "^1.1.0",


### PR DESCRIPTION
Instead of https://github.com/facebook/react/pull/11339, per @sebmarkbage 