### PR TITLE
Disable warning for <noindex>

### DIFF
--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -62,6 +62,7 @@ if (__DEV__) {
     time: true,
     // There are working polyfills for <dialog>. Let people use it.
     dialog: true,
+    noindex: true
   };
 
   var validatePropertiesInDevelopment = function(type, props) {


### PR DESCRIPTION
I have warning with it. This tag is supported by all browsers.