### PR TITLE
Exporting toJSON from react-test-renderer.

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -680,6 +680,8 @@ const ReactTestRendererFiber = {
   /* eslint-disable camelcase */
   unstable_batchedUpdates: batchedUpdates,
   /* eslint-enable camelcase */
+
+  toJSON: toJSON,
 };
 
 export default ReactTestRendererFiber;

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -13,6 +13,7 @@
 const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 const React = require('react');
+const ReactDOM = require('react-dom');
 const ReactTestRenderer = require('react-test-renderer');
 const prettyFormat = require('pretty-format');
 
@@ -955,6 +956,31 @@ describe('ReactTestRenderer', () => {
         },
         type: App,
       }),
+    );
+  });
+
+  it('supports portal.', () => {
+    // We need to provide an object with the correct
+    // APIs to be used by both `react-test-renderer` and
+    // `React.createPortal()`.
+    const ELEMENT_NODE = 1;
+    const container = { children: [], nodeType: ELEMENT_NODE };
+
+    const Portal = () => (
+      ReactDOM.createPortal(
+        <div>hello</div>,
+        container
+      )
+    );
+
+    ReactTestRenderer.create(
+      <div>
+        <Portal />
+      </div>
+    );
+
+    expect(ReactTestRenderer.toJSON(container.children[0])).toEqual(
+      { type: 'div', props: {}, children: ['hello'] }
     );
   });
 });


### PR DESCRIPTION
Hi,

It's far from a perfect solution but it can buy some time and help users
to use `createPortal` with `react-test-renderer`.

Issue related:
- #11565 
 
The idea is to allow users to convert the rendered elements of a portal to JSON. 
See the test for more details about this.

Please let me know if there are any improvements in this PR.
If the solution is not ideal, it can be closed.

Thank you.