### PR TITLE
Prefix _context property on returned ReactContext from createContext …

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -675,7 +675,7 @@ class ReactDOMServerRenderer {
   pushProvider<T>(provider: ReactProvider<T>): void {
     this.providerIndex += 1;
     this.providerStack[this.providerIndex] = provider;
-    const context: ReactContext<any> = provider.type.context;
+    const context: ReactContext<any> = provider.type._context;
     context._currentValue = provider.props.value;
   }
 
@@ -689,7 +689,7 @@ class ReactDOMServerRenderer {
     }
     this.providerStack[this.providerIndex] = null;
     this.providerIndex -= 1;
-    const context: ReactContext<any> = provider.type.context;
+    const context: ReactContext<any> = provider.type._context;
     if (this.providerIndex < 0) {
       context._currentValue = context._defaultValue;
     } else {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -868,7 +868,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     renderExpirationTime,
   ) {
     const providerType: ReactProviderType<any> = workInProgress.type;
-    const context: ReactContext<any> = providerType.context;
+    const context: ReactContext<any> = providerType._context;
 
     const newProps = workInProgress.pendingProps;
     const oldProps = workInProgress.memoizedProps;

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -32,7 +32,7 @@ export default function(stack: Stack) {
   }
 
   function pushProvider(providerFiber: Fiber): void {
-    const context: ReactContext<any> = providerFiber.type.context;
+    const context: ReactContext<any> = providerFiber.type._context;
 
     push(changedBitsCursor, context._changedBits, providerFiber);
     push(valueCursor, context._currentValue, providerFiber);
@@ -60,7 +60,7 @@ export default function(stack: Stack) {
     pop(valueCursor, providerFiber);
     pop(changedBitsCursor, providerFiber);
 
-    const context: ReactContext<any> = providerFiber.type.context;
+    const context: ReactContext<any> = providerFiber.type._context;
     context._currentValue = currentValue;
     context._changedBits = changedBits;
   }

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -44,7 +44,7 @@ export function createContext<T>(
 
   context.Provider = {
     $$typeof: REACT_PROVIDER_TYPE,
-    context,
+    _context: context,
   };
   context.Consumer = context;
 

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -62,7 +62,7 @@ export type ReactProvider<T> = {
 
 export type ReactProviderType<T> = {
   $$typeof: Symbol | number,
-  context: ReactContext<T>,
+  _context: ReactContext<T>,
 };
 
 export type ReactConsumer<T> = {


### PR DESCRIPTION
Context 🤣:
https://twitter.com/AndaristRake/status/979835281871441920

`Provider`/`Consumer` are circular (with a comment about it, so I guess it's by design) which makes this possible:
```js
const ctx = React.createContext()
ctx.Consumer.Consumer.Consumer.Consumer.Provider
```

which is funny, but I don't know if anything can be done about it.

cc @acdlite 