### PR TITLE
String ref warning shows name of ref

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -111,12 +111,13 @@ function coerceRef(
         if (!didWarnAboutStringRefInStrictMode[componentName]) {
           warning(
             false,
-            'A string ref has been found within a strict mode tree. ' +
+            'A string ref, "%s", has been found within a strict mode tree. ' +
               'String refs are a source of potential bugs and should be avoided. ' +
               'We recommend using a ref callback instead.' +
               '\n%s' +
               '\n\nLearn more about using refs safely here:' +
               '\nhttps://fb.me/react-strict-mode-string-ref',
+            mixedRef,
             getStackAddendumByWorkInProgressFiber(returnFiber),
           );
           didWarnAboutStringRefInStrictMode[componentName] = true;

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
@@ -1075,7 +1075,7 @@ describe('ReactIncrementalSideEffects', () => {
 
     ReactNoop.render(<Foo />);
     expect(ReactNoop.flush).toWarnDev(
-      'Warning: A string ref has been found within a strict mode tree.',
+      'Warning: A string ref, "bar", has been found within a strict mode tree.',
     );
 
     expect(fooInstance.refs.bar.test).toEqual('test');

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -776,7 +776,7 @@ describe('ReactStrictMode', () => {
       expect(() => {
         renderer = ReactTestRenderer.create(<OuterComponent />);
       }).toWarnDev(
-        'Warning: A string ref has been found within a strict mode tree. ' +
+        'Warning: A string ref, "somestring", has been found within a strict mode tree. ' +
           'String refs are a source of potential bugs and should be avoided. ' +
           'We recommend using a ref callback instead.\n\n' +
           '    in OuterComponent (at **)\n\n' +
@@ -817,7 +817,7 @@ describe('ReactStrictMode', () => {
       expect(() => {
         renderer = ReactTestRenderer.create(<OuterComponent />);
       }).toWarnDev(
-        'Warning: A string ref has been found within a strict mode tree. ' +
+        'Warning: A string ref, "somestring", has been found within a strict mode tree. ' +
           'String refs are a source of potential bugs and should be avoided. ' +
           'We recommend using a ref callback instead.\n\n' +
           '    in InnerComponent (at **)\n' +


### PR DESCRIPTION
Follow-up for PR #12161

It occurred to me that the error message could be a bit more helpful if we showed the ref name.