### PR TITLE
Call and Return components should use ReactElement

### DIFF
--- a/packages/react-call-return/src/ReactCallReturn.js
+++ b/packages/react-call-return/src/ReactCallReturn.js
@@ -7,25 +7,33 @@
  * @flow
  */
 
-import {REACT_CALL_TYPE, REACT_RETURN_TYPE} from 'shared/ReactSymbols';
+import {
+  REACT_CALL_TYPE,
+  REACT_RETURN_TYPE,
+  REACT_ELEMENT_TYPE,
+} from 'shared/ReactSymbols';
 
 import type {ReactCall, ReactNodeList, ReactReturn} from 'shared/ReactTypes';
 
-type CallHandler<T> = (props: T, returns: Array<mixed>) => ReactNodeList;
+type CallHandler<T, V> = (props: T, returns: Array<V>) => ReactNodeList;
 
-export function unstable_createCall<T>(
-  children: mixed,
-  handler: CallHandler<T>,
+export function unstable_createCall<T, V>(
+  children: ReactNodeList,
+  handler: CallHandler<T, V>,
   props: T,
   key: ?string = null,
-): ReactCall {
+): ReactCall<V> {
   const call = {
     // This tag allow us to uniquely identify this as a React Call
-    $$typeof: REACT_CALL_TYPE,
+    $$typeof: REACT_ELEMENT_TYPE,
+    type: REACT_CALL_TYPE,
     key: key == null ? null : '' + key,
-    children: children,
-    handler: handler,
-    props: props,
+    ref: null,
+    props: {
+      props,
+      handler,
+      children: children,
+    },
   };
 
   if (__DEV__) {
@@ -39,11 +47,16 @@ export function unstable_createCall<T>(
   return call;
 }
 
-export function unstable_createReturn(value: mixed): ReactReturn {
+export function unstable_createReturn<V>(value: V): ReactReturn<V> {
   const returnNode = {
-    // This tag allow us to uniquely identify this as a React Return
-    $$typeof: REACT_RETURN_TYPE,
-    value: value,
+    // This tag allow us to uniquely identify this as a React Call
+    $$typeof: REACT_ELEMENT_TYPE,
+    type: REACT_RETURN_TYPE,
+    key: null,
+    ref: null,
+    props: {
+      value,
+    },
   };
 
   if (__DEV__) {
@@ -63,7 +76,7 @@ export function unstable_isCall(object: mixed): boolean {
   return (
     typeof object === 'object' &&
     object !== null &&
-    object.$$typeof === REACT_CALL_TYPE
+    object.type === REACT_CALL_TYPE
   );
 }
 
@@ -74,7 +87,7 @@ export function unstable_isReturn(object: mixed): boolean {
   return (
     typeof object === 'object' &&
     object !== null &&
-    object.$$typeof === REACT_RETURN_TYPE
+    object.type === REACT_RETURN_TYPE
   );
 }
 

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -621,11 +621,6 @@ class ReactDOMServerRenderer {
             'Portals are not currently supported by the server renderer. ' +
               'Render them conditionally so that they only appear on the client render.',
           );
-          invariant(
-            $$typeof !== REACT_CALL_TYPE && $$typeof !== REACT_RETURN_TYPE,
-            'The experimental Call and Return types are not currently ' +
-              'supported by the server renderer.',
-          );
           // Catch-all to prevent an infinite loop if React.Children.toArray() supports some new type.
           invariant(
             false,
@@ -678,6 +673,12 @@ class ReactDOMServerRenderer {
     context: Object,
     parentNamespace: string,
   ): string {
+    invariant(
+      element.type !== REACT_CALL_TYPE && element.type !== REACT_RETURN_TYPE,
+      'The experimental Call and Return types are not currently ' +
+        'supported by the server renderer.',
+    );
+
     const tag = element.type.toLowerCase();
 
     let namespace = parentNamespace;

--- a/packages/react-reconciler/src/ReactDebugFiberPerf.js
+++ b/packages/react-reconciler/src/ReactDebugFiberPerf.js
@@ -16,6 +16,7 @@ import {
   HostComponent,
   HostText,
   HostPortal,
+  CallComponent,
   ReturnComponent,
   Fragment,
 } from 'shared/ReactTypeOfWork';
@@ -166,6 +167,7 @@ const shouldIgnoreFiber = (fiber: Fiber): boolean => {
     case HostComponent:
     case HostText:
     case HostPortal:
+    case CallComponent:
     case ReturnComponent:
     case Fragment:
       return true;

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -311,99 +311,102 @@ export function createFiberFromElement(
   const type = element.type;
   const key = element.key;
   const pendingProps = element.props;
-
-  switch (type) {
-    case REACT_FRAGMENT_TYPE:
-      return createFiberFromFragment(
-        pendingProps.children,
-        internalContextTag,
-        expirationTime,
-        key,
-      );
-    case REACT_CALL_TYPE:
-      fiber = createFiber(CallComponent, pendingProps, key, internalContextTag);
-      fiber.type = REACT_CALL_TYPE;
-      fiber.expirationTime = expirationTime;
-      return fiber;
-    case REACT_RETURN_TYPE:
-      fiber = createFiber(
-        ReturnComponent,
-        pendingProps,
-        key,
-        internalContextTag,
-      );
-      fiber.type = REACT_RETURN_TYPE;
-      fiber.expirationTime = expirationTime;
-      return fiber;
-    default: {
-      if (typeof type === 'function') {
-        fiber = shouldConstruct(type)
-          ? createFiber(ClassComponent, pendingProps, key, internalContextTag)
-          : createFiber(
-              IndeterminateComponent,
-              pendingProps,
-              key,
-              internalContextTag,
-            );
-        fiber.type = type;
-      } else if (typeof type === 'string') {
-        fiber = createFiber(
-          HostComponent,
+  if (typeof type === 'function') {
+    fiber = shouldConstruct(type)
+      ? createFiber(ClassComponent, pendingProps, key, internalContextTag)
+      : createFiber(
+          IndeterminateComponent,
           pendingProps,
           key,
           internalContextTag,
         );
-        fiber.type = type;
-      } else if (
-        typeof type === 'object' &&
-        type !== null &&
-        typeof type.tag === 'number'
-      ) {
-        // Currently assumed to be a continuation and therefore is a fiber already.
-        // TODO: The yield system is currently broken for updates in some cases.
-        // The reified yield stores a fiber, but we don't know which fiber that is;
-        // the current or a workInProgress? When the continuation gets rendered here
-        // we don't know if we can reuse that fiber or if we need to clone it.
-        // There is probably a clever way to restructure this.
-        fiber = ((type: any): Fiber);
-        fiber.pendingProps = pendingProps;
-      } else {
-        let info = '';
-        if (__DEV__) {
-          if (
-            type === undefined ||
-            (typeof type === 'object' &&
-              type !== null &&
-              Object.keys(type).length === 0)
-          ) {
-            info +=
-              ' You likely forgot to export your component from the file ' +
-              "it's defined in, or you might have mixed up default and named imports.";
-          }
-          const ownerName = owner ? getComponentName(owner) : null;
-          if (ownerName) {
-            info += '\n\nCheck the render method of `' + ownerName + '`.';
-          }
-        }
-        invariant(
-          false,
-          'Element type is invalid: expected a string (for built-in components) ' +
-            'or a class/function (for composite components) but got: %s.%s',
-          type == null ? type : typeof type,
-          info,
+    fiber.type = type;
+  } else if (typeof type === 'string') {
+    fiber = createFiber(HostComponent, pendingProps, key, internalContextTag);
+    fiber.type = type;
+  } else {
+    switch (type) {
+      case REACT_FRAGMENT_TYPE:
+        return createFiberFromFragment(
+          pendingProps.children,
+          internalContextTag,
+          expirationTime,
+          key,
         );
+      case REACT_CALL_TYPE:
+        fiber = createFiber(
+          CallComponent,
+          pendingProps,
+          key,
+          internalContextTag,
+        );
+        fiber.type = REACT_CALL_TYPE;
+        break;
+      case REACT_RETURN_TYPE:
+        fiber = createFiber(
+          ReturnComponent,
+          pendingProps,
+          key,
+          internalContextTag,
+        );
+        fiber.type = REACT_RETURN_TYPE;
+        break;
+      default: {
+        if (
+          typeof type === 'object' &&
+          type !== null &&
+          typeof type.tag === 'number'
+        ) {
+          // Currently assumed to be a continuation and therefore is a
+          // fiber already.
+          // TODO: The yield system is currently broken for updates in some
+          // cases. The reified yield stores a fiber, but we don't know which
+          // fiber that is; the current or a workInProgress? When the
+          // continuation gets rendered here we don't know if we can reuse that
+          // fiber or if we need to clone it. There is probably a clever way to
+          // restructure this.
+          fiber = ((type: any): Fiber);
+          fiber.pendingProps = pendingProps;
+        } else {
+          let info = '';
+          if (__DEV__) {
+            if (
+              type === undefined ||
+              (typeof type === 'object' &&
+                type !== null &&
+                Object.keys(type).length === 0)
+            ) {
+              info +=
+                ' You likely forgot to export your component from the file ' +
+                "it's defined in, or you might have mixed up default and " +
+                'named imports.';
+            }
+            const ownerName = owner ? getComponentName(owner) : null;
+            if (ownerName) {
+              info += '\n\nCheck the render method of `' + ownerName + '`.';
+            }
+          }
+          invariant(
+            false,
+            'Element type is invalid: expected a string (for built-in ' +
+              'components) or a class/function (for composite components) ' +
+              'but got: %s.%s',
+            type == null ? type : typeof type,
+            info,
+          );
+        }
       }
-
-      if (__DEV__) {
-        fiber._debugSource = element._source;
-        fiber._debugOwner = element._owner;
-      }
-
-      fiber.expirationTime = expirationTime;
-
-      return fiber;
     }
   }
+
+  if (__DEV__) {
+    fiber._debugSource = element._source;
+    fiber._debugOwner = element._owner;
+  }
+
+  fiber.expirationTime = expirationTime;
+
+  return fiber;
 }
 
 export function createFiberFromFragment(

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -7,12 +7,7 @@
  */
 
 import type {ReactElement, Source} from 'shared/ReactElementType';
-import type {
-  ReactCall,
-  ReactFragment,
-  ReactPortal,
-  ReactReturn,
-} from 'shared/ReactTypes';
+import type {ReactFragment, ReactPortal} from 'shared/ReactTypes';
 import type {TypeOfWork} from 'shared/ReactTypeOfWork';
 import type {TypeOfInternalContext} from './ReactTypeOfInternalContext';
 import type {TypeOfSideEffect} from 'shared/ReactTypeOfSideEffect';
@@ -36,6 +31,11 @@ import getComponentName from 'shared/getComponentName';
 
 import {NoWork} from './ReactFiberExpirationTime';
 import {NoContext, AsyncUpdates} from './ReactTypeOfInternalContext';
+import {
+  REACT_FRAGMENT_TYPE,
+  REACT_RETURN_TYPE,
+  REACT_CALL_TYPE,
+} from 'shared/ReactSymbols';
 
 let hasBadMapPolyfill;
 
@@ -311,67 +311,99 @@ export function createFiberFromElement(
   const type = element.type;
   const key = element.key;
   const pendingProps = element.props;
-  if (typeof type === 'function') {
-    fiber = shouldConstruct(type)
-      ? createFiber(ClassComponent, pendingProps, key, internalContextTag)
-      : createFiber(
-          IndeterminateComponent,
+
+  switch (type) {
+    case REACT_FRAGMENT_TYPE:
+      return createFiberFromFragment(
+        pendingProps.children,
+        internalContextTag,
+        expirationTime,
+        key,
+      );
+    case REACT_CALL_TYPE:
+      fiber = createFiber(CallComponent, pendingProps, key, internalContextTag);
+      fiber.type = REACT_CALL_TYPE;
+      fiber.expirationTime = expirationTime;
+      return fiber;
+    case REACT_RETURN_TYPE:
+      fiber = createFiber(
+        ReturnComponent,
+        pendingProps,
+        key,
+        internalContextTag,
+      );
+      fiber.type = REACT_RETURN_TYPE;
+      fiber.expirationTime = expirationTime;
+      return fiber;
+    default: {
+      if (typeof type === 'function') {
+        fiber = shouldConstruct(type)
+          ? createFiber(ClassComponent, pendingProps, key, internalContextTag)
+          : createFiber(
+              IndeterminateComponent,
+              pendingProps,
+              key,
+              internalContextTag,
+            );
+        fiber.type = type;
+      } else if (typeof type === 'string') {
+        fiber = createFiber(
+          HostComponent,
           pendingProps,
           key,
           internalContextTag,
         );
-    fiber.type = type;
-  } else if (typeof type === 'string') {
-    fiber = createFiber(HostComponent, pendingProps, key, internalContextTag);
-    fiber.type = type;
-  } else if (
-    typeof type === 'object' &&
-    type !== null &&
-    typeof type.tag === 'number'
-  ) {
-    // Currently assumed to be a continuation and therefore is a fiber already.
-    // TODO: The yield system is currently broken for updates in some cases.
-    // The reified yield stores a fiber, but we don't know which fiber that is;
-    // the current or a workInProgress? When the continuation gets rendered here
-    // we don't know if we can reuse that fiber or if we need to clone it.
-    // There is probably a clever way to restructure this.
-    fiber = ((type: any): Fiber);
-    fiber.pendingProps = pendingProps;
-  } else {
-    let info = '';
-    if (__DEV__) {
-      if (
-        type === undefined ||
-        (typeof type === 'object' &&
-          type !== null &&
-          Object.keys(type).length === 0)
+        fiber.type = type;
+      } else if (
+        typeof type === 'object' &&
+        type !== null &&
+        typeof type.tag === 'number'
       ) {
-        info +=
-          ' You likely forgot to export your component from the file ' +
-          "it's defined in, or you might have mixed up default and named imports.";
+        // Currently assumed to be a continuation and therefore is a fiber already.
+        // TODO: The yield system is currently broken for updates in some cases.
+        // The reified yield stores a fiber, but we don't know which fiber that is;
+        // the current or a workInProgress? When the continuation gets rendered here
+        // we don't know if we can reuse that fiber or if we need to clone it.
+        // There is probably a clever way to restructure this.
+        fiber = ((type: any): Fiber);
+        fiber.pendingProps = pendingProps;
+      } else {
+        let info = '';
+        if (__DEV__) {
+          if (
+            type === undefined ||
+            (typeof type === 'object' &&
+              type !== null &&
+              Object.keys(type).length === 0)
+          ) {
+            info +=
+              ' You likely forgot to export your component from the file ' +
+              "it's defined in, or you might have mixed up default and named imports.";
+          }
+          const ownerName = owner ? getComponentName(owner) : null;
+          if (ownerName) {
+            info += '\n\nCheck the render method of `' + ownerName + '`.';
+          }
+        }
+        invariant(
+          false,
+          'Element type is invalid: expected a string (for built-in components) ' +
+            'or a class/function (for composite components) but got: %s.%s',
+          type == null ? type : typeof type,
+          info,
+        );
       }
-      const ownerName = owner ? getComponentName(owner) : null;
-      if (ownerName) {
-        info += '\n\nCheck the render method of `' + ownerName + '`.';
+
+      if (__DEV__) {
+        fiber._debugSource = element._source;
+        fiber._debugOwner = element._owner;
       }
+
+      fiber.expirationTime = expirationTime;
+
+      return fiber;
     }
-    invariant(
-      false,
-      'Element type is invalid: expected a string (for built-in components) ' +
-        'or a class/function (for composite components) but got: %s.%s',
-      type == null ? type : typeof type,
-      info,
-    );
   }
-
-  if (__DEV__) {
-    fiber._debugSource = element._source;
-    fiber._debugOwner = element._owner;
-  }
-
-  fiber.expirationTime = expirationTime;
-
-  return fiber;
 }
 
 export function createFiberFromFragment(
@@ -398,27 +430,6 @@ export function createFiberFromText(
 export function createFiberFromHostInstanceForDeletion(): Fiber {
   const fiber = createFiber(HostComponent, null, null, NoContext);
   fiber.type = 'DELETED';
-  return fiber;
-}
-
-export function createFiberFromCall(
-  call: ReactCall,
-  internalContextTag: TypeOfInternalContext,
-  expirationTime: ExpirationTime,
-): Fiber {
-  const fiber = createFiber(CallComponent, call, call.key, internalContextTag);
-  fiber.type = call.handler;
-  fiber.expirationTime = expirationTime;
-  return fiber;
-}
-
-export function createFiberFromReturn(
-  returnNode: ReactReturn,
-  internalContextTag: TypeOfInternalContext,
-  expirationTime: ExpirationTime,
-): Fiber {
-  const fiber = createFiber(ReturnComponent, null, null, internalContextTag);
-  fiber.expirationTime = expirationTime;
   return fiber;
 }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -8,7 +8,6 @@
  */
 
 import type {HostConfig} from 'react-reconciler';
-import type {ReactCall} from 'shared/ReactTypes';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {HostContext} from './ReactFiberHostContext';
 import type {HydrationContext} from './ReactFiberHydrationContext';
@@ -535,18 +534,18 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   }
 
   function updateCallComponent(current, workInProgress, renderExpirationTime) {
-    let nextCall = (workInProgress.pendingProps: ReactCall);
+    let nextProps = workInProgress.pendingProps;
     if (hasContextChanged()) {
       // Normally we can bail out on props equality but if context has changed
       // we don't do the bailout and we have to reuse existing props instead.
-    } else if (workInProgress.memoizedProps === nextCall) {
-      nextCall = workInProgress.memoizedProps;
+    } else if (workInProgress.memoizedProps === nextProps) {
+      nextProps = workInProgress.memoizedProps;
       // TODO: When bailing out, we might need to return the stateNode instead
       // of the child. To check it for work.
       // return bailoutOnAlreadyFinishedWork(current, workInProgress);
     }
 
-    const nextChildren = nextCall.children;
+    const nextChildren = nextProps.children;
 
     // The following is a fork of reconcileChildrenAtExpirationTime but using
     // stateNode to store the child.
@@ -566,7 +565,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       );
     }
 
-    memoizeProps(workInProgress, nextCall);
+    memoizeProps(workInProgress, nextProps);
     // This doesn't take arbitrary time so we could synchronously just begin
     // eagerly do the work of workInProgress.child as an optimization.
     return workInProgress.stateNode;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -8,7 +8,6 @@
  */
 
 import type {HostConfig} from 'react-reconciler';
-import type {ReactCall} from 'shared/ReactTypes';
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {HostContext} from './ReactFiberHostContext';
@@ -93,7 +92,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       ) {
         invariant(false, 'A call cannot have host component children.');
       } else if (node.tag === ReturnComponent) {
-        returns.push(node.type);
+        returns.push(node.pendingProps.value);
       } else if (node.child !== null) {
         node.child.return = node;
         node = node.child;
@@ -115,9 +114,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     workInProgress: Fiber,
     renderExpirationTime: ExpirationTime,
   ) {
-    const call = (workInProgress.memoizedProps: ?ReactCall);
+    const props = workInProgress.memoizedProps;
     invariant(
-      call,
+      props,
       'Should be resolved by now. This error is likely caused by a bug in ' +
         'React. Please file an issue.',
     );
@@ -135,9 +134,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     // TODO: Compare this to a generator or opaque helpers like Children.
     const returns: Array<mixed> = [];
     appendAllReturns(returns, workInProgress);
-    const fn = call.handler;
-    const props = call.props;
-    const nextChildren = fn(props, returns);
+    const fn = props.handler;
+    const childProps = props.props;
+    const nextChildren = fn(childProps, returns);
 
     const currentFirstChild = current !== null ? current.child : null;
     workInProgress.child = reconcileChildFibers(

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -298,10 +298,9 @@ exports[`ReactDebugFiberPerf supports returns 1`] = `
 ⚛ (React Tree Reconciliation)
   ⚛ App [mount]
     ⚛ CoParent [mount]
-      ⚛ <ReactCall> [mount]
-        ⚛ Indirection [mount]
-          ⚛ CoChild [mount]
-          ⚛ CoChild [mount]
+      ⚛ Indirection [mount]
+        ⚛ CoChild [mount]
+        ⚛ CoChild [mount]
       ⚛ Continuation [mount]
       ⚛ Continuation [mount]
 

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -298,7 +298,7 @@ exports[`ReactDebugFiberPerf supports returns 1`] = `
 ⚛ (React Tree Reconciliation)
   ⚛ App [mount]
     ⚛ CoParent [mount]
-      ⚛ HandleReturns [mount]
+      ⚛ <ReactCall> [mount]
         ⚛ Indirection [mount]
           ⚛ CoChild [mount]
           ⚛ CoChild [mount]

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -11,8 +11,6 @@ import warning from 'fbjs/lib/warning';
 import {
   getIteratorFn,
   REACT_ELEMENT_TYPE,
-  REACT_CALL_TYPE,
-  REACT_RETURN_TYPE,
   REACT_PORTAL_TYPE,
 } from 'shared/ReactSymbols';
 
@@ -125,8 +123,6 @@ function traverseAllChildrenImpl(
       case 'object':
         switch (children.$$typeof) {
           case REACT_ELEMENT_TYPE:
-          case REACT_CALL_TYPE:
-          case REACT_RETURN_TYPE:
           case REACT_PORTAL_TYPE:
             invokeCallback = true;
         }

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -95,7 +95,8 @@ describe('ReactChildren', () => {
       context,
     );
     expect(callback).toHaveBeenCalledWith(reactCall, 0);
-    expect(mappedChildren[0]).toEqual(reactCall);
+    expect(mappedChildren[0].type).toEqual(reactCall.type);
+    expect(mappedChildren[0].props).toEqual(reactCall.props);
   });
 
   it('should support Return components', () => {
@@ -119,7 +120,8 @@ describe('ReactChildren', () => {
       context,
     );
     expect(callback).toHaveBeenCalledWith(reactReturn, 0);
-    expect(mappedChildren[0]).toEqual(reactReturn);
+    expect(mappedChildren[0].props).toEqual(reactReturn.props);
+    expect(mappedChildren[0].type).toEqual(reactReturn.type);
   });
 
   it('should treat single arrayless child as being in array', () => {

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -10,8 +10,8 @@
 
 export type ReactNode =
   | React$Element<any>
-  | ReactCall
-  | ReactReturn
+  | ReactCall<any>
+  | ReactReturn<any>
   | ReactPortal
   | ReactText
   | ReactFragment;
@@ -24,18 +24,27 @@ export type ReactText = string | number;
 
 export type ReactEmpty = null | void | boolean;
 
-export type ReactCall = {
+export type ReactCall<V> = {
   $$typeof: Symbol | number,
+  type: Symbol | number,
   key: null | string,
-  children: any,
-  // This should be a more specific CallHandler
-  handler: (props: any, returns: Array<mixed>) => ReactNodeList,
-  props: any,
+  ref: null,
+  props: {
+    props: any,
+    // This should be a more specific CallHandler
+    handler: (props: any, returns: Array<V>) => ReactNodeList,
+    children?: ReactNodeList,
+  },
 };
 
-export type ReactReturn = {
+export type ReactReturn<V> = {
   $$typeof: Symbol | number,
-  value: mixed,
+  type: Symbol | number,
+  key: null,
+  ref: null,
+  props: {
+    value: V,
+  },
 };
 
 export type ReactPortal = {

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -26,13 +26,13 @@ function getComponentName(fiber: Fiber): string | null {
   }
   switch (type) {
     case REACT_FRAGMENT_TYPE:
-      return '<ReactFragment>';
+      return 'ReactFragment';
     case REACT_PORTAL_TYPE:
-      return '<ReactPortal>';
+      return 'ReactPortal';
     case REACT_CALL_TYPE:
-      return '<ReactCall>';
+      return 'ReactCall';
     case REACT_RETURN_TYPE:
-      return '<ReactReturn>';
+      return 'ReactReturn';
   }
   return null;
 }

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -9,18 +9,30 @@
 
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
-import {REACT_CALL_TYPE} from 'shared/ReactSymbols';
+import {
+  REACT_CALL_TYPE,
+  REACT_FRAGMENT_TYPE,
+  REACT_RETURN_TYPE,
+  REACT_PORTAL_TYPE,
+} from 'shared/ReactSymbols';
 
 function getComponentName(fiber: Fiber): string | null {
   const {type} = fiber;
-  if (type === REACT_CALL_TYPE) {
-    return '<ReactCall>';
+  if (typeof type === 'function') {
+    return type.displayName || type.name;
   }
   if (typeof type === 'string') {
     return type;
   }
-  if (typeof type === 'function') {
-    return type.displayName || type.name;
+  switch (type) {
+    case REACT_FRAGMENT_TYPE:
+      return '<ReactFragment>';
+    case REACT_PORTAL_TYPE:
+      return '<ReactPortal>';
+    case REACT_CALL_TYPE:
+      return '<ReactCall>';
+    case REACT_RETURN_TYPE:
+      return '<ReactReturn>';
   }
   return null;
 }

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -9,8 +9,13 @@
 
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
+import {REACT_CALL_TYPE} from 'shared/ReactSymbols';
+
 function getComponentName(fiber: Fiber): string | null {
   const {type} = fiber;
+  if (type === REACT_CALL_TYPE) {
+    return '<ReactCall>';
+  }
   if (typeof type === 'string') {
     return type;
   }


### PR DESCRIPTION
ReactChildFiber contains lots of branches that do the same thing for different child types. We can unify them by having more child types be ReactElements. This requires that the `type` and `key` fields are sufficient to determine the identity of the child.

The main benefit is decreased file size, especially as we add more component types, like context providers and consumers.

This updates Call and Return components to use ReactElement. Portals are left alone for now because their identity includes the host instance.