### PR TITLE
Interactive updates

### DIFF
--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -463,6 +463,8 @@ const ReactNoop = {
 
   unbatchedUpdates: NoopRenderer.unbatchedUpdates,
 
+  interactiveUpdates: NoopRenderer.interactiveUpdates,
+
   flushSync(fn: () => mixed) {
     yieldedValues = [];
     NoopRenderer.flushSync(fn);

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -258,6 +258,7 @@ export type Reconciler<C, I, TI> = {
   unbatchedUpdates<A>(fn: () => A): A,
   flushSync<A>(fn: () => A): A,
   deferredUpdates<A>(fn: () => A): A,
+  interactiveUpdates<A>(fn: () => A): A,
   injectIntoDevTools(devToolsConfig: DevToolsConfig<I, TI>): boolean,
   computeUniqueAsyncExpiration(): ExpirationTime,
 
@@ -302,6 +303,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     unbatchedUpdates,
     flushSync,
     deferredUpdates,
+    interactiveUpdates,
   } = ReactFiberScheduler(config);
 
   function scheduleRootUpdate(
@@ -431,6 +433,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     unbatchedUpdates,
 
     deferredUpdates,
+
+    interactiveUpdates,
 
     flushSync,
 

--- a/packages/react-reconciler/src/__tests__/ReactInteractiveUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactInteractiveUpdates-test.js
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactNoop;
+
+describe('ReactInteractiveUpdates', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+  });
+
+  function span(prop) {
+    return {type: 'span', children: [], prop};
+  }
+
+  it('Example: Submit button that disables itself on submit', () => {
+    let ops = [];
+
+    function SubmitButton(props) {
+      return (
+        <span
+          prop={{
+            onClick() {
+              if (props.disabled) {
+                return;
+              }
+              // Submit the form
+              ops.push('Submit form');
+              // Update the button to disable it.
+              ReactNoop.render(<SubmitButton disabled={true} />);
+            },
+          }}
+        />
+      );
+    }
+
+    function click() {
+      ReactNoop.interactiveUpdates(() => {
+        const children = ReactNoop.getChildren();
+        const eventHandler = children[0].prop.onClick;
+        eventHandler();
+      });
+    }
+
+    // Initial mount
+    ReactNoop.render(<SubmitButton disabled={false} />);
+    ReactNoop.flush();
+
+    // Click the button to submit the form
+    click();
+    expect(ops).toEqual(['Submit form']);
+
+    ops = [];
+
+    // The form should not submit again no matter how many times we
+    // click it.
+    click();
+    click();
+    click();
+    click();
+    click();
+    expect(ops).toEqual([]);
+  });
+
+  it('Example: Button that toggles on and off', () => {
+    function Input(props) {
+      return (
+        <span
+          prop={{
+            enabled: props.enabled,
+            onToggle: () =>
+              ReactNoop.render(<Input enabled={!props.enabled} />),
+          }}
+        />
+      );
+    }
+
+    // Toggles the current state of the view.
+    function toggle() {
+      ReactNoop.interactiveUpdates(() => {
+        const children = ReactNoop.getChildren();
+        const eventHandler = children[0].prop.onToggle;
+        eventHandler();
+      });
+    }
+
+    // Reads the current, flushed state
+    function isEnabled() {
+      const children = ReactNoop.getChildren();
+      return children[0].prop.enabled === true;
+    }
+
+    // Initial mount
+    ReactNoop.render(<Input enabled={false} />);
+    ReactNoop.flush();
+
+    // Toggle the view
+    toggle();
+    // The update hasn't flushed yet because it's async
+    expect(isEnabled()).toBe(false);
+
+    // If we toggle again, then flush the remaining work, the final
+    // state should be false, because the second toggle is based on
+    // the state after the first one has processed.
+    toggle();
+    ReactNoop.flush();
+    expect(isEnabled()).toBe(false);
+  });
+});


### PR DESCRIPTION
An interactive update is the result of a user interaction. They have higher priority than default, non interactive updates (like server events).

What's special about interactive updates in async mode is that one interactive update may affect the behavior of a subsequent one. For example, a "Submit" button on a form field that disables itself once it's clicked. If the user clicks it twice, but the first update hasn't flushed by the time the second click occurs, the form will submit twice because we haven't updated the event handler yet.

The behavior we want is for the final result of a series of interactive updates to be deterministic.

The solution I've used here is to detect when an interactive update is scheduled while another one is in flight. In that case, the first one is synchronously flushed. This must happen *before* any event handlers are called.

I've added tests to prove this works with ReactNoop. Still need to add it to ReactDOM.

TODO:

- [ ] Wrap all appropriate events in ReactDOM with `interactiveUpdates`.
- [ ] ReactNative?