### PR TITLE
Warn about unsafe toWarnDev() nesting in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,6 +65,7 @@ module.exports = {
     // CUSTOM RULES
     // the second argument of warning/invariant should be a literal string
     'react-internal/no-primitive-constructors': ERROR,
+    'react-internal/no-to-warn-dev-within-to-throw': ERROR,
     'react-internal/warning-and-invariant-args': ERROR,
   },
 

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -1729,13 +1729,18 @@ describe('ReactCompositeComponent', () => {
     expect(() => {
       expect(() => {
         ReactTestUtils.renderIntoDocument(<RenderTextInvalidConstructor />);
-        // eslint-disable-next-line react-internal/no-to-warn-dev-within-to-throw
-      }).toWarnDev(
+      }).toThrow();
+    }).toWarnDev(
+      [
+        // Expect two errors because invokeGuardedCallback will dispatch an error event,
+        // Causing the warning to be logged again.
         'Warning: RenderTextInvalidConstructor(...): No `render` method found on the returned component instance: ' +
           'did you accidentally return an object from the constructor?',
-        {withoutStack: true},
-      );
-    }).toThrow();
+        'Warning: RenderTextInvalidConstructor(...): No `render` method found on the returned component instance: ' +
+          'did you accidentally return an object from the constructor?',
+      ],
+      {withoutStack: true},
+    );
   });
 
   it('should return error if render is not defined', () => {
@@ -1744,12 +1749,17 @@ describe('ReactCompositeComponent', () => {
     expect(() => {
       expect(() => {
         ReactTestUtils.renderIntoDocument(<RenderTestUndefinedRender />);
-        // eslint-disable-next-line react-internal/no-to-warn-dev-within-to-throw
-      }).toWarnDev(
+      }).toThrow();
+    }).toWarnDev(
+      [
+        // Expect two errors because invokeGuardedCallback will dispatch an error event,
+        // Causing the warning to be logged again.
         'Warning: RenderTestUndefinedRender(...): No `render` method found on the returned ' +
           'component instance: you may have forgotten to define `render`.',
-        {withoutStack: true},
-      );
-    }).toThrow();
+        'Warning: RenderTestUndefinedRender(...): No `render` method found on the returned ' +
+          'component instance: you may have forgotten to define `render`.',
+      ],
+      {withoutStack: true},
+    );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -433,6 +433,7 @@ describe('ReactCompositeComponent', () => {
       'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
         "but doesn't extend React.Component. This is likely to cause errors. " +
         'Change ClassWithRenderNotExtended to extend React.Component instead.',
+      {withoutStack: true},
     );
 
     // Test deduplication
@@ -1732,6 +1733,7 @@ describe('ReactCompositeComponent', () => {
       }).toWarnDev(
         'Warning: RenderTextInvalidConstructor(...): No `render` method found on the returned component instance: ' +
           'did you accidentally return an object from the constructor?',
+        {withoutStack: true},
       );
     }).toThrow();
   });
@@ -1746,6 +1748,7 @@ describe('ReactCompositeComponent', () => {
       }).toWarnDev(
         'Warning: RenderTestUndefinedRender(...): No `render` method found on the returned ' +
           'component instance: you may have forgotten to define `render`.',
+        {withoutStack: true},
       );
     }).toThrow();
   });

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -428,12 +428,12 @@ describe('ReactCompositeComponent', () => {
     expect(() => {
       expect(() => {
         ReactDOM.render(<ClassWithRenderNotExtended />, container);
-      }).toWarnDev(
-        'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
-          "but doesn't extend React.Component. This is likely to cause errors. " +
-          'Change ClassWithRenderNotExtended to extend React.Component instead.',
-      );
-    }).toThrow(TypeError);
+      }).toThrow(TypeError);
+    }).toWarnDev(
+      'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
+        "but doesn't extend React.Component. This is likely to cause errors. " +
+        'Change ClassWithRenderNotExtended to extend React.Component instead.',
+    );
 
     // Test deduplication
     expect(() => {
@@ -1728,6 +1728,7 @@ describe('ReactCompositeComponent', () => {
     expect(() => {
       expect(() => {
         ReactTestUtils.renderIntoDocument(<RenderTextInvalidConstructor />);
+        // eslint-disable-next-line react-internal/no-to-warn-dev-within-to-throw
       }).toWarnDev(
         'Warning: RenderTextInvalidConstructor(...): No `render` method found on the returned component instance: ' +
           'did you accidentally return an object from the constructor?',
@@ -1741,6 +1742,7 @@ describe('ReactCompositeComponent', () => {
     expect(() => {
       expect(() => {
         ReactTestUtils.renderIntoDocument(<RenderTestUndefinedRender />);
+        // eslint-disable-next-line react-internal/no-to-warn-dev-within-to-throw
       }).toWarnDev(
         'Warning: RenderTestUndefinedRender(...): No `render` method found on the returned ' +
           'component instance: you may have forgotten to define `render`.',

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -359,7 +359,7 @@ describe('ReactDOMTextarea', () => {
             {'there'}
           </textarea>,
         ),
-      ).toThrow();
+      ).toThrow('<textarea> can only have at most one child');
     }).toWarnDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
     );

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -352,19 +352,17 @@ describe('ReactDOMTextarea', () => {
 
   it('should throw with multiple or invalid children', () => {
     expect(() => {
-      expect(
-        () =>
-          ReactTestUtils.renderIntoDocument(
-            <textarea>
-              {'hello'}
-              {'there'}
-            </textarea>,
-          ),
-        // eslint-disable-next-line react-internal/no-to-warn-dev-within-to-throw
-      ).toWarnDev(
-        'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
-      );
-    }).toThrow();
+      expect(() =>
+        ReactTestUtils.renderIntoDocument(
+          <textarea>
+            {'hello'}
+            {'there'}
+          </textarea>,
+        ),
+      ).toThrow();
+    }).toWarnDev(
+      'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+    );
 
     let node;
     expect(() => {

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -352,13 +352,15 @@ describe('ReactDOMTextarea', () => {
 
   it('should throw with multiple or invalid children', () => {
     expect(() => {
-      expect(() =>
-        ReactTestUtils.renderIntoDocument(
-          <textarea>
-            {'hello'}
-            {'there'}
-          </textarea>,
-        ),
+      expect(
+        () =>
+          ReactTestUtils.renderIntoDocument(
+            <textarea>
+              {'hello'}
+              {'there'}
+            </textarea>,
+          ),
+        // eslint-disable-next-line react-internal/no-to-warn-dev-within-to-throw
       ).toWarnDev(
         'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
       );
@@ -373,10 +375,10 @@ describe('ReactDOMTextarea', () => {
               <strong />
             </textarea>,
           )),
-      ).toWarnDev(
-        'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
-      );
-    }).not.toThrow();
+      ).not.toThrow();
+    }).toWarnDev(
+      'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+    );
 
     expect(node.value).toBe('[object Object]');
   });

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -646,12 +646,12 @@ describe('ReactDOMServer', () => {
     expect(() => {
       expect(() =>
         ReactDOMServer.renderToString(<ClassWithRenderNotExtended />),
-      ).toWarnDev(
-        'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
-          "but doesn't extend React.Component. This is likely to cause errors. " +
-          'Change ClassWithRenderNotExtended to extend React.Component instead.',
-      );
-    }).toThrow(TypeError);
+      ).toThrow(TypeError);
+    }).toWarnDev(
+      'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
+        "but doesn't extend React.Component. This is likely to cause errors. " +
+        'Change ClassWithRenderNotExtended to extend React.Component instead.',
+    );
 
     // Test deduplication
     expect(() => {

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -651,6 +651,7 @@ describe('ReactDOMServer', () => {
       'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
         "but doesn't extend React.Component. This is likely to cause errors. " +
         'Change ClassWithRenderNotExtended to extend React.Component instead.',
+      {withoutStack: true},
     );
 
     // Test deduplication

--- a/scripts/eslint-rules/__tests__/no-to-warn-dev-within-to-throw-test.internal.js
+++ b/scripts/eslint-rules/__tests__/no-to-warn-dev-within-to-throw-test.internal.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+const rule = require('../no-to-warn-dev-within-to-throw');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
+
+ruleTester.run('eslint-rules/no-to-warn-dev-within-to-throw', rule, {
+  valid: [
+    'expect(callback).toWarnDev("warning");',
+    'expect(function() { expect(callback).toThrow("error") }).toWarnDev("warning");',
+  ],
+  invalid: [
+    {
+      code:
+        'expect(function() { expect(callback).toWarnDev("warning") }).toThrow("error");',
+      errors: [
+        {
+          message: 'toWarnDev() matcher should not be nested',
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/eslint-rules/index.js
+++ b/scripts/eslint-rules/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   rules: {
     'no-primitive-constructors': require('./no-primitive-constructors'),
+    'no-to-warn-dev-within-to-throw': require('./no-to-warn-dev-within-to-throw'),
     'warning-and-invariant-args': require('./warning-and-invariant-args'),
   },
 };

--- a/scripts/eslint-rules/no-to-warn-dev-within-to-throw.js
+++ b/scripts/eslint-rules/no-to-warn-dev-within-to-throw.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+module.exports = function(context) {
+  return {
+    Identifier(node) {
+      if (node.name === 'toWarnDev') {
+        let current = node;
+        while (current.parent) {
+          if (current.type === 'CallExpression') {
+            if (
+              current &&
+              current.callee &&
+              current.callee.property &&
+              current.callee.property.name === 'toThrow'
+            ) {
+              context.report(node, 'toWarnDev() matcher should not be nested');
+            }
+          }
+          current = current.parent;
+        }
+      }
+    },
+  };
+};

--- a/scripts/jest/matchers/__tests__/toWarnDev-test.js
+++ b/scripts/jest/matchers/__tests__/toWarnDev-test.js
@@ -54,166 +54,159 @@ describe('toWarnDev', () => {
   });
 
   if (__DEV__) {
+    // Helper methods avoids invalid toWarn().toThrow() nesting
+    // See no-to-warn-dev-within-to-throw
+    const expectToWarnAndToThrow = (expectBlock, expectedErrorMessage) => {
+      let caughtError;
+      try {
+        expectBlock();
+      } catch (error) {
+        caughtError = error;
+      }
+      expect(caughtError).toBeDefined();
+      expect(caughtError.message).toContain(expectedErrorMessage);
+    };
+
     it('fails if a warning does not contain a stack', () => {
-      expect(() => {
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello');
         }).toWarnDev('Hello');
-      }).toThrow(
-        'Received warning unexpectedly does not include a component stack'
-      );
+      }, 'Received warning unexpectedly does not include a component stack');
     });
 
     it('fails if some warnings do not contain a stack', () => {
-      expect(() => {
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello\n    in div');
           console.error('Good day\n    in div');
           console.error('Bye');
         }).toWarnDev(['Hello', 'Good day', 'Bye']);
-      }).toThrow(
-        'Received warning unexpectedly does not include a component stack'
-      );
-      expect(() => {
+      }, 'Received warning unexpectedly does not include a component stack');
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello');
           console.error('Good day\n    in div');
           console.error('Bye\n    in div');
         }).toWarnDev(['Hello', 'Good day', 'Bye']);
-      }).toThrow(
-        'Received warning unexpectedly does not include a component stack'
-      );
-      expect(() => {
+      }, 'Received warning unexpectedly does not include a component stack');
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello\n    in div');
           console.error('Good day');
           console.error('Bye\n    in div');
         }).toWarnDev(['Hello', 'Good day', 'Bye']);
-      }).toThrow(
-        'Received warning unexpectedly does not include a component stack'
-      );
-      expect(() => {
+      }, 'Received warning unexpectedly does not include a component stack');
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello');
           console.error('Good day');
           console.error('Bye');
         }).toWarnDev(['Hello', 'Good day', 'Bye']);
-      }).toThrow(
-        'Received warning unexpectedly does not include a component stack'
-      );
+      }, 'Received warning unexpectedly does not include a component stack');
     });
 
     it('fails if warning is expected to not have a stack, but does', () => {
-      expect(() => {
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello\n    in div');
         }).toWarnDev('Hello', {withoutStack: true});
-      }).toThrow('Received warning unexpectedly includes a component stack');
-      expect(() => {
+      }, 'Received warning unexpectedly includes a component stack');
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello\n    in div');
           console.error('Good day');
           console.error('Bye\n    in div');
         }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: true});
-      }).toThrow('Received warning unexpectedly includes a component stack');
+      }, 'Received warning unexpectedly includes a component stack');
     });
 
     it('fails if expected stack-less warning number does not match the actual one', () => {
-      expect(() => {
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello\n    in div');
           console.error('Good day');
           console.error('Bye\n    in div');
         }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: 4});
-      }).toThrow(
-        'Expected 4 warnings without a component stack but received 1'
-      );
+      }, 'Expected 4 warnings without a component stack but received 1');
     });
 
     it('fails if withoutStack is invalid', () => {
-      expect(() => {
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi');
         }).toWarnDev('Hi', {withoutStack: null});
-      }).toThrow('Instead received object');
-      expect(() => {
+      }, 'Instead received object');
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi');
         }).toWarnDev('Hi', {withoutStack: {}});
-      }).toThrow('Instead received object');
-      expect(() => {
+      }, 'Instead received object');
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi');
         }).toWarnDev('Hi', {withoutStack: 'haha'});
-      }).toThrow('Instead received string');
+      }, 'Instead received string');
     });
 
     it('fails if the argument number does not match', () => {
-      expect(() => {
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi %s', 'Sara', 'extra');
         }).toWarnDev('Hi', {withoutStack: true});
-      }).toThrow('Received 2 arguments for a message with 1 placeholders');
+      }, 'Received 2 arguments for a message with 1 placeholders');
 
-      expect(() => {
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi %s');
         }).toWarnDev('Hi', {withoutStack: true});
-      }).toThrow('Received 0 arguments for a message with 1 placeholders');
+      }, 'Received 0 arguments for a message with 1 placeholders');
     });
 
     it('fails if stack is passed twice', () => {
-      expect(() => {
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi %s%s', '\n    in div', '\n    in div');
         }).toWarnDev('Hi');
-      }).toThrow('Received more than one component stack for a warning');
+      }, 'Received more than one component stack for a warning');
     });
 
     it('fails if multiple strings are passed without an array wrapper', () => {
-      expect(() => {
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi \n    in div');
         }).toWarnDev('Hi', 'Bye');
-      }).toThrow(
-        'toWarnDev() second argument, when present, should be an object'
-      );
-      expect(() => {
+      }, 'toWarnDev() second argument, when present, should be an object');
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi \n    in div');
           console.error('Bye \n    in div');
         }).toWarnDev('Hi', 'Bye');
-      }).toThrow(
-        'toWarnDev() second argument, when present, should be an object'
-      );
-      expect(() => {
+      }, 'toWarnDev() second argument, when present, should be an object');
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi \n    in div');
           console.error('Wow \n    in div');
           console.error('Bye \n    in div');
         }).toWarnDev('Hi', 'Bye');
-      }).toThrow(
-        'toWarnDev() second argument, when present, should be an object'
-      );
-      expect(() => {
+      }, 'toWarnDev() second argument, when present, should be an object');
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi \n    in div');
           console.error('Wow \n    in div');
           console.error('Bye \n    in div');
         }).toWarnDev('Hi', 'Wow', 'Bye');
-      }).toThrow(
-        'toWarnDev() second argument, when present, should be an object'
-      );
+      }, 'toWarnDev() second argument, when present, should be an object');
     });
 
     it('fails on more than two arguments', () => {
-      expect(() => {
+      expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi \n    in div');
           console.error('Wow \n    in div');
           console.error('Bye \n    in div');
         }).toWarnDev('Hi', undefined, 'Bye');
-      }).toThrow('toWarnDev() received more than two arguments.');
+      }, 'toWarnDev() received more than two arguments.');
     });
   }
 });


### PR DESCRIPTION
Resolves #12428

This is a work in progress because we have 3 tests (currently marked with ESLint suppression comments) that fail if the nesting order is reversed. (When we replay failed work, the warning is logged a second time- even though we only expect it once.)