### PR TITLE
Re-add haste modules for ReactTypes and ReactNativeRTTypes shims

### DIFF
--- a/packages/react-rt-renderer/src/ReactNativeRTTypes.js
+++ b/packages/react-rt-renderer/src/ReactNativeRTTypes.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
+ * @providesModule ReactNativeRTTypes
  */
 
 /**

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
+ * @providesModule ReactTypes
  */
 
 export type ReactNode =

--- a/scripts/circleci/check_modules.sh
+++ b/scripts/circleci/check_modules.sh
@@ -6,12 +6,15 @@ set -e
 EXPECTED='packages/react-cs-renderer/src/ReactNativeCSTypes.js
 packages/react-native-renderer/src/ReactNativeTypes.js
 packages/react-rt-renderer/src/ReactNativeRTTypes.js
-packages/shared/ReactTypes.js
 scripts/rollup/wrappers.js'
 ACTUAL=$(git grep -l @providesModule -- './*.js' ':!scripts/rollup/shims/*.js')
 
+# Colors
+red=$'\e[1;31m'
+end=$'\e[0m'
+
 if [ "$EXPECTED" != "$ACTUAL" ]; then
-  echo "@providesModule crept into some new files?"
+  printf "%s\n" "${red}ERROR: @providesModule crept into some new files?${end}"
   diff -u <(echo "$EXPECTED") <(echo "$ACTUAL") || true
   exit 1
 fi

--- a/scripts/circleci/check_modules.sh
+++ b/scripts/circleci/check_modules.sh
@@ -6,6 +6,7 @@ set -e
 EXPECTED='packages/react-cs-renderer/src/ReactNativeCSTypes.js
 packages/react-native-renderer/src/ReactNativeTypes.js
 packages/react-rt-renderer/src/ReactNativeRTTypes.js
+packages/shared/ReactTypes.js
 scripts/rollup/wrappers.js'
 ACTUAL=$(git grep -l @providesModule -- './*.js' ':!scripts/rollup/shims/*.js')
 

--- a/scripts/circleci/check_modules.sh
+++ b/scripts/circleci/check_modules.sh
@@ -5,6 +5,8 @@ set -e
 # Make sure we don't introduce accidental @providesModule annotations.
 EXPECTED='packages/react-cs-renderer/src/ReactNativeCSTypes.js
 packages/react-native-renderer/src/ReactNativeTypes.js
+packages/react-rt-renderer/src/ReactNativeRTTypes.js
+packages/shared/ReactTypes.js
 scripts/rollup/wrappers.js'
 ACTUAL=$(git grep -l @providesModule -- './*.js' ':!scripts/rollup/shims/*.js')
 


### PR DESCRIPTION
Looks like these got removed accidentally in d9c1dbd which caused a downstream test failure when attempting to sync RN.