### PR TITLE
Add a warning for style values containing !important

### DIFF
--- a/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
@@ -186,6 +186,36 @@ describe('CSSPropertyOperations', () => {
     ]);
   });
 
+  it('should warn about style containing !important', () => {
+    class Comp extends React.Component {
+      static displayName = 'Comp';
+
+      render() {
+        return (
+          <div
+            style={{
+              backgroundColor: 'red!important',
+              color: 'green!important',
+            }}
+          />
+        );
+      }
+    }
+
+    const root = document.createElement('div');
+
+    expect(() => ReactDOM.render(<Comp />, root)).toWarnDev([
+      'Warning: Style property values shouldn\'t contain "!important". ' +
+        'Try "backgroundColor: red" instead.' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
+      'Warning: Style property values shouldn\'t contain "!important". ' +
+        'Try "color: green" instead.' +
+        '\n    in div (at **)' +
+        '\n    in Comp (at **)',
+    ]);
+  });
+
   it('should warn about style containing a NaN value', () => {
     class Comp extends React.Component {
       static displayName = 'Comp';

--- a/packages/react-dom/src/shared/warnValidStyle.js
+++ b/packages/react-dom/src/shared/warnValidStyle.js
@@ -18,6 +18,9 @@ if (__DEV__) {
   // style values shouldn't contain a semicolon
   const badStyleValueWithSemicolonPattern = /;\s*$/;
 
+  // style values shouldn't contain important
+  const badStyleValueWithImportantPattern = /!important\s*$/;
+
   const warnedStyleNames = {};
   const warnedStyleValues = {};
   let warnedForNaNValue = false;
@@ -69,6 +72,22 @@ if (__DEV__) {
     );
   };
 
+  const warnStyleValueWithImportant = function(name, value, getStack) {
+    if (warnedStyleValues.hasOwnProperty(value) && warnedStyleValues[value]) {
+      return;
+    }
+
+    warnedStyleValues[value] = true;
+    warning(
+      false,
+      'Style property values shouldn\'t contain "!important". ' +
+        'Try "%s: %s" instead.%s',
+      name,
+      value.replace(badStyleValueWithImportantPattern, ''),
+      getStack(),
+    );
+  };
+
   const warnStyleValueIsNaN = function(name, value, getStack) {
     if (warnedForNaNValue) {
       return;
@@ -104,6 +123,8 @@ if (__DEV__) {
       warnBadVendoredStyleName(name, getStack);
     } else if (badStyleValueWithSemicolonPattern.test(value)) {
       warnStyleValueWithSemicolon(name, value, getStack);
+    } else if (badStyleValueWithImportantPattern.test(value)) {
+      warnStyleValueWithImportant(name, value, getStack);
     }
 
     if (typeof value === 'number') {


### PR DESCRIPTION
Related to #1881.

This patch ensures that a warning is displayed when `!important` is included in an inline style value, as those values will cause the style not to be applied to the DOM node. (Current behaviour is silent failure.)