### PR TITLE
Remove IE8-specific focus polyfill

### DIFF
--- a/packages/react-dom/src/client/ReactInputSelection.js
+++ b/packages/react-dom/src/client/ReactInputSelection.js
@@ -6,7 +6,6 @@
  */
 
 import containsNode from 'fbjs/lib/containsNode';
-import focusNode from 'fbjs/lib/focusNode';
 import getActiveElement from 'fbjs/lib/getActiveElement';
 
 import * as ReactDOMSelection from './ReactDOMSelection';
@@ -70,7 +69,7 @@ export function restoreSelection(priorSelectionInformation) {
       }
     }
 
-    focusNode(priorFocusedElem);
+    priorFocusedElem.focus();
 
     for (let i = 0; i < ancestors.length; i++) {
       const info = ancestors[i];


### PR DESCRIPTION
It looked like this:

```js
function focusNode(node) {
  // IE8 can throw "Can't move focus to the control because it is invisible,
  // not enabled, or of a type that does not accept the focus." for all kinds of
  // reasons that are too expensive and fragile to test.
  try {
    node.focus();
  } catch (e) {}
}
```

We know it's definitely a node because we previously checked `containsNode` on `document.documentElement` with it.

So this should always be safe to call now.