### PR TITLE
Pre-release version fix

### DIFF
--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -26,7 +26,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || 16.3.0-alpha.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-call-return/package.json
+++ b/packages/react-call-return/package.json
@@ -14,6 +14,6 @@
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || 16.3.0-alpha.0"
   }
 }

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -19,7 +19,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || 16.3.0-alpha.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-noop-renderer/package.json
+++ b/packages/react-noop-renderer/package.json
@@ -11,7 +11,7 @@
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0",
     "regenerator-runtime": "^0.11.0",
-    "react-reconciler": "*"
+    "react-reconciler": "* || 0.8.0-alpha.0"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -21,7 +21,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || 16.3.0-alpha.0"
   },
   "dependencies": {
     "fbjs": "^0.8.16",

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || 16.3.0-alpha.0"
   },
   "files": [
     "LICENSE",

--- a/scripts/release/build-commands/update-noop-renderer-dependencies.js
+++ b/scripts/release/build-commands/update-noop-renderer-dependencies.js
@@ -13,7 +13,7 @@ const getReactReconcilerVersion = async cwd => {
   return json.version;
 };
 
-const update = async ({cwd, dry, packages}) => {
+const update = async ({cwd, dry}) => {
   const path = join(cwd, 'packages', 'react-noop-renderer', 'package.json');
   const json = await readJson(path);
 

--- a/scripts/release/build-commands/update-noop-renderer-dependencies.js
+++ b/scripts/release/build-commands/update-noop-renderer-dependencies.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const {readJson, writeJson} = require('fs-extra');
+const {join} = require('path');
+const semver = require('semver');
+const {execUnlessDry, logPromise} = require('../utils');
+
+const getReactReconcilerVersion = async cwd => {
+  const path = join(cwd, 'packages', 'react-reconciler', 'package.json');
+  const json = await readJson(path);
+  return json.version;
+};
+
+const update = async ({cwd, dry, packages}) => {
+  const path = join(cwd, 'packages', 'react-noop-renderer', 'package.json');
+  const json = await readJson(path);
+
+  // IMPORTANT: This script must be run after update-package-versions,
+  // Since it depends up the updated react-reconciler version.
+  const reconcilerVersion = await getReactReconcilerVersion(cwd);
+
+  // There is no wildcard for semver that includes prerelease ranges as well.
+  // This causes problems for our Yarn workspaces setup,
+  // Since the noop-renderer depends on react-reconciler.
+  // So we have a special case check for this that ensures semver compatibility.
+  if (semver.prerelease(reconcilerVersion)) {
+    json.dependencies['react-reconciler'] = `* || ${reconcilerVersion}`;
+  } else {
+    json.dependencies['react-reconciler'] = '*';
+  }
+
+  await writeJson(path, json, {spaces: 2});
+
+  await execUnlessDry(
+    `git commit -am "Updating dependencies for react-noop-renderer"`,
+    {cwd, dry}
+  );
+};
+
+module.exports = async params => {
+  return logPromise(update(params), 'Updating noop renderer dependencies');
+};

--- a/scripts/release/build-commands/update-package-versions.js
+++ b/scripts/release/build-commands/update-package-versions.js
@@ -56,6 +56,10 @@ const update = async ({cwd, dry, packages, version}) => {
 
       if (project !== 'react') {
         let peerVersion = json.peerDependencies.react.replace('^', '');
+
+        // If the previous release was a pre-release version,
+        // The peer dependency will contain multiple versions, eg "^16.0.0 || 16.3.0-alpha.0"
+        // In this case, assume the first one will be the major and extract it.
         if (peerVersion.includes(' || ')) {
           peerVersion = peerVersion.split(' || ')[0];
         }

--- a/scripts/release/build-commands/update-package-versions.js
+++ b/scripts/release/build-commands/update-package-versions.js
@@ -30,30 +30,49 @@ const update = async ({cwd, dry, packages, version}) => {
     const updateProjectPackage = async project => {
       const path = join(cwd, 'packages', project, 'package.json');
       const json = await readJson(path);
+      const prerelease = semver.prerelease(version);
 
       // Unstable packages (eg version < 1.0) are treated specially:
       // Rather than use the release version (eg 16.1.0)-
       // We just auto-increment the minor version (eg 0.1.0 -> 0.2.0).
       // If we're doing a prerelease, we also append the suffix (eg 0.2.0-beta).
       if (semver.lt(json.version, '1.0.0')) {
-        const prerelease = semver.prerelease(version);
         let suffix = '';
         if (prerelease) {
           suffix = `-${prerelease.join('.')}`;
         }
 
-        json.version = `0.${semver.minor(json.version) + 1}.0${suffix}`;
+        // If this is a new pre-release, increment the minor.
+        // Else just increment (or remove) the pre-release suffix.
+        // This way our minor version isn't incremented unnecessarily with each prerelease.
+        const minor = semver.prerelease(json.version)
+          ? semver.minor(json.version)
+          : semver.minor(json.version) + 1;
+
+        json.version = `0.${minor}.0${suffix}`;
       } else {
         json.version = version;
       }
 
       if (project !== 'react') {
-        const peerVersion = json.peerDependencies.react.replace('^', '');
+        let peerVersion = json.peerDependencies.react.replace('^', '');
+        if (peerVersion.includes(' || ')) {
+          peerVersion = peerVersion.split(' || ')[0];
+        }
 
         // Release engineers can manually update minor and bugfix versions,
         // But we should ensure that major versions always match.
         if (semver.major(version) !== semver.major(peerVersion)) {
           json.peerDependencies.react = `^${semver.major(version)}.0.0`;
+        } else {
+          json.peerDependencies.react = `^${peerVersion}`;
+        }
+
+        // If this is a prerelease, update the react dependency as well.
+        // A dependency on a major version won't satisfy a prerelease version.
+        // So rather than eg "^16.0.0" we need "^16.0.0 || 16.3.0-alpha.0"
+        if (prerelease) {
+          json.peerDependencies.react += ` || ${version}`;
         }
       }
 

--- a/scripts/release/build.js
+++ b/scripts/release/build.js
@@ -23,6 +23,7 @@ const run = async () => {
   const runAutomatedTests = require('./build-commands/run-automated-tests');
   const runAutomatedBundleTests = require('./build-commands/run-automated-bundle-tests');
   const updateGit = require('./build-commands/update-git');
+  const updateNoopRendererDependencies = require('./build-commands/update-noop-renderer-dependencies');
   const updatePackageVersions = require('./build-commands/update-package-versions');
   const updateYarnDependencies = require('./build-commands/update-yarn-dependencies');
   const validateVersion = require('./build-commands/validate-version');
@@ -42,6 +43,7 @@ const run = async () => {
     await updateYarnDependencies(params);
     await runAutomatedTests(params);
     await updatePackageVersions(params);
+    await updateNoopRendererDependencies(params);
     await buildArtifacts(params);
     await runAutomatedBundleTests(params);
     await addGitTag(params);


### PR DESCRIPTION
Resolves #12147.

Release script properly updates peer deps for prerelease versions.

# Local release script test
## Fix previous release
`./scripts/release/build.js -v 16.3.0-alpha.0 --dry`
```diff
diff --git a/packages/react-art/package.json b/packages/react-art/package.json
index 7c12d814c..8dfd12640 100644
--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -26,7 +26,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || 16.3.0-alpha.0"
   },
   "files": [
     "LICENSE",
diff --git a/packages/react-call-return/package.json b/packages/react-call-return/package.json
index 331b2f7d3..42840493a 100644
--- a/packages/react-call-return/package.json
+++ b/packages/react-call-return/package.json
@@ -14,6 +14,6 @@
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || 16.3.0-alpha.0"
   }
 }
diff --git a/packages/react-dom/package.json b/packages/react-dom/package.json
index 1b29ebdcd..379a754ac 100644
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -19,7 +19,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || 16.3.0-alpha.0"
   },
   "files": [
     "LICENSE",
diff --git a/packages/react-noop-renderer/package.json b/packages/react-noop-renderer/package.json
index afd4aaef7..0e32ea3f4 100644
--- a/packages/react-noop-renderer/package.json
+++ b/packages/react-noop-renderer/package.json
@@ -11,7 +11,7 @@
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0",
     "regenerator-runtime": "^0.11.0",
-    "react-reconciler": "*"
+    "react-reconciler": "* || 0.8.0-alpha.0"
   },
   "peerDependencies": {
     "react": "^16.0.0"
diff --git a/packages/react-reconciler/package.json b/packages/react-reconciler/package.json
index 1a3bc47ba..394d89a4f 100644
--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -21,7 +21,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || 16.3.0-alpha.0"
   },
   "dependencies": {
     "fbjs": "^0.8.16",
diff --git a/packages/react-test-renderer/package.json b/packages/react-test-renderer/package.json
index 334ae31ef..7aaa839f3 100644
--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || 16.3.0-alpha.0"
   },
   "files": [
     "LICENSE",
```

## Simulate next prerelease
`./scripts/release/build.js -v 16.3.0-alpha.1 --dry`
```diff
diff --git a/package.json b/package.json
index 602cd80ad..caee1d1a2 100644
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "16.3.0-alpha.0",
+  "version": "16.3.0-alpha.1",
   "workspaces": [
     "packages/*"
   ],
diff --git a/packages/react-art/package.json b/packages/react-art/package.json
index 8dfd12640..87c530c0a 100644
--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-art",
   "description": "React ART is a JavaScript library for drawing vector graphics using React. It provides declarative and reactive bindings to the ART library. Using the same declarative API you can render the output to either Canvas, SVG or VML (IE8).",
-  "version": "16.3.0-alpha.0",
+  "version": "16.3.0-alpha.1",
   "main": "index.js",
   "repository": "facebook/react",
   "keywords": [
@@ -26,7 +26,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || 16.3.0-alpha.0"
+    "react": "^16.0.0 || 16.3.0-alpha.1"
   },
   "files": [
     "LICENSE",
diff --git a/packages/react-call-return/package.json b/packages/react-call-return/package.json
index 42840493a..722802842 100644
--- a/packages/react-call-return/package.json
+++ b/packages/react-call-return/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-call-return",
   "description": "Experimental APIs for multi-pass rendering in React.",
-  "version": "0.6.0-alpha.0",
+  "version": "0.6.0-alpha.1",
   "repository": "facebook/react",
   "files": [
     "LICENSE",
@@ -14,6 +14,6 @@
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || 16.3.0-alpha.0"
+    "react": "^16.0.0 || 16.3.0-alpha.1"
   }
 }
diff --git a/packages/react-dom/package.json b/packages/react-dom/package.json
index 379a754ac..beea3e497 100644
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dom",
-  "version": "16.3.0-alpha.0",
+  "version": "16.3.0-alpha.1",
   "description": "React package for working with the DOM.",
   "main": "index.js",
   "repository": "facebook/react",
@@ -19,7 +19,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || 16.3.0-alpha.0"
+    "react": "^16.0.0 || 16.3.0-alpha.1"
   },
   "files": [
     "LICENSE",
diff --git a/packages/react-noop-renderer/package.json b/packages/react-noop-renderer/package.json
index 0e32ea3f4..b401ce96c 100644
--- a/packages/react-noop-renderer/package.json
+++ b/packages/react-noop-renderer/package.json
@@ -11,7 +11,7 @@
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0",
     "regenerator-runtime": "^0.11.0",
-    "react-reconciler": "* || 0.8.0-alpha.0"
+    "react-reconciler": "* || 0.8.0-alpha.1"
   },
   "peerDependencies": {
     "react": "^16.0.0"
diff --git a/packages/react-reconciler/package.json b/packages/react-reconciler/package.json
index 394d89a4f..d8bb6fd52 100644
--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-reconciler",
   "description": "React package for creating custom renderers.",
-  "version": "0.8.0-alpha.0",
+  "version": "0.8.0-alpha.1",
   "keywords": [
     "react"
   ],
@@ -21,7 +21,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || 16.3.0-alpha.0"
+    "react": "^16.0.0 || 16.3.0-alpha.1"
   },
   "dependencies": {
     "fbjs": "^0.8.16",
diff --git a/packages/react-test-renderer/package.json b/packages/react-test-renderer/package.json
index 7aaa839f3..74bb83f43 100644
--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-test-renderer",
-  "version": "16.3.0-alpha.0",
+  "version": "16.3.0-alpha.1",
   "description": "React package for snapshot testing.",
   "main": "index.js",
   "repository": "facebook/react",
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || 16.3.0-alpha.0"
+    "react": "^16.0.0 || 16.3.0-alpha.1"
   },
   "files": [
     "LICENSE",
diff --git a/packages/react/package.json b/packages/react/package.json
index 1df29de8f..e02915d2a 100644
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "react"
   ],
-  "version": "16.3.0-alpha.0",
+  "version": "16.3.0-alpha.1",
   "homepage": "https://reactjs.org/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",
diff --git a/packages/shared/ReactVersion.js b/packages/shared/ReactVersion.js
index 3781246bb..08787db3b 100644
--- a/packages/shared/ReactVersion.js
+++ b/packages/shared/ReactVersion.js
@@ -8,4 +8,4 @@
 'use strict';
 
 // TODO: this is special because it gets imported during build.
-module.exports = '16.3.0-alpha.0';
+module.exports = '16.3.0-alpha.1';
```

## Simulate next major
`./scripts/release/build.js -v 16.3.0 --dry`
```diff
diff --git a/package.json b/package.json
index caee1d1a2..9fbfe74d5 100644
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "16.3.0-alpha.1",
+  "version": "16.3.0",
   "workspaces": [
     "packages/*"
   ],
diff --git a/packages/react-art/package.json b/packages/react-art/package.json
index 87c530c0a..57c1ff719 100644
--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-art",
   "description": "React ART is a JavaScript library for drawing vector graphics using React. It provides declarative and reactive bindings to the ART library. Using the same declarative API you can render the output to either Canvas, SVG or VML (IE8).",
-  "version": "16.3.0-alpha.1",
+  "version": "16.3.0",
   "main": "index.js",
   "repository": "facebook/react",
   "keywords": [
@@ -26,7 +26,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || 16.3.0-alpha.1"
+    "react": "^16.0.0"
   },
   "files": [
     "LICENSE",
diff --git a/packages/react-call-return/package.json b/packages/react-call-return/package.json
index 722802842..afdfc6330 100644
--- a/packages/react-call-return/package.json
+++ b/packages/react-call-return/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-call-return",
   "description": "Experimental APIs for multi-pass rendering in React.",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0",
   "repository": "facebook/react",
   "files": [
     "LICENSE",
@@ -14,6 +14,6 @@
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || 16.3.0-alpha.1"
+    "react": "^16.0.0"
   }
 }
diff --git a/packages/react-dom/package.json b/packages/react-dom/package.json
index beea3e497..1011ee25c 100644
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dom",
-  "version": "16.3.0-alpha.1",
+  "version": "16.3.0",
   "description": "React package for working with the DOM.",
   "main": "index.js",
   "repository": "facebook/react",
@@ -19,7 +19,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || 16.3.0-alpha.1"
+    "react": "^16.0.0"
   },
   "files": [
     "LICENSE",
diff --git a/packages/react-noop-renderer/package.json b/packages/react-noop-renderer/package.json
index b401ce96c..afd4aaef7 100644
--- a/packages/react-noop-renderer/package.json
+++ b/packages/react-noop-renderer/package.json
@@ -11,7 +11,7 @@
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0",
     "regenerator-runtime": "^0.11.0",
-    "react-reconciler": "* || 0.8.0-alpha.1"
+    "react-reconciler": "*"
   },
   "peerDependencies": {
     "react": "^16.0.0"
diff --git a/packages/react-reconciler/package.json b/packages/react-reconciler/package.json
index d8bb6fd52..349bf5d99 100644
--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-reconciler",
   "description": "React package for creating custom renderers.",
-  "version": "0.8.0-alpha.1",
+  "version": "0.8.0",
   "keywords": [
     "react"
   ],
@@ -21,7 +21,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || 16.3.0-alpha.1"
+    "react": "^16.0.0"
   },
   "dependencies": {
     "fbjs": "^0.8.16",
diff --git a/packages/react-test-renderer/package.json b/packages/react-test-renderer/package.json
index 74bb83f43..86656a54b 100644
--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-test-renderer",
-  "version": "16.3.0-alpha.1",
+  "version": "16.3.0",
   "description": "React package for snapshot testing.",
   "main": "index.js",
   "repository": "facebook/react",
@@ -20,7 +20,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || 16.3.0-alpha.1"
+    "react": "^16.0.0"
   },
   "files": [
     "LICENSE",
diff --git a/packages/react/package.json b/packages/react/package.json
index e02915d2a..2fe8ee328 100644
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "react"
   ],
-  "version": "16.3.0-alpha.1",
+  "version": "16.3.0",
   "homepage": "https://reactjs.org/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",
diff --git a/packages/shared/ReactVersion.js b/packages/shared/ReactVersion.js
index 08787db3b..53edb59dd 100644
--- a/packages/shared/ReactVersion.js
+++ b/packages/shared/ReactVersion.js
@@ -8,4 +8,4 @@
 'use strict';
 
 // TODO: this is special because it gets imported during build.
-module.exports = '16.3.0-alpha.1';
+module.exports = '16.3.0';
```