### PR TITLE
Use 2 workers for all tests on CI

### DIFF
--- a/scripts/circleci/test_entry_point.sh
+++ b/scripts/circleci/test_entry_point.sh
@@ -10,7 +10,7 @@ if [ $((0 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('node ./scripts/prettier/index')
   COMMANDS_TO_RUN+=('node ./scripts/tasks/flow')
   COMMANDS_TO_RUN+=('node ./scripts/tasks/eslint')
-  COMMANDS_TO_RUN+=('yarn test --runInBand')
+  COMMANDS_TO_RUN+=('yarn test --maxWorkers=2')
   COMMANDS_TO_RUN+=('./scripts/circleci/check_license.sh')
   COMMANDS_TO_RUN+=('./scripts/circleci/check_modules.sh')
   COMMANDS_TO_RUN+=('./scripts/circleci/test_print_warnings.sh')
@@ -18,13 +18,13 @@ if [ $((0 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
 fi
 
 if [ $((1 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
-  COMMANDS_TO_RUN+=('yarn test-prod --runInBand')
+  COMMANDS_TO_RUN+=('yarn test-prod --maxWorkers=2')
 fi
 
 if [ $((2 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('./scripts/circleci/build.sh')
-  COMMANDS_TO_RUN+=('yarn test-build --runInBand')
-  COMMANDS_TO_RUN+=('yarn test-build-prod --runInBand')
+  COMMANDS_TO_RUN+=('yarn test-build --maxWorkers=2')
+  COMMANDS_TO_RUN+=('yarn test-build-prod --maxWorkers=2')
   COMMANDS_TO_RUN+=('./scripts/circleci/upload_build.sh')
 fi
 


### PR DESCRIPTION
Since #11983 worked I'm curious if it's better to always use two workers? Maybe CI will finish faster.