### PR TITLE
fix error when has the element id is 'nodeName'

### DIFF
--- a/packages/react-dom/src/client/ReactInputSelection.js
+++ b/packages/react-dom/src/client/ReactInputSelection.js
@@ -24,7 +24,11 @@ function isInDocument(node) {
  */
 
 export function hasSelectionCapabilities(elem) {
-  const nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+  if (!elem || elem.window === elem) {
+    return false;
+  }
+
+  const nodeName = elem.nodeName && elem.nodeName.toLowerCase();
   return (
     nodeName &&
     ((nodeName === 'input' && elem.type === 'text') ||

--- a/packages/react-dom/src/client/inputValueTracking.js
+++ b/packages/react-dom/src/client/inputValueTracking.js
@@ -16,6 +16,10 @@ type WrapperState = {_valueTracker: ?ValueTracker};
 type ElementWithValueTracker = HTMLInputElement & WrapperState;
 
 function isCheckable(elem: HTMLInputElement) {
+  if (elem.window === elem) {
+    return false;
+  }
+
   const type = elem.type;
   const nodeName = elem.nodeName;
   return (

--- a/packages/react-dom/src/events/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/ChangeEventPlugin.js
@@ -202,6 +202,10 @@ function getTargetInstForInputEventPolyfill(topLevelType, targetInst) {
  * SECTION: handle `click` event
  */
 function shouldUseClickEvent(elem) {
+  if (elem.window === elem) {
+    return false;
+  }
+
   // Use the `click` event to detect changes to checkbox and radio inputs.
   // This approach works across all browsers, whereas `change` does not fire
   // until `blur` in IE8.

--- a/packages/react-dom/src/events/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/ChangeEventPlugin.js
@@ -60,6 +60,10 @@ var activeElementInst = null;
  * SECTION: handle `change` event
  */
 function shouldUseChangeEvent(elem) {
+  if (elem.window === elem) {
+    return false;
+  }
+
   var nodeName = elem.nodeName && elem.nodeName.toLowerCase();
   return (
     nodeName === 'select' || (nodeName === 'input' && elem.type === 'file')

--- a/packages/shared/isTextInputElement.js
+++ b/packages/shared/isTextInputElement.js
@@ -29,7 +29,11 @@ var supportedInputTypes: {[key: string]: true | void} = {
 };
 
 function isTextInputElement(elem: ?HTMLElement): boolean {
-  var nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+  if (!elem || elem.window === elem) {
+    return false;
+  }
+
+  var nodeName = elem.nodeName && elem.nodeName.toLowerCase();
 
   if (nodeName === 'input') {
     return !!supportedInputTypes[((elem: any): HTMLInputElement).type];


### PR DESCRIPTION
When there is an dom element id 'nodeName', `window.nodeName` will be filled with element.
Which caused react-dom `select`, `input` & `textarea` check function failed.
Add check logic to skip `window`.