### PR TITLE
added link to reactjs docs for test renderer

### DIFF
--- a/packages/react-test-renderer/README.md
+++ b/packages/react-test-renderer/README.md
@@ -4,6 +4,8 @@ This package provides an experimental React renderer that can be used to render 
 
 Essentially, this package makes it easy to grab a snapshot of the "DOM tree" rendered by a React DOM or React Native component without using a browser or jsdom.
 
+Documentation:
+
 [https://reactjs.org/docs/test-renderer.html](https://reactjs.org/docs/test-renderer.html)
 
 Usage:

--- a/packages/react-test-renderer/README.md
+++ b/packages/react-test-renderer/README.md
@@ -4,6 +4,8 @@ This package provides an experimental React renderer that can be used to render 
 
 Essentially, this package makes it easy to grab a snapshot of the "DOM tree" rendered by a React DOM or React Native component without using a browser or jsdom.
 
+[https://reactjs.org/docs/test-renderer.html](https://reactjs.org/docs/test-renderer.html)
+
 Usage:
 
 ```jsx


### PR DESCRIPTION
Add link to reactjs.com documentation for `react-test-renderer` to the `react-test-renderer/README.md`for fellow googlers that end up on the npm/yarn package page and think there is no documentation on how to use this thing 😸.