### PR TITLE
Put React.Fragment under a feature flag

### DIFF
--- a/packages/react-cs-renderer/src/ReactNativeCSFeatureFlags.js
+++ b/packages/react-cs-renderer/src/ReactNativeCSFeatureFlags.js
@@ -14,6 +14,7 @@ import type {FeatureFlags} from 'shared/ReactFeatureFlags';
 var ReactNativeCSFeatureFlags: FeatureFlags = {
   enableAsyncSubtreeAPI: true,
   enableAsyncSchedulingByDefaultInReactDOM: false,
+  enableReactFragment: false,
   // React Native CS uses persistent reconciler.
   enableMutatingReconciler: false,
   enableNoopReconciler: false,

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegration-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegration-test.js
@@ -17,6 +17,7 @@ let ReactDOMServer;
 let ReactTestUtils;
 
 const stream = require('stream');
+const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 const TEXT_NODE_TYPE = 3;
 
@@ -403,54 +404,56 @@ describe('ReactDOMServerIntegration', () => {
       expect(parent.childNodes[2].tagName).toBe('P');
     });
 
-    itRenders('a fragment with one child', async render => {
-      let e = await render(<React.Fragment><div>text1</div></React.Fragment>);
-      let parent = e.parentNode;
-      expect(parent.childNodes[0].tagName).toBe('DIV');
-    });
+    if (ReactFeatureFlags.enableReactFragment) {
+      itRenders('a fragment with one child', async render => {
+        let e = await render(<React.Fragment><div>text1</div></React.Fragment>);
+        let parent = e.parentNode;
+        expect(parent.childNodes[0].tagName).toBe('DIV');
+      });
 
-    itRenders('a fragment with several children', async render => {
-      let Header = props => {
-        return <p>header</p>;
-      };
-      let Footer = props => {
-        return <React.Fragment><h2>footer</h2><h3>about</h3></React.Fragment>;
-      };
-      let e = await render(
-        <React.Fragment>
-          <div>text1</div>
-          <span>text2</span>
-          <Header />
-          <Footer />
-        </React.Fragment>,
-      );
-      let parent = e.parentNode;
-      expect(parent.childNodes[0].tagName).toBe('DIV');
-      expect(parent.childNodes[1].tagName).toBe('SPAN');
-      expect(parent.childNodes[2].tagName).toBe('P');
-      expect(parent.childNodes[3].tagName).toBe('H2');
-      expect(parent.childNodes[4].tagName).toBe('H3');
-    });
-
-    itRenders('a nested fragment', async render => {
-      let e = await render(
-        <React.Fragment>
+      itRenders('a fragment with several children', async render => {
+        let Header = props => {
+          return <p>header</p>;
+        };
+        let Footer = props => {
+          return <React.Fragment><h2>footer</h2><h3>about</h3></React.Fragment>;
+        };
+        let e = await render(
           <React.Fragment>
             <div>text1</div>
-          </React.Fragment>
-          <span>text2</span>
+            <span>text2</span>
+            <Header />
+            <Footer />
+          </React.Fragment>,
+        );
+        let parent = e.parentNode;
+        expect(parent.childNodes[0].tagName).toBe('DIV');
+        expect(parent.childNodes[1].tagName).toBe('SPAN');
+        expect(parent.childNodes[2].tagName).toBe('P');
+        expect(parent.childNodes[3].tagName).toBe('H2');
+        expect(parent.childNodes[4].tagName).toBe('H3');
+      });
+
+      itRenders('a nested fragment', async render => {
+        let e = await render(
           <React.Fragment>
             <React.Fragment>
-              <React.Fragment>{null}<p /></React.Fragment>{false}
+              <div>text1</div>
             </React.Fragment>
-          </React.Fragment>
-        </React.Fragment>,
-      );
-      let parent = e.parentNode;
-      expect(parent.childNodes[0].tagName).toBe('DIV');
-      expect(parent.childNodes[1].tagName).toBe('SPAN');
-      expect(parent.childNodes[2].tagName).toBe('P');
-    });
+            <span>text2</span>
+            <React.Fragment>
+              <React.Fragment>
+                <React.Fragment>{null}<p /></React.Fragment>{false}
+              </React.Fragment>
+            </React.Fragment>
+          </React.Fragment>,
+        );
+        let parent = e.parentNode;
+        expect(parent.childNodes[0].tagName).toBe('DIV');
+        expect(parent.childNodes[1].tagName).toBe('SPAN');
+        expect(parent.childNodes[2].tagName).toBe('P');
+      });
+    }
 
     itRenders('an iterable', async render => {
       const threeDivIterable = {
@@ -484,7 +487,9 @@ describe('ReactDOMServerIntegration', () => {
       // but server returns empty HTML. So we compare parent text.
       expect((await render(<div>{''}</div>)).textContent).toBe('');
 
-      expect(await render(<React.Fragment />)).toBe(null);
+      if (ReactFeatureFlags.enableReactFragment) {
+        expect(await render(<React.Fragment />)).toBe(null);
+      }
       expect(await render([])).toBe(null);
       expect(await render(false)).toBe(null);
       expect(await render(true)).toBe(null);

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -18,6 +18,7 @@ import type {
 
 var ReactTypeOfSideEffect = require('shared/ReactTypeOfSideEffect');
 var ReactTypeOfWork = require('shared/ReactTypeOfWork');
+var ReactFeatureFlags = require('shared/ReactFeatureFlags');
 var emptyObject = require('fbjs/lib/emptyObject');
 var invariant = require('fbjs/lib/invariant');
 var {REACT_PORTAL_TYPE} = require('./ReactPortal');
@@ -1432,6 +1433,7 @@ function ChildReconciler(shouldClone, shouldTrackSideEffects) {
     // This leads to an ambiguity between <>{[...]}</> and <>...</>.
     // We treat the ambiguous cases above the same.
     if (
+      ReactFeatureFlags.enableReactFragment &&
       typeof newChild === 'object' &&
       newChild !== null &&
       newChild.type === REACT_FRAGMENT_TYPE &&

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -8,6 +8,8 @@
  */
 'use strict';
 
+var ReactFeatureFlags = require('shared/ReactFeatureFlags');
+
 let React;
 let ReactNoop;
 
@@ -31,691 +33,699 @@ describe('ReactFragment', () => {
     return {type: 'div', children, prop: undefined};
   }
 
-  it('should render a single child via noop renderer', () => {
-    const element = (
-      <React.Fragment>
-        <span>foo</span>
-      </React.Fragment>
-    );
+  if (ReactFeatureFlags.enableReactFragment) {
+    it('should render a single child via noop renderer', () => {
+      const element = (
+        <React.Fragment>
+          <span>foo</span>
+        </React.Fragment>
+      );
 
-    ReactNoop.render(element);
-    ReactNoop.flush();
+      ReactNoop.render(element);
+      ReactNoop.flush();
 
-    expect(ReactNoop.getChildren()).toEqual([span()]);
-  });
+      expect(ReactNoop.getChildren()).toEqual([span()]);
+    });
 
-  it('should render zero children via noop renderer', () => {
-    const element = <React.Fragment />;
+    it('should render zero children via noop renderer', () => {
+      const element = <React.Fragment />;
 
-    ReactNoop.render(element);
-    ReactNoop.flush();
+      ReactNoop.render(element);
+      ReactNoop.flush();
 
-    expect(ReactNoop.getChildren()).toEqual([]);
-  });
+      expect(ReactNoop.getChildren()).toEqual([]);
+    });
 
-  it('should render multiple children via noop renderer', () => {
-    const element = (
-      <React.Fragment>
-        hello <span>world</span>
-      </React.Fragment>
-    );
+    it('should render multiple children via noop renderer', () => {
+      const element = (
+        <React.Fragment>
+          hello <span>world</span>
+        </React.Fragment>
+      );
 
-    ReactNoop.render(element);
-    ReactNoop.flush();
+      ReactNoop.render(element);
+      ReactNoop.flush();
 
-    expect(ReactNoop.getChildren()).toEqual([text('hello '), span()]);
-  });
+      expect(ReactNoop.getChildren()).toEqual([text('hello '), span()]);
+    });
 
-  it('should render an iterable via noop renderer', () => {
-    const element = (
-      <React.Fragment>
-        {new Set([<span key="a">hi</span>, <span key="b">bye</span>])}
-      </React.Fragment>
-    );
+    it('should render an iterable via noop renderer', () => {
+      const element = (
+        <React.Fragment>
+          {new Set([<span key="a">hi</span>, <span key="b">bye</span>])}
+        </React.Fragment>
+      );
 
-    ReactNoop.render(element);
-    ReactNoop.flush();
+      ReactNoop.render(element);
+      ReactNoop.flush();
 
-    expect(ReactNoop.getChildren()).toEqual([span(), span()]);
-  });
+      expect(ReactNoop.getChildren()).toEqual([span(), span()]);
+    });
 
-  it('should preserve state of children with 1 level nesting', function() {
-    var ops = [];
+    it('should preserve state of children with 1 level nesting', function() {
+      var ops = [];
 
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
       }
 
-      render() {
-        return <div>Hello</div>;
-      }
-    }
-
-    function Foo({condition}) {
-      return condition
-        ? <Stateful key="a" />
-        : <React.Fragment>
-            <Stateful key="a" />
-            <div key="b">World</div>
-          </React.Fragment>;
-    }
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div(), div()]);
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
-
-  it('should preserve state between top-level fragments', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
+      function Foo({condition}) {
+        return condition
+          ? <Stateful key="a" />
+          : <React.Fragment>
+              <Stateful key="a" />
+              <div key="b">World</div>
+            </React.Fragment>;
       }
 
-      render() {
-        return <div>Hello</div>;
-      }
-    }
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
 
-    function Foo({condition}) {
-      return condition
-        ? <React.Fragment>
-            <Stateful />
-          </React.Fragment>
-        : <React.Fragment>
-            <Stateful />
-          </React.Fragment>;
-    }
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
 
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+      expect(ops).toEqual(['Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div(), div()]);
 
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
 
-    expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
 
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    it('should preserve state between top-level fragments', function() {
+      var ops = [];
 
-    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
 
-  it('should preserve state of children nested at same level', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
+        render() {
+          return <div>Hello</div>;
+        }
       }
 
-      render() {
-        return <div>Hello</div>;
+      function Foo({condition}) {
+        return condition
+          ? <React.Fragment>
+              <Stateful />
+            </React.Fragment>
+          : <React.Fragment>
+              <Stateful />
+            </React.Fragment>;
       }
-    }
 
-    function Foo({condition}) {
-      return condition
-        ? <React.Fragment>
-            <React.Fragment>
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual(['Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
+
+    it('should preserve state of children nested at same level', function() {
+      var ops = [];
+
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
+      }
+
+      function Foo({condition}) {
+        return condition
+          ? <React.Fragment>
+              <React.Fragment>
+                <React.Fragment>
+                  <Stateful key="a" />
+                </React.Fragment>
+              </React.Fragment>
+            </React.Fragment>
+          : <React.Fragment>
+              <React.Fragment>
+                <React.Fragment>
+                  <div />
+                  <Stateful key="a" />
+                </React.Fragment>
+              </React.Fragment>
+            </React.Fragment>;
+      }
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual(['Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div(), div()]);
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
+
+    it('should not preserve state in non-top-level fragment nesting', function() {
+      var ops = [];
+
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
+      }
+
+      function Foo({condition}) {
+        return condition
+          ? <React.Fragment>
+              <React.Fragment><Stateful key="a" /></React.Fragment>
+            </React.Fragment>
+          : <React.Fragment><Stateful key="a" /></React.Fragment>;
+      }
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
+
+    it('should not preserve state of children if nested 2 levels without siblings', function() {
+      var ops = [];
+
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
+      }
+
+      function Foo({condition}) {
+        return condition
+          ? <Stateful key="a" />
+          : <React.Fragment>
               <React.Fragment>
                 <Stateful key="a" />
               </React.Fragment>
-            </React.Fragment>
-          </React.Fragment>
-        : <React.Fragment>
-            <React.Fragment>
+            </React.Fragment>;
+      }
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
+
+    it('should not preserve state of children if nested 2 levels with siblings', function() {
+      var ops = [];
+
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
+      }
+
+      function Foo({condition}) {
+        return condition
+          ? <Stateful key="a" />
+          : <React.Fragment>
               <React.Fragment>
-                <div />
                 <Stateful key="a" />
               </React.Fragment>
-            </React.Fragment>
-          </React.Fragment>;
-    }
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div(), div()]);
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
-
-  it('should not preserve state in non-top-level fragment nesting', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
+              <div />
+            </React.Fragment>;
       }
 
-      render() {
-        return <div>Hello</div>;
-      }
-    }
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
 
-    function Foo({condition}) {
-      return condition
-        ? <React.Fragment>
-            <React.Fragment><Stateful key="a" /></React.Fragment>
-          </React.Fragment>
-        : <React.Fragment><Stateful key="a" /></React.Fragment>;
-    }
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
 
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div(), div()]);
 
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
 
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
 
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    it('should preserve state between array nested in fragment and fragment', function() {
+      var ops = [];
 
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
 
-  it('should not preserve state of children if nested 2 levels without siblings', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
+        render() {
+          return <div>Hello</div>;
+        }
       }
 
-      render() {
-        return <div>Hello</div>;
-      }
-    }
-
-    function Foo({condition}) {
-      return condition
-        ? <Stateful key="a" />
-        : <React.Fragment>
-            <React.Fragment>
+      function Foo({condition}) {
+        return condition
+          ? <React.Fragment>
               <Stateful key="a" />
             </React.Fragment>
-          </React.Fragment>;
-    }
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
-
-  it('should not preserve state of children if nested 2 levels with siblings', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
+          : <React.Fragment>
+              {[<Stateful key="a" />]}
+            </React.Fragment>;
       }
 
-      render() {
-        return <div>Hello</div>;
-      }
-    }
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
 
-    function Foo({condition}) {
-      return condition
-        ? <Stateful key="a" />
-        : <React.Fragment>
-            <React.Fragment>
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual(['Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
+
+    it('should preserve state between top level fragment and array', function() {
+      var ops = [];
+
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
+      }
+
+      function Foo({condition}) {
+        return condition
+          ? [<Stateful key="a" />]
+          : <React.Fragment>
               <Stateful key="a" />
+            </React.Fragment>;
+      }
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual(['Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
+
+    it('should not preserve state between array nested in fragment and double nested fragment', function() {
+      var ops = [];
+
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
+      }
+
+      function Foo({condition}) {
+        return condition
+          ? <React.Fragment>{[<Stateful key="a" />]}</React.Fragment>
+          : <React.Fragment>
+              <React.Fragment><Stateful key="a" /></React.Fragment>
+            </React.Fragment>;
+      }
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
+
+    it('should not preserve state between array nested in fragment and double nested array', function() {
+      var ops = [];
+
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
+      }
+
+      function Foo({condition}) {
+        return condition
+          ? <React.Fragment>{[<Stateful key="a" />]}</React.Fragment>
+          : [[<Stateful key="a" />]];
+      }
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
+
+    it('should preserve state between double nested fragment and double nested array', function() {
+      var ops = [];
+
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
+      }
+
+      function Foo({condition}) {
+        return condition
+          ? <React.Fragment>
+              <React.Fragment><Stateful key="a" /></React.Fragment>
             </React.Fragment>
-            <div />
-          </React.Fragment>;
-    }
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div(), div()]);
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
-
-  it('should preserve state between array nested in fragment and fragment', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
+          : [[<Stateful key="a" />]];
       }
 
-      render() {
-        return <div>Hello</div>;
-      }
-    }
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
 
-    function Foo({condition}) {
-      return condition
-        ? <React.Fragment>
-            <Stateful key="a" />
-          </React.Fragment>
-        : <React.Fragment>
-            {[<Stateful key="a" />]}
-          </React.Fragment>;
-    }
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
 
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+      expect(ops).toEqual(['Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
 
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
 
-    expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
 
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    it('should not preserve state of children when the keys are different', function() {
+      var ops = [];
 
-    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
 
-  it('should preserve state between top level fragment and array', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
+        render() {
+          return <div>Hello</div>;
+        }
       }
 
-      render() {
-        return <div>Hello</div>;
-      }
-    }
-
-    function Foo({condition}) {
-      return condition
-        ? [<Stateful key="a" />]
-        : <React.Fragment>
-            <Stateful key="a" />
-          </React.Fragment>;
-    }
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
-
-  it('should not preserve state between array nested in fragment and double nested fragment', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
-      }
-
-      render() {
-        return <div>Hello</div>;
-      }
-    }
-
-    function Foo({condition}) {
-      return condition
-        ? <React.Fragment>{[<Stateful key="a" />]}</React.Fragment>
-        : <React.Fragment>
-            <React.Fragment><Stateful key="a" /></React.Fragment>
-          </React.Fragment>;
-    }
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
-
-  it('should not preserve state between array nested in fragment and double nested array', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
-      }
-
-      render() {
-        return <div>Hello</div>;
-      }
-    }
-
-    function Foo({condition}) {
-      return condition
-        ? <React.Fragment>{[<Stateful key="a" />]}</React.Fragment>
-        : [[<Stateful key="a" />]];
-    }
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
-
-  it('should preserve state between double nested fragment and double nested array', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
-      }
-
-      render() {
-        return <div>Hello</div>;
-      }
-    }
-
-    function Foo({condition}) {
-      return condition
-        ? <React.Fragment>
-            <React.Fragment><Stateful key="a" /></React.Fragment>
-          </React.Fragment>
-        : [[<Stateful key="a" />]];
-    }
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
-
-  it('should not preserve state of children when the keys are different', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
-      }
-
-      render() {
-        return <div>Hello</div>;
-      }
-    }
-
-    function Foo({condition}) {
-      return condition
-        ? <React.Fragment key="a">
-            <Stateful />
-          </React.Fragment>
-        : <React.Fragment key="b">
-            <Stateful />
-            <span>World</span>
-          </React.Fragment>;
-    }
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div(), span()]);
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
-
-  it('should not preserve state between unkeyed and keyed fragment', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
-      }
-
-      render() {
-        return <div>Hello</div>;
-      }
-    }
-
-    function Foo({condition}) {
-      return condition
-        ? <React.Fragment key="a">
-            <Stateful />
-          </React.Fragment>
-        : <React.Fragment>
-            <Stateful />
-          </React.Fragment>;
-    }
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-  });
-
-  it('should preserve state with reordering in multiple levels', function() {
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
-      }
-
-      render() {
-        return <div>Hello</div>;
-      }
-    }
-
-    function Foo({condition}) {
-      return condition
-        ? <div>
-            <React.Fragment key="c">
-              <span>foo</span>
-              <div key="b">
-                <Stateful key="a" />
-              </div>
+      function Foo({condition}) {
+        return condition
+          ? <React.Fragment key="a">
+              <Stateful />
             </React.Fragment>
-            <span>boop</span>
-          </div>
-        : <div>
-            <span>beep</span>
-            <React.Fragment key="c">
-              <div key="b">
-                <Stateful key="a" />
-              </div>
-              <span>bar</span>
+          : <React.Fragment key="b">
+              <Stateful />
+              <span>World</span>
+            </React.Fragment>;
+      }
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div(), span()]);
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
+
+    it('should not preserve state between unkeyed and keyed fragment', function() {
+      var ops = [];
+
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
+      }
+
+      function Foo({condition}) {
+        return condition
+          ? <React.Fragment key="a">
+              <Stateful />
             </React.Fragment>
-          </div>;
-    }
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div(span(), div(div()), span())]);
-
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div(span(), div(div()), span())]);
-  });
-
-  it('should not preserve state when switching to a keyed fragment to an array', function() {
-    spyOn(console, 'error');
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
+          : <React.Fragment>
+              <Stateful />
+            </React.Fragment>;
       }
 
-      render() {
-        return <div>Hello</div>;
-      }
-    }
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
 
-    function Foo({condition}) {
-      return condition
-        ? <div>
-            {<React.Fragment key="foo"><Stateful /></React.Fragment>}<span />
-          </div>
-        : <div>{[<Stateful />]}<span /></div>;
-    }
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
 
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
 
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
 
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div()]);
+    });
 
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    it('should preserve state with reordering in multiple levels', function() {
+      var ops = [];
 
-    expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
-    expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'Each child in an array or iterator should have a unique "key" prop.',
-    );
-  });
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
 
-  it('should preserve state when it does not change positions', function() {
-    spyOn(console, 'error');
-    var ops = [];
-
-    class Stateful extends React.Component {
-      componentDidUpdate() {
-        ops.push('Update Stateful');
+        render() {
+          return <div>Hello</div>;
+        }
       }
 
-      render() {
-        return <div>Hello</div>;
+      function Foo({condition}) {
+        return condition
+          ? <div>
+              <React.Fragment key="c">
+                <span>foo</span>
+                <div key="b">
+                  <Stateful key="a" />
+                </div>
+              </React.Fragment>
+              <span>boop</span>
+            </div>
+          : <div>
+              <span>beep</span>
+              <React.Fragment key="c">
+                <div key="b">
+                  <Stateful key="a" />
+                </div>
+                <span>bar</span>
+              </React.Fragment>
+            </div>;
       }
-    }
 
-    function Foo({condition}) {
-      return condition
-        ? [<span />, <React.Fragment><Stateful /></React.Fragment>]
-        : [<span />, <React.Fragment><Stateful /></React.Fragment>];
-    }
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
 
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
 
-    ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+      expect(ops).toEqual(['Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([
+        div(span(), div(div()), span()),
+      ]);
 
-    expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([span(), div()]);
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
 
-    ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([
+        div(span(), div(div()), span()),
+      ]);
+    });
 
-    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([span(), div()]);
-    expectDev(console.error.calls.count()).toBe(3);
-    for (let errorIndex = 0; errorIndex < 3; ++errorIndex) {
-      expectDev(console.error.calls.argsFor(errorIndex)[0]).toContain(
+    it('should not preserve state when switching to a keyed fragment to an array', function() {
+      spyOn(console, 'error');
+      var ops = [];
+
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
+      }
+
+      function Foo({condition}) {
+        return condition
+          ? <div>
+              {<React.Fragment key="foo"><Stateful /></React.Fragment>}<span />
+            </div>
+          : <div>{[<Stateful />]}<span /></div>;
+      }
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual([]);
+      expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
         'Each child in an array or iterator should have a unique "key" prop.',
       );
-    }
-  });
+    });
+
+    it('should preserve state when it does not change positions', function() {
+      spyOn(console, 'error');
+      var ops = [];
+
+      class Stateful extends React.Component {
+        componentDidUpdate() {
+          ops.push('Update Stateful');
+        }
+
+        render() {
+          return <div>Hello</div>;
+        }
+      }
+
+      function Foo({condition}) {
+        return condition
+          ? [<span />, <React.Fragment><Stateful /></React.Fragment>]
+          : [<span />, <React.Fragment><Stateful /></React.Fragment>];
+      }
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      ReactNoop.render(<Foo condition={false} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual(['Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([span(), div()]);
+
+      ReactNoop.render(<Foo condition={true} />);
+      ReactNoop.flush();
+
+      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+      expect(ReactNoop.getChildren()).toEqual([span(), div()]);
+      expectDev(console.error.calls.count()).toBe(3);
+      for (let errorIndex = 0; errorIndex < 3; ++errorIndex) {
+        expectDev(console.error.calls.argsFor(errorIndex)[0]).toContain(
+          'Each child in an array or iterator should have a unique "key" prop.',
+        );
+      }
+    });
+  } else {
+    it('should not run any tests', function() {});
+  }
 });

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -8,6 +8,7 @@
 'use strict';
 
 var ReactVersion = require('shared/ReactVersion');
+var ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 var ReactBaseClasses = require('./ReactBaseClasses');
 var ReactChildren = require('./ReactChildren');
@@ -43,7 +44,9 @@ var React = {
   Component: ReactBaseClasses.Component,
   PureComponent: ReactBaseClasses.PureComponent,
   unstable_AsyncComponent: ReactBaseClasses.AsyncComponent,
-  Fragment: REACT_FRAGMENT_TYPE,
+  Fragment: ReactFeatureFlags.enableReactFragment
+    ? REACT_FRAGMENT_TYPE
+    : undefined,
 
   createElement: createElement,
   cloneElement: cloneElement,

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -44,9 +44,6 @@ var React = {
   Component: ReactBaseClasses.Component,
   PureComponent: ReactBaseClasses.PureComponent,
   unstable_AsyncComponent: ReactBaseClasses.AsyncComponent,
-  Fragment: ReactFeatureFlags.enableReactFragment
-    ? REACT_FRAGMENT_TYPE
-    : undefined,
 
   createElement: createElement,
   cloneElement: cloneElement,
@@ -62,6 +59,10 @@ var React = {
     assign: require('object-assign'),
   },
 };
+
+if (ReactFeatureFlags.enableReactFragment) {
+  React.Fragment = REACT_FRAGMENT_TYPE;
+}
 
 if (__DEV__) {
   Object.assign(React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED, {

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+var ReactFeatureFlags = require('shared/ReactFeatureFlags');
+
 // TODO: All these warnings should become static errors using Flow instead
 // of dynamic errors when using JSX with Flow.
 var React;
@@ -85,48 +87,50 @@ describe('ReactJSXElementValidator', () => {
     );
   });
 
-  it('warns for fragments with illegal attributes', () => {
-    spyOn(console, 'error');
+  if (ReactFeatureFlags.enableReactFragment) {
+    it('warns for fragments with illegal attributes', () => {
+      spyOn(console, 'error');
 
-    class Foo extends React.Component {
-      render() {
-        return <React.Fragment a={1} b={2}>hello</React.Fragment>;
+      class Foo extends React.Component {
+        render() {
+          return <React.Fragment a={1} b={2}>hello</React.Fragment>;
+        }
       }
-    }
 
-    ReactTestUtils.renderIntoDocument(<Foo />);
+      ReactTestUtils.renderIntoDocument(<Foo />);
 
-    expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain('Invalid prop `');
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      '` supplied to `React.Fragment`. React.Fragment ' +
-        'can only have `key` and `children` props.',
-    );
-  });
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain('Invalid prop `');
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        '` supplied to `React.Fragment`. React.Fragment ' +
+          'can only have `key` and `children` props.',
+      );
+    });
 
-  it('warns for fragments with refs', () => {
-    spyOn(console, 'error');
+    it('warns for fragments with refs', () => {
+      spyOn(console, 'error');
 
-    class Foo extends React.Component {
-      render() {
-        return (
-          <React.Fragment
-            ref={bar => {
-              this.foo = bar;
-            }}>
-            hello
-          </React.Fragment>
-        );
+      class Foo extends React.Component {
+        render() {
+          return (
+            <React.Fragment
+              ref={bar => {
+                this.foo = bar;
+              }}>
+              hello
+            </React.Fragment>
+          );
+        }
       }
-    }
 
-    ReactTestUtils.renderIntoDocument(<Foo />);
+      ReactTestUtils.renderIntoDocument(<Foo />);
 
-    expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'Invalid attribute `ref` supplied to `React.Fragment`.',
-    );
-  });
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Invalid attribute `ref` supplied to `React.Fragment`.',
+      );
+    });
+  }
 
   it('warns for keys for iterables of elements in rest args', () => {
     spyOn(console, 'error');
@@ -151,31 +155,33 @@ describe('ReactJSXElementValidator', () => {
     );
   });
 
-  it('does not warn for fragments of multiple elements without keys', () => {
-    ReactTestUtils.renderIntoDocument(
-      <React.Fragment>
-        <span>1</span>
-        <span>2</span>
-      </React.Fragment>,
-    );
-  });
+  if (ReactFeatureFlags.enableReactFragment) {
+    it('does not warn for fragments of multiple elements without keys', () => {
+      ReactTestUtils.renderIntoDocument(
+        <React.Fragment>
+          <span>1</span>
+          <span>2</span>
+        </React.Fragment>,
+      );
+    });
 
-  it('warns for fragments of multiple elements with same key', () => {
-    spyOn(console, 'error');
+    it('warns for fragments of multiple elements with same key', () => {
+      spyOn(console, 'error');
 
-    ReactTestUtils.renderIntoDocument(
-      <React.Fragment>
-        <span key="a">1</span>
-        <span key="a">2</span>
-        <span key="b">3</span>
-      </React.Fragment>,
-    );
+      ReactTestUtils.renderIntoDocument(
+        <React.Fragment>
+          <span key="a">1</span>
+          <span key="a">2</span>
+          <span key="b">3</span>
+        </React.Fragment>,
+      );
 
-    expectDev(console.error.calls.count()).toBe(1);
-    expectDev(console.error.calls.argsFor(0)[0]).toContain(
-      'Encountered two children with the same key, `a`.',
-    );
-  });
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+        'Encountered two children with the same key, `a`.',
+      );
+    });
+  }
 
   it('does not warn for arrays of elements with keys', () => {
     spyOn(console, 'error');

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -15,6 +15,7 @@ export type FeatureFlags = {|
   enableMutatingReconciler: boolean,
   enableNoopReconciler: boolean,
   enablePersistentReconciler: boolean,
+  enableReactFragment: boolean,
 |};
 
 var ReactFeatureFlags: FeatureFlags = {
@@ -26,6 +27,8 @@ var ReactFeatureFlags: FeatureFlags = {
   enableNoopReconciler: false,
   // Experimental persistent mode (CS):
   enablePersistentReconciler: false,
+  // Exports React.Fragment
+  enableReactFragment: false,
 };
 
 if (__DEV__) {


### PR DESCRIPTION
Let's feature flag the React.Fragment export so that it's not publicly consumable until 16.2.0. At this point, Typescript 2.6.2 should also be released to support this.