### PR TITLE
Add `yarn build --pretty`

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -51,6 +51,7 @@ const requestedBundleTypes = (argv.type || '')
 const requestedBundleNames = (argv._[0] || '')
   .split(',')
   .map(type => type.toLowerCase());
+const forcePrettyOutput = argv['pretty'];
 const syncFBSourcePath = argv['sync-fbsource'];
 const syncWWWPath = argv['sync-www'];
 const shouldExtractErrors = argv['extract-errors'];
@@ -191,7 +192,7 @@ function getPlugins(
   const isInGlobalScope = bundleType === UMD_DEV || bundleType === UMD_PROD;
   const isFBBundle = bundleType === FB_DEV || bundleType === FB_PROD;
   const isRNBundle = bundleType === RN_DEV || bundleType === RN_PROD;
-  const shouldStayReadable = isFBBundle || isRNBundle;
+  const shouldStayReadable = isFBBundle || isRNBundle || forcePrettyOutput;
   return [
     // Extract error codes from invariant() messages into a file.
     shouldExtractErrors && {
@@ -471,7 +472,9 @@ async function buildEverything() {
   }
 
   console.log(Stats.printResults());
-  Stats.saveResults();
+  if (!forcePrettyOutput) {
+    Stats.saveResults();
+  }
 
   if (shouldExtractErrors) {
     console.warn(


### PR DESCRIPTION
This is handy for looking at generated production UMD bundles without mangling.

<img width="460" alt="screen shot 2017-12-07 at 22 45 31" src="https://user-images.githubusercontent.com/810438/33742468-642bcac2-dba0-11e7-95d9-8f38f0ce1f56.png">
