### PR TITLE
Validate built bundles with a few ESLint rules

### DIFF
--- a/scripts/circleci/build.sh
+++ b/scripts/circleci/build.sh
@@ -5,6 +5,9 @@ set -e
 yarn build --extract-errors
 git checkout -- scripts/error-codes/codes.json
 
+# Do a sanity check on bundles
+node ./scripts/rollup/validate/index
+
 # Check that the standalone reconciler isn't borked
 cd fixtures/reconciler
 yarn

--- a/scripts/rollup/validate/eslintignore
+++ b/scripts/rollup/validate/eslintignore
@@ -1,0 +1,4 @@
+# Don't validate noop renderer bundle.
+# Unlike others, it currently uses ES6 syntax (generators).
+# We also don't use or publish it.
+**/react-noop-renderer/**

--- a/scripts/rollup/validate/eslintrc.cjs.js
+++ b/scripts/rollup/validate/eslintrc.cjs.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  env: {
+    commonjs: true,
+    browser: true,
+  },
+  globals: {
+    // ES 6
+    Map: true,
+    Set: true,
+    Proxy: true,
+    Symbol: true,
+    WeakMap: true,
+    // Vendor specific
+    MSApp: true,
+    __REACT_DEVTOOLS_GLOBAL_HOOK__: true,
+    // CommonJS / Node
+    process: true,
+  },
+  parserOptions: {
+    ecmaVersion: 5,
+    sourceType: 'script',
+  },
+  rules: {
+    'no-undef': 'error',
+    'no-shadow-restricted-names': 'error',
+  },
+};

--- a/scripts/rollup/validate/eslintrc.fb.js
+++ b/scripts/rollup/validate/eslintrc.fb.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  env: {
+    commonjs: true,
+    browser: true,
+  },
+  globals: {
+    // ES6
+    Map: true,
+    Set: true,
+    Symbol: true,
+    Proxy: true,
+    WeakMap: true,
+    // Vendor specific
+    MSApp: true,
+    __REACT_DEVTOOLS_GLOBAL_HOOK__: true,
+    // FB
+    __DEV__: true,
+  },
+  parserOptions: {
+    ecmaVersion: 5,
+    sourceType: 'script',
+  },
+  rules: {
+    'no-undef': 'error',
+    'no-shadow-restricted-names': 'error',
+  },
+};

--- a/scripts/rollup/validate/eslintrc.rn.js
+++ b/scripts/rollup/validate/eslintrc.rn.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  env: {
+    commonjs: true,
+    browser: true,
+  },
+  globals: {
+    // ES6
+    Map: true,
+    Set: true,
+    Symbol: true,
+    Proxy: true,
+    WeakMap: true,
+    // Vendor specific
+    MSApp: true,
+    __REACT_DEVTOOLS_GLOBAL_HOOK__: true,
+    // FB
+    __DEV__: true,
+  },
+  parserOptions: {
+    ecmaVersion: 5,
+    sourceType: 'script',
+  },
+  rules: {
+    'no-undef': 'error',
+    'no-shadow-restricted-names': 'error',
+  },
+};

--- a/scripts/rollup/validate/eslintrc.umd.js
+++ b/scripts/rollup/validate/eslintrc.umd.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  env: {
+    browser: true,
+  },
+  globals: {
+    // ES6
+    Map: true,
+    Set: true,
+    Symbol: true,
+    Proxy: true,
+    WeakMap: true,
+    // Vendor specific
+    MSApp: true,
+    __REACT_DEVTOOLS_GLOBAL_HOOK__: true,
+    // UMD wrapper code
+    // TODO: this is too permissive.
+    // Ideally we should only allow these *inside* the UMD wrapper.
+    module: true,
+    define: true,
+    require: true,
+    global: true,
+  },
+  parserOptions: {
+    ecmaVersion: 5,
+    sourceType: 'script',
+  },
+  rules: {
+    'no-undef': 'error',
+    'no-shadow-restricted-names': 'error',
+  },
+};

--- a/scripts/rollup/validate/index.js
+++ b/scripts/rollup/validate/index.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const chalk = require('chalk');
+const path = require('path');
+const spawnSync = require('child_process').spawnSync;
+
+const extension = process.platform === 'win32' ? '.cmd' : '';
+
+// Performs sanity checks on bundles *built* by Rollup.
+// Helps catch Rollup regressions.
+function run(format, filePatterns) {
+  console.log(`Linting ${format} bundles...`);
+  const result = spawnSync(
+    path.join('node_modules', '.bin', 'eslint' + extension),
+    [
+      filePatterns,
+      '--config',
+      path.join(__dirname, `eslintrc.${format}.js`),
+      // Disregard our ESLint rules that apply to the source.
+      '--no-eslintrc',
+      // Use a different ignore file.
+      '--ignore-path',
+      path.join(__dirname, 'eslintignore'),
+    ],
+    {
+      // Allow colors to pass through
+      stdio: 'inherit',
+    }
+  );
+  if (result.status !== 0) {
+    console.error(chalk.red(`Linting of ${format} bundles has failed.`));
+    process.exit(result.status);
+  } else {
+    console.log(chalk.green(`Linted ${format} bundles successfully!`));
+    console.log();
+  }
+}
+
+run('fb', `./build/facebook-www/*.js`);
+run('rn', `./build/{react-cs,react-native,react-rt}/*.js`);
+run('umd', `./build/packages/*/umd/*.js`);
+run('cjs', [`./build/packages/*/*.js`, `./build/packages/*/cjs/*.js`]);


### PR DESCRIPTION
I bumped into a scary Rollup bug yesterday: https://github.com/rollup/rollup/issues/1645#issuecomment-341277757. This adds a very limited (and fast) lint on compiled bundles to prevent this sort of regressions from happening. It only runs on CI.