### PR TITLE
Clearer ssr error message 11902

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -870,6 +870,21 @@ describe('ReactDOMServerIntegration', () => {
               'an array instead.'
             : ''),
       );
+
+      itThrowsWhenRendering(
+        'badly-typed elements',
+        async render => {
+          spyOnDev(console, 'error');
+          const EmptyComponent = {};
+          await render(<EmptyComponent />);
+        },
+        'Element type is invalid: expected a string (for built-in components) or a class/function ' +
+          '(for composite components) but got: object.' +
+          (__DEV__
+            ? " You likely forgot to export your component from the file it's defined in, " +
+              'or you might have mixed up default and named imports.'
+            : ''),
+      );
     });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -873,38 +873,20 @@ describe('ReactDOMServerIntegration', () => {
     });
 
     describe('badly-typed elements', function() {
-      beforeEach(() => {
-        if (__DEV__) {
-          spyOnDev(console, 'error');
-          const originalCreateElement = React.createElement;
-          spyOnDev(React, 'createElement').and.callFake(el => {
-            const reactElement = originalCreateElement(el);
-
-            const isNull = el === null;
-            const receivedType = isNull ? 'null' : typeof el;
-
-            expect(console.error.calls.count()).toBe(1);
-            expect(console.error.calls.argsFor(0)[0]).toContain(
-              'Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a ' +
-                `class/function (for composite components) but got: ${
-                  receivedType
-                }.` +
-                (!isNull
-                  ? " You likely forgot to export your component from the file it's defined in, " +
-                    'or you might have mixed up default and named imports.'
-                  : ''),
-            );
-
-            return reactElement;
-          });
-        }
-      });
-
       itThrowsWhenRendering(
         'object',
         async render => {
-          const EmptyComponent = {};
-          await render(<EmptyComponent />);
+          let EmptyComponent = {};
+          expect(() => {
+            EmptyComponent = <EmptyComponent />;
+          }).toWarnDev(
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: object. You likely forgot to export your ' +
+              "component from the file it's defined in, or you might have mixed up " +
+              'default and named imports.',
+          );
+          await render(EmptyComponent);
         },
         'Element type is invalid: expected a string (for built-in components) or a class/function ' +
           '(for composite components) but got: object.' +
@@ -917,18 +899,35 @@ describe('ReactDOMServerIntegration', () => {
       itThrowsWhenRendering(
         'null',
         async render => {
-          const NullComponent = null;
-          await render(<NullComponent />);
+          let NullComponent = null;
+          expect(() => {
+            NullComponent = <NullComponent />;
+          }).toWarnDev(
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: null.',
+          );
+          await render(NullComponent);
         },
         'Element type is invalid: expected a string (for built-in components) or a class/function ' +
-          '(for composite components) but got: null.',
+          '(for composite components) but got: null',
       );
 
       itThrowsWhenRendering(
         'undefined',
         async render => {
-          const UndefinedComponent = undefined;
-          await render(<UndefinedComponent />);
+          let UndefinedComponent = undefined;
+          expect(() => {
+            UndefinedComponent = <UndefinedComponent />;
+          }).toWarnDev(
+            'Warning: React.createElement: type is invalid -- expected a string ' +
+              '(for built-in components) or a class/function (for composite ' +
+              'components) but got: undefined. You likely forgot to export your ' +
+              "component from the file it's defined in, or you might have mixed up " +
+              'default and named imports.',
+          );
+
+          await render(UndefinedComponent);
         },
         'Element type is invalid: expected a string (for built-in components) or a class/function ' +
           '(for composite components) but got: undefined.' +

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -885,6 +885,32 @@ describe('ReactDOMServerIntegration', () => {
               'or you might have mixed up default and named imports.'
             : ''),
       );
+
+      itThrowsWhenRendering(
+        'null',
+        async render => {
+          spyOnDev(console, 'error');
+          const NullComponent = null;
+          await render(<NullComponent />);
+        },
+        'Element type is invalid: expected a string (for built-in components) or a class/function ' +
+          '(for composite components) but got: null.',
+      );
+
+      itThrowsWhenRendering(
+        'undefined',
+        async render => {
+          spyOnDev(console, 'error');
+          const UndefinedComponent = undefined;
+          await render(<UndefinedComponent />);
+        },
+        'Element type is invalid: expected a string (for built-in components) or a class/function ' +
+          '(for composite components) but got: undefined.' +
+          (__DEV__
+            ? " You likely forgot to export your component from the file it's defined in, " +
+              'or you might have mixed up default and named imports.'
+            : ''),
+      );
     });
   });
 });

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -889,12 +889,33 @@ class ReactDOMServerRenderer {
             break;
         }
       }
+
+      let info = '';
+      if (__DEV__) {
+        const owner = elementType._owner;
+        if (
+          elementType === undefined ||
+          (typeof elementType === 'object' &&
+            elementType !== null &&
+            Object.keys(elementType).length === 0)
+        ) {
+          info +=
+            ' You likely forgot to export your component from the file ' +
+            "it's defined in, or you might have mixed up default and " +
+            'named imports.';
+        }
+        const ownerName = owner ? getComponentName(owner) : null;
+        if (ownerName) {
+          info += '\n\nCheck the render method of `' + ownerName + '`.';
+        }
+      }
       invariant(
         false,
         'Element type is invalid: expected a string (for built-in ' +
           'components) or a class/function (for composite components) ' +
-          'but got: %s.',
+          'but got: %s.%s',
         elementType == null ? elementType : typeof elementType,
+        info,
       );
     }
   }

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -892,7 +892,7 @@ class ReactDOMServerRenderer {
 
       let info = '';
       if (__DEV__) {
-        const owner = elementType._owner;
+        const owner = elementType && elementType._owner;
         if (
           elementType === undefined ||
           (typeof elementType === 'object' &&

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -892,7 +892,7 @@ class ReactDOMServerRenderer {
 
       let info = '';
       if (__DEV__) {
-        const owner = elementType && elementType._owner;
+        const owner = nextElement._owner;
         if (
           elementType === undefined ||
           (typeof elementType === 'object' &&


### PR DESCRIPTION
Resolves #11902

Only in development was a [`warning`](https://github.com/facebook/react/blob/master/packages/react/src/ReactElementValidator.js#L280) being thrown about `ReactElements` with non `string` type. Nothing stopped the code from continuing to execute calling the `string` method on invalid types. 

I added a check in `ReactPartialRenderer.js` that throws an error before `toLowerCase` is called. Also a simple test of this new behavior.