### PR TITLE
Add warning in server renderer if class doesn't extend React.Component

### DIFF
--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -338,6 +338,11 @@ describe('ReactCompositeComponent', () => {
           'Change ClassWithRenderNotExtended to extend React.Component instead.',
       );
     }).toThrow(TypeError);
+
+    // Test deduplication
+    expect(() => {
+      ReactDOM.render(<ClassWithRenderNotExtended />, container);
+    }).toThrow(TypeError);
   });
 
   it('should warn about `setState` in render', () => {

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -554,4 +554,25 @@ describe('ReactDOMServer', () => {
       'The experimental Call and Return types are not currently supported by the server renderer.',
     );
   });
+
+  it('should warn when server rendering a class with a render method that does not extend React.Component', () => {
+    spyOnDevAndProd(console, 'error');
+    class ClassWithRenderNotExtended {
+      render() {
+        return <div />;
+      }
+    }
+    expect(console.error.calls.count()).toBe(0);
+    expect(() => {
+      ReactDOMServer.renderToString(<ClassWithRenderNotExtended />);
+    }).toThrow(TypeError);
+    if (__DEV__) {
+      expect(console.error.calls.count()).toBe(1);
+      expect(console.error.calls.argsFor(0)[0]).toContain(
+        'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
+          "but doesn't extend React.Component. This is likely to cause errors. " +
+          'Change ClassWithRenderNotExtended to extend React.Component instead.',
+      );
+    }
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -556,23 +556,25 @@ describe('ReactDOMServer', () => {
   });
 
   it('should warn when server rendering a class with a render method that does not extend React.Component', () => {
-    spyOnDevAndProd(console, 'error');
     class ClassWithRenderNotExtended {
       render() {
         return <div />;
       }
     }
-    expect(console.error.calls.count()).toBe(0);
+
     expect(() => {
-      ReactDOMServer.renderToString(<ClassWithRenderNotExtended />);
-    }).toThrow(TypeError);
-    if (__DEV__) {
-      expect(console.error.calls.count()).toBe(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
+      expect(() =>
+        ReactDOMServer.renderToString(<ClassWithRenderNotExtended />),
+      ).toWarnDev(
         'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
           "but doesn't extend React.Component. This is likely to cause errors. " +
           'Change ClassWithRenderNotExtended to extend React.Component instead.',
       );
-    }
+    }).toThrow(TypeError);
+
+    // Test deduplication
+    expect(() => {
+      ReactDOMServer.renderToString(<ClassWithRenderNotExtended />);
+    }).toThrow(TypeError);
   });
 });

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -122,6 +122,7 @@ let didWarnDefaultSelectValue = false;
 let didWarnDefaultTextareaValue = false;
 let didWarnInvalidOptionChildren = false;
 const didWarnAboutNoopUpdateForComponent = {};
+const didWarnAboutBadClass = {};
 const valuePropNames = ['value', 'defaultValue'];
 const newlineEatingTags = {
   listing: true,
@@ -427,13 +428,17 @@ function resolve(
           typeof Component.prototype.render === 'function'
         ) {
           const componentName = getComponentName(Component);
-          warning(
-            false,
-            "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +
-              'This is likely to cause errors. Change %s to extend React.Component instead.',
-            componentName,
-            componentName,
-          );
+
+          if (componentName !== null && !didWarnAboutBadClass[componentName]) {
+            warning(
+              false,
+              "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +
+                'This is likely to cause errors. Change %s to extend React.Component instead.',
+              componentName,
+              componentName,
+            );
+            didWarnAboutBadClass[componentName] = true;
+          }
         }
       }
       inst = Component(element.props, publicContext, updater);

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -427,9 +427,9 @@ function resolve(
           Component.prototype &&
           typeof Component.prototype.render === 'function'
         ) {
-          const componentName = getComponentName(Component);
+          const componentName = getComponentName(Component) || 'Unknown';
 
-          if (componentName !== null && !didWarnAboutBadClass[componentName]) {
+          if (!didWarnAboutBadClass[componentName]) {
             warning(
               false,
               "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -421,6 +421,21 @@ function resolve(
     if (shouldConstruct(Component)) {
       inst = new Component(element.props, publicContext, updater);
     } else {
+      if (__DEV__) {
+        if (
+          Component.prototype &&
+          typeof Component.prototype.render === 'function'
+        ) {
+          const componentName = getComponentName(Component);
+          warning(
+            false,
+            "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +
+              'This is likely to cause errors. Change %s to extend React.Component instead.',
+            componentName,
+            componentName,
+          );
+        }
+      }
       inst = Component(element.props, publicContext, updater);
       if (inst == null || inst.render == null) {
         child = inst;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -60,9 +60,11 @@ import {
 import {NoWork, Never} from './ReactFiberExpirationTime';
 
 let warnedAboutStatelessRefs;
+let didWarnAboutBadClass;
 
 if (__DEV__) {
   warnedAboutStatelessRefs = {};
+  didWarnAboutBadClass = {};
 }
 
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
@@ -459,13 +461,17 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     if (__DEV__) {
       if (fn.prototype && typeof fn.prototype.render === 'function') {
         const componentName = getComponentName(workInProgress);
-        warning(
-          false,
-          "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +
-            'This is likely to cause errors. Change %s to extend React.Component instead.',
-          componentName,
-          componentName,
-        );
+
+        if (componentName !== null && !didWarnAboutBadClass[componentName]) {
+          warning(
+            false,
+            "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +
+              'This is likely to cause errors. Change %s to extend React.Component instead.',
+            componentName,
+            componentName,
+          );
+          didWarnAboutBadClass[componentName] = true;
+        }
       }
       ReactCurrentOwner.current = workInProgress;
       value = fn(props, context);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -460,9 +460,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     if (__DEV__) {
       if (fn.prototype && typeof fn.prototype.render === 'function') {
-        const componentName = getComponentName(workInProgress);
+        const componentName = getComponentName(workInProgress) || 'Unknown';
 
-        if (componentName !== null && !didWarnAboutBadClass[componentName]) {
+        if (!didWarnAboutBadClass[componentName]) {
           warning(
             false,
             "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +


### PR DESCRIPTION
Let me know if the check is done in the wrong spot or if my test is invalid or need more tests somewhere. 

In dev mode, while server rendering, a warning will be thrown if there is a class that doesn't extend React.Component.

Close #11991 