### PR TITLE
Ignore RN events on unknown nodes

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
+++ b/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
@@ -31,6 +31,10 @@ const ReactNativeBridgeEventPlugin = {
     nativeEvent: AnyNativeEvent,
     nativeEventTarget: Object,
   ): ?Object {
+    if (targetInst == null) {
+      // Probably a node belonging to another renderer's tree.
+      return null;
+    }
     const bubbleDispatchConfig = customBubblingEventTypes[topLevelType];
     const directDispatchConfig = customDirectEventTypes[topLevelType];
     invariant(


### PR DESCRIPTION
If we have multiple RN renderers running simultaneously, we should be able to send a single event to all of them and only if it recognizes the event will it do anything with it. Crucially, this avoids the 'Unsupported top level event type "%s" dispatched' invariant in those cases.