### PR TITLE
Expose react-art/{Circle,Rectange/Wedge} on npm

### DIFF
--- a/fixtures/art/VectorWidget.js
+++ b/fixtures/art/VectorWidget.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var Circle = require('react-art/lib/Circle.art');
+var Circle = require('react-art/Circle');
 var React = require('react');
 var ReactART = require('react-art');
 var Group = ReactART.Group;

--- a/packages/react-art/npm/Circle.js
+++ b/packages/react-art/npm/Circle.js
@@ -1,19 +1,3 @@
-'use strict';
-
-var _extends =
-  Object.assign ||
-  function(target) {
-    for (var i = 1; i < arguments.length; i++) {
-      var source = arguments[i];
-      for (var key in source) {
-        if (Object.prototype.hasOwnProperty.call(source, key)) {
-          target[key] = source[key];
-        }
-      }
-    }
-    return target;
-  };
-
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -33,9 +17,12 @@ var _extends =
  *
  */
 
+'use strict';
+
+var assign = require('object-assign');
 var PropTypes = require('prop-types');
 var React = require('react');
-var ReactART = require('..');
+var ReactART = require('react-art');
 
 var createReactClass = require('create-react-class');
 
@@ -61,7 +48,7 @@ var Circle = createReactClass({
       .arc(0, radius * 2, radius)
       .arc(0, radius * -2, radius)
       .close();
-    return React.createElement(Shape, _extends({}, this.props, {d: path}));
+    return React.createElement(Shape, assign({}, this.props, {d: path}));
   },
 });
 

--- a/packages/react-art/npm/Rectangle.js
+++ b/packages/react-art/npm/Rectangle.js
@@ -1,19 +1,3 @@
-'use strict';
-
-var _extends =
-  Object.assign ||
-  function(target) {
-    for (var i = 1; i < arguments.length; i++) {
-      var source = arguments[i];
-      for (var key in source) {
-        if (Object.prototype.hasOwnProperty.call(source, key)) {
-          target[key] = source[key];
-        }
-      }
-    }
-    return target;
-  };
-
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -40,9 +24,12 @@ var _extends =
  *
  */
 
+'use strict';
+
+var assign = require('object-assign');
 var PropTypes = require('prop-types');
 var React = require('react');
-var ReactART = require('..');
+var ReactART = require('react-art');
 
 var createReactClass = require('create-react-class');
 
@@ -146,7 +133,7 @@ var Rectangle = createReactClass({
     }
     path.line(0, -height + (bl + tl));
 
-    return React.createElement(Shape, _extends({}, this.props, {d: path}));
+    return React.createElement(Shape, assign({}, this.props, {d: path}));
   },
 });
 

--- a/packages/react-art/npm/Wedge.js
+++ b/packages/react-art/npm/Wedge.js
@@ -20,7 +20,7 @@
  *
  */
 
- 'use strict';
+'use strict';
 
 var assign = require('object-assign');
 var PropTypes = require('prop-types');

--- a/packages/react-art/npm/Wedge.js
+++ b/packages/react-art/npm/Wedge.js
@@ -1,19 +1,3 @@
-'use strict';
-
-var _extends =
-  Object.assign ||
-  function(target) {
-    for (var i = 1; i < arguments.length; i++) {
-      var source = arguments[i];
-      for (var key in source) {
-        if (Object.prototype.hasOwnProperty.call(source, key)) {
-          target[key] = source[key];
-        }
-      }
-    }
-    return target;
-  };
-
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -36,9 +20,12 @@ var _extends =
  *
  */
 
+ 'use strict';
+
+var assign = require('object-assign');
 var PropTypes = require('prop-types');
 var React = require('react');
-var ReactART = require('..');
+var ReactART = require('react-art');
 
 var createReactClass = require('create-react-class');
 
@@ -193,7 +180,7 @@ var Wedge = createReactClass({
       path = this._createArcPath(startAngle, endAngle, or, ir);
     }
 
-    return React.createElement(Shape, _extends({}, this.props, {d: path}));
+    return React.createElement(Shape, assign({}, this.props, {d: path}));
   },
 });
 

--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -32,7 +32,10 @@
     "README.md",
     "index.js",
     "cjs/",
-    "umd/"
+    "umd/",
+    "Circle.js",
+    "Rectangle.js",
+    "Wedge.js"
   ],
   "browserify": {
     "transform": [


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/11254.

Verified by looking into build folder:

<img width="212" alt="screen shot 2017-10-23 at 17 07 58" src="https://user-images.githubusercontent.com/810438/31900042-20947920-b815-11e7-974a-45d544bbd13a.png">
<img width="202" alt="screen shot 2017-10-23 at 17 08 02" src="https://user-images.githubusercontent.com/810438/31900047-23d0e632-b815-11e7-81eb-3f2eb695fb10.png">


and running updated fixture:

<img width="395" alt="screen shot 2017-10-23 at 17 08 44" src="https://user-images.githubusercontent.com/810438/31900014-0f19a364-b815-11e7-8a28-d5093bc06d4b.png">

One thing I'm not super happy about it is we can't import them easily in tests. But I don't care tbqh.