### PR TITLE
Add a way to suppress DevTools logs and warnings

### DIFF
--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.js
@@ -37,6 +37,12 @@ export function injectInternals(internals: Object): boolean {
     return false;
   }
   const hook = __REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (hook.isDisabled) {
+    // This isn't a real property on the hook, but it can be set to opt out
+    // of DevTools integration and associated warnings and logs.
+    // https://github.com/facebook/react/issues/3877
+    return true;
+  }
   if (!hook.supportsFiber) {
     if (__DEV__) {
       warning(


### PR DESCRIPTION
Addresses https://github.com/facebook/react/issues/3877.

The idea is that the people who need it can shim the `__REACT_DEVTOOLS_GLOBAL_HOOK__` global in their webpack/browserify configs with an object like `({ isDisabled: true })`.

Basically same approach as I suggested in https://github.com/facebook/react/issues/3877#issuecomment-340201139, but doesn't produce an extra warning.