### PR TITLE
Use package.json names for AMD bundles

### DIFF
--- a/fixtures/packaging/requirejs-manual-paths/dev.html
+++ b/fixtures/packaging/requirejs-manual-paths/dev.html
@@ -1,10 +1,15 @@
 <html>
   <body>
     <script src="https://unpkg.com/requirejs@2.3.2/require.js"></script>
-    <script src="../../../build/dist/react.production.min.js"></script>
-    <script src="../../../build/dist/react-dom.production.min.js"></script>
     <div id="container"></div>
     <script>
+      requirejs.config({
+        paths: {
+          react: '../../../build/dist/react.development',
+          'react-dom': '../../../build/dist/react-dom.development'
+        }
+      });
+
       require(['react', 'react-dom'], function(React, ReactDOM) {
         ReactDOM.render(
           React.createElement('h1', null, 'Hello World!'),

--- a/fixtures/packaging/requirejs-manual-paths/prod.html
+++ b/fixtures/packaging/requirejs-manual-paths/prod.html
@@ -1,10 +1,15 @@
 <html>
   <body>
     <script src="https://unpkg.com/requirejs@2.3.2/require.js"></script>
-    <script src="../../../build/dist/react.production.min.js"></script>
-    <script src="../../../build/dist/react-dom.production.min.js"></script>
     <div id="container"></div>
     <script>
+      requirejs.config({
+        paths: {
+          react: '../../../build/dist/react.production.min',
+          'react-dom': '../../../build/dist/react-dom.production.min'
+        }
+      });
+
       require(['react', 'react-dom'], function(React, ReactDOM) {
         ReactDOM.render(
           React.createElement('h1', null, 'Hello World!'),

--- a/fixtures/packaging/requirejs/dev.html
+++ b/fixtures/packaging/requirejs/dev.html
@@ -1,15 +1,10 @@
 <html>
   <body>
     <script src="https://unpkg.com/requirejs@2.3.2/require.js"></script>
+    <script src="../../../build/dist/react.development.js"></script>
+    <script src="../../../build/dist/react-dom.development.js"></script>
     <div id="container"></div>
     <script>
-      requirejs.config({
-        paths: {
-          react: '../../../build/dist/react.development',
-          'react-dom': '../../../build/dist/react-dom.development'
-        }
-      });
-
       require(['react', 'react-dom'], function(React, ReactDOM) {
         ReactDOM.render(
           React.createElement('h1', null, 'Hello World!'),

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -109,7 +109,7 @@ function getBabelConfig(updateBabelOptions, bundleType, filename) {
   }
 }
 
-function getRollupOutputOptions(outputPath, format, globals, globalName) {
+function getRollupOutputOptions(outputPath, format, globals, bundle) {
   return Object.assign(
     {},
     {
@@ -117,8 +117,11 @@ function getRollupOutputOptions(outputPath, format, globals, globalName) {
       format,
       globals,
       interop: false,
-      name: globalName,
+      name: bundle.global,
       sourcemap: false,
+      amd: {
+        id: bundle.entry,
+      },
     }
   );
 }
@@ -379,7 +382,7 @@ async function createBundle(bundle, bundleType) {
     mainOutputPath,
     format,
     peerGlobals,
-    bundle.global
+    bundle
   );
 
   console.log(`${chalk.bgYellow.black(' BUILDING ')} ${logKey}`);

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -4,8 +4,8 @@
       "filename": "react.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react",
-      "size": 55375,
-      "gzip": 15018
+      "size": 55384,
+      "gzip": 15020
     },
     {
       "filename": "react.production.min.js",
@@ -46,8 +46,8 @@
       "filename": "react-dom.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 561031,
-      "gzip": 132753
+      "size": 560474,
+      "gzip": 132549
     },
     {
       "filename": "react-dom.production.min.js",
@@ -88,8 +88,8 @@
       "filename": "react-dom-test-utils.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 41264,
-      "gzip": 11741
+      "size": 41564,
+      "gzip": 11896
     },
     {
       "filename": "react-dom-test-utils.production.min.js",
@@ -123,8 +123,8 @@
       "filename": "react-dom-unstable-native-dependencies.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 63124,
-      "gzip": 16553
+      "size": 63166,
+      "gzip": 16560
     },
     {
       "filename": "react-dom-unstable-native-dependencies.production.min.js",
@@ -165,8 +165,8 @@
       "filename": "react-dom-server.browser.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 93545,
-      "gzip": 25061
+      "size": 94147,
+      "gzip": 25200
     },
     {
       "filename": "react-dom-server.browser.production.min.js",
@@ -221,8 +221,8 @@
       "filename": "react-art.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-art",
-      "size": 357962,
-      "gzip": 80313
+      "size": 358044,
+      "gzip": 80316
     },
     {
       "filename": "react-art.production.min.js",


### PR DESCRIPTION
Currently, the AMD distributions don't specify module names.  Therefore, when they are inlined in a bundle or imported with a `script` tag:

```html
<script src = "https://unpkg.com/requirejs@2.3.2/require.js"></script>
<script src = "https://unpkg.com/react@16.2.0/umd/react.production.min.js"></script>
<script src = "https://unpkg.com/react-dom@16.2.0/umd/react-dom.production.min.js"></script>
<script>
  define('', ['require', 'exports', 'react', 'react-dom'] // …
    var React = require('react');
```

RequireJS throws [mismatched define errors](https://requirejs.org/docs/errors.html#mismatch):

```
Uncaught Error: Mismatched anonymous define() module: function (React) { 'use strict';
Uncaught Error: Mismatched anonymous define() module: function () { 'use strict';
```

This patch passes the bundle names into `rollup`, so the AMD definitions can use them.

By naming the builds, they can be easily [consumed from the Bazel build tool](https://github.com/bazelbuild/rules_typescript/issues/102).  Bazel inlines AMD dependencies, but doesn't otherwise transpile their module syntaxes.

I have minimal familiarity with AMD.  I don't believe adding module names should affect other environments.