### PR TITLE
added verification check for misspelled propTypes

### DIFF
--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -221,7 +221,14 @@ function validatePropTypes(element) {
   }
   var name = componentClass.displayName || componentClass.name;
   var propTypes = componentClass.propTypes;
-
+  if (componentClass.PropTypes !== undefined) {
+    warning(
+      false,
+      'Static propTypes method should be accessed by `%s.propTypes` instead of `%s.PropTypes`',
+      name,
+      name,
+    );
+  }
   if (propTypes) {
     currentlyValidatingElement = element;
     checkPropTypes(propTypes, element.props, 'prop', name, getStackAddendum);


### PR DESCRIPTION
### Prerequisites 
- [X] All test ran successfully
- [X] Code formatted with prettier
- [X] Code linting done
- [X] Flow run completed
- [X] completed the CLA.

## Changes
Added the check if `PropTypes` is entered instead of `propTypes` in the static method of class for props types check.
*Please let me know if i have to change anything*