### PR TITLE
track each individual file that has already been annotated with flow

### DIFF
--- a/scripts/circleci/track_stats.sh
+++ b/scripts/circleci/track_stats.sh
@@ -4,5 +4,7 @@ set -e
 
 ALL_FILES=`find packages -name '*.js' | grep -v umd/ | grep -v __tests__ | grep -v __mocks__`
 COUNT_ALL_FILES=`echo "$ALL_FILES" | wc -l`
-COUNT_WITH_FLOW=`grep '@flow' $ALL_FILES | perl -pe 's/:.+//' | wc -l`
-node scripts/facts-tracker/index.js "flow-files" "$COUNT_WITH_FLOW/$COUNT_ALL_FILES"
+FLOW_ANNOTATED_FILES=`grep '@flow' $ALL_FILES | perl -pe 's/:.+//'`
+COUNT_FLOW_ANNOTATED_FILES=`echo "$FLOW_ANNOTATED_FILES" | wc -l`
+INLINED_FLOW_ANNOTATED_FILES=`echo "$FLOW_ANNOTATED_FILES" | perl -pe 's/\n/ /'`
+node scripts/facts-tracker/index.js "flow-files" "$INLINED_FLOW_ANNOTATED_FILES $COUNT_FLOW_ANNOTATED_FILES/$COUNT_ALL_FILES"


### PR DESCRIPTION
A start to #11328. Specifically based on https://github.com/facebook/react/issues/11328#issuecomment-338956385. I think ideally this would be a more tabular format, but I'm not sure if it's worth breaking the previous format of single line additions. I'm open to suggestions.

It also might be nice to log files that we have left to type annotate instead of files that are already done. That way it's easier to see what work still has to be done.

The new format would look something like:

```
12958f1928bc0a file1annotated.js file2annotated.js 108/216
```