### PR TITLE
Run Jest tests with "development" environment

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -1,8 +1,6 @@
 'use strict';
 
-// React's test can only work in NODE_ENV=test because of how things
-// are set up. So we might as well enforce it.
-process.env.NODE_ENV = 'test';
+process.env.NODE_ENV = 'development';
 
 var path = require('path');
 


### PR DESCRIPTION
We used to require setting it to `'test'` because `rewrite-modules` step [treated it specially](https://github.com/facebook/fbjs/blob/c69904a511b900266935168223063dd8772dfc40/packages/babel-preset-fbjs/plugins/rewrite-modules.js#L21). This prevented us from running tests with other `NODE_ENV` values.

Since we dropped Haste and no longer use `rewrite-modules`, we can now run tests with any environment value. I'm changing this to `'development'` now but will later introduce a `'production'` mode separately.