### PR TITLE
Read debugRenderPhaseSideEffects from GK

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeFeatureFlags.js
+++ b/packages/react-native-renderer/src/ReactNativeFeatureFlags.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import invariant from 'fbjs/lib/invariant';
+
+import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
+import typeof * as FeatureFlagsShimType from './ReactNativeFeatureFlags';
+
+// Re-export dynamic flags from the fbsource version.
+export const {debugRenderPhaseSideEffects} = require('ReactFeatureFlags');
+
+// The rest of the flags are static for better dead code elimination.
+export const enableAsyncSubtreeAPI = true;
+export const enableAsyncSchedulingByDefaultInReactDOM = false;
+export const enableReactFragment = false;
+export const enableCreateRoot = false;
+export const enableUserTimingAPI = __DEV__;
+export const enableMutatingReconciler = true;
+export const enableNoopReconciler = false;
+export const enablePersistentReconciler = false;
+
+// Only used in www builds.
+export function addUserTimingListener() {
+  invariant(false, 'Not implemented.');
+}
+
+// Flow magic to verify the exports of this file match the original version.
+// eslint-disable-next-line no-unused-vars
+type Check<_X, Y: _X, X: Y = _X> = null;
+// eslint-disable-next-line no-unused-expressions
+(null: Check<FeatureFlagsShimType, FeatureFlagsType>);

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -129,6 +129,7 @@ const bundles = [
       'deepFreezeAndThrowOnMutationInDev',
       'flattenStyle',
     ],
+    featureFlags: 'react-native-renderer/src/ReactNativeFeatureFlags',
   },
 
   /******* React Native RT *******/

--- a/scripts/rollup/shims/rollup/ReactFeatureFlags-www.js
+++ b/scripts/rollup/shims/rollup/ReactFeatureFlags-www.js
@@ -12,11 +12,11 @@ import typeof * as FeatureFlagsShimType from './ReactFeatureFlags-www';
 
 // Re-export dynamic flags from the www version.
 export const {
+  debugRenderPhaseSideEffects,
   enableAsyncSchedulingByDefaultInReactDOM,
 } = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.
-export const debugRenderPhaseSideEffects = false;
 export const enableAsyncSubtreeAPI = true;
 export const enableReactFragment = false;
 export const enableCreateRoot = true;


### PR DESCRIPTION
We plan to opt some engineers into this newly-added GK to help identify unsafe side-effects within lifecycle hooks and `setState` callbacks. This PR adds the ability to determine this value at runtime (rather than static as it is for NPM builds) .

Verified that this inserts the following line to the fbsource and www builds:

```js
var debugRenderPhaseSideEffects = require("ReactFeatureFlags").debugRenderPhaseSideEffects;
```

For the www build, this should be a simple matter of reading this value from the GK module.

I'm not sure yet of the best way to inject it for React Native builds, given that the Rollup build reads the value from `ReactFeatureFlags` during initialization. We'll have to make sure that app code injects before `ReactNative` is initialized. I believe this should be possible, but it may depend on how we hoist requires in that environment.