### PR TITLE
Lint untracked files with `yarn linc`

### DIFF
--- a/scripts/prettier/index.js
+++ b/scripts/prettier/index.js
@@ -11,9 +11,9 @@
 
 const chalk = require('chalk');
 const glob = require('glob');
-const execFileSync = require('child_process').execFileSync;
 const prettier = require('prettier');
 const fs = require('fs');
+const listChangedFiles = require('../shared/listChangedFiles');
 
 const mode = process.argv[2] || 'check';
 const shouldWrite = mode === 'write' || mode === 'write-changed';
@@ -56,32 +56,7 @@ const config = {
   },
 };
 
-function exec(command, args) {
-  console.log('> ' + [command].concat(args).join(' '));
-  var options = {
-    cwd: process.cwd(),
-    env: process.env,
-    stdio: 'pipe',
-    encoding: 'utf-8',
-  };
-  return execFileSync(command, args, options);
-}
-
-var mergeBase = exec('git', ['merge-base', 'HEAD', 'master']).trim();
-var changedFiles = new Set([
-  ...exec('git', [
-    'diff',
-    '-z',
-    '--name-only',
-    '--diff-filter=ACMRTUB',
-    mergeBase,
-  ]).match(/[^\0]+/g),
-  ...exec('git', ['ls-files', '--others', '--exclude-standard'])
-    .trim()
-    .toString()
-    .split('\n'),
-]);
-
+var changedFiles = listChangedFiles();
 let didWarn = false;
 let didError = false;
 Object.keys(config).forEach(key => {

--- a/scripts/prettier/index.js
+++ b/scripts/prettier/index.js
@@ -68,15 +68,19 @@ function exec(command, args) {
 }
 
 var mergeBase = exec('git', ['merge-base', 'HEAD', 'master']).trim();
-var changedFiles = new Set(
-  exec('git', [
+var changedFiles = new Set([
+  ...exec('git', [
     'diff',
     '-z',
     '--name-only',
     '--diff-filter=ACMRTUB',
     mergeBase,
-  ]).match(/[^\0]+/g)
-);
+  ]).match(/[^\0]+/g),
+  ...exec('git', ['ls-files', '--others', '--exclude-standard'])
+    .trim()
+    .toString()
+    .split('\n'),
+]);
 
 let didWarn = false;
 let didError = false;

--- a/scripts/shared/listChangedFiles.js
+++ b/scripts/shared/listChangedFiles.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const execFileSync = require('child_process').execFileSync;
+
+const exec = (command, args) => {
+  console.log('> ' + [command].concat(args).join(' '));
+  var options = {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: 'pipe',
+    encoding: 'utf-8',
+  };
+  return execFileSync(command, args, options);
+};
+const execGitCmd = args =>
+  exec('git', args)
+    .trim()
+    .toString()
+    .split('\n');
+
+const mergeBase = execGitCmd(['merge-base', 'HEAD', 'master']);
+
+const listChangedFiles = () => {
+  return new Set([
+    ...execGitCmd(['diff', '--name-only', '--diff-filter=ACMRTUB', mergeBase]),
+    ...execGitCmd(['ls-files', '--others', '--exclude-standard']),
+  ]);
+};
+
+module.exports = listChangedFiles;

--- a/scripts/tasks/linc.js
+++ b/scripts/tasks/linc.js
@@ -13,17 +13,20 @@ const mergeBase = execFileSync('git', ['merge-base', 'HEAD', 'master'], {
   stdio: 'pipe',
   encoding: 'utf-8',
 }).trim();
-const changedFiles = execFileSync(
-  'git',
-  ['diff', '--name-only', '--diff-filter=ACMRTUB', mergeBase],
-  {
+
+const execGitCmd = args =>
+  execFileSync('git', args, {
     stdio: 'pipe',
     encoding: 'utf-8',
-  }
-)
-  .trim()
-  .toString()
-  .split('\n');
+  })
+    .trim()
+    .toString()
+    .split('\n');
+
+const changedFiles = [
+  ...execGitCmd(['diff', '--name-only', '--diff-filter=ACMRTUB', mergeBase]),
+  ...execGitCmd(['ls-files', '--others', '--exclude-standard']),
+];
 const jsFiles = changedFiles.filter(file => file.match(/.js$/g));
 
 const report = lintOnFiles(jsFiles);

--- a/scripts/tasks/linc.js
+++ b/scripts/tasks/linc.js
@@ -8,25 +8,9 @@
 'use strict';
 
 const lintOnFiles = require('../eslint');
-const execFileSync = require('child_process').execFileSync;
-const mergeBase = execFileSync('git', ['merge-base', 'HEAD', 'master'], {
-  stdio: 'pipe',
-  encoding: 'utf-8',
-}).trim();
+const listChangedFiles = require('../shared/listChangedFiles');
 
-const execGitCmd = args =>
-  execFileSync('git', args, {
-    stdio: 'pipe',
-    encoding: 'utf-8',
-  })
-    .trim()
-    .toString()
-    .split('\n');
-
-const changedFiles = [
-  ...execGitCmd(['diff', '--name-only', '--diff-filter=ACMRTUB', mergeBase]),
-  ...execGitCmd(['ls-files', '--others', '--exclude-standard']),
-];
+const changedFiles = [...listChangedFiles()];
 const jsFiles = changedFiles.filter(file => file.match(/.js$/g));
 
 const report = lintOnFiles(jsFiles);


### PR DESCRIPTION
This PR refers to #11646 

Untracked git files will also be linted by `yarn linc`, except for those ignored by `.gitignore`.
