### PR TITLE
remove reconcileChildren use reconcileChildrenAtExpirationTime directly

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -98,16 +98,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     memoizeState,
   );
 
-  // TODO: Remove this and use reconcileChildrenAtExpirationTime directly.
-  function reconcileChildren(current, workInProgress, nextChildren) {
-    reconcileChildrenAtExpirationTime(
-      current,
-      workInProgress,
-      nextChildren,
-      workInProgress.expirationTime,
-    );
-  }
-
   function reconcileChildrenAtExpirationTime(
     current,
     workInProgress,
@@ -155,7 +145,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     ) {
       return bailoutOnAlreadyFinishedWork(current, workInProgress);
     }
-    reconcileChildren(current, workInProgress, nextChildren);
+    reconcileChildrenAtExpirationTime(
+      current,
+      workInProgress,
+      nextChildren,
+      workInProgress.expirationTime,
+    );
     memoizeProps(workInProgress, nextChildren);
     return workInProgress.child;
   }
@@ -202,7 +197,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
     // React DevTools reads this flag.
     workInProgress.effectTag |= PerformedWork;
-    reconcileChildren(current, workInProgress, nextChildren);
+    reconcileChildrenAtExpirationTime(
+      current,
+      workInProgress,
+      nextChildren,
+      workInProgress.expirationTime,
+    );
     memoizeProps(workInProgress, nextProps);
     return workInProgress.child;
   }
@@ -282,7 +282,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
     // React DevTools reads this flag.
     workInProgress.effectTag |= PerformedWork;
-    reconcileChildren(current, workInProgress, nextChildren);
+    reconcileChildrenAtExpirationTime(
+      current,
+      workInProgress,
+      nextChildren,
+      workInProgress.expirationTime,
+    );
     // Memoize props and state using the values we just used to render.
     // TODO: Restructure so we never read values from the instance.
     memoizeState(workInProgress, instance.state);
@@ -361,7 +366,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         // Otherwise reset hydration state in case we aborted and resumed another
         // root.
         resetHydrationState();
-        reconcileChildren(current, workInProgress, element);
+        reconcileChildrenAtExpirationTime(
+          current,
+          workInProgress,
+          element,
+          workInProgress.expirationTime,
+        );
       }
       memoizeState(workInProgress, state);
       return workInProgress.child;
@@ -427,7 +437,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       return null;
     }
 
-    reconcileChildren(current, workInProgress, nextChildren);
+    reconcileChildrenAtExpirationTime(
+      current,
+      workInProgress,
+      nextChildren,
+      workInProgress.expirationTime,
+    );
     memoizeProps(workInProgress, nextProps);
     return workInProgress.child;
   }
@@ -534,7 +549,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           }
         }
       }
-      reconcileChildren(current, workInProgress, value);
+      reconcileChildrenAtExpirationTime(
+        current,
+        workInProgress,
+        value,
+        workInProgress.expirationTime,
+      );
       memoizeProps(workInProgress, props);
       return workInProgress.child;
     }
@@ -625,7 +645,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       );
       memoizeProps(workInProgress, nextChildren);
     } else {
-      reconcileChildren(current, workInProgress, nextChildren);
+      reconcileChildrenAtExpirationTime(
+        current,
+        workInProgress,
+        nextChildren,
+        workInProgress.expirationTime,
+      );
       memoizeProps(workInProgress, nextChildren);
     }
     return workInProgress.child;


### PR DESCRIPTION
one TODO item in the source code is: remove `reconcileChildren` use `reconcileChildrenAtExpirationTime` directly. Please have a review if I have done this right. 

Thanks,
Vincent