### PR TITLE
Add a fallback component name for warnings

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -213,7 +213,7 @@ export default function(
           shouldUpdate !== undefined,
           '%s.shouldComponentUpdate(): Returned undefined instead of a ' +
             'boolean value. Make sure to return true or false.',
-          getComponentName(workInProgress) || 'Unknown',
+          getComponentName(workInProgress) || 'Component',
         );
       }
 
@@ -364,23 +364,18 @@ export default function(
         name,
         name,
       );
-    }
-
-    const state = instance.state;
-    if (state && (typeof state !== 'object' || isArray(state))) {
-      warning(
-        false,
-        '%s.state: must be set to an object or null',
-        getComponentName(workInProgress),
-      );
-    }
-    if (typeof instance.getChildContext === 'function') {
-      warning(
-        typeof type.childContextTypes === 'object',
-        '%s.getChildContext(): childContextTypes must be defined in order to ' +
-          'use getChildContext().',
-        getComponentName(workInProgress),
-      );
+      const state = instance.state;
+      if (state && (typeof state !== 'object' || isArray(state))) {
+        warning(false, '%s.state: must be set to an object or null', name);
+      }
+      if (typeof instance.getChildContext === 'function') {
+        warning(
+          typeof type.childContextTypes === 'object',
+          '%s.getChildContext(): childContextTypes must be defined in order to ' +
+            'use getChildContext().',
+          name,
+        );
+      }
     }
   }
 
@@ -491,7 +486,7 @@ export default function(
           '%s.componentWillMount(): Assigning directly to this.state is ' +
             "deprecated (except inside a component's " +
             'constructor). Use setState instead.',
-          getComponentName(workInProgress),
+          getComponentName(workInProgress) || 'Component',
         );
       }
       updater.enqueueReplaceState(instance, instance.state, null);
@@ -549,7 +544,7 @@ export default function(
               true) ||
           typeof instance.UNSAFE_componentWillReceiveProps === 'function'
         ) {
-          const componentName = getComponentName(workInProgress) || 'Unknown';
+          const componentName = getComponentName(workInProgress) || 'Component';
           if (!didWarnAboutWillReceivePropsAndDerivedState[componentName]) {
             warning(
               false,


### PR DESCRIPTION
There used to be no fallback, leading to warnings like this for anonymous components:

<img width="1273" alt="screen shot 2018-03-22 at 5 05 04 pm" src="https://user-images.githubusercontent.com/810438/37785948-529e525c-2df3-11e8-914f-519a2085781f.png">
<img width="1207" alt="screen shot 2018-03-22 at 5 03 42 pm" src="https://user-images.githubusercontent.com/810438/37785954-565ff328-2df3-11e8-87b5-3171adb34af1.png">

This fixes them:

<img width="1271" alt="screen shot 2018-03-22 at 5 04 42 pm" src="https://user-images.githubusercontent.com/810438/37785968-5da72f2a-2df3-11e8-817d-35a2ddf5743c.png">
<img width="1299" alt="screen shot 2018-03-22 at 5 04 15 pm" src="https://user-images.githubusercontent.com/810438/37785972-611752d4-2df3-11e8-8850-9061ee2501db.png">

I tried writing a unit test but it's pretty annoying to reproduce without `createClass`, and that has its own warnings so it gets a bit confusing. Issues like https://github.com/facebook/react/issues/12428 and https://github.com/facebook/react/issues/12427 also made writing tests a bit painful. I'm happy to revisit with a test when those are resolved.