### PR TITLE
Replace unstable_AsyncComponent with unstable_AsyncMode

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
@@ -14,7 +14,7 @@ let ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 let ReactDOM;
 
-const AsyncMode = React.Unstable_AsyncMode;
+const AsyncMode = React.unstable_AsyncMode;
 
 describe('ReactDOMFiberAsync', () => {
   let container;

--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
@@ -14,7 +14,7 @@ let ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 let ReactDOM;
 
-const AsyncComponent = React.unstable_AsyncComponent;
+const AsyncMode = React.Unstable_AsyncMode;
 
 describe('ReactDOMFiberAsync', () => {
   let container;
@@ -40,23 +40,22 @@ describe('ReactDOMFiberAsync', () => {
       jest.resetModules();
       ReactFeatureFlags = require('shared/ReactFeatureFlags');
       container = document.createElement('div');
-      ReactFeatureFlags.enableAsyncSubtreeAPI = false;
       ReactDOM = require('react-dom');
     });
 
     it('renders synchronously', () => {
       ReactDOM.render(
-        <AsyncComponent>
+        <AsyncMode>
           <div>Hi</div>
-        </AsyncComponent>,
+        </AsyncMode>,
         container,
       );
       expect(container.textContent).toEqual('Hi');
 
       ReactDOM.render(
-        <AsyncComponent>
+        <AsyncMode>
           <div>Bye</div>
-        </AsyncComponent>,
+        </AsyncMode>,
         container,
       );
       expect(container.textContent).toEqual('Bye');
@@ -68,7 +67,6 @@ describe('ReactDOMFiberAsync', () => {
       jest.resetModules();
       ReactFeatureFlags = require('shared/ReactFeatureFlags');
       container = document.createElement('div');
-      ReactFeatureFlags.enableAsyncSubtreeAPI = true;
       ReactFeatureFlags.enableCreateRoot = true;
       ReactDOM = require('react-dom');
     });
@@ -108,9 +106,9 @@ describe('ReactDOMFiberAsync', () => {
       expect(container.textContent).toEqual('1');
     });
 
-    it('AsyncComponent creates an async subtree', () => {
+    it('AsyncMode creates an async subtree', () => {
       let instance;
-      class Component extends React.unstable_AsyncComponent {
+      class Component extends React.Component {
         state = {step: 0};
         render() {
           instance = this;
@@ -119,9 +117,9 @@ describe('ReactDOMFiberAsync', () => {
       }
 
       ReactDOM.render(
-        <div>
+        <AsyncMode>
           <Component />
-        </div>,
+        </AsyncMode>,
         container,
       );
       jest.runAllTimers();
@@ -133,12 +131,6 @@ describe('ReactDOMFiberAsync', () => {
     });
 
     it('updates inside an async subtree are async by default', () => {
-      class Component extends React.unstable_AsyncComponent {
-        render() {
-          return <Child />;
-        }
-      }
-
       let instance;
       class Child extends React.Component {
         state = {step: 0};
@@ -150,7 +142,9 @@ describe('ReactDOMFiberAsync', () => {
 
       ReactDOM.render(
         <div>
-          <Component />
+          <AsyncMode>
+            <Child />
+          </AsyncMode>
         </div>,
         container,
       );
@@ -264,7 +258,7 @@ describe('ReactDOMFiberAsync', () => {
       let ops = [];
       let instance;
 
-      class Component extends React.unstable_AsyncComponent {
+      class Component extends React.Component {
         state = {text: ''};
         push(val) {
           this.setState(state => ({text: state.text + val}));
@@ -278,7 +272,12 @@ describe('ReactDOMFiberAsync', () => {
         }
       }
 
-      ReactDOM.render(<Component />, container);
+      ReactDOM.render(
+        <AsyncMode>
+          <Component />
+        </AsyncMode>,
+        container,
+      );
       jest.runAllTimers();
 
       // Updates are async by default

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
@@ -12,7 +12,7 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 let ReactDOMServer = require('react-dom/server');
-let AsyncComponent = React.unstable_AsyncComponent;
+let AsyncMode = React.Unstable_AsyncMode;
 
 describe('ReactDOMRoot', () => {
   let container;
@@ -70,7 +70,7 @@ describe('ReactDOMRoot', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
-    AsyncComponent = React.unstable_AsyncComponent;
+    AsyncMode = React.Unstable_AsyncMode;
   });
 
   it('renders children', () => {
@@ -92,7 +92,7 @@ describe('ReactDOMRoot', () => {
 
   it('`root.render` returns a thenable work object', () => {
     const root = ReactDOM.createRoot(container);
-    const work = root.render(<AsyncComponent>Hi</AsyncComponent>);
+    const work = root.render(<AsyncMode>Hi</AsyncMode>);
     let ops = [];
     work.then(() => {
       ops.push('inside callback: ' + container.textContent);
@@ -110,7 +110,7 @@ describe('ReactDOMRoot', () => {
 
   it('resolves `work.then` callback synchronously if the work already committed', () => {
     const root = ReactDOM.createRoot(container);
-    const work = root.render(<AsyncComponent>Hi</AsyncComponent>);
+    const work = root.render(<AsyncMode>Hi</AsyncMode>);
     flush();
     let ops = [];
     work.then(() => {
@@ -209,10 +209,10 @@ describe('ReactDOMRoot', () => {
   });
 
   it('can wait for a batch to finish', () => {
-    const Async = React.unstable_AsyncComponent;
+    const AsyncMode = React.Unstable_AsyncMode;
     const root = ReactDOM.createRoot(container);
     const batch = root.createBatch();
-    batch.render(<Async>Foo</Async>);
+    batch.render(<AsyncMode>Foo</AsyncMode>);
 
     flush();
 
@@ -252,7 +252,7 @@ describe('ReactDOMRoot', () => {
 
   it('can commit an empty batch', () => {
     const root = ReactDOM.createRoot(container);
-    root.render(<AsyncComponent>1</AsyncComponent>);
+    root.render(<AsyncMode>1</AsyncMode>);
 
     expire(2000);
     // This batch has a later expiration time than the earlier update.

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
@@ -209,7 +209,6 @@ describe('ReactDOMRoot', () => {
   });
 
   it('can wait for a batch to finish', () => {
-    const AsyncMode = React.Unstable_AsyncMode;
     const root = ReactDOM.createRoot(container);
     const batch = root.createBatch();
     batch.render(<AsyncMode>Foo</AsyncMode>);

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.internal.js
@@ -12,7 +12,7 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 let ReactDOMServer = require('react-dom/server');
-let AsyncMode = React.Unstable_AsyncMode;
+let AsyncMode = React.unstable_AsyncMode;
 
 describe('ReactDOMRoot', () => {
   let container;
@@ -70,7 +70,7 @@ describe('ReactDOMRoot', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
-    AsyncMode = React.Unstable_AsyncMode;
+    AsyncMode = React.unstable_AsyncMode;
   });
 
   it('renders children', () => {

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -318,7 +318,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       // Insert
       const created = createFiberFromText(
         textContent,
-        returnFiber.internalContextTag,
+        returnFiber.mode,
         expirationTime,
       );
       created.return = returnFiber;
@@ -351,7 +351,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       // Insert
       const created = createFiberFromElement(
         element,
-        returnFiber.internalContextTag,
+        returnFiber.mode,
         expirationTime,
       );
       created.ref = coerceRef(current, element);
@@ -375,7 +375,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       // Insert
       const created = createFiberFromPortal(
         portal,
-        returnFiber.internalContextTag,
+        returnFiber.mode,
         expirationTime,
       );
       created.return = returnFiber;
@@ -399,7 +399,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       // Insert
       const created = createFiberFromFragment(
         fragment,
-        returnFiber.internalContextTag,
+        returnFiber.mode,
         expirationTime,
         key,
       );
@@ -424,7 +424,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       // node.
       const created = createFiberFromText(
         '' + newChild,
-        returnFiber.internalContextTag,
+        returnFiber.mode,
         expirationTime,
       );
       created.return = returnFiber;
@@ -436,7 +436,7 @@ function ChildReconciler(shouldTrackSideEffects) {
         case REACT_ELEMENT_TYPE: {
           const created = createFiberFromElement(
             newChild,
-            returnFiber.internalContextTag,
+            returnFiber.mode,
             expirationTime,
           );
           created.ref = coerceRef(null, newChild);
@@ -446,7 +446,7 @@ function ChildReconciler(shouldTrackSideEffects) {
         case REACT_PORTAL_TYPE: {
           const created = createFiberFromPortal(
             newChild,
-            returnFiber.internalContextTag,
+            returnFiber.mode,
             expirationTime,
           );
           created.return = returnFiber;
@@ -457,7 +457,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       if (isArray(newChild) || getIteratorFn(newChild)) {
         const created = createFiberFromFragment(
           newChild,
-          returnFiber.internalContextTag,
+          returnFiber.mode,
           expirationTime,
           null,
         );
@@ -1045,7 +1045,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     deleteRemainingChildren(returnFiber, currentFirstChild);
     const created = createFiberFromText(
       textContent,
-      returnFiber.internalContextTag,
+      returnFiber.mode,
       expirationTime,
     );
     created.return = returnFiber;
@@ -1097,7 +1097,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     if (element.type === REACT_FRAGMENT_TYPE) {
       const created = createFiberFromFragment(
         element.props.children,
-        returnFiber.internalContextTag,
+        returnFiber.mode,
         expirationTime,
         element.key,
       );
@@ -1106,7 +1106,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     } else {
       const created = createFiberFromElement(
         element,
-        returnFiber.internalContextTag,
+        returnFiber.mode,
         expirationTime,
       );
       created.ref = coerceRef(currentFirstChild, element);
@@ -1152,7 +1152,7 @@ function ChildReconciler(shouldTrackSideEffects) {
 
     const created = createFiberFromPortal(
       portal,
-      returnFiber.internalContextTag,
+      returnFiber.mode,
       expirationTime,
     );
     created.return = returnFiber;

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -9,7 +9,7 @@
 import type {ReactElement, Source} from 'shared/ReactElementType';
 import type {ReactPortal} from 'shared/ReactTypes';
 import type {TypeOfWork} from 'shared/ReactTypeOfWork';
-import type {TypeOfInternalContext} from './ReactTypeOfInternalContext';
+import type {TypeOfMode} from './ReactTypeOfMode';
 import type {TypeOfSideEffect} from 'shared/ReactTypeOfSideEffect';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {UpdateQueue} from './ReactFiberUpdateQueue';
@@ -33,7 +33,7 @@ import {
 import getComponentName from 'shared/getComponentName';
 
 import {NoWork} from './ReactFiberExpirationTime';
-import {NoContext, AsyncMode, StrictMode} from './ReactTypeOfInternalContext';
+import {NoContext, AsyncMode, StrictMode} from './ReactTypeOfMode';
 import {
   REACT_FRAGMENT_TYPE,
   REACT_RETURN_TYPE,
@@ -121,11 +121,11 @@ export type Fiber = {|
 
   // Bitfield that describes properties about the fiber and its subtree. E.g.
   // the AsyncMode flag indicates whether the subtree should be async-by-
-  // default. When a fiber is created, it inherits the internalContextTag of its
+  // default. When a fiber is created, it inherits the mode of its
   // parent. Additional flags can be set at creation time, but after than the
   // value should remain unchanged throughout the fiber's lifetime, particularly
   // before its child fibers are created.
-  internalContextTag: TypeOfInternalContext,
+  mode: TypeOfMode,
 
   // Effect
   effectTag: TypeOfSideEffect,
@@ -168,7 +168,7 @@ function FiberNode(
   tag: TypeOfWork,
   pendingProps: mixed,
   key: null | string,
-  internalContextTag: TypeOfInternalContext,
+  mode: TypeOfMode,
 ) {
   // Instance
   this.tag = tag;
@@ -189,7 +189,7 @@ function FiberNode(
   this.updateQueue = null;
   this.memoizedState = null;
 
-  this.internalContextTag = internalContextTag;
+  this.mode = mode;
 
   // Effects
   this.effectTag = NoEffect;
@@ -230,10 +230,10 @@ const createFiber = function(
   tag: TypeOfWork,
   pendingProps: mixed,
   key: null | string,
-  internalContextTag: TypeOfInternalContext,
+  mode: TypeOfMode,
 ): Fiber {
   // $FlowFixMe: the shapes are exact here but Flow doesn't like constructors
-  return new FiberNode(tag, pendingProps, key, internalContextTag);
+  return new FiberNode(tag, pendingProps, key, mode);
 };
 
 function shouldConstruct(Component) {
@@ -257,7 +257,7 @@ export function createWorkInProgress(
       current.tag,
       pendingProps,
       current.key,
-      current.internalContextTag,
+      current.mode,
     );
     workInProgress.type = current.type;
     workInProgress.stateNode = current.stateNode;
@@ -300,13 +300,13 @@ export function createWorkInProgress(
 }
 
 export function createHostRootFiber(isAsync): Fiber {
-  const internalContextTag = isAsync ? AsyncMode | StrictMode : NoContext;
-  return createFiber(HostRoot, null, null, internalContextTag);
+  const mode = isAsync ? AsyncMode | StrictMode : NoContext;
+  return createFiber(HostRoot, null, null, mode);
 }
 
 export function createFiberFromElement(
   element: ReactElement,
-  internalContextTag: TypeOfInternalContext,
+  mode: TypeOfMode,
   expirationTime: ExpirationTime,
 ): Fiber {
   let owner = null;
@@ -329,17 +329,17 @@ export function createFiberFromElement(
       case REACT_FRAGMENT_TYPE:
         return createFiberFromFragment(
           pendingProps.children,
-          internalContextTag,
+          mode,
           expirationTime,
           key,
         );
       case REACT_ASYNC_MODE_TYPE:
         fiberTag = Mode;
-        internalContextTag |= AsyncMode | StrictMode;
+        mode |= AsyncMode | StrictMode;
         break;
       case REACT_STRICT_MODE_TYPE:
         fiberTag = Mode;
-        internalContextTag |= StrictMode;
+        mode |= StrictMode;
         break;
       case REACT_CALL_TYPE:
         fiberTag = CallComponent;
@@ -383,7 +383,7 @@ export function createFiberFromElement(
     }
   }
 
-  fiber = createFiber(fiberTag, pendingProps, key, internalContextTag);
+  fiber = createFiber(fiberTag, pendingProps, key, mode);
   fiber.type = type;
   fiber.expirationTime = expirationTime;
 
@@ -426,21 +426,21 @@ function throwOnInvalidElementType(type, owner) {
 
 export function createFiberFromFragment(
   elements: ReactFragment,
-  internalContextTag: TypeOfInternalContext,
+  mode: TypeOfMode,
   expirationTime: ExpirationTime,
   key: null | string,
 ): Fiber {
-  const fiber = createFiber(Fragment, elements, key, internalContextTag);
+  const fiber = createFiber(Fragment, elements, key, mode);
   fiber.expirationTime = expirationTime;
   return fiber;
 }
 
 export function createFiberFromText(
   content: string,
-  internalContextTag: TypeOfInternalContext,
+  mode: TypeOfMode,
   expirationTime: ExpirationTime,
 ): Fiber {
-  const fiber = createFiber(HostText, content, null, internalContextTag);
+  const fiber = createFiber(HostText, content, null, mode);
   fiber.expirationTime = expirationTime;
   return fiber;
 }
@@ -453,16 +453,11 @@ export function createFiberFromHostInstanceForDeletion(): Fiber {
 
 export function createFiberFromPortal(
   portal: ReactPortal,
-  internalContextTag: TypeOfInternalContext,
+  mode: TypeOfMode,
   expirationTime: ExpirationTime,
 ): Fiber {
   const pendingProps = portal.children !== null ? portal.children : [];
-  const fiber = createFiber(
-    HostPortal,
-    pendingProps,
-    portal.key,
-    internalContextTag,
-  );
+  const fiber = createFiber(HostPortal, pendingProps, portal.key, mode);
   fiber.expirationTime = expirationTime;
   fiber.stateNode = {
     containerInfo: portal.containerInfo,

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -33,11 +33,7 @@ import {
 import getComponentName from 'shared/getComponentName';
 
 import {NoWork} from './ReactFiberExpirationTime';
-import {
-  NoContext,
-  AsyncUpdates,
-  StrictMode,
-} from './ReactTypeOfInternalContext';
+import {NoContext, AsyncMode, StrictMode} from './ReactTypeOfInternalContext';
 import {
   REACT_FRAGMENT_TYPE,
   REACT_RETURN_TYPE,
@@ -45,6 +41,7 @@ import {
   REACT_STRICT_MODE_TYPE,
   REACT_PROVIDER_TYPE,
   REACT_CONTEXT_TYPE,
+  REACT_ASYNC_MODE_TYPE,
 } from 'shared/ReactSymbols';
 
 let hasBadMapPolyfill;
@@ -123,7 +120,7 @@ export type Fiber = {|
   memoizedState: any,
 
   // Bitfield that describes properties about the fiber and its subtree. E.g.
-  // the AsyncUpdates flag indicates whether the subtree should be async-by-
+  // the AsyncMode flag indicates whether the subtree should be async-by-
   // default. When a fiber is created, it inherits the internalContextTag of its
   // parent. Additional flags can be set at creation time, but after than the
   // value should remain unchanged throughout the fiber's lifetime, particularly
@@ -303,7 +300,7 @@ export function createWorkInProgress(
 }
 
 export function createHostRootFiber(isAsync): Fiber {
-  const internalContextTag = isAsync ? AsyncUpdates | StrictMode : NoContext;
+  const internalContextTag = isAsync ? AsyncMode | StrictMode : NoContext;
   return createFiber(HostRoot, null, null, internalContextTag);
 }
 
@@ -336,6 +333,10 @@ export function createFiberFromElement(
           expirationTime,
           key,
         );
+      case REACT_ASYNC_MODE_TYPE:
+        fiberTag = Mode;
+        internalContextTag |= AsyncMode | StrictMode;
+        break;
       case REACT_STRICT_MODE_TYPE:
         fiberTag = Mode;
         internalContextTag |= StrictMode;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -67,7 +67,7 @@ import {
 } from './ReactFiberContext';
 import {pushProvider} from './ReactFiberNewContext';
 import {NoWork, Never} from './ReactFiberExpirationTime';
-import {AsyncMode, StrictMode} from './ReactTypeOfInternalContext';
+import {AsyncMode, StrictMode} from './ReactTypeOfMode';
 import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
 
 let didWarnAboutBadClass;
@@ -293,7 +293,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       if (
         debugRenderPhaseSideEffects ||
         (debugRenderPhaseSideEffectsForStrictMode &&
-          workInProgress.internalContextTag & StrictMode)
+          workInProgress.mode & StrictMode)
       ) {
         instance.render();
       }
@@ -302,7 +302,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       if (
         debugRenderPhaseSideEffects ||
         (debugRenderPhaseSideEffectsForStrictMode &&
-          workInProgress.internalContextTag & StrictMode)
+          workInProgress.mode & StrictMode)
       ) {
         instance.render();
       }
@@ -438,7 +438,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     // Check the host config to see if the children are offscreen/hidden.
     if (
       renderExpirationTime !== Never &&
-      workInProgress.internalContextTag & AsyncMode &&
+      workInProgress.mode & AsyncMode &&
       shouldDeprioritizeSubtree(type, nextProps)
     ) {
       // Down-prioritize the children.

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -67,7 +67,7 @@ import {
 } from './ReactFiberContext';
 import {pushProvider} from './ReactFiberNewContext';
 import {NoWork, Never} from './ReactFiberExpirationTime';
-import {AsyncUpdates, StrictMode} from './ReactTypeOfInternalContext';
+import {AsyncMode, StrictMode} from './ReactTypeOfInternalContext';
 import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
 
 let didWarnAboutBadClass;
@@ -438,7 +438,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     // Check the host config to see if the children are offscreen/hidden.
     if (
       renderExpirationTime !== Never &&
-      workInProgress.internalContextTag & AsyncUpdates &&
+      workInProgress.internalContextTag & AsyncMode &&
       shouldDeprioritizeSubtree(type, nextProps)
     ) {
       // Down-prioritize the children.

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -14,7 +14,6 @@ import {Update} from 'shared/ReactTypeOfSideEffect';
 import {
   debugRenderPhaseSideEffects,
   debugRenderPhaseSideEffectsForStrictMode,
-  enableAsyncSubtreeAPI,
   warnAboutDeprecatedLifecycles,
 } from 'shared/ReactFeatureFlags';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings';
@@ -27,7 +26,7 @@ import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
-import {AsyncUpdates, StrictMode} from './ReactTypeOfInternalContext';
+import {StrictMode} from './ReactTypeOfInternalContext';
 import {
   cacheContext,
   getMaskedContext,
@@ -605,13 +604,6 @@ export default function(
 
     if (workInProgress.type != null && workInProgress.type.prototype != null) {
       const prototype = workInProgress.type.prototype;
-
-      if (enableAsyncSubtreeAPI) {
-        if (prototype.unstable_isAsyncReactComponent === true) {
-          workInProgress.internalContextTag |= AsyncUpdates;
-          workInProgress.internalContextTag |= StrictMode;
-        }
-      }
     }
 
     if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -26,7 +26,7 @@ import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
-import {StrictMode} from './ReactTypeOfInternalContext';
+import {StrictMode} from './ReactTypeOfMode';
 import {
   cacheContext,
   getMaskedContext,
@@ -394,7 +394,7 @@ export default function(
     if (
       debugRenderPhaseSideEffects ||
       (debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.internalContextTag & StrictMode)
+        workInProgress.mode & StrictMode)
     ) {
       new ctor(props, context); // eslint-disable-line no-new
     }
@@ -547,7 +547,7 @@ export default function(
       if (
         debugRenderPhaseSideEffects ||
         (debugRenderPhaseSideEffectsForStrictMode &&
-          workInProgress.internalContextTag & StrictMode)
+          workInProgress.mode & StrictMode)
       ) {
         // Invoke method an extra time to help detect side-effects.
         type.getDerivedStateFromProps.call(
@@ -602,12 +602,8 @@ export default function(
     instance.refs = emptyObject;
     instance.context = getMaskedContext(workInProgress, unmaskedContext);
 
-    if (workInProgress.type != null && workInProgress.type.prototype != null) {
-      const prototype = workInProgress.type.prototype;
-    }
-
     if (__DEV__) {
-      if (workInProgress.internalContextTag & StrictMode) {
+      if (workInProgress.mode & StrictMode) {
         ReactStrictModeWarnings.recordUnsafeLifecycleWarnings(
           workInProgress,
           instance,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -81,7 +81,7 @@ import {
   expirationTimeToMs,
   computeExpirationBucket,
 } from './ReactFiberExpirationTime';
-import {AsyncMode} from './ReactTypeOfInternalContext';
+import {AsyncMode} from './ReactTypeOfMode';
 import {getUpdateExpirationTime} from './ReactFiberUpdateQueue';
 import {resetContext as resetLegacyContext} from './ReactFiberContext';
 import {resetProviderStack} from './ReactFiberNewContext';
@@ -1200,7 +1200,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     } else {
       // No explicit expiration context was set, and we're not currently
       // performing work. Calculate a new expiration time.
-      if (fiber.internalContextTag & AsyncMode) {
+      if (fiber.mode & AsyncMode) {
         // This is an async update
         expirationTime = computeAsyncExpiration();
       } else {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -81,7 +81,7 @@ import {
   expirationTimeToMs,
   computeExpirationBucket,
 } from './ReactFiberExpirationTime';
-import {AsyncUpdates} from './ReactTypeOfInternalContext';
+import {AsyncMode} from './ReactTypeOfInternalContext';
 import {getUpdateExpirationTime} from './ReactFiberUpdateQueue';
 import {resetContext as resetLegacyContext} from './ReactFiberContext';
 import {resetProviderStack} from './ReactFiberNewContext';
@@ -1200,7 +1200,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     } else {
       // No explicit expiration context was set, and we're not currently
       // performing work. Calculate a new expiration time.
-      if (fiber.internalContextTag & AsyncUpdates) {
+      if (fiber.internalContextTag & AsyncMode) {
         // This is an async update
         expirationTime = computeAsyncExpiration();
       } else {

--- a/packages/react-reconciler/src/ReactFiberUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberUpdateQueue.js
@@ -18,7 +18,7 @@ import {Callback as CallbackEffect} from 'shared/ReactTypeOfSideEffect';
 import {ClassComponent, HostRoot} from 'shared/ReactTypeOfWork';
 import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
-import {StrictMode} from './ReactTypeOfInternalContext';
+import {StrictMode} from './ReactTypeOfMode';
 
 import {NoWork} from './ReactFiberExpirationTime';
 
@@ -278,7 +278,7 @@ export function processUpdateQueue<State>(
     if (
       debugRenderPhaseSideEffects ||
       (debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.internalContextTag & StrictMode)
+        workInProgress.mode & StrictMode)
     ) {
       getStateFromUpdate(update, instance, state, props);
     }

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -11,7 +11,7 @@ import type {Fiber} from './ReactFiber';
 
 import getComponentName from 'shared/getComponentName';
 import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
-import {StrictMode} from './ReactTypeOfInternalContext';
+import {StrictMode} from './ReactTypeOfMode';
 import warning from 'fbjs/lib/warning';
 
 type LIFECYCLE =
@@ -104,7 +104,7 @@ if (__DEV__) {
     let maybeStrictRoot = null;
 
     while (fiber !== null) {
-      if (fiber.internalContextTag & StrictMode) {
+      if (fiber.mode & StrictMode) {
         maybeStrictRoot = fiber;
       }
 

--- a/packages/react-reconciler/src/ReactTypeOfInternalContext.js
+++ b/packages/react-reconciler/src/ReactTypeOfInternalContext.js
@@ -9,6 +9,6 @@
 
 export type TypeOfInternalContext = number;
 
-export const NoContext = 0b00000000;
-export const AsyncUpdates = 0b00000001;
-export const StrictMode = 0b00000010;
+export const NoContext = 0b00;
+export const AsyncMode = 0b01;
+export const StrictMode = 0b10;

--- a/packages/react-reconciler/src/ReactTypeOfMode.js
+++ b/packages/react-reconciler/src/ReactTypeOfMode.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-export type TypeOfInternalContext = number;
+export type TypeOfMode = number;
 
 export const NoContext = 0b00;
 export const AsyncMode = 0b01;

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -45,7 +45,7 @@ const React = {
 
   Fragment: REACT_FRAGMENT_TYPE,
   StrictMode: REACT_STRICT_MODE_TYPE,
-  Unstable_AsyncMode: REACT_ASYNC_MODE_TYPE,
+  unstable_AsyncMode: REACT_ASYNC_MODE_TYPE,
 
   createElement: __DEV__ ? createElementWithValidation : createElement,
   cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -7,9 +7,13 @@
 
 import assign from 'object-assign';
 import ReactVersion from 'shared/ReactVersion';
-import {REACT_FRAGMENT_TYPE, REACT_STRICT_MODE_TYPE} from 'shared/ReactSymbols';
+import {
+  REACT_FRAGMENT_TYPE,
+  REACT_STRICT_MODE_TYPE,
+  REACT_ASYNC_MODE_TYPE,
+} from 'shared/ReactSymbols';
 
-import {AsyncComponent, Component, PureComponent} from './ReactBaseClasses';
+import {Component, PureComponent} from './ReactBaseClasses';
 import {forEach, map, count, toArray, only} from './ReactChildren';
 import ReactCurrentOwner from './ReactCurrentOwner';
 import {
@@ -38,10 +42,10 @@ const React = {
 
   Component,
   PureComponent,
-  unstable_AsyncComponent: AsyncComponent,
 
   Fragment: REACT_FRAGMENT_TYPE,
   StrictMode: REACT_STRICT_MODE_TYPE,
+  Unstable_AsyncMode: REACT_ASYNC_MODE_TYPE,
 
   createElement: __DEV__ ? createElementWithValidation : createElement,
   cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,

--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -136,23 +136,4 @@ pureComponentPrototype.constructor = PureComponent;
 Object.assign(pureComponentPrototype, Component.prototype);
 pureComponentPrototype.isPureReactComponent = true;
 
-/**
- * Special component type that opts subtree into async rendering mode.
- */
-function AsyncComponent(props, context, updater) {
-  this.props = props;
-  this.context = context;
-  this.refs = emptyObject;
-  this.updater = updater || ReactNoopUpdateQueue;
-}
-
-const asyncComponentPrototype = (AsyncComponent.prototype = new ComponentDummy());
-asyncComponentPrototype.constructor = AsyncComponent;
-// Avoid an extra prototype jump for these methods.
-Object.assign(asyncComponentPrototype, Component.prototype);
-asyncComponentPrototype.unstable_isAsyncReactComponent = true;
-asyncComponentPrototype.render = function() {
-  return this.props.children;
-};
-
-export {AsyncComponent, Component, PureComponent};
+export {Component, PureComponent};

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -19,6 +19,7 @@ import {
   getIteratorFn,
   REACT_FRAGMENT_TYPE,
   REACT_STRICT_MODE_TYPE,
+  REACT_ASYNC_MODE_TYPE,
 } from 'shared/ReactSymbols';
 import checkPropTypes from 'prop-types/checkPropTypes';
 import warning from 'fbjs/lib/warning';
@@ -287,6 +288,7 @@ export function createElementWithValidation(type, props, children) {
     typeof type === 'function' ||
     // Note: its typeof might be other than 'symbol' or 'number' if it's a polyfill.
     type === REACT_FRAGMENT_TYPE ||
+    type === REACT_ASYNC_MODE_TYPE ||
     type === REACT_STRICT_MODE_TYPE;
 
   // We warn in this case but don't throw. We expect the element creation to

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -286,9 +286,9 @@ describe('ReactStrictMode', () => {
         UNSAFE_componentWillReceiveProps() {}
         render() {
           return (
-            <React.Unstable_AsyncMode>
+            <React.unstable_AsyncMode>
               <AsyncRoot />
-            </React.Unstable_AsyncMode>
+            </React.unstable_AsyncMode>
           );
         }
       }
@@ -353,9 +353,9 @@ describe('ReactStrictMode', () => {
         UNSAFE_componentWillReceiveProps() {}
         render() {
           return (
-            <React.Unstable_AsyncMode>
+            <React.unstable_AsyncMode>
               <AsyncRoot />
-            </React.Unstable_AsyncMode>
+            </React.unstable_AsyncMode>
           );
         }
       }
@@ -420,22 +420,22 @@ describe('ReactStrictMode', () => {
       class AsyncRootOne extends React.Component {
         render() {
           return (
-            <React.Unstable_AsyncMode>
+            <React.unstable_AsyncMode>
               <Foo>
                 <Bar />
               </Foo>
-            </React.Unstable_AsyncMode>
+            </React.unstable_AsyncMode>
           );
         }
       }
       class AsyncRootTwo extends React.Component {
         render() {
           return (
-            <React.Unstable_AsyncMode>
+            <React.unstable_AsyncMode>
               <Foo>
                 <Baz />
               </Foo>
-            </React.Unstable_AsyncMode>
+            </React.unstable_AsyncMode>
           );
         }
       }
@@ -486,9 +486,9 @@ describe('ReactStrictMode', () => {
       class AsyncRoot extends React.Component {
         render() {
           return (
-            <React.Unstable_AsyncMode>
+            <React.unstable_AsyncMode>
               {this.props.foo ? <Foo /> : <Bar />}
-            </React.Unstable_AsyncMode>
+            </React.unstable_AsyncMode>
           );
         }
       }
@@ -537,9 +537,9 @@ describe('ReactStrictMode', () => {
       class AsyncRoot extends React.Component {
         render() {
           return (
-            <React.Unstable_AsyncMode>
+            <React.unstable_AsyncMode>
               <ErrorBoundary />
-            </React.Unstable_AsyncMode>
+            </React.unstable_AsyncMode>
           );
         }
       }

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -285,10 +285,14 @@ describe('ReactStrictMode', () => {
         UNSAFE_componentWillUpdate() {}
         UNSAFE_componentWillReceiveProps() {}
         render() {
-          return <AsyncRoot />;
+          return (
+            <React.Unstable_AsyncMode>
+              <AsyncRoot />
+            </React.Unstable_AsyncMode>
+          );
         }
       }
-      class AsyncRoot extends React.unstable_AsyncComponent {
+      class AsyncRoot extends React.Component {
         UNSAFE_componentWillMount() {}
         UNSAFE_componentWillUpdate() {}
         render() {
@@ -326,7 +330,6 @@ describe('ReactStrictMode', () => {
         rendered = ReactTestRenderer.create(<SyncRoot />);
       }).toWarnDev(
         'Unsafe lifecycle methods were found within a strict-mode tree:' +
-          '\n    in AsyncRoot (at **)' +
           '\n    in SyncRoot (at **)' +
           '\n\ncomponentWillMount: Please update the following components ' +
           'to use componentDidMount instead: AsyncRoot' +
@@ -349,10 +352,14 @@ describe('ReactStrictMode', () => {
         UNSAFE_componentWillUpdate() {}
         UNSAFE_componentWillReceiveProps() {}
         render() {
-          return <AsyncRoot />;
+          return (
+            <React.Unstable_AsyncMode>
+              <AsyncRoot />
+            </React.Unstable_AsyncMode>
+          );
         }
       }
-      class AsyncRoot extends React.unstable_AsyncComponent {
+      class AsyncRoot extends React.Component {
         UNSAFE_componentWillMount() {}
         UNSAFE_componentWillUpdate() {}
         render() {
@@ -380,7 +387,6 @@ describe('ReactStrictMode', () => {
         () => (rendered = ReactTestRenderer.create(<SyncRoot />)),
       ).toWarnDev(
         'Unsafe lifecycle methods were found within a strict-mode tree:' +
-          '\n    in AsyncRoot (at **)' +
           '\n    in SyncRoot (at **)' +
           '\n\ncomponentWillMount: Please update the following components ' +
           'to use componentDidMount instead: AsyncRoot, Parent' +
@@ -411,21 +417,25 @@ describe('ReactStrictMode', () => {
           );
         }
       }
-      class AsyncRootOne extends React.unstable_AsyncComponent {
+      class AsyncRootOne extends React.Component {
         render() {
           return (
-            <Foo>
-              <Bar />
-            </Foo>
+            <React.Unstable_AsyncMode>
+              <Foo>
+                <Bar />
+              </Foo>
+            </React.Unstable_AsyncMode>
           );
         }
       }
-      class AsyncRootTwo extends React.unstable_AsyncComponent {
+      class AsyncRootTwo extends React.Component {
         render() {
           return (
-            <Foo>
-              <Baz />
-            </Foo>
+            <React.Unstable_AsyncMode>
+              <Foo>
+                <Baz />
+              </Foo>
+            </React.Unstable_AsyncMode>
           );
         }
       }
@@ -473,9 +483,13 @@ describe('ReactStrictMode', () => {
     });
 
     it('should warn about components not present during the initial render', () => {
-      class AsyncRoot extends React.unstable_AsyncComponent {
+      class AsyncRoot extends React.Component {
         render() {
-          return this.props.foo ? <Foo /> : <Bar />;
+          return (
+            <React.Unstable_AsyncMode>
+              {this.props.foo ? <Foo /> : <Bar />}
+            </React.Unstable_AsyncMode>
+          );
         }
       }
       class Foo extends React.Component {
@@ -520,9 +534,13 @@ describe('ReactStrictMode', () => {
     it('should not warn about uncommitted lifecycles in the event of an error', () => {
       let caughtError;
 
-      class AsyncRoot extends React.unstable_AsyncComponent {
+      class AsyncRoot extends React.Component {
         render() {
-          return <ErrorBoundary />;
+          return (
+            <React.Unstable_AsyncMode>
+              <ErrorBoundary />
+            </React.Unstable_AsyncMode>
+          );
         }
       }
       class ErrorBoundary extends React.Component {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -9,7 +9,6 @@
 
 import invariant from 'fbjs/lib/invariant';
 
-export const enableAsyncSubtreeAPI = true;
 // Exports ReactDOM.createRoot
 export const enableCreateRoot = false;
 export const enableUserTimingAPI = __DEV__;

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -33,6 +33,9 @@ export const REACT_PROVIDER_TYPE = hasSymbol
 export const REACT_CONTEXT_TYPE = hasSymbol
   ? Symbol.for('react.context')
   : 0xeace;
+export const REACT_ASYNC_MODE_TYPE = hasSymbol
+  ? Symbol.for('react.async_mode')
+  : 0xeacf;
 
 const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric.js
@@ -14,7 +14,6 @@ import typeof * as FabricFeatureFlagsType from './ReactFeatureFlags.native-fabri
 
 export const debugRenderPhaseSideEffects = false;
 export const debugRenderPhaseSideEffectsForStrictMode = false;
-export const enableAsyncSubtreeAPI = true;
 export const enableCreateRoot = false;
 export const enableUserTimingAPI = __DEV__;
 export const warnAboutDeprecatedLifecycles = false;

--- a/packages/shared/forks/ReactFeatureFlags.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.native.js
@@ -20,7 +20,6 @@ export const {
 } = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.
-export const enableAsyncSubtreeAPI = true;
 export const enableCreateRoot = false;
 export const enableUserTimingAPI = __DEV__;
 export const enableMutatingReconciler = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -18,7 +18,6 @@ export const {
 } = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.
-export const enableAsyncSubtreeAPI = true;
 export const enableCreateRoot = true;
 export const enableNewContextAPI = true;
 


### PR DESCRIPTION
Mirrors the StrictMode API and uses the new Mode type of work.

Also changes `fiber.internalContextTag` -> `fiber.mode`, now that we have a better name.
