### PR TITLE
Extend input type check in selection capabilities (#12062)

### DIFF
--- a/fixtures/dom/src/components/fixtures/text-inputs/ReplaceEmailInput.js
+++ b/fixtures/dom/src/components/fixtures/text-inputs/ReplaceEmailInput.js
@@ -7,15 +7,19 @@ class ReplaceEmailInput extends React.Component {
     formSubmitted: false,
   };
 
+  onReset = () => {
+    this.setState({formSubmitted: false});
+  };
+
+  onSubmit = event => {
+    event.preventDefault();
+    this.setState({formSubmitted: true});
+  };
+
   render() {
     return (
       <Fixture>
-        <form
-          className="control-box"
-          onSubmit={event => {
-            event.preventDefault();
-            this.setState({formSubmitted: true});
-          }}>
+        <form className="control-box" onSubmit={this.onSubmit}>
           <fieldset>
             <legend>Email</legend>
             {!this.state.formSubmitted ? (
@@ -25,6 +29,9 @@ class ReplaceEmailInput extends React.Component {
             )}
           </fieldset>
         </form>
+        <button type="button" onClick={this.onReset}>
+          Reset
+        </button>
       </Fixture>
     );
   }

--- a/fixtures/dom/src/components/fixtures/text-inputs/ReplaceEmailInput.js
+++ b/fixtures/dom/src/components/fixtures/text-inputs/ReplaceEmailInput.js
@@ -1,0 +1,33 @@
+import Fixture from '../../Fixture';
+
+const React = window.React;
+
+class ReplaceEmailInput extends React.Component {
+  state = {
+    formSubmitted: false,
+  };
+
+  render() {
+    return (
+      <Fixture>
+        <form
+          className="control-box"
+          onSubmit={event => {
+            event.preventDefault();
+            this.setState({formSubmitted: true});
+          }}>
+          <fieldset>
+            <legend>Email</legend>
+            {!this.state.formSubmitted ? (
+              <input type="email" />
+            ) : (
+              <input type="text" disabled={true} />
+            )}
+          </fieldset>
+        </form>
+      </Fixture>
+    );
+  }
+}
+
+export default ReplaceEmailInput;

--- a/fixtures/dom/src/components/fixtures/text-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/text-inputs/index.js
@@ -2,6 +2,7 @@ import Fixture from '../../Fixture';
 import FixtureSet from '../../FixtureSet';
 import TestCase from '../../TestCase';
 import InputTestCase from './InputTestCase';
+import ReplaceEmailInput from './ReplaceEmailInput';
 
 const React = window.React;
 
@@ -108,6 +109,21 @@ class TextInputFixtures extends React.Component {
           </TestCase.ExpectedResult>
 
           <InputTestCase type="url" defaultValue="" />
+        </TestCase>
+
+        <TestCase
+          title="Replacing email input with text disabled input"
+          relatedIssues="12062">
+          <TestCase.Steps>
+            <li>Type "test@test.com"</li>
+            <li>Press enter</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            There should be no selection-related error in the console.
+          </TestCase.ExpectedResult>
+
+          <ReplaceEmailInput />
         </TestCase>
 
         <TestCase title="All inputs" description="General test of all inputs">

--- a/packages/react-dom/src/client/ReactInputSelection.js
+++ b/packages/react-dom/src/client/ReactInputSelection.js
@@ -26,7 +26,12 @@ export function hasSelectionCapabilities(elem) {
   const nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
   return (
     nodeName &&
-    ((nodeName === 'input' && elem.type === 'text') ||
+    ((nodeName === 'input' &&
+      (elem.type === 'text' ||
+        elem.type === 'search' ||
+        elem.type === 'tel' ||
+        elem.type === 'url' ||
+        elem.type === 'password')) ||
       nodeName === 'textarea' ||
       elem.contentEditable === 'true')
   );
@@ -52,7 +57,10 @@ export function restoreSelection(priorSelectionInformation) {
   const priorFocusedElem = priorSelectionInformation.focusedElem;
   const priorSelectionRange = priorSelectionInformation.selectionRange;
   if (curFocusedElem !== priorFocusedElem && isInDocument(priorFocusedElem)) {
-    if (hasSelectionCapabilities(priorFocusedElem)) {
+    if (
+      priorSelectionRange !== null &&
+      hasSelectionCapabilities(priorFocusedElem)
+    ) {
       setSelection(priorFocusedElem, priorSelectionRange);
     }
 

--- a/packages/react-dom/src/client/ReactInputSelection.js
+++ b/packages/react-dom/src/client/ReactInputSelection.js
@@ -22,6 +22,11 @@ function isInDocument(node) {
  * Input selection module for React.
  */
 
+/**
+ * @hasSelectionCapabilities: we get the element types that support selection
+ * from https://html.spec.whatwg.org/#do-not-apply, looking at `selectionStart`
+ * and `selectionEnd` rows.
+ */
 export function hasSelectionCapabilities(elem) {
   const nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
   return (


### PR DESCRIPTION
`restoreSelection` did not account for input elements that have changed
type after the commit phase. The new `text` input supported selection
but the old `email` did not and `setSelection` was incorrectly trying to
restore `null` selection state.

We also extend input type check in selection capabilities to cover cases
where input type is `search`, `tel`, `url`, or `password`.

Fix #12062 