### PR TITLE
Added ReactFeatureFlags shim for React Native

### DIFF
--- a/scripts/rollup/shims/react-native/ReactFeatureFlags.js
+++ b/scripts/rollup/shims/react-native/ReactFeatureFlags.js
@@ -1,14 +1,10 @@
 /**
- * Copyright 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  *
  * @providesModule ReactFeatureFlags
- * @flow
- * @format
  */
 
 'use strict';

--- a/scripts/rollup/shims/react-native/ReactFeatureFlags.js
+++ b/scripts/rollup/shims/react-native/ReactFeatureFlags.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactFeatureFlags
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+var ReactFeatureFlags = {
+  debugRenderPhaseSideEffects: false,
+};
+
+module.exports = ReactFeatureFlags;


### PR DESCRIPTION
PR #11603 added a feature-flag-fork for the React Native renderer, dubbed `ReactNativeFeatureFlags`. This fork uses statically-defined flags for everything but the recently-added `debugRenderPhaseSideEffects`, which gets loaded at runtime via the `ReactFeatureFlags ` module. This PR adds a missing shim for the `ReactFeatureFlags` module. (I should have included it with the previous PR but didn't.)