### PR TITLE
Sync scheduling by default, with an async opt-in

### DIFF
--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -478,8 +478,6 @@ const ARTRenderer = ReactFiberReconciler({
 
   now: ReactDOMFrameScheduling.now,
 
-  useSyncScheduling: true,
-
   mutation: {
     appendChild(parentInstance, child) {
       if (child.parentNode === parentInstance) {

--- a/packages/react-cs-renderer/src/ReactNativeCS.js
+++ b/packages/react-cs-renderer/src/ReactNativeCS.js
@@ -182,8 +182,6 @@ const ReactNativeCSFiberRenderer = ReactFiberReconciler({
     return false;
   },
 
-  useSyncScheduling: false,
-
   now(): number {
     // TODO: Enable expiration by implementing this method.
     return 0;

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -28,10 +28,7 @@ import * as EventPluginHub from 'events/EventPluginHub';
 import * as EventPluginRegistry from 'events/EventPluginRegistry';
 import * as EventPropagators from 'events/EventPropagators';
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';
-import {
-  enableAsyncSchedulingByDefaultInReactDOM,
-  enableCreateRoot,
-} from 'shared/ReactFeatureFlags';
+import {enableCreateRoot} from 'shared/ReactFeatureFlags';
 import ReactVersion from 'shared/ReactVersion';
 import * as ReactDOMFrameScheduling from 'shared/ReactDOMFrameScheduling';
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
@@ -981,8 +978,6 @@ const DOMRenderer = ReactFiberReconciler({
 
   scheduleDeferredCallback: ReactDOMFrameScheduling.rIC,
   cancelDeferredCallback: ReactDOMFrameScheduling.cIC,
-
-  useSyncScheduling: !enableAsyncSchedulingByDefaultInReactDOM,
 });
 
 ReactGenericBatching.injection.injectFiberBatchedUpdates(

--- a/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
@@ -193,8 +193,6 @@ const NativeRenderer = ReactFiberReconciler({
     return false;
   },
 
-  useSyncScheduling: true,
-
   mutation: {
     appendChild(
       parentInstance: Instance,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -59,6 +59,7 @@ import {
   invalidateContextProvider,
 } from './ReactFiberContext';
 import {NoWork, Never} from './ReactFiberExpirationTime';
+import {AsyncUpdates} from './ReactTypeOfInternalContext';
 
 if (__DEV__) {
   var warnedAboutStatelessRefs = {};
@@ -71,11 +72,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   scheduleWork: (fiber: Fiber, expirationTime: ExpirationTime) => void,
   computeExpirationForFiber: (fiber: Fiber) => ExpirationTime,
 ) {
-  const {
-    shouldSetTextContent,
-    useSyncScheduling,
-    shouldDeprioritizeSubtree,
-  } = config;
+  const {shouldSetTextContent, shouldDeprioritizeSubtree} = config;
 
   const {pushHostContext, pushHostContainer} = hostContext;
 
@@ -403,7 +400,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     // Check the host config to see if the children are offscreen/hidden.
     if (
       renderExpirationTime !== Never &&
-      !useSyncScheduling &&
+      workInProgress.internalContextTag & AsyncUpdates &&
       shouldDeprioritizeSubtree(type, nextProps)
     ) {
       // Down-prioritize the children.

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -95,8 +95,6 @@ export type HostConfig<T, P, I, TI, HI, PI, C, CC, CX, PL> = {
 
   now(): number,
 
-  useSyncScheduling?: boolean,
-
   +hydration?: HydrationHostConfig<T, P, I, TI, HI, C, CX, PL>,
 
   +mutation?: MutableUpdatesHostConfig<T, P, I, TI, C, PL>,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -182,7 +182,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     now,
     scheduleDeferredCallback,
     cancelDeferredCallback,
-    useSyncScheduling,
     prepareForCommit,
     resetAfterCommit,
   } = config;
@@ -1173,12 +1172,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     } else {
       // No explicit expiration context was set, and we're not currently
       // performing work. Calculate a new expiration time.
-      if (useSyncScheduling && !(fiber.internalContextTag & AsyncUpdates)) {
-        // This is a sync update
-        expirationTime = Sync;
-      } else {
+      if (fiber.internalContextTag & AsyncUpdates) {
         // This is an async update
         expirationTime = computeAsyncExpiration();
+      } else {
+        // This is a sync update
+        expirationTime = Sync;
       }
     }
     return expirationTime;

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.js
@@ -45,7 +45,6 @@ describe('ReactFiberHostContext', () => {
       now: function() {
         return 0;
       },
-      useSyncScheduling: true,
       mutation: {
         appendChildToContainer: function() {
           return null;

--- a/packages/react-rt-renderer/src/ReactNativeRTFiberRenderer.js
+++ b/packages/react-rt-renderer/src/ReactNativeRTFiberRenderer.js
@@ -153,8 +153,6 @@ const NativeRTRenderer = ReactFiberReconciler({
     return false;
   },
 
-  useSyncScheduling: true,
-
   now(): number {
     // TODO: Enable expiration by implementing this method.
     return 0;

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -203,8 +203,6 @@ const TestRenderer = ReactFiberReconciler({
     clearTimeout(timeoutID);
   },
 
-  useSyncScheduling: true,
-
   getPublicInstance,
 
   now(): number {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -10,7 +10,6 @@
 import invariant from 'fbjs/lib/invariant';
 
 export const enableAsyncSubtreeAPI = true;
-export const enableAsyncSchedulingByDefaultInReactDOM = false;
 // Exports ReactDOM.createRoot
 export const enableCreateRoot = false;
 export const enableUserTimingAPI = __DEV__;

--- a/packages/shared/forks/ReactFeatureFlags.native-cs.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-cs.js
@@ -14,7 +14,6 @@ import typeof * as CSFeatureFlagsType from './ReactFeatureFlags.native-cs';
 
 export const debugRenderPhaseSideEffects = false;
 export const enableAsyncSubtreeAPI = true;
-export const enableAsyncSchedulingByDefaultInReactDOM = false;
 export const enableCreateRoot = false;
 export const enableUserTimingAPI = __DEV__;
 

--- a/packages/shared/forks/ReactFeatureFlags.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.native.js
@@ -17,7 +17,6 @@ export const {debugRenderPhaseSideEffects} = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.
 export const enableAsyncSubtreeAPI = true;
-export const enableAsyncSchedulingByDefaultInReactDOM = false;
 export const enableCreateRoot = false;
 export const enableUserTimingAPI = __DEV__;
 export const enableMutatingReconciler = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -11,10 +11,7 @@ import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as FeatureFlagsShimType from './ReactFeatureFlags.www';
 
 // Re-export dynamic flags from the www version.
-export const {
-  debugRenderPhaseSideEffects,
-  enableAsyncSchedulingByDefaultInReactDOM,
-} = require('ReactFeatureFlags');
+export const {debugRenderPhaseSideEffects} = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.
 export const enableAsyncSubtreeAPI = true;


### PR DESCRIPTION
Removes the `useSyncScheduling` option from the HostConfig, since it's no longer needed. Instead of globally flipping between sync and async, our strategy will be to opt-in specific trees and subtrees.