### PR TITLE
Fixes bug when initial mount of a host component is `hidden`

### DIFF
--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -130,6 +130,12 @@ let SharedHostConfig = {
     oldProps: Props,
     newProps: Props,
   ): null | {} {
+    if (oldProps === null) {
+      throw new Error('Should have old props');
+    }
+    if (newProps === null) {
+      throw new Error('Should have old props');
+    }
     return UPDATE_SIGNAL;
   },
 
@@ -196,6 +202,9 @@ const NoopRenderer = ReactFiberReconciler({
       oldProps: Props,
       newProps: Props,
     ): void {
+      if (oldProps === null) {
+        throw new Error('Should have old props');
+      }
       instance.prop = newProps.prop;
     },
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
@@ -758,7 +758,7 @@ describe('ReactIncrementalSideEffects', () => {
     // items. Including the set state since that is deprioritized.
     // TODO: The cycles it takes to do this could be lowered with further
     // optimizations.
-    ReactNoop.flushDeferredPri(60 + 5);
+    ReactNoop.flushDeferredPri(35);
     expect(ReactNoop.getChildren()).toEqual([
       div(
         // Updated.
@@ -790,7 +790,7 @@ describe('ReactIncrementalSideEffects', () => {
       ),
     ]);
 
-    expect(ops).toEqual(['Bar', 'Bar']);
+    expect(ops).toEqual(['Bar', 'Bar', 'Bar']);
   });
   // TODO: Test that side-effects are not cut off when a work in progress node
   // moves to "current" without flushing due to having lower priority. Does this


### PR DESCRIPTION
`oldProps` was null. This went uncaught by the unit tests because ReactNoop did not use `oldProps` in either `prepareUpdate` or `completeUpdate`. I added some invariants so we don't regress in the future.