### PR TITLE
Fix an infinite loop in new context

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -776,6 +776,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     renderExpirationTime: ExpirationTime,
   ): void {
     let fiber = workInProgress.child;
+    if (fiber !== null) {
+      // Set the return pointer of the child to the work-in-progress fiber.
+      fiber.return = workInProgress;
+    }
     while (fiber !== null) {
       let nextFiber;
       // Visit this fiber.


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/12389.

The issue was caused by top-level `.return` pointer not getting updated before descending. Then [this condition](https://github.com/facebook/react/blob/e1ff342bf7f451fb995e0ea2bfb10889deef022f/packages/react-reconciler/src/ReactFiberBeginWork.js#L842) would never be false and we'd loop forever.

It doesn't affect other cases because we update `.return` in the loop. The top-level parent is just outside of the loop.