### PR TITLE
Updates at the same priority should not interrupt current render

### DIFF
--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -455,7 +455,11 @@ var ReactNoop = {
 
   unbatchedUpdates: NoopRenderer.unbatchedUpdates,
 
-  flushSync: NoopRenderer.flushSync,
+  flushSync(fn: () => mixed) {
+    yieldedValues = [];
+    NoopRenderer.flushSync(fn);
+    return yieldedValues;
+  },
 
   // Logs the current state of the tree.
   dumpTree(rootID: string = DEFAULT_ROOT_ID) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1202,7 +1202,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           if (
             !isWorking &&
             root === nextRoot &&
-            expirationTime <= nextRenderExpirationTime
+            expirationTime < nextRenderExpirationTime
           ) {
             // Restart the root from the top.
             if (nextUnitOfWork !== null) {


### PR DESCRIPTION
When we're rendering work at a specific level, and a higher priority update comes in, we interrupt the current work and restart at the higher priority. The rationale is that the high priority update is likely cheaper to render that the lower one, so it's usually worth throwing out the current work to get the high pri update on the screen as soon as possible.

Currently, we also interrupt the current work if an update of *equal* priority is scheduled. The rationale here is less clear: the only reason to do this is if both updates are expected to flush at the same time, to prevent tearing. But this usually isn't the case. Separate setStates are usually distinct updates that can be flushed separately, especially if the components that are being updated are in separate subtrees.

An exception is in Flux-like systems where multiple setStates are the result of a single conceptual update/event/dispatch. We can add an explicit API for batching in the future; in fact, we'd likely need one anyway to account for expiration accidentally causing consecutive updates to fall into separate buckets.