### PR TITLE
Dynamically initialize RESERVED_PROPS

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -309,6 +309,10 @@ function processContext(type, context) {
 }
 
 const STYLE = 'style';
+
+/**
+ * @nocollapse
+ */
 const RESERVED_PROPS = {
   children: null,
   dangerouslySetInnerHTML: null,

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -12,6 +12,9 @@ import ReactCurrentOwner from './ReactCurrentOwner';
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
+/**
+ * @nocollapse
+ */
 const RESERVED_PROPS = {
   key: true,
   ref: true,


### PR DESCRIPTION
Fixes #12368 

Google Closure Compiler will optimize away the properties from objects if the property is not directly used. In these cases properties are only used dynamically.

I have tested this with Google Closure Compiler and I can confirm this fixes e.g. `renderToString` in Closure optimized app.

If there is some reason to not use `Set` in `ReactElement`, that is not strictly required. Fixing `ReactPartialRenderer` is enough for my use case.