### PR TITLE
Update CI environment (Node 8, Yarn 1.2.1)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,12 @@
 machine:
   timezone: America/Los_Angeles
   node:
-    version: 6
+    version: 8
   ruby:
     version: 2.2.3
   environment:
     TRAVIS_REPO_SLUG: facebook/react
-    YARN_VERSION: 0.17.8
+    YARN_VERSION: 1.2.1
     PATH: "${PATH}:${HOME}/.yarn/bin"
 
 dependencies:


### PR DESCRIPTION
Node 8 for speed.

Yarn 1.2.1 for proper Workspaces support. 