### PR TITLE
Begin replacing propertyInfo.* access with functions

### DIFF
--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -15,8 +15,7 @@ import {
   isWhitelisted,
   hasBooleanValue,
   hasOverloadedBooleanValue,
-  hasNumericValue,
-  hasPositiveNumericValue,
+  shouldIgnoreValue,
   shouldSetAttribute,
   shouldUseProperty,
 } from '../shared/DOMProperty';
@@ -45,18 +44,6 @@ function isAttributeNameSafe(attributeName) {
     warning(false, 'Invalid attribute name: `%s`', attributeName);
   }
   return false;
-}
-
-// shouldIgnoreValue() is currently duplicated in DOMMarkupOperations.
-// TODO: Find a better place for this.
-function shouldIgnoreValue(name, value) {
-  return (
-    value == null ||
-    (hasBooleanValue(name) && !value) ||
-    (hasNumericValue(name) && isNaN(value)) ||
-    (hasPositiveNumericValue(name) && value < 1) ||
-    (hasOverloadedBooleanValue(name) && value === false)
-  );
 }
 
 /**

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -10,6 +10,7 @@ import {
   ATTRIBUTE_NAME_START_CHAR,
   ID_ATTRIBUTE_NAME,
   ROOT_ATTRIBUTE_NAME,
+  getAttributeName,
   getAttributeNamespace,
   getPropertyInfo,
   shouldSetAttribute,
@@ -77,7 +78,7 @@ export function getValueForProperty(node, name, expected) {
       if (propertyInfo.mustUseProperty) {
         return node[name];
       } else {
-        var attributeName = propertyInfo.attributeName;
+        var attributeName = getAttributeName(name);
 
         var stringValue = null;
 
@@ -165,7 +166,7 @@ export function setValueForProperty(node, name, value) {
       // `toString`ed by IE8/9.
       node[name] = value;
     } else {
-      var attributeName = propertyInfo.attributeName;
+      var attributeName = getAttributeName(name);
       var namespace = getAttributeNamespace(name);
       // `setAttribute` with objects becomes only `[object]` in IE8/9,
       // ('' + value) makes it output the correct toString()-value.
@@ -237,7 +238,8 @@ export function deleteValueForProperty(node, name) {
         node[name] = '';
       }
     } else {
-      node.removeAttribute(propertyInfo.attributeName);
+      const attributeName = getAttributeName(name);
+      node.removeAttribute(attributeName);
     }
   } else {
     node.removeAttribute(name);

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -75,7 +75,7 @@ export function getValueForProperty(node, name, expected) {
     var propertyInfo = getPropertyInfo(name);
     if (propertyInfo) {
       if (propertyInfo.mustUseProperty) {
-        return node[propertyInfo.propertyName];
+        return node[name];
       } else {
         var attributeName = propertyInfo.attributeName;
 
@@ -163,7 +163,7 @@ export function setValueForProperty(node, name, value) {
     } else if (propertyInfo.mustUseProperty) {
       // Contrary to `setAttribute`, object properties are properly
       // `toString`ed by IE8/9.
-      node[propertyInfo.propertyName] = value;
+      node[name] = value;
     } else {
       var attributeName = propertyInfo.attributeName;
       var namespace = getAttributeNamespace(name);
@@ -231,11 +231,10 @@ export function deleteValueForProperty(node, name) {
   var propertyInfo = getPropertyInfo(name);
   if (propertyInfo) {
     if (propertyInfo.mustUseProperty) {
-      var propName = propertyInfo.propertyName;
       if (propertyInfo.hasBooleanValue) {
-        node[propName] = false;
+        node[name] = false;
       } else {
-        node[propName] = '';
+        node[name] = '';
       }
     } else {
       node.removeAttribute(propertyInfo.attributeName);

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -10,6 +10,7 @@ import {
   ATTRIBUTE_NAME_START_CHAR,
   ID_ATTRIBUTE_NAME,
   ROOT_ATTRIBUTE_NAME,
+  getAttributeNamespace,
   getPropertyInfo,
   shouldSetAttribute,
 } from '../shared/DOMProperty';
@@ -165,7 +166,7 @@ export function setValueForProperty(node, name, value) {
       node[propertyInfo.propertyName] = value;
     } else {
       var attributeName = propertyInfo.attributeName;
-      var namespace = propertyInfo.attributeNamespace;
+      var namespace = getAttributeNamespace(name);
       // `setAttribute` with objects becomes only `[object]` in IE8/9,
       // ('' + value) makes it output the correct toString()-value.
       if (namespace) {

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -26,20 +26,20 @@ import warning from 'fbjs/lib/warning';
 var VALID_ATTRIBUTE_NAME_REGEX = new RegExp(
   '^[' + ATTRIBUTE_NAME_START_CHAR + '][' + ATTRIBUTE_NAME_CHAR + ']*$',
 );
-var illegalAttributeNameCache = {};
-var validatedAttributeNameCache = {};
+var illegalAttributeNameCache = new Set();
+var validatedAttributeNameCache = new Set();
 function isAttributeNameSafe(attributeName) {
-  if (validatedAttributeNameCache.hasOwnProperty(attributeName)) {
+  if (validatedAttributeNameCache.has(attributeName)) {
     return true;
   }
-  if (illegalAttributeNameCache.hasOwnProperty(attributeName)) {
+  if (illegalAttributeNameCache.has(attributeName)) {
     return false;
   }
   if (VALID_ATTRIBUTE_NAME_REGEX.test(attributeName)) {
-    validatedAttributeNameCache[attributeName] = true;
+    validatedAttributeNameCache.add(attributeName);
     return true;
   }
-  illegalAttributeNameCache[attributeName] = true;
+  illegalAttributeNameCache.add(attributeName);
   if (__DEV__) {
     warning(false, 'Invalid attribute name: `%s`', attributeName);
   }

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -12,7 +12,7 @@ import {
   ROOT_ATTRIBUTE_NAME,
   getAttributeName,
   getAttributeNamespace,
-  getPropertyInfo,
+  isWhitelisted,
   hasBooleanValue,
   hasOverloadedBooleanValue,
   hasNumericValue,
@@ -78,8 +78,7 @@ export function setAttributeForRoot(node) {
  */
 export function getValueForProperty(node, name, expected) {
   if (__DEV__) {
-    var propertyInfo = getPropertyInfo(name);
-    if (propertyInfo) {
+    if (isWhitelisted(name)) {
       if (shouldUseProperty(name)) {
         return node[name];
       } else {
@@ -160,9 +159,7 @@ export function getValueForAttribute(node, name, expected) {
  * @param {*} value
  */
 export function setValueForProperty(node, name, value) {
-  var propertyInfo = getPropertyInfo(name);
-
-  if (propertyInfo && shouldSetAttribute(name, value)) {
+  if (isWhitelisted(name) && shouldSetAttribute(name, value)) {
     if (shouldIgnoreValue(name, value)) {
       deleteValueForProperty(node, name);
       return;
@@ -234,8 +231,7 @@ export function deleteValueForAttribute(node, name) {
  * @param {string} name
  */
 export function deleteValueForProperty(node, name) {
-  var propertyInfo = getPropertyInfo(name);
-  if (propertyInfo) {
+  if (isWhitelisted(name)) {
     if (shouldUseProperty(name)) {
       if (hasBooleanValue(name)) {
         node[name] = false;

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -14,6 +14,7 @@ import {
   getAttributeNamespace,
   getPropertyInfo,
   shouldSetAttribute,
+  shouldUseProperty,
 } from '../shared/DOMProperty';
 import warning from 'fbjs/lib/warning';
 
@@ -75,7 +76,7 @@ export function getValueForProperty(node, name, expected) {
   if (__DEV__) {
     var propertyInfo = getPropertyInfo(name);
     if (propertyInfo) {
-      if (propertyInfo.mustUseProperty) {
+      if (shouldUseProperty(name)) {
         return node[name];
       } else {
         var attributeName = getAttributeName(name);
@@ -161,7 +162,7 @@ export function setValueForProperty(node, name, value) {
     if (shouldIgnoreValue(propertyInfo, value)) {
       deleteValueForProperty(node, name);
       return;
-    } else if (propertyInfo.mustUseProperty) {
+    } else if (shouldUseProperty(name)) {
       // Contrary to `setAttribute`, object properties are properly
       // `toString`ed by IE8/9.
       node[name] = value;
@@ -231,7 +232,7 @@ export function deleteValueForAttribute(node, name) {
 export function deleteValueForProperty(node, name) {
   var propertyInfo = getPropertyInfo(name);
   if (propertyInfo) {
-    if (propertyInfo.mustUseProperty) {
+    if (shouldUseProperty(name)) {
       if (propertyInfo.hasBooleanValue) {
         node[name] = false;
       } else {

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -24,7 +24,11 @@ import setTextContent from './setTextContent';
 import {listenTo, trapBubbledEvent} from '../events/ReactBrowserEventEmitter';
 import * as CSSPropertyOperations from '../shared/CSSPropertyOperations';
 import {Namespaces, getIntrinsicNamespace} from '../shared/DOMNamespaces';
-import {getPropertyInfo, shouldSetAttribute} from '../shared/DOMProperty';
+import {
+  getAttributeName,
+  getPropertyInfo,
+  shouldSetAttribute,
+} from '../shared/DOMProperty';
 import assertValidProps from '../shared/assertValidProps';
 import {DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE} from '../shared/HTMLNodeType';
 import isCustomComponent from '../shared/isCustomComponent';
@@ -952,7 +956,6 @@ export function diffHydratedProperties(
     } else if (__DEV__) {
       // Validate that the properties correspond to their expected values.
       var serverValue;
-      var propertyInfo;
       if (suppressHydrationWarning) {
         // Don't bother comparing. We're ignoring all these warnings.
       } else if (
@@ -995,9 +998,10 @@ export function diffHydratedProperties(
           warnForPropDifference(propKey, serverValue, nextProp);
         }
       } else if (shouldSetAttribute(propKey, nextProp)) {
-        if ((propertyInfo = getPropertyInfo(propKey))) {
+        if (getPropertyInfo(propKey)) {
+          const attributeName = getAttributeName(propKey);
           // $FlowFixMe - Should be inferred as not undefined.
-          extraAttributeNames.delete(propertyInfo.attributeName);
+          extraAttributeNames.delete(attributeName);
           serverValue = DOMPropertyOperations.getValueForProperty(
             domElement,
             propKey,

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -26,7 +26,7 @@ import * as CSSPropertyOperations from '../shared/CSSPropertyOperations';
 import {Namespaces, getIntrinsicNamespace} from '../shared/DOMNamespaces';
 import {
   getAttributeName,
-  getPropertyInfo,
+  isWhitelisted,
   shouldSetAttribute,
 } from '../shared/DOMProperty';
 import assertValidProps from '../shared/assertValidProps';
@@ -998,7 +998,7 @@ export function diffHydratedProperties(
           warnForPropDifference(propKey, serverValue, nextProp);
         }
       } else if (shouldSetAttribute(propKey, nextProp)) {
-        if (getPropertyInfo(propKey)) {
+        if (isWhitelisted(propKey)) {
           const attributeName = getAttributeName(propKey);
           // $FlowFixMe - Should be inferred as not undefined.
           extraAttributeNames.delete(attributeName);

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -26,20 +26,20 @@ import warning from 'fbjs/lib/warning';
 var VALID_ATTRIBUTE_NAME_REGEX = new RegExp(
   '^[' + ATTRIBUTE_NAME_START_CHAR + '][' + ATTRIBUTE_NAME_CHAR + ']*$',
 );
-var illegalAttributeNameCache = {};
-var validatedAttributeNameCache = {};
+var illegalAttributeNameCache = new Set();
+var validatedAttributeNameCache = new Set();
 function isAttributeNameSafe(attributeName) {
-  if (validatedAttributeNameCache.hasOwnProperty(attributeName)) {
+  if (validatedAttributeNameCache.has(attributeName)) {
     return true;
   }
-  if (illegalAttributeNameCache.hasOwnProperty(attributeName)) {
+  if (illegalAttributeNameCache.has(attributeName)) {
     return false;
   }
   if (VALID_ATTRIBUTE_NAME_REGEX.test(attributeName)) {
-    validatedAttributeNameCache[attributeName] = true;
+    validatedAttributeNameCache.add(attributeName);
     return true;
   }
-  illegalAttributeNameCache[attributeName] = true;
+  illegalAttributeNameCache.add(attributeName);
   if (__DEV__) {
     warning(false, 'Invalid attribute name: `%s`', attributeName);
   }

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -10,6 +10,7 @@ import {
   ATTRIBUTE_NAME_START_CHAR,
   ID_ATTRIBUTE_NAME,
   ROOT_ATTRIBUTE_NAME,
+  getAttributeName,
   getPropertyInfo,
   shouldAttributeAcceptBooleanValue,
   shouldSetAttribute,
@@ -85,7 +86,7 @@ export function createMarkupForProperty(name, value) {
     if (shouldIgnoreValue(propertyInfo, value)) {
       return '';
     }
-    var attributeName = propertyInfo.attributeName;
+    var attributeName = getAttributeName(name);
     if (
       propertyInfo.hasBooleanValue ||
       (propertyInfo.hasOverloadedBooleanValue && value === true)

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -14,9 +14,8 @@ import {
   isWhitelisted,
   hasBooleanValue,
   hasOverloadedBooleanValue,
-  hasNumericValue,
-  hasPositiveNumericValue,
   shouldAttributeAcceptBooleanValue,
+  shouldIgnoreValue,
   shouldSetAttribute,
 } from '../shared/DOMProperty';
 import quoteAttributeValueForBrowser from './quoteAttributeValueForBrowser';
@@ -45,18 +44,6 @@ function isAttributeNameSafe(attributeName) {
     warning(false, 'Invalid attribute name: `%s`', attributeName);
   }
   return false;
-}
-
-// shouldIgnoreValue() is currently duplicated in DOMPropertyOperations.
-// TODO: Find a better place for this.
-function shouldIgnoreValue(name, value) {
-  return (
-    value == null ||
-    (hasBooleanValue(name) && !value) ||
-    (hasNumericValue(name) && isNaN(value)) ||
-    (hasPositiveNumericValue(name) && value < 1) ||
-    (hasOverloadedBooleanValue(name) && value === false)
-  );
 }
 
 /**

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -12,6 +12,10 @@ import {
   ROOT_ATTRIBUTE_NAME,
   getAttributeName,
   getPropertyInfo,
+  hasBooleanValue,
+  hasOverloadedBooleanValue,
+  hasNumericValue,
+  hasPositiveNumericValue,
   shouldAttributeAcceptBooleanValue,
   shouldSetAttribute,
 } from '../shared/DOMProperty';
@@ -45,13 +49,13 @@ function isAttributeNameSafe(attributeName) {
 
 // shouldIgnoreValue() is currently duplicated in DOMPropertyOperations.
 // TODO: Find a better place for this.
-function shouldIgnoreValue(propertyInfo, value) {
+function shouldIgnoreValue(name, value) {
   return (
     value == null ||
-    (propertyInfo.hasBooleanValue && !value) ||
-    (propertyInfo.hasNumericValue && isNaN(value)) ||
-    (propertyInfo.hasPositiveNumericValue && value < 1) ||
-    (propertyInfo.hasOverloadedBooleanValue && value === false)
+    (hasBooleanValue(name) && !value) ||
+    (hasNumericValue(name) && isNaN(value)) ||
+    (hasPositiveNumericValue(name) && value < 1) ||
+    (hasOverloadedBooleanValue(name) && value === false)
   );
 }
 
@@ -83,13 +87,13 @@ export function createMarkupForRoot() {
 export function createMarkupForProperty(name, value) {
   var propertyInfo = getPropertyInfo(name);
   if (propertyInfo) {
-    if (shouldIgnoreValue(propertyInfo, value)) {
+    if (shouldIgnoreValue(name, value)) {
       return '';
     }
     var attributeName = getAttributeName(name);
     if (
-      propertyInfo.hasBooleanValue ||
-      (propertyInfo.hasOverloadedBooleanValue && value === true)
+      hasBooleanValue(name) ||
+      (hasOverloadedBooleanValue(name) && value === true)
     ) {
       return attributeName;
     } else if (

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -11,7 +11,7 @@ import {
   ID_ATTRIBUTE_NAME,
   ROOT_ATTRIBUTE_NAME,
   getAttributeName,
-  getPropertyInfo,
+  isWhitelisted,
   hasBooleanValue,
   hasOverloadedBooleanValue,
   hasNumericValue,
@@ -85,8 +85,7 @@ export function createMarkupForRoot() {
  * @return {?string} Markup string, or null if the property was invalid.
  */
 export function createMarkupForProperty(name, value) {
-  var propertyInfo = getPropertyInfo(name);
-  if (propertyInfo) {
+  if (isWhitelisted(name)) {
     if (shouldIgnoreValue(name, value)) {
       return '';
     }

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -143,8 +143,16 @@ export function shouldSetAttribute(name, value) {
   }
 }
 
-export function getPropertyInfo(name) {
-  return properties.hasOwnProperty(name) ? properties[name] : null;
+// TODO: the fact that we rely on this in many code paths seems bad.
+// It shouldn't be observable whether something is whitelisted if it
+// doesn't have special behavior except being an alias. But at least
+// we're explicit about this now.
+export function isWhitelisted(name) {
+  return properties.hasOwnProperty(name);
+}
+
+function getPropertyInfo(name) {
+  return isWhitelisted(name) ? properties[name] : null;
 }
 
 export function shouldAttributeAcceptBooleanValue(name) {
@@ -191,10 +199,7 @@ export function getAttributeName(name) {
   if (attributeNames.has(name)) {
     return attributeNames.get(name);
   }
-  // TODO: it is odd that this depends on `properties` whitelist.
-  const attributeName = properties.hasOwnProperty(name)
-    ? name.toLowerCase()
-    : name;
+  const attributeName = isWhitelisted(name) ? name.toLowerCase() : name;
   attributeNames.set(name, attributeName);
   return attributeName;
 }

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -109,7 +109,7 @@ export const ROOT_ATTRIBUTE_NAME = 'data-reactroot';
  *   Removed when strictly equal to false; present without a value when
  *   strictly equal to true; present with a value otherwise.
  */
-export const properties = {};
+const properties = {};
 
 /**
  * Checks whether a property name is a writeable attribute.

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -52,7 +52,6 @@ function injectDOMPropertyConfig(domPropertyConfig) {
 
     var propertyInfo = {
       attributeName: lowerCased,
-      propertyName: propName,
 
       mustUseProperty: checkMask(propConfig, MUST_USE_PROPERTY),
       hasBooleanValue: checkMask(propConfig, HAS_BOOLEAN_VALUE),
@@ -109,9 +108,6 @@ export const ROOT_ATTRIBUTE_NAME = 'data-reactroot';
  *
  * attributeName:
  *   Used when rendering markup or with `*Attribute()`.
- * propertyName:
- *   Used on DOM node instances. (This includes properties that mutate due to
- *   external factors.)
  * mustUseProperty:
  *   Whether the property must be accessed and mutated as an object property.
  * hasBooleanValue:

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -9,16 +9,16 @@
 
 // These attributes should be all lowercase to allow for
 // case insensitive checks
-var RESERVED_PROPS = {
-  children: true,
-  dangerouslySetInnerHTML: true,
-  defaultValue: true,
-  defaultChecked: true,
-  innerHTML: true,
-  suppressContentEditableWarning: true,
-  suppressHydrationWarning: true,
-  style: true,
-};
+var RESERVED_PROPS = new Set([
+  'children',
+  'dangerouslySetInnerHTML',
+  'defaultValue',
+  'defaultChecked',
+  'innerHTML',
+  'suppressContentEditableWarning',
+  'suppressHydrationWarning',
+  'style',
+]);
 
 // A simple string attribute.
 const STRING = 0;
@@ -162,14 +162,14 @@ export function shouldAttributeAcceptBooleanValue(name: string) {
     return true;
   }
   if (propertyTypes.has(name)) {
-    const propertyType = propertyTypes.get(name);
-    return (
-      propertyType === BOOLEAN ||
-      propertyType === STRING_BOOLEAN ||
-      propertyType === OVERLOADED_BOOLEAN
-    );
+    switch (propertyTypes.get(name)) {
+      case BOOLEAN:
+      case STRING_BOOLEAN:
+      case OVERLOADED_BOOLEAN:
+        return true;
+    }
   }
-  var prefix = name.toLowerCase().slice(0, 5);
+  const prefix = name.toLowerCase().slice(0, 5);
   return prefix === 'data-' || prefix === 'aria-';
 }
 
@@ -183,7 +183,7 @@ export function shouldAttributeAcceptBooleanValue(name: string) {
  * @return {boolean} If the name is within reserved props
  */
 export function isReservedProp(name: string) {
-  return RESERVED_PROPS.hasOwnProperty(name);
+  return RESERVED_PROPS.has(name);
 }
 
 const attributeNames: Map<string, string> = new Map([
@@ -207,23 +207,27 @@ export function getAttributeName(name: string): string {
   return attributeName;
 }
 
+const NS_XLINK = 'http://www.w3.org/1999/xlink';
+const NS_XML = 'http://www.w3.org/XML/1998/namespace';
+const attributeNamespaces: Map<string, string> = new Map([
+  ['xlinkActuate', NS_XLINK],
+  ['xlinkArcrole', NS_XLINK],
+  ['xlinkHref', NS_XLINK],
+  ['xlinkRole', NS_XLINK],
+  ['xlinkShow', NS_XLINK],
+  ['xlinkTitle', NS_XLINK],
+  ['xlinkType', NS_XLINK],
+  ['xmlBase', NS_XML],
+  ['xmlLang', NS_XML],
+  ['xmlSpace', NS_XML],
+]);
+
 export function getAttributeNamespace(name: string): string | null {
-  switch (name) {
-    case 'xlinkActuate':
-    case 'xlinkArcrole':
-    case 'xlinkHref':
-    case 'xlinkRole':
-    case 'xlinkShow':
-    case 'xlinkTitle':
-    case 'xlinkType':
-      return 'http://www.w3.org/1999/xlink';
-    case 'xmlBase':
-    case 'xmlLang':
-    case 'xmlSpace':
-      return 'http://www.w3.org/XML/1998/namespace';
-    default:
-      return null;
+  const attributeNamespace = attributeNamespaces.get(name);
+  if (typeof attributeNamespace === 'string') {
+    return attributeNamespace;
   }
+  return null;
 }
 
 export function hasBooleanValue(name: string): boolean {

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -239,29 +239,19 @@ export function hasOverloadedBooleanValue(name) {
   return false;
 }
 
-export function hasNumericValue(name) {
-  const propertyInfo = getPropertyInfo(name);
-  if (propertyInfo !== null) {
-    return propertyInfo.hasNumericValue;
-  }
-  return false;
-}
-
-export function hasPositiveNumericValue(name) {
-  const propertyInfo = getPropertyInfo(name);
-  if (propertyInfo !== null) {
-    return propertyInfo.hasPositiveNumericValue;
-  }
-  return false;
-}
-
 export function shouldIgnoreValue(name, value) {
+  if (value == null) {
+    return true;
+  }
+  const propertyInfo = getPropertyInfo(name);
+  if (propertyInfo === null) {
+    return false;
+  }
   return (
-    value == null ||
-    (hasBooleanValue(name) && !value) ||
-    (hasNumericValue(name) && isNaN(value)) ||
-    (hasPositiveNumericValue(name) && value < 1) ||
-    (hasOverloadedBooleanValue(name) && value === false)
+    (propertyInfo.hasBooleanValue && !value) ||
+    (propertyInfo.hasNumericValue && isNaN(value)) ||
+    (propertyInfo.hasPositiveNumericValue && value < 1) ||
+    (propertyInfo.hasOverloadedBooleanValue && value === false)
   );
 }
 

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -94,8 +94,6 @@ export const ROOT_ATTRIBUTE_NAME = 'data-reactroot';
  * Map from property "standard name" to an object with info about how to set
  * the property in the DOM. Each object contains:
  *
- * mustUseProperty:
- *   Whether the property must be accessed and mutated as an object property.
  * hasBooleanValue:
  *   Whether the property should be removed when set to a falsey value.
  * hasNumericValue:

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -255,6 +255,16 @@ export function hasPositiveNumericValue(name) {
   return false;
 }
 
+export function shouldIgnoreValue(name, value) {
+  return (
+    value == null ||
+    (hasBooleanValue(name) && !value) ||
+    (hasNumericValue(name) && isNaN(value)) ||
+    (hasPositiveNumericValue(name) && value < 1) ||
+    (hasOverloadedBooleanValue(name) && value === false)
+  );
+}
+
 const usePropertiesFor = new Set(['checked', 'multiple', 'muted', 'selected']);
 
 export function shouldUseProperty(name) {

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -33,7 +33,6 @@ const HAS_STRING_BOOLEAN_VALUE = 0x40;
 
 function injectDOMPropertyConfig(domPropertyConfig) {
   var Properties = domPropertyConfig.Properties || {};
-  var DOMAttributeNamespaces = domPropertyConfig.DOMAttributeNamespaces || {};
   var DOMAttributeNames = domPropertyConfig.DOMAttributeNames || {};
 
   for (var propName in Properties) {
@@ -53,7 +52,6 @@ function injectDOMPropertyConfig(domPropertyConfig) {
 
     var propertyInfo = {
       attributeName: lowerCased,
-      attributeNamespace: null,
       propertyName: propName,
 
       mustUseProperty: checkMask(propConfig, MUST_USE_PROPERTY),
@@ -87,10 +85,6 @@ function injectDOMPropertyConfig(domPropertyConfig) {
       propertyInfo.attributeName = attributeName;
     }
 
-    if (DOMAttributeNamespaces.hasOwnProperty(propName)) {
-      propertyInfo.attributeNamespace = DOMAttributeNamespaces[propName];
-    }
-
     // Downcase references to whitelist properties to check for membership
     // without case-sensitivity. This allows the whitelist to pick up
     // `allowfullscreen`, which should be written using the property configuration
@@ -115,7 +109,6 @@ export const ROOT_ATTRIBUTE_NAME = 'data-reactroot';
  *
  * attributeName:
  *   Used when rendering markup or with `*Attribute()`.
- * attributeNamespace
  * propertyName:
  *   Used on DOM node instances. (This includes properties that mutate due to
  *   external factors.)
@@ -201,6 +194,25 @@ export function isReservedProp(name) {
   return RESERVED_PROPS.hasOwnProperty(name);
 }
 
+export function getAttributeNamespace(name) {
+  switch (name) {
+    case 'xlinkActuate':
+    case 'xlinkArcrole':
+    case 'xlinkHref':
+    case 'xlinkRole':
+    case 'xlinkShow':
+    case 'xlinkTitle':
+    case 'xlinkType':
+      return 'http://www.w3.org/1999/xlink';
+    case 'xmlBase':
+    case 'xmlLang':
+    case 'xmlSpace':
+      return 'http://www.w3.org/XML/1998/namespace';
+    default:
+      return null;
+  }
+}
+
 var HTMLDOMPropertyConfig = {
   // When adding attributes to this list, be sure to also add them to
   // the `possibleStandardNames` module to ensure casing and incorrect
@@ -269,11 +281,6 @@ var HTMLDOMPropertyConfig = {
     htmlFor: 'for',
     httpEquiv: 'http-equiv',
   },
-};
-
-var NS = {
-  xlink: 'http://www.w3.org/1999/xlink',
-  xml: 'http://www.w3.org/XML/1998/namespace',
 };
 
 /**
@@ -385,18 +392,6 @@ var SVGDOMPropertyConfig = {
     autoReverse: 'autoReverse',
     externalResourcesRequired: 'externalResourcesRequired',
     preserveAlpha: 'preserveAlpha',
-  },
-  DOMAttributeNamespaces: {
-    xlinkActuate: NS.xlink,
-    xlinkArcrole: NS.xlink,
-    xlinkHref: NS.xlink,
-    xlinkRole: NS.xlink,
-    xlinkShow: NS.xlink,
-    xlinkTitle: NS.xlink,
-    xlinkType: NS.xlink,
-    xmlBase: NS.xml,
-    xmlLang: NS.xml,
-    xmlSpace: NS.xml,
   },
 };
 

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -218,6 +218,38 @@ export function getAttributeNamespace(name) {
   }
 }
 
+export function hasBooleanValue(name) {
+  const propertyInfo = getPropertyInfo(name);
+  if (propertyInfo !== null) {
+    return propertyInfo.hasBooleanValue;
+  }
+  return false;
+}
+
+export function hasOverloadedBooleanValue(name) {
+  const propertyInfo = getPropertyInfo(name);
+  if (propertyInfo !== null) {
+    return propertyInfo.hasOverloadedBooleanValue;
+  }
+  return false;
+}
+
+export function hasNumericValue(name) {
+  const propertyInfo = getPropertyInfo(name);
+  if (propertyInfo !== null) {
+    return propertyInfo.hasNumericValue;
+  }
+  return false;
+}
+
+export function hasPositiveNumericValue(name) {
+  const propertyInfo = getPropertyInfo(name);
+  if (propertyInfo !== null) {
+    return propertyInfo.hasPositiveNumericValue;
+  }
+  return false;
+}
+
 const usePropertiesFor = new Set(['checked', 'multiple', 'muted', 'selected']);
 
 export function shouldUseProperty(name) {

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -24,7 +24,6 @@ function checkMask(value, bitmask) {
   return (value & bitmask) === bitmask;
 }
 
-const MUST_USE_PROPERTY = 0x1;
 const HAS_BOOLEAN_VALUE = 0x4;
 const HAS_NUMERIC_VALUE = 0x8;
 const HAS_POSITIVE_NUMERIC_VALUE = 0x10 | 0x8;
@@ -49,7 +48,6 @@ function injectDOMPropertyConfig(domPropertyConfig) {
     var propConfig = Properties[propName];
 
     var propertyInfo = {
-      mustUseProperty: checkMask(propConfig, MUST_USE_PROPERTY),
       hasBooleanValue: checkMask(propConfig, HAS_BOOLEAN_VALUE),
       hasNumericValue: checkMask(propConfig, HAS_NUMERIC_VALUE),
       hasPositiveNumericValue: checkMask(
@@ -220,6 +218,12 @@ export function getAttributeNamespace(name) {
   }
 }
 
+const usePropertiesFor = new Set(['checked', 'multiple', 'muted', 'selected']);
+
+export function shouldUseProperty(name) {
+  return usePropertiesFor.has(name);
+}
+
 var HTMLDOMPropertyConfig = {
   // When adding attributes to this list, be sure to also add them to
   // the `possibleStandardNames` module to ensure casing and incorrect
@@ -233,7 +237,7 @@ var HTMLDOMPropertyConfig = {
     autoFocus: HAS_BOOLEAN_VALUE,
     autoPlay: HAS_BOOLEAN_VALUE,
     capture: HAS_OVERLOADED_BOOLEAN_VALUE,
-    checked: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
+    checked: HAS_BOOLEAN_VALUE,
     cols: HAS_POSITIVE_NUMERIC_VALUE,
     contentEditable: HAS_STRING_BOOLEAN_VALUE,
     controls: HAS_BOOLEAN_VALUE,
@@ -247,8 +251,8 @@ var HTMLDOMPropertyConfig = {
     loop: HAS_BOOLEAN_VALUE,
     // Caution; `option.selected` is not updated if `select.multiple` is
     // disabled with `removeAttribute`.
-    multiple: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
-    muted: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
+    multiple: HAS_BOOLEAN_VALUE,
+    muted: HAS_BOOLEAN_VALUE,
     noValidate: HAS_BOOLEAN_VALUE,
     open: HAS_BOOLEAN_VALUE,
     playsInline: HAS_BOOLEAN_VALUE,
@@ -259,7 +263,7 @@ var HTMLDOMPropertyConfig = {
     rowSpan: HAS_NUMERIC_VALUE,
     scoped: HAS_BOOLEAN_VALUE,
     seamless: HAS_BOOLEAN_VALUE,
-    selected: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
+    selected: HAS_BOOLEAN_VALUE,
     size: HAS_POSITIVE_NUMERIC_VALUE,
     start: HAS_NUMERIC_VALUE,
     // support for projecting regular DOM Elements via V1 named slots ( shadow dom )

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import warning from 'fbjs/lib/warning';
@@ -38,6 +40,8 @@ const POSITIVE_NUMERIC = 4;
 // strictly equal to true; present with a value otherwise.
 const OVERLOADED_BOOLEAN = 5;
 
+type PropertyType = 0 | 1 | 2 | 3 | 4 | 5;
+
 function injectDOMPropertyConfig(domPropertyConfig) {
   for (var propName in domPropertyConfig) {
     if (__DEV__) {
@@ -69,13 +73,13 @@ export const ATTRIBUTE_NAME_CHAR =
 export const ID_ATTRIBUTE_NAME = 'data-reactid';
 export const ROOT_ATTRIBUTE_NAME = 'data-reactroot';
 
-const propertyTypes = new Map();
+const propertyTypes: Map<string, PropertyType> = new Map();
 
 /**
  * Checks whether a property name is a writeable attribute.
  * @method
  */
-export function shouldSetAttribute(name, value) {
+export function shouldSetAttribute(name: string, value: mixed) {
   if (isReservedProp(name)) {
     return false;
   }
@@ -107,11 +111,11 @@ export function shouldSetAttribute(name, value) {
 // It shouldn't be observable whether something is whitelisted if it
 // doesn't have special behavior except being an alias. But at least
 // we're explicit about this now.
-export function isWhitelisted(name) {
+export function isWhitelisted(name: string) {
   return propertyTypes.has(name);
 }
 
-export function shouldAttributeAcceptBooleanValue(name) {
+export function shouldAttributeAcceptBooleanValue(name: string) {
   if (isReservedProp(name)) {
     return true;
   }
@@ -136,11 +140,11 @@ export function shouldAttributeAcceptBooleanValue(name) {
  * @param {string} name
  * @return {boolean} If the name is within reserved props
  */
-export function isReservedProp(name) {
+export function isReservedProp(name: string) {
   return RESERVED_PROPS.hasOwnProperty(name);
 }
 
-const attributeNames = new Map([
+const attributeNames: Map<string, string> = new Map([
   ['acceptCharset', 'accept-charset'],
   ['className', 'class'],
   ['htmlFor', 'for'],
@@ -151,16 +155,17 @@ const attributeNames = new Map([
   ['preserveAlpha', 'preserveAlpha'],
 ]);
 
-export function getAttributeName(name) {
-  if (attributeNames.has(name)) {
-    return attributeNames.get(name);
+export function getAttributeName(name: string): string {
+  let attributeName = attributeNames.get(name);
+  if (typeof attributeName === 'string') {
+    return attributeName;
   }
-  const attributeName = isWhitelisted(name) ? name.toLowerCase() : name;
+  attributeName = isWhitelisted(name) ? name.toLowerCase() : name;
   attributeNames.set(name, attributeName);
   return attributeName;
 }
 
-export function getAttributeNamespace(name) {
+export function getAttributeNamespace(name: string): string | null {
   switch (name) {
     case 'xlinkActuate':
     case 'xlinkArcrole':
@@ -179,15 +184,15 @@ export function getAttributeNamespace(name) {
   }
 }
 
-export function hasBooleanValue(name) {
+export function hasBooleanValue(name: string): boolean {
   return propertyTypes.get(name) === BOOLEAN;
 }
 
-export function hasOverloadedBooleanValue(name) {
+export function hasOverloadedBooleanValue(name: string): boolean {
   return propertyTypes.get(name) === OVERLOADED_BOOLEAN;
 }
 
-export function shouldIgnoreValue(name, value) {
+export function shouldIgnoreValue(name: string, value: mixed): boolean {
   if (value == null) {
     return true;
   }
@@ -201,7 +206,8 @@ export function shouldIgnoreValue(name, value) {
     case OVERLOADED_BOOLEAN:
       return value === false;
     case POSITIVE_NUMERIC:
-      if (value < 1) {
+      // Intentional implicit coercion (e.g. '0' < 1)
+      if ((value: any) < 1) {
         return true;
       }
     // intentional fallthrough
@@ -212,9 +218,14 @@ export function shouldIgnoreValue(name, value) {
   }
 }
 
-const usePropertiesFor = new Set(['checked', 'multiple', 'muted', 'selected']);
+const usePropertiesFor: Set<string> = new Set([
+  'checked',
+  'multiple',
+  'muted',
+  'selected',
+]);
 
-export function shouldUseProperty(name) {
+export function shouldUseProperty(name: string): boolean {
   return usePropertiesFor.has(name);
 }
 

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -20,23 +20,29 @@ var RESERVED_PROPS = {
   style: true,
 };
 
-function checkMask(value, bitmask) {
-  return (value & bitmask) === bitmask;
-}
-
-const HAS_BOOLEAN_VALUE = 0x4;
-const HAS_NUMERIC_VALUE = 0x8;
-const HAS_POSITIVE_NUMERIC_VALUE = 0x10 | 0x8;
-const HAS_OVERLOADED_BOOLEAN_VALUE = 0x20;
-const HAS_STRING_BOOLEAN_VALUE = 0x40;
+// A simple string attribute.
+const STRING = 0;
+// A simple string attribute that also accepts booleans from the user
+// (but coerces them to string and doesn't have any special handling for them).
+const STRING_BOOLEAN = 1;
+// An attribute that should be removed when set to a falsey value.
+const BOOLEAN = 2;
+// An attribute that must be numeric or parse as a numeric and should be
+// removed when set to a falsey value.
+const NUMERIC = 3;
+// An attribute that must be positive numeric or parse as a positive
+// numeric and should be removed when set to a falsey value.
+const POSITIVE_NUMERIC = 4;
+// An attribute that can be used as a flag as well as with a value.
+// Removed when strictly equal to false; present without a value when
+// strictly equal to true; present with a value otherwise.
+const OVERLOADED_BOOLEAN = 5;
 
 function injectDOMPropertyConfig(domPropertyConfig) {
-  var Properties = domPropertyConfig.Properties || {};
-
-  for (var propName in Properties) {
+  for (var propName in domPropertyConfig) {
     if (__DEV__) {
       warning(
-        !properties.hasOwnProperty(propName),
+        !propertyTypes.has(propName),
         "injectDOMPropertyConfig(...): You're trying to inject DOM property " +
           "'%s' which has already been injected. You may be accidentally " +
           'injecting the same DOM property config twice, or you may be ' +
@@ -44,39 +50,12 @@ function injectDOMPropertyConfig(domPropertyConfig) {
         propName,
       );
     }
-
-    var propConfig = Properties[propName];
-
-    var propertyInfo = {
-      hasBooleanValue: checkMask(propConfig, HAS_BOOLEAN_VALUE),
-      hasNumericValue: checkMask(propConfig, HAS_NUMERIC_VALUE),
-      hasPositiveNumericValue: checkMask(
-        propConfig,
-        HAS_POSITIVE_NUMERIC_VALUE,
-      ),
-      hasOverloadedBooleanValue: checkMask(
-        propConfig,
-        HAS_OVERLOADED_BOOLEAN_VALUE,
-      ),
-      hasStringBooleanValue: checkMask(propConfig, HAS_STRING_BOOLEAN_VALUE),
-    };
-    if (__DEV__) {
-      warning(
-        propertyInfo.hasBooleanValue +
-          propertyInfo.hasNumericValue +
-          propertyInfo.hasOverloadedBooleanValue <=
-          1,
-        'DOMProperty: Value can be one of boolean, overloaded boolean, or ' +
-          'numeric value, but not a combination: %s',
-        propName,
-      );
-    }
-
     // Downcase references to whitelist properties to check for membership
     // without case-sensitivity. This allows the whitelist to pick up
     // `allowfullscreen`, which should be written using the property configuration
     // for `allowFullscreen`
-    properties[propName] = propertyInfo;
+    const propertyType = domPropertyConfig[propName];
+    propertyTypes.set(propName, propertyType);
   }
 }
 
@@ -90,24 +69,7 @@ export const ATTRIBUTE_NAME_CHAR =
 export const ID_ATTRIBUTE_NAME = 'data-reactid';
 export const ROOT_ATTRIBUTE_NAME = 'data-reactroot';
 
-/**
- * Map from property "standard name" to an object with info about how to set
- * the property in the DOM. Each object contains:
- *
- * hasBooleanValue:
- *   Whether the property should be removed when set to a falsey value.
- * hasNumericValue:
- *   Whether the property must be numeric or parse as a numeric and should be
- *   removed when set to a falsey value.
- * hasPositiveNumericValue:
- *   Whether the property must be positive numeric or parse as a positive
- *   numeric and should be removed when set to a falsey value.
- * hasOverloadedBooleanValue:
- *   Whether the property can be used as a flag as well as with a value.
- *   Removed when strictly equal to false; present without a value when
- *   strictly equal to true; present with a value otherwise.
- */
-const properties = {};
+const propertyTypes = new Map();
 
 /**
  * Checks whether a property name is a writeable attribute.
@@ -146,23 +108,19 @@ export function shouldSetAttribute(name, value) {
 // doesn't have special behavior except being an alias. But at least
 // we're explicit about this now.
 export function isWhitelisted(name) {
-  return properties.hasOwnProperty(name);
-}
-
-function getPropertyInfo(name) {
-  return isWhitelisted(name) ? properties[name] : null;
+  return propertyTypes.has(name);
 }
 
 export function shouldAttributeAcceptBooleanValue(name) {
   if (isReservedProp(name)) {
     return true;
   }
-  let propertyInfo = getPropertyInfo(name);
-  if (propertyInfo) {
+  if (propertyTypes.has(name)) {
+    const propertyType = propertyTypes.get(name);
     return (
-      propertyInfo.hasBooleanValue ||
-      propertyInfo.hasStringBooleanValue ||
-      propertyInfo.hasOverloadedBooleanValue
+      propertyType === BOOLEAN ||
+      propertyType === STRING_BOOLEAN ||
+      propertyType === OVERLOADED_BOOLEAN
     );
   }
   var prefix = name.toLowerCase().slice(0, 5);
@@ -222,35 +180,36 @@ export function getAttributeNamespace(name) {
 }
 
 export function hasBooleanValue(name) {
-  const propertyInfo = getPropertyInfo(name);
-  if (propertyInfo !== null) {
-    return propertyInfo.hasBooleanValue;
-  }
-  return false;
+  return propertyTypes.get(name) === BOOLEAN;
 }
 
 export function hasOverloadedBooleanValue(name) {
-  const propertyInfo = getPropertyInfo(name);
-  if (propertyInfo !== null) {
-    return propertyInfo.hasOverloadedBooleanValue;
-  }
-  return false;
+  return propertyTypes.get(name) === OVERLOADED_BOOLEAN;
 }
 
 export function shouldIgnoreValue(name, value) {
   if (value == null) {
     return true;
   }
-  const propertyInfo = getPropertyInfo(name);
-  if (propertyInfo === null) {
+  if (!propertyTypes.has(name)) {
     return false;
   }
-  return (
-    (propertyInfo.hasBooleanValue && !value) ||
-    (propertyInfo.hasNumericValue && isNaN(value)) ||
-    (propertyInfo.hasPositiveNumericValue && value < 1) ||
-    (propertyInfo.hasOverloadedBooleanValue && value === false)
-  );
+  const propertyType = propertyTypes.get(name);
+  switch (propertyType) {
+    case BOOLEAN:
+      return !value;
+    case OVERLOADED_BOOLEAN:
+      return value === false;
+    case POSITIVE_NUMERIC:
+      if (value < 1) {
+        return true;
+      }
+    // intentional fallthrough
+    case NUMERIC:
+      return isNaN(value);
+    default:
+      return false;
+  }
 }
 
 const usePropertiesFor = new Set(['checked', 'multiple', 'muted', 'selected']);
@@ -263,66 +222,64 @@ var HTMLDOMPropertyConfig = {
   // When adding attributes to this list, be sure to also add them to
   // the `possibleStandardNames` module to ensure casing and incorrect
   // name warnings.
-  Properties: {
-    allowFullScreen: HAS_BOOLEAN_VALUE,
-    // specifies target context for links with `preload` type
-    async: HAS_BOOLEAN_VALUE,
-    // Note: there is a special case that prevents it from being written to the DOM
-    // on the client side because the browsers are inconsistent. Instead we call focus().
-    autoFocus: HAS_BOOLEAN_VALUE,
-    autoPlay: HAS_BOOLEAN_VALUE,
-    capture: HAS_OVERLOADED_BOOLEAN_VALUE,
-    checked: HAS_BOOLEAN_VALUE,
-    cols: HAS_POSITIVE_NUMERIC_VALUE,
-    contentEditable: HAS_STRING_BOOLEAN_VALUE,
-    controls: HAS_BOOLEAN_VALUE,
-    default: HAS_BOOLEAN_VALUE,
-    defer: HAS_BOOLEAN_VALUE,
-    disabled: HAS_BOOLEAN_VALUE,
-    download: HAS_OVERLOADED_BOOLEAN_VALUE,
-    draggable: HAS_STRING_BOOLEAN_VALUE,
-    formNoValidate: HAS_BOOLEAN_VALUE,
-    hidden: HAS_BOOLEAN_VALUE,
-    loop: HAS_BOOLEAN_VALUE,
-    // Caution; `option.selected` is not updated if `select.multiple` is
-    // disabled with `removeAttribute`.
-    multiple: HAS_BOOLEAN_VALUE,
-    muted: HAS_BOOLEAN_VALUE,
-    noValidate: HAS_BOOLEAN_VALUE,
-    open: HAS_BOOLEAN_VALUE,
-    playsInline: HAS_BOOLEAN_VALUE,
-    readOnly: HAS_BOOLEAN_VALUE,
-    required: HAS_BOOLEAN_VALUE,
-    reversed: HAS_BOOLEAN_VALUE,
-    rows: HAS_POSITIVE_NUMERIC_VALUE,
-    rowSpan: HAS_NUMERIC_VALUE,
-    scoped: HAS_BOOLEAN_VALUE,
-    seamless: HAS_BOOLEAN_VALUE,
-    selected: HAS_BOOLEAN_VALUE,
-    size: HAS_POSITIVE_NUMERIC_VALUE,
-    start: HAS_NUMERIC_VALUE,
-    // support for projecting regular DOM Elements via V1 named slots ( shadow dom )
-    span: HAS_POSITIVE_NUMERIC_VALUE,
-    spellCheck: HAS_STRING_BOOLEAN_VALUE,
-    // Style must be explicitly set in the attribute list. React components
-    // expect a style object
-    style: 0,
-    // Keep it in the whitelist because it is case-sensitive for SVG.
-    tabIndex: 0,
-    // itemScope is for for Microdata support.
-    // See http://schema.org/docs/gs.html
-    itemScope: HAS_BOOLEAN_VALUE,
-    // These attributes must stay in the white-list because they have
-    // different attribute names (see `attributeNames`)
-    // TODO: this doesn't seem great? Probably means we depend on
-    // existence in the whitelist somewhere we shouldn't need to.
-    acceptCharset: 0,
-    className: 0,
-    htmlFor: 0,
-    httpEquiv: 0,
-    // Set the string boolean flag to allow the behavior
-    value: HAS_STRING_BOOLEAN_VALUE,
-  },
+  allowFullScreen: BOOLEAN,
+  // specifies target context for links with `preload` type
+  async: BOOLEAN,
+  // Note: there is a special case that prevents it from being written to the DOM
+  // on the client side because the browsers are inconsistent. Instead we call focus().
+  autoFocus: BOOLEAN,
+  autoPlay: BOOLEAN,
+  capture: OVERLOADED_BOOLEAN,
+  checked: BOOLEAN,
+  cols: POSITIVE_NUMERIC,
+  contentEditable: STRING_BOOLEAN,
+  controls: BOOLEAN,
+  default: BOOLEAN,
+  defer: BOOLEAN,
+  disabled: BOOLEAN,
+  download: OVERLOADED_BOOLEAN,
+  draggable: STRING_BOOLEAN,
+  formNoValidate: BOOLEAN,
+  hidden: BOOLEAN,
+  loop: BOOLEAN,
+  // Caution; `option.selected` is not updated if `select.multiple` is
+  // disabled with `removeAttribute`.
+  multiple: BOOLEAN,
+  muted: BOOLEAN,
+  noValidate: BOOLEAN,
+  open: BOOLEAN,
+  playsInline: BOOLEAN,
+  readOnly: BOOLEAN,
+  required: BOOLEAN,
+  reversed: BOOLEAN,
+  rows: POSITIVE_NUMERIC,
+  rowSpan: NUMERIC,
+  scoped: BOOLEAN,
+  seamless: BOOLEAN,
+  selected: BOOLEAN,
+  size: POSITIVE_NUMERIC,
+  start: NUMERIC,
+  // support for projecting regular DOM Elements via V1 named slots ( shadow dom )
+  span: POSITIVE_NUMERIC,
+  spellCheck: STRING_BOOLEAN,
+  // Style must be explicitly set in the attribute list. React components
+  // expect a style object
+  style: STRING,
+  // Keep it in the whitelist because it is case-sensitive for SVG.
+  tabIndex: STRING,
+  // itemScope is for for Microdata support.
+  // See http://schema.org/docs/gs.html
+  itemScope: BOOLEAN,
+  // These attributes must stay in the white-list because they have
+  // different attribute names (see `attributeNames`)
+  // TODO: this doesn't seem great? Probably means we depend on
+  // existence in the whitelist somewhere we shouldn't need to.
+  acceptCharset: STRING,
+  className: STRING,
+  htmlFor: STRING,
+  httpEquiv: STRING,
+  // Set the string boolean flag to allow the behavior
+  value: STRING_BOOLEAN,
 };
 
 /**
@@ -425,11 +382,9 @@ var SVG_ATTRS = [
 ];
 
 var SVGDOMPropertyConfig = {
-  Properties: {
-    autoReverse: HAS_STRING_BOOLEAN_VALUE,
-    externalResourcesRequired: HAS_STRING_BOOLEAN_VALUE,
-    preserveAlpha: HAS_STRING_BOOLEAN_VALUE,
-  },
+  autoReverse: STRING_BOOLEAN,
+  externalResourcesRequired: STRING_BOOLEAN,
+  preserveAlpha: STRING_BOOLEAN,
 };
 
 var CAMELIZE = /[\-\:]([a-z])/g;
@@ -437,7 +392,7 @@ var capitalize = token => token[1].toUpperCase();
 
 SVG_ATTRS.forEach(original => {
   var reactName = original.replace(CAMELIZE, capitalize);
-  SVGDOMPropertyConfig.Properties[reactName] = 0;
+  SVGDOMPropertyConfig[reactName] = STRING;
   attributeNames.set(reactName, original);
 });
 

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -1,52 +1,52 @@
 {
   "bundleSizes": {
     "react.development.js (UMD_DEV)": {
-      "size": 54742,
-      "gzip": 14879
+      "size": 54827,
+      "gzip": 14889
     },
     "react.production.min.js (UMD_PROD)": {
-      "size": 6617,
-      "gzip": 2819
+      "size": 6638,
+      "gzip": 2814
     },
     "react.development.js (NODE_DEV)": {
-      "size": 45158,
-      "gzip": 12576
+      "size": 45243,
+      "gzip": 12588
     },
     "react.production.min.js (NODE_PROD)": {
-      "size": 5412,
-      "gzip": 2389
+      "size": 5433,
+      "gzip": 2366
     },
     "React-dev.js (FB_DEV)": {
-      "size": 44502,
-      "gzip": 12082
+      "size": 44587,
+      "gzip": 12097
     },
     "React-prod.js (FB_PROD)": {
-      "size": 12810,
-      "gzip": 3444
+      "size": 12883,
+      "gzip": 3454
     },
     "react-dom.development.js (UMD_DEV)": {
-      "size": 578564,
-      "gzip": 134721
+      "size": 572561,
+      "gzip": 133380
     },
     "react-dom.production.min.js (UMD_PROD)": {
-      "size": 97670,
-      "gzip": 31735
+      "size": 95778,
+      "gzip": 31225
     },
     "react-dom.development.js (NODE_DEV)": {
-      "size": 559983,
-      "gzip": 130224
+      "size": 553984,
+      "gzip": 129036
     },
     "react-dom.production.min.js (NODE_PROD)": {
-      "size": 95570,
-      "gzip": 30694
+      "size": 93845,
+      "gzip": 30099
     },
     "ReactDOM-dev.js (FB_DEV)": {
-      "size": 585814,
-      "gzip": 134776
+      "size": 571848,
+      "gzip": 131110
     },
     "ReactDOM-prod.js (FB_PROD)": {
-      "size": 277160,
-      "gzip": 52569
+      "size": 271685,
+      "gzip": 51451
     },
     "react-dom-test-utils.development.js (NODE_DEV)": {
       "size": 36193,
@@ -61,120 +61,120 @@
       "gzip": 10379
     },
     "react-dom-unstable-native-dependencies.development.js (UMD_DEV)": {
-      "size": 64022,
-      "gzip": 16712
+      "size": 64058,
+      "gzip": 16719
     },
     "react-dom-unstable-native-dependencies.production.min.js (UMD_PROD)": {
-      "size": 11366,
-      "gzip": 3901
+      "size": 11360,
+      "gzip": 3905
     },
     "react-dom-unstable-native-dependencies.development.js (NODE_DEV)": {
-      "size": 59584,
-      "gzip": 15531
+      "size": 59620,
+      "gzip": 15536
     },
     "react-dom-unstable-native-dependencies.production.min.js (NODE_PROD)": {
-      "size": 10910,
-      "gzip": 3773
+      "size": 10902,
+      "gzip": 3779
     },
     "ReactDOMUnstableNativeDependencies-dev.js (FB_DEV)": {
-      "size": 60088,
-      "gzip": 15423
+      "size": 58735,
+      "gzip": 14915
     },
     "ReactDOMUnstableNativeDependencies-prod.js (FB_PROD)": {
-      "size": 26641,
-      "gzip": 5347
+      "size": 26979,
+      "gzip": 5417
     },
     "react-dom-server.browser.development.js (UMD_DEV)": {
-      "size": 97093,
-      "gzip": 26255
+      "size": 91639,
+      "gzip": 25022
     },
     "react-dom-server.browser.production.min.js (UMD_PROD)": {
-      "size": 15633,
-      "gzip": 6193
+      "size": 13606,
+      "gzip": 5631
     },
     "react-dom-server.browser.development.js (NODE_DEV)": {
-      "size": 86149,
-      "gzip": 23571
+      "size": 80697,
+      "gzip": 22363
     },
     "react-dom-server.browser.production.min.js (NODE_PROD)": {
-      "size": 14825,
-      "gzip": 5981
+      "size": 12962,
+      "gzip": 5382
     },
     "ReactDOMServer-dev.js (FB_DEV)": {
-      "size": 89552,
-      "gzip": 23612
+      "size": 83905,
+      "gzip": 22343
     },
     "ReactDOMServer-prod.js (FB_PROD)": {
-      "size": 32280,
-      "gzip": 8358
+      "size": 27288,
+      "gzip": 7465
     },
     "react-dom-server.node.development.js (NODE_DEV)": {
-      "size": 88117,
-      "gzip": 24074
+      "size": 82665,
+      "gzip": 22871
     },
     "react-dom-server.node.production.min.js (NODE_PROD)": {
-      "size": 15650,
-      "gzip": 6286
+      "size": 13786,
+      "gzip": 5689
     },
     "react-art.development.js (UMD_DEV)": {
-      "size": 361939,
-      "gzip": 80379
+      "size": 361747,
+      "gzip": 80408
     },
     "react-art.production.min.js (UMD_PROD)": {
-      "size": 84286,
+      "size": 84292,
       "gzip": 26065
     },
     "react-art.development.js (NODE_DEV)": {
-      "size": 286024,
-      "gzip": 61273
+      "size": 285834,
+      "gzip": 61333
     },
     "react-art.production.min.js (NODE_PROD)": {
-      "size": 47969,
-      "gzip": 15083
+      "size": 47976,
+      "gzip": 15085
     },
     "ReactART-dev.js (FB_DEV)": {
-      "size": 297400,
-      "gzip": 63247
+      "size": 290183,
+      "gzip": 61074
     },
     "ReactART-prod.js (FB_PROD)": {
-      "size": 148574,
-      "gzip": 25513
+      "size": 149114,
+      "gzip": 25640
     },
     "ReactNativeRenderer-dev.js (RN_DEV)": {
-      "size": 416454,
-      "gzip": 91923
+      "size": 415491,
+      "gzip": 91701
     },
     "ReactNativeRenderer-prod.js (RN_PROD)": {
-      "size": 201601,
-      "gzip": 34894
+      "size": 201086,
+      "gzip": 34724
     },
     "ReactRTRenderer-dev.js (RN_DEV)": {
-      "size": 291644,
-      "gzip": 62222
+      "size": 290573,
+      "gzip": 61998
     },
     "ReactRTRenderer-prod.js (RN_PROD)": {
-      "size": 138617,
-      "gzip": 23508
+      "size": 138274,
+      "gzip": 23358
     },
     "ReactCSRenderer-dev.js (RN_DEV)": {
-      "size": 281365,
-      "gzip": 59056
+      "size": 281173,
+      "gzip": 59079
     },
     "ReactCSRenderer-prod.js (RN_PROD)": {
-      "size": 130905,
-      "gzip": 22024
+      "size": 130921,
+      "gzip": 22026
     },
     "react-test-renderer.development.js (NODE_DEV)": {
-      "size": 282598,
-      "gzip": 60077
+      "size": 282399,
+      "gzip": 60134
     },
     "react-test-renderer.production.min.js (NODE_PROD)": {
       "size": 46329,
       "gzip": 14428
     },
     "ReactTestRenderer-dev.js (FB_DEV)": {
-      "size": 294070,
-      "gzip": 62012
+      "size": 286844,
+      "gzip": 59878
     },
     "react-test-renderer-shallow.development.js (NODE_DEV)": {
       "size": 10233,
@@ -189,12 +189,12 @@
       "gzip": 2725
     },
     "react-noop-renderer.development.js (NODE_DEV)": {
-      "size": 17474,
-      "gzip": 4854
+      "size": 18189,
+      "gzip": 5097
     },
     "react-reconciler.development.js (NODE_DEV)": {
-      "size": 264451,
-      "gzip": 55691
+      "size": 264252,
+      "gzip": 55746
     },
     "react-reconciler.production.min.js (NODE_PROD)": {
       "size": 39641,
@@ -217,8 +217,8 @@
       "gzip": 3917
     },
     "react-noop-renderer.production.min.js (NODE_PROD)": {
-      "size": 6011,
-      "gzip": 2419
+      "size": 6371,
+      "gzip": 2550
     },
     "react-reconciler-reflection.development.js (NODE_DEV)": {
       "size": 10398,


### PR DESCRIPTION
The goal is to remove the "injection" step at initialization. I find it confusing because we always have to look in three places: the configs, the initialization logic, and then the use of those properties. I think this is partly why the logic got so tangled by now.

I'm starting by removing the `propertyInfo.*` properties one by one, replacing them with function calls. There might be better implementations—happy to revise them. In some cases it may seem like we'd have to repeat an attribute name a few more times than before, but I think it probably gzips well, and in any case I'll make sure the size is smaller or the same before merging.

Note I'm not changing logic yet. There are a few oddities in how code paths differ based on whether `propertyInfo` exists—which ideally shouldn't be the case. I'll looking at that later.