### PR TITLE
Tweaks the build script

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -72,7 +72,7 @@ const closureOptions = {
 
 function getBabelConfig(updateBabelOptions, bundleType, filename) {
   let options = {
-    exclude: 'node_modules/**',
+    exclude: '/**/node_modules/**',
     presets: [],
     plugins: [],
   };

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const forks = require('./forks');
 const bundleTypes = require('./bundles').bundleTypes;
 
@@ -44,9 +43,9 @@ function getPeerGlobals(externals, moduleType) {
 
 // Determines node_modules packages that are safe to assume will exist.
 function getDependencies(bundleType, entry) {
-  const packageJson = require(path.basename(
-    path.dirname(require.resolve(entry))
-  ) + '/package.json');
+  // Replaces any part of the entry that follow the package name (like
+  // "/server" in "react-dom/server") by the path to the package settings
+  const packageJson = require(entry.replace(/(\/.*)?$/, '/package.json'));
   // Both deps and peerDeps are assumed as accessible.
   return Array.from(
     new Set([


### PR DESCRIPTION
This diff tweaks two things:

- The babel configuration now is configured to ignore all node_modules folders, wherever they are on the disk.
- The `getDependencies` function won't break if the resolved path of the entry doesn't exactly match the entry name.