### PR TITLE
Improved toWarnDev matcher to avoid swallowing errors

### DIFF
--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -70,6 +70,12 @@ const createMatcherFor = consoleMethod =>
         // Restore the unspied method so that unexpected errors fail tests.
         console[consoleMethod] = originalMethod;
 
+        // Any unexpected Errors thrown by the callback should fail the test.
+        // This should take precedence since unexpected errors could block warnings.
+        if (caughtError) {
+          throw caughtError;
+        }
+
         // Any unexpected warnings should be treated as a failure.
         if (unexpectedWarnings.length > 0) {
           return {
@@ -87,11 +93,6 @@ const createMatcherFor = consoleMethod =>
               )}`,
             pass: false,
           };
-        }
-
-        // Any unexpected Errors thrown by the callback should fail the test.
-        if (caughtError) {
-          throw caughtError;
         }
 
         return {pass: true};


### PR DESCRIPTION
While writing tests for unsafe async warnings, I noticed that in certain cases, errors were swallowed by the `toWarnDev` matcher and resulted in confusing test failures. For example, if an error prevented the code being tested from logging an expected warning- the test would fail saying that the warning hadn't been logged rather than reporting the unexpected error. I think a better approach for this is to always treat caught errors as the highest-priority reason for failing a test.

I reran all of the test cases for this matcher that I originally ran with PR #11786 and ensured they all still pass.