### PR TITLE
Auto-install (or update) release script Yarn deps before running

### DIFF
--- a/scripts/release/build.js
+++ b/scripts/release/build.js
@@ -2,26 +2,28 @@
 
 'use strict';
 
-const chalk = require('chalk');
-const logUpdate = require('log-update');
-
-const buildArtifacts = require('./build-commands/build-artifacts');
-const checkCircleCiStatus = require('./build-commands/check-circle-ci-status');
-const checkEnvironmentVariables = require('./build-commands/check-environment-variables');
-const checkNpmPermissions = require('./build-commands/check-npm-permissions');
-const checkPackageDependencies = require('./build-commands/check-package-dependencies');
-const checkUncommittedChanges = require('./build-commands/check-uncommitted-changes');
-const installYarnDependencies = require('./build-commands/install-yarn-dependencies');
-const parseBuildParameters = require('./build-commands/parse-build-parameters');
-const printPostBuildSummary = require('./build-commands/print-post-build-summary');
-const runAutomatedTests = require('./build-commands/run-automated-tests');
-const updateGit = require('./build-commands/update-git');
-const updatePackageVersions = require('./build-commands/update-package-versions');
-const updateYarnDependencies = require('./build-commands/update-yarn-dependencies');
-const validateVersion = require('./build-commands/validate-version');
+const {exec} = require('child_process');
 
 // Follows the steps outlined in github.com/facebook/react/issues/10620
 const run = async () => {
+  const chalk = require('chalk');
+  const logUpdate = require('log-update');
+
+  const buildArtifacts = require('./build-commands/build-artifacts');
+  const checkCircleCiStatus = require('./build-commands/check-circle-ci-status');
+  const checkEnvironmentVariables = require('./build-commands/check-environment-variables');
+  const checkNpmPermissions = require('./build-commands/check-npm-permissions');
+  const checkPackageDependencies = require('./build-commands/check-package-dependencies');
+  const checkUncommittedChanges = require('./build-commands/check-uncommitted-changes');
+  const installYarnDependencies = require('./build-commands/install-yarn-dependencies');
+  const parseBuildParameters = require('./build-commands/parse-build-parameters');
+  const printPostBuildSummary = require('./build-commands/print-post-build-summary');
+  const runAutomatedTests = require('./build-commands/run-automated-tests');
+  const updateGit = require('./build-commands/update-git');
+  const updatePackageVersions = require('./build-commands/update-package-versions');
+  const updateYarnDependencies = require('./build-commands/update-yarn-dependencies');
+  const validateVersion = require('./build-commands/validate-version');
+
   try {
     const params = parseBuildParameters();
 
@@ -52,4 +54,13 @@ const run = async () => {
   }
 };
 
-run();
+// Install (or update) release script dependencies before proceeding.
+// This needs to be done before we require() the first NPM module.
+exec('yarn install', {cwd: __dirname}, (error, stdout, stderr) => {
+  if (error) {
+    console.error(error);
+    process.exit(1);
+  } else {
+    run();
+  }
+});


### PR DESCRIPTION
Stepping through a dry-run of the new release process for `16.1.0-beta` and realized that there was no guaranteed that we were running the latest version of the release script dependencies.