### PR TITLE
Improve cryptic error message when creating a component starting with a lowercase letter

### DIFF
--- a/packages/react-native-renderer/src/__mocks__/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native-renderer/src/__mocks__/ReactNativeViewConfigRegistry.js
@@ -88,11 +88,16 @@ exports.get = function(name: string): ReactNativeBaseComponentViewConfig {
   let viewConfig;
   if (!viewConfigs.has(name)) {
     const callback = viewConfigCallbacks.get(name);
-    invariant(
-      typeof callback === 'function',
-      'View config not found for name %s',
-      name,
-    );
+    if (typeof callback !== 'function') {
+      invariant(
+        false,
+        'View config not found for name %s.%s',
+        name,
+        typeof name[0] === 'string' && /[a-z]/.test(name[0])
+          ? ' Make sure to start component names with a capital letter.'
+          : '',
+      );
+    }
     viewConfigCallbacks.set(name, null);
     viewConfig = callback();
     processEventTypes(viewConfig);

--- a/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
+++ b/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
@@ -90,11 +90,16 @@ exports.get = function(name: string): ReactNativeBaseComponentViewConfig {
   let viewConfig;
   if (!viewConfigs.has(name)) {
     const callback = viewConfigCallbacks.get(name);
-    invariant(
-      typeof callback === 'function',
-      'View config not found for name %s',
-      name,
-    );
+    if (typeof callback !== 'function') {
+      invariant(
+        false,
+        'View config not found for name %s.%s',
+        name,
+        typeof name[0] === 'string' && /[a-z]/.test(name[0])
+          ? ' Make sure to start component names with a capital letter.'
+          : '',
+      );
+    }
     viewConfigCallbacks.set(name, null);
     viewConfig = callback();
     processEventTypes(viewConfig);


### PR DESCRIPTION
This PR fixes https://github.com/facebook/react-native/issues/18473 by adding a recovery suggestion to the error that appears when creating a component starting with a lowercase letter. (e.g. if you try to render `<myComponent/>` instead of `<MyComponent/>`)

The change was initially approved and landed in PR https://github.com/facebook/react-native/pull/18488 but it was suggested to open the PR here instead so that (1) the core react project could benefit from the change, and (2) so it wouldn't get overwritten later when react-native updated from react.

The change passes both react and react-native test suites locally.