### PR TITLE
Add react-lifecycles-compat and update tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "prettier": "1.8.1",
     "prop-types": "^15.6.0",
     "random-seed": "^0.3.0",
+    "react-lifecycles-compat": "^1.0.2",
     "rimraf": "^2.6.1",
     "rollup": "^0.52.1",
     "rollup-plugin-babel": "^3.0.1",

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.internal.js
@@ -61,13 +61,7 @@ describe('ReactComponentLifeCycle', () => {
   });
 
   describe('react-lifecycles-compat', () => {
-    // TODO Replace this with react-lifecycles-compat once it's been published
-    function polyfill(Component) {
-      Component.prototype.componentWillMount = function() {};
-      Component.prototype.componentWillMount.__suppressDeprecationWarning = true;
-      Component.prototype.componentWillReceiveProps = function() {};
-      Component.prototype.componentWillReceiveProps.__suppressDeprecationWarning = true;
-    }
+    const polyfill = require('react-lifecycles-compat');
 
     it('should not warn about deprecated cWM/cWRP for polyfilled components', () => {
       class PolyfilledComponent extends React.Component {

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.internal.js
@@ -65,13 +65,7 @@ describe('ReactDOMServerLifecycles', () => {
   });
 
   describe('react-lifecycles-compat', () => {
-    // TODO Replace this with react-lifecycles-compat once it's been published
-    function polyfill(Component) {
-      Component.prototype.componentWillMount = function() {};
-      Component.prototype.componentWillMount.__suppressDeprecationWarning = true;
-      Component.prototype.componentWillReceiveProps = function() {};
-      Component.prototype.componentWillReceiveProps.__suppressDeprecationWarning = true;
-    }
+    const polyfill = require('react-lifecycles-compat');
 
     it('should not warn about deprecated cWM/cWRP for polyfilled components', () => {
       class PolyfilledComponent extends React.Component {

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.internal.js
@@ -56,13 +56,7 @@ describe('ReactShallowRenderer', () => {
   });
 
   describe('react-lifecycles-compat', () => {
-    // TODO Replace this with react-lifecycles-compat once it's been published
-    function polyfill(Component) {
-      Component.prototype.componentWillMount = function() {};
-      Component.prototype.componentWillMount.__suppressDeprecationWarning = true;
-      Component.prototype.componentWillReceiveProps = function() {};
-      Component.prototype.componentWillReceiveProps.__suppressDeprecationWarning = true;
-    }
+    const polyfill = require('react-lifecycles-compat');
 
     it('should not warn about deprecated cWM/cWRP for polyfilled components', () => {
       class PolyfilledComponent extends React.Component {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4412,6 +4412,10 @@ react-dom@15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
+react-lifecycles-compat@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-1.0.2.tgz#551d8b1d156346e5fcf30ffac9b32ce3f78b8850"
+
 react@15.5.4:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"


### PR DESCRIPTION
Now that `react-lifecycles-compat` has been published to NPM, update tests to use the real polyfill.