### PR TITLE
Include react-is in FB build targets

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -238,7 +238,7 @@ const bundles = [
   /******* React Is *******/
   {
     label: 'react-is',
-    bundleTypes: [NODE_DEV, NODE_PROD, UMD_DEV, UMD_PROD],
+    bundleTypes: [NODE_DEV, NODE_PROD, FB_DEV, FB_PROD, UMD_DEV, UMD_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react-is',
     global: 'ReactIs',


### PR DESCRIPTION
Recently, `react-is` was added as a dependency to the shallow renderer (#12392). This breaks the FB sync script, since we were not previously syncing the `react-is` package.

I'm not super familiar with www internals, but I think the simplest solution is to tag `react-is` as one of the FB build targets (so that it gets synced) and then add a yarn stub for it.