### PR TITLE
Fix IE9 Undo Bug

### DIFF
--- a/fixtures/dom/src/components/fixtures/text-inputs/BubbledInputTestCase.js
+++ b/fixtures/dom/src/components/fixtures/text-inputs/BubbledInputTestCase.js
@@ -1,0 +1,32 @@
+import Fixture from '../../Fixture';
+const React = window.React;
+
+const noop = () => {};
+
+class BubbledInputTestCase extends React.Component {
+  state = {
+    value: '',
+  };
+
+  onChange = event => {
+    this.setState({
+      value: (event.srcElement || event.target).value,
+    });
+  };
+
+  render() {
+    return (
+      <Fixture>
+        <div className="control-box" onChange={this.onChange}>
+          <fieldset>
+            <legend>Controlled Text</legend>
+            <input value={this.state.value} onChange={noop} />
+            <p className="hint">Value: {JSON.stringify(this.state.value)}</p>
+          </fieldset>
+        </div>
+      </Fixture>
+    );
+  }
+}
+
+export default BubbledInputTestCase;

--- a/fixtures/dom/src/components/fixtures/text-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/text-inputs/index.js
@@ -2,6 +2,7 @@ import Fixture from '../../Fixture';
 import FixtureSet from '../../FixtureSet';
 import TestCase from '../../TestCase';
 import InputTestCase from './InputTestCase';
+import BubbledInputTestCase from './BubbledInputTestCase';
 import ReplaceEmailInput from './ReplaceEmailInput';
 
 const React = window.React;
@@ -139,6 +140,19 @@ class TextInputFixtures extends React.Component {
           </TestCase.ExpectedResult>
 
           <ReplaceEmailInput />
+        </TestCase>
+
+        <TestCase title="Bubbled Change Events" affectedBrowsers="IE9" relatedIssues="708,11609">
+          <TestCase.Steps>
+            <li>Enter text</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            Each input's value should change as expected, despite the change
+            event being attached to the parent element
+          </TestCase.ExpectedResult>
+
+          <BubbledInputTestCase type="text" />
         </TestCase>
 
         <TestCase title="All inputs" description="General test of all inputs">

--- a/fixtures/dom/src/components/fixtures/text-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/text-inputs/index.js
@@ -142,7 +142,10 @@ class TextInputFixtures extends React.Component {
           <ReplaceEmailInput />
         </TestCase>
 
-        <TestCase title="Bubbled Change Events" affectedBrowsers="IE9" relatedIssues="708,11609">
+        <TestCase
+          title="Bubbled Change Events"
+          affectedBrowsers="IE9"
+          relatedIssues="708,11609">
           <TestCase.Steps>
             <li>Enter text</li>
           </TestCase.Steps>


### PR DESCRIPTION
This commit fixes a case where IE9 raises an exception if modifying a detached text node.

This is reproducible with the following steps:

1. Open http://react-dom-ie9-undo.surge.sh/text-inputs?version=16.3.0 in IE9
2. Scroll to the "Bubbled Change Events" fixture
2. Change the text in input
3. Start debugging in the IE9 developer tools
4. Press ctrl+z to undo your text change
5. IE9 raises an exception when setting the nodeValue of the text label to the right of the input "invalid arguments".

The "local" build for that branch addresses the issue by removing a subscription to `onpropertychange` unique to IE9, which avoids a forced batch update that appears to be the root of the problem.

---

Fixes https://github.com/facebook/react/issues/11609