### PR TITLE
Split static and dynamic www feature flags

### DIFF
--- a/scripts/rollup/shims/rollup/ReactFeatureFlags-www.js
+++ b/scripts/rollup/shims/rollup/ReactFeatureFlags-www.js
@@ -10,16 +10,20 @@
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as FeatureFlagsShimType from './ReactFeatureFlags-www';
 
-// Re-export all flags from the www version.
+// Re-export dynamic flags from the www version.
 export const {
-  enableAsyncSubtreeAPI,
   enableAsyncSchedulingByDefaultInReactDOM,
-  enableReactFragment,
-  enableCreateRoot,
-  enableMutatingReconciler,
-  enableNoopReconciler,
-  enablePersistentReconciler,
 } = require('ReactFeatureFlags');
+
+// The rest of the flags are static for better dead code elimination.
+export const enableAsyncSubtreeAPI = true;
+export const enableReactFragment = false;
+export const enableCreateRoot = false;
+
+// The www bundles only use the mutating reconciler.
+export const enableMutatingReconciler = true;
+export const enableNoopReconciler = false;
+export const enablePersistentReconciler = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
This makes it so that www feature flags only include things that are actually behind a GK.

In theory this would reduce the bundle size of FB bundles. In practice, it currently doesn't because even though we know more of them statically, we still end up with code like

```js
var flag = false;

if (flag) {
  // ...
}
```

in production bundles. This is because we use Uglify for FB builds which is not as smart as GCC.

I have, however, verified that if we *were* to use GCC, it would strip them out (whereas it can’t possibly strip them out in the current version). So this seems incrementally better.

It might also be the case that the www minifer already handles conditions like this. In that case, even though it doesn’t show up as a win here, it might actually be in www after compilation. 