### PR TITLE
Add a test for bad Map polyfill, and work around Rollup bug

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -44,7 +44,8 @@ if (__DEV__) {
     var testMap = new Map([[nonExtensibleObject, null]]);
     var testSet = new Set([nonExtensibleObject]);
     // This is necessary for Rollup to not consider these unused.
-    // TODO: report this as a Rollup bug.
+    // https://github.com/rollup/rollup/issues/1771
+    // TODO: we can remove these if Rollup fixes the bug.
     testMap.set(0, 0);
     testSet.add(0);
   } catch (e) {

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -41,10 +41,12 @@ if (__DEV__) {
   var hasBadMapPolyfill = false;
   try {
     var nonExtensibleObject = Object.preventExtensions({});
-    /* eslint-disable no-new */
-    new Map([[nonExtensibleObject, null]]);
-    new Set([nonExtensibleObject]);
-    /* eslint-enable no-new */
+    var testMap = new Map([[nonExtensibleObject, null]]);
+    var testSet = new Set([nonExtensibleObject]);
+    // This is necessary for Rollup to not consider these unused.
+    // TODO: report this as a Rollup bug.
+    testMap.set(0, 0);
+    testSet.add(0);
   } catch (e) {
     // TODO: Consider warning about bad polyfills
     hasBadMapPolyfill = true;


### PR DESCRIPTION
This adds test coverage for these lines:

https://github.com/facebook/react/blob/59763bf7f3ab3b06cd8ab5a5a83ae3dafc667aa9/packages/react-reconciler/src/ReactFiber.js#L41-L51

I only did this for `Map` because it's a bit hacky, and I figured this would be enough to find regressions.

It fails the bundle tests because apparently Rollup strips the `new` calls out (which is how we discovered the problem with this check). So I added a workaround for that, and a TODO to report this to Rollup.