### PR TITLE
[RFC] Add a new React.createRef() API for ref objects

### DIFF
--- a/packages/react-dom/src/__tests__/ReactComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponent-test.js
@@ -145,7 +145,7 @@ describe('ReactComponent', () => {
     ReactTestUtils.renderIntoDocument(<Parent child={<span />} />);
   });
 
-  it('should support new-style refs', () => {
+  it('should support callback-style refs', () => {
     var innerObj = {};
     var outerObj = {};
 
@@ -177,6 +177,51 @@ describe('ReactComponent', () => {
       componentDidMount() {
         expect(this.innerRef.getObject()).toEqual(innerObj);
         expect(this.outerRef.getObject()).toEqual(outerObj);
+        mounted = true;
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(<Component />);
+    expect(mounted).toBe(true);
+  });
+
+  it('should support object-style refs', () => {
+    var innerObj = {};
+    var outerObj = {};
+
+    class Wrapper extends React.Component {
+      getObject = () => {
+        return this.props.object;
+      };
+
+      render() {
+        return <div>{this.props.children}</div>;
+      }
+    }
+
+    var mounted = false;
+
+    class Component extends React.Component {
+      constructor() {
+        super();
+        this.innerRef = React.createRef();
+        this.outerRef = React.createRef();
+      }
+      render() {
+        var inner = (
+          <Wrapper object={innerObj} ref={this.innerRef} />
+        );
+        var outer = (
+          <Wrapper object={outerObj} ref={this.outerRef}>
+            {inner}
+          </Wrapper>
+        );
+        return outer;
+      }
+
+      componentDidMount() {
+        expect(this.innerRef.contents.getObject()).toEqual(innerObj);
+        expect(this.outerRef.contents.getObject()).toEqual(outerObj);
         mounted = true;
       }
     }

--- a/packages/react-dom/src/__tests__/ReactComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponent-test.js
@@ -208,9 +208,7 @@ describe('ReactComponent', () => {
         this.outerRef = React.createRef();
       }
       render() {
-        var inner = (
-          <Wrapper object={innerObj} ref={this.innerRef} />
-        );
+        var inner = <Wrapper object={innerObj} ref={this.innerRef} />;
         var outer = (
           <Wrapper object={outerObj} ref={this.outerRef}>
             {inner}

--- a/packages/react-dom/src/__tests__/ReactComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponent-test.js
@@ -218,8 +218,8 @@ describe('ReactComponent', () => {
       }
 
       componentDidMount() {
-        expect(this.innerRef.contents.getObject()).toEqual(innerObj);
-        expect(this.outerRef.contents.getObject()).toEqual(outerObj);
+        expect(this.innerRef.value.getObject()).toEqual(innerObj);
+        expect(this.outerRef.value.getObject()).toEqual(outerObj);
         mounted = true;
       }
     }

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
@@ -1011,13 +1011,13 @@ describe('ReactErrorBoundaries', () => {
       'ErrorBoundary render error',
       'ErrorBoundary componentDidUpdate',
     ]);
-    expect(errorMessageRef.contents.toString()).toEqual('[object HTMLDivElement]');
+    expect(errorMessageRef.contents.toString()).toEqual(
+      '[object HTMLDivElement]',
+    );
 
     log.length = 0;
     ReactDOM.unmountComponentAtNode(container);
-    expect(log).toEqual([
-      'ErrorBoundary componentWillUnmount',
-    ]);
+    expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
     expect(errorMessageRef.contents).toEqual(null);
   });
 

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
@@ -937,7 +937,7 @@ describe('ReactErrorBoundaries', () => {
     expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
   });
 
-  it('resets refs if mounting aborts', () => {
+  it('resets callback refs if mounting aborts', () => {
     function childRef(x) {
       log.push('Child ref is set to ' + x);
     }
@@ -979,6 +979,46 @@ describe('ReactErrorBoundaries', () => {
       'ErrorBoundary componentWillUnmount',
       'Error message ref is set to null',
     ]);
+  });
+
+  it('resets object refs if mounting aborts', () => {
+    let childRef = React.createRef();
+    let errorMessageRef = React.createRef();
+
+    var container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary errorMessageRef={errorMessageRef}>
+        <div ref={childRef} />
+        <BrokenRender />
+      </ErrorBoundary>,
+      container,
+    );
+    expect(container.textContent).toBe('Caught an error: Hello.');
+    expect(log).toEqual([
+      'ErrorBoundary constructor',
+      'ErrorBoundary componentWillMount',
+      'ErrorBoundary render success',
+      'BrokenRender constructor',
+      'BrokenRender componentWillMount',
+      'BrokenRender render [!]',
+      // Handle error:
+      // Finish mounting with null children
+      'ErrorBoundary componentDidMount',
+      // Handle the error
+      'ErrorBoundary componentDidCatch',
+      // Render the error message
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      'ErrorBoundary componentDidUpdate',
+    ]);
+    expect(errorMessageRef.contents.toString()).toEqual('[object HTMLDivElement]');
+
+    log.length = 0;
+    ReactDOM.unmountComponentAtNode(container);
+    expect(log).toEqual([
+      'ErrorBoundary componentWillUnmount',
+    ]);
+    expect(errorMessageRef.contents).toEqual(null);
   });
 
   it('successfully mounts if no error occurs', () => {

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
@@ -1011,9 +1011,7 @@ describe('ReactErrorBoundaries', () => {
       'ErrorBoundary render error',
       'ErrorBoundary componentDidUpdate',
     ]);
-    expect(errorMessageRef.value.toString()).toEqual(
-      '[object HTMLDivElement]',
-    );
+    expect(errorMessageRef.value.toString()).toEqual('[object HTMLDivElement]');
 
     log.length = 0;
     ReactDOM.unmountComponentAtNode(container);

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
@@ -1011,14 +1011,14 @@ describe('ReactErrorBoundaries', () => {
       'ErrorBoundary render error',
       'ErrorBoundary componentDidUpdate',
     ]);
-    expect(errorMessageRef.contents.toString()).toEqual(
+    expect(errorMessageRef.value.toString()).toEqual(
       '[object HTMLDivElement]',
     );
 
     log.length = 0;
     ReactDOM.unmountComponentAtNode(container);
     expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
-    expect(errorMessageRef.contents).toEqual(null);
+    expect(errorMessageRef.value).toEqual(null);
   });
 
   it('successfully mounts if no error occurs', () => {

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -123,7 +123,7 @@ function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<*> {
 
 function coerceRef(current: Fiber | null, element: ReactElement) {
   let mixedRef = element.ref;
-  if (mixedRef !== null && typeof mixedRef !== 'function') {
+  if (mixedRef !== null && typeof mixedRef !== 'function' && typeof mixedRef !== 'object') {
     if (element._owner) {
       const owner: ?Fiber = (element._owner: any);
       let inst;

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -123,7 +123,11 @@ function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<*> {
 
 function coerceRef(current: Fiber | null, element: ReactElement) {
   let mixedRef = element.ref;
-  if (mixedRef !== null && typeof mixedRef !== 'function' && typeof mixedRef !== 'object') {
+  if (
+    mixedRef !== null &&
+    typeof mixedRef !== 'function' &&
+    typeof mixedRef !== 'object'
+  ) {
     if (element._owner) {
       const owner: ?Fiber = (element._owner: any);
       let inst;

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -8,6 +8,7 @@
 
 import type {ReactElement, Source} from 'shared/ReactElementType';
 import type {
+  RefObject,
   ReactCall,
   ReactFragment,
   ReactPortal,
@@ -95,7 +96,7 @@ export type Fiber = {|
 
   // The ref last used to attach this node.
   // I'll avoid adding an owner field for prod and model that as functions.
-  ref: null | (((handle: mixed) => void) & {_stringRef: ?string}),
+  ref: null | (((handle: mixed) => void) & {_stringRef: ?string}) | RefObject,
 
   // Input is the data coming into process this fiber. Arguments. Props.
   pendingProps: any, // This type will be more specific once we overload the tag.

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -88,7 +88,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           }
         }
       } else {
-        ref.contents = null;
+        ref.value = null;
       }
     }
   }
@@ -177,7 +177,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       if (typeof ref === 'function') {
         ref(instanceToUse);
       } else {
-        ref.contents = instanceToUse;
+        ref.value = instanceToUse;
       }
     }
   }
@@ -188,7 +188,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       if (typeof currentRef === 'function') {
         currentRef(null);
       } else {
-        currentRef.contents = null;
+        currentRef.value = null;
       }
     }
   }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -73,18 +73,22 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   function safelyDetachRef(current: Fiber) {
     const ref = current.ref;
     if (ref !== null) {
-      if (__DEV__) {
-        invokeGuardedCallback(null, ref, null, null);
-        if (hasCaughtError()) {
-          const refError = clearCaughtError();
-          captureError(current, refError);
+      if (typeof ref === "function") {
+        if (__DEV__) {
+          invokeGuardedCallback(null, ref, null, null);
+          if (hasCaughtError()) {
+            const refError = clearCaughtError();
+            captureError(current, refError);
+          }
+        } else {
+          try {
+            ref(null);
+          } catch (refError) {
+            captureError(current, refError);
+          }
         }
       } else {
-        try {
-          ref(null);
-        } catch (refError) {
-          captureError(current, refError);
-        }
+        ref.contents = null;
       }
     }
   }
@@ -162,12 +166,18 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     const ref = finishedWork.ref;
     if (ref !== null) {
       const instance = finishedWork.stateNode;
+      let instanceToUse;
       switch (finishedWork.tag) {
         case HostComponent:
-          ref(getPublicInstance(instance));
+          instanceToUse = getPublicInstance(instance);
           break;
         default:
-          ref(instance);
+          instanceToUse = instance;
+      }
+      if (typeof ref === 'function') {
+        ref(instanceToUse);
+      } else {
+        ref.contents = instanceToUse;
       }
     }
   }
@@ -175,7 +185,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   function commitDetachRef(current: Fiber) {
     const currentRef = current.ref;
     if (currentRef !== null) {
-      currentRef(null);
+      if (typeof currentRef === 'function') {
+        currentRef(null);
+      } else {
+        currentRef.contents = null;
+      }
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -73,7 +73,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   function safelyDetachRef(current: Fiber) {
     const ref = current.ref;
     if (ref !== null) {
-      if (typeof ref === "function") {
+      if (typeof ref === 'function') {
         if (__DEV__) {
           invokeGuardedCallback(null, ref, null, null);
           if (hasCaughtError()) {

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -9,6 +9,7 @@ import assign from 'object-assign';
 import ReactVersion from 'shared/ReactVersion';
 import {enableReactFragment} from 'shared/ReactFeatureFlags';
 
+import {createRef} from './ReactCreateRef';
 import {Component, PureComponent, AsyncComponent} from './ReactBaseClasses';
 import {forEach, map, count, toArray, only} from './ReactChildren';
 import ReactCurrentOwner from './ReactCurrentOwner';
@@ -31,7 +32,7 @@ const REACT_FRAGMENT_TYPE =
     Symbol.for('react.fragment')) ||
   0xeacb;
 
-var React = {
+const React = {
   Children: {
     map,
     forEach,
@@ -40,6 +41,7 @@ var React = {
     only,
   },
 
+  createRef,
   Component,
   PureComponent,
   unstable_AsyncComponent: AsyncComponent,

--- a/packages/react/src/ReactCreateRef.js
+++ b/packages/react/src/ReactCreateRef.js
@@ -6,7 +6,7 @@
  */
 
 export type RefObject = {
-	contents: Node | null
+	contents: any,
 };
 
 export function createRef(): RefObject {

--- a/packages/react/src/ReactCreateRef.js
+++ b/packages/react/src/ReactCreateRef.js
@@ -5,9 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type RefObject = {
-	contents: any,
-};
+import type {RefObject} from 'shared/ReactTypes';
 
 export function createRef(): RefObject {
 	const refObject = {

--- a/packages/react/src/ReactCreateRef.js
+++ b/packages/react/src/ReactCreateRef.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export type RefObject = {
+	contents: Node | null
+};
+
+export function createRef(): RefObject {
+	const refObject = {
+		contents: null,
+	};
+	if (__DEV__) {
+		Object.seal(refObject);
+	}
+	return refObject;
+}

--- a/packages/react/src/ReactCreateRef.js
+++ b/packages/react/src/ReactCreateRef.js
@@ -8,11 +8,11 @@
 import type {RefObject} from 'shared/ReactTypes';
 
 export function createRef(): RefObject {
-	const refObject = {
-		contents: null,
-	};
-	if (__DEV__) {
-		Object.seal(refObject);
-	}
-	return refObject;
+  const refObject = {
+    contents: null,
+  };
+  if (__DEV__) {
+    Object.seal(refObject);
+  }
+  return refObject;
 }

--- a/packages/react/src/ReactCreateRef.js
+++ b/packages/react/src/ReactCreateRef.js
@@ -7,9 +7,10 @@
 
 import type {RefObject} from 'shared/ReactTypes';
 
+// an immutable object with a single mutable value
 export function createRef(): RefObject {
   const refObject = {
-    contents: null,
+    value: null,
   };
   if (__DEV__) {
     Object.seal(refObject);

--- a/packages/react/src/ReactCreateRef.js
+++ b/packages/react/src/ReactCreateRef.js
@@ -3,6 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ * @flow
  */
 
 import type {RefObject} from 'shared/ReactTypes';

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -46,6 +46,6 @@ export type ReactPortal = {
   implementation: any,
 };
 
-export type RefObject = {
-  contents: any,
-};
+export type RefObject = {|
+  value: any,
+|};

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -45,3 +45,8 @@ export type ReactPortal = {
   // TODO: figure out the API for cross-renderer implementation.
   implementation: any,
 };
+
+export type RefObject = {
+	contents: any,
+};
+

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -47,6 +47,5 @@ export type ReactPortal = {
 };
 
 export type RefObject = {
-	contents: any,
+  contents: any,
 };
-


### PR DESCRIPTION
This PR adds a new API into the `react` package and the relevant logic to support this in `react-dom` along with tests. The ideas behind this stem from this issue from @sebmarkbage: https://github.com/facebook/react/issues/10581.

Currently, we offer two ways of using refs in React – string refs and callback refs. In the future, we'd like to deprecate and remove string refs from React. 

I'm proposing this PR as replacement for string refs that provide similar functionality to how they currently work but without many of the issues that string refs currently have (a list of them can be found at #1373).

The `React.createRef()` API will create an immutable object ref (where it's value is a mutable object referencing the actual ref). Accessing the ref value can be done via `ref.value`. An example of how this works is below:

```jsx
class MyComponent extends React.Component {
  constructor() {
    super();
    this.divRef = React.createRef();
  }

  render() {
    return <div><input type="text" ref={this.divRef} /></div>;
  }

  componentDidMount() {
    this.divRef.value.focus();
  }
}
```

This alternative API shouldn't provide any big real wins over callback refs – other than being a nice convenience feature. There might be some small wins in performance – as a common pattern is to assign a ref value in a closure created in the render phase of a component – this avoids that (even more so when a ref property is assigned to a non-existent component instance property).