### PR TITLE
Disable createRoot for open source builds

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -10,7 +10,7 @@
 import invariant from 'fbjs/lib/invariant';
 
 // Exports ReactDOM.createRoot
-export const enableCreateRoot = true;
+export const enableCreateRoot = false;
 export const enableUserTimingAPI = __DEV__;
 
 // Mutating mode (React DOM, React ART, React Native):


### PR DESCRIPTION
Not a stable API yet. Seems like it was unintentionally toggled in #12201.
Test pass. FB bundle still has it.