### PR TITLE
Deduplication of warn when selected is set on <option>

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -567,12 +567,21 @@ describe('ReactDOMSelect', () => {
       </select>,
     );
     if (__DEV__) {
+      // Test deduplication
+      expect(console.error.calls.count()).toBe(1);
+    }
+
+    ReactTestUtils.renderIntoDocument(
+      <select>
+        <option selected={true} />
+        <option selected={true} />
+      </select>,
+    );
+    if (__DEV__) {
       expect(console.error.calls.argsFor(0)[0]).toContain(
         'Use the `defaultValue` or `value` props on <select> instead of ' +
           'setting `selected` on <option>.',
       );
-      // Test deduplication
-      expect(console.error.calls.count()).toBe(1);
     }
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -556,10 +556,10 @@ describe('ReactDOMSelect', () => {
       expect(console.error.calls.count()).toBe(1);
     }
   });
-  
+
   it('should warn if selected is set on <option>', () => {
     spyOnDev(console, 'error');
-  
+
     ReactTestUtils.renderIntoDocument(
       <select>
         <option selected={true} />

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -540,6 +540,7 @@ describe('ReactDOMSelect', () => {
       </select>,
     );
     if (__DEV__) {
+      expect(console.error.calls.count()).toBe(1);
       expect(console.error.calls.argsFor(0)[0]).toContain(
         '`value` prop on `select` should not be null. ' +
           'Consider using an empty string to clear the component or `undefined` ' +
@@ -577,12 +578,11 @@ describe('ReactDOMSelect', () => {
       </select>,
     );
     if (__DEV__) {
+      expect(console.error.calls.count()).toBe(1);
       expect(console.error.calls.argsFor(0)[0]).toContain(
         'Use the `defaultValue` or `value` props on <select> instead of ' +
           'setting `selected` on <option>.',
       );
-      // Test deduplication
-      expect(console.error.calls.count()).toBe(1);
     }
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -567,7 +567,6 @@ describe('ReactDOMSelect', () => {
       </select>,
     );
     if (__DEV__) {
-      // Test deduplication
       expect(console.error.calls.count()).toBe(1);
     }
 
@@ -582,6 +581,8 @@ describe('ReactDOMSelect', () => {
         'Use the `defaultValue` or `value` props on <select> instead of ' +
           'setting `selected` on <option>.',
       );
+      // Test deduplication
+      expect(console.error.calls.count()).toBe(1);
     }
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -556,6 +556,25 @@ describe('ReactDOMSelect', () => {
       expect(console.error.calls.count()).toBe(1);
     }
   });
+  
+  it('should warn if selected is set on <option>', () => {
+    spyOnDev(console, 'error');
+  
+    ReactTestUtils.renderIntoDocument(
+      <select>
+        <option selected={true} />
+        <option selected={true} />
+      </select>,
+    );
+    if (__DEV__) {
+      expect(console.error.calls.argsFor(0)[0]).toContain(
+        'Use the `defaultValue` or `value` props on <select> instead of ' +
+          'setting `selected` on <option>.',
+      );
+      // Test deduplication
+      expect(console.error.calls.count()).toBe(1);
+    }
+  });
 
   it('should warn if value is null and multiple is true', () => {
     spyOnDev(console, 'error');

--- a/packages/react-dom/src/client/ReactDOMFiberOption.js
+++ b/packages/react-dom/src/client/ReactDOMFiberOption.js
@@ -37,13 +37,15 @@ function flattenChildren(children) {
 
 export function validateProps(element: Element, props: Object) {
   // TODO (yungsters): Remove support for `selected` in <option>.
-  if (__DEV__ && !didWarnSelectedSetOnOption) {
-    warning(
-      props.selected == null,
-      'Use the `defaultValue` or `value` props on <select> instead of ' +
-        'setting `selected` on <option>.',
-    );
-    didWarnSelectedSetOnOption = true;
+  if (__DEV__) {
+    if (!didWarnSelectedSetOnOption) {
+      warning(
+        props.selected == null,
+        'Use the `defaultValue` or `value` props on <select> instead of ' +
+          'setting `selected` on <option>.',
+      );
+      didWarnSelectedSetOnOption = true;
+    }
   }
 }
 

--- a/packages/react-dom/src/client/ReactDOMFiberOption.js
+++ b/packages/react-dom/src/client/ReactDOMFiberOption.js
@@ -10,6 +10,8 @@
 import React from 'react';
 import warning from 'fbjs/lib/warning';
 
+let didWarnSelectedSetOnOption = false;
+
 function flattenChildren(children) {
   let content = '';
 
@@ -35,12 +37,13 @@ function flattenChildren(children) {
 
 export function validateProps(element: Element, props: Object) {
   // TODO (yungsters): Remove support for `selected` in <option>.
-  if (__DEV__) {
+  if (__DEV__ && !didWarnSelectedSetOnOption) {
     warning(
       props.selected == null,
       'Use the `defaultValue` or `value` props on <select> instead of ' +
         'setting `selected` on <option>.',
     );
+    didWarnSelectedSetOnOption = true;
   }
 }
 


### PR DESCRIPTION
Deduplication of warning when selected is set on `<option>` instead of `<select>`. Closes: #11795 

**Test check list:**

- [x] Ran `yarn`
- [x] Wrote a failing test
- [x] Fixed failing test
- [x] Passed all tests with `yarn test`, `yarn test-prod`
- [x] Ran `yarn prettier`
- [x] Ran `yarn lint`
- [x] Ran `yarn flow`
- [x] Completed CLA