### PR TITLE
Support onLoad and onError on <link>

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1400,10 +1400,7 @@ describe('ReactDOMComponent', () => {
       const onLoad = jest.fn();
 
       ReactDOM.render(
-        <link
-          href="http://example.org/link"
-          onLoad={onLoad}
-        />,
+        <link href="http://example.org/link" onLoad={onLoad} />,
         container,
       );
 
@@ -1421,10 +1418,7 @@ describe('ReactDOMComponent', () => {
       const onError = jest.fn();
 
       ReactDOM.render(
-        <link
-          href="http://example.org/link"
-          onError={onError}
-        />,
+        <link href="http://example.org/link" onError={onError} />,
         container,
       );
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1395,7 +1395,7 @@ describe('ReactDOMComponent', () => {
       }
     });
 
-    it('should work load event on <link> component', () => {
+    it('should receive an load event on <link> elements', () => {
       const container = document.createElement('div');
       const onLoad = jest.fn();
 
@@ -1413,7 +1413,7 @@ describe('ReactDOMComponent', () => {
       expect(onLoad).toHaveBeenCalledTimes(1);
     });
 
-    it('should work error event on <link> component', () => {
+    it('should receive an error event on <link> elements', () => {
       const container = document.createElement('div');
       const onError = jest.fn();
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1395,33 +1395,46 @@ describe('ReactDOMComponent', () => {
       }
     });
 
-    it('should work load and error events on <link> component', () => {
-      spyOnDevAndProd(console, 'log');
+    it('should work load event on <link> component', () => {
       const container = document.createElement('div');
+      const onLoad = jest.fn();
+
       ReactDOM.render(
         <link
           href="http://example.org/link"
-          onLoad={e => console.log('onLoad called')}
-          onError={e => console.log('onError called')}
+          onLoad={onLoad}
         />,
         container,
       );
 
       const loadEvent = document.createEvent('Event');
-      const errorEvent = document.createEvent('Event');
       const link = container.getElementsByTagName('link')[0];
 
       loadEvent.initEvent('load', false, false);
-      errorEvent.initEvent('error', false, false);
-
       link.dispatchEvent(loadEvent);
+
+      expect(onLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it('should work error event on <link> component', () => {
+      const container = document.createElement('div');
+      const onError = jest.fn();
+
+      ReactDOM.render(
+        <link
+          href="http://example.org/link"
+          onError={onError}
+        />,
+        container,
+      );
+
+      const errorEvent = document.createEvent('Event');
+      const link = container.getElementsByTagName('link')[0];
+
+      errorEvent.initEvent('error', false, false);
       link.dispatchEvent(errorEvent);
 
-      if (__DEV__) {
-        expect(console.log.calls.count()).toBe(2);
-        expect(console.log.calls.argsFor(0)[0]).toContain('onLoad called');
-        expect(console.log.calls.argsFor(1)[0]).toContain('onError called');
-      }
+      expect(onError).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1395,7 +1395,7 @@ describe('ReactDOMComponent', () => {
       }
     });
 
-    it('should receive an load event on <link> elements', () => {
+    it('should receive a load event on <link> elements', () => {
       const container = document.createElement('div');
       const onLoad = jest.fn();
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1394,6 +1394,35 @@ describe('ReactDOMComponent', () => {
         expect(console.log.calls.argsFor(1)[0]).toContain('onLoad called');
       }
     });
+
+    it('should work load and error events on <link> component', () => {
+      spyOnDevAndProd(console, 'log');
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <link
+          href="http://example.org/link"
+          onLoad={e => console.log('onLoad called')}
+          onError={e => console.log('onError called')}
+        />,
+        container,
+      );
+
+      const loadEvent = document.createEvent('Event');
+      const errorEvent = document.createEvent('Event');
+      const link = container.getElementsByTagName('link')[0];
+
+      loadEvent.initEvent('load', false, false);
+      errorEvent.initEvent('error', false, false);
+
+      link.dispatchEvent(loadEvent);
+      link.dispatchEvent(errorEvent);
+
+      if (__DEV__) {
+        expect(console.log.calls.count()).toBe(2);
+        expect(console.log.calls.argsFor(0)[0]).toContain('onLoad called');
+        expect(console.log.calls.argsFor(1)[0]).toContain('onError called');
+      }
+    });
   });
 
   describe('updateComponent', () => {

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -484,6 +484,7 @@ export function setInitialProperties(
       break;
     case 'img':
     case 'image':
+    case 'link':
       trapBubbledEvent('topError', 'error', domElement);
       trapBubbledEvent('topLoad', 'load', domElement);
       props = rawProps;
@@ -858,6 +859,7 @@ export function diffHydratedProperties(
       break;
     case 'img':
     case 'image':
+    case 'link':
       trapBubbledEvent('topError', 'error', domElement);
       trapBubbledEvent('topLoad', 'load', domElement);
       break;


### PR DESCRIPTION
This PR add `onLoad` and `onError` to `<link />` component.

HTML [spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link)

Similar to https://github.com/facebook/react/pull/6815/ ,probably just miss it when migrating to Fiber.

Added unit test related to this case (we probably want to add more for other component such as `object`, `iframe` as well)

**Before**
![screen shot 2017-12-10 at 9 26 32 pm](https://user-images.githubusercontent.com/3906130/33817039-1eba1102-ddf2-11e7-9d22-73e38f85715c.png)

**After**
![screen shot 2017-12-10 at 9 27 22 pm](https://user-images.githubusercontent.com/3906130/33817040-1ed30e6e-ddf2-11e7-98ec-dcf932400d62.png)

link preload such as
`<link rel="preload" href="external.css" as="style" onLoad="this.rel='stylesheet'">` should work