### PR TITLE
Rename bits to unstable_observedBits

### DIFF
--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -72,7 +72,7 @@ export type ReactConsumer<T> = {
   ref: null,
   props: {
     children: (value: T) => ReactNodeList,
-    bits?: number,
+    unstable_observedBits?: number,
   },
 };
 


### PR DESCRIPTION
This had me confused for a while. I was trying to write an example using bits and it wouldn't work. Then I found out that the real prop name was unstable_observedBits.
