### PR TITLE
Remove dependency on React

### DIFF
--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -12,9 +12,6 @@
     "url": "https://github.com/facebook/react/issues"
   },
   "homepage": "https://reactjs.org/",
-  "peerDependencies": {
-    "react": "^16.0.0 || 16.3.0-alpha.3"
-  },
   "files": [
     "LICENSE",
     "README.md",


### PR DESCRIPTION
Is this necessary? I'd like to use the package in enzyme to avoid having to recopy/paste the symbols for better debugging names, but a hard dep in enzyme proper on a version of react isn't gonna work. This seems safe since nothing explicitly depends on React in here?
