### PR TITLE
Eliminate unnecessary numeric equality checks

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -248,7 +248,7 @@ describe('ReactDOMInput', () => {
     }
   });
 
-  it('performs as state change from "" to 0', () => {
+  it('performs a state change from "" to 0', () => {
     class Stub extends React.Component {
       state = {
         value: '',

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -254,7 +254,7 @@ describe('ReactDOMInput', () => {
         value: '',
       };
       render() {
-        return <input type="number" value={this.state.value} readOnly />;
+        return <input type="number" value={this.state.value} readOnly={true} />;
       }
     }
 

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -595,6 +595,7 @@ describe('ReactDOMInput', () => {
     var node = container.firstChild;
 
     expect(node.value).toBe('0');
+    expect(node.defaultValue).toBe('0');
   });
 
   it('should properly transition from 0 to an empty value', function() {
@@ -606,6 +607,19 @@ describe('ReactDOMInput', () => {
     var node = container.firstChild;
 
     expect(node.value).toBe('');
+    expect(node.defaultValue).toBe('');
+  });
+
+  it('should properly transition a text input from 0 to an empty 0.0', function() {
+    var container = document.createElement('div');
+
+    ReactDOM.render(<input type="text" value={0} />, container);
+    ReactDOM.render(<input type="text" value="0.0" />, container);
+
+    var node = container.firstChild;
+
+    expect(node.value).toBe('0.0');
+    expect(node.defaultValue).toBe('0.0');
   });
 
   it('should have the correct target value', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -248,6 +248,23 @@ describe('ReactDOMInput', () => {
     }
   });
 
+  it('performs as state change from "" to 0', () => {
+    class Stub extends React.Component {
+      state = {
+        value: '',
+      };
+      render() {
+        return <input type="number" value={this.state.value} readOnly />;
+      }
+    }
+
+    var stub = ReactTestUtils.renderIntoDocument(<Stub />);
+    var node = ReactDOM.findDOMNode(stub);
+    stub.setState({value: 0});
+
+    expect(node.value).toEqual('0');
+  });
+
   it('distinguishes precision for extra zeroes in string number values', () => {
     spyOnDev(console, 'error');
     class Stub extends React.Component {
@@ -620,6 +637,30 @@ describe('ReactDOMInput', () => {
 
     expect(node.value).toBe('0.0');
     expect(node.defaultValue).toBe('0.0');
+  });
+
+  it('should properly transition a number input from "" to 0', function() {
+    var container = document.createElement('div');
+
+    ReactDOM.render(<input type="number" value="" />, container);
+    ReactDOM.render(<input type="number" value={0} />, container);
+
+    var node = container.firstChild;
+
+    expect(node.value).toBe('0');
+    expect(node.defaultValue).toBe('0');
+  });
+
+  it('should properly transition a number input from "" to "0"', function() {
+    var container = document.createElement('div');
+
+    ReactDOM.render(<input type="number" value="" />, container);
+    ReactDOM.render(<input type="number" value="0" />, container);
+
+    var node = container.firstChild;
+
+    expect(node.value).toBe('0');
+    expect(node.defaultValue).toBe('0');
   });
 
   it('should have the correct target value', () => {

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -182,8 +182,11 @@ export function updateWrapper(element: Element, props: Object) {
 
   if (value != null) {
     if (props.type === 'number') {
-      // eslint-disable-next-line
-      if (node.value != value || (value === 0 && node.value === '')) {
+      if (
+        (value === 0 && node.value === '') ||
+        // eslint-disable-next-line
+        node.value != value
+      ) {
         node.value = '' + value;
       }
     } else if (node.value !== '' + value) {

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -181,19 +181,9 @@ export function updateWrapper(element: Element, props: Object) {
   var value = getSafeValue(props.value);
 
   if (value != null) {
-    if (value === 0 && node.value === '') {
-      node.value = '0';
-      // Note: IE9 reports a number inputs as 'text', so check props instead.
-    } else if (props.type === 'number') {
-      // Simulate `input.valueAsNumber`. IE9 does not support it
-      var valueAsNumber = parseFloat(node.value) || 0;
-
-      if (
-        // eslint-disable-next-line
-        value != valueAsNumber ||
-        // eslint-disable-next-line
-        (value == valueAsNumber && node.value != value)
-      ) {
+    if (props.type === 'number') {
+      // eslint-disable-next-line
+      if (node.valueAsNumber !== value && node.value != value) {
         node.value = '' + value;
       }
     } else if (node.value !== '' + value) {

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -183,7 +183,7 @@ export function updateWrapper(element: Element, props: Object) {
   if (value != null) {
     if (props.type === 'number') {
       // eslint-disable-next-line
-      if (node.valueAsNumber !== value && node.value != value) {
+      if (node.value != value) {
         node.value = '' + value;
       }
     } else if (node.value !== '' + value) {

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -183,7 +183,7 @@ export function updateWrapper(element: Element, props: Object) {
   if (value != null) {
     if (props.type === 'number') {
       // eslint-disable-next-line
-      if (node.value != value) {
+      if (node.value != value || (value === 0 && node.value === '')) {
         node.value = '' + value;
       }
     } else if (node.value !== '' + value) {


### PR DESCRIPTION
This commit changes the way numeric equality for number inputs works such that it compares loose equality for numbers. This seems sufficient, and eliminates quite a bit of branching around numeric equality.

This additionally addresses Flow type issues on #11741, and it is based off that branch

**Test plan:**

1. Open http://react-concise-numbers.surge.sh
2. Run through the Text and Number test fixtures

**Tested in:**

* [x] Chrome 43, 62
* [x] Safari 7.1, 11
* [x] Firefox 52 (ESR), 58
* [x] IE 9, 10, 11
* [x] Edge 14, 16