### PR TITLE
Fix benchmark runner

### DIFF
--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -4,10 +4,10 @@
 
 In most cases, the only two commands you might want to use are:
 
-- `yarn bench`
-- `yarn build -- --type=UMD_PROD && yarn bench -- --skip-build`
+- `yarn start`
+- `yarn build core,dom-client --type=UMD_PROD && yarn start --skip-build`
 
-The first command will run benchmarks with all the default settings. A local and remote build will occcur on all bundles, both local and remote repos will be run against all benchmarks.
+The first command will run benchmarks with all the default settings. A local and remote build will occur on React and ReactDOM UMD bundles, both local and remote repos will be run against all benchmarks.
 
 The second command will run all benchmarks but skip the build process. This is useful for when doing local performance tweaking and the remote repo has already had its bundles built. Both local and remote repos will be run against all benchmarks with this command too.
 
@@ -15,27 +15,27 @@ The other commands are as follows:
 
 ```bash
 # will compare local repo vs remote merge base repo
-yarn bench
+yarn start
 
 # will compare local repo vs remote merge base repo
 # this can significantly improve bench times due to no build
-yarn bench -- --skip-build
+yarn start --skip-build
 
 # will only build and run local repo against benchmarks (no remote values will be shown)
-yarn bench -- --local
+yarn start --local
 
 # will only build and run remote merge base repo against benchmarks (no local values will be shown)
-yarn bench -- --remote
+yarn start --remote
 
 # will only build and run remote master repo against benchmarks
-yarn bench -- --remote=master
+yarn start --remote=master
 
-# same as "yarn bench"
-yarn bench -- --remote --local
+# same as "yarn start"
+yarn start --remote --local
 
 # runs benchmarks with Chrome in headless mode
-yarn bench -- --headless
+yarn start --headless
 
 # runs only specific string matching benchmarks
-yarn bench -- --benchmark=hacker
+yarn start --benchmark=hacker
 ```

--- a/scripts/bench/build.js
+++ b/scripts/bench/build.js
@@ -42,21 +42,12 @@ function getDefaultReactPath() {
   return join(__dirname, 'remote-repo');
 }
 
-async function buldAllBundles(reactPath = getDefaultReactPath()) {
-  // build the react FB bundles in the build
-  await executeCommand(`cd ${reactPath} && yarn && yarn build`);
-}
-
 async function buildBenchmark(reactPath = getDefaultReactPath(), benchmark) {
   // get the build.js from the benchmark directory and execute it
   await require(join(__dirname, 'benchmarks', benchmark, 'build.js'))(
     reactPath,
     asyncCopyTo
   );
-}
-
-function getBundleResults(reactPath = getDefaultReactPath()) {
-  return require(join(reactPath, 'scripts', 'rollup', 'results.json'));
 }
 
 async function getMergeBaseFromLocalGitRepo(localRepo) {
@@ -106,17 +97,16 @@ async function buildBenchmarkBundlesFromGitRepo(
       // then we checkout the merge base
       await Git.Checkout.tree(repo, commit);
     }
-    await buildAllBundles();
+    await buildReactBundles();
   }
-  return getBundleResults();
 }
 
-async function buildAllBundles(reactPath, skipBuild) {
+async function buildReactBundles(reactPath = getDefaultReactPath(), skipBuild) {
   if (!skipBuild) {
-    // build all bundles so we can get all stats and use bundles for benchmarks
-    await buldAllBundles(reactPath);
+    await executeCommand(
+      `cd ${reactPath} && yarn && yarn build core,dom-client --type=UMD_PROD`
+    );
   }
-  return getBundleResults(reactPath);
 }
 
 // if run directly via CLI
@@ -125,7 +115,7 @@ if (require.main === module) {
 }
 
 module.exports = {
-  buildAllBundles,
+  buildReactBundles,
   buildBenchmark,
   buildBenchmarkBundlesFromGitRepo,
   getMergeBaseFromLocalGitRepo,

--- a/scripts/bench/runner.js
+++ b/scripts/bench/runner.js
@@ -4,7 +4,7 @@ const {readdirSync, statSync} = require('fs');
 const {join} = require('path');
 const runBenchmark = require('./benchmark');
 const {
-  buildAllBundles,
+  buildReactBundles,
   buildBenchmark,
   buildBenchmarkBundlesFromGitRepo,
   getMergeBaseFromLocalGitRepo,
@@ -72,10 +72,8 @@ async function benchmarkRemoteMaster() {
       chalk.gray(`- Merge base commit ${chalk.white(commit.tostrS())}`)
     );
   }
+  await buildBenchmarkBundlesFromGitRepo(commit, skipBuild);
   return {
-    // we build the bundles from the React repo
-    bundles: await buildBenchmarkBundlesFromGitRepo(commit, skipBuild),
-    // we use these bundles to run the benchmarks
     benchmarks: await runBenchmarks(),
   };
 }
@@ -84,10 +82,8 @@ async function benchmarkRemoteMaster() {
 // of the local react repo
 async function benchmarkLocal(reactPath) {
   console.log(chalk.gray(`- Building React bundles...`));
+  await buildReactBundles(reactPath, skipBuild);
   return {
-    // we build the bundles from the React repo
-    bundles: await buildAllBundles(reactPath, skipBuild),
-    // we use these bundles to run the benchmarks
     benchmarks: await runBenchmarks(reactPath),
   };
 }

--- a/scripts/bench/stats.js
+++ b/scripts/bench/stats.js
@@ -93,52 +93,6 @@ function addBenchmarkResults(table, localResults, remoteMasterResults) {
   });
 }
 
-function addBundleSizeComparsions(table, localResults, remoteMasterResults) {
-  const bundlesRowHeader = [chalk.white.bold('Bundles')];
-  if (remoteMasterResults) {
-    bundlesRowHeader.push(chalk.white.bold('Size'));
-  }
-  if (localResults) {
-    bundlesRowHeader.push(chalk.white.bold('Size'));
-  }
-  if (localResults && remoteMasterResults) {
-    bundlesRowHeader.push(chalk.white.bold('Diff'));
-  }
-  table.push(bundlesRowHeader);
-
-  const bundles = Object.keys(
-    (localResults && localResults.bundles.bundleSizes) ||
-      (remoteMasterResults && remoteMasterResults.bundles.bundleSizes)
-  );
-  bundles.forEach(bundle => {
-    const row = [chalk.gray(bundle)];
-    let remoteSize = 0;
-    if (remoteMasterResults) {
-      const remoteBundle = (remoteSize =
-        remoteMasterResults.bundles.bundleSizes[bundle]);
-
-      if (remoteBundle) {
-        remoteSize = remoteSize.size;
-      }
-      row.push(chalk.white(remoteSize + ' kb'));
-    }
-    let localSize = 0;
-    if (localResults) {
-      const localBundle = localResults.bundles.bundleSizes[bundle];
-
-      if (localBundle) {
-        localSize = localBundle.size;
-      }
-      localSize = localResults.bundles.bundleSizes[bundle].size;
-      row.push(chalk.white(localSize + ' kb'));
-    }
-    if (localResults && remoteMasterResults) {
-      row.push(percentChange(remoteSize, localSize, 0, 0));
-    }
-    table.push(row);
-  });
-}
-
 function printResults(localResults, remoteMasterResults) {
   const head = [''];
   if (remoteMasterResults) {
@@ -151,10 +105,7 @@ function printResults(localResults, remoteMasterResults) {
     head.push('');
   }
   const table = new Table({head});
-
-  addBundleSizeComparsions(table, localResults, remoteMasterResults);
   addBenchmarkResults(table, localResults, remoteMasterResults);
-
   console.log(table.toString());
 }
 


### PR DESCRIPTION
I used it today, and decided to change a few things to make it more usable.

* Fixed `lighthouse` dependency version, this one is broken.
* Fixed instructions to match Yarn 1.0 syntax and the command name.
* Removed the build stats table: we already have it on the build.
* This allowed me to always build just React/ReactDOM UMDs without being confusing. Since otherwise the build is impossibly slow for iteration, and I ended up building just React/ReactDOM UMDs anyway.