### PR TITLE
Enhance `React.Children.only` to specify number of children > 1

### DIFF
--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -396,11 +396,24 @@ function toArray(children) {
  * @return {ReactElement} The first and only `ReactElement` contained in the
  * structure.
  */
-function onlyChild(children) {
-  invariant(
-    isValidElement(children),
-    'React.Children.only expected to receive a single React element child.',
-  );
+function onlyChild(children, count = 1) {
+  if (count === 1) {
+    invariant(
+      isValidElement(children),
+      'React.Children.only expected to receive a single React element child.',
+    );
+  } else {
+    invariant(
+      countChildren(children) === count,
+      'React.Children.only expected children of a different length',
+    );
+    forEachChildren(children, child => {
+      invariant(
+        isValidElement(child),
+        'React.Children.only must be passed all valid React elements.',
+      );
+    });
+  }
   return children;
 }
 

--- a/packages/react/src/__tests__/onlyChild-test.js
+++ b/packages/react/src/__tests__/onlyChild-test.js
@@ -72,4 +72,58 @@ describe('onlyChild', () => {
     );
     expect(React.Children.only(instance.props.children)).toEqual(<span />);
   });
+
+  it('should check for number of children if passed second parameter', () => {
+    const instance = (
+      <WrapComponent>
+        <span />
+        <span />
+        <span />
+      </WrapComponent>
+    );
+
+    expect(React.Children.only(instance.props.children, 3)).toEqual([
+      <span />,
+      <span />,
+      <span />,
+    ]);
+  });
+
+  it('should throw if incorrect number of children are passed', () => {
+    const instance = (
+      <WrapComponent>
+        <span />
+        <span />
+      </WrapComponent>
+    );
+
+    expect(function() {
+      React.Children.only(instance.props.children, 3);
+    }).toThrow();
+  });
+
+  it('should fail when passed some null/undefined values', () => {
+    let instance = (
+      <WrapComponent>
+        <span />
+        {null}
+        <span />
+      </WrapComponent>
+    );
+
+    expect(function() {
+      React.Children.only(instance.props.children, 3);
+    }).toThrow();
+
+    instance = (
+      <WrapComponent>
+        <span />
+        {undefined}
+      </WrapComponent>
+    );
+
+    expect(function() {
+      React.Children.only(instance.props.children, 2);
+    }).toThrow();
+  });
 });


### PR DESCRIPTION
Hey all,
First time touching this repo, so sorry if this is a duplicate PR or anything is out of place (please close if so 😄)
I have completed all the steps listed in the PR notes.

This PR simply adds a second optional param to `React.Children.only` to check for children of a specified length. 

Note:
1. Let me know you want me to verify that the `count` param is `> 1` explicitly
2. I would like to add more helpful error messages (with parameter info included) but the linter fails due to: `"The second argument to invariant must be a string literal"`

Use Case(s):
- [`eitherx`](https://github.com/mfix22/eitherx/blob/master/src/eitherx.js#L17)