### PR TITLE
Temporarily disable Danger in CI

### DIFF
--- a/scripts/circleci/test_entry_point.sh
+++ b/scripts/circleci/test_entry_point.sh
@@ -25,7 +25,9 @@ if [ $((2 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('./scripts/circleci/build.sh')
   COMMANDS_TO_RUN+=('yarn test-build --maxWorkers=2')
   COMMANDS_TO_RUN+=('yarn test-build-prod --maxWorkers=2')
-  COMMANDS_TO_RUN+=('node ./scripts/tasks/danger')
+  # The Github API requests danger makes are currently failing. Disabling it
+  # until we can fix that.
+  # COMMANDS_TO_RUN+=('node ./scripts/tasks/danger')
   COMMANDS_TO_RUN+=('./scripts/circleci/upload_build.sh')
 fi
 


### PR DESCRIPTION
Looks like Danger has started failing recently, and it's causing builds to fail. Disabling it for now until we can figure out the problem

Example failure: https://circleci.com/gh/facebook/react/9035#tests/containers/2