### PR TITLE
Fix now-missing errorInfo argument to componentDidCatch()

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -95,10 +95,7 @@ function callGetDerivedStateFromCatch(ctor: any, capturedValues: Array<mixed>) {
   for (let i = 0; i < capturedValues.length; i++) {
     const capturedValue: CapturedValue<mixed> = (capturedValues[i]: any);
     const error = capturedValue.value;
-    const stack = capturedValue.stack;
-    const partialState = ctor.getDerivedStateFromCatch.call(null, error, {
-      componentStack: stack !== null ? stack : '',
-    });
+    const partialState = ctor.getDerivedStateFromCatch.call(null, error);
     if (partialState !== null && partialState !== undefined) {
       Object.assign(resultState, partialState);
     }

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -95,7 +95,10 @@ function callGetDerivedStateFromCatch(ctor: any, capturedValues: Array<mixed>) {
   for (let i = 0; i < capturedValues.length; i++) {
     const capturedValue: CapturedValue<mixed> = (capturedValues[i]: any);
     const error = capturedValue.value;
-    const partialState = ctor.getDerivedStateFromCatch.call(null, error);
+    const stack = capturedValue.stack;
+    const partialState = ctor.getDerivedStateFromCatch.call(null, error, {
+      componentStack: stack !== null ? stack : '',
+    });
     if (partialState !== null && partialState !== undefined) {
       Object.assign(resultState, partialState);
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -270,8 +270,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           for (let i = 0; i < capturedErrors.length; i++) {
             const errorInfo = capturedErrors[i];
             const error = errorInfo.value;
+            const stack = errorInfo.stack;
             logError(finishedWork, errorInfo);
-            instance.componentDidCatch(error);
+            instance.componentDidCatch(error, {
+              componentStack: stack !== null ? stack : '',
+            });
           }
         }
         break;

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1307,11 +1307,50 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('Caught an error: oops!')]);
   });
 
-  it('provides component stack to the error boundary', () => {
+  it('provides component stack to the error boundary (componentDidCatch)', () => {
     class ErrorBoundary extends React.Component {
       state = {error: null};
       componentDidCatch(error, errorInfo) {
         this.setState({error, errorInfo});
+      }
+      render() {
+        if (this.state.errorInfo) {
+          return (
+            <span
+              prop={`Caught an error:${normalizeCodeLocInfo(
+                this.state.errorInfo.componentStack,
+              )}.`}
+            />
+          );
+        }
+        return this.props.children;
+      }
+    }
+
+    function BrokenRender(props) {
+      throw new Error('Hello');
+    }
+
+    ReactNoop.render(
+      <ErrorBoundary>
+        <BrokenRender />
+      </ErrorBoundary>,
+    );
+    ReactNoop.flushDeferredPri();
+    expect(ReactNoop.getChildren()).toEqual([
+      span(
+        'Caught an error:\n' +
+          '    in BrokenRender (at **)\n' +
+          '    in ErrorBoundary (at **).',
+      ),
+    ]);
+  });
+
+  it('provides component stack to the error boundary (getDerivedStateFromCatch)', () => {
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+      static getDerivedStateFromCatch(error, errorInfo) {
+        return {error, errorInfo};
       }
       render() {
         if (this.state.errorInfo) {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1340,8 +1340,8 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren()).toEqual([
       span(
         'Caught an error:\n' +
-          '    in BrokenRender (at **)\n' +
-          '    in ErrorBoundary (at **).',
+          (__DEV__ ? '    in BrokenRender (at **)\n' : '    in BrokenRender\n') +
+          (__DEV__ ? '    in ErrorBoundary (at **).' : '    in ErrorBoundary.'),
       ),
     ]);
   });
@@ -1379,8 +1379,8 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren()).toEqual([
       span(
         'Caught an error:\n' +
-          '    in BrokenRender (at **)\n' +
-          '    in ErrorBoundary (at **).',
+          (__DEV__ ? '    in BrokenRender (at **)\n' : '    in BrokenRender\n') +
+          (__DEV__ ? '    in ErrorBoundary (at **).' : '    in ErrorBoundary.'),
       ),
     ]);
   });


### PR DESCRIPTION
It was removed, probably accidentally, in #12201.
I'm adding it back and also adding it for `getDerivedStateFromCatch`.