### PR TITLE
Fix `yarn linc` command on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "scripts": {
     "build": "npm run version-check && node scripts/rollup/build.js",
-    "linc": "git diff --name-only --diff-filter=ACMRTUB `git merge-base HEAD master` | grep '\\.js$' | xargs eslint --",
+    "linc": "git diff --name-only --diff-filter=ACMRTUB `git merge-base HEAD master` -- '*.js' | xargs eslint --",
     "lint": "node ./scripts/tasks/eslint.js",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
     "test": "jest",


### PR DESCRIPTION
this issue:
https://github.com/facebook/react/issues/11444

I just got the idea that we can match .js files without using grep in a second pipe,
but by passing directly to `git diff`