### PR TITLE
Set correct event type into SimulateNative methods

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -429,6 +429,34 @@ describe('ReactTestUtils', () => {
         jasmine.objectContaining({target: input}),
       );
     });
+
+    it('should set the correct event type when simulating synthetic events', () => {
+      expect.assertions(1);
+
+      let handler = function(event) {
+        expect(event.nativeEvent.type).toEqual('click');
+      };
+
+      let button = ReactTestUtils.renderIntoDocument(
+        <button onClick={handler} />,
+      );
+
+      ReactTestUtils.Simulate.click(button);
+    });
+
+    it('should set the correct event type when simulating native events', () => {
+      expect.assertions(1);
+
+      let handler = function(event) {
+        expect(event.nativeEvent.type).toEqual('click');
+      };
+
+      let button = ReactTestUtils.renderIntoDocument(
+        <button onClick={handler} />,
+      );
+
+      ReactTestUtils.SimulateNative.click(button);
+    });
   });
 
   it('should call setState callback with no arguments', () => {

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -32,7 +32,9 @@ var {
 
 var topLevelTypes = BrowserEventConstants.topLevelTypes;
 
-function Event(suffix) {}
+function FakeNativeEvent(type) {
+  this.type = type;
+}
 
 /**
  * @class ReactTestUtils
@@ -359,9 +361,8 @@ function makeSimulator(eventType) {
     var dispatchConfig =
       EventPluginRegistry.eventNameDispatchConfigs[eventType];
 
-    var fakeNativeEvent = new Event();
+    var fakeNativeEvent = new FakeNativeEvent(eventType.toLowerCase());
     fakeNativeEvent.target = domNode;
-    fakeNativeEvent.type = eventType.toLowerCase();
 
     // We don't use SyntheticEvent.getPooled in order to not have to worry about
     // properly destroying any properties assigned from `eventData` upon release
@@ -438,20 +439,21 @@ buildSimulators();
  * to dispatch synthetic events.
  */
 
-function makeNativeSimulator(eventType) {
+function makeNativeSimulator(topLevelType) {
   return function(domComponentOrNode, nativeEventData) {
-    var fakeNativeEvent = new Event(eventType);
+    var eventType = topLevelTypes[topLevelType];
+    var fakeNativeEvent = new FakeNativeEvent(eventType);
     Object.assign(fakeNativeEvent, nativeEventData);
     if (ReactTestUtils.isDOMComponent(domComponentOrNode)) {
       ReactTestUtils.simulateNativeEventOnDOMComponent(
-        eventType,
+        topLevelType,
         domComponentOrNode,
         fakeNativeEvent,
       );
     } else if (domComponentOrNode.tagName) {
       // Will allow on actual dom nodes.
       ReactTestUtils.simulateNativeEventOnNode(
-        eventType,
+        topLevelType,
         domComponentOrNode,
         fakeNativeEvent,
       );


### PR DESCRIPTION
This commit fixes an issue where events generated by the test utils had no type. These events are not real DOM Event objects and their constructor did not assign the provided event type property:

This through me for a bit of a loop because I didn't realize the `Event` class was defined locally to this module; that it wasn't a DOM event. I've renamed this constructor to `FakeNativeEvent` for clarity.

Additionally, it looks like the Event object was being constructed with the top level type (`topClick` vs `click`). This commit ensures that ReactTestUtils.Simulate and ReactTestUtils.SimulateNative correctly assign the event type.

**Why does this matter?**

Working through https://github.com/facebook/react/pull/11550, which evaluates assigning local listeners instead of event delegation, one of the biggest pieces of overhead is [the `dispatchEvent.bind(topLevelType)` done for every event attachment](https://github.com/facebook/react/blob/master/packages/react-dom/src/events/ReactDOMEventListener.js#L130). I believe we could just use the event type, avoiding the cost of the bind. 

**Other questions**

Do we need a fake event constructor? Is it incorrect for `ReactTestUtils.SimulateNative` to dispatch a fake DOM event instead of just using the DOM Event constructor?
