### PR TITLE
Adds warning for older unstable methods

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -222,6 +222,7 @@ describe('ReactDOMFiber', () => {
 
   // TODO: remove in React 17
   it('should support unstable_createPortal alias', () => {
+    spyOnDev(console, 'warn');
     const portalContainer = document.createElement('div');
 
     ReactDOM.render(
@@ -232,6 +233,16 @@ describe('ReactDOMFiber', () => {
     );
     expect(portalContainer.innerHTML).toBe('<div>portal</div>');
     expect(container.innerHTML).toBe('<div></div>');
+
+    if (__DEV__) {
+      expect(console.warn.calls.count()).toBe(1);
+      expect(console.warn.calls.argsFor(0)[0]).toContain(
+        'The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
+          'and will be removed in React 17+. Update your code to use ' +
+          'ReactDOM.createPortal() instead. It has the exact same API, ' +
+          'but without the "unstable_" prefix.',
+      );
+    }
 
     ReactDOM.unmountComponentAtNode(container);
     expect(portalContainer.innerHTML).toBe('');

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -75,6 +75,7 @@ const {precacheFiberNode, updateFiberProps} = ReactDOMComponentTree;
 let SUPPRESS_HYDRATION_WARNING;
 let topLevelUpdateWarnings;
 let warnOnInvalidCallback;
+let didWarnAboutUnstableCreatePortal = false;
 
 if (__DEV__) {
   SUPPRESS_HYDRATION_WARNING = 'suppressHydrationWarning';
@@ -1276,7 +1277,19 @@ const ReactDOM: Object = {
 
   // Temporary alias since we already shipped React 16 RC with it.
   // TODO: remove in React 17.
-  unstable_createPortal: createPortal,
+  unstable_createPortal(...args) {
+    if (!didWarnAboutUnstableCreatePortal) {
+      didWarnAboutUnstableCreatePortal = true;
+      lowPriorityWarning(
+        false,
+        'The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
+          'and will be removed in React 17+. Update your code to use ' +
+          'ReactDOM.createPortal() instead. It has the exact same API, ' +
+          'but without the "unstable_" prefix.',
+      );
+    }
+    return createPortal(...args);
+  },
 
   unstable_batchedUpdates: ReactGenericBatching.batchedUpdates,
 


### PR DESCRIPTION
I noticed some methods like `unstable_createPortal` are scheduled for removal in React 17 and do not have warnings at the moment. If this commit looks good (and necessary) I'll add warnings to other methods too.

Hope this helps :)