### PR TITLE
Prefix internal context properties with underscore

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -675,7 +675,7 @@ class ReactDOMServerRenderer {
     this.providerIndex += 1;
     this.providerStack[this.providerIndex] = provider;
     const context: ReactContext<any> = provider.type.context;
-    context.currentValue = provider.props.value;
+    context._currentValue = provider.props.value;
   }
 
   popProvider<T>(provider: ReactProvider<T>): void {
@@ -690,13 +690,13 @@ class ReactDOMServerRenderer {
     this.providerIndex -= 1;
     const context: ReactContext<any> = provider.type.context;
     if (this.providerIndex < 0) {
-      context.currentValue = context.defaultValue;
+      context._currentValue = context._defaultValue;
     } else {
       // We assume this type is correct because of the index check above.
       const previousProvider: ReactProvider<any> = (this.providerStack[
         this.providerIndex
       ]: any);
-      context.currentValue = previousProvider.props.value;
+      context._currentValue = previousProvider.props.value;
     }
   }
 
@@ -865,7 +865,7 @@ class ReactDOMServerRenderer {
           case REACT_CONTEXT_TYPE: {
             const consumer: ReactConsumer<any> = (nextChild: any);
             const nextProps: any = consumer.props;
-            const nextValue = consumer.type.currentValue;
+            const nextValue = consumer.type._currentValue;
 
             const nextChildren = toArray(nextProps.children(nextValue));
             const frame: Frame = {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -893,8 +893,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           changedBits = 0;
         } else {
           changedBits =
-            typeof context.calculateChangedBits === 'function'
-              ? context.calculateChangedBits(oldValue, newValue)
+            typeof context._calculateChangedBits === 'function'
+              ? context._calculateChangedBits(oldValue, newValue)
               : MAX_SIGNED_31_BIT_INT;
           if (__DEV__) {
             warning(
@@ -942,8 +942,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     const newProps = workInProgress.pendingProps;
     const oldProps = workInProgress.memoizedProps;
 
-    const newValue = context.currentValue;
-    const changedBits = context.changedBits;
+    const newValue = context._currentValue;
+    const changedBits = context._changedBits;
 
     if (hasLegacyContextChanged()) {
       // Normally we can bail out on props equality but if context has changed

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -26,11 +26,11 @@ if (__DEV__) {
 export function pushProvider(providerFiber: Fiber): void {
   const context: ReactContext<any> = providerFiber.type.context;
   index += 1;
-  changedBitsStack[index] = context.changedBits;
-  currentValueStack[index] = context.currentValue;
+  changedBitsStack[index] = context._changedBits;
+  currentValueStack[index] = context._currentValue;
   stack[index] = providerFiber;
-  context.currentValue = providerFiber.pendingProps.value;
-  context.changedBits = providerFiber.stateNode;
+  context._currentValue = providerFiber.pendingProps.value;
+  context._changedBits = providerFiber.stateNode;
 
   if (__DEV__) {
     warning(
@@ -54,16 +54,16 @@ export function popProvider(providerFiber: Fiber): void {
   stack[index] = null;
   index -= 1;
   const context: ReactContext<any> = providerFiber.type.context;
-  context.currentValue = currentValue;
-  context.changedBits = changedBits;
+  context._currentValue = currentValue;
+  context._changedBits = changedBits;
 }
 
 export function resetProviderStack(): void {
   for (let i = index; i > -1; i--) {
     const providerFiber = stack[i];
     const context: ReactContext<any> = providerFiber.type.context;
-    context.currentValue = context.defaultValue;
-    context.changedBits = 0;
+    context._currentValue = context._defaultValue;
+    context._changedBits = 0;
     changedBitsStack[i] = null;
     currentValueStack[i] = null;
     stack[i] = null;

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -33,10 +33,10 @@ export function createContext<T>(
 
   const context: ReactContext<T> = {
     $$typeof: REACT_CONTEXT_TYPE,
-    calculateChangedBits,
-    defaultValue,
-    currentValue: defaultValue,
-    changedBits: 0,
+    _calculateChangedBits: calculateChangedBits,
+    _defaultValue: defaultValue,
+    _currentValue: defaultValue,
+    _changedBits: 0,
     // These are circular
     Provider: (null: any),
     Consumer: (null: any),

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -80,10 +80,12 @@ export type ReactContext<T> = {
   $$typeof: Symbol | number,
   Consumer: ReactContext<T>,
   Provider: ReactProviderType<T>,
-  calculateChangedBits: ((a: T, b: T) => number) | null,
-  defaultValue: T,
-  currentValue: T,
-  changedBits: number,
+
+  _calculateChangedBits: ((a: T, b: T) => number) | null,
+  _defaultValue: T,
+
+  _currentValue: T,
+  _changedBits: number,
 
   // DEV only
   _currentRenderer?: Object | null,


### PR DESCRIPTION
So these aren't mistaken for public properties. Ideally, we'd use symbols or private fields.

Addresses https://github.com/facebook/react/issues/12203