### PR TITLE
Add a regression test for #12200

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -795,7 +795,7 @@ describe('ReactDOMSelect', () => {
 
   it('should not select first option by default when multiple is set and no defaultValue is set', () => {
     const stub = (
-      <select multiple onChange={noop}>
+      <select multiple={true} onChange={noop}>
         <option value="a">a</option>
         <option value="b">b</option>
         <option value="c">c</option>

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -792,4 +792,20 @@ describe('ReactDOMSelect', () => {
 
     document.body.removeChild(container);
   });
+
+  it('should not select first option by default when multiple is set and no defaultValue is set', () => {
+    const stub = (
+      <select multiple onChange={noop}>
+        <option value="a">a</option>
+        <option value="b">b</option>
+        <option value="c">c</option>
+      </select>
+    );
+    const container = document.createElement('div');
+    const node = ReactDOM.render(stub, container);
+
+    expect(node.options[0].selected).toBe(false); // a
+    expect(node.options[1].selected).toBe(false); // b
+    expect(node.options[2].selected).toBe(false); // c
+  });
 });

--- a/packages/react-dom/src/client/ReactDOMFiberSelect.js
+++ b/packages/react-dom/src/client/ReactDOMFiberSelect.js
@@ -173,6 +173,7 @@ export function initWrapperState(element: Element, props: Object) {
 
 export function postMountWrapper(element: Element, props: Object) {
   const node = ((element: any): SelectWithWrapperState);
+  node.selectedIndex = -1;
   node.multiple = !!props.multiple;
   const value = props.value;
   if (value != null) {

--- a/packages/react-dom/src/client/ReactDOMFiberSelect.js
+++ b/packages/react-dom/src/client/ReactDOMFiberSelect.js
@@ -173,8 +173,6 @@ export function initWrapperState(element: Element, props: Object) {
 
 export function postMountWrapper(element: Element, props: Object) {
   const node = ((element: any): SelectWithWrapperState);
-  //Set selected index to -1 before doing anything else to prevent first option from being selected by default
-  node.selectedIndex = -1;
   node.multiple = !!props.multiple;
   const value = props.value;
   if (value != null) {

--- a/packages/react-dom/src/client/ReactDOMFiberSelect.js
+++ b/packages/react-dom/src/client/ReactDOMFiberSelect.js
@@ -173,6 +173,7 @@ export function initWrapperState(element: Element, props: Object) {
 
 export function postMountWrapper(element: Element, props: Object) {
   const node = ((element: any): SelectWithWrapperState);
+  //Set selected index to -1 before doing anything else to prevent first option from being selected by default
   node.selectedIndex = -1;
   node.multiple = !!props.multiple;
   const value = props.value;


### PR DESCRIPTION
## Problem

When creating a select element and setting multiple the first element would be selected. This was due to the multiple prop being set after the children we're appended.

An non-react example case created by @aweary can been seen here - https://jsfiddle.net/dm6vkq9q/

## Tradeoffs / Misc

In my original solution I added a new hook to set props for just the select element before the children we're appended. This worked only because it was setting just the select props first. An alternative idea proposed was to switch the order of appendChildren > setProps to setProps > appendChildren. this will not work in the instance that we have a defualtValue set for our select input. When we change this order a defaultValue is ignored. There we're also many other tests that broke in this process. Although this is bit of a hacky solution this will not require us to make any dangerous changes to the code base.

## Solution

In postMountWrapper in ReactDOMFiberSelect.js I set selectedIndex for the select element to -1

## Issue
https://github.com/facebook/react/issues/12200

## Related closed pull requests
https://github.com/facebook/react/pull/12240

@aweary @gaearon 