### PR TITLE
Replaced an Object keys for each loop with a for key in object loop

### DIFF
--- a/packages/react-dom/src/events/__tests__/BeforeInputEventPlugin-test.js
+++ b/packages/react-dom/src/events/__tests__/BeforeInputEventPlugin-test.js
@@ -43,9 +43,7 @@ describe('BeforeInputEventPlugin', () => {
 
   function simulateEvent(elem, type, data) {
     const event = new Event(type, {bubbles: true});
-    for (let key in data) {
-      event[key] = data[key];
-    }
+    Object.assign(event, data);
     elem.dispatchEvent(event);
   }
 

--- a/packages/react-dom/src/events/__tests__/BeforeInputEventPlugin-test.js
+++ b/packages/react-dom/src/events/__tests__/BeforeInputEventPlugin-test.js
@@ -43,9 +43,9 @@ describe('BeforeInputEventPlugin', () => {
 
   function simulateEvent(elem, type, data) {
     const event = new Event(type, {bubbles: true});
-    Object.keys(data).forEach(key => {
+    for (let key in data) {
       event[key] = data[key];
-    });
+    }
     elem.dispatchEvent(event);
   }
 


### PR DESCRIPTION
Replaced an Object keys for each loop with a for key in object loop which improves unit performance by +-300%.

`forEach(...)` is a good solution in general, but when it comes to using `Object.keys`. It's significantly quicker to to use `for (let key in obj)`. Functionality remains the same, code is also more legible and the loop performs faster this way so there are multiple benefits to doing it this way.
