### PR TITLE
root.createBatch

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
@@ -9,16 +9,68 @@
 
 'use strict';
 
-require('shared/ReactFeatureFlags').enableCreateRoot = true;
 var React = require('react');
 var ReactDOM = require('react-dom');
 var ReactDOMServer = require('react-dom/server');
+var AsyncComponent = React.unstable_AsyncComponent;
 
 describe('ReactDOMRoot', () => {
   let container;
 
+  let scheduledCallback;
+  let flush;
+  let now;
+  let expire;
+
   beforeEach(() => {
     container = document.createElement('div');
+
+    // Override requestIdleCallback
+    scheduledCallback = null;
+    flush = function(units = Infinity) {
+      if (scheduledCallback !== null) {
+        var didStop = false;
+        while (scheduledCallback !== null && !didStop) {
+          const cb = scheduledCallback;
+          scheduledCallback = null;
+          cb({
+            timeRemaining() {
+              if (units > 0) {
+                return 999;
+              }
+              didStop = true;
+              return 0;
+            },
+          });
+          units--;
+        }
+      }
+    };
+    global.performance = {
+      now() {
+        return now;
+      },
+    };
+    global.requestIdleCallback = function(cb) {
+      scheduledCallback = cb;
+    };
+
+    now = 0;
+    expire = function(ms) {
+      now += ms;
+    };
+    global.performance = {
+      now() {
+        return now;
+      },
+    };
+
+    jest.resetModules();
+    require('shared/ReactFeatureFlags').enableCreateRoot = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMServer = require('react-dom/server');
+    AsyncComponent = React.unstable_AsyncComponent;
   });
 
   it('renders children', () => {
@@ -33,6 +85,35 @@ describe('ReactDOMRoot', () => {
     expect(container.textContent).toEqual('Hi');
     root.unmount();
     expect(container.textContent).toEqual('');
+  });
+
+  it('`root.render` returns a thenable work object', () => {
+    const root = ReactDOM.createRoot(container);
+    const work = root.render(<AsyncComponent>Hi</AsyncComponent>);
+    let ops = [];
+    work.then(() => {
+      ops.push('inside callback: ' + container.textContent);
+    });
+    ops.push('before committing: ' + container.textContent);
+    flush();
+    ops.push('after committing: ' + container.textContent);
+    expect(ops).toEqual([
+      'before committing: ',
+      // `then` callback should fire during commit phase
+      'inside callback: Hi',
+      'after committing: Hi',
+    ]);
+  });
+
+  it('resolves `work.then` callback synchronously if the work already committed', () => {
+    const root = ReactDOM.createRoot(container);
+    const work = root.render(<AsyncComponent>Hi</AsyncComponent>);
+    flush();
+    let ops = [];
+    work.then(() => {
+      ops.push('inside callback');
+    });
+    expect(ops).toEqual(['inside callback']);
   });
 
   it('supports hydration', async () => {
@@ -94,5 +175,153 @@ describe('ReactDOMRoot', () => {
       </div>,
     );
     expect(container.textContent).toEqual('abdc');
+  });
+
+  it('can defer a commit by batching it', () => {
+    const root = ReactDOM.createRoot(container);
+    const batch = root.createBatch();
+    batch.render(<div>Hi</div>);
+    // Hasn't committed yet
+    expect(container.textContent).toEqual('');
+    // Commit
+    batch.commit();
+    expect(container.textContent).toEqual('Hi');
+  });
+
+  it('does not restart a completed batch when committing if there were no intervening updates', () => {
+    let ops = [];
+    function Foo(props) {
+      ops.push('Foo');
+      return props.children;
+    }
+    const root = ReactDOM.createRoot(container);
+    const batch = root.createBatch();
+    batch.render(<Foo>Hi</Foo>);
+    // Flush all async work.
+    flush();
+    // Root should complete without committing.
+    expect(ops).toEqual(['Foo']);
+    expect(container.textContent).toEqual('');
+
+    ops = [];
+
+    // Commit. Shouldn't re-render Foo.
+    batch.commit();
+    expect(ops).toEqual([]);
+    expect(container.textContent).toEqual('Hi');
+  });
+
+  it('can wait for a batch to finish', () => {
+    const Async = React.unstable_AsyncComponent;
+    const root = ReactDOM.createRoot(container);
+    const batch = root.createBatch();
+    batch.render(<Async>Foo</Async>);
+
+    flush();
+
+    // Hasn't updated yet
+    expect(container.textContent).toEqual('');
+
+    let ops = [];
+    batch.then(() => {
+      // Still hasn't updated
+      ops.push(container.textContent);
+      // Should synchronously commit
+      batch.commit();
+      ops.push(container.textContent);
+    });
+
+    expect(ops).toEqual(['', 'Foo']);
+  });
+
+  it('`batch.render` returns a thenable work object', () => {
+    const root = ReactDOM.createRoot(container);
+    const batch = root.createBatch();
+    const work = batch.render('Hi');
+    let ops = [];
+    work.then(() => {
+      ops.push('inside callback: ' + container.textContent);
+    });
+    ops.push('before committing: ' + container.textContent);
+    batch.commit();
+    ops.push('after committing: ' + container.textContent);
+    expect(ops).toEqual([
+      'before committing: ',
+      // `then` callback should fire during commit phase
+      'inside callback: Hi',
+      'after committing: Hi',
+    ]);
+  });
+
+  it('can commit an empty batch', () => {
+    const root = ReactDOM.createRoot(container);
+    root.render(<AsyncComponent>1</AsyncComponent>);
+
+    expire(2000);
+    // This batch has a later expiration time than the earlier update.
+    const batch = root.createBatch();
+
+    // This should not flush the earlier update.
+    batch.commit();
+    expect(container.textContent).toEqual('');
+
+    flush();
+    expect(container.textContent).toEqual('1');
+  });
+
+  it('two batches created simultaneously are committed separately', () => {
+    // (In other words, they have distinct expiration times)
+    const root = ReactDOM.createRoot(container);
+    const batch1 = root.createBatch();
+    batch1.render(1);
+    const batch2 = root.createBatch();
+    batch2.render(2);
+
+    expect(container.textContent).toEqual('');
+
+    batch1.commit();
+    expect(container.textContent).toEqual('1');
+
+    batch2.commit();
+    expect(container.textContent).toEqual('2');
+  });
+
+  it('commits an earlier batch without committing a later batch', () => {
+    const root = ReactDOM.createRoot(container);
+    const batch1 = root.createBatch();
+    batch1.render(1);
+
+    // This batch has a later expiration time
+    expire(2000);
+    const batch2 = root.createBatch();
+    batch2.render(2);
+
+    expect(container.textContent).toEqual('');
+
+    batch1.commit();
+    expect(container.textContent).toEqual('1');
+
+    batch2.commit();
+    expect(container.textContent).toEqual('2');
+  });
+
+  it('commits a later batch without commiting an earlier batch', () => {
+    const root = ReactDOM.createRoot(container);
+    const batch1 = root.createBatch();
+    batch1.render(1);
+
+    // This batch has a later expiration time
+    expire(2000);
+    const batch2 = root.createBatch();
+    batch2.render(2);
+
+    expect(container.textContent).toEqual('');
+
+    batch2.commit();
+    expect(container.textContent).toEqual('2');
+
+    batch1.commit();
+    flush();
+    expect(container.textContent).toEqual('1');
   });
 });

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -8,6 +8,12 @@
  */
 
 import type {ReactNodeList} from 'shared/ReactTypes';
+// TODO: This type is shared between the reconciler and ReactDOM, but will
+// eventually be lifted out to the renderer.
+import type {
+  FiberRoot,
+  Batch as FiberRootBatch,
+} from 'react-reconciler/src/ReactFiberRoot';
 
 import '../shared/checkReact';
 import '../shared/ReactDOMInjection';
@@ -84,6 +90,63 @@ if (__DEV__) {
         'polyfill in older browsers. http://fb.me/react-polyfills',
     );
   }
+
+  var topLevelUpdateWarnings = (container: DOMContainer) => {
+    if (__DEV__) {
+      if (
+        container._reactRootContainer &&
+        container.nodeType !== COMMENT_NODE
+      ) {
+        const hostInstance = DOMRenderer.findHostInstanceWithNoPortals(
+          container._reactRootContainer._internalRoot.current,
+        );
+        if (hostInstance) {
+          warning(
+            hostInstance.parentNode === container,
+            'render(...): It looks like the React-rendered content of this ' +
+              'container was removed without using React. This is not ' +
+              'supported and will cause errors. Instead, call ' +
+              'ReactDOM.unmountComponentAtNode to empty a container.',
+          );
+        }
+      }
+
+      const isRootRenderedBySomeReact = !!container._reactRootContainer;
+      const rootEl = getReactRootElementInContainer(container);
+      const hasNonRootReactChild = !!(
+        rootEl && ReactDOMComponentTree.getInstanceFromNode(rootEl)
+      );
+
+      warning(
+        !hasNonRootReactChild || isRootRenderedBySomeReact,
+        'render(...): Replacing React-rendered children with a new root ' +
+          'component. If you intended to update the children of this node, ' +
+          'you should instead have the existing children update their state ' +
+          'and render the new components instead of calling ReactDOM.render.',
+      );
+
+      warning(
+        container.nodeType !== ELEMENT_NODE ||
+          !((container: any): Element).tagName ||
+          ((container: any): Element).tagName.toUpperCase() !== 'BODY',
+        'render(): Rendering components directly into document.body is ' +
+          'discouraged, since its children are often manipulated by third-party ' +
+          'scripts and browser extensions. This may lead to subtle ' +
+          'reconciliation issues. Try rendering into a container element created ' +
+          'for your app.',
+      );
+    }
+  };
+
+  var warnOnInvalidCallback = function(callback: mixed, callerName: string) {
+    warning(
+      callback === null || typeof callback === 'function',
+      '%s(...): Expected the last optional `callback` argument to be a ' +
+        'function. Instead received: %s.',
+      callerName,
+      callback,
+    );
+  };
 }
 
 ReactControlledComponent.injection.injectFiberControlledHostComponent(
@@ -92,10 +155,10 @@ ReactControlledComponent.injection.injectFiberControlledHostComponent(
 
 type DOMContainer =
   | (Element & {
-      _reactRootContainer: ?Object,
+      _reactRootContainer: ?Root,
     })
   | (Document & {
-      _reactRootContainer: ?Object,
+      _reactRootContainer: ?Root,
     });
 
 type Container = Element | Document;
@@ -117,6 +180,281 @@ type HostContext = HostContextDev | HostContextProd;
 
 let eventsEnabled: ?boolean = null;
 let selectionInformation: ?mixed = null;
+
+type Batch = FiberRootBatch & {
+  render(children: ReactNodeList): Work,
+  then(onComplete: () => mixed): void,
+  commit(): void,
+
+  // The ReactRoot constuctor is hoisted but the prototype methods are not. If
+  // we move ReactRoot to be above ReactBatch, the inverse error occurs.
+  // $FlowFixMe Hoisting issue.
+  _root: Root,
+  _hasChildren: boolean,
+  _children: ReactNodeList,
+
+  _callbacks: Array<() => mixed> | null,
+  _didComplete: boolean,
+};
+
+function ReactBatch(root: ReactRoot) {
+  const expirationTime = DOMRenderer.computeUniqueAsyncExpiration();
+  this._expirationTime = expirationTime;
+  this._root = root;
+  this._next = null;
+  this._callbacks = null;
+  this._didComplete = false;
+  this._hasChildren = false;
+  this._children = null;
+  this._defer = true;
+}
+ReactBatch.prototype.render = function(children: ReactNodeList) {
+  invariant(
+    this._defer,
+    'batch.render: Cannot render a batch that already committed.',
+  );
+  this._hasChildren = true;
+  this._children = children;
+  const internalRoot = this._root._internalRoot;
+  const expirationTime = this._expirationTime;
+  const work = new ReactWork();
+  DOMRenderer.updateContainerAtExpirationTime(
+    children,
+    internalRoot,
+    null,
+    expirationTime,
+    work._onCommit,
+  );
+  return work;
+};
+ReactBatch.prototype.then = function(onComplete: () => mixed) {
+  if (this._didComplete) {
+    onComplete();
+    return;
+  }
+  let callbacks = this._callbacks;
+  if (callbacks === null) {
+    callbacks = this._callbacks = [];
+  }
+  callbacks.push(onComplete);
+};
+ReactBatch.prototype.commit = function() {
+  const internalRoot = this._root._internalRoot;
+  let firstBatch = internalRoot.firstBatch;
+  invariant(
+    this._defer && firstBatch !== null,
+    'batch.commit: Cannot commit a batch multiple times.',
+  );
+
+  if (!this._hasChildren) {
+    // This batch is empty. Return.
+    this._next = null;
+    this._defer = false;
+    return;
+  }
+
+  let expirationTime = this._expirationTime;
+
+  // Ensure this is the first batch in the list.
+  if (firstBatch !== this) {
+    // This batch is not the earliest batch. We need to move it to the front.
+    // Update its expiration time to be the expiration time of the earliest
+    // batch, so that we can flush it without flushing the other batches.
+    if (this._hasChildren) {
+      expirationTime = this._expirationTime = firstBatch._expirationTime;
+      // Rendering this batch again ensures its children will be the final state
+      // when we flush (updates are processed in insertion order: last
+      // update wins).
+      // TODO: This forces a restart. Should we print a warning?
+      this.render(this._children);
+    }
+
+    // Remove the batch from the list.
+    let previous = null;
+    let batch = firstBatch;
+    while (batch !== this) {
+      previous = batch;
+      batch = batch._next;
+    }
+    invariant(
+      previous !== null,
+      'batch.commit: Cannot commit a batch multiple times.',
+    );
+    previous._next = batch._next;
+
+    // Add it to the front.
+    this._next = firstBatch;
+    firstBatch = internalRoot.firstBatch = this;
+  }
+
+  // Synchronously flush all the work up to this batch's expiration time.
+  this._defer = false;
+  DOMRenderer.flushRoot(internalRoot, expirationTime);
+
+  // Pop the batch from the list.
+  const next = this._next;
+  this._next = null;
+  firstBatch = internalRoot.firstBatch = next;
+
+  // Append the next earliest batch's children to the update queue.
+  if (firstBatch !== null && firstBatch._hasChildren) {
+    firstBatch.render(firstBatch._children);
+  }
+};
+ReactBatch.prototype._onComplete = function() {
+  if (this._didComplete) {
+    return;
+  }
+  this._didComplete = true;
+  const callbacks = this._callbacks;
+  if (callbacks === null) {
+    return;
+  }
+  // TODO: Error handling.
+  for (let i = 0; i < callbacks.length; i++) {
+    const callback = callbacks[i];
+    callback();
+  }
+};
+
+type Work = {
+  then(onCommit: () => mixed): void,
+  _onCommit: () => void,
+  _callbacks: Array<() => mixed> | null,
+  _didCommit: boolean,
+};
+
+function ReactWork() {
+  this._callbacks = null;
+  this._didCommit = false;
+  // TODO: Avoid need to bind by replacing callbacks in the update queue with
+  // list of Work objects.
+  this._onCommit = this._onCommit.bind(this);
+}
+ReactWork.prototype.then = function(onCommit: () => mixed): void {
+  if (this._didCommit) {
+    onCommit();
+    return;
+  }
+  let callbacks = this._callbacks;
+  if (callbacks === null) {
+    callbacks = this._callbacks = [];
+  }
+  callbacks.push(onCommit);
+};
+ReactWork.prototype._onCommit = function(): void {
+  if (this._didCommit) {
+    return;
+  }
+  this._didCommit = true;
+  const callbacks = this._callbacks;
+  if (callbacks === null) {
+    return;
+  }
+  // TODO: Error handling.
+  for (let i = 0; i < callbacks.length; i++) {
+    const callback = callbacks[i];
+    invariant(
+      typeof callback === 'function',
+      'Invalid argument passed as callback. Expected a function. Instead ' +
+        'received: %s',
+      callback,
+    );
+    callback();
+  }
+};
+
+type Root = {
+  render(children: ReactNodeList, callback: ?() => mixed): Work,
+  unmount(callback: ?() => mixed): Work,
+  legacy_renderSubtreeIntoContainer(
+    parentComponent: ?React$Component<any, any>,
+    children: ReactNodeList,
+    callback: ?() => mixed,
+  ): Work,
+  createBatch(): Batch,
+
+  _internalRoot: FiberRoot,
+};
+
+function ReactRoot(container: Container, hydrate: boolean) {
+  const root = DOMRenderer.createContainer(container, hydrate);
+  this._internalRoot = root;
+}
+ReactRoot.prototype.render = function(
+  children: ReactNodeList,
+  callback: ?() => mixed,
+): Work {
+  const root = this._internalRoot;
+  const work = new ReactWork();
+  callback = callback === undefined ? null : callback;
+  if (__DEV__) {
+    warnOnInvalidCallback(callback, 'render');
+  }
+  if (callback !== null) {
+    work.then(callback);
+  }
+  DOMRenderer.updateContainer(children, root, null, work._onCommit);
+  return work;
+};
+ReactRoot.prototype.unmount = function(callback: ?() => mixed): Work {
+  const root = this._internalRoot;
+  const work = new ReactWork();
+  callback = callback === undefined ? null : callback;
+  if (__DEV__) {
+    warnOnInvalidCallback(callback, 'render');
+  }
+  if (callback !== null) {
+    work.then(callback);
+  }
+  DOMRenderer.updateContainer(null, root, null, work._onCommit);
+  return work;
+};
+ReactRoot.prototype.legacy_renderSubtreeIntoContainer = function(
+  parentComponent: ?React$Component<any, any>,
+  children: ReactNodeList,
+  callback: ?() => mixed,
+): Work {
+  const root = this._internalRoot;
+  const work = new ReactWork();
+  callback = callback === undefined ? null : callback;
+  if (__DEV__) {
+    warnOnInvalidCallback(callback, 'render');
+  }
+  if (callback !== null) {
+    work.then(callback);
+  }
+  DOMRenderer.updateContainer(children, root, parentComponent, work._onCommit);
+  return work;
+};
+ReactRoot.prototype.createBatch = function(): Batch {
+  const batch = new ReactBatch(this);
+  const expirationTime = batch._expirationTime;
+
+  const internalRoot = this._internalRoot;
+  const firstBatch = internalRoot.firstBatch;
+  if (firstBatch === null) {
+    internalRoot.firstBatch = batch;
+    batch._next = null;
+  } else {
+    // Insert sorted by expiration time then insertion order
+    let insertAfter = null;
+    let insertBefore = firstBatch;
+    while (
+      insertBefore !== null &&
+      insertBefore._expirationTime <= expirationTime
+    ) {
+      insertAfter = insertBefore;
+      insertBefore = insertBefore._next;
+    }
+    batch._next = insertBefore;
+    if (insertAfter !== null) {
+      insertAfter._next = batch;
+    }
+  }
+
+  return batch;
+};
 
 /**
  * True if the supplied DOM node is a valid node element.
@@ -654,108 +992,115 @@ ReactGenericBatching.injection.injectFiberBatchedUpdates(
 
 let warnedAboutHydrateAPI = false;
 
-function renderSubtreeIntoContainer(
+function legacyCreateRootFromDOMContainer(
+  container: DOMContainer,
+  forceHydrate: boolean,
+): Root {
+  const shouldHydrate =
+    forceHydrate || shouldHydrateDueToLegacyHeuristic(container);
+  // First clear any existing content.
+  if (!shouldHydrate) {
+    let warned = false;
+    let rootSibling;
+    while ((rootSibling = container.lastChild)) {
+      if (__DEV__) {
+        if (
+          !warned &&
+          rootSibling.nodeType === ELEMENT_NODE &&
+          (rootSibling: any).hasAttribute(ROOT_ATTRIBUTE_NAME)
+        ) {
+          warned = true;
+          warning(
+            false,
+            'render(): Target node has markup rendered by React, but there ' +
+              'are unrelated nodes as well. This is most commonly caused by ' +
+              'white-space inserted around server-rendered markup.',
+          );
+        }
+      }
+      container.removeChild(rootSibling);
+    }
+  }
+  if (__DEV__) {
+    if (shouldHydrate && !forceHydrate && !warnedAboutHydrateAPI) {
+      warnedAboutHydrateAPI = true;
+      lowPriorityWarning(
+        false,
+        'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
+          'will stop working in React v17. Replace the ReactDOM.render() call ' +
+          'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+      );
+    }
+  }
+  const root: Root = new ReactRoot(container, shouldHydrate);
+  return root;
+}
+
+function legacyRenderSubtreeIntoContainer(
   parentComponent: ?React$Component<any, any>,
   children: ReactNodeList,
   container: DOMContainer,
   forceHydrate: boolean,
   callback: ?Function,
 ) {
+  // TODO: Ensure all entry points contain this check
   invariant(
     isValidContainer(container),
     'Target container is not a DOM element.',
   );
 
   if (__DEV__) {
-    if (container._reactRootContainer && container.nodeType !== COMMENT_NODE) {
-      const hostInstance = DOMRenderer.findHostInstanceWithNoPortals(
-        container._reactRootContainer.current,
-      );
-      if (hostInstance) {
-        warning(
-          hostInstance.parentNode === container,
-          'render(...): It looks like the React-rendered content of this ' +
-            'container was removed without using React. This is not ' +
-            'supported and will cause errors. Instead, call ' +
-            'ReactDOM.unmountComponentAtNode to empty a container.',
-        );
-      }
-    }
-
-    const isRootRenderedBySomeReact = !!container._reactRootContainer;
-    const rootEl = getReactRootElementInContainer(container);
-    const hasNonRootReactChild = !!(
-      rootEl && ReactDOMComponentTree.getInstanceFromNode(rootEl)
-    );
-
-    warning(
-      !hasNonRootReactChild || isRootRenderedBySomeReact,
-      'render(...): Replacing React-rendered children with a new root ' +
-        'component. If you intended to update the children of this node, ' +
-        'you should instead have the existing children update their state ' +
-        'and render the new components instead of calling ReactDOM.render.',
-    );
-
-    warning(
-      container.nodeType !== ELEMENT_NODE ||
-        !((container: any): Element).tagName ||
-        ((container: any): Element).tagName.toUpperCase() !== 'BODY',
-      'render(): Rendering components directly into document.body is ' +
-        'discouraged, since its children are often manipulated by third-party ' +
-        'scripts and browser extensions. This may lead to subtle ' +
-        'reconciliation issues. Try rendering into a container element created ' +
-        'for your app.',
-    );
+    topLevelUpdateWarnings(container);
   }
 
-  let root = container._reactRootContainer;
+  // TODO: Without `any` type, Flow says "Property cannot be accessed on any
+  // member of intersection type." Whyyyyyy.
+  let root: Root = (container._reactRootContainer: any);
   if (!root) {
-    const shouldHydrate =
-      forceHydrate || shouldHydrateDueToLegacyHeuristic(container);
-    // First clear any existing content.
-    if (!shouldHydrate) {
-      let warned = false;
-      let rootSibling;
-      while ((rootSibling = container.lastChild)) {
-        if (__DEV__) {
-          if (
-            !warned &&
-            rootSibling.nodeType === ELEMENT_NODE &&
-            (rootSibling: any).hasAttribute(ROOT_ATTRIBUTE_NAME)
-          ) {
-            warned = true;
-            warning(
-              false,
-              'render(): Target node has markup rendered by React, but there ' +
-                'are unrelated nodes as well. This is most commonly caused by ' +
-                'white-space inserted around server-rendered markup.',
-            );
-          }
-        }
-        container.removeChild(rootSibling);
-      }
+    // Initial mount
+    root = container._reactRootContainer = legacyCreateRootFromDOMContainer(
+      container,
+      forceHydrate,
+    );
+    if (typeof callback === 'function') {
+      const originalCallback = callback;
+      callback = function() {
+        const instance = DOMRenderer.getPublicRootInstance(root._internalRoot);
+        originalCallback.call(instance);
+      };
     }
-    if (__DEV__) {
-      if (shouldHydrate && !forceHydrate && !warnedAboutHydrateAPI) {
-        warnedAboutHydrateAPI = true;
-        lowPriorityWarning(
-          false,
-          'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
-            'will stop working in React v17. Replace the ReactDOM.render() call ' +
-            'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
-        );
-      }
-    }
-    const newRoot = DOMRenderer.createContainer(container, shouldHydrate);
-    root = container._reactRootContainer = newRoot;
     // Initial mount should not be batched.
     DOMRenderer.unbatchedUpdates(() => {
-      DOMRenderer.updateContainer(children, newRoot, parentComponent, callback);
+      if (parentComponent != null) {
+        root.legacy_renderSubtreeIntoContainer(
+          parentComponent,
+          children,
+          callback,
+        );
+      } else {
+        root.render(children, callback);
+      }
     });
   } else {
-    DOMRenderer.updateContainer(children, root, parentComponent, callback);
+    if (typeof callback === 'function') {
+      const originalCallback = callback;
+      callback = function() {
+        const instance = DOMRenderer.getPublicRootInstance(root._internalRoot);
+        originalCallback.call(instance);
+      };
+    }
+    // Update
+    if (parentComponent != null) {
+      root.legacy_renderSubtreeIntoContainer(
+        parentComponent,
+        children,
+        callback,
+      );
+    } else {
+      root.render(children, callback);
+    }
   }
-  return DOMRenderer.getPublicRootInstance(root);
+  return DOMRenderer.getPublicRootInstance(root._internalRoot);
 }
 
 function createPortal(
@@ -770,33 +1115,6 @@ function createPortal(
   // TODO: pass ReactDOM portal implementation as third argument
   return ReactPortal.createPortal(children, container, null, key);
 }
-
-type ReactRootNode = {
-  render(children: ReactNodeList, callback: ?() => mixed): void,
-  unmount(callback: ?() => mixed): void,
-
-  _reactRootContainer: *,
-};
-
-type RootOptions = {
-  hydrate?: boolean,
-};
-
-function ReactRoot(container: Container, hydrate: boolean) {
-  const root = DOMRenderer.createContainer(container, hydrate);
-  this._reactRootContainer = root;
-}
-ReactRoot.prototype.render = function(
-  children: ReactNodeList,
-  callback: ?() => mixed,
-): void {
-  const root = this._reactRootContainer;
-  DOMRenderer.updateContainer(children, root, null, callback);
-};
-ReactRoot.prototype.unmount = function(callback) {
-  const root = this._reactRootContainer;
-  DOMRenderer.updateContainer(null, root, null, callback);
-};
 
 const ReactDOM: Object = {
   createPortal,
@@ -846,7 +1164,13 @@ const ReactDOM: Object = {
 
   hydrate(element: React$Node, container: DOMContainer, callback: ?Function) {
     // TODO: throw or warn if we couldn't hydrate?
-    return renderSubtreeIntoContainer(null, element, container, true, callback);
+    return legacyRenderSubtreeIntoContainer(
+      null,
+      element,
+      container,
+      true,
+      callback,
+    );
   },
 
   render(
@@ -854,7 +1178,7 @@ const ReactDOM: Object = {
     container: DOMContainer,
     callback: ?Function,
   ) {
-    return renderSubtreeIntoContainer(
+    return legacyRenderSubtreeIntoContainer(
       null,
       element,
       container,
@@ -873,7 +1197,7 @@ const ReactDOM: Object = {
       parentComponent != null && ReactInstanceMap.has(parentComponent),
       'parentComponent must be a valid React Component',
     );
-    return renderSubtreeIntoContainer(
+    return legacyRenderSubtreeIntoContainer(
       parentComponent,
       element,
       containerNode,
@@ -902,7 +1226,7 @@ const ReactDOM: Object = {
 
       // Unmount should not be batched.
       DOMRenderer.unbatchedUpdates(() => {
-        renderSubtreeIntoContainer(null, null, container, false, () => {
+        legacyRenderSubtreeIntoContainer(null, null, container, false, () => {
           container._reactRootContainer = null;
         });
       });
@@ -960,11 +1284,15 @@ const ReactDOM: Object = {
   },
 };
 
+type RootOptions = {
+  hydrate?: boolean,
+};
+
 if (enableCreateRoot) {
   ReactDOM.createRoot = function createRoot(
     container: DOMContainer,
     options?: RootOptions,
-  ): ReactRootNode {
+  ): ReactRoot {
     const hydrate = options != null && options.hydrate === true;
     return new ReactRoot(container, hydrate);
   };

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -13,6 +13,14 @@ import type {ExpirationTime} from './ReactFiberExpirationTime';
 import {createHostRootFiber} from './ReactFiber';
 import {NoWork} from './ReactFiberExpirationTime';
 
+// TODO: This should be lifted into the renderer.
+export type Batch = {
+  _defer: boolean,
+  _expirationTime: ExpirationTime,
+  _onComplete: () => mixed,
+  _next: Batch | null,
+};
+
 export type FiberRoot = {
   // Any additional information from the host associated with this root.
   containerInfo: any,
@@ -34,6 +42,10 @@ export type FiberRoot = {
   pendingContext: Object | null,
   // Determines if we should attempt to hydrate on the initial mount
   +hydrate: boolean,
+  // List of top-level batches. This list indicates whether a commit should be
+  // deferred. Also contains completion callbacks.
+  // TODO: Lift this into the renderer
+  firstBatch: Batch | null,
   // Linked-list of roots
   nextScheduledRoot: FiberRoot | null,
 };
@@ -55,6 +67,7 @@ export function createFiberRoot(
     context: null,
     pendingContext: null,
     hydrate,
+    firstBatch: null,
     nextScheduledRoot: null,
   };
   uninitializedFiber.stateNode = root;

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -607,7 +607,7 @@ var ReactTestRendererFiber = {
         if (root == null || root.current == null) {
           return;
         }
-        TestRenderer.updateContainer(null, root, null);
+        TestRenderer.updateContainer(null, root, null, null);
         container = null;
         root = null;
       },


### PR DESCRIPTION
Alternative to https://github.com/facebook/react/pull/11346

API for batching top-level updates and deferring the commit.

- `root.createBatch` creates a batch with an async expiration time associated with it.
- `batch.render` updates the children that the batch renders.
- `batch.then` resolves when the root has completed.
- `batch.commit` synchronously flushes any remaining work and commits.

No two batches can have the same expiration time. The only way to commit a batch is by calling its `commit` method. E.g. flushing one batch will not cause a different batch to also flush.

TODO: Specify error handling behavior.