### PR TITLE
annotation typo

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -122,7 +122,7 @@ export type Fiber = {|
   // Bitfield that describes properties about the fiber and its subtree. E.g.
   // the AsyncMode flag indicates whether the subtree should be async-by-
   // default. When a fiber is created, it inherits the mode of its
-  // parent. Additional flags can be set at creation time, but after than the
+  // parent. Additional flags can be set at creation time, but after then the
   // value should remain unchanged throughout the fiber's lifetime, particularly
   // before its child fibers are created.
   mode: TypeOfMode,

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -122,7 +122,7 @@ export type Fiber = {|
   // Bitfield that describes properties about the fiber and its subtree. E.g.
   // the AsyncMode flag indicates whether the subtree should be async-by-
   // default. When a fiber is created, it inherits the mode of its
-  // parent. Additional flags can be set at creation time, but after then the
+  // parent. Additional flags can be set at creation time, but after that the
   // value should remain unchanged throughout the fiber's lifetime, particularly
   // before its child fibers are created.
   mode: TypeOfMode,


### PR DESCRIPTION
If I guess correctly,  `after than` means `after then`