### PR TITLE
Move npm output from build/packages/* to build/node_modules/*

### DIFF
--- a/fixtures/art/package.json
+++ b/fixtures/art/package.json
@@ -5,9 +5,9 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
-    "react": "file:../../build/packages/react",
-    "react-art": "file:../../build/packages/react-art",
-    "react-dom": "file:../../build/packages/react-dom",
+    "react": "link:../../build/node_modules/react",
+    "react-art": "link:../../build/node_modules/react-art/",
+    "react-dom": "link:../../build/node_modules/react-dom",
     "webpack": "^1.14.0"
   },
   "scripts": {

--- a/fixtures/art/yarn.lock
+++ b/fixtures/art/yarn.lock
@@ -1742,31 +1742,17 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-"react-art@file:../../build/packages/react-art":
-  version "16.0.0"
-  dependencies:
-    art "^0.10.1"
-    create-react-class "^15.6.2"
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react-art@link:../../build/node_modules/react-art":
+  version "0.0.0"
+  uid ""
 
-"react-dom@file:../../build/packages/react-dom":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react-dom@link:../../build/node_modules/react-dom":
+  version "0.0.0"
+  uid ""
 
-"react@file:../../build/packages/react":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react@link:../../build/node_modules/react":
+  version "0.0.0"
+  uid ""
 
 "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.4, readable-stream@^2.2.6:
   version "2.2.6"

--- a/fixtures/packaging/browserify/dev/package.json
+++ b/fixtures/packaging/browserify/dev/package.json
@@ -3,8 +3,8 @@
   "name": "browserify-dev-fixture",
   "dependencies": {
     "browserify": "^13.3.0",
-    "react": "file:../../../../build/packages/react",
-    "react-dom": "file:../../../../build/packages/react-dom"
+    "react": "link:../../../../build/node_modules/react",
+    "react-dom": "link:../../../../build/node_modules/react-dom"
   },
   "scripts": {
     "build": "rm -f output.js && browserify ./input.js -o output.js"

--- a/fixtures/packaging/browserify/dev/yarn.lock
+++ b/fixtures/packaging/browserify/dev/yarn.lock
@@ -739,21 +739,13 @@ randombytes@^2.0.0, randombytes@^2.0.1:
   dependencies:
     safe-buffer "^5.1.0"
 
-"react-dom@file:../../../../build/packages/react-dom":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react-dom@link:../../../../build/node_modules/react-dom":
+  version "0.0.0"
+  uid ""
 
-"react@file:../../../../build/packages/react":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react@link:../../../../build/node_modules/react":
+  version "0.0.0"
+  uid ""
 
 read-only-stream@^2.0.0:
   version "2.0.0"

--- a/fixtures/packaging/browserify/prod/package.json
+++ b/fixtures/packaging/browserify/prod/package.json
@@ -3,8 +3,8 @@
   "name": "browserify-prod-fixture",
   "dependencies": {
     "browserify": "^13.3.0",
-    "react": "file:../../../../build/packages/react",
-    "react-dom": "file:../../../../build/packages/react-dom"
+    "react": "link:../../../../build/node_modules/react",
+    "react-dom": "link:../../../../build/node_modules/react-dom"
   },
   "scripts": {
     "build": "rm -f output.js && browserify ./input.js -g [envify --NODE_ENV 'production'] -o output.js"

--- a/fixtures/packaging/browserify/prod/yarn.lock
+++ b/fixtures/packaging/browserify/prod/yarn.lock
@@ -750,21 +750,13 @@ randombytes@^2.0.0, randombytes@^2.0.1:
   dependencies:
     safe-buffer "^5.1.0"
 
-"react-dom@file:../../../../build/packages/react-dom":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react-dom@link:../../../../build/node_modules/react-dom":
+  version "0.0.0"
+  uid ""
 
-"react@file:../../../../build/packages/react":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react@link:../../../../build/node_modules/react":
+  version "0.0.0"
+  uid ""
 
 read-only-stream@^2.0.0:
   version "2.0.0"

--- a/fixtures/packaging/brunch/dev/package.json
+++ b/fixtures/packaging/brunch/dev/package.json
@@ -4,8 +4,8 @@
   "devDependencies": {
     "brunch": "^2.9.1",
     "javascript-brunch": "^2.0.0",
-    "react": "file:../../../../build/packages/react",
-    "react-dom": "file:../../../../build/packages/react-dom"
+    "react": "link:../../../../build/node_modules/react",
+    "react-dom": "link:../../../../build/node_modules/react-dom"
   },
   "scripts": {
     "build": "rm -rf public && brunch build"

--- a/fixtures/packaging/brunch/dev/yarn.lock
+++ b/fixtures/packaging/brunch/dev/yarn.lock
@@ -1704,21 +1704,13 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-"react-dom@file:../../../../build/packages/react-dom":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react-dom@link:../../../../build/node_modules/react-dom":
+  version "0.0.0"
+  uid ""
 
-"react@file:../../../../build/packages/react":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react@link:../../../../build/node_modules/react":
+  version "0.0.0"
+  uid ""
 
 read-components@~0.7:
   version "0.7.0"

--- a/fixtures/packaging/brunch/prod/package.json
+++ b/fixtures/packaging/brunch/prod/package.json
@@ -4,8 +4,8 @@
   "devDependencies": {
     "brunch": "^2.9.1",
     "javascript-brunch": "^2.0.0",
-    "react": "file:../../../../build/packages/react",
-    "react-dom": "file:../../../../build/packages/react-dom"
+    "react": "link:../../../../build/node_modules/react",
+    "react-dom": "link:../../../../build/node_modules/react-dom"
   },
   "scripts": {
     "build": "rm -rf public && brunch build -p"

--- a/fixtures/packaging/brunch/prod/yarn.lock
+++ b/fixtures/packaging/brunch/prod/yarn.lock
@@ -1704,21 +1704,13 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-"react-dom@file:../../../../build/packages/react-dom":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react-dom@link:../../../../build/node_modules/react-dom":
+  version "0.0.0"
+  uid ""
 
-"react@file:../../../../build/packages/react":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react@link:../../../../build/node_modules/react":
+  version "0.0.0"
+  uid ""
 
 read-components@~0.7:
   version "0.7.0"

--- a/fixtures/packaging/webpack-alias/dev/config.js
+++ b/fixtures/packaging/webpack-alias/dev/config.js
@@ -6,7 +6,7 @@ module.exports = {
     filename: 'output.js',
   },
   resolve: {
-    root: path.resolve('../../../../build/packages'),
+    root: path.resolve('../../../../build/node_modules'),
     alias: {
       react: 'react/umd/react.development',
       'react-dom': 'react-dom/umd/react-dom.development',

--- a/fixtures/packaging/webpack-alias/prod/config.js
+++ b/fixtures/packaging/webpack-alias/prod/config.js
@@ -6,7 +6,7 @@ module.exports = {
     filename: 'output.js',
   },
   resolve: {
-    root: path.resolve('../../../../build/packages'),
+    root: path.resolve('../../../../build/node_modules'),
     alias: {
       react: 'react/umd/react.production.min',
       'react-dom': 'react-dom/umd/react-dom.production.min',

--- a/fixtures/packaging/webpack/dev/config.js
+++ b/fixtures/packaging/webpack/dev/config.js
@@ -6,6 +6,6 @@ module.exports = {
     filename: 'output.js',
   },
   resolve: {
-    root: path.resolve('../../../../build/packages/'),
+    root: path.resolve('../../../../build/node_modules/'),
   },
 };

--- a/fixtures/packaging/webpack/prod/config.js
+++ b/fixtures/packaging/webpack/prod/config.js
@@ -7,7 +7,7 @@ module.exports = {
     filename: 'output.js',
   },
   resolve: {
-    root: path.resolve('../../../../build/packages/'),
+    root: path.resolve('../../../../build/node_modules/'),
   },
   plugins: [
     new webpack.DefinePlugin({

--- a/fixtures/ssr/package.json
+++ b/fixtures/ssr/package.json
@@ -12,8 +12,8 @@
     "ignore-styles": "^5.0.1",
     "import-export": "^1.0.1",
     "node-fetch": "^1.6.3",
-    "react": "file:../../build/packages/react",
-    "react-dom": "file:../../build/packages/react-dom"
+    "react": "link:../../build/node_modules/react",
+    "react-dom": "link:../../build/node_modules/react-dom"
   },
   "scripts": {
     "start": "concurrently \"npm run start:server\" \"npm run start:client\"",

--- a/fixtures/ssr/yarn.lock
+++ b/fixtures/ssr/yarn.lock
@@ -4200,13 +4200,9 @@ react-dev-utils@^0.5.2:
     sockjs-client "1.0.1"
     strip-ansi "3.0.1"
 
-"react-dom@file:../../build/packages/react-dom":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react-dom@link:../../build/node_modules/react-dom":
+  version "0.0.0"
+  uid ""
 
 react-scripts@0.9.5:
   version "0.9.5"
@@ -4253,13 +4249,9 @@ react-scripts@0.9.5:
   optionalDependencies:
     fsevents "1.0.17"
 
-"react@file:../../build/packages/react":
-  version "16.0.0"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
+"react@link:../../build/node_modules/react":
+  version "0.0.0"
+  uid ""
 
 read-pkg-up@^1.0.1:
   version "1.0.1"

--- a/scripts/jest/config.build.js
+++ b/scripts/jest/config.build.js
@@ -17,9 +17,11 @@ const packages = readdirSync(packagesRoot).filter(dir => {
 const moduleNameMapper = {};
 packages.forEach(name => {
   // Root entry point
-  moduleNameMapper[`^${name}$`] = `<rootDir>/build/packages/${name}`;
+  moduleNameMapper[`^${name}$`] = `<rootDir>/build/node_modules/${name}`;
   // Named entry points
-  moduleNameMapper[`^${name}/(.*)$`] = `<rootDir>/build/packages/${name}/$1`;
+  moduleNameMapper[`^${name}/(.*)$`] = `<rootDir>/build/node_modules/${
+    name
+  }/$1`;
 });
 
 module.exports = Object.assign({}, sourceConfig, {

--- a/scripts/release/publish-commands/check-build-status.js
+++ b/scripts/release/publish-commands/check-build-status.js
@@ -8,7 +8,13 @@ const {readJson} = require('fs-extra');
 const {join} = require('path');
 
 module.exports = async ({cwd, version}) => {
-  const packagePath = join(cwd, 'build', 'packages', 'react', 'package.json');
+  const packagePath = join(
+    cwd,
+    'build',
+    'node_modules',
+    'react',
+    'package.json'
+  );
 
   if (!existsSync(packagePath)) {
     throw Error('No build found');

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -15,13 +15,13 @@ const push = async ({cwd, dry, packages, version}) => {
 
   const publishProject = async project => {
     try {
-      const path = join(cwd, 'build', 'packages', project);
+      const path = join(cwd, 'build', 'node_modules', project);
       await execUnlessDry(`npm publish --tag ${tag}`, {cwd: path, dry});
 
       const packagePath = join(
         cwd,
         'build',
-        'packages',
+        'node_modules',
         project,
         'package.json'
       );

--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -31,11 +31,11 @@ function getBundleOutputPaths(bundleType, filename, packageName) {
   switch (bundleType) {
     case NODE_DEV:
     case NODE_PROD:
-      return [`build/packages/${packageName}/cjs/${filename}`];
+      return [`build/node_modules/${packageName}/cjs/${filename}`];
     case UMD_DEV:
     case UMD_PROD:
       return [
-        `build/packages/${packageName}/umd/${filename}`,
+        `build/node_modules/${packageName}/umd/${filename}`,
         `build/dist/${filename}`,
       ];
     case FB_DEV:
@@ -101,7 +101,7 @@ function getTarOptions(tgzName, packageName) {
   const CONTENTS_FOLDER = 'package';
   return {
     src: tgzName,
-    dest: `build/packages/${packageName}`,
+    dest: `build/node_modules/${packageName}`,
     tar: {
       entries: [CONTENTS_FOLDER],
       map(header) {
@@ -115,31 +115,31 @@ function getTarOptions(tgzName, packageName) {
 
 async function prepareNpmPackage(name) {
   await Promise.all([
-    asyncCopyTo('LICENSE', `build/packages/${name}/LICENSE`),
+    asyncCopyTo('LICENSE', `build/node_modules/${name}/LICENSE`),
     asyncCopyTo(
       `packages/${name}/package.json`,
-      `build/packages/${name}/package.json`
+      `build/node_modules/${name}/package.json`
     ),
     asyncCopyTo(
       `packages/${name}/README.md`,
-      `build/packages/${name}/README.md`
+      `build/node_modules/${name}/README.md`
     ),
-    asyncCopyTo(`packages/${name}/npm`, `build/packages/${name}`),
+    asyncCopyTo(`packages/${name}/npm`, `build/node_modules/${name}`),
   ]);
   const tgzName = (await asyncExecuteCommand(
-    `npm pack build/packages/${name}`
+    `npm pack build/node_modules/${name}`
   )).trim();
-  await asyncRimRaf(`build/packages/${name}`);
+  await asyncRimRaf(`build/node_modules/${name}`);
   await asyncExtractTar(getTarOptions(tgzName, name));
   unlinkSync(tgzName);
 }
 
 async function prepareNpmPackages() {
-  if (!existsSync('build/packages')) {
+  if (!existsSync('build/node_modules')) {
     // We didn't build any npm packages.
     return;
   }
-  const builtPackageFolders = readdirSync('build/packages').filter(
+  const builtPackageFolders = readdirSync('build/node_modules').filter(
     dir => dir.charAt(0) !== '.'
   );
   await Promise.all(builtPackageFolders.map(prepareNpmPackage));

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -4,8 +4,8 @@
       "filename": "react.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react",
-      "size": 55220,
-      "gzip": 14986
+      "size": 55396,
+      "gzip": 15025
     },
     {
       "filename": "react.production.min.js",
@@ -18,8 +18,8 @@
       "filename": "react.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react",
-      "size": 45636,
-      "gzip": 12675
+      "size": 45812,
+      "gzip": 12711
     },
     {
       "filename": "react.production.min.js",
@@ -32,8 +32,8 @@
       "filename": "React-dev.js",
       "bundleType": "FB_DEV",
       "packageName": "react",
-      "size": 44974,
-      "gzip": 12197
+      "size": 45150,
+      "gzip": 12229
     },
     {
       "filename": "React-prod.js",
@@ -46,43 +46,43 @@
       "filename": "react-dom.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 560424,
-      "gzip": 132739
+      "size": 560105,
+      "gzip": 132646
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 93669,
-      "gzip": 30753
+      "size": 93530,
+      "gzip": 30695
     },
     {
       "filename": "react-dom.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 544457,
-      "gzip": 128965
+      "size": 544138,
+      "gzip": 128866
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 92090,
-      "gzip": 29815
+      "size": 91951,
+      "gzip": 29748
     },
     {
       "filename": "ReactDOM-dev.js",
       "bundleType": "FB_DEV",
       "packageName": "react-dom",
-      "size": 561931,
-      "gzip": 131204
+      "size": 561584,
+      "gzip": 131098
     },
     {
       "filename": "ReactDOM-prod.js",
       "bundleType": "FB_PROD",
       "packageName": "react-dom",
-      "size": 265369,
-      "gzip": 51278
+      "size": 264984,
+      "gzip": 51187
     },
     {
       "filename": "react-dom-test-utils.development.js",

--- a/scripts/rollup/validate/index.js
+++ b/scripts/rollup/validate/index.js
@@ -64,11 +64,14 @@ const bundles = [
   },
   {
     format: 'umd',
-    filePatterns: [`./build/packages/*/umd/*.js`],
+    filePatterns: [`./build/node_modules/*/umd/*.js`],
   },
   {
     format: 'cjs',
-    filePatterns: [`./build/packages/*/*.js`, `./build/packages/*/cjs/*.js`],
+    filePatterns: [
+      `./build/node_modules/*/*.js`,
+      `./build/node_modules/*/cjs/*.js`,
+    ],
   },
 ];
 


### PR DESCRIPTION
This fixes Node resolution mechanism in built packages and accomplishes two goals:

* We can now use Node.js shell inside `packages/node_modules` which is handy for manual testing.

<img width="498" alt="screen shot 2018-01-04 at 6 17 57 pm" src="https://user-images.githubusercontent.com/810438/34578833-5e3e1d10-f17e-11e7-9c69-f576e845eae6.png">

* We can now use `link:` instead of `file:` in fixtures. This is important because previously Yarn would cache the fixtures until the version change. So it was easy to accidentally test a cached previous version of React in a fixture. Now they always point to the latest build output.
  
I verified that the build completes and all fixtures work. I haven't tested the release manager directly but hopefully my changes make sense.

Btw, I considered keeping `build/packages` and setting up `build/packages/node_modules` with symlinks as an alternative but in the end it seemed less straightforward than just putting them in a folder called `node_modules` in the first place.
  