### PR TITLE
Unfreeze the react-dom/server interface

### DIFF
--- a/packages/react-dom/server.browser.js
+++ b/packages/react-dom/server.browser.js
@@ -9,4 +9,10 @@
 
 'use strict';
 
-module.exports = require('./src/server/ReactDOMServerBrowser');
+var ReactDOMServer = require('./src/server/ReactDOMServerBrowser');
+
+// TODO: decide on the top-level export form.
+// This is hacky but makes it work with both Rollup and Jest
+module.exports = ReactDOMServer.default
+  ? ReactDOMServer.default
+  : ReactDOMServer;

--- a/packages/react-dom/server.node.js
+++ b/packages/react-dom/server.node.js
@@ -9,4 +9,10 @@
 
 'use strict';
 
-module.exports = require('./src/server/ReactDOMServerNode');
+var ReactDOMServer = require('./src/server/ReactDOMServerNode');
+
+// TODO: decide on the top-level export form.
+// This is hacky but makes it work with both Rollup and Jest
+module.exports = ReactDOMServer.default
+  ? ReactDOMServer.default
+  : ReactDOMServer;

--- a/packages/react-dom/src/server/ReactDOMServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMServerBrowser.js
@@ -33,6 +33,5 @@ export default {
   renderToStaticMarkup,
   renderToNodeStream,
   renderToStaticNodeStream,
+  version: ReactVersion,
 };
-
-export const version = ReactVersion;

--- a/packages/react-dom/src/server/ReactDOMServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMServerBrowser.js
@@ -27,7 +27,8 @@ function renderToStaticNodeStream() {
   );
 }
 
-export {
+// Note: when changing this, also consider https://github.com/facebook/react/issues/11526
+export default {
   renderToString,
   renderToStaticMarkup,
   renderToNodeStream,

--- a/packages/react-dom/src/server/ReactDOMServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMServerNode.js
@@ -20,6 +20,6 @@ export default {
   renderToStaticMarkup,
   renderToNodeStream,
   renderToStaticNodeStream,
+  version: ReactVersion,
 };
 
-export const version = ReactVersion;

--- a/packages/react-dom/src/server/ReactDOMServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMServerNode.js
@@ -22,4 +22,3 @@ export default {
   renderToStaticNodeStream,
   version: ReactVersion,
 };
-

--- a/packages/react-dom/src/server/ReactDOMServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMServerNode.js
@@ -14,7 +14,8 @@ import {
   renderToStaticNodeStream,
 } from './ReactDOMNodeStreamRenderer';
 
-export {
+// Note: when changing this, also consider https://github.com/facebook/react/issues/11526
+export default {
   renderToString,
   renderToStaticMarkup,
   renderToNodeStream,


### PR DESCRIPTION
this allows stubbing of the exposed named functions, as was possible before v16.1

fixes #11526
