### PR TITLE
Add a workaround for incomplete Proxy polyfill issue

### DIFF
--- a/packages/events/SyntheticEvent.js
+++ b/packages/events/SyntheticEvent.js
@@ -12,7 +12,6 @@ import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 
 let didWarnForAddedNewProperty = false;
-const isProxySupported = typeof Proxy === 'function';
 const EVENT_POOL_SIZE = 10;
 
 const shouldBeReleasedProperties = [
@@ -234,6 +233,11 @@ SyntheticEvent.extend = function(Interface) {
  * in which some Event properties are set to undefined (GH#10010)
  */
 if (__DEV__) {
+  const isProxySupported =
+    typeof Proxy === 'function' &&
+    // https://github.com/facebook/react/issues/12011
+    !Object.isSealed(new Proxy({}, {}));
+
   if (isProxySupported) {
     /*eslint-disable no-func-assign */
     SyntheticEvent = new Proxy(SyntheticEvent, {


### PR DESCRIPTION
This works around https://github.com/facebook/react/issues/12011.
I feel "meh" about this but it's DEV-only so I don't mind it either.