### PR TITLE
Work around IE/Edge bug when rendering inputs in separate windows via portals

### DIFF
--- a/packages/react-dom/src/client/inputValueTracking.js
+++ b/packages/react-dom/src/client/inputValueTracking.js
@@ -80,6 +80,7 @@ function trackValueOnNode(node: any): ?ValueTracker {
     },
   });
 
+  // This is a work around for IE11 and Edge 15,14 for #Issue11768
   Object.defineProperty(node, valueField, {
     enumerable: descriptor.enumerable,
   });

--- a/packages/react-dom/src/client/inputValueTracking.js
+++ b/packages/react-dom/src/client/inputValueTracking.js
@@ -70,7 +70,6 @@ function trackValueOnNode(node: any): ?ValueTracker {
   }
 
   Object.defineProperty(node, valueField, {
-    enumerable: descriptor.enumerable,
     configurable: true,
     get: function() {
       return descriptor.get.call(this);
@@ -79,6 +78,10 @@ function trackValueOnNode(node: any): ?ValueTracker {
       currentValue = '' + value;
       descriptor.set.call(this, value);
     },
+  });
+
+  Object.defineProperty(node, valueField, {
+    enumerable: descriptor.enumerable,
   });
 
   const tracker = {

--- a/packages/react-dom/src/client/inputValueTracking.js
+++ b/packages/react-dom/src/client/inputValueTracking.js
@@ -79,8 +79,10 @@ function trackValueOnNode(node: any): ?ValueTracker {
       descriptor.set.call(this, value);
     },
   });
-
-  // This is a work around for IE11 and Edge 15,14 for #Issue11768
+  // We could've passed this the first time
+  // but it triggers a bug in IE11 and Edge 14/15.
+  // Calling defineProperty() again should be equivalent.
+  // https://github.com/facebook/react/issues/11768
   Object.defineProperty(node, valueField, {
     enumerable: descriptor.enumerable,
   });


### PR DESCRIPTION
**Contributing checklist**
- [X] Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
- [X] Run `yarn` in the repository root.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [X] Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
- [X] Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
- [X] If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
- [X] Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
- [X] Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
- [X] Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
- [X] If you haven't already, complete the CLA.

### Problem : 
- Issue https://github.com/facebook/react/issues/11768
- Input element in a portal was throwing error only when tested on
  - IE 11
  - Edge 15
  - Edge 14
- Sample jsfiddle https://github.com/kgorgi/react-popout-bug

### Solution:
- Moved `enumerable` descriptor to another `defineProperty` of same `node` object.
- there are no side effects to this as 
> The Object.defineProperty() method defines a new property directly on an object, or modifies an existing property on an object, and returns the object. 
- This seems to solve the problem for the browsers mentioned above.
