### PR TITLE
Move class component code to BeginWork

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -152,6 +152,7 @@ if (__DEV__) {
 
 function FiberNode(
   tag: TypeOfWork,
+  pendingProps: mixed,
   key: null | string,
   internalContextTag: TypeOfInternalContext,
 ) {
@@ -169,7 +170,7 @@ function FiberNode(
 
   this.ref = null;
 
-  this.pendingProps = null;
+  this.pendingProps = pendingProps;
   this.memoizedProps = null;
   this.updateQueue = null;
   this.memoizedState = null;
@@ -213,11 +214,12 @@ function FiberNode(
 //    compatible.
 var createFiber = function(
   tag: TypeOfWork,
+  pendingProps: mixed,
   key: null | string,
   internalContextTag: TypeOfInternalContext,
 ): Fiber {
   // $FlowFixMe: the shapes are exact here but Flow doesn't like constructors
-  return new FiberNode(tag, key, internalContextTag);
+  return new FiberNode(tag, pendingProps, key, internalContextTag);
 };
 
 function shouldConstruct(Component) {
@@ -239,6 +241,7 @@ export function createWorkInProgress(
     // reclaim the extra memory if needed.
     workInProgress = createFiber(
       current.tag,
+      pendingProps,
       current.key,
       current.internalContextTag,
     );
@@ -255,6 +258,8 @@ export function createWorkInProgress(
     workInProgress.alternate = current;
     current.alternate = workInProgress;
   } else {
+    workInProgress.pendingProps = pendingProps;
+
     // We already have an alternate.
     // Reset the effect tag.
     workInProgress.effectTag = NoEffect;
@@ -266,7 +271,6 @@ export function createWorkInProgress(
   }
 
   workInProgress.expirationTime = expirationTime;
-  workInProgress.pendingProps = pendingProps;
 
   workInProgress.child = current.child;
   workInProgress.memoizedProps = current.memoizedProps;
@@ -297,17 +301,22 @@ export function createFiberFromElement(
   }
 
   let fiber;
-  const {type, key} = element;
+  const type = element.type;
+  const key = element.key;
+  const pendingProps = element.props;
   if (typeof type === 'function') {
     fiber = shouldConstruct(type)
-      ? createFiber(ClassComponent, key, internalContextTag)
-      : createFiber(IndeterminateComponent, key, internalContextTag);
+      ? createFiber(ClassComponent, pendingProps, key, internalContextTag)
+      : createFiber(
+          IndeterminateComponent,
+          pendingProps,
+          key,
+          internalContextTag,
+        );
     fiber.type = type;
-    fiber.pendingProps = element.props;
   } else if (typeof type === 'string') {
-    fiber = createFiber(HostComponent, key, internalContextTag);
+    fiber = createFiber(HostComponent, pendingProps, key, internalContextTag);
     fiber.type = type;
-    fiber.pendingProps = element.props;
   } else if (
     typeof type === 'object' &&
     type !== null &&
@@ -320,7 +329,7 @@ export function createFiberFromElement(
     // we don't know if we can reuse that fiber or if we need to clone it.
     // There is probably a clever way to restructure this.
     fiber = ((type: any): Fiber);
-    fiber.pendingProps = element.props;
+    fiber.pendingProps = pendingProps;
   } else {
     let info = '';
     if (__DEV__) {
@@ -364,8 +373,7 @@ export function createFiberFromFragment(
   expirationTime: ExpirationTime,
   key: null | string,
 ): Fiber {
-  const fiber = createFiber(Fragment, key, internalContextTag);
-  fiber.pendingProps = elements;
+  const fiber = createFiber(Fragment, elements, key, internalContextTag);
   fiber.expirationTime = expirationTime;
   return fiber;
 }
@@ -375,14 +383,13 @@ export function createFiberFromText(
   internalContextTag: TypeOfInternalContext,
   expirationTime: ExpirationTime,
 ): Fiber {
-  const fiber = createFiber(HostText, null, internalContextTag);
-  fiber.pendingProps = content;
+  const fiber = createFiber(HostText, content, null, internalContextTag);
   fiber.expirationTime = expirationTime;
   return fiber;
 }
 
 export function createFiberFromHostInstanceForDeletion(): Fiber {
-  const fiber = createFiber(HostComponent, null, NoContext);
+  const fiber = createFiber(HostComponent, null, null, NoContext);
   fiber.type = 'DELETED';
   return fiber;
 }
@@ -392,9 +399,8 @@ export function createFiberFromCall(
   internalContextTag: TypeOfInternalContext,
   expirationTime: ExpirationTime,
 ): Fiber {
-  const fiber = createFiber(CallComponent, call.key, internalContextTag);
+  const fiber = createFiber(CallComponent, call, call.key, internalContextTag);
   fiber.type = call.handler;
-  fiber.pendingProps = call;
   fiber.expirationTime = expirationTime;
   return fiber;
 }
@@ -404,7 +410,7 @@ export function createFiberFromReturn(
   internalContextTag: TypeOfInternalContext,
   expirationTime: ExpirationTime,
 ): Fiber {
-  const fiber = createFiber(ReturnComponent, null, internalContextTag);
+  const fiber = createFiber(ReturnComponent, null, null, internalContextTag);
   fiber.expirationTime = expirationTime;
   return fiber;
 }
@@ -414,8 +420,13 @@ export function createFiberFromPortal(
   internalContextTag: TypeOfInternalContext,
   expirationTime: ExpirationTime,
 ): Fiber {
-  const fiber = createFiber(HostPortal, portal.key, internalContextTag);
-  fiber.pendingProps = portal.children || [];
+  const pendingProps = portal.children !== null ? portal.children : [];
+  const fiber = createFiber(
+    HostPortal,
+    pendingProps,
+    portal.key,
+    internalContextTag,
+  );
   fiber.expirationTime = expirationTime;
   fiber.stateNode = {
     containerInfo: portal.containerInfo,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -142,13 +142,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   }
 
   function updateFragment(current, workInProgress) {
-    var nextChildren = workInProgress.pendingProps;
+    const nextChildren = workInProgress.pendingProps;
     if (hasContextChanged()) {
       // Normally we can bail out on props equality but if context has changed
       // we don't do the bailout and we have to reuse existing props instead.
-      if (nextChildren === null) {
-        nextChildren = workInProgress.memoizedProps;
-      }
     } else if (
       nextChildren === null ||
       workInProgress.memoizedProps === nextChildren
@@ -169,18 +166,14 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   }
 
   function updateFunctionalComponent(current, workInProgress) {
-    var fn = workInProgress.type;
-    var nextProps = workInProgress.pendingProps;
+    const fn = workInProgress.type;
+    const nextProps = workInProgress.pendingProps;
 
-    const memoizedProps = workInProgress.memoizedProps;
     if (hasContextChanged()) {
       // Normally we can bail out on props equality but if context has changed
       // we don't do the bailout and we have to reuse existing props instead.
-      if (nextProps === null) {
-        nextProps = memoizedProps;
-      }
     } else {
-      if (nextProps === null || memoizedProps === nextProps) {
+      if (workInProgress.memoizedProps === nextProps) {
         return bailoutOnAlreadyFinishedWork(current, workInProgress);
       }
       // TODO: consider bringing fn.shouldComponentUpdate() back.
@@ -380,21 +373,13 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     const type = workInProgress.type;
     const memoizedProps = workInProgress.memoizedProps;
-    let nextProps = workInProgress.pendingProps;
-    if (nextProps === null) {
-      nextProps = memoizedProps;
-      invariant(
-        nextProps !== null,
-        'We should always have pending or current props. This error is ' +
-          'likely caused by a bug in React. Please file an issue.',
-      );
-    }
+    const nextProps = workInProgress.pendingProps;
     const prevProps = current !== null ? current.memoizedProps : null;
 
     if (hasContextChanged()) {
       // Normally we can bail out on props equality but if context has changed
       // we don't do the bailout and we have to reuse existing props instead.
-    } else if (nextProps === null || memoizedProps === nextProps) {
+    } else if (memoizedProps === nextProps) {
       return bailoutOnAlreadyFinishedWork(current, workInProgress);
     }
 
@@ -436,10 +421,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     if (current === null) {
       tryToClaimNextHydratableInstance(workInProgress);
     }
-    let nextProps = workInProgress.pendingProps;
-    if (nextProps === null) {
-      nextProps = workInProgress.memoizedProps;
-    }
+    const nextProps = workInProgress.pendingProps;
     memoizeProps(workInProgress, nextProps);
     // Nothing to do here. This is terminal. We'll do the completion step
     // immediately after.
@@ -541,19 +523,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   }
 
   function updateCallComponent(current, workInProgress, renderExpirationTime) {
-    var nextCall = (workInProgress.pendingProps: null | ReactCall);
+    var nextCall = (workInProgress.pendingProps: ReactCall);
     if (hasContextChanged()) {
       // Normally we can bail out on props equality but if context has changed
       // we don't do the bailout and we have to reuse existing props instead.
-      if (nextCall === null) {
-        nextCall = current && current.memoizedProps;
-        invariant(
-          nextCall !== null,
-          'We should always have pending or current props. This error is ' +
-            'likely caused by a bug in React. Please file an issue.',
-        );
-      }
-    } else if (nextCall === null || workInProgress.memoizedProps === nextCall) {
+    } else if (workInProgress.memoizedProps === nextCall) {
       nextCall = workInProgress.memoizedProps;
       // TODO: When bailing out, we might need to return the stateNode instead
       // of the child. To check it for work.
@@ -592,22 +566,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     renderExpirationTime,
   ) {
     pushHostContainer(workInProgress, workInProgress.stateNode.containerInfo);
-    let nextChildren = workInProgress.pendingProps;
+    const nextChildren = workInProgress.pendingProps;
     if (hasContextChanged()) {
       // Normally we can bail out on props equality but if context has changed
       // we don't do the bailout and we have to reuse existing props instead.
-      if (nextChildren === null) {
-        nextChildren = current && current.memoizedProps;
-        invariant(
-          nextChildren != null,
-          'We should always have pending or current props. This error is ' +
-            'likely caused by a bug in React. Please file an issue.',
-        );
-      }
-    } else if (
-      nextChildren === null ||
-      workInProgress.memoizedProps === nextChildren
-    ) {
+    } else if (workInProgress.memoizedProps === nextChildren) {
       return bailoutOnAlreadyFinishedWork(current, workInProgress);
     }
 

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -450,14 +450,7 @@ export default function(
 
     const instance = workInProgress.stateNode;
     const state = instance.state || null;
-
-    let props = workInProgress.pendingProps;
-    invariant(
-      props,
-      'There must be pending props for an initial mount. This error is ' +
-        'likely caused by a bug in React. Please file an issue.',
-    );
-
+    const props = workInProgress.pendingProps;
     const unmaskedContext = getUnmaskedContext(workInProgress);
 
     instance.props = props;
@@ -610,17 +603,7 @@ export default function(
     resetInputPointers(workInProgress, instance);
 
     const oldProps = workInProgress.memoizedProps;
-    let newProps = workInProgress.pendingProps;
-    if (!newProps) {
-      // If there aren't any new props, then we'll reuse the memoized props.
-      // This could be from already completed work.
-      newProps = oldProps;
-      invariant(
-        newProps != null,
-        'There should always be pending or memoized props. This error is ' +
-          'likely caused by a bug in React. Please file an issue.',
-      );
-    }
+    const newProps = workInProgress.pendingProps;
     const oldContext = instance.context;
     const newUnmaskedContext = getUnmaskedContext(workInProgress);
     const newContext = getMaskedContext(workInProgress, newUnmaskedContext);

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -10,34 +10,16 @@
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
-import {Update} from 'shared/ReactTypeOfSideEffect';
-import {
-  debugRenderPhaseSideEffects,
-  enableAsyncSubtreeAPI,
-} from 'shared/ReactFeatureFlags';
+import {debugRenderPhaseSideEffects} from 'shared/ReactFeatureFlags';
 import {isMounted} from 'shared/ReactFiberTreeReflection';
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';
-import emptyObject from 'fbjs/lib/emptyObject';
 import getComponentName from 'shared/getComponentName';
-import shallowEqual from 'fbjs/lib/shallowEqual';
 import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
-import {AsyncUpdates} from './ReactTypeOfInternalContext';
-import {
-  cacheContext,
-  getMaskedContext,
-  getUnmaskedContext,
-  isContextConsumer,
-} from './ReactFiberContext';
-import {
-  insertUpdateIntoFiber,
-  processUpdateQueue,
-} from './ReactFiberUpdateQueue';
-import {hasContextChanged} from './ReactFiberContext';
+import {insertUpdateIntoFiber} from './ReactFiberUpdateQueue';
 
-const fakeInternalInstance = {};
 const isArray = Array.isArray;
 
 if (__DEV__) {
@@ -52,39 +34,20 @@ if (__DEV__) {
       callback,
     );
   };
-
-  // This is so gross but it's at least non-critical and can be removed if
-  // it causes problems. This is meant to give a nicer error message for
-  // ReactDOM15.unstable_renderSubtreeIntoContainer(reactDOM16Component,
-  // ...)) which otherwise throws a "_processChildContext is not a function"
-  // exception.
-  Object.defineProperty(fakeInternalInstance, '_processChildContext', {
-    enumerable: false,
-    value: function() {
-      invariant(
-        false,
-        '_processChildContext is not available in React 16+. This likely ' +
-          'means you have multiple copies of React and are attempting to nest ' +
-          'a React 15 tree inside a React 16 tree using ' +
-          "unstable_renderSubtreeIntoContainer, which isn't supported. Try " +
-          'to make sure you have only one copy of React (and ideally, switch ' +
-          'to ReactDOM.createPortal).',
-      );
-    },
-  });
-  Object.freeze(fakeInternalInstance);
 }
 
 export default function(
   scheduleWork: (fiber: Fiber, expirationTime: ExpirationTime) => void,
   computeExpirationForFiber: (fiber: Fiber) => ExpirationTime,
-  memoizeProps: (workInProgress: Fiber, props: any) => void,
-  memoizeState: (workInProgress: Fiber, state: any) => void,
 ) {
   // Class component state updater
-  const updater = {
+  const classUpdater = {
     isMounted,
-    enqueueSetState(instance, partialState, callback) {
+    enqueueSetState(
+      instance: any,
+      partialState: mixed,
+      callback: ?() => mixed,
+    ) {
       const fiber = ReactInstanceMap.get(instance);
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
@@ -103,7 +66,7 @@ export default function(
       insertUpdateIntoFiber(fiber, update);
       scheduleWork(fiber, expirationTime);
     },
-    enqueueReplaceState(instance, state, callback) {
+    enqueueReplaceState(instance: any, state: mixed, callback: ?() => mixed) {
       const fiber = ReactInstanceMap.get(instance);
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
@@ -122,7 +85,7 @@ export default function(
       insertUpdateIntoFiber(fiber, update);
       scheduleWork(fiber, expirationTime);
     },
-    enqueueForceUpdate(instance, callback) {
+    enqueueForceUpdate(instance: any, callback: ?() => mixed) {
       const fiber = ReactInstanceMap.get(instance);
       callback = callback === undefined ? null : callback;
       if (__DEV__) {
@@ -142,60 +105,6 @@ export default function(
       scheduleWork(fiber, expirationTime);
     },
   };
-
-  function checkShouldComponentUpdate(
-    workInProgress,
-    oldProps,
-    newProps,
-    oldState,
-    newState,
-    newContext,
-  ) {
-    if (
-      oldProps === null ||
-      (workInProgress.updateQueue !== null &&
-        workInProgress.updateQueue.hasForceUpdate)
-    ) {
-      // If the workInProgress already has an Update effect, return true
-      return true;
-    }
-
-    const instance = workInProgress.stateNode;
-    const type = workInProgress.type;
-    if (typeof instance.shouldComponentUpdate === 'function') {
-      startPhaseTimer(workInProgress, 'shouldComponentUpdate');
-      const shouldUpdate = instance.shouldComponentUpdate(
-        newProps,
-        newState,
-        newContext,
-      );
-      stopPhaseTimer();
-
-      // Simulate an async bailout/interruption by invoking lifecycle twice.
-      if (debugRenderPhaseSideEffects) {
-        instance.shouldComponentUpdate(newProps, newState, newContext);
-      }
-
-      if (__DEV__) {
-        warning(
-          shouldUpdate !== undefined,
-          '%s.shouldComponentUpdate(): Returned undefined instead of a ' +
-            'boolean value. Make sure to return true or false.',
-          getComponentName(workInProgress) || 'Unknown',
-        );
-      }
-
-      return shouldUpdate;
-    }
-
-    if (type.prototype && type.prototype.isPureReactComponent) {
-      return (
-        !shallowEqual(oldProps, newProps) || !shallowEqual(oldState, newState)
-      );
-    }
-
-    return true;
-  }
 
   function checkClassInstance(workInProgress: Fiber) {
     const instance = workInProgress.stateNode;
@@ -344,41 +253,7 @@ export default function(
     }
   }
 
-  function resetInputPointers(workInProgress: Fiber, instance: any) {
-    instance.props = workInProgress.memoizedProps;
-    instance.state = workInProgress.memoizedState;
-  }
-
-  function adoptClassInstance(workInProgress: Fiber, instance: any): void {
-    instance.updater = updater;
-    workInProgress.stateNode = instance;
-    // The instance needs access to the fiber so that it can schedule updates
-    ReactInstanceMap.set(instance, workInProgress);
-    if (__DEV__) {
-      instance._reactInternalInstance = fakeInternalInstance;
-    }
-  }
-
-  function constructClassInstance(workInProgress: Fiber, props: any): any {
-    const ctor = workInProgress.type;
-    const unmaskedContext = getUnmaskedContext(workInProgress);
-    const needsContext = isContextConsumer(workInProgress);
-    const context = needsContext
-      ? getMaskedContext(workInProgress, unmaskedContext)
-      : emptyObject;
-    const instance = new ctor(props, context);
-    adoptClassInstance(workInProgress, instance);
-
-    // Cache unmasked context so we can avoid recreating masked context unless necessary.
-    // ReactFiberContext usually updates this cache but can't for newly-created instances.
-    if (needsContext) {
-      cacheContext(workInProgress, unmaskedContext, context);
-    }
-
-    return instance;
-  }
-
-  function callComponentWillMount(workInProgress, instance) {
+  function callComponentWillMount(workInProgress: Fiber, instance: any) {
     startPhaseTimer(workInProgress, 'componentWillMount');
     const oldState = instance.state;
     instance.componentWillMount();
@@ -399,15 +274,15 @@ export default function(
           getComponentName(workInProgress),
         );
       }
-      updater.enqueueReplaceState(instance, instance.state, null);
+      classUpdater.enqueueReplaceState(instance, instance.state, null);
     }
   }
 
   function callComponentWillReceiveProps(
-    workInProgress,
-    instance,
-    newProps,
-    newContext,
+    workInProgress: Fiber,
+    instance: any,
+    newProps: mixed,
+    newContext: mixed,
   ) {
     startPhaseTimer(workInProgress, 'componentWillReceiveProps');
     const oldState = instance.state;
@@ -433,291 +308,62 @@ export default function(
           didWarnAboutStateAssignmentForComponent[componentName] = true;
         }
       }
-      updater.enqueueReplaceState(instance, instance.state, null);
+      classUpdater.enqueueReplaceState(instance, instance.state, null);
     }
   }
 
-  // Invokes the mount life-cycles on a previously never rendered instance.
-  function mountClassInstance(
+  function callShouldComponentUpdate(
     workInProgress: Fiber,
-    renderExpirationTime: ExpirationTime,
-  ): void {
-    const current = workInProgress.alternate;
+    instance: any,
+    nextProps: mixed,
+    nextState: mixed,
+    nextContext: mixed,
+  ): boolean {
+    startPhaseTimer(workInProgress, 'shouldComponentUpdate');
+    const shouldUpdate = instance.shouldComponentUpdate(
+      nextProps,
+      nextState,
+      nextContext,
+    );
+    stopPhaseTimer();
+    // Simulate an async bailout/interruption by invoking lifecycle twice.
+    if (debugRenderPhaseSideEffects) {
+      instance.shouldComponentUpdate(nextProps, nextState, nextContext);
+    }
 
     if (__DEV__) {
-      checkClassInstance(workInProgress);
-    }
-
-    const instance = workInProgress.stateNode;
-    const state = instance.state || null;
-    const props = workInProgress.pendingProps;
-    const unmaskedContext = getUnmaskedContext(workInProgress);
-
-    instance.props = props;
-    instance.state = workInProgress.memoizedState = state;
-    instance.refs = emptyObject;
-    instance.context = getMaskedContext(workInProgress, unmaskedContext);
-
-    if (
-      enableAsyncSubtreeAPI &&
-      workInProgress.type != null &&
-      workInProgress.type.prototype != null &&
-      workInProgress.type.prototype.unstable_isAsyncReactComponent === true
-    ) {
-      workInProgress.internalContextTag |= AsyncUpdates;
-    }
-
-    if (typeof instance.componentWillMount === 'function') {
-      callComponentWillMount(workInProgress, instance);
-      // If we had additional state updates during this life-cycle, let's
-      // process them now.
-      const updateQueue = workInProgress.updateQueue;
-      if (updateQueue !== null) {
-        instance.state = processUpdateQueue(
-          current,
-          workInProgress,
-          updateQueue,
-          instance,
-          props,
-          renderExpirationTime,
-        );
-      }
-    }
-    if (typeof instance.componentDidMount === 'function') {
-      workInProgress.effectTag |= Update;
-    }
-  }
-
-  // Called on a preexisting class instance. Returns false if a resumed render
-  // could be reused.
-  // function resumeMountClassInstance(
-  //   workInProgress: Fiber,
-  //   priorityLevel: PriorityLevel,
-  // ): boolean {
-  //   const instance = workInProgress.stateNode;
-  //   resetInputPointers(workInProgress, instance);
-
-  //   let newState = workInProgress.memoizedState;
-  //   let newProps = workInProgress.pendingProps;
-  //   if (!newProps) {
-  //     // If there isn't any new props, then we'll reuse the memoized props.
-  //     // This could be from already completed work.
-  //     newProps = workInProgress.memoizedProps;
-  //     invariant(
-  //       newProps != null,
-  //       'There should always be pending or memoized props. This error is ' +
-  //         'likely caused by a bug in React. Please file an issue.',
-  //     );
-  //   }
-  //   const newUnmaskedContext = getUnmaskedContext(workInProgress);
-  //   const newContext = getMaskedContext(workInProgress, newUnmaskedContext);
-
-  //   const oldContext = instance.context;
-  //   const oldProps = workInProgress.memoizedProps;
-
-  //   if (
-  //     typeof instance.componentWillReceiveProps === 'function' &&
-  //     (oldProps !== newProps || oldContext !== newContext)
-  //   ) {
-  //     callComponentWillReceiveProps(
-  //       workInProgress,
-  //       instance,
-  //       newProps,
-  //       newContext,
-  //     );
-  //   }
-
-  //   // Process the update queue before calling shouldComponentUpdate
-  //   const updateQueue = workInProgress.updateQueue;
-  //   if (updateQueue !== null) {
-  //     newState = processUpdateQueue(
-  //       workInProgress,
-  //       updateQueue,
-  //       instance,
-  //       newState,
-  //       newProps,
-  //       priorityLevel,
-  //     );
-  //   }
-
-  //   // TODO: Should we deal with a setState that happened after the last
-  //   // componentWillMount and before this componentWillMount? Probably
-  //   // unsupported anyway.
-
-  //   if (
-  //     !checkShouldComponentUpdate(
-  //       workInProgress,
-  //       workInProgress.memoizedProps,
-  //       newProps,
-  //       workInProgress.memoizedState,
-  //       newState,
-  //       newContext,
-  //     )
-  //   ) {
-  //     // Update the existing instance's state, props, and context pointers even
-  //     // though we're bailing out.
-  //     instance.props = newProps;
-  //     instance.state = newState;
-  //     instance.context = newContext;
-  //     return false;
-  //   }
-
-  //   // Update the input pointers now so that they are correct when we call
-  //   // componentWillMount
-  //   instance.props = newProps;
-  //   instance.state = newState;
-  //   instance.context = newContext;
-
-  //   if (typeof instance.componentWillMount === 'function') {
-  //     callComponentWillMount(workInProgress, instance);
-  //     // componentWillMount may have called setState. Process the update queue.
-  //     const newUpdateQueue = workInProgress.updateQueue;
-  //     if (newUpdateQueue !== null) {
-  //       newState = processUpdateQueue(
-  //         workInProgress,
-  //         newUpdateQueue,
-  //         instance,
-  //         newState,
-  //         newProps,
-  //         priorityLevel,
-  //       );
-  //     }
-  //   }
-
-  //   if (typeof instance.componentDidMount === 'function') {
-  //     workInProgress.effectTag |= Update;
-  //   }
-
-  //   instance.state = newState;
-
-  //   return true;
-  // }
-
-  // Invokes the update life-cycles and returns false if it shouldn't rerender.
-  function updateClassInstance(
-    current: Fiber,
-    workInProgress: Fiber,
-    renderExpirationTime: ExpirationTime,
-  ): boolean {
-    const instance = workInProgress.stateNode;
-    resetInputPointers(workInProgress, instance);
-
-    const oldProps = workInProgress.memoizedProps;
-    const newProps = workInProgress.pendingProps;
-    const oldContext = instance.context;
-    const newUnmaskedContext = getUnmaskedContext(workInProgress);
-    const newContext = getMaskedContext(workInProgress, newUnmaskedContext);
-
-    // Note: During these life-cycles, instance.props/instance.state are what
-    // ever the previously attempted to render - not the "current". However,
-    // during componentDidUpdate we pass the "current" props.
-
-    if (
-      typeof instance.componentWillReceiveProps === 'function' &&
-      (oldProps !== newProps || oldContext !== newContext)
-    ) {
-      callComponentWillReceiveProps(
-        workInProgress,
-        instance,
-        newProps,
-        newContext,
+      warning(
+        shouldUpdate !== undefined,
+        '%s.shouldComponentUpdate(): Returned undefined instead of a ' +
+          'boolean value. Make sure to return true or false.',
+        getComponentName(workInProgress) || 'Unknown',
       );
     }
-
-    // Compute the next state using the memoized state and the update queue.
-    const oldState = workInProgress.memoizedState;
-    // TODO: Previous state can be null.
-    let newState;
-    if (workInProgress.updateQueue !== null) {
-      newState = processUpdateQueue(
-        current,
-        workInProgress,
-        workInProgress.updateQueue,
-        instance,
-        newProps,
-        renderExpirationTime,
-      );
-    } else {
-      newState = oldState;
-    }
-
-    if (
-      oldProps === newProps &&
-      oldState === newState &&
-      !hasContextChanged() &&
-      !(
-        workInProgress.updateQueue !== null &&
-        workInProgress.updateQueue.hasForceUpdate
-      )
-    ) {
-      // If an update was already in progress, we should schedule an Update
-      // effect even though we're bailing out, so that cWU/cDU are called.
-      if (typeof instance.componentDidUpdate === 'function') {
-        if (
-          oldProps !== current.memoizedProps ||
-          oldState !== current.memoizedState
-        ) {
-          workInProgress.effectTag |= Update;
-        }
-      }
-      return false;
-    }
-
-    const shouldUpdate = checkShouldComponentUpdate(
-      workInProgress,
-      oldProps,
-      newProps,
-      oldState,
-      newState,
-      newContext,
-    );
-
-    if (shouldUpdate) {
-      if (typeof instance.componentWillUpdate === 'function') {
-        startPhaseTimer(workInProgress, 'componentWillUpdate');
-        instance.componentWillUpdate(newProps, newState, newContext);
-        stopPhaseTimer();
-
-        // Simulate an async bailout/interruption by invoking lifecycle twice.
-        if (debugRenderPhaseSideEffects) {
-          instance.componentWillUpdate(newProps, newState, newContext);
-        }
-      }
-      if (typeof instance.componentDidUpdate === 'function') {
-        workInProgress.effectTag |= Update;
-      }
-    } else {
-      // If an update was already in progress, we should schedule an Update
-      // effect even though we're bailing out, so that cWU/cDU are called.
-      if (typeof instance.componentDidUpdate === 'function') {
-        if (
-          oldProps !== current.memoizedProps ||
-          oldState !== current.memoizedState
-        ) {
-          workInProgress.effectTag |= Update;
-        }
-      }
-
-      // If shouldComponentUpdate returned false, we should still update the
-      // memoized props/state to indicate that this work can be reused.
-      memoizeProps(workInProgress, newProps);
-      memoizeState(workInProgress, newState);
-    }
-
-    // Update the existing instance's state, props, and context pointers even
-    // if shouldComponentUpdate returns false.
-    instance.props = newProps;
-    instance.state = newState;
-    instance.context = newContext;
-
     return shouldUpdate;
   }
 
+  function callComponentWillUpdate(
+    workInProgress: Fiber,
+    instance: any,
+    nextProps: mixed,
+    nextState: mixed,
+    nextContext: mixed,
+  ) {
+    startPhaseTimer(workInProgress, 'componentWillUpdate');
+    instance.componentWillUpdate(nextProps, nextState, nextContext);
+    stopPhaseTimer();
+    // Simulate an async bailout/interruption by invoking lifecycle twice.
+    if (debugRenderPhaseSideEffects) {
+      instance.componentWillUpdate(nextProps, nextState, nextContext);
+    }
+  }
+
   return {
-    adoptClassInstance,
-    constructClassInstance,
-    mountClassInstance,
-    // resumeMountClassInstance,
-    updateClassInstance,
+    classUpdater,
+    checkClassInstance,
+    callComponentWillMount,
+    callComponentWillReceiveProps,
+    callShouldComponentUpdate,
+    callComponentWillUpdate,
   };
 }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -41,7 +41,6 @@ import {
   popContextProvider,
   popTopLevelContextObject,
 } from './ReactFiberContext';
-import {Never} from './ReactFiberExpirationTime';
 
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   config: HostConfig<T, P, I, TI, HI, PI, C, CC, CX, PL>,
@@ -392,18 +391,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     workInProgress: Fiber,
     renderExpirationTime: ExpirationTime,
   ): Fiber | null {
-    // Get the latest props.
-    let newProps = workInProgress.pendingProps;
-    if (newProps === null) {
-      newProps = workInProgress.memoizedProps;
-    } else if (
-      workInProgress.expirationTime !== Never ||
-      renderExpirationTime === Never
-    ) {
-      // Reset the pending props, unless this was a down-prioritization.
-      workInProgress.pendingProps = null;
-    }
-
+    const newProps = workInProgress.pendingProps;
     switch (workInProgress.tag) {
       case FunctionalComponent:
         return null;


### PR DESCRIPTION
### (Based on top of #11580)

The existing separation between the BeginWork module and the ClassComponent module is awkward. There's some redundant code and over-abstraction that is eliminated by colocating class component logic with the same logic for other types of work. Specifically: anything related to bailouts or reconciliation should be in BeginWork.

Lifecycle-related code is kept in the separate module, since it's unique to class components. In a future WASM implementation, this would be the boundary between the reconciler and JS.

This will make future refactors of the begin phase easier since all the code is in the same place.