### PR TITLE
Expose persistent reconciler to custom renderers

### DIFF
--- a/packages/react-reconciler/npm/persistent.js
+++ b/packages/react-reconciler/npm/persistent.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-reconciler-persistent.production.min.js');
+} else {
+  module.exports = require('./cjs/react-reconciler-persistent.development.js');
+}

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -12,6 +12,7 @@
     "LICENSE",
     "README.md",
     "index.js",
+    "persistent.js",
     "reflection.js",
     "cjs/"
   ],

--- a/packages/react-reconciler/persistent.js
+++ b/packages/react-reconciler/persistent.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+// This is the same export as in index.js,
+// with persistent reconciler flags turned on.
+const ReactFiberReconciler = require('./src/ReactFiberReconciler');
+
+// TODO: decide on the top-level export form.
+// This is hacky but makes it work with both Rollup and Jest.
+module.exports = ReactFiberReconciler.default
+  ? ReactFiberReconciler.default
+  : ReactFiberReconciler;

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import invariant from 'fbjs/lib/invariant';
+
+import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
+import typeof * as PersistentFeatureFlagsType from './ReactFeatureFlags.persistent';
+
+export const debugRenderPhaseSideEffects = false;
+export const debugRenderPhaseSideEffectsForStrictMode = false;
+export const enableCreateRoot = false;
+export const enableUserTimingAPI = __DEV__;
+export const warnAboutDeprecatedLifecycles = false;
+
+// react-reconciler/persistent entry point
+// uses a persistent reconciler.
+export const enableMutatingReconciler = false;
+export const enableNoopReconciler = false;
+export const enablePersistentReconciler = true;
+
+// Only used in www builds.
+export function addUserTimingListener() {
+  invariant(false, 'Not implemented.');
+}
+
+// Flow magic to verify the exports of this file match the original version.
+// eslint-disable-next-line no-unused-vars
+type Check<_X, Y: _X, X: Y = _X> = null;
+// eslint-disable-next-line no-unused-expressions
+(null: Check<PersistentFeatureFlagsType, FeatureFlagsType>);

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -205,6 +205,16 @@ const bundles = [
     externals: ['react'],
   },
 
+  /******* React Persistent Reconciler *******/
+  {
+    label: 'react-reconciler-persistent',
+    bundleTypes: [NODE_DEV, NODE_PROD],
+    moduleType: RECONCILER,
+    entry: 'react-reconciler/persistent',
+    global: 'ReactPersistentReconciler',
+    externals: ['react'],
+  },
+
   /******* Reflection *******/
   {
     label: 'reconciler-reflection',

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -36,6 +36,8 @@ const forks = Object.freeze({
         return 'shared/forks/ReactFeatureFlags.native.js';
       case 'react-native-renderer/src/ReactFabric':
         return 'shared/forks/ReactFeatureFlags.native-fabric.js';
+      case 'react-reconciler/persistent':
+        return 'shared/forks/ReactFeatureFlags.persistent.js';
       default:
         switch (bundleType) {
           case FB_DEV:

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -384,6 +384,20 @@
       "packageName": "react-native-renderer",
       "size": 204787,
       "gzip": 35784
+    },
+    {
+      "filename": "react-reconciler-persistent.development.js",
+      "bundleType": "NODE_DEV",
+      "packageName": "react-reconciler",
+      "size": 288790,
+      "gzip": 60630
+    },
+    {
+      "filename": "react-reconciler-persistent.production.min.js",
+      "bundleType": "NODE_PROD",
+      "packageName": "react-reconciler",
+      "size": 41151,
+      "gzip": 13111
     }
   ]
 }


### PR DESCRIPTION
Ideally we'd write a test for this via `react-noop` but that requires some rewiring so I didn't bother. It's even more experimental than the main `react-reconciler` anyway. We can fix this later.

Test plan:

```js
var r = require('react-reconciler/persistent');
var rend = r({
  now() { return Date.now() },
  persistence: {},
  scheduleDeferredCallback() {}
});

var c = rend.createContainer({}, true, false)
rend.updateContainer('lol', c, null);
```

This was enough to smoke-test it and verify the flag gets set (if you remove `/persistent` it crashes). There might be other issues but I think it's good for starters.