### PR TITLE
Blacklist spyOn(). Add explicit spyOnProd() and spyOnDevAndProd()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,5 +60,7 @@ module.exports = {
 
   globals: {
     spyOnDev: true,
+    spyOnDevAndProd: true,
+    spyOnProd: true,
   },
 };

--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -122,7 +122,7 @@ describe('DOMPropertyOperations', () => {
         <input type="radio" value="" onChange={function() {}} />,
         container,
       );
-      spyOn(container.firstChild, 'setAttribute');
+      spyOnDevAndProd(container.firstChild, 'setAttribute');
       ReactDOM.render(
         <input type="radio" value={0} onChange={function() {}} />,
         container,
@@ -133,7 +133,7 @@ describe('DOMPropertyOperations', () => {
     it('should always assign the value attribute for non-inputs', function() {
       var container = document.createElement('div');
       ReactDOM.render(<progress />, container);
-      spyOn(container.firstChild, 'setAttribute');
+      spyOnDevAndProd(container.firstChild, 'setAttribute');
       ReactDOM.render(<progress value={30} />, container);
       ReactDOM.render(<progress value="30" />, container);
       expect(container.firstChild.setAttribute.calls.count()).toBe(2);

--- a/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.internal.js
@@ -375,14 +375,14 @@ describe('ReactBrowserEventEmitter', () => {
   });
 
   it('should listen to events only once', () => {
-    spyOn(EventTarget.prototype, 'addEventListener');
+    spyOnDevAndProd(EventTarget.prototype, 'addEventListener');
     ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
     ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
     expect(EventTarget.prototype.addEventListener.calls.count()).toBe(1);
   });
 
   it('should work with event plugins without dependencies', () => {
-    spyOn(EventTarget.prototype, 'addEventListener');
+    spyOnDevAndProd(EventTarget.prototype, 'addEventListener');
 
     ReactBrowserEventEmitter.listenTo(ON_CLICK_KEY, document);
 
@@ -392,7 +392,7 @@ describe('ReactBrowserEventEmitter', () => {
   });
 
   it('should work with event plugins with dependencies', () => {
-    spyOn(EventTarget.prototype, 'addEventListener');
+    spyOnDevAndProd(EventTarget.prototype, 'addEventListener');
 
     ReactBrowserEventEmitter.listenTo(ON_CHANGE_KEY, document);
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -877,7 +877,7 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should work error event on <source> element', () => {
-      spyOn(console, 'log');
+      spyOnDevAndProd(console, 'log');
       var container = document.createElement('div');
       ReactDOM.render(
         <video>
@@ -1239,7 +1239,7 @@ describe('ReactDOMComponent', () => {
 
     it('should support custom elements which extend native elements', () => {
       var container = document.createElement('div');
-      spyOn(document, 'createElement').and.callThrough();
+      spyOnDevAndProd(document, 'createElement').and.callThrough();
       ReactDOM.render(<div is="custom-div" />, container);
       expect(document.createElement).toHaveBeenCalledWith('div', {
         is: 'custom-div',
@@ -1247,7 +1247,7 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should work load and error events on <image> element in SVG', () => {
-      spyOn(console, 'log');
+      spyOnDevAndProd(console, 'log');
       var container = document.createElement('div');
       ReactDOM.render(
         <svg>

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -1149,7 +1149,7 @@ describe('ReactDOMFiber', () => {
     var actualDocument;
     var textNode;
 
-    spyOn(iframeContainer, 'appendChild').and.callFake(node => {
+    spyOnDevAndProd(iframeContainer, 'appendChild').and.callFake(node => {
       actualDocument = node.ownerDocument;
       textNode = node;
     });

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -1247,7 +1247,7 @@ describe('ReactDOMInput', () => {
   it('sets type, step, min, max before value always', () => {
     var log = [];
     var originalCreateElement = document.createElement;
-    spyOn(document, 'createElement').and.callFake(function(type) {
+    spyOnDevAndProd(document, 'createElement').and.callFake(function(type) {
       var el = originalCreateElement.apply(this, arguments);
       if (type === 'input') {
         Object.defineProperty(el, 'value', {
@@ -1256,7 +1256,7 @@ describe('ReactDOMInput', () => {
             log.push('set value');
           },
         });
-        spyOn(el, 'setAttribute').and.callFake(function(name, value) {
+        spyOnDevAndProd(el, 'setAttribute').and.callFake(function(name, value) {
           log.push('set ' + name);
         });
       }
@@ -1311,7 +1311,7 @@ describe('ReactDOMInput', () => {
 
     var log = [];
     var originalCreateElement = document.createElement;
-    spyOn(document, 'createElement').and.callFake(function(type) {
+    spyOnDevAndProd(document, 'createElement').and.callFake(function(type) {
       var el = originalCreateElement.apply(this, arguments);
       if (type === 'input') {
         Object.defineProperty(el, 'value', {
@@ -1319,7 +1319,7 @@ describe('ReactDOMInput', () => {
             log.push(`node.value = ${strify(val)}`);
           },
         });
-        spyOn(el, 'setAttribute').and.callFake(function(name, val) {
+        spyOnDevAndProd(el, 'setAttribute').and.callFake(function(name, val) {
           log.push(`node.setAttribute(${strify(name)}, ${strify(val)})`);
         });
       }

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -270,7 +270,7 @@ describe('ReactTestUtils', () => {
           e.persist();
         },
       };
-      spyOn(obj, 'handler').and.callThrough();
+      spyOnDevAndProd(obj, 'handler').and.callThrough();
       const container = document.createElement('div');
       const instance = ReactDOM.render(
         <input type="text" onChange={obj.handler} />,
@@ -306,7 +306,7 @@ describe('ReactTestUtils', () => {
           e.persist();
         },
       };
-      spyOn(obj, 'handler').and.callThrough();
+      spyOnDevAndProd(obj, 'handler').and.callThrough();
       const container = document.createElement('div');
       const instance = ReactDOM.render(
         <SomeComponent handleChange={obj.handler} />,

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
@@ -24,8 +24,7 @@ describe('ReactIncrementalErrorLogging', () => {
   }
 
   it('should log errors that occur during the begin phase', () => {
-    // Intentionally spy in production too.
-    spyOn(console, 'error');
+    spyOnDevAndProd(console, 'error');
 
     class ErrorThrowingComponent extends React.Component {
       componentWillMount() {
@@ -70,8 +69,7 @@ describe('ReactIncrementalErrorLogging', () => {
   });
 
   it('should log errors that occur during the commit phase', () => {
-    // Intentionally spy in production too.
-    spyOn(console, 'error');
+    spyOnDevAndProd(console, 'error');
 
     class ErrorThrowingComponent extends React.Component {
       componentDidMount() {
@@ -121,8 +119,7 @@ describe('ReactIncrementalErrorLogging', () => {
     try {
       React = require('react');
       ReactNoop = require('react-noop-renderer');
-      // Intentionally spy in production too.
-      spyOn(console, 'error');
+      spyOnDevAndProd(console, 'error');
 
       class ErrorThrowingComponent extends React.Component {
         render() {
@@ -169,8 +166,7 @@ describe('ReactIncrementalErrorLogging', () => {
   });
 
   it('should relay info about error boundary and retry attempts if applicable', () => {
-    // Intentionally spy in production too.
-    spyOn(console, 'error');
+    spyOnDevAndProd(console, 'error');
 
     class ParentComponent extends React.Component {
       render() {

--- a/packages/react/src/__tests__/ReactElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.js
@@ -449,7 +449,7 @@ describe('ReactElementValidator', () => {
   });
 
   it('should warn if component declares PropTypes instead of propTypes', () => {
-    spyOn(console, 'error');
+    spyOnDevAndProd(console, 'error');
     class MisspelledPropTypesComponent extends React.Component {
       static PropTypes = {
         prop: PropTypes.string,

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -404,7 +404,7 @@ describe('ReactJSXElementValidator', () => {
   });
 
   it('should warn if component declares PropTypes instead of propTypes', () => {
-    spyOn(console, 'error');
+    spyOnDevAndProd(console, 'error');
     class MisspelledPropTypesComponent extends React.Component {
       render() {
         return <span>{this.props.prop}</span>;

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -21,7 +21,7 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
   // It's too easy to accidentally use the more familiar spyOn() helper though,
   // So we disable it entirely.
   // Spying on both dev and prod will require using both spyOnDev() and spyOnProd().
-  global.spyOn = function spyOn() {
+  global.spyOn = function() {
     throw new Error(
       'Do not use spyOn(). ' +
         'It can accidentally hide unexpected errors in production builds. ' +

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -13,9 +13,31 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
   // https://github.com/facebook/jest/blob/v20.0.4/packages/jest-matchers/src/spyMatchers.js#L160
   const isSpy = spy => spy.calls && typeof spy.calls.count === 'function';
 
-  // Dev-only spyOn should be ignored in production runs.
-  global.spyOnDev =
-    process.env.NODE_ENV === 'production' ? () => {} : global.spyOn;
+  const spyOn = global.spyOn;
+  const noop = function() {};
+
+  // Spying on console methods in production builds can mask errors.
+  // This is why we added an explicit spyOnDev() helper.
+  // It's too easy to accidentally use the more familiar spyOn() helper though,
+  // So we disable it entirely.
+  // Spying on both dev and prod will require using both spyOnDev() and spyOnProd().
+  global.spyOn = function spyOn() {
+    throw new Error(
+      'Do not use spyOn(). ' +
+        'It can accidentally hide unexpected errors in production builds. ' +
+        'Use spyOnDev(), spyOnProd(), or spyOnDevAndProd() instead.'
+    );
+  };
+
+  if (process.env.NODE_ENV === 'production') {
+    global.spyOnDev = noop;
+    global.spyOnProd = spyOn;
+    global.spyOnDevAndProd = spyOn;
+  } else {
+    global.spyOnDev = spyOn;
+    global.spyOnProd = noop;
+    global.spyOnDevAndProd = spyOn;
+  }
 
   ['error', 'warn'].forEach(methodName => {
     var oldMethod = console[methodName];
@@ -33,19 +55,17 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
     env.afterEach(() => {
       if (console[methodName] !== newMethod && !isSpy(console[methodName])) {
         throw new Error(
-          'Test did not tear down console.' + methodName + ' mock properly.'
+          `Test did not tear down console.${methodName} mock properly.`
         );
       }
       if (console[methodName].__callCount !== 0) {
         throw new Error(
-          'Expected test not to call console.' +
-            methodName +
-            '(). ' +
+          `Expected test not to call console.${methodName}(). ` +
             'If the warning is expected, mock it out using ' +
-            "spyOn(console, '" +
-            methodName +
-            "') and test that the " +
-            'warning occurs.'
+            `spyOnDev(console, '${methodName}') or spyOnProd(console, '${
+              methodName
+            }'), ` +
+            'and test that the warning occurs.'
         );
       }
     });

--- a/scripts/jest/spec-equivalence-reporter/setupTests.js
+++ b/scripts/jest/spec-equivalence-reporter/setupTests.js
@@ -27,7 +27,7 @@ global.spyOn = function() {
   throw new Error(
     'Do not use spyOn(). ' +
       'It can accidentally hide unexpected errors in production builds. ' +
-      'Use spyOnDev() and/or spyOnProd() instead.'
+      'Use spyOnDev(), spyOnProd(), or spyOnDevAndProd() instead.'
   );
 };
 

--- a/scripts/jest/spec-equivalence-reporter/setupTests.js
+++ b/scripts/jest/spec-equivalence-reporter/setupTests.js
@@ -16,8 +16,31 @@ global.expect = function() {
   return expect.apply(this, arguments);
 };
 
+const spyOn = global.spyOn;
+
+// Spying on console methods in production builds can mask errors.
+// This is why we added an explicit spyOnDev() helper.
+// It's too easy to accidentally use the more familiar spyOn() helper though,
+// So we disable it entirely.
+// Spying on both dev and prod will require using both spyOnDev() and spyOnProd().
+global.spyOn = function() {
+  throw new Error(
+    'Do not use spyOn(). ' +
+      'It can accidentally hide unexpected errors in production builds. ' +
+      'Use spyOnDev() and/or spyOnProd() instead.'
+  );
+};
+
 global.spyOnDev = function(...args) {
   if (__DEV__) {
+    return spyOn(...args);
+  }
+};
+
+global.spyOnDevAndProd = spyOn;
+
+global.spyOnProd = function(...args) {
+  if (!__DEV__) {
     return spyOn(...args);
   }
 };

--- a/scripts/jest/typescript/jest.d.ts
+++ b/scripts/jest/typescript/jest.d.ts
@@ -11,8 +11,9 @@ declare var it: {
 declare function expect(val: any): Expect;
 declare var jest: Jest;
 declare function pit(name: string, fn: any): void;
-declare function spyOn(obj: any, key: string): any;
 declare function spyOnDev(obj: any, key: string): any;
+declare function spyOnDevAndProd(obj: any, key: string): any;
+declare function spyOnProd(obj: any, key: string): any;
 declare function xdescribe(name: string, fn: any): void;
 declare function xit(name: string, fn: any): void;
 


### PR DESCRIPTION
Seems like it's too easy to use `spyOn` when we shouldn't. Let's blacklist it in favor of explicitly-scoped spy methods.

There is a comment in `scripts/jest/setupTests.js` that I don't understand. It says:
> // TODO: Stop using spyOn in all the test since that seem deprecated.

Why do we think `spyOn` is deprecated? The official Jest docs list [`jest.spyOn` as being available for 19.0.0+](https://facebook.github.io/jest/docs/en/jest-object.html). Is this comment maybe referring to the call-through behavioral differences or something?

I also updated `scripts/jest/spec-equivalence-reporter/setupTests.js` and `scripts/jest/typescript/jest.d.ts` although neither is necessary at this time.