### PR TITLE
Remove an extra allocation for open source bundles

### DIFF
--- a/packages/react-dom/src/events/EventListener.js
+++ b/packages/react-dom/src/events/EventListener.js
@@ -7,11 +7,18 @@
  * @flow
  */
 
-export function addEventListener(
+export function addEventBubbleListener(
   element: Element,
   eventType: string,
   listener: Function,
-  useCapture: boolean,
 ): void {
-  element.addEventListener(eventType, listener, useCapture);
+  element.addEventListener(eventType, listener, false);
+}
+
+export function addEventCaptureListener(
+  element: Element,
+  eventType: string,
+  listener: Function,
+): void {
+  element.addEventListener(eventType, listener, true);
 }

--- a/packages/react-dom/src/events/EventListener.js
+++ b/packages/react-dom/src/events/EventListener.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export function addEventListener(
+  element: Element,
+  eventType: string,
+  listener: Function,
+  useCapture: boolean,
+): void {
+  element.addEventListener(eventType, listener, useCapture);
+}

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -8,7 +8,6 @@
 import {batchedUpdates} from 'events/ReactGenericBatching';
 import {isFiberMounted} from 'react-reconciler/reflection';
 import {HostRoot} from 'shared/ReactTypeOfWork';
-import EventListener from 'fbjs/lib/EventListener';
 
 import getEventTarget from './getEventTarget';
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
@@ -124,10 +123,10 @@ export function trapBubbledEvent(topLevelType, handlerBaseName, element) {
   if (!element) {
     return null;
   }
-  return EventListener.listen(
-    element,
+  element.addEventListener(
     handlerBaseName,
     dispatchEvent.bind(null, topLevelType),
+    false,
   );
 }
 
@@ -145,10 +144,10 @@ export function trapCapturedEvent(topLevelType, handlerBaseName, element) {
   if (!element) {
     return null;
   }
-  return EventListener.capture(
-    element,
+  element.addEventListener(
     handlerBaseName,
     dispatchEvent.bind(null, topLevelType),
+    true,
   );
 }
 

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -9,7 +9,7 @@ import {batchedUpdates} from 'events/ReactGenericBatching';
 import {isFiberMounted} from 'react-reconciler/reflection';
 import {HostRoot} from 'shared/ReactTypeOfWork';
 
-import {addEventListener} from './EventListener';
+import {addEventBubbleListener, addEventCaptureListener} from './EventListener';
 import getEventTarget from './getEventTarget';
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
 
@@ -124,11 +124,10 @@ export function trapBubbledEvent(topLevelType, handlerBaseName, element) {
   if (!element) {
     return null;
   }
-  addEventListener(
+  addEventBubbleListener(
     element,
     handlerBaseName,
     dispatchEvent.bind(null, topLevelType),
-    false,
   );
 }
 
@@ -146,11 +145,10 @@ export function trapCapturedEvent(topLevelType, handlerBaseName, element) {
   if (!element) {
     return null;
   }
-  addEventListener(
+  addEventCaptureListener(
     element,
     handlerBaseName,
     dispatchEvent.bind(null, topLevelType),
-    true,
   );
 }
 

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -9,6 +9,7 @@ import {batchedUpdates} from 'events/ReactGenericBatching';
 import {isFiberMounted} from 'react-reconciler/reflection';
 import {HostRoot} from 'shared/ReactTypeOfWork';
 
+import {addEventListener} from './EventListener';
 import getEventTarget from './getEventTarget';
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
 
@@ -123,7 +124,8 @@ export function trapBubbledEvent(topLevelType, handlerBaseName, element) {
   if (!element) {
     return null;
   }
-  element.addEventListener(
+  addEventListener(
+    element,
     handlerBaseName,
     dispatchEvent.bind(null, topLevelType),
     false,
@@ -144,7 +146,8 @@ export function trapCapturedEvent(topLevelType, handlerBaseName, element) {
   if (!element) {
     return null;
   }
-  element.addEventListener(
+  addEventListener(
+    element,
     handlerBaseName,
     dispatchEvent.bind(null, topLevelType),
     true,

--- a/packages/react-dom/src/events/forks/EventListener-www.js
+++ b/packages/react-dom/src/events/forks/EventListener-www.js
@@ -12,17 +12,20 @@ var EventListenerWWW = require('EventListener');
 import typeof * as EventListenerType from '../EventListener';
 import typeof * as EventListenerShimType from './EventListener-www';
 
-export function addEventListener(
+export function addEventBubbleListener(
   element: Element,
   eventType: string,
   listener: Function,
-  useCapture: boolean,
 ): void {
-  if (useCapture) {
-    EventListenerWWW.capture(element, eventType, listener);
-  } else {
-    EventListenerWWW.listen(element, eventType, listener);
-  }
+  EventListenerWWW.listen(element, eventType, listener);
+}
+
+export function addEventCaptureListener(
+  element: Element,
+  eventType: string,
+  listener: Function,
+): void {
+  EventListenerWWW.capture(element, eventType, listener);
 }
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/react-dom/src/events/forks/EventListener-www.js
+++ b/packages/react-dom/src/events/forks/EventListener-www.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+var EventListenerWWW = require('EventListener');
+
+import typeof * as EventListenerType from '../EventListener';
+import typeof * as EventListenerShimType from './EventListener-www';
+
+export function addEventListener(
+  element: Element,
+  eventType: string,
+  listener: Function,
+  useCapture: boolean,
+): void {
+  if (useCapture) {
+    EventListenerWWW.capture(element, eventType, listener);
+  } else {
+    EventListenerWWW.listen(element, eventType, listener);
+  }
+}
+
+// Flow magic to verify the exports of this file match the original version.
+// eslint-disable-next-line no-unused-vars
+type Check<_X, Y: _X, X: Y = _X> = null;
+// eslint-disable-next-line no-unused-expressions
+(null: Check<EventListenerShimType, EventListenerType>);

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -24,3 +24,11 @@ declare module 'ReactFiberErrorDialog' {
     showErrorDialog: (error: mixed) => boolean,
   };
 }
+
+// EventListener www fork
+declare module 'EventListener' {
+  declare module.exports: {
+    listen: (target: Element, type: string, callback: Function) => mixed,
+    capture: (target: Element, type: string, callback: Function) => mixed,
+  };
+}

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -101,6 +101,18 @@ const forks = Object.freeze({
         return null;
     }
   },
+
+  // We wrap top-level listeners into guards on www.
+  'react-dom/src/events/EventListener': (bundleType, entry) => {
+    switch (bundleType) {
+      case FB_DEV:
+      case FB_PROD:
+        // Use the www fork which is integrated with TimeSlice profiling.
+        return 'react-dom/src/events/forks/EventListener-www.js';
+      default:
+        return null;
+    }
+  },
 });
 
 module.exports = forks;

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -25,8 +25,8 @@
       "gzip": 3454
     },
     "react-dom.development.js (UMD_DEV)": {
-      "size": 574360,
-      "gzip": 134529
+      "size": 573647,
+      "gzip": 134534
     },
     "react-dom.production.min.js (UMD_PROD)": {
       "size": 96372,
@@ -41,8 +41,8 @@
       "gzip": 30295
     },
     "ReactDOM-dev.js (FB_DEV)": {
-      "size": 573766,
-      "gzip": 132409
+      "size": 575260,
+      "gzip": 132862
     },
     "ReactDOM-prod.js (FB_PROD)": {
       "size": 272322,

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -25,8 +25,8 @@
       "gzip": 3454
     },
     "react-dom.development.js (UMD_DEV)": {
-      "size": 573647,
-      "gzip": 134534
+      "size": 574360,
+      "gzip": 134529
     },
     "react-dom.production.min.js (UMD_PROD)": {
       "size": 96372,
@@ -41,8 +41,8 @@
       "gzip": 30295
     },
     "ReactDOM-dev.js (FB_DEV)": {
-      "size": 575260,
-      "gzip": 132862
+      "size": 573766,
+      "gzip": 132409
     },
     "ReactDOM-prod.js (FB_PROD)": {
       "size": 272322,


### PR DESCRIPTION
This is an alternative to https://github.com/facebook/react/pull/11617 that doesn't break our internal www override of EventListener. The benefit is it gets rid of the `{ remove: function() {} }` allocation in open source (which we don't use) but still routes React listeners through our www fork which is integrated with TimeSlice. This uses the new forking mechanism.