### PR TITLE
Skip portals when rendering on server-side.

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -331,16 +331,13 @@ describe('ReactDOMServerHydration', () => {
     );
   });
 
-  it('should throw rendering portals on the server', () => {
+  it('should skip rendering portals on the server', () => {
     const div = document.createElement('div');
-    expect(() => {
+    expect(
       ReactDOMServer.renderToString(
         <div>{ReactDOM.createPortal(<div />, div)}</div>,
-      );
-    }).toThrow(
-      'Portals are not currently supported by the server renderer. ' +
-        'Render them conditionally so that they only appear on the client render.',
-    );
+      ),
+    ).toBe('<div data-reactroot=""></div>');
   });
 
   it('should be able to render and hydrate Mode components', () => {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -670,6 +670,11 @@ function resolve(
       context = Object.assign({}, context, childContext);
     }
   }
+
+  if (React.isPortalElement(child)) {
+    child = null;
+  }
+
   return {child, context};
 }
 

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -22,6 +22,7 @@ import {
   createFactory,
   cloneElement,
   isValidElement,
+  isPortalElement,
   jsx,
 } from './ReactElement';
 import {createContext} from './ReactContext';
@@ -96,6 +97,7 @@ const React = {
   cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,
   createFactory: __DEV__ ? createFactoryWithValidation : createFactory,
   isValidElement: isValidElement,
+  isPortalElement: isPortalElement,
 
   version: ReactVersion,
 

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -7,7 +7,7 @@
 
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
-import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
+import {REACT_ELEMENT_TYPE, REACT_PORTAL_TYPE} from 'shared/ReactSymbols';
 
 import ReactCurrentOwner from './ReactCurrentOwner';
 
@@ -501,5 +501,20 @@ export function isValidElement(object) {
     typeof object === 'object' &&
     object !== null &&
     object.$$typeof === REACT_ELEMENT_TYPE
+  );
+}
+
+/**
+ * Verifies the object is a ReactPortal.
+ * See https://reactjs.org/docs/react-api.html#isportalelement
+ * @param {?object} object
+ * @return {boolean} True if `object` is a portal component.
+ * @final
+ */
+export function isPortalElement(object) {
+  return (
+    typeof object === 'object' &&
+    object !== null &&
+    object.$$typeof === REACT_PORTAL_TYPE
   );
 }


### PR DESCRIPTION
Hi,

Here is an option that just skips portals while rendering on the server-side environment.

I'll try to find some ideas to help dealing with modals on tests.

Please let me know if there are any improvements in this PR. 
If the solution is not ideal, it can be closed.

Thank you.