### PR TITLE
Use Rollup legacy mode for www builds

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -582,6 +582,8 @@ function createBundle(bundle, bundleType) {
       bundle.modulesToStub,
       bundle.featureFlags
     ),
+    // We can't use getters in www.
+    legacy: bundleType === FB_DEV || bundleType === FB_PROD,
   })
     .then(result =>
       result.write(


### PR DESCRIPTION
Turns out our internal transforms break on getters.
Let's just not emit them in www bundles.

Diff: https://gist.github.com/gaearon/9f79b3d2e177013292f3a20a83207f03/revisions