### PR TITLE
Expanded DEV-only warnings for gDSFP and legacy lifecycles

### DIFF
--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -720,7 +720,9 @@ describe('ReactComponentLifeCycle', () => {
         'AllLegacyLifecycles uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
         '  componentWillMount\n' +
         '  componentWillReceiveProps\n' +
-        '  componentWillUpdate',
+        '  componentWillUpdate\n\n' +
+        'The above lifecycles should be removed. Learn more about this warning here:\n' +
+        'https://fb.me/react-async-component-lifecycle-hooks',
     );
 
     class WillMount extends React.Component {
@@ -737,7 +739,9 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => ReactDOM.render(<WillMount />, container)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'WillMount uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
-        '  componentWillMount',
+        '  componentWillMount\n\n' +
+        'The above lifecycles should be removed. Learn more about this warning here:\n' +
+        'https://fb.me/react-async-component-lifecycle-hooks',
     );
 
     class WillMountAndUpdate extends React.Component {
@@ -756,7 +760,9 @@ describe('ReactComponentLifeCycle', () => {
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'WillMountAndUpdate uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
         '  componentWillMount\n' +
-        '  componentWillUpdate',
+        '  componentWillUpdate\n\n' +
+        'The above lifecycles should be removed. Learn more about this warning here:\n' +
+        'https://fb.me/react-async-component-lifecycle-hooks',
     );
 
     class WillReceiveProps extends React.Component {
@@ -773,7 +779,9 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => ReactDOM.render(<WillReceiveProps />, container)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'WillReceiveProps uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
-        '  componentWillReceiveProps',
+        '  componentWillReceiveProps\n\n' +
+        'The above lifecycles should be removed. Learn more about this warning here:\n' +
+        'https://fb.me/react-async-component-lifecycle-hooks',
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -708,7 +708,7 @@ describe('ReactComponentLifeCycle', () => {
         return null;
       }
       componentWillMount() {}
-      componentWillReceiveProps() {}
+      UNSAFE_componentWillReceiveProps() {}
       componentWillUpdate() {}
       render() {
         return null;
@@ -719,7 +719,7 @@ describe('ReactComponentLifeCycle', () => {
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'AllLegacyLifecycles uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
         '  componentWillMount\n' +
-        '  componentWillReceiveProps\n' +
+        '  UNSAFE_componentWillReceiveProps\n' +
         '  componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
@@ -730,7 +730,7 @@ describe('ReactComponentLifeCycle', () => {
       static getDerivedStateFromProps() {
         return null;
       }
-      componentWillMount() {}
+      UNSAFE_componentWillMount() {}
       render() {
         return null;
       }
@@ -739,7 +739,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => ReactDOM.render(<WillMount />, container)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'WillMount uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
-        '  componentWillMount\n\n' +
+        '  UNSAFE_componentWillMount\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
     );
@@ -750,7 +750,7 @@ describe('ReactComponentLifeCycle', () => {
         return null;
       }
       componentWillMount() {}
-      componentWillUpdate() {}
+      UNSAFE_componentWillUpdate() {}
       render() {
         return null;
       }
@@ -760,7 +760,7 @@ describe('ReactComponentLifeCycle', () => {
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'WillMountAndUpdate uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
         '  componentWillMount\n' +
-        '  componentWillUpdate\n\n' +
+        '  UNSAFE_componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
     );

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -669,7 +669,7 @@ describe('ReactComponentLifeCycle', () => {
 
     const container = document.createElement('div');
     expect(() => ReactDOM.render(<Component />, container)).toWarnDev(
-      'Defines both componentWillReceiveProps',
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.',
     );
   });
 
@@ -695,7 +695,85 @@ describe('ReactComponentLifeCycle', () => {
 
     const container = document.createElement('div');
     expect(() => ReactDOM.render(<Component />, container)).toWarnDev(
-      'Defines both componentWillReceiveProps',
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.',
+    );
+  });
+
+  it('should warn about deprecated lifecycles (cWM/cWRP/cWU) if new static gDSFP is present', () => {
+    const container = document.createElement('div');
+
+    class AllLegacyLifecycles extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      componentWillMount() {}
+      componentWillReceiveProps() {}
+      componentWillUpdate() {}
+      render() {
+        return null;
+      }
+    }
+
+    expect(() => ReactDOM.render(<AllLegacyLifecycles />, container)).toWarnDev(
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
+        'AllLegacyLifecycles uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+        '  componentWillMount\n' +
+        '  componentWillReceiveProps\n' +
+        '  componentWillUpdate',
+    );
+
+    class WillMount extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      componentWillMount() {}
+      render() {
+        return null;
+      }
+    }
+
+    expect(() => ReactDOM.render(<WillMount />, container)).toWarnDev(
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
+        'WillMount uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+        '  componentWillMount',
+    );
+
+    class WillMountAndUpdate extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      componentWillMount() {}
+      componentWillUpdate() {}
+      render() {
+        return null;
+      }
+    }
+
+    expect(() => ReactDOM.render(<WillMountAndUpdate />, container)).toWarnDev(
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
+        'WillMountAndUpdate uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+        '  componentWillMount\n' +
+        '  componentWillUpdate',
+    );
+
+    class WillReceiveProps extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      componentWillReceiveProps() {}
+      render() {
+        return null;
+      }
+    }
+
+    expect(() => ReactDOM.render(<WillReceiveProps />, container)).toWarnDev(
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
+        'WillReceiveProps uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+        '  componentWillReceiveProps',
     );
   });
 

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -437,37 +437,37 @@ export default function(
         // If getDerivedStateFromProps() is defined, "unsafe" lifecycles won't be called.
         // Warn about these lifecycles if they are present.
         // Don't warn about react-lifecycles-compat polyfilled methods though.
-        let willMount = null;
-        let willReceiveProps = null;
-        let willUpdate = null;
+        let foundWillMountName = null;
+        let foundWillReceivePropsName = null;
+        let foundWillUpdateName = null;
         if (
           typeof instance.componentWillMount === 'function' &&
           instance.componentWillMount.__suppressDeprecationWarning !== true
         ) {
-          willMount = 'componentWillMount';
+          foundWillMountName = 'componentWillMount';
         } else if (typeof instance.UNSAFE_componentWillMount === 'function') {
-          willMount = 'UNSAFE_componentWillMount';
+          foundWillMountName = 'UNSAFE_componentWillMount';
         }
         if (
           typeof instance.componentWillReceiveProps === 'function' &&
           instance.componentWillReceiveProps.__suppressDeprecationWarning !==
             true
         ) {
-          willReceiveProps = 'componentWillReceiveProps';
+          foundWillReceivePropsName = 'componentWillReceiveProps';
         } else if (
           typeof instance.UNSAFE_componentWillReceiveProps === 'function'
         ) {
-          willReceiveProps = 'UNSAFE_componentWillReceiveProps';
+          foundWillReceivePropsName = 'UNSAFE_componentWillReceiveProps';
         }
         if (typeof instance.componentWillUpdate === 'function') {
-          willUpdate = 'componentWillUpdate';
+          foundWillUpdateName = 'componentWillUpdate';
         } else if (typeof instance.UNSAFE_componentWillUpdate === 'function') {
-          willUpdate = 'UNSAFE_componentWillUpdate';
+          foundWillUpdateName = 'UNSAFE_componentWillUpdate';
         }
         if (
-          willMount !== null ||
-          willReceiveProps !== null ||
-          willUpdate !== null
+          foundWillMountName !== null ||
+          foundWillReceivePropsName !== null ||
+          foundWillUpdateName !== null
         ) {
           const componentName = getComponentName(workInProgress) || 'Component';
           if (!didWarnAboutLegacyLifecyclesAndDerivedState[componentName]) {
@@ -480,9 +480,11 @@ export default function(
                 'The above lifecycles should be removed. Learn more about this warning here:\n' +
                 'https://fb.me/react-async-component-lifecycle-hooks',
               componentName,
-              willMount !== null ? `\n  ${willMount}` : '',
-              willReceiveProps !== null ? `\n  ${willReceiveProps}` : '',
-              willUpdate !== null ? `\n  ${willUpdate}` : '',
+              foundWillMountName !== null ? `\n  ${foundWillMountName}` : '',
+              foundWillReceivePropsName !== null
+                ? `\n  ${foundWillReceivePropsName}`
+                : '',
+              foundWillUpdateName !== null ? `\n  ${foundWillUpdateName}` : '',
             );
             didWarnAboutLegacyLifecyclesAndDerivedState[componentName] = true;
           }

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -457,7 +457,7 @@ export default function(
           typeof instance.UNSAFE_componentWillUpdate === 'function';
 
         if (definesWillMount || definesWillReceiveProps || definesWillUpdate) {
-          const componentName = getComponentName(workInProgress) || 'Unknown';
+          const componentName = getComponentName(workInProgress) || 'Component';
           if (!didWarnAboutLegacyLifecyclesAndDerivedState[componentName]) {
             warning(
               false,

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -464,7 +464,9 @@ export default function(
               'Unsafe legacy lifecycles will not be called for components using ' +
                 'the new getDerivedStateFromProps() API.\n\n' +
                 '%s uses getDerivedStateFromProps() but also contains the following legacy lifecycles:' +
-                '%s%s%s',
+                '%s%s%s\n\n' +
+                'The above lifecycles should be removed. Learn more about this warning here:\n' +
+                'https://fb.me/react-async-component-lifecycle-hooks',
               componentName,
               definesWillMount ? '\n  componentWillMount' : '',
               definesWillReceiveProps ? '\n  componentWillReceiveProps' : '',

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -437,21 +437,38 @@ export default function(
         // If getDerivedStateFromProps() is defined, "unsafe" lifecycles won't be called.
         // Warn about these lifecycles if they are present.
         // Don't warn about react-lifecycles-compat polyfilled methods though.
-        const definesWillMount =
-          (typeof instance.componentWillMount === 'function' &&
-            instance.componentWillMount.__suppressDeprecationWarning !==
-              true) ||
-          typeof instance.UNSAFE_componentWillMount === 'function';
-        const definesWillReceiveProps =
-          (typeof instance.componentWillReceiveProps === 'function' &&
-            instance.componentWillReceiveProps.__suppressDeprecationWarning !==
-              true) ||
-          typeof instance.UNSAFE_componentWillReceiveProps === 'function';
-        const definesWillUpdate =
-          typeof instance.componentWillUpdate === 'function' ||
-          typeof instance.UNSAFE_componentWillUpdate === 'function';
-
-        if (definesWillMount || definesWillReceiveProps || definesWillUpdate) {
+        let willMount = null;
+        let willReceiveProps = null;
+        let willUpdate = null;
+        if (
+          typeof instance.componentWillMount === 'function' &&
+          instance.componentWillMount.__suppressDeprecationWarning !== true
+        ) {
+          willMount = 'componentWillMount';
+        } else if (typeof instance.UNSAFE_componentWillMount === 'function') {
+          willMount = 'UNSAFE_componentWillMount';
+        }
+        if (
+          typeof instance.componentWillReceiveProps === 'function' &&
+          instance.componentWillReceiveProps.__suppressDeprecationWarning !==
+            true
+        ) {
+          willReceiveProps = 'componentWillReceiveProps';
+        } else if (
+          typeof instance.UNSAFE_componentWillReceiveProps === 'function'
+        ) {
+          willReceiveProps = 'UNSAFE_componentWillReceiveProps';
+        }
+        if (typeof instance.componentWillUpdate === 'function') {
+          willUpdate = 'componentWillUpdate';
+        } else if (typeof instance.UNSAFE_componentWillUpdate === 'function') {
+          willUpdate = 'UNSAFE_componentWillUpdate';
+        }
+        if (
+          willMount !== null ||
+          willReceiveProps !== null ||
+          willUpdate !== null
+        ) {
           const componentName = getComponentName(workInProgress) || 'Component';
           if (!didWarnAboutLegacyLifecyclesAndDerivedState[componentName]) {
             warning(
@@ -463,9 +480,9 @@ export default function(
                 'The above lifecycles should be removed. Learn more about this warning here:\n' +
                 'https://fb.me/react-async-component-lifecycle-hooks',
               componentName,
-              definesWillMount ? '\n  componentWillMount' : '',
-              definesWillReceiveProps ? '\n  componentWillReceiveProps' : '',
-              definesWillUpdate ? '\n  componentWillUpdate' : '',
+              willMount !== null ? `\n  ${willMount}` : '',
+              willReceiveProps !== null ? `\n  ${willReceiveProps}` : '',
+              willUpdate !== null ? `\n  ${willUpdate}` : '',
             );
             didWarnAboutLegacyLifecyclesAndDerivedState[componentName] = true;
           }

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -372,7 +372,7 @@ class ReactShallowRenderer {
           typeof instance.UNSAFE_componentWillUpdate === 'function';
 
         if (definesWillMount || definesWillReceiveProps || definesWillUpdate) {
-          const componentName = getName(type, instance);
+          const componentName = getName(type, instance) || 'Component';
           if (!didWarnAboutLegacyLifecyclesAndDerivedState[componentName]) {
             warning(
               false,

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -357,37 +357,37 @@ class ReactShallowRenderer {
         // If getDerivedStateFromProps() is defined, "unsafe" lifecycles won't be called.
         // Warn about these lifecycles if they are present.
         // Don't warn about react-lifecycles-compat polyfilled methods though.
-        let willMount = null;
-        let willReceiveProps = null;
-        let willUpdate = null;
+        let foundWillMountName = null;
+        let foundWillReceivePropsName = null;
+        let foundWillUpdateName = null;
         if (
           typeof instance.componentWillMount === 'function' &&
           instance.componentWillMount.__suppressDeprecationWarning !== true
         ) {
-          willMount = 'componentWillMount';
+          foundWillMountName = 'componentWillMount';
         } else if (typeof instance.UNSAFE_componentWillMount === 'function') {
-          willMount = 'UNSAFE_componentWillMount';
+          foundWillMountName = 'UNSAFE_componentWillMount';
         }
         if (
           typeof instance.componentWillReceiveProps === 'function' &&
           instance.componentWillReceiveProps.__suppressDeprecationWarning !==
             true
         ) {
-          willReceiveProps = 'componentWillReceiveProps';
+          foundWillReceivePropsName = 'componentWillReceiveProps';
         } else if (
           typeof instance.UNSAFE_componentWillReceiveProps === 'function'
         ) {
-          willReceiveProps = 'UNSAFE_componentWillReceiveProps';
+          foundWillReceivePropsName = 'UNSAFE_componentWillReceiveProps';
         }
         if (typeof instance.componentWillUpdate === 'function') {
-          willUpdate = 'componentWillUpdate';
+          foundWillUpdateName = 'componentWillUpdate';
         } else if (typeof instance.UNSAFE_componentWillUpdate === 'function') {
-          willUpdate = 'UNSAFE_componentWillUpdate';
+          foundWillUpdateName = 'UNSAFE_componentWillUpdate';
         }
         if (
-          willMount !== null ||
-          willReceiveProps !== null ||
-          willUpdate !== null
+          foundWillMountName !== null ||
+          foundWillReceivePropsName !== null ||
+          foundWillUpdateName !== null
         ) {
           const componentName = getName(type, instance) || 'Component';
           if (!didWarnAboutLegacyLifecyclesAndDerivedState[componentName]) {
@@ -400,9 +400,11 @@ class ReactShallowRenderer {
                 'The above lifecycles should be removed. Learn more about this warning here:\n' +
                 'https://fb.me/react-async-component-lifecycle-hooks',
               componentName,
-              willMount !== null ? `\n  ${willMount}` : '',
-              willReceiveProps !== null ? `\n  ${willReceiveProps}` : '',
-              willUpdate !== null ? `\n  ${willUpdate}` : '',
+              foundWillMountName !== null ? `\n  ${foundWillMountName}` : '',
+              foundWillReceivePropsName !== null
+                ? `\n  ${foundWillReceivePropsName}`
+                : '',
+              foundWillUpdateName !== null ? `\n  ${foundWillUpdateName}` : '',
             );
             didWarnAboutLegacyLifecyclesAndDerivedState[componentName] = true;
           }

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -379,7 +379,9 @@ class ReactShallowRenderer {
               'Unsafe legacy lifecycles will not be called for components using ' +
                 'the new getDerivedStateFromProps() API.\n\n' +
                 '%s uses getDerivedStateFromProps() but also contains the following legacy lifecycles:' +
-                '%s%s%s',
+                '%s%s%s\n\n' +
+                'The above lifecycles should be removed. Learn more about this warning here:\n' +
+                'https://fb.me/react-async-component-lifecycle-hooks',
               componentName,
               definesWillMount ? '\n  componentWillMount' : '',
               definesWillReceiveProps ? '\n  componentWillReceiveProps' : '',

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -357,21 +357,38 @@ class ReactShallowRenderer {
         // If getDerivedStateFromProps() is defined, "unsafe" lifecycles won't be called.
         // Warn about these lifecycles if they are present.
         // Don't warn about react-lifecycles-compat polyfilled methods though.
-        const definesWillMount =
-          (typeof instance.componentWillMount === 'function' &&
-            instance.componentWillMount.__suppressDeprecationWarning !==
-              true) ||
-          typeof instance.UNSAFE_componentWillMount === 'function';
-        const definesWillReceiveProps =
-          (typeof instance.componentWillReceiveProps === 'function' &&
-            instance.componentWillReceiveProps.__suppressDeprecationWarning !==
-              true) ||
-          typeof instance.UNSAFE_componentWillReceiveProps === 'function';
-        const definesWillUpdate =
-          typeof instance.componentWillUpdate === 'function' ||
-          typeof instance.UNSAFE_componentWillUpdate === 'function';
-
-        if (definesWillMount || definesWillReceiveProps || definesWillUpdate) {
+        let willMount = null;
+        let willReceiveProps = null;
+        let willUpdate = null;
+        if (
+          typeof instance.componentWillMount === 'function' &&
+          instance.componentWillMount.__suppressDeprecationWarning !== true
+        ) {
+          willMount = 'componentWillMount';
+        } else if (typeof instance.UNSAFE_componentWillMount === 'function') {
+          willMount = 'UNSAFE_componentWillMount';
+        }
+        if (
+          typeof instance.componentWillReceiveProps === 'function' &&
+          instance.componentWillReceiveProps.__suppressDeprecationWarning !==
+            true
+        ) {
+          willReceiveProps = 'componentWillReceiveProps';
+        } else if (
+          typeof instance.UNSAFE_componentWillReceiveProps === 'function'
+        ) {
+          willReceiveProps = 'UNSAFE_componentWillReceiveProps';
+        }
+        if (typeof instance.componentWillUpdate === 'function') {
+          willUpdate = 'componentWillUpdate';
+        } else if (typeof instance.UNSAFE_componentWillUpdate === 'function') {
+          willUpdate = 'UNSAFE_componentWillUpdate';
+        }
+        if (
+          willMount !== null ||
+          willReceiveProps !== null ||
+          willUpdate !== null
+        ) {
           const componentName = getName(type, instance) || 'Component';
           if (!didWarnAboutLegacyLifecyclesAndDerivedState[componentName]) {
             warning(
@@ -383,9 +400,9 @@ class ReactShallowRenderer {
                 'The above lifecycles should be removed. Learn more about this warning here:\n' +
                 'https://fb.me/react-async-component-lifecycle-hooks',
               componentName,
-              definesWillMount ? '\n  componentWillMount' : '',
-              definesWillReceiveProps ? '\n  componentWillReceiveProps' : '',
-              definesWillUpdate ? '\n  componentWillUpdate' : '',
+              willMount !== null ? `\n  ${willMount}` : '',
+              willReceiveProps !== null ? `\n  ${willReceiveProps}` : '',
+              willUpdate !== null ? `\n  ${willUpdate}` : '',
             );
             didWarnAboutLegacyLifecyclesAndDerivedState[componentName] = true;
           }

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -125,8 +125,90 @@ describe('ReactShallowRenderer', () => {
     }
 
     const shallowRenderer = createRenderer();
-    expect(() => shallowRenderer.render(<Component foo={2} />)).toWarnDev(
-      'Defines both componentWillReceiveProps() and static getDerivedStateFromProps()',
+    expect(() => shallowRenderer.render(<Component />)).toWarnDev(
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.',
+    );
+  });
+
+  it('should warn about deprecated lifecycles (cWM/cWRP/cWU) if new static gDSFP is present', () => {
+    let shallowRenderer;
+
+    class AllLegacyLifecycles extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      componentWillMount() {}
+      componentWillReceiveProps() {}
+      componentWillUpdate() {}
+      render() {
+        return null;
+      }
+    }
+
+    shallowRenderer = createRenderer();
+    expect(() => shallowRenderer.render(<AllLegacyLifecycles />)).toWarnDev(
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
+        'AllLegacyLifecycles uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+        '  componentWillMount\n' +
+        '  componentWillReceiveProps\n' +
+        '  componentWillUpdate',
+    );
+
+    class WillMount extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      componentWillMount() {}
+      render() {
+        return null;
+      }
+    }
+
+    shallowRenderer = createRenderer();
+    expect(() => shallowRenderer.render(<WillMount />)).toWarnDev(
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
+        'WillMount uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+        '  componentWillMount',
+    );
+
+    class WillMountAndUpdate extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      componentWillMount() {}
+      componentWillUpdate() {}
+      render() {
+        return null;
+      }
+    }
+
+    shallowRenderer = createRenderer();
+    expect(() => shallowRenderer.render(<WillMountAndUpdate />)).toWarnDev(
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
+        'WillMountAndUpdate uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+        '  componentWillMount\n' +
+        '  componentWillUpdate',
+    );
+
+    class WillReceiveProps extends React.Component {
+      state = {};
+      static getDerivedStateFromProps() {
+        return null;
+      }
+      componentWillReceiveProps() {}
+      render() {
+        return null;
+      }
+    }
+
+    shallowRenderer = createRenderer();
+    expect(() => shallowRenderer.render(<WillReceiveProps />)).toWarnDev(
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
+        'WillReceiveProps uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+        '  componentWillReceiveProps',
     );
   });
 
@@ -1238,9 +1320,7 @@ describe('ReactShallowRenderer', () => {
 
     const shallowRenderer = createRenderer();
     expect(() => shallowRenderer.render(<ComponentWithWarnings />)).toWarnDev(
-      'ComponentWithWarnings: Defines both componentWillReceiveProps() and static ' +
-        'getDerivedStateFromProps() methods. We recommend using ' +
-        'only getDerivedStateFromProps().',
+      'ComponentWithWarnings uses getDerivedStateFromProps() but also contains the following legacy lifecycles',
     );
 
     // Should not log duplicate warning

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -152,7 +152,9 @@ describe('ReactShallowRenderer', () => {
         'AllLegacyLifecycles uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
         '  componentWillMount\n' +
         '  componentWillReceiveProps\n' +
-        '  componentWillUpdate',
+        '  componentWillUpdate\n\n' +
+        'The above lifecycles should be removed. Learn more about this warning here:\n' +
+        'https://fb.me/react-async-component-lifecycle-hooks',
     );
 
     class WillMount extends React.Component {
@@ -170,7 +172,9 @@ describe('ReactShallowRenderer', () => {
     expect(() => shallowRenderer.render(<WillMount />)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'WillMount uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
-        '  componentWillMount',
+        '  componentWillMount\n\n' +
+        'The above lifecycles should be removed. Learn more about this warning here:\n' +
+        'https://fb.me/react-async-component-lifecycle-hooks',
     );
 
     class WillMountAndUpdate extends React.Component {
@@ -190,7 +194,9 @@ describe('ReactShallowRenderer', () => {
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'WillMountAndUpdate uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
         '  componentWillMount\n' +
-        '  componentWillUpdate',
+        '  componentWillUpdate\n\n' +
+        'The above lifecycles should be removed. Learn more about this warning here:\n' +
+        'https://fb.me/react-async-component-lifecycle-hooks',
     );
 
     class WillReceiveProps extends React.Component {
@@ -208,7 +214,9 @@ describe('ReactShallowRenderer', () => {
     expect(() => shallowRenderer.render(<WillReceiveProps />)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'WillReceiveProps uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
-        '  componentWillReceiveProps',
+        '  componentWillReceiveProps\n\n' +
+        'The above lifecycles should be removed. Learn more about this warning here:\n' +
+        'https://fb.me/react-async-component-lifecycle-hooks',
     );
   });
 

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -139,7 +139,7 @@ describe('ReactShallowRenderer', () => {
         return null;
       }
       componentWillMount() {}
-      componentWillReceiveProps() {}
+      UNSAFE_componentWillReceiveProps() {}
       componentWillUpdate() {}
       render() {
         return null;
@@ -151,7 +151,7 @@ describe('ReactShallowRenderer', () => {
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'AllLegacyLifecycles uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
         '  componentWillMount\n' +
-        '  componentWillReceiveProps\n' +
+        '  UNSAFE_componentWillReceiveProps\n' +
         '  componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
@@ -162,7 +162,7 @@ describe('ReactShallowRenderer', () => {
       static getDerivedStateFromProps() {
         return null;
       }
-      componentWillMount() {}
+      UNSAFE_componentWillMount() {}
       render() {
         return null;
       }
@@ -172,7 +172,7 @@ describe('ReactShallowRenderer', () => {
     expect(() => shallowRenderer.render(<WillMount />)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'WillMount uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
-        '  componentWillMount\n\n' +
+        '  UNSAFE_componentWillMount\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
     );
@@ -183,7 +183,7 @@ describe('ReactShallowRenderer', () => {
         return null;
       }
       componentWillMount() {}
-      componentWillUpdate() {}
+      UNSAFE_componentWillUpdate() {}
       render() {
         return null;
       }
@@ -194,7 +194,7 @@ describe('ReactShallowRenderer', () => {
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
         'WillMountAndUpdate uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
         '  componentWillMount\n' +
-        '  componentWillUpdate\n\n' +
+        '  UNSAFE_componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
     );

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -475,7 +475,13 @@ describe('create-react-class-integration', () => {
 
     expect(() => {
       ReactDOM.render(<Component />, document.createElement('div'));
-    }).toWarnDev('Defines both componentWillReceiveProps');
+    }).toWarnDev(
+      'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
+        'Unknown uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+        '  componentWillMount\n' +
+        '  componentWillReceiveProps\n' +
+        '  componentWillUpdate',
+    );
     ReactDOM.render(<Component foo={1} />, document.createElement('div'));
   });
 

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -480,7 +480,9 @@ describe('create-react-class-integration', () => {
         'Unknown uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
         '  componentWillMount\n' +
         '  componentWillReceiveProps\n' +
-        '  componentWillUpdate',
+        '  componentWillUpdate\n\n' +
+        'The above lifecycles should be removed. Learn more about this warning here:\n' +
+        'https://fb.me/react-async-component-lifecycle-hooks',
     );
     ReactDOM.render(<Component foo={1} />, document.createElement('div'));
   });

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -477,7 +477,7 @@ describe('create-react-class-integration', () => {
       ReactDOM.render(<Component />, document.createElement('div'));
     }).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API.\n\n' +
-        'Unknown uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+        'Component uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
         '  componentWillMount\n' +
         '  componentWillReceiveProps\n' +
         '  componentWillUpdate\n\n' +


### PR DESCRIPTION
After a lot of discussion and careful consideration, the team has reaffirmed the initial decision to not call _unsafe_ legacy lifecycles `componentWillMount`, `componentWillReceiveProps`, and `componentWillUpdate` for any component that defines the new static `getDerivedStateFromProps` lifecycle. (This applies to the "UNSAFE_" aliases as well.)

The reason for this decision ultimately boils down to support for the [react-lifecycles-compat polyfill](https://github.com/reactjs/react-lifecycles-compat) and concerns about consistent, predictable behavior for future version of React.

As @jquense pointed out with issue #12411, conditional lifecycle behavior is a _new_ thing, and it is not intuitive. For this reason, we needed to improve the granularity and wording of the DEV warning. This PR does that, first by expanding the warning conditionals to explicitly check for `componentWillMount` and `componentWillUpdate` as well (rather than just `componentWillReceiveProps`) and secondly by explicitly stating that "_Unsafe legacy lifecycles will not be called for components using the new getDerivedStateFromProps() API_".

The entire new DEV warning is:
```
Unsafe legacy lifecycles will not be called for components using the new 
getDerivedStateFromProps() API.

<YourComponentName> uses getDerivedStateFromProps() but also contains 
the following legacy lifecycles:
  componentWillMount
  componentWillReceiveProps
  componentWillUpdate

The above lifecycles should be removed. Learn more about this warning here:
https://fb.me/react-async-component-lifecycle-hooks
```

Tests have been updated as well to verify the new behavior.

Resolves #12411