### PR TITLE
ReactDOM.createRoot creates an async root

### DIFF
--- a/packages/react-cs-renderer/src/ReactNativeCS.js
+++ b/packages/react-cs-renderer/src/ReactNativeCS.js
@@ -265,7 +265,11 @@ const ReactCS = CSStatefulComponent({
     let container = {
       pendingChild: null,
     };
-    let root = ReactNativeCSFiberRenderer.createContainer(container, false);
+    let root = ReactNativeCSFiberRenderer.createContainer(
+      container,
+      false,
+      false,
+    );
     return {root, container};
   },
   render({

--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
@@ -69,26 +69,18 @@ describe('ReactDOMFiberAsync', () => {
       ReactFeatureFlags = require('shared/ReactFeatureFlags');
       container = document.createElement('div');
       ReactFeatureFlags.enableAsyncSubtreeAPI = true;
+      ReactFeatureFlags.enableCreateRoot = true;
       ReactDOM = require('react-dom');
     });
 
-    it('AsyncComponent at the root makes the entire tree async', () => {
-      ReactDOM.render(
-        <AsyncComponent>
-          <div>Hi</div>
-        </AsyncComponent>,
-        container,
-      );
+    it('createRoot makes the entire tree async', () => {
+      const root = ReactDOM.createRoot(container);
+      root.render(<div>Hi</div>);
       expect(container.textContent).toEqual('');
       jest.runAllTimers();
       expect(container.textContent).toEqual('Hi');
 
-      ReactDOM.render(
-        <AsyncComponent>
-          <div>Bye</div>
-        </AsyncComponent>,
-        container,
-      );
+      root.render(<div>Bye</div>);
       expect(container.textContent).toEqual('Hi');
       jest.runAllTimers();
       expect(container.textContent).toEqual('Bye');
@@ -104,12 +96,8 @@ describe('ReactDOMFiberAsync', () => {
         }
       }
 
-      ReactDOM.render(
-        <AsyncComponent>
-          <Component />
-        </AsyncComponent>,
-        container,
-      );
+      const root = ReactDOM.createRoot(container);
+      root.render(<Component />);
       expect(container.textContent).toEqual('');
       jest.runAllTimers();
       expect(container.textContent).toEqual('0');

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
@@ -76,14 +76,17 @@ describe('ReactDOMRoot', () => {
   it('renders children', () => {
     const root = ReactDOM.createRoot(container);
     root.render(<div>Hi</div>);
+    flush();
     expect(container.textContent).toEqual('Hi');
   });
 
   it('unmounts children', () => {
     const root = ReactDOM.createRoot(container);
     root.render(<div>Hi</div>);
+    flush();
     expect(container.textContent).toEqual('Hi');
     root.unmount();
+    flush();
     expect(container.textContent).toEqual('');
   });
 
@@ -138,6 +141,7 @@ describe('ReactDOMRoot', () => {
         <span />
       </div>,
     );
+    flush();
     if (__DEV__) {
       expect(console.error.calls.count()).toBe(0);
     }
@@ -151,6 +155,7 @@ describe('ReactDOMRoot', () => {
         <span />
       </div>,
     );
+    flush();
     if (__DEV__) {
       expect(console.error.calls.count()).toBe(1);
       expect(console.error.calls.argsFor(0)[0]).toMatch('Extra attributes');
@@ -167,6 +172,7 @@ describe('ReactDOMRoot', () => {
         <span>d</span>
       </div>,
     );
+    flush();
     expect(container.textContent).toEqual('abcd');
     root.render(
       <div>
@@ -174,6 +180,7 @@ describe('ReactDOMRoot', () => {
         <span>c</span>
       </div>,
     );
+    flush();
     expect(container.textContent).toEqual('abdc');
   });
 

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -376,8 +376,8 @@ type Root = {
   _internalRoot: FiberRoot,
 };
 
-function ReactRoot(container: Container, hydrate: boolean) {
-  const root = DOMRenderer.createContainer(container, hydrate);
+function ReactRoot(container: Container, isAsync: boolean, hydrate: boolean) {
+  const root = DOMRenderer.createContainer(container, isAsync, hydrate);
   this._internalRoot = root;
 }
 ReactRoot.prototype.render = function(
@@ -1031,8 +1031,9 @@ function legacyCreateRootFromDOMContainer(
       );
     }
   }
-  const root: Root = new ReactRoot(container, shouldHydrate);
-  return root;
+  // Legacy roots are not async by default.
+  const isAsync = false;
+  return new ReactRoot(container, isAsync, shouldHydrate);
 }
 
 function legacyRenderSubtreeIntoContainer(
@@ -1300,7 +1301,7 @@ if (enableCreateRoot) {
     options?: RootOptions,
   ): ReactRoot {
     const hydrate = options != null && options.hydrate === true;
-    return new ReactRoot(container, hydrate);
+    return new ReactRoot(container, true, hydrate);
   };
 }
 

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -48,7 +48,11 @@ const ReactNativeRenderer: ReactNativeType = {
     if (!root) {
       // TODO (bvaughn): If we decide to keep the wrapper component,
       // We could create a wrapper for containerTag as well to reduce special casing.
-      root = ReactNativeFiberRenderer.createContainer(containerTag, false);
+      root = ReactNativeFiberRenderer.createContainer(
+        containerTag,
+        false,
+        false,
+      );
       roots.set(containerTag, root);
     }
     ReactNativeFiberRenderer.updateContainer(element, root, null, callback);

--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -341,7 +341,7 @@ var ReactNoop = {
     if (!root) {
       const container = {rootID: rootID, children: []};
       rootContainers.set(rootID, container);
-      root = NoopRenderer.createContainer(container, false);
+      root = NoopRenderer.createContainer(container, true, false);
       roots.set(rootID, root);
     }
     NoopRenderer.updateContainer(element, root, null, callback);
@@ -361,7 +361,7 @@ var ReactNoop = {
     if (!root) {
       const container = {rootID: rootID, children: []};
       rootContainers.set(rootID, container);
-      root = PersistentNoopRenderer.createContainer(container, false);
+      root = PersistentNoopRenderer.createContainer(container, true, false);
       persistentRoots.set(rootID, root);
     }
     PersistentNoopRenderer.updateContainer(element, root, null, callback);

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -35,7 +35,7 @@ import {
 import getComponentName from 'shared/getComponentName';
 
 import {NoWork} from './ReactFiberExpirationTime';
-import {NoContext} from './ReactTypeOfInternalContext';
+import {NoContext, AsyncUpdates} from './ReactTypeOfInternalContext';
 
 if (__DEV__) {
   var hasBadMapPolyfill = false;
@@ -288,9 +288,9 @@ export function createWorkInProgress(
   return workInProgress;
 }
 
-export function createHostRootFiber(): Fiber {
-  const fiber = createFiber(HostRoot, null, NoContext);
-  return fiber;
+export function createHostRootFiber(isAsync): Fiber {
+  const internalContextTag = isAsync ? AsyncUpdates : NoContext;
+  return createFiber(HostRoot, null, null, internalContextTag);
 }
 
 export function createFiberFromElement(

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -52,11 +52,12 @@ export type FiberRoot = {
 
 export function createFiberRoot(
   containerInfo: any,
+  isAsync: boolean,
   hydrate: boolean,
 ): FiberRoot {
   // Cyclic construction. This cheats the type system right now because
   // stateNode is any.
-  const uninitializedFiber = createHostRootFiber();
+  const uninitializedFiber = createHostRootFiber(isAsync);
   const root = {
     current: uninitializedFiber,
     containerInfo: containerInfo,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1738,7 +1738,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   }
 
   return {
-    computeAsyncExpiration,
     computeExpirationForFiber,
     scheduleWork,
     requestWork,

--- a/packages/react-rt-renderer/src/ReactNativeRT.js
+++ b/packages/react-rt-renderer/src/ReactNativeRT.js
@@ -40,7 +40,11 @@ const ReactNativeRTFiber: ReactNativeRTType = {
     if (!root) {
       // TODO (bvaughn): If we decide to keep the wrapper component,
       // We could create a wrapper for containerTag as well to reduce special casing.
-      root = ReactNativeRTFiberRenderer.createContainer(containerTag, false);
+      root = ReactNativeRTFiberRenderer.createContainer(
+        containerTag,
+        false,
+        false,
+      );
       roots.set(containerTag, root);
     }
     ReactNativeRTFiberRenderer.updateContainer(element, root, null, callback);

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -572,7 +572,11 @@ const ReactTestRendererFiber = {
       createNodeMock,
       tag: 'CONTAINER',
     };
-    let root: FiberRoot | null = TestRenderer.createContainer(container, false);
+    let root: FiberRoot | null = TestRenderer.createContainer(
+      container,
+      false,
+      false,
+    );
     invariant(root != null, 'something went wrong');
     TestRenderer.updateContainer(element, root, null, null);
 


### PR DESCRIPTION
Makes `createRoot` the opt-in API for async updates. Now we don't have to check the top-level element to see if it's an async container.