### PR TITLE
Release script follow-up

### DIFF
--- a/scripts/release/publish-commands/print-post-publish-summary.js
+++ b/scripts/release/publish-commands/print-post-publish-summary.js
@@ -6,44 +6,73 @@ const chalk = require('chalk');
 const semver = require('semver');
 const {getUnexecutedCommands} = require('../utils');
 
+const printSteps = steps => {
+  return steps
+    .filter(Boolean) // Remove no-op steps
+    .map((step, index) => `${index + 1}. ${step}`)
+    .join('\n');
+};
+
+const printSections = sections => {
+  return sections
+    .map((section, index) => {
+      const [title, ...steps] = section;
+
+      return chalk`
+        {bold.underline Step ${index + 1}: ${title}}
+
+        ${printSteps(steps)}
+      `.replace(/\n +/g, '\n');
+    })
+    .join('');
+};
+
 module.exports = ({dry, version}) => {
   const isPrerelease = semver.prerelease(version);
 
-  let finalReleaseSteps = '';
+  const sections = [];
+
+  // Certain follow-up steps are for stable releases only.
   if (!isPrerelease) {
-    finalReleaseSteps = chalk`
-        {bold.underline Step 1: Create GitHub release}
+    sections.push([
+      'Create GitHub release',
+      chalk`Open new release page: {blue.bold https://github.com/facebook/react/releases/new}`,
+      chalk`Choose {bold ${version}} from the dropdown menu`,
+      chalk`Paste the new release notes from {yellow.bold CHANGELOG.md}`,
+      chalk`Attach all files in {yellow.bold build/dist/*.js} except {yellow.bold react-art.*} to the release.`,
+      chalk`Press {bold "Publish release"}!`,
+    ]);
 
-        1. Open new release page: {blue.bold https://github.com/facebook/react/releases/new}
-        2. Choose {bold ${version}} from the dropdown menu
-        3. Paste the new release notes from {yellow.bold CHANGELOG.md}
-        4. Attach all files in {yellow.bold build/dist/*.js} except {yellow.bold react-art.*} to the release.
-        5. Press {bold "Publish release"}!
-
-        {bold.underline Step 2: Update the version on reactjs.org}
-
-        1. Git clone (or update) {blue.bold https://github.com/reactjs/reactjs.org}
-        2. Open the {bold.yellow src/site-constants.js} file
-        3. Update the {bold version} value to {bold ${version}}
-        4. Open a Pull Request to {bold master}
-    `;
+    sections.push([
+      'Update the version on reactjs.org',
+      chalk`Git clone (or update) {blue.bold https://github.com/reactjs/reactjs.org}`,
+      chalk`Open the {bold.yellow src/site-constants.js} file`,
+      chalk`Update the {bold version} value to {bold ${version}}`,
+      chalk`Open a Pull Request to {bold master}`,
+    ]);
   }
+
+  sections.push([
+    'Test the new release',
+    chalk`Install CRA: {bold npm i -g create-react-app}`,
+    chalk`Create a test application: {bold create-react-app myapp && cd myapp}`,
+    isPrerelease
+      ? chalk`Install the pre-release versions: {bold yarn add react@next react-dom@next}`
+      : null,
+    chalk`Run the app: {bold yarn start}`,
+  ]);
+
+  sections.push([
+    'Notify the DOM team',
+    chalk`Notify DOM team members: {bold @nhunzaker @jquense @aweary}`,
+  ]);
 
   console.log(
     chalk`
     {green.bold Publish successful!}
     ${getUnexecutedCommands()}
     Next there are a couple of manual steps:
-    ${finalReleaseSteps}
-    {bold.underline Step ${isPrerelease ? '1' : '3'}: Test the new release}
-
-    1. Install CRA: {bold npm i -g create-react-app}
-    2. Create a test application: {bold create-react-app myapp}
-    3. Run it: {bold cd myapp && npm start}
-
-    {bold.underline Step ${isPrerelease ? '2' : '4'}: Notify the DOM team}
-
-    1. Notify DOM team members: {bold @nhunzaker @jquense @aweary}
+    ${printSections(sections)}
   `.replace(/\n +/g, '\n')
   );
 };

--- a/scripts/release/publish-commands/print-post-publish-summary.js
+++ b/scripts/release/publish-commands/print-post-publish-summary.js
@@ -3,37 +3,45 @@
 'use strict';
 
 const chalk = require('chalk');
+const semver = require('semver');
 const {getUnexecutedCommands} = require('../utils');
 
-module.exports = ({version}) => {
+module.exports = ({dry, version}) => {
+  const isPrerelease = semver.prerelease(version);
+
+  let finalReleaseSteps = '';
+  if (!isPrerelease) {
+    finalReleaseSteps = chalk`
+        {bold.underline Step 1: Create GitHub release}
+
+        1. Open new release page: {blue.bold https://github.com/facebook/react/releases/new}
+        2. Choose {bold ${version}} from the dropdown menu
+        3. Paste the new release notes from {yellow.bold CHANGELOG.md}
+        4. Attach all files in {yellow.bold build/dist/*.js} except {yellow.bold react-art.*} to the release.
+        5. Press {bold "Publish release"}!
+
+        {bold.underline Step 2: Update the version on reactjs.org}
+
+        1. Git clone (or update) {blue.bold https://github.com/reactjs/reactjs.org}
+        2. Open the {bold.yellow src/site-constants.js} file
+        3. Update the {bold version} value to {bold ${version}}
+        4. Open a Pull Request to {bold master}
+    `;
+  }
+
   console.log(
     chalk`
     {green.bold Publish successful!}
     ${getUnexecutedCommands()}
     Next there are a couple of manual steps:
-
-    {bold.underline Step 1: Create GitHub release}
-
-    1. Open new release page: {blue.bold https://github.com/facebook/react/releases/new}
-    2. Choose {bold ${version}} from the dropdown menu
-    3. Paste the new release notes from {yellow.bold CHANGELOG.md}
-    4. Attach all files in {yellow.bold build/dist/*.js} except {yellow.bold react-art.*} to the release.
-    5. Press {bold "Publish release"}!
-
-    {bold.underline Step 2: Update the version on reactjs.org}
-
-    1. Git clone (or update) {blue.bold https://github.com/reactjs/reactjs.org}
-    2. Open the {bold.yellow src/site-constants.js} file
-    3. Update the {bold version} value to {bold ${version}}
-    4. Open a Pull Request to {bold master}
-
-    {bold.underline Step 3: Test the new release}
+    ${finalReleaseSteps}
+    {bold.underline Step ${isPrerelease ? '1' : '3'}: Test the new release}
 
     1. Install CRA: {bold npm i -g create-react-app}
     2. Create a test application: {bold create-react-app myapp}
     3. Run it: {bold cd myapp && npm start}
 
-    {bold.underline Step 4: Notify the DOM team}
+    {bold.underline Step ${isPrerelease ? '2' : '4'}: Notify the DOM team}
 
     1. Notify DOM team members: {bold @nhunzaker @jquense @aweary}
   `.replace(/\n +/g, '\n')

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -30,6 +30,10 @@ const push = async ({cwd, dry, version}) => {
       const packageVersion = packageJSON.version;
 
       if (!dry) {
+        // Wait a couple of seconds before querying NPM for status;
+        // Anecdotally, querying too soon can result in a false negative.
+        await new Promise(resolve => setTimeout(resolve, 5000));
+
         const status = JSON.parse(
           await execRead(`npm info ${project} dist-tags --json`)
         );


### PR DESCRIPTION
Resolves #11481

* 2255f9f: Add a timeout before querying npm right after publish
* 2213b98: Conditionally log some post publish steps
* 3d415be: Conditionally print ready-to-paste `yarn add` instructions for CRA prerelease testing

### Prerelease log
<img width="510" alt="screen shot 2017-11-07 at 4 28 05 pm" src="https://user-images.githubusercontent.com/29597/32505850-164d2b02-c3db-11e7-9a4f-c1ba92bf57a4.png">

### Stable log
<img width="521" alt="screen shot 2017-11-07 at 4 28 28 pm" src="https://user-images.githubusercontent.com/29597/32505847-1459b608-c3db-11e7-946e-fe7f5ea4afaf.png">
