### PR TITLE
Fixed potential false-positive in toWarnDev matcher

### DIFF
--- a/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
+++ b/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
@@ -41,7 +41,9 @@ module.exports = function(initModules) {
     if (console.error.calls && console.error.calls.reset) {
       console.error.calls.reset();
     } else {
-      spyOnDev(console, 'error');
+      // TODO: Rewrite tests that use this helper to enumerate expeceted errors.
+      // This will enable the helper to use the .toWarnDev() matcher instead of spying.
+      spyOnDev(console, 'error', true);
     }
 
     const result = await fn();

--- a/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
+++ b/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
@@ -43,7 +43,7 @@ module.exports = function(initModules) {
     } else {
       // TODO: Rewrite tests that use this helper to enumerate expeceted errors.
       // This will enable the helper to use the .toWarnDev() matcher instead of spying.
-      spyOnDev(console, 'error', true);
+      spyOnDev(console, 'error');
     }
 
     const result = await fn();

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
@@ -13,7 +13,7 @@
 let React;
 let ReactNoop;
 
-// NOTE: This test requires traditional spies for console.error verification.
+// This test requires traditional spies for console.error verification.
 // The .toWarnDev() matcher treates unexpected warnings as errors.
 // Unfortunately, if an error boundary is active, ReactFiberScheduler swallows
 // any Errors that are thrown synchronously by .toWarnDev().

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
@@ -20,10 +20,6 @@ describe('ReactIncrementalErrorLogging', () => {
     ReactNoop = require('react-noop-renderer');
   });
 
-  function normalizeCodeLocInfo(str) {
-    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
-  }
-
   it('should log errors that occur during the begin phase', () => {
     // Errors are redundantly logged in production mode by ReactFiberErrorLogger.
     // It's okay to ignore them for the purpose of this test.

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
@@ -13,6 +13,13 @@
 let React;
 let ReactNoop;
 
+// NOTE: This test requires traditional spies for console.error verification.
+// The .toWarnDev() matcher treates unexpected warnings as errors.
+// Unfortunately, if an error boundary is active, ReactFiberScheduler swallows
+// any Errors that are thrown synchronously by .toWarnDev().
+// And Errors that are queued to be returned later by the matcher are preempted
+// by the errors intentionally thrown by the Components in this test.
+// This means the matcher could only produce false positives.
 describe('ReactIncrementalErrorLogging', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -25,7 +32,7 @@ describe('ReactIncrementalErrorLogging', () => {
   }
 
   it('should log errors that occur during the begin phase', () => {
-    spyOnDevAndProd(console, 'error');
+    spyOnDevAndProd(console, 'error', true);
 
     class ErrorThrowingComponent extends React.Component {
       componentWillMount() {
@@ -70,7 +77,7 @@ describe('ReactIncrementalErrorLogging', () => {
   });
 
   it('should log errors that occur during the commit phase', () => {
-    spyOnDevAndProd(console, 'error');
+    spyOnDevAndProd(console, 'error', true);
 
     class ErrorThrowingComponent extends React.Component {
       componentDidMount() {
@@ -120,7 +127,7 @@ describe('ReactIncrementalErrorLogging', () => {
     try {
       React = require('react');
       ReactNoop = require('react-noop-renderer');
-      spyOnDevAndProd(console, 'error');
+      spyOnDevAndProd(console, 'error', true);
 
       class ErrorThrowingComponent extends React.Component {
         render() {
@@ -167,7 +174,7 @@ describe('ReactIncrementalErrorLogging', () => {
   });
 
   it('should relay info about error boundary and retry attempts if applicable', () => {
-    spyOnDevAndProd(console, 'error');
+    spyOnDevAndProd(console, 'error', true);
 
     class ParentComponent extends React.Component {
       render() {

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -19,8 +19,10 @@ const createMatcherFor = consoleMethod =>
 
       const unexpectedWarnings = [];
 
-      // In order to avoid possible false positives from failed validations,
-      // Hang onto any thrown Errors and re-throw them only if all validations pass.
+      // Catch errors thrown by the callback,
+      // But only rethrow them if all test expectations have been satisfied.
+      // Otherwise an Error in the callback can mask a failed expectation,
+      // and result in a test that passes when it shouldn't.
       let caughtError;
 
       const consoleSpy = message => {
@@ -87,6 +89,7 @@ const createMatcherFor = consoleMethod =>
           };
         }
 
+        // Any unexpected Errors thrown by the callback should fail the test.
         if (caughtError) {
           throw caughtError;
         }

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -15,25 +15,8 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
   // https://github.com/facebook/jest/blob/v20.0.4/packages/jest-matchers/src/spyMatchers.js#L160
   const isSpy = spy => spy.calls && typeof spy.calls.count === 'function';
 
-  // This is the Jasmine spyOn() method.
-  // Unlike jest.spyOn(), it does not pass through to the method it spies on by default.
-  const jasmineSpyOn = global.spyOn;
-
+  const spyOn = global.spyOn;
   const noop = function() {};
-  const spyOn = function(object, methodName, ignoreConsoleWarning) {
-    if (
-      object === console &&
-      (methodName === 'warn' || methodName === 'error') &&
-      ignoreConsoleWarning !== true
-    ) {
-      throw new Error(
-        'Do not spy on the console directly. ' +
-          'Use toWarnDev() or toLowPriorityWarnDev() instead.'
-      );
-    }
-
-    return jasmineSpyOn(object, methodName);
-  };
 
   // Spying on console methods in production builds can mask errors.
   // This is why we added an explicit spyOnDev() helper.

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -15,8 +15,21 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
   // https://github.com/facebook/jest/blob/v20.0.4/packages/jest-matchers/src/spyMatchers.js#L160
   const isSpy = spy => spy.calls && typeof spy.calls.count === 'function';
 
-  const spyOn = global.spyOn;
+  // This is the Jasmine spyOn() method.
+  // Unlike jest.spyOn(), it does not pass through to the method it spies on by default.
+  const jasmineSpyOn = global.spyOn;
+
   const noop = function() {};
+  const spyOn = function(object, methodName) {
+    if (object === console) {
+      throw new Error(
+        'Do not spy on the console directly. ' +
+          'Use toWarnDev() or toLowPriorityWarnDev() instead.'
+      );
+    }
+
+    jasmineSpyOn(object, methodName);
+  };
 
   // Spying on console methods in production builds can mask errors.
   // This is why we added an explicit spyOnDev() helper.

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -20,15 +20,19 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
   const jasmineSpyOn = global.spyOn;
 
   const noop = function() {};
-  const spyOn = function(object, methodName) {
-    if (object === console) {
+  const spyOn = function(object, methodName, ignoreConsoleWarning) {
+    if (
+      object === console &&
+      (methodName === 'warn' || methodName === 'error') &&
+      !ignoreConsoleWarning
+    ) {
       throw new Error(
         'Do not spy on the console directly. ' +
           'Use toWarnDev() or toLowPriorityWarnDev() instead.'
       );
     }
 
-    jasmineSpyOn(object, methodName);
+    return jasmineSpyOn(object, methodName);
   };
 
   // Spying on console methods in production builds can mask errors.

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -24,7 +24,7 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
     if (
       object === console &&
       (methodName === 'warn' || methodName === 'error') &&
-      !ignoreConsoleWarning
+      ignoreConsoleWarning !== true
     ) {
       throw new Error(
         'Do not spy on the console directly. ' +


### PR DESCRIPTION
~~Spying on `console.error` or `console.warn` will now fail tests by default, with an error suggesting the use of the new `toWarnDev` matcher instead.~~ (This has been removed.)

Updated `.toWarnDev()` matcher to report a failed expectation to Jest even if an `Error` was thrown by its callback. Giving precedence to failed expectations prevents a thrown error from potentially masking failed expectations (and removes a source of potential false-positives from our tests).

As of this point, all but 2 of our tests have been updated to the new matcher:
* `ReactIncrementalErrorLogging-test.internal`: There's one test case that I'm unsure of how to update. I'll look at it again tomorrow.
* `ReactDOMServerIntegrationTestUtils`: It's possible to update this test util but it will take time since several, procedurally-generated tests use it. For the time being, I've added a TODO comment for following up on it.
  