### PR TITLE
Support string values for capture attribute.

### DIFF
--- a/packages/react-dom/src/shared/HTMLDOMPropertyConfig.js
+++ b/packages/react-dom/src/shared/HTMLDOMPropertyConfig.js
@@ -30,7 +30,7 @@ var HTMLDOMPropertyConfig = {
     // autoFocus is polyfilled/normalized by AutoFocusUtils
     // autoFocus: HAS_BOOLEAN_VALUE,
     autoPlay: HAS_BOOLEAN_VALUE,
-    capture: HAS_BOOLEAN_VALUE,
+    capture: HAS_OVERLOADED_BOOLEAN_VALUE,
     checked: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     cols: HAS_POSITIVE_NUMERIC_VALUE,
     contentEditable: HAS_STRING_BOOLEAN_VALUE,


### PR DESCRIPTION
  * Uses HAS_OVERLOADED_BOOLEAN_VALUE instead of HAS_BOOLEAN_VALUE
  * Allows for ```<input type="file" capture="user" />```

Fixes #11419 