### PR TITLE
Bugfix: nextFlushedRoot should always be set when performing work

### DIFF
--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
@@ -2001,4 +2001,16 @@ describe('ReactErrorBoundaries', () => {
     // Error should be the first thrown
     expect(caughtError.message).toBe('child sad');
   });
+
+  it('propagates uncaught error inside unbatched initial mount', () => {
+    function Foo() {
+      throw new Error('foo error');
+    }
+    const container = document.createElement('div');
+    expect(() => {
+      ReactDOM.unstable_batchedUpdates(() => {
+        ReactDOM.render(<Foo />, container);
+      });
+    }).toThrow('foo error');
+  });
 });

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1330,7 +1330,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       if (isUnbatchingUpdates) {
         // ...unless we're inside unbatchedUpdates, in which case we should
         // flush it now.
-        performWorkOnRoot(root, Sync);
+        nextFlushedRoot = root;
+        nextFlushedExpirationTime = Sync;
+        performWorkOnRoot(nextFlushedRoot, nextFlushedExpirationTime);
       }
       return;
     }


### PR DESCRIPTION
Fixes an issue where `performWorkOnRoot` was called, but `nextFlushedRoot` was not set. This happened in a special branch where we synchronously flush newly mounted DOM trees outside the normal work loop.

Arguably, `performWorkOnRoot` should read from the globally assigned root and expiration time instead of accepting arguments, since those arguments are expected to be the same as the global values, anyway. I decided against that since the global values could be null, so reading from them would require extra null checks.