### PR TITLE
Update results.json from master before the build

### DIFF
--- a/scripts/circleci/build.sh
+++ b/scripts/circleci/build.sh
@@ -2,6 +2,11 @@
 		
 set -e		
 
+# Update the local size measurements to the master version
+# so that the size diff printed at the end of the build is
+# accurate.
+curl -o scripts/rollup/results.json http://react.zpao.com/builds/master/latest/results.json
+
 yarn build --extract-errors
 # Note: since we run the full build including extracting error codes,
 # it is important that we *don't* reset the change to `scripts/error-codes/codes.json`.


### PR DESCRIPTION
This should ensure that CI always displays correct build file difference. A prerequisite for https://github.com/facebook/react/pull/11865.

We might actually want to delete that file from the repo and always download it during the local build. Then we can delete it from the repo, always have accurate stats on local builds, and solve merge conflicts. But then we need to make sure we bail out gracefully if network fails.