### PR TITLE
[Discussion] Added legacy_Component/legacy_PureComponent

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -223,7 +223,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         // We do this here rather than inside of ReactFiberClassComponent,
         // To more realistically simulate the interruption behavior of async,
         // Which would never call componentWillMount() twice on the same instance.
-        if (debugRenderPhaseSideEffects) {
+        if (
+          debugRenderPhaseSideEffects &&
+          !workInProgress.type.prototype
+            .unstable_ignoreDebugRenderPhaseSideEffects
+        ) {
           constructClassInstance(workInProgress, workInProgress.pendingProps);
           mountClassInstance(workInProgress, renderExpirationTime);
         }
@@ -275,12 +279,20 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     if (__DEV__) {
       ReactDebugCurrentFiber.setCurrentPhase('render');
       nextChildren = instance.render();
-      if (debugRenderPhaseSideEffects) {
+      if (
+        debugRenderPhaseSideEffects &&
+        !workInProgress.type.prototype
+          .unstable_ignoreDebugRenderPhaseSideEffects
+      ) {
         instance.render();
       }
       ReactDebugCurrentFiber.setCurrentPhase(null);
     } else {
-      if (debugRenderPhaseSideEffects) {
+      if (
+        debugRenderPhaseSideEffects &&
+        !workInProgress.type.prototype
+          .unstable_ignoreDebugRenderPhaseSideEffects
+      ) {
         instance.render();
       }
       nextChildren = instance.render();

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -175,7 +175,11 @@ export default function(
       stopPhaseTimer();
 
       // Simulate an async bailout/interruption by invoking lifecycle twice.
-      if (debugRenderPhaseSideEffects) {
+      if (
+        debugRenderPhaseSideEffects &&
+        !workInProgress.type.prototype
+          .unstable_ignoreDebugRenderPhaseSideEffects
+      ) {
         instance.shouldComponentUpdate(newProps, newState, newContext);
       }
 
@@ -413,7 +417,10 @@ export default function(
     stopPhaseTimer();
 
     // Simulate an async bailout/interruption by invoking lifecycle twice.
-    if (debugRenderPhaseSideEffects) {
+    if (
+      debugRenderPhaseSideEffects &&
+      !workInProgress.type.prototype.unstable_ignoreDebugRenderPhaseSideEffects
+    ) {
       instance.componentWillReceiveProps(newProps, newContext);
     }
 
@@ -677,7 +684,11 @@ export default function(
         stopPhaseTimer();
 
         // Simulate an async bailout/interruption by invoking lifecycle twice.
-        if (debugRenderPhaseSideEffects) {
+        if (
+          debugRenderPhaseSideEffects &&
+          !workInProgress.type.prototype
+            .unstable_ignoreDebugRenderPhaseSideEffects
+        ) {
           instance.componentWillUpdate(newProps, newState, newContext);
         }
       }

--- a/packages/react-reconciler/src/ReactFiberUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberUpdateQueue.js
@@ -180,13 +180,22 @@ export function getUpdateExpirationTime(fiber: Fiber): ExpirationTime {
   return updateQueue.expirationTime;
 }
 
-function getStateFromUpdate(update, instance, prevState, props) {
+function getStateFromUpdate(
+  workInProgress,
+  update,
+  instance,
+  prevState,
+  props,
+) {
   const partialState = update.partialState;
   if (typeof partialState === 'function') {
     const updateFn = partialState;
 
     // Invoke setState callback an extra time to help detect side-effects.
-    if (debugRenderPhaseSideEffects) {
+    if (
+      debugRenderPhaseSideEffects &&
+      !workInProgress.type.prototype.unstable_ignoreDebugRenderPhaseSideEffects
+    ) {
       updateFn.call(instance, prevState, props);
     }
 
@@ -279,10 +288,22 @@ export function processUpdateQueue<State>(
     // Process the update
     let partialState;
     if (update.isReplace) {
-      state = getStateFromUpdate(update, instance, state, props);
+      state = getStateFromUpdate(
+        workInProgress,
+        update,
+        instance,
+        state,
+        props,
+      );
       dontMutatePrevState = true;
     } else {
-      partialState = getStateFromUpdate(update, instance, state, props);
+      partialState = getStateFromUpdate(
+        workInProgress,
+        update,
+        instance,
+        state,
+        props,
+      );
       if (partialState) {
         if (dontMutatePrevState) {
           // $FlowFixMe: Idk how to type this properly.

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -9,7 +9,13 @@ import assign from 'object-assign';
 import ReactVersion from 'shared/ReactVersion';
 import {REACT_FRAGMENT_TYPE} from 'shared/ReactSymbols';
 
-import {Component, PureComponent, AsyncComponent} from './ReactBaseClasses';
+import {
+  Component,
+  LegacyComponent,
+  LegacyPureComponent,
+  PureComponent,
+  AsyncComponent,
+} from './ReactBaseClasses';
 import {forEach, map, count, toArray, only} from './ReactChildren';
 import ReactCurrentOwner from './ReactCurrentOwner';
 import {
@@ -35,6 +41,8 @@ const React = {
   },
 
   Component,
+  legacy_Component: LegacyComponent,
+  legacy_PureComponent: LegacyPureComponent,
   PureComponent,
   unstable_AsyncComponent: AsyncComponent,
 


### PR DESCRIPTION
Proof of concept to more incrementally introduce the `debugRenderPhaseSideEffects` GK. The idea behind this PR is to first code-mod a codebase to extend `legacy_` components, and then gradually migrate them back to `Component` once they had been deemed side-effect free.

I'm not thrilled about this approach. 😄 

This would cause a small regression in bundle size:
![screen shot 2017-12-07 at 7 12 12 am](https://user-images.githubusercontent.com/29597/33734000-5f537c58-db40-11e7-972d-fb39c4219da9.png)