### PR TITLE
Don't reset error codes on CI build

### DIFF
--- a/scripts/circleci/build.sh
+++ b/scripts/circleci/build.sh
@@ -3,6 +3,10 @@
 set -e		
 
 yarn build --extract-errors
+# Note: since we run the full build including extracting error codes,
+# it is important that we *don't* reset the change to `scripts/error-codes/codes.json`.
+# When production bundle tests run later, it needs to be available.
+# See https://github.com/facebook/react/pull/11655.
 
 # Do a sanity check on bundles
 node ./scripts/rollup/validate/index

--- a/scripts/circleci/build.sh
+++ b/scripts/circleci/build.sh
@@ -3,7 +3,6 @@
 set -e		
 
 yarn build --extract-errors
-git checkout -- scripts/error-codes/codes.json
 
 # Do a sanity check on bundles
 node ./scripts/rollup/validate/index


### PR DESCRIPTION
I think this was added in #8486 but if I'm not mistaken it causes issues after my changes in #11633.

Specifically, prod tests *on bundles* now run after build and actually *depend* on the up-to-date error code file being available. Otherwise any newly added invariants can't be ["decoded"](https://github.com/facebook/react/blob/f0ba6bbf200e301e97c3170f42f12bd2d20fd967/scripts/jest/setupTests.js#L57-L75), as they're not in the committed error code file.

I noticed this in https://github.com/facebook/react/pull/11652. Will see if the same fix there works. If it does, I'll merge this.