### PR TITLE
Warn if unsafe lifecycle methods are found in an async subtree

### DIFF
--- a/packages/react-call-return/src/__tests__/ReactCallReturn-test.js
+++ b/packages/react-call-return/src/__tests__/ReactCallReturn-test.js
@@ -291,9 +291,8 @@ describe('ReactCallReturn', () => {
       </Call>,
     );
     expect(ReactNoop.flush).toWarnDev(
-      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: Return',
+      'UNSAFE_componentWillMount: Please update the following components ' +
+        'to use componentDidMount instead: Return',
     );
 
     expect(ops).toEqual([

--- a/packages/react-call-return/src/__tests__/ReactCallReturn-test.js
+++ b/packages/react-call-return/src/__tests__/ReactCallReturn-test.js
@@ -291,7 +291,7 @@ describe('ReactCallReturn', () => {
       </Call>,
     );
     expect(ReactNoop.flush).toWarnDev(
-      'UNSAFE_componentWillMount: Please update the following components ' +
+      'componentWillMount: Please update the following components ' +
         'to use componentDidMount instead: Return',
     );
 

--- a/packages/react-call-return/src/__tests__/ReactCallReturn-test.js
+++ b/packages/react-call-return/src/__tests__/ReactCallReturn-test.js
@@ -291,7 +291,9 @@ describe('ReactCallReturn', () => {
       </Call>,
     );
     expect(ReactNoop.flush).toWarnDev(
-      'Return: An unsafe lifecycle method, UNSAFE_componentWillMount, has been detected in an async tree.',
+      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: Return',
     );
 
     expect(ops).toEqual([

--- a/packages/react-call-return/src/__tests__/ReactCallReturn-test.js
+++ b/packages/react-call-return/src/__tests__/ReactCallReturn-test.js
@@ -290,7 +290,9 @@ describe('ReactCallReturn', () => {
         <Return value={2} />
       </Call>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'Return: An unsafe lifecycle method, UNSAFE_componentWillMount, has been detected in an async tree.',
+    );
 
     expect(ops).toEqual([
       'Mount Return 1',

--- a/packages/react-reconciler/src/ReactDebugAsyncWarnings.js
+++ b/packages/react-reconciler/src/ReactDebugAsyncWarnings.js
@@ -24,7 +24,8 @@ type FiberToLifecycleMap = Map<Fiber, LifecycleToComponentsMap>;
 const DID_WARN_KEY = '__didWarnAboutUnsafeAsyncLifecycles';
 
 const ReactDebugAsyncWarnings = {
-  flushPendingAsyncWarnings(maybeAsyncRoot: Fiber): void {},
+  discardPendingWarnings(): void {},
+  flushPendingAsyncWarnings(): void {},
   recordLifecycleWarnings(fiber: Fiber, instance: any): void {},
 };
 
@@ -37,15 +38,13 @@ if (__DEV__) {
 
   let pendingWarningsMap: FiberToLifecycleMap = new Map();
 
-  ReactDebugAsyncWarnings.flushPendingAsyncWarnings = (
-    maybeAsyncRoot: Fiber,
-  ) => {
+  ReactDebugAsyncWarnings.discardPendingWarnings = () => {
+    pendingWarningsMap = new Map();
+  };
+
+  ReactDebugAsyncWarnings.flushPendingAsyncWarnings = () => {
     ((pendingWarningsMap: any): FiberToLifecycleMap).forEach(
       (lifecycleWarningsMap, asyncRoot) => {
-        if (asyncRoot !== maybeAsyncRoot) {
-          return;
-        }
-
         const lifecyclesWarningMesages = [];
 
         Object.keys(lifecycleWarningsMap).forEach(lifecycle => {
@@ -85,10 +84,10 @@ if (__DEV__) {
             lifecyclesWarningMesages.join('\n\n'),
           );
         }
-
-        pendingWarningsMap.delete(asyncRoot);
       },
     );
+
+    pendingWarningsMap = new Map();
   };
 
   const getAsyncRoot = (fiber: Fiber): Fiber => {

--- a/packages/react-reconciler/src/ReactDebugAsyncWarnings.js
+++ b/packages/react-reconciler/src/ReactDebugAsyncWarnings.js
@@ -57,13 +57,15 @@ if (__DEV__) {
               fiber.type[DID_WARN_KEY] = true;
             });
 
+            const formatted = lifecycle.replace('UNSAFE_', '');
             const suggestion = LIFECYCLE_SUGGESTIONS[lifecycle];
+            const sortedComponentNames = Array.from(componentNames)
+              .sort()
+              .join(', ');
 
             lifecyclesWarningMesages.push(
-              `${lifecycle}: Please update the following components to use ` +
-                `${suggestion} instead: ${Array.from(componentNames)
-                  .sort()
-                  .join(', ')}`,
+              `${formatted}: Please update the following components to use ` +
+                `${suggestion} instead: ${sortedComponentNames}`,
             );
           }
         });

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -46,6 +46,9 @@ let didWarnAboutLegacyWillReceiveProps;
 let didWarnAboutLegacyWillUpdate;
 let didWarnAboutStateAssignmentForComponent;
 let didWarnAboutUndefinedDerivedState;
+let didWarnAboutUnsafeWillMountInAsyncTree;
+let didWarnAboutUnsafeWillReceivePropsInAsyncTree;
+let didWarnAboutUnsafeWillUpdateInAsyncTree;
 let didWarnAboutUninitializedState;
 let didWarnAboutWillReceivePropsAndDerivedState;
 let warnOnInvalidCallback;
@@ -59,6 +62,9 @@ if (__DEV__) {
   didWarnAboutStateAssignmentForComponent = {};
   didWarnAboutUndefinedDerivedState = {};
   didWarnAboutUninitializedState = {};
+  didWarnAboutUnsafeWillMountInAsyncTree = {};
+  didWarnAboutUnsafeWillReceivePropsInAsyncTree = {};
+  didWarnAboutUnsafeWillUpdateInAsyncTree = {};
   didWarnAboutWillReceivePropsAndDerivedState = {};
 
   const didWarnOnInvalidCallback = {};
@@ -506,6 +512,22 @@ export default function(
     newProps,
     newContext,
   ) {
+    if (__DEV__) {
+      if (workInProgress.internalContextTag & AsyncUpdates) {
+        const componentName = getComponentName(workInProgress) || 'Component';
+        if (!didWarnAboutUnsafeWillReceivePropsInAsyncTree[componentName]) {
+          warning(
+            false,
+            '%s: An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
+              'has been detected in an async tree. ' +
+              'Learn more at https://fb.me/react-async-component-lifecycle-hooks',
+            componentName,
+          );
+          didWarnAboutUnsafeWillReceivePropsInAsyncTree[componentName] = true;
+        }
+      }
+    }
+
     const oldState = instance.state;
     if (typeof instance.componentWillReceiveProps === 'function') {
       if (__DEV__) {
@@ -646,6 +668,22 @@ export default function(
       typeof instance.UNSAFE_componentWillMount === 'function' ||
       typeof instance.componentWillMount === 'function'
     ) {
+      if (__DEV__) {
+        if (workInProgress.internalContextTag & AsyncUpdates) {
+          const componentName = getComponentName(workInProgress) || 'Component';
+          if (!didWarnAboutUnsafeWillMountInAsyncTree[componentName]) {
+            warning(
+              false,
+              '%s: An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
+                'has been detected in an async tree. ' +
+                'Learn more at https://fb.me/react-async-component-lifecycle-hooks',
+              componentName,
+            );
+            didWarnAboutUnsafeWillMountInAsyncTree[componentName] = true;
+          }
+        }
+      }
+
       callComponentWillMount(workInProgress, instance);
       // If we had additional state updates during this life-cycle, let's
       // process them now.
@@ -875,6 +913,23 @@ export default function(
         typeof instance.UNSAFE_componentWillUpdate === 'function' ||
         typeof instance.componentWillUpdate === 'function'
       ) {
+        if (__DEV__) {
+          if (workInProgress.internalContextTag & AsyncUpdates) {
+            const componentName =
+              getComponentName(workInProgress) || 'Component';
+            if (!didWarnAboutUnsafeWillUpdateInAsyncTree[componentName]) {
+              warning(
+                false,
+                '%s: An unsafe lifecycle method, UNSAFE_componentWillUpdate, ' +
+                  'has been detected in an async tree. ' +
+                  'Learn more at https://fb.me/react-async-component-lifecycle-hooks',
+                componentName,
+              );
+              didWarnAboutUnsafeWillUpdateInAsyncTree[componentName] = true;
+            }
+          }
+        }
+
         if (typeof instance.componentWillUpdate === 'function') {
           if (__DEV__) {
             if (warnAboutDeprecatedLifecycles) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -16,6 +16,7 @@ import type {ExpirationTime} from './ReactFiberExpirationTime';
 import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
 import ReactErrorUtils from 'shared/ReactErrorUtils';
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
+import ReactDebugAsyncWarnings from './ReactDebugAsyncWarnings';
 import {
   PerformedWork,
   Placement,
@@ -543,6 +544,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       );
       if (__DEV__) {
         ReactDebugCurrentFiber.resetCurrentFiber();
+        ReactDebugAsyncWarnings.flushPendingAsyncWarnings();
       }
 
       const returnFiber = workInProgress.return;

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -311,6 +311,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   }
 
   function commitAllLifeCycles() {
+    if (__DEV__) {
+      ReactDebugAsyncWarnings.flushPendingAsyncWarnings();
+    }
+
     while (nextEffect !== null) {
       const effectTag = nextEffect.effectTag;
 
@@ -544,7 +548,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       );
       if (__DEV__) {
         ReactDebugCurrentFiber.resetCurrentFiber();
-        ReactDebugAsyncWarnings.flushPendingAsyncWarnings(workInProgress);
       }
 
       const returnFiber = workInProgress.return;
@@ -653,6 +656,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   }
 
   function performFailedUnitOfWork(workInProgress: Fiber): Fiber | null {
+    if (__DEV__) {
+      ReactDebugAsyncWarnings.discardPendingWarnings();
+    }
+
     // The current, flushed, state of this fiber is the alternate.
     // Ideally nothing should rely on this, but relying on it here
     // means that we don't need an additional field on the work in

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -544,7 +544,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       );
       if (__DEV__) {
         ReactDebugCurrentFiber.resetCurrentFiber();
-        ReactDebugAsyncWarnings.flushPendingAsyncWarnings();
+        ReactDebugAsyncWarnings.flushPendingAsyncWarnings(workInProgress);
       }
 
       const returnFiber = workInProgress.return;

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -1430,8 +1430,8 @@ describe('ReactIncremental', () => {
       changeState() {
         this.setState({foo: 'bar'});
       }
-      componentWillUpdate() {
-        ops.push('componentWillUpdate');
+      componentDidUpdate() {
+        ops.push('componentDidUpdate');
       }
       render() {
         ops.push('render');
@@ -1451,7 +1451,7 @@ describe('ReactIncremental', () => {
     instance.changeState();
     ReactNoop.flush();
 
-    expect(ops).toEqual(['componentWillUpdate', 'render']);
+    expect(ops).toEqual(['render', 'componentDidUpdate']);
     expect(instance.state).toEqual({foo: 'bar'});
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -2336,9 +2336,8 @@ describe('ReactIncremental', () => {
 
     ReactNoop.render(<MyComponent />);
     expect(ReactNoop.flush).toWarnDev(
-      'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: MyComponent',
+      'UNSAFE_componentWillReceiveProps: Please update the following components ' +
+        'to use static getDerivedStateFromProps instead: MyComponent',
     );
 
     expect(ops).toEqual([

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -2336,7 +2336,7 @@ describe('ReactIncremental', () => {
 
     ReactNoop.render(<MyComponent />);
     expect(ReactNoop.flush).toWarnDev(
-      'UNSAFE_componentWillReceiveProps: Please update the following components ' +
+      'componentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: MyComponent',
     );
 

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -2335,7 +2335,11 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<MyComponent />);
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: MyComponent',
+    );
 
     expect(ops).toEqual([
       'render',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
@@ -49,8 +49,9 @@ describe('ReactIncrementalErrorLogging', () => {
 
     expect(() => {
       expect(ReactNoop.flushDeferredPri).toWarnDev([
-        'ErrorThrowingComponent: An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-          'has been detected in an async tree.',
+        'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
+          'has been detected within an async tree. ' +
+          'Please update the following components: ErrorThrowingComponent',
         'The above error occurred in the <ErrorThrowingComponent> component:\n' +
           '    in ErrorThrowingComponent (at **)\n' +
           '    in span (at **)\n' +

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
@@ -48,13 +48,15 @@ describe('ReactIncrementalErrorLogging', () => {
     );
 
     expect(() => {
-      expect(ReactNoop.flushDeferredPri).toWarnDev(
+      expect(ReactNoop.flushDeferredPri).toWarnDev([
+        'ErrorThrowingComponent: An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
+          'has been detected in an async tree.',
         'The above error occurred in the <ErrorThrowingComponent> component:\n' +
           '    in ErrorThrowingComponent (at **)\n' +
           '    in span (at **)\n' +
           '    in div (at **)\n\n' +
           'Consider adding an error boundary to your tree to customize error handling behavior.',
-      );
+      ]);
     }).toThrowError('componentWillMount error');
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
@@ -49,7 +49,7 @@ describe('ReactIncrementalErrorLogging', () => {
 
     expect(() => {
       expect(ReactNoop.flushDeferredPri).toWarnDev([
-        'UNSAFE_componentWillMount: Please update the following components ' +
+        'componentWillMount: Please update the following components ' +
           'to use componentDidMount instead: ErrorThrowingComponent',
         'The above error occurred in the <ErrorThrowingComponent> component:\n' +
           '    in ErrorThrowingComponent (at **)\n' +

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
@@ -48,15 +48,13 @@ describe('ReactIncrementalErrorLogging', () => {
     );
 
     expect(() => {
-      expect(ReactNoop.flushDeferredPri).toWarnDev([
-        'componentWillMount: Please update the following components ' +
-          'to use componentDidMount instead: ErrorThrowingComponent',
+      expect(ReactNoop.flushDeferredPri).toWarnDev(
         'The above error occurred in the <ErrorThrowingComponent> component:\n' +
           '    in ErrorThrowingComponent (at **)\n' +
           '    in span (at **)\n' +
           '    in div (at **)\n\n' +
           'Consider adding an error boundary to your tree to customize error handling behavior.',
-      ]);
+      );
     }).toThrowError('componentWillMount error');
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.internal.js
@@ -49,9 +49,8 @@ describe('ReactIncrementalErrorLogging', () => {
 
     expect(() => {
       expect(ReactNoop.flushDeferredPri).toWarnDev([
-        'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-          'has been detected within an async tree. ' +
-          'Please update the following components: ErrorThrowingComponent',
+        'UNSAFE_componentWillMount: Please update the following components ' +
+          'to use componentDidMount instead: ErrorThrowingComponent',
         'The above error occurred in the <ErrorThrowingComponent> component:\n' +
           '    in ErrorThrowingComponent (at **)\n' +
           '    in span (at **)\n' +

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -255,9 +255,9 @@ describe('ReactDebugFiberPerf', () => {
     );
     addComment('Should not print a warning');
     expect(ReactNoop.flush).toWarnDev([
-      'UNSAFE_componentWillMount: Please update the following components ' +
+      'componentWillMount: Please update the following components ' +
         'to use componentDidMount instead: NotCascading' +
-        '\n\nUNSAFE_componentWillReceiveProps: Please update the following components ' +
+        '\n\ncomponentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: NotCascading',
     ]);
     ReactNoop.render(
@@ -294,11 +294,11 @@ describe('ReactDebugFiberPerf', () => {
     ReactNoop.render(<AllLifecycles />);
     addComment('Mount');
     expect(ReactNoop.flush).toWarnDev(
-      'UNSAFE_componentWillMount: Please update the following components ' +
+      'componentWillMount: Please update the following components ' +
         'to use componentDidMount instead: AllLifecycles' +
-        '\n\nUNSAFE_componentWillReceiveProps: Please update the following components ' +
+        '\n\ncomponentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: AllLifecycles' +
-        '\n\nUNSAFE_componentWillUpdate: Please update the following components ' +
+        '\n\ncomponentWillUpdate: Please update the following components ' +
         'to use componentDidUpdate instead: AllLifecycles',
     );
     ReactNoop.render(<AllLifecycles />);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -254,14 +254,20 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Should not print a warning');
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'NotCascading: An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
+        'has been detected in an async tree.',
+    );
     ReactNoop.render(
       <Parent>
         <NotCascading />
       </Parent>,
     );
     addComment('Should not print a warning');
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'NotCascading: An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
+        'has been detected in an async tree.',
+    );
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -288,10 +294,18 @@ describe('ReactDebugFiberPerf', () => {
     }
     ReactNoop.render(<AllLifecycles />);
     addComment('Mount');
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'AllLifecycles: An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
+        'has been detected in an async tree.',
+    );
     ReactNoop.render(<AllLifecycles />);
     addComment('Update');
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev([
+      'AllLifecycles: An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
+        'has been detected in an async tree.',
+      'AllLifecycles: An unsafe lifecycle method, UNSAFE_componentWillUpdate, ' +
+        'has been detected in an async tree.',
+    ]);
     ReactNoop.render(null);
     addComment('Unmount');
     ReactNoop.flush();

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -254,20 +254,21 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Should not print a warning');
-    expect(ReactNoop.flush).toWarnDev(
-      'NotCascading: An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-        'has been detected in an async tree.',
-    );
+    expect(ReactNoop.flush).toWarnDev([
+      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: NotCascading',
+      'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: NotCascading',
+    ]);
     ReactNoop.render(
       <Parent>
         <NotCascading />
       </Parent>,
     );
     addComment('Should not print a warning');
-    expect(ReactNoop.flush).toWarnDev(
-      'NotCascading: An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
-        'has been detected in an async tree.',
-    );
+    ReactNoop.flush();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -294,18 +295,20 @@ describe('ReactDebugFiberPerf', () => {
     }
     ReactNoop.render(<AllLifecycles />);
     addComment('Mount');
-    expect(ReactNoop.flush).toWarnDev(
-      'AllLifecycles: An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-        'has been detected in an async tree.',
-    );
+    expect(ReactNoop.flush).toWarnDev([
+      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: AllLifecycles',
+      'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: AllLifecycles',
+      'An unsafe lifecycle method, UNSAFE_componentWillUpdate, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: AllLifecycles',
+    ]);
     ReactNoop.render(<AllLifecycles />);
     addComment('Update');
-    expect(ReactNoop.flush).toWarnDev([
-      'AllLifecycles: An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
-        'has been detected in an async tree.',
-      'AllLifecycles: An unsafe lifecycle method, UNSAFE_componentWillUpdate, ' +
-        'has been detected in an async tree.',
-    ]);
+    ReactNoop.flush();
     ReactNoop.render(null);
     addComment('Unmount');
     ReactNoop.flush();

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -255,12 +255,10 @@ describe('ReactDebugFiberPerf', () => {
     );
     addComment('Should not print a warning');
     expect(ReactNoop.flush).toWarnDev([
-      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: NotCascading',
-      'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: NotCascading',
+      'UNSAFE_componentWillMount: Please update the following components ' +
+        'to use componentDidMount instead: NotCascading' +
+        '\n\nUNSAFE_componentWillReceiveProps: Please update the following components ' +
+        'to use static getDerivedStateFromProps instead: NotCascading',
     ]);
     ReactNoop.render(
       <Parent>
@@ -295,17 +293,14 @@ describe('ReactDebugFiberPerf', () => {
     }
     ReactNoop.render(<AllLifecycles />);
     addComment('Mount');
-    expect(ReactNoop.flush).toWarnDev([
-      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: AllLifecycles',
-      'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: AllLifecycles',
-      'An unsafe lifecycle method, UNSAFE_componentWillUpdate, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: AllLifecycles',
-    ]);
+    expect(ReactNoop.flush).toWarnDev(
+      'UNSAFE_componentWillMount: Please update the following components ' +
+        'to use componentDidMount instead: AllLifecycles' +
+        '\n\nUNSAFE_componentWillReceiveProps: Please update the following components ' +
+        'to use static getDerivedStateFromProps instead: AllLifecycles' +
+        '\n\nUNSAFE_componentWillUpdate: Please update the following components ' +
+        'to use componentDidUpdate instead: AllLifecycles',
+    );
     ReactNoop.render(<AllLifecycles />);
     addComment('Update');
     ReactNoop.flush();

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
@@ -50,9 +50,7 @@ describe('ReactIncrementalReflection', () => {
     ReactNoop.render(<Foo />);
 
     // Render part way through but don't yet commit the updates.
-    expect(() => ReactNoop.flushDeferredPri(20)).toWarnDev(
-      'Component: An unsafe lifecycle method, UNSAFE_componentWillMount, has been detected in an async tree.',
-    );
+    ReactNoop.flushDeferredPri(20);
 
     expect(ops).toEqual(['componentWillMount', false]);
 
@@ -61,7 +59,11 @@ describe('ReactIncrementalReflection', () => {
     ops = [];
 
     // Render the rest and commit the updates.
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: Component',
+    );
 
     expect(ops).toEqual(['componentDidMount', true]);
 
@@ -100,7 +102,9 @@ describe('ReactIncrementalReflection', () => {
 
     ReactNoop.render(<Foo mount={true} />);
     expect(ReactNoop.flush).toWarnDev(
-      'Component: An unsafe lifecycle method, UNSAFE_componentWillMount, has been detected in an async tree.',
+      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: Component',
     );
 
     expect(ops).toEqual(['Component']);
@@ -172,9 +176,14 @@ describe('ReactIncrementalReflection', () => {
 
     ReactNoop.render(<Foo step={0} />);
     // Flush past Component but don't complete rendering everything yet.
-    expect(() => ReactNoop.flushDeferredPri(30)).toWarnDev(
-      'Component: An unsafe lifecycle method, UNSAFE_componentWillMount, has been detected in an async tree.',
-    );
+    expect(() => ReactNoop.flushDeferredPri(30)).toWarnDev([
+      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: Component',
+      'An unsafe lifecycle method, UNSAFE_componentWillUpdate, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: Component',
+    ]);
 
     expect(ops).toEqual([
       'componentWillMount',
@@ -204,9 +213,7 @@ describe('ReactIncrementalReflection', () => {
     // Flush next step which will cause an update but not yet render a new host
     // node.
     ReactNoop.render(<Foo step={1} />);
-    expect(ReactNoop.flush).toWarnDev(
-      'Component: An unsafe lifecycle method, UNSAFE_componentWillUpdate, has been detected in an async tree.',
-    );
+    ReactNoop.flush();
 
     expect(ops).toEqual([
       'componentWillUpdate',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
@@ -174,12 +174,7 @@ describe('ReactIncrementalReflection', () => {
 
     ReactNoop.render(<Foo step={0} />);
     // Flush past Component but don't complete rendering everything yet.
-    expect(() => ReactNoop.flushDeferredPri(30)).toWarnDev(
-      'UNSAFE_componentWillMount: Please update the following components ' +
-        'to use componentDidMount instead: Component' +
-        '\n\nUNSAFE_componentWillUpdate: Please update the following components ' +
-        'to use componentDidUpdate instead: Component',
-    );
+    ReactNoop.flushDeferredPri(30);
 
     expect(ops).toEqual([
       'componentWillMount',
@@ -195,7 +190,12 @@ describe('ReactIncrementalReflection', () => {
     // not find any host nodes in it.
     expect(ReactNoop.findInstance(classInstance)).toBe(null);
 
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'UNSAFE_componentWillMount: Please update the following components ' +
+        'to use componentDidMount instead: Component' +
+        '\n\nUNSAFE_componentWillUpdate: Please update the following components ' +
+        'to use componentDidUpdate instead: Component',
+    );
 
     const hostSpan = classInstance.span;
     expect(hostSpan).toBeDefined();

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
@@ -60,9 +60,8 @@ describe('ReactIncrementalReflection', () => {
 
     // Render the rest and commit the updates.
     expect(ReactNoop.flush).toWarnDev(
-      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: Component',
+      'UNSAFE_componentWillMount: Please update the following components ' +
+        'to use componentDidMount instead: Component',
     );
 
     expect(ops).toEqual(['componentDidMount', true]);
@@ -102,9 +101,8 @@ describe('ReactIncrementalReflection', () => {
 
     ReactNoop.render(<Foo mount={true} />);
     expect(ReactNoop.flush).toWarnDev(
-      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: Component',
+      'UNSAFE_componentWillMount: Please update the following components ' +
+        'to use componentDidMount instead: Component',
     );
 
     expect(ops).toEqual(['Component']);
@@ -176,14 +174,12 @@ describe('ReactIncrementalReflection', () => {
 
     ReactNoop.render(<Foo step={0} />);
     // Flush past Component but don't complete rendering everything yet.
-    expect(() => ReactNoop.flushDeferredPri(30)).toWarnDev([
-      'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: Component',
-      'An unsafe lifecycle method, UNSAFE_componentWillUpdate, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: Component',
-    ]);
+    expect(() => ReactNoop.flushDeferredPri(30)).toWarnDev(
+      'UNSAFE_componentWillMount: Please update the following components ' +
+        'to use componentDidMount instead: Component' +
+        '\n\nUNSAFE_componentWillUpdate: Please update the following components ' +
+        'to use componentDidUpdate instead: Component',
+    );
 
     expect(ops).toEqual([
       'componentWillMount',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
@@ -60,7 +60,7 @@ describe('ReactIncrementalReflection', () => {
 
     // Render the rest and commit the updates.
     expect(ReactNoop.flush).toWarnDev(
-      'UNSAFE_componentWillMount: Please update the following components ' +
+      'componentWillMount: Please update the following components ' +
         'to use componentDidMount instead: Component',
     );
 
@@ -101,7 +101,7 @@ describe('ReactIncrementalReflection', () => {
 
     ReactNoop.render(<Foo mount={true} />);
     expect(ReactNoop.flush).toWarnDev(
-      'UNSAFE_componentWillMount: Please update the following components ' +
+      'componentWillMount: Please update the following components ' +
         'to use componentDidMount instead: Component',
     );
 
@@ -191,9 +191,9 @@ describe('ReactIncrementalReflection', () => {
     expect(ReactNoop.findInstance(classInstance)).toBe(null);
 
     expect(ReactNoop.flush).toWarnDev(
-      'UNSAFE_componentWillMount: Please update the following components ' +
+      'componentWillMount: Please update the following components ' +
         'to use componentDidMount instead: Component' +
-        '\n\nUNSAFE_componentWillUpdate: Please update the following components ' +
+        '\n\ncomponentWillUpdate: Please update the following components ' +
         'to use componentDidUpdate instead: Component',
     );
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
@@ -50,7 +50,9 @@ describe('ReactIncrementalReflection', () => {
     ReactNoop.render(<Foo />);
 
     // Render part way through but don't yet commit the updates.
-    ReactNoop.flushDeferredPri(20);
+    expect(() => ReactNoop.flushDeferredPri(20)).toWarnDev(
+      'Component: An unsafe lifecycle method, UNSAFE_componentWillMount, has been detected in an async tree.',
+    );
 
     expect(ops).toEqual(['componentWillMount', false]);
 
@@ -97,7 +99,9 @@ describe('ReactIncrementalReflection', () => {
     }
 
     ReactNoop.render(<Foo mount={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'Component: An unsafe lifecycle method, UNSAFE_componentWillMount, has been detected in an async tree.',
+    );
 
     expect(ops).toEqual(['Component']);
     ops = [];
@@ -168,7 +172,9 @@ describe('ReactIncrementalReflection', () => {
 
     ReactNoop.render(<Foo step={0} />);
     // Flush past Component but don't complete rendering everything yet.
-    ReactNoop.flushDeferredPri(30);
+    expect(() => ReactNoop.flushDeferredPri(30)).toWarnDev(
+      'Component: An unsafe lifecycle method, UNSAFE_componentWillMount, has been detected in an async tree.',
+    );
 
     expect(ops).toEqual([
       'componentWillMount',
@@ -198,7 +204,9 @@ describe('ReactIncrementalReflection', () => {
     // Flush next step which will cause an update but not yet render a new host
     // node.
     ReactNoop.render(<Foo step={1} />);
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'Component: An unsafe lifecycle method, UNSAFE_componentWillUpdate, has been detected in an async tree.',
+    );
 
     expect(ops).toEqual([
       'componentWillUpdate',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
@@ -346,17 +346,16 @@ describe('ReactIncrementalScheduling', () => {
     }
 
     ReactNoop.render(<Foo step={1} />);
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
+        'has been detected within an async tree. ' +
+        'Please update the following components: Foo',
+    );
 
     ReactNoop.render(<Foo step={2} />);
-    expect(() => {
-      expect(ReactNoop.flush()).toEqual([
-        'has callback before setState: false',
-        'has callback after setState: false',
-      ]);
-    }).toWarnDev(
-      'Foo: An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
-        'has been detected in an async tree.',
-    );
+    expect(ReactNoop.flush()).toEqual([
+      'has callback before setState: false',
+      'has callback after setState: false',
+    ]);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
@@ -349,9 +349,14 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.flush();
 
     ReactNoop.render(<Foo step={2} />);
-    expect(ReactNoop.flush()).toEqual([
-      'has callback before setState: false',
-      'has callback after setState: false',
-    ]);
+    expect(() => {
+      expect(ReactNoop.flush()).toEqual([
+        'has callback before setState: false',
+        'has callback after setState: false',
+      ]);
+    }).toWarnDev(
+      'Foo: An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
+        'has been detected in an async tree.',
+    );
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
@@ -347,9 +347,8 @@ describe('ReactIncrementalScheduling', () => {
 
     ReactNoop.render(<Foo step={1} />);
     expect(ReactNoop.flush).toWarnDev(
-      'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
-        'has been detected within an async tree. ' +
-        'Please update the following components: Foo',
+      'UNSAFE_componentWillReceiveProps: Please update the following components ' +
+        'to use static getDerivedStateFromProps instead: Foo',
     );
 
     ReactNoop.render(<Foo step={2} />);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
@@ -347,7 +347,7 @@ describe('ReactIncrementalScheduling', () => {
 
     ReactNoop.render(<Foo step={1} />);
     expect(ReactNoop.flush).toWarnDev(
-      'UNSAFE_componentWillReceiveProps: Please update the following components ' +
+      'componentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: Foo',
     );
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -307,20 +307,18 @@ describe('ReactIncrementalUpdates', () => {
       }
     }
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
+        'has been detected within an async tree.',
+    );
 
     ops = [];
 
-    expect(() => {
-      ReactNoop.flushSync(() => {
-        instance.setState({a: 'a'});
+    ReactNoop.flushSync(() => {
+      instance.setState({a: 'a'});
 
-        ReactNoop.render(<Foo />); // Trigger componentWillReceiveProps
-      });
-    }).toWarnDev(
-      'Foo: An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
-        'has been detected in an async tree.',
-    );
+      ReactNoop.render(<Foo />); // Trigger componentWillReceiveProps
+    });
 
     expect(instance.state).toEqual({a: 'a', b: 'b'});
     expect(ops).toEqual(['componentWillReceiveProps', 'render']);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -308,8 +308,8 @@ describe('ReactIncrementalUpdates', () => {
     }
     ReactNoop.render(<Foo />);
     expect(ReactNoop.flush).toWarnDev(
-      'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
-        'has been detected within an async tree.',
+      'UNSAFE_componentWillReceiveProps: Please update the following components ' +
+        'to use static getDerivedStateFromProps instead: Foo',
     );
 
     ops = [];

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -311,10 +311,16 @@ describe('ReactIncrementalUpdates', () => {
 
     ops = [];
 
-    ReactNoop.flushSync(() => {
-      instance.setState({a: 'a'});
-      ReactNoop.render(<Foo />); // Trigger componentWillReceiveProps
-    });
+    expect(() => {
+      ReactNoop.flushSync(() => {
+        instance.setState({a: 'a'});
+
+        ReactNoop.render(<Foo />); // Trigger componentWillReceiveProps
+      });
+    }).toWarnDev(
+      'Foo: An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
+        'has been detected in an async tree.',
+    );
 
     expect(instance.state).toEqual({a: 'a', b: 'b'});
     expect(ops).toEqual(['componentWillReceiveProps', 'render']);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -308,7 +308,7 @@ describe('ReactIncrementalUpdates', () => {
     }
     ReactNoop.render(<Foo />);
     expect(ReactNoop.flush).toWarnDev(
-      'UNSAFE_componentWillReceiveProps: Please update the following components ' +
+      'componentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: Foo',
     );
 

--- a/packages/react/src/__tests__/ReactAsyncClassComponent-test.internal.js
+++ b/packages/react/src/__tests__/ReactAsyncClassComponent-test.internal.js
@@ -159,29 +159,21 @@ describe('ReactAsyncClassComponent', () => {
       }
 
       let rendered;
-
       expect(() => {
         rendered = ReactTestRenderer.create(<SyncRoot />);
-      }).toWarnDev([
-        'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-          'has been detected within an async tree. ' +
-          'Please update the following components: AsyncRoot' +
-          '\n\nThe async tree is located:' +
+      }).toWarnDev(
+        'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRoot (at **)' +
-          '\n    in SyncRoot (at **)',
-        'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
-          'has been detected within an async tree. ' +
-          'Please update the following components: Child' +
-          '\n\nThe async tree is located:' +
-          '\n    in AsyncRoot (at **)' +
-          '\n    in SyncRoot (at **)',
-        'An unsafe lifecycle method, UNSAFE_componentWillUpdate, ' +
-          'has been detected within an async tree. ' +
-          'Please update the following components: AsyncRoot' +
-          '\n\nThe async tree is located:' +
-          '\n    in AsyncRoot (at **)' +
-          '\n    in SyncRoot (at **)',
-      ]);
+          '\n    in SyncRoot (at **)' +
+          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          'to use componentDidMount instead: AsyncRoot' +
+          '\n\nUNSAFE_componentWillReceiveProps: Please update the following components ' +
+          'to use static getDerivedStateFromProps instead: Child' +
+          '\n\nUNSAFE_componentWillUpdate: Please update the following components ' +
+          'to use componentDidUpdate instead: AsyncRoot' +
+          '\n\nLearn more about this warning here:' +
+          '\nhttps://fb.me/react-async-component-lifecycle-hooks',
+      );
 
       // Dedupe
       rendered.update(<SyncRoot />);
@@ -223,26 +215,19 @@ describe('ReactAsyncClassComponent', () => {
 
       expect(
         () => (rendered = ReactTestRenderer.create(<SyncRoot />)),
-      ).toWarnDev([
-        'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-          'has been detected within an async tree. Please update ' +
-          'the following components: AsyncRoot, Parent' +
-          '\n\nThe async tree is located:' +
+      ).toWarnDev(
+        'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRoot (at **)' +
-          '\n    in SyncRoot (at **)',
-        'An unsafe lifecycle method, UNSAFE_componentWillReceiveProps, ' +
-          'has been detected within an async tree. Please update ' +
-          'the following components: Parent, Child' +
-          '\n\nThe async tree is located:' +
-          '\n    in AsyncRoot (at **)' +
-          '\n    in SyncRoot (at **)',
-        'An unsafe lifecycle method, UNSAFE_componentWillUpdate, ' +
-          'has been detected within an async tree. Please update ' +
-          'the following components: AsyncRoot, Parent' +
-          '\n\nThe async tree is located:' +
-          '\n    in AsyncRoot (at **)' +
-          '\n    in SyncRoot (at **)',
-      ]);
+          '\n    in SyncRoot (at **)' +
+          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          'to use componentDidMount instead: AsyncRoot, Parent' +
+          '\n\nUNSAFE_componentWillReceiveProps: Please update the following components ' +
+          'to use static getDerivedStateFromProps instead: Parent, Child' +
+          '\n\nUNSAFE_componentWillUpdate: Please update the following components ' +
+          'to use componentDidUpdate instead: AsyncRoot, Parent' +
+          '\n\nLearn more about this warning here:' +
+          '\nhttps://fb.me/react-async-component-lifecycle-hooks',
+      );
 
       // Dedupe
       rendered.update(<SyncRoot />);
@@ -305,20 +290,18 @@ describe('ReactAsyncClassComponent', () => {
       expect(
         () => (rendered = ReactTestRenderer.create(<SyncRoot />)),
       ).toWarnDev([
-        'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-          'has been detected within an async tree. Please update ' +
-          'the following components: Foo, Bar' +
-          '\n\nThe async tree is located:' +
+        'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRootOne (at **)' +
           '\n    in div (at **)' +
-          '\n    in SyncRoot (at **)',
-        'An unsafe lifecycle method, UNSAFE_componentWillMount, ' +
-          'has been detected within an async tree. Please update ' +
-          'the following components: Baz' +
-          '\n\nThe async tree is located:' +
+          '\n    in SyncRoot (at **)' +
+          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          'to use componentDidMount instead: Foo, Bar',
+        'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRootTwo (at **)' +
           '\n    in div (at **)' +
-          '\n    in SyncRoot (at **)',
+          '\n    in SyncRoot (at **)' +
+          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          'to use componentDidMount instead: Baz',
       ]);
 
       // Dedupe

--- a/packages/react/src/__tests__/ReactAsyncClassComponent-test.internal.js
+++ b/packages/react/src/__tests__/ReactAsyncClassComponent-test.internal.js
@@ -373,7 +373,7 @@ describe('ReactAsyncClassComponent', () => {
       rendered.update(<AsyncRoot foo={false} />);
     });
 
-    it('should warn about lifecycles even in the event of an error', () => {
+    it('should not warn about uncommitted lifecycles in the event of an error', () => {
       let caughtError;
 
       class AsyncRoot extends React.unstable_AsyncComponent {
@@ -408,20 +408,14 @@ describe('ReactAsyncClassComponent', () => {
 
       expect(() => {
         ReactTestRenderer.create(<AsyncRoot foo={true} />);
-      }).toWarnDev([
-        'Unsafe lifecycle methods were found within the following async tree:' +
-          '\n    in AsyncRoot (at **)' +
-          '\n\ncomponentWillMount: Please update the following components ' +
-          'to use componentDidMount instead: Foo' +
-          '\n\nLearn more about this warning here:' +
-          '\nhttps://fb.me/react-async-component-lifecycle-hooks',
+      }).toWarnDev(
         'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRoot (at **)' +
           '\n\ncomponentWillMount: Please update the following components ' +
           'to use componentDidMount instead: Bar' +
           '\n\nLearn more about this warning here:' +
           '\nhttps://fb.me/react-async-component-lifecycle-hooks',
-      ]);
+      );
 
       expect(caughtError).not.toBe(null);
     });

--- a/packages/react/src/__tests__/ReactAsyncClassComponent-test.internal.js
+++ b/packages/react/src/__tests__/ReactAsyncClassComponent-test.internal.js
@@ -184,11 +184,11 @@ describe('ReactAsyncClassComponent', () => {
         'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRoot (at **)' +
           '\n    in SyncRoot (at **)' +
-          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          '\n\ncomponentWillMount: Please update the following components ' +
           'to use componentDidMount instead: AsyncRoot' +
-          '\n\nUNSAFE_componentWillReceiveProps: Please update the following components ' +
+          '\n\ncomponentWillReceiveProps: Please update the following components ' +
           'to use static getDerivedStateFromProps instead: Bar, Foo' +
-          '\n\nUNSAFE_componentWillUpdate: Please update the following components ' +
+          '\n\ncomponentWillUpdate: Please update the following components ' +
           'to use componentDidUpdate instead: AsyncRoot' +
           '\n\nLearn more about this warning here:' +
           '\nhttps://fb.me/react-async-component-lifecycle-hooks',
@@ -238,11 +238,11 @@ describe('ReactAsyncClassComponent', () => {
         'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRoot (at **)' +
           '\n    in SyncRoot (at **)' +
-          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          '\n\ncomponentWillMount: Please update the following components ' +
           'to use componentDidMount instead: AsyncRoot, Parent' +
-          '\n\nUNSAFE_componentWillReceiveProps: Please update the following components ' +
+          '\n\ncomponentWillReceiveProps: Please update the following components ' +
           'to use static getDerivedStateFromProps instead: Child, Parent' +
-          '\n\nUNSAFE_componentWillUpdate: Please update the following components ' +
+          '\n\ncomponentWillUpdate: Please update the following components ' +
           'to use componentDidUpdate instead: AsyncRoot, Parent' +
           '\n\nLearn more about this warning here:' +
           '\nhttps://fb.me/react-async-component-lifecycle-hooks',
@@ -313,13 +313,13 @@ describe('ReactAsyncClassComponent', () => {
           '\n    in AsyncRootOne (at **)' +
           '\n    in div (at **)' +
           '\n    in SyncRoot (at **)' +
-          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          '\n\ncomponentWillMount: Please update the following components ' +
           'to use componentDidMount instead: Bar, Foo',
         'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRootTwo (at **)' +
           '\n    in div (at **)' +
           '\n    in SyncRoot (at **)' +
-          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          '\n\ncomponentWillMount: Please update the following components ' +
           'to use componentDidMount instead: Baz',
       ]);
 
@@ -353,7 +353,7 @@ describe('ReactAsyncClassComponent', () => {
       }).toWarnDev(
         'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRoot (at **)' +
-          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          '\n\ncomponentWillMount: Please update the following components ' +
           'to use componentDidMount instead: Foo' +
           '\n\nLearn more about this warning here:' +
           '\nhttps://fb.me/react-async-component-lifecycle-hooks',
@@ -362,7 +362,7 @@ describe('ReactAsyncClassComponent', () => {
       expect(() => rendered.update(<AsyncRoot foo={false} />)).toWarnDev(
         'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRoot (at **)' +
-          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          '\n\ncomponentWillMount: Please update the following components ' +
           'to use componentDidMount instead: Bar' +
           '\n\nLearn more about this warning here:' +
           '\nhttps://fb.me/react-async-component-lifecycle-hooks',
@@ -411,13 +411,13 @@ describe('ReactAsyncClassComponent', () => {
       }).toWarnDev([
         'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRoot (at **)' +
-          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          '\n\ncomponentWillMount: Please update the following components ' +
           'to use componentDidMount instead: Foo' +
           '\n\nLearn more about this warning here:' +
           '\nhttps://fb.me/react-async-component-lifecycle-hooks',
         'Unsafe lifecycle methods were found within the following async tree:' +
           '\n    in AsyncRoot (at **)' +
-          '\n\nUNSAFE_componentWillMount: Please update the following components ' +
+          '\n\ncomponentWillMount: Please update the following components ' +
           'to use componentDidMount instead: Bar' +
           '\n\nLearn more about this warning here:' +
           '\nhttps://fb.me/react-async-component-lifecycle-hooks',


### PR DESCRIPTION
Part two of #12046

This PR identifies class-components using unsafe lifecycles (`componenWillMount`, `componenWillReceiveProps`, `componenWillUpdate`) during the **begin phase**, and prints warnings about them (and with the location of the async subtree they belong to) during the **commit phase**. In the event of an error, pending warnings are discarded by `performFailedUnitOfWork`.

## Example warning

A warning for a particular async subtree will look like this:
> Unsafe lifecycle methods were found within the following async tree:
> &nbsp; &nbsp; &nbsp; in AsyncRoot (at AsyncRoot.js:260)
> &nbsp; &nbsp; &nbsp; in div (at SyncRoot.js:259)
> &nbsp; &nbsp; &nbsp; in SyncRoot (at SyncRoot.js:306)
>
> componentWillMount: Please update the following components to use componentDidMount instead: Foo, Bar
>
> componentWillReceiveProps: Please update the following components to use static getDerivedDataFromState instead: Foo
>
> componentWillUpdate: Please update the following components to use componentDidUpdate instead: Foo, Bar, Baz
>
> Learn more about this warning here:
> https://fb.me/react-async-component-lifecycle-hooks

## How are warnings grouped?

I put a lot of consideration into how to group/coalesce the warnings, as well as how to dedup them. I landed on the following:
* Grouped by async subtree, and then printed by lifecycle. I think this grouping makes as much sense as anything else, in terms of how you would approach tracking down and fixing the lifecycles. (Although I'm happy to tweak the wording and format if anyone has suggestions.)
* Deduped per class component type (by way of an dev-only, expando attribute). This was a nice tradeoff between uniqueness concerns (mentioned below) and implementation complexity.

## Alternatives considered

I considered different deduping strategies but this felt the most pragmatic. Other considerations were:
* Per async-subtree (aka per component stack). Major drawback: Components not rendered initially (due to conditional logic, blockers, etc) would never get reported.
* Per unsafe component name: Major drawback: Component names might be vague (eg "Text") and might have collisions- which could lead to several rounds of fixings warnings about a component with a given name.
* No deduping: Major drawback: Lots of irritating console noise.

## Open Questions

- [ ] Is the way I'm flushing or discarding `pendingWarningsMap` safe? Are there cases (like interruptions) that it won't handle well? (cc @acdlite)
- [x] In the event of an error, warnings may be split into multiple messages since the code below the boundary is committed in a different pass. I think this is okay since it's not a common case.