### PR TITLE
Add a shim for react@16.1.0 + react-dom@16.0.0 compatibility

### DIFF
--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -57,6 +57,9 @@ if (__DEV__) {
   Object.assign(React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED, {
     // These should not be included in production.
     ReactDebugCurrentFrame: require('./ReactDebugCurrentFrame'),
+    // Shim for React DOM 16.0.0 which still destructured (but not used) this.
+    // TODO: remove in React 17.0.
+    ReactComponentTreeHook: {},
   });
 }
 


### PR DESCRIPTION
This was a Stack-only module that nevertheless was still being destructured (but not used) by `react-dom@16.0.0`:

<img width="546" alt="screen shot 2017-10-27 at 4 51 02 pm" src="https://user-images.githubusercontent.com/810438/32113062-0cdde3ba-bb37-11e7-9648-edc12310549c.png">

I deleted it on master as part of Stack cleanup, but I just realized this makes `react-dom@16.0.0` incompatible with `react@16.1.0`. Which is not a huge deal, as we used to only support synchronized versions, but we agreed that we want to relax that a little bit.

So I put a shim back in. I verified that it fails without it:

<img width="773" alt="screen shot 2017-10-27 at 4 47 42 pm" src="https://user-images.githubusercontent.com/810438/32113104-2f092396-bb37-11e7-8406-49cc626a7037.png">

and works with it:

<img width="331" alt="screen shot 2017-10-27 at 4 48 52 pm" src="https://user-images.githubusercontent.com/810438/32113108-343ff178-bb37-11e7-8c7d-8f013508c362.png">

As a followup I propose to add Flow types for cross-package internals so we don’t accidentally break them within a major.