### PR TITLE
DO NOT MERGE: Investigate switching out event delegation for direct attachment (mostly)

### DIFF
--- a/fixtures/dom/.gitignore
+++ b/fixtures/dom/.gitignore
@@ -8,8 +8,8 @@ coverage
 
 # production
 build
-public/react.development.js
-public/react-dom.development.js
+public/react.*.js
+public/react-dom.*.js
 
 # misc
 .DS_Store

--- a/fixtures/dom/package.json
+++ b/fixtures/dom/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "start": "react-scripts start",
     "prestart": "cp ../../build/dist/{react,react-dom}.{development,production.min}.js public/",
+    "prebuild": "cp ../../build/dist/{react,react-dom}.{development,production.min}.js public/",
     "build": "react-scripts build && cp build/index.html build/200.html",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/fixtures/dom/package.json
+++ b/fixtures/dom/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "prestart": "cp ../../build/dist/{react,react-dom}.development.js public/",
+    "prestart": "cp ../../build/dist/{react,react-dom}.{development,production.min}.js public/",
     "build": "react-scripts build && cp build/index.html build/200.html",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.js
+++ b/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.js
@@ -373,26 +373,27 @@ describe('ReactBrowserEventEmitter', () => {
   });
 
   it('should listen to events only once', () => {
+    let button = document.createElement('button');
     spyOn(EventTarget.prototype, 'addEventListener');
-    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
-    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
+    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, button);
+    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, button);
     expect(EventTarget.prototype.addEventListener.calls.count()).toBe(1);
   });
 
   it('should work with event plugins without dependencies', () => {
+    let button = document.createElement('button');
     spyOn(EventTarget.prototype, 'addEventListener');
-
-    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
-
+    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, button);
     expect(EventTarget.prototype.addEventListener.calls.argsFor(0)[0]).toBe(
       'click',
     );
   });
 
   it('should work with event plugins with dependencies', () => {
+    let button = document.createElement('button');
     spyOn(EventTarget.prototype, 'addEventListener');
 
-    ReactBrowserEventEmitter.listenTo(ON_CHANGE_KEY, document);
+    ReactBrowserEventEmitter.listenTo(ON_CHANGE_KEY, button);
 
     var setEventListeners = [];
     var listenCalls = EventTarget.prototype.addEventListener.calls.allArgs();

--- a/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.js
+++ b/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.js
@@ -373,27 +373,26 @@ describe('ReactBrowserEventEmitter', () => {
   });
 
   it('should listen to events only once', () => {
-    let button = document.createElement('button');
     spyOn(EventTarget.prototype, 'addEventListener');
-    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, button);
-    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, button);
+    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
+    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
     expect(EventTarget.prototype.addEventListener.calls.count()).toBe(1);
   });
 
   it('should work with event plugins without dependencies', () => {
-    let button = document.createElement('button');
     spyOn(EventTarget.prototype, 'addEventListener');
-    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, button);
+
+    ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
+
     expect(EventTarget.prototype.addEventListener.calls.argsFor(0)[0]).toBe(
       'click',
     );
   });
 
   it('should work with event plugins with dependencies', () => {
-    let button = document.createElement('button');
     spyOn(EventTarget.prototype, 'addEventListener');
 
-    ReactBrowserEventEmitter.listenTo(ON_CHANGE_KEY, button);
+    ReactBrowserEventEmitter.listenTo(ON_CHANGE_KEY, document);
 
     var setEventListeners = [];
     var listenCalls = EventTarget.prototype.addEventListener.calls.allArgs();

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -26,7 +26,7 @@ import * as CSSPropertyOperations from '../shared/CSSPropertyOperations';
 import {Namespaces, getIntrinsicNamespace} from '../shared/DOMNamespaces';
 import {getPropertyInfo, shouldSetAttribute} from '../shared/DOMProperty';
 import assertValidProps from '../shared/assertValidProps';
-import {DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE} from '../shared/HTMLNodeType';
+import {DOCUMENT_NODE} from '../shared/HTMLNodeType';
 import isCustomComponent from '../shared/isCustomComponent';
 import {validateProperties as validateARIAProperties} from '../shared/ReactDOMInvalidARIAHook';
 import {validateProperties as validateInputProperties} from '../shared/ReactDOMNullInputValuePropHook';

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -21,7 +21,7 @@ import * as ReactDOMFiberTextarea from './ReactDOMFiberTextarea';
 import * as inputValueTracking from './inputValueTracking';
 import setInnerHTML from './setInnerHTML';
 import setTextContent from './setTextContent';
-import {listenTo, trapBubbledEvent} from '../events/ReactBrowserEventEmitter';
+import {listenTo} from '../events/ReactBrowserEventEmitter';
 import * as CSSPropertyOperations from '../shared/CSSPropertyOperations';
 import {Namespaces, getIntrinsicNamespace} from '../shared/DOMNamespaces';
 import {getPropertyInfo, shouldSetAttribute} from '../shared/DOMProperty';
@@ -188,63 +188,12 @@ if (__DEV__) {
   };
 }
 
-function ensureListeningTo(rootContainerElement, registrationName) {
-  var isDocumentOrFragment =
-    rootContainerElement.nodeType === DOCUMENT_NODE ||
-    rootContainerElement.nodeType === DOCUMENT_FRAGMENT_NODE;
-  var doc = isDocumentOrFragment
-    ? rootContainerElement
-    : rootContainerElement.ownerDocument;
-  listenTo(registrationName, doc);
-}
-
 function getOwnerDocumentFromRootContainer(
   rootContainerElement: Element | Document,
 ): Document {
   return rootContainerElement.nodeType === DOCUMENT_NODE
     ? (rootContainerElement: any)
     : rootContainerElement.ownerDocument;
-}
-
-// There are so many media events, it makes sense to just
-// maintain a list rather than create a `trapBubbledEvent` for each
-var mediaEvents = {
-  topAbort: 'abort',
-  topCanPlay: 'canplay',
-  topCanPlayThrough: 'canplaythrough',
-  topDurationChange: 'durationchange',
-  topEmptied: 'emptied',
-  topEncrypted: 'encrypted',
-  topEnded: 'ended',
-  topError: 'error',
-  topLoadedData: 'loadeddata',
-  topLoadedMetadata: 'loadedmetadata',
-  topLoadStart: 'loadstart',
-  topPause: 'pause',
-  topPlay: 'play',
-  topPlaying: 'playing',
-  topProgress: 'progress',
-  topRateChange: 'ratechange',
-  topSeeked: 'seeked',
-  topSeeking: 'seeking',
-  topStalled: 'stalled',
-  topSuspend: 'suspend',
-  topTimeUpdate: 'timeupdate',
-  topVolumeChange: 'volumechange',
-  topWaiting: 'waiting',
-};
-
-function trapClickOnNonInteractiveElement(node: HTMLElement) {
-  // Mobile Safari does not fire properly bubble click events on
-  // non-interactive elements, which means delegated click listeners do not
-  // fire. The workaround for this bug involves attaching an empty click
-  // listener on the target node.
-  // http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
-  // Just set it using the onclick property so that we don't have to manage any
-  // bookkeeping for it. Not sure if we need to clear it when the listener is
-  // removed.
-  // TODO: Only do this for the relevant Safaris maybe?
-  node.onclick = emptyFunction;
 }
 
 function setInitialDOMProperties(
@@ -300,7 +249,7 @@ function setInitialDOMProperties(
         if (__DEV__ && typeof nextProp !== 'function') {
           warnForInvalidEventListener(propKey, nextProp);
         }
-        ensureListeningTo(rootContainerElement, propKey);
+        listenTo(propKey, domElement, rootContainerElement);
       }
     } else if (isCustomComponentTag) {
       DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
@@ -455,47 +404,12 @@ export function setInitialProperties(
   // TODO: Make sure that we check isMounted before firing any of these events.
   var props: Object;
   switch (tag) {
-    case 'iframe':
-    case 'object':
-      trapBubbledEvent('topLoad', 'load', domElement);
-      props = rawProps;
-      break;
-    case 'video':
-    case 'audio':
-      // Create listener for each media event
-      for (var event in mediaEvents) {
-        if (mediaEvents.hasOwnProperty(event)) {
-          trapBubbledEvent(event, mediaEvents[event], domElement);
-        }
-      }
-      props = rawProps;
-      break;
-    case 'source':
-      trapBubbledEvent('topError', 'error', domElement);
-      props = rawProps;
-      break;
-    case 'img':
-    case 'image':
-      trapBubbledEvent('topError', 'error', domElement);
-      trapBubbledEvent('topLoad', 'load', domElement);
-      props = rawProps;
-      break;
-    case 'form':
-      trapBubbledEvent('topReset', 'reset', domElement);
-      trapBubbledEvent('topSubmit', 'submit', domElement);
-      props = rawProps;
-      break;
-    case 'details':
-      trapBubbledEvent('topToggle', 'toggle', domElement);
-      props = rawProps;
-      break;
     case 'input':
       ReactDOMFiberInput.initWrapperState(domElement, rawProps);
       props = ReactDOMFiberInput.getHostProps(domElement, rawProps);
-      trapBubbledEvent('topInvalid', 'invalid', domElement);
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
-      ensureListeningTo(rootContainerElement, 'onChange');
+      listenTo('onChange', domElement, rootContainerElement);
       break;
     case 'option':
       ReactDOMFiberOption.validateProps(domElement, rawProps);
@@ -504,18 +418,16 @@ export function setInitialProperties(
     case 'select':
       ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
       props = ReactDOMFiberSelect.getHostProps(domElement, rawProps);
-      trapBubbledEvent('topInvalid', 'invalid', domElement);
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
-      ensureListeningTo(rootContainerElement, 'onChange');
+      listenTo('onChange', domElement);
       break;
     case 'textarea':
       ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
       props = ReactDOMFiberTextarea.getHostProps(domElement, rawProps);
-      trapBubbledEvent('topInvalid', 'invalid', domElement);
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
-      ensureListeningTo(rootContainerElement, 'onChange');
+      listenTo('onChange', domElement);
       break;
     default:
       props = rawProps;
@@ -551,10 +463,6 @@ export function setInitialProperties(
       ReactDOMFiberSelect.postMountWrapper(domElement, rawProps);
       break;
     default:
-      if (typeof props.onClick === 'function') {
-        // TODO: This cast may not be sound for SVG, MathML or custom elements.
-        trapClickOnNonInteractiveElement(((domElement: any): HTMLElement));
-      }
       break;
   }
 }
@@ -599,13 +507,6 @@ export function diffProperties(
     default:
       lastProps = lastRawProps;
       nextProps = nextRawProps;
-      if (
-        typeof lastProps.onClick !== 'function' &&
-        typeof nextProps.onClick === 'function'
-      ) {
-        // TODO: This cast may not be sound for SVG, MathML or custom elements.
-        trapClickOnNonInteractiveElement(((domElement: any): HTMLElement));
-      }
       break;
   }
 
@@ -736,7 +637,7 @@ export function diffProperties(
         if (__DEV__ && typeof nextProp !== 'function') {
           warnForInvalidEventListener(propKey, nextProp);
         }
-        ensureListeningTo(rootContainerElement, propKey);
+        listenTo(propKey, domElement, rootContainerElement);
       }
       if (!updatePayload && lastProp !== nextProp) {
         // This is a special case. If any listener updates we need to ensure
@@ -823,57 +724,26 @@ export function diffHydratedProperties(
 
   // TODO: Make sure that we check isMounted before firing any of these events.
   switch (tag) {
-    case 'iframe':
-    case 'object':
-      trapBubbledEvent('topLoad', 'load', domElement);
-      break;
-    case 'video':
-    case 'audio':
-      // Create listener for each media event
-      for (var event in mediaEvents) {
-        if (mediaEvents.hasOwnProperty(event)) {
-          trapBubbledEvent(event, mediaEvents[event], domElement);
-        }
-      }
-      break;
-    case 'source':
-      trapBubbledEvent('topError', 'error', domElement);
-      break;
-    case 'img':
-    case 'image':
-      trapBubbledEvent('topError', 'error', domElement);
-      trapBubbledEvent('topLoad', 'load', domElement);
-      break;
-    case 'form':
-      trapBubbledEvent('topReset', 'reset', domElement);
-      trapBubbledEvent('topSubmit', 'submit', domElement);
-      break;
-    case 'details':
-      trapBubbledEvent('topToggle', 'toggle', domElement);
-      break;
     case 'input':
       ReactDOMFiberInput.initWrapperState(domElement, rawProps);
-      trapBubbledEvent('topInvalid', 'invalid', domElement);
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
-      ensureListeningTo(rootContainerElement, 'onChange');
+      listenTo('onChange', rootContainerElement);
       break;
     case 'option':
       ReactDOMFiberOption.validateProps(domElement, rawProps);
       break;
     case 'select':
       ReactDOMFiberSelect.initWrapperState(domElement, rawProps);
-      trapBubbledEvent('topInvalid', 'invalid', domElement);
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
-      ensureListeningTo(rootContainerElement, 'onChange');
+      listenTo('onChange', rootContainerElement);
       break;
     case 'textarea':
       ReactDOMFiberTextarea.initWrapperState(domElement, rawProps);
-      trapBubbledEvent('topInvalid', 'invalid', domElement);
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
-      ensureListeningTo(rootContainerElement, 'onChange');
+      listenTo('onChange', rootContainerElement);
       break;
   }
 
@@ -940,7 +810,7 @@ export function diffHydratedProperties(
         if (__DEV__ && typeof nextProp !== 'function') {
           warnForInvalidEventListener(propKey, nextProp);
         }
-        ensureListeningTo(rootContainerElement, propKey);
+        listenTo(propKey, domElement);
       }
     } else if (__DEV__) {
       // Validate that the properties correspond to their expected values.
@@ -1052,10 +922,6 @@ export function diffHydratedProperties(
       // TODO: Consider not doing this for input and textarea.
       break;
     default:
-      if (typeof rawProps.onClick === 'function') {
-        // TODO: This cast may not be sound for SVG, MathML or custom elements.
-        trapClickOnNonInteractiveElement(((domElement: any): HTMLElement));
-      }
       break;
   }
 

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -110,6 +110,18 @@ export function isEnabled() {
   return _enabled;
 }
 
+let typeCache = {};
+
+function getDispatcher(topLevelType) {
+  if (topLevelType in typeCache) {
+    return typeCache[topLevelType];
+  }
+
+  typeCache[topLevelType] = dispatchEvent.bind(null, topLevelType);
+
+  return typeCache[topLevelType];
+}
+
 /**
  * Traps top-level events by using event bubbling.
  *
@@ -124,11 +136,8 @@ export function trapBubbledEvent(topLevelType, handlerBaseName, element) {
   if (!element) {
     return null;
   }
-  return EventListener.listen(
-    element,
-    handlerBaseName,
-    dispatchEvent.bind(null, topLevelType),
-  );
+
+  EventListener.listen(element, handlerBaseName, getDispatcher(topLevelType));
 }
 
 /**
@@ -145,11 +154,8 @@ export function trapCapturedEvent(topLevelType, handlerBaseName, element) {
   if (!element) {
     return null;
   }
-  return EventListener.capture(
-    element,
-    handlerBaseName,
-    dispatchEvent.bind(null, topLevelType),
-  );
+
+  EventListener.capture(element, handlerBaseName, getDispatcher(topLevelType));
 }
 
 export function dispatchEvent(topLevelType, nativeEvent) {

--- a/packages/react-dom/src/events/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/SelectEventPlugin.js
@@ -15,7 +15,6 @@ import shallowEqual from 'fbjs/lib/shallowEqual';
 import {isListeningToAllDependencies} from './ReactBrowserEventEmitter';
 import {getNodeFromInstance} from '../client/ReactDOMComponentTree';
 import * as ReactInputSelection from '../client/ReactInputSelection';
-import {DOCUMENT_NODE} from '../shared/HTMLNodeType';
 
 var skipSelectionChangeEvent =
   ExecutionEnvironment.canUseDOM &&

--- a/packages/react-dom/src/events/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/SelectEventPlugin.js
@@ -140,15 +140,9 @@ var SelectEventPlugin = {
     nativeEvent,
     nativeEventTarget,
   ) {
-    var doc =
-      nativeEventTarget.window === nativeEventTarget
-        ? nativeEventTarget.document
-        : nativeEventTarget.nodeType === DOCUMENT_NODE
-          ? nativeEventTarget
-          : nativeEventTarget.ownerDocument;
     // Track whether all listeners exists for this plugin. If none exist, we do
     // not extract events. See #3639.
-    if (!doc || !isListeningToAllDependencies('onSelect', doc)) {
+    if (!isListeningToAllDependencies('onSelect', nativeEventTarget)) {
       return null;
     }
 

--- a/packages/react-dom/src/events/__tests__/SimpleEventPlugin-test.js
+++ b/packages/react-dom/src/events/__tests__/SimpleEventPlugin-test.js
@@ -165,32 +165,4 @@ describe('SimpleEventPlugin', function() {
       });
     });
   });
-
-  describe('iOS bubbling click fix', function() {
-    // See http://www.quirksmode.org/blog/archives/2010/09/click_event_del.html
-
-    it('does not add a local click to interactive elements', function() {
-      var container = document.createElement('div');
-
-      ReactDOM.render(<button onClick={onClick} />, container);
-
-      var node = container.firstChild;
-
-      node.dispatchEvent(new MouseEvent('click'));
-
-      expect(onClick.mock.calls.length).toBe(0);
-    });
-
-    it('adds a local click listener to non-interactive elements', function() {
-      var container = document.createElement('div');
-
-      ReactDOM.render(<div onClick={onClick} />, container);
-
-      var node = container.firstChild;
-
-      node.dispatchEvent(new MouseEvent('click'));
-
-      expect(onClick.mock.calls.length).toBe(0);
-    });
-  });
 });


### PR DESCRIPTION
This PR replaces the traditional event delegation technique employed by React with direct attachment to DOM nodes. This is just an investigation. I'm attracted to it for a number of reasons:

1. We can remove a lot of code
2. This is another way of addressing scroll jank issues (https://github.com/facebook/react/pull/9333) 
3. This _might_ fix some issues with disabled interactive element bubbling. I do not know.
4. I might discover a nice middle-ground that is ultimately better.

Intuitively, event delegation should be faster. It does less work. However I want to figure out _how_ much faster it really is, particularly on weaker devices and IE 9/10. I'm curious about:

- Start up time
- Memory usage
- Ongoing update costs

I put up a build here:

**production:**
http://react-local-listeners.surge.sh/react.production.min.js
http://react-local-listeners.surge.sh/react-dom.production.min.js

**development:**
http://react-local-listeners.surge.sh/react.development.js
http://react-local-listeners.surge.sh/react-dom.development.js

Now to find some benchmarks.