### PR TITLE
Refactor DOM attribute code (take two)

### DIFF
--- a/fixtures/attribute-behavior/AttributeTableSnapshot.md
+++ b/fixtures/attribute-behavior/AttributeTableSnapshot.md
@@ -118,8 +118,8 @@
 | `accentHeight=(string 'false')`| (changed)| `"false"` |
 | `accentHeight=(string 'on')`| (changed)| `"on"` |
 | `accentHeight=(string 'off')`| (changed)| `"off"` |
-| `accentHeight=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `accentHeight=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `accentHeight=(symbol)`| (initial, warning)| `<null>` |
+| `accentHeight=(function)`| (initial, warning)| `<null>` |
 | `accentHeight=(null)`| (initial)| `<null>` |
 | `accentHeight=(undefined)`| (initial)| `<null>` |
 
@@ -218,8 +218,8 @@
 | `acceptCharset=(string 'false')`| (changed)| `"false"` |
 | `acceptCharset=(string 'on')`| (changed)| `"on"` |
 | `acceptCharset=(string 'off')`| (changed)| `"off"` |
-| `acceptCharset=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<empty string>` |
-| `acceptCharset=(function)`| (initial, warning, ssr mismatch)| `<empty string>` |
+| `acceptCharset=(symbol)`| (initial, warning)| `<empty string>` |
+| `acceptCharset=(function)`| (initial, warning)| `<empty string>` |
 | `acceptCharset=(null)`| (initial)| `<empty string>` |
 | `acceptCharset=(undefined)`| (initial)| `<empty string>` |
 
@@ -368,8 +368,8 @@
 | `alignmentBaseline=(string 'false')`| (changed)| `"false"` |
 | `alignmentBaseline=(string 'on')`| (changed)| `"on"` |
 | `alignmentBaseline=(string 'off')`| (changed)| `"off"` |
-| `alignmentBaseline=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `alignmentBaseline=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `alignmentBaseline=(symbol)`| (initial, warning)| `<null>` |
+| `alignmentBaseline=(function)`| (initial, warning)| `<null>` |
 | `alignmentBaseline=(null)`| (initial)| `<null>` |
 | `alignmentBaseline=(undefined)`| (initial)| `<null>` |
 
@@ -393,8 +393,8 @@
 | `allowFullScreen=(string 'false')`| (changed)| `<boolean: true>` |
 | `allowFullScreen=(string 'on')`| (changed)| `<boolean: true>` |
 | `allowFullScreen=(string 'off')`| (changed)| `<boolean: true>` |
-| `allowFullScreen=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `allowFullScreen=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `allowFullScreen=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `allowFullScreen=(function)`| (initial, warning)| `<boolean: false>` |
 | `allowFullScreen=(null)`| (initial)| `<boolean: false>` |
 | `allowFullScreen=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -593,8 +593,8 @@
 | `arabicForm=(string 'false')`| (changed)| `"false"` |
 | `arabicForm=(string 'on')`| (changed)| `"on"` |
 | `arabicForm=(string 'off')`| (changed)| `"off"` |
-| `arabicForm=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `arabicForm=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `arabicForm=(symbol)`| (initial, warning)| `<null>` |
+| `arabicForm=(function)`| (initial, warning)| `<null>` |
 | `arabicForm=(null)`| (initial)| `<null>` |
 | `arabicForm=(undefined)`| (initial)| `<null>` |
 
@@ -743,8 +743,8 @@
 | `async=(string 'false')`| (changed)| `<boolean: true>` |
 | `async=(string 'on')`| (changed)| `<boolean: true>` |
 | `async=(string 'off')`| (changed)| `<boolean: true>` |
-| `async=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `async=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `async=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `async=(function)`| (initial, warning)| `<boolean: false>` |
 | `async=(null)`| (initial)| `<boolean: false>` |
 | `async=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -893,8 +893,8 @@
 | `autoPlay=(string 'false')`| (changed)| `<boolean: true>` |
 | `autoPlay=(string 'on')`| (changed)| `<boolean: true>` |
 | `autoPlay=(string 'off')`| (changed)| `<boolean: true>` |
-| `autoPlay=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `autoPlay=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `autoPlay=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `autoPlay=(function)`| (initial, warning)| `<boolean: false>` |
 | `autoPlay=(null)`| (initial)| `<boolean: false>` |
 | `autoPlay=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -918,8 +918,8 @@
 | `autoReverse=(string 'false')`| (initial, ssr mismatch)| `<null>` |
 | `autoReverse=(string 'on')`| (initial, ssr mismatch)| `<null>` |
 | `autoReverse=(string 'off')`| (initial, ssr mismatch)| `<null>` |
-| `autoReverse=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `autoReverse=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `autoReverse=(symbol)`| (initial, warning)| `<null>` |
+| `autoReverse=(function)`| (initial, warning)| `<null>` |
 | `autoReverse=(null)`| (initial)| `<null>` |
 | `autoReverse=(undefined)`| (initial)| `<null>` |
 
@@ -1043,8 +1043,8 @@
 | `baselineShift=(string 'false')`| (changed)| `"false"` |
 | `baselineShift=(string 'on')`| (changed)| `"on"` |
 | `baselineShift=(string 'off')`| (changed)| `"off"` |
-| `baselineShift=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `baselineShift=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `baselineShift=(symbol)`| (initial, warning)| `<null>` |
+| `baselineShift=(function)`| (initial, warning)| `<null>` |
 | `baselineShift=(null)`| (initial)| `<null>` |
 | `baselineShift=(undefined)`| (initial)| `<null>` |
 
@@ -1243,8 +1243,8 @@
 | `capHeight=(string 'false')`| (changed)| `"false"` |
 | `capHeight=(string 'on')`| (changed)| `"on"` |
 | `capHeight=(string 'off')`| (changed)| `"off"` |
-| `capHeight=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `capHeight=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `capHeight=(symbol)`| (initial, warning)| `<null>` |
+| `capHeight=(function)`| (initial, warning)| `<null>` |
 | `capHeight=(null)`| (initial)| `<null>` |
 | `capHeight=(undefined)`| (initial)| `<null>` |
 
@@ -1268,8 +1268,8 @@
 | `capture=(string 'false')`| (changed)| `"false"` |
 | `capture=(string 'on')`| (changed)| `"on"` |
 | `capture=(string 'off')`| (changed)| `"off"` |
-| `capture=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `capture=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `capture=(symbol)`| (initial, warning)| `<null>` |
+| `capture=(function)`| (initial, warning)| `<null>` |
 | `capture=(null)`| (initial)| `<null>` |
 | `capture=(undefined)`| (initial)| `<null>` |
 
@@ -1393,8 +1393,8 @@
 | `checked=(string 'false')`| (changed)| `<boolean: true>` |
 | `checked=(string 'on')`| (changed)| `<boolean: true>` |
 | `checked=(string 'off')`| (changed)| `<boolean: true>` |
-| `checked=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `checked=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `checked=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `checked=(function)`| (initial, warning)| `<boolean: false>` |
 | `checked=(null)`| (initial)| `<boolean: false>` |
 | `checked=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -1568,8 +1568,8 @@
 | `className=(string 'false')`| (changed)| `"false"` |
 | `className=(string 'on')`| (changed)| `"on"` |
 | `className=(string 'off')`| (changed)| `"off"` |
-| `className=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<empty string>` |
-| `className=(function)`| (initial, warning, ssr mismatch)| `<empty string>` |
+| `className=(symbol)`| (initial, warning)| `<empty string>` |
+| `className=(function)`| (initial, warning)| `<empty string>` |
 | `className=(null)`| (initial)| `<empty string>` |
 | `className=(undefined)`| (initial)| `<empty string>` |
 
@@ -1643,8 +1643,8 @@
 | `clipPath=(string 'false')`| (changed)| `"false"` |
 | `clipPath=(string 'on')`| (changed)| `"on"` |
 | `clipPath=(string 'off')`| (changed)| `"off"` |
-| `clipPath=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `clipPath=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `clipPath=(symbol)`| (initial, warning)| `<null>` |
+| `clipPath=(function)`| (initial, warning)| `<null>` |
 | `clipPath=(null)`| (initial)| `<null>` |
 | `clipPath=(undefined)`| (initial)| `<null>` |
 
@@ -1718,8 +1718,8 @@
 | `clipRule=(string 'false')`| (changed)| `"false"` |
 | `clipRule=(string 'on')`| (changed)| `"on"` |
 | `clipRule=(string 'off')`| (changed)| `"off"` |
-| `clipRule=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `clipRule=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `clipRule=(symbol)`| (initial, warning)| `<null>` |
+| `clipRule=(function)`| (initial, warning)| `<null>` |
 | `clipRule=(null)`| (initial)| `<null>` |
 | `clipRule=(undefined)`| (initial)| `<null>` |
 
@@ -1793,8 +1793,8 @@
 | `colorInterpolation=(string 'false')`| (changed)| `"false"` |
 | `colorInterpolation=(string 'on')`| (changed)| `"on"` |
 | `colorInterpolation=(string 'off')`| (changed)| `"off"` |
-| `colorInterpolation=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `colorInterpolation=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `colorInterpolation=(symbol)`| (initial, warning)| `<null>` |
+| `colorInterpolation=(function)`| (initial, warning)| `<null>` |
 | `colorInterpolation=(null)`| (initial)| `<null>` |
 | `colorInterpolation=(undefined)`| (initial)| `<null>` |
 
@@ -1843,8 +1843,8 @@
 | `colorInterpolationFilters=(string 'false')`| (changed)| `"false"` |
 | `colorInterpolationFilters=(string 'on')`| (changed)| `"on"` |
 | `colorInterpolationFilters=(string 'off')`| (changed)| `"off"` |
-| `colorInterpolationFilters=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `colorInterpolationFilters=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `colorInterpolationFilters=(symbol)`| (initial, warning)| `<null>` |
+| `colorInterpolationFilters=(function)`| (initial, warning)| `<null>` |
 | `colorInterpolationFilters=(null)`| (initial)| `<null>` |
 | `colorInterpolationFilters=(undefined)`| (initial)| `<null>` |
 
@@ -1893,8 +1893,8 @@
 | `colorProfile=(string 'false')`| (changed)| `"false"` |
 | `colorProfile=(string 'on')`| (changed)| `"on"` |
 | `colorProfile=(string 'off')`| (changed)| `"off"` |
-| `colorProfile=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `colorProfile=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `colorProfile=(symbol)`| (initial, warning)| `<null>` |
+| `colorProfile=(function)`| (initial, warning)| `<null>` |
 | `colorProfile=(null)`| (initial)| `<null>` |
 | `colorProfile=(undefined)`| (initial)| `<null>` |
 
@@ -1943,8 +1943,8 @@
 | `colorRendering=(string 'false')`| (changed)| `"false"` |
 | `colorRendering=(string 'on')`| (changed)| `"on"` |
 | `colorRendering=(string 'off')`| (changed)| `"off"` |
-| `colorRendering=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `colorRendering=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `colorRendering=(symbol)`| (initial, warning)| `<null>` |
+| `colorRendering=(function)`| (initial, warning)| `<null>` |
 | `colorRendering=(null)`| (initial)| `<null>` |
 | `colorRendering=(undefined)`| (initial)| `<null>` |
 
@@ -1968,7 +1968,7 @@
 | `cols=(string 'false')`| (initial)| `<number: 20>` |
 | `cols=(string 'on')`| (initial)| `<number: 20>` |
 | `cols=(string 'off')`| (initial)| `<number: 20>` |
-| `cols=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<number: 20>` |
+| `cols=(symbol)`| (initial, warning)| `<number: 20>` |
 | `cols=(function)`| (initial, warning)| `<number: 20>` |
 | `cols=(null)`| (initial)| `<number: 20>` |
 | `cols=(undefined)`| (initial)| `<number: 20>` |
@@ -2043,7 +2043,7 @@
 | `contentEditable=(string 'false')`| (changed)| `"false"` |
 | `contentEditable=(string 'on')`| (initial)| `"inherit"` |
 | `contentEditable=(string 'off')`| (initial)| `"inherit"` |
-| `contentEditable=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `"inherit"` |
+| `contentEditable=(symbol)`| (initial, warning)| `"inherit"` |
 | `contentEditable=(function)`| (initial, warning)| `"inherit"` |
 | `contentEditable=(null)`| (initial)| `"inherit"` |
 | `contentEditable=(undefined)`| (initial)| `"inherit"` |
@@ -2143,8 +2143,8 @@
 | `controls=(string 'false')`| (changed)| `<boolean: true>` |
 | `controls=(string 'on')`| (changed)| `<boolean: true>` |
 | `controls=(string 'off')`| (changed)| `<boolean: true>` |
-| `controls=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `controls=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `controls=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `controls=(function)`| (initial, warning)| `<boolean: false>` |
 | `controls=(null)`| (initial)| `<boolean: false>` |
 | `controls=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -2518,8 +2518,8 @@
 | `default=(string 'false')`| (changed)| `<boolean: true>` |
 | `default=(string 'on')`| (changed)| `<boolean: true>` |
 | `default=(string 'off')`| (changed)| `<boolean: true>` |
-| `default=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `default=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `default=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `default=(function)`| (initial, warning)| `<boolean: false>` |
 | `default=(null)`| (initial)| `<boolean: false>` |
 | `default=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -2568,8 +2568,8 @@
 | `defaultChecked=(string 'false')`| (initial, ssr mismatch)| `<boolean: false>` |
 | `defaultChecked=(string 'on')`| (initial, ssr mismatch)| `<boolean: false>` |
 | `defaultChecked=(string 'off')`| (initial, ssr mismatch)| `<boolean: false>` |
-| `defaultChecked=(symbol)`| (initial, ssr mismatch)| `<boolean: false>` |
-| `defaultChecked=(function)`| (initial, ssr mismatch)| `<boolean: false>` |
+| `defaultChecked=(symbol)`| (initial)| `<boolean: false>` |
+| `defaultChecked=(function)`| (initial)| `<boolean: false>` |
 | `defaultChecked=(null)`| (initial)| `<boolean: false>` |
 | `defaultChecked=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -2593,8 +2593,8 @@
 | `defaultValue=(string 'false')`| (changed)| `"false"` |
 | `defaultValue=(string 'on')`| (changed)| `"on"` |
 | `defaultValue=(string 'off')`| (changed)| `"off"` |
-| `defaultValue=(symbol)`| (initial, ssr error, ssr mismatch)| `<empty string>` |
-| `defaultValue=(function)`| (initial, ssr mismatch)| `<empty string>` |
+| `defaultValue=(symbol)`| (initial, ssr warning)| `<empty string>` |
+| `defaultValue=(function)`| (initial, ssr warning)| `<empty string>` |
 | `defaultValue=(null)`| (initial, ssr warning)| `<empty string>` |
 | `defaultValue=(undefined)`| (initial)| `<empty string>` |
 
@@ -2643,8 +2643,8 @@
 | `defer=(string 'false')`| (changed)| `<boolean: true>` |
 | `defer=(string 'on')`| (changed)| `<boolean: true>` |
 | `defer=(string 'off')`| (changed)| `<boolean: true>` |
-| `defer=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `defer=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `defer=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `defer=(function)`| (initial, warning)| `<boolean: false>` |
 | `defer=(null)`| (initial)| `<boolean: false>` |
 | `defer=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -2768,8 +2768,8 @@
 | `disabled=(string 'false')`| (changed)| `<boolean: true>` |
 | `disabled=(string 'on')`| (changed)| `<boolean: true>` |
 | `disabled=(string 'off')`| (changed)| `<boolean: true>` |
-| `disabled=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `disabled=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `disabled=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `disabled=(function)`| (initial, warning)| `<boolean: false>` |
 | `disabled=(null)`| (initial)| `<boolean: false>` |
 | `disabled=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -2868,8 +2868,8 @@
 | `dominantBaseline=(string 'false')`| (changed)| `"false"` |
 | `dominantBaseline=(string 'on')`| (changed)| `"on"` |
 | `dominantBaseline=(string 'off')`| (changed)| `"off"` |
-| `dominantBaseline=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `dominantBaseline=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `dominantBaseline=(symbol)`| (initial, warning)| `<null>` |
+| `dominantBaseline=(function)`| (initial, warning)| `<null>` |
 | `dominantBaseline=(null)`| (initial)| `<null>` |
 | `dominantBaseline=(undefined)`| (initial)| `<null>` |
 
@@ -2893,8 +2893,8 @@
 | `download=(string 'false')`| (changed)| `"false"` |
 | `download=(string 'on')`| (changed)| `"on"` |
 | `download=(string 'off')`| (changed)| `"off"` |
-| `download=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<empty string>` |
-| `download=(function)`| (initial, warning, ssr mismatch)| `<empty string>` |
+| `download=(symbol)`| (initial, warning)| `<empty string>` |
+| `download=(function)`| (initial, warning)| `<empty string>` |
 | `download=(null)`| (initial)| `<empty string>` |
 | `download=(undefined)`| (initial)| `<empty string>` |
 
@@ -2943,7 +2943,7 @@
 | `draggable=(string 'false')`| (initial)| `<boolean: false>` |
 | `draggable=(string 'on')`| (initial)| `<boolean: false>` |
 | `draggable=(string 'off')`| (initial)| `<boolean: false>` |
-| `draggable=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<boolean: false>` |
+| `draggable=(symbol)`| (initial, warning)| `<boolean: false>` |
 | `draggable=(function)`| (initial, warning)| `<boolean: false>` |
 | `draggable=(null)`| (initial)| `<boolean: false>` |
 | `draggable=(undefined)`| (initial)| `<boolean: false>` |
@@ -3168,8 +3168,8 @@
 | `enableBackground=(string 'false')`| (changed)| `"false"` |
 | `enableBackground=(string 'on')`| (changed)| `"on"` |
 | `enableBackground=(string 'off')`| (changed)| `"off"` |
-| `enableBackground=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `enableBackground=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `enableBackground=(symbol)`| (initial, warning)| `<null>` |
+| `enableBackground=(function)`| (initial, warning)| `<null>` |
 | `enableBackground=(null)`| (initial)| `<null>` |
 | `enableBackground=(undefined)`| (initial)| `<null>` |
 
@@ -3268,7 +3268,7 @@
 | `externalResourcesRequired=(string 'false')`| (changed, ssr mismatch)| `"false"` |
 | `externalResourcesRequired=(string 'on')`| (changed, ssr mismatch)| `"on"` |
 | `externalResourcesRequired=(string 'off')`| (changed, ssr mismatch)| `"off"` |
-| `externalResourcesRequired=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
+| `externalResourcesRequired=(symbol)`| (initial, warning)| `<null>` |
 | `externalResourcesRequired=(function)`| (initial, warning)| `<null>` |
 | `externalResourcesRequired=(null)`| (initial)| `<null>` |
 | `externalResourcesRequired=(undefined)`| (initial)| `<null>` |
@@ -3318,8 +3318,8 @@
 | `fillOpacity=(string 'false')`| (changed)| `"false"` |
 | `fillOpacity=(string 'on')`| (changed)| `"on"` |
 | `fillOpacity=(string 'off')`| (changed)| `"off"` |
-| `fillOpacity=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `fillOpacity=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `fillOpacity=(symbol)`| (initial, warning)| `<null>` |
+| `fillOpacity=(function)`| (initial, warning)| `<null>` |
 | `fillOpacity=(null)`| (initial)| `<null>` |
 | `fillOpacity=(undefined)`| (initial)| `<null>` |
 
@@ -3368,8 +3368,8 @@
 | `fillRule=(string 'false')`| (changed)| `"false"` |
 | `fillRule=(string 'on')`| (changed)| `"on"` |
 | `fillRule=(string 'off')`| (changed)| `"off"` |
-| `fillRule=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `fillRule=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `fillRule=(symbol)`| (initial, warning)| `<null>` |
+| `fillRule=(function)`| (initial, warning)| `<null>` |
 | `fillRule=(null)`| (initial)| `<null>` |
 | `fillRule=(undefined)`| (initial)| `<null>` |
 
@@ -3518,8 +3518,8 @@
 | `floodColor=(string 'false')`| (changed)| `"false"` |
 | `floodColor=(string 'on')`| (changed)| `"on"` |
 | `floodColor=(string 'off')`| (changed)| `"off"` |
-| `floodColor=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `floodColor=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `floodColor=(symbol)`| (initial, warning)| `<null>` |
+| `floodColor=(function)`| (initial, warning)| `<null>` |
 | `floodColor=(null)`| (initial)| `<null>` |
 | `floodColor=(undefined)`| (initial)| `<null>` |
 
@@ -3568,8 +3568,8 @@
 | `floodOpacity=(string 'false')`| (changed)| `"false"` |
 | `floodOpacity=(string 'on')`| (changed)| `"on"` |
 | `floodOpacity=(string 'off')`| (changed)| `"off"` |
-| `floodOpacity=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `floodOpacity=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `floodOpacity=(symbol)`| (initial, warning)| `<null>` |
+| `floodOpacity=(function)`| (initial, warning)| `<null>` |
 | `floodOpacity=(null)`| (initial)| `<null>` |
 | `floodOpacity=(undefined)`| (initial)| `<null>` |
 
@@ -3793,8 +3793,8 @@
 | `fontFamily=(string 'false')`| (changed)| `"false"` |
 | `fontFamily=(string 'on')`| (changed)| `"on"` |
 | `fontFamily=(string 'off')`| (changed)| `"off"` |
-| `fontFamily=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `fontFamily=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `fontFamily=(symbol)`| (initial, warning)| `<null>` |
+| `fontFamily=(function)`| (initial, warning)| `<null>` |
 | `fontFamily=(null)`| (initial)| `<null>` |
 | `fontFamily=(undefined)`| (initial)| `<null>` |
 
@@ -3818,8 +3818,8 @@
 | `fontSize=(string 'false')`| (changed)| `"false"` |
 | `fontSize=(string 'on')`| (changed)| `"on"` |
 | `fontSize=(string 'off')`| (changed)| `"off"` |
-| `fontSize=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `fontSize=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `fontSize=(symbol)`| (initial, warning)| `<null>` |
+| `fontSize=(function)`| (initial, warning)| `<null>` |
 | `fontSize=(null)`| (initial)| `<null>` |
 | `fontSize=(undefined)`| (initial)| `<null>` |
 
@@ -3843,8 +3843,8 @@
 | `fontSizeAdjust=(string 'false')`| (changed)| `"false"` |
 | `fontSizeAdjust=(string 'on')`| (changed)| `"on"` |
 | `fontSizeAdjust=(string 'off')`| (changed)| `"off"` |
-| `fontSizeAdjust=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `fontSizeAdjust=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `fontSizeAdjust=(symbol)`| (initial, warning)| `<null>` |
+| `fontSizeAdjust=(function)`| (initial, warning)| `<null>` |
 | `fontSizeAdjust=(null)`| (initial)| `<null>` |
 | `fontSizeAdjust=(undefined)`| (initial)| `<null>` |
 
@@ -3868,8 +3868,8 @@
 | `fontStretch=(string 'false')`| (changed)| `"false"` |
 | `fontStretch=(string 'on')`| (changed)| `"on"` |
 | `fontStretch=(string 'off')`| (changed)| `"off"` |
-| `fontStretch=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `fontStretch=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `fontStretch=(symbol)`| (initial, warning)| `<null>` |
+| `fontStretch=(function)`| (initial, warning)| `<null>` |
 | `fontStretch=(null)`| (initial)| `<null>` |
 | `fontStretch=(undefined)`| (initial)| `<null>` |
 
@@ -3893,8 +3893,8 @@
 | `fontStyle=(string 'false')`| (changed)| `"false"` |
 | `fontStyle=(string 'on')`| (changed)| `"on"` |
 | `fontStyle=(string 'off')`| (changed)| `"off"` |
-| `fontStyle=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `fontStyle=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `fontStyle=(symbol)`| (initial, warning)| `<null>` |
+| `fontStyle=(function)`| (initial, warning)| `<null>` |
 | `fontStyle=(null)`| (initial)| `<null>` |
 | `fontStyle=(undefined)`| (initial)| `<null>` |
 
@@ -3918,8 +3918,8 @@
 | `fontVariant=(string 'false')`| (changed)| `"false"` |
 | `fontVariant=(string 'on')`| (changed)| `"on"` |
 | `fontVariant=(string 'off')`| (changed)| `"off"` |
-| `fontVariant=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `fontVariant=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `fontVariant=(symbol)`| (initial, warning)| `<null>` |
+| `fontVariant=(function)`| (initial, warning)| `<null>` |
 | `fontVariant=(null)`| (initial)| `<null>` |
 | `fontVariant=(undefined)`| (initial)| `<null>` |
 
@@ -3943,8 +3943,8 @@
 | `fontWeight=(string 'false')`| (changed)| `"false"` |
 | `fontWeight=(string 'on')`| (changed)| `"on"` |
 | `fontWeight=(string 'off')`| (changed)| `"off"` |
-| `fontWeight=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `fontWeight=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `fontWeight=(symbol)`| (initial, warning)| `<null>` |
+| `fontWeight=(function)`| (initial, warning)| `<null>` |
 | `fontWeight=(null)`| (initial)| `<null>` |
 | `fontWeight=(undefined)`| (initial)| `<null>` |
 
@@ -4143,8 +4143,8 @@
 | `formNoValidate=(string 'false')`| (changed)| `<boolean: true>` |
 | `formNoValidate=(string 'on')`| (changed)| `<boolean: true>` |
 | `formNoValidate=(string 'off')`| (changed)| `<boolean: true>` |
-| `formNoValidate=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `formNoValidate=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `formNoValidate=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `formNoValidate=(function)`| (initial, warning)| `<boolean: false>` |
 | `formNoValidate=(null)`| (initial)| `<boolean: false>` |
 | `formNoValidate=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -4518,8 +4518,8 @@
 | `glyphName=(string 'false')`| (changed)| `"false"` |
 | `glyphName=(string 'on')`| (changed)| `"on"` |
 | `glyphName=(string 'off')`| (changed)| `"off"` |
-| `glyphName=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `glyphName=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `glyphName=(symbol)`| (initial, warning)| `<null>` |
+| `glyphName=(function)`| (initial, warning)| `<null>` |
 | `glyphName=(null)`| (initial)| `<null>` |
 | `glyphName=(undefined)`| (initial)| `<null>` |
 
@@ -4543,8 +4543,8 @@
 | `glyphOrientationHorizontal=(string 'false')`| (changed)| `"false"` |
 | `glyphOrientationHorizontal=(string 'on')`| (changed)| `"on"` |
 | `glyphOrientationHorizontal=(string 'off')`| (changed)| `"off"` |
-| `glyphOrientationHorizontal=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `glyphOrientationHorizontal=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `glyphOrientationHorizontal=(symbol)`| (initial, warning)| `<null>` |
+| `glyphOrientationHorizontal=(function)`| (initial, warning)| `<null>` |
 | `glyphOrientationHorizontal=(null)`| (initial)| `<null>` |
 | `glyphOrientationHorizontal=(undefined)`| (initial)| `<null>` |
 
@@ -4568,8 +4568,8 @@
 | `glyphOrientationVertical=(string 'false')`| (changed)| `"false"` |
 | `glyphOrientationVertical=(string 'on')`| (changed)| `"on"` |
 | `glyphOrientationVertical=(string 'off')`| (changed)| `"off"` |
-| `glyphOrientationVertical=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `glyphOrientationVertical=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `glyphOrientationVertical=(symbol)`| (initial, warning)| `<null>` |
+| `glyphOrientationVertical=(function)`| (initial, warning)| `<null>` |
 | `glyphOrientationVertical=(null)`| (initial)| `<null>` |
 | `glyphOrientationVertical=(undefined)`| (initial)| `<null>` |
 
@@ -4768,8 +4768,8 @@
 | `hidden=(string 'false')`| (changed)| `<boolean: true>` |
 | `hidden=(string 'on')`| (changed)| `<boolean: true>` |
 | `hidden=(string 'off')`| (changed)| `<boolean: true>` |
-| `hidden=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `hidden=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `hidden=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `hidden=(function)`| (initial, warning)| `<boolean: false>` |
 | `hidden=(null)`| (initial)| `<boolean: false>` |
 | `hidden=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -4868,8 +4868,8 @@
 | `horizAdvX=(string 'false')`| (changed)| `"false"` |
 | `horizAdvX=(string 'on')`| (changed)| `"on"` |
 | `horizAdvX=(string 'off')`| (changed)| `"off"` |
-| `horizAdvX=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `horizAdvX=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `horizAdvX=(symbol)`| (initial, warning)| `<null>` |
+| `horizAdvX=(function)`| (initial, warning)| `<null>` |
 | `horizAdvX=(null)`| (initial)| `<null>` |
 | `horizAdvX=(undefined)`| (initial)| `<null>` |
 
@@ -4893,8 +4893,8 @@
 | `horizOriginX=(string 'false')`| (changed)| `"false"` |
 | `horizOriginX=(string 'on')`| (changed)| `"on"` |
 | `horizOriginX=(string 'off')`| (changed)| `"off"` |
-| `horizOriginX=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `horizOriginX=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `horizOriginX=(symbol)`| (initial, warning)| `<null>` |
+| `horizOriginX=(function)`| (initial, warning)| `<null>` |
 | `horizOriginX=(null)`| (initial)| `<null>` |
 | `horizOriginX=(undefined)`| (initial)| `<null>` |
 
@@ -4968,8 +4968,8 @@
 | `htmlFor=(string 'false')`| (changed)| `"false"` |
 | `htmlFor=(string 'on')`| (changed)| `"on"` |
 | `htmlFor=(string 'off')`| (changed)| `"off"` |
-| `htmlFor=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<empty string>` |
-| `htmlFor=(function)`| (initial, warning, ssr mismatch)| `<empty string>` |
+| `htmlFor=(symbol)`| (initial, warning)| `<empty string>` |
+| `htmlFor=(function)`| (initial, warning)| `<empty string>` |
 | `htmlFor=(null)`| (initial)| `<empty string>` |
 | `htmlFor=(undefined)`| (initial)| `<empty string>` |
 
@@ -5018,8 +5018,8 @@
 | `httpEquiv=(string 'false')`| (changed)| `"false"` |
 | `httpEquiv=(string 'on')`| (changed)| `"on"` |
 | `httpEquiv=(string 'off')`| (changed)| `"off"` |
-| `httpEquiv=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<empty string>` |
-| `httpEquiv=(function)`| (initial, warning, ssr mismatch)| `<empty string>` |
+| `httpEquiv=(symbol)`| (initial, warning)| `<empty string>` |
+| `httpEquiv=(function)`| (initial, warning)| `<empty string>` |
 | `httpEquiv=(null)`| (initial)| `<empty string>` |
 | `httpEquiv=(undefined)`| (initial)| `<empty string>` |
 
@@ -5168,8 +5168,8 @@
 | `imageRendering=(string 'false')`| (changed)| `"false"` |
 | `imageRendering=(string 'on')`| (changed)| `"on"` |
 | `imageRendering=(string 'off')`| (changed)| `"off"` |
-| `imageRendering=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `imageRendering=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `imageRendering=(symbol)`| (initial, warning)| `<null>` |
+| `imageRendering=(function)`| (initial, warning)| `<null>` |
 | `imageRendering=(null)`| (initial)| `<null>` |
 | `imageRendering=(undefined)`| (initial)| `<null>` |
 
@@ -5493,8 +5493,8 @@
 | `itemScope=(string 'false')`| (changed)| `<empty string>` |
 | `itemScope=(string 'on')`| (changed)| `<empty string>` |
 | `itemScope=(string 'off')`| (changed)| `<empty string>` |
-| `itemScope=(symbol)`| (initial, warning, ssr mismatch)| `<null>` |
-| `itemScope=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `itemScope=(symbol)`| (initial, warning)| `<null>` |
+| `itemScope=(function)`| (initial, warning)| `<null>` |
 | `itemScope=(null)`| (initial)| `<null>` |
 | `itemScope=(undefined)`| (initial)| `<null>` |
 
@@ -6093,8 +6093,8 @@
 | `letterSpacing=(string 'false')`| (changed)| `"false"` |
 | `letterSpacing=(string 'on')`| (changed)| `"on"` |
 | `letterSpacing=(string 'off')`| (changed)| `"off"` |
-| `letterSpacing=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `letterSpacing=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `letterSpacing=(symbol)`| (initial, warning)| `<null>` |
+| `letterSpacing=(function)`| (initial, warning)| `<null>` |
 | `letterSpacing=(null)`| (initial)| `<null>` |
 | `letterSpacing=(undefined)`| (initial)| `<null>` |
 
@@ -6143,8 +6143,8 @@
 | `lightingColor=(string 'false')`| (changed)| `"false"` |
 | `lightingColor=(string 'on')`| (changed)| `"on"` |
 | `lightingColor=(string 'off')`| (changed)| `"off"` |
-| `lightingColor=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `lightingColor=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `lightingColor=(symbol)`| (initial, warning)| `<null>` |
+| `lightingColor=(function)`| (initial, warning)| `<null>` |
 | `lightingColor=(null)`| (initial)| `<null>` |
 | `lightingColor=(undefined)`| (initial)| `<null>` |
 
@@ -6243,8 +6243,8 @@
 | `loop=(string 'false')`| (changed)| `<boolean: true>` |
 | `loop=(string 'on')`| (changed)| `<boolean: true>` |
 | `loop=(string 'off')`| (changed)| `<boolean: true>` |
-| `loop=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `loop=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `loop=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `loop=(function)`| (initial, warning)| `<boolean: false>` |
 | `loop=(null)`| (initial)| `<boolean: false>` |
 | `loop=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -6443,8 +6443,8 @@
 | `markerEnd=(string 'false')`| (changed)| `"false"` |
 | `markerEnd=(string 'on')`| (changed)| `"on"` |
 | `markerEnd=(string 'off')`| (changed)| `"off"` |
-| `markerEnd=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `markerEnd=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `markerEnd=(symbol)`| (initial, warning)| `<null>` |
+| `markerEnd=(function)`| (initial, warning)| `<null>` |
 | `markerEnd=(null)`| (initial)| `<null>` |
 | `markerEnd=(undefined)`| (initial)| `<null>` |
 
@@ -6493,8 +6493,8 @@
 | `markerMid=(string 'false')`| (changed)| `"false"` |
 | `markerMid=(string 'on')`| (changed)| `"on"` |
 | `markerMid=(string 'off')`| (changed)| `"off"` |
-| `markerMid=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `markerMid=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `markerMid=(symbol)`| (initial, warning)| `<null>` |
+| `markerMid=(function)`| (initial, warning)| `<null>` |
 | `markerMid=(null)`| (initial)| `<null>` |
 | `markerMid=(undefined)`| (initial)| `<null>` |
 
@@ -6518,8 +6518,8 @@
 | `markerStart=(string 'false')`| (changed)| `"false"` |
 | `markerStart=(string 'on')`| (changed)| `"on"` |
 | `markerStart=(string 'off')`| (changed)| `"off"` |
-| `markerStart=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `markerStart=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `markerStart=(symbol)`| (initial, warning)| `<null>` |
+| `markerStart=(function)`| (initial, warning)| `<null>` |
 | `markerStart=(null)`| (initial)| `<null>` |
 | `markerStart=(undefined)`| (initial)| `<null>` |
 
@@ -7068,8 +7068,8 @@
 | `multiple=(string 'false')`| (changed)| `<boolean: true>` |
 | `multiple=(string 'on')`| (changed)| `<boolean: true>` |
 | `multiple=(string 'off')`| (changed)| `<boolean: true>` |
-| `multiple=(symbol)`| (changed, warning)| `<boolean: true>` |
-| `multiple=(function)`| (changed, warning)| `<boolean: true>` |
+| `multiple=(symbol)`| (changed, warning, ssr mismatch)| `<boolean: true>` |
+| `multiple=(function)`| (changed, warning, ssr mismatch)| `<boolean: true>` |
 | `multiple=(null)`| (initial)| `<boolean: false>` |
 | `multiple=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -7193,8 +7193,8 @@
 | `noValidate=(string 'false')`| (changed)| `<boolean: true>` |
 | `noValidate=(string 'on')`| (changed)| `<boolean: true>` |
 | `noValidate=(string 'off')`| (changed)| `<boolean: true>` |
-| `noValidate=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `noValidate=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `noValidate=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `noValidate=(function)`| (initial, warning)| `<boolean: false>` |
 | `noValidate=(null)`| (initial)| `<boolean: false>` |
 | `noValidate=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -7443,8 +7443,8 @@
 | `open=(string 'false')`| (changed)| `<boolean: true>` |
 | `open=(string 'on')`| (changed)| `<boolean: true>` |
 | `open=(string 'off')`| (changed)| `<boolean: true>` |
-| `open=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `open=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `open=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `open=(function)`| (initial, warning)| `<boolean: false>` |
 | `open=(null)`| (initial)| `<boolean: false>` |
 | `open=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -7693,8 +7693,8 @@
 | `overlinePosition=(string 'false')`| (changed)| `"false"` |
 | `overlinePosition=(string 'on')`| (changed)| `"on"` |
 | `overlinePosition=(string 'off')`| (changed)| `"off"` |
-| `overlinePosition=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `overlinePosition=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `overlinePosition=(symbol)`| (initial, warning)| `<null>` |
+| `overlinePosition=(function)`| (initial, warning)| `<null>` |
 | `overlinePosition=(null)`| (initial)| `<null>` |
 | `overlinePosition=(undefined)`| (initial)| `<null>` |
 
@@ -7718,8 +7718,8 @@
 | `overlineThickness=(string 'false')`| (changed)| `"false"` |
 | `overlineThickness=(string 'on')`| (changed)| `"on"` |
 | `overlineThickness=(string 'off')`| (changed)| `"off"` |
-| `overlineThickness=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `overlineThickness=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `overlineThickness=(symbol)`| (initial, warning)| `<null>` |
+| `overlineThickness=(function)`| (initial, warning)| `<null>` |
 | `overlineThickness=(null)`| (initial)| `<null>` |
 | `overlineThickness=(undefined)`| (initial)| `<null>` |
 
@@ -7768,8 +7768,8 @@
 | `paintOrder=(string 'false')`| (changed)| `"false"` |
 | `paintOrder=(string 'on')`| (changed)| `"on"` |
 | `paintOrder=(string 'off')`| (changed)| `"off"` |
-| `paintOrder=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `paintOrder=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `paintOrder=(symbol)`| (initial, warning)| `<null>` |
+| `paintOrder=(function)`| (initial, warning)| `<null>` |
 | `paintOrder=(null)`| (initial)| `<null>` |
 | `paintOrder=(undefined)`| (initial)| `<null>` |
 
@@ -7793,8 +7793,8 @@
 | `panose-1=(string 'false')`| (changed, warning)| `"false"` |
 | `panose-1=(string 'on')`| (changed, warning)| `"on"` |
 | `panose-1=(string 'off')`| (changed, warning)| `"off"` |
-| `panose-1=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `panose-1=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `panose-1=(symbol)`| (initial, warning)| `<null>` |
+| `panose-1=(function)`| (initial, warning)| `<null>` |
 | `panose-1=(null)`| (initial, warning)| `<null>` |
 | `panose-1=(undefined)`| (initial, warning)| `<null>` |
 
@@ -7993,8 +7993,8 @@
 | `playsInline=(string 'false')`| (changed)| `<empty string>` |
 | `playsInline=(string 'on')`| (changed)| `<empty string>` |
 | `playsInline=(string 'off')`| (changed)| `<empty string>` |
-| `playsInline=(symbol)`| (initial, warning, ssr mismatch)| `<null>` |
-| `playsInline=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `playsInline=(symbol)`| (initial, warning)| `<null>` |
+| `playsInline=(function)`| (initial, warning)| `<null>` |
 | `playsInline=(null)`| (initial)| `<null>` |
 | `playsInline=(undefined)`| (initial)| `<null>` |
 
@@ -8043,8 +8043,8 @@
 | `pointerEvents=(string 'false')`| (changed)| `"false"` |
 | `pointerEvents=(string 'on')`| (changed)| `"on"` |
 | `pointerEvents=(string 'off')`| (changed)| `"off"` |
-| `pointerEvents=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `pointerEvents=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `pointerEvents=(symbol)`| (initial, warning)| `<null>` |
+| `pointerEvents=(function)`| (initial, warning)| `<null>` |
 | `pointerEvents=(null)`| (initial)| `<null>` |
 | `pointerEvents=(undefined)`| (initial)| `<null>` |
 
@@ -8243,7 +8243,7 @@
 | `preserveAlpha=(string 'false')`| (initial)| `<boolean: false>` |
 | `preserveAlpha=(string 'on')`| (initial)| `<boolean: false>` |
 | `preserveAlpha=(string 'off')`| (initial)| `<boolean: false>` |
-| `preserveAlpha=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<boolean: false>` |
+| `preserveAlpha=(symbol)`| (initial, warning)| `<boolean: false>` |
 | `preserveAlpha=(function)`| (initial, warning)| `<boolean: false>` |
 | `preserveAlpha=(null)`| (initial)| `<boolean: false>` |
 | `preserveAlpha=(undefined)`| (initial)| `<boolean: false>` |
@@ -8468,8 +8468,8 @@
 | `readOnly=(string 'false')`| (changed)| `<boolean: true>` |
 | `readOnly=(string 'on')`| (changed)| `<boolean: true>` |
 | `readOnly=(string 'off')`| (changed)| `<boolean: true>` |
-| `readOnly=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `readOnly=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `readOnly=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `readOnly=(function)`| (initial, warning)| `<boolean: false>` |
 | `readOnly=(null)`| (initial)| `<boolean: false>` |
 | `readOnly=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -8618,8 +8618,8 @@
 | `renderingIntent=(string 'false')`| (changed)| `"false"` |
 | `renderingIntent=(string 'on')`| (changed)| `"on"` |
 | `renderingIntent=(string 'off')`| (changed)| `"off"` |
-| `renderingIntent=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `renderingIntent=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `renderingIntent=(symbol)`| (initial, warning)| `<null>` |
+| `renderingIntent=(function)`| (initial, warning)| `<null>` |
 | `renderingIntent=(null)`| (initial)| `<null>` |
 | `renderingIntent=(undefined)`| (initial)| `<null>` |
 
@@ -8693,8 +8693,8 @@
 | `required=(string 'false')`| (changed)| `<boolean: true>` |
 | `required=(string 'on')`| (changed)| `<boolean: true>` |
 | `required=(string 'off')`| (changed)| `<boolean: true>` |
-| `required=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `required=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `required=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `required=(function)`| (initial, warning)| `<boolean: false>` |
 | `required=(null)`| (initial)| `<boolean: false>` |
 | `required=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -8868,8 +8868,8 @@
 | `reversed=(string 'false')`| (changed)| `<boolean: true>` |
 | `reversed=(string 'on')`| (changed)| `<boolean: true>` |
 | `reversed=(string 'off')`| (changed)| `<boolean: true>` |
-| `reversed=(symbol)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
-| `reversed=(function)`| (initial, warning, ssr mismatch)| `<boolean: false>` |
+| `reversed=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `reversed=(function)`| (initial, warning)| `<boolean: false>` |
 | `reversed=(null)`| (initial)| `<boolean: false>` |
 | `reversed=(undefined)`| (initial)| `<boolean: false>` |
 
@@ -8943,7 +8943,7 @@
 | `rows=(string 'false')`| (initial)| `<number: 2>` |
 | `rows=(string 'on')`| (initial)| `<number: 2>` |
 | `rows=(string 'off')`| (initial)| `<number: 2>` |
-| `rows=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<number: 2>` |
+| `rows=(symbol)`| (initial, warning)| `<number: 2>` |
 | `rows=(function)`| (initial, warning)| `<number: 2>` |
 | `rows=(null)`| (initial)| `<number: 2>` |
 | `rows=(undefined)`| (initial)| `<number: 2>` |
@@ -9118,8 +9118,8 @@
 | `scoped=(string 'false')`| (changed)| `<empty string>` |
 | `scoped=(string 'on')`| (changed)| `<empty string>` |
 | `scoped=(string 'off')`| (changed)| `<empty string>` |
-| `scoped=(symbol)`| (initial, warning, ssr mismatch)| `<null>` |
-| `scoped=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `scoped=(symbol)`| (initial, warning)| `<null>` |
+| `scoped=(function)`| (initial, warning)| `<null>` |
 | `scoped=(null)`| (initial)| `<null>` |
 | `scoped=(undefined)`| (initial)| `<null>` |
 
@@ -9168,8 +9168,8 @@
 | `seamless=(string 'false')`| (changed)| `<empty string>` |
 | `seamless=(string 'on')`| (changed)| `<empty string>` |
 | `seamless=(string 'off')`| (changed)| `<empty string>` |
-| `seamless=(symbol)`| (initial, warning, ssr mismatch)| `<null>` |
-| `seamless=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `seamless=(symbol)`| (initial, warning)| `<null>` |
+| `seamless=(function)`| (initial, warning)| `<null>` |
 | `seamless=(null)`| (initial)| `<null>` |
 | `seamless=(undefined)`| (initial)| `<null>` |
 
@@ -9343,8 +9343,8 @@
 | `shapeRendering=(string 'false')`| (changed)| `"false"` |
 | `shapeRendering=(string 'on')`| (changed)| `"on"` |
 | `shapeRendering=(string 'off')`| (changed)| `"off"` |
-| `shapeRendering=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `shapeRendering=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `shapeRendering=(symbol)`| (initial, warning)| `<null>` |
+| `shapeRendering=(function)`| (initial, warning)| `<null>` |
 | `shapeRendering=(null)`| (initial)| `<null>` |
 | `shapeRendering=(undefined)`| (initial)| `<null>` |
 
@@ -9368,7 +9368,7 @@
 | `size=(string 'false')`| (initial)| `<number: 20>` |
 | `size=(string 'on')`| (initial)| `<number: 20>` |
 | `size=(string 'off')`| (initial)| `<number: 20>` |
-| `size=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<number: 20>` |
+| `size=(symbol)`| (initial, warning)| `<number: 20>` |
 | `size=(function)`| (initial, warning)| `<number: 20>` |
 | `size=(null)`| (initial)| `<number: 20>` |
 | `size=(undefined)`| (initial)| `<number: 20>` |
@@ -9568,7 +9568,7 @@
 | `spellCheck=(string 'false')`| (changed)| `<boolean: false>` |
 | `spellCheck=(string 'on')`| (initial)| `<boolean: true>` |
 | `spellCheck=(string 'off')`| (initial)| `<boolean: true>` |
-| `spellCheck=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<boolean: true>` |
+| `spellCheck=(symbol)`| (initial, warning)| `<boolean: true>` |
 | `spellCheck=(function)`| (initial, warning)| `<boolean: true>` |
 | `spellCheck=(null)`| (initial)| `<boolean: true>` |
 | `spellCheck=(undefined)`| (initial)| `<boolean: true>` |
@@ -9818,7 +9818,7 @@
 | `start=(string 'false')`| (initial)| `<number: 1>` |
 | `start=(string 'on')`| (initial)| `<number: 1>` |
 | `start=(string 'off')`| (initial)| `<number: 1>` |
-| `start=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<number: 1>` |
+| `start=(symbol)`| (initial, warning)| `<number: 1>` |
 | `start=(function)`| (initial, warning)| `<number: 1>` |
 | `start=(null)`| (initial)| `<number: 1>` |
 | `start=(undefined)`| (initial)| `<number: 1>` |
@@ -10068,8 +10068,8 @@
 | `stopColor=(string 'false')`| (changed)| `"false"` |
 | `stopColor=(string 'on')`| (changed)| `"on"` |
 | `stopColor=(string 'off')`| (changed)| `"off"` |
-| `stopColor=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `stopColor=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `stopColor=(symbol)`| (initial, warning)| `<null>` |
+| `stopColor=(function)`| (initial, warning)| `<null>` |
 | `stopColor=(null)`| (initial)| `<null>` |
 | `stopColor=(undefined)`| (initial)| `<null>` |
 
@@ -10093,8 +10093,8 @@
 | `stopOpacity=(string 'false')`| (changed)| `"false"` |
 | `stopOpacity=(string 'on')`| (changed)| `"on"` |
 | `stopOpacity=(string 'off')`| (changed)| `"off"` |
-| `stopOpacity=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `stopOpacity=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `stopOpacity=(symbol)`| (initial, warning)| `<null>` |
+| `stopOpacity=(function)`| (initial, warning)| `<null>` |
 | `stopOpacity=(null)`| (initial)| `<null>` |
 | `stopOpacity=(undefined)`| (initial)| `<null>` |
 
@@ -10168,8 +10168,8 @@
 | `strikethroughPosition=(string 'false')`| (changed)| `"false"` |
 | `strikethroughPosition=(string 'on')`| (changed)| `"on"` |
 | `strikethroughPosition=(string 'off')`| (changed)| `"off"` |
-| `strikethroughPosition=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `strikethroughPosition=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `strikethroughPosition=(symbol)`| (initial, warning)| `<null>` |
+| `strikethroughPosition=(function)`| (initial, warning)| `<null>` |
 | `strikethroughPosition=(null)`| (initial)| `<null>` |
 | `strikethroughPosition=(undefined)`| (initial)| `<null>` |
 
@@ -10193,8 +10193,8 @@
 | `strikethroughThickness=(string 'false')`| (changed)| `"false"` |
 | `strikethroughThickness=(string 'on')`| (changed)| `"on"` |
 | `strikethroughThickness=(string 'off')`| (changed)| `"off"` |
-| `strikethroughThickness=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `strikethroughThickness=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `strikethroughThickness=(symbol)`| (initial, warning)| `<null>` |
+| `strikethroughThickness=(function)`| (initial, warning)| `<null>` |
 | `strikethroughThickness=(null)`| (initial)| `<null>` |
 | `strikethroughThickness=(undefined)`| (initial)| `<null>` |
 
@@ -10468,8 +10468,8 @@
 | `strokeDasharray=(string 'false')`| (changed)| `"false"` |
 | `strokeDasharray=(string 'on')`| (changed)| `"on"` |
 | `strokeDasharray=(string 'off')`| (changed)| `"off"` |
-| `strokeDasharray=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `strokeDasharray=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `strokeDasharray=(symbol)`| (initial, warning)| `<null>` |
+| `strokeDasharray=(function)`| (initial, warning)| `<null>` |
 | `strokeDasharray=(null)`| (initial)| `<null>` |
 | `strokeDasharray=(undefined)`| (initial)| `<null>` |
 
@@ -10493,8 +10493,8 @@
 | `strokeDashoffset=(string 'false')`| (changed)| `"false"` |
 | `strokeDashoffset=(string 'on')`| (changed)| `"on"` |
 | `strokeDashoffset=(string 'off')`| (changed)| `"off"` |
-| `strokeDashoffset=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `strokeDashoffset=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `strokeDashoffset=(symbol)`| (initial, warning)| `<null>` |
+| `strokeDashoffset=(function)`| (initial, warning)| `<null>` |
 | `strokeDashoffset=(null)`| (initial)| `<null>` |
 | `strokeDashoffset=(undefined)`| (initial)| `<null>` |
 
@@ -10518,8 +10518,8 @@
 | `strokeLinecap=(string 'false')`| (changed)| `"false"` |
 | `strokeLinecap=(string 'on')`| (changed)| `"on"` |
 | `strokeLinecap=(string 'off')`| (changed)| `"off"` |
-| `strokeLinecap=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `strokeLinecap=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `strokeLinecap=(symbol)`| (initial, warning)| `<null>` |
+| `strokeLinecap=(function)`| (initial, warning)| `<null>` |
 | `strokeLinecap=(null)`| (initial)| `<null>` |
 | `strokeLinecap=(undefined)`| (initial)| `<null>` |
 
@@ -10543,8 +10543,8 @@
 | `strokeLinejoin=(string 'false')`| (changed)| `"false"` |
 | `strokeLinejoin=(string 'on')`| (changed)| `"on"` |
 | `strokeLinejoin=(string 'off')`| (changed)| `"off"` |
-| `strokeLinejoin=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `strokeLinejoin=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `strokeLinejoin=(symbol)`| (initial, warning)| `<null>` |
+| `strokeLinejoin=(function)`| (initial, warning)| `<null>` |
 | `strokeLinejoin=(null)`| (initial)| `<null>` |
 | `strokeLinejoin=(undefined)`| (initial)| `<null>` |
 
@@ -10568,8 +10568,8 @@
 | `strokeMiterlimit=(string 'false')`| (changed)| `"false"` |
 | `strokeMiterlimit=(string 'on')`| (changed)| `"on"` |
 | `strokeMiterlimit=(string 'off')`| (changed)| `"off"` |
-| `strokeMiterlimit=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `strokeMiterlimit=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `strokeMiterlimit=(symbol)`| (initial, warning)| `<null>` |
+| `strokeMiterlimit=(function)`| (initial, warning)| `<null>` |
 | `strokeMiterlimit=(null)`| (initial)| `<null>` |
 | `strokeMiterlimit=(undefined)`| (initial)| `<null>` |
 
@@ -10593,8 +10593,8 @@
 | `strokeOpacity=(string 'false')`| (changed)| `"false"` |
 | `strokeOpacity=(string 'on')`| (changed)| `"on"` |
 | `strokeOpacity=(string 'off')`| (changed)| `"off"` |
-| `strokeOpacity=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `strokeOpacity=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `strokeOpacity=(symbol)`| (initial, warning)| `<null>` |
+| `strokeOpacity=(function)`| (initial, warning)| `<null>` |
 | `strokeOpacity=(null)`| (initial)| `<null>` |
 | `strokeOpacity=(undefined)`| (initial)| `<null>` |
 
@@ -10618,8 +10618,8 @@
 | `strokeWidth=(string 'false')`| (changed)| `"false"` |
 | `strokeWidth=(string 'on')`| (changed)| `"on"` |
 | `strokeWidth=(string 'off')`| (changed)| `"off"` |
-| `strokeWidth=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `strokeWidth=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `strokeWidth=(symbol)`| (initial, warning)| `<null>` |
+| `strokeWidth=(function)`| (initial, warning)| `<null>` |
 | `strokeWidth=(null)`| (initial)| `<null>` |
 | `strokeWidth=(undefined)`| (initial)| `<null>` |
 
@@ -10768,7 +10768,7 @@
 | `tabIndex=(string 'false')`| (initial)| `<number: -1>` |
 | `tabIndex=(string 'on')`| (initial)| `<number: -1>` |
 | `tabIndex=(string 'off')`| (initial)| `<number: -1>` |
-| `tabIndex=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<number: -1>` |
+| `tabIndex=(symbol)`| (initial, warning)| `<number: -1>` |
 | `tabIndex=(function)`| (initial, warning)| `<number: -1>` |
 | `tabIndex=(null)`| (initial)| `<number: -1>` |
 | `tabIndex=(undefined)`| (initial)| `<number: -1>` |
@@ -10793,7 +10793,7 @@
 | `tabIndex=(string 'false')`| (initial)| `<number: -1>` |
 | `tabIndex=(string 'on')`| (initial)| `<number: -1>` |
 | `tabIndex=(string 'off')`| (initial)| `<number: -1>` |
-| `tabIndex=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<number: -1>` |
+| `tabIndex=(symbol)`| (initial, warning)| `<number: -1>` |
 | `tabIndex=(function)`| (initial, warning)| `<number: -1>` |
 | `tabIndex=(null)`| (initial)| `<number: -1>` |
 | `tabIndex=(undefined)`| (initial)| `<number: -1>` |
@@ -10993,8 +10993,8 @@
 | `textAnchor=(string 'false')`| (changed)| `"false"` |
 | `textAnchor=(string 'on')`| (changed)| `"on"` |
 | `textAnchor=(string 'off')`| (changed)| `"off"` |
-| `textAnchor=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `textAnchor=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `textAnchor=(symbol)`| (initial, warning)| `<null>` |
+| `textAnchor=(function)`| (initial, warning)| `<null>` |
 | `textAnchor=(null)`| (initial)| `<null>` |
 | `textAnchor=(undefined)`| (initial)| `<null>` |
 
@@ -11018,8 +11018,8 @@
 | `textDecoration=(string 'false')`| (changed)| `"false"` |
 | `textDecoration=(string 'on')`| (changed)| `"on"` |
 | `textDecoration=(string 'off')`| (changed)| `"off"` |
-| `textDecoration=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `textDecoration=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `textDecoration=(symbol)`| (initial, warning)| `<null>` |
+| `textDecoration=(function)`| (initial, warning)| `<null>` |
 | `textDecoration=(null)`| (initial)| `<null>` |
 | `textDecoration=(undefined)`| (initial)| `<null>` |
 
@@ -11068,8 +11068,8 @@
 | `textRendering=(string 'false')`| (changed)| `"false"` |
 | `textRendering=(string 'on')`| (changed)| `"on"` |
 | `textRendering=(string 'off')`| (changed)| `"off"` |
-| `textRendering=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `textRendering=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `textRendering=(symbol)`| (initial, warning)| `<null>` |
+| `textRendering=(function)`| (initial, warning)| `<null>` |
 | `textRendering=(null)`| (initial)| `<null>` |
 | `textRendering=(undefined)`| (initial)| `<null>` |
 
@@ -11343,8 +11343,8 @@
 | `underlinePosition=(string 'false')`| (changed)| `"false"` |
 | `underlinePosition=(string 'on')`| (changed)| `"on"` |
 | `underlinePosition=(string 'off')`| (changed)| `"off"` |
-| `underlinePosition=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `underlinePosition=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `underlinePosition=(symbol)`| (initial, warning)| `<null>` |
+| `underlinePosition=(function)`| (initial, warning)| `<null>` |
 | `underlinePosition=(null)`| (initial)| `<null>` |
 | `underlinePosition=(undefined)`| (initial)| `<null>` |
 
@@ -11368,8 +11368,8 @@
 | `underlineThickness=(string 'false')`| (changed)| `"false"` |
 | `underlineThickness=(string 'on')`| (changed)| `"on"` |
 | `underlineThickness=(string 'off')`| (changed)| `"off"` |
-| `underlineThickness=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `underlineThickness=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `underlineThickness=(symbol)`| (initial, warning)| `<null>` |
+| `underlineThickness=(function)`| (initial, warning)| `<null>` |
 | `underlineThickness=(null)`| (initial)| `<null>` |
 | `underlineThickness=(undefined)`| (initial)| `<null>` |
 
@@ -11468,8 +11468,8 @@
 | `unicodeBidi=(string 'false')`| (changed)| `"false"` |
 | `unicodeBidi=(string 'on')`| (changed)| `"on"` |
 | `unicodeBidi=(string 'off')`| (changed)| `"off"` |
-| `unicodeBidi=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `unicodeBidi=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `unicodeBidi=(symbol)`| (initial, warning)| `<null>` |
+| `unicodeBidi=(function)`| (initial, warning)| `<null>` |
 | `unicodeBidi=(null)`| (initial)| `<null>` |
 | `unicodeBidi=(undefined)`| (initial)| `<null>` |
 
@@ -11493,8 +11493,8 @@
 | `unicodeRange=(string 'false')`| (changed)| `"false"` |
 | `unicodeRange=(string 'on')`| (changed)| `"on"` |
 | `unicodeRange=(string 'off')`| (changed)| `"off"` |
-| `unicodeRange=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `unicodeRange=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `unicodeRange=(symbol)`| (initial, warning)| `<null>` |
+| `unicodeRange=(function)`| (initial, warning)| `<null>` |
 | `unicodeRange=(null)`| (initial)| `<null>` |
 | `unicodeRange=(undefined)`| (initial)| `<null>` |
 
@@ -11543,7 +11543,7 @@
 | `unitsPerEm=(string 'false')`| (initial)| `<null>` |
 | `unitsPerEm=(string 'on')`| (initial)| `<null>` |
 | `unitsPerEm=(string 'off')`| (initial)| `<null>` |
-| `unitsPerEm=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
+| `unitsPerEm=(symbol)`| (initial, warning)| `<null>` |
 | `unitsPerEm=(function)`| (initial, warning)| `<null>` |
 | `unitsPerEm=(null)`| (initial)| `<null>` |
 | `unitsPerEm=(undefined)`| (initial)| `<null>` |
@@ -11743,8 +11743,8 @@
 | `vAlphabetic=(string 'false')`| (changed)| `"false"` |
 | `vAlphabetic=(string 'on')`| (changed)| `"on"` |
 | `vAlphabetic=(string 'off')`| (changed)| `"off"` |
-| `vAlphabetic=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `vAlphabetic=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `vAlphabetic=(symbol)`| (initial, warning)| `<null>` |
+| `vAlphabetic=(function)`| (initial, warning)| `<null>` |
 | `vAlphabetic=(null)`| (initial)| `<null>` |
 | `vAlphabetic=(undefined)`| (initial)| `<null>` |
 
@@ -11768,8 +11768,8 @@
 | `value=(string 'false')`| (changed)| `"false"` |
 | `value=(string 'on')`| (changed)| `"on"` |
 | `value=(string 'off')`| (changed)| `"off"` |
-| `value=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<empty string>` |
-| `value=(function)`| (initial, warning, ssr mismatch)| `<empty string>` |
+| `value=(symbol)`| (initial, warning, ssr warning)| `<empty string>` |
+| `value=(function)`| (initial, warning, ssr warning)| `<empty string>` |
 | `value=(null)`| (initial, warning, ssr warning)| `<empty string>` |
 | `value=(undefined)`| (initial)| `<empty string>` |
 
@@ -11793,8 +11793,8 @@
 | `value=(string 'false')`| (changed)| `"false"` |
 | `value=(string 'on')`| (changed)| `"on"` |
 | `value=(string 'off')`| (changed)| `"off"` |
-| `value=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<empty string>` |
-| `value=(function)`| (initial, warning, ssr mismatch)| `<empty string>` |
+| `value=(symbol)`| (initial, warning)| `<empty string>` |
+| `value=(function)`| (initial, warning)| `<empty string>` |
 | `value=(null)`| (initial, warning, ssr warning)| `<empty string>` |
 | `value=(undefined)`| (initial)| `<empty string>` |
 
@@ -11818,7 +11818,7 @@
 | `value=(string 'false')`| (initial)| `<empty string>` |
 | `value=(string 'on')`| (initial)| `<empty string>` |
 | `value=(string 'off')`| (initial)| `<empty string>` |
-| `value=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<empty string>` |
+| `value=(symbol)`| (initial, warning)| `<empty string>` |
 | `value=(function)`| (initial, warning)| `<empty string>` |
 | `value=(null)`| (initial, warning, ssr warning)| `<empty string>` |
 | `value=(undefined)`| (initial)| `<empty string>` |
@@ -11868,8 +11868,8 @@
 | `value=(string 'false')`| (changed)| `"false"` |
 | `value=(string 'on')`| (changed)| `"on"` |
 | `value=(string 'off')`| (changed)| `"off"` |
-| `value=(symbol)`| (changed, error, warning, ssr error)| `` |
-| `value=(function)`| (changed, warning)| `"function f() {}"` |
+| `value=(symbol)`| (changed, error, warning, ssr mismatch)| `` |
+| `value=(function)`| (changed, warning, ssr mismatch)| `"function f() {}"` |
 | `value=(null)`| (initial)| `<empty string>` |
 | `value=(undefined)`| (initial)| `<empty string>` |
 
@@ -11968,8 +11968,8 @@
 | `vectorEffect=(string 'false')`| (changed)| `"false"` |
 | `vectorEffect=(string 'on')`| (changed)| `"on"` |
 | `vectorEffect=(string 'off')`| (changed)| `"off"` |
-| `vectorEffect=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `vectorEffect=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `vectorEffect=(symbol)`| (initial, warning)| `<null>` |
+| `vectorEffect=(function)`| (initial, warning)| `<null>` |
 | `vectorEffect=(null)`| (initial)| `<null>` |
 | `vectorEffect=(undefined)`| (initial)| `<null>` |
 
@@ -12118,8 +12118,8 @@
 | `vertAdvY=(string 'false')`| (changed)| `"false"` |
 | `vertAdvY=(string 'on')`| (changed)| `"on"` |
 | `vertAdvY=(string 'off')`| (changed)| `"off"` |
-| `vertAdvY=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `vertAdvY=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `vertAdvY=(symbol)`| (initial, warning)| `<null>` |
+| `vertAdvY=(function)`| (initial, warning)| `<null>` |
 | `vertAdvY=(null)`| (initial)| `<null>` |
 | `vertAdvY=(undefined)`| (initial)| `<null>` |
 
@@ -12143,8 +12143,8 @@
 | `vertOriginX=(string 'false')`| (changed)| `"false"` |
 | `vertOriginX=(string 'on')`| (changed)| `"on"` |
 | `vertOriginX=(string 'off')`| (changed)| `"off"` |
-| `vertOriginX=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `vertOriginX=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `vertOriginX=(symbol)`| (initial, warning)| `<null>` |
+| `vertOriginX=(function)`| (initial, warning)| `<null>` |
 | `vertOriginX=(null)`| (initial)| `<null>` |
 | `vertOriginX=(undefined)`| (initial)| `<null>` |
 
@@ -12168,8 +12168,8 @@
 | `vertOriginY=(string 'false')`| (changed)| `"false"` |
 | `vertOriginY=(string 'on')`| (changed)| `"on"` |
 | `vertOriginY=(string 'off')`| (changed)| `"off"` |
-| `vertOriginY=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `vertOriginY=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `vertOriginY=(symbol)`| (initial, warning)| `<null>` |
+| `vertOriginY=(function)`| (initial, warning)| `<null>` |
 | `vertOriginY=(null)`| (initial)| `<null>` |
 | `vertOriginY=(undefined)`| (initial)| `<null>` |
 
@@ -12193,8 +12193,8 @@
 | `vHanging=(string 'false')`| (changed)| `"false"` |
 | `vHanging=(string 'on')`| (changed)| `"on"` |
 | `vHanging=(string 'off')`| (changed)| `"off"` |
-| `vHanging=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `vHanging=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `vHanging=(symbol)`| (initial, warning)| `<null>` |
+| `vHanging=(function)`| (initial, warning)| `<null>` |
 | `vHanging=(null)`| (initial)| `<null>` |
 | `vHanging=(undefined)`| (initial)| `<null>` |
 
@@ -12218,8 +12218,8 @@
 | `vIdeographic=(string 'false')`| (changed)| `"false"` |
 | `vIdeographic=(string 'on')`| (changed)| `"on"` |
 | `vIdeographic=(string 'off')`| (changed)| `"off"` |
-| `vIdeographic=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `vIdeographic=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `vIdeographic=(symbol)`| (initial, warning)| `<null>` |
+| `vIdeographic=(function)`| (initial, warning)| `<null>` |
 | `vIdeographic=(null)`| (initial)| `<null>` |
 | `vIdeographic=(undefined)`| (initial)| `<null>` |
 
@@ -12343,8 +12343,8 @@
 | `vMathematical=(string 'false')`| (changed)| `"false"` |
 | `vMathematical=(string 'on')`| (changed)| `"on"` |
 | `vMathematical=(string 'off')`| (changed)| `"off"` |
-| `vMathematical=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `vMathematical=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `vMathematical=(symbol)`| (initial, warning)| `<null>` |
+| `vMathematical=(function)`| (initial, warning)| `<null>` |
 | `vMathematical=(null)`| (initial)| `<null>` |
 | `vMathematical=(undefined)`| (initial)| `<null>` |
 
@@ -12518,8 +12518,8 @@
 | `wordSpacing=(string 'false')`| (changed)| `"false"` |
 | `wordSpacing=(string 'on')`| (changed)| `"on"` |
 | `wordSpacing=(string 'off')`| (changed)| `"off"` |
-| `wordSpacing=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `wordSpacing=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `wordSpacing=(symbol)`| (initial, warning)| `<null>` |
+| `wordSpacing=(function)`| (initial, warning)| `<null>` |
 | `wordSpacing=(null)`| (initial)| `<null>` |
 | `wordSpacing=(undefined)`| (initial)| `<null>` |
 
@@ -12593,8 +12593,8 @@
 | `writingMode=(string 'false')`| (changed)| `"false"` |
 | `writingMode=(string 'on')`| (changed)| `"on"` |
 | `writingMode=(string 'off')`| (changed)| `"off"` |
-| `writingMode=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `writingMode=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `writingMode=(symbol)`| (initial, warning)| `<null>` |
+| `writingMode=(function)`| (initial, warning)| `<null>` |
 | `writingMode=(null)`| (initial)| `<null>` |
 | `writingMode=(undefined)`| (initial)| `<null>` |
 
@@ -12743,8 +12743,8 @@
 | `xHeight=(string 'false')`| (changed)| `"false"` |
 | `xHeight=(string 'on')`| (changed)| `"on"` |
 | `xHeight=(string 'off')`| (changed)| `"off"` |
-| `xHeight=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xHeight=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xHeight=(symbol)`| (initial, warning)| `<null>` |
+| `xHeight=(function)`| (initial, warning)| `<null>` |
 | `xHeight=(null)`| (initial)| `<null>` |
 | `xHeight=(undefined)`| (initial)| `<null>` |
 
@@ -12968,8 +12968,8 @@
 | `xlinkActuate=(string 'false')`| (changed)| `"false"` |
 | `xlinkActuate=(string 'on')`| (changed)| `"on"` |
 | `xlinkActuate=(string 'off')`| (changed)| `"off"` |
-| `xlinkActuate=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xlinkActuate=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xlinkActuate=(symbol)`| (initial, warning)| `<null>` |
+| `xlinkActuate=(function)`| (initial, warning)| `<null>` |
 | `xlinkActuate=(null)`| (initial)| `<null>` |
 | `xlinkActuate=(undefined)`| (initial)| `<null>` |
 
@@ -13018,8 +13018,8 @@
 | `xlinkArcrole=(string 'false')`| (changed)| `"false"` |
 | `xlinkArcrole=(string 'on')`| (changed)| `"on"` |
 | `xlinkArcrole=(string 'off')`| (changed)| `"off"` |
-| `xlinkArcrole=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xlinkArcrole=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xlinkArcrole=(symbol)`| (initial, warning)| `<null>` |
+| `xlinkArcrole=(function)`| (initial, warning)| `<null>` |
 | `xlinkArcrole=(null)`| (initial)| `<null>` |
 | `xlinkArcrole=(undefined)`| (initial)| `<null>` |
 
@@ -13043,8 +13043,8 @@
 | `xlinkHref=(string 'false')`| (changed)| `"false"` |
 | `xlinkHref=(string 'on')`| (changed)| `"on"` |
 | `xlinkHref=(string 'off')`| (changed)| `"off"` |
-| `xlinkHref=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xlinkHref=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xlinkHref=(symbol)`| (initial, warning)| `<null>` |
+| `xlinkHref=(function)`| (initial, warning)| `<null>` |
 | `xlinkHref=(null)`| (initial)| `<null>` |
 | `xlinkHref=(undefined)`| (initial)| `<null>` |
 
@@ -13068,8 +13068,8 @@
 | `xlinkRole=(string 'false')`| (changed)| `"false"` |
 | `xlinkRole=(string 'on')`| (changed)| `"on"` |
 | `xlinkRole=(string 'off')`| (changed)| `"off"` |
-| `xlinkRole=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xlinkRole=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xlinkRole=(symbol)`| (initial, warning)| `<null>` |
+| `xlinkRole=(function)`| (initial, warning)| `<null>` |
 | `xlinkRole=(null)`| (initial)| `<null>` |
 | `xlinkRole=(undefined)`| (initial)| `<null>` |
 
@@ -13093,8 +13093,8 @@
 | `xlinkShow=(string 'false')`| (changed)| `"false"` |
 | `xlinkShow=(string 'on')`| (changed)| `"on"` |
 | `xlinkShow=(string 'off')`| (changed)| `"off"` |
-| `xlinkShow=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xlinkShow=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xlinkShow=(symbol)`| (initial, warning)| `<null>` |
+| `xlinkShow=(function)`| (initial, warning)| `<null>` |
 | `xlinkShow=(null)`| (initial)| `<null>` |
 | `xlinkShow=(undefined)`| (initial)| `<null>` |
 
@@ -13118,8 +13118,8 @@
 | `xlinkTitle=(string 'false')`| (changed)| `"false"` |
 | `xlinkTitle=(string 'on')`| (changed)| `"on"` |
 | `xlinkTitle=(string 'off')`| (changed)| `"off"` |
-| `xlinkTitle=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xlinkTitle=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xlinkTitle=(symbol)`| (initial, warning)| `<null>` |
+| `xlinkTitle=(function)`| (initial, warning)| `<null>` |
 | `xlinkTitle=(null)`| (initial)| `<null>` |
 | `xlinkTitle=(undefined)`| (initial)| `<null>` |
 
@@ -13143,8 +13143,8 @@
 | `xlinkType=(string 'false')`| (changed)| `"false"` |
 | `xlinkType=(string 'on')`| (changed)| `"on"` |
 | `xlinkType=(string 'off')`| (changed)| `"off"` |
-| `xlinkType=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xlinkType=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xlinkType=(symbol)`| (initial, warning)| `<null>` |
+| `xlinkType=(function)`| (initial, warning)| `<null>` |
 | `xlinkType=(null)`| (initial)| `<null>` |
 | `xlinkType=(undefined)`| (initial)| `<null>` |
 
@@ -13243,8 +13243,8 @@
 | `xmlBase=(string 'false')`| (changed)| `"false"` |
 | `xmlBase=(string 'on')`| (changed)| `"on"` |
 | `xmlBase=(string 'off')`| (changed)| `"off"` |
-| `xmlBase=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xmlBase=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xmlBase=(symbol)`| (initial, warning)| `<null>` |
+| `xmlBase=(function)`| (initial, warning)| `<null>` |
 | `xmlBase=(null)`| (initial)| `<null>` |
 | `xmlBase=(undefined)`| (initial)| `<null>` |
 
@@ -13268,8 +13268,8 @@
 | `xmlLang=(string 'false')`| (changed)| `"false"` |
 | `xmlLang=(string 'on')`| (changed)| `"on"` |
 | `xmlLang=(string 'off')`| (changed)| `"off"` |
-| `xmlLang=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xmlLang=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xmlLang=(symbol)`| (initial, warning)| `<null>` |
+| `xmlLang=(function)`| (initial, warning)| `<null>` |
 | `xmlLang=(null)`| (initial)| `<null>` |
 | `xmlLang=(undefined)`| (initial)| `<null>` |
 
@@ -13343,8 +13343,8 @@
 | `xmlnsXlink=(string 'false')`| (changed)| `"false"` |
 | `xmlnsXlink=(string 'on')`| (changed)| `"on"` |
 | `xmlnsXlink=(string 'off')`| (changed)| `"off"` |
-| `xmlnsXlink=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xmlnsXlink=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xmlnsXlink=(symbol)`| (initial, warning)| `<null>` |
+| `xmlnsXlink=(function)`| (initial, warning)| `<null>` |
 | `xmlnsXlink=(null)`| (initial)| `<null>` |
 | `xmlnsXlink=(undefined)`| (initial)| `<null>` |
 
@@ -13368,8 +13368,8 @@
 | `xmlSpace=(string 'false')`| (changed)| `"false"` |
 | `xmlSpace=(string 'on')`| (changed)| `"on"` |
 | `xmlSpace=(string 'off')`| (changed)| `"off"` |
-| `xmlSpace=(symbol)`| (initial, warning, ssr error, ssr mismatch)| `<null>` |
-| `xmlSpace=(function)`| (initial, warning, ssr mismatch)| `<null>` |
+| `xmlSpace=(symbol)`| (initial, warning)| `<null>` |
+| `xmlSpace=(function)`| (initial, warning)| `<null>` |
 | `xmlSpace=(null)`| (initial)| `<null>` |
 | `xmlSpace=(undefined)`| (initial)| `<null>` |
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -442,6 +442,97 @@ describe('ReactDOMComponent', () => {
       expect(container.firstChild.className).toEqual('');
     });
 
+    it('should not set null/undefined attributes', () => {
+      var container = document.createElement('div');
+      // Initial render.
+      ReactDOM.render(<img src={null} data-foo={undefined} />, container);
+      var node = container.firstChild;
+      expect(node.hasAttribute('src')).toBe(false);
+      expect(node.hasAttribute('data-foo')).toBe(false);
+      // Update in one direction.
+      ReactDOM.render(<img src={undefined} data-foo={null} />, container);
+      expect(node.hasAttribute('src')).toBe(false);
+      expect(node.hasAttribute('data-foo')).toBe(false);
+      // Update in another direction.
+      ReactDOM.render(<img src={null} data-foo={undefined} />, container);
+      expect(node.hasAttribute('src')).toBe(false);
+      expect(node.hasAttribute('data-foo')).toBe(false);
+      // Removal.
+      ReactDOM.render(<img />, container);
+      expect(node.hasAttribute('src')).toBe(false);
+      expect(node.hasAttribute('data-foo')).toBe(false);
+      // Addition.
+      ReactDOM.render(<img src={undefined} data-foo={null} />, container);
+      expect(node.hasAttribute('src')).toBe(false);
+      expect(node.hasAttribute('data-foo')).toBe(false);
+    });
+
+    it('should apply React-specific aliases to HTML elements', () => {
+      var container = document.createElement('div');
+      ReactDOM.render(<form acceptCharset="foo" />, container);
+      var node = container.firstChild;
+      // Test attribute initialization.
+      expect(node.getAttribute('accept-charset')).toBe('foo');
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Test attribute update.
+      ReactDOM.render(<form acceptCharset="boo" />, container);
+      expect(node.getAttribute('accept-charset')).toBe('boo');
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Test attribute removal by setting to null.
+      ReactDOM.render(<form acceptCharset={null} />, container);
+      expect(node.hasAttribute('accept-charset')).toBe(false);
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Restore.
+      ReactDOM.render(<form acceptCharset="foo" />, container);
+      expect(node.getAttribute('accept-charset')).toBe('foo');
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Test attribute removal by setting to undefined.
+      ReactDOM.render(<form acceptCharset={undefined} />, container);
+      expect(node.hasAttribute('accept-charset')).toBe(false);
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Restore.
+      ReactDOM.render(<form acceptCharset="foo" />, container);
+      expect(node.getAttribute('accept-charset')).toBe('foo');
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+      // Test attribute removal.
+      ReactDOM.render(<form />, container);
+      expect(node.hasAttribute('accept-charset')).toBe(false);
+      expect(node.hasAttribute('acceptCharset')).toBe(false);
+    });
+
+    it('should apply React-specific aliases to SVG elements', () => {
+      var container = document.createElement('div');
+      ReactDOM.render(<svg arabicForm="foo" />, container);
+      var node = container.firstChild;
+      // Test attribute initialization.
+      expect(node.getAttribute('arabic-form')).toBe('foo');
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Test attribute update.
+      ReactDOM.render(<svg arabicForm="boo" />, container);
+      expect(node.getAttribute('arabic-form')).toBe('boo');
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Test attribute removal by setting to null.
+      ReactDOM.render(<svg arabicForm={null} />, container);
+      expect(node.hasAttribute('arabic-form')).toBe(false);
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Restore.
+      ReactDOM.render(<svg arabicForm="foo" />, container);
+      expect(node.getAttribute('arabic-form')).toBe('foo');
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Test attribute removal by setting to undefined.
+      ReactDOM.render(<svg arabicForm={undefined} />, container);
+      expect(node.hasAttribute('arabic-form')).toBe(false);
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Restore.
+      ReactDOM.render(<svg arabicForm="foo" />, container);
+      expect(node.getAttribute('arabic-form')).toBe('foo');
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Test attribute removal.
+      ReactDOM.render(<svg />, container);
+      expect(node.hasAttribute('arabic-form')).toBe(false);
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+    });
+
     it('should properly update custom attributes on custom elements', () => {
       const container = document.createElement('div');
       ReactDOM.render(<some-custom-element foo="bar" />, container);
@@ -449,6 +540,25 @@ describe('ReactDOMComponent', () => {
       const node = container.firstChild;
       expect(node.hasAttribute('foo')).toBe(false);
       expect(node.getAttribute('bar')).toBe('buzz');
+    });
+
+    it('should not apply React-specific aliases to custom elements', () => {
+      var container = document.createElement('div');
+      ReactDOM.render(<some-custom-element arabicForm="foo" />, container);
+      var node = container.firstChild;
+      // Should not get transformed to arabic-form as SVG would be.
+      expect(node.getAttribute('arabicForm')).toBe('foo');
+      expect(node.hasAttribute('arabic-form')).toBe(false);
+      // Test attribute update.
+      ReactDOM.render(<some-custom-element arabicForm="boo" />, container);
+      expect(node.getAttribute('arabicForm')).toBe('boo');
+      // Test attribute removal and addition.
+      ReactDOM.render(<some-custom-element acceptCharset="buzz" />, container);
+      // Verify the previous attribute was removed.
+      expect(node.hasAttribute('arabicForm')).toBe(false);
+      // Should not get transformed to accept-charset as HTML would be.
+      expect(node.getAttribute('acceptCharset')).toBe('buzz');
+      expect(node.hasAttribute('accept-charset')).toBe(false);
     });
 
     it('should clear a single style prop when changing `style`', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -62,6 +62,16 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<div width={null} />);
         expect(e.hasAttribute('width')).toBe(false);
       });
+
+      itRenders('no string prop with function value', async render => {
+        const e = await render(<div width={function() {}} />, 1);
+        expect(e.hasAttribute('width')).toBe(false);
+      });
+
+      itRenders('no string prop with symbol value', async render => {
+        const e = await render(<div width={Symbol('foo')} />, 1);
+        expect(e.hasAttribute('width')).toBe(false);
+      });
     });
 
     describe('boolean properties', function() {
@@ -122,6 +132,16 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<div hidden={null} />);
         expect(e.hasAttribute('hidden')).toBe(false);
       });
+
+      itRenders('no boolean prop with function value', async render => {
+        const e = await render(<div hidden={function() {}} />, 1);
+        expect(e.hasAttribute('hidden')).toBe(false);
+      });
+
+      itRenders('no boolean prop with symbol value', async render => {
+        const e = await render(<div hidden={Symbol('foo')} />, 1);
+        expect(e.hasAttribute('hidden')).toBe(false);
+      });
     });
 
     describe('download property (combined boolean/string attribute)', function() {
@@ -162,6 +182,16 @@ describe('ReactDOMServerIntegration', () => {
 
       itRenders('no download prop with undefined value', async render => {
         const e = await render(<div download={undefined} />);
+        expect(e.hasAttribute('download')).toBe(false);
+      });
+
+      itRenders('no download prop with function value', async render => {
+        const e = await render(<div download={function() {}} />, 1);
+        expect(e.hasAttribute('download')).toBe(false);
+      });
+
+      itRenders('no download prop with symbol value', async render => {
+        const e = await render(<div download={Symbol('foo')} />, 1);
         expect(e.hasAttribute('download')).toBe(false);
       });
     });

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -287,6 +287,11 @@ describe('ReactDOMServerIntegration', () => {
         },
       );
 
+      itRenders('numeric property with zero value', async render => {
+        const e = await render(<ol start={0} />);
+        expect(e.getAttribute('start')).toBe('0');
+      });
+
       itRenders(
         'no positive numeric property with zero value',
         async render => {
@@ -295,9 +300,27 @@ describe('ReactDOMServerIntegration', () => {
         },
       );
 
-      itRenders('numeric property with zero value', async render => {
-        const e = await render(<ol start={0} />);
-        expect(e.getAttribute('start')).toBe('0');
+      itRenders('no numeric prop with function value', async render => {
+        const e = await render(<ol start={function() {}} />, 1);
+        expect(e.hasAttribute('start')).toBe(false);
+      });
+
+      itRenders('no numeric prop with symbol value', async render => {
+        const e = await render(<ol start={Symbol('foo')} />, 1);
+        expect(e.hasAttribute('start')).toBe(false);
+      });
+
+      itRenders(
+        'no positive numeric prop with function value',
+        async render => {
+          const e = await render(<input size={function() {}} />, 1);
+          expect(e.hasAttribute('size')).toBe(false);
+        },
+      );
+
+      itRenders('no positive numeric prop with symbol value', async render => {
+        const e = await render(<input size={Symbol('foo')} />, 1);
+        expect(e.hasAttribute('size')).toBe(false);
       });
     });
 

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -7,7 +7,8 @@
 
 import {
   getPropertyInfo,
-  shouldSetAttribute,
+  shouldSkipAttribute,
+  shouldTreatAttributeValueAsNull,
   isAttributeNameSafe,
 } from '../shared/DOMProperty';
 
@@ -112,13 +113,14 @@ export function getValueForAttribute(node, name, expected) {
  * @param {*} value
  */
 export function setValueForProperty(node, name, value, isCustomComponentTag) {
+  if (shouldSkipAttribute(name, isCustomComponentTag)) {
+    return;
+  }
+  if (shouldTreatAttributeValueAsNull(name, value, isCustomComponentTag)) {
+    value = null;
+  }
   const propertyInfo = getPropertyInfo(name);
-
-  if (
-    !isCustomComponentTag &&
-    propertyInfo &&
-    shouldSetAttribute(name, value)
-  ) {
+  if (!isCustomComponentTag && propertyInfo) {
     if (shouldIgnoreValue(propertyInfo, value)) {
       if (propertyInfo.mustUseProperty) {
         if (propertyInfo.hasBooleanValue) {
@@ -149,19 +151,11 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
         node.setAttribute(attributeName, '' + value);
       }
     }
-  } else {
-    const useValue = isCustomComponentTag || shouldSetAttribute(name, value);
-    setValueForAttribute(node, name, useValue ? value : null);
-  }
-}
-
-export function setValueForAttribute(node, name, value) {
-  if (!isAttributeNameSafe(name)) {
-    return;
-  }
-  if (value == null) {
-    node.removeAttribute(name);
-  } else {
-    node.setAttribute(name, '' + value);
+  } else if (isAttributeNameSafe(name)) {
+    if (value == null) {
+      node.removeAttribute(name);
+    } else {
+      node.setAttribute(name, '' + value);
+    }
   }
 }

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -9,8 +9,8 @@
 
 import {
   getPropertyInfo,
-  shouldSkipAttribute,
-  shouldTreatAttributeValueAsNull,
+  shouldIgnoreAttribute,
+  shouldRemoveAttribute,
   isAttributeNameSafe,
   BOOLEAN,
   OVERLOADED_BOOLEAN,
@@ -44,9 +44,7 @@ export function getValueForProperty(
           if (value === '') {
             return true;
           }
-          if (
-            shouldTreatAttributeValueAsNull(name, expected, propertyInfo, false)
-          ) {
+          if (shouldRemoveAttribute(name, expected, propertyInfo, false)) {
             return value;
           }
           if (value === '' + (expected: any)) {
@@ -55,9 +53,7 @@ export function getValueForProperty(
           return value;
         }
       } else if (node.hasAttribute(attributeName)) {
-        if (
-          shouldTreatAttributeValueAsNull(name, expected, propertyInfo, false)
-        ) {
+        if (shouldRemoveAttribute(name, expected, propertyInfo, false)) {
           // We had an attribute but shouldn't have had one, so read it
           // for the error message.
           return node.getAttribute(attributeName);
@@ -74,9 +70,7 @@ export function getValueForProperty(
         stringValue = node.getAttribute(attributeName);
       }
 
-      if (
-        shouldTreatAttributeValueAsNull(name, expected, propertyInfo, false)
-      ) {
+      if (shouldRemoveAttribute(name, expected, propertyInfo, false)) {
         return stringValue === null ? expected : stringValue;
       } else if (stringValue === '' + (expected: any)) {
         return expected;
@@ -126,17 +120,10 @@ export function setValueForProperty(
   isCustomComponentTag: boolean,
 ) {
   const propertyInfo = getPropertyInfo(name);
-  if (shouldSkipAttribute(name, propertyInfo, isCustomComponentTag)) {
+  if (shouldIgnoreAttribute(name, propertyInfo, isCustomComponentTag)) {
     return;
   }
-  if (
-    shouldTreatAttributeValueAsNull(
-      name,
-      value,
-      propertyInfo,
-      isCustomComponentTag,
-    )
-  ) {
+  if (shouldRemoveAttribute(name, value, propertyInfo, isCustomComponentTag)) {
     value = null;
   }
   // If the prop isn't in the special list, treat it as a simple attribute.

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -6,8 +6,6 @@
  */
 
 import {
-  ID_ATTRIBUTE_NAME,
-  ROOT_ATTRIBUTE_NAME,
   getPropertyInfo,
   shouldSetAttribute,
   isAttributeNameSafe,
@@ -23,18 +21,6 @@ function shouldIgnoreValue(propertyInfo, value) {
     (propertyInfo.hasPositiveNumericValue && value < 1) ||
     (propertyInfo.hasOverloadedBooleanValue && value === false)
   );
-}
-
-/**
- * Operations for dealing with DOM properties.
- */
-
-export function setAttributeForID(node, id) {
-  node.setAttribute(ID_ATTRIBUTE_NAME, id);
-}
-
-export function setAttributeForRoot(node) {
-  node.setAttribute(ROOT_ATTRIBUTE_NAME, '');
 }
 
 /**

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -128,7 +128,7 @@ export function setValueForProperty(
   if (!propertyInfo) {
     if (isAttributeNameSafe(name)) {
       const attributeName = name;
-      if (value == null) {
+      if (value === null) {
         node.removeAttribute(attributeName);
       } else {
         node.setAttribute(attributeName, '' + (value: any));

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -12,6 +12,8 @@ import {
   shouldSkipAttribute,
   shouldTreatAttributeValueAsNull,
   isAttributeNameSafe,
+  BOOLEAN,
+  OVERLOADED_BOOLEAN,
 } from '../shared/DOMProperty';
 
 import type {PropertyInfo} from '../shared/DOMProperty';
@@ -36,7 +38,7 @@ export function getValueForProperty(
 
       let stringValue = null;
 
-      if (propertyInfo.hasOverloadedBooleanValue) {
+      if (propertyInfo.type === OVERLOADED_BOOLEAN) {
         if (node.hasAttribute(attributeName)) {
           const value = node.getAttribute(attributeName);
           if (value === '') {
@@ -60,7 +62,7 @@ export function getValueForProperty(
           // for the error message.
           return node.getAttribute(attributeName);
         }
-        if (propertyInfo.hasBooleanValue) {
+        if (propertyInfo.type === BOOLEAN) {
           // If this was a boolean, it doesn't matter what the value is
           // the fact that we have it is the same as the expected.
           return expected;
@@ -149,15 +151,12 @@ export function setValueForProperty(
     }
     return;
   }
-  const {
-    hasBooleanValue,
-    hasOverloadedBooleanValue,
-    mustUseProperty,
-  } = propertyInfo;
+  const {mustUseProperty} = propertyInfo;
   if (mustUseProperty) {
     const {propertyName} = propertyInfo;
     if (value === null) {
-      (node: any)[propertyName] = hasBooleanValue ? false : '';
+      const {type} = propertyInfo;
+      (node: any)[propertyName] = type === BOOLEAN ? false : '';
     } else {
       // Contrary to `setAttribute`, object properties are properly
       // `toString`ed by IE8/9.
@@ -170,8 +169,9 @@ export function setValueForProperty(
   if (value === null) {
     node.removeAttribute(attributeName);
   } else {
+    const {type} = propertyInfo;
     let attributeValue;
-    if (hasBooleanValue || (hasOverloadedBooleanValue && value === true)) {
+    if (type === BOOLEAN || (type === OVERLOADED_BOOLEAN && value === true)) {
       attributeValue = '';
     } else {
       // `setAttribute` with objects becomes only `[object]` in IE8/9,

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -41,7 +41,14 @@ export function getValueForProperty(
             if (value === '') {
               return true;
             }
-            if (shouldTreatAttributeValueAsNull(name, expected, false)) {
+            if (
+              shouldTreatAttributeValueAsNull(
+                name,
+                expected,
+                propertyInfo,
+                false,
+              )
+            ) {
               return value;
             }
             if (value === '' + (expected: any)) {
@@ -50,7 +57,9 @@ export function getValueForProperty(
             return value;
           }
         } else if (node.hasAttribute(attributeName)) {
-          if (shouldTreatAttributeValueAsNull(name, expected, false)) {
+          if (
+            shouldTreatAttributeValueAsNull(name, expected, propertyInfo, false)
+          ) {
             // We had an attribute but shouldn't have had one, so read it
             // for the error message.
             return node.getAttribute(attributeName);
@@ -67,7 +76,9 @@ export function getValueForProperty(
           stringValue = node.getAttribute(attributeName);
         }
 
-        if (shouldTreatAttributeValueAsNull(name, expected, false)) {
+        if (
+          shouldTreatAttributeValueAsNull(name, expected, propertyInfo, false)
+        ) {
           return stringValue === null ? expected : stringValue;
         } else if (stringValue === '' + (expected: any)) {
           return expected;
@@ -117,15 +128,22 @@ export function setValueForProperty(
   value: mixed,
   isCustomComponentTag: boolean,
 ) {
-  if (shouldSkipAttribute(name, isCustomComponentTag)) {
+  const propertyInfo = getPropertyInfo(name);
+  if (shouldSkipAttribute(name, propertyInfo, isCustomComponentTag)) {
     return;
   }
-  const propertyInfo = isCustomComponentTag ? null : getPropertyInfo(name);
-  if (shouldTreatAttributeValueAsNull(name, value, isCustomComponentTag)) {
+  if (
+    shouldTreatAttributeValueAsNull(
+      name,
+      value,
+      propertyInfo,
+      isCustomComponentTag,
+    )
+  ) {
     value = null;
   }
   // If the prop isn't in the special list, treat it as a simple attribute.
-  if (!propertyInfo) {
+  if (isCustomComponentTag || !propertyInfo) {
     if (isAttributeNameSafe(name)) {
       const attributeName = name;
       if (value === null) {

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -189,7 +189,7 @@ export function deleteValueForAttribute(node, name) {
  * @param {DOMElement} node
  * @param {string} name
  */
-export function deleteValueForProperty(node, name) {
+function deleteValueForProperty(node, name) {
   const propertyInfo = getPropertyInfo(name);
   if (propertyInfo) {
     if (propertyInfo.mustUseProperty) {

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -140,7 +140,7 @@ export function setValueForProperty(
     value = null;
   }
   // If the prop isn't in the special list, treat it as a simple attribute.
-  if (isCustomComponentTag || !propertyInfo) {
+  if (isCustomComponentTag || propertyInfo === null) {
     if (isAttributeNameSafe(name)) {
       const attributeName = name;
       if (value === null) {

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -7,22 +7,11 @@
 
 import {
   getPropertyInfo,
+  shouldIgnoreValue,
   shouldSkipAttribute,
   shouldTreatAttributeValueAsNull,
   isAttributeNameSafe,
 } from '../shared/DOMProperty';
-
-// shouldIgnoreValue() is currently duplicated in DOMMarkupOperations.
-// TODO: Find a better place for this.
-function shouldIgnoreValue(propertyInfo, value) {
-  return (
-    value == null ||
-    (propertyInfo.hasBooleanValue && !value) ||
-    (propertyInfo.hasNumericValue && isNaN(value)) ||
-    (propertyInfo.hasPositiveNumericValue && value < 1) ||
-    (propertyInfo.hasOverloadedBooleanValue && value === false)
-  );
-}
 
 /**
  * Get the value for a property on a node. Only used in DEV for SSR validation.

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -124,7 +124,7 @@ export function setValueForProperty(
   if (shouldTreatAttributeValueAsNull(name, value, isCustomComponentTag)) {
     value = null;
   }
-  // If the prop is in the special list, treat it as a simple attribute.
+  // If the prop isn't in the special list, treat it as a simple attribute.
   if (!propertyInfo) {
     if (isAttributeNameSafe(name)) {
       const attributeName = name;

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -111,10 +111,14 @@ export function getValueForAttribute(node, name, expected) {
  * @param {string} name
  * @param {*} value
  */
-export function setValueForProperty(node, name, value) {
+export function setValueForProperty(node, name, value, isCustomComponentTag) {
   const propertyInfo = getPropertyInfo(name);
 
-  if (propertyInfo && shouldSetAttribute(name, value)) {
+  if (
+    !isCustomComponentTag &&
+    propertyInfo &&
+    shouldSetAttribute(name, value)
+  ) {
     if (shouldIgnoreValue(propertyInfo, value)) {
       if (propertyInfo.mustUseProperty) {
         if (propertyInfo.hasBooleanValue) {
@@ -146,11 +150,8 @@ export function setValueForProperty(node, name, value) {
       }
     }
   } else {
-    setValueForAttribute(
-      node,
-      name,
-      shouldSetAttribute(name, value) ? value : null,
-    );
+    const useValue = isCustomComponentTag || shouldSetAttribute(name, value);
+    setValueForAttribute(node, name, useValue ? value : null);
   }
 }
 

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -178,13 +178,3 @@ export function setValueForAttribute(node, name, value) {
     node.setAttribute(name, '' + value);
   }
 }
-
-/**
- * Deletes an attributes from a node.
- *
- * @param {DOMElement} node
- * @param {string} name
- */
-export function deleteValueForAttribute(node, name) {
-  node.removeAttribute(name);
-}

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import {
@@ -17,12 +19,17 @@ import {
  * The "expected" argument is used as a hint of what the expected value is.
  * Some properties have multiple equivalent values.
  */
-export function getValueForProperty(node, name, expected) {
+export function getValueForProperty(
+  node: Element,
+  name: string,
+  expected: mixed,
+): mixed {
   if (__DEV__) {
     const propertyInfo = getPropertyInfo(name);
     if (propertyInfo) {
       if (propertyInfo.mustUseProperty) {
-        return node[propertyInfo.propertyName];
+        const {propertyName} = propertyInfo;
+        return (node: any)[propertyName];
       } else {
         const attributeName = propertyInfo.attributeName;
 
@@ -37,7 +44,7 @@ export function getValueForProperty(node, name, expected) {
             if (shouldTreatAttributeValueAsNull(name, expected, false)) {
               return value;
             }
-            if (value === '' + expected) {
+            if (value === '' + (expected: any)) {
               return expected;
             }
             return value;
@@ -62,7 +69,7 @@ export function getValueForProperty(node, name, expected) {
 
         if (shouldTreatAttributeValueAsNull(name, expected, false)) {
           return stringValue === null ? expected : stringValue;
-        } else if (stringValue === '' + expected) {
+        } else if (stringValue === '' + (expected: any)) {
           return expected;
         } else {
           return stringValue;
@@ -77,7 +84,11 @@ export function getValueForProperty(node, name, expected) {
  * The third argument is used as a hint of what the expected value is. Some
  * attributes have multiple equivalent values.
  */
-export function getValueForAttribute(node, name, expected) {
+export function getValueForAttribute(
+  node: Element,
+  name: string,
+  expected: mixed,
+): mixed {
   if (__DEV__) {
     if (!isAttributeNameSafe(name)) {
       return;
@@ -86,7 +97,7 @@ export function getValueForAttribute(node, name, expected) {
       return expected === undefined ? undefined : null;
     }
     const value = node.getAttribute(name);
-    if (value === '' + expected) {
+    if (value === '' + (expected: any)) {
       return expected;
     }
     return value;
@@ -100,7 +111,12 @@ export function getValueForAttribute(node, name, expected) {
  * @param {string} name
  * @param {*} value
  */
-export function setValueForProperty(node, name, value, isCustomComponentTag) {
+export function setValueForProperty(
+  node: Element,
+  name: string,
+  value: mixed,
+  isCustomComponentTag: boolean,
+) {
   if (shouldSkipAttribute(name, isCustomComponentTag)) {
     return;
   }
@@ -115,7 +131,7 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
       if (value == null) {
         node.removeAttribute(attributeName);
       } else {
-        node.setAttribute(attributeName, '' + value);
+        node.setAttribute(attributeName, '' + (value: any));
       }
     }
     return;
@@ -128,11 +144,11 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
   if (mustUseProperty) {
     const {propertyName} = propertyInfo;
     if (value === null) {
-      node[propertyName] = hasBooleanValue ? false : '';
+      (node: any)[propertyName] = hasBooleanValue ? false : '';
     } else {
       // Contrary to `setAttribute`, object properties are properly
       // `toString`ed by IE8/9.
-      node[propertyName] = value;
+      (node: any)[propertyName] = value;
     }
     return;
   }
@@ -147,7 +163,7 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
     } else {
       // `setAttribute` with objects becomes only `[object]` in IE8/9,
       // ('' + value) makes it output the correct toString()-value.
-      attributeValue = '' + value;
+      attributeValue = '' + (value: any);
     }
     if (attributeNamespace) {
       node.setAttributeNS(attributeNamespace, attributeName, attributeValue);

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -7,7 +7,6 @@
 
 import {
   getPropertyInfo,
-  shouldIgnoreValue,
   shouldSkipAttribute,
   shouldTreatAttributeValueAsNull,
   isAttributeNameSafe,
@@ -35,7 +34,7 @@ export function getValueForProperty(node, name, expected) {
             if (value === '') {
               return true;
             }
-            if (shouldIgnoreValue(propertyInfo, expected)) {
+            if (shouldTreatAttributeValueAsNull(name, expected, false)) {
               return value;
             }
             if (value === '' + expected) {
@@ -44,7 +43,7 @@ export function getValueForProperty(node, name, expected) {
             return value;
           }
         } else if (node.hasAttribute(attributeName)) {
-          if (shouldIgnoreValue(propertyInfo, expected)) {
+          if (shouldTreatAttributeValueAsNull(name, expected, false)) {
             // We had an attribute but shouldn't have had one, so read it
             // for the error message.
             return node.getAttribute(attributeName);
@@ -61,7 +60,7 @@ export function getValueForProperty(node, name, expected) {
           stringValue = node.getAttribute(attributeName);
         }
 
-        if (shouldIgnoreValue(propertyInfo, expected)) {
+        if (shouldTreatAttributeValueAsNull(name, expected, false)) {
           return stringValue === null ? expected : stringValue;
         } else if (stringValue === '' + expected) {
           return expected;
@@ -128,7 +127,7 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
   } = propertyInfo;
   if (mustUseProperty) {
     const {propertyName} = propertyInfo;
-    if (shouldIgnoreValue(propertyInfo, value)) {
+    if (value === null) {
       node[propertyName] = hasBooleanValue ? false : '';
     } else {
       // Contrary to `setAttribute`, object properties are properly
@@ -139,7 +138,7 @@ export function setValueForProperty(node, name, value, isCustomComponentTag) {
   }
   // The rest are treated as attributes with special cases.
   const {attributeName, attributeNamespace} = propertyInfo;
-  if (shouldIgnoreValue(propertyInfo, value)) {
+  if (value === null) {
     node.removeAttribute(attributeName);
   } else {
     let attributeValue;

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -130,8 +130,15 @@ export function setValueForProperty(node, name, value) {
 
   if (propertyInfo && shouldSetAttribute(name, value)) {
     if (shouldIgnoreValue(propertyInfo, value)) {
-      deleteValueForProperty(node, name);
-      return;
+      if (propertyInfo.mustUseProperty) {
+        if (propertyInfo.hasBooleanValue) {
+          node[propertyInfo.propertyName] = false;
+        } else {
+          node[propertyInfo.propertyName] = '';
+        }
+      } else {
+        node.removeAttribute(propertyInfo.attributeName);
+      }
     } else if (propertyInfo.mustUseProperty) {
       // Contrary to `setAttribute`, object properties are properly
       // `toString`ed by IE8/9.
@@ -158,7 +165,6 @@ export function setValueForProperty(node, name, value) {
       name,
       shouldSetAttribute(name, value) ? value : null,
     );
-    return;
   }
 }
 
@@ -181,28 +187,4 @@ export function setValueForAttribute(node, name, value) {
  */
 export function deleteValueForAttribute(node, name) {
   node.removeAttribute(name);
-}
-
-/**
- * Deletes the value for a property on a node.
- *
- * @param {DOMElement} node
- * @param {string} name
- */
-function deleteValueForProperty(node, name) {
-  const propertyInfo = getPropertyInfo(name);
-  if (propertyInfo) {
-    if (propertyInfo.mustUseProperty) {
-      const propName = propertyInfo.propertyName;
-      if (propertyInfo.hasBooleanValue) {
-        node[propName] = false;
-      } else {
-        node[propName] = '';
-      }
-    } else {
-      node.removeAttribute(propertyInfo.attributeName);
-    }
-  } else {
-    node.removeAttribute(name);
-  }
 }

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -314,13 +314,13 @@ function setInitialDOMProperties(
         }
         ensureListeningTo(rootContainerElement, propKey);
       }
-    } else if (isCustomComponentTag) {
-      DOMPropertyOperations.setValueForAttribute(domElement, propKey, nextProp);
     } else if (nextProp != null) {
-      // If we're updating to null or undefined, we should remove the property
-      // from the DOM node instead of inadvertently setting to a string. This
-      // brings us in line with the same behavior we have on initial render.
-      DOMPropertyOperations.setValueForProperty(domElement, propKey, nextProp);
+      DOMPropertyOperations.setValueForProperty(
+        domElement,
+        propKey,
+        nextProp,
+        isCustomComponentTag,
+      );
     }
   }
 }
@@ -341,14 +341,13 @@ function updateDOMProperties(
       setInnerHTML(domElement, propValue);
     } else if (propKey === CHILDREN) {
       setTextContent(domElement, propValue);
-    } else if (isCustomComponentTag) {
-      DOMPropertyOperations.setValueForAttribute(
+    } else {
+      DOMPropertyOperations.setValueForProperty(
         domElement,
         propKey,
         propValue,
+        isCustomComponentTag,
       );
-    } else {
-      DOMPropertyOperations.setValueForProperty(domElement, propKey, propValue);
     }
   }
 }

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -26,8 +26,8 @@ import * as CSSPropertyOperations from '../shared/CSSPropertyOperations';
 import {Namespaces, getIntrinsicNamespace} from '../shared/DOMNamespaces';
 import {
   getPropertyInfo,
-  shouldSkipAttribute,
-  shouldTreatAttributeValueAsNull,
+  shouldIgnoreAttribute,
+  shouldRemoveAttribute,
 } from '../shared/DOMProperty';
 import assertValidProps from '../shared/assertValidProps';
 import {DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE} from '../shared/HTMLNodeType';
@@ -1009,8 +1009,8 @@ export function diffHydratedProperties(
           warnForPropDifference(propKey, serverValue, nextProp);
         }
       } else if (
-        !shouldSkipAttribute(propKey, propertyInfo, isCustomComponentTag) &&
-        !shouldTreatAttributeValueAsNull(
+        !shouldIgnoreAttribute(propKey, propertyInfo, isCustomComponentTag) &&
+        !shouldRemoveAttribute(
           propKey,
           nextProp,
           propertyInfo,

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -966,7 +966,7 @@ export function diffHydratedProperties(
     ) {
       // Validate that the properties correspond to their expected values.
       let serverValue;
-      let propertyInfo;
+      const propertyInfo = getPropertyInfo(propKey);
       if (suppressHydrationWarning) {
         // Don't bother comparing. We're ignoring all these warnings.
       } else if (
@@ -1009,14 +1009,15 @@ export function diffHydratedProperties(
           warnForPropDifference(propKey, serverValue, nextProp);
         }
       } else if (
-        !shouldSkipAttribute(propKey, isCustomComponentTag) &&
+        !shouldSkipAttribute(propKey, propertyInfo, isCustomComponentTag) &&
         !shouldTreatAttributeValueAsNull(
           propKey,
           nextProp,
+          propertyInfo,
           isCustomComponentTag,
         )
       ) {
-        if ((propertyInfo = getPropertyInfo(propKey))) {
+        if (propertyInfo !== null) {
           // $FlowFixMe - Should be inferred as not undefined.
           extraAttributeNames.delete(propertyInfo.attributeName);
           serverValue = DOMPropertyOperations.getValueForProperty(

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -1000,7 +1000,7 @@ export function diffHydratedProperties(
         if (nextProp !== serverValue) {
           warnForPropDifference(propKey, serverValue, nextProp);
         }
-      } else if (shouldSetAttribute(propKey, nextProp)) {
+      } else if (shouldSetAttribute(propKey, nextProp, isCustomComponentTag)) {
         if ((propertyInfo = getPropertyInfo(propKey))) {
           // $FlowFixMe - Should be inferred as not undefined.
           extraAttributeNames.delete(propertyInfo.attributeName);

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -351,13 +351,8 @@ function updateDOMProperties(
       } else {
         DOMPropertyOperations.deleteValueForAttribute(domElement, propKey);
       }
-    } else if (propValue != null) {
-      DOMPropertyOperations.setValueForProperty(domElement, propKey, propValue);
     } else {
-      // If we're updating to null or undefined, we should remove the property
-      // from the DOM node instead of inadvertently setting to a string. This
-      // brings us in line with the same behavior we have on initial render.
-      DOMPropertyOperations.deleteValueForProperty(domElement, propKey);
+      DOMPropertyOperations.setValueForProperty(domElement, propKey, propValue);
     }
   }
 }

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -959,7 +959,11 @@ export function diffHydratedProperties(
         }
         ensureListeningTo(rootContainerElement, propKey);
       }
-    } else if (__DEV__) {
+    } else if (
+      __DEV__ &&
+      // Convince Flow we've calculated it (it's DEV-only in this method.)
+      typeof isCustomComponentTag === 'boolean'
+    ) {
       // Validate that the properties correspond to their expected values.
       let serverValue;
       let propertyInfo;

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -342,15 +342,11 @@ function updateDOMProperties(
     } else if (propKey === CHILDREN) {
       setTextContent(domElement, propValue);
     } else if (isCustomComponentTag) {
-      if (propValue != null) {
-        DOMPropertyOperations.setValueForAttribute(
-          domElement,
-          propKey,
-          propValue,
-        );
-      } else {
-        DOMPropertyOperations.deleteValueForAttribute(domElement, propKey);
-      }
+      DOMPropertyOperations.setValueForAttribute(
+        domElement,
+        propKey,
+        propValue,
+      );
     } else {
       DOMPropertyOperations.setValueForProperty(domElement, propKey, propValue);
     }

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -24,7 +24,11 @@ import setTextContent from './setTextContent';
 import {listenTo, trapBubbledEvent} from '../events/ReactBrowserEventEmitter';
 import * as CSSPropertyOperations from '../shared/CSSPropertyOperations';
 import {Namespaces, getIntrinsicNamespace} from '../shared/DOMNamespaces';
-import {getPropertyInfo, shouldSetAttribute} from '../shared/DOMProperty';
+import {
+  getPropertyInfo,
+  shouldSkipAttribute,
+  shouldTreatAttributeValueAsNull,
+} from '../shared/DOMProperty';
 import assertValidProps from '../shared/assertValidProps';
 import {DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE} from '../shared/HTMLNodeType';
 import isCustomComponent from '../shared/isCustomComponent';
@@ -1000,7 +1004,14 @@ export function diffHydratedProperties(
         if (nextProp !== serverValue) {
           warnForPropDifference(propKey, serverValue, nextProp);
         }
-      } else if (shouldSetAttribute(propKey, nextProp, isCustomComponentTag)) {
+      } else if (
+        !shouldSkipAttribute(propKey, isCustomComponentTag) &&
+        !shouldTreatAttributeValueAsNull(
+          propKey,
+          nextProp,
+          isCustomComponentTag,
+        )
+      ) {
         if ((propertyInfo = getPropertyInfo(propKey))) {
           // $FlowFixMe - Should be inferred as not undefined.
           extraAttributeNames.delete(propertyInfo.attributeName);

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -1024,6 +1024,7 @@ export function diffHydratedProperties(
             domElement,
             propKey,
             nextProp,
+            propertyInfo,
           );
         } else {
           let ownNamespace = parentNamespace;

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -133,7 +133,7 @@ export function updateChecked(element: Element, props: Object) {
   const node = ((element: any): InputWithWrapperState);
   const checked = props.checked;
   if (checked != null) {
-    DOMPropertyOperations.setValueForProperty(node, 'checked', checked);
+    DOMPropertyOperations.setValueForProperty(node, 'checked', checked, false);
   }
 }
 

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -14,8 +14,8 @@ import {
   OVERLOADED_BOOLEAN,
   getPropertyInfo,
   isAttributeNameSafe,
-  shouldSkipAttribute,
-  shouldTreatAttributeValueAsNull,
+  shouldIgnoreAttribute,
+  shouldRemoveAttribute,
 } from '../shared/DOMProperty';
 import quoteAttributeValueForBrowser from './quoteAttributeValueForBrowser';
 
@@ -46,10 +46,10 @@ export function createMarkupForRoot(): string {
  */
 export function createMarkupForProperty(name: string, value: mixed): string {
   const propertyInfo = getPropertyInfo(name);
-  if (name !== 'style' && shouldSkipAttribute(name, propertyInfo, false)) {
+  if (name !== 'style' && shouldIgnoreAttribute(name, propertyInfo, false)) {
     return '';
   }
-  if (shouldTreatAttributeValueAsNull(name, value, propertyInfo, false)) {
+  if (shouldRemoveAttribute(name, value, propertyInfo, false)) {
     return '';
   }
   if (propertyInfo) {

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -45,9 +45,6 @@ export function createMarkupForProperty(name, value) {
     return '';
   }
   if (shouldTreatAttributeValueAsNull(name, value, false)) {
-    value = null;
-  }
-  if (value === null) {
     return '';
   }
   const propertyInfo = getPropertyInfo(name);

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -10,22 +10,11 @@ import {
   ROOT_ATTRIBUTE_NAME,
   getPropertyInfo,
   shouldAttributeAcceptBooleanValue,
+  shouldIgnoreValue,
   shouldSetAttribute,
   isAttributeNameSafe,
 } from '../shared/DOMProperty';
 import quoteAttributeValueForBrowser from './quoteAttributeValueForBrowser';
-
-// shouldIgnoreValue() is currently duplicated in DOMPropertyOperations.
-// TODO: Find a better place for this.
-function shouldIgnoreValue(propertyInfo, value) {
-  return (
-    value == null ||
-    (propertyInfo.hasBooleanValue && !value) ||
-    (propertyInfo.hasNumericValue && isNaN(value)) ||
-    (propertyInfo.hasPositiveNumericValue && value < 1) ||
-    (propertyInfo.hasOverloadedBooleanValue && value === false)
-  );
-}
 
 /**
  * Operations for dealing with DOM properties.

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -9,10 +9,9 @@ import {
   ID_ATTRIBUTE_NAME,
   ROOT_ATTRIBUTE_NAME,
   getPropertyInfo,
-  shouldAttributeAcceptBooleanValue,
-  shouldIgnoreValue,
-  shouldSetAttribute,
   isAttributeNameSafe,
+  shouldSkipAttribute,
+  shouldTreatAttributeValueAsNull,
 } from '../shared/DOMProperty';
 import quoteAttributeValueForBrowser from './quoteAttributeValueForBrowser';
 
@@ -42,30 +41,29 @@ export function createMarkupForRoot() {
  * @return {?string} Markup string, or null if the property was invalid.
  */
 export function createMarkupForProperty(name, value) {
+  if (name !== 'style' && shouldSkipAttribute(name)) {
+    return '';
+  }
+  if (shouldTreatAttributeValueAsNull(name, value, false)) {
+    value = null;
+  }
+  if (value === null) {
+    return '';
+  }
   const propertyInfo = getPropertyInfo(name);
   if (propertyInfo) {
-    if (shouldIgnoreValue(propertyInfo, value)) {
-      return '';
-    }
     const attributeName = propertyInfo.attributeName;
     if (
       propertyInfo.hasBooleanValue ||
       (propertyInfo.hasOverloadedBooleanValue && value === true)
     ) {
       return attributeName + '=""';
-    } else if (
-      typeof value !== 'boolean' ||
-      shouldAttributeAcceptBooleanValue(name, false)
-    ) {
+    } else {
       return attributeName + '=' + quoteAttributeValueForBrowser(value);
     }
-  } else if (shouldSetAttribute(name, value, false)) {
-    if (value == null) {
-      return '';
-    }
+  } else {
     return name + '=' + quoteAttributeValueForBrowser(value);
   }
-  return null;
 }
 
 /**

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -52,12 +52,10 @@ export function createMarkupForProperty(name: string, value: mixed): string {
   if (shouldRemoveAttribute(name, value, propertyInfo, false)) {
     return '';
   }
-  if (propertyInfo) {
+  if (propertyInfo !== null) {
     const attributeName = propertyInfo.attributeName;
-    if (
-      propertyInfo.type === BOOLEAN ||
-      (propertyInfo.type === OVERLOADED_BOOLEAN && value === true)
-    ) {
+    const {type} = propertyInfo;
+    if (type === BOOLEAN || (type === OVERLOADED_BOOLEAN && value === true)) {
       return attributeName + '=""';
     } else {
       return attributeName + '=' + quoteAttributeValueForBrowser(value);

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import {
@@ -25,11 +27,11 @@ import quoteAttributeValueForBrowser from './quoteAttributeValueForBrowser';
  * @param {string} id Unescaped ID.
  * @return {string} Markup string.
  */
-export function createMarkupForID(id) {
+export function createMarkupForID(id: string): string {
   return ID_ATTRIBUTE_NAME + '=' + quoteAttributeValueForBrowser(id);
 }
 
-export function createMarkupForRoot() {
+export function createMarkupForRoot(): string {
   return ROOT_ATTRIBUTE_NAME + '=""';
 }
 
@@ -40,7 +42,7 @@ export function createMarkupForRoot() {
  * @param {*} value
  * @return {?string} Markup string, or null if the property was invalid.
  */
-export function createMarkupForProperty(name, value) {
+export function createMarkupForProperty(name: string, value: mixed): string {
   if (name !== 'style' && shouldSkipAttribute(name, false)) {
     return '';
   }
@@ -70,7 +72,10 @@ export function createMarkupForProperty(name, value) {
  * @param {*} value
  * @return {string} Markup string, or empty string if the property was invalid.
  */
-export function createMarkupForCustomAttribute(name, value) {
+export function createMarkupForCustomAttribute(
+  name: string,
+  value: mixed,
+): string {
   if (!isAttributeNameSafe(name) || value == null) {
     return '';
   }

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -66,11 +66,11 @@ export function createMarkupForProperty(name, value) {
       return attributeName + '=""';
     } else if (
       typeof value !== 'boolean' ||
-      shouldAttributeAcceptBooleanValue(name)
+      shouldAttributeAcceptBooleanValue(name, false)
     ) {
       return attributeName + '=' + quoteAttributeValueForBrowser(value);
     }
-  } else if (shouldSetAttribute(name, value)) {
+  } else if (shouldSetAttribute(name, value, false)) {
     if (value == null) {
       return '';
     }

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -10,6 +10,8 @@
 import {
   ID_ATTRIBUTE_NAME,
   ROOT_ATTRIBUTE_NAME,
+  BOOLEAN,
+  OVERLOADED_BOOLEAN,
   getPropertyInfo,
   isAttributeNameSafe,
   shouldSkipAttribute,
@@ -53,8 +55,8 @@ export function createMarkupForProperty(name: string, value: mixed): string {
   if (propertyInfo) {
     const attributeName = propertyInfo.attributeName;
     if (
-      propertyInfo.hasBooleanValue ||
-      (propertyInfo.hasOverloadedBooleanValue && value === true)
+      propertyInfo.type === BOOLEAN ||
+      (propertyInfo.type === OVERLOADED_BOOLEAN && value === true)
     ) {
       return attributeName + '=""';
     } else {

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -41,7 +41,7 @@ export function createMarkupForRoot() {
  * @return {?string} Markup string, or null if the property was invalid.
  */
 export function createMarkupForProperty(name, value) {
-  if (name !== 'style' && shouldSkipAttribute(name)) {
+  if (name !== 'style' && shouldSkipAttribute(name, false)) {
     return '';
   }
   if (shouldTreatAttributeValueAsNull(name, value, false)) {

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -43,13 +43,13 @@ export function createMarkupForRoot(): string {
  * @return {?string} Markup string, or null if the property was invalid.
  */
 export function createMarkupForProperty(name: string, value: mixed): string {
-  if (name !== 'style' && shouldSkipAttribute(name, false)) {
-    return '';
-  }
-  if (shouldTreatAttributeValueAsNull(name, value, false)) {
-    return '';
-  }
   const propertyInfo = getPropertyInfo(name);
+  if (name !== 'style' && shouldSkipAttribute(name, propertyInfo, false)) {
+    return '';
+  }
+  if (shouldTreatAttributeValueAsNull(name, value, propertyInfo, false)) {
+    return '';
+  }
   if (propertyInfo) {
     const attributeName = propertyInfo.attributeName;
     if (

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -10,6 +10,7 @@
 import warning from 'fbjs/lib/warning';
 
 export type PropertyInfo = {|
+  acceptsBooleanValue: boolean,
   attributeName: string,
   attributeNamespace: string | null,
   propertyName: string,
@@ -54,24 +55,37 @@ function injectDOMPropertyConfig(domPropertyConfig) {
     const lowerCased = propName.toLowerCase();
     const propConfig = Properties[propName];
 
+    const isReserved = checkMask(propConfig, IS_RESERVED);
+    const mustUseProperty = checkMask(propConfig, MUST_USE_PROPERTY);
+    const hasBooleanValue = checkMask(propConfig, HAS_BOOLEAN_VALUE);
+    const hasNumericValue = checkMask(propConfig, HAS_NUMERIC_VALUE);
+    const hasPositiveNumericValue = checkMask(
+      propConfig,
+      HAS_POSITIVE_NUMERIC_VALUE,
+    );
+    const hasOverloadedBooleanValue = checkMask(
+      propConfig,
+      HAS_OVERLOADED_BOOLEAN_VALUE,
+    );
+    const hasStringBooleanValue = checkMask(
+      propConfig,
+      HAS_STRING_BOOLEAN_VALUE,
+    );
+    const acceptsBooleanValue =
+      hasBooleanValue || hasOverloadedBooleanValue || hasStringBooleanValue;
+
     const propertyInfo: PropertyInfo = {
       attributeName: lowerCased,
       attributeNamespace: null,
+      acceptsBooleanValue,
       propertyName: propName,
-
-      mustUseProperty: checkMask(propConfig, MUST_USE_PROPERTY),
-      hasBooleanValue: checkMask(propConfig, HAS_BOOLEAN_VALUE),
-      hasNumericValue: checkMask(propConfig, HAS_NUMERIC_VALUE),
-      hasPositiveNumericValue: checkMask(
-        propConfig,
-        HAS_POSITIVE_NUMERIC_VALUE,
-      ),
-      hasOverloadedBooleanValue: checkMask(
-        propConfig,
-        HAS_OVERLOADED_BOOLEAN_VALUE,
-      ),
-      hasStringBooleanValue: checkMask(propConfig, HAS_STRING_BOOLEAN_VALUE),
-      isReserved: checkMask(propConfig, IS_RESERVED),
+      isReserved,
+      mustUseProperty,
+      hasBooleanValue,
+      hasNumericValue,
+      hasPositiveNumericValue,
+      hasOverloadedBooleanValue,
+      hasStringBooleanValue,
     };
     if (__DEV__) {
       warning(
@@ -204,11 +218,7 @@ export function isBadlyTypedAttributeValue(
         return false;
       }
       if (propertyInfo !== null) {
-        return !(
-          propertyInfo.hasBooleanValue ||
-          propertyInfo.hasStringBooleanValue ||
-          propertyInfo.hasOverloadedBooleanValue
-        );
+        return !propertyInfo.acceptsBooleanValue;
       } else {
         const prefix = name.toLowerCase().slice(0, 5);
         return prefix !== 'data-' && prefix !== 'aria-';

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -180,17 +180,7 @@ export function shouldSkipAttribute(name, isCustomComponentTag) {
   return false;
 }
 
-export function shouldTreatAttributeValueAsNull(
-  name,
-  value,
-  isCustomComponentTag,
-) {
-  if (value === null) {
-    return true;
-  }
-  if (isCustomComponentTag) {
-    return typeof value === 'undefined';
-  }
+export function isBadlyTypedAttributeValue(name, value, isCustomComponentTag) {
   switch (typeof value) {
     case 'boolean':
       return !shouldAttributeAcceptBooleanValue(name, isCustomComponentTag);
@@ -205,14 +195,25 @@ export function shouldTreatAttributeValueAsNull(
   }
 }
 
+export function shouldTreatAttributeValueAsNull(
+  name,
+  value,
+  isCustomComponentTag,
+) {
+  if (value === null || typeof value === 'undefined') {
+    return true;
+  }
+  if (isBadlyTypedAttributeValue(name, value, isCustomComponentTag)) {
+    return true;
+  }
+  return false;
+}
+
 export function shouldSetAttribute(name, value, isCustomComponentTag) {
   if (shouldSkipAttribute(name, isCustomComponentTag)) {
     return false;
   }
-  if (
-    value !== null &&
-    shouldTreatAttributeValueAsNull(name, value, isCustomComponentTag)
-  ) {
+  if (shouldTreatAttributeValueAsNull(name, value, isCustomComponentTag)) {
     return false;
   }
   return true;

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -240,10 +240,10 @@ export function shouldTreatAttributeValueAsNull(
   }
   const propertyInfo = getPropertyInfo(name);
   if (propertyInfo) {
-    if (propertyInfo.hasBooleanValue) {
-      return !value;
-    } else if (propertyInfo.hasOverloadedBooleanValue) {
-      return value === false;
+    if (propertyInfo.hasBooleanValue && !value) {
+      return true;
+    } else if (propertyInfo.hasOverloadedBooleanValue && value === false) {
+      return true;
     } else if (propertyInfo.hasNumericValue && isNaN(value)) {
       return true;
     } else if (propertyInfo.hasPositiveNumericValue && (value: any) < 1) {

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -234,16 +234,6 @@ export function shouldTreatAttributeValueAsNull(
   return false;
 }
 
-export function shouldSetAttribute(name, value, isCustomComponentTag) {
-  if (shouldSkipAttribute(name, isCustomComponentTag)) {
-    return false;
-  }
-  if (shouldTreatAttributeValueAsNull(name, value, isCustomComponentTag)) {
-    return false;
-  }
-  return true;
-}
-
 export function getPropertyInfo(name) {
   return properties.hasOwnProperty(name) ? properties[name] : null;
 }

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -81,8 +81,8 @@ export function shouldSkipAttribute(
   propertyInfo: PropertyInfo | null,
   isCustomComponentTag: boolean,
 ): boolean {
-  if (propertyInfo !== null && propertyInfo.type === RESERVED) {
-    return true;
+  if (propertyInfo !== null) {
+    return propertyInfo.type === RESERVED;
   }
   if (isCustomComponentTag) {
     return false;

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -76,7 +76,7 @@ export function isAttributeNameSafe(attributeName: string): boolean {
   return false;
 }
 
-export function shouldSkipAttribute(
+export function shouldIgnoreAttribute(
   name: string,
   propertyInfo: PropertyInfo | null,
   isCustomComponentTag: boolean,
@@ -97,7 +97,7 @@ export function shouldSkipAttribute(
   return false;
 }
 
-export function isBadlyTypedAttributeValue(
+export function shouldRemoveAttributeWithWarning(
   name: string,
   value: mixed,
   propertyInfo: PropertyInfo | null,
@@ -127,7 +127,7 @@ export function isBadlyTypedAttributeValue(
   }
 }
 
-export function shouldTreatAttributeValueAsNull(
+export function shouldRemoveAttribute(
   name: string,
   value: mixed,
   propertyInfo: PropertyInfo | null,
@@ -137,7 +137,12 @@ export function shouldTreatAttributeValueAsNull(
     return true;
   }
   if (
-    isBadlyTypedAttributeValue(name, value, propertyInfo, isCustomComponentTag)
+    shouldRemoveAttributeWithWarning(
+      name,
+      value,
+      propertyInfo,
+      isCustomComponentTag,
+    )
   ) {
     return true;
   }

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -208,7 +208,7 @@ export function isBadlyTypedAttributeValue(
   switch (typeof value) {
     case 'function':
     // $FlowIssue symbol is perfectly valid here
-    case 'symbol':
+    case 'symbol': // eslint-disable-line
       return true;
     case 'boolean':
       break;

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -9,7 +9,7 @@
 
 import warning from 'fbjs/lib/warning';
 
-type PropertyInfo = {|
+export type PropertyInfo = {|
   attributeName: string,
   attributeNamespace: string | null,
   propertyName: string,

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -199,23 +199,24 @@ export function isBadlyTypedAttributeValue(
     // $FlowIssue symbol is perfectly valid here
     case 'symbol': // eslint-disable-line
       return true;
-    case 'boolean':
-      break;
+    case 'boolean': {
+      if (isCustomComponentTag) {
+        return false;
+      }
+      if (propertyInfo !== null) {
+        return !(
+          propertyInfo.hasBooleanValue ||
+          propertyInfo.hasStringBooleanValue ||
+          propertyInfo.hasOverloadedBooleanValue
+        );
+      } else {
+        const prefix = name.toLowerCase().slice(0, 5);
+        return prefix !== 'data-' && prefix !== 'aria-';
+      }
+    }
     default:
       return false;
   }
-  if (isCustomComponentTag) {
-    return false;
-  }
-  if (propertyInfo !== null) {
-    return !(
-      propertyInfo.hasBooleanValue ||
-      propertyInfo.hasStringBooleanValue ||
-      propertyInfo.hasOverloadedBooleanValue
-    );
-  }
-  const prefix = name.toLowerCase().slice(0, 5);
-  return prefix !== 'data-' && prefix !== 'aria-';
 }
 
 export function shouldTreatAttributeValueAsNull(

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -238,6 +238,11 @@ export function shouldTreatAttributeValueAsNull(
   if (value === null || typeof value === 'undefined') {
     return true;
   }
+  if (
+    isBadlyTypedAttributeValue(name, value, propertyInfo, isCustomComponentTag)
+  ) {
+    return true;
+  }
   if (propertyInfo !== null) {
     if (propertyInfo.hasBooleanValue && !value) {
       return true;
@@ -249,12 +254,7 @@ export function shouldTreatAttributeValueAsNull(
       return true;
     }
   }
-  return isBadlyTypedAttributeValue(
-    name,
-    value,
-    propertyInfo,
-    isCustomComponentTag,
-  );
+  return false;
 }
 
 export function getPropertyInfo(name: string): PropertyInfo | null {

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -228,10 +228,7 @@ export function shouldTreatAttributeValueAsNull(
       return true;
     }
   }
-  if (isBadlyTypedAttributeValue(name, value, isCustomComponentTag)) {
-    return true;
-  }
-  return false;
+  return isBadlyTypedAttributeValue(name, value, isCustomComponentTag);
 }
 
 export function getPropertyInfo(name) {

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -431,7 +431,7 @@ const capitalize = token => token[1].toUpperCase();
     'http://www.w3.org/XML/1998/namespace',
   );
 });
-properties['xmlnsXlink'] = new PropertyInfoRecord(
+properties.xmlnsXlink = new PropertyInfoRecord(
   'xmlnsXlink',
   STRING,
   false, // mustUseProperty

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -3,9 +3,23 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import warning from 'fbjs/lib/warning';
+
+type PropertyInfo = {|
+  attributeName: string,
+  attributeNamespace: string | null,
+  propertyName: string,
+  mustUseProperty: boolean,
+  hasBooleanValue: boolean,
+  hasNumericValue: boolean,
+  hasPositiveNumericValue: boolean,
+  hasOverloadedBooleanValue: boolean,
+  hasStringBooleanValue: boolean,
+|};
 
 // These attributes should be all lowercase to allow for
 // case insensitive checks
@@ -54,7 +68,7 @@ function injectDOMPropertyConfig(domPropertyConfig) {
     const lowerCased = propName.toLowerCase();
     const propConfig = Properties[propName];
 
-    const propertyInfo = {
+    const propertyInfo: PropertyInfo = {
       attributeName: lowerCased,
       attributeNamespace: null,
       propertyName: propName,
@@ -118,7 +132,7 @@ export const VALID_ATTRIBUTE_NAME_REGEX = new RegExp(
 const illegalAttributeNameCache = {};
 const validatedAttributeNameCache = {};
 
-export function isAttributeNameSafe(attributeName) {
+export function isAttributeNameSafe(attributeName: string): boolean {
   if (validatedAttributeNameCache.hasOwnProperty(attributeName)) {
     return true;
   }
@@ -163,7 +177,10 @@ export function isAttributeNameSafe(attributeName) {
  */
 export const properties = {};
 
-export function shouldSkipAttribute(name, isCustomComponentTag) {
+export function shouldSkipAttribute(
+  name: string,
+  isCustomComponentTag: boolean,
+): boolean {
   if (isReservedProp(name)) {
     return true;
   }
@@ -180,12 +197,17 @@ export function shouldSkipAttribute(name, isCustomComponentTag) {
   return false;
 }
 
-export function isBadlyTypedAttributeValue(name, value, isCustomComponentTag) {
+export function isBadlyTypedAttributeValue(
+  name: string,
+  value: mixed,
+  isCustomComponentTag: boolean,
+): boolean {
   if (isReservedProp(name)) {
     return false;
   }
   switch (typeof value) {
     case 'function':
+    // $FlowIssue symbol is perfectly valid here
     case 'symbol':
       return true;
     case 'boolean':
@@ -209,10 +231,10 @@ export function isBadlyTypedAttributeValue(name, value, isCustomComponentTag) {
 }
 
 export function shouldTreatAttributeValueAsNull(
-  name,
-  value,
-  isCustomComponentTag,
-) {
+  name: string,
+  value: mixed,
+  isCustomComponentTag: boolean,
+): boolean {
   if (value === null || typeof value === 'undefined') {
     return true;
   }
@@ -224,14 +246,14 @@ export function shouldTreatAttributeValueAsNull(
       return value === false;
     } else if (propertyInfo.hasNumericValue && isNaN(value)) {
       return true;
-    } else if (propertyInfo.hasPositiveNumericValue && value < 1) {
+    } else if (propertyInfo.hasPositiveNumericValue && (value: any) < 1) {
       return true;
     }
   }
   return isBadlyTypedAttributeValue(name, value, isCustomComponentTag);
 }
 
-export function getPropertyInfo(name) {
+export function getPropertyInfo(name: string): PropertyInfo | null {
   return properties.hasOwnProperty(name) ? properties[name] : null;
 }
 
@@ -244,7 +266,7 @@ export function getPropertyInfo(name) {
  * @param {string} name
  * @return {boolean} If the name is within reserved props
  */
-export function isReservedProp(name) {
+export function isReservedProp(name: string): boolean {
   return RESERVED_PROPS.hasOwnProperty(name);
 }
 

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -218,6 +218,16 @@ export function shouldSetAttribute(name, value, isCustomComponentTag) {
   return true;
 }
 
+export function shouldIgnoreValue(propertyInfo, value) {
+  return (
+    value == null ||
+    (propertyInfo.hasBooleanValue && !value) ||
+    (propertyInfo.hasNumericValue && isNaN(value)) ||
+    (propertyInfo.hasPositiveNumericValue && value < 1) ||
+    (propertyInfo.hasOverloadedBooleanValue && value === false)
+  );
+}
+
 export function getPropertyInfo(name) {
   return properties.hasOwnProperty(name) ? properties[name] : null;
 }

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -191,7 +191,7 @@ if (__DEV__) {
 
     if (
       typeof value === 'boolean' &&
-      !shouldAttributeAcceptBooleanValue(name)
+      !shouldAttributeAcceptBooleanValue(name, false)
     ) {
       if (value) {
         warning(
@@ -235,7 +235,7 @@ if (__DEV__) {
     }
 
     // Warn when a known attribute is a bad type
-    if (!shouldSetAttribute(name, value)) {
+    if (!shouldSetAttribute(name, value, false)) {
       warnedProperties[name] = true;
       return false;
     }

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -14,8 +14,8 @@ import warning from 'fbjs/lib/warning';
 
 import {
   ATTRIBUTE_NAME_CHAR,
-  isReservedProp,
   isBadlyTypedAttributeValue,
+  getPropertyInfo,
 } from './DOMProperty';
 import isCustomComponent from './isCustomComponent';
 import possibleStandardNames from './possibleStandardNames';
@@ -154,7 +154,8 @@ if (__DEV__) {
       return true;
     }
 
-    const isReserved = isReservedProp(name);
+    const propertyInfo = getPropertyInfo(name);
+    const isReserved = propertyInfo !== null && propertyInfo.isReserved;
 
     // Known attributes should match the casing specified in the property config.
     if (possibleStandardNames.hasOwnProperty(lowerCasedName)) {
@@ -190,7 +191,7 @@ if (__DEV__) {
 
     if (
       typeof value === 'boolean' &&
-      isBadlyTypedAttributeValue(name, value, false)
+      isBadlyTypedAttributeValue(name, value, propertyInfo, false)
     ) {
       if (value) {
         warning(
@@ -234,7 +235,7 @@ if (__DEV__) {
     }
 
     // Warn when a known attribute is a bad type
-    if (isBadlyTypedAttributeValue(name, value, false)) {
+    if (isBadlyTypedAttributeValue(name, value, propertyInfo, false)) {
       warnedProperties[name] = true;
       return false;
     }

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -14,6 +14,7 @@ import warning from 'fbjs/lib/warning';
 
 import {
   ATTRIBUTE_NAME_CHAR,
+  RESERVED,
   isBadlyTypedAttributeValue,
   getPropertyInfo,
 } from './DOMProperty';
@@ -155,7 +156,7 @@ if (__DEV__) {
     }
 
     const propertyInfo = getPropertyInfo(name);
-    const isReserved = propertyInfo !== null && propertyInfo.isReserved;
+    const isReserved = propertyInfo !== null && propertyInfo.type === RESERVED;
 
     // Known attributes should match the casing specified in the property config.
     if (possibleStandardNames.hasOwnProperty(lowerCasedName)) {

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -15,7 +15,7 @@ import warning from 'fbjs/lib/warning';
 import {
   ATTRIBUTE_NAME_CHAR,
   RESERVED,
-  isBadlyTypedAttributeValue,
+  shouldRemoveAttributeWithWarning,
   getPropertyInfo,
 } from './DOMProperty';
 import isCustomComponent from './isCustomComponent';
@@ -192,7 +192,7 @@ if (__DEV__) {
 
     if (
       typeof value === 'boolean' &&
-      isBadlyTypedAttributeValue(name, value, propertyInfo, false)
+      shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)
     ) {
       if (value) {
         warning(
@@ -236,7 +236,7 @@ if (__DEV__) {
     }
 
     // Warn when a known attribute is a bad type
-    if (isBadlyTypedAttributeValue(name, value, propertyInfo, false)) {
+    if (shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)) {
       warnedProperties[name] = true;
       return false;
     }

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -15,8 +15,7 @@ import warning from 'fbjs/lib/warning';
 import {
   ATTRIBUTE_NAME_CHAR,
   isReservedProp,
-  shouldAttributeAcceptBooleanValue,
-  shouldSetAttribute,
+  isBadlyTypedAttributeValue,
 } from './DOMProperty';
 import isCustomComponent from './isCustomComponent';
 import possibleStandardNames from './possibleStandardNames';
@@ -191,7 +190,7 @@ if (__DEV__) {
 
     if (
       typeof value === 'boolean' &&
-      !shouldAttributeAcceptBooleanValue(name, false)
+      isBadlyTypedAttributeValue(name, value, false)
     ) {
       if (value) {
         warning(
@@ -235,7 +234,7 @@ if (__DEV__) {
     }
 
     // Warn when a known attribute is a bad type
-    if (!shouldSetAttribute(name, value, false)) {
+    if (isBadlyTypedAttributeValue(name, value, false)) {
       warnedProperties[name] = true;
       return false;
     }


### PR DESCRIPTION
Re-submit of https://github.com/facebook/react/pull/11804 which I reverted.

There's still a bug here. `shouldTreatAsNull` is the wrong way to think about it because this causes booleans that default to `true` to become `false` whereas our intention is to ignore them for functions/symbols.

I'll need to look at this again and figure out how to fix this.