### PR TITLE
Fix DEV performance regression by avoiding Object.assign on Fibers

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -471,3 +471,47 @@ export function createFiberFromPortal(
   };
   return fiber;
 }
+
+// Used for stashing WIP properties to replay failed work in DEV.
+export function assignFiberPropertiesInDEV(
+  target: Fiber | null,
+  source: Fiber,
+): Fiber {
+  if (target === null) {
+    // This Fiber's initial properties will always be overwritten.
+    // We only use a Fiber to ensure the same hidden class so DEV isn't slow.
+    target = createFiber(IndeterminateComponent, null, null, NoContext);
+  }
+
+  // This is intentionally written as a list of all properties.
+  // We tried to use Object.assign() instead but this is called in
+  // the hottest path, and Object.assign() was too slow:
+  // https://github.com/facebook/react/issues/12502
+  // This code is DEV-only so size is not a concern.
+
+  target.tag = source.tag;
+  target.key = source.key;
+  target.type = source.type;
+  target.stateNode = source.stateNode;
+  target.return = source.return;
+  target.child = source.child;
+  target.sibling = source.sibling;
+  target.index = source.index;
+  target.ref = source.ref;
+  target.pendingProps = source.pendingProps;
+  target.memoizedProps = source.memoizedProps;
+  target.updateQueue = source.updateQueue;
+  target.memoizedState = source.memoizedState;
+  target.mode = source.mode;
+  target.effectTag = source.effectTag;
+  target.nextEffect = source.nextEffect;
+  target.firstEffect = source.firstEffect;
+  target.lastEffect = source.lastEffect;
+  target.expirationTime = source.expirationTime;
+  target.alternate = source.alternate;
+  target._debugID = source._debugID;
+  target._debugSource = source._debugSource;
+  target._debugOwner = source._debugOwner;
+  target._debugIsCurrentlyTiming = source._debugIsCurrentlyTiming;
+  return target;
+}

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -791,7 +791,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
       stashedWorkInProgressProperties = assignFiberPropertiesInDEV(
-        null,
+        stashedWorkInProgressProperties,
         workInProgress,
       );
     }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -72,7 +72,7 @@ import {
   startCommitLifeCyclesTimer,
   stopCommitLifeCyclesTimer,
 } from './ReactDebugFiberPerf';
-import {createWorkInProgress} from './ReactFiber';
+import {createWorkInProgress, assignFiberPropertiesInDEV} from './ReactFiber';
 import {onCommitRoot} from './ReactFiberDevToolsHook';
 import {
   NoWork,
@@ -260,7 +260,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     stashedWorkInProgressProperties = null;
     replayUnitOfWork = (failedUnitOfWork: Fiber, isAsync: boolean) => {
       // Retore the original state of the work-in-progress
-      Object.assign(failedUnitOfWork, stashedWorkInProgressProperties);
+      assignFiberPropertiesInDEV(
+        failedUnitOfWork,
+        stashedWorkInProgressProperties,
+      );
       switch (failedUnitOfWork.tag) {
         case HostRoot:
           popHostContainer(failedUnitOfWork);
@@ -787,7 +790,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
 
     if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
-      stashedWorkInProgressProperties = Object.assign({}, workInProgress);
+      stashedWorkInProgressProperties = assignFiberPropertiesInDEV(
+        null,
+        workInProgress,
+      );
     }
     let next = beginWork(current, workInProgress, nextRenderExpirationTime);
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.internal.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment node
+ */
+
+'use strict';
+
+describe('ReactIncrementalErrorReplay-test', () => {
+  it('copies all keys when stashing potentially failing work', () => {
+    // Note: this test is fragile and relies on internals.
+    // We almost always try to avoid such tests, but here the cost of
+    // the list getting out of sync (and causing subtle bugs in rare cases)
+    // is higher than the cost of maintaing the test.
+    const {
+      // Any Fiber factory function will do.
+      createHostRootFiber,
+      // This is the method we're going to test.
+      // If this is no longer used, you can delete this test file.
+      assignFiberPropertiesInDEV,
+    } = require('../ReactFiber');
+
+    // Get a real fiber.
+    const realFiber = createHostRootFiber(false);
+    const stash = assignFiberPropertiesInDEV(null, realFiber);
+
+    // Verify we get all the same fields.
+    expect(realFiber).toEqual(stash);
+
+    // Mutate the original.
+    for (let key in realFiber) {
+      realFiber[key] = key + '_' + Math.random();
+    }
+    expect(realFiber).not.toEqual(stash);
+
+    // Verify we can still "revert" to the stashed properties.
+    expect(assignFiberPropertiesInDEV(realFiber, stash)).toBe(realFiber);
+    expect(realFiber).toEqual(stash);
+  });
+});


### PR DESCRIPTION
As far as I can see it fixes https://github.com/facebook/react/issues/12502.

Previously the function containing the `Object.assign` call was at the top of self time.

<img width="771" alt="before" src="https://user-images.githubusercontent.com/810438/38169163-8b0113aa-355a-11e8-867b-7da5331b5d81.png">

Now it's not even on the radar.

<img width="730" alt="screen shot 2018-04-01 at 03 13 59" src="https://user-images.githubusercontent.com/810438/38169170-c4439138-355a-11e8-9322-9094d147567b.png">

The repro case from https://github.com/facebook/react/issues/12502#issuecomment-377728965 feels about 2x faster.

I’m not a big fan of the testing strategy but I think it won't be too much of a burden long term, and the hackiness is worth it here.