### PR TITLE
New feature flags to help detect unexpected lifecycle side effects

### DIFF
--- a/packages/react-cs-renderer/src/ReactNativeCSFeatureFlags.js
+++ b/packages/react-cs-renderer/src/ReactNativeCSFeatureFlags.js
@@ -17,6 +17,8 @@ export const enableAsyncSchedulingByDefaultInReactDOM = false;
 export const enableReactFragment = false;
 export const enableCreateRoot = false;
 export const enableUserTimingAPI = __DEV__;
+export const invokePrecommitLifecycleHooksTwice = false;
+export const invokeSetStateCallbackTwice = false;
 
 // React Native CS uses persistent reconciler.
 export const enableMutatingReconciler = false;

--- a/packages/react-cs-renderer/src/ReactNativeCSFeatureFlags.js
+++ b/packages/react-cs-renderer/src/ReactNativeCSFeatureFlags.js
@@ -12,13 +12,12 @@ import invariant from 'fbjs/lib/invariant';
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as CSFeatureFlagsType from './ReactNativeCSFeatureFlags';
 
+export const debugRenderPhaseSideEffects = false;
 export const enableAsyncSubtreeAPI = true;
 export const enableAsyncSchedulingByDefaultInReactDOM = false;
 export const enableReactFragment = false;
 export const enableCreateRoot = false;
 export const enableUserTimingAPI = __DEV__;
-export const invokePrecommitLifecycleHooksTwice = false;
-export const invokeSetStateCallbackTwice = false;
 
 // React Native CS uses persistent reconciler.
 export const enableMutatingReconciler = false;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -36,7 +36,7 @@ import {
   Ref,
 } from 'shared/ReactTypeOfSideEffect';
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
-import {invokePrecommitLifecycleHooksTwice} from 'shared/ReactFeatureFlags';
+import {debugRenderPhaseSideEffects} from 'shared/ReactFeatureFlags';
 import invariant from 'fbjs/lib/invariant';
 import getComponentName from 'shared/getComponentName';
 import warning from 'fbjs/lib/warning';
@@ -270,12 +270,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     if (__DEV__) {
       ReactDebugCurrentFiber.setCurrentPhase('render');
       nextChildren = instance.render();
-      if (invokePrecommitLifecycleHooksTwice) {
+      if (debugRenderPhaseSideEffects) {
         instance.render();
       }
       ReactDebugCurrentFiber.setCurrentPhase(null);
     } else {
-      if (invokePrecommitLifecycleHooksTwice) {
+      if (debugRenderPhaseSideEffects) {
         instance.render();
       }
       nextChildren = instance.render();

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -36,6 +36,7 @@ import {
   Ref,
 } from 'shared/ReactTypeOfSideEffect';
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
+import {invokePrecommitLifecycleHooksTwice} from 'shared/ReactFeatureFlags';
 import invariant from 'fbjs/lib/invariant';
 import getComponentName from 'shared/getComponentName';
 import warning from 'fbjs/lib/warning';
@@ -269,8 +270,14 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     if (__DEV__) {
       ReactDebugCurrentFiber.setCurrentPhase('render');
       nextChildren = instance.render();
+      if (invokePrecommitLifecycleHooksTwice) {
+        instance.render();
+      }
       ReactDebugCurrentFiber.setCurrentPhase(null);
     } else {
+      if (invokePrecommitLifecycleHooksTwice) {
+        instance.render();
+      }
       nextChildren = instance.render();
     }
     // React DevTools reads this flag.

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -11,7 +11,10 @@ import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
 import {Update} from 'shared/ReactTypeOfSideEffect';
-import {enableAsyncSubtreeAPI} from 'shared/ReactFeatureFlags';
+import {
+  enableAsyncSubtreeAPI,
+  invokePrecommitLifecycleHooksTwice,
+} from 'shared/ReactFeatureFlags';
 import {isMounted} from 'shared/ReactFiberTreeReflection';
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';
 import emptyObject from 'fbjs/lib/emptyObject';
@@ -167,6 +170,11 @@ export default function(
         newContext,
       );
       stopPhaseTimer();
+
+      // Simulate an async bailout/interruption by invoking lifecycle twice.
+      if (invokePrecommitLifecycleHooksTwice) {
+        instance.shouldComponentUpdate(newProps, newState, newContext);
+      }
 
       if (__DEV__) {
         warning(
@@ -374,8 +382,12 @@ export default function(
     startPhaseTimer(workInProgress, 'componentWillMount');
     const oldState = instance.state;
     instance.componentWillMount();
-
     stopPhaseTimer();
+
+    // Simulate an async bailout/interruption by invoking lifecycle twice.
+    if (invokePrecommitLifecycleHooksTwice) {
+      instance.componentWillMount();
+    }
 
     if (oldState !== instance.state) {
       if (__DEV__) {
@@ -401,6 +413,11 @@ export default function(
     const oldState = instance.state;
     instance.componentWillReceiveProps(newProps, newContext);
     stopPhaseTimer();
+
+    // Simulate an async bailout/interruption by invoking lifecycle twice.
+    if (invokePrecommitLifecycleHooksTwice) {
+      instance.componentWillReceiveProps(newProps, newContext);
+    }
 
     if (instance.state !== oldState) {
       if (__DEV__) {
@@ -677,6 +694,11 @@ export default function(
         startPhaseTimer(workInProgress, 'componentWillUpdate');
         instance.componentWillUpdate(newProps, newState, newContext);
         stopPhaseTimer();
+
+        // Simulate an async bailout/interruption by invoking lifecycle twice.
+        if (invokePrecommitLifecycleHooksTwice) {
+          instance.componentWillUpdate(newProps, newState, newContext);
+        }
       }
       if (typeof instance.componentDidUpdate === 'function') {
         workInProgress.effectTag |= Update;

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -12,8 +12,8 @@ import type {ExpirationTime} from './ReactFiberExpirationTime';
 
 import {Update} from 'shared/ReactTypeOfSideEffect';
 import {
+  debugRenderPhaseSideEffects,
   enableAsyncSubtreeAPI,
-  invokePrecommitLifecycleHooksTwice,
 } from 'shared/ReactFeatureFlags';
 import {isMounted} from 'shared/ReactFiberTreeReflection';
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';
@@ -172,7 +172,7 @@ export default function(
       stopPhaseTimer();
 
       // Simulate an async bailout/interruption by invoking lifecycle twice.
-      if (invokePrecommitLifecycleHooksTwice) {
+      if (debugRenderPhaseSideEffects) {
         instance.shouldComponentUpdate(newProps, newState, newContext);
       }
 
@@ -385,7 +385,7 @@ export default function(
     stopPhaseTimer();
 
     // Simulate an async bailout/interruption by invoking lifecycle twice.
-    if (invokePrecommitLifecycleHooksTwice) {
+    if (debugRenderPhaseSideEffects) {
       instance.componentWillMount();
     }
 
@@ -415,7 +415,7 @@ export default function(
     stopPhaseTimer();
 
     // Simulate an async bailout/interruption by invoking lifecycle twice.
-    if (invokePrecommitLifecycleHooksTwice) {
+    if (debugRenderPhaseSideEffects) {
       instance.componentWillReceiveProps(newProps, newContext);
     }
 
@@ -696,7 +696,7 @@ export default function(
         stopPhaseTimer();
 
         // Simulate an async bailout/interruption by invoking lifecycle twice.
-        if (invokePrecommitLifecycleHooksTwice) {
+        if (debugRenderPhaseSideEffects) {
           instance.componentWillUpdate(newProps, newState, newContext);
         }
       }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -620,6 +620,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     if (__DEV__) {
       ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
     }
+
     let next = beginWork(current, workInProgress, nextRenderExpirationTime);
     if (__DEV__) {
       ReactDebugCurrentFiber.resetCurrentFiber();

--- a/packages/react-reconciler/src/ReactFiberUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberUpdateQueue.js
@@ -10,7 +10,7 @@
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
-import {invokeSetStateCallbackTwice} from 'shared/ReactFeatureFlags';
+import {debugRenderPhaseSideEffects} from 'shared/ReactFeatureFlags';
 import {Callback as CallbackEffect} from 'shared/ReactTypeOfSideEffect';
 import {ClassComponent, HostRoot} from 'shared/ReactTypeOfWork';
 import invariant from 'fbjs/lib/invariant';
@@ -184,7 +184,7 @@ function getStateFromUpdate(update, instance, prevState, props) {
     const updateFn = partialState;
 
     // Invoke setState callback an extra time to help detect side-effects.
-    if (invokeSetStateCallbackTwice) {
+    if (debugRenderPhaseSideEffects) {
       updateFn.call(instance, prevState, props);
     }
 

--- a/packages/react-reconciler/src/ReactFiberUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberUpdateQueue.js
@@ -10,6 +10,7 @@
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
+import {invokeSetStateCallbackTwice} from 'shared/ReactFeatureFlags';
 import {Callback as CallbackEffect} from 'shared/ReactTypeOfSideEffect';
 import {ClassComponent, HostRoot} from 'shared/ReactTypeOfWork';
 import invariant from 'fbjs/lib/invariant';
@@ -181,6 +182,12 @@ function getStateFromUpdate(update, instance, prevState, props) {
   const partialState = update.partialState;
   if (typeof partialState === 'function') {
     const updateFn = partialState;
+
+    // Invoke setState callback an extra time to help detect side-effects.
+    if (invokeSetStateCallbackTwice) {
+      updateFn.call(instance, prevState, props);
+    }
+
     return updateFn.call(instance, prevState, props);
   } else {
     return partialState;

--- a/packages/react/src/__tests__/ReactAsyncClassComponent-test.js
+++ b/packages/react/src/__tests__/ReactAsyncClassComponent-test.js
@@ -14,11 +14,11 @@ var ReactFeatureFlags;
 var ReactTestRenderer;
 
 describe('ReactAsyncClassComponent', () => {
-  describe('invokePrecommitLifecycleHooksTwice', () => {
+  describe('debugRenderPhaseSideEffects', () => {
     beforeEach(() => {
       jest.resetModules();
       ReactFeatureFlags = require('shared/ReactFeatureFlags');
-      ReactFeatureFlags.invokePrecommitLifecycleHooksTwice = true;
+      ReactFeatureFlags.debugRenderPhaseSideEffects = true;
       React = require('react');
       ReactTestRenderer = require('react-test-renderer');
     });
@@ -91,16 +91,6 @@ describe('ReactAsyncClassComponent', () => {
         'shouldComponentUpdate',
         'shouldComponentUpdate',
       ]);
-    });
-  });
-
-  describe('invokeSetStateCallbackTwice', () => {
-    beforeEach(() => {
-      jest.resetModules();
-      ReactFeatureFlags = require('shared/ReactFeatureFlags');
-      ReactFeatureFlags.invokeSetStateCallbackTwice = true;
-      React = require('react');
-      ReactTestRenderer = require('react-test-renderer');
     });
 
     it('should invoke setState callbacks twice', () => {

--- a/packages/react/src/__tests__/ReactAsyncClassComponent-test.js
+++ b/packages/react/src/__tests__/ReactAsyncClassComponent-test.js
@@ -61,6 +61,7 @@ describe('ReactAsyncClassComponent', () => {
         'componentWillMount',
         'componentWillMount',
         'render',
+        'render',
         'componentDidMount',
       ]);
 
@@ -75,6 +76,7 @@ describe('ReactAsyncClassComponent', () => {
         'shouldComponentUpdate',
         'componentWillUpdate',
         'componentWillUpdate',
+        'render',
         'render',
         'componentDidUpdate',
       ]);

--- a/packages/react/src/__tests__/ReactAsyncClassComponent-test.js
+++ b/packages/react/src/__tests__/ReactAsyncClassComponent-test.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactFeatureFlags;
+var ReactTestRenderer;
+
+describe('ReactAsyncClassComponent', () => {
+  describe('invokePrecommitLifecycleHooksTwice', () => {
+    beforeEach(() => {
+      jest.resetModules();
+      ReactFeatureFlags = require('shared/ReactFeatureFlags');
+      ReactFeatureFlags.invokePrecommitLifecycleHooksTwice = true;
+      React = require('react');
+      ReactTestRenderer = require('react-test-renderer');
+    });
+
+    it('should invoke precommit lifecycle methods twice', () => {
+      let log = [];
+      let shouldComponentUpdate = false;
+      class ClassComponent extends React.Component {
+        state = {};
+        componentDidMount() {
+          log.push('componentDidMount');
+        }
+        componentDidUpdate() {
+          log.push('componentDidUpdate');
+        }
+        componentWillMount() {
+          log.push('componentWillMount');
+        }
+        componentWillReceiveProps() {
+          log.push('componentWillReceiveProps');
+        }
+        componentWillUnmount() {
+          log.push('componentWillUnmount');
+        }
+        componentWillUpdate() {
+          log.push('componentWillUpdate');
+        }
+        shouldComponentUpdate() {
+          log.push('shouldComponentUpdate');
+          return shouldComponentUpdate;
+        }
+        render() {
+          log.push('render');
+          return null;
+        }
+      }
+
+      const component = ReactTestRenderer.create(<ClassComponent />);
+      expect(log).toEqual([
+        'componentWillMount',
+        'componentWillMount',
+        'render',
+        'componentDidMount',
+      ]);
+
+      log = [];
+      shouldComponentUpdate = true;
+
+      component.update(<ClassComponent />);
+      expect(log).toEqual([
+        'componentWillReceiveProps',
+        'componentWillReceiveProps',
+        'shouldComponentUpdate',
+        'shouldComponentUpdate',
+        'componentWillUpdate',
+        'componentWillUpdate',
+        'render',
+        'componentDidUpdate',
+      ]);
+
+      log = [];
+      shouldComponentUpdate = false;
+
+      component.update(<ClassComponent />);
+      expect(log).toEqual([
+        'componentWillReceiveProps',
+        'componentWillReceiveProps',
+        'shouldComponentUpdate',
+        'shouldComponentUpdate',
+      ]);
+    });
+  });
+
+  describe('invokeSetStateCallbackTwice', () => {
+    beforeEach(() => {
+      jest.resetModules();
+      ReactFeatureFlags = require('shared/ReactFeatureFlags');
+      ReactFeatureFlags.invokeSetStateCallbackTwice = true;
+      React = require('react');
+      ReactTestRenderer = require('react-test-renderer');
+    });
+
+    it('should invoke setState callbacks twice', () => {
+      class ClassComponent extends React.Component {
+        state = {
+          count: 1,
+        };
+        render() {
+          return null;
+        }
+      }
+
+      let setStateCount = 0;
+
+      const rendered = ReactTestRenderer.create(<ClassComponent />);
+      const instance = rendered.getInstance();
+      instance.setState(state => {
+        setStateCount++;
+        return {
+          count: state.count + 1,
+        };
+      });
+
+      // Callback should be invoked twice
+      expect(setStateCount).toBe(2);
+      // But each time `state` should be the previous value
+      expect(instance.state.count).toBe(2);
+    });
+  });
+});

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -24,10 +24,8 @@ export const enableNoopReconciler = false;
 // Experimental persistent mode (CS):
 export const enablePersistentReconciler = false;
 
-// Helps identify side effects in begin-phase lifecycle hooks:
-export const invokePrecommitLifecycleHooksTwice = false;
-// Helps identify side effects in setState callback:
-export const invokeSetStateCallbackTwice = false;
+// Helps identify side effects in begin-phase lifecycle hooks and setState reducers:
+export const debugRenderPhaseSideEffects = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -24,6 +24,11 @@ export const enableNoopReconciler = false;
 // Experimental persistent mode (CS):
 export const enablePersistentReconciler = false;
 
+// Helps identify side effects in begin-phase lifecycle hooks:
+export const invokePrecommitLifecycleHooksTwice = false;
+// Helps identify side effects in setState callback:
+export const invokeSetStateCallbackTwice = false;
+
 // Only used in www builds.
 export function addUserTimingListener() {
   invariant(false, 'Not implemented.');

--- a/scripts/rollup/shims/rollup/ReactFeatureFlags-www.js
+++ b/scripts/rollup/shims/rollup/ReactFeatureFlags-www.js
@@ -19,6 +19,8 @@ export const {
 export const enableAsyncSubtreeAPI = true;
 export const enableReactFragment = false;
 export const enableCreateRoot = true;
+export const invokePrecommitLifecycleHooksTwice = false;
+export const invokeSetStateCallbackTwice = false;
 
 // The www bundles only use the mutating reconciler.
 export const enableMutatingReconciler = true;

--- a/scripts/rollup/shims/rollup/ReactFeatureFlags-www.js
+++ b/scripts/rollup/shims/rollup/ReactFeatureFlags-www.js
@@ -16,11 +16,10 @@ export const {
 } = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.
+export const debugRenderPhaseSideEffects = false;
 export const enableAsyncSubtreeAPI = true;
 export const enableReactFragment = false;
 export const enableCreateRoot = true;
-export const invokePrecommitLifecycleHooksTwice = false;
-export const invokeSetStateCallbackTwice = false;
 
 // The www bundles only use the mutating reconciler.
 export const enableMutatingReconciler = true;


### PR DESCRIPTION
Avoiding side effects in the will-mount/will-update/etc lifecycle hooks becomes very important with async rendering. Unfortunately it's not always easy to detect. This PR adds 2 new feature flags (both disabled by default) to help with this. These flags invoke methods that are supposed to be side-effect-free a second time, roughly approximating what happens when React throws away incomplete work.

Before I started this, I planned to repeat the whole begin phase (eg: _cWRP -> sCU -> cWU -> cWRP -> sCU -> cWU -> render_) rather than just individual methods (eg _cWRP -> cWRP -> sCU -> sCU -> cWU -> cWU -> render_). That looks to be more complicated than I had assumed though, and I'm not convinced it's worth the extra effort and complexity. (Since these methods should not have side effects, it should be okay to call them in either sequence.) Happy to discuss this more in depth if others disagree though!

Once these flags are approved, my next step will be to connect them to a GK for the Facebook internal builds, similar to `enableAsyncSchedulingByDefaultInReactDOM`.