### PR TITLE
[fabric] register ReactFabric to be callable module

### DIFF
--- a/scripts/rollup/shims/react-native/ReactFabric.js
+++ b/scripts/rollup/shims/react-native/ReactFabric.js
@@ -9,6 +9,8 @@
  */
 'use strict';
 
+const BatchedBridge = require('BatchedBridge');
+
 // TODO @sema: Adjust types
 import type {ReactNativeType} from 'ReactNativeTypes';
 
@@ -20,4 +22,7 @@ if (__DEV__) {
   ReactFabric = require('ReactFabric-prod');
 }
 
+BatchedBridge.registerCallableModule('ReactFabric', ReactFabric);
+
 module.exports = (ReactFabric: ReactNativeType);
+


### PR DESCRIPTION
ReactFabric needs to be callable from native side for now, to handle unmounting.
