### PR TITLE
Update create-react-class@15.6.3 (and update tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "coffee-script": "^1.8.0",
     "core-js": "^2.2.1",
     "coveralls": "^2.11.6",
-    "create-react-class": "^15.6.2",
+    "create-react-class": "^15.6.3",
     "cross-env": "^5.1.1",
     "danger": "^3.0.4",
     "del": "^2.0.2",

--- a/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
@@ -37,13 +37,13 @@ describe('create-react-class-integration', () => {
       displayName: 'MyComponent',
       mixins: [
         {
-          componentWillMount() {
+          UNSAFE_componentWillMount() {
             this.log('mixin.componentWillMount');
           },
           componentDidMount() {
             this.log('mixin.componentDidMount');
           },
-          componentWillUpdate() {
+          UNSAFE_componentWillUpdate() {
             this.log('mixin.componentWillUpdate');
           },
           componentDidUpdate() {
@@ -61,13 +61,13 @@ describe('create-react-class-integration', () => {
         this.log('getInitialState');
         return {};
       },
-      componentWillMount() {
+      UNSAFE_componentWillMount() {
         this.log('componentWillMount');
       },
       componentDidMount() {
         this.log('componentDidMount');
       },
-      componentWillUpdate() {
+      UNSAFE_componentWillUpdate() {
         this.log('componentWillUpdate');
       },
       componentDidUpdate() {
@@ -85,25 +85,11 @@ describe('create-react-class-integration', () => {
 
     const container = document.createElement('div');
 
-    // TODO (RFC #6) The below lifecycle warnings are unavoidable for now,
-    // Until create-react-class recognizes the UNSAFE_* methods.
-    // (If we try to use them before them, it will error because
-    // we are defining the same method twice.)
-    // Update the above component to use the new UNSAFE_* methods
-    // (and remove the expected warnings) once create-react-class has been updated.
-    expect(() => ReactDOM.render(<Component />, container)).toWarnDev([
+    expect(() => ReactDOM.render(<Component />, container)).toWarnDev(
       'Warning: MyComponent: isMounted is deprecated. Instead, make sure to ' +
         'clean up subscriptions and pending requests in componentWillUnmount ' +
         'to prevent memory leaks.',
-      'componentWillMount is deprecated and will be removed in the next major version. ' +
-        'Use componentDidMount instead. As a temporary workaround, ' +
-        'you can rename to UNSAFE_componentWillMount.' +
-        '\n\nPlease update the following components: MyComponent',
-      'componentWillUpdate is deprecated and will be removed in the next major version. ' +
-        'Use componentDidUpdate instead. As a temporary workaround, ' +
-        'you can rename to UNSAFE_componentWillUpdate.' +
-        '\n\nPlease update the following components: MyComponent',
-    ]);
+    );
 
     // Dedupe
     ReactDOM.render(<Component />, container);

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -152,8 +152,7 @@ describe('create-react-class-integration', () => {
     );
   });
 
-  // TODO (RFC #6) Reenable after create-react-class updated.
-  xit('should warn when misspelling UNSAFE_componentWillReceiveProps', () => {
+  it('should warn when misspelling UNSAFE_componentWillReceiveProps', () => {
     expect(() =>
       createReactClass({
         UNSAFE_componentWillRecieveProps: function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,6 +1446,14 @@ create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-class@^15.6.3:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 cross-env@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.1.tgz#b6d8ab97f304c0f71dae7277b75fe424c08dfa74"


### PR DESCRIPTION
Addressing some TODOs now that `create-react-class` 15.6.3 has been released.