### PR TITLE
React lifecycles compat

### DIFF
--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.internal.js
@@ -55,4 +55,55 @@ describe('ReactComponentLifeCycle', () => {
     ReactDOM.render(<MyComponent x={2} />, container);
     ReactDOM.render(<MyComponent key="new" x={1} />, container);
   });
+
+  describe('react-lifecycles-compat', () => {
+    // TODO Replace this with react-lifecycles-compat once it's been published
+    function polyfill(Component) {
+      Component.prototype.componentWillMount = function() {};
+      Component.prototype.componentWillMount.__suppressDeprecationWarning = true;
+      Component.prototype.componentWillReceiveProps = function() {};
+      Component.prototype.componentWillReceiveProps.__suppressDeprecationWarning = true;
+    }
+
+    it('should not warn about deprecated cWM/cWRP for polyfilled components', () => {
+      class PolyfilledComponent extends React.Component {
+        state = {};
+        static getDerivedStateFromProps() {
+          return null;
+        }
+        render() {
+          return null;
+        }
+      }
+
+      polyfill(PolyfilledComponent);
+
+      const container = document.createElement('div');
+      ReactDOM.render(<PolyfilledComponent />, container);
+    });
+
+    it('should not warn about unsafe lifecycles within "strict" tree for polyfilled components', () => {
+      const {StrictMode} = React;
+
+      class PolyfilledComponent extends React.Component {
+        state = {};
+        static getDerivedStateFromProps() {
+          return null;
+        }
+        render() {
+          return null;
+        }
+      }
+
+      polyfill(PolyfilledComponent);
+
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <StrictMode>
+          <PolyfilledComponent />
+        </StrictMode>,
+        container,
+      );
+    });
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.internal.js
@@ -24,6 +24,10 @@ describe('ReactComponentLifeCycle', () => {
     ReactDOM = require('react-dom');
   });
 
+  afterEach(() => {
+    jest.resetModules();
+  });
+
   // TODO (RFC #6) Merge this back into ReactComponentLifeCycles-test once
   // the 'warnAboutDeprecatedLifecycles' feature flag has been removed.
   it('warns about deprecated unsafe lifecycles', function() {

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -499,7 +499,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(instance.state.stateField).toBe('goodbye');
   });
 
-  it('should call nested lifecycle methods in the right order', () => {
+  it('should call nested legacy lifecycle methods in the right order', () => {
     let log;
     const logger = function(msg) {
       return function() {
@@ -509,11 +509,6 @@ describe('ReactComponentLifeCycle', () => {
       };
     };
     class Outer extends React.Component {
-      state = {};
-      static getDerivedStateFromProps(props, prevState) {
-        log.push('outer getDerivedStateFromProps');
-        return null;
-      }
       UNSAFE_componentWillMount = logger('outer componentWillMount');
       componentDidMount = logger('outer componentDidMount');
       UNSAFE_componentWillReceiveProps = logger(
@@ -533,11 +528,6 @@ describe('ReactComponentLifeCycle', () => {
     }
 
     class Inner extends React.Component {
-      state = {};
-      static getDerivedStateFromProps(props, prevState) {
-        log.push('inner getDerivedStateFromProps');
-        return null;
-      }
       UNSAFE_componentWillMount = logger('inner componentWillMount');
       componentDidMount = logger('inner componentDidMount');
       UNSAFE_componentWillReceiveProps = logger(
@@ -554,18 +544,9 @@ describe('ReactComponentLifeCycle', () => {
 
     const container = document.createElement('div');
     log = [];
-    expect(() => ReactDOM.render(<Outer x={1} />, container)).toWarnDev([
-      'Warning: Outer: Defines both componentWillReceiveProps() and static ' +
-        'getDerivedStateFromProps() methods. ' +
-        'We recommend using only getDerivedStateFromProps().',
-      'Warning: Inner: Defines both componentWillReceiveProps() and static ' +
-        'getDerivedStateFromProps() methods. ' +
-        'We recommend using only getDerivedStateFromProps().',
-    ]);
+    ReactDOM.render(<Outer x={1} />, container);
     expect(log).toEqual([
-      'outer getDerivedStateFromProps',
       'outer componentWillMount',
-      'inner getDerivedStateFromProps',
       'inner componentWillMount',
       'inner componentDidMount',
       'outer componentDidMount',
@@ -576,11 +557,9 @@ describe('ReactComponentLifeCycle', () => {
     ReactDOM.render(<Outer x={2} />, container);
     expect(log).toEqual([
       'outer componentWillReceiveProps',
-      'outer getDerivedStateFromProps',
       'outer shouldComponentUpdate',
       'outer componentWillUpdate',
       'inner componentWillReceiveProps',
-      'inner getDerivedStateFromProps',
       'inner shouldComponentUpdate',
       'inner componentWillUpdate',
       'inner componentDidUpdate',
@@ -593,6 +572,105 @@ describe('ReactComponentLifeCycle', () => {
       'outer componentWillUnmount',
       'inner componentWillUnmount',
     ]);
+  });
+
+  it('should call nested new lifecycle methods in the right order', () => {
+    let log;
+    const logger = function(msg) {
+      return function() {
+        // return true for shouldComponentUpdate
+        log.push(msg);
+        return true;
+      };
+    };
+    class Outer extends React.Component {
+      state = {};
+      static getDerivedStateFromProps(props, prevState) {
+        log.push('outer getDerivedStateFromProps');
+        return null;
+      }
+      componentDidMount = logger('outer componentDidMount');
+      shouldComponentUpdate = logger('outer shouldComponentUpdate');
+      componentDidUpdate = logger('outer componentDidUpdate');
+      componentWillUnmount = logger('outer componentWillUnmount');
+      render() {
+        return (
+          <div>
+            <Inner x={this.props.x} />
+          </div>
+        );
+      }
+    }
+
+    class Inner extends React.Component {
+      state = {};
+      static getDerivedStateFromProps(props, prevState) {
+        log.push('inner getDerivedStateFromProps');
+        return null;
+      }
+      componentDidMount = logger('inner componentDidMount');
+      shouldComponentUpdate = logger('inner shouldComponentUpdate');
+      componentDidUpdate = logger('inner componentDidUpdate');
+      componentWillUnmount = logger('inner componentWillUnmount');
+      render() {
+        return <span>{this.props.x}</span>;
+      }
+    }
+
+    const container = document.createElement('div');
+    log = [];
+    ReactDOM.render(<Outer x={1} />, container);
+    expect(log).toEqual([
+      'outer getDerivedStateFromProps',
+      'inner getDerivedStateFromProps',
+      'inner componentDidMount',
+      'outer componentDidMount',
+    ]);
+
+    // Dedup warnings
+    log = [];
+    ReactDOM.render(<Outer x={2} />, container);
+    expect(log).toEqual([
+      'outer getDerivedStateFromProps',
+      'outer shouldComponentUpdate',
+      'inner getDerivedStateFromProps',
+      'inner shouldComponentUpdate',
+      'inner componentDidUpdate',
+      'outer componentDidUpdate',
+    ]);
+
+    log = [];
+    ReactDOM.unmountComponentAtNode(container);
+    expect(log).toEqual([
+      'outer componentWillUnmount',
+      'inner componentWillUnmount',
+    ]);
+  });
+
+  it('should not invoke deprecated lifecycles (cWM/cWRP/cWU) if new static gDSFP is present', () => {
+    class Component extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      componentWillMount() {
+        throw Error('unexpected');
+      }
+      componentWillReceiveProps() {
+        throw Error('unexpected');
+      }
+      componentWillUpdate() {
+        throw Error('unexpected');
+      }
+      render() {
+        return null;
+      }
+    }
+
+    const container = document.createElement('div');
+    expect(() => ReactDOM.render(<Component />, container)).toWarnDev(
+      'Defines both componentWillReceiveProps',
+    );
   });
 
   it('calls effects on module-pattern component', function() {

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -673,6 +673,32 @@ describe('ReactComponentLifeCycle', () => {
     );
   });
 
+  it('should not invoke new unsafe lifecycles (cWM/cWRP/cWU) if static gDSFP is present', () => {
+    class Component extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      UNSAFE_componentWillMount() {
+        throw Error('unexpected');
+      }
+      UNSAFE_componentWillReceiveProps() {
+        throw Error('unexpected');
+      }
+      UNSAFE_componentWillUpdate() {
+        throw Error('unexpected');
+      }
+      render() {
+        return null;
+      }
+    }
+
+    const container = document.createElement('div');
+    expect(() => ReactDOM.render(<Component />, container)).toWarnDev(
+      'Defines both componentWillReceiveProps',
+    );
+  });
+
   it('calls effects on module-pattern component', function() {
     const log = [];
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.internal.js
@@ -22,6 +22,29 @@ describe('ReactDOMServerLifecycles', () => {
     ReactDOMServer = require('react-dom/server');
   });
 
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('should not invoke cWM if static gDSFP is present', () => {
+    class Component extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      componentWillMount() {
+        throw Error('unexpected');
+      }
+      render() {
+        return null;
+      }
+    }
+
+    expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
+      'Component: componentWillMount() is deprecated and will be removed in the next major version.',
+    );
+  });
+
   // TODO (RFC #6) Merge this back into ReactDOMServerLifecycles-test once
   // the 'warnAboutDeprecatedLifecycles' feature flag has been removed.
   it('should warn about deprecated lifecycle hooks', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.internal.js
@@ -40,4 +40,30 @@ describe('ReactDOMServerLifecycles', () => {
     // De-duped
     ReactDOMServer.renderToString(<Component />);
   });
+
+  describe('react-lifecycles-compat', () => {
+    // TODO Replace this with react-lifecycles-compat once it's been published
+    function polyfill(Component) {
+      Component.prototype.componentWillMount = function() {};
+      Component.prototype.componentWillMount.__suppressDeprecationWarning = true;
+      Component.prototype.componentWillReceiveProps = function() {};
+      Component.prototype.componentWillReceiveProps.__suppressDeprecationWarning = true;
+    }
+
+    it('should not warn about deprecated cWM/cWRP for polyfilled components', () => {
+      class PolyfilledComponent extends React.Component {
+        state = {};
+        static getDerivedStateFromProps() {
+          return null;
+        }
+        render() {
+          return null;
+        }
+      }
+
+      polyfill(PolyfilledComponent);
+
+      ReactDOMServer.renderToString(<PolyfilledComponent />);
+    });
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
@@ -33,7 +33,7 @@ describe('ReactDOMServerLifecycles', () => {
     resetModules();
   });
 
-  it('should invoke the correct lifecycle hooks', () => {
+  it('should invoke the correct legacy lifecycle hooks', () => {
     const log = [];
 
     class Outer extends React.Component {
@@ -63,6 +63,59 @@ describe('ReactDOMServerLifecycles', () => {
       'inner componentWillMount',
       'inner render',
     ]);
+  });
+
+  it('should invoke the correct new lifecycle hooks', () => {
+    const log = [];
+
+    class Outer extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        log.push('outer getDerivedStateFromProps');
+        return null;
+      }
+      render() {
+        log.push('outer render');
+        return <Inner />;
+      }
+    }
+
+    class Inner extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        log.push('inner getDerivedStateFromProps');
+        return null;
+      }
+      render() {
+        log.push('inner render');
+        return null;
+      }
+    }
+
+    ReactDOMServer.renderToString(<Outer />);
+    expect(log).toEqual([
+      'outer getDerivedStateFromProps',
+      'outer render',
+      'inner getDerivedStateFromProps',
+      'inner render',
+    ]);
+  });
+
+  it('should not invoke cWM if static gDSFP is present', () => {
+    class Component extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      UNSAFE_componentWillMount() {
+        throw Error('unexpected');
+      }
+      render() {
+        return null;
+      }
+    }
+
+    ReactDOMServer.renderToString(<Component />);
   });
 
   it('should update instance.state with value returned from getDerivedStateFromProps', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
@@ -101,7 +101,7 @@ describe('ReactDOMServerLifecycles', () => {
     ]);
   });
 
-  it('should not invoke cWM if static gDSFP is present', () => {
+  it('should not invoke unsafe cWM if static gDSFP is present', () => {
     class Component extends React.Component {
       state = {};
       static getDerivedStateFromProps() {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -514,7 +514,10 @@ function resolve(
     if (inst.UNSAFE_componentWillMount || inst.componentWillMount) {
       if (inst.componentWillMount) {
         if (__DEV__) {
-          if (warnAboutDeprecatedLifecycles) {
+          if (
+            warnAboutDeprecatedLifecycles &&
+            inst.componentWillMount.__suppressDeprecationWarning !== true
+          ) {
             const componentName = getComponentName(Component) || 'Unknown';
 
             if (!didWarnAboutDeprecatedWillMount[componentName]) {
@@ -534,8 +537,10 @@ function resolve(
           }
         }
 
-        inst.componentWillMount();
-      } else {
+        if (typeof Component.getDerivedStateFromProps !== 'function') {
+          inst.componentWillMount();
+        }
+      } else if (typeof Component.getDerivedStateFromProps !== 'function') {
         inst.UNSAFE_componentWillMount();
       }
       if (queue.length) {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -537,10 +537,14 @@ function resolve(
           }
         }
 
+        // In order to support react-lifecycles-compat polyfilled components,
+        // Unsafe lifecycles should not be invoked for any component with the new gDSFP.
         if (typeof Component.getDerivedStateFromProps !== 'function') {
           inst.componentWillMount();
         }
       } else if (typeof Component.getDerivedStateFromProps !== 'function') {
+        // In order to support react-lifecycles-compat polyfilled components,
+        // Unsafe lifecycles should not be invoked for any component with the new gDSFP.
         inst.UNSAFE_componentWillMount();
       }
       if (queue.length) {

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -631,8 +631,9 @@ export default function(
     }
 
     if (
-      typeof instance.UNSAFE_componentWillMount === 'function' ||
-      typeof instance.componentWillMount === 'function'
+      (typeof instance.UNSAFE_componentWillMount === 'function' ||
+        typeof instance.componentWillMount === 'function') &&
+      typeof workInProgress.type.getDerivedStateFromProps !== 'function'
     ) {
       callComponentWillMount(workInProgress, instance);
       // If we had additional state updates during this life-cycle, let's
@@ -781,14 +782,16 @@ export default function(
     if (
       (typeof instance.UNSAFE_componentWillReceiveProps === 'function' ||
         typeof instance.componentWillReceiveProps === 'function') &&
-      (oldProps !== newProps || oldContext !== newContext)
+      typeof workInProgress.type.getDerivedStateFromProps !== 'function'
     ) {
-      callComponentWillReceiveProps(
-        workInProgress,
-        instance,
-        newProps,
-        newContext,
-      );
+      if (oldProps !== newProps || oldContext !== newContext) {
+        callComponentWillReceiveProps(
+          workInProgress,
+          instance,
+          newProps,
+          newContext,
+        );
+      }
     }
 
     let partialState;
@@ -860,8 +863,9 @@ export default function(
 
     if (shouldUpdate) {
       if (
-        typeof instance.UNSAFE_componentWillUpdate === 'function' ||
-        typeof instance.componentWillUpdate === 'function'
+        (typeof instance.UNSAFE_componentWillUpdate === 'function' ||
+          typeof instance.componentWillUpdate === 'function') &&
+        typeof workInProgress.type.getDerivedStateFromProps !== 'function'
       ) {
         if (typeof instance.componentWillUpdate === 'function') {
           startPhaseTimer(workInProgress, 'componentWillUpdate');

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -630,6 +630,8 @@ export default function(
       }
     }
 
+    // In order to support react-lifecycles-compat polyfilled components,
+    // Unsafe lifecycles should not be invoked for any component with the new gDSFP.
     if (
       (typeof instance.UNSAFE_componentWillMount === 'function' ||
         typeof instance.componentWillMount === 'function') &&
@@ -779,6 +781,8 @@ export default function(
     // ever the previously attempted to render - not the "current". However,
     // during componentDidUpdate we pass the "current" props.
 
+    // In order to support react-lifecycles-compat polyfilled components,
+    // Unsafe lifecycles should not be invoked for any component with the new gDSFP.
     if (
       (typeof instance.UNSAFE_componentWillReceiveProps === 'function' ||
         typeof instance.componentWillReceiveProps === 'function') &&
@@ -862,6 +866,8 @@ export default function(
     );
 
     if (shouldUpdate) {
+      // In order to support react-lifecycles-compat polyfilled components,
+      // Unsafe lifecycles should not be invoked for any component with the new gDSFP.
       if (
         (typeof instance.UNSAFE_componentWillUpdate === 'function' ||
           typeof instance.componentWillUpdate === 'function') &&

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -524,8 +524,11 @@ export default function(
 
     if (typeof type.getDerivedStateFromProps === 'function') {
       if (__DEV__) {
+        // Don't warn about react-lifecycles-compat polyfilled components
         if (
-          typeof instance.componentWillReceiveProps === 'function' ||
+          (typeof instance.componentWillReceiveProps === 'function' &&
+            instance.componentWillReceiveProps.__suppressDeprecationWarning !==
+              true) ||
           typeof instance.UNSAFE_componentWillReceiveProps === 'function'
         ) {
           const componentName = getComponentName(workInProgress) || 'Unknown';

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -199,7 +199,9 @@ if (__DEV__) {
       return;
     }
 
-    // Don't warn about react-lifecycles-compat polyfilled components
+    // Don't warn about react-lifecycles-compat polyfilled components.
+    // Note that it is sufficient to check for the presence of a
+    // single lifecycle, componentWillMount, with the polyfill flag.
     if (
       typeof instance.componentWillMount === 'function' &&
       instance.componentWillMount.__suppressDeprecationWarning === true
@@ -233,7 +235,9 @@ if (__DEV__) {
       return;
     }
 
-    // Don't warn about react-lifecycles-compat polyfilled components
+    // Don't warn about react-lifecycles-compat polyfilled components.
+    // Note that it is sufficient to check for the presence of a
+    // single lifecycle, componentWillMount, with the polyfill flag.
     if (
       typeof instance.componentWillMount === 'function' &&
       instance.componentWillMount.__suppressDeprecationWarning === true

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -199,6 +199,14 @@ if (__DEV__) {
       return;
     }
 
+    // Don't warn about react-lifecycles-compat polyfilled components
+    if (
+      typeof instance.componentWillMount === 'function' &&
+      instance.componentWillMount.__suppressDeprecationWarning === true
+    ) {
+      return;
+    }
+
     if (typeof instance.componentWillMount === 'function') {
       pendingComponentWillMountWarnings.push(fiber);
     }
@@ -222,6 +230,14 @@ if (__DEV__) {
     // An expand property is probably okay to use here since it's DEV-only,
     // and will only be set in the event of serious warnings.
     if (didWarnAboutUnsafeLifecycles.has(fiber.type)) {
+      return;
+    }
+
+    // Don't warn about react-lifecycles-compat polyfilled components
+    if (
+      typeof instance.componentWillMount === 'function' &&
+      instance.componentWillMount.__suppressDeprecationWarning === true
+    ) {
       return;
     }
 

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -204,10 +204,14 @@ class ReactShallowRenderer {
           }
         }
 
+        // In order to support react-lifecycles-compat polyfilled components,
+        // Unsafe lifecycles should not be invoked for any component with the new gDSFP.
         if (typeof element.type.getDerivedStateFromProps !== 'function') {
           this._instance.componentWillMount();
         }
       } else if (typeof element.type.getDerivedStateFromProps !== 'function') {
+        // In order to support react-lifecycles-compat polyfilled components,
+        // Unsafe lifecycles should not be invoked for any component with the new gDSFP.
         this._instance.UNSAFE_componentWillMount();
       }
 
@@ -250,6 +254,8 @@ class ReactShallowRenderer {
             }
           }
         }
+        // In order to support react-lifecycles-compat polyfilled components,
+        // Unsafe lifecycles should not be invoked for any component with the new gDSFP.
         if (typeof element.type.getDerivedStateFromProps !== 'function') {
           this._instance.componentWillReceiveProps(props, context);
         }
@@ -257,6 +263,8 @@ class ReactShallowRenderer {
         typeof this._instance.UNSAFE_componentWillReceiveProps === 'function' &&
         typeof element.type.getDerivedStateFromProps !== 'function'
       ) {
+        // In order to support react-lifecycles-compat polyfilled components,
+        // Unsafe lifecycles should not be invoked for any component with the new gDSFP.
         this._instance.UNSAFE_componentWillReceiveProps(props, context);
       }
 
@@ -303,6 +311,8 @@ class ReactShallowRenderer {
           }
         }
 
+        // In order to support react-lifecycles-compat polyfilled components,
+        // Unsafe lifecycles should not be invoked for any component with the new gDSFP.
         if (typeof type.getDerivedStateFromProps !== 'function') {
           this._instance.componentWillUpdate(props, state, context);
         }
@@ -310,6 +320,8 @@ class ReactShallowRenderer {
         typeof this._instance.UNSAFE_componentWillUpdate === 'function' &&
         typeof type.getDerivedStateFromProps !== 'function'
       ) {
+        // In order to support react-lifecycles-compat polyfilled components,
+        // Unsafe lifecycles should not be invoked for any component with the new gDSFP.
         this._instance.UNSAFE_componentWillUpdate(props, state, context);
       }
     }

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -180,7 +180,12 @@ class ReactShallowRenderer {
 
       if (typeof this._instance.componentWillMount === 'function') {
         if (__DEV__) {
-          if (warnAboutDeprecatedLifecycles) {
+          // Don't warn about react-lifecycles-compat polyfilled components
+          if (
+            warnAboutDeprecatedLifecycles &&
+            this._instance.componentWillMount.__suppressDeprecationWarning !==
+              true
+          ) {
             const componentName = getName(element.type, this._instance);
             if (!didWarnAboutLegacyWillMount[componentName]) {
               warning(
@@ -316,8 +321,11 @@ class ReactShallowRenderer {
 
     if (typeof type.getDerivedStateFromProps === 'function') {
       if (__DEV__) {
+        // Don't warn about react-lifecycles-compat polyfilled components
         if (
-          typeof this._instance.componentWillReceiveProps === 'function' ||
+          (typeof this._instance.componentWillReceiveProps === 'function' &&
+            this._instance.componentWillReceiveProps
+              .__suppressDeprecationWarning !== true) ||
           typeof this._instance.UNSAFE_componentWillReceiveProps === 'function'
         ) {
           const componentName = getName(type, this._instance);

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -203,8 +203,11 @@ class ReactShallowRenderer {
             }
           }
         }
-        this._instance.componentWillMount();
-      } else {
+
+        if (typeof element.type.getDerivedStateFromProps !== 'function') {
+          this._instance.componentWillMount();
+        }
+      } else if (typeof element.type.getDerivedStateFromProps !== 'function') {
         this._instance.UNSAFE_componentWillMount();
       }
 
@@ -247,9 +250,12 @@ class ReactShallowRenderer {
             }
           }
         }
-        this._instance.componentWillReceiveProps(props, context);
+        if (typeof element.type.getDerivedStateFromProps !== 'function') {
+          this._instance.componentWillReceiveProps(props, context);
+        }
       } else if (
-        typeof this._instance.UNSAFE_componentWillReceiveProps === 'function'
+        typeof this._instance.UNSAFE_componentWillReceiveProps === 'function' &&
+        typeof element.type.getDerivedStateFromProps !== 'function'
       ) {
         this._instance.UNSAFE_componentWillReceiveProps(props, context);
       }
@@ -297,9 +303,12 @@ class ReactShallowRenderer {
           }
         }
 
-        this._instance.componentWillUpdate(props, state, context);
+        if (typeof type.getDerivedStateFromProps !== 'function') {
+          this._instance.componentWillUpdate(props, state, context);
+        }
       } else if (
-        typeof this._instance.UNSAFE_componentWillUpdate === 'function'
+        typeof this._instance.UNSAFE_componentWillUpdate === 'function' &&
+        typeof type.getDerivedStateFromProps !== 'function'
       ) {
         this._instance.UNSAFE_componentWillUpdate(props, state, context);
       }

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.internal.js
@@ -23,6 +23,10 @@ describe('ReactShallowRenderer', () => {
     React = require('react');
   });
 
+  afterEach(() => {
+    jest.resetModules();
+  });
+
   // TODO (RFC #6) Merge this back into ReactShallowRenderer-test once
   // the 'warnAboutDeprecatedLifecycles' feature flag has been removed.
   it('should warn if deprecated lifecycles exist', () => {

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.internal.js
@@ -50,4 +50,31 @@ describe('ReactShallowRenderer', () => {
     // Verify no duplicate warnings
     shallowRenderer.render(<ComponentWithWarnings />);
   });
+
+  describe('react-lifecycles-compat', () => {
+    // TODO Replace this with react-lifecycles-compat once it's been published
+    function polyfill(Component) {
+      Component.prototype.componentWillMount = function() {};
+      Component.prototype.componentWillMount.__suppressDeprecationWarning = true;
+      Component.prototype.componentWillReceiveProps = function() {};
+      Component.prototype.componentWillReceiveProps.__suppressDeprecationWarning = true;
+    }
+
+    it('should not warn about deprecated cWM/cWRP for polyfilled components', () => {
+      class PolyfilledComponent extends React.Component {
+        state = {};
+        static getDerivedStateFromProps() {
+          return null;
+        }
+        render() {
+          return null;
+        }
+      }
+
+      polyfill(PolyfilledComponent);
+
+      const shallowRenderer = createRenderer();
+      shallowRenderer.render(<PolyfilledComponent />);
+    });
+  });
 });

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -42,17 +42,8 @@ describe('ReactStrictMode', () => {
         componentDidUpdate() {
           log.push('componentDidUpdate');
         }
-        UNSAFE_componentWillMount() {
-          log.push('componentWillMount');
-        }
-        UNSAFE_componentWillReceiveProps() {
-          log.push('componentWillReceiveProps');
-        }
         componentWillUnmount() {
           log.push('componentWillUnmount');
-        }
-        UNSAFE_componentWillUpdate() {
-          log.push('componentWillUpdate');
         }
         shouldComponentUpdate() {
           log.push('shouldComponentUpdate');
@@ -64,22 +55,13 @@ describe('ReactStrictMode', () => {
         }
       }
 
-      let component;
-
-      expect(() => {
-        component = ReactTestRenderer.create(<ClassComponent />);
-      }).toWarnDev(
-        'ClassComponent: Defines both componentWillReceiveProps() ' +
-          'and static getDerivedStateFromProps() methods. ' +
-          'We recommend using only getDerivedStateFromProps().',
-      );
+      const component = ReactTestRenderer.create(<ClassComponent />);
 
       expect(log).toEqual([
         'constructor',
         'constructor',
         'getDerivedStateFromProps',
         'getDerivedStateFromProps',
-        'componentWillMount',
         'render',
         'render',
         'componentDidMount',
@@ -90,11 +72,9 @@ describe('ReactStrictMode', () => {
 
       component.update(<ClassComponent />);
       expect(log).toEqual([
-        'componentWillReceiveProps',
         'getDerivedStateFromProps',
         'getDerivedStateFromProps',
         'shouldComponentUpdate',
-        'componentWillUpdate',
         'render',
         'render',
         'componentDidUpdate',
@@ -105,7 +85,6 @@ describe('ReactStrictMode', () => {
 
       component.update(<ClassComponent />);
       expect(log).toEqual([
-        'componentWillReceiveProps',
         'getDerivedStateFromProps',
         'getDerivedStateFromProps',
         'shouldComponentUpdate',

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -449,4 +449,34 @@ describe('create-react-class-integration', () => {
       ReactDOM.render(<Component />, document.createElement('div')),
     ).toWarnDev('Did not properly initialize state during construction.');
   });
+
+  it('should not invoke deprecated lifecycles (cWM/cWRP/cWU) if new static gDSFP is present', () => {
+    const Component = createReactClass({
+      statics: {
+        getDerivedStateFromProps: function() {
+          return null;
+        },
+      },
+      componentWillMount: function() {
+        throw Error('unexpected');
+      },
+      componentWillReceiveProps: function() {
+        throw Error('unexpected');
+      },
+      componentWillUpdate: function() {
+        throw Error('unexpected');
+      },
+      getInitialState: function() {
+        return {};
+      },
+      render: function() {
+        return null;
+      },
+    });
+
+    expect(() => {
+      ReactDOM.render(<Component />, document.createElement('div'));
+    }).toWarnDev('Defines both componentWillReceiveProps');
+    ReactDOM.render(<Component foo={1} />, document.createElement('div'));
+  });
 });


### PR DESCRIPTION
In order to support the upcoming [`react-lifecycles-compat` module](https://github.com/reactjs/react-lifecycles-compat) and various edge-cases that are possible when considering eg class inheritance and other React-like libraries, this PR makes the following changes:
* If a component defines `static getDerivedStateFromProps`, React will not invoke any of the following instance methods: `componentWillMount`, `componentWillReceiveProps`, and `componentWillUpdate`.
* If React detects that a component has been polyfilled by `react-lifecycles-compat` (based on the presence of a `__suppressDeprecationWarning` flag) it will suppress both deprecation and unsafe lifecycle warnings. (Those lifecycles won't be executed anyway, and in this case it can be assumed the lifecycles only exist for backwards compatibility purposes.)

All affected tests have been updated and some new ones have been added.

I have left a TODO comment in a few tests to replace an inline approximation of the new polyfill with the _actual_ module once it's been published.