### PR TITLE
Updated minimatch version to 3.0.2 due to High severity security vuln…

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,5 +137,8 @@
       "packages/**/*.js"
     ],
     "timers": "fake"
+  },
+  "dependencies": {
+    "minimatch": "3.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3307,6 +3307,12 @@ mimic-fn@^1.0.0:
   dependencies:
     brace-expansion "^1.0.0"
 
+minimatch@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.2.tgz#0f398a7300ea441e9c348c83d98ab8c9dbf9c40a"
+  dependencies:
+    brace-expansion "^1.0.0"
+
 minimatch@^2.0.3:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"


### PR DESCRIPTION
Current minimatch version in use has a Regex DDoS vulnerability making it vulnerable to a Regular Expression Denial Of Service (ReDoS) attack. An attacker can pass a string value to the minimatch(path,pattern) function to cause a ReDoS.

This defect is fixed in version 3.0.2 (current verison).

**TESTS:**
Test Suites: 122 passed, 122 total
Tests:       26 skipped, 2547 passed, 2573 total
Snapshots:   20 passed, 20 total

Time:        74.541s
Ran all test suites.
✨  Done in 76.02s.

**LINT**
yarn run v1.3.2
$ node ./scripts/tasks/eslint.js

Lint passed.
✨  Done in 12.61s.

**FLOW**
$ yarn flow
yarn run v1.3.2
$ node ./scripts/tasks/flow.js
Found 0 errors
Flow passed
✨  Done in 9.66s.