### PR TITLE
Add warning for componentDidReceiveProps()

### DIFF
--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -550,7 +550,9 @@ describe('ReactCompositeComponent', () => {
     expectDev(console.error.calls.argsFor(0)[0]).toBe(
       'Warning: Component has a method called ' +
         'componentDidReceiveProps(). But there is no such lifecycle method. ' +
-        'Did you mean componentDidUpdate()?',
+        'If you meant to update the state in response to changing props, ' +
+        'use componentWillReceiveProps(). If you meant to fetch data or ' +
+        'run side-effects or mutations after React has updated the UI, use componentDidUpdate().',
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -533,6 +533,27 @@ describe('ReactCompositeComponent', () => {
     );
   });
 
+  it('should warn when componentDidReceiveProps method is defined', () => {
+    spyOn(console, 'error');
+
+    class Component extends React.Component {
+      componentDidReceiveProps = () => {};
+
+      render() {
+        return <div />;
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(<Component />);
+
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toBe(
+      'Warning: Component has a method called ' +
+        'componentDidReceiveProps(). But there is no such lifecycle method. ' +
+        'Did you mean componentDidUpdate()?',
+    );
+  });
+
   it('should warn when defaultProps was defined as an instance property', () => {
     spyOn(console, 'error');
 

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -287,7 +287,9 @@ export default function(
         noComponentDidReceiveProps,
         '%s has a method called ' +
           'componentDidReceiveProps(). But there is no such lifecycle method. ' +
-          'Did you mean componentDidUpdate()?',
+          'If you meant to update the state in response to changing props, ' +
+          'use componentWillReceiveProps(). If you meant to fetch data or ' +
+          'run side-effects or mutations after React has updated the UI, use componentDidUpdate().',
         name,
       );
       const noComponentWillRecieveProps =

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -281,6 +281,15 @@ export default function(
           'Did you mean componentWillUnmount()?',
         name,
       );
+      const noComponentDidReceiveProps =
+        typeof instance.componentDidReceiveProps !== 'function';
+      warning(
+        noComponentDidReceiveProps,
+        '%s has a method called ' +
+          'componentDidReceiveProps(). But there is no such lifecycle method. ' +
+          'Did you mean componentDidUpdate()?',
+        name,
+      );
       const noComponentWillRecieveProps =
         typeof instance.componentWillRecieveProps !== 'function';
       warning(


### PR DESCRIPTION
As per [Dan's suggestion on Twitter](https://twitter.com/dan_abramov/status/927833084728397824), this is a tiny little PR that adds `componentDidReceiveProps` to the list of invalid lifecycle methods to throw warnings for.