### PR TITLE
NativeMethodsMixin DEV-only methods should not warn

### DIFF
--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -192,6 +192,8 @@ if (__DEV__) {
       !NativeMethodsMixin_DEV.UNSAFE_componentWillReceiveProps,
     'Do not override existing functions.',
   );
+  // TODO (bvaughn) Remove cWM and cWRP in a future version of React Native,
+  // Once these lifecycles have been remove from the reconciler.
   NativeMethodsMixin_DEV.componentWillMount = function() {
     throwOnStylesProp(this, this.props);
   };
@@ -207,6 +209,7 @@ if (__DEV__) {
 
   // React may warn about cWM/cWRP/cWU methods being deprecated.
   // Add a flag to suppress these warnings for this special case.
+  // TODO (bvaughn) Remove this flag once the above methods have been removed.
   NativeMethodsMixin_DEV.componentWillMount.__suppressDeprecationWarning = true;
   NativeMethodsMixin_DEV.componentWillReceiveProps.__suppressDeprecationWarning = true;
 }

--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -204,6 +204,11 @@ if (__DEV__) {
   NativeMethodsMixin_DEV.UNSAFE_componentWillReceiveProps = function(newProps) {
     throwOnStylesProp(this, newProps);
   };
+
+  // React may warn about cWM/cWRP/cWU methods being deprecated.
+  // Add a flag to suppress these warnings for this special case.
+  NativeMethodsMixin_DEV.componentWillMount.__suppressDeprecationWarning = true;
+  NativeMethodsMixin_DEV.componentWillReceiveProps.__suppressDeprecationWarning = true;
 }
 
 export default NativeMethodsMixin;

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -201,19 +201,16 @@ if (__DEV__) {
     }
 
     // Don't warn about react-lifecycles-compat polyfilled components.
-    // Note that it is sufficient to check for the presence of a
-    // single lifecycle, componentWillMount, with the polyfill flag.
     if (
       typeof instance.componentWillMount === 'function' &&
-      instance.componentWillMount.__suppressDeprecationWarning === true
+      instance.componentWillMount.__suppressDeprecationWarning !== true
     ) {
-      return;
-    }
-
-    if (typeof instance.componentWillMount === 'function') {
       pendingComponentWillMountWarnings.push(fiber);
     }
-    if (typeof instance.componentWillReceiveProps === 'function') {
+    if (
+      typeof instance.componentWillReceiveProps === 'function' &&
+      instance.componentWillReceiveProps.__suppressDeprecationWarning !== true
+    ) {
       pendingComponentWillReceivePropsWarnings.push(fiber);
     }
     if (typeof instance.componentWillUpdate === 'function') {

--- a/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
@@ -117,12 +117,17 @@ describe('create-react-class-integration', () => {
   });
 
   describe('ReactNative NativeMethodsMixin', () => {
-    it('should not warn about default DEV-only legacy lifecycle methods', () => {
-      const ReactNative = require('react-native-renderer');
-      const {
-        NativeMethodsMixin,
-      } = ReactNative.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+    let ReactNative;
+    let NativeMethodsMixin;
 
+    beforeEach(() => {
+      ReactNative = require('react-native-renderer');
+      NativeMethodsMixin =
+        ReactNative.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+          .NativeMethodsMixin;
+    });
+
+    it('should not warn about default DEV-only legacy lifecycle methods', () => {
       const View = createReactClass({
         mixins: [NativeMethodsMixin],
         render: () => null,
@@ -132,11 +137,6 @@ describe('create-react-class-integration', () => {
     });
 
     it('should warn if users specify their own legacy lifecycles', () => {
-      const ReactNative = require('react-native-renderer');
-      const {
-        NativeMethodsMixin,
-      } = ReactNative.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
-
       const View = createReactClass({
         displayName: 'MyNativeComponent',
         mixins: [NativeMethodsMixin],

--- a/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
@@ -136,24 +136,35 @@ describe('create-react-class-integration', () => {
       ReactNative.render(<View />, 1);
     });
 
-    it('should warn if users specify their own legacy lifecycles', () => {
+    it('should warn if users specify their own legacy componentWillMount', () => {
       const View = createReactClass({
         displayName: 'MyNativeComponent',
         mixins: [NativeMethodsMixin],
         componentWillMount: () => {},
-        componentWillReceiveProps: () => {},
         render: () => null,
       });
 
-      expect(() => ReactNative.render(<View />, 1)).toLowPriorityWarnDev([
+      expect(() => ReactNative.render(<View />, 1)).toLowPriorityWarnDev(
         'componentWillMount is deprecated and will be removed in the next major version. ' +
           'Use componentDidMount instead. As a temporary workaround, ' +
           'you can rename to UNSAFE_componentWillMount.' +
           '\n\nPlease update the following components: MyNativeComponent',
+      );
+    });
+
+    it('should warn if users specify their own legacy componentWillReceiveProps', () => {
+      const View = createReactClass({
+        displayName: 'MyNativeComponent',
+        mixins: [NativeMethodsMixin],
+        componentWillReceiveProps: () => {},
+        render: () => null,
+      });
+
+      expect(() => ReactNative.render(<View />, 1)).toLowPriorityWarnDev(
         'componentWillReceiveProps is deprecated and will be removed in the next major version. ' +
           'Use static getDerivedStateFromProps instead.' +
           '\n\nPlease update the following components: MyNativeComponent',
-      ]);
+      );
     });
   });
 });

--- a/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
@@ -10,17 +10,17 @@
 'use strict';
 
 let React;
-let ReactDOM;
 let ReactFeatureFlags;
 let createReactClass;
 
 describe('create-react-class-integration', () => {
   beforeEach(() => {
+    jest.resetModules();
+
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.warnAboutDeprecatedLifecycles = true;
 
     React = require('react');
-    ReactDOM = require('react-dom');
     createReactClass = require('create-react-class/factory')(
       React.Component,
       React.isValidElement,
@@ -31,6 +31,8 @@ describe('create-react-class-integration', () => {
   // TODO (RFC #6) Merge this back into createReactClassIntegration-test once
   // the 'warnAboutDeprecatedLifecycles' feature flag has been removed.
   it('isMounted works', () => {
+    const ReactDOM = require('react-dom');
+
     const ops = [];
     let instance;
     const Component = createReactClass({
@@ -112,5 +114,46 @@ describe('create-react-class-integration', () => {
       'componentWillUnmount: true',
       'after unmount: false',
     ]);
+  });
+
+  describe('ReactNative NativeMethodsMixin', () => {
+    it('should not warn about default DEV-only legacy lifecycle methods', () => {
+      const ReactNative = require('react-native-renderer');
+      const {
+        NativeMethodsMixin,
+      } = ReactNative.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+      const View = createReactClass({
+        mixins: [NativeMethodsMixin],
+        render: () => null,
+      });
+
+      ReactNative.render(<View />, 1);
+    });
+
+    it('should warn if users specify their own legacy lifecycles', () => {
+      const ReactNative = require('react-native-renderer');
+      const {
+        NativeMethodsMixin,
+      } = ReactNative.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+      const View = createReactClass({
+        displayName: 'MyNativeComponent',
+        mixins: [NativeMethodsMixin],
+        componentWillMount: () => {},
+        componentWillReceiveProps: () => {},
+        render: () => null,
+      });
+
+      expect(() => ReactNative.render(<View />, 1)).toLowPriorityWarnDev([
+        'componentWillMount is deprecated and will be removed in the next major version. ' +
+          'Use componentDidMount instead. As a temporary workaround, ' +
+          'you can rename to UNSAFE_componentWillMount.' +
+          '\n\nPlease update the following components: MyNativeComponent',
+        'componentWillReceiveProps is deprecated and will be removed in the next major version. ' +
+          'Use static getDerivedStateFromProps instead.' +
+          '\n\nPlease update the following components: MyNativeComponent',
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Built-in React Native components (e.g. `View`) currently trigger deprecation warnings for lifecycles `componentWillMount` and `componentWillReceiveProps` due to [these DEV-only mixins added by the `NativeMethodsMixin` component](https://github.com/facebook/react/blob/41b8c65f1e81ba48192fbb65fd5c742638ef4f82/packages/react-native-renderer/src/NativeMethodsMixin.js#L183-L207).

Long term, we should remove the deprecated lifecycles _but_ for the time being, I think we should just suppress the warnings from _the builtin_ methods specifically using a similar technique as the [`react-lifecycles-compat` polyfill](https://github.com/reactjs/react-lifecycles-compat). This will hopefully improve the in-between period for the RN community significantly.