### PR TITLE
ReactDOM.flushControlled

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
@@ -378,5 +378,28 @@ describe('ReactDOMFiberAsync', () => {
         'after batchedUpdates: 2',
       ]);
     });
+
+    it('flushControlled returns nothing', () => {
+      // In the future, we may want to return a thenable "work" object.
+      let inst;
+      class Counter extends React.Component {
+        state = {counter: 0};
+        increment = () =>
+          this.setState(state => ({counter: state.counter + 1}));
+        render() {
+          inst = this;
+          return this.state.counter;
+        }
+      }
+      ReactDOM.render(<Counter />, container);
+      expect(container.textContent).toEqual('0');
+
+      const returnValue = ReactDOM.flushControlled(() => {
+        inst.increment();
+        return 'something';
+      });
+      expect(container.textContent).toEqual('1');
+      expect(returnValue).toBe(undefined);
+    });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
@@ -333,9 +333,9 @@ describe('ReactDOMFiberAsync', () => {
       expect(container.textContent).toEqual('1');
 
       let ops = [];
-      ReactDOM.flushControlled(() => {
+      ReactDOM.unstable_flushControlled(() => {
         inst.increment();
-        ReactDOM.flushControlled(() => {
+        ReactDOM.unstable_flushControlled(() => {
           inst.increment();
           ops.push('end of inner flush: ' + container.textContent);
         });
@@ -365,7 +365,7 @@ describe('ReactDOMFiberAsync', () => {
       let ops = [];
       ReactDOM.unstable_batchedUpdates(() => {
         inst.increment();
-        ReactDOM.flushControlled(() => {
+        ReactDOM.unstable_flushControlled(() => {
           inst.increment();
           ops.push('end of flushControlled fn: ' + container.textContent);
         });
@@ -394,7 +394,7 @@ describe('ReactDOMFiberAsync', () => {
       ReactDOM.render(<Counter />, container);
       expect(container.textContent).toEqual('0');
 
-      const returnValue = ReactDOM.flushControlled(() => {
+      const returnValue = ReactDOM.unstable_flushControlled(() => {
         inst.increment();
         return 'something';
       });

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -1288,7 +1288,7 @@ const ReactDOM: Object = {
 
   flushSync: DOMRenderer.flushSync,
 
-  flushControlled: DOMRenderer.flushControlled,
+  unstable_flushControlled: DOMRenderer.flushControlled,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // For TapEventPlugin which is popular in open source

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -1288,6 +1288,8 @@ const ReactDOM: Object = {
 
   flushSync: DOMRenderer.flushSync,
 
+  flushControlled: DOMRenderer.flushControlled,
+
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // For TapEventPlugin which is popular in open source
     EventPluginHub,

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -256,6 +256,7 @@ export type Reconciler<C, I, TI> = {
   batchedUpdates<A>(fn: () => A): A,
   unbatchedUpdates<A>(fn: () => A): A,
   flushSync<A>(fn: () => A): A,
+  flushControlled<A>(fn: () => A): A,
   deferredUpdates<A>(fn: () => A): A,
   injectIntoDevTools(devToolsConfig: DevToolsConfig<I, TI>): boolean,
   computeUniqueAsyncExpiration(): ExpirationTime,
@@ -300,6 +301,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     batchedUpdates,
     unbatchedUpdates,
     flushSync,
+    flushControlled,
     deferredUpdates,
   } = ReactFiberScheduler(config);
 
@@ -432,6 +434,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     deferredUpdates,
 
     flushSync,
+
+    flushControlled,
 
     getPublicRootInstance(
       container: OpaqueRoot,

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -256,7 +256,7 @@ export type Reconciler<C, I, TI> = {
   batchedUpdates<A>(fn: () => A): A,
   unbatchedUpdates<A>(fn: () => A): A,
   flushSync<A>(fn: () => A): A,
-  flushControlled<A>(fn: () => A): A,
+  flushControlled(fn: () => mixed): void,
   deferredUpdates<A>(fn: () => A): A,
   injectIntoDevTools(devToolsConfig: DevToolsConfig<I, TI>): boolean,
   computeUniqueAsyncExpiration(): ExpirationTime,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1764,6 +1764,19 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
   }
 
+  function flushControlled<A>(fn: () => A): A {
+    const previousIsBatchingUpdates = isBatchingUpdates;
+    isBatchingUpdates = true;
+    try {
+      return syncUpdates(fn);
+    } finally {
+      isBatchingUpdates = previousIsBatchingUpdates;
+      if (!isBatchingUpdates && !isRendering) {
+        performWork(Sync, null);
+      }
+    }
+  }
+
   return {
     computeExpirationForFiber,
     scheduleWork,
@@ -1772,6 +1785,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     batchedUpdates,
     unbatchedUpdates,
     flushSync,
+    flushControlled,
     deferredUpdates,
     computeUniqueAsyncExpiration,
   };

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1764,11 +1764,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
   }
 
-  function flushControlled<A>(fn: () => A): A {
+  function flushControlled(fn: () => mixed): void {
     const previousIsBatchingUpdates = isBatchingUpdates;
     isBatchingUpdates = true;
     try {
-      return syncUpdates(fn);
+      syncUpdates(fn);
     } finally {
       isBatchingUpdates = previousIsBatchingUpdates;
       if (!isBatchingUpdates && !isRendering) {


### PR DESCRIPTION
New API for wrapping event handlers that need to fire before React yields to the browser. Previously we thought that `flushSync` was sufficient for this use case, but it turns out that `flushSync` is only safe if you're guaranteed to be at the top of the stack; that is, if you know for sure that your event handler is not nested inside another React event handler or lifecycle. This isn't true for cases like `el.focus`, `el.click`, or `dispatchEvent`, where an event handler can be invoked synchronously from inside an existing stack.

`flushControlled` has similar semantics to `batchedUpdates`, where if you nest multiple batches, the work is not flushed until the end of the outermost batch. The work is not guaranteed to synchronously flush, as with `flushSync`, but it is guaranteed to flush before React yields to the browser.

`flushSync` is still the preferred API in most cases, such as inside a `requestAnimationFrame` callback.