### PR TITLE
Introducing ReactDOM  unstable_createSandboxedPortal

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -1126,7 +1126,20 @@ function createPortal(
     'Target container is not a DOM element.',
   );
   // TODO: pass ReactDOM portal implementation as third argument
-  return ReactPortal.createPortal(children, container, null, key);
+  return ReactPortal.createPortal(children, container, null, key, false);
+}
+
+function createSandboxedPortal(
+  children: ReactNodeList,
+  container: DOMContainer,
+  key: ?string = null,
+) {
+  invariant(
+    isValidContainer(container),
+    'Target container is not a DOM element.',
+  );
+  // TODO: pass ReactDOM portal implementation as third argument
+  return ReactPortal.createPortal(children, container, null, key, true);
 }
 
 const ReactDOM: Object = {
@@ -1290,6 +1303,8 @@ const ReactDOM: Object = {
     }
     return createPortal(...args);
   },
+
+  unstable_createSandboxedPortal: createSandboxedPortal,
 
   unstable_batchedUpdates: ReactGenericBatching.batchedUpdates,
 

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -453,6 +453,7 @@ export function createFiberFromPortal(
     containerInfo: portal.containerInfo,
     pendingChildren: null, // Used by persistent updates
     implementation: portal.implementation,
+    sandbox: portal.sandbox,
   };
   return fiber;
 }

--- a/packages/shared/ReactPortal.js
+++ b/packages/shared/ReactPortal.js
@@ -17,6 +17,7 @@ export function createPortal(
   // TODO: figure out the API for cross-renderer implementation.
   implementation: any,
   key: ?string = null,
+  sandbox: ?bool = false
 ): ReactPortal {
   return {
     // This tag allow us to uniquely identify this as a React Portal
@@ -24,6 +25,7 @@ export function createPortal(
     key: key == null ? null : '' + key,
     children,
     containerInfo,
+    sandbox,
     implementation,
   };
 }

--- a/packages/shared/ReactPortal.js
+++ b/packages/shared/ReactPortal.js
@@ -17,7 +17,7 @@ export function createPortal(
   // TODO: figure out the API for cross-renderer implementation.
   implementation: any,
   key: ?string = null,
-  sandbox: ?bool = false
+  sandbox: ?boolean = false,
 ): ReactPortal {
   return {
     // This tag allow us to uniquely identify this as a React Portal

--- a/packages/shared/ReactTreeTraversal.js
+++ b/packages/shared/ReactTreeTraversal.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {HostComponent} from './ReactTypeOfWork';
+import {HostComponent, HostPortal} from './ReactTypeOfWork';
 
 function getParent(inst) {
   do {
@@ -15,6 +15,9 @@ function getParent(inst) {
     // events to their parent. We could also go through parentNode on the
     // host node but that wouldn't work for React Native and doesn't let us
     // do the portal feature.
+    if (inst && inst.tag === HostPortal && inst.stateNode.sandbox) {
+      return null;
+    }
   } while (inst && inst.tag !== HostComponent);
   if (inst) {
     return inst;


### PR DESCRIPTION
This pull request is related to #11387 issue.

My questions:

1. Is my assumption about fixing this issue is about updating `ReactTreeTraversal` `getParent` with additional condition?
2. Do I need to create new type `TypeOfWork` to introduce `createSandboxedPortal` feature or can I use `HostPortal` with additional property as I made now?
