### PR TITLE
Enable warnAboutDeprecatedLifecycles for ReactNative

### DIFF
--- a/scripts/rollup/shims/react-native/ReactFeatureFlags.js
+++ b/scripts/rollup/shims/react-native/ReactFeatureFlags.js
@@ -12,7 +12,7 @@
 const ReactFeatureFlags = {
   debugRenderPhaseSideEffects: false,
   debugRenderPhaseSideEffectsForStrictMode: false,
-  warnAboutDeprecatedLifecycles: false,
+  warnAboutDeprecatedLifecycles: true,
 };
 
 module.exports = ReactFeatureFlags;


### PR DESCRIPTION
I am currently in the process of landing a codemod internally (at Facebook) to rename all of the deprecated lifecycles. This codemod will also remove the lifecycles from react-native open source components. Once it lands, the `warnAboutDeprecatedLifecycles` flag will help prevent the old lifecycles from sneaking back in.

Once this change lands here, it will go down with the next ReactNative sync to fbsource, and from there it will be auto-synced to the react-native repo and will make its way into the next RN release cut. (This process will take a couple of weeks.)