### PR TITLE
Bumped create-subscription package version

### DIFF
--- a/packages/create-subscription/package.json
+++ b/packages/create-subscription/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-subscription",
   "description": "utility for subscribing to external data sources inside React components",
-  "version": "0.1.0",
+  "version": "16.3.0",
   "repository": "facebook/react",
   "files": [
     "LICENSE",


### PR DESCRIPTION
Our release script will increment it during the next 16.3.1 release to be locked with the other versions.

(Should we manually publish a version 16.3.0 of this package?)