### PR TITLE
Rewrite ReactDOMComponentTree-test to test behavior using Public API

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
@@ -25,21 +25,17 @@ describe('ReactDOMComponentTree', () => {
     return instance.type;
   }
 
-  function getTextOf(instance) {
-    return instance.memoizedProps;
-  }
-
   function getInstanceFromNode(node) {
-    const instanceKey = Object
-        .keys(node)
-        .find(key => key.startsWith('__reactInternalInstance$'));
+    const instanceKey = Object.keys(node).find(key =>
+      key.startsWith('__reactInternalInstance$'),
+    );
     return node[instanceKey];
   }
 
   function getFiberPropsFromNode(node) {
-    const props = Object
-        .keys(node)
-        .find(key => key.startsWith('__reactEventHandlers$'));
+    const props = Object.keys(node).find(key =>
+      key.startsWith('__reactEventHandlers$'),
+    );
     return node[props];
   }
 
@@ -57,11 +53,10 @@ describe('ReactDOMComponentTree', () => {
     elem.dispatchEvent(event);
   }
 
-  const setUntrackedInputValue = Object
-    .getOwnPropertyDescriptor(
-      HTMLInputElement.prototype,
-      'value',
-    ).set;
+  const setUntrackedInputValue = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value',
+  ).set;
 
   beforeEach(() => {
     React = require('react');
@@ -102,25 +97,25 @@ describe('ReactDOMComponentTree', () => {
 
   it('finds closest instance for node when an event happens', done => {
     const elemID = 'aID';
-    const innerHTML = {__html: `<div id="${elemID}"></div>`}
+    const innerHTML = {__html: `<div id="${elemID}"></div>`};
 
     class ClosestInstance extends React.Component {
-      id = 'closestInstance'
+      id = 'closestInstance';
       _onClick = e => {
         const node = e.currentTarget;
         const instance = getInstanceFromNode(node);
         expect(instance).toBeDefined();
-        expect(getTypeOf(instance)).toBe('div')
+        expect(getTypeOf(instance)).toBe('div');
         expect(node.id).toBe(this.id);
         done();
-      }
+      };
       render() {
         return (
           <div
             id="closestInstance"
             onClick={this._onClick}
-            dangerouslySetInnerHTML={innerHTML}>
-          </div>
+            dangerouslySetInnerHTML={innerHTML}
+          />
         );
       }
     }
@@ -145,10 +140,10 @@ describe('ReactDOMComponentTree', () => {
         expect(node.value).toEqual(finishValue);
         const instance = getInstanceFromNode(node);
         expect(instance).toBeDefined();
-        expect(getTypeOf(instance)).toBe('input')
+        expect(getTypeOf(instance)).toBe('input');
         expect(node.id).toBe(inputID);
-        done()
-      }
+        done();
+      };
       render() {
         return (
           <div>
@@ -188,7 +183,7 @@ describe('ReactDOMComponentTree', () => {
           expect(updatedProps.value).toBe(finishValue);
           done();
         });
-      }
+      };
       render() {
         return (
           <div>

--- a/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
@@ -145,7 +145,6 @@ describe('ReactDOMComponentTree', () => {
         'element for the lifetime of the component. More info: ' +
         'https://fb.me/react-controlled-components',
     );
-
   });
 
   it('finds instance of node that is attempted to be unmounted', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
@@ -165,7 +165,11 @@ describe('ReactDOMComponentTree', () => {
 
   it('finds instance from node to stop rendering over other react rendered components', () => {
     spyOn(console, 'error');
-    const component = <div><span>Hello</span></div>;
+    const component = (
+      <div>
+        <span>Hello</span>
+      </div>
+    );
     const anotherComponent = <div />;
     const container = document.createElement('div');
     const instance = ReactDOM.render(component, container);

--- a/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
@@ -79,10 +79,11 @@ describe('ReactDOMComponentTree', () => {
   });
 
   it('finds closest instance for node when an event happens', () => {
-    const elemID = 'aID';
-    const innerHTML = {__html: `<div id="${elemID}"></div>`};
-    const testID = 'closestInstance';
+    const nonReactElemID = 'aID';
+    const innerHTML = {__html: `<div id="${nonReactElemID}"></div>`};
+    const closestInstanceID = 'closestInstance';
     let currentTargetID = null;
+
     class ClosestInstance extends React.Component {
       _onClick = e => {
         currentTargetID = e.currentTarget.id;
@@ -90,7 +91,7 @@ describe('ReactDOMComponentTree', () => {
       render() {
         return (
           <div
-            id={testID}
+            id={closestInstanceID}
             onClick={this._onClick}
             dangerouslySetInnerHTML={innerHTML}
           />
@@ -103,8 +104,8 @@ describe('ReactDOMComponentTree', () => {
     ReactDOM.render(<section>{component}</section>, container);
     document.body.appendChild(container);
     expect(currentTargetID).toBe(null);
-    simulateClick(document.getElementById(elemID));
-    expect(currentTargetID).toBe(testID);
+    simulateClick(document.getElementById(nonReactElemID));
+    expect(currentTargetID).toBe(closestInstanceID);
   });
 
   it('finds a controlled instance from node and gets its current fiber props', () => {


### PR DESCRIPTION
This is part of #11299

I've tried to identify cases where code within ReactDOMComponentTree is exercised via the public API and have updated accordingly but I'm not entirely sure whether I'm on the right track. I thought I'd PR to get feedback from the community. Looking forward to comments.