### PR TITLE
Fix context stack misalignment caused by error replay

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -268,6 +268,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
     stashedWorkInProgressProperties = null;
     isReplayingFailedUnitOfWork = false;
+    originalReplayError = null;
     replayUnitOfWork = (
       failedUnitOfWork: Fiber,
       error: mixed,
@@ -301,6 +302,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       originalReplayError = error;
       invokeGuardedCallback(null, workLoop, null, isAsync);
       isReplayingFailedUnitOfWork = false;
+      originalReplayError = null;
       if (hasCaughtError()) {
         clearCaughtError();
       } else {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -274,7 +274,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       error: mixed,
       isAsync: boolean,
     ) => {
-      // Retore the original state of the work-in-progress
+      // Restore the original state of the work-in-progress
       assignFiberPropertiesInDEV(
         failedUnitOfWork,
         stashedWorkInProgressProperties,

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+
+'use strict';
+
+let React;
+let ReactNoop;
+
+describe('ReactIncrementalErrorReplay', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+  });
+
+  function div(...children) {
+    children = children.map(c => (typeof c === 'string' ? {text: c} : c));
+    return {type: 'div', children, prop: undefined};
+  }
+
+  function span(prop) {
+    return {type: 'span', children: [], prop};
+  }
+
+  it('should fail gracefully on error in the host environment', () => {
+    ReactNoop.simulateErrorInHostConfig(() => {
+      ReactNoop.render(<span />);
+      expect(() => ReactNoop.flush()).toThrow('Error in host config.');
+    });
+  });
+
+  it('should fail gracefully on error that does not reproduce on replay', () => {
+    let didInit = false;
+
+    function badLazyInit() {
+      const needsInit = !didInit;
+      didInit = true;
+      if (needsInit) {
+        throw new Error('Hi');
+      }
+    }
+
+    class App extends React.Component {
+      render() {
+        badLazyInit();
+        return <div />;
+      }
+    }
+    ReactNoop.render(<App />);
+    expect(() => ReactNoop.flush()).toThrow('Hi');
+  });
+});


### PR DESCRIPTION
Adds failing tests for https://github.com/facebook/react/issues/12449 and a possibly related bug I found. These run against real bundles—let's not add feature flags there. I verified they passed with previous version of the reconciler.