### PR TITLE
Keep quoting consistent in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ class HelloMessage extends React.Component {
 
 ReactDOM.render(
   <HelloMessage name="John" />,
-  document.getElementById('container')
+  document.getElementById("container")
 );
 ```
 


### PR DESCRIPTION
Use double quotes in the README example. 

Double quotes seem to be most common, so I went with those: 

```sh
$ rg "\"" | wc -l
   40310

$ rg "'" | wc -l
   24884
```

Couple meta questions with this being my first PR:

1. Do we care about consistent use of quotes in the codebase?
2. Should I have created an issue for this first? It was a tiny bit of work, so I didn't.
