### PR TITLE
Remove HTMLCanvasElement test mock

### DIFF
--- a/scripts/jest/setupEnvironment.js
+++ b/scripts/jest/setupEnvironment.js
@@ -44,7 +44,4 @@ if (typeof window !== 'undefined') {
       event.preventDefault();
     }
   });
-
-  // Mock for ReactART.
-  HTMLCanvasElement.prototype.getContext = () => ({});
 }


### PR DESCRIPTION
## Summary

This PR fixes most test failures reported by Jest's new --detectLeaks feature

Note: I wasn't able to see [any measurable difference](http://dp.hanlon.io/350E3H0z2Z3d) in heap usage using --logHeapUsage so this probably isn't as big of a deal as it would seem, just good to fix if we can

## Details
Now that detectLeaks works in Jest 22, I ran it on the React repo and found that ~110/130 tests report leaks. That number is approximate because some tests **leak intermittently**

After investigating the leaks, I found that 1 line accounted for ~100 of the leaks. Removing this line reduces the failures from ~110 to ~10. 

It looks like assigning a function to any window attribute inside setupEnvironment will leak the Window after the test due to the setupEnvironment closure. **I've filed a bug in Jest [here](https://github.com/facebook/jest/issues/5309)**

## Testing

Running this command:

```bash
yarn test --detectLeaks
```

### Before
![](http://dp.hanlon.io/3o163d0P0n2C/Image%202018-01-14%20at%203.56.25%20PM.png)

### After
![](http://dp.hanlon.io/3g2v1O3r263D/Image%202018-01-14%20at%203.41.38%20PM.png)

Note: a good file to test this with which will reliably fail on master and work on this branch is `invertObject-test.js`. These test could be in `env=node` yet this like still leaks Window object:

```bash
yarn test --detectLeaks invertObject-test.js
```