### PR TITLE
Update user timing to record when we are about to commit

### DIFF
--- a/packages/react-reconciler/src/ReactDebugFiberPerf.js
+++ b/packages/react-reconciler/src/ReactDebugFiberPerf.js
@@ -393,7 +393,7 @@ export function stopWorkLoopTimer(
     commitCountInCurrentWorkLoop = 0;
     let label = didCompleteRoot
       ? '(React Tree Reconciliation: Completed Root)'
-      : '(React Tree Reconciliation)';
+      : '(React Tree Reconciliation: Yielded)';
     // Pause any measurements until the next loop.
     pauseTimers();
     endMark(label, '(React Tree Reconciliation)', warning);

--- a/packages/react-reconciler/src/ReactDebugFiberPerf.js
+++ b/packages/react-reconciler/src/ReactDebugFiberPerf.js
@@ -369,7 +369,7 @@ export function startWorkLoopTimer(nextUnitOfWork: Fiber | null): void {
   }
 }
 
-export function stopWorkLoopTimer(interruptedBy: Fiber | null): void {
+export function stopWorkLoopTimer(interruptedBy: Fiber | null, didCompleteRoot?: boolean): void {
   if (enableUserTimingAPI) {
     if (!supportsUserTiming) {
       return;
@@ -388,10 +388,13 @@ export function stopWorkLoopTimer(interruptedBy: Fiber | null): void {
       warning = 'There were cascading updates';
     }
     commitCountInCurrentWorkLoop = 0;
+    let label = didCompleteRoot ?
+      '(React Tree Reconciliation: Completed Root)' :
+      '(React Tree Reconciliation)';
     // Pause any measurements until the next loop.
     pauseTimers();
     endMark(
-      '(React Tree Reconciliation)',
+      label,
       '(React Tree Reconciliation)',
       warning,
     );

--- a/packages/react-reconciler/src/ReactDebugFiberPerf.js
+++ b/packages/react-reconciler/src/ReactDebugFiberPerf.js
@@ -369,7 +369,10 @@ export function startWorkLoopTimer(nextUnitOfWork: Fiber | null): void {
   }
 }
 
-export function stopWorkLoopTimer(interruptedBy: Fiber | null, didCompleteRoot?: boolean): void {
+export function stopWorkLoopTimer(
+  interruptedBy: Fiber | null,
+  didCompleteRoot?: boolean,
+): void {
   if (enableUserTimingAPI) {
     if (!supportsUserTiming) {
       return;
@@ -388,16 +391,12 @@ export function stopWorkLoopTimer(interruptedBy: Fiber | null, didCompleteRoot?:
       warning = 'There were cascading updates';
     }
     commitCountInCurrentWorkLoop = 0;
-    let label = didCompleteRoot ?
-      '(React Tree Reconciliation: Completed Root)' :
-      '(React Tree Reconciliation)';
+    let label = didCompleteRoot
+      ? '(React Tree Reconciliation: Completed Root)'
+      : '(React Tree Reconciliation)';
     // Pause any measurements until the next loop.
     pauseTimers();
-    endMark(
-      label,
-      '(React Tree Reconciliation)',
-      warning,
-    );
+    endMark(label, '(React Tree Reconciliation)', warning);
   }
 }
 

--- a/packages/react-reconciler/src/ReactDebugFiberPerf.js
+++ b/packages/react-reconciler/src/ReactDebugFiberPerf.js
@@ -371,7 +371,7 @@ export function startWorkLoopTimer(nextUnitOfWork: Fiber | null): void {
 
 export function stopWorkLoopTimer(
   interruptedBy: Fiber | null,
-  didCompleteRoot?: boolean,
+  didCompleteRoot: boolean,
 ): void {
   if (enableUserTimingAPI) {
     if (!supportsUserTiming) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -958,13 +958,13 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     } while (true);
 
     // We're done performing work. Time to clean up.
-    let didCompleteRoot = null;
+    let didCompleteRoot = false;
+    isWorking = false;
 
     // Yield back to main thread.
     if (didFatal) {
       stopWorkLoopTimer(interruptedBy, didCompleteRoot);
       interruptedBy = null;
-      isWorking = false;
       // There was a fatal error.
       if (__DEV__) {
         stack.resetStackAfterFatalErrorInDev();
@@ -976,7 +976,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         didCompleteRoot = true;
         stopWorkLoopTimer(interruptedBy, didCompleteRoot);
         interruptedBy = null;
-        isWorking = false;
         // The root successfully completed. It's ready for commit.
         root.pendingCommitExpirationTime = expirationTime;
         const finishedWork = root.current.alternate;
@@ -985,7 +984,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         // The root did not complete.
         stopWorkLoopTimer(interruptedBy, didCompleteRoot);
         interruptedBy = null;
-        isWorking = false;
         invariant(
           false,
           'Expired work should have completed. This error is likely caused ' +
@@ -995,7 +993,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     } else {
       stopWorkLoopTimer(interruptedBy, didCompleteRoot);
       interruptedBy = null;
-      isWorking = false;
       // There's more work to do, but we ran out of time. Yield back to
       // the renderer.
       return null;

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -958,7 +958,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     } while (true);
 
     // We're done performing work. Time to clean up.
-    stopWorkLoopTimer(interruptedBy);
+    const didCompleteRoot = (nextUnitOfWork === null) && isRootReadyForCommit;
+    stopWorkLoopTimer(interruptedBy, didCompleteRoot);
     interruptedBy = null;
     isWorking = false;
 

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -958,13 +958,13 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     } while (true);
 
     // We're done performing work. Time to clean up.
-    const didCompleteRoot = nextUnitOfWork === null && isRootReadyForCommit;
-    stopWorkLoopTimer(interruptedBy, didCompleteRoot);
-    interruptedBy = null;
-    isWorking = false;
+    let didCompleteRoot = null;
 
     // Yield back to main thread.
     if (didFatal) {
+      stopWorkLoopTimer(interruptedBy, didCompleteRoot);
+      interruptedBy = null;
+      isWorking = false;
       // There was a fatal error.
       if (__DEV__) {
         stack.resetStackAfterFatalErrorInDev();
@@ -973,12 +973,19 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     } else if (nextUnitOfWork === null) {
       // We reached the root.
       if (isRootReadyForCommit) {
+        didCompleteRoot = true;
+        stopWorkLoopTimer(interruptedBy, didCompleteRoot);
+        interruptedBy = null;
+        isWorking = false;
         // The root successfully completed. It's ready for commit.
         root.pendingCommitExpirationTime = expirationTime;
         const finishedWork = root.current.alternate;
         return finishedWork;
       } else {
         // The root did not complete.
+        stopWorkLoopTimer(interruptedBy, didCompleteRoot);
+        interruptedBy = null;
+        isWorking = false;
         invariant(
           false,
           'Expired work should have completed. This error is likely caused ' +
@@ -986,6 +993,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         );
       }
     } else {
+      stopWorkLoopTimer(interruptedBy, didCompleteRoot);
+      interruptedBy = null;
+      isWorking = false;
       // There's more work to do, but we ran out of time. Yield back to
       // the renderer.
       return null;

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -958,7 +958,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     } while (true);
 
     // We're done performing work. Time to clean up.
-    const didCompleteRoot = (nextUnitOfWork === null) && isRootReadyForCommit;
+    const didCompleteRoot = nextUnitOfWork === null && isRootReadyForCommit;
     stopWorkLoopTimer(interruptedBy, didCompleteRoot);
     interruptedBy = null;
     isWorking = false;

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -181,7 +181,7 @@ exports[`ReactDebugFiberPerf measures deferred work in chunks 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Start mounting Parent and A
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Yielded)
   ⚛ Parent [mount]
     ⚛ A [mount]
       ⚛ Child [mount]
@@ -189,7 +189,7 @@ exports[`ReactDebugFiberPerf measures deferred work in chunks 1`] = `
 ⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Mount B just a little (but not enough to memoize)
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Yielded)
   ⚛ Parent [mount]
     ⚛ B [mount]
 
@@ -235,7 +235,7 @@ exports[`ReactDebugFiberPerf recovers from caught errors 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Stop on Baddie and restart from Boundary
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Yielded)
   ⚛ Parent [mount]
     ⛔ Boundary [mount] Warning: An error was thrown inside this error boundary
       ⚛ Parent [mount]
@@ -265,7 +265,7 @@ exports[`ReactDebugFiberPerf recovers from fatal errors 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Will fatal
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Yielded)
   ⚛ Parent [mount]
     ⚛ Baddie [mount]
 
@@ -341,7 +341,7 @@ exports[`ReactDebugFiberPerf supports returns 1`] = `
 exports[`ReactDebugFiberPerf warns if an in-progress update is interrupted 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Yielded)
   ⚛ Foo [mount]
 
 ⚛ (Waiting for async callback... will force flush in 5230 ms)

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -4,7 +4,7 @@ exports[`ReactDebugFiberPerf captures all lifecycles 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Mount
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ AllLifecycles [mount]
     ⚛ AllLifecycles.componentWillMount
     ⚛ AllLifecycles.getChildContext
@@ -18,7 +18,7 @@ exports[`ReactDebugFiberPerf captures all lifecycles 1`] = `
 ⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Update
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ AllLifecycles [update]
     ⚛ AllLifecycles.componentWillReceiveProps
     ⚛ AllLifecycles.shouldComponentUpdate
@@ -34,7 +34,7 @@ exports[`ReactDebugFiberPerf captures all lifecycles 1`] = `
 ⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Unmount
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
 
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)
@@ -48,7 +48,7 @@ exports[`ReactDebugFiberPerf deduplicates lifecycle names during commit to reduc
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // The commit phase should mention A and B just once
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [update]
     ⚛ A [update]
     ⚛ B [update]
@@ -66,7 +66,7 @@ exports[`ReactDebugFiberPerf deduplicates lifecycle names during commit to reduc
 
 // Because of deduplication, we don't know B was cascading,
 // but we should still see the warning for the commit phase.
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [update]
     ⚛ A [update]
     ⚛ B [update]
@@ -80,7 +80,7 @@ exports[`ReactDebugFiberPerf deduplicates lifecycle names during commit to reduc
     ⚛ A.componentDidUpdate
     ⚛ B.componentDidUpdate
 
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ B [update]
 
 ⚛ (Committing Changes)
@@ -92,7 +92,7 @@ exports[`ReactDebugFiberPerf deduplicates lifecycle names during commit to reduc
 `;
 
 exports[`ReactDebugFiberPerf does not schedule an extra callback if setState is called during a synchronous commit phase 1`] = `
-"⚛ (React Tree Reconciliation)
+"⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Component [mount]
 
 ⛔ (Committing Changes) Warning: Lifecycle hook scheduled a cascading update
@@ -101,7 +101,7 @@ exports[`ReactDebugFiberPerf does not schedule an extra callback if setState is 
   ⚛ (Calling Lifecycle Methods: 1 Total)
     ⛔ Component.componentDidMount Warning: Scheduled a cascading update
 
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Component [update]
 
 ⚛ (Committing Changes)
@@ -115,7 +115,7 @@ exports[`ReactDebugFiberPerf does not treat setState from cWM or cWRP as cascadi
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Should not print a warning
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
     ⚛ NotCascading [mount]
       ⚛ NotCascading.componentWillMount
@@ -128,7 +128,7 @@ exports[`ReactDebugFiberPerf does not treat setState from cWM or cWRP as cascadi
 ⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Should not print a warning
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [update]
     ⚛ NotCascading [update]
       ⚛ NotCascading.componentWillReceiveProps
@@ -144,7 +144,7 @@ exports[`ReactDebugFiberPerf measures a simple reconciliation 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Mount
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
     ⚛ Child [mount]
 
@@ -156,7 +156,7 @@ exports[`ReactDebugFiberPerf measures a simple reconciliation 1`] = `
 ⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Update
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [update]
     ⚛ Child [update]
 
@@ -168,7 +168,7 @@ exports[`ReactDebugFiberPerf measures a simple reconciliation 1`] = `
 ⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Unmount
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
 
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)
@@ -196,7 +196,7 @@ exports[`ReactDebugFiberPerf measures deferred work in chunks 1`] = `
 ⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Complete B and Parent
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
     ⚛ B [mount]
       ⚛ Child [mount]
@@ -210,7 +210,7 @@ exports[`ReactDebugFiberPerf measures deferred work in chunks 1`] = `
 
 exports[`ReactDebugFiberPerf measures deprioritized work 1`] = `
 "// Flush the parent
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
 
 ⚛ (Committing Changes)
@@ -221,7 +221,7 @@ exports[`ReactDebugFiberPerf measures deprioritized work 1`] = `
 ⚛ (Waiting for async callback... will force flush in 10737418210 ms)
 
 // Flush the child
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Child [mount]
 
 ⚛ (Committing Changes)
@@ -241,7 +241,7 @@ exports[`ReactDebugFiberPerf recovers from caught errors 1`] = `
       ⚛ Parent [mount]
         ⚛ Baddie [mount]
 
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
     ⚛ Boundary [mount]
 
@@ -250,7 +250,7 @@ exports[`ReactDebugFiberPerf recovers from caught errors 1`] = `
   ⚛ (Committing Host Effects: 2 Total)
   ⚛ (Calling Lifecycle Methods: 0 Total)
 
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Boundary [update]
     ⚛ ErrorReport [mount]
 
@@ -269,7 +269,7 @@ exports[`ReactDebugFiberPerf recovers from fatal errors 1`] = `
   ⚛ Parent [mount]
     ⚛ Baddie [mount]
 
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
 
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)
@@ -279,7 +279,7 @@ exports[`ReactDebugFiberPerf recovers from fatal errors 1`] = `
 ⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Will reconcile from a clean state
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
     ⚛ Child [mount]
 
@@ -294,7 +294,7 @@ exports[`ReactDebugFiberPerf skips parents during setState 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Should include just A and B, no Parents
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ A [update]
   ⚛ B [update]
 
@@ -308,7 +308,7 @@ exports[`ReactDebugFiberPerf skips parents during setState 1`] = `
 exports[`ReactDebugFiberPerf supports portals 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
     ⚛ Child [mount]
 
@@ -322,7 +322,7 @@ exports[`ReactDebugFiberPerf supports portals 1`] = `
 exports[`ReactDebugFiberPerf supports returns 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ App [mount]
     ⚛ CoParent [mount]
       ⚛ Indirection [mount]
@@ -345,14 +345,14 @@ exports[`ReactDebugFiberPerf warns if an in-progress update is interrupted 1`] =
   ⚛ Foo [mount]
 
 ⚛ (Waiting for async callback... will force flush in 5230 ms)
-  ⛔ (React Tree Reconciliation) Warning: A top-level update interrupted the previous render
+  ⛔ (React Tree Reconciliation: Completed Root) Warning: A top-level update interrupted the previous render
     ⚛ Foo [mount]
   ⚛ (Committing Changes)
     ⚛ (Committing Snapshot Effects: 0 Total)
     ⚛ (Committing Host Effects: 1 Total)
     ⚛ (Calling Lifecycle Methods: 0 Total)
 
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
 
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)
@@ -364,7 +364,7 @@ exports[`ReactDebugFiberPerf warns if an in-progress update is interrupted 1`] =
 exports[`ReactDebugFiberPerf warns if async work expires (starvation) 1`] = `
 "⛔ (Waiting for async callback... will force flush in 5230 ms) Warning: React was blocked by main thread
 
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Foo [mount]
 
 ⚛ (Committing Changes)
@@ -378,7 +378,7 @@ exports[`ReactDebugFiberPerf warns on cascading renders from setState 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Should print a warning
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
     ⚛ Cascading [mount]
 
@@ -388,7 +388,7 @@ exports[`ReactDebugFiberPerf warns on cascading renders from setState 1`] = `
   ⚛ (Calling Lifecycle Methods: 1 Total)
     ⛔ Cascading.componentDidMount Warning: Scheduled a cascading update
 
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Cascading [update]
 
 ⚛ (Committing Changes)
@@ -402,7 +402,7 @@ exports[`ReactDebugFiberPerf warns on cascading renders from top-level render 1`
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 
 // Rendering the first root
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Cascading [mount]
 
 ⛔ (Committing Changes) Warning: Lifecycle hook scheduled a cascading update
@@ -412,7 +412,7 @@ exports[`ReactDebugFiberPerf warns on cascading renders from top-level render 1`
     ⛔ Cascading.componentDidMount Warning: Scheduled a cascading update
 
 // Scheduling another root from componentDidMount
-⚛ (React Tree Reconciliation)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Child [mount]
 
 ⚛ (Committing Changes)


### PR DESCRIPTION
**what is the change?:**
After repeatedly logging '(React Tree Reconciliation)' we vary the
message slightly for the last reconciliation, which happens right before
we commit.

**why make this change?:**
When debugging performance of async. rendering in the devtools it will be helpful if we can
quickly see where the 'commit' happens in a potentially long list of
sliced '(React Tree Reconciliation)' logs.

**test plan:**
Built and ran one of the fixtures. Also ran the unit test.

![screen shot 2018-03-15 at 1 54 30 pm](https://user-images.githubusercontent.com/1114467/37491374-d739ce68-285a-11e8-9dd9-5b3cc95aad5e.png)
