### PR TITLE
Move isAttributeNameSafe to DOMProperty

### DIFF
--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -6,39 +6,12 @@
  */
 
 import {
-  ATTRIBUTE_NAME_CHAR,
-  ATTRIBUTE_NAME_START_CHAR,
   ID_ATTRIBUTE_NAME,
   ROOT_ATTRIBUTE_NAME,
   getPropertyInfo,
   shouldSetAttribute,
+  isAttributeNameSafe,
 } from '../shared/DOMProperty';
-import warning from 'fbjs/lib/warning';
-
-// isAttributeNameSafe() is currently duplicated in DOMMarkupOperations.
-// TODO: Find a better place for this.
-const VALID_ATTRIBUTE_NAME_REGEX = new RegExp(
-  '^[' + ATTRIBUTE_NAME_START_CHAR + '][' + ATTRIBUTE_NAME_CHAR + ']*$',
-);
-const illegalAttributeNameCache = {};
-const validatedAttributeNameCache = {};
-function isAttributeNameSafe(attributeName) {
-  if (validatedAttributeNameCache.hasOwnProperty(attributeName)) {
-    return true;
-  }
-  if (illegalAttributeNameCache.hasOwnProperty(attributeName)) {
-    return false;
-  }
-  if (VALID_ATTRIBUTE_NAME_REGEX.test(attributeName)) {
-    validatedAttributeNameCache[attributeName] = true;
-    return true;
-  }
-  illegalAttributeNameCache[attributeName] = true;
-  if (__DEV__) {
-    warning(false, 'Invalid attribute name: `%s`', attributeName);
-  }
-  return false;
-}
 
 // shouldIgnoreValue() is currently duplicated in DOMMarkupOperations.
 // TODO: Find a better place for this.

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -6,41 +6,14 @@
  */
 
 import {
-  ATTRIBUTE_NAME_CHAR,
-  ATTRIBUTE_NAME_START_CHAR,
   ID_ATTRIBUTE_NAME,
   ROOT_ATTRIBUTE_NAME,
   getPropertyInfo,
   shouldAttributeAcceptBooleanValue,
   shouldSetAttribute,
+  isAttributeNameSafe,
 } from '../shared/DOMProperty';
 import quoteAttributeValueForBrowser from './quoteAttributeValueForBrowser';
-import warning from 'fbjs/lib/warning';
-
-// isAttributeNameSafe() is currently duplicated in DOMPropertyOperations.
-// TODO: Find a better place for this.
-const VALID_ATTRIBUTE_NAME_REGEX = new RegExp(
-  '^[' + ATTRIBUTE_NAME_START_CHAR + '][' + ATTRIBUTE_NAME_CHAR + ']*$',
-);
-const illegalAttributeNameCache = {};
-const validatedAttributeNameCache = {};
-function isAttributeNameSafe(attributeName) {
-  if (validatedAttributeNameCache.hasOwnProperty(attributeName)) {
-    return true;
-  }
-  if (illegalAttributeNameCache.hasOwnProperty(attributeName)) {
-    return false;
-  }
-  if (VALID_ATTRIBUTE_NAME_REGEX.test(attributeName)) {
-    validatedAttributeNameCache[attributeName] = true;
-    return true;
-  }
-  illegalAttributeNameCache[attributeName] = true;
-  if (__DEV__) {
-    warning(false, 'Invalid attribute name: `%s`', attributeName);
-  }
-  return false;
-}
 
 // shouldIgnoreValue() is currently duplicated in DOMPropertyOperations.
 // TODO: Find a better place for this.

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -111,6 +111,30 @@ export const ATTRIBUTE_NAME_CHAR =
 
 export const ID_ATTRIBUTE_NAME = 'data-reactid';
 export const ROOT_ATTRIBUTE_NAME = 'data-reactroot';
+export const VALID_ATTRIBUTE_NAME_REGEX = new RegExp(
+  '^[' + ATTRIBUTE_NAME_START_CHAR + '][' + ATTRIBUTE_NAME_CHAR + ']*$',
+);
+
+const illegalAttributeNameCache = {};
+const validatedAttributeNameCache = {};
+
+export function isAttributeNameSafe(attributeName) {
+  if (validatedAttributeNameCache.hasOwnProperty(attributeName)) {
+    return true;
+  }
+  if (illegalAttributeNameCache.hasOwnProperty(attributeName)) {
+    return false;
+  }
+  if (VALID_ATTRIBUTE_NAME_REGEX.test(attributeName)) {
+    validatedAttributeNameCache[attributeName] = true;
+    return true;
+  }
+  illegalAttributeNameCache[attributeName] = true;
+  if (__DEV__) {
+    warning(false, 'Invalid attribute name: `%s`', attributeName);
+  }
+  return false;
+}
 
 /**
  * Map from property "standard name" to an object with info about how to set


### PR DESCRIPTION
Deduping `isAttributeNameSafe`. `DOMProperty` feels like the best place for `isAttributeNameSafe` since: 

* It already depends on the regexes it exports
* It contains other attribute logic like `shouldSetAttribute