### PR TITLE
tests: add regression test for reading ReactCurrentOwner stateNode

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -377,23 +377,23 @@ describe('ReactDOM', () => {
     }
   });
 
-  it('should not throw a TypeError when reading stateNode on ReactCurrentOwner', () => {
+  it('should not crash calling findDOMNode inside a functional component', () => {
+    const container = document.createElement('div');
+
     class Component extends React.Component {
       render() {
         return <div />;
       }
     }
 
-    const App = () => ReactDOM.findDOMNode(Component);
-    const container = document.createElement('div');
-    const stateNodeErr = new TypeError(
-      "Cannot read property '_warnedAboutRefsInRender' of null",
-    );
+    const instance = ReactTestUtils.renderIntoDocument(<Component />);
+    const App = () => {
+      ReactDOM.findDOMNode(instance);
+      return <div />;
+    };
 
     if (__DEV__) {
-      expect(() => {
-        ReactDOM.render(<App />, container);
-      }).not.toThrow(stateNodeErr);
+      ReactDOM.render(<App />, container);
     }
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -377,6 +377,26 @@ describe('ReactDOM', () => {
     }
   });
 
+  it('should not throw a TypeError when reading stateNode on ReactCurrentOwner', () => {
+    class Component extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
+
+    const App = () => ReactDOM.findDOMNode(Component);
+    const container = document.createElement('div');
+    const stateNodeErr = new TypeError(
+      "Cannot read property '_warnedAboutRefsInRender' of null",
+    );
+
+    if (__DEV__) {
+      expect(() => {
+        ReactDOM.render(<App />, container);
+      }).not.toThrow(stateNodeErr);
+    }
+  });
+
   it('throws in DEV if jsdom is destroyed by the time setState() is called', () => {
     class App extends React.Component {
       state = {x: 1};


### PR DESCRIPTION
Follow up PR for #12407. Adds a regression test related to issue #12299.

Before the #12407 fix this test case would fail as:

```
Expected the function not to throw an error matching:
  [TypeError: Cannot read property '_warnedAboutRefsInRender' of null]
Instead, it threw:
  TypeError: Cannot read property '_warnedAboutRefsInRender' of null
```
