### PR TITLE
Warn if functional component accesses context object without contextTypes

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationContext-test.js
@@ -105,17 +105,19 @@ describe('ReactDOMServerIntegration', () => {
       expect(e.textContent).toBe('');
     });
 
-    itRenders('stateless child without context', async render => {
+    it('stateless child without context', () => {
       function StatelessChildWithoutContext(props, context) {
         // this should render blank; context isn't passed to this component.
         return <div>{context.text}</div>;
       }
-
-      const e = await render(
+      const html = ReactDOMServer.renderToString(
         <PurpleContext>
           <StatelessChildWithoutContext />
         </PurpleContext>,
       );
+      const domElement = document.createElement('div');
+      domElement.innerHTML = html;
+      const e = domElement.firstChild;
       expect(e.textContent).toBe('');
     });
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -44,6 +44,7 @@ import {
   debugRenderPhaseSideEffectsForStrictMode,
 } from 'shared/ReactFeatureFlags';
 import invariant from 'fbjs/lib/invariant';
+import emptyObject from 'fbjs/lib/emptyObject';
 import getComponentName from 'shared/getComponentName';
 import warning from 'fbjs/lib/warning';
 import ReactDebugCurrentFiber from './ReactDebugCurrentFiber';
@@ -72,11 +73,39 @@ import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
 let didWarnAboutBadClass;
 let didWarnAboutGetDerivedStateOnFunctionalComponent;
 let didWarnAboutStatelessRefs;
+let emptyContextThatWarnsOnAccess;
 
 if (__DEV__) {
   didWarnAboutBadClass = {};
   didWarnAboutGetDerivedStateOnFunctionalComponent = {};
   didWarnAboutStatelessRefs = {};
+
+  emptyContextThatWarnsOnAccess =
+    typeof Proxy === 'function'
+      ? new Proxy(emptyObject, {
+          get(target, name) {
+            const owner = ReactCurrentOwner.current;
+            let info = '';
+            if (owner !== null) {
+              const componentName = getComponentName(owner);
+              if (componentName != null) {
+                info = ` Check the definition of ${componentName}.\n`;
+              }
+            }
+            warning(
+              false,
+              'Missing contextTypes: Attempted to read the context ' +
+                "property '%s', but contextTypes was not defined.%s\n" +
+                'In future versions, React will not pass any context (nor an ' +
+                'empty object) to functional components unless contextTypes ' +
+                'is defined.',
+              name,
+              info,
+            );
+            return target[name];
+          },
+        })
+      : emptyObject;
 }
 
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
@@ -216,7 +245,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     if (__DEV__) {
       ReactCurrentOwner.current = workInProgress;
       ReactDebugCurrentFiber.setCurrentPhase('render');
-      nextChildren = fn(nextProps, context);
+      if (context === emptyObject) {
+        nextChildren = fn(nextProps, emptyContextThatWarnsOnAccess);
+      } else {
+        nextChildren = fn(nextProps, context);
+      }
       ReactDebugCurrentFiber.setCurrentPhase(null);
     } else {
       nextChildren = fn(nextProps, context);
@@ -567,7 +600,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         }
       }
       ReactCurrentOwner.current = workInProgress;
-      value = fn(props, context);
+      if (context === emptyObject) {
+        value = fn(props, emptyContextThatWarnsOnAccess);
+      } else {
+        value = fn(props, context);
+      }
     } else {
       value = fn(props, context);
     }

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -2098,7 +2098,14 @@ describe('ReactIncremental', () => {
         </IndirectionFn>
       </Intl>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'Missing contextTypes: Attempted to read the context property ' +
+        "'toJSON', but contextTypes was not defined. Check the definition " +
+        'of IndirectionFn.\n\n' +
+        'In future versions, React will not pass any context ' +
+        '(nor an empty object) to functional components unless contextTypes ' +
+        'is defined.',
+    );
     expect(ops).toEqual([
       'Intl:read {}',
       'Intl:provide {"locale":"fr"}',
@@ -2186,7 +2193,14 @@ describe('ReactIncremental', () => {
         </IndirectionFn>
       </Stateful>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'Missing contextTypes: Attempted to read the context property ' +
+        "'toJSON', but contextTypes was not defined. Check the definition " +
+        'of IndirectionFn.\n\n' +
+        'In future versions, React will not pass any context ' +
+        '(nor an empty object) to functional components unless contextTypes ' +
+        'is defined.',
+    );
     expect(ops).toEqual([
       'Intl:read {}',
       'Intl:provide {"locale":"fr"}',
@@ -2198,7 +2212,14 @@ describe('ReactIncremental', () => {
 
     ops.length = 0;
     statefulInst.setState({locale: 'gr'});
-    ReactNoop.flush();
+    expect(ReactNoop.flush).toWarnDev(
+      'Missing contextTypes: Attempted to read the context property ' +
+        "'toJSON', but contextTypes was not defined. Check the definition " +
+        'of IndirectionFn.\n\n' +
+        'In future versions, React will not pass any context ' +
+        '(nor an empty object) to functional components unless contextTypes ' +
+        'is defined.',
+    );
     expect(ops).toEqual([
       // Intl is below setState() so it might have been
       // affected by it. Therefore we re-render and recompute


### PR DESCRIPTION
Currently, if contextTypes is not defined, we pass an empty object. In the future, we will pass nothing. This fires a warning when the empty context object is accessed.

Alternative to #12341, which jumps straight to not passing the empty object at all.