### PR TITLE
Context providers and consumers should bailout on already finished work

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -859,45 +859,68 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
 
     const newValue = newProps.value;
+    workInProgress.memoizedProps = newProps;
 
     let changedBits: number;
     if (oldProps === null) {
       // Initial render
       changedBits = MAX_SIGNED_31_BIT_INT;
     } else {
-      const oldValue = oldProps.value;
-      // Use Object.is to compare the new context value to the old value.
-      // Inlined Object.is polyfill.
-      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
-      if (
-        (oldValue === newValue &&
-          (oldValue !== 0 || 1 / oldValue === 1 / newValue)) ||
-        (oldValue !== oldValue && newValue !== newValue) // eslint-disable-line no-self-compare
-      ) {
-        // No change.
+      if (oldProps.value === newProps.value) {
+        // No change. Bailout early if children are the same.
+        if (oldProps.children === newProps.children) {
+          workInProgress.stateNode = 0;
+          pushProvider(workInProgress);
+          return bailoutOnAlreadyFinishedWork(current, workInProgress);
+        }
         changedBits = 0;
       } else {
-        changedBits =
-          typeof context.calculateChangedBits === 'function'
-            ? context.calculateChangedBits(oldValue, newValue)
-            : MAX_SIGNED_31_BIT_INT;
-        if (__DEV__) {
-          warning(
-            (changedBits & MAX_SIGNED_31_BIT_INT) === changedBits,
-            'calculateChangedBits: Expected the return value to be a ' +
-              '31-bit integer. Instead received: %s',
-            changedBits,
-          );
-        }
-        changedBits |= 0;
+        const oldValue = oldProps.value;
+        // Use Object.is to compare the new context value to the old value.
+        // Inlined Object.is polyfill.
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+        if (
+          (oldValue === newValue &&
+            (oldValue !== 0 || 1 / oldValue === 1 / newValue)) ||
+          (oldValue !== oldValue && newValue !== newValue) // eslint-disable-line no-self-compare
+        ) {
+          // No change. Bailout early if children are the same.
+          if (oldProps.children === newProps.children) {
+            workInProgress.stateNode = 0;
+            pushProvider(workInProgress);
+            return bailoutOnAlreadyFinishedWork(current, workInProgress);
+          }
+          changedBits = 0;
+        } else {
+          changedBits =
+            typeof context.calculateChangedBits === 'function'
+              ? context.calculateChangedBits(oldValue, newValue)
+              : MAX_SIGNED_31_BIT_INT;
+          if (__DEV__) {
+            warning(
+              (changedBits & MAX_SIGNED_31_BIT_INT) === changedBits,
+              'calculateChangedBits: Expected the return value to be a ' +
+                '31-bit integer. Instead received: %s',
+              changedBits,
+            );
+          }
+          changedBits |= 0;
 
-        if (changedBits !== 0) {
-          propagateContextChange(
-            workInProgress,
-            context,
-            changedBits,
-            renderExpirationTime,
-          );
+          if (changedBits === 0) {
+            // No change. Bailout early if children are the same.
+            if (oldProps.children === newProps.children) {
+              workInProgress.stateNode = 0;
+              pushProvider(workInProgress);
+              return bailoutOnAlreadyFinishedWork(current, workInProgress);
+            }
+          } else {
+            propagateContextChange(
+              workInProgress,
+              context,
+              changedBits,
+              renderExpirationTime,
+            );
+          }
         }
       }
     }
@@ -905,7 +928,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     workInProgress.stateNode = changedBits;
     pushProvider(workInProgress);
 
-    workInProgress.memoizedProps = newProps;
     const newChildren = newProps.children;
     reconcileChildren(current, workInProgress, newChildren);
     return workInProgress.child;
@@ -923,14 +945,23 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     const newValue = context.currentValue;
     const changedBits = context.changedBits;
 
-    if (changedBits === 0) {
-      if (hasLegacyContextChanged()) {
-        // Normally we can bail out on props equality but if context has changed
-        // we don't do the bailout and we have to reuse existing props instead.
-      } else if (oldProps === newProps) {
-        return bailoutOnAlreadyFinishedWork(current, workInProgress);
-      }
-    } else {
+    if (hasLegacyContextChanged()) {
+      // Normally we can bail out on props equality but if context has changed
+      // we don't do the bailout and we have to reuse existing props instead.
+    } else if (changedBits === 0 && oldProps === newProps) {
+      return bailoutOnAlreadyFinishedWork(current, workInProgress);
+    }
+    workInProgress.memoizedProps = newProps;
+
+    let observedBits = newProps.observedBits;
+    if (observedBits === undefined || observedBits === null) {
+      // Subscribe to all changes by default
+      observedBits = MAX_SIGNED_31_BIT_INT;
+    }
+    // Store the observedBits on the fiber's stateNode for quick access.
+    workInProgress.stateNode = observedBits;
+
+    if ((changedBits & observedBits) !== 0) {
       // Context change propagation stops at matching consumers, for time-
       // slicing. Continue the propagation here.
       propagateContextChange(
@@ -939,17 +970,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         changedBits,
         renderExpirationTime,
       );
+    } else if (oldProps !== null && oldProps.children === newProps.children) {
+      // No change. Bailout early if children are the same.
+      return bailoutOnAlreadyFinishedWork(current, workInProgress);
     }
 
-    // Store the observedBits on the fiber's stateNode for quick access.
-    let observedBits = newProps.observedBits;
-    if (observedBits === undefined || observedBits === null) {
-      // Subscribe to all changes by default
-      observedBits = MAX_SIGNED_31_BIT_INT;
-    }
-    workInProgress.stateNode = observedBits;
-
-    workInProgress.memoizedProps = newProps;
     const render = newProps.children;
 
     if (typeof render !== 'function') {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -977,12 +977,13 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     const render = newProps.children;
 
-    if (typeof render !== 'function') {
-      invariant(
-        false,
-        "A context consumer was rendered with multiple children, or a child that isn't a function. " +
-          'A context consumer expects a single child that is a function. ' +
-          'If you did pass a function, make sure there is no trailing or leading whitespace around it.',
+    if (__DEV__) {
+      warning(
+        typeof render === 'function',
+        'A context consumer was rendered with multiple children, or a child ' +
+          "that isn't a function. A context consumer expects a single child " +
+          'that is a function. If you did pass a function, make sure there ' +
+          'is no trailing or leading whitespace around it.',
       );
     }
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
@@ -112,16 +112,40 @@ describe('ReactIncrementalTriangle', () => {
   }
 
   function randomAction() {
-    switch (randomInteger(0, 5)) {
-      case 0:
+    const weights = [
+      [FLUSH, 1],
+      [STEP, 1],
+      [INTERRUPT, 1],
+      [TOGGLE, 1],
+      [EXPIRE, 1],
+    ];
+    let totalWeight = 0;
+    for (let i = 0; i < weights.length; i++) {
+      totalWeight += weights[i][1];
+    }
+
+    const randomNumber = Math.random() * totalWeight;
+    let actionType;
+    let remainingWeight = randomNumber;
+    for (let i = 0; i < weights.length; i++) {
+      const [option, weight] = weights[i];
+      remainingWeight -= weight;
+      if (remainingWeight <= 0) {
+        actionType = option;
+        break;
+      }
+    }
+
+    switch (actionType) {
+      case FLUSH:
         return flush(randomInteger(0, TOTAL_TRIANGLES * 1.5));
-      case 1:
+      case STEP:
         return step(randomInteger(0, 10));
-      case 2:
+      case INTERRUPT:
         return interrupt();
-      case 3:
+      case TOGGLE:
         return toggle(randomInteger(0, TOTAL_CHILDREN));
-      case 4:
+      case EXPIRE:
         return expire(randomInteger(0, 1500));
       default:
         throw new Error('Switch statement should be exhaustive');

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
@@ -35,6 +35,13 @@ describe('ReactIncrementalTriangle', () => {
     };
   }
 
+  const FLUSH_ALL = 'FLUSH_ALL';
+  function flushAll() {
+    return {
+      type: FLUSH_ALL,
+    };
+  }
+
   const STEP = 'STEP';
   function step(counter) {
     return {
@@ -78,6 +85,8 @@ describe('ReactIncrementalTriangle', () => {
     switch (action.type) {
       case FLUSH:
         return `flush(${action.unitsOfWork})`;
+      case FLUSH_ALL:
+        return 'flushAll()';
       case STEP:
         return `step(${action.counter})`;
       case INTERRUPT:
@@ -114,6 +123,7 @@ describe('ReactIncrementalTriangle', () => {
   function randomAction() {
     const weights = [
       [FLUSH, 1],
+      [FLUSH_ALL, 1],
       [STEP, 1],
       [INTERRUPT, 1],
       [TOGGLE, 1],
@@ -139,12 +149,14 @@ describe('ReactIncrementalTriangle', () => {
     switch (actionType) {
       case FLUSH:
         return flush(randomInteger(0, TOTAL_TRIANGLES * 1.5));
+      case FLUSH_ALL:
+        return flushAll();
       case STEP:
         return step(randomInteger(0, 10));
       case INTERRUPT:
         return interrupt();
       case TOGGLE:
-        return toggle(randomInteger(0, TOTAL_CHILDREN));
+        return toggle(randomInteger(0, TOTAL_TRIANGLES));
       case EXPIRE:
         return expire(randomInteger(0, 1500));
       default:
@@ -161,6 +173,9 @@ describe('ReactIncrementalTriangle', () => {
   }
 
   function TriangleSimulator(rootID) {
+    const CounterContext = React.createContext([]);
+    const ActiveContext = React.createContext(0);
+
     let triangles = [];
     let leafTriangles = [];
     let yieldAfterEachRender = false;
@@ -169,27 +184,22 @@ describe('ReactIncrementalTriangle', () => {
         super();
         this.index = triangles.length;
         triangles.push(this);
-        if (props.depth === 0) {
+        if (props.remainingDepth === 0) {
           this.leafIndex = leafTriangles.length;
           leafTriangles.push(this);
         }
         this.state = {isActive: false};
       }
       activate() {
-        if (this.props.depth !== 0) {
-          throw new Error('Cannot activate non-leaf component');
-        }
         this.setState({isActive: true});
       }
       deactivate() {
-        if (this.props.depth !== 0) {
-          throw new Error('Cannot deactivate non-leaf component');
-        }
         this.setState({isActive: false});
       }
       shouldComponentUpdate(nextProps, nextState) {
         return (
           this.props.counter !== nextProps.counter ||
+          this.props.activeDepth !== nextProps.activeDepth ||
           this.state.isActive !== nextState.isActive
         );
       }
@@ -197,19 +207,56 @@ describe('ReactIncrementalTriangle', () => {
         if (yieldAfterEachRender) {
           ReactNoop.yield(this);
         }
-        const {counter, depth} = this.props;
-        if (depth === 0) {
-          const output = JSON.stringify({
-            prop: counter,
-            isActive: this.state.isActive,
-          });
-          return <span prop={output} />;
-        }
-        return [
-          <Triangle key={1} counter={counter} depth={depth - 1} />,
-          <Triangle key={2} counter={counter} depth={depth - 1} />,
-          <Triangle key={3} counter={counter} depth={depth - 1} />,
-        ];
+        const {counter, remainingDepth} = this.props;
+        return (
+          <ActiveContext.Consumer>
+            {activeContext => (
+              <CounterContext.Consumer>
+                {counterContext => {
+                  const activeDepthProp = this.state.isActive
+                    ? this.props.activeDepth + 1
+                    : this.props.activeDepth;
+                  const activeDepthContext = this.state.isActive
+                    ? activeContext + 1
+                    : activeContext;
+                  if (remainingDepth === 0) {
+                    // Leaf
+                    const output = JSON.stringify({
+                      prop: counter,
+                      isActive: this.state.isActive,
+                      counterContext: counterContext,
+                      activeDepthProp,
+                      activeDepthContext,
+                    });
+                    return <span prop={output} />;
+                  }
+
+                  return (
+                    <ActiveContext.Provider value={activeDepthContext}>
+                      <CounterContext.Provider value={counter}>
+                        <Triangle
+                          counter={counter}
+                          activeDepth={activeDepthProp}
+                          remainingDepth={remainingDepth - 1}
+                        />
+                        <Triangle
+                          counter={counter}
+                          activeDepth={activeDepthProp}
+                          remainingDepth={remainingDepth - 1}
+                        />
+                        <Triangle
+                          counter={counter}
+                          activeDepth={activeDepthProp}
+                          remainingDepth={remainingDepth - 1}
+                        />
+                      </CounterContext.Provider>
+                    </ActiveContext.Provider>
+                  );
+                }}
+              </CounterContext.Consumer>
+            )}
+          </ActiveContext.Consumer>
+        );
       }
     }
 
@@ -227,7 +274,13 @@ describe('ReactIncrementalTriangle', () => {
       }
       render() {
         appInstance = this;
-        return <Triangle counter={this.state.counter} depth={3} />;
+        return (
+          <Triangle
+            counter={this.state.counter}
+            activeDepth={0}
+            remainingDepth={this.props.remainingDepth}
+          />
+        );
       }
     }
 
@@ -238,11 +291,11 @@ describe('ReactIncrementalTriangle', () => {
       // Remounts the whole tree by changing the key
       if (rootID) {
         ReactNoop.renderToRootWithID(
-          <App depth={MAX_DEPTH} key={keyCounter++} />,
+          <App remainingDepth={MAX_DEPTH} key={keyCounter++} />,
           rootID,
         );
       } else {
-        ReactNoop.render(<App depth={MAX_DEPTH} key={keyCounter++} />);
+        ReactNoop.render(<App remainingDepth={MAX_DEPTH} key={keyCounter++} />);
       }
       ReactNoop.flush();
       assertConsistentTree();
@@ -251,9 +304,7 @@ describe('ReactIncrementalTriangle', () => {
 
     reset();
 
-    function assertConsistentTree(activeTriangle, counter) {
-      const activeIndex = activeTriangle ? activeTriangle.leafIndex : -1;
-
+    function assertConsistentTree(activeTriangleIndices = new Set(), counter) {
       const children = ReactNoop.getChildren(rootID);
 
       if (children.length !== TOTAL_CHILDREN) {
@@ -268,27 +319,43 @@ describe('ReactIncrementalTriangle', () => {
         const output = JSON.parse(child.prop);
         const prop = output.prop;
         const isActive = output.isActive;
+        const counterContext = output.counterContext;
+        const activeDepthProp = output.activeDepthProp;
+        const activeDepthContext = output.activeDepthContext;
 
         // If an expected counter is not specified, use the value of the
         // first child.
         if (expectedCounter === undefined) {
           expectedCounter = prop;
         }
-        const expectedIsActive = i === activeIndex;
+        const expectedIsActive = activeTriangleIndices.has(i);
 
         if (prop !== expectedCounter) {
           throw new Error(
-            `Triangle ${i} is inconsistent: prop ${prop} instead of ${
-              expectedCounter
-            }`,
+            `Triangle ${i} is inconsistent: prop ${prop} instead of ` +
+              expectedCounter,
           );
         }
 
         if (isActive !== expectedIsActive) {
           throw new Error(
-            `Triangle ${i} is inconsistent: isActive ${isActive} instead of ${
-              expectedIsActive
-            }`,
+            `Triangle ${i} is inconsistent: isActive ${isActive} instead of ` +
+              expectedIsActive,
+          );
+        }
+
+        if (counterContext !== prop) {
+          throw new Error(
+            `Triangle ${i} is inconsistent: prop ${prop} does not match ` +
+              `counterContext ${counterContext}`,
+          );
+        }
+
+        if (activeDepthContext !== activeDepthProp) {
+          throw new Error(
+            `Triangle ${i} is inconsistent: activeDepthProp ` +
+              `${activeDepthProp} does not match activeDepthContext ` +
+              activeDepthContext,
           );
         }
       }
@@ -298,7 +365,8 @@ describe('ReactIncrementalTriangle', () => {
       const app = reset();
       let expectedCounterAtEnd = app.state.counter;
 
-      let activeTriangle = null;
+      let activeIndices = new Set();
+      let activeLeafIndices = new Set();
       let action;
       while (true) {
         action = yield;
@@ -310,6 +378,9 @@ describe('ReactIncrementalTriangle', () => {
             case FLUSH:
               ReactNoop.flushUnitsOfWork(action.unitsOfWork);
               break;
+            case FLUSH_ALL:
+              ReactNoop.flush();
+              break;
             case STEP:
               ReactNoop.deferredUpdates(() => {
                 app.setCounter(action.counter);
@@ -320,18 +391,23 @@ describe('ReactIncrementalTriangle', () => {
               app.interrupt();
               break;
             case TOGGLE:
-              const targetTriangle = leafTriangles[action.childIndex];
+              const targetTriangle = triangles[action.childIndex];
               if (targetTriangle === undefined) {
                 throw new Error('Target index is out of bounds');
               }
-              if (targetTriangle === activeTriangle) {
-                activeTriangle = null;
+              const index = targetTriangle.index;
+              const leafIndex = targetTriangle.leafIndex;
+              if (activeIndices.has(index)) {
+                activeIndices.delete(index);
+                if (leafIndex !== undefined) {
+                  activeLeafIndices.delete(leafIndex);
+                }
                 targetTriangle.deactivate();
               } else {
-                if (activeTriangle !== null) {
-                  activeTriangle.deactivate();
+                activeIndices.add(index);
+                if (leafIndex !== undefined) {
+                  activeLeafIndices.add(leafIndex);
                 }
-                activeTriangle = targetTriangle;
                 targetTriangle.activate();
               }
               break;
@@ -339,14 +415,14 @@ describe('ReactIncrementalTriangle', () => {
               ReactNoop.expire(action.ms);
               break;
             default:
-              break;
+              throw new Error('Switch statement should be exhaustive');
           }
         });
-        assertConsistentTree(activeTriangle);
+        assertConsistentTree(activeLeafIndices);
       }
       // Flush remaining work
       ReactNoop.flush();
-      assertConsistentTree(activeTriangle, expectedCounterAtEnd);
+      assertConsistentTree(activeLeafIndices, expectedCounterAtEnd);
     }
 
     function simulate(...actions) {
@@ -381,6 +457,7 @@ describe('ReactIncrementalTriangle', () => {
       simulate(step(4), flush(52), expire(1476), flush(17), step(0));
       simulate(interrupt(), toggle(10), step(2), expire(990), flush(46));
       simulate(interrupt(), step(6), step(7), toggle(6), interrupt());
+      simulate(interrupt(), toggle(31), toggle(31), toggle(13), step(1));
     });
 
     it('generative tests', () => {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
@@ -175,10 +175,11 @@ describe('ReactIncrementalTriangle', () => {
         }
         const {counter, depth} = this.props;
         if (depth === 0) {
-          if (this.state.isActive) {
-            return <span prop={'*' + counter + '*'} />;
-          }
-          return <span prop={counter} />;
+          const output = JSON.stringify({
+            prop: counter,
+            isActive: this.state.isActive,
+          });
+          return <span prop={output} />;
         }
         return [
           <Triangle key={1} counter={counter} depth={depth - 1} />,
@@ -235,32 +236,36 @@ describe('ReactIncrementalTriangle', () => {
         throw new Error('Wrong number of children.');
       }
 
+      let expectedCounter = counter;
+
       for (let i = 0; i < children.length; i++) {
         let child = children[i];
-        let num = child.prop;
+
+        const output = JSON.parse(child.prop);
+        const prop = output.prop;
+        const isActive = output.isActive;
 
         // If an expected counter is not specified, use the value of the
         // first child.
-        if (counter === undefined) {
-          if (typeof num === 'string') {
-            counter = parseInt(num.substr(1, num.length - 2), 10);
-          } else {
-            counter = num;
-          }
+        if (expectedCounter === undefined) {
+          expectedCounter = prop;
+        }
+        const expectedIsActive = i === activeIndex;
+
+        if (prop !== expectedCounter) {
+          throw new Error(
+            `Triangle ${i} is inconsistent: prop ${prop} instead of ${
+              expectedCounter
+            }`,
+          );
         }
 
-        if (i === activeIndex) {
-          if (num !== `*${counter}*`) {
-            throw new Error(
-              `Triangle ${i} is inconsistent: ${num} instead of *${counter}*.`,
-            );
-          }
-        } else {
-          if (num !== counter) {
-            throw new Error(
-              `Triangle ${i} is inconsistent: ${num} instead of ${counter}.`,
-            );
-          }
+        if (isActive !== expectedIsActive) {
+          throw new Error(
+            `Triangle ${i} is inconsistent: isActive ${isActive} instead of ${
+              expectedIsActive
+            }`,
+          );
         }
       }
     }

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -683,6 +683,72 @@ describe('ReactNewContext', () => {
     expect(ReactNoop.getChildren()).toEqual([span('Context: 1, Step: 1')]);
   });
 
+  it('provider bails out if children and value are unchanged (like sCU)', () => {
+    const Context = React.createContext(0);
+
+    function Child() {
+      ReactNoop.yield('Child');
+      return <span prop="Child" />;
+    }
+
+    const children = <Child />;
+
+    function App(props) {
+      ReactNoop.yield('App');
+      return (
+        <Context.Provider value={props.value}>{children}</Context.Provider>
+      );
+    }
+
+    // Initial mount
+    ReactNoop.render(<App value={1} />);
+    expect(ReactNoop.flush()).toEqual(['App', 'Child']);
+    expect(ReactNoop.getChildren()).toEqual([span('Child')]);
+
+    // Update
+    ReactNoop.render(<App value={1} />);
+    expect(ReactNoop.flush()).toEqual([
+      'App',
+      // Child does not re-render
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('Child')]);
+  });
+
+  it('consumer bails out if children and value are unchanged (like sCU)', () => {
+    const Context = React.createContext(0);
+
+    function Child() {
+      ReactNoop.yield('Child');
+      return <span prop="Child" />;
+    }
+
+    function renderConsumer(context) {
+      return <Child context={context} />;
+    }
+
+    function App(props) {
+      ReactNoop.yield('App');
+      return (
+        <Context.Provider value={props.value}>
+          <Context.Consumer>{renderConsumer}</Context.Consumer>
+        </Context.Provider>
+      );
+    }
+
+    // Initial mount
+    ReactNoop.render(<App value={1} />);
+    expect(ReactNoop.flush()).toEqual(['App', 'Child']);
+    expect(ReactNoop.getChildren()).toEqual([span('Child')]);
+
+    // Update
+    ReactNoop.render(<App value={1} />);
+    expect(ReactNoop.flush()).toEqual([
+      'App',
+      // Child does not re-render
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('Child')]);
+  });
+
   describe('fuzz test', () => {
     const Fragment = React.Fragment;
     const contextKeys = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -644,6 +644,19 @@ describe('ReactNewContext', () => {
     }
   });
 
+  it('warns if consumer child is not a function', () => {
+    spyOnDev(console, 'error');
+    const Context = React.createContext(0);
+    ReactNoop.render(<Context.Consumer />);
+    expect(ReactNoop.flush).toThrow('render is not a function');
+    if (__DEV__) {
+      expect(console.error.calls.argsFor(0)[0]).toContain(
+        'A context consumer was rendered with multiple children, or a child ' +
+          "that isn't a function",
+      );
+    }
+  });
+
   it("does not re-render if there's an update in a child", () => {
     const Context = React.createContext(0);
 


### PR DESCRIPTION
Fixes bug where a consumer would re-render even if its props and context had not changed.

- [x] Confirm https://github.com/facebook/react/issues/12218 is fixed
- [x] Confirm https://github.com/facebook/react/issues/12246 is fixed
- [x] Integrate context fuzz tester into main fuzz tester, since that would have caught this bug. These tests are most effective when you combine as many features together as possible.
