### PR TITLE
Capture and recover from errors within a single render phase

### DIFF
--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
@@ -1798,7 +1798,7 @@ describe('ReactErrorBoundaries', () => {
     expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
   });
 
-  it('lets different boundaries catch their own first errors', () => {
+  it('lets different boundaries catch their own errors', () => {
     function renderUnmountError(error) {
       return <div>Caught an unmounting error: {error.message}.</div>;
     }
@@ -1843,7 +1843,7 @@ describe('ReactErrorBoundaries', () => {
     );
 
     expect(container.firstChild.textContent).toBe(
-      'Caught an unmounting error: E1.' + 'Caught an updating error: E3.',
+      'Caught an unmounting error: E2.' + 'Caught an updating error: E4.',
     );
     expect(log).toEqual([
       // Begin update phase
@@ -1877,8 +1877,10 @@ describe('ReactErrorBoundaries', () => {
       // After the commit phase, attempt to recover from any errors that
       // were captured
       'InnerUnmountBoundary componentDidCatch',
+      'InnerUnmountBoundary componentDidCatch',
       'InnerUnmountBoundary componentWillUpdate',
       'InnerUnmountBoundary render error',
+      'InnerUpdateBoundary componentDidCatch',
       'InnerUpdateBoundary componentDidCatch',
       'InnerUpdateBoundary componentWillUpdate',
       'InnerUpdateBoundary render error',

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
@@ -627,7 +627,7 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender render [!]',
       // Catch and render an error message
       'ErrorBoundary componentDidCatch',
-      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary componentWillMount',
       'ErrorBoundary render error',
       'ErrorBoundary componentDidMount',
     ]);
@@ -653,7 +653,7 @@ describe('ReactErrorBoundaries', () => {
       'BrokenConstructor constructor [!]',
       // Catch and render an error message
       'ErrorBoundary componentDidCatch',
-      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary componentWillMount',
       'ErrorBoundary render error',
       'ErrorBoundary componentDidMount',
     ]);
@@ -679,7 +679,7 @@ describe('ReactErrorBoundaries', () => {
       'BrokenComponentWillMount constructor',
       'BrokenComponentWillMount componentWillMount [!]',
       'ErrorBoundary componentDidCatch',
-      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary componentWillMount',
       'ErrorBoundary render error',
       'ErrorBoundary componentDidMount',
     ]);
@@ -761,7 +761,7 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
       'ErrorBoundary componentDidCatch',
-      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary componentWillMount',
       'ErrorBoundary render error',
       'ErrorMessage constructor',
       'ErrorMessage componentWillMount',
@@ -800,6 +800,7 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
       'RetryErrorBoundary componentDidCatch [!]',
+      'RetryErrorBoundary componentWillMount',
       // Retry
       'RetryErrorBoundary render',
       'BrokenRender constructor',
@@ -808,7 +809,7 @@ describe('ReactErrorBoundaries', () => {
       // This time, the error propagates to the higher boundary
       'ErrorBoundary componentDidCatch',
       // Render the error
-      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary componentWillMount',
       'ErrorBoundary render error',
       'ErrorBoundary componentDidMount',
     ]);
@@ -835,7 +836,7 @@ describe('ReactErrorBoundaries', () => {
       'BrokenComponentWillMountErrorBoundary componentWillMount [!]',
       // The error propagates to the higher boundary
       'ErrorBoundary componentDidCatch',
-      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary componentWillMount',
       'ErrorBoundary render error',
       'ErrorBoundary componentDidMount',
     ]);
@@ -870,11 +871,12 @@ describe('ReactErrorBoundaries', () => {
       // It adjusts state but throws displaying the message
       // Attempt to handle the error
       'BrokenRenderErrorBoundary componentDidCatch',
+      'BrokenRenderErrorBoundary componentWillMount',
       'BrokenRenderErrorBoundary render error [!]',
       // Boundary fails with new error, propagate to next boundary
       // Attempt to handle the error again
       'ErrorBoundary componentDidCatch',
-      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary componentWillMount',
       'ErrorBoundary render error',
       'ErrorBoundary componentDidMount',
     ]);
@@ -910,7 +912,7 @@ describe('ReactErrorBoundaries', () => {
       // Capture the error
       'ErrorBoundary componentDidCatch',
       // Render the error message
-      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary componentWillMount',
       'ErrorBoundary render error',
       'ErrorBoundary componentDidMount',
     ]);
@@ -947,7 +949,7 @@ describe('ReactErrorBoundaries', () => {
       // Capture the error
       'ErrorBoundary componentDidCatch',
       // Render the error message
-      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary componentWillMount',
       'ErrorBoundary render error',
       'Error message ref is set to [object HTMLDivElement]',
       'ErrorBoundary componentDidMount',

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
@@ -819,7 +819,7 @@ describe('ReactErrorBoundaries', () => {
     expect(log).toEqual(['ErrorBoundary componentWillUnmount']);
   });
 
-  it('propagates errors inside boundary during componentWillMount', () => {
+  fit('propagates errors inside boundary during componentWillMount', () => {
     const container = document.createElement('div');
     ReactDOM.render(
       <ErrorBoundary>
@@ -909,6 +909,10 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
+      // Continue rendering siblings
+      'Normal constructor',
+      'Normal componentWillMount',
+      'Normal render',
       // Capture the error
       'ErrorBoundary componentDidCatch',
       // Render the error message

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.js
@@ -625,13 +625,11 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      // Fiber mounts with null children before capturing error
-      'ErrorBoundary componentDidMount',
       // Catch and render an error message
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
-      'ErrorBoundary componentDidUpdate',
+      'ErrorBoundary componentDidMount',
     ]);
 
     log.length = 0;
@@ -653,13 +651,11 @@ describe('ReactErrorBoundaries', () => {
       'ErrorBoundary componentWillMount',
       'ErrorBoundary render success',
       'BrokenConstructor constructor [!]',
-      // Fiber mounts with null children before capturing error
-      'ErrorBoundary componentDidMount',
       // Catch and render an error message
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
-      'ErrorBoundary componentDidUpdate',
+      'ErrorBoundary componentDidMount',
     ]);
 
     log.length = 0;
@@ -682,11 +678,10 @@ describe('ReactErrorBoundaries', () => {
       'ErrorBoundary render success',
       'BrokenComponentWillMount constructor',
       'BrokenComponentWillMount componentWillMount [!]',
-      'ErrorBoundary componentDidMount',
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
-      'ErrorBoundary componentDidUpdate',
+      'ErrorBoundary componentDidMount',
     ]);
 
     log.length = 0;
@@ -765,7 +760,6 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      'ErrorBoundary componentDidMount',
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
@@ -773,7 +767,7 @@ describe('ReactErrorBoundaries', () => {
       'ErrorMessage componentWillMount',
       'ErrorMessage render',
       'ErrorMessage componentDidMount',
-      'ErrorBoundary componentDidUpdate',
+      'ErrorBoundary componentDidMount',
     ]);
 
     log.length = 0;
@@ -805,22 +799,18 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      // In Fiber, failed error boundaries render null before attempting to recover
-      'RetryErrorBoundary componentDidMount',
       'RetryErrorBoundary componentDidCatch [!]',
-      'ErrorBoundary componentDidMount',
       // Retry
       'RetryErrorBoundary render',
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
       // This time, the error propagates to the higher boundary
-      'RetryErrorBoundary componentWillUnmount',
       'ErrorBoundary componentDidCatch',
       // Render the error
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
-      'ErrorBoundary componentDidUpdate',
+      'ErrorBoundary componentDidMount',
     ]);
 
     log.length = 0;
@@ -844,11 +834,10 @@ describe('ReactErrorBoundaries', () => {
       'BrokenComponentWillMountErrorBoundary constructor',
       'BrokenComponentWillMountErrorBoundary componentWillMount [!]',
       // The error propagates to the higher boundary
-      'ErrorBoundary componentDidMount',
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
-      'ErrorBoundary componentDidUpdate',
+      'ErrorBoundary componentDidMount',
     ]);
 
     log.length = 0;
@@ -879,19 +868,15 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender render [!]',
       // The first error boundary catches the error
       // It adjusts state but throws displaying the message
-      // Finish mounting with null children
-      'BrokenRenderErrorBoundary componentDidMount',
       // Attempt to handle the error
       'BrokenRenderErrorBoundary componentDidCatch',
-      'ErrorBoundary componentDidMount',
       'BrokenRenderErrorBoundary render error [!]',
       // Boundary fails with new error, propagate to next boundary
-      'BrokenRenderErrorBoundary componentWillUnmount',
       // Attempt to handle the error again
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
-      'ErrorBoundary componentDidUpdate',
+      'ErrorBoundary componentDidMount',
     ]);
 
     log.length = 0;
@@ -922,14 +907,12 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      // Finish mounting with null children
-      'ErrorBoundary componentDidMount',
-      // Handle the error
+      // Capture the error
       'ErrorBoundary componentDidCatch',
       // Render the error message
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
-      'ErrorBoundary componentDidUpdate',
+      'ErrorBoundary componentDidMount',
     ]);
 
     log.length = 0;
@@ -961,16 +944,13 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      // Handle error:
-      // Finish mounting with null children
-      'ErrorBoundary componentDidMount',
-      // Handle the error
+      // Capture the error
       'ErrorBoundary componentDidCatch',
       // Render the error message
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
       'Error message ref is set to [object HTMLDivElement]',
-      'ErrorBoundary componentDidUpdate',
+      'ErrorBoundary componentDidMount',
     ]);
 
     log.length = 0;
@@ -1034,14 +1014,12 @@ describe('ReactErrorBoundaries', () => {
       'Normal2 render',
       // BrokenConstructor will abort rendering:
       'BrokenConstructor constructor [!]',
-      // Finish updating with null children
-      'Normal componentWillUnmount',
-      'ErrorBoundary componentDidUpdate',
-      // Handle the error
+      // Capture the error
       'ErrorBoundary componentDidCatch',
       // Render the error message
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
+      'Normal componentWillUnmount',
       'ErrorBoundary componentDidUpdate',
     ]);
 
@@ -1083,14 +1061,12 @@ describe('ReactErrorBoundaries', () => {
       // BrokenComponentWillMount will abort rendering:
       'BrokenComponentWillMount constructor',
       'BrokenComponentWillMount componentWillMount [!]',
-      // Finish updating with null children
-      'Normal componentWillUnmount',
-      'ErrorBoundary componentDidUpdate',
-      // Handle the error
+      // Capture the error
       'ErrorBoundary componentDidCatch',
       // Render the error message
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
+      'Normal componentWillUnmount',
       'ErrorBoundary componentDidUpdate',
     ]);
 
@@ -1127,14 +1103,12 @@ describe('ReactErrorBoundaries', () => {
       'Normal render',
       // BrokenComponentWillReceiveProps will abort rendering:
       'BrokenComponentWillReceiveProps componentWillReceiveProps [!]',
-      // Finish updating with null children
-      'Normal componentWillUnmount',
-      'BrokenComponentWillReceiveProps componentWillUnmount',
-      'ErrorBoundary componentDidUpdate',
-      // Handle the error
+      // Capture the error
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
+      'Normal componentWillUnmount',
+      'BrokenComponentWillReceiveProps componentWillUnmount',
       'ErrorBoundary componentDidUpdate',
     ]);
 
@@ -1172,14 +1146,12 @@ describe('ReactErrorBoundaries', () => {
       // BrokenComponentWillUpdate will abort rendering:
       'BrokenComponentWillUpdate componentWillReceiveProps',
       'BrokenComponentWillUpdate componentWillUpdate [!]',
-      // Finish updating with null children
-      'Normal componentWillUnmount',
-      'BrokenComponentWillUpdate componentWillUnmount',
-      'ErrorBoundary componentDidUpdate',
-      // Handle the error
+      // Capture the error
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
+      'Normal componentWillUnmount',
+      'BrokenComponentWillUpdate componentWillUnmount',
       'ErrorBoundary componentDidUpdate',
     ]);
 
@@ -1222,13 +1194,11 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      // Finish updating with null children
-      'Normal componentWillUnmount',
-      'ErrorBoundary componentDidUpdate',
-      // Handle the error
+      // Capture the error
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
+      'Normal componentWillUnmount',
       'ErrorBoundary componentDidUpdate',
     ]);
 
@@ -1281,15 +1251,13 @@ describe('ReactErrorBoundaries', () => {
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
       'BrokenRender render [!]',
-      // Finish updating with null children
-      'Child1 ref is set to null',
-      'ErrorBoundary componentDidUpdate',
-      // Handle the error
+      // Capture the error
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
-      'Error message ref is set to [object HTMLDivElement]',
+      'Child1 ref is set to null',
       // Child2 ref is never set because its mounting aborted
+      'Error message ref is set to [object HTMLDivElement]',
       'ErrorBoundary componentDidUpdate',
     ]);
 
@@ -1307,7 +1275,7 @@ describe('ReactErrorBoundaries', () => {
       <ErrorBoundary>
         <BrokenComponentWillUnmount />
         <BrokenComponentWillUnmount />
-        <Normal />
+        <Normal>Normal</Normal>
       </ErrorBoundary>,
       container,
     );
@@ -1328,15 +1296,25 @@ describe('ReactErrorBoundaries', () => {
       'BrokenComponentWillUnmount componentWillReceiveProps',
       'BrokenComponentWillUnmount componentWillUpdate',
       'BrokenComponentWillUnmount render',
-      // Unmounting throws:
+      // The first error boundary is unmounted, which throws:
       'BrokenComponentWillUnmount componentWillUnmount [!]',
       // Fiber proceeds with lifecycles despite errors
       'Normal componentWillUnmount',
       // The components have updated in this phase
       'BrokenComponentWillUnmount componentDidUpdate',
       'ErrorBoundary componentDidUpdate',
-      // Now that commit phase is done, Fiber unmounts the boundary's children
+      // Now that commit phase is done, we update the error boundaries
+      // Capture the error
+      'ErrorBoundary componentDidCatch',
+      // The error handler schedules an update
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+
+      // The second, sibling error boundary will be unmounted. This
+      // triggers *another* error.
       'BrokenComponentWillUnmount componentWillUnmount [!]',
+      'ErrorBoundary componentDidUpdate',
+      // Capture the error
       'ErrorBoundary componentDidCatch',
       // The initial render was aborted, so
       // Fiber retries from the root.
@@ -1386,20 +1364,23 @@ describe('ReactErrorBoundaries', () => {
       'BrokenComponentWillUnmount componentWillReceiveProps',
       'BrokenComponentWillUnmount componentWillUpdate',
       'BrokenComponentWillUnmount render',
-      // Unmounting throws:
+      // Unmount the innermost BrokenComponentWillUnmount, which throws.
       'BrokenComponentWillUnmount componentWillUnmount [!]',
       // Fiber proceeds with lifecycles despite errors
       'BrokenComponentWillUnmount componentDidUpdate',
       'Normal componentDidUpdate',
       'ErrorBoundary componentDidUpdate',
-      'Normal componentWillUnmount',
-      'BrokenComponentWillUnmount componentWillUnmount [!]',
-      // Now that commit phase is done, Fiber handles errors
+      // Now that commit phase is done, capture the error:
       'ErrorBoundary componentDidCatch',
-      // The initial render was aborted, so
-      // Fiber retries from the root.
       'ErrorBoundary componentWillUpdate',
-      // Render an error now (stack will do it later)
+      'ErrorBoundary render error',
+      'Normal componentWillUnmount',
+      // Now the second error boundary is unmounted.
+      'BrokenComponentWillUnmount componentWillUnmount [!]',
+      'ErrorBoundary componentDidUpdate',
+      // Capture the second error
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
       // Done
       'ErrorBoundary componentDidUpdate',
@@ -1714,13 +1695,19 @@ describe('ReactErrorBoundaries', () => {
       'LastChild componentDidMount',
       'ErrorBoundary componentDidMount',
       // Now we are ready to handle the error
-      // Safely unmount every child
+      // Capture the error
+      'ErrorBoundary componentDidCatch',
+      'ErrorBoundary componentWillUpdate',
+      'ErrorBoundary render error',
+      // The second BrokenComponentWillUnmount is unmounted, triggering
+      // another error.
       'BrokenComponentWillUnmount componentWillUnmount [!]',
       // Continue unmounting safely despite any errors
       'Normal componentWillUnmount',
       'BrokenComponentDidMount componentWillUnmount',
       'LastChild componentWillUnmount',
-      // Handle the error
+      'ErrorBoundary componentDidUpdate',
+      // Capture the second error
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
@@ -1759,11 +1746,11 @@ describe('ReactErrorBoundaries', () => {
       // All lifecycles run
       'BrokenComponentDidUpdate componentDidUpdate [!]',
       'ErrorBoundary componentDidUpdate',
-      'BrokenComponentDidUpdate componentWillUnmount',
       // Then, error is handled
       'ErrorBoundary componentDidCatch',
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
+      'BrokenComponentDidUpdate componentWillUnmount',
       'ErrorBoundary componentDidUpdate',
     ]);
 
@@ -1795,12 +1782,12 @@ describe('ReactErrorBoundaries', () => {
       'BrokenComponentDidMountErrorBoundary componentDidMount [!]',
       // Fiber proceeds with the hooks
       'ErrorBoundary componentDidMount',
-      'BrokenComponentDidMountErrorBoundary componentWillUnmount',
       // The error propagates to the higher boundary
       'ErrorBoundary componentDidCatch',
       // Fiber retries from the root
       'ErrorBoundary componentWillUpdate',
       'ErrorBoundary render error',
+      'BrokenComponentDidMountErrorBoundary componentWillUnmount',
       'ErrorBoundary componentDidUpdate',
     ]);
 
@@ -1887,14 +1874,14 @@ describe('ReactErrorBoundaries', () => {
       'OuterErrorBoundary componentDidUpdate',
       // After the commit phase, attempt to recover from any errors that
       // were captured
-      'BrokenComponentDidUpdate componentWillUnmount',
-      'BrokenComponentDidUpdate componentWillUnmount',
       'InnerUnmountBoundary componentDidCatch',
-      'InnerUpdateBoundary componentDidCatch',
       'InnerUnmountBoundary componentWillUpdate',
       'InnerUnmountBoundary render error',
+      'InnerUpdateBoundary componentDidCatch',
       'InnerUpdateBoundary componentWillUpdate',
       'InnerUpdateBoundary render error',
+      'BrokenComponentDidUpdate componentWillUnmount',
+      'BrokenComponentDidUpdate componentWillUnmount',
       'InnerUnmountBoundary componentDidUpdate',
       'InnerUpdateBoundary componentDidUpdate',
     ]);
@@ -1933,34 +1920,41 @@ describe('ReactErrorBoundaries', () => {
     expect(err2.message).toMatch(/got: undefined/);
   });
 
-  it('renders empty output if error boundary does not handle the error', () => {
+  it('propagates to next boundary if boundary does not handle the error', () => {
     const container = document.createElement('div');
-    ReactDOM.render(
-      <div>
-        Sibling
-        <NoopErrorBoundary>
-          <BrokenRender />
-        </NoopErrorBoundary>
-      </div>,
-      container,
-    );
-    expect(container.firstChild.textContent).toBe('Sibling');
+    expect(() =>
+      ReactDOM.render(
+        <div>
+          Sibling
+          <NoopErrorBoundary>
+            <BrokenRender />
+          </NoopErrorBoundary>
+        </div>,
+        container,
+      ),
+    ).toThrow('Hello');
+    expect(container.firstChild).toBe(null);
     expect(log).toEqual([
       'NoopErrorBoundary constructor',
       'NoopErrorBoundary componentWillMount',
       'NoopErrorBoundary render',
       'BrokenRender constructor',
       'BrokenRender componentWillMount',
+      // Render throws an error
       'BrokenRender render [!]',
-      // In Fiber, noop error boundaries render null
-      'NoopErrorBoundary componentDidMount',
+      // Capture the error and retry
       'NoopErrorBoundary componentDidCatch',
-      // Nothing happens.
+      'NoopErrorBoundary render',
+      // The same failure happens again
+      'BrokenRender constructor',
+      'BrokenRender componentWillMount',
+      'BrokenRender render [!]',
+      // This time, the error propagates up to the root and is thrown
     ]);
 
     log.length = 0;
     ReactDOM.unmountComponentAtNode(container);
-    expect(log).toEqual(['NoopErrorBoundary componentWillUnmount']);
+    expect(log).toEqual([]);
   });
 
   it('passes first error when two errors happen in commit', () => {

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1362,32 +1362,27 @@ describe('ReactUpdates', () => {
   });
 
   it('does not fall into an infinite error loop', () => {
-    function BadRender() {
-      throw new Error('error');
+    class BadMount extends React.Component {
+      componentDidMount() {
+        throw new Error('error');
+      }
+      render() {
+        return null;
+      }
     }
 
     class ErrorBoundary extends React.Component {
       componentDidCatch() {
-        this.props.parent.remount();
+        // Noop
       }
       render() {
-        return <BadRender />;
-      }
-    }
-
-    class NonTerminating extends React.Component {
-      state = {step: 0};
-      remount() {
-        this.setState(state => ({step: state.step + 1}));
-      }
-      render() {
-        return <ErrorBoundary key={this.state.step} parent={this} />;
+        return <BadMount />;
       }
     }
 
     const container = document.createElement('div');
     expect(() => {
-      ReactDOM.render(<NonTerminating />, container);
+      ReactDOM.render(<ErrorBoundary />, container);
     }).toThrow('Maximum');
   });
 });

--- a/packages/react-reconciler/src/ReactCapturedValue.js
+++ b/packages/react-reconciler/src/ReactCapturedValue.js
@@ -28,8 +28,8 @@ export type CapturedValue<T> = {
 };
 
 // Object that is passed to the error logger module.
-// TODO: This is different for legacy reasons, but I don't think it's
-// exposed to anyone outside FB, so we can probably change it
+// TODO: CapturedError is different from CapturedValue for legacy reasons, but I
+// don't think it's exposed to anyone outside FB, so we can probably change it.
 export type CapturedError = {
   componentName: string | null,
   componentStack: string,
@@ -40,6 +40,7 @@ export type CapturedError = {
   willRetry: boolean,
 };
 
+// Call this immediately after the value is thrown.
 export function createCapturedValue<T>(
   value: T,
   source: Fiber | null,
@@ -72,6 +73,10 @@ export function logError(capturedValue: CapturedValue<mixed>): void {
   }
 }
 
+// Create a CapturedError object from a CapturedValue before it is passed to
+// the error logger.
+// TODO: CapturedError is different from CapturedValue for legacy reasons, but I
+// don't think it's exposed to anyone outside FB, so we can probably change it.
 function createCapturedError(
   capturedValue: CapturedValue<mixed>,
 ): CapturedError {

--- a/packages/react-reconciler/src/ReactCapturedValue.js
+++ b/packages/react-reconciler/src/ReactCapturedValue.js
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Fiber} from './ReactFiber';
+
+import {ClassComponent} from 'shared/ReactTypeOfWork';
+import getComponentName from 'shared/getComponentName';
+import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
+
+import {logCapturedError} from './ReactFiberErrorLogger';
+
+const getPrototypeOf =
+  Object.getPrototypeOf === 'function' ? Object.getPrototypeOf : null;
+const objectToString = Object.prototype.toString;
+
+export type CapturedValue<T> = {
+  value: T,
+  isError: boolean,
+  source: Fiber | null,
+  boundary: Fiber | null,
+  stack: string | null,
+};
+
+// Object that is passed to the error logger module.
+// TODO: This is different for legacy reasons, but I don't think it's
+// exposed to anyone outside FB, so we can probably change it
+export type CapturedError = {
+  componentName: string | null,
+  componentStack: string,
+  error: mixed,
+  errorBoundary: Fiber | null,
+  errorBoundaryFound: boolean,
+  errorBoundaryName: string | null,
+  willRetry: boolean,
+};
+
+export function createCapturedValue<T>(
+  value: T,
+  source: Fiber | null,
+): CapturedValue<T> {
+  const valueIsError = isError(value);
+  return {
+    value,
+    isError: valueIsError,
+    source,
+    boundary: null,
+    // Don't compute the stack unless this is an error.
+    stack:
+      source !== null && valueIsError
+        ? getStackAddendumByWorkInProgressFiber(source)
+        : null,
+  };
+}
+
+export function logError(capturedValue: CapturedValue<mixed>): void {
+  const capturedError = createCapturedError(capturedValue);
+  try {
+    logCapturedError(capturedError);
+  } catch (e) {
+    // Prevent cycle if logCapturedError() throws.
+    // A cycle may still occur if logCapturedError renders a component that throws.
+    const suppressLogging = e && e.suppressReactErrorLogging;
+    if (!suppressLogging) {
+      console.error(e);
+    }
+  }
+}
+
+function createCapturedError(
+  capturedValue: CapturedValue<mixed>,
+): CapturedError {
+  const source = capturedValue.source;
+  const boundary = capturedValue.boundary;
+  const stack = capturedValue.stack;
+
+  const capturedError: CapturedError = {
+    componentName: source !== null ? getComponentName(source) : null,
+    error: capturedValue.value,
+    errorBoundary: boundary,
+    componentStack: stack !== null ? stack : '',
+    errorBoundaryName: null,
+    errorBoundaryFound: false,
+    willRetry: false,
+  };
+
+  if (boundary !== null) {
+    capturedError.errorBoundaryName = getComponentName(boundary);
+    // TODO: These are always the same. Why is it needed?
+    capturedError.errorBoundaryFound = capturedError.willRetry =
+      boundary.tag === ClassComponent;
+  } else {
+    capturedError.errorBoundaryName = null;
+    capturedError.errorBoundaryFound = capturedError.willRetry = false;
+  }
+
+  return capturedError;
+}
+
+function isError(value: mixed): boolean {
+  if (value instanceof Error) {
+    return true;
+  }
+
+  // instanceof fails across realms. Check the prototype chain.
+  if (getPrototypeOf !== null) {
+    let proto = getPrototypeOf(value);
+    while (proto !== null) {
+      if (objectToString.call(proto) === '[object Error]') {
+        return true;
+      }
+      proto = getPrototypeOf(value);
+    }
+    return false;
+  }
+
+  // If getPrototypeOf is not available, fall back to duck typing.
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof value.stack === 'string' &&
+    typeof value.message === 'string'
+  );
+}

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -1163,6 +1163,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     returnFiber: Fiber,
     currentFirstChild: Fiber | null,
     newChild: any,
+    deleteExistingChildren: boolean,
     expirationTime: ExpirationTime,
   ): Fiber | null {
     // This function is not recursive.
@@ -1180,6 +1181,11 @@ function ChildReconciler(shouldTrackSideEffects) {
       newChild.key === null
     ) {
       newChild = newChild.props.children;
+    }
+
+    if (deleteExistingChildren) {
+      deleteRemainingChildren(returnFiber, currentFirstChild);
+      currentFirstChild = null;
     }
 
     // Handle object types

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -1184,6 +1184,9 @@ function ChildReconciler(shouldTrackSideEffects) {
     }
 
     if (deleteExistingChildren) {
+      // Schedule all the existing children for deletion. This has the
+      // effect of re-mounting children even if their identity matches,
+      // as if all the keys changed.
       deleteRemainingChildren(returnFiber, currentFirstChild);
       currentFirstChild = null;
     }

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -270,11 +270,6 @@ export function createWorkInProgress(
     // We already have an alternate.
     // Reset the effect tag.
     workInProgress.effectTag = NoEffect;
-
-    // The effect list is no longer valid.
-    workInProgress.nextEffect = null;
-    workInProgress.firstEffect = null;
-    workInProgress.lastEffect = null;
   }
 
   workInProgress.expirationTime = expirationTime;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -13,6 +13,7 @@ import type {HostContext} from './ReactFiberHostContext';
 import type {HydrationContext} from './ReactFiberHydrationContext';
 import type {FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
+import type {CapturedError} from './ReactFiberScheduler';
 
 import {
   IndeterminateComponent,
@@ -31,7 +32,6 @@ import {
   PerformedWork,
   Placement,
   ContentReset,
-  Err,
   Ref,
 } from 'shared/ReactTypeOfSideEffect';
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
@@ -58,6 +58,7 @@ import {
   invalidateContextProvider,
 } from './ReactFiberContext';
 import {NoWork, Never} from './ReactFiberExpirationTime';
+import {logError} from './ReactFiberScheduler';
 
 let warnedAboutStatelessRefs;
 
@@ -71,6 +72,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   hydrationContext: HydrationContext<C, CX>,
   scheduleWork: (fiber: Fiber, expirationTime: ExpirationTime) => void,
   computeExpirationForFiber: (fiber: Fiber) => ExpirationTime,
+  markUncaughtError: (error: mixed) => void,
 ) {
   const {
     shouldSetTextContent,
@@ -105,6 +107,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       current,
       workInProgress,
       nextChildren,
+      false,
       workInProgress.expirationTime,
     );
   }
@@ -113,6 +116,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     current,
     workInProgress,
     nextChildren,
+    deleteExistingChildren,
     renderExpirationTime,
   ) {
     if (current === null) {
@@ -124,6 +128,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         workInProgress,
         null,
         nextChildren,
+        deleteExistingChildren,
         renderExpirationTime,
       );
     } else {
@@ -137,6 +142,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         workInProgress,
         current.child,
         nextChildren,
+        deleteExistingChildren,
         renderExpirationTime,
       );
     }
@@ -204,16 +210,29 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   function updateClassComponent(
     current: Fiber | null,
     workInProgress: Fiber,
+    capturedValues: Array<mixed> | null,
     renderExpirationTime: ExpirationTime,
   ) {
     // Push context providers early to prevent context stack mismatches.
     // During mounting we don't know the child context yet as the instance doesn't exist.
     // We will invalidate the child context in finishClassComponent() right after rendering.
     const hasContext = pushContextProvider(workInProgress);
+    const instance = workInProgress.stateNode;
+
+    let didCaptureError = false;
+    if (capturedValues !== null) {
+      didCaptureError = true;
+      invariant(instance !== null, 'Expected class to have an instance.');
+      // TODO: Pattern matching. Check that this is an error.
+      const capturedError: CapturedError = (capturedValues[0]: any);
+      logError(workInProgress, capturedError);
+      const error = capturedError.error;
+      instance.componentDidCatch(error);
+    }
 
     let shouldUpdate;
     if (current === null) {
-      if (!workInProgress.stateNode) {
+      if (instance === null) {
         // In the initial pass we might need to construct the instance.
         constructClassInstance(workInProgress, workInProgress.pendingProps);
         mountClassInstance(workInProgress, renderExpirationTime);
@@ -229,9 +248,20 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
         shouldUpdate = true;
       } else {
-        invariant(false, 'Resuming work not yet implemented.');
-        // In a resume, we'll already have an instance we can reuse.
-        // shouldUpdate = resumeMountClassInstance(workInProgress, renderExpirationTime);
+        if (capturedValues !== null) {
+          // A capture is more like an update than another mount,
+          // because we haven't received new props from the parent.
+          shouldUpdate = true;
+          updateClassInstance(current, workInProgress, renderExpirationTime);
+        } else {
+          // In a resume, we'll already have an instance we can reuse.
+          // shouldUpdate = resumeMountClassInstance(workInProgress, renderExpirationTime);
+          invariant(
+            capturedValues !== null,
+            'Resuming work not yet implemented.',
+          );
+          shouldUpdate = true;
+        }
       }
     } else {
       shouldUpdate = updateClassInstance(
@@ -240,11 +270,25 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         renderExpirationTime,
       );
     }
+
+    const updateQueue = workInProgress.updateQueue;
+    if (updateQueue !== null && updateQueue.capturedValues !== null) {
+      // We already called componentDidCatch inside updateClassInstance.
+      // We're checking here again so we can grab the values off the
+      // update queue.
+      // TODO: Refactor class components.
+      capturedValues = updateQueue.capturedValues;
+      updateQueue.capturedValues = null;
+      shouldUpdate = true;
+      didCaptureError = true;
+    }
     return finishClassComponent(
       current,
       workInProgress,
       shouldUpdate,
       hasContext,
+      didCaptureError,
+      renderExpirationTime,
     );
   }
 
@@ -253,11 +297,13 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     workInProgress: Fiber,
     shouldUpdate: boolean,
     hasContext: boolean,
+    didCaptureError: boolean,
+    renderExpirationTime: ExpirationTime,
   ) {
     // Refs should update even if shouldComponentUpdate returns false
     markRef(current, workInProgress);
 
-    if (!shouldUpdate) {
+    if (!shouldUpdate && !didCaptureError) {
       // Context providers should defer to sCU for rendering
       if (hasContext) {
         invalidateContextProvider(workInProgress, false);
@@ -286,7 +332,13 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
     // React DevTools reads this flag.
     workInProgress.effectTag |= PerformedWork;
-    reconcileChildren(current, workInProgress, nextChildren);
+    reconcileChildrenAtExpirationTime(
+      current,
+      workInProgress,
+      nextChildren,
+      didCaptureError,
+      renderExpirationTime,
+    );
     // Memoize props and state using the values we just used to render.
     // TODO: Restructure so we never read values from the instance.
     memoizeState(workInProgress, instance.state);
@@ -315,9 +367,47 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     pushHostContainer(workInProgress, root.containerInfo);
   }
 
-  function updateHostRoot(current, workInProgress, renderExpirationTime) {
+  function unmountFailedRoot(
+    current,
+    workInProgress,
+    capturedValues,
+    renderExpirationTime,
+  ) {
+    // TODO: Pattern matching. Check that this is an error.
+    const didError = true;
+    const capturedError: CapturedError = (capturedValues[0]: any);
+    const error = capturedError.error;
+    markUncaughtError(error);
+    reconcileChildrenAtExpirationTime(
+      current,
+      workInProgress,
+      null,
+      didError,
+      renderExpirationTime,
+    );
+    return null;
+  }
+
+  function updateHostRoot(
+    current,
+    workInProgress,
+    capturedValues,
+    renderExpirationTime,
+  ) {
     pushHostRootContext(workInProgress);
-    const updateQueue = workInProgress.updateQueue;
+    if (capturedValues !== null) {
+      // TODO: Pattern matching. Check that this is an error.
+      const capturedError: CapturedError = (capturedValues[0]: any);
+      logError(workInProgress, capturedError);
+      return unmountFailedRoot(
+        current,
+        workInProgress,
+        capturedValues,
+        renderExpirationTime,
+      );
+    }
+
+    let updateQueue = workInProgress.updateQueue;
     if (updateQueue !== null) {
       const prevState = workInProgress.memoizedState;
       const state = processUpdateQueue(
@@ -328,6 +418,21 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         null,
         renderExpirationTime,
       );
+      updateQueue = workInProgress.updateQueue;
+      if (updateQueue !== null && updateQueue.capturedValues !== null) {
+        capturedValues = updateQueue.capturedValues;
+        updateQueue.capturedValues = null;
+        // TODO: Pattern matching. Check that this is an error.
+        const capturedError: CapturedError = (capturedValues[0]: any);
+        logError(workInProgress, capturedError);
+        memoizeState(workInProgress, state);
+        return unmountFailedRoot(
+          current,
+          workInProgress,
+          capturedValues,
+          renderExpirationTime,
+        );
+      }
       if (prevState === state) {
         // If the state is the same as before, that's a bailout because we had
         // no work that expires at this time.
@@ -359,6 +464,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           workInProgress,
           null,
           element,
+          false,
           renderExpirationTime,
         );
       } else {
@@ -489,7 +595,14 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       const hasContext = pushContextProvider(workInProgress);
       adoptClassInstance(workInProgress, value);
       mountClassInstance(workInProgress, renderExpirationTime);
-      return finishClassComponent(current, workInProgress, true, hasContext);
+      return finishClassComponent(
+        current,
+        workInProgress,
+        true,
+        hasContext,
+        false,
+        renderExpirationTime,
+      );
     } else {
       // Proceed under the assumption that this is a functional component
       workInProgress.tag = FunctionalComponent;
@@ -554,6 +667,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         workInProgress,
         workInProgress.stateNode,
         nextChildren,
+        false,
         renderExpirationTime,
       );
     } else {
@@ -561,6 +675,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         workInProgress,
         workInProgress.stateNode,
         nextChildren,
+        false,
         renderExpirationTime,
       );
     }
@@ -595,6 +710,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         workInProgress,
         null,
         nextChildren,
+        false,
         renderExpirationTime,
       );
       memoizeProps(workInProgress, nextChildren);
@@ -686,8 +802,14 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   function beginWork(
     current: Fiber | null,
     workInProgress: Fiber,
+    capturedValues: Array<mixed> | null,
     renderExpirationTime: ExpirationTime,
   ): Fiber | null {
+    // The effect list is no longer valid.
+    workInProgress.nextEffect = null;
+    workInProgress.firstEffect = null;
+    workInProgress.lastEffect = null;
+
     if (
       workInProgress.expirationTime === NoWork ||
       workInProgress.expirationTime > renderExpirationTime
@@ -708,10 +830,16 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         return updateClassComponent(
           current,
           workInProgress,
+          capturedValues,
           renderExpirationTime,
         );
       case HostRoot:
-        return updateHostRoot(current, workInProgress, renderExpirationTime);
+        return updateHostRoot(
+          current,
+          workInProgress,
+          capturedValues,
+          renderExpirationTime,
+        );
       case HostComponent:
         return updateHostComponent(
           current,
@@ -751,73 +879,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
   }
 
-  function beginFailedWork(
-    current: Fiber | null,
-    workInProgress: Fiber,
-    renderExpirationTime: ExpirationTime,
-  ) {
-    // Push context providers here to avoid a push/pop context mismatch.
-    switch (workInProgress.tag) {
-      case ClassComponent:
-        pushContextProvider(workInProgress);
-        break;
-      case HostRoot:
-        pushHostRootContext(workInProgress);
-        break;
-      default:
-        invariant(
-          false,
-          'Invalid type of work. This error is likely caused by a bug in React. ' +
-            'Please file an issue.',
-        );
-    }
-
-    // Add an error effect so we can handle the error during the commit phase
-    workInProgress.effectTag |= Err;
-
-    // This is a weird case where we do "resume" work — work that failed on
-    // our first attempt. Because we no longer have a notion of "progressed
-    // deletions," reset the child to the current child to make sure we delete
-    // it again. TODO: Find a better way to handle this, perhaps during a more
-    // general overhaul of error handling.
-    if (current === null) {
-      workInProgress.child = null;
-    } else if (workInProgress.child !== current.child) {
-      workInProgress.child = current.child;
-    }
-
-    if (
-      workInProgress.expirationTime === NoWork ||
-      workInProgress.expirationTime > renderExpirationTime
-    ) {
-      return bailoutOnLowPriority(current, workInProgress);
-    }
-
-    // If we don't bail out, we're going be recomputing our children so we need
-    // to drop our effect list.
-    workInProgress.firstEffect = null;
-    workInProgress.lastEffect = null;
-
-    // Unmount the current children as if the component rendered null
-    const nextChildren = null;
-    reconcileChildrenAtExpirationTime(
-      current,
-      workInProgress,
-      nextChildren,
-      renderExpirationTime,
-    );
-
-    if (workInProgress.tag === ClassComponent) {
-      const instance = workInProgress.stateNode;
-      workInProgress.memoizedProps = instance.props;
-      workInProgress.memoizedState = instance.state;
-    }
-
-    return workInProgress.child;
-  }
-
   return {
     beginWork,
-    beginFailedWork,
   };
 }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -13,7 +13,7 @@ import type {HostContext} from './ReactFiberHostContext';
 import type {HydrationContext} from './ReactFiberHydrationContext';
 import type {FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
-import type {CapturedError} from './ReactFiberScheduler';
+import type {CapturedValue} from './ReactCapturedValue';
 
 import {
   IndeterminateComponent,
@@ -36,6 +36,7 @@ import {
 } from 'shared/ReactTypeOfSideEffect';
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
 import {debugRenderPhaseSideEffects} from 'shared/ReactFeatureFlags';
+import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
 import invariant from 'fbjs/lib/invariant';
 import getComponentName from 'shared/getComponentName';
 import warning from 'fbjs/lib/warning';
@@ -57,8 +58,9 @@ import {
   pushTopLevelContextObject,
   invalidateContextProvider,
 } from './ReactFiberContext';
+
 import {NoWork, Never} from './ReactFiberExpirationTime';
-import {logError} from './ReactFiberScheduler';
+import {logError} from './ReactCapturedValue';
 
 let warnedAboutStatelessRefs;
 
@@ -210,7 +212,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   function updateClassComponent(
     current: Fiber | null,
     workInProgress: Fiber,
-    capturedValues: Array<mixed> | null,
+    capturedValues: Array<CapturedValue<mixed>> | null,
     renderExpirationTime: ExpirationTime,
   ) {
     // Push context providers early to prevent context stack mismatches.
@@ -224,10 +226,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       didCaptureError = true;
       invariant(instance !== null, 'Expected class to have an instance.');
       // TODO: Pattern matching. Check that this is an error.
-      const capturedError: CapturedError = (capturedValues[0]: any);
-      logError(workInProgress, capturedError);
-      const error = capturedError.error;
-      instance.componentDidCatch(error);
+      const capturedValue: CapturedValue<mixed> = (capturedValues[0]: any);
+      if (capturedValue.isError) {
+        logError(capturedValue);
+        instance.componentDidCatch(capturedValue.value);
+      }
     }
 
     let shouldUpdate;
@@ -373,11 +376,20 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     capturedValues,
     renderExpirationTime,
   ) {
-    // TODO: Pattern matching. Check that this is an error.
-    const didError = true;
-    const capturedError: CapturedError = (capturedValues[0]: any);
-    const error = capturedError.error;
+    const capturedValue: CapturedValue<mixed> = (capturedValues[0]: any);
+    if (capturedValue.isError) {
+      logError(capturedValue);
+    } else {
+      capturedValue.isError = true;
+      const source = capturedValue.source;
+      if (source !== null) {
+        capturedValue.stack = getStackAddendumByWorkInProgressFiber(source);
+      }
+    }
+    const error = capturedValue.value;
     markUncaughtError(error);
+
+    const didError = true;
     reconcileChildrenAtExpirationTime(
       current,
       workInProgress,
@@ -396,9 +408,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   ) {
     pushHostRootContext(workInProgress);
     if (capturedValues !== null) {
-      // TODO: Pattern matching. Check that this is an error.
-      const capturedError: CapturedError = (capturedValues[0]: any);
-      logError(workInProgress, capturedError);
       return unmountFailedRoot(
         current,
         workInProgress,
@@ -422,9 +431,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       if (updateQueue !== null && updateQueue.capturedValues !== null) {
         capturedValues = updateQueue.capturedValues;
         updateQueue.capturedValues = null;
-        // TODO: Pattern matching. Check that this is an error.
-        const capturedError: CapturedError = (capturedValues[0]: any);
-        logError(workInProgress, capturedError);
         memoizeState(workInProgress, state);
         return unmountFailedRoot(
           current,
@@ -802,7 +808,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   function beginWork(
     current: Fiber | null,
     workInProgress: Fiber,
-    capturedValues: Array<mixed> | null,
+    capturedValues: Array<CapturedValue<mixed>> | null,
     renderExpirationTime: ExpirationTime,
   ): Fiber | null {
     // The effect list is no longer valid.

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -94,7 +94,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     adoptClassInstance,
     constructClassInstance,
     mountClassInstance,
-    // resumeMountClassInstance,
+    resumeMountClassInstance,
     updateClassInstance,
   } = ReactFiberClassComponent(
     scheduleWork,
@@ -251,20 +251,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
         shouldUpdate = true;
       } else {
-        if (capturedValues !== null) {
-          // A capture is more like an update than another mount,
-          // because we haven't received new props from the parent.
-          shouldUpdate = true;
-          updateClassInstance(current, workInProgress, renderExpirationTime);
-        } else {
-          // In a resume, we'll already have an instance we can reuse.
-          // shouldUpdate = resumeMountClassInstance(workInProgress, renderExpirationTime);
-          invariant(
-            capturedValues !== null,
-            'Resuming work not yet implemented.',
-          );
-          shouldUpdate = true;
-        }
+        // In a resume, we'll already have an instance we can reuse.
+        shouldUpdate = resumeMountClassInstance(
+          workInProgress,
+          renderExpirationTime,
+        );
       }
     } else {
       shouldUpdate = updateClassInstance(

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -440,6 +440,15 @@ export default function(
     }
   }
 
+  function callComponentDidCatch(instance: any, capturedValues: Array<mixed>) {
+    for (let i = 0; i < capturedValues.length; i++) {
+      const capturedValue: CapturedValue<mixed> = (capturedValues[i]: any);
+      logError(capturedValue);
+      const error = capturedValue.value;
+      instance.componentDidCatch(error);
+    }
+  }
+
   // Invokes the mount life-cycles on a previously never rendered instance.
   function mountClassInstance(
     workInProgress: Fiber,
@@ -537,19 +546,11 @@ export default function(
       let updateQueue = workInProgress.updateQueue;
       if (updateQueue !== null && updateQueue.capturedValues !== null) {
         const capturedValues = updateQueue.capturedValues;
-
         // Don't remove these from the update queue yet. We need them in
         // finishClassComponent. Do the reset there.
         // TODO: This is awkward. Refactor class components.
         // updateQueue.capturedValues = null;
-
-        const capturedValue: CapturedValue<mixed> = (capturedValues[0]: any);
-        if (capturedValue.isError) {
-          logError(capturedValue);
-        }
-        const error = capturedValue.value;
-        instance.componentDidCatch(error);
-
+        callComponentDidCatch(instance, capturedValues);
         newState = processUpdateQueue(
           null,
           workInProgress,
@@ -673,21 +674,13 @@ export default function(
       let updateQueue = workInProgress.updateQueue;
       if (updateQueue !== null && updateQueue.capturedValues !== null) {
         const capturedValues = updateQueue.capturedValues;
-
         // Don't remove these from the update queue yet. We need them in
         // finishClassComponent. Do the reset there.
         // TODO: This is awkward. Refactor class components.
         // updateQueue.capturedValues = null;
-
-        const capturedValue: CapturedValue<mixed> = (capturedValues[0]: any);
-        if (capturedValue.isError) {
-          logError(capturedValue);
-        }
-        const error = capturedValue.value;
-        instance.componentDidCatch(error);
-
+        callComponentDidCatch(instance, capturedValues);
         newState = processUpdateQueue(
-          current,
+          null,
           workInProgress,
           updateQueue,
           instance,

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -9,7 +9,7 @@
 
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
-import type {CapturedError} from './ReactFiberScheduler';
+import type {CapturedValue} from './ReactCapturedValue';
 
 import {Update} from 'shared/ReactTypeOfSideEffect';
 import {
@@ -37,7 +37,7 @@ import {
   processUpdateQueue,
 } from './ReactFiberUpdateQueue';
 import {hasContextChanged} from './ReactFiberContext';
-import {logError} from './ReactFiberScheduler';
+import {logError} from './ReactCapturedValue';
 
 const fakeInternalInstance = {};
 const isArray = Array.isArray;
@@ -650,11 +650,13 @@ export default function(
         // TODO: This is awkward. Refactor class components.
         // updateQueue.capturedValues = null;
 
-        // TODO: Pattern matching. Check that this is an error.
-        const capturedError: CapturedError = (capturedValues[0]: any);
-        logError(workInProgress, capturedError);
-        const error = capturedError.error;
+        const capturedValue: CapturedValue<mixed> = (capturedValues[0]: any);
+        if (capturedValue.isError) {
+          logError(capturedValue);
+        }
+        const error = capturedValue.value;
         instance.componentDidCatch(error);
+
         newState = processUpdateQueue(
           current,
           workInProgress,

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -443,6 +443,7 @@ export default function(
   function callComponentDidCatch(instance: any, capturedValues: Array<mixed>) {
     for (let i = 0; i < capturedValues.length; i++) {
       const capturedValue: CapturedValue<mixed> = (capturedValues[i]: any);
+      // For now, we can assume these are all errors.
       logError(capturedValue);
       const error = capturedValue.value;
       instance.componentDidCatch(error);

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -52,6 +52,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   hostContext: HostContext<C, CX>,
   hydrationContext: HydrationContext<C, CX>,
   captureThrownValues: () => boolean,
+  captureErrors: () => boolean,
 ) {
   const {
     createInstance,
@@ -409,7 +410,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           instance !== null &&
           typeof instance.componentDidCatch === 'function'
         ) {
-          const didCapture = captureThrownValues();
+          const didCapture = captureErrors();
           if (didCapture) {
             workInProgress.effectTag |= Err;
             return workInProgress;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -32,13 +32,7 @@ import {
   ReturnComponent,
   Fragment,
 } from 'shared/ReactTypeOfWork';
-import {
-  NoEffect,
-  Placement,
-  Ref,
-  Update,
-  Err,
-} from 'shared/ReactTypeOfSideEffect';
+import {Placement, Ref, Update} from 'shared/ReactTypeOfSideEffect';
 import invariant from 'fbjs/lib/invariant';
 
 import {reconcileChildFibers} from './ReactChildFiber';
@@ -51,8 +45,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   config: HostConfig<T, P, I, TI, HI, PI, C, CC, CX, PL>,
   hostContext: HostContext<C, CX>,
   hydrationContext: HydrationContext<C, CX>,
-  captureThrownValues: () => boolean,
-  captureErrors: () => boolean,
 ) {
   const {
     createInstance,
@@ -404,29 +396,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       case FunctionalComponent:
         return null;
       case ClassComponent: {
-        const instance = workInProgress.stateNode;
-        if (
-          (workInProgress.effectTag & Err) === NoEffect &&
-          instance !== null &&
-          typeof instance.componentDidCatch === 'function'
-        ) {
-          const didCapture = captureErrors();
-          if (didCapture) {
-            workInProgress.effectTag |= Err;
-            return workInProgress;
-          }
-        }
-
         // We are leaving this subtree, so pop context if any.
         popContextProvider(workInProgress);
         return null;
       }
       case HostRoot: {
-        const didCapture = captureThrownValues();
-        if (didCapture) {
-          return workInProgress;
-        }
-
         popHostContainer(workInProgress);
         popTopLevelContextObject(workInProgress);
         const fiberRoot = (workInProgress.stateNode: FiberRoot);

--- a/packages/react-reconciler/src/ReactFiberErrorDialog.js
+++ b/packages/react-reconciler/src/ReactFiberErrorDialog.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {CapturedError} from './ReactFiberScheduler';
+import type {CapturedError} from './ReactCapturedValue';
 
 // This module is forked in different environments.
 // By default, return `true` to log errors to the console.

--- a/packages/react-reconciler/src/ReactFiberErrorLogger.js
+++ b/packages/react-reconciler/src/ReactFiberErrorLogger.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {CapturedError} from './ReactFiberScheduler';
+import type {CapturedError} from './ReactCapturedValue';
 
 import {showErrorDialog} from './ReactFiberErrorDialog';
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -344,6 +344,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       callback,
       isReplace: false,
       isForced: false,
+      isCapture: false,
+      capturedValue: null,
       next: null,
     };
     insertUpdateIntoFiber(current, update);

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -76,7 +76,10 @@ import {
   computeExpirationBucket,
 } from './ReactFiberExpirationTime';
 import {AsyncUpdates} from './ReactTypeOfInternalContext';
-import {getUpdateExpirationTime} from './ReactFiberUpdateQueue';
+import {
+  getUpdateExpirationTime,
+  insertUpdateIntoFiber,
+} from './ReactFiberUpdateQueue';
 import {resetContext} from './ReactFiberContext';
 
 const {
@@ -154,6 +157,27 @@ if (__DEV__) {
   };
 }
 
+export function logError(boundaryFiber: Fiber, capturedError: CapturedError) {
+  const errorBoundaryFound = boundaryFiber.tag === ClassComponent;
+  capturedError.errorBoundary = boundaryFiber;
+  capturedError.errorBoundaryFound = errorBoundaryFound;
+  capturedError.errorBoundaryName = errorBoundaryFound
+    ? getComponentName(boundaryFiber)
+    : null;
+  // TODO: These are always the same. Why is it needed?
+  capturedError.willRetry = errorBoundaryFound;
+  try {
+    logCapturedError(capturedError);
+  } catch (e) {
+    // Prevent cycle if logCapturedError() throws.
+    // A cycle may still occur if logCapturedError renders a component that throws.
+    const suppressLogging = e && e.suppressReactErrorLogging;
+    if (!suppressLogging) {
+      console.error(e);
+    }
+  }
+}
+
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   config: HostConfig<T, P, I, TI, HI, PI, C, CC, CX, PL>,
 ) {
@@ -162,17 +186,19 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     config,
   );
   const {popHostContainer, popHostContext, resetHostContainer} = hostContext;
-  const {beginWork, beginFailedWork} = ReactFiberBeginWork(
+  const {beginWork} = ReactFiberBeginWork(
     config,
     hostContext,
     hydrationContext,
     scheduleWork,
     computeExpirationForFiber,
+    markUncaughtError,
   );
   const {completeWork} = ReactFiberCompleteWork(
     config,
     hostContext,
     hydrationContext,
+    captureThrownValues,
   );
   const {
     commitResetTextContent,
@@ -182,7 +208,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     commitLifeCycles,
     commitAttachRef,
     commitDetachRef,
-  } = ReactFiberCommitWork(config, captureError);
+  } = ReactFiberCommitWork(config, onCommitPhaseError);
   const {
     now,
     scheduleDeferredCallback,
@@ -215,21 +241,13 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   // The next fiber with an effect that we're currently committing.
   let nextEffect: Fiber | null = null;
 
-  // Keep track of which fibers have captured an error that need to be handled.
-  // Work is removed from this collection after componentDidCatch is called.
-  let capturedErrors: Map<Fiber, CapturedError> | null = null;
-  // Keep track of which fibers have failed during the current batch of work.
-  // This is a different set than capturedErrors, because it is not reset until
-  // the end of the batch. This is needed to propagate errors correctly if a
-  // subtree fails more than once.
-  let failedBoundaries: Set<Fiber> | null = null;
-  // Error boundaries that captured an error during the current commit.
-  let commitPhaseBoundaries: Set<Fiber> | null = null;
+  let hasUncaughtError: boolean = false;
   let firstUncaughtError: mixed | null = null;
-  let didFatal: boolean = false;
 
   let isCommitting: boolean = false;
-  let isUnmounting: boolean = false;
+
+  let thrownValues: Array<mixed> | null = null;
+  let capturedValues: Array<mixed> | null = null;
 
   // Used for performance tracking.
   let interruptedBy: Fiber | null = null;
@@ -240,6 +258,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     // Reset the cursors
     resetContext();
     resetHostContainer();
+
+    thrownValues = null;
+    capturedValues = null;
   }
 
   function commitAllHostEffects() {
@@ -296,9 +317,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           break;
         }
         case Deletion: {
-          isUnmounting = true;
           commitDeletion(nextEffect);
-          isUnmounting = false;
           break;
         }
       }
@@ -325,11 +344,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         commitAttachRef(nextEffect);
       }
 
-      if (effectTag & Err) {
-        recordEffect();
-        commitErrorHandling(nextEffect);
-      }
-
       const next = nextEffect.nextEffect;
       // Ensure that we clean these up so that we don't accidentally keep them.
       // I'm not actually sure this matters because we can't reset firstEffect
@@ -343,10 +357,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   }
 
   function commitRoot(finishedWork: Fiber): ExpirationTime {
-    // We keep track of this so that captureError can collect any boundaries
-    // that capture an error during the commit phase. The reason these aren't
-    // local to this function is because errors that occur during cWU are
-    // captured elsewhere, to prevent the unmount from being interrupted.
     isWorking = true;
     isCommitting = true;
     startCommitTimer();
@@ -410,7 +420,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           'Should have next effect. This error is likely caused by a bug ' +
             'in React. Please file an issue.',
         );
-        captureError(nextEffect, error);
+        onCommitPhaseError(nextEffect, error);
         // Clean-up
         if (nextEffect !== null) {
           nextEffect = nextEffect.nextEffect;
@@ -456,7 +466,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           'Should have next effect. This error is likely caused by a bug ' +
             'in React. Please file an issue.',
         );
-        captureError(nextEffect, error);
+        onCommitPhaseError(nextEffect, error);
         if (nextEffect !== null) {
           nextEffect = nextEffect.nextEffect;
         }
@@ -474,26 +484,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       ReactFiberInstrumentation.debugTool.onCommitWork(finishedWork);
     }
 
-    // If we caught any errors during this commit, schedule their boundaries
-    // to update.
-    if (commitPhaseBoundaries) {
-      commitPhaseBoundaries.forEach(scheduleErrorRecovery);
-      commitPhaseBoundaries = null;
-    }
-
-    if (firstUncaughtError !== null) {
-      const error = firstUncaughtError;
-      firstUncaughtError = null;
-      onUncaughtError(error);
-    }
-
     const remainingTime = root.current.expirationTime;
-
-    if (remainingTime === NoWork) {
-      capturedErrors = null;
-      failedBoundaries = null;
-    }
-
     return remainingTime;
   }
 
@@ -549,7 +540,18 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       const returnFiber = workInProgress.return;
       const siblingFiber = workInProgress.sibling;
 
-      resetExpirationTime(workInProgress, nextRenderExpirationTime);
+      if (next !== workInProgress) {
+        if (workInProgress.effectTag & Err) {
+          // Restarting an error boundary
+          stopFailedWorkTimer(workInProgress);
+        } else {
+          stopWorkTimer(workInProgress);
+        }
+        resetExpirationTime(workInProgress, nextRenderExpirationTime);
+      } else {
+        // This fiber did not complete.
+        stopWorkTimer(workInProgress);
+      }
 
       if (next !== null) {
         stopWorkTimer(workInProgress);
@@ -594,7 +596,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         }
       }
 
-      stopWorkTimer(workInProgress);
       if (__DEV__ && ReactFiberInstrumentation.debugTool) {
         ReactFiberInstrumentation.debugTool.onCompleteWork(workInProgress);
       }
@@ -633,41 +634,13 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
     }
 
-    let next = beginWork(current, workInProgress, nextRenderExpirationTime);
-    if (__DEV__) {
-      ReactDebugCurrentFiber.resetCurrentFiber();
-    }
-    if (__DEV__ && ReactFiberInstrumentation.debugTool) {
-      ReactFiberInstrumentation.debugTool.onBeginWork(workInProgress);
-    }
-
-    if (next === null) {
-      // If this doesn't spawn new work, complete the current work.
-      next = completeUnitOfWork(workInProgress);
-    }
-
-    ReactCurrentOwner.current = null;
-
-    return next;
-  }
-
-  function performFailedUnitOfWork(workInProgress: Fiber): Fiber | null {
-    // The current, flushed, state of this fiber is the alternate.
-    // Ideally nothing should rely on this, but relying on it here
-    // means that we don't need an additional field on the work in
-    // progress.
-    const current = workInProgress.alternate;
-
-    // See if beginning this work spawns more work.
-    startWorkTimer(workInProgress);
-    if (__DEV__) {
-      ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
-    }
-    let next = beginFailedWork(
+    let next = beginWork(
       current,
       workInProgress,
+      capturedValues,
       nextRenderExpirationTime,
     );
+    capturedValues = null;
     if (__DEV__) {
       ReactDebugCurrentFiber.resetCurrentFiber();
     }
@@ -686,14 +659,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   }
 
   function workLoop(expirationTime: ExpirationTime) {
-    if (capturedErrors !== null) {
-      // If there are unhandled errors, switch to the slow work loop.
-      // TODO: How to avoid this check in the fast path? Maybe the renderer
-      // could keep track of which roots have unhandled errors and call a
-      // forked version of renderRoot.
-      slowWorkLoopThatChecksForFailedWork(expirationTime);
-      return;
-    }
     if (
       nextRenderExpirationTime === NoWork ||
       nextRenderExpirationTime > expirationTime
@@ -714,57 +679,53 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
   }
 
-  function slowWorkLoopThatChecksForFailedWork(expirationTime: ExpirationTime) {
-    if (
-      nextRenderExpirationTime === NoWork ||
-      nextRenderExpirationTime > expirationTime
-    ) {
-      return;
-    }
+  function unwindToNearestBoundary(sourceFiber: Fiber, thrownValue: mixed) {
+    // Push the thrown value onto the global list.
 
-    if (nextRenderExpirationTime <= mostRecentCurrentTime) {
-      // Flush all expired work.
-      while (nextUnitOfWork !== null) {
-        if (hasCapturedError(nextUnitOfWork)) {
-          // Use a forked version of performUnitOfWork
-          nextUnitOfWork = performFailedUnitOfWork(nextUnitOfWork);
-        } else {
-          nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
-        }
-      }
+    // TODO: Pattern matching. Check that this is an error.
+    const capturedError: CapturedError = {
+      componentName: getComponentName(sourceFiber),
+      componentStack: getStackAddendumByWorkInProgressFiber(sourceFiber),
+      error: thrownValue,
+      errorBoundary: null,
+      errorBoundaryFound: false,
+      errorBoundaryName: null,
+      willRetry: false,
+    };
+    if (thrownValues === null) {
+      thrownValues = [capturedError];
     } else {
-      // Flush asynchronous work until the deadline runs out of time.
-      while (nextUnitOfWork !== null && !shouldYield()) {
-        if (hasCapturedError(nextUnitOfWork)) {
-          // Use a forked version of performUnitOfWork
-          nextUnitOfWork = performFailedUnitOfWork(nextUnitOfWork);
-        } else {
-          nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
-        }
-      }
+      thrownValues.push(capturedError);
     }
-  }
 
-  function renderRootCatchBlock(
-    root: FiberRoot,
-    failedWork: Fiber,
-    boundary: Fiber,
-    expirationTime: ExpirationTime,
-  ) {
-    // We're going to restart the error boundary that captured the error.
-    // Conceptually, we're unwinding the stack. We need to unwind the
-    // context stack, too.
-    unwindContexts(failedWork, boundary);
+    popContexts(sourceFiber);
 
-    // Restart the error boundary using a forked version of
-    // performUnitOfWork that deletes the boundary's children. The entire
-    // failed subree will be unmounted. During the commit phase, a special
-    // lifecycle method is called on the error boundary, which triggers
-    // a re-render.
-    nextUnitOfWork = performFailedUnitOfWork(boundary);
+    // TODO: If the value is something other than an error (like a
+    // promise), continue working on the siblings, and unwind using
+    // the normal complete phase algorithm. This should be safe, because
+    // we assume the value was thrown from inside the render method. For
+    // errors, we have to skip the siblings and immediately unwind to
+    // the nearest boundary, because the tree may be in a corrupt state.
+    let boundaryFiber = null;
+    let fiber = sourceFiber.return;
+    traversal: while (fiber !== null) {
+      switch (fiber.tag) {
+        case ClassComponent:
+          const instance = fiber.stateNode;
+          if (typeof instance.componentDidCatch === 'function') {
+            boundaryFiber = fiber;
+            break traversal;
+          }
+          break;
+        case HostRoot:
+          boundaryFiber = fiber;
+          break;
+      }
+      popContexts(fiber);
+      fiber = fiber.return;
+    }
 
-    // Continue working.
-    workLoop(expirationTime);
+    return boundaryFiber;
   }
 
   function renderRoot(
@@ -802,339 +763,168 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     startWorkLoopTimer(nextUnitOfWork);
 
-    let didError = false;
-    let error = null;
-    if (__DEV__) {
-      invokeGuardedCallback(null, workLoop, null, expirationTime);
-      if (hasCaughtError()) {
-        didError = true;
-        error = clearCaughtError();
-      }
-    } else {
-      try {
-        workLoop(expirationTime);
-      } catch (e) {
-        didError = true;
-        error = e;
-      }
-    }
+    let didThrow;
+    let thrownValue;
+    do {
+      didThrow = false;
+      thrownValue = null;
 
-    // An error was thrown during the render phase.
-    while (didError) {
-      if (didFatal) {
-        // This was a fatal error. Don't attempt to recover from it.
-        firstUncaughtError = error;
-        break;
-      }
-
-      const failedWork = nextUnitOfWork;
-      if (failedWork === null) {
-        // An error was thrown but there's no current unit of work. This can
-        // happen during the commit phase if there's a bug in the renderer.
-        didFatal = true;
-        continue;
-      }
-
-      // "Capture" the error by finding the nearest boundary. If there is no
-      // error boundary, we use the root.
-      const boundary = captureError(failedWork, error);
-      invariant(
-        boundary !== null,
-        'Should have found an error boundary. This error is likely ' +
-          'caused by a bug in React. Please file an issue.',
-      );
-
-      if (didFatal) {
-        // The error we just captured was a fatal error. This happens
-        // when the error propagates to the root more than once.
-        continue;
-      }
-
-      didError = false;
-      error = null;
       if (__DEV__) {
-        invokeGuardedCallback(
-          null,
-          renderRootCatchBlock,
-          null,
-          root,
-          failedWork,
-          boundary,
-          expirationTime,
-        );
+        invokeGuardedCallback(null, workLoop, null, expirationTime);
         if (hasCaughtError()) {
-          didError = true;
-          error = clearCaughtError();
-          continue;
+          didThrow = true;
+          thrownValue = clearCaughtError();
         }
       } else {
         try {
-          renderRootCatchBlock(root, failedWork, boundary, expirationTime);
-          error = null;
+          workLoop(expirationTime);
         } catch (e) {
-          didError = true;
-          error = e;
-          continue;
+          didThrow = true;
+          thrownValue = e;
         }
       }
-      // We're finished working. Exit the error loop.
-      break;
-    }
 
-    const uncaughtError = firstUncaughtError;
+      if (!didThrow) {
+        break;
+      }
+
+      if (nextUnitOfWork === null) {
+        // Should have a nextUnitOfWork here.
+        hasUncaughtError = true;
+        firstUncaughtError = thrownValue;
+        break;
+      }
+
+      const boundary = unwindToNearestBoundary(nextUnitOfWork, thrownValue);
+      if (boundary !== null) {
+        nextUnitOfWork = completeUnitOfWork(boundary);
+      } else {
+        // The root failed to render. This is a fatal error.
+        hasUncaughtError = true;
+        firstUncaughtError = thrownValue;
+        break;
+      }
+    } while (true);
+
+    if (hasUncaughtError) {
+      onUncaughtError(firstUncaughtError);
+      hasUncaughtError = false;
+      firstUncaughtError = null;
+      // Set this to null to indicate there's no more work left.
+      // That way the stack is reset next time we work on this root.
+      nextUnitOfWork = null;
+    }
 
     // We're done performing work. Time to clean up.
     stopWorkLoopTimer(interruptedBy);
     interruptedBy = null;
     isWorking = false;
-    didFatal = false;
-    firstUncaughtError = null;
-
-    if (uncaughtError !== null) {
-      onUncaughtError(uncaughtError);
-    }
 
     return root.isReadyForCommit ? root.current.alternate : null;
   }
 
-  // Returns the boundary that captured the error, or null if the error is ignored
-  function captureError(failedWork: Fiber, error: mixed): Fiber | null {
-    // It is no longer valid because we exited the user code.
-    ReactCurrentOwner.current = null;
-    if (__DEV__) {
-      ReactDebugCurrentFiber.resetCurrentFiber();
-    }
-
-    // Search for the nearest error boundary.
-    let boundary: Fiber | null = null;
-
-    // Passed to logCapturedError()
-    let errorBoundaryFound: boolean = false;
-    let willRetry: boolean = false;
-    let errorBoundaryName: string | null = null;
-
-    // Host containers are a special case. If the failed work itself is a host
-    // container, then it acts as its own boundary. In all other cases, we
-    // ignore the work itself and only search through the parents.
-    if (failedWork.tag === HostRoot) {
-      boundary = failedWork;
-
-      if (isFailedBoundary(failedWork)) {
-        // If this root already failed, there must have been an error when
-        // attempting to unmount it. This is a worst-case scenario and
-        // should only be possible if there's a bug in the renderer.
-        didFatal = true;
-      }
-    } else {
-      let node = failedWork.return;
-      while (node !== null && boundary === null) {
-        if (node.tag === ClassComponent) {
-          const instance = node.stateNode;
-          if (typeof instance.componentDidCatch === 'function') {
-            errorBoundaryFound = true;
-            errorBoundaryName = getComponentName(node);
-
-            // Found an error boundary!
-            boundary = node;
-            willRetry = true;
-          }
-        } else if (node.tag === HostRoot) {
-          // Treat the root like a no-op error boundary
-          boundary = node;
-        }
-
-        if (isFailedBoundary(node)) {
-          // This boundary is already in a failed state.
-
-          // If we're currently unmounting, that means this error was
-          // thrown while unmounting a failed subtree. We should ignore
-          // the error.
-          if (isUnmounting) {
-            return null;
-          }
-
-          // If we're in the commit phase, we should check to see if
-          // this boundary already captured an error during this commit.
-          // This case exists because multiple errors can be thrown during
-          // a single commit without interruption.
-          if (
-            commitPhaseBoundaries !== null &&
-            (commitPhaseBoundaries.has(node) ||
-              (node.alternate !== null &&
-                commitPhaseBoundaries.has(node.alternate)))
-          ) {
-            // If so, we should ignore this error.
-            return null;
-          }
-
-          // The error should propagate to the next boundary -— we keep looking.
-          boundary = null;
-          willRetry = false;
-        }
-
-        node = node.return;
-      }
-    }
-
-    if (boundary !== null) {
-      // Add to the collection of failed boundaries. This lets us know that
-      // subsequent errors in this subtree should propagate to the next boundary.
-      if (failedBoundaries === null) {
-        failedBoundaries = new Set();
-      }
-      failedBoundaries.add(boundary);
-
-      // This method is unsafe outside of the begin and complete phases.
-      // We might be in the commit phase when an error is captured.
-      // The risk is that the return path from this Fiber may not be accurate.
-      // That risk is acceptable given the benefit of providing users more context.
-      const componentStack = getStackAddendumByWorkInProgressFiber(failedWork);
-      const componentName = getComponentName(failedWork);
-
-      // Add to the collection of captured errors. This is stored as a global
-      // map of errors and their component stack location keyed by the boundaries
-      // that capture them. We mostly use this Map as a Set; it's a Map only to
-      // avoid adding a field to Fiber to store the error.
-      if (capturedErrors === null) {
-        capturedErrors = new Map();
-      }
-
-      const capturedError = {
-        componentName,
-        componentStack,
-        error,
-        errorBoundary: errorBoundaryFound ? boundary.stateNode : null,
-        errorBoundaryFound,
-        errorBoundaryName,
-        willRetry,
-      };
-
-      capturedErrors.set(boundary, capturedError);
-
-      try {
-        logCapturedError(capturedError);
-      } catch (e) {
-        // Prevent cycle if logCapturedError() throws.
-        // A cycle may still occur if logCapturedError renders a component that throws.
-        const suppressLogging = e && e.suppressReactErrorLogging;
-        if (!suppressLogging) {
-          console.error(e);
-        }
-      }
-
-      // If we're in the commit phase, defer scheduling an update on the
-      // boundary until after the commit is complete
-      if (isCommitting) {
-        if (commitPhaseBoundaries === null) {
-          commitPhaseBoundaries = new Set();
-        }
-        commitPhaseBoundaries.add(boundary);
-      } else {
-        // Otherwise, schedule an update now.
-        // TODO: Is this actually necessary during the render phase? Is it
-        // possible to unwind and continue rendering at the same priority,
-        // without corrupting internal state?
-        scheduleErrorRecovery(boundary);
-      }
-      return boundary;
-    } else if (firstUncaughtError === null) {
-      // If no boundary is found, we'll need to throw the error
-      firstUncaughtError = error;
-    }
-    return null;
-  }
-
-  function hasCapturedError(fiber: Fiber): boolean {
-    // TODO: capturedErrors should store the boundary instance, to avoid needing
-    // to check the alternate.
-    return (
-      capturedErrors !== null &&
-      (capturedErrors.has(fiber) ||
-        (fiber.alternate !== null && capturedErrors.has(fiber.alternate)))
-    );
-  }
-
-  function isFailedBoundary(fiber: Fiber): boolean {
-    // TODO: failedBoundaries should store the boundary instance, to avoid
-    // needing to check the alternate.
-    return (
-      failedBoundaries !== null &&
-      (failedBoundaries.has(fiber) ||
-        (fiber.alternate !== null && failedBoundaries.has(fiber.alternate)))
-    );
-  }
-
-  function commitErrorHandling(effectfulFiber: Fiber) {
-    let capturedError;
-    if (capturedErrors !== null) {
-      capturedError = capturedErrors.get(effectfulFiber);
-      capturedErrors.delete(effectfulFiber);
-      if (capturedError == null) {
-        if (effectfulFiber.alternate !== null) {
-          effectfulFiber = effectfulFiber.alternate;
-          capturedError = capturedErrors.get(effectfulFiber);
-          capturedErrors.delete(effectfulFiber);
-        }
-      }
-    }
-
-    invariant(
-      capturedError != null,
-      'No error for given unit of work. This error is likely caused by a ' +
-        'bug in React. Please file an issue.',
-    );
-
-    switch (effectfulFiber.tag) {
+  function popContexts(workInProgress: Fiber) {
+    switch (workInProgress.tag) {
       case ClassComponent:
-        const instance = effectfulFiber.stateNode;
-
-        const info: HandleErrorInfo = {
-          componentStack: capturedError.componentStack,
-        };
-
-        // Allow the boundary to handle the error, usually by scheduling
-        // an update to itself
-        instance.componentDidCatch(capturedError.error, info);
-        return;
+        popContextProvider(workInProgress);
+        break;
+      case HostComponent:
+        popHostContext(workInProgress);
+        break;
       case HostRoot:
-        if (firstUncaughtError === null) {
-          firstUncaughtError = capturedError.error;
-        }
-        return;
-      default:
-        invariant(
-          false,
-          'Invalid type of work. This error is likely caused by a bug in ' +
-            'React. Please file an issue.',
-        );
+        popHostContainer(workInProgress);
+        break;
+      case HostPortal:
+        popHostContainer(workInProgress);
+        break;
     }
+    stopWorkTimer(workInProgress);
   }
 
-  function unwindContexts(from: Fiber, to: Fiber) {
-    let node = from;
-    while (node !== null) {
-      switch (node.tag) {
+  // Called during complete phase
+  function captureThrownValues(): boolean {
+    if (thrownValues === null) {
+      return false;
+    }
+
+    capturedValues = thrownValues;
+    // Clear the values from the scheduler.
+    thrownValues = null;
+    return true;
+  }
+
+  function markUncaughtError(error: mixed): void {
+    hasUncaughtError = true;
+    firstUncaughtError = error;
+  }
+
+  function scheduleCapture(
+    sourceFiber,
+    boundaryFiber,
+    capturedValue,
+    expirationTime,
+  ) {
+    // TODO: Pattern matching. Check that this is an error.
+    const capturedError: CapturedError = {
+      componentName: getComponentName(sourceFiber),
+      componentStack: getStackAddendumByWorkInProgressFiber(sourceFiber),
+      error: capturedValue,
+      // Set these once the boundary captures, during the render phase.
+      errorBoundary: null,
+      errorBoundaryFound: false,
+      errorBoundaryName: null,
+      willRetry: false,
+    };
+
+    const update = {
+      expirationTime,
+      partialState: null,
+      callback: null,
+      isReplace: false,
+      isForced: false,
+      isCapture: true,
+      capturedValue: capturedError,
+      next: null,
+    };
+    insertUpdateIntoFiber(boundaryFiber, update);
+    scheduleWork(boundaryFiber, expirationTime);
+  }
+
+  function dispatch(
+    sourceFiber: Fiber,
+    value: mixed,
+    expirationTime: ExpirationTime,
+  ) {
+    invariant(
+      !isWorking || isCommitting,
+      'dispatch: Cannot dispatch during the render phase.',
+    );
+    let fiber = sourceFiber.return;
+    while (fiber !== null) {
+      switch (fiber.tag) {
         case ClassComponent:
-          popContextProvider(node);
-          break;
-        case HostComponent:
-          popHostContext(node);
+          const instance = fiber.stateNode;
+          if (typeof instance.componentDidCatch === 'function') {
+            scheduleCapture(sourceFiber, fiber, value, expirationTime);
+            return;
+          }
           break;
         case HostRoot:
-          popHostContainer(node);
-          break;
-        case HostPortal:
-          popHostContainer(node);
-          break;
+          scheduleCapture(sourceFiber, fiber, value, expirationTime);
+          return;
       }
-      if (node === to || node.alternate === to) {
-        stopFailedWorkTimer(node);
-        break;
-      } else {
-        stopWorkTimer(node);
-      }
-      node = node.return;
+      fiber = fiber.return;
     }
+
+    if (sourceFiber.tag === HostRoot) {
+      // Error was thrown at the root. There is no parent, so the root
+      // itself should capture it.
+      scheduleCapture(sourceFiber, sourceFiber, value, expirationTime);
+    }
+  }
+
+  function onCommitPhaseError(fiber: Fiber, error: mixed) {
+    return dispatch(fiber, error, Sync);
   }
 
   function computeAsyncExpiration() {
@@ -1264,10 +1054,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       }
       node = node.return;
     }
-  }
-
-  function scheduleErrorRecovery(fiber: Fiber) {
-    scheduleWorkImpl(fiber, Sync, true);
   }
 
   function recalculateCurrentTime(): ExpirationTime {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -17,6 +17,7 @@ import type {CapturedValue} from './ReactCapturedValue';
 import ReactErrorUtils from 'shared/ReactErrorUtils';
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
 import {
+  NoEffect,
   PerformedWork,
   Placement,
   Update,
@@ -163,8 +164,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     config,
     hostContext,
     hydrationContext,
-    captureThrownValues,
-    captureErrors,
   );
   const {
     commitResetTextContent,
@@ -484,7 +483,43 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     workInProgress.expirationTime = newExpirationTime;
   }
 
-  function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
+  function captureThrownValues(): boolean {
+    if (thrownValues === null) {
+      return false;
+    }
+    capturedValues = thrownValues;
+    // Reset the list of thrown values, now that they've been captured.
+    thrownValues = null;
+    return true;
+  }
+
+  function captureErrors(): boolean {
+    if (thrownValues === null) {
+      return false;
+    }
+    let errors = null;
+    for (let i = 0; i < thrownValues.length; i++) {
+      const value = thrownValues[i];
+      if (value.isError) {
+        thrownValues.splice(i, 1);
+        if (errors === null) {
+          errors = [value];
+        } else {
+          errors.push(value);
+        }
+      }
+    }
+    if (thrownValues.length === 0) {
+      thrownValues = null;
+    }
+    capturedValues = errors;
+    return true;
+  }
+
+  function unwindUnitOfWork(workInProgress: Fiber): Fiber | null {
+    // Attempt to complete the current unit of work, then move to the
+    // next sibling. If there are no more siblings, return to the
+    // parent fiber.
     while (true) {
       // The current, flushed, state of this fiber is the alternate.
       // Ideally nothing should rely on this, but relying on it here
@@ -494,19 +529,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       if (__DEV__) {
         ReactDebugCurrentFiber.setCurrentFiber(workInProgress);
       }
-      const next = completeWork(
-        current,
-        workInProgress,
-        nextRenderExpirationTime,
-      );
-      if (__DEV__) {
-        ReactDebugCurrentFiber.resetCurrentFiber();
-      }
 
-      const returnFiber = workInProgress.return;
-      const siblingFiber = workInProgress.sibling;
-
-      if (next !== workInProgress) {
+      let next;
+      if (thrownValues === null) {
+        // This fiber completed.
+        next = completeWork(current, workInProgress, nextRenderExpirationTime);
         if (workInProgress.effectTag & Err) {
           // Restarting an error boundary
           stopFailedWorkTimer(workInProgress);
@@ -515,9 +542,53 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         }
         resetExpirationTime(workInProgress, nextRenderExpirationTime);
       } else {
-        // This fiber did not complete.
+        // This fiber did not complete because something threw. Pop values off
+        // the stack without entering the complete phase. If this is a boundary,
+        // capture values if possible.
+        popContexts(workInProgress);
+        switch (workInProgress.tag) {
+          case ClassComponent: {
+            const instance = workInProgress.stateNode;
+            if (
+              (workInProgress.effectTag & Err) === NoEffect &&
+              instance !== null &&
+              typeof instance.componentDidCatch === 'function'
+            ) {
+              const didCapture = captureErrors();
+              if (didCapture) {
+                workInProgress.effectTag |= Err;
+                // Render the boundary again
+                next = workInProgress;
+              } else {
+                next = null;
+              }
+            } else {
+              next = null;
+            }
+            break;
+          }
+          case HostRoot:
+            const didCapture = captureThrownValues();
+            if (didCapture) {
+              // Render the boundary again
+              next = workInProgress;
+            } else {
+              next = null;
+            }
+            break;
+          default:
+            next = null;
+        }
+        // Because this fiber did not complete, don't reset its expiration time.
         stopWorkTimer(workInProgress);
       }
+
+      if (__DEV__) {
+        ReactDebugCurrentFiber.resetCurrentFiber();
+      }
+
+      const returnFiber = workInProgress.return;
+      const siblingFiber = workInProgress.sibling;
 
       if (next !== null) {
         stopWorkTimer(workInProgress);
@@ -616,7 +687,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     if (next === null) {
       // If this doesn't spawn new work, complete the current work.
-      next = completeUnitOfWork(workInProgress);
+      next = unwindUnitOfWork(workInProgress);
     }
 
     ReactCurrentOwner.current = null;
@@ -643,32 +714,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         nextUnitOfWork = performUnitOfWork(nextUnitOfWork);
       }
     }
-  }
-
-  function unwindToNearestErrorBoundary(sourceFiber) {
-    popContexts(sourceFiber);
-    let boundaryFiber = null;
-    let fiber = sourceFiber.return;
-    traversal: while (fiber !== null) {
-      switch (fiber.tag) {
-        case ClassComponent:
-          const instance = fiber.stateNode;
-          if (
-            typeof instance.componentDidCatch === 'function' &&
-            !(fiber.effectTag & Err)
-          ) {
-            boundaryFiber = fiber;
-            break traversal;
-          }
-          break;
-        case HostRoot:
-          boundaryFiber = fiber;
-          break;
-      }
-      popContexts(fiber);
-      fiber = fiber.return;
-    }
-    return boundaryFiber;
   }
 
   function renderRoot(
@@ -745,29 +790,18 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       } else {
         thrownValues.push(capturedValue);
       }
-      if (capturedValue.isError) {
-        const boundaryFiber = unwindToNearestErrorBoundary(sourceFiber);
-        capturedValue.boundary = boundaryFiber;
-        if (boundaryFiber !== null) {
-          nextUnitOfWork = completeUnitOfWork(boundaryFiber);
-        } else {
-          // The root failed to render. This is a fatal error.
-          hasUncaughtError = true;
-          firstUncaughtError = thrownValue;
-          break;
-        }
+
+      // Move to next sibling, or return to parent
+      popContexts(sourceFiber);
+      if (sourceFiber.sibling !== null) {
+        nextUnitOfWork = sourceFiber.sibling;
+      } else if (sourceFiber.return !== null) {
+        nextUnitOfWork = unwindUnitOfWork(sourceFiber.return);
       } else {
-        // Move to next sibling, or return to parent
-        if (sourceFiber.sibling !== null) {
-          nextUnitOfWork = sourceFiber.sibling;
-        } else if (sourceFiber.return !== null) {
-          nextUnitOfWork = completeUnitOfWork(sourceFiber.return);
-        } else {
-          // The root failed to render. This is a fatal error.
-          hasUncaughtError = true;
-          firstUncaughtError = thrownValue;
-          break;
-        }
+        // The root failed to render. This is a fatal error.
+        hasUncaughtError = true;
+        firstUncaughtError = thrownValue;
+        break;
       }
     } while (true);
 
@@ -804,40 +838,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         break;
     }
     stopWorkTimer(workInProgress);
-  }
-
-  // Called during complete phase
-  function captureThrownValues(): boolean {
-    if (thrownValues === null) {
-      return false;
-    }
-    capturedValues = thrownValues;
-    // Reset the list of thrown values, now that they've been captured.
-    thrownValues = null;
-    return true;
-  }
-
-  function captureErrors(): boolean {
-    if (thrownValues === null) {
-      return false;
-    }
-    let errors = null;
-    for (let i = 0; i < thrownValues.length; i++) {
-      const value = thrownValues[i];
-      if (value.isError) {
-        thrownValues.splice(i, 1);
-        if (errors === null) {
-          errors = [value];
-        } else {
-          errors.push(value);
-        }
-      }
-    }
-    if (thrownValues.length === 0) {
-      thrownValues = null;
-    }
-    capturedValues = errors;
-    return true;
   }
 
   function markUncaughtError(error: mixed): void {

--- a/packages/react-reconciler/src/ReactFiberUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberUpdateQueue.js
@@ -9,6 +9,7 @@
 
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
+import type {CapturedValue} from './ReactCapturedValue';
 
 import {debugRenderPhaseSideEffects} from 'shared/ReactFeatureFlags';
 import {Callback as CallbackEffect} from 'shared/ReactTypeOfSideEffect';
@@ -37,8 +38,7 @@ export type Update<State> = {
   callback: Callback | null,
   isReplace: boolean,
   isForced: boolean,
-  isCapture: boolean,
-  capturedValue: mixed | null,
+  capturedValue: CapturedValue<mixed> | null,
   next: Update<State> | null,
 };
 
@@ -66,7 +66,7 @@ export type UpdateQueue<State> = {
   callbackList: Array<Update<State>> | null,
   hasForceUpdate: boolean,
   isInitialized: boolean,
-  capturedValues: Array<mixed> | null,
+  capturedValues: Array<CapturedValue<mixed>> | null,
 
   // Dev only
   isProcessing?: boolean,
@@ -309,7 +309,7 @@ export function processUpdateQueue<State>(
       }
       callbackList.push(update);
     }
-    if (update.isCapture) {
+    if (update.capturedValue !== null) {
       let capturedValues = queue.capturedValues;
       if (capturedValues === null) {
         queue.capturedValues = [update.capturedValue];

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -2717,7 +2717,9 @@ describe('ReactIncremental', () => {
     expect(ReactNoop.flush()).toEqual([]);
   });
 
-  it('does not break with a bad Map polyfill', () => {
+  // We don't currently use fibers as keys. Re-enable this test if we
+  // ever do again.
+  it.skip('does not break with a bad Map polyfill', () => {
     const realMapSet = Map.prototype.set;
 
     function triggerCodePathThatUsesFibersAsMapKeys() {

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -221,22 +221,15 @@ exports[`ReactDebugFiberPerf recovers from caught errors 1`] = `
 // Stop on Baddie and restart from Boundary
 ⚛ (React Tree Reconciliation)
   ⚛ Parent [mount]
-    ⛔ Boundary [mount] Warning: An error was thrown inside this error boundary
+    ⚛ Boundary [mount]
       ⚛ Parent [mount]
         ⚛ Baddie [mount]
-    ⚛ Boundary [mount]
-
-⛔ (Committing Changes) Warning: Lifecycle hook scheduled a cascading update
-  ⚛ (Committing Host Effects: 2 Total)
-  ⚛ (Calling Lifecycle Methods: 1 Total)
-
-⚛ (React Tree Reconciliation)
-  ⚛ Boundary [update]
-    ⚛ ErrorReport [mount]
+    ⛔ Boundary [mount] Warning: An error was thrown inside this error boundary
+      ⚛ ErrorReport [mount]
 
 ⚛ (Committing Changes)
   ⚛ (Committing Host Effects: 2 Total)
-  ⚛ (Calling Lifecycle Methods: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
 "
 `;
 
@@ -249,8 +242,8 @@ exports[`ReactDebugFiberPerf recovers from fatal errors 1`] = `
     ⚛ Baddie [mount]
 
 ⚛ (Committing Changes)
-  ⚛ (Committing Host Effects: 1 Total)
-  ⚛ (Calling Lifecycle Methods: 1 Total)
+  ⚛ (Committing Host Effects: 0 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
 
 ⚛ (Waiting for async callback...)
 

--- a/packages/react-reconciler/src/forks/ReactFiberErrorDialog.native.js
+++ b/packages/react-reconciler/src/forks/ReactFiberErrorDialog.native.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {CapturedError} from '../ReactFiberScheduler';
+import type {CapturedError} from '../ReactCapturedValue';
 
 // Module provided by RN:
 import ExceptionsManager from 'ExceptionsManager';

--- a/packages/react-reconciler/src/forks/ReactFiberErrorDialog.www.js
+++ b/packages/react-reconciler/src/forks/ReactFiberErrorDialog.www.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {CapturedError} from '../ReactFiberScheduler';
+import type {CapturedError} from '../ReactCapturedValue';
 
 import invariant from 'fbjs/lib/invariant';
 

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
@@ -460,8 +460,8 @@ describe('ReactTestRenderer', () => {
     expect(log).toEqual([
       'Boundary render',
       'Angry render',
-      'Boundary componentDidMount',
       'Boundary render',
+      'Boundary componentDidMount',
     ]);
   });
 


### PR DESCRIPTION
A rewrite of error handling, with semantics that more closely match stack unwinding.

Errors that are thrown during the render phase unwind to the nearest error boundary, like before. But rather than synchronously unmount the children before retrying, we restart the failed subtree within the same render phase. The failed children are still unmounted (as if all their keys changed) but without an extra commit.

Commit phase errors are different. They work by scheduling an error on the update queue of the error boundary. When we enter the render phase, the error is popped off the queue. The rest of the algorithm is the same.

In the future, this same algorithm will be used for throwing non-errors, though those will be handled slightly differently: rather than unwind directly to the boundary, we'll continue rendering the siblings. Unwinding will work using the normal complete phase algorithm.

This is required for blockers, unless we ship the two implementations side-by-side.

Open question: could we release this in a minor version? Error boundaries are a public feature. On the other hand, the changes are only observable if an error is thrown. We also warn, so nobody should be relying on error boundaries for anything other than their intended purpose.

Behavior that has changed:

- Render phase error recovery is no longer synchronous in async mode. They have the same priority as whatever component threw the error.
- Previously, when an error boundary captured an error, the children were deleted and committed first, before attempting to re-render. Now they are re-rendered in a single pass without an extra commit to unmount.
- `componentDidCatch` used to always fire in the commit phase. Now it's always called in the render phase.
- All errors are modeled as render phase errors. Even errors that are thrown during the commit phase are implemented by scheduling an update, entering the render phase, then capturing. Modeling it this way has many benefits, the most obvious being that we no longer need to keep track of a global set of failed error boundaries. But it means that this will now cause an infinite loop:

```js
class InfiniteErrorLoop extends React.Component {
  componentDidCatch() {
    // Noop. ThrowsOnMount will mount and throw infinitely,
    // until the stack overflows ("Maximum update depth" error).
  }
  render() {
    return <ThrowsOnMount />;
  }
}
```

I think this is fine. In fact, I think these semantics make more sense. In my head, I model it like this:

```js
function performWork() {
  renderPhase(); // Has its own try-catch, so doesn't throw
  try {
    commitPhase(); // Throws
  } catch (error) {
    componentDidCatch();
    // Try again
    // If componentDidCatch is a noop, we'll eventually get a stack overflow.
    performWork();
  }
}
```

It's similar to the case where you call `setState` inside `componentDidUpdate` without a guard. Please tell me if you disagree and I'll do my best to convince you :D

TODO:

- [x] Test that render phase error recovery now works in async
- [x] Don't capture non-errors.
- [x] Use "resume mount" instead of "resume update" path on initial mount
- [x] Don't complete parents of children that threw
- [ ] Moar comments

Potential follow-ups

- Add `this.unstable_dispatchError` for capturing errors outside React lifecycles? I've implemented internally (it's how React lifecycles work, too) but it's not exposed.