### PR TITLE
Changed the way we double-invoke cWM lifecycle hook

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -216,6 +216,16 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         // In the initial pass we might need to construct the instance.
         constructClassInstance(workInProgress, workInProgress.pendingProps);
         mountClassInstance(workInProgress, renderExpirationTime);
+
+        // Simulate an async bailout/interruption by invoking lifecycle twice.
+        // We do this here rather than inside of ReactFiberClassComponent,
+        // To more realistically simulate the interruption behavior of async,
+        // Which would never call componentWillMount() twice on the same instance.
+        if (debugRenderPhaseSideEffects) {
+          constructClassInstance(workInProgress, workInProgress.pendingProps);
+          mountClassInstance(workInProgress, renderExpirationTime);
+        }
+
         shouldUpdate = true;
       } else {
         invariant(false, 'Resuming work not yet implemented.');

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -384,11 +384,6 @@ export default function(
     instance.componentWillMount();
     stopPhaseTimer();
 
-    // Simulate an async bailout/interruption by invoking lifecycle twice.
-    if (debugRenderPhaseSideEffects) {
-      instance.componentWillMount();
-    }
-
     if (oldState !== instance.state) {
       if (__DEV__) {
         warning(

--- a/packages/react/src/__tests__/ReactAsyncClassComponent-test.internal.js
+++ b/packages/react/src/__tests__/ReactAsyncClassComponent-test.internal.js
@@ -28,6 +28,10 @@ describe('ReactAsyncClassComponent', () => {
       let shouldComponentUpdate = false;
       class ClassComponent extends React.Component {
         state = {};
+        constructor() {
+          super();
+          log.push('constructor');
+        }
         componentDidMount() {
           log.push('componentDidMount');
         }
@@ -58,7 +62,9 @@ describe('ReactAsyncClassComponent', () => {
 
       const component = ReactTestRenderer.create(<ClassComponent />);
       expect(log).toEqual([
+        'constructor',
         'componentWillMount',
+        'constructor',
         'componentWillMount',
         'render',
         'render',

--- a/packages/react/src/__tests__/ReactAsyncClassComponent-test.internal.js
+++ b/packages/react/src/__tests__/ReactAsyncClassComponent-test.internal.js
@@ -28,8 +28,8 @@ describe('ReactAsyncClassComponent', () => {
       let shouldComponentUpdate = false;
       class ClassComponent extends React.Component {
         state = {};
-        constructor() {
-          super();
+        constructor(props) {
+          super(props);
           log.push('constructor');
         }
         componentDidMount() {


### PR DESCRIPTION
Moved the double-lifecycle check for cWM from `ReactFiberClassComponent` to `ReactFiberBeginWork` to more realistically simulate the interruption behavior of async (which would never call cWM twice on the same instance). I believe this is a safe move because the only effects `constructClassInstance` and `mountClassInstance` have are either on the instance (one of which which will get thrown away) or the WIP fiber (which will be overridden the 2nd time).