### PR TITLE
Handle packages without dependencies

### DIFF
--- a/scripts/release/build-commands/check-package-dependencies.js
+++ b/scripts/release/build-commands/check-package-dependencies.js
@@ -25,7 +25,10 @@ const check = async ({cwd, packages}) => {
     const rootVersion = rootPackage.devDependencies[module];
 
     projectPackages.forEach(projectPackage => {
-      const projectVersion = projectPackage.dependencies[module];
+      // Not all packages have dependencies (eg react-is)
+      const projectVersion = projectPackage.dependencies
+        ? projectPackage.dependencies[module]
+        : undefined;
 
       if (rootVersion !== projectVersion && projectVersion !== undefined) {
         invalidDependencies.push(


### PR DESCRIPTION
Noticed the release script didn't handle this case when trying to publish an alpha containing the new `react-is` package.