### PR TITLE
Remove unused wheel event detection in isEventSupported

### DIFF
--- a/packages/react-dom/src/events/isEventSupported.js
+++ b/packages/react-dom/src/events/isEventSupported.js
@@ -7,16 +7,6 @@
 
 import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 
-let useHasFeature;
-if (ExecutionEnvironment.canUseDOM) {
-  useHasFeature =
-    document.implementation &&
-    document.implementation.hasFeature &&
-    // always returns true in newer browsers as per the standard.
-    // @see http://dom.spec.whatwg.org/#dom-domimplementation-hasfeature
-    document.implementation.hasFeature('', '') !== true;
-}
-
 /**
  * Checks if an event is supported in the current execution environment.
  *
@@ -46,11 +36,6 @@ function isEventSupported(eventNameSuffix, capture) {
     const element = document.createElement('div');
     element.setAttribute(eventName, 'return;');
     isSupported = typeof element[eventName] === 'function';
-  }
-
-  if (!isSupported && useHasFeature && eventNameSuffix === 'wheel') {
-    // This is the only way to test support for the `wheel` event in IE9+.
-    isSupported = document.implementation.hasFeature('Events.wheel', '3.0');
   }
 
   return isSupported;


### PR DESCRIPTION
Just noticed this working through #9333. We don't check for wheel support anymore, so this code can be removed.