### PR TITLE
Don't pass a Fiber to showErrorDialog()

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -54,7 +54,7 @@ function logError(boundary: Fiber, errorInfo: CapturedValue<mixed>) {
   const capturedError: CapturedError = {
     componentName: source !== null ? getComponentName(source) : null,
     error: errorInfo.value,
-    errorBoundary: boundary,
+    errorBoundary: null,
     componentStack: stack !== null ? stack : '',
     errorBoundaryName: null,
     errorBoundaryFound: false,
@@ -62,12 +62,10 @@ function logError(boundary: Fiber, errorInfo: CapturedValue<mixed>) {
   };
 
   if (boundary !== null) {
+    capturedError.errorBoundary = boundary.stateNode;
     capturedError.errorBoundaryName = getComponentName(boundary);
     capturedError.errorBoundaryFound = capturedError.willRetry =
       boundary.tag === ClassComponent;
-  } else {
-    capturedError.errorBoundaryName = null;
-    capturedError.errorBoundaryFound = capturedError.willRetry = false;
   }
 
   try {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -61,11 +61,11 @@ function logError(boundary: Fiber, errorInfo: CapturedValue<mixed>) {
     willRetry: false,
   };
 
-  if (boundary !== null) {
+  if (boundary !== null && boundary.tag === ClassComponent) {
     capturedError.errorBoundary = boundary.stateNode;
     capturedError.errorBoundaryName = getComponentName(boundary);
-    capturedError.errorBoundaryFound = capturedError.willRetry =
-      boundary.tag === ClassComponent;
+    capturedError.errorBoundaryFound = true;
+    capturedError.willRetry = true;
   }
 
   try {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -53,9 +53,9 @@ function logError(boundary: Fiber, errorInfo: CapturedValue<mixed>) {
 
   const capturedError: CapturedError = {
     componentName: source !== null ? getComponentName(source) : null,
+    componentStack: stack !== null ? stack : '',
     error: errorInfo.value,
     errorBoundary: null,
-    componentStack: stack !== null ? stack : '',
     errorBoundaryName: null,
     errorBoundaryFound: false,
     willRetry: false,


### PR DESCRIPTION
There are two places where we create CapturedError. The one in reconciliation phase correctly passes the `stateNode` but we accidentally broke it for the commit phase. This should fix it. To reduce duplication (which confused me at first), I removed the `else` branch which was already taken care of with the default values.