### PR TITLE
Upload build stats to the server

### DIFF
--- a/scripts/circleci/upload_build.sh
+++ b/scripts/circleci/upload_build.sh
@@ -10,6 +10,7 @@ if [ -z $CI_PULL_REQUEST ] && [ -n "$BUILD_SERVER_ENDPOINT" ]; then
     -F "react-dom.production.min=@build/dist/react-dom.production.min.js" \
     -F "react-dom-server.browser.development=@build/dist/react-dom-server.browser.development.js" \
     -F "react-dom-server.browser.production.min=@build/dist/react-dom-server.browser.production.min.js" \
+    -F "results.json=@build/../scripts/rollup/results.json" \
     -F "commit=$CIRCLE_SHA1" \
     -F "date=`git log --format='%ct' -1`" \
     -F "pull_request=false" \


### PR DESCRIPTION
Let's see if this works.

The goal is to upload build stats from master to @zpao's server. (We already upload the builds anyway.)

If this works then we can change https://github.com/facebook/react/pull/11865 to always compare the build size against master (by reading it from @zpao's server) instead of against the last recorded size. Recording them is currently not enforced so they get out of date. But if this approach works then we can delete the sizes from the repository altogether (and solve the other problem of merge conflicts).