### PR TITLE
Use Prettier Config API

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,18 @@
+const {esNextPaths} = require('./scripts/shared/pathsByLanguageVersion');
+
+module.exports = {
+  bracketSpacing: false,
+  singleQuote: true,
+  jsxBracketSameLine: true,
+  trailingComma: 'es5',
+  printWidth: 80,
+
+  overrides: [
+    {
+      files: esNextPaths,
+      options: {
+        trailingComma: 'all',
+      },
+    },
+  ],
+};

--- a/scripts/prettier/index.js
+++ b/scripts/prettier/index.js
@@ -7,98 +7,67 @@
 'use strict';
 
 // Based on similar script in Jest
-// https://github.com/facebook/jest/blob/master/scripts/prettier.js
+// https://github.com/facebook/jest/blob/a7acc5ae519613647ff2c253dd21933d6f94b47f/scripts/prettier.js
 
 const chalk = require('chalk');
 const glob = require('glob');
 const prettier = require('prettier');
 const fs = require('fs');
 const listChangedFiles = require('../shared/listChangedFiles');
-const {esNextPaths} = require('../shared/pathsByLanguageVersion');
+const prettierConfigPath = require.resolve('../../.prettierrc');
 
 const mode = process.argv[2] || 'check';
 const shouldWrite = mode === 'write' || mode === 'write-changed';
 const onlyChanged = mode === 'check-changed' || mode === 'write-changed';
 
-const defaultOptions = {
-  bracketSpacing: false,
-  singleQuote: true,
-  jsxBracketSameLine: true,
-  trailingComma: 'all',
-  printWidth: 80,
-};
-const config = {
-  default: {
-    patterns: ['**/*.js'],
-    ignore: [
-      '**/node_modules/**',
-      // ESNext paths can have trailing commas.
-      // We'll handle them separately below.
-      ...esNextPaths,
-    ],
-    options: {
-      trailingComma: 'es5',
-    },
-  },
-  esNext: {
-    patterns: [...esNextPaths],
-    ignore: ['**/node_modules/**'],
-  },
-};
-
 const changedFiles = onlyChanged ? listChangedFiles() : null;
 let didWarn = false;
 let didError = false;
-Object.keys(config).forEach(key => {
-  const patterns = config[key].patterns;
-  const options = config[key].options;
-  const ignore = config[key].ignore;
 
-  const globPattern =
-    patterns.length > 1 ? `{${patterns.join(',')}}` : `${patterns.join(',')}`;
-  const files = glob
-    .sync(globPattern, {ignore})
-    .filter(f => !onlyChanged || changedFiles.has(f));
+const files = glob
+  .sync('**/*.js', {ignore: '**/node_modules/**'})
+  .filter(f => !onlyChanged || changedFiles.has(f));
 
-  if (!files.length) {
-    return;
-  }
+if (!files.length) {
+  return;
+}
 
-  const args = Object.assign({}, defaultOptions, options);
-  files.forEach(file => {
-    try {
-      const input = fs.readFileSync(file, 'utf8');
-      if (shouldWrite) {
-        const output = prettier.format(input, args);
-        if (output !== input) {
-          fs.writeFileSync(file, output, 'utf8');
-        }
-      } else {
-        if (!prettier.check(input, args)) {
-          if (!didWarn) {
-            console.log(
-              '\n' +
-                chalk.red(
-                  `  This project uses prettier to format all JavaScript code.\n`
-                ) +
-                chalk.dim(`    Please run `) +
-                chalk.reset('yarn prettier-all') +
-                chalk.dim(
-                  ` and add changes to files listed below to your commit:`
-                ) +
-                `\n\n`
-            );
-            didWarn = true;
-          }
-          console.log(file);
-        }
-      }
-    } catch (error) {
-      didError = true;
-      console.log('\n\n' + error.message);
-      console.log(file);
-    }
+files.forEach(file => {
+  const options = prettier.resolveConfig.sync(file, {
+    config: prettierConfigPath,
   });
+  try {
+    const input = fs.readFileSync(file, 'utf8');
+    if (shouldWrite) {
+      const output = prettier.format(input, options);
+      if (output !== input) {
+        fs.writeFileSync(file, output, 'utf8');
+      }
+    } else {
+      if (!prettier.check(input, options)) {
+        if (!didWarn) {
+          console.log(
+            '\n' +
+              chalk.red(
+                `  This project uses prettier to format all JavaScript code.\n`
+              ) +
+              chalk.dim(`    Please run `) +
+              chalk.reset('yarn prettier-all') +
+              chalk.dim(
+                ` and add changes to files listed below to your commit:`
+              ) +
+              `\n\n`
+          );
+          didWarn = true;
+        }
+        console.log(file);
+      }
+    }
+  } catch (error) {
+    didError = true;
+    console.log('\n\n' + error.message);
+    console.log(file);
+  }
 });
 
 if (didWarn || didError) {


### PR DESCRIPTION
Currently when a developer is using a text editor Prettier plugin such as [prettier-vscode](https://github.com/prettier/prettier-vscode) or [prettier-atom](https://github.com/prettier/prettier-atom), the formatting functionality will format the files with incorrect settings (such as double quotes and no trailing commas). This is easily fixed by moving a lot of the logic in `scripts/prettier/index.js` upstream to Prettier via a configuration (`.prettierrc.js`) file.

I've used `scripts/shared/pathsByLanguageVersion` to maintain the addition of the `trailingComma: "all"` setting for ESNext files.

All four "modes" (`check`, `check-changed`, `write`, `write-changed`) have been maintained. 

I have tested this by enabling format-on-save in prettier-vscode and saving both ES5 and ESNext files to check if the correct settings are applied. I have also tested the `check-changed` and `write-changed` files apply the correct rules to the two different types of files.