### PR TITLE
Highlight production bundles in bold in the Danger integration comment

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -36,16 +36,22 @@ function generateMDTable(headers, body) {
  * Generates a user-readable string from a percentage change
  * @param {string[]} headers
  */
-function emojiPercent(change) {
-  if (change > 0) {
+function addPercent(change, includeEmoji) {
+  if (change > 0 && includeEmoji) {
     return `:small_red_triangle:+${change}%`;
-  } else if (change <= 0) {
+  } else if (change > 0) {
+    return `+${change}%`;
+  } else {
     return `${change}%`;
   }
 }
 
-function boldRow(row) {
-  return row.map(element => `**${element}**`);
+function setBoldness(row, isProd) {
+  if (isProd) {
+    return row.map(element => `**${element}**`);
+  } else {
+    return row;
+  }
 }
 
 // Grab the results.json before we ran CI via the GH API
@@ -84,8 +90,8 @@ fetch(commitURL(parentOfOldestCommit)).then(async response => {
         reactProd.prevFileSizeChange !== 0 ||
         reactProd.prevGzipSizeChange !== 0
       ) {
-        const changeSize = emojiPercent(reactProd.prevFileSizeChange);
-        const changeGzip = emojiPercent(reactProd.prevGzipSizeChange);
+        const changeSize = addPercent(reactProd.prevFileSizeChange, true);
+        const changeGzip = addPercent(reactProd.prevGzipSizeChange, true);
         markdown(`React: size: ${changeSize}, gzip: ${changeGzip}`);
       }
     }
@@ -98,8 +104,8 @@ fetch(commitURL(parentOfOldestCommit)).then(async response => {
         reactDOMProd.prevFileSizeChange !== 0 ||
         reactDOMProd.prevGzipSizeChange !== 0
       ) {
-        const changeSize = emojiPercent(reactDOMProd.prevFileSizeChange);
-        const changeGzip = emojiPercent(reactDOMProd.prevGzipSizeChange);
+        const changeSize = addPercent(reactDOMProd.prevFileSizeChange, true);
+        const changeGzip = addPercent(reactDOMProd.prevGzipSizeChange, true);
         markdown(`ReactDOM: size: ${changeSize}, gzip: ${changeGzip}`);
       }
     }
@@ -124,30 +130,22 @@ fetch(commitURL(parentOfOldestCommit)).then(async response => {
         'ENV',
       ];
 
-      const mdRows = changedFiles.map(
-        r =>
-          r.bundleType.includes('PROD')
-            ? boldRow([
-                r.filename,
-                emojiPercent(r.prevFileSizeChange),
-                emojiPercent(r.prevGzipSizeChange),
-                r.prevSize,
-                r.prevFileSize,
-                r.prevGzip,
-                r.prevGzipSize,
-                r.bundleType,
-              ])
-            : [
-                r.filename,
-                r.prevFileSizeChange,
-                r.prevGzipSizeChange,
-                r.prevSize,
-                r.prevFileSize,
-                r.prevGzip,
-                r.prevGzipSize,
-                r.bundleType,
-              ]
-      );
+      const mdRows = changedFiles.map(r => {
+        const isProd = r.bundleType.includes('PROD');
+        return setBoldness(
+          [
+            r.filename,
+            addPercent(r.prevFileSizeChange, isProd),
+            addPercent(r.prevGzipSizeChange, isProd),
+            r.prevSize,
+            r.prevFileSize,
+            r.prevGzip,
+            r.prevGzipSize,
+            r.bundleType,
+          ],
+          isProd
+        );
+      });
 
       allTables.push(`\n## ${name}`);
       allTables.push(generateMDTable(mdHeaders, mdRows));

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -44,6 +44,10 @@ function emojiPercent(change) {
   }
 }
 
+function boldRow(row) {
+  return row.map(element => `**${element}**`);
+}
+
 // Grab the results.json before we ran CI via the GH API
 // const baseMerge = danger.github.pr.base.sha
 const parentOfOldestCommit = danger.git.commits[0].parents[0];
@@ -120,16 +124,29 @@ fetch(commitURL(parentOfOldestCommit)).then(async response => {
         'ENV',
       ];
 
-      const mdRows = changedFiles.map(r => [
-        r.filename,
-        emojiPercent(r.prevFileSizeChange),
-        emojiPercent(r.prevGzipSizeChange),
-        r.prevSize,
-        r.prevFileSize,
-        r.prevGzip,
-        r.prevGzipSize,
-        r.bundleType,
-      ]);
+      const mdRows = changedFiles.map(r =>
+        r.bundleType.includes('PROD') ?
+         boldRow([
+            r.filename,
+            emojiPercent(r.prevFileSizeChange),
+            emojiPercent(r.prevGzipSizeChange),
+            r.prevSize,
+            r.prevFileSize,
+            r.prevGzip,
+            r.prevGzipSize,
+            r.bundleType,
+          ]) :
+          [
+            r.filename,
+            r.prevFileSizeChange,
+            r.prevGzipSizeChange,
+            r.prevSize,
+            r.prevFileSize,
+            r.prevGzip,
+            r.prevGzipSize,
+            r.bundleType,
+          ]
+       );
 
       allTables.push(`\n## ${name}`);
       allTables.push(generateMDTable(mdHeaders, mdRows));

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -46,8 +46,8 @@ function addPercent(change, includeEmoji) {
   }
 }
 
-function setBoldness(row, isProd) {
-  if (isProd) {
+function setBoldness(row, isBold) {
+  if (isBold) {
     return row.map(element => `**${element}**`);
   } else {
     return row;

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -124,29 +124,30 @@ fetch(commitURL(parentOfOldestCommit)).then(async response => {
         'ENV',
       ];
 
-      const mdRows = changedFiles.map(r =>
-        r.bundleType.includes('PROD') ?
-         boldRow([
-            r.filename,
-            emojiPercent(r.prevFileSizeChange),
-            emojiPercent(r.prevGzipSizeChange),
-            r.prevSize,
-            r.prevFileSize,
-            r.prevGzip,
-            r.prevGzipSize,
-            r.bundleType,
-          ]) :
-          [
-            r.filename,
-            r.prevFileSizeChange,
-            r.prevGzipSizeChange,
-            r.prevSize,
-            r.prevFileSize,
-            r.prevGzip,
-            r.prevGzipSize,
-            r.bundleType,
-          ]
-       );
+      const mdRows = changedFiles.map(
+        r =>
+          r.bundleType.includes('PROD')
+            ? boldRow([
+                r.filename,
+                emojiPercent(r.prevFileSizeChange),
+                emojiPercent(r.prevGzipSizeChange),
+                r.prevSize,
+                r.prevFileSize,
+                r.prevGzip,
+                r.prevGzipSize,
+                r.bundleType,
+              ])
+            : [
+                r.filename,
+                r.prevFileSizeChange,
+                r.prevGzipSizeChange,
+                r.prevSize,
+                r.prevFileSize,
+                r.prevGzip,
+                r.prevGzipSize,
+                r.bundleType,
+              ]
+      );
 
       allTables.push(`\n## ${name}`);
       allTables.push(generateMDTable(mdHeaders, mdRows));


### PR DESCRIPTION
This PR modified Danger integration comment:

- change the output so that production bundles are bold in the results
- remove the red triangle on increase from the development bundles

address #[12043]