### PR TITLE
Feature flag: Use custom requestIdleCallback even when native one exists

### DIFF
--- a/packages/shared/ReactDOMFrameScheduling.js
+++ b/packages/shared/ReactDOMFrameScheduling.js
@@ -17,6 +17,7 @@
 
 import type {Deadline} from 'react-reconciler';
 
+import {alwaysUseRequestIdleCallbackPolyfill} from 'shared/ReactFeatureFlags';
 import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 import warning from 'fbjs/lib/warning';
 
@@ -69,6 +70,7 @@ if (!ExecutionEnvironment.canUseDOM) {
     clearTimeout(timeoutID);
   };
 } else if (
+  alwaysUseRequestIdleCallbackPolyfill ||
   typeof requestIdleCallback !== 'function' ||
   typeof cancelIdleCallback !== 'function'
 ) {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -38,6 +38,8 @@ export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 // Warn about deprecated, async-unsafe lifecycles; relates to RFC #6:
 export const warnAboutDeprecatedLifecycles = false;
 
+export const alwaysUseRequestIdleCallbackPolyfill = false;
+
 // Only used in www builds.
 export function addUserTimingListener() {
   invariant(false, 'Not implemented.');

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric.js
@@ -24,6 +24,7 @@ export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const enableMutatingReconciler = false;
 export const enableNoopReconciler = false;
 export const enablePersistentReconciler = true;
+export const alwaysUseRequestIdleCallbackPolyfill = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.native.js
@@ -27,6 +27,7 @@ export const enableUserTimingAPI = __DEV__;
 export const enableMutatingReconciler = true;
 export const enableNoopReconciler = false;
 export const enablePersistentReconciler = false;
+export const alwaysUseRequestIdleCallbackPolyfill = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -25,6 +25,7 @@ export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const enableMutatingReconciler = false;
 export const enableNoopReconciler = false;
 export const enablePersistentReconciler = true;
+export const alwaysUseRequestIdleCallbackPolyfill = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -17,6 +17,7 @@ export const {
   debugRenderPhaseSideEffectsForStrictMode,
   warnAboutDeprecatedLifecycles,
   replayFailedUnitOfWorkWithInvokeGuardedCallback,
+  alwaysUseRequestIdleCallbackPolyfill,
 } = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.


### PR DESCRIPTION
We'll use this in www to test whether the polyfill is better at scheduling high-pri async work than the native one. My preliminary tests suggest "yes" but it's hard to say for certain, given how difficult it is to consistently reproduce the starvation issues we've been seeing.