### PR TITLE
Update additional tests to use .toWarnDev() matcher

### DIFF
--- a/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.internal.js
@@ -277,15 +277,11 @@ describe('ReactBrowserEventEmitter', () => {
     putListener(CHILD, ON_CLICK_KEY, recordIDAndReturnFalse.bind(null, CHILD));
     putListener(PARENT, ON_CLICK_KEY, recordID.bind(null, PARENT));
     putListener(GRANDPARENT, ON_CLICK_KEY, recordID.bind(null, GRANDPARENT));
-    spyOnDev(console, 'error');
     ReactTestUtils.Simulate.click(CHILD);
     expect(idCallOrder.length).toBe(3);
     expect(idCallOrder[0]).toBe(CHILD);
     expect(idCallOrder[1]).toBe(PARENT);
     expect(idCallOrder[2]).toBe(GRANDPARENT);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toEqual(0);
-    }
   });
 
   /**

--- a/packages/react-dom/src/__tests__/ReactComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponent-test.js
@@ -46,7 +46,6 @@ describe('ReactComponent', () => {
   });
 
   it('should throw (in dev) when children are mutated during render', () => {
-    spyOnDev(console, 'error');
     function Wrapper(props) {
       props.children[1] = <p key={1} />; // Mutation is illegal
       return <div>{props.children}</div>;
@@ -73,8 +72,6 @@ describe('ReactComponent', () => {
   });
 
   it('should throw (in dev) when children are mutated during update', () => {
-    spyOnDev(console, 'error');
-
     class Wrapper extends React.Component {
       componentDidMount() {
         this.props.children[1] = <p key={1} />; // Mutation is illegal
@@ -355,10 +352,13 @@ describe('ReactComponent', () => {
   });
 
   it('throws usefully when rendering badly-typed elements', () => {
-    spyOnDev(console, 'error');
-
     const X = undefined;
-    expect(() => ReactTestUtils.renderIntoDocument(<X />)).toThrowError(
+    expect(() => {
+      expect(() => ReactTestUtils.renderIntoDocument(<X />)).toWarnDev(
+        'React.createElement: type is invalid -- expected a string (for built-in components) ' +
+          'or a class/function (for composite components) but got: undefined.',
+      );
+    }).toThrowError(
       'Element type is invalid: expected a string (for built-in components) ' +
         'or a class/function (for composite components) but got: undefined.' +
         (__DEV__
@@ -368,20 +368,18 @@ describe('ReactComponent', () => {
     );
 
     const Y = null;
-    expect(() => ReactTestUtils.renderIntoDocument(<Y />)).toThrowError(
+    expect(() => {
+      expect(() => ReactTestUtils.renderIntoDocument(<Y />)).toWarnDev(
+        'React.createElement: type is invalid -- expected a string (for built-in components) ' +
+          'or a class/function (for composite components) but got: null.',
+      );
+    }).toThrowError(
       'Element type is invalid: expected a string (for built-in components) ' +
         'or a class/function (for composite components) but got: null.',
     );
-
-    if (__DEV__) {
-      // One warning for each element creation
-      expect(console.error.calls.count()).toBe(2);
-    }
   });
 
   it('includes owner name in the error about badly-typed elements', () => {
-    spyOnDev(console, 'error');
-
     const X = undefined;
 
     function Indirection(props) {
@@ -400,7 +398,12 @@ describe('ReactComponent', () => {
       return <Bar />;
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toThrowError(
+    expect(() => {
+      expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toWarnDev(
+        'React.createElement: type is invalid -- expected a string (for built-in components) ' +
+          'or a class/function (for composite components) but got: undefined.',
+      );
+    }).toThrowError(
       'Element type is invalid: expected a string (for built-in components) ' +
         'or a class/function (for composite components) but got: undefined.' +
         (__DEV__
@@ -409,11 +412,6 @@ describe('ReactComponent', () => {
             '\n\nCheck the render method of `Bar`.'
           : ''),
     );
-
-    if (__DEV__) {
-      // One warning for each element creation
-      expect(console.error.calls.count()).toBe(1);
-    }
   });
 
   it('throws if a plain object is used as a child', () => {
@@ -530,18 +528,13 @@ describe('ReactComponent', () => {
       function Foo() {
         return Foo;
       }
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
-      ReactDOM.render(<Foo />, container);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Functions are not valid as a React child. This may happen if ' +
-            'you return a Component instead of <Component /> from render. ' +
-            'Or maybe you meant to call this function rather than return it.\n' +
-            '    in Foo (at **)',
-        );
-      }
+      expect(() => ReactDOM.render(<Foo />, container)).toWarnDev(
+        'Warning: Functions are not valid as a React child. This may happen if ' +
+          'you return a Component instead of <Component /> from render. ' +
+          'Or maybe you meant to call this function rather than return it.\n' +
+          '    in Foo (at **)',
+      );
     });
 
     it('warns on function as a return value from a class', () => {
@@ -550,18 +543,13 @@ describe('ReactComponent', () => {
           return Foo;
         }
       }
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
-      ReactDOM.render(<Foo />, container);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Functions are not valid as a React child. This may happen if ' +
-            'you return a Component instead of <Component /> from render. ' +
-            'Or maybe you meant to call this function rather than return it.\n' +
-            '    in Foo (at **)',
-        );
-      }
+      expect(() => ReactDOM.render(<Foo />, container)).toWarnDev(
+        'Warning: Functions are not valid as a React child. This may happen if ' +
+          'you return a Component instead of <Component /> from render. ' +
+          'Or maybe you meant to call this function rather than return it.\n' +
+          '    in Foo (at **)',
+      );
     });
 
     it('warns on function as a child to host component', () => {
@@ -572,20 +560,15 @@ describe('ReactComponent', () => {
           </div>
         );
       }
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
-      ReactDOM.render(<Foo />, container);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Functions are not valid as a React child. This may happen if ' +
-            'you return a Component instead of <Component /> from render. ' +
-            'Or maybe you meant to call this function rather than return it.\n' +
-            '    in span (at **)\n' +
-            '    in div (at **)\n' +
-            '    in Foo (at **)',
-        );
-      }
+      expect(() => ReactDOM.render(<Foo />, container)).toWarnDev(
+        'Warning: Functions are not valid as a React child. This may happen if ' +
+          'you return a Component instead of <Component /> from render. ' +
+          'Or maybe you meant to call this function rather than return it.\n' +
+          '    in span (at **)\n' +
+          '    in div (at **)\n' +
+          '    in Foo (at **)',
+      );
     });
 
     it('does not warn for function-as-a-child that gets resolved', () => {
@@ -601,7 +584,6 @@ describe('ReactComponent', () => {
     });
 
     it('deduplicates function type warnings based on component type', () => {
-      spyOnDev(console, 'error');
       class Foo extends React.PureComponent {
         constructor() {
           super();
@@ -621,26 +603,23 @@ describe('ReactComponent', () => {
         }
       }
       const container = document.createElement('div');
-      const component = ReactDOM.render(<Foo />, container);
+      let component;
+      expect(() => {
+        component = ReactDOM.render(<Foo />, container);
+      }).toWarnDev([
+        'Warning: Functions are not valid as a React child. This may happen if ' +
+          'you return a Component instead of <Component /> from render. ' +
+          'Or maybe you meant to call this function rather than return it.\n' +
+          '    in div (at **)\n' +
+          '    in Foo (at **)',
+        'Warning: Functions are not valid as a React child. This may happen if ' +
+          'you return a Component instead of <Component /> from render. ' +
+          'Or maybe you meant to call this function rather than return it.\n' +
+          '    in span (at **)\n' +
+          '    in div (at **)\n' +
+          '    in Foo (at **)',
+      ]);
       component.setState({type: 'portobello mushrooms'});
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Functions are not valid as a React child. This may happen if ' +
-            'you return a Component instead of <Component /> from render. ' +
-            'Or maybe you meant to call this function rather than return it.\n' +
-            '    in div (at **)\n' +
-            '    in Foo (at **)',
-        );
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-          'Warning: Functions are not valid as a React child. This may happen if ' +
-            'you return a Component instead of <Component /> from render. ' +
-            'Or maybe you meant to call this function rather than return it.\n' +
-            '    in span (at **)\n' +
-            '    in div (at **)\n' +
-            '    in Foo (at **)',
-        );
-      }
     });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
@@ -17,7 +17,6 @@ let TestComponent;
 describe('ReactCompositeComponent-state', () => {
   beforeEach(() => {
     React = require('react');
-
     ReactDOM = require('react-dom');
 
     TestComponent = class extends React.Component {
@@ -381,8 +380,6 @@ describe('ReactCompositeComponent-state', () => {
   });
 
   it('should treat assigning to this.state inside cWRP as a replaceState, with a warning', () => {
-    spyOnDev(console, 'error');
-
     let ops = [];
     class Test extends React.Component {
       state = {step: 1, extra: true};
@@ -409,27 +406,20 @@ describe('ReactCompositeComponent-state', () => {
     const container = document.createElement('div');
     ReactDOM.render(<Test />, container);
     // Update
-    ReactDOM.render(<Test />, container);
+    expect(() => ReactDOM.render(<Test />, container)).toWarnDev(
+      'Warning: Test.componentWillReceiveProps(): Assigning directly to ' +
+        "this.state is deprecated (except inside a component's constructor). " +
+        'Use setState instead.',
+    );
 
     expect(ops).toEqual([
       'render -- step: 1, extra: true',
       'render -- step: 3, extra: false',
       'callback -- step: 3, extra: false',
     ]);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toEqual(1);
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: Test.componentWillReceiveProps(): Assigning directly to ' +
-          "this.state is deprecated (except inside a component's constructor). " +
-          'Use setState instead.',
-      );
-    }
 
-    // Check deduplication
+    // Check deduplication; (no additional warnings are expected)
     ReactDOM.render(<Test />, container);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toEqual(1);
-    }
   });
 
   it('should treat assigning to this.state inside cWM as a replaceState, with a warning', () => {
@@ -459,19 +449,15 @@ describe('ReactCompositeComponent-state', () => {
 
     // Mount
     const container = document.createElement('div');
-    ReactDOM.render(<Test />, container);
+    expect(() => ReactDOM.render(<Test />, container)).toWarnDev(
+      'Warning: Test.componentWillMount(): Assigning directly to ' +
+        "this.state is deprecated (except inside a component's constructor). " +
+        'Use setState instead.',
+    );
 
     expect(ops).toEqual([
       'render -- step: 3, extra: false',
       'callback -- step: 3, extra: false',
     ]);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toEqual(1);
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: Test.componentWillMount(): Assigning directly to ' +
-          "this.state is deprecated (except inside a component's constructor). " +
-          'Use setState instead.',
-      );
-    }
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -109,8 +109,6 @@ describe('ReactDOM', () => {
   });
 
   it('throws in render() if the mount callback is not a function', () => {
-    spyOnDev(console, 'error');
-
     function Foo() {
       this.a = 1;
       this.b = 2;
@@ -125,42 +123,44 @@ describe('ReactDOM', () => {
     }
 
     const myDiv = document.createElement('div');
-    expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrowError(
-      'Invalid argument passed as callback. Expected a function. Instead ' +
-        'received: no',
-    );
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(0)[0]).toContain(
+    expect(() => {
+      expect(() => {
+        ReactDOM.render(<A />, myDiv, 'no');
+      }).toWarnDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: no.',
       );
-    }
-    expect(() => ReactDOM.render(<A />, myDiv, {foo: 'bar'})).toThrowError(
+    }).toThrowError(
       'Invalid argument passed as callback. Expected a function. Instead ' +
-        'received: [object Object]',
+        'received: no',
     );
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(1)[0]).toContain(
+
+    expect(() => {
+      expect(() => {
+        ReactDOM.render(<A />, myDiv, {foo: 'bar'});
+      }).toWarnDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: [object Object].',
       );
-    }
-    expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrowError(
+    }).toThrowError(
       'Invalid argument passed as callback. Expected a function. Instead ' +
         'received: [object Object]',
     );
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(2)[0]).toContain(
+
+    expect(() => {
+      expect(() => {
+        ReactDOM.render(<A />, myDiv, new Foo());
+      }).toWarnDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: [object Object].',
       );
-      expect(console.error.calls.count()).toBe(3);
-    }
+    }).toThrowError(
+      'Invalid argument passed as callback. Expected a function. Instead ' +
+        'received: [object Object]',
+    );
   });
 
   it('throws in render() if the update callback is not a function', () => {
-    spyOnDev(console, 'error');
-
     function Foo() {
       this.a = 1;
       this.b = 2;
@@ -176,39 +176,43 @@ describe('ReactDOM', () => {
 
     const myDiv = document.createElement('div');
     ReactDOM.render(<A />, myDiv);
-    expect(() => ReactDOM.render(<A />, myDiv, 'no')).toThrowError(
-      'Invalid argument passed as callback. Expected a function. Instead ' +
-        'received: no',
-    );
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(0)[0]).toContain(
+    expect(() => {
+      expect(() => {
+        ReactDOM.render(<A />, myDiv, 'no');
+      }).toWarnDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: no.',
       );
-    }
-    ReactDOM.render(<A />, myDiv); // Re-mount
-    expect(() => ReactDOM.render(<A />, myDiv, {foo: 'bar'})).toThrowError(
+    }).toThrowError(
       'Invalid argument passed as callback. Expected a function. Instead ' +
-        'received: [object Object]',
+        'received: no',
     );
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(1)[0]).toContain(
+
+    ReactDOM.render(<A />, myDiv); // Re-mount
+    expect(() => {
+      expect(() => {
+        ReactDOM.render(<A />, myDiv, {foo: 'bar'});
+      }).toWarnDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: [object Object].',
       );
-    }
-    ReactDOM.render(<A />, myDiv); // Re-mount
-    expect(() => ReactDOM.render(<A />, myDiv, new Foo())).toThrowError(
+    }).toThrowError(
       'Invalid argument passed as callback. Expected a function. Instead ' +
         'received: [object Object]',
     );
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(2)[0]).toContain(
+
+    ReactDOM.render(<A />, myDiv); // Re-mount
+    expect(() => {
+      expect(() => {
+        ReactDOM.render(<A />, myDiv, new Foo());
+      }).toWarnDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: [object Object].',
       );
-      expect(console.error.calls.count()).toBe(3);
-    }
+    }).toThrowError(
+      'Invalid argument passed as callback. Expected a function. Instead ' +
+        'received: [object Object]',
+    );
   });
 
   it('preserves focus', () => {
@@ -375,28 +379,24 @@ describe('ReactDOM', () => {
 
   // https://github.com/facebook/react/issues/11689
   it('should warn when attempting to inject an event plugin', () => {
-    spyOnDev(console, 'warn');
-    ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.EventPluginHub.injection.injectEventPluginsByName(
-      {
-        TapEventPlugin: {
-          extractEvents() {},
+    expect(() => {
+      ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.EventPluginHub.injection.injectEventPluginsByName(
+        {
+          TapEventPlugin: {
+            extractEvents() {},
+          },
         },
-      },
-    );
-    if (__DEV__) {
-      expect(console.warn.calls.count()).toBe(1);
-      expect(console.warn.calls.argsFor(0)[0]).toContain(
-        'Injecting custom event plugins (TapEventPlugin) is deprecated ' +
-          'and will not work in React 17+. Please update your code ' +
-          'to not depend on React internals. The stack trace for this ' +
-          'warning should reveal the library that is using them. ' +
-          'See https://github.com/facebook/react/issues/11689 for a discussion.',
       );
-    }
+    }).toLowPriorityWarnDev(
+      'Injecting custom event plugins (TapEventPlugin) is deprecated ' +
+        'and will not work in React 17+. Please update your code ' +
+        'to not depend on React internals. The stack trace for this ' +
+        'warning should reveal the library that is using them. ' +
+        'See https://github.com/facebook/react/issues/11689 for a discussion.',
+    );
   });
 
   it('throws in DEV if jsdom is destroyed by the time setState() is called', () => {
-    spyOnDev(console, 'error');
     class App extends React.Component {
       state = {x: 1};
       render() {

--- a/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
@@ -19,10 +19,6 @@ describe('ReactDOM unknown attribute', () => {
     ReactDOM = require('react-dom');
   });
 
-  function normalizeCodeLocInfo(str) {
-    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
-  }
-
   function testUnknownAttributeRemoval(givenValue) {
     const el = document.createElement('div');
     ReactDOM.render(<div unknown="something" />, el);
@@ -46,20 +42,13 @@ describe('ReactDOM unknown attribute', () => {
     });
 
     it('changes values true, false to null, and also warns once', () => {
-      spyOnDev(console, 'error');
-
-      testUnknownAttributeAssignment(true, null);
+      expect(() => testUnknownAttributeAssignment(true, null)).toWarnDev(
+        'Received `true` for a non-boolean attribute `unknown`.\n\n' +
+          'If you want to write it to the DOM, pass a string instead: ' +
+          'unknown="true" or unknown={value.toString()}.\n' +
+          '    in div (at **)',
+      );
       testUnknownAttributeAssignment(false, null);
-
-      if (__DEV__) {
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toMatch(
-          'Received `true` for a non-boolean attribute `unknown`.\n\n' +
-            'If you want to write it to the DOM, pass a string instead: ' +
-            'unknown="true" or unknown={value.toString()}.\n' +
-            '    in div (at **)',
-        );
-        expect(console.error.calls.count()).toBe(1);
-      }
     });
 
     it('removes unknown attributes that were rendered but are now missing', () => {
@@ -82,17 +71,11 @@ describe('ReactDOM unknown attribute', () => {
     });
 
     it('coerces NaN to strings and warns', () => {
-      spyOnDev(console, 'error');
-
-      testUnknownAttributeAssignment(NaN, 'NaN');
-      if (__DEV__) {
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toMatch(
-          'Warning: Received NaN for the `unknown` attribute. ' +
-            'If this is expected, cast the value to a string.\n' +
-            '    in div (at **)',
-        );
-        expect(console.error.calls.count()).toBe(1);
-      }
+      expect(() => testUnknownAttributeAssignment(NaN, 'NaN')).toWarnDev(
+        'Warning: Received NaN for the `unknown` attribute. ' +
+          'If this is expected, cast the value to a string.\n' +
+          '    in div (at **)',
+      );
     });
 
     it('coerces objects to strings and warns', () => {
@@ -107,54 +90,41 @@ describe('ReactDOM unknown attribute', () => {
     });
 
     it('removes symbols and warns', () => {
-      spyOnDev(console, 'error');
-
-      testUnknownAttributeRemoval(Symbol('foo'));
-      if (__DEV__) {
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Invalid value for prop `unknown` on <div> tag. Either remove it ' +
-            'from the element, or pass a string or number value to keep it ' +
-            'in the DOM. For details, see https://fb.me/react-attribute-behavior\n' +
-            '    in div (at **)',
-        );
-        expect(console.error.calls.count()).toBe(1);
-      }
+      expect(() => testUnknownAttributeRemoval(Symbol('foo'))).toWarnDev(
+        'Warning: Invalid value for prop `unknown` on <div> tag. Either remove it ' +
+          'from the element, or pass a string or number value to keep it ' +
+          'in the DOM. For details, see https://fb.me/react-attribute-behavior\n' +
+          '    in div (at **)',
+      );
     });
 
     it('removes functions and warns', () => {
-      spyOnDev(console, 'error');
-
-      testUnknownAttributeRemoval(function someFunction() {});
-      if (__DEV__) {
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Invalid value for prop `unknown` on <div> tag. Either remove ' +
-            'it from the element, or pass a string or number value to ' +
-            'keep it in the DOM. For details, see ' +
-            'https://fb.me/react-attribute-behavior\n' +
-            '    in div (at **)',
-        );
-        expect(console.error.calls.count()).toBe(1);
-      }
+      expect(() =>
+        testUnknownAttributeRemoval(function someFunction() {}),
+      ).toWarnDev(
+        'Warning: Invalid value for prop `unknown` on <div> tag. Either remove ' +
+          'it from the element, or pass a string or number value to ' +
+          'keep it in the DOM. For details, see ' +
+          'https://fb.me/react-attribute-behavior\n' +
+          '    in div (at **)',
+      );
     });
 
     it('allows camelCase unknown attributes and warns', () => {
-      spyOnDev(console, 'error');
-
       const el = document.createElement('div');
-      ReactDOM.render(<div helloWorld="something" />, el);
-      expect(el.firstChild.getAttribute('helloworld')).toBe('something');
 
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toMatch(
-          'React does not recognize the `helloWorld` prop on a DOM element. ' +
-            'If you intentionally want it to appear in the DOM as a custom ' +
-            'attribute, spell it as lowercase `helloworld` instead. ' +
-            'If you accidentally passed it from a parent component, remove ' +
-            'it from the DOM element.\n' +
-            '    in div (at **)',
-        );
-      }
+      expect(() =>
+        ReactDOM.render(<div helloWorld="something" />, el),
+      ).toWarnDev(
+        'React does not recognize the `helloWorld` prop on a DOM element. ' +
+          'If you intentionally want it to appear in the DOM as a custom ' +
+          'attribute, spell it as lowercase `helloworld` instead. ' +
+          'If you accidentally passed it from a parent component, remove ' +
+          'it from the DOM element.\n' +
+          '    in div (at **)',
+      );
+
+      expect(el.firstChild.getAttribute('helloworld')).toBe('something');
     });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -147,110 +147,97 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should warn for unknown prop', () => {
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
-      ReactDOM.render(<div foo={() => {}} />, container);
-      if (__DEV__) {
-        expect(console.error.calls.count(0)).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Invalid value for prop `foo` on <div> tag. Either remove it ' +
-            'from the element, or pass a string or number value to keep ' +
-            'it in the DOM. For details, see https://fb.me/react-attribute-behavior' +
-            '\n    in div (at **)',
-        );
-      }
+      expect(() =>
+        ReactDOM.render(<div foo={() => {}} />, container),
+      ).toWarnDev(
+        'Warning: Invalid value for prop `foo` on <div> tag. Either remove it ' +
+          'from the element, or pass a string or number value to keep ' +
+          'it in the DOM. For details, see https://fb.me/react-attribute-behavior' +
+          '\n    in div (at **)',
+      );
     });
 
     it('should group multiple unknown prop warnings together', () => {
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
-      ReactDOM.render(<div foo={() => {}} baz={() => {}} />, container);
-      if (__DEV__) {
-        expect(console.error.calls.count(0)).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Invalid values for props `foo`, `baz` on <div> tag. Either remove ' +
-            'them from the element, or pass a string or number value to keep ' +
-            'them in the DOM. For details, see https://fb.me/react-attribute-behavior' +
-            '\n    in div (at **)',
-        );
-      }
+      expect(() =>
+        ReactDOM.render(<div foo={() => {}} baz={() => {}} />, container),
+      ).toWarnDev(
+        'Warning: Invalid values for props `foo`, `baz` on <div> tag. Either remove ' +
+          'them from the element, or pass a string or number value to keep ' +
+          'them in the DOM. For details, see https://fb.me/react-attribute-behavior' +
+          '\n    in div (at **)',
+      );
     });
 
     it('should warn for onDblClick prop', () => {
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
-      ReactDOM.render(<div onDblClick={() => {}} />, container);
-      if (__DEV__) {
-        expect(console.error.calls.count(0)).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Invalid event handler property `onDblClick`. Did you mean `onDoubleClick`?\n    in div (at **)',
-        );
-      }
+      expect(() =>
+        ReactDOM.render(<div onDblClick={() => {}} />, container),
+      ).toWarnDev(
+        'Warning: Invalid event handler property `onDblClick`. Did you mean `onDoubleClick`?\n    in div (at **)',
+      );
     });
 
     it('should warn for unknown string event handlers', () => {
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
-      ReactDOM.render(<div onUnknown="alert(&quot;hack&quot;)" />, container);
+      expect(() =>
+        ReactDOM.render(<div onUnknown="alert(&quot;hack&quot;)" />, container),
+      ).toWarnDev(
+        'Warning: Unknown event handler property `onUnknown`. It will be ignored.\n    in div (at **)',
+      );
       expect(container.firstChild.hasAttribute('onUnknown')).toBe(false);
       expect(container.firstChild.onUnknown).toBe(undefined);
-      ReactDOM.render(<div onunknown="alert(&quot;hack&quot;)" />, container);
+      expect(() =>
+        ReactDOM.render(<div onunknown="alert(&quot;hack&quot;)" />, container),
+      ).toWarnDev(
+        'Warning: Unknown event handler property `onunknown`. It will be ignored.\n    in div (at **)',
+      );
       expect(container.firstChild.hasAttribute('onunknown')).toBe(false);
       expect(container.firstChild.onunknown).toBe(undefined);
-      ReactDOM.render(<div on-unknown="alert(&quot;hack&quot;)" />, container);
+      expect(() =>
+        ReactDOM.render(
+          <div on-unknown="alert(&quot;hack&quot;)" />,
+          container,
+        ),
+      ).toWarnDev(
+        'Warning: Unknown event handler property `on-unknown`. It will be ignored.\n    in div (at **)',
+      );
       expect(container.firstChild.hasAttribute('on-unknown')).toBe(false);
       expect(container.firstChild['on-unknown']).toBe(undefined);
-      if (__DEV__) {
-        expect(console.error.calls.count(0)).toBe(3);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Unknown event handler property `onUnknown`. It will be ignored.\n    in div (at **)',
-        );
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-          'Warning: Unknown event handler property `onunknown`. It will be ignored.\n    in div (at **)',
-        );
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(2)[0])).toBe(
-          'Warning: Unknown event handler property `on-unknown`. It will be ignored.\n    in div (at **)',
-        );
-      }
     });
 
     it('should warn for unknown function event handlers', () => {
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
-      ReactDOM.render(<div onUnknown={function() {}} />, container);
+      expect(() =>
+        ReactDOM.render(<div onUnknown={function() {}} />, container),
+      ).toWarnDev(
+        'Warning: Unknown event handler property `onUnknown`. It will be ignored.\n    in div (at **)',
+      );
       expect(container.firstChild.hasAttribute('onUnknown')).toBe(false);
       expect(container.firstChild.onUnknown).toBe(undefined);
-      ReactDOM.render(<div onunknown={function() {}} />, container);
+      expect(() =>
+        ReactDOM.render(<div onunknown={function() {}} />, container),
+      ).toWarnDev(
+        'Warning: Unknown event handler property `onunknown`. It will be ignored.\n    in div (at **)',
+      );
       expect(container.firstChild.hasAttribute('onunknown')).toBe(false);
       expect(container.firstChild.onunknown).toBe(undefined);
-      ReactDOM.render(<div on-unknown={function() {}} />, container);
+      expect(() =>
+        ReactDOM.render(<div on-unknown={function() {}} />, container),
+      ).toWarnDev(
+        'Warning: Unknown event handler property `on-unknown`. It will be ignored.\n    in div (at **)',
+      );
       expect(container.firstChild.hasAttribute('on-unknown')).toBe(false);
       expect(container.firstChild['on-unknown']).toBe(undefined);
-      if (__DEV__) {
-        expect(console.error.calls.count(0)).toBe(3);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Unknown event handler property `onUnknown`. It will be ignored.\n    in div (at **)',
-        );
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-          'Warning: Unknown event handler property `onunknown`. It will be ignored.\n    in div (at **)',
-        );
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(2)[0])).toBe(
-          'Warning: Unknown event handler property `on-unknown`. It will be ignored.\n    in div (at **)',
-        );
-      }
     });
 
     it('should warn for badly cased React attributes', () => {
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
-      ReactDOM.render(<div CHILDREN="5" />, container);
+      expect(() => ReactDOM.render(<div CHILDREN="5" />, container)).toWarnDev(
+        'Warning: Invalid DOM property `CHILDREN`. Did you mean `children`?\n    in div (at **)',
+      );
       expect(container.firstChild.getAttribute('CHILDREN')).toBe('5');
-      if (__DEV__) {
-        expect(console.error.calls.count(0)).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Invalid DOM property `CHILDREN`. Did you mean `children`?\n    in div (at **)',
-        );
-      }
     });
 
     it('should not warn for "0" as a unitless style value', () => {
@@ -264,20 +251,13 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should warn nicely about NaN in style', () => {
-      spyOnDev(console, 'error');
-
       const style = {fontSize: NaN};
       const div = document.createElement('div');
+      expect(() => ReactDOM.render(<span style={style} />, div)).toWarnDev(
+        'Warning: `NaN` is an invalid value for the `fontSize` css style property.' +
+          '\n    in span (at **)',
+      );
       ReactDOM.render(<span style={style} />, div);
-      ReactDOM.render(<span style={style} />, div);
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toEqual(
-          'Warning: `NaN` is an invalid value for the `fontSize` css style property.' +
-            '\n    in span (at **)',
-        );
-      }
     });
 
     it('should update styles if initially null', () => {
@@ -575,44 +555,38 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should reject attribute key injection attack on markup', () => {
-      spyOnDev(console, 'error');
-      for (let i = 0; i < 3; i++) {
-        const container = document.createElement('div');
-        const element = React.createElement(
-          'x-foo-component',
-          {'blah" onclick="beevil" noise="hi': 'selected'},
-          null,
-        );
-        ReactDOM.render(element, container);
-      }
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toEqual(
-          'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
-        );
-      }
+      expect(() => {
+        for (let i = 0; i < 3; i++) {
+          const container = document.createElement('div');
+          const element = React.createElement(
+            'x-foo-component',
+            {'blah" onclick="beevil" noise="hi': 'selected'},
+            null,
+          );
+          ReactDOM.render(element, container);
+        }
+      }).toWarnDev(
+        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
+      );
     });
 
     it('should reject attribute key injection attack on update', () => {
-      spyOnDev(console, 'error');
-      for (let i = 0; i < 3; i++) {
-        const container = document.createElement('div');
-        const beforeUpdate = React.createElement('x-foo-component', {}, null);
-        ReactDOM.render(beforeUpdate, container);
+      expect(() => {
+        for (let i = 0; i < 3; i++) {
+          const container = document.createElement('div');
+          const beforeUpdate = React.createElement('x-foo-component', {}, null);
+          ReactDOM.render(beforeUpdate, container);
 
-        const afterUpdate = React.createElement(
-          'x-foo-component',
-          {'blah" onclick="beevil" noise="hi': 'selected'},
-          null,
-        );
-        ReactDOM.render(afterUpdate, container);
-      }
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toEqual(
-          'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
-        );
-      }
+          const afterUpdate = React.createElement(
+            'x-foo-component',
+            {'blah" onclick="beevil" noise="hi': 'selected'},
+            null,
+          );
+          ReactDOM.render(afterUpdate, container);
+        }
+      }).toWarnDev(
+        'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
+      );
     });
 
     it('should update arbitrary attributes for tags containing dashes', () => {
@@ -857,17 +831,13 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should warn about non-string "is" attribute', () => {
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
-      ReactDOM.render(<button is={function() {}} />, container);
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Received a `function` for a string attribute `is`. If this is expected, cast ' +
-            'the value to a string.',
-        );
-      }
+      expect(() =>
+        ReactDOM.render(<button is={function() {}} />, container),
+      ).toWarnDev(
+        'Received a `function` for a string attribute `is`. If this is expected, cast ' +
+          'the value to a string.',
+      );
     });
 
     it('should not update when switching between null/undefined', () => {
@@ -1020,59 +990,41 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should not duplicate uppercased selfclosing tags', () => {
-      spyOnDev(console, 'error');
       class Container extends React.Component {
         render() {
           return React.createElement('BR', null);
         }
       }
 
-      const returnedValue = ReactDOMServer.renderToString(<Container />);
+      let returnedValue;
+
+      expect(() => {
+        returnedValue = ReactDOMServer.renderToString(<Container />);
+      }).toWarnDev('<BR /> is using uppercase HTML.');
       expect(returnedValue).not.toContain('</BR>');
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          '<BR /> is using uppercase HTML.',
-        );
-      }
     });
 
     it('should warn on upper case HTML tags, not SVG nor custom tags', () => {
-      spyOnDev(console, 'error');
       ReactTestUtils.renderIntoDocument(
         React.createElement('svg', null, React.createElement('PATH')),
       );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(0);
-      }
       ReactTestUtils.renderIntoDocument(React.createElement('CUSTOM-TAG'));
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(0);
-      }
-      ReactTestUtils.renderIntoDocument(React.createElement('IMG'));
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          '<IMG /> is using uppercase HTML.',
-        );
-      }
+
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(React.createElement('IMG')),
+      ).toWarnDev('<IMG /> is using uppercase HTML.');
     });
 
     it('should warn on props reserved for future use', () => {
-      spyOnDev(console, 'error');
-      ReactTestUtils.renderIntoDocument(<div aria="hello" />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'The `aria` attribute is reserved for future use in React. ' +
-            'Pass individual `aria-` attributes instead.',
-        );
-      }
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(<div aria="hello" />),
+      ).toWarnDev(
+        'The `aria` attribute is reserved for future use in React. ' +
+          'Pass individual `aria-` attributes instead.',
+      );
     });
 
     it('should warn if the tag is unrecognized', () => {
-      spyOnDev(console, 'error');
-
       let realToString;
       try {
         realToString = Object.prototype.toString;
@@ -1089,9 +1041,13 @@ describe('ReactDOMComponent', () => {
         };
         Object.prototype.toString = wrappedToString; // eslint-disable-line no-extend-native
 
-        ReactTestUtils.renderIntoDocument(<bar />);
+        expect(() => ReactTestUtils.renderIntoDocument(<bar />)).toWarnDev(
+          'The tag <bar> is unrecognized in this browser',
+        );
         // Test deduplication
-        ReactTestUtils.renderIntoDocument(<foo />);
+        expect(() => ReactTestUtils.renderIntoDocument(<foo />)).toWarnDev(
+          'The tag <foo> is unrecognized in this browser',
+        );
         ReactTestUtils.renderIntoDocument(<foo />);
         // This is a funny case.
         // Chrome is the only major browser not shipping <time>. But as of July
@@ -1100,25 +1056,14 @@ describe('ReactDOMComponent', () => {
         // it soon will be, and many apps have been using it anyway.
         ReactTestUtils.renderIntoDocument(<time />);
         // Corner case. Make sure out deduplication logic doesn't break with weird tag.
-        ReactTestUtils.renderIntoDocument(<hasOwnProperty />);
+        expect(() =>
+          ReactTestUtils.renderIntoDocument(<hasOwnProperty />),
+        ).toWarnDev([
+          '<hasOwnProperty /> is using uppercase HTML',
+          'The tag <hasOwnProperty> is unrecognized in this browser',
+        ]);
       } finally {
         Object.prototype.toString = realToString; // eslint-disable-line no-extend-native
-      }
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(4);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'The tag <bar> is unrecognized in this browser',
-        );
-        expect(console.error.calls.argsFor(1)[0]).toContain(
-          'The tag <foo> is unrecognized in this browser',
-        );
-        expect(console.error.calls.argsFor(2)[0]).toContain(
-          '<hasOwnProperty /> is using uppercase HTML',
-        );
-        expect(console.error.calls.argsFor(3)[0]).toContain(
-          'The tag <hasOwnProperty> is unrecognized in this browser',
-        );
       }
     });
 
@@ -1158,8 +1103,6 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should emit a warning once for a named custom component using shady DOM', () => {
-      spyOnDev(console, 'error');
-
       const defaultCreateElement = document.createElement.bind(document);
 
       try {
@@ -1174,26 +1117,17 @@ describe('ReactDOMComponent', () => {
           }
         }
         const node = document.createElement('div');
-        ReactDOM.render(<ShadyComponent />, node);
-        if (__DEV__) {
-          expect(console.error.calls.count()).toBe(1);
-          expect(console.error.calls.argsFor(0)[0]).toContain(
-            'ShadyComponent is using shady DOM. Using shady DOM with React can ' +
-              'cause things to break subtly.',
-          );
-        }
+        expect(() => ReactDOM.render(<ShadyComponent />, node)).toWarnDev(
+          'ShadyComponent is using shady DOM. Using shady DOM with React can ' +
+            'cause things to break subtly.',
+        );
         mountComponent({is: 'custom-shady-div2'});
-        if (__DEV__) {
-          expect(console.error.calls.count()).toBe(1);
-        }
       } finally {
         document.createElement = defaultCreateElement;
       }
     });
 
     it('should emit a warning once for an unnamed custom component using shady DOM', () => {
-      spyOnDev(console, 'error');
-
       const defaultCreateElement = document.createElement.bind(document);
 
       try {
@@ -1203,19 +1137,13 @@ describe('ReactDOMComponent', () => {
           return container;
         };
 
-        mountComponent({is: 'custom-shady-div'});
-        if (__DEV__) {
-          expect(console.error.calls.count()).toBe(1);
-          expect(console.error.calls.argsFor(0)[0]).toContain(
-            'A component is using shady DOM. Using shady DOM with React can ' +
-              'cause things to break subtly.',
-          );
-        }
+        expect(() => mountComponent({is: 'custom-shady-div'})).toWarnDev(
+          'A component is using shady DOM. Using shady DOM with React can ' +
+            'cause things to break subtly.',
+        );
 
+        // No additional warnings are expected
         mountComponent({is: 'custom-shady-div2'});
-        if (__DEV__) {
-          expect(console.error.calls.count()).toBe(1);
-        }
       } finally {
         document.createElement = defaultCreateElement;
       }
@@ -1223,7 +1151,6 @@ describe('ReactDOMComponent', () => {
 
     it('should treat menuitem as a void element but still create the closing tag', () => {
       // menuitem is not implemented in jsdom, so this triggers the unknown warning error
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
 
       const returnedValue = ReactDOMServer.renderToString(
@@ -1256,25 +1183,15 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should validate against use of innerHTML', () => {
-      spyOnDev(console, 'error');
-      mountComponent({innerHTML: '<span>Hi Jim!</span>'});
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Directly setting property `innerHTML` is not permitted. ',
-        );
-      }
+      expect(() =>
+        mountComponent({innerHTML: '<span>Hi Jim!</span>'}),
+      ).toWarnDev('Directly setting property `innerHTML` is not permitted. ');
     });
 
     it('should validate against use of innerHTML without case sensitivity', () => {
-      spyOnDev(console, 'error');
-      mountComponent({innerhtml: '<span>Hi Jim!</span>'});
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Directly setting property `innerHTML` is not permitted. ',
-        );
-      }
+      expect(() =>
+        mountComponent({innerhtml: '<span>Hi Jim!</span>'}),
+      ).toWarnDev('Directly setting property `innerHTML` is not permitted. ');
     });
 
     it('should validate use of dangerouslySetInnerHTML', () => {
@@ -1302,17 +1219,14 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should warn about contentEditable and children', () => {
-      spyOnDev(console, 'error');
-      mountComponent({contentEditable: true, children: ''});
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: A component is `contentEditable` and contains `children` ' +
-            'managed by React. It is now your responsibility to guarantee that ' +
-            'none of those nodes are unexpectedly modified or duplicated. This ' +
-            'is probably not intentional.\n    in div (at **)',
-        );
-      }
+      expect(() =>
+        mountComponent({contentEditable: true, children: ''}),
+      ).toWarnDev(
+        'Warning: A component is `contentEditable` and contains `children` ' +
+          'managed by React. It is now your responsibility to guarantee that ' +
+          'none of those nodes are unexpectedly modified or duplicated. This ' +
+          'is probably not intentional.\n    in div (at **)',
+      );
     });
 
     it('should respect suppressContentEditableWarning', () => {
@@ -1442,17 +1356,14 @@ describe('ReactDOMComponent', () => {
     });
 
     it('should warn about contentEditable and children', () => {
-      spyOnDev(console, 'error');
-      ReactDOM.render(
-        <div contentEditable={true}>
-          <div />
-        </div>,
-        container,
-      );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain('contentEditable');
-      }
+      expect(() => {
+        ReactDOM.render(
+          <div contentEditable={true}>
+            <div />
+          </div>,
+          container,
+        );
+      }).toWarnDev('contentEditable');
     });
 
     it('should validate against invalid styles', () => {
@@ -1564,56 +1475,45 @@ describe('ReactDOMComponent', () => {
 
   describe('nesting validation', () => {
     it('warns on invalid nesting', () => {
-      spyOnDev(console, 'error');
-      ReactTestUtils.renderIntoDocument(
-        <div>
-          <tr />
-          <tr />
-        </div>,
-      );
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
-            '<div>.' +
-            '\n    in tr (at **)' +
-            '\n    in div (at **)',
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(
+          <div>
+            <tr />
+            <tr />
+          </div>,
         );
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-          'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
-            '<div>.' +
-            '\n    in tr (at **)' +
-            '\n    in div (at **)',
-        );
-      }
+      }).toWarnDev([
+        'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
+          '<div>.' +
+          '\n    in tr (at **)' +
+          '\n    in div (at **)',
+        'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
+          '<div>.' +
+          '\n    in tr (at **)' +
+          '\n    in div (at **)',
+      ]);
     });
 
     it('warns on invalid nesting at root', () => {
-      spyOnDev(console, 'error');
       const p = document.createElement('p');
-      ReactDOM.render(
-        <span>
-          <p />
-        </span>,
-        p,
-      );
 
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: validateDOMNesting(...): <p> cannot appear as a descendant ' +
-            'of <p>.' +
-            // There is no outer `p` here because root container is not part of the stack.
-            '\n    in p (at **)' +
-            '\n    in span (at **)',
+      expect(() => {
+        ReactDOM.render(
+          <span>
+            <p />
+          </span>,
+          p,
         );
-      }
+      }).toWarnDev(
+        'Warning: validateDOMNesting(...): <p> cannot appear as a descendant ' +
+          'of <p>.' +
+          // There is no outer `p` here because root container is not part of the stack.
+          '\n    in p (at **)' +
+          '\n    in span (at **)',
+      );
     });
 
     it('warns nicely for table rows', () => {
-      spyOnDev(console, 'error');
-
       class Row extends React.Component {
         render() {
           return <tr>x</tr>;
@@ -1630,41 +1530,29 @@ describe('ReactDOMComponent', () => {
         }
       }
 
-      ReactTestUtils.renderIntoDocument(<Foo />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(3);
-
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
-            '<table>. Add a <tbody> to your code to match the DOM tree generated ' +
-            'by the browser.' +
-            '\n    in tr (at **)' +
-            '\n    in Row (at **)' +
-            '\n    in table (at **)' +
-            '\n    in Foo (at **)',
-        );
-
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-          'Warning: validateDOMNesting(...): Text nodes cannot appear as a ' +
-            'child of <tr>.' +
-            '\n    in tr (at **)' +
-            '\n    in Row (at **)' +
-            '\n    in table (at **)' +
-            '\n    in Foo (at **)',
-        );
-
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(2)[0])).toBe(
-          'Warning: validateDOMNesting(...): Whitespace text nodes cannot ' +
-            "appear as a child of <table>. Make sure you don't have any extra " +
-            'whitespace between tags on each line of your source code.' +
-            '\n    in table (at **)' +
-            '\n    in Foo (at **)',
-        );
-      }
+      expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toWarnDev([
+        'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
+          '<table>. Add a <tbody> to your code to match the DOM tree generated ' +
+          'by the browser.' +
+          '\n    in tr (at **)' +
+          '\n    in Row (at **)' +
+          '\n    in table (at **)' +
+          '\n    in Foo (at **)',
+        'Warning: validateDOMNesting(...): Text nodes cannot appear as a ' +
+          'child of <tr>.' +
+          '\n    in tr (at **)' +
+          '\n    in Row (at **)' +
+          '\n    in table (at **)' +
+          '\n    in Foo (at **)',
+        'Warning: validateDOMNesting(...): Whitespace text nodes cannot ' +
+          "appear as a child of <table>. Make sure you don't have any extra " +
+          'whitespace between tags on each line of your source code.' +
+          '\n    in table (at **)' +
+          '\n    in Foo (at **)',
+      ]);
     });
 
     it('gives useful context in warnings', () => {
-      spyOnDev(console, 'error');
       function Row() {
         return <tr />;
       }
@@ -1694,19 +1582,13 @@ describe('ReactDOMComponent', () => {
       function App1() {
         return <Viz1 />;
       }
-      ReactTestUtils.renderIntoDocument(<App1 />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(
-          normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
-        ).toContain(
-          '\n    in tr (at **)' +
-            '\n    in Row (at **)' +
-            '\n    in FancyRow (at **)' +
-            '\n    in table (at **)' +
-            '\n    in Viz1 (at **)',
-        );
-      }
+      expect(() => ReactTestUtils.renderIntoDocument(<App1 />)).toWarnDev(
+        '\n    in tr (at **)' +
+          '\n    in Row (at **)' +
+          '\n    in FancyRow (at **)' +
+          '\n    in table (at **)' +
+          '\n    in Viz1 (at **)',
+      );
 
       function Viz2() {
         return (
@@ -1718,74 +1600,56 @@ describe('ReactDOMComponent', () => {
       function App2() {
         return <Viz2 />;
       }
-      ReactTestUtils.renderIntoDocument(<App2 />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-        expect(
-          normalizeCodeLocInfo(console.error.calls.argsFor(1)[0]),
-        ).toContain(
-          '\n    in tr (at **)' +
-            '\n    in Row (at **)' +
-            '\n    in FancyRow (at **)' +
-            '\n    in table (at **)' +
-            '\n    in Table (at **)' +
-            '\n    in FancyTable (at **)' +
-            '\n    in Viz2 (at **)',
-        );
-      }
-
-      ReactTestUtils.renderIntoDocument(
-        <FancyTable>
-          <FancyRow />
-        </FancyTable>,
+      expect(() => ReactTestUtils.renderIntoDocument(<App2 />)).toWarnDev(
+        '\n    in tr (at **)' +
+          '\n    in Row (at **)' +
+          '\n    in FancyRow (at **)' +
+          '\n    in table (at **)' +
+          '\n    in Table (at **)' +
+          '\n    in FancyTable (at **)' +
+          '\n    in Viz2 (at **)',
       );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(3);
-        expect(
-          normalizeCodeLocInfo(console.error.calls.argsFor(2)[0]),
-        ).toContain(
-          '\n    in tr (at **)' +
-            '\n    in Row (at **)' +
-            '\n    in FancyRow (at **)' +
-            '\n    in table (at **)' +
-            '\n    in Table (at **)' +
-            '\n    in FancyTable (at **)',
-        );
-      }
 
-      ReactTestUtils.renderIntoDocument(
-        <table>
-          <FancyRow />
-        </table>,
-      );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(4);
-        expect(
-          normalizeCodeLocInfo(console.error.calls.argsFor(3)[0]),
-        ).toContain(
-          '\n    in tr (at **)' +
-            '\n    in Row (at **)' +
-            '\n    in FancyRow (at **)' +
-            '\n    in table (at **)',
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(
+          <FancyTable>
+            <FancyRow />
+          </FancyTable>,
         );
-      }
+      }).toWarnDev(
+        '\n    in tr (at **)' +
+          '\n    in Row (at **)' +
+          '\n    in FancyRow (at **)' +
+          '\n    in table (at **)' +
+          '\n    in Table (at **)' +
+          '\n    in FancyTable (at **)',
+      );
 
-      ReactTestUtils.renderIntoDocument(
-        <FancyTable>
-          <tr />
-        </FancyTable>,
-      );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(5);
-        expect(
-          normalizeCodeLocInfo(console.error.calls.argsFor(4)[0]),
-        ).toContain(
-          '\n    in tr (at **)' +
-            '\n    in table (at **)' +
-            '\n    in Table (at **)' +
-            '\n    in FancyTable (at **)',
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(
+          <table>
+            <FancyRow />
+          </table>,
         );
-      }
+      }).toWarnDev(
+        '\n    in tr (at **)' +
+          '\n    in Row (at **)' +
+          '\n    in FancyRow (at **)' +
+          '\n    in table (at **)',
+      );
+
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(
+          <FancyTable>
+            <tr />
+          </FancyTable>,
+        );
+      }).toWarnDev(
+        '\n    in tr (at **)' +
+          '\n    in table (at **)' +
+          '\n    in Table (at **)' +
+          '\n    in FancyTable (at **)',
+      );
 
       class Link extends React.Component {
         render() {
@@ -1793,305 +1657,228 @@ describe('ReactDOMComponent', () => {
         }
       }
 
-      ReactTestUtils.renderIntoDocument(
-        <Link>
-          <div>
-            <Link />
-          </div>
-        </Link>,
-      );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(6);
-        expect(
-          normalizeCodeLocInfo(console.error.calls.argsFor(5)[0]),
-        ).toContain(
-          '\n    in a (at **)' +
-            '\n    in Link (at **)' +
-            '\n    in div (at **)' +
-            '\n    in a (at **)' +
-            '\n    in Link (at **)',
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(
+          <Link>
+            <div>
+              <Link />
+            </div>
+          </Link>,
         );
-      }
+      }).toWarnDev(
+        '\n    in a (at **)' +
+          '\n    in Link (at **)' +
+          '\n    in div (at **)' +
+          '\n    in a (at **)' +
+          '\n    in Link (at **)',
+      );
     });
 
     it('should warn about incorrect casing on properties (ssr)', () => {
-      spyOnDev(console, 'error');
-      ReactDOMServer.renderToString(
-        React.createElement('input', {type: 'text', tabindex: '1'}),
-      );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain('tabIndex');
-      }
+      expect(() => {
+        ReactDOMServer.renderToString(
+          React.createElement('input', {type: 'text', tabindex: '1'}),
+        );
+      }).toWarnDev('tabIndex');
     });
 
     it('should warn about incorrect casing on event handlers (ssr)', () => {
-      spyOnDev(console, 'error');
-      ReactDOMServer.renderToString(
-        React.createElement('input', {type: 'text', oninput: '1'}),
+      expect(() => {
+        ReactDOMServer.renderToString(
+          React.createElement('input', {type: 'text', oninput: '1'}),
+        );
+      }).toWarnDev(
+        'Invalid event handler property `oninput`. ' +
+          'React events use the camelCase naming convention, ' +
+          // Note: we don't know the right event name so we
+          // use a generic one (onClick) as a suggestion.
+          // This is because we don't bundle the event system
+          // on the server.
+          'for example `onClick`.',
       );
       ReactDOMServer.renderToString(
         React.createElement('input', {type: 'text', onKeydown: '1'}),
       );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Invalid event handler property `oninput`. ' +
-            'React events use the camelCase naming convention, ' +
-            // Note: we don't know the right event name so we
-            // use a generic one (onClick) as a suggestion.
-            // This is because we don't bundle the event system
-            // on the server.
-            'for example `onClick`.',
-        );
-        // We can't warn for `onKeydown` on the server because
-        // there is no way tell if this is a valid event or not
-        // without access to the event system (which we don't bundle).
-      }
+      // We can't warn for `onKeydown` on the server because
+      // there is no way tell if this is a valid event or not
+      // without access to the event system (which we don't bundle).
     });
 
     it('should warn about incorrect casing on properties', () => {
-      spyOnDev(console, 'error');
-      ReactTestUtils.renderIntoDocument(
-        React.createElement('input', {type: 'text', tabindex: '1'}),
-      );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain('tabIndex');
-      }
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(
+          React.createElement('input', {type: 'text', tabindex: '1'}),
+        );
+      }).toWarnDev('tabIndex');
     });
 
     it('should warn about incorrect casing on event handlers', () => {
-      spyOnDev(console, 'error');
-      ReactTestUtils.renderIntoDocument(
-        React.createElement('input', {type: 'text', oninput: '1'}),
-      );
-      ReactTestUtils.renderIntoDocument(
-        React.createElement('input', {type: 'text', onKeydown: '1'}),
-      );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-        expect(console.error.calls.argsFor(0)[0]).toContain('onInput');
-        expect(console.error.calls.argsFor(1)[0]).toContain('onKeyDown');
-      }
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(
+          React.createElement('input', {type: 'text', oninput: '1'}),
+        );
+      }).toWarnDev('onInput');
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(
+          React.createElement('input', {type: 'text', onKeydown: '1'}),
+        );
+      }).toWarnDev('onKeyDown');
     });
 
     it('should warn about class', () => {
-      spyOnDev(console, 'error');
-      ReactTestUtils.renderIntoDocument(
-        React.createElement('div', {class: 'muffins'}),
-      );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain('className');
-      }
+      expect(() => {
+        ReactTestUtils.renderIntoDocument(
+          React.createElement('div', {class: 'muffins'}),
+        );
+      }).toWarnDev('className');
     });
 
     it('should warn about class (ssr)', () => {
-      spyOnDev(console, 'error');
-      ReactDOMServer.renderToString(
-        React.createElement('div', {class: 'muffins'}),
-      );
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain('className');
-      }
+      expect(() => {
+        ReactDOMServer.renderToString(
+          React.createElement('div', {class: 'muffins'}),
+        );
+      }).toWarnDev('className');
     });
 
     it('should warn about props that are no longer supported', () => {
-      spyOnDev(console, 'error');
       ReactTestUtils.renderIntoDocument(<div />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(0);
-      }
 
-      ReactTestUtils.renderIntoDocument(<div onFocusIn={() => {}} />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-      }
-
-      ReactTestUtils.renderIntoDocument(<div onFocusOut={() => {}} />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-      }
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(<div onFocusIn={() => {}} />),
+      ).toWarnDev(
+        'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+      );
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(<div onFocusOut={() => {}} />),
+      ).toWarnDev(
+        'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+      );
     });
 
     it('should warn about props that are no longer supported without case sensitivity', () => {
-      spyOnDev(console, 'error');
       ReactTestUtils.renderIntoDocument(<div />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(0);
-      }
-
-      ReactTestUtils.renderIntoDocument(<div onfocusin={() => {}} />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-      }
-
-      ReactTestUtils.renderIntoDocument(<div onfocusout={() => {}} />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-      }
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(<div onfocusin={() => {}} />),
+      ).toWarnDev(
+        'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+      );
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(<div onfocusout={() => {}} />),
+      ).toWarnDev(
+        'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+      );
     });
 
     it('should warn about props that are no longer supported (ssr)', () => {
-      spyOnDev(console, 'error');
       ReactDOMServer.renderToString(<div />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(0);
-      }
-
-      ReactDOMServer.renderToString(<div onFocusIn={() => {}} />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-      }
-
-      ReactDOMServer.renderToString(<div onFocusOut={() => {}} />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-      }
+      expect(() =>
+        ReactDOMServer.renderToString(<div onFocusIn={() => {}} />),
+      ).toWarnDev(
+        'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+      );
+      expect(() =>
+        ReactDOMServer.renderToString(<div onFocusOut={() => {}} />),
+      ).toWarnDev(
+        'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+      );
     });
 
     it('should warn about props that are no longer supported without case sensitivity (ssr)', () => {
-      spyOnDev(console, 'error');
       ReactDOMServer.renderToString(<div />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(0);
-      }
-
-      ReactDOMServer.renderToString(<div onfocusin={() => {}} />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-      }
-
-      ReactDOMServer.renderToString(<div onfocusout={() => {}} />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-      }
+      expect(() =>
+        ReactDOMServer.renderToString(<div onfocusin={() => {}} />),
+      ).toWarnDev(
+        'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+      );
+      expect(() =>
+        ReactDOMServer.renderToString(<div onfocusout={() => {}} />),
+      ).toWarnDev(
+        'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+      );
     });
 
     it('gives source code refs for unknown prop warning', () => {
-      spyOnDev(console, 'error');
-      ReactTestUtils.renderIntoDocument(<div class="paladin" />);
-      ReactTestUtils.renderIntoDocument(<input type="text" onclick="1" />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
-        );
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-          'Warning: Invalid event handler property `onclick`. Did you mean ' +
-            '`onClick`?\n    in input (at **)',
-        );
-      }
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(<div class="paladin" />),
+      ).toWarnDev(
+        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+      );
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(<input type="text" onclick="1" />),
+      ).toWarnDev(
+        'Warning: Invalid event handler property `onclick`. Did you mean ' +
+          '`onClick`?\n    in input (at **)',
+      );
     });
 
     it('gives source code refs for unknown prop warning (ssr)', () => {
-      spyOnDev(console, 'error');
-      ReactDOMServer.renderToString(<div class="paladin" />);
-      ReactDOMServer.renderToString(<input type="text" oninput="1" />);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
-        );
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(1)[0])).toBe(
-          'Warning: Invalid event handler property `oninput`. ' +
-            // Note: we don't know the right event name so we
-            // use a generic one (onClick) as a suggestion.
-            // This is because we don't bundle the event system
-            // on the server.
-            'React events use the camelCase naming convention, for example `onClick`.' +
-            '\n    in input (at **)',
-        );
-      }
+      expect(() =>
+        ReactDOMServer.renderToString(<div class="paladin" />),
+      ).toWarnDev(
+        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+      );
+      expect(() =>
+        ReactDOMServer.renderToString(<input type="text" oninput="1" />),
+      ).toWarnDev(
+        'Warning: Invalid event handler property `oninput`. ' +
+          // Note: we don't know the right event name so we
+          // use a generic one (onClick) as a suggestion.
+          // This is because we don't bundle the event system
+          // on the server.
+          'React events use the camelCase naming convention, for example `onClick`.' +
+          '\n    in input (at **)',
+      );
     });
 
     it('gives source code refs for unknown prop warning for update render', () => {
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
 
       ReactTestUtils.renderIntoDocument(<div className="paladin" />, container);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(0);
-      }
-
-      ReactTestUtils.renderIntoDocument(<div class="paladin" />, container);
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-          'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
-        );
-      }
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(<div class="paladin" />, container),
+      ).toWarnDev(
+        'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
+      );
     });
 
     it('gives source code refs for unknown prop warning for exact elements', () => {
-      spyOnDev(console, 'error');
-
-      ReactTestUtils.renderIntoDocument(
-        <div className="foo1">
-          <div class="foo2" />
-          <div onClick={() => {}} />
-          <div onclick={() => {}} />
-          <div className="foo5" />
-          <div className="foo6" />
-        </div>,
-      );
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-
-        expect(console.error.calls.argsFor(0)[0]).toContain('className');
-        let matches = console.error.calls
-          .argsFor(0)[0]
-          .match(/.*\(.*:(\d+)\).*/);
-        const previousLine = matches[1];
-
-        expect(console.error.calls.argsFor(1)[0]).toContain('onClick');
-        matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/);
-        const currentLine = matches[1];
-
-        //verify line number has a proper relative difference,
-        //since hard coding the line number would make test too brittle
-        expect(parseInt(previousLine, 10) + 2).toBe(parseInt(currentLine, 10));
-      }
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(
+          <div className="foo1">
+            <span class="foo2" />
+            <div onClick={() => {}} />
+            <strong onclick={() => {}} />
+            <div className="foo5" />
+            <div className="foo6" />
+          </div>,
+        ),
+      ).toWarnDev([
+        'Invalid DOM property `class`. Did you mean `className`?\n    in span (at **)',
+        'Invalid event handler property `onclick`. Did you mean `onClick`?\n    in strong (at **)',
+      ]);
     });
 
     it('gives source code refs for unknown prop warning for exact elements (ssr)', () => {
-      spyOnDev(console, 'error');
-
-      ReactDOMServer.renderToString(
-        <div className="foo1">
-          <div class="foo2" />
-          <div onClick="foo3" />
-          <div onclick="foo4" />
-          <div className="foo5" />
-          <div className="foo6" />
-        </div>,
-      );
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-
-        expect(console.error.calls.argsFor(0)[0]).toContain('className');
-        let matches = console.error.calls
-          .argsFor(0)[0]
-          .match(/.*\(.*:(\d+)\).*/);
-        const previousLine = (matches || [])[1];
-
-        expect(console.error.calls.argsFor(1)[0]).toContain('onClick');
-        matches =
-          console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/) || {};
-        const currentLine = (matches || [])[1];
-
-        //verify line number has a proper relative difference,
-        //since hard coding the line number would make test too brittle
-        expect(parseInt(previousLine, 10) + 2).toBe(parseInt(currentLine, 10));
-      }
+      expect(() =>
+        ReactDOMServer.renderToString(
+          <div className="foo1">
+            <span class="foo2" />
+            <div onClick="foo3" />
+            <strong onclick="foo4" />
+            <div className="foo5" />
+            <div className="foo6" />
+          </div>,
+        ),
+      ).toWarnDev([
+        'Invalid DOM property `class`. Did you mean `className`?\n    in span (at **)',
+        'Invalid event handler property `onclick`. ' +
+          'React events use the camelCase naming convention, for example `onClick`.' +
+          '\n    in strong (at **)',
+      ]);
     });
 
     it('gives source code refs for unknown prop warning for exact elements in composition', () => {
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
 
       class Parent extends React.Component {
@@ -2109,7 +1896,7 @@ describe('ReactDOMComponent', () => {
 
       class Child1 extends React.Component {
         render() {
-          return <div class="paladin">Child1</div>;
+          return <span class="paladin">Child1</span>;
         }
       }
 
@@ -2121,7 +1908,7 @@ describe('ReactDOMComponent', () => {
 
       class Child3 extends React.Component {
         render() {
-          return <div onclick="1">Child3</div>;
+          return <strong onclick="1">Child3</strong>;
         }
       }
 
@@ -2131,29 +1918,15 @@ describe('ReactDOMComponent', () => {
         }
       }
 
-      ReactTestUtils.renderIntoDocument(<Parent />, container);
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-
-        expect(console.error.calls.argsFor(0)[0]).toContain('className');
-        let matches = console.error.calls
-          .argsFor(0)[0]
-          .match(/.*\(.*:(\d+)\).*/);
-        const previousLine = (matches || [])[1];
-
-        expect(console.error.calls.argsFor(1)[0]).toContain('onClick');
-        matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/);
-        const currentLine = (matches || [])[1];
-
-        //verify line number has a proper relative difference,
-        //since hard coding the line number would make test too brittle
-        expect(parseInt(previousLine, 10) + 12).toBe(parseInt(currentLine, 10));
-      }
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(<Parent />, container),
+      ).toWarnDev([
+        'Invalid DOM property `class`. Did you mean `className`?\n    in span (at **)',
+        'Invalid event handler property `onclick`. Did you mean `onClick`?\n    in strong (at **)',
+      ]);
     });
 
     it('gives source code refs for unknown prop warning for exact elements in composition (ssr)', () => {
-      spyOnDev(console, 'error');
       const container = document.createElement('div');
 
       class Parent extends React.Component {
@@ -2171,7 +1944,7 @@ describe('ReactDOMComponent', () => {
 
       class Child1 extends React.Component {
         render() {
-          return <div class="paladin">Child1</div>;
+          return <span class="paladin">Child1</span>;
         }
       }
 
@@ -2183,7 +1956,7 @@ describe('ReactDOMComponent', () => {
 
       class Child3 extends React.Component {
         render() {
-          return <div onclick="1">Child3</div>;
+          return <strong onclick="1">Child3</strong>;
         }
       }
 
@@ -2193,71 +1966,49 @@ describe('ReactDOMComponent', () => {
         }
       }
 
-      ReactDOMServer.renderToString(<Parent />, container);
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-
-        expect(console.error.calls.argsFor(0)[0]).toContain('className');
-        let matches = console.error.calls
-          .argsFor(0)[0]
-          .match(/.*\(.*:(\d+)\).*/);
-        const previousLine = (matches || [])[1];
-
-        expect(console.error.calls.argsFor(1)[0]).toContain('onClick');
-        matches = console.error.calls.argsFor(1)[0].match(/.*\(.*:(\d+)\).*/);
-        const currentLine = (matches || [])[1];
-
-        //verify line number has a proper relative difference,
-        //since hard coding the line number would make test too brittle
-        expect(parseInt(previousLine, 10) + 12).toBe(parseInt(currentLine, 10));
-      }
+      expect(() =>
+        ReactDOMServer.renderToString(<Parent />, container),
+      ).toWarnDev([
+        'Invalid DOM property `class`. Did you mean `className`?\n    in span (at **)',
+        'Invalid event handler property `onclick`. ' +
+          'React events use the camelCase naming convention, for example `onClick`.' +
+          '\n    in strong (at **)',
+      ]);
     });
 
     it('should suggest property name if available', () => {
-      spyOnDev(console, 'error');
-
-      ReactTestUtils.renderIntoDocument(
-        React.createElement('label', {for: 'test'}),
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(
+          React.createElement('label', {for: 'test'}),
+        ),
+      ).toWarnDev(
+        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
-      ReactTestUtils.renderIntoDocument(
-        React.createElement('input', {type: 'text', autofocus: true}),
+
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(
+          React.createElement('input', {type: 'text', autofocus: true}),
+        ),
+      ).toWarnDev(
+        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-
-        expect(console.error.calls.argsFor(0)[0]).toBe(
-          'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
-        );
-
-        expect(console.error.calls.argsFor(1)[0]).toBe(
-          'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
-        );
-      }
     });
 
     it('should suggest property name if available (ssr)', () => {
-      spyOnDev(console, 'error');
-
-      ReactDOMServer.renderToString(
-        React.createElement('label', {for: 'test'}),
+      expect(() =>
+        ReactDOMServer.renderToString(
+          React.createElement('label', {for: 'test'}),
+        ),
+      ).toWarnDev(
+        'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
-      ReactDOMServer.renderToString(
-        React.createElement('input', {type: 'text', autofocus: true}),
+      expect(() =>
+        ReactDOMServer.renderToString(
+          React.createElement('input', {type: 'text', autofocus: true}),
+        ),
+      ).toWarnDev(
+        'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(2);
-
-        expect(console.error.calls.argsFor(0)[0]).toBe(
-          'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
-        );
-
-        expect(console.error.calls.argsFor(1)[0]).toBe(
-          'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
-        );
-      }
     });
   });
 
@@ -2287,50 +2038,41 @@ describe('ReactDOMComponent', () => {
 
   describe('Attributes with aliases', function() {
     it('sets aliased attributes on HTML attributes', function() {
-      spyOnDev(console, 'error');
-
-      const el = ReactTestUtils.renderIntoDocument(<div class="test" />);
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div class="test" />);
+      }).toWarnDev(
+        'Warning: Invalid DOM property `class`. Did you mean `className`?',
+      );
 
       expect(el.className).toBe('test');
-
-      if (__DEV__) {
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid DOM property `class`. Did you mean `className`?',
-        );
-      }
     });
 
     it('sets incorrectly cased aliased attributes on HTML attributes with a warning', function() {
-      spyOnDev(console, 'error');
-
-      const el = ReactTestUtils.renderIntoDocument(<div cLASS="test" />);
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div cLASS="test" />);
+      }).toWarnDev(
+        'Warning: Invalid DOM property `cLASS`. Did you mean `className`?',
+      );
 
       expect(el.className).toBe('test');
-
-      if (__DEV__) {
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid DOM property `cLASS`. Did you mean `className`?',
-        );
-      }
     });
 
     it('sets aliased attributes on SVG elements with a warning', function() {
-      spyOnDev(console, 'error');
-
-      const el = ReactTestUtils.renderIntoDocument(
-        <svg>
-          <text arabic-form="initial" />
-        </svg>,
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(
+          <svg>
+            <text arabic-form="initial" />
+          </svg>,
+        );
+      }).toWarnDev(
+        'Warning: Invalid DOM property `arabic-form`. Did you mean `arabicForm`?',
       );
       const text = el.querySelector('text');
 
       expect(text.hasAttribute('arabic-form')).toBe(true);
-
-      if (__DEV__) {
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid DOM property `arabic-form`. Did you mean `arabicForm`?',
-        );
-      }
     });
 
     it('sets aliased attributes on custom elements', function() {
@@ -2377,36 +2119,30 @@ describe('ReactDOMComponent', () => {
     });
 
     it('does not assign a boolean custom attributes as a string', function() {
-      spyOnDev(console, 'error');
-
-      const el = ReactTestUtils.renderIntoDocument(<div whatever={true} />);
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div whatever={true} />);
+      }).toWarnDev(
+        'Received `true` for a non-boolean attribute `whatever`.\n\n' +
+          'If you want to write it to the DOM, pass a string instead: ' +
+          'whatever="true" or whatever={value.toString()}.',
+      );
 
       expect(el.hasAttribute('whatever')).toBe(false);
-
-      if (__DEV__) {
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Received `true` for a non-boolean attribute `whatever`.\n\n' +
-            'If you want to write it to the DOM, pass a string instead: ' +
-            'whatever="true" or whatever={value.toString()}.',
-        );
-      }
     });
 
     it('does not assign an implicit boolean custom attributes', function() {
-      spyOnDev(console, 'error');
-
-      // eslint-disable-next-line react/jsx-boolean-value
-      const el = ReactTestUtils.renderIntoDocument(<div whatever />);
+      let el;
+      expect(() => {
+        // eslint-disable-next-line react/jsx-boolean-value
+        el = ReactTestUtils.renderIntoDocument(<div whatever />);
+      }).toWarnDev(
+        'Received `true` for a non-boolean attribute `whatever`.\n\n' +
+          'If you want to write it to the DOM, pass a string instead: ' +
+          'whatever="true" or whatever={value.toString()}.',
+      );
 
       expect(el.hasAttribute('whatever')).toBe(false);
-
-      if (__DEV__) {
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Received `true` for a non-boolean attribute `whatever`.\n\n' +
-            'If you want to write it to the DOM, pass a string instead: ' +
-            'whatever="true" or whatever={value.toString()}.',
-        );
-      }
     });
 
     it('assigns a numeric custom attributes as a string', function() {
@@ -2416,17 +2152,12 @@ describe('ReactDOMComponent', () => {
     });
 
     it('will not assign a function custom attributes', function() {
-      spyOnDev(console, 'error');
-
-      const el = ReactTestUtils.renderIntoDocument(<div whatever={() => {}} />);
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div whatever={() => {}} />);
+      }).toWarnDev('Warning: Invalid value for prop `whatever` on <div> tag');
 
       expect(el.hasAttribute('whatever')).toBe(false);
-
-      if (__DEV__) {
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid value for prop `whatever` on <div> tag',
-        );
-      }
     });
 
     it('will assign an object custom attributes', function() {
@@ -2435,87 +2166,66 @@ describe('ReactDOMComponent', () => {
     });
 
     it('allows cased data attributes', function() {
-      spyOnDev(console, 'error');
-
-      const el = ReactTestUtils.renderIntoDocument(<div data-fooBar="true" />);
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div data-fooBar="true" />);
+      }).toWarnDev(
+        'React does not recognize the `data-fooBar` prop on a DOM element. ' +
+          'If you intentionally want it to appear in the DOM as a custom ' +
+          'attribute, spell it as lowercase `data-foobar` instead. ' +
+          'If you accidentally passed it from a parent component, remove ' +
+          'it from the DOM element.\n' +
+          '    in div (at **)',
+      );
       expect(el.getAttribute('data-foobar')).toBe('true');
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toMatch(
-          'React does not recognize the `data-fooBar` prop on a DOM element. ' +
-            'If you intentionally want it to appear in the DOM as a custom ' +
-            'attribute, spell it as lowercase `data-foobar` instead. ' +
-            'If you accidentally passed it from a parent component, remove ' +
-            'it from the DOM element.\n' +
-            '    in div (at **)',
-        );
-      }
     });
 
     it('allows cased custom attributes', function() {
-      spyOnDev(console, 'error');
-
-      const el = ReactTestUtils.renderIntoDocument(<div fooBar="true" />);
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div fooBar="true" />);
+      }).toWarnDev(
+        'React does not recognize the `fooBar` prop on a DOM element. ' +
+          'If you intentionally want it to appear in the DOM as a custom ' +
+          'attribute, spell it as lowercase `foobar` instead. ' +
+          'If you accidentally passed it from a parent component, remove ' +
+          'it from the DOM element.\n' +
+          '    in div (at **)',
+      );
       expect(el.getAttribute('foobar')).toBe('true');
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toMatch(
-          'React does not recognize the `fooBar` prop on a DOM element. ' +
-            'If you intentionally want it to appear in the DOM as a custom ' +
-            'attribute, spell it as lowercase `foobar` instead. ' +
-            'If you accidentally passed it from a parent component, remove ' +
-            'it from the DOM element.\n' +
-            '    in div (at **)',
-        );
-      }
     });
 
     it('warns on NaN attributes', function() {
-      spyOnDev(console, 'error');
-
-      const el = ReactTestUtils.renderIntoDocument(<div whatever={NaN} />);
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div whatever={NaN} />);
+      }).toWarnDev(
+        'Warning: Received NaN for the `whatever` attribute. If this is ' +
+          'expected, cast the value to a string.\n    in div',
+      );
 
       expect(el.getAttribute('whatever')).toBe('NaN');
-
-      if (__DEV__) {
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Received NaN for the `whatever` attribute. If this is ' +
-            'expected, cast the value to a string.\n    in div',
-        );
-      }
     });
 
     it('removes a property when it becomes invalid', function() {
-      spyOnDev(console, 'error');
-
       const container = document.createElement('div');
       ReactDOM.render(<div whatever={0} />, container);
-      ReactDOM.render(<div whatever={() => {}} />, container);
+      expect(() =>
+        ReactDOM.render(<div whatever={() => {}} />, container),
+      ).toWarnDev('Warning: Invalid value for prop `whatever` on <div> tag.');
       const el = container.firstChild;
-
       expect(el.hasAttribute('whatever')).toBe(false);
-
-      if (__DEV__) {
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid value for prop `whatever` on <div> tag.',
-        );
-      }
     });
 
     it('warns on bad casing of known HTML attributes', function() {
-      spyOnDev(console, 'error');
-
-      const el = ReactTestUtils.renderIntoDocument(<div SiZe="30" />);
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div SiZe="30" />);
+      }).toWarnDev(
+        'Warning: Invalid DOM property `SiZe`. Did you mean `size`?',
+      );
 
       expect(el.getAttribute('size')).toBe('30');
-
-      if (__DEV__) {
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid DOM property `SiZe`. Did you mean `size`?',
-        );
-      }
     });
   });
 
@@ -2581,19 +2291,16 @@ describe('ReactDOMComponent', () => {
 
   describe('String boolean attributes', function() {
     it('does not assign string boolean attributes for custom attributes', function() {
-      spyOnDev(console, 'error');
-
-      const el = ReactTestUtils.renderIntoDocument(<div whatever={true} />);
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div whatever={true} />);
+      }).toWarnDev(
+        'Received `true` for a non-boolean attribute `whatever`.\n\n' +
+          'If you want to write it to the DOM, pass a string instead: ' +
+          'whatever="true" or whatever={value.toString()}.',
+      );
 
       expect(el.hasAttribute('whatever')).toBe(false);
-
-      if (__DEV__) {
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Received `true` for a non-boolean attribute `whatever`.\n\n' +
-            'If you want to write it to the DOM, pass a string instead: ' +
-            'whatever="true" or whatever={value.toString()}.',
-        );
-      }
     });
 
     it('stringifies the boolean true for allowed attributes', function() {
@@ -2618,47 +2325,41 @@ describe('ReactDOMComponent', () => {
 
   describe('Hyphenated SVG elements', function() {
     it('the font-face element is not a custom element', function() {
-      spyOnDev(console, 'error');
-      const el = ReactTestUtils.renderIntoDocument(
-        <svg>
-          <font-face x-height={false} />
-        </svg>,
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(
+          <svg>
+            <font-face x-height={false} />
+          </svg>,
+        );
+      }).toWarnDev(
+        'Warning: Invalid DOM property `x-height`. Did you mean `xHeight`',
       );
 
       expect(el.querySelector('font-face').hasAttribute('x-height')).toBe(
         false,
       );
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid DOM property `x-height`. Did you mean `xHeight`',
-        );
-      }
     });
 
     it('the font-face element does not allow unknown boolean values', function() {
-      spyOnDev(console, 'error');
-      const el = ReactTestUtils.renderIntoDocument(
-        <svg>
-          <font-face whatever={false} />
-        </svg>,
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(
+          <svg>
+            <font-face whatever={false} />
+          </svg>,
+        );
+      }).toWarnDev(
+        'Received `false` for a non-boolean attribute `whatever`.\n\n' +
+          'If you want to write it to the DOM, pass a string instead: ' +
+          'whatever="false" or whatever={value.toString()}.\n\n' +
+          'If you used to conditionally omit it with whatever={condition && value}, ' +
+          'pass whatever={condition ? value : undefined} instead.',
       );
 
       expect(el.querySelector('font-face').hasAttribute('whatever')).toBe(
         false,
       );
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Received `false` for a non-boolean attribute `whatever`.\n\n' +
-            'If you want to write it to the DOM, pass a string instead: ' +
-            'whatever="false" or whatever={value.toString()}.\n\n' +
-            'If you used to conditionally omit it with whatever={condition && value}, ' +
-            'pass whatever={condition ? value : undefined} instead.',
-        );
-      }
     });
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
@@ -177,42 +177,28 @@ describe('ReactDOMComponentTree', () => {
 
     const component = <Controlled />;
     const instance = ReactDOM.render(component, container);
-    spyOnDev(console, 'error');
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(0);
-    }
-    simulateInput(instance.a, finishValue);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Warning: A component is changing an uncontrolled input of ' +
-          'type text to be controlled. Input elements should not ' +
-          'switch from uncontrolled to controlled (or vice versa). ' +
-          'Decide between using a controlled or uncontrolled input ' +
-          'element for the lifetime of the component. More info: ' +
-          'https://fb.me/react-controlled-components',
-      );
-    }
+    expect(() => simulateInput(instance.a, finishValue)).toWarnDev(
+      'Warning: A component is changing an uncontrolled input of ' +
+        'type text to be controlled. Input elements should not ' +
+        'switch from uncontrolled to controlled (or vice versa). ' +
+        'Decide between using a controlled or uncontrolled input ' +
+        'element for the lifetime of the component. More info: ' +
+        'https://fb.me/react-controlled-components',
+    );
   });
 
   it('finds instance of node that is attempted to be unmounted', () => {
-    spyOnDev(console, 'error');
     const component = <div />;
     const node = ReactDOM.render(<div>{component}</div>, container);
-    ReactDOM.unmountComponentAtNode(node);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        "unmountComponentAtNode(): The node you're attempting to unmount " +
-          'was rendered by React and is not a top-level container. You may ' +
-          'have accidentally passed in a React root node instead of its ' +
-          'container.',
-      );
-    }
+    expect(() => ReactDOM.unmountComponentAtNode(node)).toWarnDev(
+      "unmountComponentAtNode(): The node you're attempting to unmount " +
+        'was rendered by React and is not a top-level container. You may ' +
+        'have accidentally passed in a React root node instead of its ' +
+        'container.',
+    );
   });
 
   it('finds instance from node to stop rendering over other react rendered components', () => {
-    spyOnDev(console, 'error');
     const component = (
       <div>
         <span>Hello</span>
@@ -220,15 +206,11 @@ describe('ReactDOMComponentTree', () => {
     );
     const anotherComponent = <div />;
     const instance = ReactDOM.render(component, container);
-    ReactDOM.render(anotherComponent, instance);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'render(...): Replacing React-rendered children with a new root ' +
-          'component. If you intended to update the children of this node, ' +
-          'you should instead have the existing children update their state ' +
-          'and render the new components instead of calling ReactDOM.render.',
-      );
-    }
+    expect(() => ReactDOM.render(anotherComponent, instance)).toWarnDev(
+      'render(...): Replacing React-rendered children with a new root ' +
+        'component. If you intended to update the children of this node, ' +
+        'you should instead have the existing children update their state ' +
+        'and render the new components instead of calling ReactDOM.render.',
+    );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -15,10 +15,6 @@ const ReactTestUtils = require('react-dom/test-utils');
 const PropTypes = require('prop-types');
 
 describe('ReactDOMFiber', () => {
-  function normalizeCodeLocInfo(str) {
-    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
-  }
-
   let container;
 
   beforeEach(() => {
@@ -222,27 +218,23 @@ describe('ReactDOMFiber', () => {
 
   // TODO: remove in React 17
   it('should support unstable_createPortal alias', () => {
-    spyOnDev(console, 'warn');
     const portalContainer = document.createElement('div');
 
-    ReactDOM.render(
-      <div>
-        {ReactDOM.unstable_createPortal(<div>portal</div>, portalContainer)}
-      </div>,
-      container,
+    expect(() =>
+      ReactDOM.render(
+        <div>
+          {ReactDOM.unstable_createPortal(<div>portal</div>, portalContainer)}
+        </div>,
+        container,
+      ),
+    ).toLowPriorityWarnDev(
+      'The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
+        'and will be removed in React 17+. Update your code to use ' +
+        'ReactDOM.createPortal() instead. It has the exact same API, ' +
+        'but without the "unstable_" prefix.',
     );
     expect(portalContainer.innerHTML).toBe('<div>portal</div>');
     expect(container.innerHTML).toBe('<div></div>');
-
-    if (__DEV__) {
-      expect(console.warn.calls.count()).toBe(1);
-      expect(console.warn.calls.argsFor(0)[0]).toContain(
-        'The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
-          'and will be removed in React 17+. Update your code to use ' +
-          'ReactDOM.createPortal() instead. It has the exact same API, ' +
-          'but without the "unstable_" prefix.',
-      );
-    }
 
     ReactDOM.unmountComponentAtNode(container);
     expect(portalContainer.innerHTML).toBe('');
@@ -930,40 +922,30 @@ describe('ReactDOMFiber', () => {
   });
 
   it('should warn for non-functional event listeners', () => {
-    spyOnDev(console, 'error');
     class Example extends React.Component {
       render() {
         return <div onClick="woops" />;
       }
     }
-    ReactDOM.render(<Example />, container);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toContain(
-        'Expected `onClick` listener to be a function, instead got a value of `string` type.\n' +
-          '    in div (at **)\n' +
-          '    in Example (at **)',
-      );
-    }
+    expect(() => ReactDOM.render(<Example />, container)).toWarnDev(
+      'Expected `onClick` listener to be a function, instead got a value of `string` type.\n' +
+        '    in div (at **)\n' +
+        '    in Example (at **)',
+    );
   });
 
   it('should warn with a special message for `false` event listeners', () => {
-    spyOnDev(console, 'error');
     class Example extends React.Component {
       render() {
         return <div onClick={false} />;
       }
     }
-    ReactDOM.render(<Example />, container);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toContain(
-        'Expected `onClick` listener to be a function, instead got `false`.\n\n' +
-          'If you used to conditionally omit it with onClick={condition && value}, ' +
-          'pass onClick={condition ? value : undefined} instead.\n',
-        '    in div (at **)\n' + '    in Example (at **)',
-      );
-    }
+    expect(() => ReactDOM.render(<Example />, container)).toWarnDev(
+      'Expected `onClick` listener to be a function, instead got `false`.\n\n' +
+        'If you used to conditionally omit it with onClick={condition && value}, ' +
+        'pass onClick={condition ? value : undefined} instead.\n',
+      '    in div (at **)\n' + '    in Example (at **)',
+    );
   });
 
   it('should not update event handlers until commit', () => {
@@ -1059,23 +1041,15 @@ describe('ReactDOMFiber', () => {
   });
 
   it('should not warn when rendering into an empty container', () => {
-    spyOnDev(console, 'error');
     ReactDOM.render(<div>foo</div>, container);
     expect(container.innerHTML).toBe('<div>foo</div>');
     ReactDOM.render(null, container);
     expect(container.innerHTML).toBe('');
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(0);
-    }
     ReactDOM.render(<div>bar</div>, container);
     expect(container.innerHTML).toBe('<div>bar</div>');
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(0);
-    }
   });
 
   it('should warn when replacing a container which was manually updated outside of React', () => {
-    spyOnDev(console, 'error');
     // when not messing with the DOM outside of React
     ReactDOM.render(<div key="1">foo</div>, container);
     ReactDOM.render(<div key="1">bar</div>, container);
@@ -1083,64 +1057,51 @@ describe('ReactDOMFiber', () => {
     // then we mess with the DOM before an update
     // we know this will error - that is expected right now
     // It's an error of type 'NotFoundError' with no message
+    container.innerHTML = '<div>MEOW.</div>';
+
     expect(() => {
-      container.innerHTML = '<div>MEOW.</div>';
-      ReactDOM.render(<div key="2">baz</div>, container);
-    }).toThrowError();
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
+      expect(() =>
+        ReactDOM.render(<div key="2">baz</div>, container),
+      ).toWarnDev(
         'render(...): ' +
           'It looks like the React-rendered content of this container was ' +
           'removed without using React. This is not supported and will ' +
           'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
           'to empty a container.',
       );
-    }
+    }).toThrowError();
   });
 
   it('should warn when doing an update to a container manually updated outside of React', () => {
-    spyOnDev(console, 'error');
     // when not messing with the DOM outside of React
     ReactDOM.render(<div>foo</div>, container);
     ReactDOM.render(<div>bar</div>, container);
     expect(container.innerHTML).toBe('<div>bar</div>');
     // then we mess with the DOM before an update
     container.innerHTML = '<div>MEOW.</div>';
-    ReactDOM.render(<div>baz</div>, container);
-    // silently fails to update
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'render(...): ' +
-          'It looks like the React-rendered content of this container was ' +
-          'removed without using React. This is not supported and will ' +
-          'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
-          'to empty a container.',
-      );
-    }
+    expect(() => ReactDOM.render(<div>baz</div>, container)).toWarnDev(
+      'render(...): ' +
+        'It looks like the React-rendered content of this container was ' +
+        'removed without using React. This is not supported and will ' +
+        'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
+        'to empty a container.',
+    );
   });
 
   it('should warn when doing an update to a container manually cleared outside of React', () => {
-    spyOnDev(console, 'error');
     // when not messing with the DOM outside of React
     ReactDOM.render(<div>foo</div>, container);
     ReactDOM.render(<div>bar</div>, container);
     expect(container.innerHTML).toBe('<div>bar</div>');
     // then we mess with the DOM before an update
     container.innerHTML = '';
-    ReactDOM.render(<div>baz</div>, container);
-    // silently fails to update
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'render(...): ' +
-          'It looks like the React-rendered content of this container was ' +
-          'removed without using React. This is not supported and will ' +
-          'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
-          'to empty a container.',
-      );
-    }
+    expect(() => ReactDOM.render(<div>baz</div>, container)).toWarnDev(
+      'render(...): ' +
+        'It looks like the React-rendered content of this container was ' +
+        'removed without using React. This is not supported and will ' +
+        'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
+        'to empty a container.',
+    );
   });
 
   it('should render a text component with a text DOM node on the same document as the container', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMInvalidARIAHook-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInvalidARIAHook-test.js
@@ -26,74 +26,47 @@ describe('ReactDOMInvalidARIAHook', () => {
 
   describe('aria-* props', () => {
     it('should allow valid aria-* props', () => {
-      spyOnDev(console, 'error');
       mountComponent({'aria-label': 'Bumble bees'});
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(0);
-      }
     });
     it('should warn for one invalid aria-* prop', () => {
-      spyOnDev(console, 'error');
-      mountComponent({'aria-badprop': 'maybe'});
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid aria prop `aria-badprop` on <div> tag. ' +
-            'For details, see https://fb.me/invalid-aria-prop',
-        );
-      }
+      expect(() => mountComponent({'aria-badprop': 'maybe'})).toWarnDev(
+        'Warning: Invalid aria prop `aria-badprop` on <div> tag. ' +
+          'For details, see https://fb.me/invalid-aria-prop',
+      );
     });
     it('should warn for many invalid aria-* props', () => {
-      spyOnDev(console, 'error');
-      mountComponent({
-        'aria-badprop': 'Very tall trees',
-        'aria-malprop': 'Turbulent seas',
-      });
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid aria props `aria-badprop`, `aria-malprop` on <div> ' +
-            'tag. For details, see https://fb.me/invalid-aria-prop',
-        );
-      }
+      expect(() =>
+        mountComponent({
+          'aria-badprop': 'Very tall trees',
+          'aria-malprop': 'Turbulent seas',
+        }),
+      ).toWarnDev(
+        'Warning: Invalid aria props `aria-badprop`, `aria-malprop` on <div> ' +
+          'tag. For details, see https://fb.me/invalid-aria-prop',
+      );
     });
     it('should warn for an improperly cased aria-* prop', () => {
-      spyOnDev(console, 'error');
       // The valid attribute name is aria-haspopup.
-      mountComponent({'aria-hasPopup': 'true'});
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Unknown ARIA attribute `aria-hasPopup`. ' +
-            'Did you mean `aria-haspopup`?',
-        );
-      }
+      expect(() => mountComponent({'aria-hasPopup': 'true'})).toWarnDev(
+        'Warning: Unknown ARIA attribute `aria-hasPopup`. ' +
+          'Did you mean `aria-haspopup`?',
+      );
     });
 
     it('should warn for use of recognized camel case aria attributes', () => {
-      spyOnDev(console, 'error');
       // The valid attribute name is aria-haspopup.
-      mountComponent({ariaHasPopup: 'true'});
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid ARIA attribute `ariaHasPopup`. ' +
-            'Did you mean `aria-haspopup`?',
-        );
-      }
+      expect(() => mountComponent({ariaHasPopup: 'true'})).toWarnDev(
+        'Warning: Invalid ARIA attribute `ariaHasPopup`. ' +
+          'Did you mean `aria-haspopup`?',
+      );
     });
 
     it('should warn for use of unrecognized camel case aria attributes', () => {
-      spyOnDev(console, 'error');
       // The valid attribute name is aria-haspopup.
-      mountComponent({ariaSomethingInvalid: 'true'});
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(console.error.calls.argsFor(0)[0]).toContain(
-          'Warning: Invalid ARIA attribute `ariaSomethingInvalid`. ARIA ' +
-            'attributes follow the pattern aria-* and must be lowercase.',
-        );
-      }
+      expect(() => mountComponent({ariaSomethingInvalid: 'true'})).toWarnDev(
+        'Warning: Invalid ARIA attribute `ariaSomethingInvalid`. ARIA ' +
+          'attributes follow the pattern aria-* and must be lowercase.',
+      );
     });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMOption-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMOption-test.js
@@ -10,10 +10,6 @@
 'use strict';
 
 describe('ReactDOMOption', () => {
-  function normalizeCodeLocInfo(str) {
-    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
-  }
-
   let React;
   let ReactDOM;
   let ReactTestUtils;
@@ -37,24 +33,21 @@ describe('ReactDOMOption', () => {
   });
 
   it('should ignore and warn invalid children types', () => {
-    spyOnDev(console, 'error');
     const el = (
       <option>
         {1} <div /> {2}
       </option>
     );
-    const node = ReactTestUtils.renderIntoDocument(el);
+    let node;
+    expect(() => {
+      node = ReactTestUtils.renderIntoDocument(el);
+    }).toWarnDev(
+      '<div> cannot appear as a child of <option>.\n' +
+        '    in div (at **)\n' +
+        '    in option (at **)',
+    );
     expect(node.innerHTML).toBe('1  2');
     ReactTestUtils.renderIntoDocument(el);
-    if (__DEV__) {
-      // only warn once
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toContain(
-        '<div> cannot appear as a child of <option>.\n' +
-          '    in div (at **)\n' +
-          '    in option (at **)',
-      );
-    }
   });
 
   it('should ignore null/undefined/false children without warning', () => {
@@ -66,14 +59,9 @@ describe('ReactDOMOption', () => {
         {undefined} {2}
       </option>
     );
-    spyOnDev(console, 'error');
     stub = ReactTestUtils.renderIntoDocument(stub);
 
     const node = ReactDOM.findDOMNode(stub);
-
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(0);
-    }
     expect(node.innerHTML).toBe('1  2');
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
@@ -130,8 +130,6 @@ describe('ReactDOMRoot', () => {
       ),
     );
 
-    spyOnDev(console, 'error');
-
     // Does not hydrate by default
     const container1 = document.createElement('div');
     container1.innerHTML = markup;
@@ -142,9 +140,6 @@ describe('ReactDOMRoot', () => {
       </div>,
     );
     flush();
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(0);
-    }
 
     // Accepts `hydrate` option
     const container2 = document.createElement('div');
@@ -155,15 +150,10 @@ describe('ReactDOMRoot', () => {
         <span />
       </div>,
     );
-    flush();
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toMatch('Extra attributes');
-    }
+    expect(flush).toWarnDev('Extra attributes');
   });
 
   it('does not clear existing children', async () => {
-    spyOnDev(console, 'error');
     container.innerHTML = '<div>a</div><div>b</div>';
     const root = ReactDOM.createRoot(container);
     root.render(

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -532,34 +532,37 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should warn if value is null', () => {
-    spyOnDev(console, 'error');
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(
+        <select value={null}>
+          <option value="test" />
+        </select>,
+      ),
+    ).toWarnDev(
+      '`value` prop on `select` should not be null. ' +
+        'Consider using an empty string to clear the component or `undefined` ' +
+        'for uncontrolled components.',
+    );
 
     ReactTestUtils.renderIntoDocument(
       <select value={null}>
         <option value="test" />
       </select>,
     );
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        '`value` prop on `select` should not be null. ' +
-          'Consider using an empty string to clear the component or `undefined` ' +
-          'for uncontrolled components.',
-      );
-    }
-
-    ReactTestUtils.renderIntoDocument(
-      <select value={null}>
-        <option value="test" />
-      </select>,
-    );
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-    }
   });
 
   it('should warn if selected is set on <option>', () => {
-    spyOnDev(console, 'error');
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(
+        <select>
+          <option selected={true} />
+          <option selected={true} />
+        </select>,
+      ),
+    ).toWarnDev(
+      'Use the `defaultValue` or `value` props on <select> instead of ' +
+        'setting `selected` on <option>.',
+    );
 
     ReactTestUtils.renderIntoDocument(
       <select>
@@ -567,51 +570,27 @@ describe('ReactDOMSelect', () => {
         <option selected={true} />
       </select>,
     );
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-    }
-
-    ReactTestUtils.renderIntoDocument(
-      <select>
-        <option selected={true} />
-        <option selected={true} />
-      </select>,
-    );
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Use the `defaultValue` or `value` props on <select> instead of ' +
-          'setting `selected` on <option>.',
-      );
-    }
   });
 
   it('should warn if value is null and multiple is true', () => {
-    spyOnDev(console, 'error');
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(
+        <select value={null} multiple={true}>
+          <option value="test" />
+        </select>,
+      ),
+    ).toWarnDev(
+      '`value` prop on `select` should not be null. ' +
+        'Consider using an empty array when `multiple` is ' +
+        'set to `true` to clear the component or `undefined` ' +
+        'for uncontrolled components.',
+    );
+
     ReactTestUtils.renderIntoDocument(
       <select value={null} multiple={true}>
         <option value="test" />
       </select>,
     );
-
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        '`value` prop on `select` should not be null. ' +
-          'Consider using an empty array when `multiple` is ' +
-          'set to `true` to clear the component or `undefined` ' +
-          'for uncontrolled components.',
-      );
-    }
-
-    ReactTestUtils.renderIntoDocument(
-      <select value={null} multiple={true}>
-        <option value="test" />
-      </select>,
-    );
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-    }
   });
 
   it('should refresh state on change', () => {
@@ -631,23 +610,21 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should warn if value and defaultValue props are specified', () => {
-    spyOnDev(console, 'error');
-    ReactTestUtils.renderIntoDocument(
-      <select value="giraffe" defaultValue="giraffe" readOnly={true}>
-        <option value="monkey">A monkey!</option>
-        <option value="giraffe">A giraffe!</option>
-        <option value="gorilla">A gorilla!</option>
-      </select>,
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(
+        <select value="giraffe" defaultValue="giraffe" readOnly={true}>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+          <option value="gorilla">A gorilla!</option>
+        </select>,
+      ),
+    ).toWarnDev(
+      'Select elements must be either controlled or uncontrolled ' +
+        '(specify either the value prop, or the defaultValue prop, but not ' +
+        'both). Decide between using a controlled or uncontrolled select ' +
+        'element and remove one of these props. More info: ' +
+        'https://fb.me/react-controlled-components',
     );
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Select elements must be either controlled or uncontrolled ' +
-          '(specify either the value prop, or the defaultValue prop, but not ' +
-          'both). Decide between using a controlled or uncontrolled select ' +
-          'element and remove one of these props. More info: ' +
-          'https://fb.me/react-controlled-components',
-      );
-    }
 
     ReactTestUtils.renderIntoDocument(
       <select value="giraffe" defaultValue="giraffe" readOnly={true}>
@@ -656,9 +633,6 @@ describe('ReactDOMSelect', () => {
         <option value="gorilla">A gorilla!</option>
       </select>,
     );
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-    }
   });
 
   it('should be able to safely remove select onChange', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -207,8 +207,6 @@ describe('ReactDOMTextarea', () => {
 
     expect(node.value).toBe('0');
 
-    spyOnDev(console, 'error'); // deprecation warning for `children` content
-
     ReactDOM.render(<textarea>1</textarea>, container);
 
     expect(node.value).toBe('0');
@@ -247,15 +245,16 @@ describe('ReactDOMTextarea', () => {
   });
 
   it('should treat children like `defaultValue`', () => {
-    spyOnDev(console, 'error');
-
     const container = document.createElement('div');
     let stub = <textarea>giraffe</textarea>;
-    const node = renderTextarea(stub, container);
+    let node;
 
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-    }
+    expect(() => {
+      node = renderTextarea(stub, container);
+    }).toWarnDev(
+      'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+    );
+
     expect(node.value).toBe('giraffe');
 
     // Changing children should do nothing, it functions like `defaultValue`.
@@ -301,67 +300,69 @@ describe('ReactDOMTextarea', () => {
   });
 
   it('should allow numbers as children', () => {
-    spyOnDev(console, 'error');
-    const node = renderTextarea(<textarea>{17}</textarea>);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-    }
+    let node;
+    expect(() => {
+      node = renderTextarea(<textarea>{17}</textarea>);
+    }).toWarnDev(
+      'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+    );
     expect(node.value).toBe('17');
   });
 
   it('should allow booleans as children', () => {
-    spyOnDev(console, 'error');
-    const node = renderTextarea(<textarea>{false}</textarea>);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-    }
+    let node;
+    expect(() => {
+      node = renderTextarea(<textarea>{false}</textarea>);
+    }).toWarnDev(
+      'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+    );
     expect(node.value).toBe('false');
   });
 
   it('should allow objects as children', () => {
-    spyOnDev(console, 'error');
     const obj = {
       toString: function() {
         return 'sharkswithlasers';
       },
     };
-    const node = renderTextarea(<textarea>{obj}</textarea>);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-    }
+    let node;
+    expect(() => {
+      node = renderTextarea(<textarea>{obj}</textarea>);
+    }).toWarnDev(
+      'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+    );
     expect(node.value).toBe('sharkswithlasers');
   });
 
   it('should throw with multiple or invalid children', () => {
-    spyOnDev(console, 'error');
-
-    expect(function() {
-      ReactTestUtils.renderIntoDocument(
-        <textarea>
-          {'hello'}
-          {'there'}
-        </textarea>,
+    expect(() => {
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(
+          <textarea>
+            {'hello'}
+            {'there'}
+          </textarea>,
+        ),
+      ).toWarnDev(
+        'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
       );
     }).toThrow();
 
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-    }
-
     let node;
-    expect(function() {
-      node = renderTextarea(
-        <textarea>
-          <strong />
-        </textarea>,
+    expect(() => {
+      expect(
+        () =>
+          (node = renderTextarea(
+            <textarea>
+              <strong />
+            </textarea>,
+          )),
+      ).toWarnDev(
+        'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
       );
     }).not.toThrow();
 
     expect(node.value).toBe('[object Object]');
-
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(2);
-    }
   });
 
   it('should unmount', () => {
@@ -371,43 +372,34 @@ describe('ReactDOMTextarea', () => {
   });
 
   it('should warn if value is null', () => {
-    spyOnDev(console, 'error');
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<textarea value={null} />),
+    ).toWarnDev(
+      '`value` prop on `textarea` should not be null. ' +
+        'Consider using an empty string to clear the component or `undefined` ' +
+        'for uncontrolled components.',
+    );
 
+    // No additional warnings are expected
     ReactTestUtils.renderIntoDocument(<textarea value={null} />);
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        '`value` prop on `textarea` should not be null. ' +
-          'Consider using an empty string to clear the component or `undefined` ' +
-          'for uncontrolled components.',
-      );
-    }
-
-    ReactTestUtils.renderIntoDocument(<textarea value={null} />);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-    }
   });
 
   it('should warn if value and defaultValue are specified', () => {
-    spyOnDev(console, 'error');
-    ReactTestUtils.renderIntoDocument(
-      <textarea value="foo" defaultValue="bar" readOnly={true} />,
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(
+        <textarea value="foo" defaultValue="bar" readOnly={true} />,
+      ),
+    ).toWarnDev(
+      'Textarea elements must be either controlled or uncontrolled ' +
+        '(specify either the value prop, or the defaultValue prop, but not ' +
+        'both). Decide between using a controlled or uncontrolled textarea ' +
+        'and remove one of these props. More info: ' +
+        'https://fb.me/react-controlled-components',
     );
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Textarea elements must be either controlled or uncontrolled ' +
-          '(specify either the value prop, or the defaultValue prop, but not ' +
-          'both). Decide between using a controlled or uncontrolled textarea ' +
-          'and remove one of these props. More info: ' +
-          'https://fb.me/react-controlled-components',
-      );
-    }
 
+    // No additional warnings are expected
     ReactTestUtils.renderIntoDocument(
       <textarea value="foo" defaultValue="bar" readOnly={true} />,
     );
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-    }
   });
 });

--- a/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
+++ b/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
@@ -50,17 +50,12 @@ describe('ReactMount', () => {
 
     // Test that unmounting at a root node gives a helpful warning
     const rootDiv = mainContainerDiv.firstChild;
-    spyOnDev(console, 'error');
-    ReactDOM.unmountComponentAtNode(rootDiv);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        "Warning: unmountComponentAtNode(): The node you're attempting to " +
-          'unmount was rendered by React and is not a top-level container. You ' +
-          'may have accidentally passed in a React root node instead of its ' +
-          'container.',
-      );
-    }
+    expect(() => ReactDOM.unmountComponentAtNode(rootDiv)).toWarnDev(
+      "Warning: unmountComponentAtNode(): The node you're attempting to " +
+        'unmount was rendered by React and is not a top-level container. You ' +
+        'may have accidentally passed in a React root node instead of its ' +
+        'container.',
+    );
   });
 
   it('should warn when unmounting a non-container, non-root node', () => {
@@ -77,16 +72,11 @@ describe('ReactMount', () => {
 
     // Test that unmounting at a non-root node gives a different warning
     const nonRootDiv = mainContainerDiv.firstChild.firstChild;
-    spyOnDev(console, 'error');
-    ReactDOM.unmountComponentAtNode(nonRootDiv);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toBe(
-        "Warning: unmountComponentAtNode(): The node you're attempting to " +
-          'unmount was rendered by React and is not a top-level container. ' +
-          'Instead, have the parent component update its state and rerender in ' +
-          'order to remove this component.',
-      );
-    }
+    expect(() => ReactDOM.unmountComponentAtNode(nonRootDiv)).toWarnDev(
+      "Warning: unmountComponentAtNode(): The node you're attempting to " +
+        'unmount was rendered by React and is not a top-level container. ' +
+        'Instead, have the parent component update its state and rerender in ' +
+        'order to remove this component.',
+    );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -10,10 +10,6 @@
 'use strict';
 
 describe('ReactMultiChild', () => {
-  function normalizeCodeLocInfo(str) {
-    return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
-  }
-
   let React;
   let ReactDOM;
 
@@ -183,8 +179,6 @@ describe('ReactMultiChild', () => {
     });
 
     it('should warn for duplicated array keys with component stack info', () => {
-      spyOnDev(console, 'error');
-
       const container = document.createElement('div');
 
       class WrapperComponent extends React.Component {
@@ -205,32 +199,25 @@ describe('ReactMultiChild', () => {
 
       ReactDOM.render(<Parent>{[<div key="1" />]}</Parent>, container);
 
-      ReactDOM.render(
-        <Parent>{[<div key="1" />, <div key="1" />]}</Parent>,
-        container,
-      );
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(
-          normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
-        ).toContain(
-          'Encountered two children with the same key, `1`. ' +
-            'Keys should be unique so that components maintain their identity ' +
-            'across updates. Non-unique keys may cause children to be ' +
-            'duplicated and/or omitted — the behavior is unsupported and ' +
-            'could change in a future version.',
+      expect(() =>
+        ReactDOM.render(
+          <Parent>{[<div key="1" />, <div key="1" />]}</Parent>,
+          container,
+        ),
+      ).toWarnDev(
+        'Encountered two children with the same key, `1`. ' +
+          'Keys should be unique so that components maintain their identity ' +
+          'across updates. Non-unique keys may cause children to be ' +
+          'duplicated and/or omitted — the behavior is unsupported and ' +
+          'could change in a future version.',
+        '    in div (at **)\n' +
+          '    in WrapperComponent (at **)\n' +
           '    in div (at **)\n' +
-            '    in WrapperComponent (at **)\n' +
-            '    in div (at **)\n' +
-            '    in Parent (at **)',
-        );
-      }
+          '    in Parent (at **)',
+      );
     });
 
     it('should warn for duplicated iterable keys with component stack info', () => {
-      spyOnDev(console, 'error');
-
       const container = document.createElement('div');
 
       class WrapperComponent extends React.Component {
@@ -272,54 +259,42 @@ describe('ReactMultiChild', () => {
         container,
       );
 
-      ReactDOM.render(
-        <Parent>{createIterable([<div key="1" />, <div key="1" />])}</Parent>,
-        container,
-      );
-
-      if (__DEV__) {
-        expect(console.error.calls.count()).toBe(1);
-        expect(
-          normalizeCodeLocInfo(console.error.calls.argsFor(0)[0]),
-        ).toContain(
-          'Encountered two children with the same key, `1`. ' +
-            'Keys should be unique so that components maintain their identity ' +
-            'across updates. Non-unique keys may cause children to be ' +
-            'duplicated and/or omitted — the behavior is unsupported and ' +
-            'could change in a future version.',
+      expect(() =>
+        ReactDOM.render(
+          <Parent>{createIterable([<div key="1" />, <div key="1" />])}</Parent>,
+          container,
+        ),
+      ).toWarnDev(
+        'Encountered two children with the same key, `1`. ' +
+          'Keys should be unique so that components maintain their identity ' +
+          'across updates. Non-unique keys may cause children to be ' +
+          'duplicated and/or omitted — the behavior is unsupported and ' +
+          'could change in a future version.',
+        '    in div (at **)\n' +
+          '    in WrapperComponent (at **)\n' +
           '    in div (at **)\n' +
-            '    in WrapperComponent (at **)\n' +
-            '    in div (at **)\n' +
-            '    in Parent (at **)',
-        );
-      }
+          '    in Parent (at **)',
+      );
     });
   });
 
   it('should warn for using maps as children with owner info', () => {
-    spyOnDev(console, 'error');
     class Parent extends React.Component {
       render() {
         return <div>{new Map([['foo', 0], ['bar', 1]])}</div>;
       }
     }
     const container = document.createElement('div');
-    ReactDOM.render(<Parent />, container);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(normalizeCodeLocInfo(console.error.calls.argsFor(0)[0])).toBe(
-        'Warning: Using Maps as children is unsupported and will likely yield ' +
-          'unexpected results. Convert it to a sequence/iterable of keyed ' +
-          'ReactElements instead.\n' +
-          '    in div (at **)\n' +
-          '    in Parent (at **)',
-      );
-    }
+    expect(() => ReactDOM.render(<Parent />, container)).toWarnDev(
+      'Warning: Using Maps as children is unsupported and will likely yield ' +
+        'unexpected results. Convert it to a sequence/iterable of keyed ' +
+        'ReactElements instead.\n' +
+        '    in div (at **)\n' +
+        '    in Parent (at **)',
+    );
   });
 
   it('should reorder bailed-out children', () => {
-    spyOnDev(console, 'error');
-
     class LetterInner extends React.Component {
       render() {
         return <div>{this.props.char}</div>;


### PR DESCRIPTION
Follow-up for PR #11786

Update additional unit tests to use `.toWarnDev()` instead of `console` spies and if-DEV conditionals.
  