### PR TITLE
Don't emit autoFocus={false} attribute on the server

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -382,6 +382,21 @@ describe('ReactDOMServer', () => {
       expect(element.firstChild.focus).not.toHaveBeenCalled();
     });
 
+    it('should not focus on either server or client with autofocus={false}', () => {
+      var element = document.createElement('div');
+      element.innerHTML = ReactDOMServer.renderToString(
+        <input autoFocus={false} />,
+      );
+      expect(element.firstChild.autofocus).toBe(false);
+
+      element.firstChild.focus = jest.fn();
+      ReactDOM.hydrate(<input autoFocus={false} />, element);
+      expect(element.firstChild.focus).not.toHaveBeenCalled();
+
+      ReactDOM.render(<input autoFocus={false} />, element);
+      expect(element.firstChild.focus).not.toHaveBeenCalled();
+    });
+
     it('should throw with silly args', () => {
       expect(
         ReactDOMServer.renderToString.bind(ReactDOMServer, {x: 123}),

--- a/packages/react-dom/src/shared/HTMLDOMPropertyConfig.js
+++ b/packages/react-dom/src/shared/HTMLDOMPropertyConfig.js
@@ -20,11 +20,11 @@ var HTMLDOMPropertyConfig = {
   // name warnings.
   Properties: {
     allowFullScreen: HAS_BOOLEAN_VALUE,
-    autoFocus: HAS_STRING_BOOLEAN_VALUE,
     // specifies target context for links with `preload` type
     async: HAS_BOOLEAN_VALUE,
-    // autoFocus is polyfilled/normalized by AutoFocusUtils
-    // autoFocus: HAS_BOOLEAN_VALUE,
+    // Note: there is a special case that prevents it from being written to the DOM
+    // on the client side because the browsers are inconsistent. Instead we call focus().
+    autoFocus: HAS_BOOLEAN_VALUE,
     autoPlay: HAS_BOOLEAN_VALUE,
     capture: HAS_OVERLOADED_BOOLEAN_VALUE,
     checked: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,


### PR DESCRIPTION
Seems like I made a mistake in https://github.com/facebook/react/pull/11192.
Browsers don't treat `autofocus="false"` as truthy so we should use `HAS_BOOLEAN_VALUE` here.

Fixes the issue described in https://github.com/facebook/react/pull/11192#issuecomment-343903783.