### PR TITLE
Expose injectIntoDevTools() to renderers

### DIFF
--- a/packages/react-cs-renderer/src/ReactNativeCS.js
+++ b/packages/react-cs-renderer/src/ReactNativeCS.js
@@ -14,7 +14,6 @@ import type {ReactNativeCSType} from './ReactNativeCSTypes';
 import {CSStatefulComponent} from 'CSStatefulComponent';
 
 import ReactFiberReconciler from 'react-reconciler';
-import {injectInternals} from 'react-reconciler/src/ReactFiberDevToolsHook';
 import ReactVersion from 'shared/ReactVersion';
 
 const emptyObject = {};
@@ -240,9 +239,7 @@ const ReactNativeCSFiberRenderer = ReactFiberReconciler({
   },
 });
 
-injectInternals({
-  findHostInstanceByFiber: ReactNativeCSFiberRenderer.findHostInstance,
-  // This is an enum because we may add more (e.g. profiler build)
+ReactNativeCSFiberRenderer.injectIntoDevTools({
   bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,
   rendererPackageName: 'react-cs-renderer',

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -16,8 +16,6 @@ import './ReactDOMClientInjection';
 import ReactFiberReconciler from 'react-reconciler';
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import * as ReactPortal from 'react-reconciler/src/ReactPortal';
-// TODO: direct imports like some-package/src/* are bad. Fix me.
-import {injectInternals} from 'react-reconciler/src/ReactFiberDevToolsHook';
 import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 import * as ReactGenericBatching from 'events/ReactGenericBatching';
 import * as ReactControlledComponent from 'events/ReactControlledComponent';
@@ -955,10 +953,8 @@ if (ReactFeatureFlags.enableCreateRoot) {
   };
 }
 
-const foundDevTools = injectInternals({
+const foundDevTools = DOMRenderer.injectIntoDevTools({
   findFiberByHostInstance: ReactDOMComponentTree.getClosestInstanceFromNode,
-  findHostInstanceByFiber: DOMRenderer.findHostInstance,
-  // This is an enum because we may add more (e.g. profiler build)
   bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,
   rendererPackageName: 'react-dom',

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -16,7 +16,6 @@ import './ReactNativeInjection';
 import * as ReactFiberErrorLogger
   from 'react-reconciler/src/ReactFiberErrorLogger';
 import * as ReactPortal from 'react-reconciler/src/ReactPortal';
-import {injectInternals} from 'react-reconciler/src/ReactFiberDevToolsHook';
 import * as ReactGenericBatching from 'events/ReactGenericBatching';
 import TouchHistoryMath from 'events/TouchHistoryMath';
 import * as ReactGlobalSharedState from 'shared/ReactGlobalSharedState';
@@ -130,11 +129,9 @@ if (__DEV__) {
   );
 }
 
-injectInternals({
+ReactNativeFiberRenderer.injectIntoDevTools({
   findFiberByHostInstance: ReactNativeComponentTree.getClosestInstanceFromNode,
-  findHostInstanceByFiber: ReactNativeFiberRenderer.findHostInstance,
   getInspectorDataForViewTag: getInspectorDataForViewTag,
-  // This is an enum because we may add more (e.g. profiler build)
   bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,
   rendererPackageName: 'react-native-renderer',

--- a/packages/react-rt-renderer/src/ReactNativeRT.js
+++ b/packages/react-rt-renderer/src/ReactNativeRT.js
@@ -17,7 +17,6 @@ import {
   showDialog,
 } from 'react-native-renderer/src/ReactNativeFiberErrorDialog';
 import * as ReactPortal from 'react-reconciler/src/ReactPortal';
-import {injectInternals} from 'react-reconciler/src/ReactFiberDevToolsHook';
 import * as ReactGenericBatching from 'events/ReactGenericBatching';
 import ReactVersion from 'shared/ReactVersion';
 
@@ -83,11 +82,9 @@ const ReactNativeRTFiber: ReactNativeRTType = {
   flushSync: ReactNativeRTFiberRenderer.flushSync,
 };
 
-injectInternals({
+ReactNativeRTFiberRenderer.injectIntoDevTools({
   findFiberByHostInstance: getFiberFromTag,
-  findHostInstanceByFiber: ReactNativeRTFiberRenderer.findHostInstance,
   getInspectorDataForViewTag: ReactNativeRTFiberInspector.getInspectorDataForViewTag,
-  // This is an enum because we may add more (e.g. profiler build)
   bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,
   rendererPackageName: 'react-rt-renderer',


### PR DESCRIPTION
An alternative to https://github.com/facebook/react/pull/11445.
This lets third party renderers inject themselves into the devtools.

Previously, renderers had to reach into reconciler directly to do this.
However, this wouldn't work for third party renderers.

Instead, I put `injectIntoDevTools()` directly on the `ReactFiberReconciler()` return value.
This way any renderer can choose to call it (or not call it).

Also moves us closer to not using cross-package `/src/` imports.