### PR TITLE
insure suspender updates record before resolving

### DIFF
--- a/packages/simple-cache-provider/src/SimpleCacheProvider.js
+++ b/packages/simple-cache-provider/src/SimpleCacheProvider.js
@@ -125,7 +125,7 @@ export function createCache(invalidator: () => mixed): Cache {
     const pendingRecord: PendingRecord<V> = (emptyRecord: any);
     pendingRecord.status = Pending;
     pendingRecord.suspender = suspender;
-    suspender.then(
+    return suspender.then(
       value => {
         // Resource loaded successfully.
         const resolvedRecord: ResolvedRecord<V> = (pendingRecord: any);
@@ -182,8 +182,7 @@ export function createCache(invalidator: () => mixed): Cache {
       switch (record.status) {
         case Empty:
           // Load the requested resource.
-          const suspender = miss(missArg);
-          load(record, suspender);
+          const suspender = load(record, miss(missArg));
           throw suspender;
         case Pending:
           // There's already a pending request.


### PR DESCRIPTION
Obviously the way React Aysnc must work is it is manually keeping tabs on when suspenders resolve as part of its normal flow, but this prevents a false positive where the promise has resolved, but the record hasn't been updated. I understand this likely is handled automatically by any additional ticks fiber adds to the flow--I was learning about *Suspense* from the code and just thought I'd point this out in case it was a mistake.

Here's an example of what I'm talking about:

```js
const prom = Promise.resolve()

prom.then(() => console.log(1)).then(() => console.log(2))
prom.then(() => console.log(3))

1
3 // React thinks suspender has resolved
2 // but the record is set here

// an additional cycle through the work queue is now required
// to discover the record's resolution
```