### PR TITLE
Fixing typo on test

### DIFF
--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -105,7 +105,7 @@ describe('create-react-class-integration', () => {
     );
   });
 
-  it('should warn when mispelling shouldComponentUpdate', () => {
+  it('should warn when misspelling shouldComponentUpdate', () => {
     spyOn(console, 'error');
 
     createReactClass({
@@ -140,7 +140,7 @@ describe('create-react-class-integration', () => {
     );
   });
 
-  it('should warn when mispelling componentWillReceiveProps', () => {
+  it('should warn when misspelling componentWillReceiveProps', () => {
     spyOn(console, 'error');
     createReactClass({
       componentWillRecieveProps: function() {


### PR DESCRIPTION
When I saw this I had to fix it.

The test that checks for misspelling has typo on  the word `misspelling` 