### PR TITLE
Fix documentation of the release process

### DIFF
--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,10 +1,10 @@
-# React Release Script
+# React Release Scripts
 
-At a high-level, the release script runs in 2 passes: **build** and **publish**.
-1. The **build** script does the heavy lifting (eg checking CI, running automated tests, building Rollup bundles) and then prints instructions for manual verification.
-1. The **publish** script then publishes the built artifacts to NPM and pushes to GitHub.
+At a high-level, the release process uses two scripts: **build** and **publish**.
+1. The **build** script does the heavy lifting (e.g., checking CI, running automated tests, building Rollup bundles) and then prints instructions for manual verification.
+1. The **publish** script then publishes the built artifacts to npm and pushes to GitHub.
 
-Run either script without parameters to see its usage, eg:
+Run either script without parameters to see its usage, e.g.:
 ```
 ./scripts/release/build.js
 ./scripts/release/publish.js


### PR DESCRIPTION
Adjusted some grammar in the [`scripts/release/README.md`](https://github.com/facebook/react/blob/master/scripts/release/README.md) file.
- Adjusted title to infer that there are different kinds of release scripts
- The first sentence infers that there is one release script. However, it seems that the release process includes two scripts rather than being a script on its own.
- Officially, and also confirmed on the [homepage readme](https://github.com/facebook/react/blob/master/README.md#installation), the [npm](https://www.npmjs.com/) logo and name are with lowercase letters.
- Some abbreviations were missing punctuation.
