### PR TITLE
Reconcile Call component children with `current`

### DIFF
--- a/packages/react-call-return/src/__tests__/ReactCallReturn-test.js
+++ b/packages/react-call-return/src/__tests__/ReactCallReturn-test.js
@@ -255,4 +255,66 @@ describe('ReactCallReturn', () => {
     ReactNoop.flush();
     expect(ReactNoop.getChildren()).toEqual([span(100), span(200), span(500)]);
   });
+
+  it('should unmount and remount children', () => {
+    let ops = [];
+
+    class Call extends React.Component {
+      render() {
+        return ReactCallReturn.unstable_createCall(
+          this.props.children,
+          (p, returns) => returns,
+          {},
+        );
+      }
+    }
+
+    class Return extends React.Component {
+      render() {
+        ops.push(`Return ${this.props.value}`);
+        return ReactCallReturn.unstable_createReturn(this.props.children);
+      }
+
+      componentWillMount() {
+        ops.push(`Mount Return ${this.props.value}`);
+      }
+
+      componentWillUnmount() {
+        ops.push(`Unmount Return ${this.props.value}`);
+      }
+    }
+
+    ReactNoop.render(
+      <Call>
+        <Return value={1} />
+        <Return value={2} />
+      </Call>,
+    );
+    ReactNoop.flush();
+
+    expect(ops).toEqual([
+      'Mount Return 1',
+      'Return 1',
+      'Mount Return 2',
+      'Return 2',
+    ]);
+
+    ops = [];
+
+    ReactNoop.render(<Call />);
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Unmount Return 1', 'Unmount Return 2']);
+
+    ops = [];
+
+    ReactNoop.render(
+      <Call>
+        <Return value={3} />
+      </Call>,
+    );
+    ReactNoop.flush();
+
+    expect(ops).toEqual(['Mount Return 3', 'Return 3']);
+  });
 });

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -559,7 +559,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     } else {
       workInProgress.stateNode = reconcileChildFibers(
         workInProgress,
-        workInProgress.stateNode,
+        current.stateNode,
         nextChildren,
         renderExpirationTime,
       );


### PR DESCRIPTION
Solves the issue occurring in #11955. Because the `workInProgress.stateNode` was used instead of `current.stateNode`, some Fibers were being deleted twice, causing an invalid state.

The implementation of `updateCallComponent` is now also closer to `reconcileChildrenAtExpirationTime`.