### PR TITLE
RFC 6: createReactClass updates

### DIFF
--- a/addons/create-react-class/factory.js
+++ b/addons/create-react-class/factory.js
@@ -205,20 +205,6 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
     componentWillReceiveProps: 'DEFINE_MANY',
 
     /**
-     * Replacement for (deprecated) `componentWillMount`.
-     *
-     * @optional
-     */
-    UNSAFE_componentWillMount: 'DEFINE_MANY',
-
-    /**
-     * Replacement for (deprecated) `componentWillReceiveProps`.
-     *
-     * @optional
-     */
-    UNSAFE_componentWillReceiveProps: 'DEFINE_MANY',
-
-    /**
      * Invoked while deciding if the component should be updated as a result of
      * receiving new props, state and/or context.
      *
@@ -258,13 +244,6 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
     componentWillUpdate: 'DEFINE_MANY',
 
     /**
-     * Replacement for (deprecated) `shouldComponentUpdate`.
-     *
-     * @optional
-     */
-    UNSAFE_shouldComponentUpdate: 'DEFINE_MANY',
-
-    /**
      * Invoked when the component's DOM representation has been updated.
      *
      * Use this as an opportunity to operate on the DOM when the component has
@@ -290,6 +269,27 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
      * @optional
      */
     componentWillUnmount: 'DEFINE_MANY',
+
+    /**
+     * Replacement for (deprecated) `componentWillMount`.
+     *
+     * @optional
+     */
+    UNSAFE_componentWillMount: 'DEFINE_MANY',
+
+    /**
+     * Replacement for (deprecated) `componentWillReceiveProps`.
+     *
+     * @optional
+     */
+    UNSAFE_componentWillReceiveProps: 'DEFINE_MANY',
+
+    /**
+     * Replacement for (deprecated) `componentWillUpdate`.
+     *
+     * @optional
+     */
+    UNSAFE_componentWillUpdate: 'DEFINE_MANY',
 
     // ==== Advanced methods ====
 

--- a/addons/create-react-class/factory.js
+++ b/addons/create-react-class/factory.js
@@ -205,6 +205,20 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
     componentWillReceiveProps: 'DEFINE_MANY',
 
     /**
+     * Replacement for (deprecated) `componentWillMount`.
+     *
+     * @optional
+     */
+    UNSAFE_componentWillMount: 'DEFINE_MANY',
+
+    /**
+     * Replacement for (deprecated) `componentWillReceiveProps`.
+     *
+     * @optional
+     */
+    UNSAFE_componentWillReceiveProps: 'DEFINE_MANY',
+
+    /**
      * Invoked while deciding if the component should be updated as a result of
      * receiving new props, state and/or context.
      *
@@ -242,6 +256,13 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
      * @optional
      */
     componentWillUpdate: 'DEFINE_MANY',
+
+    /**
+     * Replacement for (deprecated) `shouldComponentUpdate`.
+     *
+     * @optional
+     */
+    UNSAFE_shouldComponentUpdate: 'DEFINE_MANY',
 
     /**
      * Invoked when the component's DOM representation has been updated.

--- a/addons/create-react-class/factory.js
+++ b/addons/create-react-class/factory.js
@@ -873,6 +873,12 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
           'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
         spec.displayName || 'A component'
       );
+      warning(
+        !Constructor.prototype.UNSAFE_componentWillRecieveProps,
+        '%s has a method called UNSAFE_componentWillRecieveProps(). ' +
+          'Did you mean UNSAFE_componentWillReceiveProps()?',
+        spec.displayName || 'A component'
+      );
     }
 
     // Reduce time spent doing lookups by setting these on the prototype.

--- a/addons/create-react-class/factory.js
+++ b/addons/create-react-class/factory.js
@@ -122,18 +122,6 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
     getDefaultProps: 'DEFINE_MANY_MERGED',
 
     /**
-     * This method is invoked after a component is instantiated and when it
-     * receives new props. Return an object to update state in response to
-     * prop changes. Return null to indicate no change to state.
-     *
-     * If an object is returned, its keys will be merged into the existing state.
-     *
-     * @return {object || null}
-     * @optional
-     */
-    getDerivedStateFromProps: 'DEFINE_MANY_MERGED',
-
-    /**
      * Invoked once before the component is mounted. The return value will be used
      * as the initial value of `this.state`.
      *
@@ -316,6 +304,23 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
      * @overridable
      */
     updateComponent: 'OVERRIDE_BASE'
+  };
+
+  /**
+   * Similar to ReactClassInterface but for static methods.
+   */
+  var ReactClassStaticInterface = {
+    /**
+     * This method is invoked after a component is instantiated and when it
+     * receives new props. Return an object to update state in response to
+     * prop changes. Return null to indicate no change to state.
+     *
+     * If an object is returned, its keys will be merged into the existing state.
+     *
+     * @return {object || null}
+     * @optional
+     */
+    getDerivedStateFromProps: 'DEFINE_MANY_MERGED'
   };
 
   /**
@@ -571,8 +576,8 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
 
       var isAlreadyDefined = name in Constructor;
       if (isAlreadyDefined) {
-        var specPolicy = ReactClassInterface.hasOwnProperty(name)
-          ? ReactClassInterface[name]
+        var specPolicy = ReactClassStaticInterface.hasOwnProperty(name)
+          ? ReactClassStaticInterface[name]
           : null;
 
         _invariant(

--- a/addons/create-react-class/package.json
+++ b/addons/create-react-class/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-class",
-  "version": "15.6.2",
+  "version": "15.6.3",
   "description": "Legacy API for creating React components.",
   "main": "index.js",
   "license": "MIT",

--- a/addons/create-react-class/test.js
+++ b/addons/create-react-class/test.js
@@ -522,4 +522,55 @@ describe('ReactClass-spec', () => {
         'to prevent memory leaks.'
     );
   });
+
+  it('should support getInitialState mixin', () => {
+    const Component = createReactClass({
+      mixins: [{
+        getInitialState: function(props) {
+          return {
+            foo: 'foo'
+          };
+        },
+      }],
+      getInitialState: function(props) {
+        return {
+          bar: 'bar'
+        };
+      },
+      render: function() {
+        return <div />;
+      }
+    });
+    const instance = renderIntoDocument(<Component />);
+    expect(instance.state.foo).toEqual('foo');
+    expect(instance.state.bar).toEqual('bar');
+  });
+
+  it('should merge return values for static getDerivedStateFromProps mixin', () => {
+    const Component = createReactClass({
+      mixins: [{
+        statics: {
+          getDerivedStateFromProps: function(props, prevState) {
+            return {
+              foo: 'foo'
+            };
+          }
+        },
+      }],
+      statics: {
+        getDerivedStateFromProps: function(props, prevState) {
+          return {
+            bar: 'bar'
+          };
+        }
+      },
+      render: function() {
+        return <div />;
+      }
+    });
+
+    const state = Component.getDerivedStateFromProps();
+    expect(state.foo).toEqual('foo');
+    expect(state.bar).toEqual('bar');
+  });
 });


### PR DESCRIPTION
This codemod corresponds with reactjs/rfcs/pull/6 and facebook/react/pull/12028

Make `create-react-class` factory aware of the new "UNSAFE_" lifecycle names so that:
* It warns about spelling error for `UNSAFE_componentWillRecieveProps`.
* It doesn't [trigger an invariant](https://github.com/facebook/react/blob/571a9208d5133e8737f565fe60b762d201f0d37c/addons/create-react-class/factory.js#L389-L398) if one of the new lifecycle names are mixed in as overrides.

I've built `addons/create-react-class` locally and compared it to the 15.6.2 release in NPM to verify that the only changes between the two are the additions I've made with this PR. This should make the release very low risk.