### PR TITLE
Remove @providesModule in www bundles

### DIFF
--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -93,7 +93,6 @@ ${source}`;
 ${license}
  *
  * @noflow
- * @providesModule ${globalName}-dev
  * @preventMunge
  */
 
@@ -112,7 +111,6 @@ ${source}
 ${license}
  *
  * @noflow
- * @providesModule ${globalName}-prod
  * @preventMunge
  */
 


### PR DESCRIPTION
Don't need them anymore (I tested).
I haven't updated RN headers because I'm not sure if all tooling is ready to drop them yet.