### PR TITLE
Add support for using !important in inline style values

### DIFF
--- a/packages/react-dom/src/shared/CSSPropertyOperations.js
+++ b/packages/react-dom/src/shared/CSSPropertyOperations.js
@@ -58,6 +58,9 @@ export function setValueForStyles(node, styles, getStack) {
       continue;
     }
     const isCustomProperty = styleName.indexOf('--') === 0;
+    const isImportant =
+      typeof styles[styleName] === 'string' &&
+      styles[styleName].indexOf('!important') > -1;
     if (__DEV__) {
       if (!isCustomProperty) {
         warnValidStyle(styleName, styles[styleName], getStack);
@@ -71,8 +74,14 @@ export function setValueForStyles(node, styles, getStack) {
     if (styleName === 'float') {
       styleName = 'cssFloat';
     }
-    if (isCustomProperty) {
-      style.setProperty(styleName, styleValue);
+    if (isCustomProperty || isImportant) {
+      const name = isCustomProperty ? styleName : hyphenateStyleName(styleName);
+      if (isImportant) {
+        const [value, priority] = styleValue.split('!');
+        style.setProperty(name, value, priority);
+      } else {
+        style.setProperty(name, styleValue);
+      }
     } else {
       style[styleName] = styleValue;
     }


### PR DESCRIPTION
Proposed solution for supporting the `!important` priority for inline styles (#1881). I couldn't write a test for this change; it looks like jsdom doesn't fully support the browser APIs being used. Please let me know if you've got any ideas.

I used RNW's early-warning [benchmarks](necolas.github.io/react-native-web/benchmarks) to check how this change affects the `inline-styles` timings in Chrome. I couldn't see any difference when styles don't use `!important`. There is a 10-15% increase in time taken when every node in the tree (>600) has at least one style value using `!important` and going through the new code path. Overall it looks like it avoids introducing a performance regression for existing using of `style` while enabling use of `!important` if needed.

[A micro-optimization](https://github.com/facebook/fbjs/pull/282) PR for `hyphenateStyleName` in `fbjs` helps a little too.

(This patch is related to #12179, which adds a warning when `!important` is used.)