### PR TITLE
Add `yarn debug-test` to debug tests in Chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "lint": "node ./scripts/tasks/eslint.js",
     "lint-build": "node ./scripts/rollup/validate/index.js",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
+    "debug-test": "cross-env NODE_ENV=development node --inspect-brk node_modules/.bin/jest --config ./scripts/jest/config.source.js --runInBand",
     "test": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.source.js",
     "test-prod": "cross-env NODE_ENV=production jest --config ./scripts/jest/config.source.js",
     "test-prod-build": "yarn test-build-prod",


### PR DESCRIPTION
Works just like `yarn test` and can also run with a watcher or for a particular file.


```
yarn debug-test
yarn debug-test IncrementalErrorHandling
yarn debug-test --watch IncrementalErrorHandling
```

To debug, open `chrome://inspect`, select the target and then press Play.

<img width="702" alt="screen shot 2017-12-07 at 02 59 17" src="https://user-images.githubusercontent.com/810438/33696581-cf088110-dafa-11e7-97b5-692de9ab8322.png">

You can set breakpoints too, both in individual source files and in the test itself.

<img width="681" alt="screen shot 2017-12-07 at 02 56 43" src="https://user-images.githubusercontent.com/810438/33696584-d4198c8a-dafa-11e7-9b3c-73dd0b495981.png">

Pretty neat!