### PR TITLE
fix #11759. false positive warning in IE11 when using React.Fragment

### DIFF
--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -15,11 +15,7 @@
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import getComponentName from 'shared/getComponentName';
-import {
-  getIteratorFn,
-  REACT_FRAGMENT_TYPE,
-  isReactSymbol,
-} from 'shared/ReactSymbols';
+import {getIteratorFn, REACT_FRAGMENT_TYPE} from 'shared/ReactSymbols';
 import checkPropTypes from 'prop-types/checkPropTypes';
 import warning from 'fbjs/lib/warning';
 
@@ -285,8 +281,8 @@ export function createElementWithValidation(type, props, children) {
   const validType =
     typeof type === 'string' ||
     typeof type === 'function' ||
-    isReactSymbol(type) ||
-    typeof type === 'number';
+    typeof type === 'number' ||
+    type === 'REACT_FRAGMENT_TYPE';
   // We warn in this case but don't throw. We expect the element creation to
   // succeed and there will likely be errors in render.
   if (!validType) {

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -15,7 +15,11 @@
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import getComponentName from 'shared/getComponentName';
-import {getIteratorFn, REACT_FRAGMENT_TYPE} from 'shared/ReactSymbols';
+import {
+  getIteratorFn,
+  REACT_FRAGMENT_TYPE,
+  isReactSymbol,
+} from 'shared/ReactSymbols';
 import checkPropTypes from 'prop-types/checkPropTypes';
 import warning from 'fbjs/lib/warning';
 
@@ -281,7 +285,7 @@ export function createElementWithValidation(type, props, children) {
   const validType =
     typeof type === 'string' ||
     typeof type === 'function' ||
-    typeof type === 'symbol' ||
+    isReactSymbol(type) ||
     typeof type === 'number';
   // We warn in this case but don't throw. We expect the element creation to
   // succeed and there will likely be errors in render.
@@ -336,7 +340,7 @@ export function createElementWithValidation(type, props, children) {
     }
   }
 
-  if (typeof type === 'symbol' && type === REACT_FRAGMENT_TYPE) {
+  if (type === REACT_FRAGMENT_TYPE) {
     validateFragmentProps(element);
   } else {
     validatePropTypes(element);

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -282,7 +282,9 @@ export function createElementWithValidation(type, props, children) {
     typeof type === 'string' ||
     typeof type === 'function' ||
     typeof type === 'number' ||
+    // Note: its typeof might be other than 'symbol' if it's a polyfill.
     type === REACT_FRAGMENT_TYPE;
+
   // We warn in this case but don't throw. We expect the element creation to
   // succeed and there will likely be errors in render.
   if (!validType) {

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -281,7 +281,7 @@ export function createElementWithValidation(type, props, children) {
   const validType =
     typeof type === 'string' ||
     typeof type === 'function' ||
-    // Note: its typeof might be other than 'symbol' if it's a polyfill.
+    // Note: its typeof might be other than 'symbol' or 'number' if it's a polyfill.
     type === REACT_FRAGMENT_TYPE;
 
   // We warn in this case but don't throw. We expect the element creation to

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -281,7 +281,6 @@ export function createElementWithValidation(type, props, children) {
   const validType =
     typeof type === 'string' ||
     typeof type === 'function' ||
-    typeof type === 'number' ||
     // Note: its typeof might be other than 'symbol' if it's a polyfill.
     type === REACT_FRAGMENT_TYPE;
 

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -282,7 +282,7 @@ export function createElementWithValidation(type, props, children) {
     typeof type === 'string' ||
     typeof type === 'function' ||
     typeof type === 'number' ||
-    type === 'REACT_FRAGMENT_TYPE';
+    type === REACT_FRAGMENT_TYPE;
   // We warn in this case but don't throw. We expect the element creation to
   // succeed and there will likely be errors in render.
   if (!validType) {

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -40,3 +40,16 @@ export function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<*> {
   }
   return null;
 }
+
+const reactSymbols = [
+  REACT_ELEMENT_TYPE,
+  REACT_CALL_TYPE,
+  REACT_RETURN_TYPE,
+  REACT_PORTAL_TYPE,
+  REACT_FRAGMENT_TYPE,
+  MAYBE_ITERATOR_SYMBOL,
+  FAUX_ITERATOR_SYMBOL,
+];
+export function isReactSymbol(type: any) {
+  return reactSymbols.some(r => type === r);
+}

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -40,16 +40,3 @@ export function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<*> {
   }
   return null;
 }
-
-const reactSymbols = [
-  REACT_ELEMENT_TYPE,
-  REACT_CALL_TYPE,
-  REACT_RETURN_TYPE,
-  REACT_PORTAL_TYPE,
-  REACT_FRAGMENT_TYPE,
-  MAYBE_ITERATOR_SYMBOL,
-  FAUX_ITERATOR_SYMBOL,
-];
-export function isReactSymbol(type: any) {
-  return reactSymbols.some(r => type === r);
-}


### PR DESCRIPTION
Fix #11759 
Sorry, I can't wait other contributor. I need to support IE11 without false warnings in my project)
Can you release v16.2.1 after this fix?