### PR TITLE
Rename react-is import alias in FB bundles

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -230,7 +230,9 @@ function getPlugins(
     // www still needs require('React') rather than require('react')
     isFBBundle && {
       transformBundle(source) {
-        return source.replace(/require\(['"]react['"]\)/g, "require('React')");
+        return source
+          .replace(/require\(['"]react['"]\)/g, "require('React')")
+          .replace(/require\(['"]react-is['"]\)/g, "require('ReactIs')");
       },
     },
     // Apply dead code elimination and/or minification.


### PR DESCRIPTION
Small follow up to #12458. Sorry for missing this in the previous round!

I tested this already by syncing a locally built `ReactShallowRenderer-dev.js` to www.

Side note: This is a little awkward to setup (between GitHub and the www forwarding files) but I guess it isn't common so maybe no big deal.