### PR TITLE
Remove empty value for boolean attributes in SSR

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -440,9 +440,9 @@ describe('ReactDOMSelect', () => {
       </select>
     );
     var markup = ReactDOMServer.renderToString(stub);
-    expect(markup).toContain('<option selected="" value="giraffe"');
-    expect(markup).not.toContain('<option selected="" value="monkey"');
-    expect(markup).not.toContain('<option selected="" value="gorilla"');
+    expect(markup).toContain('<option selected value="giraffe"');
+    expect(markup).not.toContain('<option selected value="monkey"');
+    expect(markup).not.toContain('<option selected value="gorilla"');
   });
 
   it('should support server-side rendering with defaultValue', () => {
@@ -454,9 +454,9 @@ describe('ReactDOMSelect', () => {
       </select>
     );
     var markup = ReactDOMServer.renderToString(stub);
-    expect(markup).toContain('<option selected="" value="giraffe"');
-    expect(markup).not.toContain('<option selected="" value="monkey"');
-    expect(markup).not.toContain('<option selected="" value="gorilla"');
+    expect(markup).toContain('<option selected value="giraffe"');
+    expect(markup).not.toContain('<option selected value="monkey"');
+    expect(markup).not.toContain('<option selected value="gorilla"');
   });
 
   it('should support server-side rendering with multiple', () => {
@@ -468,9 +468,9 @@ describe('ReactDOMSelect', () => {
       </select>
     );
     var markup = ReactDOMServer.renderToString(stub);
-    expect(markup).toContain('<option selected="" value="giraffe"');
-    expect(markup).toContain('<option selected="" value="gorilla"');
-    expect(markup).not.toContain('<option selected="" value="monkey"');
+    expect(markup).toContain('<option selected value="giraffe"');
+    expect(markup).toContain('<option selected value="gorilla"');
+    expect(markup).not.toContain('<option selected value="monkey"');
   });
 
   it('should not control defaultValue if readding options', () => {

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -90,7 +90,7 @@ export function createMarkupForProperty(name, value) {
       propertyInfo.hasBooleanValue ||
       (propertyInfo.hasOverloadedBooleanValue && value === true)
     ) {
-      return attributeName + '=""';
+      return attributeName;
     } else if (
       typeof value !== 'boolean' ||
       shouldAttributeAcceptBooleanValue(name)


### PR DESCRIPTION
Turns out this was super easy @gaearon!

For boolean attributes and overloaded boolean attributes with a value of `true` we can just render the attribute name and save people a few bytes.

I'm pretty sure this is safe for all attribute/value pairs that would hit this path.