### PR TITLE
fix(scripts/eslint): typo in eslint script

### DIFF
--- a/scripts/eslint/index.js
+++ b/scripts/eslint/index.js
@@ -13,7 +13,7 @@ const formatter = cli.getFormatter();
 
 module.exports = function lintOnFiles(filePatterns) {
   const report = cli.executeOnFiles(filePatterns);
-  const formatedResults = formatter(report.results);
-  console.log(formatedResults);
+  const formattedResults = formatter(report.results);
+  console.log(formattedResults);
   return report;
 };


### PR DESCRIPTION
Noticed a minor typo in `scripts/eslint/index.js` so I fixed it up.

Thanks!
