### PR TITLE
Reorder imports

### DIFF
--- a/fixtures/art/yarn.lock
+++ b/fixtures/art/yarn.lock
@@ -73,6 +73,10 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+art@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/art/-/art-0.10.1.tgz#38541883e399225c5e193ff246e8f157cf7b2146"
+
 asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -1741,6 +1745,7 @@ rc@^1.1.7:
 "react-art@file:../../build/packages/react-art":
   version "16.0.0"
   dependencies:
+    art "^0.10.1"
     create-react-class "^15.6.2"
     fbjs "^0.8.16"
     loose-envify "^1.1.0"

--- a/packages/events/EventPluginHub.js
+++ b/packages/events/EventPluginHub.js
@@ -7,13 +7,13 @@
 
 'use strict';
 
+var ReactErrorUtils = require('shared/ReactErrorUtils');
+var invariant = require('fbjs/lib/invariant');
+
 var EventPluginRegistry = require('./EventPluginRegistry');
 var EventPluginUtils = require('./EventPluginUtils');
-var ReactErrorUtils = require('shared/ReactErrorUtils');
-
 var accumulateInto = require('./accumulateInto');
 var forEachAccumulated = require('./forEachAccumulated');
-var invariant = require('fbjs/lib/invariant');
 
 /**
  * Internal queue of events that have accumulated their dispatches and are

--- a/packages/events/EventPluginRegistry.js
+++ b/packages/events/EventPluginRegistry.js
@@ -10,18 +10,16 @@
 'use strict';
 
 import type {DispatchConfig} from './ReactSyntheticEventType';
-
 import type {
   AnyNativeEvent,
   PluginName,
   PluginModule,
 } from './PluginModuleType';
 
-type NamesToPlugins = {[key: PluginName]: PluginModule<AnyNativeEvent>};
-
-type EventPluginOrder = null | Array<PluginName>;
-
 var invariant = require('fbjs/lib/invariant');
+
+type NamesToPlugins = {[key: PluginName]: PluginModule<AnyNativeEvent>};
+type EventPluginOrder = null | Array<PluginName>;
 
 /**
  * Injectable ordering of event plugins.

--- a/packages/events/EventPluginUtils.js
+++ b/packages/events/EventPluginUtils.js
@@ -8,7 +8,6 @@
 'use strict';
 
 var ReactErrorUtils = require('shared/ReactErrorUtils');
-
 var invariant = require('fbjs/lib/invariant');
 
 if (__DEV__) {

--- a/packages/events/EventPropagators.js
+++ b/packages/events/EventPropagators.js
@@ -7,9 +7,9 @@
 
 'use strict';
 
-var EventPluginHub = require('./EventPluginHub');
 var ReactTreeTraversal = require('shared/ReactTreeTraversal');
 
+var EventPluginHub = require('./EventPluginHub');
 var accumulateInto = require('./accumulateInto');
 var forEachAccumulated = require('./forEachAccumulated');
 

--- a/packages/events/ReactControlledComponent.js
+++ b/packages/events/ReactControlledComponent.js
@@ -7,9 +7,9 @@
 
 'use strict';
 
-var EventPluginUtils = require('./EventPluginUtils');
-
 var invariant = require('fbjs/lib/invariant');
+
+var EventPluginUtils = require('./EventPluginUtils');
 
 // Use to restore controlled state after a change event has fired.
 

--- a/packages/events/ResponderEventPlugin.js
+++ b/packages/events/ResponderEventPlugin.js
@@ -7,12 +7,12 @@
 
 'use strict';
 
+var ReactTreeTraversal = require('shared/ReactTreeTraversal');
+
 var EventPluginUtils = require('./EventPluginUtils');
 var EventPropagators = require('./EventPropagators');
-var ReactTreeTraversal = require('shared/ReactTreeTraversal');
 var ResponderSyntheticEvent = require('./ResponderSyntheticEvent');
 var ResponderTouchHistoryStore = require('./ResponderTouchHistoryStore');
-
 var accumulate = require('./accumulate');
 
 var isStartish = EventPluginUtils.isStartish;

--- a/packages/events/ResponderTouchHistoryStore.js
+++ b/packages/events/ResponderTouchHistoryStore.js
@@ -9,10 +9,9 @@
 
 'use strict';
 
-const EventPluginUtils = require('./EventPluginUtils');
-
 const invariant = require('fbjs/lib/invariant');
 
+const EventPluginUtils = require('./EventPluginUtils');
 const {isEndish, isMoveish, isStartish} = EventPluginUtils;
 
 if (__DEV__) {

--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -12,14 +12,13 @@ require('art/modes/current').setCurrent(
   require('art/modes/fast-noSideEffects'),
 );
 
+const React = require('react');
+const ReactFiberReconciler = require('react-reconciler');
+const ReactDOMFrameScheduling = require('shared/ReactDOMFrameScheduling');
 const Mode = require('art/modes/current');
 const Transform = require('art/core/transform');
 const invariant = require('fbjs/lib/invariant');
 const emptyObject = require('fbjs/lib/emptyObject');
-const React = require('react');
-const ReactFiberReconciler = require('react-reconciler');
-const ReactDOMFrameScheduling = require('shared/ReactDOMFrameScheduling');
-
 const {Component} = React;
 
 const pooledTransform = new Transform();

--- a/packages/react-cs-renderer/src/ReactNativeCS.js
+++ b/packages/react-cs-renderer/src/ReactNativeCS.js
@@ -9,18 +9,15 @@
 
 'use strict';
 
-const ReactGenericBatching = require('events/ReactGenericBatching');
-const ReactVersion = require('shared/ReactVersion');
+import type {ReactNativeCSType} from './ReactNativeCSTypes';
 
+const ReactFiberReconciler = require('react-reconciler');
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 const {
   injectInternals,
 } = require('react-reconciler/src/ReactFiberDevToolsHook');
-
-import type {ReactNativeCSType} from './ReactNativeCSTypes';
-
-const ReactFiberReconciler = require('react-reconciler');
-
+const ReactGenericBatching = require('events/ReactGenericBatching');
+const ReactVersion = require('shared/ReactVersion');
 const emptyObject = require('fbjs/lib/emptyObject');
 
 export type Container = number;

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -12,20 +12,28 @@
 import type {ReactNodeList} from 'shared/ReactTypes';
 
 require('../shared/checkReact');
-var DOMNamespaces = require('../shared/DOMNamespaces');
+
+var ReactFiberReconciler = require('react-reconciler');
+// TODO: direct imports like some-package/src/* are bad. Fix me.
+var ReactPortal = require('react-reconciler/src/ReactPortal');
+// TODO: direct imports like some-package/src/* are bad. Fix me.
+var {injectInternals} = require('react-reconciler/src/ReactFiberDevToolsHook');
 var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
-var ReactBrowserEventEmitter = require('../events/ReactBrowserEventEmitter');
+var ReactGenericBatching = require('events/ReactGenericBatching');
 var ReactControlledComponent = require('events/ReactControlledComponent');
+var ReactInstanceMap = require('shared/ReactInstanceMap');
 var ReactFeatureFlags = require('shared/ReactFeatureFlags');
+var ReactVersion = require('shared/ReactVersion');
+var ReactDOMFrameScheduling = require('shared/ReactDOMFrameScheduling');
+var {ReactCurrentOwner} = require('shared/ReactGlobalSharedState');
+var getComponentName = require('shared/getComponentName');
+var invariant = require('fbjs/lib/invariant');
+
 var ReactDOMComponentTree = require('./ReactDOMComponentTree');
 var ReactDOMFiberComponent = require('./ReactDOMFiberComponent');
-var ReactDOMFrameScheduling = require('shared/ReactDOMFrameScheduling');
-var ReactGenericBatching = require('events/ReactGenericBatching');
-var ReactFiberReconciler = require('react-reconciler');
 var ReactInputSelection = require('./ReactInputSelection');
-var ReactInstanceMap = require('shared/ReactInstanceMap');
-var ReactVersion = require('shared/ReactVersion');
-var {ReactCurrentOwner} = require('shared/ReactGlobalSharedState');
+var ReactBrowserEventEmitter = require('../events/ReactBrowserEventEmitter');
+var DOMNamespaces = require('../shared/DOMNamespaces');
 var {
   ELEMENT_NODE,
   TEXT_NODE,
@@ -34,14 +42,6 @@ var {
   DOCUMENT_FRAGMENT_NODE,
 } = require('../shared/HTMLNodeType');
 var {ROOT_ATTRIBUTE_NAME} = require('../shared/DOMProperty');
-
-// TODO: direct imports like some-package/src/* are bad. Fix me.
-var ReactPortal = require('react-reconciler/src/ReactPortal');
-var {injectInternals} = require('react-reconciler/src/ReactFiberDevToolsHook');
-
-var getComponentName = require('shared/getComponentName');
-var invariant = require('fbjs/lib/invariant');
-
 var {getChildNamespace} = DOMNamespaces;
 var {
   createElement,
@@ -60,12 +60,13 @@ var {
 var {precacheFiberNode, updateFiberProps} = ReactDOMComponentTree;
 
 if (__DEV__) {
-  var SUPPRESS_HYDRATION_WARNING = 'suppressHydrationWarning';
   var lowPriorityWarning = require('shared/lowPriorityWarning');
   var warning = require('fbjs/lib/warning');
+
   var validateDOMNesting = require('./validateDOMNesting');
   var {updatedAncestorInfo} = validateDOMNesting;
 
+  var SUPPRESS_HYDRATION_WARNING = 'suppressHydrationWarning';
   if (
     typeof Map !== 'function' ||
     Map.prototype == null ||

--- a/packages/react-dom/src/client/ReactDOMClientInjection.js
+++ b/packages/react-dom/src/client/ReactDOMClientInjection.js
@@ -7,14 +7,15 @@
 
 'use strict';
 
+var EventPluginHub = require('events/EventPluginHub');
+var EventPluginUtils = require('events/EventPluginUtils');
+
+var ReactDOMComponentTree = require('./ReactDOMComponentTree');
 var BeforeInputEventPlugin = require('../events/BeforeInputEventPlugin');
 var ChangeEventPlugin = require('../events/ChangeEventPlugin');
 var DOMEventPluginOrder = require('../events/DOMEventPluginOrder');
 var EnterLeaveEventPlugin = require('../events/EnterLeaveEventPlugin');
-var EventPluginHub = require('events/EventPluginHub');
-var EventPluginUtils = require('events/EventPluginUtils');
 var ReactBrowserEventEmitter = require('../events/ReactBrowserEventEmitter');
-var ReactDOMComponentTree = require('./ReactDOMComponentTree');
 var ReactDOMEventListener = require('../events/ReactDOMEventListener');
 var SelectEventPlugin = require('../events/SelectEventPlugin');
 var SimpleEventPlugin = require('../events/SimpleEventPlugin');

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -8,7 +8,6 @@
 'use strict';
 
 var {HostComponent, HostText} = require('shared/ReactTypeOfWork');
-
 var invariant = require('fbjs/lib/invariant');
 
 var randomKey = Math.random().toString(36).slice(2);

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -9,37 +9,36 @@
 
 'use strict';
 
-var CSSPropertyOperations = require('../shared/CSSPropertyOperations');
-var DOMNamespaces = require('../shared/DOMNamespaces');
-var DOMProperty = require('../shared/DOMProperty');
-var DOMPropertyOperations = require('./DOMPropertyOperations');
-var EventPluginRegistry = require('events/EventPluginRegistry');
-var ReactBrowserEventEmitter = require('../events/ReactBrowserEventEmitter');
-var ReactDOMFiberInput = require('./ReactDOMFiberInput');
-var ReactDOMFiberOption = require('./ReactDOMFiberOption');
-var ReactDOMFiberSelect = require('./ReactDOMFiberSelect');
-var ReactDOMFiberTextarea = require('./ReactDOMFiberTextarea');
-
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 var {
   getCurrentFiberOwnerName,
 } = require('react-reconciler/src/ReactDebugCurrentFiber');
-
-var {DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE} = require('../shared/HTMLNodeType');
-
-var assertValidProps = require('../shared/assertValidProps');
+var EventPluginRegistry = require('events/EventPluginRegistry');
 var emptyFunction = require('fbjs/lib/emptyFunction');
+
+var DOMPropertyOperations = require('./DOMPropertyOperations');
+var ReactDOMFiberInput = require('./ReactDOMFiberInput');
+var ReactDOMFiberOption = require('./ReactDOMFiberOption');
+var ReactDOMFiberSelect = require('./ReactDOMFiberSelect');
+var ReactDOMFiberTextarea = require('./ReactDOMFiberTextarea');
 var inputValueTracking = require('./inputValueTracking');
-var isCustomComponent = require('../shared/isCustomComponent');
 var setInnerHTML = require('./setInnerHTML');
 var setTextContent = require('./setTextContent');
+var ReactBrowserEventEmitter = require('../events/ReactBrowserEventEmitter');
+var CSSPropertyOperations = require('../shared/CSSPropertyOperations');
+var DOMNamespaces = require('../shared/DOMNamespaces');
+var DOMProperty = require('../shared/DOMProperty');
+var assertValidProps = require('../shared/assertValidProps');
+var {DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE} = require('../shared/HTMLNodeType');
+var isCustomComponent = require('../shared/isCustomComponent');
 
 if (__DEV__) {
-  var warning = require('fbjs/lib/warning');
   // TODO: direct imports like some-package/src/* are bad. Fix me.
   var {
     getCurrentFiberStackAddendum,
   } = require('react-reconciler/src/ReactDebugCurrentFiber');
+  var warning = require('fbjs/lib/warning');
+
   var ReactDOMInvalidARIAHook = require('../shared/ReactDOMInvalidARIAHook');
   var ReactDOMNullInputValuePropHook = require('../shared/ReactDOMNullInputValuePropHook');
   var ReactDOMUnknownPropertyHook = require('../shared/ReactDOMUnknownPropertyHook');

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -9,22 +9,15 @@
 
 'use strict';
 
-type InputWithWrapperState = HTMLInputElement & {
-  _wrapperState: {
-    initialValue: ?string,
-    initialChecked: ?boolean,
-    controlled?: boolean,
-  },
-};
-
-var DOMPropertyOperations = require('./DOMPropertyOperations');
-var ReactControlledValuePropTypes = require('../shared/ReactControlledValuePropTypes');
-var ReactDOMComponentTree = require('./ReactDOMComponentTree');
-
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 var {
   getCurrentFiberOwnerName,
 } = require('react-reconciler/src/ReactDebugCurrentFiber');
+var invariant = require('fbjs/lib/invariant');
+
+var DOMPropertyOperations = require('./DOMPropertyOperations');
+var ReactDOMComponentTree = require('./ReactDOMComponentTree');
+var ReactControlledValuePropTypes = require('../shared/ReactControlledValuePropTypes');
 
 if (__DEV__) {
   // TODO: direct imports like some-package/src/* are bad. Fix me.
@@ -34,7 +27,13 @@ if (__DEV__) {
   var warning = require('fbjs/lib/warning');
 }
 
-var invariant = require('fbjs/lib/invariant');
+type InputWithWrapperState = HTMLInputElement & {
+  _wrapperState: {
+    initialValue: ?string,
+    initialChecked: ?boolean,
+    controlled?: boolean,
+  },
+};
 
 var didWarnValueDefaultValue = false;
 var didWarnCheckedDefaultChecked = false;

--- a/packages/react-dom/src/client/ReactDOMFiberSelect.js
+++ b/packages/react-dom/src/client/ReactDOMFiberSelect.js
@@ -9,26 +9,28 @@
 
 'use strict';
 
+var {
+  getCurrentFiberOwnerName,
+} = require('react-reconciler/src/ReactDebugCurrentFiber');
+
+var ReactControlledValuePropTypes = require('../shared/ReactControlledValuePropTypes');
+
+if (__DEV__) {
+  // TODO: direct imports like some-package/src/* are bad. Fix me.
+  var {
+    getCurrentFiberStackAddendum,
+  } = require('react-reconciler/src/ReactDebugCurrentFiber');
+  var warning = require('fbjs/lib/warning');
+
+  var didWarnValueDefaultValue = false;
+}
+
 type SelectWithWrapperState = HTMLSelectElement & {
   _wrapperState: {
     initialValue: ?string,
     wasMultiple: boolean,
   },
 };
-
-var ReactControlledValuePropTypes = require('../shared/ReactControlledValuePropTypes');
-var {
-  getCurrentFiberOwnerName,
-} = require('react-reconciler/src/ReactDebugCurrentFiber');
-
-if (__DEV__) {
-  var didWarnValueDefaultValue = false;
-  var warning = require('fbjs/lib/warning');
-  // TODO: direct imports like some-package/src/* are bad. Fix me.
-  var {
-    getCurrentFiberStackAddendum,
-  } = require('react-reconciler/src/ReactDebugCurrentFiber');
-}
 
 function getDeclarationErrorAddendum() {
   var ownerName = getCurrentFiberOwnerName();

--- a/packages/react-dom/src/client/ReactDOMFiberTextarea.js
+++ b/packages/react-dom/src/client/ReactDOMFiberTextarea.js
@@ -9,23 +9,23 @@
 
 'use strict';
 
+var invariant = require('fbjs/lib/invariant');
+
+var ReactControlledValuePropTypes = require('../shared/ReactControlledValuePropTypes');
+
+if (__DEV__) {
+  // TODO: direct imports like some-package/src/* are bad. Fix me.
+  var {
+    getCurrentFiberStackAddendum,
+  } = require('react-reconciler/src/ReactDebugCurrentFiber');
+  var warning = require('fbjs/lib/warning');
+}
+
 type TextAreaWithWrapperState = HTMLTextAreaElement & {
   _wrapperState: {
     initialValue: string,
   },
 };
-
-var ReactControlledValuePropTypes = require('../shared/ReactControlledValuePropTypes');
-
-var invariant = require('fbjs/lib/invariant');
-
-if (__DEV__) {
-  var warning = require('fbjs/lib/warning');
-  // TODO: direct imports like some-package/src/* are bad. Fix me.
-  var {
-    getCurrentFiberStackAddendum,
-  } = require('react-reconciler/src/ReactDebugCurrentFiber');
-}
 
 var didWarnValDefaultVal = false;
 

--- a/packages/react-dom/src/client/ReactDOMSelection.js
+++ b/packages/react-dom/src/client/ReactDOMSelection.js
@@ -7,10 +7,9 @@
 
 'use strict';
 
-var {TEXT_NODE} = require('../shared/HTMLNodeType');
-
 var getNodeForCharacterOffset = require('./getNodeForCharacterOffset');
 var getTextContentAccessor = require('./getTextContentAccessor');
+var {TEXT_NODE} = require('../shared/HTMLNodeType');
 
 /**
  * @param {DOMElement} outerNode

--- a/packages/react-dom/src/client/ReactInputSelection.js
+++ b/packages/react-dom/src/client/ReactInputSelection.js
@@ -7,12 +7,12 @@
 
 'use strict';
 
-var ReactDOMSelection = require('./ReactDOMSelection');
-var {ELEMENT_NODE} = require('../shared/HTMLNodeType');
-
 var containsNode = require('fbjs/lib/containsNode');
 var focusNode = require('fbjs/lib/focusNode');
 var getActiveElement = require('fbjs/lib/getActiveElement');
+
+var ReactDOMSelection = require('./ReactDOMSelection');
+var {ELEMENT_NODE} = require('../shared/HTMLNodeType');
 
 function isInDocument(node) {
   return containsNode(document.documentElement, node);

--- a/packages/react-dom/src/client/setTextContent.js
+++ b/packages/react-dom/src/client/setTextContent.js
@@ -8,8 +8,9 @@
 'use strict';
 
 var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
-var escapeTextContentForBrowser = require('../shared/escapeTextContentForBrowser');
+
 var setInnerHTML = require('./setInnerHTML');
+var escapeTextContentForBrowser = require('../shared/escapeTextContentForBrowser');
 var {TEXT_NODE} = require('../shared/HTMLNodeType');
 
 /**

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -12,11 +12,11 @@ var emptyFunction = require('fbjs/lib/emptyFunction');
 var validateDOMNesting = emptyFunction;
 
 if (__DEV__) {
-  var warning = require('fbjs/lib/warning');
   // TODO: direct imports like some-package/src/* are bad. Fix me.
   var {
     getCurrentFiberStackAddendum,
   } = require('react-reconciler/src/ReactDebugCurrentFiber');
+  var warning = require('fbjs/lib/warning');
 
   // This validation code was written based on the HTML5 parsing spec:
   // https://html.spec.whatwg.org/multipage/syntax.html#has-an-element-in-scope

--- a/packages/react-dom/src/events/BeforeInputEventPlugin.js
+++ b/packages/react-dom/src/events/BeforeInputEventPlugin.js
@@ -7,13 +7,14 @@
 
 'use strict';
 
+import type {TopLevelTypes} from './BrowserEventConstants';
+
 var EventPropagators = require('events/EventPropagators');
 var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
+
 var FallbackCompositionState = require('./FallbackCompositionState');
 var SyntheticCompositionEvent = require('./SyntheticCompositionEvent');
 var SyntheticInputEvent = require('./SyntheticInputEvent');
-
-import type {TopLevelTypes} from 'BrowserEventConstants';
 
 var END_KEYCODES = [9, 13, 27, 32]; // Tab, Return, Esc, Space
 var START_KEYCODE = 229;

--- a/packages/react-dom/src/events/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/ChangeEventPlugin.js
@@ -9,16 +9,16 @@
 
 var EventPluginHub = require('events/EventPluginHub');
 var EventPropagators = require('events/EventPropagators');
-var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 var ReactControlledComponent = require('events/ReactControlledComponent');
-var ReactDOMComponentTree = require('../client/ReactDOMComponentTree');
 var ReactGenericBatching = require('events/ReactGenericBatching');
 var SyntheticEvent = require('events/SyntheticEvent');
+var isTextInputElement = require('shared/isTextInputElement');
+var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 
-var inputValueTracking = require('../client/inputValueTracking');
 var getEventTarget = require('./getEventTarget');
 var isEventSupported = require('./isEventSupported');
-var isTextInputElement = require('shared/isTextInputElement');
+var ReactDOMComponentTree = require('../client/ReactDOMComponentTree');
+var inputValueTracking = require('../client/inputValueTracking');
 
 var eventTypes = {
   change: {

--- a/packages/react-dom/src/events/EnterLeaveEventPlugin.js
+++ b/packages/react-dom/src/events/EnterLeaveEventPlugin.js
@@ -8,8 +8,9 @@
 'use strict';
 
 var EventPropagators = require('events/EventPropagators');
-var ReactDOMComponentTree = require('../client/ReactDOMComponentTree');
+
 var SyntheticMouseEvent = require('./SyntheticMouseEvent');
+var ReactDOMComponentTree = require('../client/ReactDOMComponentTree');
 
 var eventTypes = {
   mouseEnter: {

--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -8,9 +8,9 @@
 'use strict';
 
 var EventPluginRegistry = require('events/EventPluginRegistry');
-var ReactDOMEventListener = require('./ReactDOMEventListener');
 var ReactEventEmitterMixin = require('events/ReactEventEmitterMixin');
 
+var ReactDOMEventListener = require('./ReactDOMEventListener');
 var isEventSupported = require('./isEventSupported');
 var {topLevelTypes} = require('./BrowserEventConstants');
 

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -7,15 +7,14 @@
 
 'use strict';
 
-var EventListener = require('fbjs/lib/EventListener');
-var ReactDOMComponentTree = require('../client/ReactDOMComponentTree');
-var ReactFiberTreeReflection = require('shared/ReactFiberTreeReflection');
 var ReactGenericBatching = require('events/ReactGenericBatching');
+var ReactFiberTreeReflection = require('shared/ReactFiberTreeReflection');
 var ReactTypeOfWork = require('shared/ReactTypeOfWork');
+var EventListener = require('fbjs/lib/EventListener');
+var {HostRoot} = ReactTypeOfWork;
 
 var getEventTarget = require('./getEventTarget');
-
-var {HostRoot} = ReactTypeOfWork;
+var ReactDOMComponentTree = require('../client/ReactDOMComponentTree');
 
 var CALLBACK_BOOKKEEPING_POOL_SIZE = 10;
 var callbackBookkeepingPool = [];

--- a/packages/react-dom/src/events/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/SelectEventPlugin.js
@@ -9,15 +9,15 @@
 
 var EventPropagators = require('events/EventPropagators');
 var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
+var SyntheticEvent = require('events/SyntheticEvent');
+var isTextInputElement = require('shared/isTextInputElement');
+var getActiveElement = require('fbjs/lib/getActiveElement');
+var shallowEqual = require('fbjs/lib/shallowEqual');
+
 var ReactBrowserEventEmitter = require('./ReactBrowserEventEmitter');
 var ReactDOMComponentTree = require('../client/ReactDOMComponentTree');
 var ReactInputSelection = require('../client/ReactInputSelection');
-var SyntheticEvent = require('events/SyntheticEvent');
 var {DOCUMENT_NODE} = require('../shared/HTMLNodeType');
-
-var getActiveElement = require('fbjs/lib/getActiveElement');
-var isTextInputElement = require('shared/isTextInputElement');
-var shallowEqual = require('fbjs/lib/shallowEqual');
 
 var skipSelectionChangeEvent =
   ExecutionEnvironment.canUseDOM &&

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -9,10 +9,19 @@
 
 'use strict';
 
+import type {TopLevelTypes} from './BrowserEventConstants';
+import type {
+  DispatchConfig,
+  ReactSyntheticEvent,
+} from 'events/ReactSyntheticEventType';
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
+import type {EventTypes, PluginModule} from 'events/PluginModuleType';
+
 var EventPropagators = require('events/EventPropagators');
+var SyntheticEvent = require('events/SyntheticEvent');
+
 var SyntheticAnimationEvent = require('./SyntheticAnimationEvent');
 var SyntheticClipboardEvent = require('./SyntheticClipboardEvent');
-var SyntheticEvent = require('events/SyntheticEvent');
 var SyntheticFocusEvent = require('./SyntheticFocusEvent');
 var SyntheticKeyboardEvent = require('./SyntheticKeyboardEvent');
 var SyntheticMouseEvent = require('./SyntheticMouseEvent');
@@ -21,20 +30,11 @@ var SyntheticTouchEvent = require('./SyntheticTouchEvent');
 var SyntheticTransitionEvent = require('./SyntheticTransitionEvent');
 var SyntheticUIEvent = require('./SyntheticUIEvent');
 var SyntheticWheelEvent = require('./SyntheticWheelEvent');
-
 var getEventCharCode = require('./getEventCharCode');
 
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
 }
-
-import type {TopLevelTypes} from './BrowserEventConstants';
-import type {
-  DispatchConfig,
-  ReactSyntheticEvent,
-} from 'events/ReactSyntheticEventType';
-import type {Fiber} from 'react-reconciler/src/ReactFiber';
-import type {EventTypes, PluginModule} from 'events/PluginModuleType';
 
 /**
  * Turns

--- a/packages/react-dom/src/events/SyntheticKeyboardEvent.js
+++ b/packages/react-dom/src/events/SyntheticKeyboardEvent.js
@@ -8,7 +8,6 @@
 'use strict';
 
 var SyntheticUIEvent = require('./SyntheticUIEvent');
-
 var getEventCharCode = require('./getEventCharCode');
 var getEventKey = require('./getEventKey');
 var getEventModifierState = require('./getEventModifierState');

--- a/packages/react-dom/src/events/SyntheticMouseEvent.js
+++ b/packages/react-dom/src/events/SyntheticMouseEvent.js
@@ -8,7 +8,6 @@
 'use strict';
 
 var SyntheticUIEvent = require('./SyntheticUIEvent');
-
 var getEventModifierState = require('./getEventModifierState');
 
 /**

--- a/packages/react-dom/src/events/SyntheticTouchEvent.js
+++ b/packages/react-dom/src/events/SyntheticTouchEvent.js
@@ -8,7 +8,6 @@
 'use strict';
 
 var SyntheticUIEvent = require('./SyntheticUIEvent');
-
 var getEventModifierState = require('./getEventModifierState');
 
 /**

--- a/packages/react-dom/src/events/TapEventPlugin.js
+++ b/packages/react-dom/src/events/TapEventPlugin.js
@@ -11,11 +11,11 @@
 
 var EventPluginUtils = require('events/EventPluginUtils');
 var EventPropagators = require('events/EventPropagators');
-var SyntheticUIEvent = require('./SyntheticUIEvent');
 var TouchEventUtils = require('fbjs/lib/TouchEventUtils');
-
 var isStartish = EventPluginUtils.isStartish;
 var isEndish = EventPluginUtils.isEndish;
+
+var SyntheticUIEvent = require('./SyntheticUIEvent');
 
 /**
  * We are extending the Flow 'Touch' declaration to enable using bracket

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -8,7 +8,6 @@
 'use strict';
 
 var DOMProperty = require('../shared/DOMProperty');
-
 var quoteAttributeValueForBrowser = require('../shared/quoteAttributeValueForBrowser');
 
 if (__DEV__) {

--- a/packages/react-dom/src/server/ReactDOMNodeStreamRenderer.js
+++ b/packages/react-dom/src/server/ReactDOMNodeStreamRenderer.js
@@ -7,8 +7,9 @@
 
 'use strict';
 
-var ReactPartialRenderer = require('./ReactPartialRenderer');
 var Readable = require('stream').Readable;
+
+var ReactPartialRenderer = require('./ReactPartialRenderer');
 
 // This is a Readable Node.js stream which wraps the ReactDOMPartialRenderer.
 class ReactMarkupReadableStream extends Readable {

--- a/packages/react-dom/src/server/ReactDOMServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMServerBrowser.js
@@ -7,11 +7,12 @@
 
 'use strict';
 
-var ReactDOMStringRenderer = require('./ReactDOMStringRenderer');
+require('../shared/ReactDOMInjection');
+
 var ReactVersion = require('shared/ReactVersion');
 var invariant = require('fbjs/lib/invariant');
 
-require('../shared/ReactDOMInjection');
+var ReactDOMStringRenderer = require('./ReactDOMStringRenderer');
 
 module.exports = {
   renderToString: ReactDOMStringRenderer.renderToString,

--- a/packages/react-dom/src/server/ReactDOMServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMServerNode.js
@@ -7,11 +7,12 @@
 
 'use strict';
 
-var ReactDOMStringRenderer = require('./ReactDOMStringRenderer');
-var ReactDOMNodeStreamRenderer = require('./ReactDOMNodeStreamRenderer');
+require('../shared/ReactDOMInjection');
+
 var ReactVersion = require('shared/ReactVersion');
 
-require('../shared/ReactDOMInjection');
+var ReactDOMStringRenderer = require('./ReactDOMStringRenderer');
+var ReactDOMNodeStreamRenderer = require('./ReactDOMNodeStreamRenderer');
 
 module.exports = {
   renderToString: ReactDOMStringRenderer.renderToString,

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -7,25 +7,25 @@
 
 'use strict';
 
+var React = require('react');
+var emptyFunction = require('fbjs/lib/emptyFunction');
+var emptyObject = require('fbjs/lib/emptyObject');
+var hyphenateStyleName = require('fbjs/lib/hyphenateStyleName');
+var invariant = require('fbjs/lib/invariant');
+var memoizeStringOnly = require('fbjs/lib/memoizeStringOnly');
+
+var DOMMarkupOperations = require('./DOMMarkupOperations');
 var {
   Namespaces,
   getIntrinsicNamespace,
   getChildNamespace,
 } = require('../shared/DOMNamespaces');
-var DOMMarkupOperations = require('./DOMMarkupOperations');
-var React = require('react');
 var ReactControlledValuePropTypes = require('../shared/ReactControlledValuePropTypes');
-
 var assertValidProps = require('../shared/assertValidProps');
 var dangerousStyleValue = require('../shared/dangerousStyleValue');
-var emptyFunction = require('fbjs/lib/emptyFunction');
-var emptyObject = require('fbjs/lib/emptyObject');
 var escapeTextContentForBrowser = require('../shared/escapeTextContentForBrowser');
-var hyphenateStyleName = require('fbjs/lib/hyphenateStyleName');
-var invariant = require('fbjs/lib/invariant');
-var memoizeStringOnly = require('fbjs/lib/memoizeStringOnly');
-var omittedCloseTags = require('../shared/omittedCloseTags');
 var isCustomComponent = require('../shared/isCustomComponent');
+var omittedCloseTags = require('../shared/omittedCloseTags');
 
 var toArray = React.Children.toArray;
 var getStackAddendum = emptyFunction.thatReturns('');
@@ -33,6 +33,7 @@ var getStackAddendum = emptyFunction.thatReturns('');
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
   var checkPropTypes = require('prop-types/checkPropTypes');
+
   var warnValidStyle = require('../shared/warnValidStyle');
   var {
     validateProperties: validateARIAProperties,
@@ -43,6 +44,7 @@ if (__DEV__) {
   var {
     validateProperties: validateUnknownProperties,
   } = require('../shared/ReactDOMUnknownPropertyHook');
+
   var validatePropertiesInDevelopment = function(type, props) {
     validateARIAProperties(type, props);
     validateInputProperties(type, props);

--- a/packages/react-dom/src/shared/CSSPropertyOperations.js
+++ b/packages/react-dom/src/shared/CSSPropertyOperations.js
@@ -11,6 +11,7 @@ var dangerousStyleValue = require('./dangerousStyleValue');
 
 if (__DEV__) {
   var hyphenateStyleName = require('fbjs/lib/hyphenateStyleName');
+
   var warnValidStyle = require('./warnValidStyle');
 }
 

--- a/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
+++ b/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
@@ -15,6 +15,7 @@ if (__DEV__) {
   var warning = require('fbjs/lib/warning');
   var emptyFunction = require('fbjs/lib/emptyFunction');
   var PropTypes = require('prop-types');
+
   var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
 
   ReactControlledValuePropTypes.checkPropTypes = emptyFunction;

--- a/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
+++ b/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
@@ -8,8 +8,8 @@
 'use strict';
 
 if (__DEV__) {
-  var warning = require('fbjs/lib/warning');
   var {ReactDebugCurrentFrame} = require('shared/ReactGlobalSharedState');
+  var warning = require('fbjs/lib/warning');
 }
 
 var didWarnValueNull = false;

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -7,13 +7,14 @@
 
 'use strict';
 
-var DOMProperty = require('./DOMProperty');
 var EventPluginRegistry = require('events/EventPluginRegistry');
+
+var DOMProperty = require('./DOMProperty');
 var isCustomComponent = require('./isCustomComponent');
 
 if (__DEV__) {
-  var warning = require('fbjs/lib/warning');
   var {ReactDebugCurrentFrame} = require('shared/ReactGlobalSharedState');
+  var warning = require('fbjs/lib/warning');
 }
 
 function getStackAddendum() {

--- a/packages/react-dom/src/shared/assertValidProps.js
+++ b/packages/react-dom/src/shared/assertValidProps.js
@@ -8,6 +8,7 @@
 'use strict';
 
 var invariant = require('fbjs/lib/invariant');
+
 var voidElementTags = require('./voidElementTags');
 
 if (__DEV__) {

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -7,15 +7,15 @@
 
 'use strict';
 
-var BrowserEventConstants = require('../events/BrowserEventConstants');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var ReactFiberTreeReflection = require('shared/ReactFiberTreeReflection');
 var ReactInstanceMap = require('shared/ReactInstanceMap');
 var ReactTypeOfWork = require('shared/ReactTypeOfWork');
 var SyntheticEvent = require('events/SyntheticEvent');
-
 var invariant = require('fbjs/lib/invariant');
+
+var BrowserEventConstants = require('../events/BrowserEventConstants');
 
 var {findDOMNode} = ReactDOM;
 var {

--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -8,22 +8,6 @@
  */
 'use strict';
 
-const ReactNativeAttributePayload = require('./ReactNativeAttributePayload');
-
-// Module provided by RN:
-const TextInputState = require('TextInputState');
-const UIManager = require('UIManager');
-
-const invariant = require('fbjs/lib/invariant');
-const findNodeHandle = require('./findNodeHandle');
-const findNumericNodeHandle = require('./findNumericNodeHandle');
-
-const {
-  mountSafeCallback,
-  throwOnStylesProp,
-  warnForStyleProps,
-} = require('./NativeMethodsMixinUtils');
-
 import type {
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
@@ -31,6 +15,20 @@ import type {
   NativeMethodsMixinType,
   ReactNativeBaseComponentViewConfig,
 } from './ReactNativeTypes';
+
+const invariant = require('fbjs/lib/invariant');
+// Modules provided by RN:
+const TextInputState = require('TextInputState');
+const UIManager = require('UIManager');
+
+const ReactNativeAttributePayload = require('./ReactNativeAttributePayload');
+const {
+  mountSafeCallback,
+  throwOnStylesProp,
+  warnForStyleProps,
+} = require('./NativeMethodsMixinUtils');
+const findNodeHandle = require('./findNodeHandle');
+const findNumericNodeHandle = require('./findNumericNodeHandle');
 
 /**
  * `NativeMethodsMixin` provides methods to access the underlying native

--- a/packages/react-native-renderer/src/ReactNativeAttributePayload.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayload.js
@@ -8,11 +8,11 @@
  */
 'use strict';
 
-var ReactNativePropRegistry = require('./ReactNativePropRegistry');
-
-// Module provided by RN:
+// Modules provided by RN:
 var deepDiffer = require('deepDiffer');
 var flattenStyle = require('flattenStyle');
+
+var ReactNativePropRegistry = require('./ReactNativePropRegistry');
 
 var emptyObject = {};
 

--- a/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
+++ b/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
@@ -8,14 +8,14 @@
  */
 'use strict';
 
+import type {ReactNativeBaseComponentViewConfig} from './ReactNativeTypes';
+
 const EventPropagators = require('events/EventPropagators');
 const SyntheticEvent = require('events/SyntheticEvent');
 const invariant = require('fbjs/lib/invariant');
 
 const customBubblingEventTypes = {};
 const customDirectEventTypes = {};
-
-import type {ReactNativeBaseComponentViewConfig} from './ReactNativeTypes';
 
 const ReactNativeBridgeEventPlugin = {
   eventTypes: {},

--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -10,18 +10,6 @@
 
 'use strict';
 
-const React = require('react');
-const ReactNativeAttributePayload = require('./ReactNativeAttributePayload');
-
-// Modules provided by RN:
-const TextInputState = require('TextInputState');
-const UIManager = require('UIManager');
-
-const findNodeHandle = require('./findNodeHandle');
-const findNumericNodeHandle = require('./findNumericNodeHandle');
-
-const {mountSafeCallback} = require('./NativeMethodsMixinUtils');
-
 import type {
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
@@ -29,6 +17,16 @@ import type {
   NativeMethodsMixinType,
   ReactNativeBaseComponentViewConfig,
 } from './ReactNativeTypes';
+
+const React = require('react');
+// Modules provided by RN:
+const TextInputState = require('TextInputState');
+const UIManager = require('UIManager');
+
+const ReactNativeAttributePayload = require('./ReactNativeAttributePayload');
+const {mountSafeCallback} = require('./NativeMethodsMixinUtils');
+const findNodeHandle = require('./findNodeHandle');
+const findNumericNodeHandle = require('./findNumericNodeHandle');
 
 /**
  * Superclass that provides methods to access the underlying native component.

--- a/packages/react-native-renderer/src/ReactNativeEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactNativeEventEmitter.js
@@ -11,9 +11,10 @@
 var EventPluginHub = require('events/EventPluginHub');
 var EventPluginRegistry = require('events/EventPluginRegistry');
 var ReactEventEmitterMixin = require('events/ReactEventEmitterMixin');
+var ReactGenericBatching = require('events/ReactGenericBatching');
+
 var ReactNativeComponentTree = require('./ReactNativeComponentTree');
 var ReactNativeTagHandles = require('./ReactNativeTagHandles');
-var ReactGenericBatching = require('events/ReactGenericBatching');
 
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');

--- a/packages/react-native-renderer/src/ReactNativeFiberErrorDialog.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberErrorDialog.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
+import type {CapturedError} from 'react-reconciler/src/ReactFiberScheduler';
+
 // Module provided by RN:
 const ExceptionsManager = require('ExceptionsManager');
-
-import type {CapturedError} from 'react-reconciler/src/ReactFiberScheduler';
 
 /**
  * Intercept lifecycle errors and ensure they are shown with the correct stack

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -9,17 +9,6 @@
 
 'use strict';
 
-var ReactNativeAttributePayload = require('./ReactNativeAttributePayload');
-
-// Modules provided by RN:
-var TextInputState = require('TextInputState');
-var UIManager = require('UIManager');
-
-var {
-  mountSafeCallback,
-  warnForStyleProps,
-} = require('./NativeMethodsMixinUtils');
-
 import type {
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
@@ -28,6 +17,16 @@ import type {
   ReactNativeBaseComponentViewConfig,
 } from './ReactNativeTypes';
 import type {Instance} from './ReactNativeFiberRenderer';
+
+// Modules provided by RN:
+var TextInputState = require('TextInputState');
+var UIManager = require('UIManager');
+
+var ReactNativeAttributePayload = require('./ReactNativeAttributePayload');
+var {
+  mountSafeCallback,
+  warnForStyleProps,
+} = require('./NativeMethodsMixinUtils');
 
 /**
  * This component defines the same methods as NativeMethodsMixin but without the

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -8,21 +8,20 @@
  */
 'use strict';
 
-const ReactNativeComponentTree = require('./ReactNativeComponentTree');
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
+
 const ReactFiberTreeReflection = require('shared/ReactFiberTreeReflection');
 const getComponentName = require('shared/getComponentName');
-const emptyObject = require('fbjs/lib/emptyObject');
 const ReactTypeOfWork = require('shared/ReactTypeOfWork');
+const emptyObject = require('fbjs/lib/emptyObject');
 const invariant = require('fbjs/lib/invariant');
-
+const {findCurrentFiberUsingSlowPath} = ReactFiberTreeReflection;
+const {HostComponent} = ReactTypeOfWork;
 // Module provided by RN:
 const UIManager = require('UIManager');
 
+const ReactNativeComponentTree = require('./ReactNativeComponentTree');
 const {getClosestInstanceFromNode} = ReactNativeComponentTree;
-const {findCurrentFiberUsingSlowPath} = ReactFiberTreeReflection;
-const {HostComponent} = ReactTypeOfWork;
-
-import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
 let getInspectorDataForViewTag;
 

--- a/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
@@ -9,21 +9,25 @@
 
 'use strict';
 
+import type {ReactNativeBaseComponentViewConfig} from './ReactNativeTypes';
+
 const ReactFiberReconciler = require('react-reconciler');
+const emptyObject = require('fbjs/lib/emptyObject');
+const invariant = require('fbjs/lib/invariant');
+// Modules provided by RN:
+const UIManager = require('UIManager');
+const deepFreezeAndThrowOnMutationInDev = require('deepFreezeAndThrowOnMutationInDev');
+
 const ReactNativeAttributePayload = require('./ReactNativeAttributePayload');
 const ReactNativeComponentTree = require('./ReactNativeComponentTree');
 const ReactNativeFiberHostComponent = require('./ReactNativeFiberHostComponent');
 const ReactNativeTagHandles = require('./ReactNativeTagHandles');
 const ReactNativeViewConfigRegistry = require('./ReactNativeViewConfigRegistry');
-
-// Modules provided by RN:
-const UIManager = require('UIManager');
-const deepFreezeAndThrowOnMutationInDev = require('deepFreezeAndThrowOnMutationInDev');
-
-const emptyObject = require('fbjs/lib/emptyObject');
-const invariant = require('fbjs/lib/invariant');
-
-import type {ReactNativeBaseComponentViewConfig} from './ReactNativeTypes';
+const {
+  precacheFiberNode,
+  uncacheFiberNode,
+  updateFiberProps,
+} = ReactNativeComponentTree;
 
 export type Container = number;
 export type Instance = {
@@ -33,12 +37,6 @@ export type Instance = {
 };
 export type Props = Object;
 export type TextInstance = number;
-
-const {
-  precacheFiberNode,
-  uncacheFiberNode,
-  updateFiberProps,
-} = ReactNativeComponentTree;
 
 function recursivelyUncacheFiberNode(node: Instance | TextInstance) {
   if (typeof node === 'number') {

--- a/packages/react-native-renderer/src/ReactNativeInjection.js
+++ b/packages/react-native-renderer/src/ReactNativeInjection.js
@@ -19,14 +19,15 @@ require('InitializeCore');
 
 var EventPluginHub = require('events/EventPluginHub');
 var EventPluginUtils = require('events/EventPluginUtils');
+var ResponderEventPlugin = require('events/ResponderEventPlugin');
 // Module provided by RN:
 var RCTEventEmitter = require('RCTEventEmitter');
+
 var ReactNativeBridgeEventPlugin = require('./ReactNativeBridgeEventPlugin');
 var ReactNativeComponentTree = require('./ReactNativeComponentTree');
 var ReactNativeEventEmitter = require('./ReactNativeEventEmitter');
 var ReactNativeEventPluginOrder = require('./ReactNativeEventPluginOrder');
 var ReactNativeGlobalResponderHandler = require('./ReactNativeGlobalResponderHandler');
-var ResponderEventPlugin = require('events/ResponderEventPlugin');
 
 /**
  * Register the event emitter with the native bridge

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -9,29 +9,27 @@
 
 'use strict';
 
+import type {ReactNativeType} from './ReactNativeTypes';
+import type {ReactNodeList} from 'shared/ReactTypes';
+
+require('./ReactNativeInjection');
+
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 const ReactFiberErrorLogger = require('react-reconciler/src/ReactFiberErrorLogger');
 const ReactPortal = require('react-reconciler/src/ReactPortal');
 const {
   injectInternals,
 } = require('react-reconciler/src/ReactFiberDevToolsHook');
-
 const ReactGenericBatching = require('events/ReactGenericBatching');
+const ReactVersion = require('shared/ReactVersion');
+// Module provided by RN:
+const UIManager = require('UIManager');
+
 const ReactNativeFiberErrorDialog = require('./ReactNativeFiberErrorDialog');
 const ReactNativeComponentTree = require('./ReactNativeComponentTree');
 const ReactNativeFiberRenderer = require('./ReactNativeFiberRenderer');
 const ReactNativeFiberInspector = require('./ReactNativeFiberInspector');
-const ReactVersion = require('shared/ReactVersion');
-
-// Module provided by RN:
-const UIManager = require('UIManager');
-
 const findNumericNodeHandle = require('./findNumericNodeHandle');
-
-import type {ReactNativeType} from './ReactNativeTypes';
-import type {ReactNodeList} from 'shared/ReactTypes';
-
-require('./ReactNativeInjection');
 
 ReactGenericBatching.injection.injectFiberBatchedUpdates(
   ReactNativeFiberRenderer.batchedUpdates,

--- a/packages/react-native-renderer/src/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native-renderer/src/ReactNativeViewConfigRegistry.js
@@ -9,12 +9,12 @@
 
 'use strict';
 
-const invariant = require('fbjs/lib/invariant');
-
 import type {
   ReactNativeBaseComponentViewConfig,
   ViewConfigGetter,
 } from './ReactNativeTypes';
+
+const invariant = require('fbjs/lib/invariant');
 
 const viewConfigCallbacks = new Map();
 const viewConfigs = new Map();

--- a/packages/react-native-renderer/src/createReactNativeComponentClass.js
+++ b/packages/react-native-renderer/src/createReactNativeComponentClass.js
@@ -9,9 +9,9 @@
 
 'use strict';
 
-const ReactNativeViewConfigRegistry = require('./ReactNativeViewConfigRegistry');
-
 import type {ViewConfigGetter} from './ReactNativeTypes';
+
+const ReactNativeViewConfigRegistry = require('./ReactNativeViewConfigRegistry');
 
 /**
  * Creates a renderable ReactNative host component.

--- a/packages/react-native-renderer/src/findNodeHandle.js
+++ b/packages/react-native-renderer/src/findNodeHandle.js
@@ -9,17 +9,18 @@
 
 'use strict';
 
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
+
 var ReactInstanceMap = require('shared/ReactInstanceMap');
-var ReactNativeFiberRenderer = require('./ReactNativeFiberRenderer');
 var {ReactCurrentOwner} = require('shared/ReactGlobalSharedState');
 var getComponentName = require('shared/getComponentName');
 var invariant = require('fbjs/lib/invariant');
 
+var ReactNativeFiberRenderer = require('./ReactNativeFiberRenderer');
+
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
 }
-
-import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
 /**
  * ReactNative vs ReactWeb

--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -19,13 +19,12 @@
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {UpdateQueue} from 'react-reconciler/src/ReactFiberUpdateQueue';
 
-var ReactFeatureFlags = require('shared/ReactFeatureFlags');
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 var ReactFiberInstrumentation = require('react-reconciler/src/ReactFiberInstrumentation');
 var ReactFiberReconciler = require('react-reconciler');
+var ReactFeatureFlags = require('shared/ReactFeatureFlags');
 var ReactInstanceMap = require('shared/ReactInstanceMap');
 var emptyObject = require('fbjs/lib/emptyObject');
-
 var expect = require('jest-matchers');
 
 const UPDATE_SIGNAL = {};

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -16,19 +16,20 @@ import type {
   ExpirationTime,
 } from 'react-reconciler/src/ReactFiberExpirationTime';
 
-var {REACT_COROUTINE_TYPE, REACT_YIELD_TYPE} = require('./ReactCoroutine');
-var {REACT_PORTAL_TYPE} = require('./ReactPortal');
-
-var ReactFiber = require('./ReactFiber');
 var ReactTypeOfSideEffect = require('shared/ReactTypeOfSideEffect');
 var ReactTypeOfWork = require('shared/ReactTypeOfWork');
-
 var emptyObject = require('fbjs/lib/emptyObject');
 var invariant = require('fbjs/lib/invariant');
 
+var {REACT_COROUTINE_TYPE, REACT_YIELD_TYPE} = require('./ReactCoroutine');
+var {REACT_PORTAL_TYPE} = require('./ReactPortal');
+var ReactFiber = require('./ReactFiber');
+
 if (__DEV__) {
-  var {getCurrentFiberStackAddendum} = require('./ReactDebugCurrentFiber');
   var warning = require('fbjs/lib/warning');
+
+  var {getCurrentFiberStackAddendum} = require('./ReactDebugCurrentFiber');
+
   var didWarnAboutMaps = false;
   /**
    * Warn if there's no key explicitly set on dynamic arrays of children or

--- a/packages/react-reconciler/src/ReactDebugCurrentFiber.js
+++ b/packages/react-reconciler/src/ReactDebugCurrentFiber.js
@@ -9,10 +9,6 @@
 
 'use strict';
 
-import type {Fiber} from './ReactFiber';
-
-type LifeCyclePhase = 'render' | 'getChildContext';
-
 var {ReactDebugCurrentFrame} = require('shared/ReactGlobalSharedState');
 
 if (__DEV__) {
@@ -21,6 +17,10 @@ if (__DEV__) {
     getStackAddendumByWorkInProgressFiber,
   } = require('shared/ReactFiberComponentTreeHook');
 }
+
+import type {Fiber} from './ReactFiber';
+
+type LifeCyclePhase = 'render' | 'getChildContext';
 
 function getCurrentFiberOwnerName(): string | null {
   if (__DEV__) {

--- a/packages/react-reconciler/src/ReactDebugFiberPerf.js
+++ b/packages/react-reconciler/src/ReactDebugFiberPerf.js
@@ -9,6 +9,9 @@
 
 import type {Fiber} from './ReactFiber';
 
+// Trust the developer to only use this with a __DEV__ check
+let ReactDebugFiberPerf = ((null: any): typeof ReactDebugFiberPerf);
+
 type MeasurementPhase =
   | 'componentWillMount'
   | 'componentWillUnmount'
@@ -19,10 +22,8 @@ type MeasurementPhase =
   | 'componentDidMount'
   | 'getChildContext';
 
-// Trust the developer to only use this with a __DEV__ check
-let ReactDebugFiberPerf = ((null: any): typeof ReactDebugFiberPerf);
-
 if (__DEV__) {
+  const getComponentName = require('shared/getComponentName');
   const {
     HostRoot,
     HostComponent,
@@ -31,8 +32,6 @@ if (__DEV__) {
     YieldComponent,
     Fragment,
   } = require('shared/ReactTypeOfWork');
-
-  const getComponentName = require('shared/getComponentName');
 
   // Prefix measurements so that it's possible to filter them.
   // Longer prefixes are hard to read in DevTools.

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -22,6 +22,8 @@ import type {TypeOfSideEffect} from 'shared/ReactTypeOfSideEffect';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {UpdateQueue} from './ReactFiberUpdateQueue';
 
+var invariant = require('fbjs/lib/invariant');
+var {NoEffect} = require('shared/ReactTypeOfSideEffect');
 var {
   IndeterminateComponent,
   ClassComponent,
@@ -35,15 +37,11 @@ var {
 } = require('shared/ReactTypeOfWork');
 
 var {NoWork} = require('./ReactFiberExpirationTime');
-
 var {NoContext} = require('./ReactTypeOfInternalContext');
-
-var {NoEffect} = require('shared/ReactTypeOfSideEffect');
-
-var invariant = require('fbjs/lib/invariant');
 
 if (__DEV__) {
   var getComponentName = require('shared/getComponentName');
+
   var hasBadMapPolyfill = false;
   try {
     const nonExtensibleObject = Object.preventExtensions({});

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -18,22 +18,6 @@ import type {FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
 var {
-  mountChildFibersInPlace,
-  reconcileChildFibers,
-  reconcileChildFibersInPlace,
-  cloneChildFibers,
-} = require('./ReactChildFiber');
-var {processUpdateQueue} = require('./ReactFiberUpdateQueue');
-var ReactTypeOfWork = require('shared/ReactTypeOfWork');
-var {
-  getMaskedContext,
-  getUnmaskedContext,
-  hasContextChanged,
-  pushContextProvider,
-  pushTopLevelContextObject,
-  invalidateContextProvider,
-} = require('./ReactFiberContext');
-var {
   IndeterminateComponent,
   FunctionalComponent,
   ClassComponent,
@@ -45,8 +29,7 @@ var {
   CoroutineHandlerPhase,
   YieldComponent,
   Fragment,
-} = ReactTypeOfWork;
-var {NoWork, Never} = require('./ReactFiberExpirationTime');
+} = require('shared/ReactTypeOfWork');
 var {
   PerformedWork,
   Placement,
@@ -54,14 +37,32 @@ var {
   Err,
   Ref,
 } = require('shared/ReactTypeOfSideEffect');
-var ReactFiberClassComponent = require('./ReactFiberClassComponent');
 var {ReactCurrentOwner} = require('shared/ReactGlobalSharedState');
 var invariant = require('fbjs/lib/invariant');
 
+var ReactFiberClassComponent = require('./ReactFiberClassComponent');
+var {
+  mountChildFibersInPlace,
+  reconcileChildFibers,
+  reconcileChildFibersInPlace,
+  cloneChildFibers,
+} = require('./ReactChildFiber');
+var {processUpdateQueue} = require('./ReactFiberUpdateQueue');
+var {
+  getMaskedContext,
+  getUnmaskedContext,
+  hasContextChanged,
+  pushContextProvider,
+  pushTopLevelContextObject,
+  invalidateContextProvider,
+} = require('./ReactFiberContext');
+var {NoWork, Never} = require('./ReactFiberExpirationTime');
+
 if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+
   var ReactDebugCurrentFiber = require('./ReactDebugCurrentFiber');
   var {cancelWorkTimer} = require('./ReactDebugFiberPerf');
-  var warning = require('fbjs/lib/warning');
 
   var warnedAboutStatelessRefs = {};
 }

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -13,10 +13,15 @@ import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
 var {Update} = require('shared/ReactTypeOfSideEffect');
-
 var ReactFeatureFlags = require('shared/ReactFeatureFlags');
-var {AsyncUpdates} = require('./ReactTypeOfInternalContext');
+var {isMounted} = require('shared/ReactFiberTreeReflection');
+var ReactInstanceMap = require('shared/ReactInstanceMap');
+var emptyObject = require('fbjs/lib/emptyObject');
+var getComponentName = require('shared/getComponentName');
+var shallowEqual = require('fbjs/lib/shallowEqual');
+var invariant = require('fbjs/lib/invariant');
 
+var {AsyncUpdates} = require('./ReactTypeOfInternalContext');
 var {
   cacheContext,
   getMaskedContext,
@@ -28,19 +33,15 @@ var {
   processUpdateQueue,
 } = require('./ReactFiberUpdateQueue');
 var {hasContextChanged} = require('./ReactFiberContext');
-var {isMounted} = require('shared/ReactFiberTreeReflection');
-var ReactInstanceMap = require('shared/ReactInstanceMap');
-var emptyObject = require('fbjs/lib/emptyObject');
-var getComponentName = require('shared/getComponentName');
-var shallowEqual = require('fbjs/lib/shallowEqual');
-var invariant = require('fbjs/lib/invariant');
 
 const fakeInternalInstance = {};
 const isArray = Array.isArray;
 
 if (__DEV__) {
-  var {startPhaseTimer, stopPhaseTimer} = require('./ReactDebugFiberPerf');
   var warning = require('fbjs/lib/warning');
+
+  var {startPhaseTimer, stopPhaseTimer} = require('./ReactDebugFiberPerf');
+
   var warnOnInvalidCallback = function(callback: mixed, callerName: string) {
     warning(
       callback === null || typeof callback === 'function',

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -22,17 +22,16 @@ var {
   HostPortal,
   CoroutineComponent,
 } = ReactTypeOfWork;
-var {commitCallbacks} = require('./ReactFiberUpdateQueue');
-var {onCommitUnmount} = require('./ReactFiberDevToolsHook');
 var {
   invokeGuardedCallback,
   hasCaughtError,
   clearCaughtError,
 } = require('shared/ReactErrorUtils');
-
 var {Placement, Update, ContentReset} = require('shared/ReactTypeOfSideEffect');
-
 var invariant = require('fbjs/lib/invariant');
+
+var {commitCallbacks} = require('./ReactFiberUpdateQueue');
+var {onCommitUnmount} = require('./ReactFiberDevToolsHook');
 
 if (__DEV__) {
   var {startPhaseTimer, stopPhaseTimer} = require('./ReactDebugFiberPerf');

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -17,15 +17,7 @@ import type {HostContext} from './ReactFiberHostContext';
 import type {HydrationContext} from './ReactFiberHydrationContext';
 import type {FiberRoot} from './ReactFiberRoot';
 
-var {reconcileChildFibers} = require('./ReactChildFiber');
-var {
-  popContextProvider,
-  popTopLevelContextObject,
-} = require('./ReactFiberContext');
 var ReactFeatureFlags = require('shared/ReactFeatureFlags');
-var ReactTypeOfWork = require('shared/ReactTypeOfWork');
-var ReactTypeOfSideEffect = require('shared/ReactTypeOfSideEffect');
-var ReactFiberExpirationTime = require('./ReactFiberExpirationTime');
 var {
   IndeterminateComponent,
   FunctionalComponent,
@@ -38,11 +30,16 @@ var {
   CoroutineHandlerPhase,
   YieldComponent,
   Fragment,
-} = ReactTypeOfWork;
-var {Placement, Ref, Update} = ReactTypeOfSideEffect;
-var {Never} = ReactFiberExpirationTime;
-
+} = require('shared/ReactTypeOfWork');
+var {Placement, Ref, Update} = require('shared/ReactTypeOfSideEffect');
 var invariant = require('fbjs/lib/invariant');
+
+var {reconcileChildFibers} = require('./ReactChildFiber');
+var {
+  popContextProvider,
+  popTopLevelContextObject,
+} = require('./ReactFiberContext');
+var {Never} = require('./ReactFiberExpirationTime');
 
 module.exports = function<T, P, I, TI, PI, C, CC, CX, PL>(
   config: HostConfig<T, P, I, TI, PI, C, CC, CX, PL>,

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -12,18 +12,21 @@
 import type {Fiber} from './ReactFiber';
 import type {StackCursor} from './ReactFiberStack';
 
-var emptyObject = require('fbjs/lib/emptyObject');
-var getComponentName = require('shared/getComponentName');
-var invariant = require('fbjs/lib/invariant');
 var {isFiberMounted} = require('shared/ReactFiberTreeReflection');
 var {ClassComponent, HostRoot} = require('shared/ReactTypeOfWork');
+var getComponentName = require('shared/getComponentName');
+var emptyObject = require('fbjs/lib/emptyObject');
+var invariant = require('fbjs/lib/invariant');
+
 const {createCursor, pop, push} = require('./ReactFiberStack');
 
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
   var checkPropTypes = require('prop-types/checkPropTypes');
+
   var ReactDebugCurrentFiber = require('./ReactDebugCurrentFiber');
   var {startPhaseTimer, stopPhaseTimer} = require('./ReactDebugFiberPerf');
+
   var warnedAboutMissingGetChildContext = {};
 }
 

--- a/packages/react-reconciler/src/ReactFiberErrorLogger.js
+++ b/packages/react-reconciler/src/ReactFiberErrorLogger.js
@@ -9,9 +9,9 @@
 
 'use strict';
 
-const invariant = require('fbjs/lib/invariant');
-
 import type {CapturedError} from './ReactFiberScheduler';
+
+const invariant = require('fbjs/lib/invariant');
 
 const defaultShowDialog = (capturedError: CapturedError) => true;
 

--- a/packages/react-reconciler/src/ReactFiberHostContext.js
+++ b/packages/react-reconciler/src/ReactFiberHostContext.js
@@ -13,9 +13,9 @@ import type {HostConfig} from 'react-reconciler';
 import type {Fiber} from './ReactFiber';
 import type {StackCursor} from './ReactFiberStack';
 
-const {createCursor, pop, push} = require('./ReactFiberStack');
-
 const invariant = require('fbjs/lib/invariant');
+
+const {createCursor, pop, push} = require('./ReactFiberStack');
 
 declare class NoContextT {}
 const NO_CONTEXT: NoContextT = ({}: any);

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -12,10 +12,9 @@
 import type {HostConfig} from 'react-reconciler';
 import type {Fiber} from './ReactFiber';
 
-var invariant = require('fbjs/lib/invariant');
-
 const {HostComponent, HostText, HostRoot} = require('shared/ReactTypeOfWork');
 const {Deletion, Placement} = require('shared/ReactTypeOfSideEffect');
+var invariant = require('fbjs/lib/invariant');
 
 const {createFiberFromHostInstanceForDeletion} = require('./ReactFiber');
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -14,6 +14,10 @@ import type {FiberRoot} from './ReactFiberRoot';
 import type {ReactNodeList} from 'shared/ReactTypes';
 
 var ReactFeatureFlags = require('shared/ReactFeatureFlags');
+var ReactInstanceMap = require('shared/ReactInstanceMap');
+var {HostComponent} = require('shared/ReactTypeOfWork');
+var emptyObject = require('fbjs/lib/emptyObject');
+
 var {
   findCurrentUnmaskedContext,
   isContextProvider,
@@ -21,16 +25,15 @@ var {
 } = require('./ReactFiberContext');
 var {createFiberRoot} = require('./ReactFiberRoot');
 var ReactFiberScheduler = require('./ReactFiberScheduler');
-var ReactInstanceMap = require('shared/ReactInstanceMap');
-var {HostComponent} = require('shared/ReactTypeOfWork');
 var {insertUpdateIntoFiber} = require('./ReactFiberUpdateQueue');
-var emptyObject = require('fbjs/lib/emptyObject');
 
 if (__DEV__) {
+  var getComponentName = require('shared/getComponentName');
   var warning = require('fbjs/lib/warning');
+
   var ReactFiberInstrumentation = require('./ReactFiberInstrumentation');
   var ReactDebugCurrentFiber = require('./ReactDebugCurrentFiber');
-  var getComponentName = require('shared/getComponentName');
+
   var didWarnAboutNestedUpdates = false;
 }
 

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -15,6 +15,57 @@ import type {FiberRoot} from './ReactFiberRoot';
 import type {HydrationContext} from './ReactFiberHydrationContext';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
+var {
+  getStackAddendumByWorkInProgressFiber,
+} = require('shared/ReactFiberComponentTreeHook');
+var {
+  invokeGuardedCallback,
+  hasCaughtError,
+  clearCaughtError,
+} = require('shared/ReactErrorUtils');
+var {ReactCurrentOwner} = require('shared/ReactGlobalSharedState');
+var getComponentName = require('shared/getComponentName');
+var {
+  PerformedWork,
+  Placement,
+  Update,
+  PlacementAndUpdate,
+  Deletion,
+  ContentReset,
+  Callback,
+  Err,
+  Ref,
+} = require('shared/ReactTypeOfSideEffect');
+var {
+  HostRoot,
+  HostComponent,
+  HostPortal,
+  ClassComponent,
+} = require('shared/ReactTypeOfWork');
+var invariant = require('fbjs/lib/invariant');
+
+var ReactFiberBeginWork = require('./ReactFiberBeginWork');
+var ReactFiberCompleteWork = require('./ReactFiberCompleteWork');
+var ReactFiberCommitWork = require('./ReactFiberCommitWork');
+var ReactFiberHostContext = require('./ReactFiberHostContext');
+var ReactFiberHydrationContext = require('./ReactFiberHydrationContext');
+var {popContextProvider} = require('./ReactFiberContext');
+const {reset} = require('./ReactFiberStack');
+var {logCapturedError} = require('./ReactFiberErrorLogger');
+var {createWorkInProgress} = require('./ReactFiber');
+var {onCommitRoot} = require('./ReactFiberDevToolsHook');
+var {
+  NoWork,
+  Task,
+  Sync,
+  Never,
+  msToExpirationTime,
+  computeExpirationBucket,
+} = require('./ReactFiberExpirationTime');
+var {AsyncUpdates} = require('./ReactTypeOfInternalContext');
+var {getUpdateExpirationTime} = require('./ReactFiberUpdateQueue');
+var {resetContext} = require('./ReactFiberContext');
+
 export type CapturedError = {
   componentName: ?string,
   componentStack: string,
@@ -29,67 +80,9 @@ export type HandleErrorInfo = {
   componentStack: string,
 };
 
-var {popContextProvider} = require('./ReactFiberContext');
-const {reset} = require('./ReactFiberStack');
-var {
-  getStackAddendumByWorkInProgressFiber,
-} = require('shared/ReactFiberComponentTreeHook');
-var {logCapturedError} = require('./ReactFiberErrorLogger');
-var {
-  invokeGuardedCallback,
-  hasCaughtError,
-  clearCaughtError,
-} = require('shared/ReactErrorUtils');
-
-var ReactFiberBeginWork = require('./ReactFiberBeginWork');
-var ReactFiberCompleteWork = require('./ReactFiberCompleteWork');
-var ReactFiberCommitWork = require('./ReactFiberCommitWork');
-var ReactFiberHostContext = require('./ReactFiberHostContext');
-var ReactFiberHydrationContext = require('./ReactFiberHydrationContext');
-var {ReactCurrentOwner} = require('shared/ReactGlobalSharedState');
-var getComponentName = require('shared/getComponentName');
-
-var {createWorkInProgress} = require('./ReactFiber');
-var {onCommitRoot} = require('./ReactFiberDevToolsHook');
-
-var {
-  NoWork,
-  Task,
-  Sync,
-  Never,
-  msToExpirationTime,
-  computeExpirationBucket,
-} = require('./ReactFiberExpirationTime');
-
-var {AsyncUpdates} = require('./ReactTypeOfInternalContext');
-
-var {
-  PerformedWork,
-  Placement,
-  Update,
-  PlacementAndUpdate,
-  Deletion,
-  ContentReset,
-  Callback,
-  Err,
-  Ref,
-} = require('shared/ReactTypeOfSideEffect');
-
-var {
-  HostRoot,
-  HostComponent,
-  HostPortal,
-  ClassComponent,
-} = require('shared/ReactTypeOfWork');
-
-var {getUpdateExpirationTime} = require('./ReactFiberUpdateQueue');
-
-var {resetContext} = require('./ReactFiberContext');
-
-var invariant = require('fbjs/lib/invariant');
-
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
+
   var ReactFiberInstrumentation = require('./ReactFiberInstrumentation');
   var ReactDebugCurrentFiber = require('./ReactDebugCurrentFiber');
   var {

--- a/packages/react-reconciler/src/ReactFiberUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberUpdateQueue.js
@@ -13,12 +13,10 @@ import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
 const {Callback: CallbackEffect} = require('shared/ReactTypeOfSideEffect');
+const {ClassComponent, HostRoot} = require('shared/ReactTypeOfWork');
+const invariant = require('fbjs/lib/invariant');
 
 const {NoWork} = require('./ReactFiberExpirationTime');
-
-const {ClassComponent, HostRoot} = require('shared/ReactTypeOfWork');
-
-const invariant = require('fbjs/lib/invariant');
 
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');

--- a/packages/react-rt-renderer/src/ReactNativeRT.js
+++ b/packages/react-rt-renderer/src/ReactNativeRT.js
@@ -9,6 +9,9 @@
 
 'use strict';
 
+import type {ReactNativeRTType} from './ReactNativeRTTypes';
+import type {ReactNodeList} from 'shared/ReactTypes';
+
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 const ReactFiberErrorLogger = require('react-reconciler/src/ReactFiberErrorLogger');
 const ReactNativeFiberErrorDialog = require('react-native-renderer/src/ReactNativeFiberErrorDialog');
@@ -16,15 +19,12 @@ const ReactPortal = require('react-reconciler/src/ReactPortal');
 const {
   injectInternals,
 } = require('react-reconciler/src/ReactFiberDevToolsHook');
-
 const ReactGenericBatching = require('events/ReactGenericBatching');
+const ReactVersion = require('shared/ReactVersion');
+
 const ReactNativeRTComponentTree = require('./ReactNativeRTComponentTree');
 const ReactNativeRTFiberRenderer = require('./ReactNativeRTFiberRenderer');
 const ReactNativeRTFiberInspector = require('./ReactNativeRTFiberInspector');
-const ReactVersion = require('shared/ReactVersion');
-
-import type {ReactNativeRTType} from './ReactNativeRTTypes';
-import type {ReactNodeList} from 'shared/ReactTypes';
 
 /**
  * Make sure essential globals are available and are patched correctly. Please don't remove this

--- a/packages/react-rt-renderer/src/ReactNativeRTEventEmitter.js
+++ b/packages/react-rt-renderer/src/ReactNativeRTEventEmitter.js
@@ -8,11 +8,11 @@
  */
 'use strict';
 
-var ReactNativeRTComponentTree = require('./ReactNativeRTComponentTree');
 var ReactGenericBatching = require('events/ReactGenericBatching');
-
 // Module provided by RN:
 var BatchedBridge = require('BatchedBridge');
+
+var ReactNativeRTComponentTree = require('./ReactNativeRTComponentTree');
 
 var ReactNativeRTEventEmitter = {
   /**

--- a/packages/react-rt-renderer/src/ReactNativeRTFiberInspector.js
+++ b/packages/react-rt-renderer/src/ReactNativeRTFiberInspector.js
@@ -8,16 +8,16 @@
  */
 'use strict';
 
-const ReactNativeRTComponentTree = require('./ReactNativeRTComponentTree');
 const ReactFiberTreeReflection = require('shared/ReactFiberTreeReflection');
 const getComponentName = require('shared/getComponentName');
-const emptyObject = require('fbjs/lib/emptyObject');
 const ReactTypeOfWork = require('shared/ReactTypeOfWork');
+const emptyObject = require('fbjs/lib/emptyObject');
 const invariant = require('fbjs/lib/invariant');
-
-const {getFiberFromTag} = ReactNativeRTComponentTree;
 const {findCurrentFiberUsingSlowPath} = ReactFiberTreeReflection;
 const {HostComponent} = ReactTypeOfWork;
+
+const ReactNativeRTComponentTree = require('./ReactNativeRTComponentTree');
+const {getFiberFromTag} = ReactNativeRTComponentTree;
 
 let getInspectorDataForViewTag;
 

--- a/packages/react-rt-renderer/src/ReactNativeRTFiberRenderer.js
+++ b/packages/react-rt-renderer/src/ReactNativeRTFiberRenderer.js
@@ -10,14 +10,13 @@
 'use strict';
 
 const ReactFiberReconciler = require('react-reconciler');
-const ReactNativeRTComponentTree = require('./ReactNativeRTComponentTree');
-const ReactNativeRTTagHandles = require('./ReactNativeRTTagHandles');
-
+const emptyObject = require('fbjs/lib/emptyObject');
+const invariant = require('fbjs/lib/invariant');
 // Module provided by RN:
 const RTManager = require('RTManager');
 
-const emptyObject = require('fbjs/lib/emptyObject');
-const invariant = require('fbjs/lib/invariant');
+const ReactNativeRTComponentTree = require('./ReactNativeRTComponentTree');
+const ReactNativeRTTagHandles = require('./ReactNativeRTTagHandles');
 
 export type Container = number;
 export type Instance = number;

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -8,14 +8,12 @@
 
 'use strict';
 
-const checkPropTypes = require('prop-types/checkPropTypes');
 const React = require('react');
-
-const emptyObject = require('fbjs/lib/emptyObject');
-const invariant = require('fbjs/lib/invariant');
-
 const describeComponentFrame = require('shared/describeComponentFrame');
 const getComponentName = require('shared/getComponentName');
+const emptyObject = require('fbjs/lib/emptyObject');
+const invariant = require('fbjs/lib/invariant');
+const checkPropTypes = require('prop-types/checkPropTypes');
 
 class ReactShallowRenderer {
   static createRenderer = function() {

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -9,9 +9,12 @@
 
 'use strict';
 
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
+import type {FiberRoot} from 'react-reconciler/src/ReactFiberRoot';
+
 var ReactFiberReconciler = require('react-reconciler');
-var ReactFiberTreeReflection = require('shared/ReactFiberTreeReflection');
 var ReactGenericBatching = require('events/ReactGenericBatching');
+var ReactFiberTreeReflection = require('shared/ReactFiberTreeReflection');
 var emptyObject = require('fbjs/lib/emptyObject');
 var ReactTypeOfWork = require('shared/ReactTypeOfWork');
 var invariant = require('fbjs/lib/invariant');
@@ -23,9 +26,6 @@ var {
   HostText,
   HostRoot,
 } = ReactTypeOfWork;
-
-import type {Fiber} from 'react-reconciler/src/ReactFiber';
-import type {FiberRoot} from 'react-reconciler/src/ReactFiberRoot';
 
 type TestRendererOptions = {
   createNodeMock: (element: React$Element<any>) => any,

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -7,11 +7,11 @@
 
 'use strict';
 
+var ReactVersion = require('shared/ReactVersion');
+
 var ReactBaseClasses = require('./ReactBaseClasses');
 var ReactChildren = require('./ReactChildren');
 var ReactElement = require('./ReactElement');
-var ReactVersion = require('shared/ReactVersion');
-
 var onlyChild = require('./onlyChild');
 
 var createElement = ReactElement.createElement;

--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -7,11 +7,11 @@
 
 'use strict';
 
-var ReactNoopUpdateQueue = require('./ReactNoopUpdateQueue');
-
 var emptyObject = require('fbjs/lib/emptyObject');
 var invariant = require('fbjs/lib/invariant');
 var lowPriorityWarning = require('shared/lowPriorityWarning');
+
+var ReactNoopUpdateQueue = require('./ReactNoopUpdateQueue');
 
 /**
  * Base class helpers for the updating state of a component.

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -7,13 +7,14 @@
 
 'use strict';
 
-var ReactElement = require('./ReactElement');
-
 var emptyFunction = require('fbjs/lib/emptyFunction');
 var invariant = require('fbjs/lib/invariant');
 
+var ReactElement = require('./ReactElement');
+
 if (__DEV__) {
   var warning = require('fbjs/lib/warning');
+
   var {getStackAddendum} = require('./ReactDebugCurrentFrame');
 }
 

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -18,12 +18,13 @@ var ReactCurrentOwner = require('./ReactCurrentOwner');
 var ReactElement = require('./ReactElement');
 
 if (__DEV__) {
-  var ReactDebugCurrentFrame = require('./ReactDebugCurrentFrame');
-  var checkPropTypes = require('prop-types/checkPropTypes');
   var lowPriorityWarning = require('shared/lowPriorityWarning');
-  var warning = require('fbjs/lib/warning');
   var describeComponentFrame = require('shared/describeComponentFrame');
   var getComponentName = require('shared/getComponentName');
+  var checkPropTypes = require('prop-types/checkPropTypes');
+  var warning = require('fbjs/lib/warning');
+
+  var ReactDebugCurrentFrame = require('./ReactDebugCurrentFrame');
 
   var currentlyValidatingElement = null;
 

--- a/packages/react/src/onlyChild.js
+++ b/packages/react/src/onlyChild.js
@@ -6,9 +6,9 @@
  */
 'use strict';
 
-var ReactElement = require('./ReactElement');
-
 var invariant = require('fbjs/lib/invariant');
+
+var ReactElement = require('./ReactElement');
 
 /**
  * Returns the first child in a collection of children and verifies that there

--- a/packages/shared/ReactFiberComponentTreeHook.js
+++ b/packages/shared/ReactFiberComponentTreeHook.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
+
 var ReactTypeOfWork = require('./ReactTypeOfWork');
 var {
   IndeterminateComponent,
@@ -18,8 +20,6 @@ var {
 } = ReactTypeOfWork;
 var describeComponentFrame = require('./describeComponentFrame');
 var getComponentName = require('./getComponentName');
-
-import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
 function describeFiber(fiber: Fiber): string {
   switch (fiber.tag) {

--- a/packages/shared/ReactFiberTreeReflection.js
+++ b/packages/shared/ReactFiberTreeReflection.js
@@ -11,16 +11,11 @@
 
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
-var ReactInstanceMap = require('./ReactInstanceMap');
-var {ReactCurrentOwner} = require('./ReactGlobalSharedState');
-
-var getComponentName = require('./getComponentName');
 var invariant = require('fbjs/lib/invariant');
 
-if (__DEV__) {
-  var warning = require('fbjs/lib/warning');
-}
-
+var ReactInstanceMap = require('./ReactInstanceMap');
+var {ReactCurrentOwner} = require('./ReactGlobalSharedState');
+var getComponentName = require('./getComponentName');
 var {
   ClassComponent,
   HostComponent,
@@ -28,8 +23,11 @@ var {
   HostPortal,
   HostText,
 } = require('./ReactTypeOfWork');
-
 var {NoEffect, Placement} = require('./ReactTypeOfSideEffect');
+
+if (__DEV__) {
+  var warning = require('fbjs/lib/warning');
+}
 
 var MOUNTING = 1;
 var MOUNTED = 2;

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -1,200 +1,200 @@
 {
   "bundleSizes": {
     "react.development.js (UMD_DEV)": {
-      "size": 54574,
-      "gzip": 14304
+      "size": 54533,
+      "gzip": 14280
     },
     "react.production.min.js (UMD_PROD)": {
-      "size": 6634,
-      "gzip": 2764
+      "size": 6630,
+      "gzip": 2763
     },
     "react.development.js (NODE_DEV)": {
-      "size": 45478,
-      "gzip": 12054
+      "size": 45437,
+      "gzip": 12025
     },
     "react.production.min.js (NODE_PROD)": {
       "size": 5611,
       "gzip": 2364
     },
     "React-dev.js (FB_DEV)": {
-      "size": 42953,
-      "gzip": 11326
+      "size": 42912,
+      "gzip": 11311
     },
     "React-prod.js (FB_PROD)": {
       "size": 24830,
-      "gzip": 6718
+      "gzip": 6719
     },
     "react-dom.development.js (UMD_DEV)": {
-      "size": 628275,
-      "gzip": 144026
+      "size": 628548,
+      "gzip": 144062
     },
     "react-dom.production.min.js (UMD_PROD)": {
-      "size": 100910,
-      "gzip": 31885
+      "size": 100908,
+      "gzip": 31646
     },
     "react-dom.development.js (NODE_DEV)": {
-      "size": 590510,
-      "gzip": 135251
+      "size": 590784,
+      "gzip": 135367
     },
     "react-dom.production.min.js (NODE_PROD)": {
-      "size": 107143,
-      "gzip": 33563
+      "size": 107149,
+      "gzip": 33143
     },
     "ReactDOM-dev.js (FB_DEV)": {
-      "size": 590443,
-      "gzip": 135554
+      "size": 590759,
+      "gzip": 135629
     },
     "ReactDOM-prod.js (FB_PROD)": {
-      "size": 420794,
-      "gzip": 93574
+      "size": 421333,
+      "gzip": 93558
     },
     "react-dom-test-utils.development.js (NODE_DEV)": {
-      "size": 41554,
-      "gzip": 11082
+      "size": 41553,
+      "gzip": 11076
     },
     "react-dom-test-utils.production.min.js (NODE_PROD)": {
-      "size": 11608,
-      "gzip": 4241
+      "size": 11609,
+      "gzip": 4250
     },
     "ReactTestUtils-dev.js (FB_DEV)": {
-      "size": 41172,
-      "gzip": 11056
+      "size": 41171,
+      "gzip": 11041
     },
     "react-dom-unstable-native-dependencies.development.js (UMD_DEV)": {
       "size": 84862,
-      "gzip": 21266
+      "gzip": 21152
     },
     "react-dom-unstable-native-dependencies.production.min.js (UMD_PROD)": {
       "size": 14441,
-      "gzip": 4650
+      "gzip": 4652
     },
     "react-dom-unstable-native-dependencies.development.js (NODE_DEV)": {
       "size": 80643,
-      "gzip": 19931
+      "gzip": 19924
     },
     "react-dom-unstable-native-dependencies.production.min.js (NODE_PROD)": {
-      "size": 14003,
-      "gzip": 4510
+      "size": 14002,
+      "gzip": 4509
     },
     "ReactDOMUnstableNativeDependencies-dev.js (FB_DEV)": {
       "size": 80136,
-      "gzip": 19877
+      "gzip": 19870
     },
     "ReactDOMUnstableNativeDependencies-prod.js (FB_PROD)": {
       "size": 65144,
-      "gzip": 15540
+      "gzip": 15547
     },
     "react-dom-server.browser.development.js (UMD_DEV)": {
-      "size": 124580,
-      "gzip": 32216
+      "size": 124541,
+      "gzip": 32144
     },
     "react-dom-server.browser.production.min.js (UMD_PROD)": {
       "size": 15337,
-      "gzip": 5967
+      "gzip": 5975
     },
     "react-dom-server.browser.development.js (NODE_DEV)": {
-      "size": 94467,
-      "gzip": 25081
+      "size": 94428,
+      "gzip": 24913
     },
     "react-dom-server.browser.production.min.js (NODE_PROD)": {
-      "size": 15063,
-      "gzip": 5899
+      "size": 15066,
+      "gzip": 5893
     },
     "ReactDOMServer-dev.js (FB_DEV)": {
-      "size": 93901,
-      "gzip": 25000
+      "size": 93904,
+      "gzip": 24858
     },
     "ReactDOMServer-prod.js (FB_PROD)": {
-      "size": 42426,
-      "gzip": 11846
+      "size": 42609,
+      "gzip": 11796
     },
     "react-dom-server.node.development.js (NODE_DEV)": {
-      "size": 96739,
-      "gzip": 25630
+      "size": 96701,
+      "gzip": 25447
     },
     "react-dom-server.node.production.min.js (NODE_PROD)": {
-      "size": 15988,
-      "gzip": 6235
+      "size": 15991,
+      "gzip": 6227
     },
     "react-art.development.js (UMD_DEV)": {
-      "size": 374324,
-      "gzip": 82151
+      "size": 374492,
+      "gzip": 82196
     },
     "react-art.production.min.js (UMD_PROD)": {
       "size": 82762,
-      "gzip": 25775
+      "gzip": 25785
     },
     "react-art.development.js (NODE_DEV)": {
-      "size": 300081,
-      "gzip": 63132
+      "size": 300260,
+      "gzip": 63352
     },
     "react-art.production.min.js (NODE_PROD)": {
-      "size": 54393,
-      "gzip": 17033
+      "size": 54391,
+      "gzip": 17050
     },
     "ReactART-dev.js (FB_DEV)": {
-      "size": 298687,
-      "gzip": 63040
+      "size": 298866,
+      "gzip": 63281
     },
     "ReactART-prod.js (FB_PROD)": {
-      "size": 223978,
-      "gzip": 46012
+      "size": 223988,
+      "gzip": 45978
     },
     "ReactNativeRenderer-dev.js (RN_DEV)": {
-      "size": 286147,
-      "gzip": 49197
+      "size": 286160,
+      "gzip": 49086
     },
     "ReactNativeRenderer-prod.js (RN_PROD)": {
-      "size": 223837,
-      "gzip": 38577
+      "size": 223851,
+      "gzip": 38395
     },
     "ReactRTRenderer-dev.js (RN_DEV)": {
-      "size": 218004,
-      "gzip": 36738
+      "size": 218007,
+      "gzip": 36780
     },
     "ReactRTRenderer-prod.js (RN_PROD)": {
-      "size": 165480,
-      "gzip": 27593
+      "size": 165490,
+      "gzip": 27606
     },
     "ReactCSRenderer-dev.js (RN_DEV)": {
-      "size": 210411,
-      "gzip": 35016
+      "size": 210392,
+      "gzip": 35120
     },
     "ReactCSRenderer-prod.js (RN_PROD)": {
-      "size": 160471,
-      "gzip": 26308
+      "size": 160483,
+      "gzip": 26404
     },
     "react-test-renderer.development.js (NODE_DEV)": {
-      "size": 303938,
-      "gzip": 63567
+      "size": 304118,
+      "gzip": 63787
     },
     "react-test-renderer.production.min.js (NODE_PROD)": {
-      "size": 55986,
-      "gzip": 17251
+      "size": 55985,
+      "gzip": 17315
     },
     "ReactTestRenderer-dev.js (FB_DEV)": {
-      "size": 302534,
-      "gzip": 63485
+      "size": 302714,
+      "gzip": 63724
     },
     "react-test-renderer-shallow.development.js (NODE_DEV)": {
-      "size": 9290,
-      "gzip": 2321
+      "size": 9246,
+      "gzip": 2306
     },
     "react-test-renderer-shallow.production.min.js (NODE_PROD)": {
-      "size": 4630,
-      "gzip": 1665
+      "size": 4634,
+      "gzip": 1667
     },
     "ReactShallowRenderer-dev.js (FB_DEV)": {
-      "size": 9002,
-      "gzip": 2256
+      "size": 8958,
+      "gzip": 2250
     },
     "react-noop-renderer.development.js (NODE_DEV)": {
-      "size": 293219,
-      "gzip": 60806
+      "size": 293399,
+      "gzip": 61042
     },
     "react-reconciler.development.js (NODE_DEV)": {
-      "size": 278819,
-      "gzip": 57593
+      "size": 278999,
+      "gzip": 57818
     },
     "react-reconciler.production.min.js (NODE_PROD)": {
       "size": 38245,


### PR DESCRIPTION
I want to group package-level imports separately from imports reaching into other packages. I think this provides a better mental picture of what’s being shared between renderers. We were also sort of doing this with `fbjs` anyway before, now we just have more packages.

I think this is especially useful in DOM client code where there’s a mix of local DOM-specific `../events` and global `events/` references. Same with local `../shared` and global `shared/`.

In the past we used the “separate import” convention for lowercase modules like `isCustomElement` but I don’t see much sense in this grouping. It doesn’t convey a real semantic difference.

Finally, I don’t care too strongly about this. Not enough to enforce it via lint yet. But after ES modules are done, and we don‘t have weird `require`s in `__DEV__` blocks I’d be happy to automatically enforce it with an autofix lint rule that would run right before Prettier.

I verified FB and open source bundles still work.