### PR TITLE
Release script tweaks

### DIFF
--- a/scripts/release/build-commands/add-git-tag.js
+++ b/scripts/release/build-commands/add-git-tag.js
@@ -6,15 +6,18 @@ const chalk = require('chalk');
 const {execUnlessDry, logPromise} = require('../utils');
 
 const run = async ({cwd, dry, version}) => {
-  await execUnlessDry(`git tag -a ${version} -m "Tagging ${version} release"`, {
-    cwd,
-    dry,
-  });
+  await execUnlessDry(
+    `git tag -a v${version} -m "Tagging ${version} release"`,
+    {
+      cwd,
+      dry,
+    }
+  );
 };
 
 module.exports = async ({cwd, dry, version}) => {
   return logPromise(
     run({cwd, dry, version}),
-    `Creating git tag ${chalk.yellow.bold(version)}`
+    `Creating git tag ${chalk.yellow.bold(`v${version}`)}`
   );
 };

--- a/scripts/release/build-commands/build-artifacts.js
+++ b/scripts/release/build-commands/build-artifacts.js
@@ -28,5 +28,5 @@ const run = async ({cwd, dry, version}) => {
 };
 
 module.exports = async params => {
-  return logPromise(run(params), 'Building artifacts');
+  return logPromise(run(params), 'Building artifacts', true);
 };

--- a/scripts/release/build-commands/check-npm-permissions.js
+++ b/scripts/release/build-commands/check-npm-permissions.js
@@ -4,9 +4,8 @@
 
 const chalk = require('chalk');
 const {execRead, logPromise} = require('../utils');
-const {projects} = require('../config');
 
-module.exports = async () => {
+module.exports = async ({packages}) => {
   const currentUser = await execRead('npm whoami');
   const failedProjects = [];
 
@@ -22,7 +21,7 @@ module.exports = async () => {
   };
 
   await logPromise(
-    Promise.all(projects.map(checkProject)),
+    Promise.all(packages.map(checkProject)),
     `Checking ${chalk.yellow.bold(currentUser)}'s NPM permissions`
   );
 

--- a/scripts/release/build-commands/check-package-dependencies.js
+++ b/scripts/release/build-commands/check-package-dependencies.js
@@ -52,6 +52,6 @@ const check = async ({cwd, packages}) => {
   }
 };
 
-module.exports = async ({cwd}) => {
-  return logPromise(check({cwd}), 'Checking runtime dependencies');
+module.exports = async params => {
+  return logPromise(check(params), 'Checking runtime dependencies');
 };

--- a/scripts/release/build-commands/check-package-dependencies.js
+++ b/scripts/release/build-commands/check-package-dependencies.js
@@ -5,15 +5,15 @@
 const chalk = require('chalk');
 const {readJson} = require('fs-extra');
 const {join} = require('path');
-const {dependencies, projects} = require('../config');
+const {dependencies} = require('../config');
 const {logPromise} = require('../utils');
 
-const check = async ({cwd}) => {
+const check = async ({cwd, packages}) => {
   const rootPackage = await readJson(join(cwd, 'package.json'));
 
   const projectPackages = [];
-  for (let i = 0; i < projects.length; i++) {
-    const project = projects[i];
+  for (let i = 0; i < packages.length; i++) {
+    const project = packages[i];
     projectPackages.push(
       await readJson(join(cwd, join('packages', project), 'package.json'))
     );

--- a/scripts/release/build-commands/run-automated-tests.js
+++ b/scripts/release/build-commands/run-automated-tests.js
@@ -28,6 +28,7 @@ module.exports = async ({cwd}) => {
   );
   await logPromise(
     runYarnTask(cwd, 'jest', 'Jest failed'),
-    'Running Jest tests'
+    'Running Jest tests',
+    true
   );
 };

--- a/scripts/release/build-commands/update-package-versions.js
+++ b/scripts/release/build-commands/update-package-versions.js
@@ -8,10 +8,9 @@ const {readFileSync, writeFileSync} = require('fs');
 const {readJson, writeJson} = require('fs-extra');
 const {join} = require('path');
 const semver = require('semver');
-const {projects} = require('../config');
 const {execUnlessDry, logPromise} = require('../utils');
 
-const update = async ({cwd, dry, version}) => {
+const update = async ({cwd, dry, packages, version}) => {
   try {
     // Update root package.json
     const packagePath = join(cwd, 'package.json');
@@ -60,7 +59,7 @@ const update = async ({cwd, dry, version}) => {
 
       await writeJson(path, json, {spaces: 2});
     };
-    await Promise.all(projects.map(updateProjectPackage));
+    await Promise.all(packages.map(updateProjectPackage));
 
     // Version sanity check
     await exec('yarn version-check', {cwd});

--- a/scripts/release/build.js
+++ b/scripts/release/build.js
@@ -8,6 +8,7 @@ const {exec} = require('child_process');
 const run = async () => {
   const chalk = require('chalk');
   const logUpdate = require('log-update');
+  const {getPublicPackages} = require('./utils');
 
   const addGitTag = require('./build-commands/add-git-tag');
   const buildArtifacts = require('./build-commands/build-artifacts');
@@ -27,6 +28,7 @@ const run = async () => {
 
   try {
     const params = parseBuildParameters();
+    params.packages = getPublicPackages();
 
     await checkEnvironmentVariables(params);
     await validateVersion(params);
@@ -49,9 +51,7 @@ const run = async () => {
     const stack = error.stack.replace(error.message, '');
 
     console.log(
-      `${chalk.bgRed.white(' ERROR ')} ${chalk.red(message)}\n\n${chalk.gray(
-        stack
-      )}`
+      `${chalk.bgRed.white(' ERROR ')} ${chalk.red(message)}\n\n${chalk.gray(stack)}`
     );
 
     process.exit(1);

--- a/scripts/release/build.js
+++ b/scripts/release/build.js
@@ -51,7 +51,9 @@ const run = async () => {
     const stack = error.stack.replace(error.message, '');
 
     console.log(
-      `${chalk.bgRed.white(' ERROR ')} ${chalk.red(message)}\n\n${chalk.gray(stack)}`
+      `${chalk.bgRed.white(' ERROR ')} ${chalk.red(message)}\n\n${chalk.gray(
+        stack
+      )}`
     );
 
     process.exit(1);

--- a/scripts/release/config.js
+++ b/scripts/release/config.js
@@ -2,16 +2,6 @@
 
 const dependencies = ['fbjs', 'object-assign', 'prop-types'];
 
-// TODO: enumerate all non-private package folders in packages/*?
-const projects = [
-  'react',
-  'react-art',
-  'react-call-return',
-  'react-dom',
-  'react-reconciler',
-  'react-test-renderer',
-];
-
 const paramDefinitions = [
   {
     name: 'dry',
@@ -23,8 +13,7 @@ const paramDefinitions = [
     name: 'path',
     type: String,
     alias: 'p',
-    description:
-      'Location of React repository to release; defaults to [bold]{cwd}',
+    description: 'Location of React repository to release; defaults to [bold]{cwd}',
     defaultValue: '.',
   },
   {
@@ -38,5 +27,4 @@ const paramDefinitions = [
 module.exports = {
   dependencies,
   paramDefinitions,
-  projects,
 };

--- a/scripts/release/config.js
+++ b/scripts/release/config.js
@@ -13,7 +13,8 @@ const paramDefinitions = [
     name: 'path',
     type: String,
     alias: 'p',
-    description: 'Location of React repository to release; defaults to [bold]{cwd}',
+    description:
+      'Location of React repository to release; defaults to [bold]{cwd}',
     defaultValue: '.',
   },
   {

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -7,9 +7,8 @@ const {readJson} = require('fs-extra');
 const {join} = require('path');
 const semver = require('semver');
 const {execRead, execUnlessDry, logPromise} = require('../utils');
-const {projects} = require('../config');
 
-const push = async ({cwd, dry, version}) => {
+const push = async ({cwd, dry, packages, version}) => {
   const errors = [];
   const isPrerelease = semver.prerelease(version);
   const tag = isPrerelease ? 'next' : 'latest';
@@ -62,7 +61,7 @@ const push = async ({cwd, dry, version}) => {
     }
   };
 
-  await Promise.all(projects.map(publishProject));
+  await Promise.all(packages.map(publishProject));
 
   if (errors.length > 0) {
     throw Error(

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -59,7 +59,7 @@ const push = async ({cwd, dry, packages, version}) => {
         }
       }
     } catch (error) {
-      errors.push(error.message);
+      errors.push(error.stack);
     }
   };
 
@@ -70,7 +70,7 @@ const push = async ({cwd, dry, packages, version}) => {
       chalk`
       Failure publishing to NPM
 
-      {white ${errors.join('\n')}}`
+      {white ${errors.join('\n\n')}}`
     );
   }
 };

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -44,9 +44,7 @@ const push = async ({cwd, dry, version}) => {
         if (remoteVersion !== packageVersion) {
           throw Error(
             chalk`Published version {yellow.bold ${packageVersion}} for ` +
-              chalk`{bold ${project}} but NPM shows {yellow.bold ${
-                remoteVersion
-              }}`
+              chalk`{bold ${project}} but NPM shows {yellow.bold ${remoteVersion}}`
           );
         }
 
@@ -54,7 +52,8 @@ const push = async ({cwd, dry, version}) => {
         // Update the @next tag to also point to it (so @next doens't lag behind).
         if (!isPrerelease) {
           await execUnlessDry(
-            `npm dist-tag add ${project}@${packageVersion} next`
+            `npm dist-tag add ${project}@${packageVersion} next`,
+            {cwd: path, dry}
           );
         }
       }

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -43,7 +43,9 @@ const push = async ({cwd, dry, packages, version}) => {
         if (remoteVersion !== packageVersion) {
           throw Error(
             chalk`Published version {yellow.bold ${packageVersion}} for ` +
-              chalk`{bold ${project}} but NPM shows {yellow.bold ${remoteVersion}}`
+              chalk`{bold ${project}} but NPM shows {yellow.bold ${
+                remoteVersion
+              }}`
           );
         }
 

--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -4,6 +4,7 @@
 
 const chalk = require('chalk');
 const logUpdate = require('log-update');
+const {getPublicPackages} = require('./utils');
 
 const checkBuildStatus = require('./publish-commands/check-build-status');
 const commitChangelog = require('./publish-commands/commit-changelog');
@@ -15,6 +16,7 @@ const publishToNpm = require('./publish-commands/publish-to-npm');
 // Follows the steps outlined in github.com/facebook/react/issues/10620
 const run = async () => {
   const params = parsePublishParams();
+  params.packages = getPublicPackages();
 
   try {
     await checkBuildStatus(params);
@@ -29,9 +31,7 @@ const run = async () => {
     const stack = error.stack.replace(error.message, '');
 
     console.log(
-      `${chalk.bgRed.white(' ERROR ')} ${chalk.red(message)}\n\n${chalk.gray(
-        stack
-      )}`
+      `${chalk.bgRed.white(' ERROR ')} ${chalk.red(message)}\n\n${chalk.gray(stack)}`
     );
 
     process.exit(1);

--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -31,7 +31,9 @@ const run = async () => {
     const stack = error.stack.replace(error.message, '');
 
     console.log(
-      `${chalk.bgRed.white(' ERROR ')} ${chalk.red(message)}\n\n${chalk.gray(stack)}`
+      `${chalk.bgRed.white(' ERROR ')} ${chalk.red(message)}\n\n${chalk.gray(
+        stack
+      )}`
     );
 
     process.exit(1);

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -3,7 +3,9 @@
 const chalk = require('chalk');
 const {dots} = require('cli-spinners');
 const {exec} = require('child-process-promise');
+const {readdirSync, readFileSync} = require('fs');
 const logUpdate = require('log-update');
+const {join} = require('path');
 
 const execRead = async (command, options) => {
   const {stdout} = await exec(command, options);
@@ -19,6 +21,17 @@ const execUnlessDry = async (command, {cwd, dry}) => {
   } else {
     await exec(command, {cwd});
   }
+};
+
+const getPublicPackages = () => {
+  const packagesRoot = join(__dirname, '..', '..', 'packages');
+
+  return readdirSync(packagesRoot).filter(dir => {
+    const packagePath = join(packagesRoot, dir, 'package.json');
+    const packageJSON = JSON.parse(readFileSync(packagePath));
+
+    return packageJSON.private !== true;
+  });
 };
 
 const getUnexecutedCommands = () => {
@@ -40,9 +53,7 @@ const logPromise = async (promise, text, completedLabel = '') => {
   const id = setInterval(() => {
     index = ++index % frames.length;
     logUpdate(
-      `${chalk.yellow(frames[index])} ${text} ${chalk.gray(
-        '- this may take a few seconds'
-      )}`
+      `${chalk.yellow(frames[index])} ${text} ${chalk.gray('- this may take a few seconds')}`
     );
   }, interval);
 
@@ -65,6 +76,7 @@ const logPromise = async (promise, text, completedLabel = '') => {
 module.exports = {
   execRead,
   execUnlessDry,
+  getPublicPackages,
   getUnexecutedCommands,
   logPromise,
 };

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -45,15 +45,17 @@ const getUnexecutedCommands = () => {
   }
 };
 
-const logPromise = async (promise, text, completedLabel = '') => {
+const logPromise = async (promise, text, isLongRunningTask = false) => {
   const {frames, interval} = dots;
 
   let index = 0;
 
+  const inProgressMessage = `- this may take a few ${isLongRunningTask ? 'minutes' : 'seconds'}`;
+
   const id = setInterval(() => {
     index = ++index % frames.length;
     logUpdate(
-      `${chalk.yellow(frames[index])} ${text} ${chalk.gray('- this may take a few seconds')}`
+      `${chalk.yellow(frames[index])} ${text} ${chalk.gray(inProgressMessage)}`
     );
   }, interval);
 
@@ -62,7 +64,7 @@ const logPromise = async (promise, text, completedLabel = '') => {
 
     clearInterval(id);
 
-    logUpdate(`${chalk.green('✓')} ${text} ${chalk.gray(completedLabel)}`);
+    logUpdate(`${chalk.green('✓')} ${text}`);
     logUpdate.done();
 
     return returnValue;

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -50,7 +50,9 @@ const logPromise = async (promise, text, isLongRunningTask = false) => {
 
   let index = 0;
 
-  const inProgressMessage = `- this may take a few ${isLongRunningTask ? 'minutes' : 'seconds'}`;
+  const inProgressMessage = `- this may take a few ${
+    isLongRunningTask ? 'minutes' : 'seconds'
+  }`;
 
   const id = setInterval(() => {
     index = ++index % frames.length;


### PR DESCRIPTION
Resolves #11481

* Added missing options param
* Publish all packages that aren't private and remove the whitelist in config
* Add "v" prefix for release tags
* Log "minutes" for longer-running tasks (instead of "seconds")
* Push `error.stack` instead of `error.message` in parallel tasks so that we see call stack

Some screenshots...

<img width="857" alt="screen shot 2017-11-09 at 3 50 21 pm" src="https://user-images.githubusercontent.com/29597/32615499-e5ca1916-c567-11e7-9468-3e348d3fb9ce.png">

<img width="851" alt="screen shot 2017-11-09 at 3 54 34 pm" src="https://user-images.githubusercontent.com/29597/32615500-e5e09be6-c567-11e7-9858-99fc0e4502fc.png">

<img width="809" alt="screen shot 2017-11-09 at 3 54 42 pm" src="https://user-images.githubusercontent.com/29597/32615501-e61406d4-c567-11e7-8c00-51febe7e2a4c.png">

<img width="942" alt="screen shot 2017-11-09 at 4 04 43 pm" src="https://user-images.githubusercontent.com/29597/32615502-e63039d0-c567-11e7-97d3-275bb7929976.png">