### PR TITLE
Fix falling in dev mode

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -1126,7 +1126,7 @@ const ReactDOM: Object = {
   ): null | Element | Text {
     if (__DEV__) {
       let owner = (ReactCurrentOwner.current: any);
-      if (owner !== null) {
+      if (owner !== null && owner.stateNode !== null) {
         const warnedAboutRefsInRender =
           owner.stateNode._warnedAboutRefsInRender;
         warning(


### PR DESCRIPTION
`FiberNode.stateNode` could be `null`

So I get TypeError:

```
  at performWorkOnRoot (/tmp/my-project/node_modules/react-dom/cjs/react-dom.development.js:11014:24) TypeError: Cannot read property '_warnedAboutRefsInRender' of null
          at findDOMNode (/tmp/my-project/node_modules/react-dom/cjs/react-dom.development.js:15264:55)
```
I checked `react-native-render` render in `dev` it has the same check:
https://github.com/facebook/react/blob/master/packages/react-native-renderer/src/findNodeHandle.js#L73
https://github.com/facebook/react/blob/6031bea239d75e60882769f804e041f89cd22014/packages/react-native-renderer/src/findNodeHandle.js#L73
