### PR TITLE
Issue #11827 Fix ShadowDOM input bug with setDefaultValue

### DIFF
--- a/fixtures/dom/public/index.html
+++ b/fixtures/dom/public/index.html
@@ -16,6 +16,7 @@
     <title>React App</title>
     <script src="https://unpkg.com/prop-types@15.5.6/prop-types.js"></script>
     <script src="https://unpkg.com/expect@1.20.2/umd/expect.min.js"></script>
+    <script src="./native-shim.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/fixtures/dom/public/native-shim.js
+++ b/fixtures/dom/public/native-shim.js
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * This shim allows elements written in, or compiled to, ES5 to work on native
+ * implementations of Custom Elements.
+ *
+ * ES5-style classes don't work with native Custom Elements because the
+ * HTMLElement constructor uses the value of `new.target` to look up the custom
+ * element definition for the currently called constructor. `new.target` is only
+ * set when `new` is called and is only propagated via super() calls. super()
+ * is not emulatable in ES5. The pattern of `SuperClass.call(this)`` only works
+ * when extending other ES5-style classes, and does not propagate `new.target`.
+ *
+ * This shim allows the native HTMLElement constructor to work by generating and
+ * registering a stand-in class instead of the users custom element class. This
+ * stand-in class's constructor has an actual call to super().
+ * `customElements.define()` and `customElements.get()` are both overridden to
+ * hide this stand-in class from users.
+ *
+ * In order to create instance of the user-defined class, rather than the stand
+ * in, the stand-in's constructor swizzles its instances prototype and invokes
+ * the user-defined constructor. When the user-defined constructor is called
+ * directly it creates an instance of the stand-in class to get a real extension
+ * of HTMLElement and returns that.
+ *
+ * There are two important constructors: A patched HTMLElement constructor, and
+ * the StandInElement constructor. They both will be called to create an element
+ * but which is called first depends on whether the browser creates the element
+ * or the user-defined constructor is called directly. The variables
+ * `browserConstruction` and `userConstruction` control the flow between the
+ * two constructors.
+ *
+ * This shim should be better than forcing the polyfill because:
+ *   1. It's smaller
+ *   2. All reaction timings are the same as native (mostly synchronous)
+ *   3. All reaction triggering DOM operations are automatically supported
+ *
+ * There are some restrictions and requirements on ES5 constructors:
+ *   1. All constructors in a inheritance hierarchy must be ES5-style, so that
+ *      they can be called with Function.call(). This effectively means that the
+ *      whole application must be compiled to ES5.
+ *   2. Constructors must return the value of the emulated super() call. Like
+ *      `return SuperClass.call(this)`
+ *   3. The `this` reference should not be used before the emulated super() call
+ *      just like `this` is illegal to use before super() in ES6.
+ *   4. Constructors should not create other custom elements before the emulated
+ *      super() call. This is the same restriction as with native custom
+ *      elements.
+ *
+ *  Compiling valid class-based custom elements to ES5 will satisfy these
+ *  requirements with the latest version of popular transpilers.
+ */
+(() => {
+  'use strict';
+
+  // Do nothing if `customElements` does not exist.
+  if (!window.customElements) return;
+
+  const NativeHTMLElement = window.HTMLElement;
+  const nativeDefine = window.customElements.define;
+  const nativeGet = window.customElements.get;
+
+  /**
+   * Map of user-provided constructors to tag names.
+   *
+   * @type {Map<Function, string>}
+   */
+  const tagnameByConstructor = new Map();
+
+  /**
+   * Map of tag names to user-provided constructors.
+   *
+   * @type {Map<string, Function>}
+   */
+  const constructorByTagname = new Map();
+
+  /**
+   * Whether the constructors are being called by a browser process, ie parsing
+   * or createElement.
+   */
+  let browserConstruction = false;
+
+  /**
+   * Whether the constructors are being called by a user-space process, ie
+   * calling an element constructor.
+   */
+  let userConstruction = false;
+
+  window.HTMLElement = function() {
+    if (!browserConstruction) {
+      const tagname = tagnameByConstructor.get(this.constructor);
+      const fakeClass = nativeGet.call(window.customElements, tagname);
+
+      // Make sure that the fake constructor doesn't call back to this constructor
+      userConstruction = true;
+      const instance = new fakeClass();
+      return instance;
+    }
+    // Else do nothing. This will be reached by ES5-style classes doing
+    // HTMLElement.call() during initialization
+    browserConstruction = false;
+  };
+  // By setting the patched HTMLElement's prototype property to the native
+  // HTMLElement's prototype we make sure that:
+  //     document.createElement('a') instanceof HTMLElement
+  // works because instanceof uses HTMLElement.prototype, which is on the
+  // ptototype chain of built-in elements.
+  window.HTMLElement.prototype = NativeHTMLElement.prototype;
+
+  const define = (tagname, elementClass) => {
+    const elementProto = elementClass.prototype;
+    const StandInElement = class extends NativeHTMLElement {
+      constructor() {
+        // Call the native HTMLElement constructor, this gives us the
+        // under-construction instance as `this`:
+        super();
+
+        // The prototype will be wrong up because the browser used our fake
+        // class, so fix it:
+        Object.setPrototypeOf(this, elementProto);
+
+        if (!userConstruction) {
+          // Make sure that user-defined constructor bottom's out to a do-nothing
+          // HTMLElement() call
+          browserConstruction = true;
+          // Call the user-defined constructor on our instance:
+          elementClass.call(this);
+        }
+        userConstruction = false;
+      }
+    };
+    const standInProto = StandInElement.prototype;
+    StandInElement.observedAttributes = elementClass.observedAttributes;
+    standInProto.connectedCallback = elementProto.connectedCallback;
+    standInProto.disconnectedCallback = elementProto.disconnectedCallback;
+    standInProto.attributeChangedCallback =
+      elementProto.attributeChangedCallback;
+    standInProto.adoptedCallback = elementProto.adoptedCallback;
+
+    tagnameByConstructor.set(elementClass, tagname);
+    constructorByTagname.set(tagname, elementClass);
+    nativeDefine.call(window.customElements, tagname, StandInElement);
+  };
+
+  const get = tagname => constructorByTagname.get(tagname);
+
+  // Workaround for Safari bug where patching customElements can be lost, likely
+  // due to native wrapper garbage collection issue
+  Object.defineProperty(window, 'customElements', {
+    value: window.customElements,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(window.customElements, 'define', {
+    value: define,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(window.customElements, 'get', {
+    value: get,
+    configurable: true,
+    writable: true,
+  });
+})();

--- a/fixtures/dom/src/components/fixtures/number-inputs/NumberTestCaseShadowDOM.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/NumberTestCaseShadowDOM.js
@@ -7,8 +7,8 @@ const ReactDOM = window.ReactDOM;
 class NumberTestCaseShadowDOM extends React.Component {
   componentWillMount() {
     class ShadowNumberInput extends HTMLElement {
-      connectedCallback(){
-        ReactDOM.render(<NumberTestCase />, this.attachShadow({ mode: 'open' }));
+      connectedCallback() {
+        ReactDOM.render(<NumberTestCase />, this.attachShadow({mode: 'open'}));
       }
     }
 
@@ -16,9 +16,7 @@ class NumberTestCaseShadowDOM extends React.Component {
   }
 
   render() {
-    return (
-      <shadow-number-input {...this.props} />
-    );
+    return <shadow-number-input {...this.props} />;
   }
 }
 

--- a/fixtures/dom/src/components/fixtures/number-inputs/NumberTestCaseShadowDOM.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/NumberTestCaseShadowDOM.js
@@ -1,0 +1,60 @@
+import Fixture from '../../Fixture';
+
+const React = window.React;
+
+class NumberTestCaseShadowDOM extends React.Component {
+  state = {value: ''};
+
+  controlledInputElementText = `<input
+    type="number"
+    value={this.state.value}
+    onChange={this.onChange}
+  />`;
+
+  uncontrolledInputElementText = `<input type="number" defaultValue={0.5} />`;
+
+  onChange = event => {
+    const parsed = parseFloat(event.target.value, 10);
+    const value = isNaN(parsed) ? '' : parsed;
+
+    this.setState({value});
+  };
+
+  componentDidMount() {
+    this.attachShadowDomElement("#shadow-dom-host-controlled", this.controlledInputElementText);
+    this.attachShadowDomElement("#shadow-dom-host-uncontrolled", this.uncontrolledInputElementText);
+  }
+
+  attachShadowDomElement(hostElementId, stringHtmlElement) {
+    var hostElement = document.querySelector(hostElementId);
+    var shadow = hostElement.attachShadow({mode: 'open'});
+    shadow.innerHTML = stringHtmlElement;
+  }
+
+  render() {
+    return (
+      <Fixture>
+        <div>{this.props.children}</div>
+
+        <div className="control-box">
+          <fieldset>
+            <legend>Controlled</legend>
+            <span id="shadow-dom-host-controlled"></span>
+            
+            <span className="hint">
+              {' '}
+              Value: {JSON.stringify(this.state.value)}
+            </span>
+          </fieldset>
+
+          <fieldset>
+            <legend>Uncontrolled</legend>
+            <span id="shadow-dom-host-uncontrolled"></span>
+          </fieldset>
+        </div>
+      </Fixture>
+    );
+  }
+}
+
+export default NumberTestCaseShadowDOM;

--- a/fixtures/dom/src/components/fixtures/number-inputs/NumberTestCaseShadowDOM.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/NumberTestCaseShadowDOM.js
@@ -1,64 +1,23 @@
 import Fixture from '../../Fixture';
+import NumberTestCase from './NumberTestCase';
 
 const React = window.React;
+const ReactDOM = window.ReactDOM;
 
 class NumberTestCaseShadowDOM extends React.Component {
-  state = {value: ''};
+  componentWillMount() {
+    class ShadowNumberInput extends HTMLElement {
+      connectedCallback(){
+        ReactDOM.render(<NumberTestCase />, this.attachShadow({ mode: 'open' }));
+      }
+    }
 
-  controlledInputElementText = `<input
-    type="number"
-    value={this.state.value}
-    onChange={this.onChange}
-  />`;
-
-  uncontrolledInputElementText = `<input type="number" defaultValue={0.5} />`;
-
-  onChange = event => {
-    const parsed = parseFloat(event.target.value, 10);
-    const value = isNaN(parsed) ? '' : parsed;
-
-    this.setState({value});
-  };
-
-  componentDidMount() {
-    this.attachShadowDomElement(
-      '#shadow-dom-host-controlled',
-      this.controlledInputElementText
-    );
-    this.attachShadowDomElement(
-      '#shadow-dom-host-uncontrolled',
-      this.uncontrolledInputElementText
-    );
-  }
-
-  attachShadowDomElement(hostElementId, stringHtmlElement) {
-    var hostElement = document.querySelector(hostElementId);
-    var shadow = hostElement.attachShadow({mode: 'open'});
-    shadow.innerHTML = stringHtmlElement;
+    customElements.define('shadow-number-input', ShadowNumberInput);
   }
 
   render() {
     return (
-      <Fixture>
-        <div>{this.props.children}</div>
-
-        <div className="control-box">
-          <fieldset>
-            <legend>Controlled</legend>
-            <span id="shadow-dom-host-controlled" />
-
-            <span className="hint">
-              {' '}
-              Value: {JSON.stringify(this.state.value)}
-            </span>
-          </fieldset>
-
-          <fieldset>
-            <legend>Uncontrolled</legend>
-            <span id="shadow-dom-host-uncontrolled" />
-          </fieldset>
-        </div>
-      </Fixture>
+      <shadow-number-input {...this.props} />
     );
   }
 }

--- a/fixtures/dom/src/components/fixtures/number-inputs/NumberTestCaseShadowDOM.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/NumberTestCaseShadowDOM.js
@@ -21,8 +21,14 @@ class NumberTestCaseShadowDOM extends React.Component {
   };
 
   componentDidMount() {
-    this.attachShadowDomElement("#shadow-dom-host-controlled", this.controlledInputElementText);
-    this.attachShadowDomElement("#shadow-dom-host-uncontrolled", this.uncontrolledInputElementText);
+    this.attachShadowDomElement(
+      '#shadow-dom-host-controlled',
+      this.controlledInputElementText
+    );
+    this.attachShadowDomElement(
+      '#shadow-dom-host-uncontrolled',
+      this.uncontrolledInputElementText
+    );
   }
 
   attachShadowDomElement(hostElementId, stringHtmlElement) {
@@ -39,8 +45,8 @@ class NumberTestCaseShadowDOM extends React.Component {
         <div className="control-box">
           <fieldset>
             <legend>Controlled</legend>
-            <span id="shadow-dom-host-controlled"></span>
-            
+            <span id="shadow-dom-host-controlled" />
+
             <span className="hint">
               {' '}
               Value: {JSON.stringify(this.state.value)}
@@ -49,7 +55,7 @@ class NumberTestCaseShadowDOM extends React.Component {
 
           <fieldset>
             <legend>Uncontrolled</legend>
-            <span id="shadow-dom-host-uncontrolled"></span>
+            <span id="shadow-dom-host-uncontrolled" />
           </fieldset>
         </div>
       </Fixture>

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -34,6 +34,29 @@ function NumberInputs() {
       </TestCase>
 
       <TestCase
+        title="Backspacing in Shadow DOM"
+        description="The decimal place should not be lost in a Shadow DOM element">
+        <TestCase.Steps>
+          <li>Create number input inside a Shadow DOM element</li>
+          <li>Type "3.1"</li>
+          <li>Press backspace, eliminating the "1"</li>
+        </TestCase.Steps>
+
+        <TestCase.ExpectedResult>
+          The field should read "3.", preserving the decimal place
+        </TestCase.ExpectedResult>
+
+        <NumberTestCase />
+
+        <p className="footnote">
+          <b>Notes:</b> Previously, the fix for the test case titled
+          "Backspacing" did not work when the number input was attached to a
+          Shadow DOM element. This test case tests that number inputs inside a
+          Shadow DOM still properly retain the decimal point.
+        </p>
+      </TestCase>
+
+      <TestCase
         title="Decimal precision"
         description="Supports decimal precision greater than 2 places">
         <TestCase.Steps>

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -3,6 +3,7 @@ import TestCase from '../../TestCase';
 import NumberTestCase from './NumberTestCase';
 import NumberInputDecimal from './NumberInputDecimal';
 import NumberInputExtraZeroes from './NumberInputExtraZeroes';
+import NumberInputTestCaseShadowDOM from './NumberTestCaseShadowDOM';
 
 const React = window.React;
 
@@ -46,7 +47,7 @@ function NumberInputs() {
           The field should read "3.", preserving the decimal place
         </TestCase.ExpectedResult>
 
-        <NumberTestCase />
+        <NumberInputTestCaseShadowDOM />
 
         <p className="footnote">
           <b>Notes:</b> Previously, the fix for the test case titled

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -310,9 +310,11 @@ export function setDefaultValue(
   // activeElement to compare to the default value.
   //
   // https://github.com/facebook/react/issues/11827
-  const activeElement = node.ownerDocument.activeElement.shadowRoot 
-                      ? getShadowElementRoot(node.ownerDocument.activeElement)
-                      : node.ownerDocument.activeElement;
+  let activeElement = node.ownerDocument.activeElement;
+
+  if (activeElement && activeElement.shadowRoot) {
+    activeElement = getShadowElementRoot(node.ownerDocument.activeElement);
+  }
 
   if (
     // Focused number inputs synchronize on blur. See ChangeEventPlugin.js

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -304,7 +304,6 @@ export function setDefaultValue(
   type: ?string,
   value: *,
 ) {
-
   // In the case of Shadow DOM, the root node is a child of the shadowRoot.
   // If this is the case, we need to drill down to the root to get the actual
   // activeElement to compare to the default value.


### PR DESCRIPTION
Fixes Issue #11827. 

#7253 successfully fixed the number input backspace bug with removing decimals by not re-setting the default value if `node === activeElement`. However, shadowDOM elements are wrapped in a shadowRoot element, so comparing them to `node` always triggered an update to `node.defaultValue` (which triggered `input`'s validation that removed the decimal point). I've updated `setDefaultState` to check for shadow DOM element, and if so, iterate to the root `activeElement` to compare against node.

I haven't added tests yet because I need some input on that. I'm assuming the tests should go in `ReactDOMInput-test.js`. However, I'm not sure how to properly mock a shadow DOM element in these tests, and would appreciate some input on that.

- [x] complete PR checklist
- [x] add tests
