### PR TITLE
Add note about mistaken named / default export

### DIFF
--- a/packages/react-dom/src/__tests__/ReactComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponent-test.js
@@ -342,7 +342,7 @@ describe('ReactComponent', () => {
       'Element type is invalid: expected a string (for built-in components) ' +
         'or a class/function (for composite components) but got: undefined. ' +
         "You likely forgot to export your component from the file it's " +
-        'defined in.',
+        'defined in, or you might have mixed up default and named imports.',
     );
 
     var Y = null;
@@ -380,7 +380,8 @@ describe('ReactComponent', () => {
       'Element type is invalid: expected a string (for built-in components) ' +
         'or a class/function (for composite components) but got: undefined. ' +
         "You likely forgot to export your component from the file it's " +
-        'defined in.\n\nCheck the render method of `Bar`.',
+        'defined in, or you might have mixed up default and named imports.' +
+        '\n\nCheck the render method of `Bar`.',
     );
 
     // One warning for each element creation

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -332,7 +332,7 @@ export function createFiberFromElement(
       ) {
         info +=
           ' You likely forgot to export your component from the file ' +
-          "it's defined in.";
+          "it's defined in, or you might have mixed up default and named imports.";
       }
       const ownerName = owner ? getComponentName(owner) : null;
       if (ownerName) {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.js
@@ -749,7 +749,8 @@ describe('ReactIncrementalErrorHandling', () => {
         'Element type is invalid: expected a string (for built-in components) or ' +
           'a class/function (for composite components) but got: undefined. ' +
           "You likely forgot to export your component from the file it's " +
-          'defined in.\n\nCheck the render method of `BrokenRender`.',
+          'defined in, or you might have mixed up default and named imports.' +
+          '\n\nCheck the render method of `BrokenRender`.',
       ),
     ]);
     expect(console.error.calls.count()).toBe(1);
@@ -794,7 +795,8 @@ describe('ReactIncrementalErrorHandling', () => {
         'Element type is invalid: expected a string (for built-in components) or ' +
           'a class/function (for composite components) but got: undefined. ' +
           "You likely forgot to export your component from the file it's " +
-          'defined in.\n\nCheck the render method of `BrokenRender`.',
+          'defined in, or you might have mixed up default and named imports.' +
+          '\n\nCheck the render method of `BrokenRender`.',
       ),
     ]);
     expect(console.error.calls.count()).toBe(1);
@@ -810,7 +812,7 @@ describe('ReactIncrementalErrorHandling', () => {
       'Element type is invalid: expected a string (for built-in components) or ' +
         'a class/function (for composite components) but got: undefined. ' +
         "You likely forgot to export your component from the file it's " +
-        'defined in.',
+        'defined in, or you might have mixed up default and named imports.',
     );
 
     ReactNoop.render(<span prop="hi" />);

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -285,7 +285,7 @@ export function createElementWithValidation(type, props, children) {
     ) {
       info +=
         ' You likely forgot to export your component from the file ' +
-        "it's defined in.";
+        "it's defined in, or you might have mixed up default and named imports.";
     }
 
     var sourceInfo = getSourceInfoErrorAddendum(props);

--- a/packages/react/src/__tests__/ReactElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.js
@@ -274,7 +274,8 @@ describe('ReactElementValidator', () => {
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: undefined. You likely forgot to export your ' +
-        "component from the file it's defined in.",
+        "component from the file it's defined in, or you might have mixed up " +
+        'default and named imports.',
     );
     expectDev(console.error.calls.argsFor(1)[0]).toBe(
       'Warning: React.createElement: type is invalid -- expected a string ' +
@@ -295,7 +296,8 @@ describe('ReactElementValidator', () => {
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: object. You likely forgot to export your ' +
-        "component from the file it's defined in.",
+        "component from the file it's defined in, or you might have mixed up " +
+        'default and named imports.',
     );
     React.createElement('div');
     expectDev(console.error.calls.count()).toBe(5);
@@ -511,7 +513,8 @@ describe('ReactElementValidator', () => {
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: undefined. You likely forgot to export your ' +
-        "component from the file it's defined in.\n\nCheck your code at **.",
+        "component from the file it's defined in, or you might have mixed up " +
+        'default and named imports.\n\nCheck your code at **.',
     );
   });
 });

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -330,7 +330,8 @@ describe('ReactJSXElementValidator', () => {
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: undefined. You likely forgot to export your ' +
-        "component from the file it's defined in." +
+        "component from the file it's defined in, or you might have mixed up " +
+        'default and named imports.' +
         '\n\nCheck your code at **.',
     );
     expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(


### PR DESCRIPTION
This commit adds a note about the possibility of erroneously
mistaking named and default exports to an existing error message.

Ref [this issue](https://github.com/facebook/react/issues/9249#issuecomment-343210843).