### PR TITLE
Rewrite SyntheticEvent tests using public APIs only

### DIFF
--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -140,29 +140,6 @@ describe('SyntheticEvent', () => {
     expect(expectedCount).toBe(1);
   });
 
-  it('should be able to `stopPropagation`', () => {
-    var instance;
-    var expectedCount = 0;
-
-    var eventHandler = syntheticEvent => {
-      expect(syntheticEvent.isPersistent()).toBe(false);
-      syntheticEvent.persist();
-      expect(syntheticEvent.isPersistent()).toBe(true);
-      // TODO: Figure out why this is undefined when switching to public API
-      // expect(nativeEvent.cancelBubble).toBe(true);
-
-      expectedCount++;
-    };
-    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
-
-    var event;
-    event = document.createEvent('Event');
-    event.initEvent('click', true, true);
-    instance.dispatchEvent(event);
-
-    expect(expectedCount).toBe(1);
-  });
-
   it('should be nullified if the synthetic event has called destructor and log warnings`', () => {
     spyOn(console, 'error');
     var instance;

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -138,7 +138,7 @@ describe('SyntheticEvent', () => {
     expect(expectedCount).toBe(1);
   });
 
-  it('should be nullified if the synthetic event has called destructor and log warnings`', () => {
+  it('should be nullified if the synthetic event has called destructor and log warnings', () => {
     spyOn(console, 'error');
     var node;
     var expectedCount = 0;

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -41,8 +41,7 @@ describe('SyntheticEvent', () => {
     };
     node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
-    var event;
-    event = document.createEvent('Event');
+    var event = document.createEvent('Event');
     event.initEvent('click', true, true);
     // Emulate IE8
     Object.defineProperty(event, 'target', {

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -67,8 +67,6 @@ describe('SyntheticEvent', () => {
       syntheticEvent.preventDefault();
       expect(syntheticEvent.isDefaultPrevented()).toBe(true);
       expect(syntheticEvent.defaultPrevented).toBe(true);
-      // TODO: Figure out why this is undefined when switching to public API
-      // expect(nativeEvent.returnValue).toBe(false);
 
       expectedCount++;
     };
@@ -125,8 +123,6 @@ describe('SyntheticEvent', () => {
       expect(syntheticEvent.isPropagationStopped()).toBe(false);
       syntheticEvent.stopPropagation();
       expect(syntheticEvent.isPropagationStopped()).toBe(true);
-      // TODO: Figure out why this is undefined when switching to public API
-      // expect(nativeEvent.cancelBubble).toBe(true);
 
       expectedCount++;
     };

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -31,15 +31,15 @@ describe('SyntheticEvent', () => {
   });
 
   it('should normalize `target` from the nativeEvent', () => {
-    var instance;
+    var node;
     var expectedCount = 0;
 
     var eventHandler = syntheticEvent => {
-      expect(syntheticEvent.target).toBe(instance);
+      expect(syntheticEvent.target).toBe(node);
 
       expectedCount++;
     };
-    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
@@ -50,16 +50,16 @@ describe('SyntheticEvent', () => {
     });
     Object.defineProperty(event, 'srcElement', {
       get() {
-        return instance;
+        return node;
       },
     });
-    instance.dispatchEvent(event);
+    node.dispatchEvent(event);
 
     expect(expectedCount).toBe(1);
   });
 
   it('should be able to `preventDefault`', () => {
-    var instance;
+    var node;
     var expectedCount = 0;
 
     var eventHandler = syntheticEvent => {
@@ -70,18 +70,18 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
-    instance.dispatchEvent(event);
+    node.dispatchEvent(event);
 
     expect(expectedCount).toBe(1);
   });
 
   it('should be prevented if nativeEvent is prevented', () => {
-    var instance;
+    var node;
     var expectedCount = 0;
 
     var eventHandler = syntheticEvent => {
@@ -89,7 +89,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
@@ -99,7 +99,7 @@ describe('SyntheticEvent', () => {
         return true;
       },
     });
-    instance.dispatchEvent(event);
+    node.dispatchEvent(event);
 
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
@@ -112,13 +112,13 @@ describe('SyntheticEvent', () => {
         return false;
       },
     });
-    instance.dispatchEvent(event);
+    node.dispatchEvent(event);
 
     expect(expectedCount).toBe(2);
   });
 
   it('should be able to `stopPropagation`', () => {
-    var instance;
+    var node;
     var expectedCount = 0;
 
     var eventHandler = syntheticEvent => {
@@ -128,19 +128,19 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
-    instance.dispatchEvent(event);
+    node.dispatchEvent(event);
 
     expect(expectedCount).toBe(1);
   });
 
   it('should be nullified if the synthetic event has called destructor and log warnings`', () => {
     spyOn(console, 'error');
-    var instance;
+    var node;
     var expectedCount = 0;
 
     var eventHandler = syntheticEvent => {
@@ -161,24 +161,24 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
     Object.defineProperty(event, 'srcElement', {
       get() {
-        return instance;
+        return node;
       },
     });
-    instance.dispatchEvent(event);
+    node.dispatchEvent(event);
 
     expect(expectedCount).toBe(1);
   });
 
   it('should warn when setting properties of a destructored synthetic event', () => {
     spyOn(console, 'error');
-    var instance;
+    var node;
     var expectedCount = 0;
 
     var eventHandler = syntheticEvent => {
@@ -195,24 +195,24 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
     Object.defineProperty(event, 'srcElement', {
       get() {
-        return instance;
+        return node;
       },
     });
-    instance.dispatchEvent(event);
+    node.dispatchEvent(event);
 
     expect(expectedCount).toBe(1);
   });
 
   it('should warn if the synthetic event has been released when calling `preventDefault`', () => {
     spyOn(console, 'error');
-    var instance;
+    var node;
     var expectedCount = 0;
     var syntheticEvent;
 
@@ -220,12 +220,12 @@ describe('SyntheticEvent', () => {
       syntheticEvent = e;
       expectedCount++;
     };
-    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
-    instance.dispatchEvent(event);
+    node.dispatchEvent(event);
 
     syntheticEvent.preventDefault();
     expectDev(console.error.calls.count()).toBe(1);
@@ -241,7 +241,7 @@ describe('SyntheticEvent', () => {
 
   it('should warn if the synthetic event has been released when calling `stopPropagation`', () => {
     spyOn(console, 'error');
-    var instance;
+    var node;
     var expectedCount = 0;
     var syntheticEvent;
 
@@ -249,13 +249,13 @@ describe('SyntheticEvent', () => {
       syntheticEvent = e;
       expectedCount++;
     };
-    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
 
-    instance.dispatchEvent(event);
+    node.dispatchEvent(event);
 
     syntheticEvent.stopPropagation();
     expectDev(console.error.calls.count()).toBe(1);
@@ -279,8 +279,8 @@ describe('SyntheticEvent', () => {
     function assignEvent(e) {
       event = e;
     }
-    var instance = ReactDOM.render(<div onClick={assignEvent} />, element);
-    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(instance));
+    var node = ReactDOM.render(<div onClick={assignEvent} />, element);
+    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(node));
     expectDev(console.error.calls.count()).toBe(0);
 
     // access a property to cause the warning
@@ -298,7 +298,7 @@ describe('SyntheticEvent', () => {
 
   it('should warn if Proxy is supported and the synthetic event is added a property', () => {
     spyOn(console, 'error');
-    var instance;
+    var node;
     var expectedCount = 0;
     var syntheticEvent;
 
@@ -307,13 +307,13 @@ describe('SyntheticEvent', () => {
       syntheticEvent = e;
       expectedCount++;
     };
-    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
 
-    instance.dispatchEvent(event);
+    node.dispatchEvent(event);
 
     expect(syntheticEvent.foo).toBe('bar');
     if (typeof Proxy === 'function') {

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -137,6 +137,27 @@ describe('SyntheticEvent', () => {
     expect(expectedCount).toBe(1);
   });
 
+  it('should be able to `persist`', () => {
+    var node;
+    var expectedCount = 0;
+
+    var eventHandler = syntheticEvent => {
+      expect(syntheticEvent.isPersistent()).toBe(false);
+      syntheticEvent.persist();
+      expect(syntheticEvent.isPersistent()).toBe(true);
+
+      expectedCount++;
+    };
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+
+    var event;
+    event = document.createEvent('Event');
+    event.initEvent('click', true, true);
+    node.dispatchEvent(event);
+
+    expect(expectedCount).toBe(1);
+  });
+
   it('should be nullified if the synthetic event has called destructor and log warnings', () => {
     spyOn(console, 'error');
     var node;

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -80,7 +80,7 @@ describe('SyntheticEvent', () => {
     expect(expectedCount).toBe(1);
   });
 
-  test.only('should be prevented if nativeEvent is prevented', () => {
+  it('should be prevented if nativeEvent is prevented', () => {
     var instance;
     var expectedCount = 0;
 
@@ -105,12 +105,12 @@ describe('SyntheticEvent', () => {
     event.initEvent('click', true, true);
     // Emulate IE8
     Object.defineProperty(event, 'defaultPrevented', {
-      get() {}
+      get() {},
     });
     Object.defineProperty(event, 'returnValue', {
-      get(){
+      get() {
         return false;
-      }
+      },
     });
     instance.dispatchEvent(event);
 

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -136,10 +136,12 @@ describe('SyntheticEvent', () => {
   it('should be able to `persist`', () => {
     var node;
     var expectedCount = 0;
+    var persistedSyntheticEvent;
 
     var eventHandler = syntheticEvent => {
       expect(syntheticEvent.isPersistent()).toBe(false);
       syntheticEvent.persist();
+      persistedSyntheticEvent = syntheticEvent;
       expect(syntheticEvent.isPersistent()).toBe(true);
 
       expectedCount++;
@@ -151,6 +153,9 @@ describe('SyntheticEvent', () => {
     event.initEvent('click', true, true);
     node.dispatchEvent(event);
 
+    expect(persistedSyntheticEvent.type).toBe('click');
+    expect(persistedSyntheticEvent.bubbles).toBe(true);
+    expect(persistedSyntheticEvent.cancelable).toBe(true);
     expect(expectedCount).toBe(1);
   });
 

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -71,8 +71,7 @@ describe('SyntheticEvent', () => {
     };
     node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
-    var event;
-    event = document.createEvent('Event');
+    var event = document.createEvent('Event');
     event.initEvent('click', true, true);
     node.dispatchEvent(event);
 
@@ -125,8 +124,7 @@ describe('SyntheticEvent', () => {
     };
     node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
-    var event;
-    event = document.createEvent('Event');
+    var event = document.createEvent('Event');
     event.initEvent('click', true, true);
     node.dispatchEvent(event);
 
@@ -148,8 +146,7 @@ describe('SyntheticEvent', () => {
     };
     node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
-    var event;
-    event = document.createEvent('Event');
+    var event = document.createEvent('Event');
     event.initEvent('click', true, true);
     node.dispatchEvent(event);
 
@@ -172,8 +169,7 @@ describe('SyntheticEvent', () => {
     };
     node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
-    var event;
-    event = document.createEvent('Event');
+    var event = document.createEvent('Event');
     event.initEvent('click', true, true);
     node.dispatchEvent(event);
 
@@ -206,8 +202,7 @@ describe('SyntheticEvent', () => {
     };
     node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
-    var event;
-    event = document.createEvent('Event');
+    var event = document.createEvent('Event');
     event.initEvent('click', true, true);
     node.dispatchEvent(event);
 
@@ -235,8 +230,7 @@ describe('SyntheticEvent', () => {
     };
     node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
-    var event;
-    event = document.createEvent('Event');
+    var event = document.createEvent('Event');
     event.initEvent('click', true, true);
     node.dispatchEvent(event);
 
@@ -264,8 +258,7 @@ describe('SyntheticEvent', () => {
     };
     node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
-    var event;
-    event = document.createEvent('Event');
+    var event = document.createEvent('Event');
     event.initEvent('click', true, true);
 
     node.dispatchEvent(event);
@@ -322,8 +315,7 @@ describe('SyntheticEvent', () => {
     };
     node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
-    var event;
-    event = document.createEvent('Event');
+    var event = document.createEvent('Event');
     event.initEvent('click', true, true);
 
     node.dispatchEvent(event);

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -23,7 +23,6 @@ describe('SyntheticEvent', () => {
 
     createEvent = (nativeEvent, callback) => {
       var instance;
-
       var container = document.createElement('div');
       ReactDOM.render(
         <div ref={ref => (instance = ref)} onClick={callback} />,

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -11,6 +11,7 @@
 
 var React;
 var ReactDOM;
+var ReactTestUtils;
 
 describe('SyntheticEvent', () => {
   var container;
@@ -18,6 +19,7 @@ describe('SyntheticEvent', () => {
   beforeEach(() => {
     React = require('react');
     ReactDOM = require('react-dom');
+    ReactTestUtils = require('react-dom/test-utils');
 
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -37,12 +39,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(
-      <div
-        onClick={eventHandler}
-      />,
-      container,
-    );
+    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
@@ -75,12 +72,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(
-      <div
-        onClick={eventHandler}
-      />,
-      container,
-    );
+    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
@@ -99,20 +91,15 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(
-      <div
-        onClick={eventHandler}
-      />,
-      container,
-    );
+    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
     Object.defineProperty(event, 'defaultPrevented', {
-      get(){
+      get() {
         return true;
-      }
+      },
     });
     instance.dispatchEvent(event);
 
@@ -126,7 +113,8 @@ describe('SyntheticEvent', () => {
     // });
     // instance.dispatchEvent(event);
 
-    // expect(expectedCount).toBe(2);
+    // TODO: change to 2 when problem above is resolved
+    expect(expectedCount).toBe(1);
   });
 
   it('should be able to `stopPropagation`', () => {
@@ -142,12 +130,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(
-      <div
-        onClick={eventHandler}
-      />,
-      container,
-    );
+    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
@@ -170,12 +153,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(
-      <div
-        onClick={eventHandler}
-      />,
-      container,
-    );
+    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
@@ -208,12 +186,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(
-      <div
-        onClick={eventHandler}
-      />,
-      container,
-    );
+    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
@@ -247,12 +220,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    instance = ReactDOM.render(
-      <div
-        onClick={eventHandler}
-      />,
-      container,
-    );
+    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
@@ -277,12 +245,7 @@ describe('SyntheticEvent', () => {
       syntheticEvent = e;
       expectedCount++;
     };
-    instance = ReactDOM.render(
-      <div
-        onClick={eventHandler}
-      />,
-      container,
-    );
+    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
@@ -311,12 +274,7 @@ describe('SyntheticEvent', () => {
       syntheticEvent = e;
       expectedCount++;
     };
-    instance = ReactDOM.render(
-      <div
-        onClick={eventHandler}
-      />,
-      container,
-    );
+    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');
@@ -374,12 +332,7 @@ describe('SyntheticEvent', () => {
       syntheticEvent = e;
       expectedCount++;
     };
-    instance = ReactDOM.render(
-      <div
-        onClick={eventHandler}
-      />,
-      container,
-    );
+    instance = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     var event;
     event = document.createEvent('Event');

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -80,7 +80,7 @@ describe('SyntheticEvent', () => {
     expect(expectedCount).toBe(1);
   });
 
-  it('should be prevented if nativeEvent is prevented', () => {
+  test.only('should be prevented if nativeEvent is prevented', () => {
     var instance;
     var expectedCount = 0;
 
@@ -101,18 +101,20 @@ describe('SyntheticEvent', () => {
     });
     instance.dispatchEvent(event);
 
-    // TODO: figure out why this fails
-    // event = document.createEvent('Event');
-    // event.initEvent('click', true, true);
-    // Object.defineProperty(event, 'returnValue', {
-    //   get(){
-    //     return false;
-    //   }
-    // });
-    // instance.dispatchEvent(event);
+    event = document.createEvent('Event');
+    event.initEvent('click', true, true);
+    // Emulate IE8
+    Object.defineProperty(event, 'defaultPrevented', {
+      get() {}
+    });
+    Object.defineProperty(event, 'returnValue', {
+      get(){
+        return false;
+      }
+    });
+    instance.dispatchEvent(event);
 
-    // TODO: change to 2 when problem above is resolved
-    expect(expectedCount).toBe(1);
+    expect(expectedCount).toBe(2);
   });
 
   it('should be able to `stopPropagation`', () => {

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -93,11 +93,7 @@ describe('SyntheticEvent', () => {
     var event;
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
-    Object.defineProperty(event, 'defaultPrevented', {
-      get() {
-        return true;
-      },
-    });
+    event.preventDefault();
     node.dispatchEvent(event);
 
     event = document.createEvent('Event');

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -23,11 +23,14 @@ describe('SyntheticEvent', () => {
 
     createEvent = (nativeEvent, callback) => {
       var instance;
-      
+
       var container = document.createElement('div');
-      ReactDOM.render(<div ref={ref => instance = ref} onClick={callback} />, container);
-      ReactTestUtils.SimulateNative.click(instance, nativeEvent)
-    }
+      ReactDOM.render(
+        <div ref={ref => (instance = ref)} onClick={callback} />,
+        container,
+      );
+      ReactTestUtils.SimulateNative.click(instance, nativeEvent);
+    };
   });
 
   // TODO: This is not testable with the public APIs, write a test for getEventTarget
@@ -45,9 +48,9 @@ describe('SyntheticEvent', () => {
       expect(syntheticEvent.isDefaultPrevented()).toBe(false);
       syntheticEvent.preventDefault();
       expect(syntheticEvent.isDefaultPrevented()).toBe(true);
-  
+
       expect(syntheticEvent.defaultPrevented).toBe(true);
-      
+
       // TODO: Figure out why this is undefined when switching to public API
       // expect(nativeEvent.returnValue).toBe(false);
     });
@@ -55,11 +58,9 @@ describe('SyntheticEvent', () => {
 
   it('should be prevented if nativeEvent is prevented', () => {
     createEvent({defaultPrevented: true}, syntheticEvent => {
-      expect(syntheticEvent.isDefaultPrevented()).toBe(
-        true,
-      );
+      expect(syntheticEvent.isDefaultPrevented()).toBe(true);
     });
-    
+
     createEvent({returnValue: false}, syntheticEvent => {
       expect(syntheticEvent.isDefaultPrevented()).toBe(true);
     });
@@ -68,7 +69,6 @@ describe('SyntheticEvent', () => {
   it('should be able to `stopPropagation`', () => {
     var nativeEvent = {};
     createEvent(nativeEvent, syntheticEvent => {
-
       expect(syntheticEvent.isPropagationStopped()).toBe(false);
       syntheticEvent.stopPropagation();
       expect(syntheticEvent.isPropagationStopped()).toBe(true);
@@ -80,7 +80,6 @@ describe('SyntheticEvent', () => {
 
   it('should be able to `persist`', () => {
     createEvent({}, syntheticEvent => {
-
       expect(syntheticEvent.isPersistent()).toBe(false);
       syntheticEvent.persist();
       expect(syntheticEvent.isPersistent()).toBe(true);
@@ -193,7 +192,7 @@ describe('SyntheticEvent', () => {
     var syntheticEvent;
     createEvent({}, e => {
       e.foo = 'bar';
-      syntheticEvent  = e;
+      syntheticEvent = e;
     });
 
     expect(syntheticEvent.foo).toBe('bar');

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -166,11 +166,6 @@ describe('SyntheticEvent', () => {
     var event;
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
-    Object.defineProperty(event, 'srcElement', {
-      get() {
-        return node;
-      },
-    });
     node.dispatchEvent(event);
 
     expect(expectedCount).toBe(1);
@@ -200,11 +195,6 @@ describe('SyntheticEvent', () => {
     var event;
     event = document.createEvent('Event');
     event.initEvent('click', true, true);
-    Object.defineProperty(event, 'srcElement', {
-      get() {
-        return node;
-      },
-    });
     node.dispatchEvent(event);
 
     expect(expectedCount).toBe(1);


### PR DESCRIPTION
Related to #11299 

* rewritten `createEvent` to use public APIs
* removed all references `SyntheticEvent.release`

In order to test under realistic circumstances I had to move the expectations into a callback in mosts tests to overcome the effects of event pooling.