### PR TITLE
Fix/12200 regresssion select multiple

### DIFF
--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -431,7 +431,9 @@ const ARTRenderer = ReactFiberReconciler({
   createTextInstance(text, rootContainerInstance, internalInstanceHandle) {
     return text;
   },
-
+  setInitialProperties(domElement, type, props) {
+    return false;
+  },
   finalizeInitialChildren(domElement, type, props) {
     return false;
   },

--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -431,7 +431,7 @@ const ARTRenderer = ReactFiberReconciler({
   createTextInstance(text, rootContainerInstance, internalInstanceHandle) {
     return text;
   },
-  setInitialProperties(domElement, type, props) {
+  setInitialSpecialProperties(domElement, type, props) {
     return false;
   },
   finalizeInitialChildren(domElement, type, props) {

--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -431,7 +431,7 @@ const ARTRenderer = ReactFiberReconciler({
   createTextInstance(text, rootContainerInstance, internalInstanceHandle) {
     return text;
   },
-  setInitialSpecialProperties(domElement, type, props) {
+  preprocessChildrenSpecialProperties(domElement, type, props) {
     return false;
   },
   finalizeInitialChildren(domElement, type, props) {

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -609,6 +609,15 @@ const DOMRenderer = ReactFiberReconciler({
     return domElement;
   },
 
+  setInitialSpecialProperties(
+    domElement: Instance,
+    type: string,
+    props: Props,
+    rootContainerInstance: Container,
+  ): void {
+    console.log(1);
+  },
+
   appendInitialChild(
     parentInstance: Instance,
     child: Instance | TextInstance,

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -53,6 +53,7 @@ import {
   DOCUMENT_FRAGMENT_NODE,
 } from '../shared/HTMLNodeType';
 import {ROOT_ATTRIBUTE_NAME} from '../shared/DOMProperty';
+import { setInitialSpecialProperties } from './ReactDOMFiberComponent';
 const {
   createElement,
   createTextNode,
@@ -609,12 +610,13 @@ const DOMRenderer = ReactFiberReconciler({
     return domElement;
   },
 
-  setInitialSpecialProperties(
+  preprocessChildrenSpecialProperties(
     domElement: Instance,
     type: string,
     props: Props,
     rootContainerInstance: Container,
   ): void {
+    setInitialSpecialProperties(domElement, type, props, rootContainerInstance);
   },
 
   appendInitialChild(

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -615,7 +615,6 @@ const DOMRenderer = ReactFiberReconciler({
     props: Props,
     rootContainerInstance: Container,
   ): void {
-    console.log(1);
   },
 
   appendInitialChild(

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -53,7 +53,7 @@ import {
   DOCUMENT_FRAGMENT_NODE,
 } from '../shared/HTMLNodeType';
 import {ROOT_ATTRIBUTE_NAME} from '../shared/DOMProperty';
-import { setInitialSpecialProperties } from './ReactDOMFiberComponent';
+import {setInitialSpecialProperties} from './ReactDOMFiberComponent';
 const {
   createElement,
   createTextNode,

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -426,7 +426,7 @@ export function setInitialSpecialProperties(
       warning(
         false,
         '%s is using shady DOM. Using shady DOM with React can ' +
-        'cause things to break subtly.',
+          'cause things to break subtly.',
         getCurrentFiberOwnerName() || 'A component',
       );
       didWarnShadyDOM = true;
@@ -451,7 +451,6 @@ export function setInitialSpecialProperties(
     props,
     isCustomComponentTag,
   );
-
 }
 
 export function setInitialProperties(

--- a/packages/react-native-renderer/src/ReactFabricRenderer.js
+++ b/packages/react-native-renderer/src/ReactFabricRenderer.js
@@ -186,7 +186,7 @@ const ReactFabricRenderer = ReactFiberReconciler({
     };
   },
 
-  setInitialProperties(
+  setInitialSpecialProperties(
     parentInstance: Instance,
     type: string,
     props: Props,

--- a/packages/react-native-renderer/src/ReactFabricRenderer.js
+++ b/packages/react-native-renderer/src/ReactFabricRenderer.js
@@ -186,7 +186,7 @@ const ReactFabricRenderer = ReactFiberReconciler({
     };
   },
 
-  setInitialSpecialProperties(
+  preprocessChildrenSpecialProperties(
     parentInstance: Instance,
     type: string,
     props: Props,

--- a/packages/react-native-renderer/src/ReactFabricRenderer.js
+++ b/packages/react-native-renderer/src/ReactFabricRenderer.js
@@ -186,6 +186,15 @@ const ReactFabricRenderer = ReactFiberReconciler({
     };
   },
 
+  setInitialProperties(
+    parentInstance: Instance,
+    type: string,
+    props: Props,
+    rootContainerInstance: Container,
+  ): boolean {
+    return false;
+  },
+
   finalizeInitialChildren(
     parentInstance: Instance,
     type: string,

--- a/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
@@ -120,8 +120,8 @@ const NativeRenderer = ReactFiberReconciler({
     type: string,
     props: Props,
     rootContainerInstance: Container,
-  ): boolean {
-    return false;
+  ): void {
+    // We don't want to do anything here since this will be handled as normal in finalizeInitialChildren.
   },
 
   finalizeInitialChildren(

--- a/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
@@ -115,7 +115,7 @@ const NativeRenderer = ReactFiberReconciler({
     return tag;
   },
 
-  setInitialSpecialProperties(
+  preprocessChildrenSpecialProperties(
     parentInstance: Instance,
     type: string,
     props: Props,

--- a/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberRenderer.js
@@ -115,6 +115,15 @@ const NativeRenderer = ReactFiberReconciler({
     return tag;
   },
 
+  setInitialSpecialProperties(
+    parentInstance: Instance,
+    type: string,
+    props: Props,
+    rootContainerInstance: Container,
+  ): boolean {
+    return false;
+  },
+
   finalizeInitialChildren(
     parentInstance: Instance,
     type: string,

--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -109,7 +109,7 @@ let SharedHostConfig = {
     return inst;
   },
 
-  setInitialProperties(
+  setInitialSpecialProperties(
     domElement: Instance,
     type: string,
     props: Props,

--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -109,6 +109,14 @@ let SharedHostConfig = {
     return inst;
   },
 
+  setInitialProperties(
+    domElement: Instance,
+    type: string,
+    props: Props,
+  ): boolean {
+    return false;
+  },
+
   appendInitialChild(
     parentInstance: Instance,
     child: Instance | TextInstance,

--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -109,7 +109,7 @@ let SharedHostConfig = {
     return inst;
   },
 
-  setInitialSpecialProperties(
+  preprocessChildrenSpecialProperties(
     domElement: Instance,
     type: string,
     props: Props,

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -53,7 +53,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   const {
     createInstance,
     createTextInstance,
-    setInitialSpecialProperties,
+    preprocessChildrenSpecialProperties,
     appendInitialChild,
     finalizeInitialChildren,
     prepareUpdate,
@@ -504,7 +504,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
               currentHostContext,
               workInProgress,
             );
-            setInitialSpecialProperties(
+            preprocessChildrenSpecialProperties(
               instance,
               type,
               newProps,

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -53,6 +53,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   const {
     createInstance,
     createTextInstance,
+    setInitialSpecialProperties,
     appendInitialChild,
     finalizeInitialChildren,
     prepareUpdate,
@@ -502,6 +503,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
               rootContainerInstance,
               currentHostContext,
               workInProgress,
+            );
+            setInitialSpecialProperties(
+              instance,
+              type,
+              newProps,
+              rootContainerInstance,
             );
 
             appendAllChildren(instance, workInProgress);

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -59,6 +59,12 @@ export type HostConfig<T, P, I, TI, HI, PI, C, CC, CX, PL> = {
     hostContext: CX,
     internalInstanceHandle: OpaqueHandle,
   ): I,
+  setInitialSpecialProperties(
+    parentInstance: I,
+    type: T,
+    props: P,
+    rootContainerInstance: C,
+  ): void,
   appendInitialChild(parentInstance: I, child: I | TI): void,
   finalizeInitialChildren(
     parentInstance: I,

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.js
@@ -37,7 +37,7 @@ describe('ReactFiberHostContext', () => {
       createInstance: function() {
         creates++;
       },
-      setInitialSpecialProperties: function() {
+      preprocessChildrenSpecialProperties: function() {
         return null;
       },
       appendInitialChild: function() {
@@ -89,10 +89,13 @@ describe('ReactFiberHostContext', () => {
       createInstance: function() {
         return null;
       },
-      finalizeInitialChildren: function() {
+      preprocessChildrenSpecialProperties: function() {
         return null;
       },
       appendInitialChild: function() {
+        return null;
+      },
+      finalizeInitialChildren: function() {
         return null;
       },
       now: function() {

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.js
@@ -37,7 +37,7 @@ describe('ReactFiberHostContext', () => {
       createInstance: function() {
         creates++;
       },
-      setInitialProperties: function() {
+      setInitialSpecialProperties: function() {
         return null;
       },
       appendInitialChild: function() {

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.js
@@ -37,10 +37,13 @@ describe('ReactFiberHostContext', () => {
       createInstance: function() {
         creates++;
       },
-      finalizeInitialChildren: function() {
+      setInitialProperties: function() {
         return null;
       },
       appendInitialChild: function() {
+        return null;
+      },
+      finalizeInitialChildren: function() {
         return null;
       },
       now: function() {

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -148,7 +148,7 @@ const TestRenderer = ReactFiberReconciler({
     };
   },
 
-  setInitialProperties(
+  setInitialSpecialProperties(
     testElement: Instance,
     type: string,
     props: Props,

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -148,7 +148,7 @@ const TestRenderer = ReactFiberReconciler({
     };
   },
 
-  setInitialSpecialProperties(
+  preprocessChildrenSpecialProperties(
     testElement: Instance,
     type: string,
     props: Props,

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -148,6 +148,15 @@ const TestRenderer = ReactFiberReconciler({
     };
   },
 
+  setInitialProperties(
+    testElement: Instance,
+    type: string,
+    props: Props,
+    rootContainerInstance: Container,
+  ): boolean {
+    return false;
+  },
+
   appendInitialChild(
     parentInstance: Instance,
     child: Instance | TextInstance,


### PR DESCRIPTION
## Problem

When creating a select element and setting multiple the first element would be selected. This was due to the multiple prop being set after the children we're appended.

An non-react example  case created by @aweary can been seen here - https://jsfiddle.net/dm6vkq9q/

## Solution

Have a special case where if the element type were of select set the properties before the children are appended.

## Issue
https://github.com/facebook/react/issues/12200