### PR TITLE
Add Netlify integration for DOM Fixtures folder

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  base    = ""
+  publish = "fixtures/dom/build"
+  command = "yarn build --type=UMD_DEV && cd fixtures/dom/ && yarn && yarn prestart && yarn build"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
In issue #11079, @nhunzaker mentions that it would be nice to have an automatic deployment of [the DOM Fixtures folder](https://github.com/facebook/react/tree/master/fixtures/dom) for manual and automated testing purposes.

Since [Netlify offers their services for free to open source projects](https://www.netlify.com/open-source/) (an account for this will need to be set up), I thought it would be a great fit. 

This commit adds a `netlify.toml` file to the repo, allowing easier deployment out to the service.

This file will do two things:
1. On master branch update, it deploys the latest code to the main linked netlify site. For example: https://musing-lewin-a6efa4.netlify.com/
2. For every PR opened, creates a 'Deploy Preview' site for validating that PR's changes. For example: https://deploy-preview-1--musing-lewin-a6efa4.netlify.com/
The preview site is linked via GitHub in the PR. 
![image](https://user-images.githubusercontent.com/706039/37229973-7bf92c78-23ab-11e8-8ca1-aa1c63ccd2b1.png)


**Test Plan:**
Create a Netlify account and [connect the github repo you're testing to it](https://app.netlify.com/start).
After connection, Netlify should deploy the DOM fixtures build folder to a live site for you to use.