### PR TITLE
Added naive scheduleDeferredCallback implementation for RN

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
@@ -13,6 +13,7 @@ const ReactFiberReconciler = require('react-reconciler');
 const ReactNativeAttributePayload = require('./ReactNativeAttributePayload');
 const ReactNativeComponentTree = require('./ReactNativeComponentTree');
 const ReactNativeFiberHostComponent = require('./ReactNativeFiberHostComponent');
+const ReactNativeFrameScheduling = require('./ReactNativeFrameScheduling');
 const ReactNativeTagHandles = require('./ReactNativeTagHandles');
 const ReactNativeViewConfigRegistry = require('./ReactNativeViewConfigRegistry');
 
@@ -159,6 +160,8 @@ const NativeRenderer = ReactFiberReconciler({
     return instance;
   },
 
+  now: ReactNativeFrameScheduling.now,
+
   prepareForCommit(): void {
     // Noop
   },
@@ -178,11 +181,11 @@ const NativeRenderer = ReactFiberReconciler({
     // Noop
   },
 
+  scheduleDeferredCallback: ReactNativeFrameScheduling.scheduleDeferredCallback,
+
   shouldDeprioritizeSubtree(type: string, props: Props): boolean {
     return false;
   },
-
-  scheduleDeferredCallback: global.requestIdleCallback,
 
   shouldSetTextContent(type: string, props: Props): boolean {
     // TODO (bvaughn) Revisit this decision.
@@ -195,11 +198,6 @@ const NativeRenderer = ReactFiberReconciler({
   },
 
   useSyncScheduling: true,
-
-  now(): number {
-    // TODO: Enable expiration by implementing this method.
-    return 0;
-  },
 
   mutation: {
     appendChild(

--- a/packages/react-native-renderer/src/ReactNativeFrameScheduling.js
+++ b/packages/react-native-renderer/src/ReactNativeFrameScheduling.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+import type {Deadline} from 'react-reconciler';
+
+const hasNativePerformanceNow =
+  typeof performance === 'object' && typeof performance.now === 'function';
+
+const now = hasNativePerformanceNow
+  ? () => performance.now()
+  : () => Date.now();
+
+type Callback = (deadline: Deadline) => void;
+
+let isCallbackScheduled: boolean = false;
+let scheduledCallback: Callback | null = null;
+let frameDeadline: number = 0;
+
+const frameDeadlineObject: Deadline = {
+  timeRemaining: () => frameDeadline - now(),
+};
+
+function setTimeoutCallback() {
+  isCallbackScheduled = false;
+
+  // TODO (bvaughn) Hard-coded 5ms unblocks initial async testing.
+  // React API probably changing to boolean rather than time remaining.
+  // Longer-term plan is to rewrite this using shared memory,
+  // And just return the value of the bit as the boolean.
+  frameDeadline = now() + 5;
+
+  const callback = scheduledCallback;
+  scheduledCallback = null;
+  if (callback !== null) {
+    callback(frameDeadlineObject);
+  }
+}
+
+// RN has a poor polyfill for requestIdleCallback so we aren't using it.
+// This implementation is only intended for short-term use anyway.
+// We also don't implement cancel functionality b'c Fiber doesn't currently need it.
+function scheduleDeferredCallback(callback: Callback): number {
+  // We assume only one callback is scheduled at a time b'c that's how Fiber works.
+  scheduledCallback = callback;
+
+  if (!isCallbackScheduled) {
+    isCallbackScheduled = true;
+    setTimeout(setTimeoutCallback, 1);
+  }
+
+  return 0;
+}
+
+module.exports = {
+  now,
+  scheduleDeferredCallback,
+};

--- a/scripts/rollup/shims/react-native/ReactNative.js
+++ b/scripts/rollup/shims/react-native/ReactNative.js
@@ -14,9 +14,9 @@ import type {ReactNativeType} from 'ReactNativeTypes';
 let ReactNative;
 
 if (__DEV__) {
-  ReactNative = require('ReactNativeFiber-dev');
+  ReactNative = require('ReactNativeRenderer-dev');
 } else {
-  ReactNative = require('ReactNativeFiber-prod');
+  ReactNative = require('ReactNativeRenderer-prod');
 }
 
 module.exports = (ReactNative: ReactNativeType);


### PR DESCRIPTION
This unblocks initial async testing.

Based on initial testing, I'll also be submitting a related PR for [React Native's `createAnimatedComponent`](https://github.com/facebook/react-native/blob/master/Libraries/Animated/src/createAnimatedComponent.js) to make it account for potential async behavior.

Also fixed up a small thing I noticed while syncing and testing- rename RN shim's `'ReactNativeFiber-*` exports to `ReactNativeRenderer-*`. This broke after the recent project cleanup/reorg.