### PR TITLE
Use linked list instead of stack to keep track of fibers

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -683,7 +683,7 @@ class ReactDOMServerRenderer {
     this.providerIndex += 1;
     this.providerStack[this.providerIndex] = provider;
     const context: ReactContext<any> = provider.type.context;
-    context.currentValue = provider.props.value;
+    context.current = provider.props.value;
   }
 
   popProvider<T>(provider: ReactProvider<T>): void {
@@ -698,13 +698,13 @@ class ReactDOMServerRenderer {
     this.providerIndex -= 1;
     const context: ReactContext<any> = provider.type.context;
     if (this.providerIndex < 0) {
-      context.currentValue = context.defaultValue;
+      context.current = context.defaultValue;
     } else {
       // We assume this type is correct because of the index check above.
       const previousProvider: ReactProvider<any> = (this.providerStack[
         this.providerIndex
       ]: any);
-      context.currentValue = previousProvider.props.value;
+      context.current = previousProvider.props.value;
     }
   }
 
@@ -873,7 +873,7 @@ class ReactDOMServerRenderer {
           case REACT_CONTEXT_TYPE: {
             const consumer: ReactConsumer<any> = (nextChild: any);
             const nextProps: any = consumer.props;
-            const nextValue = consumer.type.currentValue;
+            const nextValue = consumer.type.current;
 
             const nextChildren = toArray(nextProps.children(nextValue));
             const frame: Frame = {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -846,8 +846,13 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     const context: ReactContext<any> = workInProgress.type;
     const newProps = workInProgress.pendingProps;
 
-    const newValue = context.currentValue;
-    const changedBits = context.changedBits;
+    const providerFiber =
+      context.current === null ? null : context.current.fiber;
+    const newValue =
+      providerFiber === null
+        ? context.defaultValue
+        : providerFiber.pendingProps.value;
+    const changedBits = providerFiber === null ? 1 : providerFiber.stateNode;
 
     if (changedBits !== 0) {
       // Context change propagation stops at matching consumers, for time-

--- a/packages/shared/ReactContext.js
+++ b/packages/shared/ReactContext.js
@@ -35,8 +35,7 @@ export function createContext<T>(
     $$typeof: REACT_CONTEXT_TYPE,
     calculateChangedBits,
     defaultValue,
-    currentValue: defaultValue,
-    changedBits: 0,
+    current: null,
     // These are circular
     Provider: (null: any),
     Consumer: (null: any),

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -82,8 +82,7 @@ export type ReactContext<T> = {
   Provider: ReactProviderType<T>,
   calculateChangedBits: ((a: T, b: T) => number) | null,
   defaultValue: T,
-  currentValue: T,
-  changedBits: number,
+  current: any,
 
   // DEV only
   _currentRenderer?: Object | null,


### PR DESCRIPTION
This is closer to the original implementation. We're already storing the current values on the context object itself, so we shouldn't be storing them on a stack, too. The only reason I added a stack of provider fibers was so we could reset all the in-progress contexts during an interruption (`resetProviderStack`). I think the presence of a stack was misleading, including to me, because it's easy to confuse it with how the legacy context API works.

The linked list version is more straightforward and hopefully harder to screw up. For `resetProviderStack`, I'm using a Set to avoid duplicate entries.

No additional tests because the behavior should be the same.