### PR TITLE
Remove DefaultProps type parameter from ReactNativeComponent

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -37,11 +37,14 @@ import findNumericNodeHandle from './findNumericNodeHandle';
  *
  * @abstract
  */
-class ReactNativeComponent<DefaultProps, Props, State> extends React.Component<
+class ReactNativeComponent<Props, State = void> extends React.Component<
   Props,
   State,
 > {
-  static defaultProps: DefaultProps;
+  /**
+   * Due to bugs in Flow's handling of React.createClass, some fields already
+   * declared in the base class need to be redeclared below.
+   */
   props: Props;
   state: State;
 


### PR DESCRIPTION
Removes the `DefaultProps` type parameter from `ReactNativeComponent`. Also, makes `State` optional and default to `void`. This is the same convention employed by [`React.PureComponent`](https://github.com/facebook/flow/blob/master/lib/react.js#L86).

**Test Plan:**
Ran `yarn lint` and `flow` successfully.