### PR TITLE
Depend on prop-types/checkPropTypes, not prop-types itself

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -754,7 +754,7 @@ describe('ReactDOMInput', () => {
     );
     expectDev(console.error.calls.count()).toBe(1);
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-      'Warning: Failed form propType: You provided a `value` prop to a form ' +
+      'Warning: Failed prop type: You provided a `value` prop to a form ' +
         'field without an `onChange` handler. This will render a read-only ' +
         'field. If the field should be mutable use `defaultValue`. ' +
         'Otherwise, set either `onChange` or `readOnly`.\n' +

--- a/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
+++ b/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
@@ -13,7 +13,6 @@ var ReactControlledValuePropTypes = {
 
 if (__DEV__) {
   var checkPropTypes = require('prop-types/checkPropTypes');
-  var PropTypes = require('prop-types');
 
   var hasReadOnlyValue = {
     button: true,
@@ -59,7 +58,6 @@ if (__DEV__) {
           'set either `onChange` or `readOnly`.',
       );
     },
-    onChange: PropTypes.func,
   };
 
   /**

--- a/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
+++ b/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
@@ -12,13 +12,9 @@ var ReactControlledValuePropTypes = {
 };
 
 if (__DEV__) {
-  var warning = require('fbjs/lib/warning');
-  var emptyFunction = require('fbjs/lib/emptyFunction');
+  var checkPropTypes = require('prop-types/checkPropTypes');
   var PropTypes = require('prop-types');
 
-  var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
-
-  ReactControlledValuePropTypes.checkPropTypes = emptyFunction;
   var hasReadOnlyValue = {
     button: true,
     checkbox: true,
@@ -66,8 +62,6 @@ if (__DEV__) {
     onChange: PropTypes.func,
   };
 
-  var loggedTypeFailures = {};
-
   /**
    * Provide a linked `value` attribute for controlled forms. You should not use
    * this outside of the ReactDOM controlled form components.
@@ -77,25 +71,7 @@ if (__DEV__) {
     props,
     getStack,
   ) {
-    for (var propName in propTypes) {
-      if (propTypes.hasOwnProperty(propName)) {
-        var error = propTypes[propName](
-          props,
-          propName,
-          tagName,
-          'prop',
-          null,
-          ReactPropTypesSecret,
-        );
-      }
-      if (error instanceof Error && !(error.message in loggedTypeFailures)) {
-        // Only monitor this failure once because there tends to be a lot of the
-        // same error.
-        loggedTypeFailures[error.message] = true;
-
-        warning(false, 'Failed form propType: %s%s', error.message, getStack());
-      }
-    }
+    checkPropTypes(propTypes, props, 'prop', tagName, getStack);
   };
 }
 

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -25,24 +25,24 @@
       "gzip": 6776
     },
     "react-dom.development.js (UMD_DEV)": {
-      "size": 629993,
-      "gzip": 144537
+      "size": 609118,
+      "gzip": 139930
     },
     "react-dom.production.min.js (UMD_PROD)": {
       "size": 101759,
       "gzip": 31837
     },
     "react-dom.development.js (NODE_DEV)": {
-      "size": 594328,
-      "gzip": 136213
+      "size": 593556,
+      "gzip": 135968
     },
     "react-dom.production.min.js (NODE_PROD)": {
       "size": 107772,
       "gzip": 33333
     },
     "ReactDOM-dev.js (FB_DEV)": {
-      "size": 594288,
-      "gzip": 136503
+      "size": 593516,
+      "gzip": 136258
     },
     "ReactDOM-prod.js (FB_PROD)": {
       "size": 422865,
@@ -85,32 +85,32 @@
       "gzip": 15630
     },
     "react-dom-server.browser.development.js (UMD_DEV)": {
-      "size": 126953,
-      "gzip": 32659
+      "size": 106084,
+      "gzip": 27905
     },
     "react-dom-server.browser.production.min.js (UMD_PROD)": {
       "size": 15612,
       "gzip": 6067
     },
     "react-dom-server.browser.development.js (NODE_DEV)": {
-      "size": 96840,
-      "gzip": 25434
+      "size": 96070,
+      "gzip": 25231
     },
     "react-dom-server.browser.production.min.js (NODE_PROD)": {
       "size": 15340,
       "gzip": 5985
     },
     "ReactDOMServer-dev.js (FB_DEV)": {
-      "size": 96316,
-      "gzip": 25374
+      "size": 95546,
+      "gzip": 25176
     },
     "ReactDOMServer-prod.js (FB_PROD)": {
       "size": 43775,
       "gzip": 12037
     },
     "react-dom-server.node.development.js (NODE_DEV)": {
-      "size": 99113,
-      "gzip": 25973
+      "size": 98343,
+      "gzip": 25770
     },
     "react-dom-server.node.production.min.js (NODE_PROD)": {
       "size": 16264,


### PR DESCRIPTION
Two small changes.

1. Instead of reimplementing `prop-types/checkPropTypes` we can just use it. I think it didn't exist when this copy was written but now we can switch to it.

2. Importing `prop-types` itself is going to be harder to DCE in DEV only once we move to ES Modules. It is doing some funky business in entry points, and builds up exports in a way that Rollup might consider side effectful. <s>It seems much simpler to just inline the implementation since we only need a subset and there are no other places where we need it.</s> We can delete it—see below.

3. Actually I just checked, and the `onChange` annotation can be removed altogether. That check existed before we had DEV-time hooks verifying prop types. So currently we fire the warning twice:

<img width="545" alt="screen shot 2017-10-31 at 23 34 24" src="https://user-images.githubusercontent.com/810438/32253732-5de671c2-be94-11e7-860f-3aa5023f1c76.png">

This removes the unnecessary extra warning, so now it is handled once just like all other host elements:

<img width="542" alt="screen shot 2017-10-31 at 23 34 02" src="https://user-images.githubusercontent.com/810438/32253737-6b366af8-be94-11e7-8a76-9687362188b4.png">

So this both makes DEV bundle smaller, and removes an unnecessary noisy warning.