### PR TITLE
Add a test-only transform to catch infinite loops

### DIFF
--- a/scripts/babel/__tests__/transform-prevent-infinite-loops-test.js
+++ b/scripts/babel/__tests__/transform-prevent-infinite-loops-test.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('transform-prevent-infinite-loops', () => {
+  // Note: instead of testing the transform by applying it,
+  // we assume that it *is* already applied. Since we expect
+  // it to be applied to all our tests.
+
+  it('fails the test for `while` loops', () => {
+    expect(global.infiniteLoopError).toBe(null);
+    expect(() => {
+      while (true) {
+        // do nothing
+      }
+    }).toThrow(RangeError);
+    // Make sure this gets set so the test would fail regardless.
+    expect(global.infiniteLoopError).not.toBe(null);
+    // Clear the flag since otherwise *this* test would fail.
+    global.infiniteLoopError = null;
+  });
+
+  it('fails the test for `for` loops', () => {
+    expect(global.infiniteLoopError).toBe(null);
+    expect(() => {
+      for (;;) {
+        // do nothing
+      }
+    }).toThrow(RangeError);
+    // Make sure this gets set so the test would fail regardless.
+    expect(global.infiniteLoopError).not.toBe(null);
+    // Clear the flag since otherwise *this* test would fail.
+    global.infiniteLoopError = null;
+  });
+});

--- a/scripts/babel/transform-prevent-infinite-loops.js
+++ b/scripts/babel/transform-prevent-infinite-loops.js
@@ -1,22 +1,32 @@
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
+ * Copyright (c) 2017, Amjad Masad
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// TODO: attribution (this is based on https://repl.it/site/blog/infinite-loops)
-
 'use strict';
 
-// This should be reasonable for all loops that happen in our tests.
-// Note that if the number is too large, the tests will take too long to fail
+// Based on https://repl.it/site/blog/infinite-loops.
+
+// This should be reasonable for all loops in the source.
+// Note that if the numbers are too large, the tests will take too long to fail
 // for this to be useful (each individual test case might hit an infinite loop).
-const MAX_ITERATIONS = 2000;
+const MAX_SOURCE_ITERATIONS = 1500;
+// Code in tests themselves is permitted to run longer.
+// For example, in the fuzz tester.
+const MAX_TEST_ITERATIONS = 5000;
 
 module.exports = ({types: t}) => ({
   visitor: {
-    'WhileStatement|ForStatement|DoWhileStatement': path => {
+    'WhileStatement|ForStatement|DoWhileStatement': (path, file) => {
+      const filename = file.file.opts.filename;
+      const MAX_ITERATIONS =
+        filename.indexOf('__tests__') === -1
+          ? MAX_SOURCE_ITERATIONS
+          : MAX_TEST_ITERATIONS;
+
       // An iterator that is incremented with each iteration
       const iterator = path.scope.parent.generateUidIdentifier('loopIt');
       const iteratorInit = t.numericLiteral(0);

--- a/scripts/babel/transform-prevent-infinite-loops.js
+++ b/scripts/babel/transform-prevent-infinite-loops.js
@@ -16,11 +16,11 @@ const MAX_ITERATIONS = 2000;
 
 module.exports = ({types: t}) => ({
   visitor: {
-    'WhileStatement|ForStatement|DoWhileStatement': p => {
+    'WhileStatement|ForStatement|DoWhileStatement': path => {
       // An iterator that is incremented with each iteration
-      const iterator = p.scope.parent.generateUidIdentifier('loopIt');
+      const iterator = path.scope.parent.generateUidIdentifier('loopIt');
       const iteratorInit = t.numericLiteral(0);
-      p.scope.parent.push({
+      path.scope.parent.push({
         id: iterator,
         init: iteratorInit,
       });
@@ -40,11 +40,11 @@ module.exports = ({types: t}) => ({
         )
       );
       // No block statment e.g. `while (1) 1;`
-      if (!p.get('body').isBlockStatement()) {
-        const statement = p.get('body').node;
-        p.get('body').replaceWith(t.blockStatement([guard, statement]));
+      if (!path.get('body').isBlockStatement()) {
+        const statement = path.get('body').node;
+        path.get('body').replaceWith(t.blockStatement([guard, statement]));
       } else {
-        p.get('body').unshiftContainer('body', guard);
+        path.get('body').unshiftContainer('body', guard);
       }
     },
   },

--- a/scripts/babel/transform-prevent-infinite-loops.js
+++ b/scripts/babel/transform-prevent-infinite-loops.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// TODO: attribution (this is based on https://repl.it/site/blog/infinite-loops)
+
+'use strict';
+
+module.exports = ({types: t}) => ({
+  visitor: {
+    'WhileStatement|ForStatement|DoWhileStatement': p => {
+      // A variable holding when the loop was started
+      const loopStart = p.scope.parent.generateUidIdentifier('loopStart');
+      const loopStartInit = t.callExpression(
+        t.memberExpression(t.identifier('Date'), t.identifier('now')),
+        []
+      );
+      p.scope.parent.push({
+        id: loopStart,
+        init: loopStartInit,
+      });
+
+      // An iterator that is incremented with each iteration
+      const iterator = p.scope.parent.generateUidIdentifier('loopIt');
+      const iteratorInit = t.numericLiteral(0);
+      p.scope.parent.push({
+        id: iterator,
+        init: iteratorInit,
+      });
+
+      // setTimeout to protect against breaking async and generator funcs.
+      p.insertBefore(
+        t.expressionStatement(
+          t.callExpression(t.identifier('setTimeout'), [
+            t.functionExpression(
+              null,
+              [],
+              t.blockStatement([
+                t.expressionStatement(
+                  t.assignmentExpression(
+                    '=',
+                    loopStart,
+                    t.identifier('Infinity')
+                  )
+                ),
+              ])
+            ),
+          ])
+        )
+      );
+
+      // If statement and throw error if it matches our criteria
+      const guard = t.ifStatement(
+        t.logicalExpression(
+          '&&',
+          t.binaryExpression(
+            '>',
+            t.updateExpression('++', iterator, true),
+            t.numericLiteral(10000) // iterations
+          ),
+          t.binaryExpression(
+            '>',
+            t.binaryExpression(
+              '-',
+              t.callExpression(
+                t.memberExpression(t.identifier('Date'), t.identifier('now')),
+                []
+              ),
+              loopStart
+            ),
+            t.numericLiteral(5000) // ms
+          )
+        ),
+        t.throwStatement(
+          t.newExpression(t.identifier('RangeError'), [
+            t.stringLiteral('Potential infinite loop.'),
+          ])
+        )
+      );
+
+      // No block statment e.g. `while (1) 1;`
+      if (!p.get('body').isBlockStatement()) {
+        const statement = p.get('body').node;
+        p.get('body').replaceWith(t.blockStatement([guard, statement]));
+      } else {
+        p.get('body').unshiftContainer('body', guard);
+      }
+    },
+  },
+});

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -34,6 +34,8 @@ var babelOptions = {
     // into ReactART builds that include JSX.
     // TODO: I have not verified that this actually works.
     require.resolve('babel-plugin-transform-react-jsx-source'),
+
+    require.resolve('../babel/transform-prevent-infinite-loops'),
   ],
   retainLines: true,
 };

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -39,6 +39,22 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
     global.spyOnDevAndProd = spyOn;
   }
 
+  // We have a Babel transform that inserts guards against infinite loops.
+  // If a loop runs for too many iterations, we throw an error and set this
+  // global variable. The global lets us detect an infinite loop even if
+  // the actual error object ends up being caught and ignored. An infinite
+  // loop must always fail the test!
+  env.beforeEach(() => {
+    global.infiniteLoopError = null;
+  });
+  env.afterEach(() => {
+    const error = global.infiniteLoopError;
+    global.infiniteLoopError = null;
+    if (error) {
+      throw error;
+    }
+  });
+
   ['error', 'warn'].forEach(methodName => {
     var oldMethod = console[methodName];
     var newMethod = function() {


### PR DESCRIPTION
I took @amasad's code from https://repl.it/site/blog/infinite-loops and decided to try it out.
It's pretty neat.

This makes the tests throw when we're inside a loop that has more than M iterations <s>and ran for more than N milliseconds. Currently, both needs to happen although we can of course adjust the conditions</s> (just guarding iterations should be enough for us)

It's only enabled for tests.

Failure looks like this:

<img width="1088" alt="screen shot 2017-12-07 at 02 41 10" src="https://user-images.githubusercontent.com/810438/33696079-6f6f6bda-daf8-11e7-8809-b48423e121d5.png">

In the past, Jest would just hang.

Open questions:

- [x] Is this useful? Do we want this at all? Does showing the loop callsite help?
- [x] We need to make sure this *always* fails the test even if the error ends up being caught.
- [x] <s>If one test case fails with this we probably want to fail others immediately (if they're also stuck in a loop). Otherwise we have to wait for each individual one to fail even though they likely stress the same path. On the other hand only the first one is the actual problem. Need to think about how to present this. Maybe two different messages ("Potential infinite loop" vs "The test failed because another test has a potential infinite loop. Search for it in the output." or something.) Or include the bad stack in all messages.</s> Not really. With our current iteration limits they fail pretty fast.
- [x] How many iterations and/or time are we okay with? — Determined this by running tests. Set different limits for source files and test filess.
- [x] License/attribution (I added @amasad to the authors at the top, pretty sure he won't mind it being MIT, but I'll make sure before merging).

Posting this for @acdlite to play with since he's spent the most time with infinite loops and probably knows what's helpful and what isn't.