### PR TITLE
Always run React.Fragment tests

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegration-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegration-test.js
@@ -316,6 +316,7 @@ function resetModules() {
 
   // TODO: can we express this test with only public API?
   ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
+  require('shared/ReactFeatureFlags').enableReactFragment = true;
 
   PropTypes = require('prop-types');
   React = require('react');
@@ -326,6 +327,7 @@ function resetModules() {
   // Resetting is important because we want to avoid any shared state
   // influencing the tests.
   jest.resetModuleRegistry();
+  require('shared/ReactFeatureFlags').enableReactFragment = true;
   ReactDOMServer = require('react-dom/server');
 }
 
@@ -404,56 +406,54 @@ describe('ReactDOMServerIntegration', () => {
       expect(parent.childNodes[2].tagName).toBe('P');
     });
 
-    if (ReactFeatureFlags.enableReactFragment) {
-      itRenders('a fragment with one child', async render => {
-        let e = await render(<React.Fragment><div>text1</div></React.Fragment>);
-        let parent = e.parentNode;
-        expect(parent.childNodes[0].tagName).toBe('DIV');
-      });
+    itRenders('a fragment with one child', async render => {
+      let e = await render(<React.Fragment><div>text1</div></React.Fragment>);
+      let parent = e.parentNode;
+      expect(parent.childNodes[0].tagName).toBe('DIV');
+    });
 
-      itRenders('a fragment with several children', async render => {
-        let Header = props => {
-          return <p>header</p>;
-        };
-        let Footer = props => {
-          return <React.Fragment><h2>footer</h2><h3>about</h3></React.Fragment>;
-        };
-        let e = await render(
+    itRenders('a fragment with several children', async render => {
+      let Header = props => {
+        return <p>header</p>;
+      };
+      let Footer = props => {
+        return <React.Fragment><h2>footer</h2><h3>about</h3></React.Fragment>;
+      };
+      let e = await render(
+        <React.Fragment>
+          <div>text1</div>
+          <span>text2</span>
+          <Header />
+          <Footer />
+        </React.Fragment>,
+      );
+      let parent = e.parentNode;
+      expect(parent.childNodes[0].tagName).toBe('DIV');
+      expect(parent.childNodes[1].tagName).toBe('SPAN');
+      expect(parent.childNodes[2].tagName).toBe('P');
+      expect(parent.childNodes[3].tagName).toBe('H2');
+      expect(parent.childNodes[4].tagName).toBe('H3');
+    });
+
+    itRenders('a nested fragment', async render => {
+      let e = await render(
+        <React.Fragment>
           <React.Fragment>
             <div>text1</div>
-            <span>text2</span>
-            <Header />
-            <Footer />
-          </React.Fragment>,
-        );
-        let parent = e.parentNode;
-        expect(parent.childNodes[0].tagName).toBe('DIV');
-        expect(parent.childNodes[1].tagName).toBe('SPAN');
-        expect(parent.childNodes[2].tagName).toBe('P');
-        expect(parent.childNodes[3].tagName).toBe('H2');
-        expect(parent.childNodes[4].tagName).toBe('H3');
-      });
-
-      itRenders('a nested fragment', async render => {
-        let e = await render(
+          </React.Fragment>
+          <span>text2</span>
           <React.Fragment>
             <React.Fragment>
-              <div>text1</div>
+              <React.Fragment>{null}<p /></React.Fragment>{false}
             </React.Fragment>
-            <span>text2</span>
-            <React.Fragment>
-              <React.Fragment>
-                <React.Fragment>{null}<p /></React.Fragment>{false}
-              </React.Fragment>
-            </React.Fragment>
-          </React.Fragment>,
-        );
-        let parent = e.parentNode;
-        expect(parent.childNodes[0].tagName).toBe('DIV');
-        expect(parent.childNodes[1].tagName).toBe('SPAN');
-        expect(parent.childNodes[2].tagName).toBe('P');
-      });
-    }
+          </React.Fragment>
+        </React.Fragment>,
+      );
+      let parent = e.parentNode;
+      expect(parent.childNodes[0].tagName).toBe('DIV');
+      expect(parent.childNodes[1].tagName).toBe('SPAN');
+      expect(parent.childNodes[2].tagName).toBe('P');
+    });
 
     itRenders('an iterable', async render => {
       const threeDivIterable = {
@@ -487,9 +487,7 @@ describe('ReactDOMServerIntegration', () => {
       // but server returns empty HTML. So we compare parent text.
       expect((await render(<div>{''}</div>)).textContent).toBe('');
 
-      if (ReactFeatureFlags.enableReactFragment) {
-        expect(await render(<React.Fragment />)).toBe(null);
-      }
+      expect(await render(<React.Fragment />)).toBe(null);
       expect(await render([])).toBe(null);
       expect(await render(false)).toBe(null);
       expect(await render(true)).toBe(null);

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -16,6 +16,10 @@ let ReactNoop;
 describe('ReactFragment', () => {
   beforeEach(function() {
     jest.resetModules();
+
+    const ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableReactFragment = true;
+
     React = require('react');
     ReactNoop = require('react-noop-renderer');
   });
@@ -33,699 +37,691 @@ describe('ReactFragment', () => {
     return {type: 'div', children, prop: undefined};
   }
 
-  if (ReactFeatureFlags.enableReactFragment) {
-    it('should render a single child via noop renderer', () => {
-      const element = (
-        <React.Fragment>
-          <span>foo</span>
-        </React.Fragment>
-      );
+  it('should render a single child via noop renderer', () => {
+    const element = (
+      <React.Fragment>
+        <span>foo</span>
+      </React.Fragment>
+    );
 
-      ReactNoop.render(element);
-      ReactNoop.flush();
+    ReactNoop.render(element);
+    ReactNoop.flush();
 
-      expect(ReactNoop.getChildren()).toEqual([span()]);
-    });
+    expect(ReactNoop.getChildren()).toEqual([span()]);
+  });
 
-    it('should render zero children via noop renderer', () => {
-      const element = <React.Fragment />;
+  it('should render zero children via noop renderer', () => {
+    const element = <React.Fragment />;
 
-      ReactNoop.render(element);
-      ReactNoop.flush();
+    ReactNoop.render(element);
+    ReactNoop.flush();
 
-      expect(ReactNoop.getChildren()).toEqual([]);
-    });
+    expect(ReactNoop.getChildren()).toEqual([]);
+  });
 
-    it('should render multiple children via noop renderer', () => {
-      const element = (
-        <React.Fragment>
-          hello <span>world</span>
-        </React.Fragment>
-      );
+  it('should render multiple children via noop renderer', () => {
+    const element = (
+      <React.Fragment>
+        hello <span>world</span>
+      </React.Fragment>
+    );
 
-      ReactNoop.render(element);
-      ReactNoop.flush();
+    ReactNoop.render(element);
+    ReactNoop.flush();
 
-      expect(ReactNoop.getChildren()).toEqual([text('hello '), span()]);
-    });
+    expect(ReactNoop.getChildren()).toEqual([text('hello '), span()]);
+  });
 
-    it('should render an iterable via noop renderer', () => {
-      const element = (
-        <React.Fragment>
-          {new Set([<span key="a">hi</span>, <span key="b">bye</span>])}
-        </React.Fragment>
-      );
+  it('should render an iterable via noop renderer', () => {
+    const element = (
+      <React.Fragment>
+        {new Set([<span key="a">hi</span>, <span key="b">bye</span>])}
+      </React.Fragment>
+    );
 
-      ReactNoop.render(element);
-      ReactNoop.flush();
+    ReactNoop.render(element);
+    ReactNoop.flush();
 
-      expect(ReactNoop.getChildren()).toEqual([span(), span()]);
-    });
+    expect(ReactNoop.getChildren()).toEqual([span(), span()]);
+  });
 
-    it('should preserve state of children with 1 level nesting', function() {
-      var ops = [];
+  it('should preserve state of children with 1 level nesting', function() {
+    var ops = [];
 
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
       }
 
-      function Foo({condition}) {
-        return condition
-          ? <Stateful key="a" />
-          : <React.Fragment>
-              <Stateful key="a" />
-              <div key="b">World</div>
-            </React.Fragment>;
+      render() {
+        return <div>Hello</div>;
+      }
+    }
+
+    function Foo({condition}) {
+      return condition
+        ? <Stateful key="a" />
+        : <React.Fragment>
+            <Stateful key="a" />
+            <div key="b">World</div>
+          </React.Fragment>;
+    }
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div(), div()]);
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
+
+  it('should preserve state between top-level fragments', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
       }
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
+      render() {
+        return <div>Hello</div>;
+      }
+    }
 
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
+    function Foo({condition}) {
+      return condition
+        ? <React.Fragment>
+            <Stateful />
+          </React.Fragment>
+        : <React.Fragment>
+            <Stateful />
+          </React.Fragment>;
+    }
 
-      expect(ops).toEqual(['Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div(), div()]);
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
 
-      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
+    expect(ops).toEqual(['Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
 
-    it('should preserve state between top-level fragments', function() {
-      var ops = [];
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
 
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
+    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
 
-        render() {
-          return <div>Hello</div>;
-        }
+  it('should preserve state of children nested at same level', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
       }
 
-      function Foo({condition}) {
-        return condition
-          ? <React.Fragment>
-              <Stateful />
-            </React.Fragment>
-          : <React.Fragment>
-              <Stateful />
-            </React.Fragment>;
+      render() {
+        return <div>Hello</div>;
       }
+    }
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual(['Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
-
-    it('should preserve state of children nested at same level', function() {
-      var ops = [];
-
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
-      }
-
-      function Foo({condition}) {
-        return condition
-          ? <React.Fragment>
-              <React.Fragment>
-                <React.Fragment>
-                  <Stateful key="a" />
-                </React.Fragment>
-              </React.Fragment>
-            </React.Fragment>
-          : <React.Fragment>
-              <React.Fragment>
-                <React.Fragment>
-                  <div />
-                  <Stateful key="a" />
-                </React.Fragment>
-              </React.Fragment>
-            </React.Fragment>;
-      }
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual(['Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div(), div()]);
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
-
-    it('should not preserve state in non-top-level fragment nesting', function() {
-      var ops = [];
-
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
-      }
-
-      function Foo({condition}) {
-        return condition
-          ? <React.Fragment>
-              <React.Fragment><Stateful key="a" /></React.Fragment>
-            </React.Fragment>
-          : <React.Fragment><Stateful key="a" /></React.Fragment>;
-      }
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
-
-    it('should not preserve state of children if nested 2 levels without siblings', function() {
-      var ops = [];
-
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
-      }
-
-      function Foo({condition}) {
-        return condition
-          ? <Stateful key="a" />
-          : <React.Fragment>
+    function Foo({condition}) {
+      return condition
+        ? <React.Fragment>
+            <React.Fragment>
               <React.Fragment>
                 <Stateful key="a" />
               </React.Fragment>
-            </React.Fragment>;
-      }
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
-
-    it('should not preserve state of children if nested 2 levels with siblings', function() {
-      var ops = [];
-
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
-      }
-
-      function Foo({condition}) {
-        return condition
-          ? <Stateful key="a" />
-          : <React.Fragment>
+            </React.Fragment>
+          </React.Fragment>
+        : <React.Fragment>
+            <React.Fragment>
               <React.Fragment>
+                <div />
                 <Stateful key="a" />
               </React.Fragment>
-              <div />
-            </React.Fragment>;
+            </React.Fragment>
+          </React.Fragment>;
+    }
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div(), div()]);
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
+
+  it('should not preserve state in non-top-level fragment nesting', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
       }
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
+      render() {
+        return <div>Hello</div>;
+      }
+    }
 
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
+    function Foo({condition}) {
+      return condition
+        ? <React.Fragment>
+            <React.Fragment><Stateful key="a" /></React.Fragment>
+          </React.Fragment>
+        : <React.Fragment><Stateful key="a" /></React.Fragment>;
+    }
 
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div(), div()]);
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
 
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
 
-    it('should preserve state between array nested in fragment and fragment', function() {
-      var ops = [];
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
 
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
 
-        render() {
-          return <div>Hello</div>;
-        }
+  it('should not preserve state of children if nested 2 levels without siblings', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
       }
 
-      function Foo({condition}) {
-        return condition
-          ? <React.Fragment>
+      render() {
+        return <div>Hello</div>;
+      }
+    }
+
+    function Foo({condition}) {
+      return condition
+        ? <Stateful key="a" />
+        : <React.Fragment>
+            <React.Fragment>
               <Stateful key="a" />
             </React.Fragment>
-          : <React.Fragment>
-              {[<Stateful key="a" />]}
-            </React.Fragment>;
+          </React.Fragment>;
+    }
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
+
+  it('should not preserve state of children if nested 2 levels with siblings', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
       }
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual(['Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
-
-    it('should preserve state between top level fragment and array', function() {
-      var ops = [];
-
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
+      render() {
+        return <div>Hello</div>;
       }
+    }
 
-      function Foo({condition}) {
-        return condition
-          ? [<Stateful key="a" />]
-          : <React.Fragment>
+    function Foo({condition}) {
+      return condition
+        ? <Stateful key="a" />
+        : <React.Fragment>
+            <React.Fragment>
               <Stateful key="a" />
-            </React.Fragment>;
-      }
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual(['Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
-
-    it('should not preserve state between array nested in fragment and double nested fragment', function() {
-      var ops = [];
-
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
-      }
-
-      function Foo({condition}) {
-        return condition
-          ? <React.Fragment>{[<Stateful key="a" />]}</React.Fragment>
-          : <React.Fragment>
-              <React.Fragment><Stateful key="a" /></React.Fragment>
-            </React.Fragment>;
-      }
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
-
-    it('should not preserve state between array nested in fragment and double nested array', function() {
-      var ops = [];
-
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
-      }
-
-      function Foo({condition}) {
-        return condition
-          ? <React.Fragment>{[<Stateful key="a" />]}</React.Fragment>
-          : [[<Stateful key="a" />]];
-      }
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
-
-    it('should preserve state between double nested fragment and double nested array', function() {
-      var ops = [];
-
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
-      }
-
-      function Foo({condition}) {
-        return condition
-          ? <React.Fragment>
-              <React.Fragment><Stateful key="a" /></React.Fragment>
             </React.Fragment>
-          : [[<Stateful key="a" />]];
+            <div />
+          </React.Fragment>;
+    }
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div(), div()]);
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
+
+  it('should preserve state between array nested in fragment and fragment', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
       }
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
+      render() {
+        return <div>Hello</div>;
+      }
+    }
 
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
+    function Foo({condition}) {
+      return condition
+        ? <React.Fragment>
+            <Stateful key="a" />
+          </React.Fragment>
+        : <React.Fragment>
+            {[<Stateful key="a" />]}
+          </React.Fragment>;
+    }
 
-      expect(ops).toEqual(['Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
 
-      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
+    expect(ops).toEqual(['Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
 
-    it('should not preserve state of children when the keys are different', function() {
-      var ops = [];
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
 
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
+    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
 
-        render() {
-          return <div>Hello</div>;
-        }
+  it('should preserve state between top level fragment and array', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
       }
 
-      function Foo({condition}) {
-        return condition
-          ? <React.Fragment key="a">
-              <Stateful />
+      render() {
+        return <div>Hello</div>;
+      }
+    }
+
+    function Foo({condition}) {
+      return condition
+        ? [<Stateful key="a" />]
+        : <React.Fragment>
+            <Stateful key="a" />
+          </React.Fragment>;
+    }
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
+
+  it('should not preserve state between array nested in fragment and double nested fragment', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
+      }
+
+      render() {
+        return <div>Hello</div>;
+      }
+    }
+
+    function Foo({condition}) {
+      return condition
+        ? <React.Fragment>{[<Stateful key="a" />]}</React.Fragment>
+        : <React.Fragment>
+            <React.Fragment><Stateful key="a" /></React.Fragment>
+          </React.Fragment>;
+    }
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
+
+  it('should not preserve state between array nested in fragment and double nested array', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
+      }
+
+      render() {
+        return <div>Hello</div>;
+      }
+    }
+
+    function Foo({condition}) {
+      return condition
+        ? <React.Fragment>{[<Stateful key="a" />]}</React.Fragment>
+        : [[<Stateful key="a" />]];
+    }
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
+
+  it('should preserve state between double nested fragment and double nested array', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
+      }
+
+      render() {
+        return <div>Hello</div>;
+      }
+    }
+
+    function Foo({condition}) {
+      return condition
+        ? <React.Fragment>
+            <React.Fragment><Stateful key="a" /></React.Fragment>
+          </React.Fragment>
+        : [[<Stateful key="a" />]];
+    }
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
+
+  it('should not preserve state of children when the keys are different', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
+      }
+
+      render() {
+        return <div>Hello</div>;
+      }
+    }
+
+    function Foo({condition}) {
+      return condition
+        ? <React.Fragment key="a">
+            <Stateful />
+          </React.Fragment>
+        : <React.Fragment key="b">
+            <Stateful />
+            <span>World</span>
+          </React.Fragment>;
+    }
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div(), span()]);
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
+
+  it('should not preserve state between unkeyed and keyed fragment', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
+      }
+
+      render() {
+        return <div>Hello</div>;
+      }
+    }
+
+    function Foo({condition}) {
+      return condition
+        ? <React.Fragment key="a">
+            <Stateful />
+          </React.Fragment>
+        : <React.Fragment>
+            <Stateful />
+          </React.Fragment>;
+    }
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div()]);
+  });
+
+  it('should preserve state with reordering in multiple levels', function() {
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
+      }
+
+      render() {
+        return <div>Hello</div>;
+      }
+    }
+
+    function Foo({condition}) {
+      return condition
+        ? <div>
+            <React.Fragment key="c">
+              <span>foo</span>
+              <div key="b">
+                <Stateful key="a" />
+              </div>
             </React.Fragment>
-          : <React.Fragment key="b">
-              <Stateful />
-              <span>World</span>
-            </React.Fragment>;
-      }
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div(), span()]);
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
-
-    it('should not preserve state between unkeyed and keyed fragment', function() {
-      var ops = [];
-
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
-      }
-
-      function Foo({condition}) {
-        return condition
-          ? <React.Fragment key="a">
-              <Stateful />
+            <span>boop</span>
+          </div>
+        : <div>
+            <span>beep</span>
+            <React.Fragment key="c">
+              <div key="b">
+                <Stateful key="a" />
+              </div>
+              <span>bar</span>
             </React.Fragment>
-          : <React.Fragment>
-              <Stateful />
-            </React.Fragment>;
+          </div>;
+    }
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div(span(), div(div()), span())]);
+
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([div(span(), div(div()), span())]);
+  });
+
+  it('should not preserve state when switching to a keyed fragment to an array', function() {
+    spyOn(console, 'error');
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
       }
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
+      render() {
+        return <div>Hello</div>;
+      }
+    }
 
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
+    function Foo({condition}) {
+      return condition
+        ? <div>
+            {<React.Fragment key="foo"><Stateful /></React.Fragment>}<span />
+          </div>
+        : <div>{[<Stateful />]}<span /></div>;
+    }
 
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
 
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div()]);
-    });
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
 
-    it('should preserve state with reordering in multiple levels', function() {
-      var ops = [];
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
 
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
+    expect(ops).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'Each child in an array or iterator should have a unique "key" prop.',
+    );
+  });
 
-        render() {
-          return <div>Hello</div>;
-        }
+  it('should preserve state when it does not change positions', function() {
+    spyOn(console, 'error');
+    var ops = [];
+
+    class Stateful extends React.Component {
+      componentDidUpdate() {
+        ops.push('Update Stateful');
       }
 
-      function Foo({condition}) {
-        return condition
-          ? <div>
-              <React.Fragment key="c">
-                <span>foo</span>
-                <div key="b">
-                  <Stateful key="a" />
-                </div>
-              </React.Fragment>
-              <span>boop</span>
-            </div>
-          : <div>
-              <span>beep</span>
-              <React.Fragment key="c">
-                <div key="b">
-                  <Stateful key="a" />
-                </div>
-                <span>bar</span>
-              </React.Fragment>
-            </div>;
+      render() {
+        return <div>Hello</div>;
       }
+    }
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
+    function Foo({condition}) {
+      return condition
+        ? [<span />, <React.Fragment><Stateful /></React.Fragment>]
+        : [<span />, <React.Fragment><Stateful /></React.Fragment>];
+    }
 
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
 
-      expect(ops).toEqual(['Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([
-        div(span(), div(div()), span()),
-      ]);
+    ReactNoop.render(<Foo condition={false} />);
+    ReactNoop.flush();
 
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
+    expect(ops).toEqual(['Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([span(), div()]);
 
-      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([
-        div(span(), div(div()), span()),
-      ]);
-    });
+    ReactNoop.render(<Foo condition={true} />);
+    ReactNoop.flush();
 
-    it('should not preserve state when switching to a keyed fragment to an array', function() {
-      spyOn(console, 'error');
-      var ops = [];
-
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
-      }
-
-      function Foo({condition}) {
-        return condition
-          ? <div>
-              {<React.Fragment key="foo"><Stateful /></React.Fragment>}<span />
-            </div>
-          : <div>{[<Stateful />]}<span /></div>;
-      }
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual([]);
-      expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
+    expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
+    expect(ReactNoop.getChildren()).toEqual([span(), div()]);
+    expectDev(console.error.calls.count()).toBe(3);
+    for (let errorIndex = 0; errorIndex < 3; ++errorIndex) {
+      expectDev(console.error.calls.argsFor(errorIndex)[0]).toContain(
         'Each child in an array or iterator should have a unique "key" prop.',
       );
-    });
-
-    it('should preserve state when it does not change positions', function() {
-      spyOn(console, 'error');
-      var ops = [];
-
-      class Stateful extends React.Component {
-        componentDidUpdate() {
-          ops.push('Update Stateful');
-        }
-
-        render() {
-          return <div>Hello</div>;
-        }
-      }
-
-      function Foo({condition}) {
-        return condition
-          ? [<span />, <React.Fragment><Stateful /></React.Fragment>]
-          : [<span />, <React.Fragment><Stateful /></React.Fragment>];
-      }
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      ReactNoop.render(<Foo condition={false} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual(['Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([span(), div()]);
-
-      ReactNoop.render(<Foo condition={true} />);
-      ReactNoop.flush();
-
-      expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-      expect(ReactNoop.getChildren()).toEqual([span(), div()]);
-      expectDev(console.error.calls.count()).toBe(3);
-      for (let errorIndex = 0; errorIndex < 3; ++errorIndex) {
-        expectDev(console.error.calls.argsFor(errorIndex)[0]).toContain(
-          'Each child in an array or iterator should have a unique "key" prop.',
-        );
-      }
-    });
-  } else {
-    it('should not run any tests', function() {});
-  }
+    }
+  });
 });

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -29,6 +29,9 @@ describe('ReactJSXElementValidator', () => {
   beforeEach(() => {
     jest.resetModules();
 
+    const ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableReactFragment = true;
+
     PropTypes = require('prop-types');
     React = require('react');
     ReactDOM = require('react-dom');
@@ -87,50 +90,48 @@ describe('ReactJSXElementValidator', () => {
     );
   });
 
-  if (ReactFeatureFlags.enableReactFragment) {
-    it('warns for fragments with illegal attributes', () => {
-      spyOn(console, 'error');
+  it('warns for fragments with illegal attributes', () => {
+    spyOn(console, 'error');
 
-      class Foo extends React.Component {
-        render() {
-          return <React.Fragment a={1} b={2}>hello</React.Fragment>;
-        }
+    class Foo extends React.Component {
+      render() {
+        return <React.Fragment a={1} b={2}>hello</React.Fragment>;
       }
+    }
 
-      ReactTestUtils.renderIntoDocument(<Foo />);
+    ReactTestUtils.renderIntoDocument(<Foo />);
 
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain('Invalid prop `');
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        '` supplied to `React.Fragment`. React.Fragment ' +
-          'can only have `key` and `children` props.',
-      );
-    });
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain('Invalid prop `');
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      '` supplied to `React.Fragment`. React.Fragment ' +
+        'can only have `key` and `children` props.',
+    );
+  });
 
-    it('warns for fragments with refs', () => {
-      spyOn(console, 'error');
+  it('warns for fragments with refs', () => {
+    spyOn(console, 'error');
 
-      class Foo extends React.Component {
-        render() {
-          return (
-            <React.Fragment
-              ref={bar => {
-                this.foo = bar;
-              }}>
-              hello
-            </React.Fragment>
-          );
-        }
+    class Foo extends React.Component {
+      render() {
+        return (
+          <React.Fragment
+            ref={bar => {
+              this.foo = bar;
+            }}>
+            hello
+          </React.Fragment>
+        );
       }
+    }
 
-      ReactTestUtils.renderIntoDocument(<Foo />);
+    ReactTestUtils.renderIntoDocument(<Foo />);
 
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Invalid attribute `ref` supplied to `React.Fragment`.',
-      );
-    });
-  }
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'Invalid attribute `ref` supplied to `React.Fragment`.',
+    );
+  });
 
   it('warns for keys for iterables of elements in rest args', () => {
     spyOn(console, 'error');
@@ -155,33 +156,31 @@ describe('ReactJSXElementValidator', () => {
     );
   });
 
-  if (ReactFeatureFlags.enableReactFragment) {
-    it('does not warn for fragments of multiple elements without keys', () => {
-      ReactTestUtils.renderIntoDocument(
-        <React.Fragment>
-          <span>1</span>
-          <span>2</span>
-        </React.Fragment>,
-      );
-    });
+  it('does not warn for fragments of multiple elements without keys', () => {
+    ReactTestUtils.renderIntoDocument(
+      <React.Fragment>
+        <span>1</span>
+        <span>2</span>
+      </React.Fragment>,
+    );
+  });
 
-    it('warns for fragments of multiple elements with same key', () => {
-      spyOn(console, 'error');
+  it('warns for fragments of multiple elements with same key', () => {
+    spyOn(console, 'error');
 
-      ReactTestUtils.renderIntoDocument(
-        <React.Fragment>
-          <span key="a">1</span>
-          <span key="a">2</span>
-          <span key="b">3</span>
-        </React.Fragment>,
-      );
+    ReactTestUtils.renderIntoDocument(
+      <React.Fragment>
+        <span key="a">1</span>
+        <span key="a">2</span>
+        <span key="b">3</span>
+      </React.Fragment>,
+    );
 
-      expectDev(console.error.calls.count()).toBe(1);
-      expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Encountered two children with the same key, `a`.',
-      );
-    });
-  }
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'Encountered two children with the same key, `a`.',
+    );
+  });
 
   it('does not warn for arrays of elements with keys', () => {
     spyOn(console, 'error');


### PR DESCRIPTION
As @acdlite points out in https://github.com/facebook/react/pull/11426#discussion_r148433105, we didn’t do this correctly. Instead of not running the tests *at all* (and potentially breaking the code) we should always run the relevant tests with the feature flag on. We don’t test both code paths because it is purely additional, although if the flag stays in for a long time, then we should think about it.