### PR TITLE
Remove dead code from DOMPropertyOperations

### DIFF
--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -187,11 +187,6 @@ export function setValueForProperty(node, name, value) {
     );
     return;
   }
-
-  if (__DEV__) {
-    var payload = {};
-    payload[name] = value;
-  }
 }
 
 export function setValueForAttribute(node, name, value) {
@@ -202,11 +197,6 @@ export function setValueForAttribute(node, name, value) {
     node.removeAttribute(name);
   } else {
     node.setAttribute(name, '' + value);
-  }
-
-  if (__DEV__) {
-    var payload = {};
-    payload[name] = value;
   }
 }
 


### PR DESCRIPTION
Just noticed this working through #11734. I'm not really sure what happened, but I think this dead code can go.