### PR TITLE
[react-is] [docs] specify the actual working alpha version of react-is

### DIFF
--- a/packages/react-is/README.md
+++ b/packages/react-is/README.md
@@ -4,12 +4,14 @@ This package allows you to test arbitrary values and see if they're a particular
 
 ## Installation
 
+For now, you'll want to install the `react-is@next` version of the package, since the `react-is` 1.0.0 version was just a placeholder.
+
 ```sh
 # Yarn
-yarn add react-is
+yarn add react-is@next
 
 # NPM
-npm install react-is --save
+npm install react-is@next --save
 ```
 
 ## Usage


### PR DESCRIPTION
Recently, I've also gotten the problem described in #12287, whereas you expect the `react-is` package to work out of the box. For future references and helping others avoid this issue, I've went ahead and added a comment for the installation part in the package's docs.