### PR TITLE
Add key validation to React.Children.toArray

### DIFF
--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -376,7 +376,14 @@ function mapSingleChildIntoContext(bookKeeping, child, childKey) {
   }
 }
 
-function mapIntoWithKeyPrefixInternal(children, array, prefix, func, context) {
+function mapIntoWithKeyPrefixInternal(
+  children,
+  array,
+  prefix,
+  func,
+  context,
+  shouldWarn,
+) {
   var escapedPrefix = '';
   if (prefix != null) {
     escapedPrefix = escapeUserProvidedKey(prefix) + '/';
@@ -387,7 +394,7 @@ function mapIntoWithKeyPrefixInternal(children, array, prefix, func, context) {
     func,
     context,
   );
-  if (traverseContext.context && traverseContext.context.shouldWarn) {
+  if (shouldWarn) {
     traverseAllChildren(
       children,
       mapSingleChildIntoContext,
@@ -418,7 +425,7 @@ function mapChildren(children, func, context) {
     return children;
   }
   var result = [];
-  mapIntoWithKeyPrefixInternal(children, result, null, func, context);
+  mapIntoWithKeyPrefixInternal(children, result, null, func, context, __DEV__);
   return result;
 }
 
@@ -448,7 +455,8 @@ function toArray(children) {
     result,
     null,
     emptyFunction.thatReturnsArgument,
-    {shouldWarn: __DEV__},
+    null,
+    __DEV__,
   );
   return result;
 }

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -347,7 +347,10 @@ describe('ReactChildren', () => {
       context,
     );
     assertCalls();
-    expectDev(console.error.calls.count()).toBe(0);
+    expectDev(console.error.calls.count()).toBe(1);
+    expectDev(console.error.calls.argsFor(0)[0]).toContain(
+      'Warning: Each child in an array or iterator should have a unique "key" prop.',
+    );
     expect(mappedChildren).toEqual([
       <div key=".0" />,
       <div key=".1" />,
@@ -931,7 +934,7 @@ describe('ReactChildren', () => {
       );
     });
 
-    it('warns for same-level unkeyed keys in an array after a React.Children.toArray', () => {
+    it('warns for same-level unkeyed elements in an array after a React.Children helper', () => {
       spyOn(console, 'error');
       class ComponentReturningArray extends React.Component {
         render() {
@@ -949,9 +952,22 @@ describe('ReactChildren', () => {
           'Each child in an array or iterator should have a unique "key" prop.' +
           ' See https://fb.me/react-warning-keys for more information.',
       );
+
+      console.error.calls.reset();
+      ReactTestUtils.renderIntoDocument(
+        React.Children.map([<span>Hello</span>, <h1>World</h1>], c => c),
+      );
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(
+        normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
+      ).toContain(
+        'Warning: ' +
+          'Each child in an array or iterator should have a unique "key" prop.' +
+          ' See https://fb.me/react-warning-keys for more information.',
+      );
     });
 
-    it('warns for same-level duplicate keys in an array after a React.Children.toArray', () => {
+    it('warns for same-level duplicate keys in an array after a React.Children helper', () => {
       spyOn(console, 'error');
       class ComponentReturningArray extends React.Component {
         render() {
@@ -972,9 +988,26 @@ describe('ReactChildren', () => {
           ' Non-unique keys may cause children to be duplicated and/or omitted —' +
           ' the behavior is unsupported and could change in a future version.',
       );
+
+      console.error.calls.reset();
+      ReactTestUtils.renderIntoDocument(
+        React.Children.map(
+          [<span key="a">Hello</span>, <h1 key="a">World</h1>],
+          c => c,
+        ),
+      );
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(
+        normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
+      ).toContain(
+        'Warning: Encountered two children with the same key, `.$a`.' +
+          ' Keys should be unique so that components maintain their identity across updates.' +
+          ' Non-unique keys may cause children to be duplicated and/or omitted —' +
+          ' the behavior is unsupported and could change in a future version.',
+      );
     });
 
-    it('warns for same-level unkeyed keys in an iterable after a React.Children.toArray', () => {
+    it('warns for same-level unkeyed elements in an iterable after a React.Children helper', () => {
       spyOn(console, 'error');
       class ComponentReturningArray extends React.Component {
         render() {
@@ -994,9 +1027,25 @@ describe('ReactChildren', () => {
           'Each child in an array or iterator should have a unique "key" prop.' +
           ' See https://fb.me/react-warning-keys for more information.',
       );
+
+      console.error.calls.reset();
+      ReactTestUtils.renderIntoDocument(
+        React.Children.map(
+          new Set([<span>Hello</span>, <h1>World</h1>]),
+          c => c,
+        ),
+      );
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(
+        normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
+      ).toContain(
+        'Warning: ' +
+          'Each child in an array or iterator should have a unique "key" prop.' +
+          ' See https://fb.me/react-warning-keys for more information.',
+      );
     });
 
-    it('warns for same-level duplicate keys in an iterable after a React.Children.toArray', () => {
+    it('warns for same-level duplicate keys in an iterable after a React.Children helper', () => {
       spyOn(console, 'error');
       class ComponentReturningArray extends React.Component {
         render() {
@@ -1007,7 +1056,23 @@ describe('ReactChildren', () => {
       }
 
       ReactTestUtils.renderIntoDocument(<ComponentReturningArray />);
+      expectDev(console.error.calls.count()).toBe(1);
+      expectDev(
+        normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
+      ).toContain(
+        'Warning: Encountered two children with the same key, `.$a`.' +
+          ' Keys should be unique so that components maintain their identity across updates.' +
+          ' Non-unique keys may cause children to be duplicated and/or omitted —' +
+          ' the behavior is unsupported and could change in a future version.',
+      );
 
+      console.error.calls.reset();
+      ReactTestUtils.renderIntoDocument(
+        React.Children.map(
+          new Set([<span key="a">Hello</span>, <h1 key="a">World</h1>]),
+          c => c,
+        ),
+      );
       expectDev(console.error.calls.count()).toBe(1);
       expectDev(
         normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
@@ -1019,7 +1084,7 @@ describe('ReactChildren', () => {
       );
     });
 
-    it('should not warn for multi-level duplicate keys in an iterable after a React.Children.toArray', () => {
+    it('should not warn for multi-level duplicate keys in an iterable after a React.Children helper', () => {
       spyOn(console, 'error');
       class ComponentReturningArray extends React.Component {
         render() {
@@ -1031,7 +1096,14 @@ describe('ReactChildren', () => {
       }
 
       ReactTestUtils.renderIntoDocument(<ComponentReturningArray />);
+      expectDev(console.error.calls.count()).toBe(0);
 
+      ReactTestUtils.renderIntoDocument(
+        React.Children.map(
+          [<span key="a">Hello</span>, [<h1 key="a">World</h1>]],
+          c => c,
+        ),
+      );
       expectDev(console.error.calls.count()).toBe(0);
     });
   });


### PR DESCRIPTION
Addresses https://github.com/facebook/react/issues/11549

This warns only on React.Children.toArray. I don't think the other children helper methods (`forEach`, `map`, and `count`) are dangerous.
