### PR TITLE
Extract throw to separate function so performUnitOfWork does not deopt

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -265,6 +265,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   let replayUnitOfWork;
   let isReplayingFailedUnitOfWork;
   let originalReplayError;
+  let rethrowOriginalError;
   if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
     stashedWorkInProgressProperties = null;
     isReplayingFailedUnitOfWork = false;
@@ -310,6 +311,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         // back to the original value.
         nextUnitOfWork = failedUnitOfWork;
       }
+    };
+    rethrowOriginalError = () => {
+      throw originalReplayError;
     };
   }
 
@@ -875,7 +879,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         // because the render phase is meant to be idempotent, and it should
         // have thrown again. Since it didn't, rethrow the original error, so
         // React's internal stack is not misaligned.
-        throw originalReplayError;
+        rethrowOriginalError();
       }
     }
     if (__DEV__ && ReactFiberInstrumentation.debugTool) {


### PR DESCRIPTION
Only affects DEV mode, but still important I think.


Follow-up to https://github.com/facebook/react/pull/12508/commits/220af1eaaf8637d7b3a756ad38e23a0ff33c48d6