### PR TITLE
Trap click events for portal root

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -577,7 +577,6 @@ function createPortal(
     isValidContainer(container),
     'Target container is not a DOM element.',
   );
-  ReactDOMFiberComponent.trapClickOnNonInteractiveElement(((container: any): HTMLElement));
   // TODO: pass ReactDOM portal implementation as third argument
   return ReactPortal.createPortal(children, container, null, key);
 }

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -577,6 +577,7 @@ function createPortal(
     isValidContainer(container),
     'Target container is not a DOM element.',
   );
+  ReactDOMFiberComponent.trapClickOnNonInteractiveElement(((container: any): HTMLElement));
   // TODO: pass ReactDOM portal implementation as third argument
   return ReactPortal.createPortal(children, container, null, key);
 }

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -228,7 +228,7 @@ function getOwnerDocumentFromRootContainer(
 
 function noop() {}
 
-function trapClickOnNonInteractiveElement(node: HTMLElement) {
+export function trapClickOnNonInteractiveElement(node: HTMLElement) {
   // Mobile Safari does not fire properly bubble click events on
   // non-interactive elements, which means delegated click listeners do not
   // fire. The workaround for this bug involves attaching an empty click

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -344,14 +344,24 @@ export function appendChildToContainer(
   container: Container,
   child: Instance | TextInstance,
 ): void {
+  let parentNode;
   if (container.nodeType === COMMENT_NODE) {
-    (container.parentNode: any).insertBefore(child, container);
-    trapClickOnNonInteractiveElement(
-      ((container.parentNode: any): HTMLElement),
-    );
+    parentNode = (container.parentNode: any);
+    parentNode.insertBefore(child, container);
   } else {
-    trapClickOnNonInteractiveElement(((container: any): HTMLElement));
-    container.appendChild(child);
+    parentNode = container;
+    parentNode.appendChild(child);
+  }
+  // This container might be used for a portal.
+  // If something inside a portal is clicked, that click should bubble
+  // through the React tree. However, on Mobile Safari the click would
+  // never bubble through the *DOM* tree unless an ancestor with onclick
+  // event exists. So we wouldn't see it and dispatch it.
+  // This is why we ensure that containers have inline onclick defined.
+  // https://github.com/facebook/react/issues/11918
+  if (parentNode.onclick === null) {
+    // TODO: This cast may not be sound for SVG, MathML or custom elements.
+    trapClickOnNonInteractiveElement(((parentNode: any): HTMLElement));
   }
 }
 

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -16,6 +16,7 @@ import {
   updateProperties,
   diffHydratedProperties,
   diffHydratedText,
+  trapClickOnNonInteractiveElement,
   warnForUnmatchedText,
   warnForDeletedHydratableElement,
   warnForDeletedHydratableText,
@@ -345,7 +346,11 @@ export function appendChildToContainer(
 ): void {
   if (container.nodeType === COMMENT_NODE) {
     (container.parentNode: any).insertBefore(child, container);
+    trapClickOnNonInteractiveElement(
+      ((container.parentNode: any): HTMLElement),
+    );
   } else {
+    trapClickOnNonInteractiveElement(((container: any): HTMLElement));
     container.appendChild(child);
   }
 }


### PR DESCRIPTION
Should resolve #11918 

Still need to run the build in iOS Safari to verify, but I'm 90% sure it will since an empty click handler fixed it in the JSFiddle provided for the issue.