### PR TITLE
Fix server render strict mode

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationStrictMode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationStrictMode-test.js
@@ -36,36 +36,36 @@ describe('ReactDOMServerIntegration', () => {
     resetModules();
   });
 
-  describe('React.Fragment', () => {
-    itRenders('a fragment with one child', async render => {
+  describe('React.StrictMode', () => {
+    itRenders('a strict mode with one child', async render => {
       let e = await render(
-        <React.Fragment>
+        <React.StrictMode>
           <div>text1</div>
-        </React.Fragment>,
+        </React.StrictMode>,
       );
       let parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
     });
 
-    itRenders('a fragment with several children', async render => {
+    itRenders('a strict mode with several children', async render => {
       let Header = props => {
         return <p>header</p>;
       };
       let Footer = props => {
         return (
-          <React.Fragment>
+          <React.StrictMode>
             <h2>footer</h2>
             <h3>about</h3>
-          </React.Fragment>
+          </React.StrictMode>
         );
       };
       let e = await render(
-        <React.Fragment>
+        <React.StrictMode>
           <div>text1</div>
           <span>text2</span>
           <Header />
           <Footer />
-        </React.Fragment>,
+        </React.StrictMode>,
       );
       let parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
@@ -75,23 +75,23 @@ describe('ReactDOMServerIntegration', () => {
       expect(parent.childNodes[4].tagName).toBe('H3');
     });
 
-    itRenders('a nested fragment', async render => {
+    itRenders('a nested strict mode', async render => {
       let e = await render(
-        <React.Fragment>
-          <React.Fragment>
+        <React.StrictMode>
+          <React.StrictMode>
             <div>text1</div>
-          </React.Fragment>
+          </React.StrictMode>
           <span>text2</span>
-          <React.Fragment>
-            <React.Fragment>
-              <React.Fragment>
+          <React.StrictMode>
+            <React.StrictMode>
+              <React.StrictMode>
                 {null}
                 <p />
-              </React.Fragment>
+              </React.StrictMode>
               {false}
-            </React.Fragment>
-          </React.Fragment>
-        </React.Fragment>,
+            </React.StrictMode>
+          </React.StrictMode>
+        </React.StrictMode>,
       );
       let parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
@@ -99,8 +99,8 @@ describe('ReactDOMServerIntegration', () => {
       expect(parent.childNodes[2].tagName).toBe('P');
     });
 
-    itRenders('an empty fragment', async render => {
-      expect(await render(<React.Fragment />)).toBe(null);
+    itRenders('an empty strict mode', async render => {
+      expect(await render(<React.StrictMode />)).toBe(null);
     });
   });
 });

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -28,6 +28,7 @@ import {ReactDebugCurrentFrame} from 'shared/ReactGlobalSharedState';
 import {warnAboutDeprecatedLifecycles} from 'shared/ReactFeatureFlags';
 import {
   REACT_FRAGMENT_TYPE,
+  REACT_STRICT_MODE_TYPE,
   REACT_CALL_TYPE,
   REACT_RETURN_TYPE,
   REACT_PORTAL_TYPE,
@@ -814,6 +815,7 @@ class ReactDOMServerRenderer {
       }
 
       switch (elementType) {
+        case REACT_STRICT_MODE_TYPE:
         case REACT_FRAGMENT_TYPE: {
           const nextChildren = toArray(
             ((nextChild: any): ReactElement).props.children,


### PR DESCRIPTION
Without this, `<StrictMode>` failed on server rendering and get following error:

```
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: symbol.
Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: symbol.
    at invariant (/Users/chentsulin/Projects/project/client/node_modules/fbjs/lib/invariant.js:42:15)
    at ReactDOMServerRenderer.render (/Users/chentsulin/Projects/project/client/node_modules/react-dom/cjs/react-dom-server.node.development.js:2415:7)
```