### PR TITLE
Output JUnit XML metadata for CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,10 @@ jobs:
     environment:
       TZ: /usr/share/zoneinfo/America/Los_Angeles
       TRAVIS_REPO_SLUG: facebook/react
+      REPORT_FORMATTER: junit
+      REPORT_DIR: reports/junit
+      JEST_JUNIT_OUTPUT: "reports/junit/jest-results.xml"
+      JEST_PROCESSOR: "jest-junit"
 
     parallelism: 4
 
@@ -34,6 +38,12 @@ jobs:
       - run:
           name: Test Packages
           command: ./scripts/circleci/test_entry_point.sh
+
+      - store_test_results:
+          path: reports/junit
+
+      - store_artifacts:
+          path: reports/junit
 
       - save_cache:
           name: Save node_modules cache

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "jasmine-check": "^1.0.0-rc.0",
     "jest": "^23.1.0",
     "jest-diff": "^23.0.1",
+    "jest-junit": "^3.4.1",
+    "junit-report-builder": "^1.2.0",
     "minimatch": "^3.0.4",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",

--- a/scripts/circleci/build.sh
+++ b/scripts/circleci/build.sh
@@ -1,20 +1,27 @@
-#!/bin/bash		
-		
-set -e		
+#!/bin/bash
+
+TEMPORARY_LOG_FILE="local_size_measurements-errors.log"
+
+. ./scripts/circleci/common.sh
 
 # On master, download the bundle sizes from last master build so that
 # the size printed in the CI logs for master commits is accurate.
 # We don't do it for pull requests because those are compared against
 # the merge base by Dangerfile instead. See https://github.com/facebook/react/pull/12606.
 if [ -z "$CI_PULL_REQUEST" ]; then
-  curl -o scripts/rollup/results.json http://react.zpao.com/builds/master/latest/results.json
+  process_command "build" "$REPORT_FORMATTER" "$TEMPORARY_LOG_FILE" curl \
+  -sS -o scripts/rollup/results.json http://react.zpao.com/builds/master/latest/results.json
 fi
 
+set -e
+
 yarn build --extract-errors
+
 # Note: since we run the full build including extracting error codes,
 # it is important that we *don't* reset the change to `scripts/error-codes/codes.json`.
 # When production bundle tests run later, it needs to be available.
 # See https://github.com/facebook/react/pull/11655.
 
 # Do a sanity check on bundles
+
 yarn lint-build

--- a/scripts/circleci/check_license.sh
+++ b/scripts/circleci/check_license.sh
@@ -6,8 +6,14 @@ set -e
 EXPECTED='scripts/circleci/check_license.sh'
 ACTUAL=$(git grep -l PATENTS)
 
+ANNOUNCEMENT=$(echo "PATENTS crept into some new files?")
+DIFF=$(diff -u <(echo "$EXPECTED") <(echo "$ACTUAL") || true)
+DATA=$ANNOUNCEMENT$DIFF
+
 if [ "$EXPECTED" != "$ACTUAL" ]; then
-  echo "PATENTS crept into some new files?"
-  diff -u <(echo "$EXPECTED") <(echo "$ACTUAL") || true
+  echo "$DATA"
+  if [ "$REPORT_FORMATTER" = "junit" ]; then
+    ./scripts/circleci/write_junit_report.sh "check_license" "$DATA" false
+  fi
   exit 1
 fi

--- a/scripts/circleci/check_modules.sh
+++ b/scripts/circleci/check_modules.sh
@@ -10,8 +10,14 @@ ACTUAL=$(git grep -l @providesModule -- './*.js' ':!scripts/rollup/shims/*.js')
 red=$'\e[1;31m'
 end=$'\e[0m'
 
+ANNOUNCEMENT=$(printf "%s\n" "${red}ERROR: @providesModule crept into some new files?${end}")
+DIFF=$(diff -u <(echo "$EXPECTED") <(echo "$ACTUAL") || true)
+DATA=$ANNOUNCEMENT$DIFF
+
 if [ "$EXPECTED" != "$ACTUAL" ]; then
-  printf "%s\n" "${red}ERROR: @providesModule crept into some new files?${end}"
-  diff -u <(echo "$EXPECTED") <(echo "$ACTUAL") || true
+  echo "$DATA"
+  if [ "$REPORT_FORMATTER" = "junit" ]; then
+    ./scripts/circleci/write_junit_report.sh "check_modules" "$DATA" false
+  fi
   exit 1
 fi

--- a/scripts/circleci/common.sh
+++ b/scripts/circleci/common.sh
@@ -1,0 +1,31 @@
+
+redirect_stderr() {
+  REPORT_FORMATTER=$1
+  TEMPORARY_LOG_FILE=$2
+
+  if [ "$REPORT_FORMATTER" = "junit" ]; then
+    "${@:3}" 2> "$TEMPORARY_LOG_FILE"
+  else
+    "${@:3}"
+  fi
+}
+
+process_command() {
+  BUILD_STEP=$1
+  REPORT_FORMATTER=$2
+  TEMPORARY_LOG_FILE=$3
+
+  redirect_stderr "$REPORT_FORMATTER" "$TEMPORARY_LOG_FILE" "${@:4}"
+
+  if [ "$REPORT_FORMATTER" = "junit" ]; then
+    ERROR=$(cat "$TEMPORARY_LOG_FILE")
+    if [ "$ERROR" != "" ];then
+      echo $ERROR
+      ./scripts/circleci/write_junit_report.sh "$BUILD_STEP" "$ERROR" false
+    fi
+    rm -f $TEMPORARY_LOG_FILE
+    if [ "$ERROR" != "" ];then
+      exit 1
+    fi
+  fi
+}

--- a/scripts/circleci/test_coverage.sh
+++ b/scripts/circleci/test_coverage.sh
@@ -1,11 +1,25 @@
 #!/bin/bash
 
+TEMPORARY_LOG_FILE="coveralls-errors.log"
+
+. ./scripts/circleci/common.sh
+
 set -e
 
-yarn test --coverage --maxWorkers=2
+yarn test --coverage --maxWorkers=2 --testResultsProcessor=${JEST_PROCESSOR}
+
+set +e
+
 if [ -z "$CI_PULL_REQUEST" ]; then
-  ./node_modules/.bin/coveralls < ./coverage/lcov.info
+  cat ./coverage/lcov.info | process_command "coveralls" "$REPORT_FORMATTER" "$TEMPORARY_LOG_FILE" \
+  ./node_modules/.bin/coveralls
+  RES=$?
+  if [ $RES -ne 0 ]; then
+    exit $RES
+  fi
 fi
+
+set -e
 
 # TODO: should we also track prod code coverage somehow?
 # yarn test-prod --coverage

--- a/scripts/circleci/test_entry_point.sh
+++ b/scripts/circleci/test_entry_point.sh
@@ -10,7 +10,7 @@ if [ $((0 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('node ./scripts/prettier/index')
   COMMANDS_TO_RUN+=('node ./scripts/tasks/flow-ci')
   COMMANDS_TO_RUN+=('node ./scripts/tasks/eslint')
-  COMMANDS_TO_RUN+=('yarn test --maxWorkers=2')
+  COMMANDS_TO_RUN+=("yarn test --maxWorkers=2 --testResultsProcessor=${JEST_PROCESSOR}")
   COMMANDS_TO_RUN+=('./scripts/circleci/check_license.sh')
   COMMANDS_TO_RUN+=('./scripts/circleci/check_modules.sh')
   COMMANDS_TO_RUN+=('./scripts/circleci/test_print_warnings.sh')

--- a/scripts/circleci/upload_build.sh
+++ b/scripts/circleci/upload_build.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-set -e
+. ./scripts/circleci/common.sh
+
+TEMPORARY_LOG_FILE="upload_build-errors.log"
 
 if [ -z "$CI_PULL_REQUEST" ] && [ -n "$BUILD_SERVER_ENDPOINT" ]; then
-  curl \
+  process_command "upload_build" "$REPORT_FORMATTER" "$TEMPORARY_LOG_FILE" curl \
     -F "react.development=@build/dist/react.development.js" \
     -F "react.production.min=@build/dist/react.production.min.js" \
     -F "react-dom.development=@build/dist/react-dom.development.js" \

--- a/scripts/circleci/write_junit_report.sh
+++ b/scripts/circleci/write_junit_report.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+# $1: build step name
+# $2: data that will be part of the junit report if the build step has failed
+# $3: boolean that indicates whether the build step is successful
+node ./scripts/tasks/junit "$1" "$2" "$3"

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -24,10 +24,15 @@ const {asyncCopyTo, asyncRimRaf} = require('./utils');
 const codeFrame = require('babel-code-frame');
 const Wrappers = require('./wrappers');
 
+const {isJUnitEnabled, writeJUnitReport} = require('../shared/reporting');
+
 // Errors in promises should be fatal.
 let loggedErrors = new Set();
 process.on('unhandledRejection', err => {
   if (loggedErrors.has(err)) {
+    if (isJUnitEnabled()) {
+      writeJUnitReport('build', err, false);
+    }
     // No need to print it twice.
     process.exit(1);
   }

--- a/scripts/rollup/validate/index.js
+++ b/scripts/rollup/validate/index.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const path = require('path');
 const spawnSync = require('child_process').spawnSync;
 const glob = require('glob');
+const {isJUnitEnabled, writeJUnitReport} = require('../../shared/reporting');
 
 const extension = process.platform === 'win32' ? '.cmd' : '';
 
@@ -29,7 +30,11 @@ function lint({format, filePatterns}) {
     }
   );
   if (result.status !== 0) {
-    console.error(chalk.red(`Linting of ${format} bundles has failed.`));
+    const lintMessage = `Linting of ${format} bundles has failed.`;
+    console.error(chalk.red(lintMessage));
+    if (isJUnitEnabled()) {
+      writeJUnitReport('lint-build', lintMessage, false);
+    }
     process.exit(result.status);
   } else {
     console.log(chalk.green(`Linted ${format} bundles successfully!`));
@@ -43,7 +48,11 @@ function checkFilesExist(bundle) {
     console.log(`Checking if files exist in ${pattern}...`);
     const files = glob.sync(pattern);
     if (files.length === 0) {
-      console.error(chalk.red(`Found no ${format} bundles in ${pattern}`));
+      const bundleMessage = `Found no ${format} bundles in ${pattern}`;
+      console.error(chalk.red(bundleMessage));
+      if (isJUnitEnabled()) {
+        writeJUnitReport('lint-build', bundleMessage, false);
+      }
       process.exit(1);
     } else {
       console.log(chalk.green(`Found ${files.length} bundles.`));

--- a/scripts/shared/reporting.js
+++ b/scripts/shared/reporting.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const chalk = require('chalk');
+const builder = require('junit-report-builder');
+
+/**
+ * Returns whether JUnit report generation mode is enabled. The activation is done through circleci
+ * configuration file
+ *
+ * @returns {boolean} Whether JUnit report generation mode is enabled
+ */
+const isJUnitEnabled = () => process.env.REPORT_FORMATTER === 'junit';
+
+/**
+ * Returns the file path  to the report corresponding to the provided build step
+ * @param {string} buildStep The build step for which a report will be generated
+ * @returns {string} The file path  to the report corresponding to the provided build step
+ */
+const reportFilePath = buildStep =>
+  path.join(process.env.REPORT_DIR, `${buildStep}-results.xml`);
+
+/**
+ * Writes the content of Junit report within the reports directory
+ *
+ * @param {String} fileNamePrefix The report file name prefix
+ * @param {String} content The content of the report
+ */
+const writeContent = (fileNamePrefix, content) => {
+  const filePath = reportFilePath(fileNamePrefix);
+  mkdirp.sync(path.dirname(filePath));
+  fs.writeFileSync(filePath, content, 'utf8');
+};
+
+/**
+ * Writes a JUnit report for a given build step
+ *
+ * @param {string} buildStep The build step name
+ * @param {any} data The data that will be part of the report if the build step has failed
+ * @param {boolean} stepHasSucceeded Whether the build step has failed
+ */
+const writeJUnitReport = (buildStep, data, stepHasSucceeded) => {
+  const reportPath = reportFilePath(buildStep);
+  console.log(chalk.gray(`Starting to write the report in ${reportPath}`));
+  const suite = builder.testSuite().name(buildStep);
+  const testCase = suite
+    .testCase()
+    .className(buildStep)
+    .name('single-test');
+  if (!stepHasSucceeded) {
+    testCase.failure(data);
+  }
+  builder.writeTo(reportPath);
+  console.log(
+    chalk.gray(
+      `Finished writing the report in ${reportPath} for the build step ${buildStep}`
+    )
+  );
+};
+
+module.exports = {
+  isJUnitEnabled,
+  writeJUnitReport,
+  writeContent,
+};

--- a/scripts/tasks/danger.js
+++ b/scripts/tasks/danger.js
@@ -9,6 +9,7 @@
 
 const path = require('path');
 const spawn = require('child_process').spawn;
+const {isJUnitEnabled, writeJUnitReport} = require('../shared/reporting');
 
 const extension = process.platform === 'win32' ? '.cmd' : '';
 
@@ -24,6 +25,9 @@ spawn(path.join('node_modules', '.bin', 'danger-ci' + extension), [], {
 }).on('close', function(code) {
   if (code !== 0) {
     console.error('Danger failed');
+    if (isJUnitEnabled()) {
+      writeJUnitReport('Danger', `Danger failed with code ${code}`, false);
+    }
   } else {
     console.log('Danger passed');
   }

--- a/scripts/tasks/junit.js
+++ b/scripts/tasks/junit.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const {isJUnitEnabled, writeJUnitReport} = require('../shared/reporting');
+
+if (!isJUnitEnabled() | (process.argv.length !== 5)) {
+  return;
+}
+
+writeJUnitReport(process.argv[2], process.argv[3], process.argv[4] === 'true');

--- a/scripts/tasks/version-check.js
+++ b/scripts/tasks/version-check.js
@@ -7,6 +7,8 @@
 
 'use strict';
 
+const {isJUnitEnabled, writeJUnitReport} = require('../shared/reporting');
+
 const reactVersion = require('../../package.json').version;
 const versions = {
   'packages/react/package.json': require('../../packages/react/package.json')
@@ -18,20 +20,24 @@ const versions = {
   'packages/shared/ReactVersion.js': require('../../packages/shared/ReactVersion'),
 };
 
+let errorMessages = [];
+
 let allVersionsMatch = true;
 Object.keys(versions).forEach(function(name) {
   const version = versions[name];
   if (version !== reactVersion) {
     allVersionsMatch = false;
-    console.log(
-      '%s version does not match package.json. Expected %s, saw %s.',
-      name,
-      reactVersion,
-      version
-    );
+    const errorMessage = `${name} version does not match package.json. Expected ${reactVersion}, saw ${version} .`;
+    console.log(errorMessage);
+    if (isJUnitEnabled()) {
+      errorMessages.push(errorMessage);
+    }
   }
 });
 
 if (!allVersionsMatch) {
+  if (isJUnitEnabled()) {
+    writeJUnitReport('version-check', errorMessages.join('\n'), false);
+  }
   process.exit(1);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1429,6 +1429,10 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
 
+date-format@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-0.0.2.tgz#fafd448f72115ef1e2b739155ae92f2be6c28dd1"
+
 debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3083,6 +3087,14 @@ jest-jasmine2@^23.1.0:
     jest-util "^23.1.0"
     pretty-format "^23.0.1"
 
+jest-junit@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-3.7.0.tgz#34abaed677439eb96557815d18b5ba01364fd897"
+  dependencies:
+    mkdirp "^0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
 jest-leak-detector@^23.0.1:
   version "23.0.1"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz#9dba07505ac3495c39d3ec09ac1e564599e861a0"
@@ -3354,6 +3366,15 @@ jsprim@^1.2.2:
 jsx-ast-utils@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
+
+junit-report-builder@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/junit-report-builder/-/junit-report-builder-1.3.1.tgz#65923e2587a54762e8fb91505ea5604dba519d55"
+  dependencies:
+    date-format "0.0.2"
+    lodash "^4.17.10"
+    mkdirp "^0.5.0"
+    xmlbuilder "^10.0.0"
 
 kind-of@^1.1.0:
   version "1.1.0"
@@ -5383,6 +5404,14 @@ ws@^4.0.0:
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+
+xmlbuilder@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-10.0.0.tgz#c64e52f8ae097fe5fd46d1c38adaade071ee1b55"
 
 xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Fixes #11949

# Summary
Currently, when the build fails, there is no way to know what happened other than going through the logs in CircleCI. 

The goal of this PR is to output JUnit XML metadata for every build step. This allows CircleCI summary page to display exactly which step has failed. 

# What this PR does:
1.  Handle Jest JUnit reports generation
   **jest-junit** reporter is used to output JUnit report reports in /junit/jest-results.xml
   :warning: `test_entry_point.sh` is calling `yarn test` several times. So, a unit test failure will be duplicated in the build summary
1. Handle ESLint JUnit reports generation
 **ESLint** script can either use the default `stylish` formatter or `junit` formatter.
 :warning: in JUnit mode, ESlint results are in XML format. Not only are they written to report fils, but also they are logged to console. This may be a noise to the build logs.

:warning:  For the tasks described below, the package `junit-report-builder` has been used. Initially, I was writing the JUnit report on my own.
1. Handle flow JUnit reports generation
  **Flow** result is treated as a single test that has a single test output
1. Handle prettier JUnit  reports generation
1. Handle check_license.sh JUnit  report generation
1. Handle check_modules.sh JUnit  report generation
1. test_print_warnings.sh
  **Nothing** to be done as this script is simply used to extract all messages from `warning()
1. Handle track_stats JUnit.sh  report generation
1. Handle build.sh JUnit.sh  report generation
1. Handle upload_build.sh JUnit  report generation
1. Handle JUnit report generation for coveralls
1. Handle JUnit report generation for Danger