### PR TITLE
[Danger] Use the PR's mergebase for a branch in the dangerfile

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -7,11 +7,30 @@
 
 'use strict';
 
+// Hi, if this is your first time editing/reading a Dangerfile, here's a summary:
+// It's a JS runtime which helps you provide continuous feedback inside GitHub.
+//
+// You can see the docs here: http://danger.systems/js/
+//
+// If you want to test changes Danger, I'd recommend checking out an existing PR
+// and then running the `danger pr` command.
+//
+// You'll need a GitHub token, you can re-use this one:
+//
+//  e622517d9f1136ea8900 07c6373666312cdfaa69
+//
+// (Just remove the space)
+//
+// So, for example:
+//
+// `DANGER_GITHUB_API_TOKEN=[ENV_ABOVE] yarn danger pr https://github.com/facebook/react/pull/11865
+
 const {markdown, danger} = require('danger');
 const fetch = require('node-fetch');
 
 const {generateResultsArray} = require('./scripts/rollup/stats');
 const {readFileSync} = require('fs');
+const {exec} = require('child_process');
 
 const currentBuildResults = JSON.parse(
   readFileSync('./scripts/rollup/results.json')
@@ -54,13 +73,51 @@ function setBoldness(row, isBold) {
   }
 }
 
-// Grab the results.json before we ran CI via the GH API
-// const baseMerge = danger.github.pr.base.sha
-const parentOfOldestCommit = danger.git.commits[0].parents[0];
-const commitURL = sha =>
-  `http://react.zpao.com/builds/master/_commits/${sha}/results.json`;
+/**
+ * Gets the commit that represents the merge between the current branch
+ * and master.
+ */
+function getMergeBase() {
+  return new Promise(res => {
+    exec('git merge-base HEAD master', (err, stdout, stderr) => {
+      if (err) {
+        throw err;
+      } else {
+        res(stdout.trim());
+      }
+    });
+  });
+}
 
-fetch(commitURL(parentOfOldestCommit)).then(async response => {
+/**
+ * Gets the commit that represents the merge between the current branch
+ * and master.
+ */
+function git(args) {
+  return new Promise(res => {
+    exec('git ' + args, (err, stdout, stderr) => {
+      if (err) {
+        throw err;
+      } else {
+        res(stdout.trim());
+      }
+    });
+  });
+}
+
+(async function() {
+  // Use git locally to grab the commit which represents the place
+  // where the branches differ
+  const logs = await git('fetch origin master');
+  markdown(`### git:\n\`\`\`sh\n${logs}\`\`\``);
+
+  const mergeBaseCommit = await getMergeBase();
+  const commitURL = sha =>
+    `http://react.zpao.com/builds/master/_commits/${sha}/results.json`;
+  const response = await fetch(commitURL(mergeBaseCommit));
+
+  // Take the JSON of the build response and
+  // make an array comparing the results for printing
   const previousBuildResults = await response.json();
   const results = generateResultsArray(
     currentBuildResults,
@@ -152,16 +209,16 @@ fetch(commitURL(parentOfOldestCommit)).then(async response => {
     }
 
     const summary = `
-<details>
-<summary>Details of bundled changes.</summary>
+  <details>
+  <summary>Details of bundled changes.</summary>
 
-<p>Comparing: ${parentOfOldestCommit}...${danger.github.pr.head.sha}</p>
+  <p>Comparing: ${mergeBaseCommit}...${danger.github.pr.head.sha}</p>
 
 
-${allTables.join('\n')}
+  ${allTables.join('\n')}
 
-</details>
-`;
+  </details>
+  `;
     markdown(summary);
   }
-});
+})();

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -78,15 +78,7 @@ function setBoldness(row, isBold) {
  * and master.
  */
 function getMergeBase() {
-  return new Promise(res => {
-    exec('git merge-base HEAD master', (err, stdout, stderr) => {
-      if (err) {
-        throw err;
-      } else {
-        res(stdout.trim());
-      }
-    });
-  });
+  return git('merge-base HEAD origin/master');
 }
 
 /**
@@ -108,9 +100,6 @@ function git(args) {
 (async function() {
   // Use git locally to grab the commit which represents the place
   // where the branches differ
-  const logs = await git('fetch origin master');
-  markdown(`### git:\n\`\`\`sh\n${logs}\`\`\``);
-
   const mergeBaseCommit = await getMergeBase();
   const commitURL = sha =>
     `http://react.zpao.com/builds/master/_commits/${sha}/results.json`;
@@ -131,6 +120,7 @@ function git(args) {
         Math.abs(r.prevFileSizeChange) > percentToWarrentShowing ||
         Math.abs(r.prevGzipSizeChange) > percentToWarrentShowing
     )
+
     .map(r => r.packageName);
 
   if (packagesToShow.length) {

--- a/scripts/circleci/test_entry_point.sh
+++ b/scripts/circleci/test_entry_point.sh
@@ -25,7 +25,7 @@ if [ $((2 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('./scripts/circleci/build.sh')
   COMMANDS_TO_RUN+=('yarn test-build --maxWorkers=2')
   COMMANDS_TO_RUN+=('yarn test-build-prod --maxWorkers=2')
-#  COMMANDS_TO_RUN+=('node ./scripts/tasks/danger')
+  COMMANDS_TO_RUN+=('node ./scripts/tasks/danger')
   COMMANDS_TO_RUN+=('./scripts/circleci/upload_build.sh')
 fi
 

--- a/scripts/rollup/stats.js
+++ b/scripts/rollup/stats.js
@@ -21,7 +21,13 @@ function saveResults() {
 }
 
 function percentChange(prev, current) {
-  return Math.floor((current - prev) / prev * 100);
+  const change = Math.floor((current - prev) / prev * 100);
+  // When a new package is created
+  if (isFinite(change)) {
+    return change;
+  } else {
+    return 100;
+  }
 }
 
 function percentChangeString(change) {


### PR DESCRIPTION
After chatting with @gaearon - we figured it made more sense to use the merge base for a PR to determine the build size changes instead of the parent commit of the first commit on the branch.

This does that, and adds some docs to the header. 

```sh
❯ yarn danger pr https://github.com/facebook/react/pull/12028
yarn run v1.3.2
$ /Users/orta/dev/projects/oss/js/react/node_modules/.bin/danger pr https://github.com/facebook/react/pull/12028
Starting Danger PR on facebook/react#12028

## Failures

## Warnings

## Messages

## Markdowns
ReactDOM: size: :small_red_triangle:+1%, gzip: :small_red_triangle:+2%
-

  <details>
  <summary>Details of bundled changes.</summary>

  <p>Comparing: bd6b533c29cc617b4ddfc0a8b623e782c468cd52...8d67e27dbd52eec339543486a8997a2a3a9094ae</p>

  [snip]
```