### PR TITLE
Release script does a fresh Yarn install of deps

### DIFF
--- a/scripts/release/build-commands/install-yarn-dependencies.js
+++ b/scripts/release/build-commands/install-yarn-dependencies.js
@@ -5,7 +5,10 @@
 const {exec} = require('child-process-promise');
 const {logPromise} = require('../utils');
 
-const install = async ({cwd}) => await exec('yarn', {cwd});
+const install = async ({cwd}) => {
+  await exec('rm -rf node_modules', {cwd});
+  await exec('yarn', {cwd});
+};
 
 module.exports = async ({cwd}) => {
   return logPromise(install({cwd}), 'Installing NPM dependencies');


### PR DESCRIPTION
This would have caught the recent Yarn workspaces / semver issue sooner.

Probably should have included this with #12148, sorry. Also relates to #12147.