### PR TITLE
Throw if `document` is missing by the time invokeGuardedCallbackDev runs

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -389,7 +389,7 @@ describe('ReactDOM', () => {
     );
     try {
       // Emulate jsdom environment cleanup.
-      // This is rouhly what happens if the test finished and then
+      // This is roughly what happens if the test finished and then
       // an asynchronous callback tried to setState() after this.
       delete global.document;
       const fn = () => instance.setState({x: 2});

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -372,4 +372,45 @@ describe('ReactDOM', () => {
       delete global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     }
   });
+
+  it('warns in DEV if jsdom is destroyed by the time setState() is called', () => {
+    spyOnDev(console, 'error');
+    class App extends React.Component {
+      state = {x: 1};
+      render() {
+        return <div />;
+      }
+    }
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(<App />, container);
+    const documentDescriptor = Object.getOwnPropertyDescriptor(
+      global,
+      'document',
+    );
+    try {
+      // Emulate jsdom environment cleanup.
+      // This is rouhly what happens if the test finished and then
+      // an asynchronous callback tried to setState() after this.
+      delete global.document;
+      const fn = () => instance.setState({x: 2});
+      if (__DEV__) {
+        expect(fn).toThrow('document is not defined');
+        expect(console.error.calls.count()).toBe(1);
+        expect(console.error.calls.argsFor(0)[0]).toContain(
+          'The `document` global was defined when React was initialized, but is not ' +
+            'defined anymore. This can happen in a test environment if a component ' +
+            'schedules an update from an asynchronous callback, but the test has already ' +
+            'finished running. To solve this, you can either unmount the component at ' +
+            'the end of your test (and ensure that any asynchronous operations get ' +
+            'canceled in `componentWillUnmount`), or you can change the test itself ' +
+            'to be asynchronous.',
+        );
+      } else {
+        expect(fn).not.toThrow();
+      }
+    } finally {
+      // Don't break other tests.
+      Object.defineProperty(global, 'document', documentDescriptor);
+    }
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -373,7 +373,7 @@ describe('ReactDOM', () => {
     }
   });
 
-  it('warns in DEV if jsdom is destroyed by the time setState() is called', () => {
+  it('throws in DEV if jsdom is destroyed by the time setState() is called', () => {
     spyOnDev(console, 'error');
     class App extends React.Component {
       state = {x: 1};
@@ -394,9 +394,7 @@ describe('ReactDOM', () => {
       delete global.document;
       const fn = () => instance.setState({x: 2});
       if (__DEV__) {
-        expect(fn).toThrow('document is not defined');
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
+        expect(fn).toThrow(
           'The `document` global was defined when React was initialized, but is not ' +
             'defined anymore. This can happen in a test environment if a component ' +
             'schedules an update from an asynchronous callback, but the test has already ' +

--- a/packages/shared/ReactErrorUtils.js
+++ b/packages/shared/ReactErrorUtils.js
@@ -8,7 +8,6 @@
  */
 
 import invariant from 'fbjs/lib/invariant';
-import warning from 'fbjs/lib/warning';
 
 const ReactErrorUtils = {
   // Used by Fiber to simulate a try-catch.
@@ -168,9 +167,11 @@ if (__DEV__) {
       e,
       f,
     ) {
-      // If document doesn't exist we know for sure we will crash in this method later.
-      // So we show a warning explaining a potential cause.
-      warning(
+      // If document doesn't exist we know for sure we will crash in this method
+      // when we call document.createEvent(). However this can cause confusing
+      // errors: https://github.com/facebookincubator/create-react-app/issues/3482
+      // So we preemptively throw with a better message instead.
+      invariant(
         typeof document !== 'undefined',
         'The `document` global was defined when React was initialized, but is not ' +
           'defined anymore. This can happen in a test environment if a component ' +

--- a/packages/shared/ReactErrorUtils.js
+++ b/packages/shared/ReactErrorUtils.js
@@ -168,6 +168,8 @@ if (__DEV__) {
       e,
       f,
     ) {
+      // If document doesn't exist we know for sure we will crash in this method later.
+      // So we show a warning explaining a potential cause.
       warning(
         typeof document !== 'undefined',
         'The `document` global was defined when React was initialized, but is not ' +

--- a/packages/shared/ReactErrorUtils.js
+++ b/packages/shared/ReactErrorUtils.js
@@ -181,6 +181,8 @@ if (__DEV__) {
           'canceled in `componentWillUnmount`), or you can change the test itself ' +
           'to be asynchronous.',
       );
+      const evt = document.createEvent('Event');
+
       // Keeps track of whether the user-provided callback threw an error. We
       // set this to true at the beginning, then set it to false right after
       // calling the function. If the function errors, `didError` will never be
@@ -236,7 +238,6 @@ if (__DEV__) {
 
       // Synchronously dispatch our fake event. If the user-provided function
       // errors, it will trigger our global error handler.
-      const evt = document.createEvent('Event');
       evt.initEvent(evtType, false, false);
       fakeNode.dispatchEvent(evt);
 

--- a/packages/shared/ReactErrorUtils.js
+++ b/packages/shared/ReactErrorUtils.js
@@ -8,6 +8,7 @@
  */
 
 import invariant from 'fbjs/lib/invariant';
+import warning from 'fbjs/lib/warning';
 
 const ReactErrorUtils = {
   // Used by Fiber to simulate a try-catch.
@@ -167,6 +168,16 @@ if (__DEV__) {
       e,
       f,
     ) {
+      warning(
+        typeof document !== 'undefined',
+        'The `document` global was defined when React was initialized, but is not ' +
+          'defined anymore. This can happen in a test environment if a component ' +
+          'schedules an update from an asynchronous callback, but the test has already ' +
+          'finished running. To solve this, you can either unmount the component at ' +
+          'the end of your test (and ensure that any asynchronous operations get ' +
+          'canceled in `componentWillUnmount`), or you can change the test itself ' +
+          'to be asynchronous.',
+      );
       // Keeps track of whether the user-provided callback threw an error. We
       // set this to true at the beginning, then set it to false right after
       // calling the function. If the function errors, `didError` will never be


### PR DESCRIPTION
The case described in https://github.com/facebookincubator/create-react-app/issues/3482 is pretty unintuitive.

This attempts to provide a better warning message when this happens. I opted not to modify the behavior since it's going to be pretty fragile and will probably break down the line anyway. Just printing a warning early.