### PR TITLE
Fix build script to handle react-is (no peer deps)

### DIFF
--- a/scripts/release/build-commands/update-package-versions.js
+++ b/scripts/release/build-commands/update-package-versions.js
@@ -54,7 +54,7 @@ const update = async ({cwd, dry, packages, version}) => {
         json.version = version;
       }
 
-      if (project !== 'react') {
+      if (project !== 'react' && json.peerDependencies) {
         let peerVersion = json.peerDependencies.react.replace('^', '');
 
         // If the previous release was a pre-release version,


### PR DESCRIPTION
The `react-is` package has no `peerDependencies` which breaks the build script. Before this package, all others had peer deps.