### PR TITLE
Use const/let in more places (#11467)

### DIFF
--- a/packages/react-dom/src/events/BeforeInputEventPlugin.js
+++ b/packages/react-dom/src/events/BeforeInputEventPlugin.js
@@ -14,13 +14,13 @@ import * as FallbackCompositionState from './FallbackCompositionState';
 import SyntheticCompositionEvent from './SyntheticCompositionEvent';
 import SyntheticInputEvent from './SyntheticInputEvent';
 
-var END_KEYCODES = [9, 13, 27, 32]; // Tab, Return, Esc, Space
-var START_KEYCODE = 229;
+const END_KEYCODES = [9, 13, 27, 32]; // Tab, Return, Esc, Space
+const START_KEYCODE = 229;
 
-var canUseCompositionEvent =
+const canUseCompositionEvent =
   ExecutionEnvironment.canUseDOM && 'CompositionEvent' in window;
 
-var documentMode = null;
+let documentMode = null;
 if (ExecutionEnvironment.canUseDOM && 'documentMode' in document) {
   documentMode = document.documentMode;
 }
@@ -28,7 +28,7 @@ if (ExecutionEnvironment.canUseDOM && 'documentMode' in document) {
 // Webkit offers a very useful `textInput` event that can be used to
 // directly represent `beforeInput`. The IE `textinput` event is not as
 // useful, so we don't use it.
-var canUseTextInputEvent =
+const canUseTextInputEvent =
   ExecutionEnvironment.canUseDOM &&
   'TextEvent' in window &&
   !documentMode &&
@@ -37,7 +37,7 @@ var canUseTextInputEvent =
 // In IE9+, we have access to composition events, but the data supplied
 // by the native compositionend event may be incorrect. Japanese ideographic
 // spaces, for instance (\u3000) are not recorded correctly.
-var useFallbackCompositionData =
+const useFallbackCompositionData =
   ExecutionEnvironment.canUseDOM &&
   (!canUseCompositionEvent ||
     (documentMode && documentMode > 8 && documentMode <= 11));
@@ -47,7 +47,7 @@ var useFallbackCompositionData =
  * text input events. Rely on keypress instead.
  */
 function isPresto() {
-  var opera = window.opera;
+  const {opera} = window;
   return (
     typeof opera === 'object' &&
     typeof opera.version === 'function' &&
@@ -55,11 +55,11 @@ function isPresto() {
   );
 }
 
-var SPACEBAR_CODE = 32;
-var SPACEBAR_CHAR = String.fromCharCode(SPACEBAR_CODE);
+const SPACEBAR_CODE = 32;
+const SPACEBAR_CHAR = String.fromCharCode(SPACEBAR_CODE);
 
 // Events and their corresponding property names.
-var eventTypes = {
+const eventTypes = {
   beforeInput: {
     phasedRegistrationNames: {
       bubbled: 'onBeforeInput',
@@ -117,7 +117,7 @@ var eventTypes = {
 };
 
 // Track whether we've ever handled a keypress on the space key.
-var hasSpaceKeypress = false;
+let hasSpaceKeypress = false;
 
 /**
  * Return whether a native keypress event is assumed to be a command.
@@ -197,7 +197,7 @@ function isFallbackCompositionEnd(topLevelType, nativeEvent) {
  * @return {?string}
  */
 function getDataFromCustomEvent(nativeEvent) {
-  var detail = nativeEvent.detail;
+  const detail = nativeEvent.detail;
   if (typeof detail === 'object' && 'data' in detail) {
     return detail.data;
   }
@@ -205,7 +205,7 @@ function getDataFromCustomEvent(nativeEvent) {
 }
 
 // Track the current IME composition status, if any.
-var isComposing = false;
+let isComposing = false;
 
 /**
  * @return {?object} A SyntheticCompositionEvent.
@@ -216,8 +216,8 @@ function extractCompositionEvent(
   nativeEvent,
   nativeEventTarget,
 ) {
-  var eventType;
-  var fallbackData;
+  let eventType;
+  let fallbackData;
 
   if (canUseCompositionEvent) {
     eventType = getCompositionEventType(topLevelType);
@@ -245,7 +245,7 @@ function extractCompositionEvent(
     }
   }
 
-  var event = SyntheticCompositionEvent.getPooled(
+  const event = SyntheticCompositionEvent.getPooled(
     eventType,
     targetInst,
     nativeEvent,
@@ -257,7 +257,7 @@ function extractCompositionEvent(
     // This matches the property of native CompositionEventInterface.
     event.data = fallbackData;
   } else {
-    var customData = getDataFromCustomEvent(nativeEvent);
+    const customData = getDataFromCustomEvent(nativeEvent);
     if (customData !== null) {
       event.data = customData;
     }
@@ -291,7 +291,7 @@ function getNativeBeforeInputChars(topLevelType: TopLevelTypes, nativeEvent) {
        * To avoid this issue, use the keypress event as if no `textInput`
        * event is available.
        */
-      var which = nativeEvent.which;
+      const which = nativeEvent.which;
       if (which !== SPACEBAR_CODE) {
         return null;
       }
@@ -301,7 +301,7 @@ function getNativeBeforeInputChars(topLevelType: TopLevelTypes, nativeEvent) {
 
     case 'topTextInput':
       // Record the characters to be added to the DOM.
-      var chars = nativeEvent.data;
+      const chars = nativeEvent.data;
 
       // If it's a spacebar character, assume that we have already handled
       // it at the keypress level and bail immediately. Android Chrome
@@ -337,7 +337,7 @@ function getFallbackBeforeInputChars(topLevelType: TopLevelTypes, nativeEvent) {
       (!canUseCompositionEvent &&
         isFallbackCompositionEnd(topLevelType, nativeEvent))
     ) {
-      var chars = FallbackCompositionState.getData();
+      const chars = FallbackCompositionState.getData();
       FallbackCompositionState.reset();
       isComposing = false;
       return chars;
@@ -400,7 +400,7 @@ function extractBeforeInputEvent(
   nativeEvent,
   nativeEventTarget,
 ) {
-  var chars;
+  let chars;
 
   if (canUseTextInputEvent) {
     chars = getNativeBeforeInputChars(topLevelType, nativeEvent);
@@ -414,7 +414,7 @@ function extractBeforeInputEvent(
     return null;
   }
 
-  var event = SyntheticInputEvent.getPooled(
+  const event = SyntheticInputEvent.getPooled(
     eventTypes.beforeInput,
     targetInst,
     nativeEvent,
@@ -444,7 +444,7 @@ function extractBeforeInputEvent(
  * allowing us to share composition fallback code for both `beforeInput` and
  * `composition` event types.
  */
-var BeforeInputEventPlugin = {
+const BeforeInputEventPlugin = {
   eventTypes: eventTypes,
 
   extractEvents: function(

--- a/packages/react-dom/src/events/BrowserEventConstants.js
+++ b/packages/react-dom/src/events/BrowserEventConstants.js
@@ -14,7 +14,7 @@ import getVendorPrefixedEventName from './getVendorPrefixedEventName';
  * trap at a lower node than `document`), binding at `document` would
  * cause duplicate events so we don't include them here.
  */
-var topLevelTypes = {
+const topLevelTypes = {
   topAbort: 'abort',
   topAnimationEnd: getVendorPrefixedEventName('animationend') || 'animationend',
   topAnimationIteration:
@@ -90,7 +90,7 @@ var topLevelTypes = {
 
 export type TopLevelTypes = $Enum<typeof topLevelTypes>;
 
-var BrowserEventConstants = {
+const BrowserEventConstants = {
   topLevelTypes,
 };
 

--- a/packages/react-dom/src/events/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/ChangeEventPlugin.js
@@ -18,7 +18,7 @@ import isEventSupported from './isEventSupported';
 import {getNodeFromInstance} from '../client/ReactDOMComponentTree';
 import * as inputValueTracking from '../client/inputValueTracking';
 
-var eventTypes = {
+const eventTypes = {
   change: {
     phasedRegistrationNames: {
       bubbled: 'onChange',
@@ -38,7 +38,7 @@ var eventTypes = {
 };
 
 function createAndAccumulateChangeEvent(inst, nativeEvent, target) {
-  var event = SyntheticEvent.getPooled(
+  const event = SyntheticEvent.getPooled(
     eventTypes.change,
     inst,
     nativeEvent,
@@ -53,21 +53,21 @@ function createAndAccumulateChangeEvent(inst, nativeEvent, target) {
 /**
  * For IE shims
  */
-var activeElement = null;
-var activeElementInst = null;
+let activeElement = null;
+let activeElementInst = null;
 
 /**
  * SECTION: handle `change` event
  */
 function shouldUseChangeEvent(elem) {
-  var nodeName = elem.nodeName && elem.nodeName.toLowerCase();
+  const nodeName = elem.nodeName && elem.nodeName.toLowerCase();
   return (
     nodeName === 'select' || (nodeName === 'input' && elem.type === 'file')
   );
 }
 
 function manualDispatchChangeEvent(nativeEvent) {
-  var event = createAndAccumulateChangeEvent(
+  const event = createAndAccumulateChangeEvent(
     activeElementInst,
     nativeEvent,
     getEventTarget(nativeEvent),
@@ -108,7 +108,7 @@ function getTargetInstForChangeEvent(topLevelType, targetInst) {
 /**
  * SECTION: handle `input` event
  */
-var isInputEventSupported = false;
+let isInputEventSupported = false;
 if (ExecutionEnvironment.canUseDOM) {
   // IE9 claims to support the input event but fails to trigger it when
   // deleting text, so we ignore its input events.
@@ -201,7 +201,7 @@ function shouldUseClickEvent(elem) {
   // Use the `click` event to detect changes to checkbox and radio inputs.
   // This approach works across all browsers, whereas `change` does not fire
   // until `blur` in IE8.
-  var nodeName = elem.nodeName;
+  const {nodeName} = elem;
   return (
     nodeName &&
     nodeName.toLowerCase() === 'input' &&
@@ -251,7 +251,7 @@ function handleControlledInputBlur(inst, node) {
  * - textarea
  * - select
  */
-var ChangeEventPlugin = {
+const ChangeEventPlugin = {
   eventTypes: eventTypes,
 
   _isInputEventSupported: isInputEventSupported,
@@ -262,9 +262,9 @@ var ChangeEventPlugin = {
     nativeEvent,
     nativeEventTarget,
   ) {
-    var targetNode = targetInst ? getNodeFromInstance(targetInst) : window;
+    const targetNode = targetInst ? getNodeFromInstance(targetInst) : window;
 
-    var getTargetInstFunc, handleEventFunc;
+    let getTargetInstFunc, handleEventFunc;
     if (shouldUseChangeEvent(targetNode)) {
       getTargetInstFunc = getTargetInstForChangeEvent;
     } else if (isTextInputElement(targetNode)) {
@@ -279,9 +279,9 @@ var ChangeEventPlugin = {
     }
 
     if (getTargetInstFunc) {
-      var inst = getTargetInstFunc(topLevelType, targetInst);
+      const inst = getTargetInstFunc(topLevelType, targetInst);
       if (inst) {
-        var event = createAndAccumulateChangeEvent(
+        const event = createAndAccumulateChangeEvent(
           inst,
           nativeEvent,
           nativeEventTarget,

--- a/packages/react-dom/src/events/DOMEventPluginOrder.js
+++ b/packages/react-dom/src/events/DOMEventPluginOrder.js
@@ -14,7 +14,7 @@
  * `ResponderEventPlugin` must occur before `SimpleEventPlugin` so that
  * preventing default on events is convenient in `SimpleEventPlugin` handlers.
  */
-var DOMEventPluginOrder = [
+const DOMEventPluginOrder = [
   'ResponderEventPlugin',
   'SimpleEventPlugin',
   'TapEventPlugin',

--- a/packages/react-dom/src/events/EnterLeaveEventPlugin.js
+++ b/packages/react-dom/src/events/EnterLeaveEventPlugin.js
@@ -13,7 +13,7 @@ import {
   getNodeFromInstance,
 } from '../client/ReactDOMComponentTree';
 
-var eventTypes = {
+const eventTypes = {
   mouseEnter: {
     registrationName: 'onMouseEnter',
     dependencies: ['topMouseOut', 'topMouseOver'],
@@ -24,7 +24,7 @@ var eventTypes = {
   },
 };
 
-var EnterLeaveEventPlugin = {
+const EnterLeaveEventPlugin = {
   eventTypes: eventTypes,
 
   /**
@@ -51,13 +51,13 @@ var EnterLeaveEventPlugin = {
       return null;
     }
 
-    var win;
+    let win;
     if (nativeEventTarget.window === nativeEventTarget) {
       // `nativeEventTarget` is probably a window object.
       win = nativeEventTarget;
     } else {
       // TODO: Figure out why `ownerDocument` is sometimes undefined in IE8.
-      var doc = nativeEventTarget.ownerDocument;
+      const doc = nativeEventTarget.ownerDocument;
       if (doc) {
         win = doc.defaultView || doc.parentWindow;
       } else {
@@ -65,11 +65,11 @@ var EnterLeaveEventPlugin = {
       }
     }
 
-    var from;
-    var to;
+    let from;
+    let to;
     if (topLevelType === 'topMouseOut') {
       from = targetInst;
-      var related = nativeEvent.relatedTarget || nativeEvent.toElement;
+      const related = nativeEvent.relatedTarget || nativeEvent.toElement;
       to = related ? getClosestInstanceFromNode(related) : null;
     } else {
       // Moving to a node from outside the window.
@@ -82,10 +82,10 @@ var EnterLeaveEventPlugin = {
       return null;
     }
 
-    var fromNode = from == null ? win : getNodeFromInstance(from);
-    var toNode = to == null ? win : getNodeFromInstance(to);
+    const fromNode = from == null ? win : getNodeFromInstance(from);
+    const toNode = to == null ? win : getNodeFromInstance(to);
 
-    var leave = SyntheticMouseEvent.getPooled(
+    const leave = SyntheticMouseEvent.getPooled(
       eventTypes.mouseLeave,
       from,
       nativeEvent,
@@ -95,7 +95,7 @@ var EnterLeaveEventPlugin = {
     leave.target = fromNode;
     leave.relatedTarget = toNode;
 
-    var enter = SyntheticMouseEvent.getPooled(
+    const enter = SyntheticMouseEvent.getPooled(
       eventTypes.mouseEnter,
       to,
       nativeEvent,

--- a/packages/react-dom/src/events/FallbackCompositionState.js
+++ b/packages/react-dom/src/events/FallbackCompositionState.js
@@ -18,7 +18,7 @@ import getTextContentAccessor from '../client/getTextContentAccessor';
  *
  *
  */
-var compositionState = {
+const compositionState = {
   _root: null,
   _startText: null,
   _fallbackText: null,
@@ -41,12 +41,12 @@ export function getData() {
     return compositionState._fallbackText;
   }
 
-  var start;
-  var startValue = compositionState._startText;
-  var startLength = startValue.length;
-  var end;
-  var endValue = getText();
-  var endLength = endValue.length;
+  let start, end;
+
+  const startValue = compositionState._startText;
+  const startLength = startValue.length;
+  const endValue = getText();
+  const endLength = endValue.length;
 
   for (start = 0; start < startLength; start++) {
     if (startValue[start] !== endValue[start]) {
@@ -54,14 +54,14 @@ export function getData() {
     }
   }
 
-  var minEnd = startLength - start;
+  const minEnd = startLength - start;
   for (end = 1; end <= minEnd; end++) {
     if (startValue[startLength - end] !== endValue[endLength - end]) {
       break;
     }
   }
 
-  var sliceTail = end > 1 ? 1 - end : undefined;
+  const sliceTail = end > 1 ? 1 - end : undefined;
   compositionState._fallbackText = endValue.slice(start, sliceTail);
   return compositionState._fallbackText;
 }

--- a/packages/react-dom/src/events/getEventCharCode.js
+++ b/packages/react-dom/src/events/getEventCharCode.js
@@ -16,8 +16,8 @@
  * @return {number} Normalized `charCode` property.
  */
 function getEventCharCode(nativeEvent) {
-  var charCode;
-  var keyCode = nativeEvent.keyCode;
+  let charCode;
+  const {keyCode} = nativeEvent;
 
   if ('charCode' in nativeEvent) {
     charCode = nativeEvent.charCode;

--- a/packages/react-dom/src/events/getEventKey.js
+++ b/packages/react-dom/src/events/getEventKey.js
@@ -13,7 +13,7 @@ import getEventCharCode from './getEventCharCode';
  * Normalization of deprecated HTML5 `key` values
  * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
  */
-var normalizeKey = {
+const normalizeKey = {
   Esc: 'Escape',
   Spacebar: ' ',
   Left: 'ArrowLeft',
@@ -33,7 +33,7 @@ var normalizeKey = {
  * Only special keys supported, all others depend on keyboard layout or browser
  * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
  */
-var translateToKey = {
+const translateToKey = {
   '8': 'Backspace',
   '9': 'Tab',
   '12': 'Clear',
@@ -83,7 +83,7 @@ function getEventKey(nativeEvent: KeyboardEvent): string {
 
     // FireFox implements `key` but returns `MozPrintableKey` for all
     // printable characters (normalized to `Unidentified`), ignore it.
-    var key = normalizeKey[nativeEvent.key] || nativeEvent.key;
+    const key = normalizeKey[nativeEvent.key] || nativeEvent.key;
     if (key !== 'Unidentified') {
       return key;
     }
@@ -91,7 +91,7 @@ function getEventKey(nativeEvent: KeyboardEvent): string {
 
   // Browser does not implement `key`, polyfill as much of it as we can.
   if (nativeEvent.type === 'keypress') {
-    var charCode = getEventCharCode(nativeEvent);
+    const charCode = getEventCharCode(nativeEvent);
 
     // The enter-key is technically both printable and non-printable and can
     // thus be captured by `keypress`, no other non-printable key should.


### PR DESCRIPTION
* Convert BeforeInputEventPlugin to const/let
* Convert BrowserEventConstats to const/let
* Convert ChangeEventPlugin to const/let
* Convert DOMEventPluginOrder to const/let
* Convert EnterLeaveEventPlugin to const/let
* Convert FallbackCompositionState to const/let
* Convert getEventCharCode to const/let
* Convert getEventKey to const/let
