### PR TITLE
Enable coverage, set jest maxWorkers to 2

### DIFF
--- a/scripts/circleci/test_coverage.sh
+++ b/scripts/circleci/test_coverage.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-yarn test --coverage --runInBand
+yarn test --coverage --maxWorkers=2
 if [ -z $CI_PULL_REQUEST ]; then
   cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
 fi

--- a/scripts/circleci/test_entry_point.sh
+++ b/scripts/circleci/test_entry_point.sh
@@ -28,9 +28,9 @@ if [ $((2 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('./scripts/circleci/upload_build.sh')
 fi
 
-# if [ $((3 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
-  # COMMANDS_TO_RUN+=('./scripts/circleci/test_coverage.sh')
-# fi
+if [ $((3 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
+ COMMANDS_TO_RUN+=('./scripts/circleci/test_coverage.sh')
+fi
 
 RETURN_CODES=()
 FAILURE=0


### PR DESCRIPTION
## Overview

This PR will re-enable coverage and _should_ fix the OOM issue

Closes https://github.com/facebook/react/issues/11975
Ref https://github.com/facebook/jest/issues/5239

## Details

When running with `--runInBand` locally I get:


![image](https://user-images.githubusercontent.com/2440089/34656611-6da5a930-f3ea-11e7-9921-524345b3baa0.png)


When running with `--maxWorkers=2` locally I get:

![image](https://user-images.githubusercontent.com/2440089/34656601-5a32d6ac-f3ea-11e7-8e21-d1d53510c7c3.png)


As mentioned in the above issue, the React Circle build should allow for 2 workers