### PR TITLE
Unify context stack implementations

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -11,6 +11,8 @@ import type {HostConfig} from 'react-reconciler';
 import type {ReactProviderType, ReactContext} from 'shared/ReactTypes';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {HostContext} from './ReactFiberHostContext';
+import type {LegacyContext} from './ReactFiberContext';
+import type {NewContext} from './ReactFiberNewContext';
 import type {HydrationContext} from './ReactFiberHydrationContext';
 import type {FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
@@ -56,15 +58,6 @@ import {
   cloneChildFibers,
 } from './ReactChildFiber';
 import {processUpdateQueue} from './ReactFiberUpdateQueue';
-import {
-  getMaskedContext,
-  getUnmaskedContext,
-  hasContextChanged as hasLegacyContextChanged,
-  pushContextProvider as pushLegacyContextProvider,
-  pushTopLevelContextObject,
-  invalidateContextProvider,
-} from './ReactFiberContext';
-import {pushProvider} from './ReactFiberNewContext';
 import {NoWork, Never} from './ReactFiberExpirationTime';
 import {AsyncMode, StrictMode} from './ReactTypeOfMode';
 import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
@@ -82,6 +75,8 @@ if (__DEV__) {
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   config: HostConfig<T, P, I, TI, HI, PI, C, CC, CX, PL>,
   hostContext: HostContext<C, CX>,
+  legacyContext: LegacyContext,
+  newContext: NewContext,
   hydrationContext: HydrationContext<C, CX>,
   scheduleWork: (fiber: Fiber, expirationTime: ExpirationTime) => void,
   computeExpirationForFiber: (fiber: Fiber) => ExpirationTime,
@@ -89,6 +84,17 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   const {shouldSetTextContent, shouldDeprioritizeSubtree} = config;
 
   const {pushHostContext, pushHostContainer} = hostContext;
+
+  const {pushProvider} = newContext;
+
+  const {
+    getMaskedContext,
+    getUnmaskedContext,
+    hasContextChanged: hasLegacyContextChanged,
+    pushContextProvider: pushLegacyContextProvider,
+    pushTopLevelContextObject,
+    invalidateContextProvider,
+  } = legacyContext;
 
   const {
     enterHydrationState,
@@ -104,6 +110,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     resumeMountClassInstance,
     updateClassInstance,
   } = ReactFiberClassComponent(
+    legacyContext,
     scheduleWork,
     computeExpirationForFiber,
     memoizeProps,

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -9,6 +9,7 @@
 
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
+import type {LegacyContext} from './ReactFiberContext';
 import type {CapturedValue} from './ReactCapturedValue';
 
 import {Update} from 'shared/ReactTypeOfSideEffect';
@@ -30,16 +31,9 @@ import warning from 'fbjs/lib/warning';
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
 import {StrictMode} from './ReactTypeOfMode';
 import {
-  cacheContext,
-  getMaskedContext,
-  getUnmaskedContext,
-  isContextConsumer,
-} from './ReactFiberContext';
-import {
   insertUpdateIntoFiber,
   processUpdateQueue,
 } from './ReactFiberUpdateQueue';
-import {hasContextChanged} from './ReactFiberContext';
 
 const fakeInternalInstance = {};
 const isArray = Array.isArray;
@@ -110,11 +104,20 @@ function callGetDerivedStateFromCatch(ctor: any, capturedValues: Array<mixed>) {
 }
 
 export default function(
+  legacyContext: LegacyContext,
   scheduleWork: (fiber: Fiber, expirationTime: ExpirationTime) => void,
   computeExpirationForFiber: (fiber: Fiber) => ExpirationTime,
   memoizeProps: (workInProgress: Fiber, props: any) => void,
   memoizeState: (workInProgress: Fiber, state: any) => void,
 ) {
+  const {
+    cacheContext,
+    getMaskedContext,
+    getUnmaskedContext,
+    isContextConsumer,
+    hasContextChanged,
+  } = legacyContext;
+
   // Class component state updater
   const updater = {
     isMounted,

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -11,6 +11,8 @@ import type {HostConfig} from 'react-reconciler';
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {HostContext} from './ReactFiberHostContext';
+import type {LegacyContext} from './ReactFiberContext';
+import type {NewContext} from './ReactFiberNewContext';
 import type {HydrationContext} from './ReactFiberHydrationContext';
 import type {FiberRoot} from './ReactFiberRoot';
 
@@ -45,15 +47,12 @@ import {
 import invariant from 'fbjs/lib/invariant';
 
 import {reconcileChildFibers} from './ReactChildFiber';
-import {
-  popContextProvider as popLegacyContextProvider,
-  popTopLevelContextObject as popTopLevelLegacyContextObject,
-} from './ReactFiberContext';
-import {popProvider} from './ReactFiberNewContext';
 
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   config: HostConfig<T, P, I, TI, HI, PI, C, CC, CX, PL>,
   hostContext: HostContext<C, CX>,
+  legacyContext: LegacyContext,
+  newContext: NewContext,
   hydrationContext: HydrationContext<C, CX>,
 ) {
   const {
@@ -72,6 +71,13 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     getHostContext,
     popHostContainer,
   } = hostContext;
+
+  const {
+    popContextProvider: popLegacyContextProvider,
+    popTopLevelContextObject: popTopLevelLegacyContextObject,
+  } = legacyContext;
+
+  const {popProvider} = newContext;
 
   const {
     prepareToHydrateHostInstance,

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -8,7 +8,7 @@
  */
 
 import type {Fiber} from './ReactFiber';
-import type {StackCursor} from './ReactFiberStack';
+import type {StackCursor, Stack} from './ReactFiberStack';
 
 import {isFiberMounted} from 'react-reconciler/reflection';
 import {ClassComponent, HostRoot} from 'shared/ReactTypeOfWork';
@@ -18,7 +18,6 @@ import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 import checkPropTypes from 'prop-types/checkPropTypes';
 
-import {createCursor, pop, push} from './ReactFiberStack';
 import ReactDebugCurrentFiber from './ReactDebugCurrentFiber';
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
 
@@ -28,273 +27,316 @@ if (__DEV__) {
   warnedAboutMissingGetChildContext = {};
 }
 
-// A cursor to the current merged context object on the stack.
-let contextStackCursor: StackCursor<Object> = createCursor(emptyObject);
-// A cursor to a boolean indicating whether the context has changed.
-let didPerformWorkStackCursor: StackCursor<boolean> = createCursor(false);
-// Keep track of the previous context object that was on the stack.
-// We use this to get access to the parent context after we have already
-// pushed the next context provider, and now need to merge their contexts.
-let previousContext: Object = emptyObject;
+export type LegacyContext = {
+  getUnmaskedContext(workInProgress: Fiber): Object,
+  cacheContext(
+    workInProgress: Fiber,
+    unmaskedContext: Object,
+    maskedContext: Object,
+  ): void,
+  getMaskedContext(workInProgress: Fiber, unmaskedContext: Object): Object,
+  hasContextChanged(): boolean,
+  isContextConsumer(fiber: Fiber): boolean,
+  isContextProvider(fiber: Fiber): boolean,
+  popContextProvider(fiber: Fiber): void,
+  popTopLevelContextObject(fiber: Fiber): void,
+  pushTopLevelContextObject(
+    fiber: Fiber,
+    context: Object,
+    didChange: boolean,
+  ): void,
+  processChildContext(fiber: Fiber, parentContext: Object): Object,
+  pushContextProvider(workInProgress: Fiber): boolean,
+  invalidateContextProvider(workInProgress: Fiber, didChange: boolean): void,
+  resetContext(): void,
+  findCurrentUnmaskedContext(fiber: Fiber): Object,
+};
 
-export function getUnmaskedContext(workInProgress: Fiber): Object {
-  const hasOwnContext = isContextProvider(workInProgress);
-  if (hasOwnContext) {
-    // If the fiber is a context provider itself, when we read its context
-    // we have already pushed its own child context on the stack. A context
-    // provider should not "see" its own child context. Therefore we read the
-    // previous (parent) context instead for a context provider.
-    return previousContext;
+export default function(stack: Stack): LegacyContext {
+  const {createCursor, push, pop} = stack;
+
+  // A cursor to the current merged context object on the stack.
+  let contextStackCursor: StackCursor<Object> = createCursor(emptyObject);
+  // A cursor to a boolean indicating whether the context has changed.
+  let didPerformWorkStackCursor: StackCursor<boolean> = createCursor(false);
+  // Keep track of the previous context object that was on the stack.
+  // We use this to get access to the parent context after we have already
+  // pushed the next context provider, and now need to merge their contexts.
+  let previousContext: Object = emptyObject;
+
+  function getUnmaskedContext(workInProgress: Fiber): Object {
+    const hasOwnContext = isContextProvider(workInProgress);
+    if (hasOwnContext) {
+      // If the fiber is a context provider itself, when we read its context
+      // we have already pushed its own child context on the stack. A context
+      // provider should not "see" its own child context. Therefore we read the
+      // previous (parent) context instead for a context provider.
+      return previousContext;
+    }
+    return contextStackCursor.current;
   }
-  return contextStackCursor.current;
-}
 
-export function cacheContext(
-  workInProgress: Fiber,
-  unmaskedContext: Object,
-  maskedContext: Object,
-) {
-  const instance = workInProgress.stateNode;
-  instance.__reactInternalMemoizedUnmaskedChildContext = unmaskedContext;
-  instance.__reactInternalMemoizedMaskedChildContext = maskedContext;
-}
-
-export function getMaskedContext(
-  workInProgress: Fiber,
-  unmaskedContext: Object,
-) {
-  const type = workInProgress.type;
-  const contextTypes = type.contextTypes;
-  if (!contextTypes) {
-    return emptyObject;
-  }
-
-  // Avoid recreating masked context unless unmasked context has changed.
-  // Failing to do this will result in unnecessary calls to componentWillReceiveProps.
-  // This may trigger infinite loops if componentWillReceiveProps calls setState.
-  const instance = workInProgress.stateNode;
-  if (
-    instance &&
-    instance.__reactInternalMemoizedUnmaskedChildContext === unmaskedContext
+  function cacheContext(
+    workInProgress: Fiber,
+    unmaskedContext: Object,
+    maskedContext: Object,
   ) {
-    return instance.__reactInternalMemoizedMaskedChildContext;
+    const instance = workInProgress.stateNode;
+    instance.__reactInternalMemoizedUnmaskedChildContext = unmaskedContext;
+    instance.__reactInternalMemoizedMaskedChildContext = maskedContext;
   }
 
-  const context = {};
-  for (let key in contextTypes) {
-    context[key] = unmaskedContext[key];
-  }
+  function getMaskedContext(workInProgress: Fiber, unmaskedContext: Object) {
+    const type = workInProgress.type;
+    const contextTypes = type.contextTypes;
+    if (!contextTypes) {
+      return emptyObject;
+    }
 
-  if (__DEV__) {
-    const name = getComponentName(workInProgress) || 'Unknown';
-    checkPropTypes(
-      contextTypes,
-      context,
-      'context',
-      name,
-      ReactDebugCurrentFiber.getCurrentFiberStackAddendum,
-    );
-  }
+    // Avoid recreating masked context unless unmasked context has changed.
+    // Failing to do this will result in unnecessary calls to componentWillReceiveProps.
+    // This may trigger infinite loops if componentWillReceiveProps calls setState.
+    const instance = workInProgress.stateNode;
+    if (
+      instance &&
+      instance.__reactInternalMemoizedUnmaskedChildContext === unmaskedContext
+    ) {
+      return instance.__reactInternalMemoizedMaskedChildContext;
+    }
 
-  // Cache unmasked context so we can avoid recreating masked context unless necessary.
-  // Context is created before the class component is instantiated so check for instance.
-  if (instance) {
-    cacheContext(workInProgress, unmaskedContext, context);
-  }
+    const context = {};
+    for (let key in contextTypes) {
+      context[key] = unmaskedContext[key];
+    }
 
-  return context;
-}
-
-export function hasContextChanged(): boolean {
-  return didPerformWorkStackCursor.current;
-}
-
-export function isContextConsumer(fiber: Fiber): boolean {
-  return fiber.tag === ClassComponent && fiber.type.contextTypes != null;
-}
-
-export function isContextProvider(fiber: Fiber): boolean {
-  return fiber.tag === ClassComponent && fiber.type.childContextTypes != null;
-}
-
-export function popContextProvider(fiber: Fiber): void {
-  if (!isContextProvider(fiber)) {
-    return;
-  }
-
-  pop(didPerformWorkStackCursor, fiber);
-  pop(contextStackCursor, fiber);
-}
-
-export function popTopLevelContextObject(fiber: Fiber) {
-  pop(didPerformWorkStackCursor, fiber);
-  pop(contextStackCursor, fiber);
-}
-
-export function pushTopLevelContextObject(
-  fiber: Fiber,
-  context: Object,
-  didChange: boolean,
-): void {
-  invariant(
-    contextStackCursor.cursor == null,
-    'Unexpected context found on stack. ' +
-      'This error is likely caused by a bug in React. Please file an issue.',
-  );
-
-  push(contextStackCursor, context, fiber);
-  push(didPerformWorkStackCursor, didChange, fiber);
-}
-
-export function processChildContext(
-  fiber: Fiber,
-  parentContext: Object,
-): Object {
-  const instance = fiber.stateNode;
-  const childContextTypes = fiber.type.childContextTypes;
-
-  // TODO (bvaughn) Replace this behavior with an invariant() in the future.
-  // It has only been added in Fiber to match the (unintentional) behavior in Stack.
-  if (typeof instance.getChildContext !== 'function') {
     if (__DEV__) {
-      const componentName = getComponentName(fiber) || 'Unknown';
-
-      if (!warnedAboutMissingGetChildContext[componentName]) {
-        warnedAboutMissingGetChildContext[componentName] = true;
-        warning(
-          false,
-          '%s.childContextTypes is specified but there is no getChildContext() method ' +
-            'on the instance. You can either define getChildContext() on %s or remove ' +
-            'childContextTypes from it.',
-          componentName,
-          componentName,
-        );
-      }
+      const name = getComponentName(workInProgress) || 'Unknown';
+      checkPropTypes(
+        contextTypes,
+        context,
+        'context',
+        name,
+        ReactDebugCurrentFiber.getCurrentFiberStackAddendum,
+      );
     }
-    return parentContext;
-  }
 
-  let childContext;
-  if (__DEV__) {
-    ReactDebugCurrentFiber.setCurrentPhase('getChildContext');
-  }
-  startPhaseTimer(fiber, 'getChildContext');
-  childContext = instance.getChildContext();
-  stopPhaseTimer();
-  if (__DEV__) {
-    ReactDebugCurrentFiber.setCurrentPhase(null);
-  }
-  for (let contextKey in childContext) {
-    invariant(
-      contextKey in childContextTypes,
-      '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
-      getComponentName(fiber) || 'Unknown',
-      contextKey,
-    );
-  }
-  if (__DEV__) {
-    const name = getComponentName(fiber) || 'Unknown';
-    checkPropTypes(
-      childContextTypes,
-      childContext,
-      'child context',
-      name,
-      // In practice, there is one case in which we won't get a stack. It's when
-      // somebody calls unstable_renderSubtreeIntoContainer() and we process
-      // context from the parent component instance. The stack will be missing
-      // because it's outside of the reconciliation, and so the pointer has not
-      // been set. This is rare and doesn't matter. We'll also remove that API.
-      ReactDebugCurrentFiber.getCurrentFiberStackAddendum,
-    );
-  }
-
-  return {...parentContext, ...childContext};
-}
-
-export function pushContextProvider(workInProgress: Fiber): boolean {
-  if (!isContextProvider(workInProgress)) {
-    return false;
-  }
-
-  const instance = workInProgress.stateNode;
-  // We push the context as early as possible to ensure stack integrity.
-  // If the instance does not exist yet, we will push null at first,
-  // and replace it on the stack later when invalidating the context.
-  const memoizedMergedChildContext =
-    (instance && instance.__reactInternalMemoizedMergedChildContext) ||
-    emptyObject;
-
-  // Remember the parent context so we can merge with it later.
-  // Inherit the parent's did-perform-work value to avoid inadvertently blocking updates.
-  previousContext = contextStackCursor.current;
-  push(contextStackCursor, memoizedMergedChildContext, workInProgress);
-  push(
-    didPerformWorkStackCursor,
-    didPerformWorkStackCursor.current,
-    workInProgress,
-  );
-
-  return true;
-}
-
-export function invalidateContextProvider(
-  workInProgress: Fiber,
-  didChange: boolean,
-): void {
-  const instance = workInProgress.stateNode;
-  invariant(
-    instance,
-    'Expected to have an instance by this point. ' +
-      'This error is likely caused by a bug in React. Please file an issue.',
-  );
-
-  if (didChange) {
-    // Merge parent and own context.
-    // Skip this if we're not updating due to sCU.
-    // This avoids unnecessarily recomputing memoized values.
-    const mergedContext = processChildContext(workInProgress, previousContext);
-    instance.__reactInternalMemoizedMergedChildContext = mergedContext;
-
-    // Replace the old (or empty) context with the new one.
-    // It is important to unwind the context in the reverse order.
-    pop(didPerformWorkStackCursor, workInProgress);
-    pop(contextStackCursor, workInProgress);
-    // Now push the new context and mark that it has changed.
-    push(contextStackCursor, mergedContext, workInProgress);
-    push(didPerformWorkStackCursor, didChange, workInProgress);
-  } else {
-    pop(didPerformWorkStackCursor, workInProgress);
-    push(didPerformWorkStackCursor, didChange, workInProgress);
-  }
-}
-
-export function resetContext(): void {
-  previousContext = emptyObject;
-  contextStackCursor.current = emptyObject;
-  didPerformWorkStackCursor.current = false;
-}
-
-export function findCurrentUnmaskedContext(fiber: Fiber): Object {
-  // Currently this is only used with renderSubtreeIntoContainer; not sure if it
-  // makes sense elsewhere
-  invariant(
-    isFiberMounted(fiber) && fiber.tag === ClassComponent,
-    'Expected subtree parent to be a mounted class component. ' +
-      'This error is likely caused by a bug in React. Please file an issue.',
-  );
-
-  let node: Fiber = fiber;
-  while (node.tag !== HostRoot) {
-    if (isContextProvider(node)) {
-      return node.stateNode.__reactInternalMemoizedMergedChildContext;
+    // Cache unmasked context so we can avoid recreating masked context unless necessary.
+    // Context is created before the class component is instantiated so check for instance.
+    if (instance) {
+      cacheContext(workInProgress, unmaskedContext, context);
     }
-    const parent = node.return;
+
+    return context;
+  }
+
+  function hasContextChanged(): boolean {
+    return didPerformWorkStackCursor.current;
+  }
+
+  function isContextConsumer(fiber: Fiber): boolean {
+    return fiber.tag === ClassComponent && fiber.type.contextTypes != null;
+  }
+
+  function isContextProvider(fiber: Fiber): boolean {
+    return fiber.tag === ClassComponent && fiber.type.childContextTypes != null;
+  }
+
+  function popContextProvider(fiber: Fiber): void {
+    if (!isContextProvider(fiber)) {
+      return;
+    }
+
+    pop(didPerformWorkStackCursor, fiber);
+    pop(contextStackCursor, fiber);
+  }
+
+  function popTopLevelContextObject(fiber: Fiber) {
+    pop(didPerformWorkStackCursor, fiber);
+    pop(contextStackCursor, fiber);
+  }
+
+  function pushTopLevelContextObject(
+    fiber: Fiber,
+    context: Object,
+    didChange: boolean,
+  ): void {
     invariant(
-      parent,
-      'Found unexpected detached subtree parent. ' +
+      contextStackCursor.cursor == null,
+      'Unexpected context found on stack. ' +
         'This error is likely caused by a bug in React. Please file an issue.',
     );
-    node = parent;
+
+    push(contextStackCursor, context, fiber);
+    push(didPerformWorkStackCursor, didChange, fiber);
   }
-  return node.stateNode.context;
+
+  function processChildContext(fiber: Fiber, parentContext: Object): Object {
+    const instance = fiber.stateNode;
+    const childContextTypes = fiber.type.childContextTypes;
+
+    // TODO (bvaughn) Replace this behavior with an invariant() in the future.
+    // It has only been added in Fiber to match the (unintentional) behavior in Stack.
+    if (typeof instance.getChildContext !== 'function') {
+      if (__DEV__) {
+        const componentName = getComponentName(fiber) || 'Unknown';
+
+        if (!warnedAboutMissingGetChildContext[componentName]) {
+          warnedAboutMissingGetChildContext[componentName] = true;
+          warning(
+            false,
+            '%s.childContextTypes is specified but there is no getChildContext() method ' +
+              'on the instance. You can either define getChildContext() on %s or remove ' +
+              'childContextTypes from it.',
+            componentName,
+            componentName,
+          );
+        }
+      }
+      return parentContext;
+    }
+
+    let childContext;
+    if (__DEV__) {
+      ReactDebugCurrentFiber.setCurrentPhase('getChildContext');
+    }
+    startPhaseTimer(fiber, 'getChildContext');
+    childContext = instance.getChildContext();
+    stopPhaseTimer();
+    if (__DEV__) {
+      ReactDebugCurrentFiber.setCurrentPhase(null);
+    }
+    for (let contextKey in childContext) {
+      invariant(
+        contextKey in childContextTypes,
+        '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
+        getComponentName(fiber) || 'Unknown',
+        contextKey,
+      );
+    }
+    if (__DEV__) {
+      const name = getComponentName(fiber) || 'Unknown';
+      checkPropTypes(
+        childContextTypes,
+        childContext,
+        'child context',
+        name,
+        // In practice, there is one case in which we won't get a stack. It's when
+        // somebody calls unstable_renderSubtreeIntoContainer() and we process
+        // context from the parent component instance. The stack will be missing
+        // because it's outside of the reconciliation, and so the pointer has not
+        // been set. This is rare and doesn't matter. We'll also remove that API.
+        ReactDebugCurrentFiber.getCurrentFiberStackAddendum,
+      );
+    }
+
+    return {...parentContext, ...childContext};
+  }
+
+  function pushContextProvider(workInProgress: Fiber): boolean {
+    if (!isContextProvider(workInProgress)) {
+      return false;
+    }
+
+    const instance = workInProgress.stateNode;
+    // We push the context as early as possible to ensure stack integrity.
+    // If the instance does not exist yet, we will push null at first,
+    // and replace it on the stack later when invalidating the context.
+    const memoizedMergedChildContext =
+      (instance && instance.__reactInternalMemoizedMergedChildContext) ||
+      emptyObject;
+
+    // Remember the parent context so we can merge with it later.
+    // Inherit the parent's did-perform-work value to avoid inadvertently blocking updates.
+    previousContext = contextStackCursor.current;
+    push(contextStackCursor, memoizedMergedChildContext, workInProgress);
+    push(
+      didPerformWorkStackCursor,
+      didPerformWorkStackCursor.current,
+      workInProgress,
+    );
+
+    return true;
+  }
+
+  function invalidateContextProvider(
+    workInProgress: Fiber,
+    didChange: boolean,
+  ): void {
+    const instance = workInProgress.stateNode;
+    invariant(
+      instance,
+      'Expected to have an instance by this point. ' +
+        'This error is likely caused by a bug in React. Please file an issue.',
+    );
+
+    if (didChange) {
+      // Merge parent and own context.
+      // Skip this if we're not updating due to sCU.
+      // This avoids unnecessarily recomputing memoized values.
+      const mergedContext = processChildContext(
+        workInProgress,
+        previousContext,
+      );
+      instance.__reactInternalMemoizedMergedChildContext = mergedContext;
+
+      // Replace the old (or empty) context with the new one.
+      // It is important to unwind the context in the reverse order.
+      pop(didPerformWorkStackCursor, workInProgress);
+      pop(contextStackCursor, workInProgress);
+      // Now push the new context and mark that it has changed.
+      push(contextStackCursor, mergedContext, workInProgress);
+      push(didPerformWorkStackCursor, didChange, workInProgress);
+    } else {
+      pop(didPerformWorkStackCursor, workInProgress);
+      push(didPerformWorkStackCursor, didChange, workInProgress);
+    }
+  }
+
+  function resetContext(): void {
+    previousContext = emptyObject;
+    contextStackCursor.current = emptyObject;
+    didPerformWorkStackCursor.current = false;
+  }
+
+  function findCurrentUnmaskedContext(fiber: Fiber): Object {
+    // Currently this is only used with renderSubtreeIntoContainer; not sure if it
+    // makes sense elsewhere
+    invariant(
+      isFiberMounted(fiber) && fiber.tag === ClassComponent,
+      'Expected subtree parent to be a mounted class component. ' +
+        'This error is likely caused by a bug in React. Please file an issue.',
+    );
+
+    let node: Fiber = fiber;
+    while (node.tag !== HostRoot) {
+      if (isContextProvider(node)) {
+        return node.stateNode.__reactInternalMemoizedMergedChildContext;
+      }
+      const parent = node.return;
+      invariant(
+        parent,
+        'Found unexpected detached subtree parent. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
+      node = parent;
+    }
+    return node.stateNode.context;
+  }
+
+  return {
+    getUnmaskedContext,
+    cacheContext,
+    getMaskedContext,
+    hasContextChanged,
+    isContextConsumer,
+    isContextProvider,
+    popContextProvider,
+    popTopLevelContextObject,
+    pushTopLevelContextObject,
+    processChildContext,
+    pushContextProvider,
+    invalidateContextProvider,
+    resetContext,
+    findCurrentUnmaskedContext,
+  };
 }

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -48,7 +48,6 @@ export type LegacyContext = {
   processChildContext(fiber: Fiber, parentContext: Object): Object,
   pushContextProvider(workInProgress: Fiber): boolean,
   invalidateContextProvider(workInProgress: Fiber, didChange: boolean): void,
-  resetContext(): void,
   findCurrentUnmaskedContext(fiber: Fiber): Object,
 };
 
@@ -292,12 +291,6 @@ export default function(stack: Stack): LegacyContext {
     }
   }
 
-  function resetContext(): void {
-    previousContext = emptyObject;
-    contextStackCursor.current = emptyObject;
-    didPerformWorkStackCursor.current = false;
-  }
-
   function findCurrentUnmaskedContext(fiber: Fiber): Object {
     // Currently this is only used with renderSubtreeIntoContainer; not sure if it
     // makes sense elsewhere
@@ -336,7 +329,6 @@ export default function(stack: Stack): LegacyContext {
     processChildContext,
     pushContextProvider,
     invalidateContextProvider,
-    resetContext,
     findCurrentUnmaskedContext,
   };
 }

--- a/packages/react-reconciler/src/ReactFiberHostContext.js
+++ b/packages/react-reconciler/src/ReactFiberHostContext.js
@@ -9,11 +9,9 @@
 
 import type {HostConfig} from 'react-reconciler';
 import type {Fiber} from './ReactFiber';
-import type {StackCursor} from './ReactFiberStack';
+import type {StackCursor, Stack} from './ReactFiberStack';
 
 import invariant from 'fbjs/lib/invariant';
-
-import {createCursor, pop, push} from './ReactFiberStack';
 
 declare class NoContextT {}
 const NO_CONTEXT: NoContextT = ({}: any);
@@ -30,8 +28,10 @@ export type HostContext<C, CX> = {
 
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   config: HostConfig<T, P, I, TI, HI, PI, C, CC, CX, PL>,
+  stack: Stack,
 ): HostContext<C, CX> {
   const {getChildHostContext, getRootHostContext} = config;
+  const {createCursor, push, pop} = stack;
 
   let contextStackCursor: StackCursor<CX | NoContextT> = createCursor(
     NO_CONTEXT,

--- a/packages/react-reconciler/src/ReactFiberHostContext.js
+++ b/packages/react-reconciler/src/ReactFiberHostContext.js
@@ -23,7 +23,6 @@ export type HostContext<C, CX> = {
   popHostContext(fiber: Fiber): void,
   pushHostContainer(fiber: Fiber, container: C): void,
   pushHostContext(fiber: Fiber): void,
-  resetHostContainer(): void,
 };
 
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
@@ -108,11 +107,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     pop(contextFiberStackCursor, fiber);
   }
 
-  function resetHostContainer() {
-    contextStackCursor.current = NO_CONTEXT;
-    rootInstanceStackCursor.current = NO_CONTEXT;
-  }
-
   return {
     getHostContext,
     getRootHostContainer,
@@ -120,6 +114,5 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     popHostContext,
     pushHostContainer,
     pushHostContext,
-    resetHostContainer,
   };
 }

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -12,64 +12,78 @@ import type {ReactContext} from 'shared/ReactTypes';
 
 import warning from 'fbjs/lib/warning';
 
-let changedBitsStack: Array<any> = [];
-let currentValueStack: Array<any> = [];
-let stack: Array<Fiber> = [];
-let index = -1;
+export type NewContext = {
+  pushProvider(providerFiber: Fiber): void,
+  popProvider(providerFiber: Fiber): void,
+  resetProviderStack(): void,
+};
 
-let rendererSigil;
-if (__DEV__) {
-  // Use this to detect multiple renderers using the same context
-  rendererSigil = {};
-}
+export default function() {
+  let changedBitsStack: Array<any> = [];
+  let currentValueStack: Array<any> = [];
+  let stack: Array<Fiber> = [];
+  let index = -1;
 
-export function pushProvider(providerFiber: Fiber): void {
-  const context: ReactContext<any> = providerFiber.type.context;
-  index += 1;
-  changedBitsStack[index] = context._changedBits;
-  currentValueStack[index] = context._currentValue;
-  stack[index] = providerFiber;
-  context._currentValue = providerFiber.pendingProps.value;
-  context._changedBits = providerFiber.stateNode;
-
+  let rendererSigil;
   if (__DEV__) {
-    warning(
-      context._currentRenderer === null ||
-        context._currentRenderer === rendererSigil,
-      'Detected multiple renderers concurrently rendering the ' +
-        'same context provider. This is currently unsupported.',
-    );
-    context._currentRenderer = rendererSigil;
+    // Use this to detect multiple renderers using the same context
+    rendererSigil = {};
   }
-}
 
-export function popProvider(providerFiber: Fiber): void {
-  if (__DEV__) {
-    warning(index > -1 && providerFiber === stack[index], 'Unexpected pop.');
-  }
-  const changedBits = changedBitsStack[index];
-  const currentValue = currentValueStack[index];
-  changedBitsStack[index] = null;
-  currentValueStack[index] = null;
-  stack[index] = null;
-  index -= 1;
-  const context: ReactContext<any> = providerFiber.type.context;
-  context._currentValue = currentValue;
-  context._changedBits = changedBits;
-}
-
-export function resetProviderStack(): void {
-  for (let i = index; i > -1; i--) {
-    const providerFiber = stack[i];
+  function pushProvider(providerFiber: Fiber): void {
     const context: ReactContext<any> = providerFiber.type.context;
-    context._currentValue = context._defaultValue;
-    context._changedBits = 0;
-    changedBitsStack[i] = null;
-    currentValueStack[i] = null;
-    stack[i] = null;
+    index += 1;
+    changedBitsStack[index] = context._changedBits;
+    currentValueStack[index] = context._currentValue;
+    stack[index] = providerFiber;
+    context._currentValue = providerFiber.pendingProps.value;
+    context._changedBits = providerFiber.stateNode;
+
     if (__DEV__) {
-      context._currentRenderer = null;
+      warning(
+        context._currentRenderer === null ||
+          context._currentRenderer === rendererSigil,
+        'Detected multiple renderers concurrently rendering the ' +
+          'same context provider. This is currently unsupported.',
+      );
+      context._currentRenderer = rendererSigil;
     }
   }
-  index = -1;
+
+  function popProvider(providerFiber: Fiber): void {
+    if (__DEV__) {
+      warning(index > -1 && providerFiber === stack[index], 'Unexpected pop.');
+    }
+    const changedBits = changedBitsStack[index];
+    const currentValue = currentValueStack[index];
+    changedBitsStack[index] = null;
+    currentValueStack[index] = null;
+    stack[index] = null;
+    index -= 1;
+    const context: ReactContext<any> = providerFiber.type.context;
+    context._currentValue = currentValue;
+    context._changedBits = changedBits;
+  }
+
+  function resetProviderStack(): void {
+    for (let i = index; i > -1; i--) {
+      const providerFiber = stack[i];
+      const context: ReactContext<any> = providerFiber.type.context;
+      context._currentValue = context._defaultValue;
+      context._changedBits = 0;
+      changedBitsStack[i] = null;
+      currentValueStack[i] = null;
+      stack[i] = null;
+      if (__DEV__) {
+        context._currentRenderer = null;
+      }
+    }
+    index = -1;
+  }
+
+  return {
+    pushProvider,
+    popProvider,
+    resetProviderStack,
+  };
 }

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -22,11 +22,6 @@ import emptyObject from 'fbjs/lib/emptyObject';
 import getComponentName from 'shared/getComponentName';
 import warning from 'fbjs/lib/warning';
 
-import {
-  findCurrentUnmaskedContext,
-  isContextProvider,
-  processChildContext,
-} from './ReactFiberContext';
 import {createFiberRoot} from './ReactFiberRoot';
 import * as ReactFiberDevToolsHook from './ReactFiberDevToolsHook';
 import ReactFiberScheduler from './ReactFiberScheduler';
@@ -274,20 +269,6 @@ export type Reconciler<C, I, TI> = {
   findHostInstanceWithNoPortals(component: Fiber): I | TI | null,
 };
 
-function getContextForSubtree(
-  parentComponent: ?React$Component<any, any>,
-): Object {
-  if (!parentComponent) {
-    return emptyObject;
-  }
-
-  const fiber = ReactInstanceMap.get(parentComponent);
-  const parentContext = findCurrentUnmaskedContext(fiber);
-  return isContextProvider(fiber)
-    ? processChildContext(fiber, parentContext)
-    : parentContext;
-}
-
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   config: HostConfig<T, P, I, TI, HI, PI, C, CC, CX, PL>,
 ): Reconciler<C, I, TI> {
@@ -308,7 +289,28 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     syncUpdates,
     interactiveUpdates,
     flushInteractiveUpdates,
+    legacyContext,
   } = ReactFiberScheduler(config);
+
+  const {
+    findCurrentUnmaskedContext,
+    isContextProvider,
+    processChildContext,
+  } = legacyContext;
+
+  function getContextForSubtree(
+    parentComponent: ?React$Component<any, any>,
+  ): Object {
+    if (!parentComponent) {
+      return emptyObject;
+    }
+
+    const fiber = ReactInstanceMap.get(parentComponent);
+    const parentContext = findCurrentUnmaskedContext(fiber);
+    return isContextProvider(fiber)
+      ? processChildContext(fiber, parentContext)
+      : parentContext;
+  }
 
   function scheduleRootUpdate(
     current: Fiber,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -301,6 +301,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     if (__DEV__) {
       ReactStrictModeWarnings.discardPendingWarnings();
+      stack.checkThatStackIsEmpty();
     }
 
     nextRoot = null;
@@ -894,6 +895,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     // Yield back to main thread.
     if (didFatal) {
       // There was a fatal error.
+      if (__DEV__) {
+        stack.resetStackAfterFatalErrorInDev();
+      }
       return null;
     } else if (nextUnitOfWork === null) {
       // We reached the root.

--- a/packages/react-reconciler/src/ReactFiberStack.js
+++ b/packages/react-reconciler/src/ReactFiberStack.js
@@ -20,7 +20,6 @@ export type Stack = {
   isEmpty(): boolean,
   push<T>(cursor: StackCursor<T>, value: T, fiber: Fiber): void,
   pop<T>(cursor: StackCursor<T>, fiber: Fiber): void,
-  reset(): void,
 };
 
 export default function(): Stack {
@@ -81,23 +80,10 @@ export default function(): Stack {
     cursor.current = value;
   }
 
-  function reset(): void {
-    while (index > -1) {
-      valueStack[index] = null;
-
-      if (__DEV__) {
-        fiberStack[index] = null;
-      }
-
-      index--;
-    }
-  }
-
   return {
     createCursor,
     isEmpty,
     pop,
     push,
-    reset,
   };
 }

--- a/packages/react-reconciler/src/ReactFiberStack.js
+++ b/packages/react-reconciler/src/ReactFiberStack.js
@@ -20,6 +20,10 @@ export type Stack = {
   isEmpty(): boolean,
   push<T>(cursor: StackCursor<T>, value: T, fiber: Fiber): void,
   pop<T>(cursor: StackCursor<T>, fiber: Fiber): void,
+
+  // DEV only
+  checkThatStackIsEmpty(): void,
+  resetStackAfterFatalErrorInDev(): void,
 };
 
 export default function(): Stack {
@@ -80,10 +84,31 @@ export default function(): Stack {
     cursor.current = value;
   }
 
+  function checkThatStackIsEmpty() {
+    if (__DEV__) {
+      if (index !== -1) {
+        warning(
+          false,
+          'Expected an empty stack. Something was not reset properly.',
+        );
+      }
+    }
+  }
+
+  function resetStackAfterFatalErrorInDev() {
+    if (__DEV__) {
+      index = -1;
+      valueStack.length = 0;
+      fiberStack.length = 0;
+    }
+  }
+
   return {
     createCursor,
     isEmpty,
     pop,
     push,
+    checkThatStackIsEmpty,
+    resetStackAfterFatalErrorInDev,
   };
 }

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -4,7 +4,15 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow
  */
+
+import type {Fiber} from './ReactFiber';
+import type {ExpirationTime} from './ReactFiberExpirationTime';
+import type {HostContext} from './ReactFiberHostContext';
+import type {LegacyContext} from './ReactFiberContext';
+import type {NewContext} from './ReactFiberNewContext';
+import type {UpdateQueue} from './ReactFiberUpdateQueue';
 
 import {createCapturedValue} from './ReactCapturedValue';
 import {ensureUpdateQueues} from './ReactFiberUpdateQueue';
@@ -25,14 +33,10 @@ import {
 
 import {enableGetDerivedStateFromCatch} from 'shared/ReactFeatureFlags';
 
-import {
-  popContextProvider as popLegacyContextProvider,
-  popTopLevelContextObject as popTopLevelLegacyContextObject,
-} from './ReactFiberContext';
-import {popProvider} from './ReactFiberNewContext';
-
-export default function(
+export default function<C, CX>(
   hostContext: HostContext<C, CX>,
+  legacyContext: LegacyContext,
+  newContext: NewContext,
   scheduleWork: (
     fiber: Fiber,
     startTime: ExpirationTime,
@@ -41,6 +45,11 @@ export default function(
   isAlreadyFailedLegacyErrorBoundary: (instance: mixed) => boolean,
 ) {
   const {popHostContainer, popHostContext} = hostContext;
+  const {
+    popContextProvider: popLegacyContextProvider,
+    popTopLevelContextObject: popTopLevelLegacyContextObject,
+  } = legacyContext;
+  const {popProvider} = newContext;
 
   function throwException(
     returnFiber: Fiber,
@@ -61,7 +70,9 @@ export default function(
           // Uncaught error
           const errorInfo = value;
           ensureUpdateQueues(workInProgress);
-          const updateQueue: UpdateQueue = (workInProgress.updateQueue: any);
+          const updateQueue: UpdateQueue<
+            any,
+          > = (workInProgress.updateQueue: any);
           updateQueue.capturedValues = [errorInfo];
           workInProgress.effectTag |= ShouldCapture;
           return;
@@ -79,7 +90,9 @@ export default function(
                 !isAlreadyFailedLegacyErrorBoundary(instance)))
           ) {
             ensureUpdateQueues(workInProgress);
-            const updateQueue: UpdateQueue = (workInProgress.updateQueue: any);
+            const updateQueue: UpdateQueue<
+              any,
+            > = (workInProgress.updateQueue: any);
             const capturedValues = updateQueue.capturedValues;
             if (capturedValues === null) {
               updateQueue.capturedValues = [value];
@@ -97,7 +110,7 @@ export default function(
     } while (workInProgress !== null);
   }
 
-  function unwindWork(workInProgress) {
+  function unwindWork(workInProgress: Fiber) {
     switch (workInProgress.tag) {
       case ClassComponent: {
         popLegacyContextProvider(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -145,8 +145,36 @@ export default function<C, CX>(
         return null;
     }
   }
+
+  function unwindInterruptedWork(interruptedWork: Fiber) {
+    switch (interruptedWork.tag) {
+      case ClassComponent: {
+        popLegacyContextProvider(interruptedWork);
+        break;
+      }
+      case HostRoot: {
+        popHostContainer(interruptedWork);
+        popTopLevelLegacyContextObject(interruptedWork);
+        break;
+      }
+      case HostComponent: {
+        popHostContext(interruptedWork);
+        break;
+      }
+      case HostPortal:
+        popHostContainer(interruptedWork);
+        break;
+      case ContextProvider:
+        popProvider(interruptedWork);
+        break;
+      default:
+        break;
+    }
+  }
+
   return {
     throwException,
     unwindWork,
+    unwindInterruptedWork,
   };
 }

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
@@ -542,6 +542,13 @@ ${formatActions(actions)}
         ['c', step(2)],
         ['b', interrupt()],
       );
+
+      simulateMultipleRoots(
+        ['c', toggle(0)],
+        ['c', step(1)],
+        ['b', flush(7)],
+        ['c', toggle(0)],
+      );
     });
 
     it('generative tests', () => {


### PR DESCRIPTION
Implements the new context API on top of the existing ReactStack that we already use for host context and legacy context. Now there is a single array that we push and pop from.

This makes the interrupt path slightly slower, since when we reset the unit of work pointer, we have to iterate over the stack (like before) *and* switch on the type of work (not like before). On the other hand, this unifies all of the unwinding behavior in the UnwindWork module.

Also changes the context modules to use module constructors, so that each renderer gets a separate instance, which is currently broken when using react-reconciler.

This is not a total unification of legacy context and the new context API. A further step would be to implement the legacy, `contextTypes`-based API on top of `React.createContext`.