### PR TITLE
Add React.isValidElementType()

### DIFF
--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -22,6 +22,7 @@ import {
   createFactory,
   cloneElement,
   isValidElement,
+  isValidElementType,
 } from './ReactElement';
 import {createContext} from './ReactContext';
 import forwardRef from './forwardRef';
@@ -56,6 +57,7 @@ const React = {
   cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,
   createFactory: __DEV__ ? createFactoryWithValidation : createFactory,
   isValidElement: isValidElement,
+  isValidElementType: isValidElementType,
 
   version: ReactVersion,
 

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -6,7 +6,15 @@
  */
 
 import warning from 'fbjs/lib/warning';
-import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
+import {
+  REACT_ELEMENT_TYPE,
+  REACT_FRAGMENT_TYPE,
+  REACT_ASYNC_MODE_TYPE,
+  REACT_STRICT_MODE_TYPE,
+  REACT_PROVIDER_TYPE,
+  REACT_CONTEXT_TYPE,
+  REACT_FORWARD_REF_TYPE,
+} from 'shared/ReactSymbols';
 
 import ReactCurrentOwner from './ReactCurrentOwner';
 
@@ -366,5 +374,27 @@ export function isValidElement(object) {
     typeof object === 'object' &&
     object !== null &&
     object.$$typeof === REACT_ELEMENT_TYPE
+  );
+}
+
+/**
+ * Verifies that the given type may be used to create a ReactElement.
+ * @param {*} type
+ * @return {boolean} True if `type` is a valid ReactElement type.
+ * @final
+ */
+export function isValidElementType(type) {
+  return (
+    typeof type === 'string' ||
+    typeof type === 'function' ||
+    // Note: its typeof might be other than 'symbol' or 'number' if it's a polyfill.
+    type === REACT_FRAGMENT_TYPE ||
+    type === REACT_ASYNC_MODE_TYPE ||
+    type === REACT_STRICT_MODE_TYPE ||
+    (typeof type === 'object' &&
+      type !== null &&
+      (type.$$typeof === REACT_PROVIDER_TYPE ||
+        type.$$typeof === REACT_CONTEXT_TYPE ||
+        type.$$typeof === REACT_FORWARD_REF_TYPE))
   );
 }

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -15,20 +15,17 @@
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import getComponentName from 'shared/getComponentName';
-import {
-  getIteratorFn,
-  REACT_FRAGMENT_TYPE,
-  REACT_STRICT_MODE_TYPE,
-  REACT_ASYNC_MODE_TYPE,
-  REACT_PROVIDER_TYPE,
-  REACT_CONTEXT_TYPE,
-  REACT_FORWARD_REF_TYPE,
-} from 'shared/ReactSymbols';
+import {getIteratorFn, REACT_FRAGMENT_TYPE} from 'shared/ReactSymbols';
 import checkPropTypes from 'prop-types/checkPropTypes';
 import warning from 'fbjs/lib/warning';
 
 import ReactCurrentOwner from './ReactCurrentOwner';
-import {isValidElement, createElement, cloneElement} from './ReactElement';
+import {
+  isValidElement,
+  isValidElementType,
+  createElement,
+  cloneElement,
+} from './ReactElement';
 import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
 
 let currentlyValidatingElement;
@@ -288,18 +285,7 @@ function validateFragmentProps(fragment) {
 }
 
 export function createElementWithValidation(type, props, children) {
-  const validType =
-    typeof type === 'string' ||
-    typeof type === 'function' ||
-    // Note: its typeof might be other than 'symbol' or 'number' if it's a polyfill.
-    type === REACT_FRAGMENT_TYPE ||
-    type === REACT_ASYNC_MODE_TYPE ||
-    type === REACT_STRICT_MODE_TYPE ||
-    (typeof type === 'object' &&
-      type !== null &&
-      (type.$$typeof === REACT_PROVIDER_TYPE ||
-        type.$$typeof === REACT_CONTEXT_TYPE ||
-        type.$$typeof === REACT_FORWARD_REF_TYPE));
+  const validType = isValidElementType(type);
 
   // We warn in this case but don't throw. We expect the element creation to
   // succeed and there will likely be errors in render.

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -314,6 +314,40 @@ describe('ReactElement', () => {
     expect(React.isValidElement(JSON.parse(jsonElement))).toBe(true);
   });
 
+  it('identifies valid element types', () => {
+    class Component extends React.Component {
+      render() {
+        return React.createElement('div');
+      }
+    }
+
+    const StatelessComponent = () => React.createElement('div');
+
+    const ForwardRefComponent = React.forwardRef((props, ref) =>
+      React.createElement(Component, {forwardedRef: ref, ...props}),
+    );
+
+    const Context = React.createContext(false);
+
+    expect(React.isValidElementType('div')).toEqual(true);
+    expect(React.isValidElementType(Component)).toEqual(true);
+    expect(React.isValidElementType(StatelessComponent)).toEqual(true);
+    expect(React.isValidElementType(ForwardRefComponent)).toEqual(true);
+    expect(React.isValidElementType(Context.Provider)).toEqual(true);
+    expect(React.isValidElementType(Context.Consumer)).toEqual(true);
+    expect(React.isValidElementType(React.createFactory('div'))).toEqual(true);
+    expect(React.isValidElementType(React.Fragment)).toEqual(true);
+    expect(React.isValidElementType(React.unstable_AsyncMode)).toEqual(true);
+    expect(React.isValidElementType(React.StrictMode)).toEqual(true);
+
+    expect(React.isValidElementType(true)).toEqual(false);
+    expect(React.isValidElementType(123)).toEqual(false);
+    expect(React.isValidElementType({})).toEqual(false);
+    expect(React.isValidElementType(null)).toEqual(false);
+    expect(React.isValidElementType(undefined)).toEqual(false);
+    expect(React.isValidElementType({type: 'div', props: {}})).toEqual(false);
+  });
+
   // NOTE: We're explicitly not using JSX here. This is intended to test
   // classic JS without JSX.
   it('is indistinguishable from a plain object', () => {


### PR DESCRIPTION
Per the conversation on #12453, there are a number of third-party libraries (particularly those that generate higher-order components) that are performing suboptimal validation of element types.

This commit exposes a function that can perform the desired check without depending upon React internals.

In #12453, we discussed exposing this check within the new `react-is` package, but as I dug in, I lost confidence that that was indeed the right course of action.

Today, element type validation occurs within `ReactElementValidator`. `ReactElementValidator` has a dependency upon `ReactElement`, but lacks a dependency upon `react-is`. (In fact, the nothing within the core `react` package takes a dependency upon `react-is`.)

It felt wrong to duplicate the existing type validation code in a separate package, and it also felt wrong to factor it into `react-is` and introduce a new dependency from `react` to `react-is`. As such, I placed the type validation logic alongside `React.isValidElement` within `ReactElement`.

I realize that expanding the surface area of React's top-level API is a dicey prospect, but I wanted to explain my reasoning and propose it in code. If you think an alternative implementation would be more ideal, please just let me know and I'll revise.