### PR TITLE
[Danger] Include 1% changes in a build, not just greater than

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -117,8 +117,8 @@ function git(args) {
   const packagesToShow = results
     .filter(
       r =>
-        Math.abs(r.prevFileSizeChange) > percentToWarrentShowing ||
-        Math.abs(r.prevGzipSizeChange) > percentToWarrentShowing
+        Math.abs(r.prevFileSizeChange) >= percentToWarrentShowing ||
+        Math.abs(r.prevGzipSizeChange) >= percentToWarrentShowing
     )
 
     .map(r => r.packageName);


### PR DESCRIPTION
Thanks for https://github.com/facebook/react/pull/12210 @gaearon - I'd been running mostly in the dark and faking data, now have an easy PR to test against!

The main change is:

```diff
-        Math.abs(r.prevFileSizeChange) > percentToWarrentShowing ||
-        Math.abs(r.prevGzipSizeChange) > percentToWarrentShowing
+        Math.abs(r.prevFileSizeChange) >= percentToWarrentShowing ||
+        Math.abs(r.prevGzipSizeChange) >= percentToWarrentShowing
```

It means that a 1% change will show 👍 

Which means it'll get picked up and shown. The other changes are to loosen up the constraint on highlighting when either react or react-dom changes outside of the closed table.

When I run `yarn danger pr https://github.com/facebook/react/pull/12210` (after checking out the branch, and running `yarn build` to get the right results.json), the output by Danger is this: 


---

ReactDOM: size: -1%, gzip: -1%
-

  <details>
  <summary>Details of bundled changes.</summary>

  <p>Comparing: c7ce0091dcb2036e19df980247c9a4388ad75741...232208e5d15d13c6deb47ad7b5ab0e1d922f9854</p>



## react-dom
File | Filesize Diff | Gzip Diff | Prev Size | Current Size | Prev Gzip | Current Gzip | ENV
 ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---
react-dom.development.js | -1% | -1% | 577.79 KB | 577.78 KB | 135.49 KB | 135.49 KB | UMD_DEV
**react-dom.production.min.js** | **:small_red_triangle:+1%** | **:small_red_triangle:+1%** | **94.51 KB** | **95.86 KB** | **30.71 KB** | **31.04 KB** | **UMD_PROD**
react-dom.development.js | -1% | -1% | 562.17 KB | 562.17 KB | 131.37 KB | 131.36 KB | NODE_DEV
**react-dom.production.min.js** | **:small_red_triangle:+1%** | **:small_red_triangle:+1%** | **93.26 KB** | **94.62 KB** | **29.9 KB** | **30.28 KB** | **NODE_PROD**

## react-art
File | Filesize Diff | Gzip Diff | Prev Size | Current Size | Prev Gzip | Current Gzip | ENV
 ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---
react-art.development.js | -1% | -1% | 380.87 KB | 380.87 KB | 84.39 KB | 84.39 KB | UMD_DEV
**react-art.production.min.js** | **:small_red_triangle:+1%** | **:small_red_triangle:+1%** | **84.77 KB** | **86.12 KB** | **26.31 KB** | **26.62 KB** | **UMD_PROD**
react-art.development.js | -1% | -1% | 306.72 KB | 306.72 KB | 65.8 KB | 65.8 KB | NODE_DEV
**react-art.production.min.js** | **:small_red_triangle:+2%** | **:small_red_triangle:+2%** | **49.56 KB** | **50.93 KB** | **15.63 KB** | **16.06 KB** | **NODE_PROD**

## react-test-renderer
File | Filesize Diff | Gzip Diff | Prev Size | Current Size | Prev Gzip | Current Gzip | ENV
 ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---
react-test-renderer.development.js | -1% | -1% | 303.76 KB | 303.76 KB | 64.77 KB | 64.77 KB | NODE_DEV
**react-test-renderer.production.min.js** | **:small_red_triangle:+2%** | **:small_red_triangle:+3%** | **48.07 KB** | **49.43 KB** | **14.96 KB** | **15.42 KB** | **NODE_PROD**

## react-noop-renderer
File | Filesize Diff | Gzip Diff | Prev Size | Current Size | Prev Gzip | Current Gzip | ENV
 ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---
react-noop-renderer.development.js | -1% | 0% | 18.34 KB | 18.34 KB | 5.18 KB | 5.18 KB | NODE_DEV
**react-noop-renderer.production.min.js** | **:small_red_triangle:+8%** | **:small_red_triangle:+4%** | **6.28 KB** | **6.79 KB** | **2.51 KB** | **2.62 KB** | **NODE_PROD**

## react-reconciler
File | Filesize Diff | Gzip Diff | Prev Size | Current Size | Prev Gzip | Current Gzip | ENV
 ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---
react-reconciler.development.js | -1% | -1% | 285.66 KB | 285.66 KB | 60.32 KB | 60.31 KB | NODE_DEV
**react-reconciler.production.min.js** | **:small_red_triangle:+3%** | **:small_red_triangle:+2%** | **41.45 KB** | **42.82 KB** | **13.04 KB** | **13.4 KB** | **NODE_PROD**

  </details>