### PR TITLE
Fix autoFocus for hydration content when it is mismatched

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -357,6 +357,7 @@ describe('ReactDOMServer', () => {
       expect(element.firstChild.focus).not.toHaveBeenCalled();
     });
 
+    // Regression test for https://github.com/facebook/react/issues/11726
     it('should not focus on either server or client with autofocus={false}', () => {
       var element = document.createElement('div');
       element.innerHTML = ReactDOMServer.renderToString(

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -372,7 +372,7 @@ describe('ReactDOMServer', () => {
       expect(element.firstChild.focus).not.toHaveBeenCalled();
     });
 
-    it('should not focus on either server or client with autofocus={false} even if the markup is mismatch', () => {
+    it('should not focus on either server or client with autofocus={false} even if there is a markup mismatch', () => {
       spyOnDev(console, 'error');
 
       var element = document.createElement('div');
@@ -387,6 +387,9 @@ describe('ReactDOMServer', () => {
       expect(element.firstChild.focus).not.toHaveBeenCalled();
       if (__DEV__) {
         expect(console.error.calls.count()).toBe(1);
+        expect(console.error.calls.argsFor(0)[0]).toBe(
+          'Warning: Text content did not match. Server: "server" Client: "client"'
+        );
       }
     });
 

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -372,6 +372,22 @@ describe('ReactDOMServer', () => {
       expect(element.firstChild.focus).not.toHaveBeenCalled();
     });
 
+    it('should not focus on either server or client with autofocus={false} even if the markup is mismatch', () => {
+      spyOnDev(console, 'error');
+
+      var element = document.createElement('div');
+      element.innerHTML = ReactDOMServer.renderToString(
+        <button autoFocus={false}>server</button>,
+      );
+      expect(element.firstChild.autofocus).toBe(false);
+
+      element.firstChild.focus = jest.fn();
+      ReactDOM.hydrate(<button autoFocus={false}>client</button>, element);
+
+      expect(element.firstChild.focus).not.toHaveBeenCalled();
+      expect(console.error.calls.count()).toBe(1);
+    });
+
     it('should throw with silly args', () => {
       expect(
         ReactDOMServer.renderToString.bind(ReactDOMServer, {x: 123}),

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -385,7 +385,9 @@ describe('ReactDOMServer', () => {
       ReactDOM.hydrate(<button autoFocus={false}>client</button>, element);
 
       expect(element.firstChild.focus).not.toHaveBeenCalled();
-      expect(console.error.calls.count()).toBe(1);
+      if (__DEV__) {
+        expect(console.error.calls.count()).toBe(1);
+      }
     });
 
     it('should throw with silly args', () => {

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -388,7 +388,7 @@ describe('ReactDOMServer', () => {
       if (__DEV__) {
         expect(console.error.calls.count()).toBe(1);
         expect(console.error.calls.argsFor(0)[0]).toBe(
-          'Warning: Text content did not match. Server: "server" Client: "client"'
+          'Warning: Text content did not match. Server: "server" Client: "client"',
         );
       }
     });

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -357,7 +357,6 @@ describe('ReactDOMServer', () => {
       expect(element.firstChild.focus).not.toHaveBeenCalled();
     });
 
-    // Regression test for https://github.com/facebook/react/issues/11726
     it('should not focus on either server or client with autofocus={false}', () => {
       var element = document.createElement('div');
       element.innerHTML = ReactDOMServer.renderToString(
@@ -373,6 +372,7 @@ describe('ReactDOMServer', () => {
       expect(element.firstChild.focus).not.toHaveBeenCalled();
     });
 
+    // Regression test for https://github.com/facebook/react/issues/11726
     it('should not focus on either server or client with autofocus={false} even if there is a markup mismatch', () => {
       spyOnDev(console, 'error');
 

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -625,7 +625,7 @@ const DOMRenderer = ReactFiberReconciler({
     rootContainerInstance: Container,
   ): boolean {
     setInitialProperties(domElement, type, props, rootContainerInstance);
-    return shouldAutoFocusHostComponent(type, props);
+    return true;
   },
 
   prepareUpdate(

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -700,6 +700,9 @@ const DOMRenderer = ReactFiberReconciler({
       newProps: Props,
       internalInstanceHandle: Object,
     ): void {
+      // This check is required for hydration
+      // but this check run twice in a non hydration context
+      // TODO: Ensure to do this check only once.
       if (shouldAutoFocusHostComponent(type, newProps)) {
         ((domElement: any):
           | HTMLButtonElement

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -625,7 +625,7 @@ const DOMRenderer = ReactFiberReconciler({
     rootContainerInstance: Container,
   ): boolean {
     setInitialProperties(domElement, type, props, rootContainerInstance);
-    return true;
+    return shouldAutoFocusHostComponent(type, props);
   },
 
   prepareUpdate(

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -700,9 +700,12 @@ const DOMRenderer = ReactFiberReconciler({
       newProps: Props,
       internalInstanceHandle: Object,
     ): void {
-      // This check is required for hydration
-      // but this check run twice in a non hydration context
-      // TODO: Ensure to do this check only once.
+      // Despite the naming that might imply otherwise, this method only
+      // fires if there is an `Update` effect scheduled during mounting.
+      // This happens if `finalizeInitialChildren` returns `true` (which it
+      // does to implement the `autoFocus` attribute on the client). But
+      // there are also other cases when this might happen (such as patching
+      // up text content during hydration mismatch). So we'll check this again.
       if (shouldAutoFocusHostComponent(type, newProps)) {
         ((domElement: any):
           | HTMLButtonElement

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -700,11 +700,13 @@ const DOMRenderer = ReactFiberReconciler({
       newProps: Props,
       internalInstanceHandle: Object,
     ): void {
-      ((domElement: any):
-        | HTMLButtonElement
-        | HTMLInputElement
-        | HTMLSelectElement
-        | HTMLTextAreaElement).focus();
+      if (shouldAutoFocusHostComponent(type, newProps)) {
+        ((domElement: any):
+          | HTMLButtonElement
+          | HTMLInputElement
+          | HTMLSelectElement
+          | HTMLTextAreaElement).focus();
+      }
     },
 
     commitUpdate(


### PR DESCRIPTION
This PR it to fix #11726.

In no hydration case, this validation is executed at here.

* https://github.com/facebook/react/blob/master/packages/react-dom/src/client/ReactDOM.js#L628  

But in hydration case, the validation doesn't pass through. So I've added the validation into before calling `focus()`. Is there any proper place to put the validation?