### PR TITLE
 Add unstable prefix to `observedBits` prop until its proven to work in practice

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -953,7 +953,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
     workInProgress.memoizedProps = newProps;
 
-    let observedBits = newProps.observedBits;
+    let observedBits = newProps.unstable_observedBits;
     if (observedBits === undefined || observedBits === null) {
       // Subscribe to all changes by default
       observedBits = MAX_SIGNED_31_BIT_INT;

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -516,7 +516,7 @@ describe('ReactNewContext', () => {
 
     function Foo() {
       return (
-        <Context.Consumer observedBits={0b01}>
+        <Context.Consumer unstable_observedBits={0b01}>
           {value => {
             ReactNoop.yield('Foo');
             return <span prop={'Foo: ' + value.foo} />;
@@ -527,7 +527,7 @@ describe('ReactNewContext', () => {
 
     function Bar() {
       return (
-        <Context.Consumer observedBits={0b10}>
+        <Context.Consumer unstable_observedBits={0b10}>
           {value => {
             ReactNoop.yield('Bar');
             return <span prop={'Bar: ' + value.bar} />;


### PR DESCRIPTION
(Based on https://github.com/facebook/react/pull/12254)

During a weekly team meeting, we agreed to make this unstable until we can prove that it's a viable optimization strategy for Relay or some other library.

