### PR TITLE
Enable createRoot API in www

### DIFF
--- a/scripts/rollup/shims/rollup/ReactFeatureFlags-www.js
+++ b/scripts/rollup/shims/rollup/ReactFeatureFlags-www.js
@@ -18,7 +18,7 @@ export const {
 // The rest of the flags are static for better dead code elimination.
 export const enableAsyncSubtreeAPI = true;
 export const enableReactFragment = false;
-export const enableCreateRoot = false;
+export const enableCreateRoot = true;
 
 // The www bundles only use the mutating reconciler.
 export const enableMutatingReconciler = true;


### PR DESCRIPTION
Re-enable createRoot API in www since it's placed under a feature flag in React OSS now.