### PR TITLE
[WIP] fix(SelectEventPlugin): reset mouseDown after drop event fires

### DIFF
--- a/packages/react-dom/src/events/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/SelectEventPlugin.js
@@ -196,6 +196,7 @@ var SelectEventPlugin = {
       // key, when multiple keydown events are fired but only one keyup is.
       // This is also our approach for IE handling, for the reason above.
       case 'topSelectionChange':
+        mouseDown = false;
         if (skipSelectionChangeEvent) {
           break;
         }


### PR DESCRIPTION
This PR most probably isn't ready, it's rather intended to fix (or at least highlight the problems of) https://github.com/facebook/react/issues/11379. The problem is that `mouseDown` never gets reset after the drop event, since this plugin never receives `topMouseUp` as `topLevelType` when dropping. 

What I did here fixes the problem, but I feel like the proper solution would be to make sure that the `topMouseUp` event is received.
