### PR TITLE
Remove EventListener fbjs utility

### DIFF
--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -8,7 +8,6 @@
 import {batchedUpdates} from 'events/ReactGenericBatching';
 import {isFiberMounted} from 'shared/ReactFiberTreeReflection';
 import {HostRoot} from 'shared/ReactTypeOfWork';
-import EventListener from 'fbjs/lib/EventListener';
 
 import getEventTarget from './getEventTarget';
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
@@ -124,10 +123,10 @@ export function trapBubbledEvent(topLevelType, handlerBaseName, element) {
   if (!element) {
     return null;
   }
-  return EventListener.listen(
-    element,
+  element.addEventListener(
     handlerBaseName,
     dispatchEvent.bind(null, topLevelType),
+    false,
   );
 }
 
@@ -145,10 +144,10 @@ export function trapCapturedEvent(topLevelType, handlerBaseName, element) {
   if (!element) {
     return null;
   }
-  return EventListener.capture(
-    element,
+  element.addEventListener(
     handlerBaseName,
     dispatchEvent.bind(null, topLevelType),
+    true,
   );
 }
 


### PR DESCRIPTION
EventListener normalizes event subscription for <= IE8. This is no longer necessary. element.addEventListener is sufficient.

Follow-up from https://github.com/facebook/react/pull/11515