### PR TITLE
DOM diff and component stack in SSR hydrate mismatch warnings (#10085)

### DIFF
--- a/fixtures/ssr/server/render.js
+++ b/fixtures/ssr/server/render.js
@@ -14,8 +14,8 @@ if (process.env.NODE_ENV === 'development') {
   assets = require('../build/asset-manifest.json');
 }
 
-export default function render() {
-  var html = renderToString(<App assets={assets} />);
+export default function render(url) {
+  var html = renderToString(<App assets={assets} url={url} />);
   // There's no way to render a doctype in React so prepend manually.
   // Also append a bootstrap script tag.
   return '<!DOCTYPE html>' + html;

--- a/fixtures/ssr/src/components/App.js
+++ b/fixtures/ssr/src/components/App.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 
 import Chrome from './Chrome';
 import Page from './Page';
+import SSRMismatchTest from './SSRMismatchTest';
 
 export default class App extends Component {
   render() {
@@ -10,6 +11,7 @@ export default class App extends Component {
         <div>
           <h1>Hello World</h1>
           <Page />
+          <SSRMismatchTest url={this.props.url} />
         </div>
       </Chrome>
     );

--- a/fixtures/ssr/src/components/SSRMismatchTest.js
+++ b/fixtures/ssr/src/components/SSRMismatchTest.js
@@ -1,0 +1,59 @@
+import React, {Component} from 'react';
+
+// Triggers the DOM mismatch warnings if requested via query string.
+export default class SSRMismatchTest extends Component {
+  render() {
+    // Default content rendered at the server.
+    let content = (
+      <div data-ssr-prop-extra={true}>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    );
+    // In the browser where `window` is available, triggering a DOM mismatch if it's requested.
+    if (typeof window !== 'undefined') {
+      const queryString = this.props.url.replace(/^[^?]+[?]?/, '');
+      if (queryString.indexOf('ssr-prop-mismatch') >= 0) {
+        // The inner structure is the same as the server render, but the root element has an extra prop.
+        content = (
+          <div data-ssr-prop-extra={true} data-ssr-prop-mismatch={true}>
+            <em>SSRMismatchTest default text</em>
+          </div>
+        );
+      } else if (queryString.indexOf('ssr-prop-extra') >= 0) {
+        // The inner structure is the same as the server render, but the root element is missing a server-rendered prop.
+        content = (
+          <div>
+            <em>SSRMismatchTest default text</em>
+          </div>
+        );
+      } else if (queryString.indexOf('ssr-text-mismatch') >= 0) {
+        // The inner structure is the same as the server render, but the inner text node content differs.
+        content = (
+          <div data-ssr-prop-extra={true}>
+            <em>SSRMismatchTest ssr-text-mismatch</em>
+          </div>
+        );
+      } else if (queryString.indexOf('ssr-children-mismatch') >= 0) {
+        // The inner structure is different from the server render.
+        content = (
+          <div data-ssr-prop-extra={true}>
+            <p>SSRMismatchTest ssr-children-mismatch</p>
+          </div>
+        );
+      }
+    }
+    return (
+      <div>
+        <div style={{paddingBottom: '10px'}}>
+          SSRMismatchTest. Open the console, select a test case:{' '}
+          <a href="/">none</a>{' '}
+          <a href="/?ssr-prop-mismatch">ssr-prop-mismatch</a>{' '}
+          <a href="/?ssr-prop-extra">ssr-prop-extra</a>{' '}
+          <a href="/?ssr-text-mismatch">ssr-text-mismatch</a>{' '}
+          <a href="/?ssr-children-mismatch">ssr-children-mismatch</a>
+        </div>
+        {content}
+      </div>
+    );
+  }
+}

--- a/fixtures/ssr/src/components/SSRMismatchTest.js
+++ b/fixtures/ssr/src/components/SSRMismatchTest.js
@@ -145,7 +145,7 @@ const testCases = [
     key: 'ssr-warnForDeletedHydratableElement-didNotHydrateInstance',
     renderServer: () => (
       <div>
-        <div />
+        <div>SSRMismatchTest default text</div>
         <span />
       </div>
     ),
@@ -243,18 +243,45 @@ const testCases = [
     ),
   },
   {
-    key: 'ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance',
+    key:
+      'ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance-replacement',
     renderServer: () => (
       <div>
-        <span />
-        <span />
+        nested{' '}
+        <p>
+          children <b>text</b>
+        </p>
       </div>
     ),
     renderBrowser: () => (
       <div>
-        <span />
-        SSRMismatchTest client text
-        <span />
+        nested{' '}
+        <div>
+          children <b>text</b>
+        </div>
+      </div>
+    ),
+  },
+  {
+    key:
+      'ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance-insertion',
+    renderServer: () => (
+      <div>
+        nested{' '}
+        <p>
+          children <b>text</b>
+        </p>
+      </div>
+    ),
+    renderBrowser: () => (
+      <div>
+        nested{' '}
+        <p>
+          children <b>text</b>
+        </p>
+        <div>
+          children <b>text</b>
+        </div>
       </div>
     ),
   },

--- a/fixtures/ssr/src/components/SSRMismatchTest.js
+++ b/fixtures/ssr/src/components/SSRMismatchTest.js
@@ -324,7 +324,7 @@ export default class SSRMismatchTest extends Component {
             ))}
           </ol>
         </div>
-        {content}
+        <div className="SSRMismatchTest__placeholder">{content}</div>
       </div>
     );
   }

--- a/fixtures/ssr/src/components/SSRMismatchTest.js
+++ b/fixtures/ssr/src/components/SSRMismatchTest.js
@@ -285,6 +285,132 @@ const testCases = [
       </div>
     ),
   },
+  {
+    key:
+      'ssr-hydrationWarningHostInstanceIndex-didNotFindHydratableInstance-replacement',
+    render: isServer => {
+      class TestPaddingBeforeInnerComponent extends React.Component {
+        render() {
+          return (
+            <React.Fragment>
+              <div data-ssr-mismatch-padding-before="2" />
+              <div data-ssr-mismatch-padding-before="3" />
+            </React.Fragment>
+          );
+        }
+      }
+      class TestPaddingBeforeComponent extends React.Component {
+        render() {
+          return (
+            <React.Fragment>
+              <div data-ssr-mismatch-padding-before="1" />
+              <TestPaddingBeforeInnerComponent />
+              <div data-ssr-mismatch-padding-before="4" />
+              <div data-ssr-mismatch-padding-before="5" />
+            </React.Fragment>
+          );
+        }
+      }
+      class TestPaddingAfterComponent extends React.Component {
+        render() {
+          return (
+            <React.Fragment>
+              <div data-ssr-mismatch-padding-after="1" />
+              <div data-ssr-mismatch-padding-after="2" />
+              <div data-ssr-mismatch-padding-after="3" />
+              <div data-ssr-mismatch-padding-after="4" />
+              <div data-ssr-mismatch-padding-after="5" />
+            </React.Fragment>
+          );
+        }
+      }
+      class TestNestedComponent extends React.Component {
+        render() {
+          if (this.props.isServer) {
+            return (
+              <div>
+                <TestPaddingBeforeComponent />
+                <h1>SSRMismatchTest default text</h1>
+                <span />
+                <TestPaddingAfterComponent />
+              </div>
+            );
+          }
+          return (
+            <div>
+              <TestPaddingBeforeComponent />
+              <h2>SSRMismatchTest default text</h2>
+              <span />
+              <TestPaddingAfterComponent />
+            </div>
+          );
+        }
+      }
+      class TestComponent extends React.Component {
+        render() {
+          return <TestNestedComponent isServer={this.props.isServer} />;
+        }
+      }
+
+      return <TestComponent isServer={isServer} />;
+    },
+  },
+
+  {
+    key:
+      'ssr-hydrationWarningHostInstanceIndex-didNotFindHydratableInstance-insertion',
+    render(isServer) {
+      class TestPaddingBeforeInnerInnerComponent extends React.Component {
+        render() {
+          return <div data-ssr-mismatch-padding-before="6" />;
+        }
+      }
+      class TestPaddingBeforeInnerComponent extends React.Component {
+        render() {
+          return (
+            <React.Fragment>
+              <div data-ssr-mismatch-padding-before="4" />
+              <div data-ssr-mismatch-padding-before="5" />
+              <TestPaddingBeforeInnerInnerComponent />
+            </React.Fragment>
+          );
+        }
+      }
+      class TestPaddingBeforeComponent extends React.Component {
+        render() {
+          return (
+            <React.Fragment>
+              <div data-ssr-mismatch-padding-before="2" />
+              <div data-ssr-mismatch-padding-before="3" />
+              <TestPaddingBeforeInnerComponent />
+              <div data-ssr-mismatch-padding-before="7" />
+              <div data-ssr-mismatch-padding-before="8" />
+              <div data-ssr-mismatch-padding-before="9" />
+            </React.Fragment>
+          );
+        }
+      }
+
+      return isServer ? (
+        <div>
+          <div data-ssr-mismatch-padding-before="1" />
+          <TestPaddingBeforeComponent />
+          <div data-ssr-mismatch-padding-before="10" />
+          <div data-ssr-mismatch-padding-before="11" />
+          <div data-ssr-mismatch-padding-before="12" />
+        </div>
+      ) : (
+        <div>
+          <div data-ssr-mismatch-padding-before="1" />
+          <TestPaddingBeforeComponent />
+          <div data-ssr-mismatch-padding-before="10" />
+          <div data-ssr-mismatch-padding-before="11" />
+          <div data-ssr-mismatch-padding-before="12" />
+          SSRMismatchTest client text
+        </div>
+      );
+    },
+  },
 ];
 
 // Triggers the DOM mismatch warnings if requested via query string.
@@ -297,13 +423,14 @@ export default class SSRMismatchTest extends Component {
     );
     if (testCaseFound) {
       // In the browser where `window` is available, triggering a DOM mismatch if it's requested.
+      const isServer = typeof window === 'undefined';
       let render;
-      if (typeof window !== 'undefined') {
-        render = testCaseFound.renderBrowser || testCaseFound.render;
-      } else {
+      if (isServer) {
         render = testCaseFound.renderServer || testCaseFound.render;
+      } else {
+        render = testCaseFound.renderBrowser || testCaseFound.render;
       }
-      content = render();
+      content = render(isServer);
     }
 
     return (

--- a/fixtures/ssr/src/components/SSRMismatchTest.js
+++ b/fixtures/ssr/src/components/SSRMismatchTest.js
@@ -1,56 +1,277 @@
 import React, {Component} from 'react';
+import ReactDOM from 'react-dom';
+
+// Helps to test hydration edge cases with the root node.
+// Sets the passed-in `serverHTML` as `innerHTML` and hydrates the passed-in `browserReact` over it.
+class SSRMismatchTestRootHydrate extends Component {
+  componentDidMount() {
+    if (this._el) {
+      this._el.innerHTML = this.props.serverHTML;
+      ReactDOM.hydrate(this.props.browserReact, this._el);
+    }
+  }
+
+  render() {
+    return (
+      <div
+        data-ssr-mismatch-test-hydrate-root
+        ref={el => {
+          this._el = el;
+        }}
+      />
+    );
+  }
+}
+
+const testCases = [
+  {
+    key: 'ssr-warnForTextDifference',
+    renderServer: () => (
+      <div>
+        <em>SSRMismatchTest server text</em>
+      </div>
+    ),
+    renderBrowser: () => (
+      // The inner element type is the same as the server render, but the inner text differs.
+      <div>
+        <em>SSRMismatchTest client text</em>
+      </div>
+    ),
+  },
+  {
+    key:
+      'ssr-warnForTextDifference-warnForUnmatchedText-didNotMatchHydratedContainerTextInstance',
+    render: () => (
+      <SSRMismatchTestRootHydrate
+        serverHTML={'SSRMismatchTest server text'}
+        browserReact={'SSRMismatchTest client text'}
+      />
+    ),
+  },
+  {
+    key:
+      'ssr-warnForTextDifference-warnForUnmatchedText-didNotMatchHydratedTextInstance',
+    renderServer: () => (
+      <div>
+        <em>
+          {'SSRMismatchTest static text and '}
+          {'server random text ' + Math.random()}
+        </em>
+      </div>
+    ),
+    renderBrowser: () => (
+      <div>
+        <em>
+          {'SSRMismatchTest static text and '}
+          {'client random text ' + Math.random()}
+        </em>
+      </div>
+    ),
+  },
+  {
+    key: 'ssr-warnForPropDifference',
+    renderServer: () => (
+      <div>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+    renderBrowser: () => (
+      // The inner element type is the same as the server render.
+      // The browser root element has an extra prop with a non-`null` value.
+      <div data-ssr-extra-prop={true} data-ssr-extra-prop-2={true}>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+  },
+  {
+    key: 'ssr-warnForPropDifference-null-no-warning',
+    renderServer: () => (
+      <div>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+    renderBrowser: () => (
+      // The inner element type is the same as the server render.
+      // The browser root element has an extra prop explicitly set to `null`.
+      <div data-ssr-extra-prop={null} data-ssr-extra-prop-2={null}>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+  },
+  {
+    key: 'ssr-warnForExtraAttributes',
+    renderServer: () => (
+      <div data-ssr-extra-prop={true} data-ssr-extra-prop-2={true}>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+    renderBrowser: () => (
+      // The inner element type is the same as the server render.
+      // The root element is missing a server-rendered prop.
+      <div>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+  },
+  {
+    key: 'ssr-warnForInvalidEventListener-false',
+    renderServer: () => <div onClick={() => {}} />,
+    renderBrowser: () => <div onClick={false} />,
+  },
+  {
+    key: 'ssr-warnForInvalidEventListener-typeof',
+    renderServer: () => <div onClick={() => {}} />,
+    renderBrowser: () => <div onClick={'a string'} />,
+  },
+  {
+    key: 'ssr-warnForDeletedHydratableElement-didNotHydrateContainerInstance',
+    render: () => (
+      <SSRMismatchTestRootHydrate
+        serverHTML={
+          'SSRMismatchTest first text' +
+          '<br />' +
+          '<br />' +
+          'SSRMismatchTest second text'
+        }
+        browserReact={[
+          'SSRMismatchTest first text',
+          <br key={1} />,
+          'SSRMismatchTest second text',
+        ]}
+      />
+    ),
+  },
+  {
+    key: 'ssr-warnForDeletedHydratableElement-didNotHydrateInstance',
+    renderServer: () => (
+      <div>
+        <div />
+        <span />
+      </div>
+    ),
+    renderBrowser: () => (
+      <div>
+        <span />
+      </div>
+    ),
+  },
+  {
+    key: 'ssr-warnForDeletedHydratableText-didNotHydrateContainerInstance',
+    render: () => (
+      <SSRMismatchTestRootHydrate
+        serverHTML={
+          'SSRMismatchTest server text' +
+          '<br />' +
+          'SSRMismatchTest default text'
+        }
+        browserReact={[<br key={1} />, 'SSRMismatchTest default text']}
+      />
+    ),
+  },
+  {
+    key: 'ssr-warnForDeletedHydratableText-didNotHydrateInstance',
+    renderServer: () => (
+      <div>
+        SSRMismatchTest server text
+        <span />
+      </div>
+    ),
+    renderBrowser: () => (
+      <div>
+        <span />
+      </div>
+    ),
+  },
+  {
+    key:
+      'ssr-warnForInsertedHydratedElement-didNotFindHydratableContainerInstance',
+    render: () => (
+      // The root element type is different (text on server, span on client), the inner text is the same.
+      <SSRMismatchTestRootHydrate
+        serverHTML={'SSRMismatchTest default text'}
+        browserReact={<span>SSRMismatchTest default text</span>}
+      />
+    ),
+  },
+  {
+    key: 'ssr-warnForInsertedHydratedElement-didNotFindHydratableInstance',
+    renderServer: () => (
+      <div>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+    renderBrowser: () => (
+      // The inner element type is different from the server render, but the inner text is the same.
+      <div>
+        <p>SSRMismatchTest default text</p>
+      </div>
+    ),
+  },
+  {
+    key:
+      'ssr-warnForInsertedHydratedText-didNotFindHydratableContainerTextInstance',
+    render: () => (
+      // The root element type is different (span on server, text on client), the inner text is the same.
+      <SSRMismatchTestRootHydrate
+        serverHTML={'<span>SSRMismatchTest default text</span>'}
+        browserReact={'SSRMismatchTest default text'}
+      />
+    ),
+  },
+  {
+    key: 'ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance',
+    renderServer: () => (
+      <div>
+        <span />
+        <span />
+      </div>
+    ),
+    renderBrowser: () => (
+      <div>
+        <span />
+        SSRMismatchTest client text
+        <span />
+      </div>
+    ),
+  },
+];
 
 // Triggers the DOM mismatch warnings if requested via query string.
 export default class SSRMismatchTest extends Component {
   render() {
-    // Default content rendered at the server.
-    let content = (
-      <div data-ssr-prop-extra={true}>
-        <em>SSRMismatchTest default text</em>
-      </div>
+    let content = null;
+    const queryParams = this.props.url.replace(/^[^?]+[?]?/, '').split('&');
+    const testCaseFound = testCases.find(
+      testCase => queryParams.indexOf(testCase.key) >= 0
     );
-    // In the browser where `window` is available, triggering a DOM mismatch if it's requested.
-    if (typeof window !== 'undefined') {
-      const queryString = this.props.url.replace(/^[^?]+[?]?/, '');
-      if (queryString.indexOf('ssr-prop-mismatch') >= 0) {
-        // The inner structure is the same as the server render, but the root element has an extra prop.
-        content = (
-          <div data-ssr-prop-extra={true} data-ssr-prop-mismatch={true}>
-            <em>SSRMismatchTest default text</em>
-          </div>
-        );
-      } else if (queryString.indexOf('ssr-prop-extra') >= 0) {
-        // The inner structure is the same as the server render, but the root element is missing a server-rendered prop.
-        content = (
-          <div>
-            <em>SSRMismatchTest default text</em>
-          </div>
-        );
-      } else if (queryString.indexOf('ssr-text-mismatch') >= 0) {
-        // The inner structure is the same as the server render, but the inner text node content differs.
-        content = (
-          <div data-ssr-prop-extra={true}>
-            <em>SSRMismatchTest ssr-text-mismatch</em>
-          </div>
-        );
-      } else if (queryString.indexOf('ssr-children-mismatch') >= 0) {
-        // The inner structure is different from the server render.
-        content = (
-          <div data-ssr-prop-extra={true}>
-            <p>SSRMismatchTest ssr-children-mismatch</p>
-          </div>
-        );
+    if (testCaseFound) {
+      // In the browser where `window` is available, triggering a DOM mismatch if it's requested.
+      let render;
+      if (typeof window !== 'undefined') {
+        render = testCaseFound.renderBrowser || testCaseFound.render;
+      } else {
+        render = testCaseFound.renderServer || testCaseFound.render;
       }
+      content = render();
     }
+
     return (
       <div>
-        <div style={{paddingBottom: '10px'}}>
-          SSRMismatchTest. Open the console, select a test case:{' '}
-          <a href="/">none</a>{' '}
-          <a href="/?ssr-prop-mismatch">ssr-prop-mismatch</a>{' '}
-          <a href="/?ssr-prop-extra">ssr-prop-extra</a>{' '}
-          <a href="/?ssr-text-mismatch">ssr-text-mismatch</a>{' '}
-          <a href="/?ssr-children-mismatch">ssr-children-mismatch</a>
+        <div style={{fontSize: '12px'}}>
+          <div>SSRMismatchTest. Open the console, select a test case:</div>
+          <ol>
+            <li style={{paddingBottom: '10px'}}>
+              <a href="/">none</a>
+            </li>
+            {testCases.map(testCase => (
+              <li key={testCase.key} style={{paddingBottom: '10px'}}>
+                <a href={'/?' + testCase.key}>{testCase.key}</a>
+                {testCaseFound && testCaseFound.key === testCase.key
+                  ? ' 👈'
+                  : ' '}
+              </li>
+            ))}
+          </ol>
         </div>
         {content}
       </div>

--- a/fixtures/ssr/src/components/SSRMismatchTest.js
+++ b/fixtures/ssr/src/components/SSRMismatchTest.js
@@ -196,14 +196,38 @@ const testCases = [
   {
     key: 'ssr-warnForInsertedHydratedElement-didNotFindHydratableInstance',
     renderServer: () => (
-      <div>
-        <em>SSRMismatchTest default text</em>
+      <div className="SSRMismatchTest__wrapper">
+        <span className="SSRMismatchTest__1">1</span>
+        <span className="SSRMismatchTest__2">2</span>
+        <span className="SSRMismatchTest__3">3</span>
+        <span className="SSRMismatchTest__4">4</span>
+        <span className="SSRMismatchTest__5">5</span>
+        <span className="SSRMismatchTest__6">6</span>
+        <strong> SSRMismatchTest default text </strong>
+        <span className="SSRMismatchTest__7">7</span>
+        <span className="SSRMismatchTest__8">8</span>
+        <span className="SSRMismatchTest__9">9</span>
+        <span className="SSRMismatchTest__10">10</span>
+        <span className="SSRMismatchTest__11">11</span>
+        <span className="SSRMismatchTest__12">12</span>
       </div>
     ),
     renderBrowser: () => (
       // The inner element type is different from the server render, but the inner text is the same.
-      <div>
-        <p>SSRMismatchTest default text</p>
+      <div className="SSRMismatchTest__wrapper">
+        <span className="SSRMismatchTest__1">1</span>
+        <span className="SSRMismatchTest__2">2</span>
+        <span className="SSRMismatchTest__3">3</span>
+        <span className="SSRMismatchTest__4">4</span>
+        <span className="SSRMismatchTest__5">5</span>
+        <span className="SSRMismatchTest__6">6</span>
+        <em> SSRMismatchTest default text </em>
+        <span className="SSRMismatchTest__7">7</span>
+        <span className="SSRMismatchTest__8">8</span>
+        <span className="SSRMismatchTest__9">9</span>
+        <span className="SSRMismatchTest__10">10</span>
+        <span className="SSRMismatchTest__11">11</span>
+        <span className="SSRMismatchTest__12">12</span>
       </div>
     ),
   },

--- a/fixtures/ssr/src/index.js
+++ b/fixtures/ssr/src/index.js
@@ -3,4 +3,6 @@ import {hydrate} from 'react-dom';
 
 import App from './components/App';
 
-hydrate(<App assets={window.assetManifest} />, document);
+// Remove the #hash (fragment identifier) component from the `url` to match the server-side value.
+const url = window.location.href.replace(/[#].*/, '');
+hydrate(<App assets={window.assetManifest} url={url} />, document);

--- a/fixtures/ssr/src/index.js
+++ b/fixtures/ssr/src/index.js
@@ -3,6 +3,6 @@ import {hydrate} from 'react-dom';
 
 import App from './components/App';
 
-// Remove the #hash (fragment identifier) component from the `url` to match the server-side value.
-const url = window.location.href.replace(/[#].*/, '');
+// No host:port and #hash (fragment identifier) components in the `url` to match the server-side value.
+const url = window.location.pathname + window.location.search;
 hydrate(<App assets={window.assetManifest} url={url} />, document);

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -143,9 +143,9 @@ describe('ReactDOMRoot', () => {
         <span />
       </div>,
     );
-    expect(jest.runAllTimers).toWarnDev('Extra attributes', {
-      withoutStack: true,
-    });
+    expect(jest.runAllTimers).toWarnDev(
+      'Extra attributes from the server: class',
+    );
   });
 
   it('does not clear existing children', async () => {

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -305,7 +305,7 @@ describe('ReactMount', () => {
         '    <!-- -->\n' +
         "    {'   '}\n" +
         '-   <p>children <b>text</b></p>\n' +
-        "+   <div>{['children ', …]}</div>\n" +
+        "+   <div>{['children ', ...]}</div>\n" +
         '  </div>\n\n' +
         '    in div (at **)\n' +
         '    in Component (at **)',
@@ -356,7 +356,7 @@ describe('ReactMount', () => {
         '    <!-- -->\n' +
         "    {'   '}\n" +
         '    <p>children <b>text</b></p>\n' +
-        "+   <div>{['children ', …]}</div>\n" +
+        "+   <div>{['children ', ...]}</div>\n" +
         '  </div>\n\n' +
         '    in div (at **)\n' +
         '    in Component (at **)',

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -663,13 +663,24 @@ describe('ReactMount', () => {
   });
 
   it('should warn when hydrate replaces an element within server-rendered nested components (replacement diff)', () => {
+    // See fixtures/ssr: ssr-hydrationWarningHostInstanceIndex-didNotFindHydratableInstance-replacement
+
+    class TestPaddingBeforeInnerComponent extends React.Component {
+      render() {
+        return (
+          <React.Fragment>
+            <div data-ssr-mismatch-padding-before="2" />
+            <div data-ssr-mismatch-padding-before="3" />
+          </React.Fragment>
+        );
+      }
+    }
     class TestPaddingBeforeComponent extends React.Component {
       render() {
         return (
           <React.Fragment>
             <div data-ssr-mismatch-padding-before="1" />
-            <div data-ssr-mismatch-padding-before="2" />
-            <div data-ssr-mismatch-padding-before="3" />
+            <TestPaddingBeforeInnerComponent />
             <div data-ssr-mismatch-padding-before="4" />
             <div data-ssr-mismatch-padding-before="5" />
           </React.Fragment>
@@ -691,7 +702,7 @@ describe('ReactMount', () => {
     }
     class TestNestedComponent extends React.Component {
       render() {
-        if (this.props.server) {
+        if (this.props.isServer) {
           return (
             <div>
               <TestPaddingBeforeComponent />
@@ -713,18 +724,18 @@ describe('ReactMount', () => {
     }
     class TestComponent extends React.Component {
       render() {
-        return <TestNestedComponent server={this.props.server} />;
+        return <TestNestedComponent isServer={this.props.isServer} />;
       }
     }
 
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString(
-      <TestComponent server={true} />,
+      <TestComponent isServer={true} />,
     );
     div.innerHTML = markup;
 
     expect(() =>
-      ReactDOM.hydrate(<TestComponent server={false} />, div),
+      ReactDOM.hydrate(<TestComponent isServer={false} />, div),
     ).toWarnDev(
       'Warning: Expected server HTML to contain a matching <h2> in <div>.\n\n' +
         '  <div data-reactroot="">\n' +
@@ -894,19 +905,48 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn when hydrate inserts a text node between matching elements (insertion diff)', () => {
-    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance
+  it('should warn when hydrate inserts a text node after matching elements (insertion diff)', () => {
+    // See fixtures/ssr: ssr-hydrationWarningHostInstanceIndex-didNotFindHydratableInstance-insertion
+
+    class TestPaddingBeforeInnerInnerComponent extends React.Component {
+      render() {
+        return <div data-ssr-mismatch-padding-before="6" />;
+      }
+    }
+    class TestPaddingBeforeInnerComponent extends React.Component {
+      render() {
+        return (
+          <React.Fragment>
+            <div data-ssr-mismatch-padding-before="4" />
+            <div data-ssr-mismatch-padding-before="5" />
+            <TestPaddingBeforeInnerInnerComponent />
+          </React.Fragment>
+        );
+      }
+    }
+    class TestPaddingBeforeComponent extends React.Component {
+      render() {
+        return (
+          <React.Fragment>
+            <div data-ssr-mismatch-padding-before="2" />
+            <div data-ssr-mismatch-padding-before="3" />
+            <TestPaddingBeforeInnerComponent />
+            <div data-ssr-mismatch-padding-before="7" />
+            <div data-ssr-mismatch-padding-before="8" />
+            <div data-ssr-mismatch-padding-before="9" />
+          </React.Fragment>
+        );
+      }
+    }
 
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString(
       <div>
-        <span data-ssr-mismatch-padding-before="1" />
-        <span />
-        <div data-ssr-mismatch-padding-after="1" />
-        <div data-ssr-mismatch-padding-after="2" />
-        <div data-ssr-mismatch-padding-after="3" />
-        <div data-ssr-mismatch-padding-after="4" />
-        <div data-ssr-mismatch-padding-after="5" />
+        <div data-ssr-mismatch-padding-before="1" />
+        <TestPaddingBeforeComponent />
+        <div data-ssr-mismatch-padding-before="10" />
+        <div data-ssr-mismatch-padding-before="11" />
+        <div data-ssr-mismatch-padding-before="12" />
       </div>,
     );
     div.innerHTML = markup;
@@ -914,7 +954,11 @@ describe('ReactMount', () => {
     expect(() =>
       ReactDOM.hydrate(
         <div>
-          <span data-ssr-mismatch-padding-before="1" />
+          <div data-ssr-mismatch-padding-before="1" />
+          <TestPaddingBeforeComponent />
+          <div data-ssr-mismatch-padding-before="10" />
+          <div data-ssr-mismatch-padding-before="11" />
+          <div data-ssr-mismatch-padding-before="12" />
           SSRMismatchTest client text
         </div>,
         div,
@@ -923,14 +967,19 @@ describe('ReactMount', () => {
       'Warning: Expected server HTML to contain a matching text node' +
         " for {'SSRMismatchTest client text'} in <div>.\n\n" +
         '  <div data-reactroot="">\n' +
-        '    <span data-ssr-mismatch-padding-before="1"></span>\n' +
+        '    <div data-ssr-mismatch-padding-before="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="5"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="6"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="7"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="8"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="9"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="10"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="11"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="12"></div>\n' +
         "+   {'SSRMismatchTest client text'}\n" +
-        '    <span></span>\n' +
-        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
         '  </div>\n\n' +
         '    in div (at **)',
     );

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -679,7 +679,9 @@ describe('ReactMount', () => {
       render() {
         return (
           <React.Fragment>
-            <div data-ssr-mismatch-padding-before="1" />
+            <div data-ssr-mismatch-padding-before="1">
+              <span />
+            </div>
             <TestPaddingBeforeInnerComponent />
             <div data-ssr-mismatch-padding-before="4" />
             <div data-ssr-mismatch-padding-before="5" />
@@ -739,7 +741,7 @@ describe('ReactMount', () => {
     ).toWarnDev(
       'Warning: Expected server HTML to contain a matching <h2> in <div>.\n\n' +
         '  <div data-reactroot="">\n' +
-        '    <div data-ssr-mismatch-padding-before="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="1"><span></span></div>\n' +
         '    <div data-ssr-mismatch-padding-before="2"></div>\n' +
         '    <div data-ssr-mismatch-padding-before="3"></div>\n' +
         '    <div data-ssr-mismatch-padding-before="4"></div>\n' +
@@ -910,15 +912,15 @@ describe('ReactMount', () => {
 
     class TestPaddingBeforeInnerInnerComponent extends React.Component {
       render() {
-        return <div data-ssr-mismatch-padding-before="6" />;
+        return <div data-ssr-mismatch-padding-before="8" />;
       }
     }
     class TestPaddingBeforeInnerComponent extends React.Component {
       render() {
         return (
           <React.Fragment>
-            <div data-ssr-mismatch-padding-before="4" />
-            <div data-ssr-mismatch-padding-before="5" />
+            <div data-ssr-mismatch-padding-before="6" />
+            <div data-ssr-mismatch-padding-before="7" />
             <TestPaddingBeforeInnerInnerComponent />
           </React.Fragment>
         );
@@ -928,12 +930,11 @@ describe('ReactMount', () => {
       render() {
         return (
           <React.Fragment>
-            <div data-ssr-mismatch-padding-before="2" />
-            <div data-ssr-mismatch-padding-before="3" />
+            <div data-ssr-mismatch-padding-before="4" />
+            <div data-ssr-mismatch-padding-before="5" />
             <TestPaddingBeforeInnerComponent />
-            <div data-ssr-mismatch-padding-before="7" />
-            <div data-ssr-mismatch-padding-before="8" />
             <div data-ssr-mismatch-padding-before="9" />
+            <div data-ssr-mismatch-padding-before="10" />
           </React.Fragment>
         );
       }
@@ -942,11 +943,15 @@ describe('ReactMount', () => {
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString(
       <div>
-        <div data-ssr-mismatch-padding-before="1" />
+        <div data-ssr-mismatch-padding-before="1">
+          <span />
+        </div>
+        <div data-ssr-mismatch-padding-before="2" />
+        <div data-ssr-mismatch-padding-before="3" />
         <TestPaddingBeforeComponent />
-        <div data-ssr-mismatch-padding-before="10" />
         <div data-ssr-mismatch-padding-before="11" />
         <div data-ssr-mismatch-padding-before="12" />
+        <div data-ssr-mismatch-padding-before="13" />
       </div>,
     );
     div.innerHTML = markup;
@@ -954,12 +959,16 @@ describe('ReactMount', () => {
     expect(() =>
       ReactDOM.hydrate(
         <div>
-          <div data-ssr-mismatch-padding-before="1" />
+          <div data-ssr-mismatch-padding-before="1">
+            <span />
+          </div>
+          <div data-ssr-mismatch-padding-before="2" />
+          <div data-ssr-mismatch-padding-before="3" />
           <TestPaddingBeforeComponent />
-          <div data-ssr-mismatch-padding-before="10" />
           <div data-ssr-mismatch-padding-before="11" />
           <div data-ssr-mismatch-padding-before="12" />
-          SSRMismatchTest client text
+          <div data-ssr-mismatch-padding-before="13" />
+          {'SSRMismatchTest client text'}
         </div>,
         div,
       ),
@@ -967,7 +976,7 @@ describe('ReactMount', () => {
       'Warning: Expected server HTML to contain a matching text node' +
         " for {'SSRMismatchTest client text'} in <div>.\n\n" +
         '  <div data-reactroot="">\n' +
-        '    <div data-ssr-mismatch-padding-before="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="1"><span></span></div>\n' +
         '    <div data-ssr-mismatch-padding-before="2"></div>\n' +
         '    <div data-ssr-mismatch-padding-before="3"></div>\n' +
         '    <div data-ssr-mismatch-padding-before="4"></div>\n' +
@@ -979,6 +988,7 @@ describe('ReactMount', () => {
         '    <div data-ssr-mismatch-padding-before="10"></div>\n' +
         '    <div data-ssr-mismatch-padding-before="11"></div>\n' +
         '    <div data-ssr-mismatch-padding-before="12"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="13"></div>\n' +
         "+   {'SSRMismatchTest client text'}\n" +
         '  </div>\n\n' +
         '    in div (at **)',

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -126,12 +126,11 @@ describe('ReactMount', () => {
     container.innerHTML = ' ' + ReactDOMServer.renderToString(<div />);
 
     expect(() => ReactDOM.hydrate(<div />, container)).toWarnDev(
-      "Warning: Did not expect server HTML to contain the text node {' '}" +
-        ' in <container> <div data-reactroot=""></div></container>.\n' +
+      "Warning: Did not expect server HTML to contain the text node {' '} in <container>.\n\n" +
         '  <container>\n' +
         "-   {' '}\n" +
         '    <div data-reactroot=""></div>\n' +
-        '  </container>\n' +
+        '  </container>\n\n' +
         '    in div (at **)',
     );
   });
@@ -141,12 +140,11 @@ describe('ReactMount', () => {
     container.innerHTML = ReactDOMServer.renderToString(<div />) + ' ';
 
     expect(() => ReactDOM.hydrate(<div />, container)).toWarnDev(
-      "Warning: Did not expect server HTML to contain the text node {' '}" +
-        ' in <container><div data-reactroot=""></div> </container>.\n' +
+      "Warning: Did not expect server HTML to contain the text node {' '} in <container>.\n\n" +
         '  <container>\n' +
         '    <div data-reactroot=""></div>\n' +
         "-   {' '}\n" +
-        '  </container>',
+        '  </container>\n',
       // Without the component stack here because it's empty: found an unexpected text node directly in the root node.
       {withoutStack: true},
     );
@@ -278,7 +276,7 @@ describe('ReactMount', () => {
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString(
       <Component>
-        nested{' '}
+        nested{'   '}
         <p>
           children <b>text</b>
         </p>
@@ -286,10 +284,14 @@ describe('ReactMount', () => {
     );
     div.innerHTML = markup;
 
+    expect(div.outerHTML).toEqual(
+      '<div>nested<!-- -->   <p>children <b>text</b></p></div>',
+    );
+
     expect(() =>
       ReactDOM.hydrate(
         <Component>
-          nested{' '}
+          nested{'   '}
           <div>
             children <b>text</b>
           </div>
@@ -297,14 +299,14 @@ describe('ReactMount', () => {
         div,
       ),
     ).toWarnDev(
-      "Warning: Expected server HTML to contain a matching <div>{['children ', …]}</div>" +
-        ' in <div>nested<!-- --> <p>children <b>text</b></p></div>.\n' +
+      'Warning: Expected server HTML to contain a matching <div> in <div>.\n\n' +
         '  <div>\n' +
         "    {'nested'}\n" +
-        "    {' '}\n" +
+        '    <!-- -->\n' +
+        "    {'   '}\n" +
         '-   <p>children <b>text</b></p>\n' +
         "+   <div>{['children ', …]}</div>\n" +
-        '  </div>\n' +
+        '  </div>\n\n' +
         '    in div (at **)\n' +
         '    in Component (at **)',
     );
@@ -322,7 +324,7 @@ describe('ReactMount', () => {
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString(
       <Component>
-        nested{' '}
+        nested{'   '}
         <p>
           children <b>text</b>
         </p>
@@ -330,10 +332,14 @@ describe('ReactMount', () => {
     );
     div.innerHTML = markup;
 
+    expect(div.outerHTML).toEqual(
+      '<div>nested<!-- -->   <p>children <b>text</b></p></div>',
+    );
+
     expect(() =>
       ReactDOM.hydrate(
         <Component>
-          nested{' '}
+          nested{'   '}
           <p>
             children <b>text</b>
           </p>
@@ -344,14 +350,14 @@ describe('ReactMount', () => {
         div,
       ),
     ).toWarnDev(
-      "Warning: Expected server HTML to contain a matching <div>{['children ', …]}</div>" +
-        ' in <div>nested<!-- --> <p>children <b>text</b></p></div>.\n' +
+      'Warning: Expected server HTML to contain a matching <div> in <div>.\n\n' +
         '  <div>\n' +
         "    {'nested'}\n" +
-        "    {' '}\n" +
+        '    <!-- -->\n' +
+        "    {'   '}\n" +
         '    <p>children <b>text</b></p>\n' +
         "+   <div>{['children ', …]}</div>\n" +
-        '  </div>\n' +
+        '  </div>\n\n' +
         '    in div (at **)\n' +
         '    in Component (at **)',
     );
@@ -498,15 +504,13 @@ describe('ReactMount', () => {
         div,
       ),
     ).toWarnDev(
-      'Warning: Did not expect server HTML to contain a <br />' +
-        ' in <div data-ssr-mismatch-test-hydrate-root="">SSRMismatchTest first text' +
-        '<br><br>SSRMismatchTest second text</div>.\n' +
+      'Warning: Did not expect server HTML to contain a <br> in <div>.\n\n' +
         '  <div data-ssr-mismatch-test-hydrate-root="">\n' +
         "    {'SSRMismatchTest first text'}\n" +
         '    <br />\n' +
         '-   <br />\n' +
         "    {'SSRMismatchTest second text'}\n" +
-        '  </div>',
+        '  </div>\n',
       // Without the component stack here because it's empty: rendering a text node directly into the root node.
       {withoutStack: true},
     );
@@ -537,9 +541,7 @@ describe('ReactMount', () => {
         div,
       ),
     ).toWarnDev(
-      'Warning: Did not expect server HTML to contain a <div>SSRMismatchTest default text</div>' +
-        ' in <div data-reactroot=""><div>SSRMismatchTest default text</div><span></span>' +
-        '<div data-ssr-mismatch-padding-after=""></div><d…</div>.\n' +
+      'Warning: Did not expect server HTML to contain a <div> in <div>.\n\n' +
         '  <div data-reactroot="">\n' +
         '-   <div>SSRMismatchTest default text</div>\n' +
         '    <span></span>\n' +
@@ -548,7 +550,7 @@ describe('ReactMount', () => {
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '  </div>\n' +
+        '  </div>\n\n' +
         '    in span (at **)\n' +
         '    in div (at **)',
     );
@@ -573,9 +575,7 @@ describe('ReactMount', () => {
     expect(() =>
       ReactDOM.hydrate([<br key={1} />, 'SSRMismatchTest default text'], div),
     ).toWarnDev(
-      "Warning: Did not expect server HTML to contain the text node {'SSRMismatchTest server text'}" +
-        ' in <div data-ssr-mismatch-test-hydrate-root="">SSRMismatchTest server text' +
-        '<br>SSRMismatchTest default text<div data-ssr-mismatch-padding-after=""><…</div>.\n' +
+      "Warning: Did not expect server HTML to contain the text node {'SSRMismatchTest server text'} in <div>.\n\n" +
         '  <div data-ssr-mismatch-test-hydrate-root="">\n' +
         "-   {'SSRMismatchTest server text'}\n" +
         '    <br />\n' +
@@ -585,7 +585,7 @@ describe('ReactMount', () => {
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '  </div>\n' +
+        '  </div>\n\n' +
         '    in br (at **)',
     );
   });
@@ -615,9 +615,7 @@ describe('ReactMount', () => {
         div,
       ),
     ).toWarnDev(
-      "Warning: Did not expect server HTML to contain the text node {'SSRMismatchTest server text'}" +
-        ' in <div data-reactroot="">SSRMismatchTest server text<span></span>' +
-        '<div data-ssr-mismatch-padding-after=""></div><div data-ssr-…</div>.\n' +
+      "Warning: Did not expect server HTML to contain the text node {'SSRMismatchTest server text'} in <div>.\n\n" +
         '  <div data-reactroot="">\n' +
         "-   {'SSRMismatchTest server text'}\n" +
         '    <span></span>\n' +
@@ -626,7 +624,7 @@ describe('ReactMount', () => {
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '  </div>\n' +
+        '  </div>\n\n' +
         '    in span (at **)\n' +
         '    in div (at **)',
     );
@@ -642,12 +640,11 @@ describe('ReactMount', () => {
     expect(() =>
       ReactDOM.hydrate(<span>SSRMismatchTest default text</span>, div),
     ).toWarnDev(
-      'Warning: Expected server HTML to contain a matching <span>SSRMismatchTest default text</span>' +
-        ' in <div>SSRMismatchTest default text</div>.\n' +
+      'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
         '  <div>\n' +
         "-   {'SSRMismatchTest default text'}\n" +
         '+   <span>SSRMismatchTest default text</span>\n' +
-        '  </div>\n' +
+        '  </div>\n\n' +
         '    in span (at **)',
     );
   });
@@ -671,12 +668,11 @@ describe('ReactMount', () => {
         div,
       ),
     ).toWarnDev(
-      'Warning: Expected server HTML to contain a matching <p>SSRMismatchTest default text</p>' +
-        ' in <div data-reactroot=""><em>SSRMismatchTest default text</em></div>.\n' +
+      'Warning: Expected server HTML to contain a matching <p> in <div>.\n\n' +
         '  <div data-reactroot="">\n' +
         '-   <em>SSRMismatchTest default text</em>\n' +
         '+   <p>SSRMismatchTest default text</p>\n' +
-        '  </div>\n' +
+        '  </div>\n\n' +
         '    in p (at **)\n' +
         '    in div (at **)',
     );
@@ -694,8 +690,12 @@ describe('ReactMount', () => {
     expect(() =>
       ReactDOM.hydrate('SSRMismatchTest default text', div),
     ).toWarnDev(
-      "Warning: Expected server HTML to contain a matching text node for {'SSRMismatchTest default text'}" +
-        ' in <div><span data-reactroot="">SSRMismatchTest default text</span></div>.',
+      'Warning: Expected server HTML to contain a matching text node' +
+        " for {'SSRMismatchTest default text'} in <div>.\n\n" +
+        '  <div>\n' +
+        '-   <span data-reactroot="">SSRMismatchTest default text</span>\n' +
+        "+   {'SSRMismatchTest default text'}\n" +
+        '  </div>\n',
       // Without the component stack here because it's empty: rendering a text node directly into the root node.
       {withoutStack: true},
     );
@@ -728,9 +728,8 @@ describe('ReactMount', () => {
         div,
       ),
     ).toWarnDev(
-      "Warning: Expected server HTML to contain a matching text node for {'SSRMismatchTest client text'}" +
-        ' in <div data-reactroot=""><span></span><span></span>' +
-        '<div data-ssr-mismatch-padding-after=""></div><div data-ssr-mismatch-paddi…</div>.\n' +
+      'Warning: Expected server HTML to contain a matching text node' +
+        " for {'SSRMismatchTest client text'} in <div>.\n\n" +
         '  <div data-reactroot="">\n' +
         '    <span></span>\n' +
         '-   <span></span>\n' +
@@ -740,7 +739,73 @@ describe('ReactMount', () => {
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
         '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '  </div>\n' +
+        '  </div>\n\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when hydrate inserts an element after a comment node', () => {
+    const div = document.createElement('div');
+    div.innerHTML = '<div><!-- a comment --></div>';
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div>
+          <span />
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
+        '  <div>\n' +
+        '    <!-- a comment -->\n' +
+        '+   <span></span>\n' +
+        '  </div>\n\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when hydrate replaces an element after a comment node', () => {
+    const div = document.createElement('div');
+    div.innerHTML = '<div><!-- a comment --><div></div></div>';
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div>
+          <span />
+          <div />
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
+        '  <div>\n' +
+        '    <!-- a comment -->\n' +
+        '-   <div></div>\n' +
+        '+   <span></span>\n' +
+        '  </div>\n\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when hydrate inserts an element after a node that is not an element, text, or comment', () => {
+    // This is an artificial test case to check how we print weird nodes if they somehow end up in the DOM.
+    const xml = document.createElement('xml');
+    xml.appendChild(
+      document.createProcessingInstruction(
+        'dom-processing-instruction',
+        'content',
+      ),
+    );
+
+    expect(() => ReactDOM.hydrate(<div />, xml)).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <div> in <xml>.\n\n' +
+        '  <xml>\n' +
+        '    <?dom-processing-instruction content?>\n' +
+        '+   <div></div>\n' +
+        '  </xml>\n\n' +
         '    in div (at **)',
     );
   });

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -810,6 +810,62 @@ describe('ReactMount', () => {
     );
   });
 
+  it('should warn with special characters in the JSX string output', () => {
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <div>{'SSRMismatchTest special characters: \'"\t\n'}</div>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div>
+          <span />
+          {'SSRMismatchTest special characters: \'"\t\n'}
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      // TODO: Currently, the special characters in the JSX string output are not escaped, the output looks invalid.
+      'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
+        '  <div data-reactroot="">\n' +
+        "-   {'SSRMismatchTest special characters: '\"\t\n'}\n" +
+        '+   <span></span>\n' +
+        '  </div>\n\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn with special characters in the HTML tag output', () => {
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <div data-ssr-mismatch-attribute-with-special-characters={'"'}>
+        <div>{'SSRMismatchTest text'}</div>
+      </div>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div data-ssr-mismatch-attribute-with-special-characters={'"'}>
+          <span>&nbsp;&mdash; &lt;div&gt;</span>
+          <div>{'SSRMismatchTest text'}</div>
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      // TODO: Currently, the special characters in the HTML string output are not escaped, the output looks invalid.
+      'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
+        '  <div data-ssr-mismatch-attribute-with-special-characters=""" data-reactroot="">\n' +
+        '-   <div>SSRMismatchTest text</div>\n' +
+        '+   <span> — <div></span>\n' +
+        '  </div>\n\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)',
+    );
+  });
+
   it('should warn if render removes React-rendered children', () => {
     const container = document.createElement('container');
 

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -286,6 +286,14 @@ describe('ReactMount', () => {
       ),
     ).toWarnDev(
       'Expected server HTML to contain a matching <div> in <div>.\n' +
+        ' <div>\n' +
+        '   nested\n' +
+        '    \n' +
+        '-   \n' +
+        '+  <div />\n' +
+        '   <p>children text</p>\n' +
+        ' </div>\n' +
+        '\n' +
         '    in div (at **)\n' +
         '    in Component (at **)',
     );
@@ -516,6 +524,11 @@ describe('ReactMount', () => {
       ReactDOM.hydrate(<span>SSRMismatchTest default text</span>, div),
     ).toWarnDev(
       'Expected server HTML to contain a matching <span> in <div>.\n' +
+        ' <div>\n' +
+        '-  SSRMismatchTest default text\n' +
+        '+  <span />\n' +
+        ' </div>\n' +
+        '\n' +
         '    in span (at **)',
     );
   });
@@ -540,6 +553,11 @@ describe('ReactMount', () => {
       ),
     ).toWarnDev(
       'Expected server HTML to contain a matching <p> in <div>.\n' +
+        ' <div>\n' +
+        '-  <em>SSRMismatchTest default text</em>\n' +
+        '+  <p />\n' +
+        ' </div>\n' +
+        '\n' +
         '    in p (at **)\n' +
         '    in div (at **)',
     );

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -264,7 +264,7 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn when a hydrated element has children mismatch, warning has replacement diff', () => {
+  it('should warn when a hydrated element has children mismatch (replacement diff)', () => {
     // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance-replacement
 
     class Component extends React.Component {
@@ -277,42 +277,130 @@ describe('ReactMount', () => {
     const markup = ReactDOMServer.renderToString(
       <Component>
         nested{'   '}
-        <p>
+        <h1>
           children <b>text</b>
-        </p>
+        </h1>
+        <div data-ssr-mismatch-padding-after="1" />
+        <div data-ssr-mismatch-padding-after="2" />
+        <div data-ssr-mismatch-padding-after="3" />
+        <div data-ssr-mismatch-padding-after="4" />
+        <div data-ssr-mismatch-padding-after="5" />
       </Component>,
     );
     div.innerHTML = markup;
 
     expect(div.outerHTML).toEqual(
-      '<div>nested<!-- -->   <p>children <b>text</b></p></div>',
+      '<div>nested<!-- -->   <h1>children <b>text</b></h1>' +
+        '<div data-ssr-mismatch-padding-after="1"></div>' +
+        '<div data-ssr-mismatch-padding-after="2"></div>' +
+        '<div data-ssr-mismatch-padding-after="3"></div>' +
+        '<div data-ssr-mismatch-padding-after="4"></div>' +
+        '<div data-ssr-mismatch-padding-after="5"></div>' +
+        '</div>',
     );
 
     expect(() =>
       ReactDOM.hydrate(
         <Component>
           nested{'   '}
-          <div>
+          <h2>
             children <b>text</b>
-          </div>
+          </h2>
         </Component>,
         div,
       ),
     ).toWarnDev(
-      'Warning: Expected server HTML to contain a matching <div> in <div>.\n\n' +
+      'Warning: Expected server HTML to contain a matching <h2> in <div>.\n\n' +
         '  <div>\n' +
         "    {'nested'}\n" +
         '    <!-- -->\n' +
         "    {'   '}\n" +
-        '-   <p>children <b>text</b></p>\n' +
-        "+   <div>{['children ', ...]}</div>\n" +
+        '-   <h1>children <b>text</b></h1>\n' +
+        "+   <h2>{['children ', ...]}</h2>\n" +
+        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
         '  </div>\n\n' +
-        '    in div (at **)\n' +
+        '    in h2 (at **)\n' +
         '    in Component (at **)',
     );
   });
 
-  it('should warn when a hydrated element has extra child element, warning has insertion diff', () => {
+  it('should warn when a hydrated element has extra child element (insertion diff)', () => {
+    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableInstance-insertion
+
+    class Component extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <Component>
+        nested{'   '}
+        <h1>
+          children <b>text</b>
+        </h1>
+        <div data-ssr-mismatch-padding="1" />
+        <div data-ssr-mismatch-padding="2" />
+        <div data-ssr-mismatch-padding="3" />
+        <div data-ssr-mismatch-padding="4" />
+        <div data-ssr-mismatch-padding="5" />
+      </Component>,
+    );
+    div.innerHTML = markup;
+
+    expect(div.outerHTML).toEqual(
+      '<div>nested<!-- -->   <h1>children <b>text</b></h1>' +
+        '<div data-ssr-mismatch-padding="1"></div>' +
+        '<div data-ssr-mismatch-padding="2"></div>' +
+        '<div data-ssr-mismatch-padding="3"></div>' +
+        '<div data-ssr-mismatch-padding="4"></div>' +
+        '<div data-ssr-mismatch-padding="5"></div>' +
+        '</div>',
+    );
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <Component>
+          nested{'   '}
+          <h1>
+            children <b>text</b>
+          </h1>
+          <div data-ssr-mismatch-padding="1" />
+          <div data-ssr-mismatch-padding="2" />
+          <div data-ssr-mismatch-padding="3" />
+          <div data-ssr-mismatch-padding="4" />
+          <div data-ssr-mismatch-padding="5" />
+          <h2>
+            extra <b>element</b>
+          </h2>
+        </Component>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <h2> in <div>.\n\n' +
+        '  <div>\n' +
+        "    {'nested'}\n" +
+        '    <!-- -->\n' +
+        "    {'   '}\n" +
+        '    <h1>children <b>text</b></h1>\n' +
+        '    <div data-ssr-mismatch-padding="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding="5"></div>\n' +
+        "+   <h2>{['extra ', ...]}</h2>\n" +
+        '  </div>\n\n' +
+        '    in h2 (at **)\n' +
+        '    in Component (at **)',
+    );
+  });
+
+  it('should warn when a hydrated element has extra child text node (insertion diff)', () => {
     // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance-insertion
 
     class Component extends React.Component {
@@ -325,40 +413,58 @@ describe('ReactMount', () => {
     const markup = ReactDOMServer.renderToString(
       <Component>
         nested{'   '}
-        <p>
+        <h1>
           children <b>text</b>
-        </p>
+        </h1>
+        <div data-ssr-mismatch-padding="1" />
+        <div data-ssr-mismatch-padding="2" />
+        <div data-ssr-mismatch-padding="3" />
+        <div data-ssr-mismatch-padding="4" />
+        <div data-ssr-mismatch-padding="5" />
       </Component>,
     );
     div.innerHTML = markup;
 
     expect(div.outerHTML).toEqual(
-      '<div>nested<!-- -->   <p>children <b>text</b></p></div>',
+      '<div>nested<!-- -->   <h1>children <b>text</b></h1>' +
+        '<div data-ssr-mismatch-padding="1"></div>' +
+        '<div data-ssr-mismatch-padding="2"></div>' +
+        '<div data-ssr-mismatch-padding="3"></div>' +
+        '<div data-ssr-mismatch-padding="4"></div>' +
+        '<div data-ssr-mismatch-padding="5"></div>' +
+        '</div>',
     );
 
     expect(() =>
       ReactDOM.hydrate(
         <Component>
           nested{'   '}
-          <p>
+          <h1>
             children <b>text</b>
-          </p>
-          <div>
-            children <b>text</b>
-          </div>
+          </h1>
+          <div data-ssr-mismatch-padding="1" />
+          <div data-ssr-mismatch-padding="2" />
+          <div data-ssr-mismatch-padding="3" />
+          <div data-ssr-mismatch-padding="4" />
+          <div data-ssr-mismatch-padding="5" />
+          {'extra text node'}
         </Component>,
         div,
       ),
     ).toWarnDev(
-      'Warning: Expected server HTML to contain a matching <div> in <div>.\n\n' +
+      "Warning: Expected server HTML to contain a matching text node for {'extra text node'} in <div>.\n\n" +
         '  <div>\n' +
         "    {'nested'}\n" +
         '    <!-- -->\n' +
         "    {'   '}\n" +
-        '    <p>children <b>text</b></p>\n' +
-        "+   <div>{['children ', ...]}</div>\n" +
+        '    <h1>children <b>text</b></h1>\n' +
+        '    <div data-ssr-mismatch-padding="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding="5"></div>\n' +
+        "+   {'extra text node'}\n" +
         '  </div>\n\n' +
-        '    in div (at **)\n' +
         '    in Component (at **)',
     );
   });
@@ -482,7 +588,7 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn when hydrate removes an element from a server-rendered sequence in the root container', () => {
+  it('should warn when hydrate removes an element within a root container (removal diff)', () => {
     // See fixtures/ssr: ssr-warnForDeletedHydratableElement-didNotHydrateContainerInstance
 
     const div = document.createElement('div');
@@ -516,7 +622,7 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn when hydrate removes an element from a server-rendered sequence', () => {
+  it('should warn when hydrate removes an element within an element (removal diff)', () => {
     // See fixtures/ssr: ssr-warnForDeletedHydratableElement-didNotHydrateInstance
 
     const div = document.createElement('div');
@@ -524,11 +630,11 @@ describe('ReactMount', () => {
       <div>
         <div>SSRMismatchTest default text</div>
         <span />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
+        <div data-ssr-mismatch-padding-after="1" />
+        <div data-ssr-mismatch-padding-after="2" />
+        <div data-ssr-mismatch-padding-after="3" />
+        <div data-ssr-mismatch-padding-after="4" />
+        <div data-ssr-mismatch-padding-after="5" />
       </div>,
     );
     div.innerHTML = markup;
@@ -545,18 +651,18 @@ describe('ReactMount', () => {
         '  <div data-reactroot="">\n' +
         '-   <div>SSRMismatchTest default text</div>\n' +
         '    <span></span>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
         '  </div>\n\n' +
         '    in span (at **)\n' +
         '    in div (at **)',
     );
   });
 
-  it('should warn when hydrate replaces an element within server-rendered nested components', () => {
+  it('should warn when hydrate replaces an element within server-rendered nested components (replacement diff)', () => {
     class TestPaddingBeforeComponent extends React.Component {
       render() {
         return (
@@ -600,6 +706,7 @@ describe('ReactMount', () => {
             <TestPaddingBeforeComponent />
             <h2>SSRMismatchTest default text</h2>
             <span />
+            <TestPaddingAfterComponent />
           </div>
         );
       }
@@ -642,7 +749,7 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn when hydrate removes a text node from a server-rendered sequence in the root container', () => {
+  it('should warn when hydrate removes a text node within a root container (removal diff)', () => {
     // See fixtures/ssr: ssr-warnForDeletedHydratableText-didNotHydrateContainerInstance
 
     const div = document.createElement('div');
@@ -651,11 +758,11 @@ describe('ReactMount', () => {
       'SSRMismatchTest server text' +
       '<br />' +
       'SSRMismatchTest default text' +
-      '<div data-ssr-mismatch-padding-after=""></div>' +
-      '<div data-ssr-mismatch-padding-after=""></div>' +
-      '<div data-ssr-mismatch-padding-after=""></div>' +
-      '<div data-ssr-mismatch-padding-after=""></div>' +
-      '<div data-ssr-mismatch-padding-after=""></div>';
+      '<div data-ssr-mismatch-padding-after="1"></div>' +
+      '<div data-ssr-mismatch-padding-after="2"></div>' +
+      '<div data-ssr-mismatch-padding-after="3"></div>' +
+      '<div data-ssr-mismatch-padding-after="4"></div>' +
+      '<div data-ssr-mismatch-padding-after="5"></div>';
     div.innerHTML = markup;
 
     expect(() =>
@@ -666,17 +773,17 @@ describe('ReactMount', () => {
         "-   {'SSRMismatchTest server text'}\n" +
         '    <br />\n' +
         "    {'SSRMismatchTest default text'}\n" +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
         '  </div>\n\n' +
         '    in br (at **)',
     );
   });
 
-  it('should warn when hydrate removes a text node from a server-rendered sequence', () => {
+  it('should warn when hydrate removes a text node within an element (removal diff)', () => {
     // See fixtures/ssr: ssr-warnForDeletedHydratableText-didNotHydrateInstance
 
     const div = document.createElement('div');
@@ -684,11 +791,11 @@ describe('ReactMount', () => {
       <div>
         SSRMismatchTest server text
         <span />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
+        <div data-ssr-mismatch-padding-after="1" />
+        <div data-ssr-mismatch-padding-after="2" />
+        <div data-ssr-mismatch-padding-after="3" />
+        <div data-ssr-mismatch-padding-after="4" />
+        <div data-ssr-mismatch-padding-after="5" />
       </div>,
     );
     div.innerHTML = markup;
@@ -705,18 +812,18 @@ describe('ReactMount', () => {
         '  <div data-reactroot="">\n' +
         "-   {'SSRMismatchTest server text'}\n" +
         '    <span></span>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
         '  </div>\n\n' +
         '    in span (at **)\n' +
         '    in div (at **)',
     );
   });
 
-  it('should warn when hydrate inserts an element to replace a text node in the root container', () => {
+  it('should warn when hydrate replaces a text node by an element within a root container (replacement diff)', () => {
     // See fixtures/ssr: ssr-warnForInsertedHydratedElement-didNotFindHydratableContainerInstance
 
     const div = document.createElement('div');
@@ -735,7 +842,30 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn when hydrate inserts an element to replace a different element', () => {
+  it('should warn when hydrate replaces an element by a text node within a root container (replacement diff)', () => {
+    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableContainerTextInstance
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <span>SSRMismatchTest default text</span>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate('SSRMismatchTest default text', div),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching text node' +
+        " for {'SSRMismatchTest default text'} in <div>.\n\n" +
+        '  <div>\n' +
+        '-   <span data-reactroot="">SSRMismatchTest default text</span>\n' +
+        "+   {'SSRMismatchTest default text'}\n" +
+        '  </div>\n',
+      // Without the component stack here because it's empty: rendering a text node directly into the root node.
+      {withoutStack: true},
+    );
+  });
+
+  it('should warn when hydrate replaces an element by a different element (replacement diff)', () => {
     // See fixtures/ssr: ssr-warnForInsertedHydratedElement-didNotFindHydratableInstance
 
     const div = document.createElement('div');
@@ -764,42 +894,19 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn when hydrate inserts a text node to replace an element in the root container', () => {
-    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableContainerTextInstance
-
-    const div = document.createElement('div');
-    const markup = ReactDOMServer.renderToString(
-      <span>SSRMismatchTest default text</span>,
-    );
-    div.innerHTML = markup;
-
-    expect(() =>
-      ReactDOM.hydrate('SSRMismatchTest default text', div),
-    ).toWarnDev(
-      'Warning: Expected server HTML to contain a matching text node' +
-        " for {'SSRMismatchTest default text'} in <div>.\n\n" +
-        '  <div>\n' +
-        '-   <span data-reactroot="">SSRMismatchTest default text</span>\n' +
-        "+   {'SSRMismatchTest default text'}\n" +
-        '  </div>\n',
-      // Without the component stack here because it's empty: rendering a text node directly into the root node.
-      {withoutStack: true},
-    );
-  });
-
-  it('should warn when hydrate inserts a text node between matching elements', () => {
+  it('should warn when hydrate inserts a text node between matching elements (insertion diff)', () => {
     // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance
 
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString(
       <div>
+        <span data-ssr-mismatch-padding-before="1" />
         <span />
-        <span />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
-        <div data-ssr-mismatch-padding-after="" />
+        <div data-ssr-mismatch-padding-after="1" />
+        <div data-ssr-mismatch-padding-after="2" />
+        <div data-ssr-mismatch-padding-after="3" />
+        <div data-ssr-mismatch-padding-after="4" />
+        <div data-ssr-mismatch-padding-after="5" />
       </div>,
     );
     div.innerHTML = markup;
@@ -807,9 +914,8 @@ describe('ReactMount', () => {
     expect(() =>
       ReactDOM.hydrate(
         <div>
-          <span />
+          <span data-ssr-mismatch-padding-before="1" />
           SSRMismatchTest client text
-          <span />
         </div>,
         div,
       ),
@@ -817,20 +923,20 @@ describe('ReactMount', () => {
       'Warning: Expected server HTML to contain a matching text node' +
         " for {'SSRMismatchTest client text'} in <div>.\n\n" +
         '  <div data-reactroot="">\n' +
-        '    <span></span>\n' +
-        '-   <span></span>\n' +
+        '    <span data-ssr-mismatch-padding-before="1"></span>\n' +
         "+   {'SSRMismatchTest client text'}\n" +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
-        '    <div data-ssr-mismatch-padding-after=""></div>\n' +
+        '    <span></span>\n' +
+        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
         '  </div>\n\n' +
         '    in div (at **)',
     );
   });
 
-  it('should warn when hydrate inserts an element after a comment node', () => {
+  it('should warn when hydrate inserts an element after a comment node (insertion diff)', () => {
     const div = document.createElement('div');
     div.innerHTML = '<div><!-- a comment --></div>';
 
@@ -852,7 +958,7 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn when hydrate replaces an element after a comment node', () => {
+  it('should warn when hydrate replaces an element after a comment node (replacement diff)', () => {
     const div = document.createElement('div');
     div.innerHTML = '<div><!-- a comment --><div></div></div>';
 
@@ -876,8 +982,9 @@ describe('ReactMount', () => {
     );
   });
 
-  it('should warn when hydrate inserts an element after a node that is not an element, text, or comment', () => {
-    // This is an artificial test case to check how we print weird nodes if they somehow end up in the DOM.
+  it('should warn when hydrate inserts an element after a non-typical node (insertion diff)', () => {
+    // A non-typical node is a node that is not typically seen in the DOM: not an element, text, or comment.
+    // This is an artificial test case to check how we print non-typical nodes if they somehow end up in the DOM.
     const xml = document.createElement('xml');
     xml.appendChild(
       document.createProcessingInstruction(

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -203,9 +203,9 @@ describe('rendering React components at document', () => {
             'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
           {withoutStack: true},
         );
-      }).toWarnDev('Warning: Text content did not match.', {
-        withoutStack: true,
-      });
+      }).toWarnDev(
+        'Warning: Text content did not match. Server: "Goodbye world" Client: "Hello world"',
+      );
     });
 
     it('should throw on full document render w/ no markup', () => {
@@ -373,7 +373,6 @@ describe('rendering React components at document', () => {
       container.textContent = 'potato';
       expect(() => ReactDOM.hydrate(<div>parsnip</div>, container)).toWarnDev(
         'Expected server HTML to contain a matching <div> in <div>.',
-        {withoutStack: true},
       );
       expect(container.textContent).toBe('parsnip');
     });
@@ -399,9 +398,9 @@ describe('rendering React components at document', () => {
 
       expect(() =>
         ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
-      ).toWarnDev('Warning: Text content did not match.', {
-        withoutStack: true,
-      });
+      ).toWarnDev(
+        'Warning: Text content did not match. Server: "Goodbye world" Client: "Hello world"',
+      );
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });
 
@@ -424,9 +423,7 @@ describe('rendering React components at document', () => {
       // getTestDocument() has an extra <meta> that we didn't render.
       expect(() =>
         ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
-      ).toWarnDev('Did not expect server HTML to contain a <meta> in <head>.', {
-        withoutStack: true,
-      });
+      ).toWarnDev('Did not expect server HTML to contain a <meta> in <head>.');
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });
 

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -368,7 +368,7 @@ describe('rendering React components at document', () => {
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });
 
-    it('renders over an existing text child without throwing, warning has replacement diff', () => {
+    it('renders over an existing text child without throwing, should warn (replacement diff)', () => {
       const container = document.createElement('div');
       container.textContent = 'potato';
       expect(() => ReactDOM.hydrate(<div>parsnip</div>, container)).toWarnDev(
@@ -382,7 +382,7 @@ describe('rendering React components at document', () => {
       expect(container.textContent).toBe('parsnip');
     });
 
-    it('renders an array of texts over an existing text child without throwing, warning has replacement diff', () => {
+    it('renders an array of texts over an existing text child without throwing, should warn (replacement diff)', () => {
       const container = document.createElement('div');
       container.textContent = 'potato';
       expect(() =>

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -372,11 +372,11 @@ describe('rendering React components at document', () => {
       const container = document.createElement('div');
       container.textContent = 'potato';
       expect(() => ReactDOM.hydrate(<div>parsnip</div>, container)).toWarnDev(
-        'Warning: Expected server HTML to contain a matching <div>parsnip</div> in <div>potato</div>.\n' +
+        'Warning: Expected server HTML to contain a matching <div> in <div>.\n\n' +
           '  <div>\n' +
           "-   {'potato'}\n" +
           '+   <div>parsnip</div>\n' +
-          '  </div>\n' +
+          '  </div>\n\n' +
           '    in div (at **)',
       );
       expect(container.textContent).toBe('parsnip');
@@ -388,12 +388,11 @@ describe('rendering React components at document', () => {
       expect(() =>
         ReactDOM.hydrate(<div>{['parsnip', 'carrot']}</div>, container),
       ).toWarnDev(
-        "Warning: Expected server HTML to contain a matching <div>{['parsnip', 'carrot']}</div>" +
-          ' in <div>potato</div>.\n' +
+        'Warning: Expected server HTML to contain a matching <div> in <div>.\n\n' +
           '  <div>\n' +
           "-   {'potato'}\n" +
           "+   <div>{['parsnip', 'carrot']}</div>\n" +
-          '  </div>\n' +
+          '  </div>\n\n' +
           '    in div (at **)',
       );
       expect(container.textContent).toBe('parsnipcarrot');
@@ -446,12 +445,11 @@ describe('rendering React components at document', () => {
       expect(() =>
         ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
       ).toWarnDev(
-        'Warning: Did not expect server HTML to contain a <meta charset="utf-8" />' +
-          ' in <head><meta charset="utf-8"><title>test doc</title></head>.\n' +
+        'Warning: Did not expect server HTML to contain a <meta> in <head>.\n\n' +
           '  <head>\n' +
           '-   <meta charset="utf-8" />\n' +
           '    <title>test doc</title>\n' +
-          '  </head>\n' +
+          '  </head>\n\n' +
           '    in title (at **)\n' +
           '    in head (at **)\n' +
           '    in html (at **)\n' +
@@ -488,14 +486,12 @@ describe('rendering React components at document', () => {
       expect(() =>
         ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
       ).toWarnDev(
-        'Warning: Did not expect server HTML to contain a <meta charset="utf-8" />' +
-          ' in <head><meta charset="utf-8"><title>' +
-          'test doc long title long title long title long title long title long ti…</head>.\n' +
+        'Warning: Did not expect server HTML to contain a <meta> in <head>.\n\n' +
           '  <head>\n' +
           '-   <meta charset="utf-8" />\n' +
           '    <title>test doc long title long title long title long title long title' +
           ' long title long title long title lon…</title>\n' +
-          '  </head>\n' +
+          '  </head>\n\n' +
           '    in title (at **)\n' +
           '    in head (at **)\n' +
           '    in html (at **)\n' +

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -490,7 +490,7 @@ describe('rendering React components at document', () => {
           '  <head>\n' +
           '-   <meta charset="utf-8" />\n' +
           '    <title>test doc long title long title long title long title long title' +
-          ' long title long title long title lon…</title>\n' +
+          ' long title long title long title lon...</title>\n' +
           '  </head>\n\n' +
           '    in title (at **)\n' +
           '    in head (at **)\n' +

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -102,9 +102,7 @@ describe('ReactDOMServerHydration', () => {
       element.innerHTML = lastMarkup;
       expect(() => {
         instance = ReactDOM.render(<TestComponent name="y" />, element);
-      }).toWarnDev('Text content did not match. Server: "x" Client: "y"', {
-        withoutStack: true,
-      });
+      }).toWarnDev('Text content did not match. Server: "x" Client: "y"');
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
       expect(element.innerHTML).not.toEqual(lastMarkup);
@@ -187,9 +185,7 @@ describe('ReactDOMServerHydration', () => {
       element.innerHTML = lastMarkup;
       expect(() => {
         instance = ReactDOM.hydrate(<TestComponent name="y" />, element);
-      }).toWarnDev('Text content did not match. Server: "x" Client: "y"', {
-        withoutStack: true,
-      });
+      }).toWarnDev('Text content did not match. Server: "x" Client: "y"');
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
       expect(element.innerHTML).not.toEqual(lastMarkup);
@@ -252,7 +248,6 @@ describe('ReactDOMServerHydration', () => {
       ReactDOM.hydrate(<button autoFocus={false}>client</button>, element),
     ).toWarnDev(
       'Warning: Text content did not match. Server: "server" Client: "client"',
-      {withoutStack: true},
     );
 
     expect(element.firstChild.focus).not.toHaveBeenCalled();
@@ -277,7 +272,6 @@ describe('ReactDOMServerHydration', () => {
       'Warning: Prop `style` did not match. Server: ' +
         '"text-decoration:none;color:black;height:10px" Client: ' +
         '"text-decoration:none;color:white;height:10px"',
-      {withoutStack: true},
     );
   });
 
@@ -325,7 +319,6 @@ describe('ReactDOMServerHydration', () => {
       'Warning: Prop `style` did not match. Server: ' +
         '"text-decoration: none; color: black; height: 10px;" Client: ' +
         '"text-decoration:none;color:black;height:10px"',
-      {withoutStack: true},
     );
   });
 

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -67,9 +67,9 @@ const HTML = '__html';
 const {html: HTML_NAMESPACE} = Namespaces;
 
 let getTextContentSignature = (textContent: string) => '';
-let getNodeSignatureForDiff = (node: Node, openTagOnly = false) => '<…>';
-let getNodeSignatureForMessage = (node: Node) => '<…>';
-let getTagWithPropsSignature = (tag: string, props: Object) => '<…>';
+let getNodeSignatureForDiff = (node: Node, openTagOnly = false) => '<...>';
+let getNodeSignatureForMessage = (node: Node) => '<...>';
+let getTagWithPropsSignature = (tag: string, props: Object) => '<...>';
 let getNodeSurroundingsAndDiff = (
   parentNode: Element | Document,
   deletedIndex: number,
@@ -98,7 +98,7 @@ if (__DEV__) {
 
   const clipStringWithEllipsis = function(str: string, clipAtLength: number) {
     return (
-      str.substring(0, clipAtLength) + (str.length > clipAtLength ? '…' : '')
+      str.substring(0, clipAtLength) + (str.length > clipAtLength ? '...' : '')
     );
   };
 
@@ -207,7 +207,7 @@ if (__DEV__) {
       }
       let markup = null;
       if (propKey === STYLE) {
-        markup = propKey + '={…}';
+        markup = propKey + '={...}';
       } else if (typeof propValue === 'function') {
         markup = propKey + '={' + propValue.name || propValue.toString() + '}';
       } else {
@@ -237,12 +237,12 @@ if (__DEV__) {
           if (typeof child === 'string') {
             ret += "'" + child + "'";
           } else {
-            ret += '…';
+            ret += '...';
           }
         }
         ret += ']}</';
       } else if (props.children) {
-        ret += '>{…}</';
+        ret += '>{...}</';
       } else {
         ret += '></';
       }

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -72,8 +72,8 @@ let getNodeSignatureForMessage = (node: Node) => '<...>';
 let getTagWithPropsSignature = (tag: string, props: Object) => '<...>';
 let getNodeSurroundingsAndDiff = (
   parentNode: Element | Document,
-  deletedIndex: number,
-  insertedIndex: number,
+  hostInstanceDeletedIndex: number,
+  hostInstanceInsertedIndex: number,
   insertTag: string | null,
   insertProps: Object | null,
   insertText: string | null,
@@ -254,8 +254,8 @@ if (__DEV__) {
 
   getNodeSurroundingsAndDiff = function(
     parentNode: Element | Document,
-    deletedIndex: number,
-    insertedIndex: number,
+    hostInstanceDeletedIndex: number,
+    hostInstanceInsertedIndex: number,
     insertTag: string | null,
     insertProps: Object | null,
     insertText: string | null,
@@ -298,12 +298,12 @@ if (__DEV__) {
         ++hydrationSkippedCount;
         continue;
       }
-      if (i - hydrationSkippedCount === deletedIndex) {
+      if (i - hydrationSkippedCount === hostInstanceDeletedIndex) {
         ret += DIFF_REMOVED + INDENT + getNodeSignatureForDiff(node);
       } else {
         ret += DIFF_UNCHANGED + INDENT + getNodeSignatureForDiff(node);
       }
-      if (i - hydrationSkippedCount === insertedIndex) {
+      if (i - hydrationSkippedCount === hostInstanceInsertedIndex) {
         insert();
       }
     }
@@ -1447,8 +1447,8 @@ export function warnForInsertedHydratedElement(
   parentNode: Element | Document,
   tag: string,
   props: Object,
-  index: number,
-  isReplaced: boolean,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
 ) {
   if (__DEV__) {
     if (didWarnInvalidHydration) {
@@ -1462,8 +1462,10 @@ export function warnForInsertedHydratedElement(
       getNodeSignatureForMessage(parentNode),
       getNodeSurroundingsAndDiff(
         parentNode,
-        isReplaced ? index : -1,
-        index,
+        hydrationWarningHostInstanceIsReplaced
+          ? hydrationWarningHostInstanceIndex
+          : -1,
+        hydrationWarningHostInstanceIndex,
         tag,
         props,
         null,
@@ -1475,8 +1477,8 @@ export function warnForInsertedHydratedElement(
 export function warnForInsertedHydratedText(
   parentNode: Element | Document,
   text: string,
-  index: number,
-  isReplaced: boolean,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
 ) {
   if (__DEV__) {
     if (text === '') {
@@ -1497,8 +1499,10 @@ export function warnForInsertedHydratedText(
       getNodeSignatureForMessage(parentNode),
       getNodeSurroundingsAndDiff(
         parentNode,
-        isReplaced ? index : -1,
-        index,
+        hydrationWarningHostInstanceIsReplaced
+          ? hydrationWarningHostInstanceIndex
+          : -1,
+        hydrationWarningHostInstanceIndex,
         null,
         null,
         text,

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -12,7 +12,6 @@ import {getCurrentFiberOwnerNameInDevOrNull} from 'react-reconciler/src/ReactCur
 import {registrationNameModules} from 'events/EventPluginRegistry';
 import warning from 'shared/warning';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import warningWithoutStack from 'shared/warningWithoutStack';
 
 import * as DOMPropertyOperations from './DOMPropertyOperations';
 import * as ReactDOMInput from './ReactDOMInput';
@@ -135,7 +134,7 @@ if (__DEV__) {
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Text content did not match. Server: "%s" Client: "%s"',
       normalizedServerText,
@@ -161,7 +160,7 @@ if (__DEV__) {
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Prop `%s` did not match. Server: %s Client: %s',
       propName,
@@ -179,7 +178,7 @@ if (__DEV__) {
     attributeNames.forEach(function(name) {
       names.push(name);
     });
-    warningWithoutStack(false, 'Extra attributes from the server: %s', names);
+    warning(false, 'Extra attributes from the server: %s', names);
   };
 
   warnForInvalidEventListener = function(registrationName, listener) {
@@ -1149,7 +1148,7 @@ export function warnForDeletedHydratableElement(
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Did not expect server HTML to contain a <%s> in <%s>.',
       child.nodeName.toLowerCase(),
@@ -1167,7 +1166,7 @@ export function warnForDeletedHydratableText(
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Did not expect server HTML to contain the text node "%s" in <%s>.',
       child.nodeValue,
@@ -1186,7 +1185,7 @@ export function warnForInsertedHydratedElement(
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Expected server HTML to contain a matching <%s> in <%s>.',
       tag,
@@ -1211,7 +1210,7 @@ export function warnForInsertedHydratedText(
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Expected server HTML to contain a matching text node for "%s" in <%s>.',
       text,

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -558,9 +558,10 @@ export function didNotFindHydratableContainerInstance(
   parentContainer: Container,
   type: string,
   props: Props,
+  index: number,
 ) {
   if (__DEV__) {
-    warnForInsertedHydratedElement(parentContainer, type, props);
+    warnForInsertedHydratedElement(parentContainer, type, props, index);
   }
 }
 
@@ -579,9 +580,10 @@ export function didNotFindHydratableInstance(
   parentInstance: Instance,
   type: string,
   props: Props,
+  index: number,
 ) {
   if (__DEV__ && parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
-    warnForInsertedHydratedElement(parentInstance, type, props);
+    warnForInsertedHydratedElement(parentInstance, type, props, index);
   }
 }
 

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -559,18 +559,27 @@ export function didNotFindHydratableContainerInstance(
   type: string,
   props: Props,
   index: number,
+  isReplaced: boolean,
 ) {
   if (__DEV__) {
-    warnForInsertedHydratedElement(parentContainer, type, props, index);
+    warnForInsertedHydratedElement(
+      parentContainer,
+      type,
+      props,
+      index,
+      isReplaced,
+    );
   }
 }
 
 export function didNotFindHydratableContainerTextInstance(
   parentContainer: Container,
   text: string,
+  index: number,
+  isReplaced: boolean,
 ) {
   if (__DEV__) {
-    warnForInsertedHydratedText(parentContainer, text);
+    warnForInsertedHydratedText(parentContainer, text, index, isReplaced);
   }
 }
 
@@ -581,9 +590,16 @@ export function didNotFindHydratableInstance(
   type: string,
   props: Props,
   index: number,
+  isReplaced: boolean,
 ) {
   if (__DEV__ && parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
-    warnForInsertedHydratedElement(parentInstance, type, props, index);
+    warnForInsertedHydratedElement(
+      parentInstance,
+      type,
+      props,
+      index,
+      isReplaced,
+    );
   }
 }
 
@@ -592,8 +608,10 @@ export function didNotFindHydratableTextInstance(
   parentProps: Props,
   parentInstance: Instance,
   text: string,
+  index: number,
+  isReplaced: boolean,
 ) {
   if (__DEV__ && parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
-    warnForInsertedHydratedText(parentInstance, text);
+    warnForInsertedHydratedText(parentInstance, text, index, isReplaced);
   }
 }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -558,16 +558,16 @@ export function didNotFindHydratableContainerInstance(
   parentContainer: Container,
   type: string,
   props: Props,
-  index: number,
-  isReplaced: boolean,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
 ) {
   if (__DEV__) {
     warnForInsertedHydratedElement(
       parentContainer,
       type,
       props,
-      index,
-      isReplaced,
+      hydrationWarningHostInstanceIndex,
+      hydrationWarningHostInstanceIsReplaced,
     );
   }
 }
@@ -575,11 +575,16 @@ export function didNotFindHydratableContainerInstance(
 export function didNotFindHydratableContainerTextInstance(
   parentContainer: Container,
   text: string,
-  index: number,
-  isReplaced: boolean,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
 ) {
   if (__DEV__) {
-    warnForInsertedHydratedText(parentContainer, text, index, isReplaced);
+    warnForInsertedHydratedText(
+      parentContainer,
+      text,
+      hydrationWarningHostInstanceIndex,
+      hydrationWarningHostInstanceIsReplaced,
+    );
   }
 }
 
@@ -589,16 +594,16 @@ export function didNotFindHydratableInstance(
   parentInstance: Instance,
   type: string,
   props: Props,
-  index: number,
-  isReplaced: boolean,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
 ) {
   if (__DEV__ && parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
     warnForInsertedHydratedElement(
       parentInstance,
       type,
       props,
-      index,
-      isReplaced,
+      hydrationWarningHostInstanceIndex,
+      hydrationWarningHostInstanceIsReplaced,
     );
   }
 }
@@ -608,10 +613,15 @@ export function didNotFindHydratableTextInstance(
   parentProps: Props,
   parentInstance: Instance,
   text: string,
-  index: number,
-  isReplaced: boolean,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
 ) {
   if (__DEV__ && parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
-    warnForInsertedHydratedText(parentInstance, text, index, isReplaced);
+    warnForInsertedHydratedText(
+      parentInstance,
+      text,
+      hydrationWarningHostInstanceIndex,
+      hydrationWarningHostInstanceIsReplaced,
+    );
   }
 }

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -102,10 +102,12 @@ function deleteHydratableInstance(
 function insertNonHydratedInstance(
   returnFiber: Fiber,
   fiber: Fiber,
-  isReplaced: boolean,
+  hydrationWarningHostInstanceIsReplaced: boolean,
 ) {
   fiber.effectTag |= Placement;
   if (__DEV__) {
+    // TODO: Find out what `hydrationWarningHostInstanceIndex` should be, `fiber.index` is wrong.
+    const hydrationWarningHostInstanceIndex = fiber.index;
     switch (returnFiber.tag) {
       case HostRoot: {
         const parentContainer = returnFiber.stateNode.containerInfo;
@@ -117,8 +119,8 @@ function insertNonHydratedInstance(
               parentContainer,
               type,
               props,
-              fiber.index,
-              isReplaced,
+              hydrationWarningHostInstanceIndex,
+              hydrationWarningHostInstanceIsReplaced,
             );
             break;
           case HostText:
@@ -126,8 +128,8 @@ function insertNonHydratedInstance(
             didNotFindHydratableContainerTextInstance(
               parentContainer,
               text,
-              fiber.index,
-              isReplaced,
+              hydrationWarningHostInstanceIndex,
+              hydrationWarningHostInstanceIsReplaced,
             );
             break;
         }
@@ -147,8 +149,8 @@ function insertNonHydratedInstance(
               parentInstance,
               type,
               props,
-              fiber.index,
-              isReplaced,
+              hydrationWarningHostInstanceIndex,
+              hydrationWarningHostInstanceIsReplaced,
             );
             break;
           case HostText:
@@ -158,8 +160,8 @@ function insertNonHydratedInstance(
               parentProps,
               parentInstance,
               text,
-              fiber.index,
-              isReplaced,
+              hydrationWarningHostInstanceIndex,
+              hydrationWarningHostInstanceIsReplaced,
             );
             break;
         }

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -99,7 +99,11 @@ function deleteHydratableInstance(
   }
 }
 
-function insertNonHydratedInstance(returnFiber: Fiber, fiber: Fiber) {
+function insertNonHydratedInstance(
+  returnFiber: Fiber,
+  fiber: Fiber,
+  isReplaced: boolean,
+) {
   fiber.effectTag |= Placement;
   if (__DEV__) {
     switch (returnFiber.tag) {
@@ -114,11 +118,17 @@ function insertNonHydratedInstance(returnFiber: Fiber, fiber: Fiber) {
               type,
               props,
               fiber.index,
+              isReplaced,
             );
             break;
           case HostText:
             const text = fiber.pendingProps;
-            didNotFindHydratableContainerTextInstance(parentContainer, text);
+            didNotFindHydratableContainerTextInstance(
+              parentContainer,
+              text,
+              fiber.index,
+              isReplaced,
+            );
             break;
         }
         break;
@@ -138,6 +148,7 @@ function insertNonHydratedInstance(returnFiber: Fiber, fiber: Fiber) {
               type,
               props,
               fiber.index,
+              isReplaced,
             );
             break;
           case HostText:
@@ -147,6 +158,8 @@ function insertNonHydratedInstance(returnFiber: Fiber, fiber: Fiber) {
               parentProps,
               parentInstance,
               text,
+              fiber.index,
+              isReplaced,
             );
             break;
         }
@@ -191,7 +204,7 @@ function tryToClaimNextHydratableInstance(fiber: Fiber): void {
   let nextInstance = nextHydratableInstance;
   if (!nextInstance) {
     // Nothing to hydrate. Make it an insertion.
-    insertNonHydratedInstance((hydrationParentFiber: any), fiber);
+    insertNonHydratedInstance((hydrationParentFiber: any), fiber, false);
     isHydrating = false;
     hydrationParentFiber = fiber;
     return;
@@ -204,7 +217,7 @@ function tryToClaimNextHydratableInstance(fiber: Fiber): void {
     nextInstance = getNextHydratableSibling(firstAttemptedInstance);
     if (!nextInstance || !tryHydrate(fiber, nextInstance)) {
       // Nothing to hydrate. Make it an insertion.
-      insertNonHydratedInstance((hydrationParentFiber: any), fiber);
+      insertNonHydratedInstance((hydrationParentFiber: any), fiber, true);
       isHydrating = false;
       hydrationParentFiber = fiber;
       return;

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -109,7 +109,12 @@ function insertNonHydratedInstance(returnFiber: Fiber, fiber: Fiber) {
           case HostComponent:
             const type = fiber.type;
             const props = fiber.pendingProps;
-            didNotFindHydratableContainerInstance(parentContainer, type, props);
+            didNotFindHydratableContainerInstance(
+              parentContainer,
+              type,
+              props,
+              fiber.index,
+            );
             break;
           case HostText:
             const text = fiber.pendingProps;
@@ -132,6 +137,7 @@ function insertNonHydratedInstance(returnFiber: Fiber, fiber: Fiber) {
               parentInstance,
               type,
               props,
+              fiber.index,
             );
             break;
           case HostText:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4454,6 +4454,12 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
+schedule@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.2.0.tgz#c20fb72cd03918aff2e79025be111d6a9d1f41f8"
+  dependencies:
+    object-assign "^4.1.1"
+
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"


### PR DESCRIPTION
Renders DOM attributes in the tags mentioned in the warnings. Borrows the idea and partially implementation of `getNodeSignature` from @giles-v https://github.com/facebook/react/pull/12115

Renders DOM diff and component stack showing visually the location where the hydration failed. Example warning with a diff (see [the `fixtures/ssr`](https://github.com/facebook/react/pull/12063/files#diff-5ec2d35d1f0d9ccc2f3a4a53d0615ba4) and [the tests](https://github.com/facebook/react/pull/12063/files#diff-1ee0c467f9deb87ae13e737c58c4ac34) for more warning examples):
```
Warning: Expected server HTML to contain a matching <div> in <div>.

  <div>
    {'nested'}
    <!-- -->
    {' '}
    <p>children <b>text</b></p>
+   <div>{['children ', …]}</div>
  </div>

    in div (at SSRMismatchTest.js:280)
    in div (at SSRMismatchTest.js:275)
    in div (at SSRMismatchTest.js:308)
    in SSRMismatchTest (at App.js:14)
    in div (at App.js:11)
    in body (at Chrome.js:17)
    in html (at Chrome.js:9)
    in Chrome (at App.js:10)
    in App (at index.js:8)
```
<img width="480" alt="react-fixtures-ssr-example" src="https://user-images.githubusercontent.com/498274/41187398-263b17e8-6b5d-11e8-8eae-57556babafc9.png">


Requires changes to ReactFiberReconciler interface functions that handle hydration errors to distinguish insertion from replacement and show insertion as one added line in the diff; show replacement as one removed, one added line, at correct position among the parentInstance's DOM children:
- add `index` (use `fiber.index`) to point at which child node the insertion or replacement occurs;
- add `isReplaced` to distinguish insertion from replacement.

<details>
<summary>
The latest screen recording from <code>fixtures/ssr</code> (7.8MB – click to expand)
</summary>

![react-fixtures-ssr-10mb](https://user-images.githubusercontent.com/498274/41187303-53d64b02-6b5b-11e8-9730-729dd2817d12.gif)

</details>

------

<details><summary>Previous revisions</summary>

```
Warning: Expected server HTML to contain a matching <div>{['children ', …]}</div> in <div>nested<!-- --> <p>children <b>text</b></p></div>.
  <div>
    {'nested'}
    {' '}
    <p>children <b>text</b></p>
+   <div>{['children ', …]}</div>
  </div>
    in div (at SSRMismatchTest.js:280)
    in div (at SSRMismatchTest.js:275)
    in div (at SSRMismatchTest.js:308)
    in SSRMismatchTest (at App.js:14)
    in div (at App.js:11)
    in body (at Chrome.js:17)
    in html (at Chrome.js:9)
    in Chrome (at App.js:10)
    in App (at index.js:8)
```

Extends the proof-of-concept at commit 6c425e7b90cd61f1124c566b26fa2a5d00261b1b

![react-ssr-warning-diff](https://user-images.githubusercontent.com/498274/36652198-11bb46fe-1a62-11e8-9fa2-a612827d1463.gif)

------

* Added textual component stack to the hydrate mismatch warnings
* Added DOM hydrate mismatch test cases to fixtures/ssr

Example warning:
```
Warning: Expected server HTML to contain a matching <p> in <div>.
    in p (at SSRMismatchTest.js:40)
    in div (at SSRMismatchTest.js:39)
    in div (at SSRMismatchTest.js:46)
    in SSRMismatchTest (at App.js:14)
    in div (at App.js:11)
    in body (at Chrome.js:17)
    in html (at Chrome.js:9)
    in Chrome (at App.js:10)
    in App (at index.js:8)
```

![react-ssr-mismatch](https://user-images.githubusercontent.com/498274/35189753-a3e6eefc-fe06-11e7-9a15-216bcf4a6e83.gif)

</details>

------

Fixes https://github.com/facebook/react/issues/10085