### PR TITLE
Fix copy paste error for file size comparison

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -106,7 +106,7 @@ fetch(commitURL(parentOfOldestCommit)).then(async response => {
     for (var name of new Set(packagesToShow)) {
       const thisBundleResults = results.filter(r => r.packageName === name);
       const changedFiles = thisBundleResults.filter(
-        r => r.prevGzipSizeChange !== 0 || r.prevGzipSizeChange !== 0
+        r => r.prevFileSizeChange !== 0 || r.prevGzipSizeChange !== 0
       );
 
       const mdHeaders = [


### PR DESCRIPTION
This PR fixes a copy paste error for file size comparison in #11865 (https://github.com/facebook/react/pull/11865#issuecomment-358642622).

I do not understand the tool chain well enough to make a test for this.


---

I found the error when looking through recent commits of this project on lgtm.com: https://lgtm.com/projects/g/facebook/react/

