### PR TITLE
Adds semver to the package dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-strip-banner": "^0.2.0",
     "run-sequence": "^1.1.4",
+    "semver": "^5.5.0",
     "targz": "^1.0.1",
     "through2": "^2.0.0",
     "tmp": "~0.0.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4941,6 +4941,10 @@ sax@^1.2.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
+semver@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
This diff simply adds `semver` to the top-level dev dependencies. Semver was used in various scripts ([ex here](https://github.com/facebook/react/blob/060581b1287ea75d128f8f6b2b7bf494fe5db4fa/scripts/rollup/plugins/use-forks-plugin.js#L10)) without being listed, which was invalid (it worked because one of React's dependencies was itself depending on semver, which was then hoisted to the top-level through package managers optimizations).
