### PR TITLE
Add react-is package

### DIFF
--- a/packages/react-is/README.md
+++ b/packages/react-is/README.md
@@ -4,30 +4,72 @@ This package allows you to test arbitrary values and see if they're a particular
 
 ## Usage
 
+### AsyncMode
 ```js
 import React from 'react';
-import {isElement} from 'react-is';
+import {isAsyncMode, typeOf} from 'react-is';
+
+const AsyncMode = React.unstable_AsyncMode;
+
+typeOf(<AsyncMode />); // "ReactAsyncMode"
+
+isAsyncMode(<AsyncMode />); // true
+```
+
+### Context
+```js
+import React from 'react';
+import {isContextConsumer, isContextProvider, typeOf} from 'react-is';
+
+const ThemeContext = React.createContext('blue');
+
+typeOf(<ThemeContext.Provider />); // "ReactContextProvider"
+typeOf(<ThemeContext.Consumer />); // "ReactContextConsumer"
+
+isContextConsumer(<ThemeContext.Consumer />); // true
+isContextProvider(<ThemeContext.Provider />); // true
+```
+
+### Element
+```js
+import React from 'react';
+import {isElement, typeOf} from 'react-is';
+
+typeOf(<div />); // "ReactElement"
+
 isElement(<div />); // true
 ```
 
+### Fragment
 ```js
 import React from 'react';
-import {isFragment} from 'react-is';
+import {isFragment, typeOf} from 'react-is';
+
+typeOf(<></>); // "ReactFragment"
+
 isFragment(<></>); // true
 ```
 
+### Portal
 ```js
 import React from 'react';
 import {createPortal} from 'react-dom';
-import {isPortal} from 'react-is';
-isPortal(createPortal(<div />, document.body)); // true
+import {isPortal, typeOf} from 'react-is';
+
+const div = document.createElement('div');
+const portal = createPortal(<div />, div);
+
+typeOf(portal); // "ReactPortal"
+
+isPortal(portal); // true
 ```
 
+### StrictMode
 ```js
 import React from 'react';
-import {createPortal} from 'react-dom';
-import {typeOf} from 'react-is';
-typeOf(<div />); // "ReactElement"
-typeOf(<></>); // "ReactFragment"
-typeOf(createPortal(<div />, document.body)); // "ReactPortal"
+import {isStrictMode, typeOf} from 'react-is';
+
+typeOf(<React.StrictMode />); // "ReactStrictMode"
+
+isStrictMode(<React.StrictMode />); // true
 ```

--- a/packages/react-is/README.md
+++ b/packages/react-is/README.md
@@ -11,7 +11,7 @@ import {isAsyncMode, typeOf} from 'react-is';
 
 const AsyncMode = React.unstable_AsyncMode;
 
-typeOf(<AsyncMode />); // "ReactAsyncMode"
+typeOf(<AsyncMode />); // ReactIs.AsyncMode
 
 isAsyncMode(<AsyncMode />); // true
 ```
@@ -23,8 +23,8 @@ import {isContextConsumer, isContextProvider, typeOf} from 'react-is';
 
 const ThemeContext = React.createContext('blue');
 
-typeOf(<ThemeContext.Provider />); // "ReactContextProvider"
-typeOf(<ThemeContext.Consumer />); // "ReactContextConsumer"
+typeOf(<ThemeContext.Provider />); // ReactIs.ContextProvider
+typeOf(<ThemeContext.Consumer />); // ReactIs.ContextConsumer
 
 isContextConsumer(<ThemeContext.Consumer />); // true
 isContextProvider(<ThemeContext.Provider />); // true
@@ -35,7 +35,7 @@ isContextProvider(<ThemeContext.Provider />); // true
 import React from 'react';
 import {isElement, typeOf} from 'react-is';
 
-typeOf(<div />); // "ReactElement"
+typeOf(<div />); // ReactIs.Element
 
 isElement(<div />); // true
 ```
@@ -45,7 +45,7 @@ isElement(<div />); // true
 import React from 'react';
 import {isFragment, typeOf} from 'react-is';
 
-typeOf(<></>); // "ReactFragment"
+typeOf(<></>); // ReactIs.Fragment
 
 isFragment(<></>); // true
 ```
@@ -59,7 +59,7 @@ import {isPortal, typeOf} from 'react-is';
 const div = document.createElement('div');
 const portal = createPortal(<div />, div);
 
-typeOf(portal); // "ReactPortal"
+typeOf(portal); // ReactIs.Portal
 
 isPortal(portal); // true
 ```
@@ -69,7 +69,7 @@ isPortal(portal); // true
 import React from 'react';
 import {isStrictMode, typeOf} from 'react-is';
 
-typeOf(<React.StrictMode />); // "ReactStrictMode"
+typeOf(<React.StrictMode />); // ReactIs.StrictMode
 
 isStrictMode(<React.StrictMode />); // true
 ```

--- a/packages/react-is/README.md
+++ b/packages/react-is/README.md
@@ -3,6 +3,7 @@
 This package allows you to test arbitrary values and see if they're a particular React type, e.g. React Elements.
 
 ## Installation
+
 ```sh
 # Yarn
 yarn add react-is
@@ -14,67 +15,75 @@ npm install react-is --save
 ## Usage
 
 ### AsyncMode
+
 ```js
-import React from 'react';
-import ReactIs from 'react-is';
+import React from "react";
+import { AsyncMode, isAsyncMode, typeOf } from "react-is";
 
-const AsyncMode = React.unstable_AsyncMode;
-
-ReactIs.isAsyncMode(<AsyncMode />); // true
-ReactIs.typeOf(<AsyncMode />) === ReactIs.AsyncMode; // true
+isAsyncMode(<React.unstable_AsyncMode />); // true
+typeOf(<React.unstable_AsyncMode />) === AsyncMode; // true
 ```
 
 ### Context
+
 ```js
-import React from 'react';
-ReactIs ReactIs from 'react-is';
+import React from "react";
+import {
+  ContextConsumer,
+  ContextProvider,
+  isContextConsumer,
+  isContextProvider,
+  typeOf
+} from "react-is";
 
-const ThemeContext = React.createContext('blue');
+const ThemeContext = React.createContext("blue");
 
-ReactIs.isContextConsumer(<ThemeContext.Consumer />); // true
-ReactIs.isContextProvider(<ThemeContext.Provider />); // true
-ReactIs.typeOf(<ThemeContext.Provider />) === ReactIs.ContextProvider; // true
-ReactIs.typeOf(<ThemeContext.Consumer />) === ReactIs.ContextConsumer; // true
+isContextConsumer(<ThemeContext.Consumer />); // true
+isContextProvider(<ThemeContext.Provider />); // true
+typeOf(<ThemeContext.Provider />) === ContextProvider; // true
+typeOf(<ThemeContext.Consumer />) === ContextConsumer; // true
 ```
 
 ### Element
-```js
-import React from 'react';
-import ReactIs from 'react-is';
 
-ReactIs.isElement(<div />); // true
-ReactIs.typeOf(<div />) === ReactIs.Element; // true
+```js
+import React from "react";
+import { Element, isElement, typeOf } from "react-is";
+
+isElement(<div />); // true
+typeOf(<div />) === Element; // true
 ```
 
 ### Fragment
-```js
-import React from 'react';
-import ReactIs from 'react-is';
 
-ReactIs.isFragment(<></>); // true
-ReactIs.typeOf(<></>) === ReactIs.Fragment; // true
+```js
+import React from "react";
+import { Fragment, isFragment, typeOf } from "react-is";
+
+isFragment(<></>); // true
+typeOf(<></>) === Fragment; // true
 ```
 
 ### Portal
-```js
-import React from 'react';
-import ReactDOM from 'react-dom';
-import ReactIs from 'react-is';
 
-const div = document.createElement('div');
+```js
+import React from "react";
+import ReactDOM from "react-dom";
+import { isPortal, Portal, typeOf } from "react-is";
+
+const div = document.createElement("div");
 const portal = ReactDOM.createPortal(<div />, div);
 
-ReactIs.isPortal(portal); // true
-ReactIs.typeOf(portal) === ReactIs.Portal; // true
+isPortal(portal); // true
+typeOf(portal) === Portal; // true
 ```
 
 ### StrictMode
+
 ```js
-import React from 'react';
-import ReactIs from 'react-is';
+import React from "react";
+import { isStrictMode, StrictMode, TypeOf } from "react-is";
 
-const {StrictMode} = React;
-
-ReactIs.isStrictMode(<StrictMode />); // true
-ReactIs.typeOf(<StrictMode />) === ReactIs.StrictMode; // true
+isStrictMode(<React.StrictMode />); // true
+typeOf(<React.StrictMode />) === StrictMode; // true
 ```

--- a/packages/react-is/README.md
+++ b/packages/react-is/README.md
@@ -1,0 +1,33 @@
+# `react-is`
+
+This package allows you to test arbitrary values and see if they're a particular React type, e.g. React Elements.
+
+## Usage
+
+```js
+import React from 'react';
+import {isElement} from 'react-is';
+isElement(<div />); // true
+```
+
+```js
+import React from 'react';
+import {isFragment} from 'react-is';
+isFragment(<></>); // true
+```
+
+```js
+import React from 'react';
+import {createPortal} from 'react-dom';
+import {isPortal} from 'react-is';
+isPortal(createPortal(<div />, document.body)); // true
+```
+
+```js
+import React from 'react';
+import {createPortal} from 'react-dom';
+import {typeOf} from 'react-is';
+typeOf(<div />); // "ReactElement"
+typeOf(<></>); // "ReactFragment"
+typeOf(createPortal(<div />, document.body)); // "ReactPortal"
+```

--- a/packages/react-is/README.md
+++ b/packages/react-is/README.md
@@ -2,74 +2,79 @@
 
 This package allows you to test arbitrary values and see if they're a particular React type, e.g. React Elements.
 
+## Installation
+```sh
+# Yarn
+yarn add react-is
+
+# NPM
+npm install react-is --save
+```
+
 ## Usage
 
 ### AsyncMode
 ```js
 import React from 'react';
-import {isAsyncMode, typeOf} from 'react-is';
+import ReactIs from 'react-is';
 
 const AsyncMode = React.unstable_AsyncMode;
 
-typeOf(<AsyncMode />); // ReactIs.AsyncMode
-
-isAsyncMode(<AsyncMode />); // true
+ReactIs.isAsyncMode(<AsyncMode />); // true
+ReactIs.typeOf(<AsyncMode />) === ReactIs.AsyncMode; // true
 ```
 
 ### Context
 ```js
 import React from 'react';
-import {isContextConsumer, isContextProvider, typeOf} from 'react-is';
+ReactIs ReactIs from 'react-is';
 
 const ThemeContext = React.createContext('blue');
 
-typeOf(<ThemeContext.Provider />); // ReactIs.ContextProvider
-typeOf(<ThemeContext.Consumer />); // ReactIs.ContextConsumer
-
-isContextConsumer(<ThemeContext.Consumer />); // true
-isContextProvider(<ThemeContext.Provider />); // true
+ReactIs.isContextConsumer(<ThemeContext.Consumer />); // true
+ReactIs.isContextProvider(<ThemeContext.Provider />); // true
+ReactIs.typeOf(<ThemeContext.Provider />) === ReactIs.ContextProvider; // true
+ReactIs.typeOf(<ThemeContext.Consumer />) === ReactIs.ContextConsumer; // true
 ```
 
 ### Element
 ```js
 import React from 'react';
-import {isElement, typeOf} from 'react-is';
+import ReactIs from 'react-is';
 
-typeOf(<div />); // ReactIs.Element
-
-isElement(<div />); // true
+ReactIs.isElement(<div />); // true
+ReactIs.typeOf(<div />) === ReactIs.Element; // true
 ```
 
 ### Fragment
 ```js
 import React from 'react';
-import {isFragment, typeOf} from 'react-is';
+import ReactIs from 'react-is';
 
-typeOf(<></>); // ReactIs.Fragment
-
-isFragment(<></>); // true
+ReactIs.isFragment(<></>); // true
+ReactIs.typeOf(<></>) === ReactIs.Fragment; // true
 ```
 
 ### Portal
 ```js
 import React from 'react';
-import {createPortal} from 'react-dom';
-import {isPortal, typeOf} from 'react-is';
+import ReactDOM from 'react-dom';
+import ReactIs from 'react-is';
 
 const div = document.createElement('div');
-const portal = createPortal(<div />, div);
+const portal = ReactDOM.createPortal(<div />, div);
 
-typeOf(portal); // ReactIs.Portal
-
-isPortal(portal); // true
+ReactIs.isPortal(portal); // true
+ReactIs.typeOf(portal) === ReactIs.Portal; // true
 ```
 
 ### StrictMode
 ```js
 import React from 'react';
-import {isStrictMode, typeOf} from 'react-is';
+import ReactIs from 'react-is';
 
-typeOf(<React.StrictMode />); // ReactIs.StrictMode
+const {StrictMode} = React;
 
-isStrictMode(<React.StrictMode />); // true
+ReactIs.isStrictMode(<StrictMode />); // true
+ReactIs.typeOf(<StrictMode />) === ReactIs.StrictMode; // true
 ```

--- a/packages/react-is/README.md
+++ b/packages/react-is/README.md
@@ -18,50 +18,44 @@ npm install react-is --save
 
 ```js
 import React from "react";
-import { AsyncMode, isAsyncMode, typeOf } from "react-is";
+import * as ReactIs from 'react-is';
 
-isAsyncMode(<React.unstable_AsyncMode />); // true
-typeOf(<React.unstable_AsyncMode />) === AsyncMode; // true
+ReactIs.isAsyncMode(<React.unstable_AsyncMode />); // true
+ReactIs.typeOf(<React.unstable_AsyncMode />) === ReactIs.AsyncMode; // true
 ```
 
 ### Context
 
 ```js
 import React from "react";
-import {
-  ContextConsumer,
-  ContextProvider,
-  isContextConsumer,
-  isContextProvider,
-  typeOf
-} from "react-is";
+import * as ReactIs from 'react-is';
 
 const ThemeContext = React.createContext("blue");
 
-isContextConsumer(<ThemeContext.Consumer />); // true
-isContextProvider(<ThemeContext.Provider />); // true
-typeOf(<ThemeContext.Provider />) === ContextProvider; // true
-typeOf(<ThemeContext.Consumer />) === ContextConsumer; // true
+ReactIs.isContextConsumer(<ThemeContext.Consumer />); // true
+ReactIs.isContextProvider(<ThemeContext.Provider />); // true
+ReactIs.typeOf(<ThemeContext.Provider />) === ReactIs.ContextProvider; // true
+ReactIs.typeOf(<ThemeContext.Consumer />) === ReactIs.ContextConsumer; // true
 ```
 
 ### Element
 
 ```js
 import React from "react";
-import { Element, isElement, typeOf } from "react-is";
+import * as ReactIs from 'react-is';
 
-isElement(<div />); // true
-typeOf(<div />) === Element; // true
+ReactIs.isElement(<div />); // true
+ReactIs.typeOf(<div />) === ReactIs.Element; // true
 ```
 
 ### Fragment
 
 ```js
 import React from "react";
-import { Fragment, isFragment, typeOf } from "react-is";
+import * as ReactIs from 'react-is';
 
-isFragment(<></>); // true
-typeOf(<></>) === Fragment; // true
+ReactIs.isFragment(<></>); // true
+ReactIs.typeOf(<></>) === ReactIs.Fragment; // true
 ```
 
 ### Portal
@@ -69,21 +63,21 @@ typeOf(<></>) === Fragment; // true
 ```js
 import React from "react";
 import ReactDOM from "react-dom";
-import { isPortal, Portal, typeOf } from "react-is";
+import * as ReactIs from 'react-is';
 
 const div = document.createElement("div");
 const portal = ReactDOM.createPortal(<div />, div);
 
-isPortal(portal); // true
-typeOf(portal) === Portal; // true
+ReactIs.isPortal(portal); // true
+ReactIs.typeOf(portal) === ReactIs.Portal; // true
 ```
 
 ### StrictMode
 
 ```js
 import React from "react";
-import { isStrictMode, StrictMode, TypeOf } from "react-is";
+import * as ReactIs from 'react-is';
 
-isStrictMode(<React.StrictMode />); // true
-typeOf(<React.StrictMode />) === StrictMode; // true
+ReactIs.isStrictMode(<React.StrictMode />); // true
+ReactIs.typeOf(<React.StrictMode />) === ReactIs.StrictMode; // true
 ```

--- a/packages/react-is/index.js
+++ b/packages/react-is/index.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+var REACT_ELEMENT_TYPE;
+var REACT_COROUTINE_TYPE;
+var REACT_YIELD_TYPE;
+var REACT_PORTAL_TYPE;
+var REACT_FRAGMENT_TYPE;
+if (typeof Symbol === 'function' && Symbol.for) {
+  REACT_ELEMENT_TYPE = Symbol.for('react.element');
+  REACT_COROUTINE_TYPE = Symbol.for('react.coroutine');
+  REACT_YIELD_TYPE = Symbol.for('react.yield');
+  REACT_PORTAL_TYPE = Symbol.for('react.portal');
+  REACT_FRAGMENT_TYPE = Symbol.for('react.fragment');
+} else {
+  REACT_ELEMENT_TYPE = 0xeac7;
+  REACT_COROUTINE_TYPE = 0xeac8;
+  REACT_YIELD_TYPE = 0xeac9;
+  REACT_PORTAL_TYPE = 0xeaca;
+  REACT_FRAGMENT_TYPE = 0xeacb;
+}
+
+function is(object, type) {
+  return (
+    typeof object === 'object' && object !== null && object.$$typeof === type
+  );
+}
+
+module.exports = {
+  typeOf(object) {
+    switch (typeof object === 'object' && object !== null && object.$$typeof) {
+      case REACT_ELEMENT_TYPE:
+        return 'ReactElement';
+      case REACT_COROUTINE_TYPE:
+        return 'ReactCoroutine';
+      case REACT_YIELD_TYPE:
+        return 'ReactYield';
+      case REACT_PORTAL_TYPE:
+        return 'ReactPortal';
+      case REACT_FRAGMENT_TYPE:
+        return 'ReactFragment';
+      default:
+        return undefined;
+    }
+  },
+  isElement(object) {
+    return is(object, REACT_ELEMENT_TYPE);
+  },
+  isCoroutine(object) {
+    return is(object, REACT_COROUTINE_TYPE);
+  },
+  isYield(object) {
+    return is(object, REACT_YIELD_TYPE);
+  },
+  isPortal(object) {
+    return is(object, REACT_PORTAL_TYPE);
+  },
+  isFragment(object) {
+    return is(object, REACT_FRAGMENT_TYPE);
+  },
+};

--- a/packages/react-is/index.js
+++ b/packages/react-is/index.js
@@ -13,6 +13,4 @@ const ReactIs = require('./src/ReactIs');
 
 // TODO: decide on the top-level export form.
 // This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactIs.default
-  ? ReactIs.default
-  : ReactIs;
+module.exports = ReactIs.default ? ReactIs.default : ReactIs;

--- a/packages/react-is/index.js
+++ b/packages/react-is/index.js
@@ -9,4 +9,10 @@
 
 'use strict';
 
-module.exports = require('./src/ReactIs');
+const ReactIs = require('./src/ReactIs');
+
+// TODO: decide on the top-level export form.
+// This is hacky but makes it work with both Rollup and Jest.
+module.exports = ReactIs.default
+  ? ReactIs.default
+  : ReactIs;

--- a/packages/react-is/index.js
+++ b/packages/react-is/index.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactIs = require('./src/ReactIs');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactIs.default ? ReactIs.default : ReactIs;
+export * from './src/ReactIs';

--- a/packages/react-is/index.js
+++ b/packages/react-is/index.js
@@ -1,67 +1,12 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
+ * Copyright (c) 2013-present, Facebook, Inc.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 'use strict';
 
-var REACT_ELEMENT_TYPE;
-var REACT_COROUTINE_TYPE;
-var REACT_YIELD_TYPE;
-var REACT_PORTAL_TYPE;
-var REACT_FRAGMENT_TYPE;
-if (typeof Symbol === 'function' && Symbol.for) {
-  REACT_ELEMENT_TYPE = Symbol.for('react.element');
-  REACT_COROUTINE_TYPE = Symbol.for('react.coroutine');
-  REACT_YIELD_TYPE = Symbol.for('react.yield');
-  REACT_PORTAL_TYPE = Symbol.for('react.portal');
-  REACT_FRAGMENT_TYPE = Symbol.for('react.fragment');
-} else {
-  REACT_ELEMENT_TYPE = 0xeac7;
-  REACT_COROUTINE_TYPE = 0xeac8;
-  REACT_YIELD_TYPE = 0xeac9;
-  REACT_PORTAL_TYPE = 0xeaca;
-  REACT_FRAGMENT_TYPE = 0xeacb;
-}
-
-function is(object, type) {
-  return (
-    typeof object === 'object' && object !== null && object.$$typeof === type
-  );
-}
-
-module.exports = {
-  typeOf(object) {
-    switch (typeof object === 'object' && object !== null && object.$$typeof) {
-      case REACT_ELEMENT_TYPE:
-        return 'ReactElement';
-      case REACT_COROUTINE_TYPE:
-        return 'ReactCoroutine';
-      case REACT_YIELD_TYPE:
-        return 'ReactYield';
-      case REACT_PORTAL_TYPE:
-        return 'ReactPortal';
-      case REACT_FRAGMENT_TYPE:
-        return 'ReactFragment';
-      default:
-        return undefined;
-    }
-  },
-  isElement(object) {
-    return is(object, REACT_ELEMENT_TYPE);
-  },
-  isCoroutine(object) {
-    return is(object, REACT_COROUTINE_TYPE);
-  },
-  isYield(object) {
-    return is(object, REACT_YIELD_TYPE);
-  },
-  isPortal(object) {
-    return is(object, REACT_PORTAL_TYPE);
-  },
-  isFragment(object) {
-    return is(object, REACT_FRAGMENT_TYPE);
-  },
-};
+module.exports = require('./src/ReactIs');

--- a/packages/react-is/npm/index.js
+++ b/packages/react-is/npm/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-is.production.min.js');
+} else {
+  module.exports = require('./cjs/react-is.development.js');
+}

--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -17,7 +17,6 @@
     "LICENSE",
     "README.md",
     "index.js",
-    "cjs/",
-    "umd/"
+    "cjs/"
   ]
 }

--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -1,12 +1,22 @@
 {
   "name": "react-is",
-  "description": "Brand checking of React Elements.",
-  "keywords": ["react"],
   "version": "1.0.0",
-  "homepage": "https://reactjs.org/",
-  "bugs": "https://github.com/facebook/react/issues",
-  "license": "MIT",
-  "files": ["index.js"],
+  "description": "Brand checking of React Elements.",
   "main": "index.js",
-  "repository": "facebook/react"
+  "repository": "facebook/react",
+  "keywords": ["react"],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/facebook/react/issues"
+  },
+  "homepage": "https://reactjs.org/",
+  "peerDependencies": {
+    "react": "^16.0.0 || 16.3.0-alpha.0"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "index.js",
+    "cjs/"
+  ]
 }

--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -17,6 +17,7 @@
     "LICENSE",
     "README.md",
     "index.js",
-    "cjs/"
+    "cjs/",
+    "umd/"
   ]
 }

--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-is",
-  "version": "1.0.0",
+  "version": "16.3.0-alpha.0",
   "description": "Brand checking of React Elements.",
   "main": "index.js",
   "repository": "facebook/react",

--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "react-is",
+  "description": "Brand checking of React Elements.",
+  "keywords": ["react"],
+  "version": "1.0.0",
+  "homepage": "https://reactjs.org/",
+  "bugs": "https://github.com/facebook/react/issues",
+  "license": "MIT",
+  "files": ["index.js"],
+  "main": "index.js",
+  "repository": "facebook/react"
+}

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -41,29 +41,37 @@ function getTypeTypeOf(object: any) {
 
 const ReactIs = {
   typeOf(object: any) {
-    switch (getType(object)) {
+    const type = getType(object);
+    switch (type) {
       case REACT_ASYNC_MODE_TYPE:
-        return 'ReactAsyncMode';
       case REACT_FRAGMENT_TYPE:
-        return 'ReactFragment';
       case REACT_STRICT_MODE_TYPE:
-        return 'ReactStrictMode';
+        return type;
     }
 
-    switch (getTypeTypeOf(object)) {
+    const typeTypeOf = getTypeTypeOf(object);
+    switch (typeTypeOf) {
       case REACT_CONTEXT_TYPE:
-        return 'ReactContextConsumer';
       case REACT_PROVIDER_TYPE:
-        return 'ReactContextProvider';
+        return typeTypeOf;
     }
 
-    switch (getTypeOf(object)) {
+    const typeOf = getTypeOf(object);
+    switch (typeOf) {
       case REACT_ELEMENT_TYPE:
-        return 'ReactElement';
       case REACT_PORTAL_TYPE:
-        return 'ReactPortal';
+        return typeOf;
     }
   },
+
+  AsyncMode: REACT_ASYNC_MODE_TYPE,
+  ContextConsumer: REACT_CONTEXT_TYPE,
+  ContextProvider: REACT_PROVIDER_TYPE,
+  Element: REACT_ELEMENT_TYPE,
+  Fragment: REACT_FRAGMENT_TYPE,
+  Portal: REACT_PORTAL_TYPE,
+  StrictMode: REACT_STRICT_MODE_TYPE,
+
   isAsyncMode(object: any) {
     return getType(object) === REACT_ASYNC_MODE_TYPE;
   },

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+import {
+  REACT_ASYNC_MODE_TYPE,
+  REACT_CONTEXT_TYPE,
+  REACT_ELEMENT_TYPE,
+  REACT_FRAGMENT_TYPE,
+  REACT_PORTAL_TYPE,
+  REACT_PROVIDER_TYPE,
+  REACT_STRICT_MODE_TYPE,
+} from 'shared/ReactSymbols';
+
+// e.g. Fragments, StrictMode
+function getType(object: any) {
+  return typeof object === 'object' && object !== null ? object.type : null;
+}
+
+// e.g. Elements, Portals
+function getTypeOf(object: any) {
+  return typeof object === 'object' && object !== null ? object.$$typeof : null;
+}
+
+// e.g. Context provider and consumer
+function getTypeTypeOf(object: any) {
+  return typeof object === 'object' &&
+    object !== null &&
+    typeof object.type === 'object' &&
+    object.type !== null
+    ? object.type.$$typeof
+    : null;
+}
+
+const ReactIs = {
+  typeOf(object: any) {
+    switch (getType(object)) {
+      case REACT_ASYNC_MODE_TYPE:
+        return 'ReactAsyncMode';
+      case REACT_FRAGMENT_TYPE:
+        return 'ReactFragment';
+      case REACT_STRICT_MODE_TYPE:
+        return 'ReactStrictMode';
+    }
+
+    switch (getTypeTypeOf(object)) {
+      case REACT_CONTEXT_TYPE:
+        return 'ReactContextConsumer';
+      case REACT_PROVIDER_TYPE:
+        return 'ReactContextProvider';
+    }
+
+    switch (getTypeOf(object)) {
+      case REACT_ELEMENT_TYPE:
+        return 'ReactElement';
+      case REACT_PORTAL_TYPE:
+        return 'ReactPortal';
+    }
+  },
+  isAsyncMode(object: any) {
+    return getType(object) === REACT_ASYNC_MODE_TYPE;
+  },
+  isContextConsumer(object: any) {
+    return getTypeTypeOf(object) === REACT_CONTEXT_TYPE;
+  },
+  isContextProvider(object: any) {
+    return getTypeTypeOf(object) === REACT_PROVIDER_TYPE;
+  },
+  isElement(object: any) {
+    return getTypeOf(object) === REACT_ELEMENT_TYPE;
+  },
+  isFragment(object: any) {
+    return getType(object) === REACT_FRAGMENT_TYPE;
+  },
+  isPortal(object: any) {
+    return getTypeOf(object) === REACT_PORTAL_TYPE;
+  },
+  isStrictMode(object: any) {
+    return getType(object) === REACT_STRICT_MODE_TYPE;
+  },
+};
+
+export default ReactIs;

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -19,50 +19,39 @@ import {
   REACT_STRICT_MODE_TYPE,
 } from 'shared/ReactSymbols';
 
-// e.g. Fragments, StrictMode
-function getType(object: any) {
-  return typeof object === 'object' && object !== null ? object.type : null;
-}
-
-// e.g. Elements, Portals
-function getTypeOf(object: any) {
-  return typeof object === 'object' && object !== null ? object.$$typeof : null;
-}
-
-// e.g. Context provider and consumer
-function getTypeTypeOf(object: any) {
-  return typeof object === 'object' &&
-    object !== null &&
-    typeof object.type === 'object' &&
-    object.type !== null
-    ? object.type.$$typeof
-    : null;
-}
-
 export function typeOf(object: any) {
-  let maybeType = getType(object);
-  switch (maybeType) {
-    case REACT_ASYNC_MODE_TYPE:
-    case REACT_FRAGMENT_TYPE:
-    case REACT_STRICT_MODE_TYPE:
-      if (getTypeOf(object) === REACT_ELEMENT_TYPE) {
-        return maybeType;
-      }
+  if (typeof object === 'object' && object !== null) {
+    const $$typeof = object.$$typeof;
+
+    switch ($$typeof) {
+      case REACT_ELEMENT_TYPE:
+        const type = object.type;
+
+        switch (type) {
+          case REACT_ASYNC_MODE_TYPE:
+          case REACT_FRAGMENT_TYPE:
+          case REACT_STRICT_MODE_TYPE:
+            return type;
+          default:
+            const $$typeofType =
+              typeof type === 'object' && type !== null
+                ? type.$$typeof
+                : undefined;
+
+            switch ($$typeofType) {
+              case REACT_CONTEXT_TYPE:
+              case REACT_PROVIDER_TYPE:
+                return $$typeofType;
+              default:
+                return $$typeof;
+            }
+        }
+      case REACT_PORTAL_TYPE:
+        return $$typeof;
+    }
   }
 
-  maybeType = getTypeTypeOf(object);
-  switch (maybeType) {
-    case REACT_CONTEXT_TYPE:
-    case REACT_PROVIDER_TYPE:
-      return maybeType;
-  }
-
-  maybeType = getTypeOf(object);
-  switch (maybeType) {
-    case REACT_ELEMENT_TYPE:
-    case REACT_PORTAL_TYPE:
-      return maybeType;
-  }
+  return undefined;
 }
 
 export const AsyncMode = REACT_ASYNC_MODE_TYPE;
@@ -74,32 +63,27 @@ export const Portal = REACT_PORTAL_TYPE;
 export const StrictMode = REACT_STRICT_MODE_TYPE;
 
 export function isAsyncMode(object: any) {
-  return (
-    getType(object) === REACT_ASYNC_MODE_TYPE &&
-    getTypeOf(object) === REACT_ELEMENT_TYPE
-  );
+  return typeOf(object) === REACT_ASYNC_MODE_TYPE;
 }
 export function isContextConsumer(object: any) {
-  return getTypeTypeOf(object) === REACT_CONTEXT_TYPE;
+  return typeOf(object) === REACT_CONTEXT_TYPE;
 }
 export function isContextProvider(object: any) {
-  return getTypeTypeOf(object) === REACT_PROVIDER_TYPE;
+  return typeOf(object) === REACT_PROVIDER_TYPE;
 }
 export function isElement(object: any) {
-  return getTypeOf(object) === REACT_ELEMENT_TYPE;
+  return (
+    typeof object === 'object' &&
+    object !== null &&
+    object.$$typeof === REACT_ELEMENT_TYPE
+  );
 }
 export function isFragment(object: any) {
-  return (
-    getType(object) === REACT_FRAGMENT_TYPE &&
-    getTypeOf(object) === REACT_ELEMENT_TYPE
-  );
+  return typeOf(object) === REACT_FRAGMENT_TYPE;
 }
 export function isPortal(object: any) {
-  return getTypeOf(object) === REACT_PORTAL_TYPE;
+  return typeOf(object) === REACT_PORTAL_TYPE;
 }
 export function isStrictMode(object: any) {
-  return (
-    getType(object) === REACT_STRICT_MODE_TYPE &&
-    getTypeOf(object) === REACT_ELEMENT_TYPE
-  );
+  return typeOf(object) === REACT_STRICT_MODE_TYPE;
 }

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -45,7 +45,9 @@ export function typeOf(object: any) {
     case REACT_ASYNC_MODE_TYPE:
     case REACT_FRAGMENT_TYPE:
     case REACT_STRICT_MODE_TYPE:
-      return maybeType;
+      if (getTypeOf(object) === REACT_ELEMENT_TYPE) {
+        return maybeType;
+      }
   }
 
   maybeType = getTypeTypeOf(object);
@@ -72,7 +74,10 @@ export const Portal = REACT_PORTAL_TYPE;
 export const StrictMode = REACT_STRICT_MODE_TYPE;
 
 export function isAsyncMode(object: any) {
-  return getType(object) === REACT_ASYNC_MODE_TYPE;
+  return (
+    getType(object) === REACT_ASYNC_MODE_TYPE &&
+    getTypeOf(object) === REACT_ELEMENT_TYPE
+  );
 }
 export function isContextConsumer(object: any) {
   return getTypeTypeOf(object) === REACT_CONTEXT_TYPE;
@@ -84,11 +89,17 @@ export function isElement(object: any) {
   return getTypeOf(object) === REACT_ELEMENT_TYPE;
 }
 export function isFragment(object: any) {
-  return getType(object) === REACT_FRAGMENT_TYPE;
+  return (
+    getType(object) === REACT_FRAGMENT_TYPE &&
+    getTypeOf(object) === REACT_ELEMENT_TYPE
+  );
 }
 export function isPortal(object: any) {
   return getTypeOf(object) === REACT_PORTAL_TYPE;
 }
 export function isStrictMode(object: any) {
-  return getType(object) === REACT_STRICT_MODE_TYPE;
+  return (
+    getType(object) === REACT_STRICT_MODE_TYPE &&
+    getTypeOf(object) === REACT_ELEMENT_TYPE
+  );
 }

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -39,60 +39,56 @@ function getTypeTypeOf(object: any) {
     : null;
 }
 
-const ReactIs = {
-  typeOf(object: any) {
-    const type = getType(object);
-    switch (type) {
-      case REACT_ASYNC_MODE_TYPE:
-      case REACT_FRAGMENT_TYPE:
-      case REACT_STRICT_MODE_TYPE:
-        return type;
-    }
+export function typeOf(object: any) {
+  let maybeType = getType(object);
+  switch (maybeType) {
+    case REACT_ASYNC_MODE_TYPE:
+    case REACT_FRAGMENT_TYPE:
+    case REACT_STRICT_MODE_TYPE:
+      return maybeType;
+  }
 
-    const typeTypeOf = getTypeTypeOf(object);
-    switch (typeTypeOf) {
-      case REACT_CONTEXT_TYPE:
-      case REACT_PROVIDER_TYPE:
-        return typeTypeOf;
-    }
+  maybeType = getTypeTypeOf(object);
+  switch (maybeType) {
+    case REACT_CONTEXT_TYPE:
+    case REACT_PROVIDER_TYPE:
+      return maybeType;
+  }
 
-    const typeOf = getTypeOf(object);
-    switch (typeOf) {
-      case REACT_ELEMENT_TYPE:
-      case REACT_PORTAL_TYPE:
-        return typeOf;
-    }
-  },
+  maybeType = getTypeOf(object);
+  switch (maybeType) {
+    case REACT_ELEMENT_TYPE:
+    case REACT_PORTAL_TYPE:
+      return maybeType;
+  }
+}
 
-  AsyncMode: REACT_ASYNC_MODE_TYPE,
-  ContextConsumer: REACT_CONTEXT_TYPE,
-  ContextProvider: REACT_PROVIDER_TYPE,
-  Element: REACT_ELEMENT_TYPE,
-  Fragment: REACT_FRAGMENT_TYPE,
-  Portal: REACT_PORTAL_TYPE,
-  StrictMode: REACT_STRICT_MODE_TYPE,
+export const AsyncMode = REACT_ASYNC_MODE_TYPE;
+export const ContextConsumer = REACT_CONTEXT_TYPE;
+export const ContextProvider = REACT_PROVIDER_TYPE;
+export const Element = REACT_ELEMENT_TYPE;
+export const Fragment = REACT_FRAGMENT_TYPE;
+export const Portal = REACT_PORTAL_TYPE;
+export const StrictMode = REACT_STRICT_MODE_TYPE;
 
-  isAsyncMode(object: any) {
-    return getType(object) === REACT_ASYNC_MODE_TYPE;
-  },
-  isContextConsumer(object: any) {
-    return getTypeTypeOf(object) === REACT_CONTEXT_TYPE;
-  },
-  isContextProvider(object: any) {
-    return getTypeTypeOf(object) === REACT_PROVIDER_TYPE;
-  },
-  isElement(object: any) {
-    return getTypeOf(object) === REACT_ELEMENT_TYPE;
-  },
-  isFragment(object: any) {
-    return getType(object) === REACT_FRAGMENT_TYPE;
-  },
-  isPortal(object: any) {
-    return getTypeOf(object) === REACT_PORTAL_TYPE;
-  },
-  isStrictMode(object: any) {
-    return getType(object) === REACT_STRICT_MODE_TYPE;
-  },
-};
-
-export default ReactIs;
+export function isAsyncMode(object: any) {
+  return getType(object) === REACT_ASYNC_MODE_TYPE;
+}
+export function isContextConsumer(object: any) {
+  return getTypeTypeOf(object) === REACT_CONTEXT_TYPE;
+}
+export function isContextProvider(object: any) {
+  return getTypeTypeOf(object) === REACT_PROVIDER_TYPE;
+}
+export function isElement(object: any) {
+  return getTypeOf(object) === REACT_ELEMENT_TYPE;
+}
+export function isFragment(object: any) {
+  return getType(object) === REACT_FRAGMENT_TYPE;
+}
+export function isPortal(object: any) {
+  return getTypeOf(object) === REACT_PORTAL_TYPE;
+}
+export function isStrictMode(object: any) {
+  return getType(object) === REACT_STRICT_MODE_TYPE;
+}

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -33,10 +33,7 @@ export function typeOf(object: any) {
           case REACT_STRICT_MODE_TYPE:
             return type;
           default:
-            const $$typeofType =
-              typeof type === 'object' && type !== null
-                ? type.$$typeof
-                : undefined;
+            const $$typeofType = type.$$typeof;
 
             switch ($$typeofType) {
               case REACT_CONTEXT_TYPE:

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -52,6 +52,14 @@ describe('ReactIs', () => {
     expect(ReactIs.isElement('div')).toBe(false);
     expect(ReactIs.isElement(true)).toBe(false);
     expect(ReactIs.isElement(123)).toBe(false);
+
+    // It should also identify more specific types as elements
+    const Context = React.createContext(false);
+    expect(ReactIs.isElement(<Context.Provider />)).toBe(true);
+    expect(ReactIs.isElement(<Context.Consumer />)).toBe(true);
+    expect(ReactIs.isElement(<React.Fragment />)).toBe(true);
+    expect(ReactIs.isElement(<React.unstable_AsyncMode />)).toBe(true);
+    expect(ReactIs.isElement(<React.StrictMode />)).toBe(true);
   });
 
   it('should identify fragments', () => {

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -22,7 +22,9 @@ describe('ReactIs', () => {
   });
 
   it('should identify async mode', () => {
-    expect(ReactIs.typeOf(<React.unstable_AsyncMode />)).toBe('ReactAsyncMode');
+    expect(ReactIs.typeOf(<React.unstable_AsyncMode />)).toBe(
+      ReactIs.AsyncMode,
+    );
     expect(ReactIs.isAsyncMode(<React.unstable_AsyncMode />)).toBe(true);
     expect(ReactIs.isAsyncMode(<React.StrictMode />)).toBe(false);
     expect(ReactIs.isAsyncMode(<div />)).toBe(false);
@@ -30,7 +32,7 @@ describe('ReactIs', () => {
 
   it('should identify context consumers', () => {
     const Context = React.createContext(false);
-    expect(ReactIs.typeOf(<Context.Consumer />)).toBe('ReactContextConsumer');
+    expect(ReactIs.typeOf(<Context.Consumer />)).toBe(ReactIs.ContextConsumer);
     expect(ReactIs.isContextConsumer(<Context.Consumer />)).toBe(true);
     expect(ReactIs.isContextConsumer(<Context.Provider />)).toBe(false);
     expect(ReactIs.isContextConsumer(<div />)).toBe(false);
@@ -38,14 +40,14 @@ describe('ReactIs', () => {
 
   it('should identify context providers', () => {
     const Context = React.createContext(false);
-    expect(ReactIs.typeOf(<Context.Provider />)).toBe('ReactContextProvider');
+    expect(ReactIs.typeOf(<Context.Provider />)).toBe(ReactIs.ContextProvider);
     expect(ReactIs.isContextProvider(<Context.Provider />)).toBe(true);
     expect(ReactIs.isContextProvider(<Context.Consumer />)).toBe(false);
     expect(ReactIs.isContextProvider(<div />)).toBe(false);
   });
 
   it('should identify elements', () => {
-    expect(ReactIs.typeOf(<div />)).toBe('ReactElement');
+    expect(ReactIs.typeOf(<div />)).toBe(ReactIs.Element);
     expect(ReactIs.isElement(<div />)).toBe(true);
     expect(ReactIs.isElement('div')).toBe(false);
     expect(ReactIs.isElement(true)).toBe(false);
@@ -53,7 +55,7 @@ describe('ReactIs', () => {
   });
 
   it('should identify fragments', () => {
-    expect(ReactIs.typeOf(<React.Fragment />)).toBe('ReactFragment');
+    expect(ReactIs.typeOf(<React.Fragment />)).toBe(ReactIs.Fragment);
     expect(ReactIs.isFragment(<React.Fragment />)).toBe(true);
     expect(ReactIs.isFragment('React.Fragment')).toBe(false);
     expect(ReactIs.isFragment(<div />)).toBe(false);
@@ -63,13 +65,13 @@ describe('ReactIs', () => {
   it('should identify portals', () => {
     const div = document.createElement('div');
     const portal = ReactDOM.createPortal(<div />, div);
-    expect(ReactIs.typeOf(portal)).toBe('ReactPortal');
+    expect(ReactIs.typeOf(portal)).toBe(ReactIs.Portal);
     expect(ReactIs.isPortal(portal)).toBe(true);
     expect(ReactIs.isPortal(div)).toBe(false);
   });
 
   it('should identify strict mode', () => {
-    expect(ReactIs.typeOf(<React.StrictMode />)).toBe('ReactStrictMode');
+    expect(ReactIs.typeOf(<React.StrictMode />)).toBe(ReactIs.StrictMode);
     expect(ReactIs.isStrictMode(<React.StrictMode />)).toBe(true);
     expect(ReactIs.isStrictMode(<React.unstable_AsyncMode />)).toBe(false);
     expect(ReactIs.isStrictMode(<div />)).toBe(false);

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let ReactIs;
+
+describe('ReactIs', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactIs = require('react-is');
+  });
+
+  it('should identify async mode', () => {
+    expect(ReactIs.typeOf(<React.unstable_AsyncMode />)).toBe('ReactAsyncMode');
+    expect(ReactIs.isAsyncMode(<React.unstable_AsyncMode />)).toBe(true);
+    expect(ReactIs.isAsyncMode(<React.StrictMode />)).toBe(false);
+    expect(ReactIs.isAsyncMode(<div />)).toBe(false);
+  });
+
+  it('should identify context consumers', () => {
+    const Context = React.createContext(false);
+    expect(ReactIs.typeOf(<Context.Consumer />)).toBe('ReactContextConsumer');
+    expect(ReactIs.isContextConsumer(<Context.Consumer />)).toBe(true);
+    expect(ReactIs.isContextConsumer(<Context.Provider />)).toBe(false);
+    expect(ReactIs.isContextConsumer(<div />)).toBe(false);
+  });
+
+  it('should identify context providers', () => {
+    const Context = React.createContext(false);
+    expect(ReactIs.typeOf(<Context.Provider />)).toBe('ReactContextProvider');
+    expect(ReactIs.isContextProvider(<Context.Provider />)).toBe(true);
+    expect(ReactIs.isContextProvider(<Context.Consumer />)).toBe(false);
+    expect(ReactIs.isContextProvider(<div />)).toBe(false);
+  });
+
+  it('should identify elements', () => {
+    expect(ReactIs.typeOf(<div />)).toBe('ReactElement');
+    expect(ReactIs.isElement(<div />)).toBe(true);
+    expect(ReactIs.isElement('div')).toBe(false);
+    expect(ReactIs.isElement(true)).toBe(false);
+    expect(ReactIs.isElement(123)).toBe(false);
+  });
+
+  it('should identify fragments', () => {
+    expect(ReactIs.typeOf(<React.Fragment />)).toBe('ReactFragment');
+    expect(ReactIs.isFragment(<React.Fragment />)).toBe(true);
+    expect(ReactIs.isFragment('React.Fragment')).toBe(false);
+    expect(ReactIs.isFragment(<div />)).toBe(false);
+    expect(ReactIs.isFragment([])).toBe(false);
+  });
+
+  it('should identify portals', () => {
+    const div = document.createElement('div');
+    const portal = ReactDOM.createPortal(<div />, div);
+    expect(ReactIs.typeOf(portal)).toBe('ReactPortal');
+    expect(ReactIs.isPortal(portal)).toBe(true);
+    expect(ReactIs.isPortal(div)).toBe(false);
+  });
+
+  it('should identify strict mode', () => {
+    expect(ReactIs.typeOf(<React.StrictMode />)).toBe('ReactStrictMode');
+    expect(ReactIs.isStrictMode(<React.StrictMode />)).toBe(true);
+    expect(ReactIs.isStrictMode(<React.unstable_AsyncMode />)).toBe(false);
+    expect(ReactIs.isStrictMode(<div />)).toBe(false);
+  });
+});

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -16,6 +16,7 @@ let ReactIs;
 describe('ReactIs', () => {
   beforeEach(() => {
     jest.resetModules();
+
     React = require('react');
     ReactDOM = require('react-dom');
     ReactIs = require('react-is');

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -22,6 +22,15 @@ describe('ReactIs', () => {
     ReactIs = require('react-is');
   });
 
+  it('should return undefined for unknown/invalid types', () => {
+    expect(ReactIs.typeOf('abc')).toBe(undefined);
+    expect(ReactIs.typeOf(true)).toBe(undefined);
+    expect(ReactIs.typeOf(123)).toBe(undefined);
+    expect(ReactIs.typeOf({})).toBe(undefined);
+    expect(ReactIs.typeOf(null)).toBe(undefined);
+    expect(ReactIs.typeOf(undefined)).toBe(undefined);
+  });
+
   it('should identify async mode', () => {
     expect(ReactIs.typeOf(<React.unstable_AsyncMode />)).toBe(
       ReactIs.AsyncMode,
@@ -54,6 +63,9 @@ describe('ReactIs', () => {
     expect(ReactIs.isElement('div')).toBe(false);
     expect(ReactIs.isElement(true)).toBe(false);
     expect(ReactIs.isElement(123)).toBe(false);
+    expect(ReactIs.isElement(null)).toBe(false);
+    expect(ReactIs.isElement(undefined)).toBe(false);
+    expect(ReactIs.isElement({})).toBe(false);
 
     // It should also identify more specific types as elements
     const Context = React.createContext(false);

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -26,6 +26,7 @@ describe('ReactIs', () => {
       ReactIs.AsyncMode,
     );
     expect(ReactIs.isAsyncMode(<React.unstable_AsyncMode />)).toBe(true);
+    expect(ReactIs.isAsyncMode({type: ReactIs.AsyncMode})).toBe(false);
     expect(ReactIs.isAsyncMode(<React.StrictMode />)).toBe(false);
     expect(ReactIs.isAsyncMode(<div />)).toBe(false);
   });
@@ -65,6 +66,7 @@ describe('ReactIs', () => {
   it('should identify fragments', () => {
     expect(ReactIs.typeOf(<React.Fragment />)).toBe(ReactIs.Fragment);
     expect(ReactIs.isFragment(<React.Fragment />)).toBe(true);
+    expect(ReactIs.isFragment({type: ReactIs.Fragment})).toBe(false);
     expect(ReactIs.isFragment('React.Fragment')).toBe(false);
     expect(ReactIs.isFragment(<div />)).toBe(false);
     expect(ReactIs.isFragment([])).toBe(false);
@@ -81,6 +83,7 @@ describe('ReactIs', () => {
   it('should identify strict mode', () => {
     expect(ReactIs.typeOf(<React.StrictMode />)).toBe(ReactIs.StrictMode);
     expect(ReactIs.isStrictMode(<React.StrictMode />)).toBe(true);
+    expect(ReactIs.isStrictMode({type: ReactIs.StrictMode})).toBe(false);
     expect(ReactIs.isStrictMode(<React.unstable_AsyncMode />)).toBe(false);
     expect(ReactIs.isStrictMode(<div />)).toBe(false);
   });

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -238,7 +238,7 @@ const bundles = [
   /******* React Is *******/
   {
     label: 'react-is',
-    bundleTypes: [UMD_DEV, UMD_PROD, NODE_DEV, NODE_PROD],
+    bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react-is',
     global: 'ReactIs',

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -238,7 +238,7 @@ const bundles = [
   /******* React Is *******/
   {
     label: 'react-is',
-    bundleTypes: [NODE_DEV, NODE_PROD],
+    bundleTypes: [NODE_DEV, NODE_PROD, UMD_DEV, UMD_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react-is',
     global: 'ReactIs',

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -234,6 +234,16 @@ const bundles = [
     global: 'ReactCallReturn',
     externals: [],
   },
+
+  /******* React Is *******/
+  {
+    label: 'react-is',
+    bundleTypes: [UMD_DEV, UMD_PROD, NODE_DEV, NODE_PROD],
+    moduleType: ISOMORPHIC,
+    entry: 'react-is',
+    global: 'ReactIs',
+    externals: [],
+  },
 ];
 
 // Based on deep-freeze by substack (public domain)

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -403,29 +403,29 @@
       "filename": "react-is.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-is",
-      "size": 3571,
-      "gzip": 1030
+      "size": 3414,
+      "gzip": 1029
     },
     {
       "filename": "react-is.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-is",
-      "size": 1559,
-      "gzip": 624
+      "size": 1470,
+      "gzip": 616
     },
     {
       "filename": "react-is.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-is",
-      "size": 3760,
-      "gzip": 1086
+      "size": 3603,
+      "gzip": 1084
     },
     {
       "filename": "react-is.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-is",
-      "size": 1641,
-      "gzip": 687
+      "size": 1552,
+      "gzip": 680
     }
   ]
 }

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -398,6 +398,34 @@
       "packageName": "react-reconciler",
       "size": 41327,
       "gzip": 13133
+    },
+    {
+      "filename": "react-is.development.js",
+      "bundleType": "UMD_DEV",
+      "packageName": "react-is",
+      "size": 3760,
+      "gzip": 1086
+    },
+    {
+      "filename": "react-is.production.min.js",
+      "bundleType": "UMD_PROD",
+      "packageName": "react-is",
+      "size": 1641,
+      "gzip": 687
+    },
+    {
+      "filename": "react-is.development.js",
+      "bundleType": "NODE_DEV",
+      "packageName": "react-is",
+      "size": 3571,
+      "gzip": 1030
+    },
+    {
+      "filename": "react-is.production.min.js",
+      "bundleType": "NODE_PROD",
+      "packageName": "react-is",
+      "size": 1559,
+      "gzip": 624
     }
   ]
 }

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -412,6 +412,20 @@
       "packageName": "react-is",
       "size": 1559,
       "gzip": 624
+    },
+    {
+      "filename": "react-is.development.js",
+      "bundleType": "UMD_DEV",
+      "packageName": "react-is",
+      "size": 3760,
+      "gzip": 1086
+    },
+    {
+      "filename": "react-is.production.min.js",
+      "bundleType": "UMD_PROD",
+      "packageName": "react-is",
+      "size": 1641,
+      "gzip": 687
     }
   ]
 }

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -403,29 +403,29 @@
       "filename": "react-is.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-is",
-      "size": 3414,
-      "gzip": 1029
+      "size": 3358,
+      "gzip": 1015
     },
     {
       "filename": "react-is.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-is",
-      "size": 1470,
-      "gzip": 616
+      "size": 1433,
+      "gzip": 607
     },
     {
       "filename": "react-is.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-is",
-      "size": 3603,
-      "gzip": 1084
+      "size": 3547,
+      "gzip": 1071
     },
     {
       "filename": "react-is.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-is",
-      "size": 1552,
-      "gzip": 680
+      "size": 1515,
+      "gzip": 670
     }
   ]
 }

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -401,20 +401,6 @@
     },
     {
       "filename": "react-is.development.js",
-      "bundleType": "UMD_DEV",
-      "packageName": "react-is",
-      "size": 3760,
-      "gzip": 1086
-    },
-    {
-      "filename": "react-is.production.min.js",
-      "bundleType": "UMD_PROD",
-      "packageName": "react-is",
-      "size": 1641,
-      "gzip": 687
-    },
-    {
-      "filename": "react-is.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-is",
       "size": 3571,

--- a/scripts/rollup/validate/eslintrc.umd.js
+++ b/scripts/rollup/validate/eslintrc.umd.js
@@ -17,6 +17,7 @@ module.exports = {
     // UMD wrapper code
     // TODO: this is too permissive.
     // Ideally we should only allow these *inside* the UMD wrapper.
+    exports: true,
     module: true,
     define: true,
     require: true,


### PR DESCRIPTION
Supersedes PR #11279 and #12092. Resolves issue #12038

~~Perhaps we could use this in React DevTools as well?~~ (This would not be the case in its current form, since this library accepts React _elements_ and DevTools receives _fibers_.)

### Tests

In addition to the newly-added unit tests, I ran `yarn build react-is` locally to build this, then `npm pack`ed the result and installed it in a fresh project. I also tested the UMD build in CodeSandbox.

### Example
```js
import React from "react";
import {
  ContextConsumer,
  ContextProvider,
  isContextConsumer,
  isContextProvider,
  typeOf
} from "react-is";

const ThemeContext = React.createContext("blue");

isContextConsumer(<ThemeContext.Consumer />); // true
isContextProvider(<ThemeContext.Provider />); // true
typeOf(<ThemeContext.Provider />) === ContextProvider; // true
typeOf(<ThemeContext.Consumer />) === ContextConsumer; // true
```

### Assumptions
* It is okay that `isElement` is looser than `typeOf` (e.g. it returns true for host elements, fragments, strict-mode, context, etc.)
* There are no additional component types (e.g. the experimental call/return types) that we want to expose for the initial release.
* It's okay to support the (currently unstable) `AsyncMode` for the initial release.
* This package should mirror the version of React rather than be versioned independently (since we'll be adding types over time).