### PR TITLE
Add noModule boolean attribute

### DIFF
--- a/fixtures/attribute-behavior/AttributeTableSnapshot.md
+++ b/fixtures/attribute-behavior/AttributeTableSnapshot.md
@@ -7173,6 +7173,31 @@
 | `nonce=(null)`| (initial)| `<null>` |
 | `nonce=(undefined)`| (initial)| `<null>` |
 
+## `noModule` (on `<script>` inside `<div>`)
+| Test Case | Flags | Result |
+| --- | --- | --- |
+| `noModule=(string)`| (changed)| `<boolean: true>` |
+| `noModule=(empty string)`| (initial)| `<boolean: false>` |
+| `noModule=(array with string)`| (changed)| `<boolean: true>` |
+| `noModule=(empty array)`| (changed)| `<boolean: true>` |
+| `noModule=(object)`| (changed)| `<boolean: true>` |
+| `noModule=(numeric string)`| (changed)| `<boolean: true>` |
+| `noModule=(-1)`| (changed)| `<boolean: true>` |
+| `noModule=(0)`| (initial)| `<boolean: false>` |
+| `noModule=(integer)`| (changed)| `<boolean: true>` |
+| `noModule=(NaN)`| (initial, warning)| `<boolean: false>` |
+| `noModule=(float)`| (changed)| `<boolean: true>` |
+| `noModule=(true)`| (changed)| `<boolean: true>` |
+| `noModule=(false)`| (initial)| `<boolean: false>` |
+| `noModule=(string 'true')`| (changed)| `<boolean: true>` |
+| `noModule=(string 'false')`| (changed)| `<boolean: true>` |
+| `noModule=(string 'on')`| (changed)| `<boolean: true>` |
+| `noModule=(string 'off')`| (changed)| `<boolean: true>` |
+| `noModule=(symbol)`| (initial, warning)| `<boolean: false>` |
+| `noModule=(function)`| (initial, warning)| `<boolean: false>` |
+| `noModule=(null)`| (initial)| `<boolean: false>` |
+| `noModule=(undefined)`| (initial)| `<boolean: false>` |
+
 ## `noValidate` (on `<form>` inside `<div>`)
 | Test Case | Flags | Result |
 | --- | --- | --- |

--- a/fixtures/attribute-behavior/src/attributes.js
+++ b/fixtures/attribute-behavior/src/attributes.js
@@ -1222,6 +1222,7 @@ const attributes = [
     tagName: 'color-profile',
     read: getSVGAttribute('color-profile'),
   },
+  {name: 'noModule', tagName: 'script'},
   {name: 'nonce', read: getAttribute('nonce')},
   {name: 'noValidate', tagName: 'form'},
   {

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -281,6 +281,7 @@ new Map([
   'formNoValidate',
   'hidden',
   'loop',
+  'noModule',
   'noValidate',
   'open',
   'playsInline',

--- a/packages/react-dom/src/shared/possibleStandardNames.js
+++ b/packages/react-dom/src/shared/possibleStandardNames.js
@@ -106,6 +106,7 @@ const possibleStandardNames = {
   multiple: 'multiple',
   muted: 'muted',
   name: 'name',
+  nomodule: 'noModule',
   nonce: 'nonce',
   novalidate: 'noValidate',
   open: 'open',


### PR DESCRIPTION
Resolves https://github.com/facebook/react/issues/11858

`nomodule` is now officially [in the HTML specification](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-nomodule), so we should support it.