### PR TITLE
Fix ReactShallowRenderer not rerendering when calling forceUpdate()

### DIFF
--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -147,9 +147,11 @@ class ReactShallowRenderer {
     // Fallback to previous instance state to support rendering React.cloneElement()
     const state = this._newState || this._instance.state || emptyObject;
 
-    if (typeof this._instance.shouldComponentUpdate === 'function') {
+    if (
+      typeof this._instance.shouldComponentUpdate === 'function' &&
+      this._forcedUpdate !== true
+    ) {
       if (
-        this._forcedUpdate ||
         this._instance.shouldComponentUpdate(props, state, context) === false
       ) {
         this._instance.context = context;

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -149,7 +149,7 @@ class ReactShallowRenderer {
 
     if (
       typeof this._instance.shouldComponentUpdate === 'function' &&
-      this._forcedUpdate !== true
+      !this._forcedUpdate
     ) {
       if (
         this._instance.shouldComponentUpdate(props, state, context) === false

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -142,6 +142,24 @@ describe('ReactShallowRenderer', () => {
     expect(scuCounter).toEqual(0);
   });
 
+  it('should rerender when calling forceUpdate', () => {
+    let renderCounter = 0;
+    class SimpleComponent extends React.Component {
+      render() {
+        renderCounter += 1;
+        return <div />;
+      }
+    }
+
+    const shallowRenderer = createRenderer();
+    shallowRenderer.render(<SimpleComponent />);
+    expect(renderCounter).toEqual(1);
+
+    const instance = shallowRenderer.getMountedInstance();
+    instance.forceUpdate();
+    expect(renderCounter).toEqual(2);
+  });
+
   it('should shallow render a functional component', () => {
     function SomeComponent(props, context) {
       return (


### PR DESCRIPTION
This is a followup to #11239. Unfortunately the fix implemented for #11236 was incorrect and it didn't solve the underlying issue of not rerendering component properly on `forceUpdate`. 

This PR solves the issue and adds necessary test to make sure it's resolved properly this time.