### PR TITLE
Undo fbjs/lib/EventListener inlining

### DIFF
--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -8,9 +8,9 @@
 'use strict';
 
 var ReactGenericBatching = require('events/ReactGenericBatching');
-var ReactErrorUtils = require('shared/ReactErrorUtils');
 var ReactFiberTreeReflection = require('shared/ReactFiberTreeReflection');
 var ReactTypeOfWork = require('shared/ReactTypeOfWork');
+var EventListener = require('fbjs/lib/EventListener');
 var warning = require('fbjs/lib/warning');
 var {HostRoot} = ReactTypeOfWork;
 
@@ -128,18 +128,11 @@ var ReactDOMEventListener = {
     if (!element) {
       return null;
     }
-    // TODO: Once we have static injection we should just wrap
-    // ReactDOMEventListener.dispatchEvent statically so we don't have to do
-    // it for every event type.
-    var callback = ReactErrorUtils.wrapEventListener(
+    return EventListener.listen(
+      element,
       handlerBaseName,
       ReactDOMEventListener.dispatchEvent.bind(null, topLevelType),
     );
-    if (element.addEventListener) {
-      element.addEventListener(handlerBaseName, callback, false);
-    } else if (element.attachEvent) {
-      element.attachEvent('on' + handlerBaseName, callback);
-    }
   },
 
   /**
@@ -156,25 +149,11 @@ var ReactDOMEventListener = {
     if (!element) {
       return null;
     }
-    if (element.addEventListener) {
-      // TODO: Once we have static injection we should just wrap
-      // ReactDOMEventListener.dispatchEvent statically so we don't have to do
-      // it for every event type.
-      var callback = ReactErrorUtils.wrapEventListener(
-        handlerBaseName,
-        ReactDOMEventListener.dispatchEvent.bind(null, topLevelType),
-      );
-      element.addEventListener(handlerBaseName, callback, true);
-    } else {
-      if (__DEV__) {
-        warning(
-          false,
-          'Attempted to listen to events during the capture phase on a ' +
-            'browser that does not support the capture phase. Your application ' +
-            'will not receive some events.',
-        );
-      }
-    }
+    return EventListener.capture(
+      element,
+      handlerBaseName,
+      ReactDOMEventListener.dispatchEvent.bind(null, topLevelType),
+    );
   },
 
   dispatchEvent: function(topLevelType, nativeEvent) {

--- a/packages/shared/ReactErrorUtils.js
+++ b/packages/shared/ReactErrorUtils.js
@@ -27,7 +27,6 @@ const ReactErrorUtils = {
         'Injected invokeGuardedCallback() must be a function.',
       );
       invokeGuardedCallback = injectedErrorUtils.invokeGuardedCallback;
-      wrapEventListener = injectedErrorUtils.wrapEventListener;
     },
   },
 
@@ -56,13 +55,6 @@ const ReactErrorUtils = {
     f: F,
   ): void {
     invokeGuardedCallback.apply(ReactErrorUtils, arguments);
-  },
-
-  /**
-   * Wrap a callback in whatever logic it needs. Used in FB to polyfill Promises.
-   */
-  wrapEventListener: function<T>(name: string, callback: T): T {
-    return wrapEventListener(name, callback);
   },
 
   /**
@@ -122,10 +114,6 @@ const ReactErrorUtils = {
       );
     }
   },
-};
-
-let wrapEventListener = function<T>(name: string, callback: T): T {
-  return callback;
 };
 
 let invokeGuardedCallback = function(name, func, context, a, b, c, d, e, f) {


### PR DESCRIPTION
This approach caused an issue internally so we're backing away from it. I reverted the changes in https://github.com/facebook/react/pull/11402, but kept the test changes since it is equivalent but better (and tests public API instead).

To solve the leak we're experiencing with our internal EventListener fork, we will use a different strategy. The plan is to attach top-level listeners by root.