### PR TITLE
Inline fbjs/lib/EventListener dependency

### DIFF
--- a/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.js
+++ b/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.js
@@ -9,7 +9,6 @@
 
 'use strict';
 
-var EventListener;
 var EventPluginHub;
 var EventPluginRegistry;
 var React;
@@ -57,7 +56,7 @@ describe('ReactBrowserEventEmitter', () => {
   beforeEach(() => {
     jest.resetModules();
     LISTENER.mockClear();
-    EventListener = require('fbjs/lib/EventListener');
+
     // TODO: can we express this test with only public API?
     EventPluginHub = require('events/EventPluginHub');
     EventPluginRegistry = require('events/EventPluginRegistry');
@@ -374,34 +373,31 @@ describe('ReactBrowserEventEmitter', () => {
   });
 
   it('should listen to events only once', () => {
-    spyOn(EventListener, 'listen');
+    spyOn(EventTarget.prototype, 'addEventListener');
     ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
     ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
-    expect(EventListener.listen.calls.count()).toBe(1);
+    expect(EventTarget.prototype.addEventListener.calls.count()).toBe(1);
   });
 
   it('should work with event plugins without dependencies', () => {
-    spyOn(EventListener, 'listen');
+    spyOn(EventTarget.prototype, 'addEventListener');
 
     ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
 
-    expect(EventListener.listen.calls.argsFor(0)[1]).toBe('click');
+    expect(EventTarget.prototype.addEventListener.calls.argsFor(0)[0]).toBe(
+      'click',
+    );
   });
 
   it('should work with event plugins with dependencies', () => {
-    spyOn(EventListener, 'listen');
-    spyOn(EventListener, 'capture');
+    spyOn(EventTarget.prototype, 'addEventListener');
 
     ReactBrowserEventEmitter.listenTo(ON_CHANGE_KEY, document);
 
     var setEventListeners = [];
-    var listenCalls = EventListener.listen.calls.allArgs();
-    var captureCalls = EventListener.capture.calls.allArgs();
+    var listenCalls = EventTarget.prototype.addEventListener.calls.allArgs();
     for (var i = 0; i < listenCalls.length; i++) {
       setEventListeners.push(listenCalls[i][1]);
-    }
-    for (i = 0; i < captureCalls.length; i++) {
-      setEventListeners.push(captureCalls[i][1]);
     }
 
     var module = EventPluginRegistry.registrationNameModules[ON_CHANGE_KEY];

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -8,6 +8,7 @@
 'use strict';
 
 var ReactGenericBatching = require('events/ReactGenericBatching');
+var ReactErrorUtils = require('shared/ReactErrorUtils');
 var ReactFiberTreeReflection = require('shared/ReactFiberTreeReflection');
 var ReactTypeOfWork = require('shared/ReactTypeOfWork');
 var {HostRoot} = ReactTypeOfWork;
@@ -126,7 +127,13 @@ var ReactDOMEventListener = {
     if (!element) {
       return null;
     }
-    var callback = ReactDOMEventListener.dispatchEvent.bind(null, topLevelType);
+    // TODO: Once we have static injection we should just wrap
+    // ReactDOMEventListener.dispatchEvent statically so we don't have to do
+    // it for every event type.
+    var callback = ReactErrorUtils.wrapEventListener(
+      handlerBaseName,
+      ReactDOMEventListener.dispatchEvent.bind(null, topLevelType),
+    );
     if (element.addEventListener) {
       element.addEventListener(handlerBaseName, callback, false);
     } else if (element.attachEvent) {
@@ -149,9 +156,12 @@ var ReactDOMEventListener = {
       return null;
     }
     if (element.addEventListener) {
-      var callback = ReactDOMEventListener.dispatchEvent.bind(
-        null,
-        topLevelType,
+      // TODO: Once we have static injection we should just wrap
+      // ReactDOMEventListener.dispatchEvent statically so we don't have to do
+      // it for every event type.
+      var callback = ReactErrorUtils.wrapEventListener(
+        handlerBaseName,
+        ReactDOMEventListener.dispatchEvent.bind(null, topLevelType),
       );
       element.addEventListener(handlerBaseName, callback, true);
     } else {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -19,6 +19,7 @@ var {
   getStackAddendumByWorkInProgressFiber,
 } = require('shared/ReactFiberComponentTreeHook');
 var {
+  wrapEventListener,
   invokeGuardedCallback,
   hasCaughtError,
   clearCaughtError,
@@ -1273,6 +1274,17 @@ module.exports = function<T, P, I, TI, PI, C, CC, CX, PL>(
   // TODO: Everything below this is written as if it has been lifted to the
   // renderers. I'll do this in a follow-up.
 
+  // Ensure performAsyncWork gets wrapped. This currently needs to be lazy because
+  // we use dynamic injection. TODO: Make this eagerly wrapping this callback once
+  // we have static injection.
+  let hasCallbackBeenScheduled: boolean = false;
+  function ensureCallbackWrapped() {
+    if (!hasCallbackBeenScheduled) {
+      performAsyncWork = wrapEventListener('reactAsyncWork', performAsyncWork);
+      hasCallbackBeenScheduled = true;
+    }
+  }
+
   // Linked-list of roots
   let firstScheduledRoot: FiberRoot | null = null;
   let lastScheduledRoot: FiberRoot | null = null;
@@ -1354,6 +1366,7 @@ module.exports = function<T, P, I, TI, PI, C, CC, CX, PL>(
       performWork(Sync, null);
     } else if (!isCallbackScheduled) {
       isCallbackScheduled = true;
+      ensureCallbackWrapped();
       scheduleDeferredCallback(performAsyncWork);
     }
   }
@@ -1434,9 +1447,9 @@ module.exports = function<T, P, I, TI, PI, C, CC, CX, PL>(
     nextFlushedExpirationTime = highestPriorityWork;
   }
 
-  function performAsyncWork(dl) {
+  let performAsyncWork = function(dl) {
     performWork(NoWork, dl);
-  }
+  };
 
   function performWork(minExpirationTime: ExpirationTime, dl: Deadline | null) {
     deadline = dl;
@@ -1466,6 +1479,7 @@ module.exports = function<T, P, I, TI, PI, C, CC, CX, PL>(
     // If there's work left over, schedule a new callback.
     if (nextFlushedRoot !== null && !isCallbackScheduled) {
       isCallbackScheduled = true;
+      ensureCallbackWrapped();
       scheduleDeferredCallback(performAsyncWork);
     }
 

--- a/packages/shared/ReactErrorUtils.js
+++ b/packages/shared/ReactErrorUtils.js
@@ -27,6 +27,7 @@ const ReactErrorUtils = {
         'Injected invokeGuardedCallback() must be a function.',
       );
       invokeGuardedCallback = injectedErrorUtils.invokeGuardedCallback;
+      wrapEventListener = injectedErrorUtils.wrapEventListener;
     },
   },
 
@@ -55,6 +56,13 @@ const ReactErrorUtils = {
     f: F,
   ): void {
     invokeGuardedCallback.apply(ReactErrorUtils, arguments);
+  },
+
+  /**
+   * Wrap a callback in whatever logic it needs. Used in FB to polyfill Promises.
+   */
+  wrapEventListener: function<T>(name: string, callback: T): T {
+    return wrapEventListener(name, callback);
   },
 
   /**
@@ -114,6 +122,10 @@ const ReactErrorUtils = {
       );
     }
   },
+};
+
+let wrapEventListener = function<T>(name: string, callback: T): T {
+  return callback;
 };
 
 let invokeGuardedCallback = function(name, func, context, a, b, c, d, e, f) {


### PR DESCRIPTION
We explicitly don't want to shim this, since things can go wrong (such as memory leaks) and we don't use the return value.

We can probably even drop the IE path now since we don't support it. Not sure if that'll be a true breaking change though.

We still need to integrate with the TimeSlice mechanism internally. I think we can do that at the error guard boundary instead since we invoke all our event handlers through that guard.

However, since that is also used for error boundaries, it might also cause those to play into the TimeSlicer. Is that what we want anyway?