### PR TITLE
Initialize React prop name/attribute name mapping without Map

### DIFF
--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -224,12 +224,12 @@ const properties = {};
 
 // A few React string attributes have a different name.
 // This is a mapping from React prop names to the attribute names.
-new Map([
+[
   ['acceptCharset', 'accept-charset'],
   ['className', 'class'],
   ['htmlFor', 'for'],
   ['httpEquiv', 'http-equiv'],
-]).forEach((attributeName, name) => {
+].forEach(([name, attributeName]) => {
   properties[name] = new PropertyInfoRecord(
     name,
     STRING,


### PR DESCRIPTION
Fixes #12349. See https://github.com/facebook/react/issues/12349#issuecomment-372184873.

Using `new Map(iterable)` isn't supported in IE11, so it ends up trying to iterate through an empty map and these attributes don't get defined in properties. Since this is only run once on startup inlining the `attributeName` array is probably fine.
