### PR TITLE
Fix flow windows

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -39,4 +39,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [version]
-^0.57.3
+^0.61.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
 test_script:
   - node --version
   - yarn lint
-#  - yarn flow (TODO: investigate why it fails on Windows)
+  - yarn flow
   - yarn build
   - yarn test
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "fbjs": "^0.8.16",
     "fbjs-scripts": "^0.6.0",
     "filesize": "^3.5.6",
-    "flow-bin": "^0.57.3",
+    "flow-bin": "^0.61.0",
     "git-branch": "^0.3.0",
     "glob": "^6.0.4",
     "glob-stream": "^6.1.0",

--- a/packages/react-reconciler/src/ReactFiberHostContext.js
+++ b/packages/react-reconciler/src/ReactFiberHostContext.js
@@ -82,8 +82,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   }
 
   function pushHostContext(fiber: Fiber): void {
-    const rootInstance = requiredContext(rootInstanceStackCursor.current);
-    const context = requiredContext(contextStackCursor.current);
+    const rootInstance: C = requiredContext(rootInstanceStackCursor.current);
+    const context: CX = requiredContext(contextStackCursor.current);
     const nextContext = getChildHostContext(context, fiber.type, rootInstance);
 
     // Don't push this Fiber's context unless it's unique.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,9 +1979,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.57.3:
-  version "0.57.3"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
+flow-bin@^0.61.0:
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.61.0.tgz#d0473a8c35dbbf4de573823f4932124397d32d35"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Ref: #11703 

- update flow to 0.61.0
  - https://github.com/facebook/flow/releases
- getChildHostContext doesn't expect `NoContextT`, refactoring to accept both.

**ReactFiberHostContext.js**

For some reason, in Windows scenario it returns `NoContextT` as `Value`

```js
const rootInstance = requiredContext(rootInstanceStackCursor.current); // could return NoContextT, not CX
const context = requiredContext(contextStackCursor.current); // could return NoContextT, not C
const nextContext = getChildHostContext(context, fiber.type, rootInstance);
```

**ReactFiberReconciler.js**

```js
getChildHostContext(parentHostContext: C, type: T, instance: CX): CX,
```

some thoughts @gaearon?

flow working: https://ci.appveyor.com/project/raphamorim/react/build/1.0.52