### PR TITLE
fix regression with non-object iterables (functions) being renderable

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -549,6 +549,17 @@ function ChildReconciler(shouldTrackSideEffects) {
       throwOnInvalidObjectType(returnFiber, newChild);
     }
 
+    if (getIteratorFn(newChild)) {
+      const created = createFiberFromFragment(
+        newChild,
+        returnFiber.internalContextTag,
+        expirationTime,
+        null,
+      );
+      created.return = returnFiber;
+      return created;
+    }
+
     if (__DEV__) {
       if (typeof newChild === 'function') {
         warnOnFunctionType();
@@ -662,6 +673,20 @@ function ChildReconciler(shouldTrackSideEffects) {
       throwOnInvalidObjectType(returnFiber, newChild);
     }
 
+    if (getIteratorFn(newChild)) {
+      if (key !== null) {
+        return null;
+      }
+
+      return updateFragment(
+        returnFiber,
+        oldFiber,
+        newChild,
+        expirationTime,
+        null,
+      );
+    }
+
     if (__DEV__) {
       if (typeof newChild === 'function') {
         warnOnFunctionType();
@@ -767,6 +792,17 @@ function ChildReconciler(shouldTrackSideEffects) {
       throwOnInvalidObjectType(returnFiber, newChild);
     }
 
+    if (getIteratorFn(newChild)) {
+      const matchedFiber = existingChildren.get(newIdx) || null;
+      return updateFragment(
+        returnFiber,
+        matchedFiber,
+        newChild,
+        expirationTime,
+        null,
+      );
+    }
+
     if (__DEV__) {
       if (typeof newChild === 'function') {
         warnOnFunctionType();
@@ -829,7 +865,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     newChildren: Array<*>,
     expirationTime: ExpirationTime,
   ): Fiber | null {
-    // This algorithm can't optimize by searching from boths ends since we
+    // This algorithm can't optimize by searching from both ends since we
     // don't have backpointers on fibers. I'm trying to see how far we can get
     // with that model. If it ends up not being worth the tradeoffs, we can
     // add it later.


### PR DESCRIPTION
- [x] Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
- [x] Run `yarn` in the repository root.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x]  Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
- [x]  Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
- [x]  Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
- [x]  Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
- [x]  If you haven't already, complete the CLA.

This closes #11396

I noticed a few other spots where there would be issues with non-object iterables could cause problems and added checks for those as well.