### PR TITLE
Only pass context to functional components if contextTypes is defined

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationContext-test.js
@@ -108,7 +108,7 @@ describe('ReactDOMServerIntegration', () => {
     itRenders('stateless child without context', async render => {
       function StatelessChildWithoutContext(props, context) {
         // this should render blank; context isn't passed to this component.
-        return <div>{context.text}</div>;
+        return <div>{context === undefined ? null : context.text}</div>;
       }
 
       const e = await render(

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -44,6 +44,7 @@ import {
   debugRenderPhaseSideEffectsForStrictMode,
 } from 'shared/ReactFeatureFlags';
 import invariant from 'fbjs/lib/invariant';
+import emptyObject from 'fbjs/lib/emptyObject';
 import getComponentName from 'shared/getComponentName';
 import warning from 'fbjs/lib/warning';
 import ReactDebugCurrentFiber from './ReactDebugCurrentFiber';
@@ -216,10 +217,18 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     if (__DEV__) {
       ReactCurrentOwner.current = workInProgress;
       ReactDebugCurrentFiber.setCurrentPhase('render');
-      nextChildren = fn(nextProps, context);
+      if (context === emptyObject) {
+        nextChildren = fn(nextProps);
+      } else {
+        nextChildren = fn(nextProps, context);
+      }
       ReactDebugCurrentFiber.setCurrentPhase(null);
     } else {
-      nextChildren = fn(nextProps, context);
+      if (context === emptyObject) {
+        nextChildren = fn(nextProps);
+      } else {
+        nextChildren = fn(nextProps, context);
+      }
     }
     // React DevTools reads this flag.
     workInProgress.effectTag |= PerformedWork;
@@ -567,9 +576,17 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         }
       }
       ReactCurrentOwner.current = workInProgress;
-      value = fn(props, context);
+      if (context === emptyObject) {
+        value = fn(props);
+      } else {
+        value = fn(props, context);
+      }
     } else {
-      value = fn(props, context);
+      if (context === emptyObject) {
+        value = fn(props);
+      } else {
+        value = fn(props, context);
+      }
     }
     // React DevTools reads this flag.
     workInProgress.effectTag |= PerformedWork;

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -2102,7 +2102,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual([
       'Intl:read {}',
       'Intl:provide {"locale":"fr"}',
-      'IndirectionFn {}',
+      'IndirectionFn undefined',
       'IndirectionClass {}',
       'ShowLocaleClass:read {"locale":"fr"}',
       'ShowLocaleFn:read {"locale":"fr"}',
@@ -2190,7 +2190,7 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual([
       'Intl:read {}',
       'Intl:provide {"locale":"fr"}',
-      'IndirectionFn {}',
+      'IndirectionFn undefined',
       'IndirectionClass {}',
       'ShowLocaleClass:read {"locale":"fr"}',
       'ShowLocaleFn:read {"locale":"fr"}',
@@ -2207,7 +2207,7 @@ describe('ReactIncremental', () => {
       'Intl:provide {"locale":"gr"}',
       // TODO: it's unfortunate that we can't reuse work on
       // these components even though they don't depend on context.
-      'IndirectionFn {}',
+      'IndirectionFn undefined',
       'IndirectionClass {}',
       // These components depend on context:
       'ShowLocaleClass:read {"locale":"gr"}',


### PR DESCRIPTION
I don't know if this counts as a breaking change or not. I would not expect users to depend on context being an empty object.

Alternatively, we can hold off on this change until 17, and in the meantime, new-style HOCs (`useRef`, `useCache`) can workaround this by checking for the existence of `contextTypes` themselves.