### PR TITLE
Reworded "invalid DOM property" warning message (#11570)

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -226,7 +226,9 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.getAttribute('CHILDREN')).toBe('5');
       expectDev(console.error.calls.count(0)).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid DOM property `CHILDREN`. Did you mean `children`?\n    in div (at **)',
+        'Warning: Invalid DOM property `CHILDREN`. In React, all properties should be' +
+          ' camelCased to avoid issues with JavaScript reserved words, such as "class".' +
+          ' Did you mean `children`?\n    in div (at **)',
       );
     });
 
@@ -1748,7 +1750,9 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<input type="text" onclick="1" />);
       expectDev(console.error.calls.count()).toBe(2);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Warning: Invalid DOM property `class`. In React, all properties' +
+          ' should be camelCased to avoid issues with JavaScript reserved words,' +
+          ' such as "class". Did you mean `className`?\n    in div (at **)',
       );
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
         'Warning: Invalid event handler property `onclick`. Did you mean ' +
@@ -1762,7 +1766,9 @@ describe('ReactDOMComponent', () => {
       ReactDOMServer.renderToString(<input type="text" onclick="1" />);
       expectDev(console.error.calls.count()).toBe(2);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Warning: Invalid DOM property `class`. In React, all properties should' +
+          ' be camelCased to avoid issues with JavaScript reserved words,' +
+          ' such as "class". Did you mean `className`?\n    in div (at **)',
       );
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
         'Warning: Invalid event handler property `onclick`. Did you mean ' +
@@ -1780,7 +1786,9 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<div class="paladin" />, container);
       expectDev(console.error.calls.count()).toBe(1);
       expectDev(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+        'Warning: Invalid DOM property `class`. In React, all properties should' +
+          ' be camelCased to avoid issues with JavaScript reserved words,' +
+          ' such as "class". Did you mean `className`?\n    in div (at **)',
       );
     });
 
@@ -1972,11 +1980,15 @@ describe('ReactDOMComponent', () => {
       expectDev(console.error.calls.count()).toBe(2);
 
       expectDev(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
+        'Warning: Invalid DOM property `for`. In React, all properties' +
+          ' should be camelCased to avoid issues with JavaScript reserved words,' +
+          ' such as "class". Did you mean `htmlFor`?\n    in label',
       );
 
       expectDev(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
+        'Warning: Invalid DOM property `autofocus`. In React, all properties should' +
+          ' be camelCased to avoid issues with JavaScript reserved words,' +
+          ' such as "class". Did you mean `autoFocus`?\n    in input',
       );
     });
 
@@ -1993,11 +2005,15 @@ describe('ReactDOMComponent', () => {
       expectDev(console.error.calls.count()).toBe(2);
 
       expectDev(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
+        'Warning: Invalid DOM property `for`. In React, all properties should' +
+          ' be camelCased to avoid issues with JavaScript reserved words,' +
+          ' such as "class". Did you mean `htmlFor`?\n    in label',
       );
 
       expectDev(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
+        'Warning: Invalid DOM property `autofocus`. In React, all properties should' +
+          ' be camelCased to avoid issues with JavaScript reserved words,' +
+          ' such as "class". Did you mean `autoFocus`?\n    in input',
       );
     });
   });
@@ -2035,7 +2051,9 @@ describe('ReactDOMComponent', () => {
       expect(el.className).toBe('test');
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid DOM property `class`. Did you mean `className`?',
+        'Warning: Invalid DOM property `class`. In React, all properties' +
+          ' should be camelCased to avoid issues with JavaScript reserved words,' +
+          ' such as "class". Did you mean `className`?',
       );
     });
 
@@ -2047,7 +2065,9 @@ describe('ReactDOMComponent', () => {
       expect(el.className).toBe('test');
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid DOM property `cLASS`. Did you mean `className`?',
+        'Warning: Invalid DOM property `cLASS`. In React, all properties should' +
+          ' be camelCased to avoid issues with JavaScript reserved words,' +
+          ' such as "class". Did you mean `className`?',
       );
     });
 
@@ -2064,7 +2084,9 @@ describe('ReactDOMComponent', () => {
       expect(text.hasAttribute('arabic-form')).toBe(true);
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid DOM property `arabic-form`. Did you mean `arabicForm`?',
+        'Warning: Invalid DOM property `arabic-form`. In React, all properties' +
+          ' should be camelCased to avoid issues with JavaScript reserved words,' +
+          ' such as "class". Did you mean `arabicForm`?',
       );
     });
 
@@ -2237,7 +2259,9 @@ describe('ReactDOMComponent', () => {
       expect(el.getAttribute('size')).toBe('30');
 
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid DOM property `SiZe`. Did you mean `size`?',
+        'Warning: Invalid DOM property `SiZe`. In React, all properties should' +
+          ' be camelCased to avoid issues with JavaScript reserved words,' +
+          ' such as "class". Did you mean `size`?',
       );
     });
   });
@@ -2352,7 +2376,9 @@ describe('ReactDOMComponent', () => {
 
       expectDev(console.error.calls.count()).toBe(1);
       expectDev(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: Invalid DOM property `x-height`. Did you mean `xHeight`',
+        'Warning: Invalid DOM property `x-height`. In React, all properties' +
+          ' should be camelCased to avoid issues with JavaScript reserved ' +
+          'words, such as "class". Did you mean `xHeight`',
       );
     });
 

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -152,7 +152,9 @@ if (__DEV__) {
       if (standardName !== name) {
         warning(
           false,
-          'Invalid DOM property `%s`. Did you mean `%s`?%s',
+          'Invalid DOM property `%s`. In React, all properties should be camelCased to ' +
+            'avoid issues with JavaScript reserved words, such as "class". ' +
+            'Did you mean `%s`?%s',
           name,
           standardName,
           getStackAddendum(),


### PR DESCRIPTION
This PR addresses issue #11570, which rewords the warning message "invalid DOM property" to be less obnoxious.

I tried to avoid making the warning message too long, and focused on 3 points.
1) The reason the warning was displayed? ` Invalid DOM property `class`.`
2) Why? `In React, all properties should be camelCased to avoid issues with JavaScript reserved words, such as "class".`
3) How can I fix it? `Did you mean `tabIndex`?`

It could be expanded more by adding the exceptions to the rule as well which are `data-*` and `aria-*` attributes, or mentioning that the camel-case naming convention also helps to avoid confusion between HTML attributes.
