### PR TITLE
Return event name from getVendorPrefixedEventName

### DIFF
--- a/packages/react-dom/src/events/BrowserEventConstants.js
+++ b/packages/react-dom/src/events/BrowserEventConstants.js
@@ -16,11 +16,9 @@ import getVendorPrefixedEventName from './getVendorPrefixedEventName';
  */
 const topLevelTypes = {
   topAbort: 'abort',
-  topAnimationEnd: getVendorPrefixedEventName('animationend') || 'animationend',
-  topAnimationIteration:
-    getVendorPrefixedEventName('animationiteration') || 'animationiteration',
-  topAnimationStart:
-    getVendorPrefixedEventName('animationstart') || 'animationstart',
+  topAnimationEnd: getVendorPrefixedEventName('animationend'),
+  topAnimationIteration: getVendorPrefixedEventName('animationiteration'),
+  topAnimationStart: getVendorPrefixedEventName('animationstart'),
   topBlur: 'blur',
   topCancel: 'cancel',
   topCanPlay: 'canplay',
@@ -81,8 +79,7 @@ const topLevelTypes = {
   topTouchEnd: 'touchend',
   topTouchMove: 'touchmove',
   topTouchStart: 'touchstart',
-  topTransitionEnd:
-    getVendorPrefixedEventName('transitionend') || 'transitionend',
+  topTransitionEnd: getVendorPrefixedEventName('transitionend'),
   topVolumeChange: 'volumechange',
   topWaiting: 'waiting',
   topWheel: 'wheel',

--- a/packages/react-dom/src/events/getVendorPrefixedEventName.js
+++ b/packages/react-dom/src/events/getVendorPrefixedEventName.js
@@ -89,7 +89,7 @@ function getVendorPrefixedEventName(eventName) {
     }
   }
 
-  return '';
+  return eventName;
 }
 
 export default getVendorPrefixedEventName;

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -46,78 +46,78 @@
       "filename": "react-dom.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 560498,
-      "gzip": 132755
+      "size": 560424,
+      "gzip": 132739
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 93742,
-      "gzip": 30770
+      "size": 93669,
+      "gzip": 30753
     },
     {
       "filename": "react-dom.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 544531,
-      "gzip": 128982
+      "size": 544457,
+      "gzip": 128965
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 92163,
-      "gzip": 29827
+      "size": 92090,
+      "gzip": 29815
     },
     {
       "filename": "ReactDOM-dev.js",
       "bundleType": "FB_DEV",
       "packageName": "react-dom",
-      "size": 562017,
-      "gzip": 131222
+      "size": 561931,
+      "gzip": 131204
     },
     {
       "filename": "ReactDOM-prod.js",
       "bundleType": "FB_PROD",
       "packageName": "react-dom",
-      "size": 265467,
-      "gzip": 51292
+      "size": 265369,
+      "gzip": 51278
     },
     {
       "filename": "react-dom-test-utils.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 41376,
-      "gzip": 11760
+      "size": 41302,
+      "gzip": 11748
     },
     {
       "filename": "react-dom-test-utils.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 10656,
-      "gzip": 3935
+      "size": 10583,
+      "gzip": 3916
     },
     {
       "filename": "react-dom-test-utils.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 36113,
-      "gzip": 10297
+      "size": 36039,
+      "gzip": 10283
     },
     {
       "filename": "react-dom-test-utils.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 10233,
-      "gzip": 3848
+      "size": 10160,
+      "gzip": 3834
     },
     {
       "filename": "ReactTestUtils-dev.js",
       "bundleType": "FB_DEV",
       "packageName": "react-dom",
-      "size": 36840,
-      "gzip": 10379
+      "size": 36754,
+      "gzip": 10368
     },
     {
       "filename": "react-dom-unstable-native-dependencies.development.js",


### PR DESCRIPTION
Instead of relying on `getVendorPrefixedEventName` returning an empty string for un-prefixed events, just return the event name. That way we don't have to duplicate the string literals and can remove the `||`. Saves a few bytes! 📦 