### PR TITLE
Improve toWarnDev matcher DX for unexpected warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "gzip-size": "^3.0.0",
     "jasmine-check": "^1.0.0-rc.0",
     "jest": "^22.0.6",
+    "jest-diff": "^22.1.0",
     "merge-stream": "^1.0.0",
     "minimatch": "^3.0.4",
     "minimist": "^1.2.0",

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const jestDiff = require('jest-diff');
+
 function normalizeCodeLocInfo(str) {
   return str && str.replace(/at .+?:\d+/g, 'at **');
 }
@@ -39,13 +41,19 @@ const createMatcherFor = consoleMethod =>
           }
         }
 
-        let errorMessage = `Unexpected warning recorded:\n${this.utils.printReceived(
-          message
-        )}`;
-        if (expectedMessages.length > 0) {
-          errorMessage += `\n\nThe following expected warnings were not yet seen:\n${expectedMessages
-            .map(unformatted => this.utils.printExpected(unformatted))
-            .join('\n')}`;
+        let errorMessage;
+        if (expectedMessages.length === 0) {
+          errorMessage =
+            'Unexpected warning recorded: ' +
+            this.utils.printReceived(normalizedMessage);
+        } else if (expectedMessages.length === 1) {
+          errorMessage =
+            'Unexpected warning recorded: ' +
+            jestDiff(normalizedMessage, expectedMessages[0]);
+        } else {
+          errorMessage =
+            'Unexpected warning recorded: ' +
+            jestDiff([normalizedMessage], expectedMessages);
         }
 
         // Record the call stack for unexpected warnings.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3213,6 +3213,15 @@ jest-diff@^22.0.6:
     jest-get-type "^22.0.6"
     pretty-format "^22.0.6"
 
+jest-diff@^22.1.0:
+  version "22.1.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.1.0.tgz#0fad9d96c87b453896bf939df3dc8aac6919ac38"
+  dependencies:
+    chalk "^2.0.1"
+    diff "^3.2.0"
+    jest-get-type "^22.1.0"
+    pretty-format "^22.1.0"
+
 jest-docblock@^22.0.6:
   version "22.0.6"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.0.6.tgz#f187fb2c67eec0999e569d563092125283084f9e"
@@ -3237,6 +3246,10 @@ jest-environment-node@^22.0.6:
 jest-get-type@^22.0.6:
   version "22.0.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.0.6.tgz#301fbc0760779fdbad37b6e3239a3c1811aa75cb"
+
+jest-get-type@^22.1.0:
+  version "22.1.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.1.0.tgz#4e90af298ed6181edc85d2da500dbd2753e0d5a9"
 
 jest-haste-map@^22.0.6:
   version "22.0.6"
@@ -4269,6 +4282,13 @@ prettier@1.8.1, prettier@^1.0.0:
 pretty-format@^22.0.6:
   version "22.0.6"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.0.6.tgz#bbb78e38445f263c2d3b9e281f4b844380990720"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
+pretty-format@^22.1.0:
+  version "22.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.1.0.tgz#2277605b40ed4529ae4db51ff62f4be817647914"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"


### PR DESCRIPTION
Use `jest-diff` to format the warnings in a way that makes it easier to spot the differences.

# Before
The differences before are hard to spot!
![screen shot 2018-01-23 at 11 19 45 am](https://user-images.githubusercontent.com/29597/35295897-556a0ce8-002f-11e8-9423-095ae356ec8b.png)

# After
## One unmatched expectation
If there's a single unmatched expectation, then just diff the individual strings:
![screen shot 2018-01-23 at 11 15 00 am](https://user-images.githubusercontent.com/29597/35295824-1c38264e-002f-11e8-9ded-43e96edbe37c.png)

## Multiple unmatched expectations
Wrap in an array and do a diff. Let Jest decide which of the inner strings is closest. In some cases the diff might not be useful (if the warning was a completely different one than you were expecting) but in other cases the output can be meaningful:
![screen shot 2018-01-23 at 11 14 34 am](https://user-images.githubusercontent.com/29597/35295838-2d4c545a-002f-11e8-855b-dcdfa9461af9.png)

## No remaining expected warnings
Just print the unexpected warning by itself:
![screen shot 2018-01-23 at 11 14 51 am](https://user-images.githubusercontent.com/29597/35295853-341dbfda-002f-11e8-9a6c-315adc250e6a.png)
