### PR TITLE
Move a comment to its original location

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -637,9 +637,9 @@ class ReactDOMServerRenderer {
     const flatChildren = flattenTopLevelChildren(children);
 
     const topFrame: Frame = {
+      type: null,
       // Assume all trees start in the HTML namespace (not totally true, but
       // this is what we did historically)
-      type: null,
       domNamespace: Namespaces.html,
       children: flatChildren,
       childIndex: 0,


### PR DESCRIPTION
`type` was added in #11818 by @acdlite below the comment that belongs to `domNamespace`