### PR TITLE
[WIP] Added toWarnInDev matcher and updated one test to use it

### DIFF
--- a/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
@@ -13,10 +13,6 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const ReactDOMServer = require('react-dom/server');
 
-function normalizeCodeLocInfo(str) {
-  return str && str.replace(/at .+?:\d+/g, 'at **');
-}
-
 describe('CSSPropertyOperations', () => {
   it('should automatically append `px` to relevant styles', () => {
     const styles = {
@@ -91,17 +87,13 @@ describe('CSSPropertyOperations', () => {
       }
     }
 
-    spyOnDev(console, 'error');
     const root = document.createElement('div');
-    ReactDOM.render(<Comp />, root);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
-        'Warning: Unsupported style property background-color. Did you mean backgroundColor?' +
-          '\n    in div (at **)' +
-          '\n    in Comp (at **)',
-      );
-    }
+
+    expect(() => ReactDOM.render(<Comp />, root)).toWarnDev(
+      'Warning: Unsupported style property background-color. Did you mean backgroundColor?' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
+    );
   });
 
   it('should warn when updating hyphenated style names', () => {
@@ -113,28 +105,21 @@ describe('CSSPropertyOperations', () => {
       }
     }
 
-    spyOnDev(console, 'error');
     const styles = {
       '-ms-transform': 'translate3d(0, 0, 0)',
       '-webkit-transform': 'translate3d(0, 0, 0)',
     };
     const root = document.createElement('div');
     ReactDOM.render(<Comp />, root);
-    ReactDOM.render(<Comp style={styles} />, root);
 
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(2);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
-        'Warning: Unsupported style property -ms-transform. Did you mean msTransform?' +
-          '\n    in div (at **)' +
-          '\n    in Comp (at **)',
-      );
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toEqual(
-        'Warning: Unsupported style property -webkit-transform. Did you mean WebkitTransform?' +
-          '\n    in div (at **)' +
-          '\n    in Comp (at **)',
-      );
-    }
+    expect(() => ReactDOM.render(<Comp style={styles} />, root)).toWarnDev([
+      'Warning: Unsupported style property -ms-transform. Did you mean msTransform?' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
+      'Warning: Unsupported style property -webkit-transform. Did you mean WebkitTransform?' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
+    ]);
   });
 
   it('warns when miscapitalizing vendored style names', () => {
@@ -154,25 +139,19 @@ describe('CSSPropertyOperations', () => {
       }
     }
 
-    spyOnDev(console, 'error');
     const root = document.createElement('div');
-    ReactDOM.render(<Comp />, root);
-    if (__DEV__) {
+
+    expect(() => ReactDOM.render(<Comp />, root)).toWarnDev([
       // msTransform is correct already and shouldn't warn
-      expect(console.error.calls.count()).toBe(2);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
-        'Warning: Unsupported vendor-prefixed style property oTransform. ' +
-          'Did you mean OTransform?' +
-          '\n    in div (at **)' +
-          '\n    in Comp (at **)',
-      );
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toEqual(
-        'Warning: Unsupported vendor-prefixed style property webkitTransform. ' +
-          'Did you mean WebkitTransform?' +
-          '\n    in div (at **)' +
-          '\n    in Comp (at **)',
-      );
-    }
+      'Warning: Unsupported vendor-prefixed style property oTransform. ' +
+        'Did you mean OTransform?' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
+      'Warning: Unsupported vendor-prefixed style property webkitTransform. ' +
+        'Did you mean WebkitTransform?' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
+    ]);
   });
 
   it('should warn about style having a trailing semicolon', () => {
@@ -193,24 +172,18 @@ describe('CSSPropertyOperations', () => {
       }
     }
 
-    spyOnDev(console, 'error');
     const root = document.createElement('div');
-    ReactDOM.render(<Comp />, root);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(2);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
-        "Warning: Style property values shouldn't contain a semicolon. " +
-          'Try "backgroundColor: blue" instead.' +
-          '\n    in div (at **)' +
-          '\n    in Comp (at **)',
-      );
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toEqual(
-        "Warning: Style property values shouldn't contain a semicolon. " +
-          'Try "color: red" instead.' +
-          '\n    in div (at **)' +
-          '\n    in Comp (at **)',
-      );
-    }
+
+    expect(() => ReactDOM.render(<Comp />, root)).toWarnDev([
+      "Warning: Style property values shouldn't contain a semicolon. " +
+        'Try "backgroundColor: blue" instead.' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
+      "Warning: Style property values shouldn't contain a semicolon. " +
+        'Try "color: red" instead.' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
+    ]);
   });
 
   it('should warn about style containing a NaN value', () => {
@@ -222,18 +195,13 @@ describe('CSSPropertyOperations', () => {
       }
     }
 
-    spyOnDev(console, 'error');
     const root = document.createElement('div');
-    ReactDOM.render(<Comp />, root);
 
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
-        'Warning: `NaN` is an invalid value for the `fontSize` css style property.' +
-          '\n    in div (at **)' +
-          '\n    in Comp (at **)',
-      );
-    }
+    expect(() => ReactDOM.render(<Comp />, root)).toWarnDev(
+      'Warning: `NaN` is an invalid value for the `fontSize` css style property.' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
+    );
   });
 
   it('should not warn when setting CSS custom properties', () => {
@@ -256,18 +224,13 @@ describe('CSSPropertyOperations', () => {
       }
     }
 
-    spyOnDev(console, 'error');
     const root = document.createElement('div');
-    ReactDOM.render(<Comp />, root);
 
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
-        'Warning: `Infinity` is an invalid value for the `fontSize` css style property.' +
-          '\n    in div (at **)' +
-          '\n    in Comp (at **)',
-      );
-    }
+    expect(() => ReactDOM.render(<Comp />, root)).toWarnDev(
+      'Warning: `Infinity` is an invalid value for the `fontSize` css style property.' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
+    );
   });
 
   it('should not add units to CSS custom properties', () => {

--- a/packages/react/src/__tests__/ReactElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.js
@@ -18,10 +18,6 @@ let ReactDOM;
 let ReactTestUtils;
 
 describe('ReactElementValidator', () => {
-  function normalizeCodeLocInfo(str) {
-    return str && str.replace(/at .+?:\d+/g, 'at **');
-  }
-
   let ComponentClass;
 
   beforeEach(() => {
@@ -39,21 +35,16 @@ describe('ReactElementValidator', () => {
   });
 
   it('warns for keys for arrays of elements in rest args', () => {
-    spyOnDev(console, 'error');
     const Component = React.createFactory(ComponentClass);
 
-    Component(null, [Component(), Component()]);
-
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Each child in an array or iterator should have a unique "key" prop.',
-      );
-    }
+    expect(() => {
+      Component(null, [Component(), Component()]);
+    }).toWarnDev(
+      'Each child in an array or iterator should have a unique "key" prop.',
+    );
   });
 
   it('warns for keys for arrays of elements with owner info', () => {
-    spyOnDev(console, 'error');
     const Component = React.createFactory(ComponentClass);
 
     class InnerClass extends React.Component {
@@ -70,59 +61,46 @@ describe('ReactElementValidator', () => {
       }
     }
 
-    ReactTestUtils.renderIntoDocument(React.createElement(ComponentWrapper));
-
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Each child in an array or iterator should have a unique "key" prop.' +
-          '\n\nCheck the render method of `InnerClass`. ' +
-          'It was passed a child from ComponentWrapper. ',
-      );
-    }
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(React.createElement(ComponentWrapper));
+    }).toWarnDev(
+      'Each child in an array or iterator should have a unique "key" prop.' +
+        '\n\nCheck the render method of `InnerClass`. ' +
+        'It was passed a child from ComponentWrapper. ',
+    );
   });
 
   it('warns for keys for arrays with no owner or parent info', () => {
-    spyOnDev(console, 'error');
-
     function Anonymous() {
       return <div />;
     }
     Object.defineProperty(Anonymous, 'name', {value: undefined});
 
     const divs = [<div />, <div />];
-    ReactTestUtils.renderIntoDocument(<Anonymous>{divs}</Anonymous>);
 
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Each child in an array or iterator should have a unique ' +
-          '"key" prop. See https://fb.me/react-warning-keys for more information.\n' +
-          '    in div (at **)',
-      );
-    }
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(<Anonymous>{divs}</Anonymous>);
+    }).toWarnDev(
+      'Warning: Each child in an array or iterator should have a unique ' +
+        '"key" prop. See https://fb.me/react-warning-keys for more information.\n' +
+        '    in div (at **)',
+    );
   });
 
   it('warns for keys for arrays of elements with no owner info', () => {
-    spyOnDev(console, 'error');
-
     const divs = [<div />, <div />];
-    ReactTestUtils.renderIntoDocument(<div>{divs}</div>);
 
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Each child in an array or iterator should have a unique ' +
-          '"key" prop.\n\nCheck the top-level render call using <div>. See ' +
-          'https://fb.me/react-warning-keys for more information.\n' +
-          '    in div (at **)',
-      );
-    }
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(<div>{divs}</div>);
+    }).toWarnDev(
+      'Warning: Each child in an array or iterator should have a unique ' +
+        '"key" prop.\n\nCheck the top-level render call using <div>. See ' +
+        'https://fb.me/react-warning-keys for more information.\n' +
+        '    in div (at **)',
+    );
   });
 
   it('warns for keys with component stack info', () => {
-    spyOnDev(console, 'error');
-
     function Component() {
       return <div>{[<div />, <div />]}</div>;
     }
@@ -135,20 +113,15 @@ describe('ReactElementValidator', () => {
       return <Parent child={<Component />} />;
     }
 
-    ReactTestUtils.renderIntoDocument(<GrandParent />);
-
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Each child in an array or iterator should have a unique ' +
-          '"key" prop.\n\nCheck the render method of `Component`. See ' +
-          'https://fb.me/react-warning-keys for more information.\n' +
-          '    in div (at **)\n' +
-          '    in Component (at **)\n' +
-          '    in Parent (at **)\n' +
-          '    in GrandParent (at **)',
-      );
-    }
+    expect(() => ReactTestUtils.renderIntoDocument(<GrandParent />)).toWarnDev(
+      'Warning: Each child in an array or iterator should have a unique ' +
+        '"key" prop.\n\nCheck the render method of `Component`. See ' +
+        'https://fb.me/react-warning-keys for more information.\n' +
+        '    in div (at **)\n' +
+        '    in Component (at **)\n' +
+        '    in Parent (at **)\n' +
+        '    in GrandParent (at **)',
+    );
   });
 
   it('does not warn for keys when passing children down', () => {
@@ -170,7 +143,6 @@ describe('ReactElementValidator', () => {
   });
 
   it('warns for keys for iterables of elements in rest args', () => {
-    spyOnDev(console, 'error');
     const Component = React.createFactory(ComponentClass);
 
     const iterable = {
@@ -185,14 +157,9 @@ describe('ReactElementValidator', () => {
       },
     };
 
-    Component(null, iterable);
-
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Each child in an array or iterator should have a unique "key" prop.',
-      );
-    }
+    expect(() => Component(null, iterable)).toWarnDev(
+      'Each child in an array or iterator should have a unique "key" prop.',
+    );
   });
 
   it('does not warns for arrays of elements with keys', () => {
@@ -238,7 +205,6 @@ describe('ReactElementValidator', () => {
     // In this test, we're making sure that if a proptype error is found in a
     // component, we give a small hint as to which parent instantiated that
     // component as per warnings about key usage in ReactElementValidator.
-    spyOnDev(console, 'error');
     function MyComp(props) {
       return React.createElement('div', null, 'My color is ' + props.color);
     }
@@ -248,61 +214,48 @@ describe('ReactElementValidator', () => {
     function ParentComp() {
       return React.createElement(MyComp, {color: 123});
     }
-    ReactTestUtils.renderIntoDocument(React.createElement(ParentComp));
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Failed prop type: ' +
-          'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
-          'expected `string`.\n' +
-          '    in MyComp (created by ParentComp)\n' +
-          '    in ParentComp',
-      );
-    }
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(React.createElement(ParentComp));
+    }).toWarnDev(
+      'Warning: Failed prop type: ' +
+        'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
+        'expected `string`.\n' +
+        '    in MyComp (created by ParentComp)\n' +
+        '    in ParentComp',
+    );
   });
 
   it('gives a helpful error when passing invalid types', () => {
-    spyOnDev(console, 'error');
-    React.createElement(undefined);
-    React.createElement(null);
-    React.createElement(true);
-    React.createElement({x: 17});
-    React.createElement({});
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(5);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: undefined. You likely forgot to export your ' +
-          "component from the file it's defined in, or you might have mixed up " +
-          'default and named imports.',
-      );
-      expect(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: null.',
-      );
-      expect(console.error.calls.argsFor(2)[0]).toBe(
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: boolean.',
-      );
-      expect(console.error.calls.argsFor(3)[0]).toBe(
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: object.',
-      );
-      expect(console.error.calls.argsFor(4)[0]).toBe(
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: object. You likely forgot to export your ' +
-          "component from the file it's defined in, or you might have mixed up " +
-          'default and named imports.',
-      );
-    }
-    React.createElement('div');
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(5);
-    }
+    expect(() => {
+      React.createElement(undefined);
+      React.createElement(null);
+      React.createElement(true);
+      React.createElement({x: 17});
+      React.createElement({});
+    }).toWarnDev([
+      'Warning: React.createElement: type is invalid -- expected a string ' +
+        '(for built-in components) or a class/function (for composite ' +
+        'components) but got: undefined. You likely forgot to export your ' +
+        "component from the file it's defined in, or you might have mixed up " +
+        'default and named imports.',
+      'Warning: React.createElement: type is invalid -- expected a string ' +
+        '(for built-in components) or a class/function (for composite ' +
+        'components) but got: null.',
+      'Warning: React.createElement: type is invalid -- expected a string ' +
+        '(for built-in components) or a class/function (for composite ' +
+        'components) but got: boolean.',
+      'Warning: React.createElement: type is invalid -- expected a string ' +
+        '(for built-in components) or a class/function (for composite ' +
+        'components) but got: object.',
+      'Warning: React.createElement: type is invalid -- expected a string ' +
+        '(for built-in components) or a class/function (for composite ' +
+        'components) but got: object. You likely forgot to export your ' +
+        "component from the file it's defined in, or you might have mixed up " +
+        'default and named imports.',
+    ]);
+
+    // Should not log any additional warnings
+    expect(() => React.createElement('div')).toWarnDev([]);
   });
 
   it('includes the owner name when passing null, undefined, boolean, or number', () => {
@@ -317,6 +270,8 @@ describe('ReactElementValidator', () => {
         'or a class/function (for composite components) but got: null.' +
         (__DEV__ ? '\n\nCheck the render method of `ParentComp`.' : ''),
     );
+
+    // We can't use .toWarnDev() here because we can't chain it with .toThrowError()
     if (__DEV__) {
       expect(console.error.calls.count()).toBe(1);
       expect(console.error.calls.argsFor(0)[0]).toBe(
@@ -329,8 +284,6 @@ describe('ReactElementValidator', () => {
   });
 
   it('should check default prop values', () => {
-    spyOnDev(console, 'error');
-
     class Component extends React.Component {
       static propTypes = {prop: PropTypes.string.isRequired};
       static defaultProps = {prop: null};
@@ -339,21 +292,16 @@ describe('ReactElementValidator', () => {
       }
     }
 
-    ReactTestUtils.renderIntoDocument(React.createElement(Component));
-
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Failed prop type: The prop `prop` is marked as required in ' +
-          '`Component`, but its value is `null`.\n' +
-          '    in Component',
-      );
-    }
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(React.createElement(Component)),
+    ).toWarnDev(
+      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
+        '`Component`, but its value is `null`.\n' +
+        '    in Component',
+    );
   });
 
   it('should not check the default for explicit null', () => {
-    spyOnDev(console, 'error');
-
     class Component extends React.Component {
       static propTypes = {prop: PropTypes.string.isRequired};
       static defaultProps = {prop: 'text'};
@@ -362,23 +310,18 @@ describe('ReactElementValidator', () => {
       }
     }
 
-    ReactTestUtils.renderIntoDocument(
-      React.createElement(Component, {prop: null}),
-    );
-
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Failed prop type: The prop `prop` is marked as required in ' +
-          '`Component`, but its value is `null`.\n' +
-          '    in Component',
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(
+        React.createElement(Component, {prop: null}),
       );
-    }
+    }).toWarnDev(
+      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
+        '`Component`, but its value is `null`.\n' +
+        '    in Component',
+    );
   });
 
   it('should check declared prop types', () => {
-    spyOnDev(console, 'error');
-
     class Component extends React.Component {
       static propTypes = {
         prop: PropTypes.string.isRequired,
@@ -388,36 +331,28 @@ describe('ReactElementValidator', () => {
       }
     }
 
-    ReactTestUtils.renderIntoDocument(React.createElement(Component));
-    ReactTestUtils.renderIntoDocument(
-      React.createElement(Component, {prop: 42}),
-    );
-
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(2);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Failed prop type: ' +
-          'The prop `prop` is marked as required in `Component`, but its value ' +
-          'is `undefined`.\n' +
-          '    in Component',
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(React.createElement(Component));
+      ReactTestUtils.renderIntoDocument(
+        React.createElement(Component, {prop: 42}),
       );
+    }).toWarnDev([
+      'Warning: Failed prop type: ' +
+        'The prop `prop` is marked as required in `Component`, but its value ' +
+        'is `undefined`.\n' +
+        '    in Component',
+      'Warning: Failed prop type: ' +
+        'Invalid prop `prop` of type `number` supplied to ' +
+        '`Component`, expected `string`.\n' +
+        '    in Component',
+    ]);
 
-      expect(console.error.calls.argsFor(1)[0]).toBe(
-        'Warning: Failed prop type: ' +
-          'Invalid prop `prop` of type `number` supplied to ' +
-          '`Component`, expected `string`.\n' +
-          '    in Component',
+    // Should not error for strings
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(
+        React.createElement(Component, {prop: 'string'}),
       );
-    }
-
-    ReactTestUtils.renderIntoDocument(
-      React.createElement(Component, {prop: 'string'}),
-    );
-
-    if (__DEV__) {
-      // Should not error for strings
-      expect(console.error.calls.count()).toBe(2);
-    }
+    }).toWarnDev([]);
   });
 
   it('should warn if a PropType creator is used as a PropType', () => {
@@ -432,24 +367,20 @@ describe('ReactElementValidator', () => {
       }
     }
 
-    ReactTestUtils.renderIntoDocument(
-      React.createElement(Component, {myProp: {value: 'hi'}}),
-    );
-
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Component: type specification of prop `myProp` is invalid; ' +
-          'the type checker function must return `null` or an `Error` but ' +
-          'returned a function. You may have forgotten to pass an argument to ' +
-          'the type checker creator (arrayOf, instanceOf, objectOf, oneOf, ' +
-          'oneOfType, and shape all require an argument).',
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(
+        React.createElement(Component, {myProp: {value: 'hi'}}),
       );
-    }
+    }).toWarnDev(
+      'Warning: Component: type specification of prop `myProp` is invalid; ' +
+        'the type checker function must return `null` or an `Error` but ' +
+        'returned a function. You may have forgotten to pass an argument to ' +
+        'the type checker creator (arrayOf, instanceOf, objectOf, oneOf, ' +
+        'oneOfType, and shape all require an argument).',
+    );
   });
 
   it('should warn if component declares PropTypes instead of propTypes', () => {
-    spyOnDevAndProd(console, 'error');
     class MisspelledPropTypesComponent extends React.Component {
       static PropTypes = {
         prop: PropTypes.string,
@@ -459,37 +390,33 @@ describe('ReactElementValidator', () => {
       }
     }
 
-    ReactTestUtils.renderIntoDocument(
-      React.createElement(MisspelledPropTypesComponent, {prop: 'Hi'}),
-    );
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        'Warning: Component MisspelledPropTypesComponent declared `PropTypes` ' +
-          'instead of `propTypes`. Did you misspell the property assignment?',
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(
+        React.createElement(MisspelledPropTypesComponent, {prop: 'Hi'}),
       );
-    }
+    }).toWarnDev(
+      'Warning: Component MisspelledPropTypesComponent declared `PropTypes` ' +
+        'instead of `propTypes`. Did you misspell the property assignment?',
+    );
   });
 
   it('should warn when accessing .type on an element factory', () => {
-    spyOnDev(console, 'warn');
     function TestComponent() {
       return <div />;
     }
-    const TestFactory = React.createFactory(TestComponent);
-    expect(TestFactory.type).toBe(TestComponent);
-    if (__DEV__) {
-      expect(console.warn.calls.count()).toBe(1);
-      expect(console.warn.calls.argsFor(0)[0]).toBe(
-        'Warning: Factory.type is deprecated. Access the class directly before ' +
-          'passing it to createFactory.',
-      );
-    }
+
+    let TestFactory = React.createFactory(TestComponent);
+    expect(() =>
+      expect(TestFactory.type).toBe(TestComponent),
+    ).toLowPriorityWarnDev(
+      'Warning: Factory.type is deprecated. Access the class directly before ' +
+        'passing it to createFactory.',
+    );
+
     // Warn once, not again
-    expect(TestFactory.type).toBe(TestComponent);
-    if (__DEV__) {
-      expect(console.warn.calls.count()).toBe(1);
-    }
+    expect(() =>
+      expect(TestFactory.type).toBe(TestComponent),
+    ).toLowPriorityWarnDev([]);
   });
 
   it('does not warn when using DOM node as children', () => {
@@ -544,18 +471,15 @@ describe('ReactElementValidator', () => {
   });
 
   it('does not blow up on key warning with undefined type', () => {
-    spyOnDev(console, 'error');
     const Foo = undefined;
-    void <Foo>{[<div />]}</Foo>;
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: React.createElement: type is invalid -- expected a string ' +
-          '(for built-in components) or a class/function (for composite ' +
-          'components) but got: undefined. You likely forgot to export your ' +
-          "component from the file it's defined in, or you might have mixed up " +
-          'default and named imports.\n\nCheck your code at **.',
-      );
-    }
+    expect(() => {
+      void <Foo>{[<div />]}</Foo>;
+    }).toWarnDev(
+      'Warning: React.createElement: type is invalid -- expected a string ' +
+        '(for built-in components) or a class/function (for composite ' +
+        'components) but got: undefined. You likely forgot to export your ' +
+        "component from the file it's defined in, or you might have mixed up " +
+        'default and named imports.\n\nCheck your code at **.',
+    );
   });
 });

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -1,0 +1,65 @@
+'use strict';
+
+function normalizeCodeLocInfo(str) {
+  return str && str.replace(/at .+?:\d+/g, 'at **');
+}
+
+module.exports = function toWarnDev(callback, expectedWarnings) {
+  if (!console.error.hasOwnProperty('calls')) {
+    spyOnDev(console, 'error');
+  }
+
+  callback();
+
+  if (__DEV__) {
+    if (typeof expectedWarnings === 'string') {
+      expectedWarnings = [expectedWarnings];
+    }
+
+    if (Array.isArray(expectedWarnings)) {
+      if (console.error.calls.count() !== expectedWarnings.length) {
+        return {
+          message: () =>
+            `Expected number of DEV warnings:\n  ${this.utils.printExpected(
+              expectedWarnings.length
+            )}\n` +
+            `Actual number of DEV warnings:\n  ${this.utils.printReceived(
+              console.error.calls.count()
+            )}`,
+          pass: false,
+        };
+      }
+
+      const actualWarnings = [];
+      for (let i = 0; i < console.error.calls.count(); i++) {
+        actualWarnings.push(
+          normalizeCodeLocInfo(console.error.calls.argsFor(i)[0])
+        );
+      }
+
+      const failure = expectedWarnings.find(expectedWarning => {
+        return !actualWarnings.includes(expectedWarning)
+          ? expectedWarning
+          : null;
+      });
+
+      if (failure) {
+        return {
+          message: () =>
+            `Expected DEV warning:\n${this.utils.printExpected(failure)}\n` +
+            `Actual DEV warnings:\n${this.utils.printReceived(
+              actualWarnings.join('\n')
+            )}`,
+          pass: false,
+        };
+      } else {
+        return {pass: true};
+      }
+    } else {
+      throw Error(
+        `toWarnDev() requires a parameter of type string or an array of strings ` +
+          `but was given ${typeof expectedWarnings}.`
+      );
+    }
+  }
+};

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -4,62 +4,99 @@ function normalizeCodeLocInfo(str) {
   return str && str.replace(/at .+?:\d+/g, 'at **');
 }
 
-module.exports = function toWarnDev(callback, expectedWarnings) {
-  if (!console.error.hasOwnProperty('calls')) {
-    spyOnDev(console, 'error');
-  }
-
-  callback();
-
+function validator(consoleSpy, expectedWarnings) {
   if (__DEV__) {
     if (typeof expectedWarnings === 'string') {
       expectedWarnings = [expectedWarnings];
-    }
-
-    if (Array.isArray(expectedWarnings)) {
-      if (console.error.calls.count() !== expectedWarnings.length) {
-        return {
-          message: () =>
-            `Expected number of DEV warnings:\n  ${this.utils.printExpected(
-              expectedWarnings.length
-            )}\n` +
-            `Actual number of DEV warnings:\n  ${this.utils.printReceived(
-              console.error.calls.count()
-            )}`,
-          pass: false,
-        };
-      }
-
-      const actualWarnings = [];
-      for (let i = 0; i < console.error.calls.count(); i++) {
-        actualWarnings.push(
-          normalizeCodeLocInfo(console.error.calls.argsFor(i)[0])
-        );
-      }
-
-      const failure = expectedWarnings.find(expectedWarning => {
-        return !actualWarnings.includes(expectedWarning)
-          ? expectedWarning
-          : null;
-      });
-
-      if (failure) {
-        return {
-          message: () =>
-            `Expected DEV warning:\n${this.utils.printExpected(failure)}\n` +
-            `Actual DEV warnings:\n${this.utils.printReceived(
-              actualWarnings.join('\n')
-            )}`,
-          pass: false,
-        };
-      } else {
-        return {pass: true};
-      }
-    } else {
+    } else if (!Array.isArray(expectedWarnings)) {
       throw Error(
         `toWarnDev() requires a parameter of type string or an array of strings ` +
           `but was given ${typeof expectedWarnings}.`
       );
     }
+
+    if (consoleSpy.calls.count() !== expectedWarnings.length) {
+      return {
+        message: () =>
+          `Expected number of DEV warnings:\n  ${this.utils.printExpected(
+            expectedWarnings.length
+          )}\n` +
+          `Actual number of DEV warnings:\n  ${this.utils.printReceived(
+            consoleSpy.calls.count()
+          )}`,
+        pass: false,
+      };
+    }
+
+    // Normalize warnings for easier comparison
+    const actualWarnings = [];
+    for (let i = 0; i < consoleSpy.calls.count(); i++) {
+      actualWarnings.push(normalizeCodeLocInfo(consoleSpy.calls.argsFor(i)[0]));
+    }
+
+    let failedExpectation;
+    for (let i = 0; i < expectedWarnings.length; i++) {
+      const expectedWarning = expectedWarnings[i];
+      let found = false;
+
+      for (let x = 0; x < expectedWarnings.length; x++) {
+        const actualWarning = actualWarnings[x];
+
+        // Allow partial matching.
+        if (
+          actualWarning === expectedWarning ||
+          actualWarning.includes(expectedWarning)
+        ) {
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        failedExpectation = expectedWarning;
+        break;
+      }
+    }
+
+    if (failedExpectation) {
+      return {
+        message: () =>
+          `Expected DEV warning:\n${this.utils.printExpected(
+            failedExpectation
+          )}\n` +
+          `Actual DEV warnings:\n${this.utils.printReceived(
+            actualWarnings.join('\n')
+          )}`,
+        pass: false,
+      };
+    }
   }
+
+  return {pass: true};
+}
+
+const createMatcherFor = consoleMethod =>
+  function(callback, expectedWarnings) {
+    if (__DEV__) {
+      if (!console[consoleMethod].hasOwnProperty('calls')) {
+        spyOnDev(console, consoleMethod);
+      } else {
+        console[consoleMethod].calls.reset();
+      }
+    }
+
+    callback();
+
+    const response = validator.call(
+      this,
+      console[consoleMethod],
+      expectedWarnings
+    );
+
+    return response;
+  };
+
+module.exports = {
+  toLowPriorityWarnDev: createMatcherFor('warn'),
+  toWarnDev: createMatcherFor('error'),
 };

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -40,7 +40,7 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
   }
 
   expect.extend({
-    toWarnDev: require('./matchers/toWarnDev'),
+    ...require('./matchers/toWarnDev'),
   });
 
   ['error', 'warn'].forEach(methodName => {

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -39,6 +39,10 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
     global.spyOnDevAndProd = spyOn;
   }
 
+  expect.extend({
+    toWarnDev: require('./matchers/toWarnDev'),
+  });
+
   ['error', 'warn'].forEach(methodName => {
     var oldMethod = console[methodName];
     var newMethod = function() {


### PR DESCRIPTION
Relates to #11626. Pushing for discussion purposes. 😄 

Open questions:
* Is this worth doing?
* Is the automatic spy-on behavior too much of a hack?
* Is this method of differentiating between low-priority (`console.warn`) and high-priority (`console.error`) warnings ok?
* Is there a way to combine `.toThrowError` and `.toWarnDev` matchers (see "_includes the owner name when passing null, undefined, boolean, or number_")?