### PR TITLE
Prevent incorrect options SSR hydrate mismatch, fix #11602

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -997,12 +997,10 @@ class ReactDOMServerRenderer {
         props = Object.assign(
           {
             selected: undefined,
-            children: undefined,
           },
           props,
           {
             selected: selected,
-            children: optionChildren,
           },
         );
       }


### PR DESCRIPTION
This fix #11602, the warning "Text content did not match", when hydrating a select with a value.

Caused by a regression that overwrites the children nodes of a option when setting the selected option. As you can see [here](https://github.com/facebook/react/blob/v15.6.2/src/renderers/dom/client/wrappers/ReactDOMOption.js#L94), the previous version only overwrites the `selected` prop 

**Before submitting a pull request**, please make sure the following is done:

- [x] Fork the repository and create your branch from `master`.
- [x] Run `yarn` in the repository root.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
- [x] Run `yarn test-prod` to test in the production environment. It supports the same options as yarn test.
- [x] If you need a debugger, run `yarn debug-test --watch TestName`, open chrome://inspect, and press "Inspect".
 - [x] Format your code with prettier (`yarn prettier`).
 - [x] Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
 - [x] Run the Flow typechecks (`yarn flow`).
 - [x] If you haven't already, complete the CLA.

