### PR TITLE
[WIP] Fix for fiber root scheduling memory leak

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1168,6 +1168,27 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     return scheduleWorkImpl(fiber, expirationTime, false);
   }
 
+  function checkRootNeedsClearing(
+    root: FiberRoot,
+    fiber: Fiber,
+    expirationTime: ExpirationTime,
+  ) {
+    if (
+      !isWorking &&
+      root === nextRoot &&
+      expirationTime < nextRenderExpirationTime
+    ) {
+      // Restart the root from the top.
+      if (nextUnitOfWork !== null) {
+        // This is an interruption. (Used for performance tracking.)
+        interruptedBy = fiber;
+      }
+      nextRoot = null;
+      nextUnitOfWork = null;
+      nextRenderExpirationTime = NoWork;
+    }
+  }
+
   function scheduleWorkImpl(
     fiber: Fiber,
     expirationTime: ExpirationTime,
@@ -1203,27 +1224,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       if (node.return === null) {
         if (node.tag === HostRoot) {
           const root: FiberRoot = (node.stateNode: any);
-          if (
-            !isWorking &&
-            root === nextRoot &&
-            expirationTime < nextRenderExpirationTime
-          ) {
-            // Restart the root from the top.
-            if (nextUnitOfWork !== null) {
-              // This is an interruption. (Used for performance tracking.)
-              interruptedBy = fiber;
-            }
-            nextRoot = null;
-            nextUnitOfWork = null;
-            nextRenderExpirationTime = NoWork;
-          }
+
+          checkRootNeedsClearing(root, fiber, expirationTime);
           requestWork(root, expirationTime);
-          if (
-            !isWorking &&
-            root === nextRoot &&
-            expirationTime < nextRenderExpirationTime
-          ) {
-          }
+          checkRootNeedsClearing(root, fiber, expirationTime);
         } else {
           if (__DEV__) {
             if (!isErrorRecovery && fiber.tag === ClassComponent) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1218,6 +1218,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
             nextRenderExpirationTime = NoWork;
           }
           requestWork(root, expirationTime);
+          if (
+            !isWorking &&
+            root === nextRoot &&
+            expirationTime < nextRenderExpirationTime
+          ) {
+          }
         } else {
           if (__DEV__) {
             if (!isErrorRecovery && fiber.tag === ClassComponent) {


### PR DESCRIPTION
**Not to be merged**

After some investigation work for a memory leak on React Native, we found that `nextRoot` was never set to `null` and left in that state upon the view fulling being unmounted. I believe that is has to do with the fact that we set `nextRoot` and `nextUnitOfWork` to `null`, then immediately call `requestWork()` which sets them back again.

This results in a memory leak as the node tree of `nextRoot` never gets garbage collected.

This is more of a temporary research fix, rather than an explicit fix. I'm sure @acdlite will have a concrete fix based from this.