### PR TITLE
Do not clear errors after they are thrown

### DIFF
--- a/packages/simple-cache-provider/src/SimpleCacheProvider.js
+++ b/packages/simple-cache-provider/src/SimpleCacheProvider.js
@@ -194,9 +194,6 @@ export function createCache(invalidator: () => mixed): Cache {
         default:
           // The requested resource previously failed loading.
           const error = record.error;
-          const emptyRecord: EmptyRecord = (record: any);
-          emptyRecord.status = 0;
-          emptyRecord.error = null;
           throw error;
       }
     },

--- a/packages/simple-cache-provider/src/__tests__/SimpleCacheProvider-test.js
+++ b/packages/simple-cache-provider/src/__tests__/SimpleCacheProvider-test.js
@@ -71,15 +71,15 @@ describe('SimpleCacheProvider', () => {
     expect(() => readUpperCase(cache, 'hello')).toThrow(error);
     expect(error.message).toBe('oh no');
 
-    // On a subsequent read, it should complete successfully.
+    // On a subsequent read, it should still throw.
     try {
       readUpperCase(cache, 'hello');
     } catch (v) {
       suspender = v;
     }
     await suspender;
-    const result = readUpperCase(cache, 'hello');
-    expect(result).toBe('HELLO');
+    expect(() => readUpperCase(cache, 'hello')).toThrow(error);
+    expect(error.message).toBe('oh no');
   });
 
   it('can preload data ahead of time', async () => {


### PR DESCRIPTION
Instead, to trigger a retry, the consumer should invalidate the cache.

In the future, we will likely add a way to invalidate only the failed records.