### PR TITLE
Refactor DOM attribute code

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -442,6 +442,97 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.className).toEqual('');
     });
 
+    it('should not set null/undefined attributes', () => {
+      var container = document.createElement('div');
+      // Initial render.
+      ReactDOM.render(<img src={null} data-foo={undefined} />, container);
+      var node = container.firstChild;
+      expect(node.hasAttribute('src')).toBe(false);
+      expect(node.hasAttribute('data-foo')).toBe(false);
+      // Update in one direction.
+      ReactDOM.render(<img src={undefined} data-foo={null} />, container);
+      expect(node.hasAttribute('src')).toBe(false);
+      expect(node.hasAttribute('data-foo')).toBe(false);
+      // Update in another direction.
+      ReactDOM.render(<img src={null} data-foo={undefined} />, container);
+      expect(node.hasAttribute('src')).toBe(false);
+      expect(node.hasAttribute('data-foo')).toBe(false);
+      // Removal.
+      ReactDOM.render(<img />, container);
+      expect(node.hasAttribute('src')).toBe(false);
+      expect(node.hasAttribute('data-foo')).toBe(false);
+      // Addition.
+      ReactDOM.render(<img src={undefined} data-foo={null} />, container);
+      expect(node.hasAttribute('src')).toBe(false);
+      expect(node.hasAttribute('data-foo')).toBe(false);
+    });
+
+    it('should apply React-specific aliases to HTML elements', () => {
+      var container = document.createElement('div');
+      ReactDOM.render(<form acceptCharset="foo" />, container);
+      var node = container.firstChild;
+      // Test attribute initialization.
+      expect(node.getAttribute('accept-charset')).toBe('foo');
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Test attribute update.
+      ReactDOM.render(<form acceptCharset="boo" />, container);
+      expect(node.getAttribute('accept-charset')).toBe('boo');
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Test attribute removal by setting to null.
+      ReactDOM.render(<form acceptCharset={null} />, container);
+      expect(node.hasAttribute('accept-charset')).toBe(false);
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Restore.
+      ReactDOM.render(<form acceptCharset="foo" />, container);
+      expect(node.getAttribute('accept-charset')).toBe('foo');
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Test attribute removal by setting to undefined.
+      ReactDOM.render(<form acceptCharset={undefined} />, container);
+      expect(node.hasAttribute('accept-charset')).toBe(false);
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Restore.
+      ReactDOM.render(<form acceptCharset="foo" />, container);
+      expect(node.getAttribute('accept-charset')).toBe('foo');
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Test attribute removal.
+      ReactDOM.render(<form />, container);
+      expect(node.hasAttribute('accept-charset')).toBe(false);
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+    });
+
+    it('should apply React-specific aliases to SVG elements', () => {
+      var container = document.createElement('div');
+      ReactDOM.render(<svg arabicForm="foo" />, container);
+      var node = container.firstChild;
+      // Test attribute initialization.
+      expect(node.getAttribute('arabic-form')).toBe('foo');
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Test attribute update.
+      ReactDOM.render(<svg arabicForm="boo" />, container);
+      expect(node.getAttribute('arabic-form')).toBe('boo');
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Test attribute removal by setting to null.
+      ReactDOM.render(<svg arabicForm={null} />, container);
+      expect(node.hasAttribute('arabic-form')).toBe(false);
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Restore.
+      ReactDOM.render(<svg arabicForm="foo" />, container);
+      expect(node.getAttribute('arabic-form')).toBe('foo');
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Test attribute removal by setting to undefined.
+      ReactDOM.render(<svg arabicForm={undefined} />, container);
+      expect(node.hasAttribute('arabic-form')).toBe(false);
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Restore.
+      ReactDOM.render(<svg arabicForm="foo" />, container);
+      expect(node.getAttribute('arabic-form')).toBe('foo');
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Test attribute removal.
+      ReactDOM.render(<svg />, container);
+      expect(node.hasAttribute('arabic-form')).toBe(false);
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+    });
+
     it('should properly update custom attributes on custom elements', () => {
       const container = document.createElement('div');
       ReactDOM.render(<some-custom-element foo="bar" />, container);
@@ -449,6 +540,25 @@ describe('ReactDOMComponent', () => {
       const node = container.firstChild;
       expect(node.hasAttribute('foo')).toBe(false);
       expect(node.getAttribute('bar')).toBe('buzz');
+    });
+
+    it('should not apply React-specific aliases to custom elements', () => {
+      var container = document.createElement('div');
+      ReactDOM.render(<some-custom-element arabicForm="foo" />, container);
+      var node = container.firstChild;
+      // Should not get transformed to arabic-form as SVG would be.
+      expect(node.getAttribute('arabicForm')).toBe('foo');
+      expect(node.hasAttribute('arabic-form')).toBe(false);
+      // Test attribute update.
+      ReactDOM.render(<some-custom-element arabicForm="boo" />, container);
+      expect(node.getAttribute('arabicForm')).toBe('boo');
+      // Test attribute removal and addition.
+      ReactDOM.render(<some-custom-element acceptCharset="buzz" />, container);
+      // Verify the previous attribute was removed.
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Should not get transformed to accept-charset as HTML would be.
+      expect(node.getAttribute('acceptCharset')).toBe('buzz');
+      expect(node.hasAttribute('accept-charset')).toBe(false);
     });
 
     it('should clear a single style prop when changing `style`', () => {

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -7,7 +7,8 @@
 
 import {
   getPropertyInfo,
-  shouldSetAttribute,
+  shouldSkipAttribute,
+  shouldTreatAttributeValueAsNull,
   isAttributeNameSafe,
 } from '../shared/DOMProperty';
 
@@ -112,13 +113,14 @@ export function getValueForAttribute(node, name, expected) {
  * @param {*} value
  */
 export function setValueForProperty(node, name, value, isCustomComponentTag) {
+  if (shouldSkipAttribute(name, isCustomComponentTag)) {
+    return;
+  }
+  if (shouldTreatAttributeValueAsNull(name, value, isCustomComponentTag)) {
+    value = null;
+  }
   const propertyInfo = getPropertyInfo(name);
-
-  if (
-    !isCustomComponentTag &&
-    propertyInfo &&
-    shouldSetAttribute(name, value)
-  ) {
+  if (!isCustomComponentTag && propertyInfo) {
     if (shouldIgnoreValue(propertyInfo, value)) {
       if (propertyInfo.mustUseProperty) {
         if (propertyInfo.hasBooleanValue) {
@@ -149,19 +151,11 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
         node.setAttribute(attributeName, '' + value);
       }
     }
-  } else {
-    const useValue = isCustomComponentTag || shouldSetAttribute(name, value);
-    setValueForAttribute(node, name, useValue ? value : null);
-  }
-}
-
-export function setValueForAttribute(node, name, value) {
-  if (!isAttributeNameSafe(name)) {
-    return;
-  }
-  if (value == null) {
-    node.removeAttribute(name);
-  } else {
-    node.setAttribute(name, '' + value);
+  } else if (isAttributeNameSafe(name)) {
+    if (value == null) {
+      node.removeAttribute(name);
+    } else {
+      node.setAttribute(name, '' + value);
+    }
   }
 }

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -6,8 +6,6 @@
  */
 
 import {
-  ID_ATTRIBUTE_NAME,
-  ROOT_ATTRIBUTE_NAME,
   getPropertyInfo,
   shouldSetAttribute,
   isAttributeNameSafe,
@@ -23,18 +21,6 @@ function shouldIgnoreValue(propertyInfo, value) {
     (propertyInfo.hasPositiveNumericValue && value < 1) ||
     (propertyInfo.hasOverloadedBooleanValue && value === false)
   );
-}
-
-/**
- * Operations for dealing with DOM properties.
- */
-
-export function setAttributeForID(node, id) {
-  node.setAttribute(ID_ATTRIBUTE_NAME, id);
-}
-
-export function setAttributeForRoot(node) {
-  node.setAttribute(ROOT_ATTRIBUTE_NAME, '');
 }
 
 /**

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -189,7 +189,7 @@ export function deleteValueForAttribute(node, name) {
  * @param {DOMElement} node
  * @param {string} name
  */
-export function deleteValueForProperty(node, name) {
+function deleteValueForProperty(node, name) {
   const propertyInfo = getPropertyInfo(name);
   if (propertyInfo) {
     if (propertyInfo.mustUseProperty) {

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -7,22 +7,11 @@
 
 import {
   getPropertyInfo,
+  shouldIgnoreValue,
   shouldSkipAttribute,
   shouldTreatAttributeValueAsNull,
   isAttributeNameSafe,
 } from '../shared/DOMProperty';
-
-// shouldIgnoreValue() is currently duplicated in DOMMarkupOperations.
-// TODO: Find a better place for this.
-function shouldIgnoreValue(propertyInfo, value) {
-  return (
-    value == null ||
-    (propertyInfo.hasBooleanValue && !value) ||
-    (propertyInfo.hasNumericValue && isNaN(value)) ||
-    (propertyInfo.hasPositiveNumericValue && value < 1) ||
-    (propertyInfo.hasOverloadedBooleanValue && value === false)
-  );
-}
 
 /**
  * Get the value for a property on a node. Only used in DEV for SSR validation.

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -124,7 +124,7 @@ export function setValueForProperty(
   if (shouldTreatAttributeValueAsNull(name, value, isCustomComponentTag)) {
     value = null;
   }
-  // If the prop is in the special list, treat it as a simple attribute.
+  // If the prop isn't in the special list, treat it as a simple attribute.
   if (!propertyInfo) {
     if (isAttributeNameSafe(name)) {
       const attributeName = name;

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -111,10 +111,14 @@ export function getValueForAttribute(node, name, expected) {
  * @param {string} name
  * @param {*} value
  */
-export function setValueForProperty(node, name, value) {
+export function setValueForProperty(node, name, value, isCustomComponentTag) {
   const propertyInfo = getPropertyInfo(name);
 
-  if (propertyInfo && shouldSetAttribute(name, value)) {
+  if (
+    !isCustomComponentTag &&
+    propertyInfo &&
+    shouldSetAttribute(name, value)
+  ) {
     if (shouldIgnoreValue(propertyInfo, value)) {
       if (propertyInfo.mustUseProperty) {
         if (propertyInfo.hasBooleanValue) {
@@ -146,11 +150,8 @@ export function setValueForProperty(node, name, value) {
       }
     }
   } else {
-    setValueForAttribute(
-      node,
-      name,
-      shouldSetAttribute(name, value) ? value : null,
-    );
+    const useValue = isCustomComponentTag || shouldSetAttribute(name, value);
+    setValueForAttribute(node, name, useValue ? value : null);
   }
 }
 

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -178,13 +178,3 @@ export function setValueForAttribute(node, name, value) {
     node.setAttribute(name, '' + value);
   }
 }
-
-/**
- * Deletes an attributes from a node.
- *
- * @param {DOMElement} node
- * @param {string} name
- */
-export function deleteValueForAttribute(node, name) {
-  node.removeAttribute(name);
-}

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import {
@@ -17,12 +19,17 @@ import {
  * The "expected" argument is used as a hint of what the expected value is.
  * Some properties have multiple equivalent values.
  */
-export function getValueForProperty(node, name, expected) {
+export function getValueForProperty(
+  node: Element,
+  name: string,
+  expected: mixed,
+): mixed {
   if (__DEV__) {
     const propertyInfo = getPropertyInfo(name);
     if (propertyInfo) {
       if (propertyInfo.mustUseProperty) {
-        return node[propertyInfo.propertyName];
+        const {propertyName} = propertyInfo;
+        return (node: any)[propertyName];
       } else {
         const attributeName = propertyInfo.attributeName;
 
@@ -37,7 +44,7 @@ export function getValueForProperty(node, name, expected) {
             if (shouldTreatAttributeValueAsNull(name, expected, false)) {
               return value;
             }
-            if (value === '' + expected) {
+            if (value === '' + (expected: any)) {
               return expected;
             }
             return value;
@@ -62,7 +69,7 @@ export function getValueForProperty(node, name, expected) {
 
         if (shouldTreatAttributeValueAsNull(name, expected, false)) {
           return stringValue === null ? expected : stringValue;
-        } else if (stringValue === '' + expected) {
+        } else if (stringValue === '' + (expected: any)) {
           return expected;
         } else {
           return stringValue;
@@ -77,7 +84,11 @@ export function getValueForProperty(node, name, expected) {
  * The third argument is used as a hint of what the expected value is. Some
  * attributes have multiple equivalent values.
  */
-export function getValueForAttribute(node, name, expected) {
+export function getValueForAttribute(
+  node: Element,
+  name: string,
+  expected: mixed,
+): mixed {
   if (__DEV__) {
     if (!isAttributeNameSafe(name)) {
       return;
@@ -86,7 +97,7 @@ export function getValueForAttribute(node, name, expected) {
       return expected === undefined ? undefined : null;
     }
     const value = node.getAttribute(name);
-    if (value === '' + expected) {
+    if (value === '' + (expected: any)) {
       return expected;
     }
     return value;
@@ -100,7 +111,12 @@ export function getValueForAttribute(node, name, expected) {
  * @param {string} name
  * @param {*} value
  */
-export function setValueForProperty(node, name, value, isCustomComponentTag) {
+export function setValueForProperty(
+  node: Element,
+  name: string,
+  value: mixed,
+  isCustomComponentTag: boolean,
+) {
   if (shouldSkipAttribute(name, isCustomComponentTag)) {
     return;
   }
@@ -115,7 +131,7 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
       if (value == null) {
         node.removeAttribute(attributeName);
       } else {
-        node.setAttribute(attributeName, '' + value);
+        node.setAttribute(attributeName, '' + (value: any));
       }
     }
     return;
@@ -128,11 +144,11 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
   if (mustUseProperty) {
     const {propertyName} = propertyInfo;
     if (value === null) {
-      node[propertyName] = hasBooleanValue ? false : '';
+      (node: any)[propertyName] = hasBooleanValue ? false : '';
     } else {
       // Contrary to `setAttribute`, object properties are properly
       // `toString`ed by IE8/9.
-      node[propertyName] = value;
+      (node: any)[propertyName] = value;
     }
     return;
   }
@@ -147,7 +163,7 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
     } else {
       // `setAttribute` with objects becomes only `[object]` in IE8/9,
       // ('' + value) makes it output the correct toString()-value.
-      attributeValue = '' + value;
+      attributeValue = '' + (value: any);
     }
     if (attributeNamespace) {
       node.setAttributeNS(attributeNamespace, attributeName, attributeValue);

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -7,7 +7,6 @@
 
 import {
   getPropertyInfo,
-  shouldIgnoreValue,
   shouldSkipAttribute,
   shouldTreatAttributeValueAsNull,
   isAttributeNameSafe,
@@ -35,7 +34,7 @@ export function getValueForProperty(node, name, expected) {
             if (value === '') {
               return true;
             }
-            if (shouldIgnoreValue(propertyInfo, expected)) {
+            if (shouldTreatAttributeValueAsNull(name, expected, false)) {
               return value;
             }
             if (value === '' + expected) {
@@ -44,7 +43,7 @@ export function getValueForProperty(node, name, expected) {
             return value;
           }
         } else if (node.hasAttribute(attributeName)) {
-          if (shouldIgnoreValue(propertyInfo, expected)) {
+          if (shouldTreatAttributeValueAsNull(name, expected, false)) {
             // We had an attribute but shouldn't have had one, so read it
             // for the error message.
             return node.getAttribute(attributeName);
@@ -61,7 +60,7 @@ export function getValueForProperty(node, name, expected) {
           stringValue = node.getAttribute(attributeName);
         }
 
-        if (shouldIgnoreValue(propertyInfo, expected)) {
+        if (shouldTreatAttributeValueAsNull(name, expected, false)) {
           return stringValue === null ? expected : stringValue;
         } else if (stringValue === '' + expected) {
           return expected;
@@ -128,7 +127,7 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
   } = propertyInfo;
   if (mustUseProperty) {
     const {propertyName} = propertyInfo;
-    if (shouldIgnoreValue(propertyInfo, value)) {
+    if (value === null) {
       node[propertyName] = hasBooleanValue ? false : '';
     } else {
       // Contrary to `setAttribute`, object properties are properly
@@ -139,7 +138,7 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
   }
   // The rest are treated as attributes with special cases.
   const {attributeName, attributeNamespace} = propertyInfo;
-  if (shouldIgnoreValue(propertyInfo, value)) {
+  if (value === null) {
     node.removeAttribute(attributeName);
   } else {
     let attributeValue;

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -130,8 +130,15 @@ export function setValueForProperty(node, name, value) {
 
   if (propertyInfo && shouldSetAttribute(name, value)) {
     if (shouldIgnoreValue(propertyInfo, value)) {
-      deleteValueForProperty(node, name);
-      return;
+      if (propertyInfo.mustUseProperty) {
+        if (propertyInfo.hasBooleanValue) {
+          node[propertyInfo.propertyName] = false;
+        } else {
+          node[propertyInfo.propertyName] = '';
+        }
+      } else {
+        node.removeAttribute(propertyInfo.attributeName);
+      }
     } else if (propertyInfo.mustUseProperty) {
       // Contrary to `setAttribute`, object properties are properly
       // `toString`ed by IE8/9.
@@ -158,7 +165,6 @@ export function setValueForProperty(node, name, value) {
       name,
       shouldSetAttribute(name, value) ? value : null,
     );
-    return;
   }
 }
 
@@ -181,28 +187,4 @@ export function setValueForAttribute(node, name, value) {
  */
 export function deleteValueForAttribute(node, name) {
   node.removeAttribute(name);
-}
-
-/**
- * Deletes the value for a property on a node.
- *
- * @param {DOMElement} node
- * @param {string} name
- */
-function deleteValueForProperty(node, name) {
-  const propertyInfo = getPropertyInfo(name);
-  if (propertyInfo) {
-    if (propertyInfo.mustUseProperty) {
-      const propName = propertyInfo.propertyName;
-      if (propertyInfo.hasBooleanValue) {
-        node[propName] = false;
-      } else {
-        node[propName] = '';
-      }
-    } else {
-      node.removeAttribute(propertyInfo.attributeName);
-    }
-  } else {
-    node.removeAttribute(name);
-  }
 }

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -314,13 +314,13 @@ function setInitialDOMProperties(
         }
         ensureListeningTo(rootContainerElement, propKey);
       }
-    } else if (isCustomComponentTag) {
-      DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
     } else if (nextProp != null) {
-      // If we're updating to null or undefined, we should remove the property
-      // from the DOM node instead of inadvertently setting to a string. This
-      // brings us in line with the same behavior we have on initial render.
-      DOMPropertyOperations.setValueForProperty(domElement, propKey, nextProp);
+      DOMPropertyOperations.setValueForProperty(
+        domElement,
+        propKey,
+        nextProp,
+        isCustomComponentTag,
+      );
     }
   }
 }
@@ -341,14 +341,13 @@ function updateDOMProperties(
       setInnerHTML(domElement, propValue);
     } else if (propKey === CHILDREN) {
       setTextContent(domElement, propValue);
-    } else if (isCustomComponentTag) {
-      DOMPropertyOperations.setValueForAttribute(
+    } else {
+      DOMPropertyOperations.setValueForProperty(
         domElement,
         propKey,
         propValue,
+        isCustomComponentTag,
       );
-    } else {
-      DOMPropertyOperations.setValueForProperty(domElement, propKey, propValue);
     }
   }
 }

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -1000,7 +1000,7 @@ export function diffHydratedProperties(
         if (nextProp !== serverValue) {
           warnForPropDifference(propKey, serverValue, nextProp);
         }
-      } else if (shouldSetAttribute(propKey, nextProp)) {
+      } else if (shouldSetAttribute(propKey, nextProp, isCustomComponentTag)) {
         if ((propertyInfo = getPropertyInfo(propKey))) {
           // $FlowFixMe - Should be inferred as not undefined.
           extraAttributeNames.delete(propertyInfo.attributeName);

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -351,13 +351,8 @@ function updateDOMProperties(
       } else {
         DOMPropertyOperations.deleteValueForAttribute(domElement, propKey);
       }
-    } else if (propValue != null) {
-      DOMPropertyOperations.setValueForProperty(domElement, propKey, propValue);
     } else {
-      // If we're updating to null or undefined, we should remove the property
-      // from the DOM node instead of inadvertently setting to a string. This
-      // brings us in line with the same behavior we have on initial render.
-      DOMPropertyOperations.deleteValueForProperty(domElement, propKey);
+      DOMPropertyOperations.setValueForProperty(domElement, propKey, propValue);
     }
   }
 }

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -959,7 +959,11 @@ export function diffHydratedProperties(
         }
         ensureListeningTo(rootContainerElement, propKey);
       }
-    } else if (__DEV__) {
+    } else if (
+      __DEV__ &&
+      // Convince Flow we've calculated it (it's DEV-only in this method.)
+      typeof isCustomComponentTag === 'boolean'
+    ) {
       // Validate that the properties correspond to their expected values.
       let serverValue;
       let propertyInfo;

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -342,15 +342,11 @@ function updateDOMProperties(
     } else if (propKey === CHILDREN) {
       setTextContent(domElement, propValue);
     } else if (isCustomComponentTag) {
-      if (propValue != null) {
-        DOMPropertyOperations.setValueForAttribute(
-          domElement,
-          propKey,
-          propValue,
-        );
-      } else {
-        DOMPropertyOperations.deleteValueForAttribute(domElement, propKey);
-      }
+      DOMPropertyOperations.setValueForAttribute(
+        domElement,
+        propKey,
+        propValue,
+      );
     } else {
       DOMPropertyOperations.setValueForProperty(domElement, propKey, propValue);
     }

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -24,7 +24,11 @@ import setTextContent from './setTextContent';
 import {listenTo, trapBubbledEvent} from '../events/ReactBrowserEventEmitter';
 import * as CSSPropertyOperations from '../shared/CSSPropertyOperations';
 import {Namespaces, getIntrinsicNamespace} from '../shared/DOMNamespaces';
-import {getPropertyInfo, shouldSetAttribute} from '../shared/DOMProperty';
+import {
+  getPropertyInfo,
+  shouldSkipAttribute,
+  shouldTreatAttributeValueAsNull,
+} from '../shared/DOMProperty';
 import assertValidProps from '../shared/assertValidProps';
 import {DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE} from '../shared/HTMLNodeType';
 import isCustomComponent from '../shared/isCustomComponent';
@@ -1000,7 +1004,14 @@ export function diffHydratedProperties(
         if (nextProp !== serverValue) {
           warnForPropDifference(propKey, serverValue, nextProp);
         }
-      } else if (shouldSetAttribute(propKey, nextProp, isCustomComponentTag)) {
+      } else if (
+        !shouldSkipAttribute(propKey, isCustomComponentTag) &&
+        !shouldTreatAttributeValueAsNull(
+          propKey,
+          nextProp,
+          isCustomComponentTag,
+        )
+      ) {
         if ((propertyInfo = getPropertyInfo(propKey))) {
           // $FlowFixMe - Should be inferred as not undefined.
           extraAttributeNames.delete(propertyInfo.attributeName);

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -133,7 +133,7 @@ export function updateChecked(element: Element, props: Object) {
   const node = ((element: any): InputWithWrapperState);
   const checked = props.checked;
   if (checked != null) {
-    DOMPropertyOperations.setValueForProperty(node, 'checked', checked);
+    DOMPropertyOperations.setValueForProperty(node, 'checked', checked, false);
   }
 }
 

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -45,9 +45,6 @@ export function createMarkupForProperty(name, value) {
     return '';
   }
   if (shouldTreatAttributeValueAsNull(name, value, false)) {
-    value = null;
-  }
-  if (value === null) {
     return '';
   }
   const propertyInfo = getPropertyInfo(name);

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -10,22 +10,11 @@ import {
   ROOT_ATTRIBUTE_NAME,
   getPropertyInfo,
   shouldAttributeAcceptBooleanValue,
+  shouldIgnoreValue,
   shouldSetAttribute,
   isAttributeNameSafe,
 } from '../shared/DOMProperty';
 import quoteAttributeValueForBrowser from './quoteAttributeValueForBrowser';
-
-// shouldIgnoreValue() is currently duplicated in DOMPropertyOperations.
-// TODO: Find a better place for this.
-function shouldIgnoreValue(propertyInfo, value) {
-  return (
-    value == null ||
-    (propertyInfo.hasBooleanValue && !value) ||
-    (propertyInfo.hasNumericValue && isNaN(value)) ||
-    (propertyInfo.hasPositiveNumericValue && value < 1) ||
-    (propertyInfo.hasOverloadedBooleanValue && value === false)
-  );
-}
 
 /**
  * Operations for dealing with DOM properties.

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -9,10 +9,9 @@ import {
   ID_ATTRIBUTE_NAME,
   ROOT_ATTRIBUTE_NAME,
   getPropertyInfo,
-  shouldAttributeAcceptBooleanValue,
-  shouldIgnoreValue,
-  shouldSetAttribute,
   isAttributeNameSafe,
+  shouldSkipAttribute,
+  shouldTreatAttributeValueAsNull,
 } from '../shared/DOMProperty';
 import quoteAttributeValueForBrowser from './quoteAttributeValueForBrowser';
 
@@ -42,30 +41,29 @@ export function createMarkupForRoot() {
  * @return {?string} Markup string, or null if the property was invalid.
  */
 export function createMarkupForProperty(name, value) {
+  if (name !== 'style' && shouldSkipAttribute(name)) {
+    return '';
+  }
+  if (shouldTreatAttributeValueAsNull(name, value, false)) {
+    value = null;
+  }
+  if (value === null) {
+    return '';
+  }
   const propertyInfo = getPropertyInfo(name);
   if (propertyInfo) {
-    if (shouldIgnoreValue(propertyInfo, value)) {
-      return '';
-    }
     const attributeName = propertyInfo.attributeName;
     if (
       propertyInfo.hasBooleanValue ||
       (propertyInfo.hasOverloadedBooleanValue && value === true)
     ) {
       return attributeName + '=""';
-    } else if (
-      typeof value !== 'boolean' ||
-      shouldAttributeAcceptBooleanValue(name, false)
-    ) {
+    } else {
       return attributeName + '=' + quoteAttributeValueForBrowser(value);
     }
-  } else if (shouldSetAttribute(name, value, false)) {
-    if (value == null) {
-      return '';
-    }
+  } else {
     return name + '=' + quoteAttributeValueForBrowser(value);
   }
-  return null;
 }
 
 /**

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import {
@@ -25,11 +27,11 @@ import quoteAttributeValueForBrowser from './quoteAttributeValueForBrowser';
  * @param {string} id Unescaped ID.
  * @return {string} Markup string.
  */
-export function createMarkupForID(id) {
+export function createMarkupForID(id: string): string {
   return ID_ATTRIBUTE_NAME + '=' + quoteAttributeValueForBrowser(id);
 }
 
-export function createMarkupForRoot() {
+export function createMarkupForRoot(): string {
   return ROOT_ATTRIBUTE_NAME + '=""';
 }
 
@@ -40,7 +42,7 @@ export function createMarkupForRoot() {
  * @param {*} value
  * @return {?string} Markup string, or null if the property was invalid.
  */
-export function createMarkupForProperty(name, value) {
+export function createMarkupForProperty(name: string, value: mixed): string {
   if (name !== 'style' && shouldSkipAttribute(name, false)) {
     return '';
   }
@@ -70,7 +72,10 @@ export function createMarkupForProperty(name, value) {
  * @param {*} value
  * @return {string} Markup string, or empty string if the property was invalid.
  */
-export function createMarkupForCustomAttribute(name, value) {
+export function createMarkupForCustomAttribute(
+  name: string,
+  value: mixed,
+): string {
   if (!isAttributeNameSafe(name) || value == null) {
     return '';
   }

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -66,11 +66,11 @@ export function createMarkupForProperty(name, value) {
       return attributeName + '=""';
     } else if (
       typeof value !== 'boolean' ||
-      shouldAttributeAcceptBooleanValue(name)
+      shouldAttributeAcceptBooleanValue(name, false)
     ) {
       return attributeName + '=' + quoteAttributeValueForBrowser(value);
     }
-  } else if (shouldSetAttribute(name, value)) {
+  } else if (shouldSetAttribute(name, value, false)) {
     if (value == null) {
       return '';
     }

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -41,7 +41,7 @@ export function createMarkupForRoot() {
  * @return {?string} Markup string, or null if the property was invalid.
  */
 export function createMarkupForProperty(name, value) {
-  if (name !== 'style' && shouldSkipAttribute(name)) {
+  if (name !== 'style' && shouldSkipAttribute(name, false)) {
     return '';
   }
   if (shouldTreatAttributeValueAsNull(name, value, false)) {

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -180,17 +180,7 @@ export function shouldSkipAttribute(name, isCustomComponentTag) {
   return false;
 }
 
-export function shouldTreatAttributeValueAsNull(
-  name,
-  value,
-  isCustomComponentTag,
-) {
-  if (value === null) {
-    return true;
-  }
-  if (isCustomComponentTag) {
-    return typeof value === 'undefined';
-  }
+export function isBadlyTypedAttributeValue(name, value, isCustomComponentTag) {
   switch (typeof value) {
     case 'boolean':
       return !shouldAttributeAcceptBooleanValue(name, isCustomComponentTag);
@@ -205,14 +195,25 @@ export function shouldTreatAttributeValueAsNull(
   }
 }
 
+export function shouldTreatAttributeValueAsNull(
+  name,
+  value,
+  isCustomComponentTag,
+) {
+  if (value === null || typeof value === 'undefined') {
+    return true;
+  }
+  if (isBadlyTypedAttributeValue(name, value, isCustomComponentTag)) {
+    return true;
+  }
+  return false;
+}
+
 export function shouldSetAttribute(name, value, isCustomComponentTag) {
   if (shouldSkipAttribute(name, isCustomComponentTag)) {
     return false;
   }
-  if (
-    value !== null &&
-    shouldTreatAttributeValueAsNull(name, value, isCustomComponentTag)
-  ) {
+  if (shouldTreatAttributeValueAsNull(name, value, isCustomComponentTag)) {
     return false;
   }
   return true;

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -234,16 +234,6 @@ export function shouldTreatAttributeValueAsNull(
   return false;
 }
 
-export function shouldSetAttribute(name, value, isCustomComponentTag) {
-  if (shouldSkipAttribute(name, isCustomComponentTag)) {
-    return false;
-  }
-  if (shouldTreatAttributeValueAsNull(name, value, isCustomComponentTag)) {
-    return false;
-  }
-  return true;
-}
-
 export function getPropertyInfo(name) {
   return properties.hasOwnProperty(name) ? properties[name] : null;
 }

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -208,7 +208,7 @@ export function isBadlyTypedAttributeValue(
   switch (typeof value) {
     case 'function':
     // $FlowIssue symbol is perfectly valid here
-    case 'symbol':
+    case 'symbol': // eslint-disable-line
       return true;
     case 'boolean':
       break;

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -228,10 +228,7 @@ export function shouldTreatAttributeValueAsNull(
       return true;
     }
   }
-  if (isBadlyTypedAttributeValue(name, value, isCustomComponentTag)) {
-    return true;
-  }
-  return false;
+  return isBadlyTypedAttributeValue(name, value, isCustomComponentTag);
 }
 
 export function getPropertyInfo(name) {

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -3,9 +3,23 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import warning from 'fbjs/lib/warning';
+
+type PropertyInfo = {|
+  attributeName: string,
+  attributeNamespace: string | null,
+  propertyName: string,
+  mustUseProperty: boolean,
+  hasBooleanValue: boolean,
+  hasNumericValue: boolean,
+  hasPositiveNumericValue: boolean,
+  hasOverloadedBooleanValue: boolean,
+  hasStringBooleanValue: boolean,
+|};
 
 // These attributes should be all lowercase to allow for
 // case insensitive checks
@@ -54,7 +68,7 @@ function injectDOMPropertyConfig(domPropertyConfig) {
     const lowerCased = propName.toLowerCase();
     const propConfig = Properties[propName];
 
-    const propertyInfo = {
+    const propertyInfo: PropertyInfo = {
       attributeName: lowerCased,
       attributeNamespace: null,
       propertyName: propName,
@@ -118,7 +132,7 @@ export const VALID_ATTRIBUTE_NAME_REGEX = new RegExp(
 const illegalAttributeNameCache = {};
 const validatedAttributeNameCache = {};
 
-export function isAttributeNameSafe(attributeName) {
+export function isAttributeNameSafe(attributeName: string): boolean {
   if (validatedAttributeNameCache.hasOwnProperty(attributeName)) {
     return true;
   }
@@ -163,7 +177,10 @@ export function isAttributeNameSafe(attributeName) {
  */
 export const properties = {};
 
-export function shouldSkipAttribute(name, isCustomComponentTag) {
+export function shouldSkipAttribute(
+  name: string,
+  isCustomComponentTag: boolean,
+): boolean {
   if (isReservedProp(name)) {
     return true;
   }
@@ -180,12 +197,17 @@ export function shouldSkipAttribute(name, isCustomComponentTag) {
   return false;
 }
 
-export function isBadlyTypedAttributeValue(name, value, isCustomComponentTag) {
+export function isBadlyTypedAttributeValue(
+  name: string,
+  value: mixed,
+  isCustomComponentTag: boolean,
+): boolean {
   if (isReservedProp(name)) {
     return false;
   }
   switch (typeof value) {
     case 'function':
+    // $FlowIssue symbol is perfectly valid here
     case 'symbol':
       return true;
     case 'boolean':
@@ -209,10 +231,10 @@ export function isBadlyTypedAttributeValue(name, value, isCustomComponentTag) {
 }
 
 export function shouldTreatAttributeValueAsNull(
-  name,
-  value,
-  isCustomComponentTag,
-) {
+  name: string,
+  value: mixed,
+  isCustomComponentTag: boolean,
+): boolean {
   if (value === null || typeof value === 'undefined') {
     return true;
   }
@@ -224,14 +246,14 @@ export function shouldTreatAttributeValueAsNull(
       return value === false;
     } else if (propertyInfo.hasNumericValue && isNaN(value)) {
       return true;
-    } else if (propertyInfo.hasPositiveNumericValue && value < 1) {
+    } else if (propertyInfo.hasPositiveNumericValue && (value: any) < 1) {
       return true;
     }
   }
   return isBadlyTypedAttributeValue(name, value, isCustomComponentTag);
 }
 
-export function getPropertyInfo(name) {
+export function getPropertyInfo(name: string): PropertyInfo | null {
   return properties.hasOwnProperty(name) ? properties[name] : null;
 }
 
@@ -244,7 +266,7 @@ export function getPropertyInfo(name) {
  * @param {string} name
  * @return {boolean} If the name is within reserved props
  */
-export function isReservedProp(name) {
+export function isReservedProp(name: string): boolean {
   return RESERVED_PROPS.hasOwnProperty(name);
 }
 

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -218,6 +218,16 @@ export function shouldSetAttribute(name, value, isCustomComponentTag) {
   return true;
 }
 
+export function shouldIgnoreValue(propertyInfo, value) {
+  return (
+    value == null ||
+    (propertyInfo.hasBooleanValue && !value) ||
+    (propertyInfo.hasNumericValue && isNaN(value)) ||
+    (propertyInfo.hasPositiveNumericValue && value < 1) ||
+    (propertyInfo.hasOverloadedBooleanValue && value === false)
+  );
+}
+
 export function getPropertyInfo(name) {
   return properties.hasOwnProperty(name) ? properties[name] : null;
 }

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -191,7 +191,7 @@ if (__DEV__) {
 
     if (
       typeof value === 'boolean' &&
-      !shouldAttributeAcceptBooleanValue(name)
+      !shouldAttributeAcceptBooleanValue(name, false)
     ) {
       if (value) {
         warning(
@@ -235,7 +235,7 @@ if (__DEV__) {
     }
 
     // Warn when a known attribute is a bad type
-    if (!shouldSetAttribute(name, value)) {
+    if (!shouldSetAttribute(name, value, false)) {
       warnedProperties[name] = true;
       return false;
     }

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -15,8 +15,7 @@ import warning from 'fbjs/lib/warning';
 import {
   ATTRIBUTE_NAME_CHAR,
   isReservedProp,
-  shouldAttributeAcceptBooleanValue,
-  shouldSetAttribute,
+  isBadlyTypedAttributeValue,
 } from './DOMProperty';
 import isCustomComponent from './isCustomComponent';
 import possibleStandardNames from './possibleStandardNames';
@@ -191,7 +190,7 @@ if (__DEV__) {
 
     if (
       typeof value === 'boolean' &&
-      !shouldAttributeAcceptBooleanValue(name, false)
+      isBadlyTypedAttributeValue(name, value, false)
     ) {
       if (value) {
         warning(
@@ -235,7 +234,7 @@ if (__DEV__) {
     }
 
     // Warn when a known attribute is a bad type
-    if (!shouldSetAttribute(name, value, false)) {
+    if (isBadlyTypedAttributeValue(name, value, false)) {
       warnedProperties[name] = true;
       return false;
     }


### PR DESCRIPTION
The main goal here is to factor the DOM attribute code in the light of how it currently works, instead of how it was conceived five years ago.

There are quite a few things in the current code that don't make sense anymore. For example, the "property" vs "attribute" distinction in method naming doesn't actually correspond to properties vs attributes. Another example: `shouldSetAttribute` doesn't actually determine whether to set an attribute. These were all results of incremental changes where we tried to tweak the behavior with the least amount of code. But they ended up making the overall flow confusing and adding a lot of special cases.

This is an attempt to simplify the code without changing what it does. Individual commits tell how I arrived at that. This mostly changes the logic around *setting* attributes/properties and doesn't touch the other parts that are still structured the old way (such as `get*Attribute|Property` pairs used for validating SSR). I think we can get to those a bit later.