### PR TITLE
Additional release script options for publishing canary versions

### DIFF
--- a/scripts/release/build-commands/check-circle-ci-status.js
+++ b/scripts/release/build-commands/check-circle-ci-status.js
@@ -43,5 +43,8 @@ const check = async ({cwd}) => {
 };
 
 module.exports = async params => {
+  if (params.local) {
+    return;
+  }
   return logPromise(check(params), 'Checking CircleCI status');
 };

--- a/scripts/release/build-commands/update-git.js
+++ b/scripts/release/build-commands/update-git.js
@@ -6,15 +6,21 @@ const chalk = require('chalk');
 const {exec} = require('child-process-promise');
 const {logPromise} = require('../utils');
 
-const update = async ({cwd}) => {
-  await exec('git fetch', {cwd});
-  await exec('git checkout master', {cwd});
-  await exec('git pull', {cwd});
+const update = async ({cwd, branch, local}) => {
+  if (!local) {
+    await exec('git fetch', {cwd});
+  }
+  await exec(`git checkout ${branch}`, {cwd});
+  if (!local) {
+    await exec('git pull', {cwd});
+  }
 };
 
-module.exports = async ({cwd}) => {
+module.exports = async params => {
   return logPromise(
-    update({cwd}),
-    `Updating checkout ${chalk.yellow.bold(cwd)}`
+    update(params),
+    `Updating checkout ${chalk.yellow.bold(
+      params.cwd
+    )} on branch ${chalk.yellow.bold(params.branch)}}`
   );
 };

--- a/scripts/release/config.js
+++ b/scripts/release/config.js
@@ -23,6 +23,25 @@ const paramDefinitions = [
     alias: 'v',
     description: 'Semantic version number',
   },
+  {
+    name: 'branch',
+    type: String,
+    alias: 'b',
+    description: 'Branch to build from; defaults to [bold]{master}',
+    defaultValue: 'master',
+  },
+  {
+    name: 'local',
+    type: Boolean,
+    description: "Don't pull changes from the remote branch. Also skips CI.",
+  },
+  {
+    name: 'tag',
+    type: String,
+    description:
+      'The npm dist tag; defaults to [bold]{latest} for a stable' +
+      'release, [bold]{next} for unstable',
+  },
 ];
 
 module.exports = {

--- a/scripts/release/config.js
+++ b/scripts/release/config.js
@@ -33,7 +33,8 @@ const paramDefinitions = [
   {
     name: 'local',
     type: Boolean,
-    description: "Don't pull changes from the remote branch. Also skips CI.",
+    description:
+      "Don't push or pull changes from remote repo. Don't check CI status.",
   },
   {
     name: 'tag',

--- a/scripts/release/publish-commands/check-build-status.js
+++ b/scripts/release/publish-commands/check-build-status.js
@@ -7,7 +7,10 @@ const {existsSync} = require('fs');
 const {readJson} = require('fs-extra');
 const {join} = require('path');
 
-module.exports = async ({cwd, version}) => {
+module.exports = async ({cwd, version, local}) => {
+  if (local) {
+    return;
+  }
   const packagePath = join(
     cwd,
     'build',

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -8,10 +8,21 @@ const {join} = require('path');
 const semver = require('semver');
 const {execRead, execUnlessDry, logPromise} = require('../utils');
 
-const push = async ({cwd, dry, packages, version}) => {
+const push = async ({cwd, dry, packages, version, tag}) => {
   const errors = [];
-  const isPrerelease = semver.prerelease(version);
-  const tag = isPrerelease ? 'next' : 'latest';
+  let isPrerelease;
+  if (tag === undefined) {
+    // No tag was provided. Check the version.
+    isPrerelease = semver.prerelease(version);
+    if (isPrerelease) {
+      tag = 'next';
+    } else {
+      tag = 'latest';
+    }
+  } else {
+    // Any tag besides `latest` is a prerelease
+    isPrerelease = tag === 'latest';
+  }
 
   const publishProject = async project => {
     try {

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -10,18 +10,13 @@ const {execRead, execUnlessDry, logPromise} = require('../utils');
 
 const push = async ({cwd, dry, packages, version, tag}) => {
   const errors = [];
-  let isPrerelease;
+  const isPrerelease = semver.prerelease(version);
   if (tag === undefined) {
-    // No tag was provided. Check the version.
-    isPrerelease = semver.prerelease(version);
-    if (isPrerelease) {
-      tag = 'next';
-    } else {
-      tag = 'latest';
-    }
-  } else {
-    // Any tag besides `latest` is a prerelease
-    isPrerelease = tag === 'latest';
+    // No tag was provided. Default to `latest` for stable releases and `next`
+    // for prereleases
+    tag = isPrerelease ? 'next' : 'latest';
+  } else if (tag === 'latest' && isPrerelease) {
+    throw new Error('The tag `latest` can only be used for stable versions.');
   }
 
   const publishProject = async project => {

--- a/scripts/release/publish-commands/push-git-remote.js
+++ b/scripts/release/publish-commands/push-git-remote.js
@@ -10,5 +10,8 @@ const push = async ({cwd, dry}) => {
 };
 
 module.exports = async params => {
+  if (params.local) {
+    return;
+  }
   return logPromise(push(params), 'Pushing to git remote');
 };


### PR DESCRIPTION
- `branch` specifies a branch other than master
- `local` skips pulling from the remote branch and checking CircleCI
- `tag` specifies an npm dist tag other than `latest` or `next`

We may add a higher-level `canary` option in the future.

Test plan: I used this to publish 16.4.0-alpha.7926752 and it worked.