### PR TITLE
Use `declare module.exports` syntax for flow libdefs

### DIFF
--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -10,10 +10,10 @@
 /* eslint-disable */
 
 declare module 'deepDiffer' {
-  declare function exports(one: any, two: any): boolean;
+  declare module.exports: (one: any, two: any) => boolean;
 }
 declare module 'deepFreezeAndThrowOnMutationInDev' {
-  declare function exports<T>(obj: T): T;
+  declare module.exports: <T>(obj: T) => T;
 }
 declare module 'flattenStyle' {
 }
@@ -83,7 +83,7 @@ declare module 'UIManager' {
   ): Promise<any>;
 }
 declare module 'View' {
-  declare var exports: typeof React$Component;
+  declare module.exports: typeof React$Component;
 }
 
 declare module 'RTManager' {


### PR DESCRIPTION
We added this to Flow in v0.25 (about 2 years ago), but never actually
deprecated the legacy `declare var exports` syntax. Hoping to do that
soon, so clearing up uses that I can find.

Test Plan: flow

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
10. If you haven't already, complete the CLA.

**Learn more about contributing:** https://reactjs.org/docs/how-to-contribute.html
