### PR TITLE
Support context components in react-test-renderer

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -370,25 +370,8 @@ function toTree(node: ?Fiber) {
     case Fragment:
       return childrenToTree(node.child);
     case ContextConsumer:
-      return {
-        nodeType: 'component',
-        type: node.type,
-        props: {...node.pendingProps},
-        instance: node.stateNode,
-        rendered: hasSiblings(node.child)
-          ? nodeAndSiblingsTrees(node.child)
-          : toTree(node.child),
-      };
     case ContextProvider:
-      return {
-        nodeType: 'component',
-        type: node.type,
-        props: {...node.memoizedProps},
-        instance: node.stateNode,
-        rendered: hasSiblings(node.child)
-          ? nodeAndSiblingsTrees(node.child)
-          : toTree(node.child),
-      };
+      return toTree(node.child);
     default:
       invariant(
         false,
@@ -456,8 +439,7 @@ class ReactTestInstance {
   }
 
   get props(): Object {
-    const fiber = this._currentFiber();
-    return fiber.memoizedProps || fiber.pendingProps;
+    return this._currentFiber().memoizedProps || {};
   }
 
   get parent(): ?ReactTestInstance {
@@ -482,14 +464,14 @@ class ReactTestInstance {
         case FunctionalComponent:
         case ClassComponent:
         case HostComponent:
-        case ContextConsumer:
-        case ContextProvider:
           children.push(wrapFiber(node));
           break;
         case HostText:
           children.push('' + node.memoizedProps);
           break;
         case Fragment:
+        case ContextConsumer:
+        case ContextProvider:
           descend = true;
           break;
         default:
@@ -572,7 +554,6 @@ function findAll(
 ): Array<ReactTestInstance> {
   const deep = options ? options.deep : true;
   const results = [];
-
   if (predicate(root)) {
     results.push(root);
     if (!deep) {
@@ -633,7 +614,6 @@ const ReactTestRendererFiber = {
     );
     invariant(root != null, 'something went wrong');
     TestRenderer.updateContainer(element, root, null, null);
-
     const entry = {
       root: undefined, // makes flow happy
       // we define a 'getter' for 'root' below using 'Object.defineProperty'

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
@@ -760,25 +760,11 @@ describe('ReactTestRenderer', () => {
 
     expect(prettyFormat(tree)).toEqual(
       prettyFormat({
-        type: Provider,
-        nodeType: 'component',
+        type: 'div',
+        nodeType: 'host',
         instance: null,
-        props: {
-          value: 'bar',
-        },
-        rendered: {
-          type: Consumer,
-          nodeType: 'component',
-          instance: null,
-          props: {},
-          rendered: {
-            type: 'div',
-            nodeType: 'host',
-            instance: null,
-            props: {},
-            rendered: ['bar'],
-          },
-        },
+        props: {},
+        rendered: ['bar'],
       }),
     );
   });
@@ -916,5 +902,31 @@ describe('ReactTestRenderer', () => {
       },
       'world',
     ]);
+  });
+
+  it('can update Providers and Consumers', () => {
+    const {Consumer, Provider} = React.createContext('foo');
+
+    const renderer = ReactTestRenderer.create(
+      <Provider value="bar">
+        <Consumer>{value => <div>{value}</div>}</Consumer>
+      </Provider>,
+    );
+
+    expect(renderer.toJSON()).toEqual({
+      type: 'div',
+      children: ['bar'],
+      props: {},
+    });
+    renderer.update(
+      <Provider value="corge">
+        <Consumer>{value => <div>{value}</div>}</Consumer>
+      </Provider>,
+    );
+    expect(renderer.toJSON()).toEqual({
+      type: 'div',
+      children: ['corge'],
+      props: {},
+    });
   });
 });

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
@@ -745,6 +745,44 @@ describe('ReactTestRenderer', () => {
     );
   });
 
+  it('toTree() handles ContextConsumer and ContextProvider components', () => {
+    const {Consumer, Provider} = React.createContext('foo');
+
+    const renderer = ReactTestRenderer.create(
+      <Provider value="bar">
+        <Consumer>{value => <div>{value}</div>}</Consumer>
+      </Provider>,
+    );
+
+    const tree = renderer.toTree();
+
+    cleanNodeOrArray(tree);
+
+    expect(prettyFormat(tree)).toEqual(
+      prettyFormat({
+        type: Provider,
+        nodeType: 'component',
+        instance: null,
+        props: {
+          value: 'bar',
+        },
+        rendered: {
+          type: Consumer,
+          nodeType: 'component',
+          instance: null,
+          props: {},
+          rendered: {
+            type: 'div',
+            nodeType: 'host',
+            instance: null,
+            props: {},
+            rendered: ['bar'],
+          },
+        },
+      }),
+    );
+  });
+
   it('root instance and createNodeMock ref return the same value', () => {
     const createNodeMock = ref => ({node: ref});
     let refInst = null;

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
@@ -22,7 +22,7 @@ describe('ReactTestRendererTraversal', () => {
   beforeEach(() => {
     jest.resetModules();
     ReactTestRenderer = require('react-test-renderer');
-    const context = React.createContext('quux');
+    const context = React.createContext('corge');
     Consumer = context.Consumer;
     Provider = context.Provider;
   });
@@ -42,10 +42,8 @@ describe('ReactTestRendererTraversal', () => {
               <View void="void" />
               <View void="void" />
             </ExampleNull>
-            <Provider value="quux" provider="provider">
-              <Consumer consumer="consumer">
-                {value => <View child="child" value={value} />}
-              </Consumer>
+            <Provider value="corge">
+              <Consumer>{value => <View value={value} />}</Consumer>
             </Provider>
           </View>
         </View>
@@ -79,8 +77,8 @@ describe('ReactTestRendererTraversal', () => {
     const hasNullProp = node => node.props.hasOwnProperty('null');
     const hasVoidProp = node => node.props.hasOwnProperty('void');
     const hasItselfProp = node => node.props.hasOwnProperty('itself');
-    const hasProviderProp = node => node.props.hasOwnProperty('provider');
-    const hasConsumerProp = node => node.props.hasOwnProperty('consumer');
+    const hasProviderType = node => node.type === Provider;
+    const hasConsumerType = node => node.type === Consumer;
 
     expect(() => render.root.find(hasFooProp)).not.toThrow(); // 1 match
     expect(() => render.root.find(hasBarProp)).toThrow(); // >1 matches
@@ -88,8 +86,8 @@ describe('ReactTestRendererTraversal', () => {
     expect(() => render.root.find(hasBingProp)).not.toThrow(); // 1 match
     expect(() => render.root.find(hasNullProp)).not.toThrow(); // 1 match
     expect(() => render.root.find(hasVoidProp)).toThrow(); // 0 matches
-    expect(() => render.root.find(hasProviderProp)).not.toThrow(); // 1 match
-    expect(() => render.root.find(hasConsumerProp)).not.toThrow(); // 1 match
+    expect(() => render.root.find(hasProviderType)).toThrow(); // 0 matches
+    expect(() => render.root.find(hasConsumerType)).toThrow(); // 0 matches
 
     // same assertion as .find(), but confirm length
     expect(render.root.findAll(hasFooProp, {deep: false})).toHaveLength(1);
@@ -133,8 +131,8 @@ describe('ReactTestRendererTraversal', () => {
     // note: there are clearly multiple <View /> in general, but there
     //       is only one being rendered at root node level
     expect(() => render.root.findByType(ExampleNull)).toThrow(); // 2 matches
-    expect(() => render.root.findByType(Provider)).not.toThrow(); // 1 match
-    expect(() => render.root.findByType(Consumer)).not.toThrow(); // 1 match
+    expect(() => render.root.findByType(Provider)).toThrow(); // 0 matches
+    expect(() => render.root.findByType(Consumer)).toThrow(); // 0 matches
 
     expect(render.root.findAllByType(ExampleFn)).toHaveLength(1);
     expect(render.root.findAllByType(View, {deep: false})).toHaveLength(1);


### PR DESCRIPTION
Potential fix for #12150. I had to use the `pendingProps` instead of `memoizedProps` for the `ContextConsumer` (I don't know enough about React's internals to know why that doesn't have a `memoizedProps`).