### PR TITLE
Use object bracket access test for RESERVED_PROPS

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -310,10 +310,10 @@ function processContext(type, context) {
 
 const STYLE = 'style';
 const RESERVED_PROPS = {
-  children: null,
-  dangerouslySetInnerHTML: null,
-  suppressContentEditableWarning: null,
-  suppressHydrationWarning: null,
+  children: true,
+  dangerouslySetInnerHTML: true,
+  suppressContentEditableWarning: true,
+  suppressHydrationWarning: true,
 };
 
 function createOpenTagMarkup(
@@ -339,7 +339,7 @@ function createOpenTagMarkup(
     }
     let markup = null;
     if (isCustomComponent(tagLowercase, props)) {
-      if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
+      if (!RESERVED_PROPS[propKey]) {
         markup = createMarkupForCustomAttribute(propKey, propValue);
       }
     } else {

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -190,10 +190,7 @@ export function createElement(type, config, children) {
     source = config.__source === undefined ? null : config.__source;
     // Remaining properties are added to a new props object
     for (propName in config) {
-      if (
-        hasOwnProperty.call(config, propName) &&
-        !RESERVED_PROPS.hasOwnProperty(propName)
-      ) {
+      if (hasOwnProperty.call(config, propName) && !RESERVED_PROPS[propName]) {
         props[propName] = config[propName];
       }
     }
@@ -324,10 +321,7 @@ export function cloneElement(element, config, children) {
       defaultProps = element.type.defaultProps;
     }
     for (propName in config) {
-      if (
-        hasOwnProperty.call(config, propName) &&
-        !RESERVED_PROPS.hasOwnProperty(propName)
-      ) {
+      if (hasOwnProperty.call(config, propName) && !RESERVED_PROPS[propName]) {
         if (config[propName] === undefined && defaultProps !== undefined) {
           // Resolve default props
           props[propName] = defaultProps[propName];


### PR DESCRIPTION
Continuing from #12370 with different solution (ping @gaearon)

- Should be even faster than previous checks using `hasOwnProperty` (if my benchmark works correctly anyway)
- Google Closure Compiler will optimize away static properties from
objects if properties aren't accessed dynamically. Using bracket access
will make Closure to keep these properties in optimized code.

---

I thought `preserveTypeAnnotations` would keep all JSDoc annotations but `@nocollapse` seems to be different than "general" JSDoc comments, so it is not kept.

After failure with that approach I started looking into why https://github.com/facebook/react/blob/master/packages/shared/isTextInputElement.js#L13-L29 works with Closure optimizations (with externs to keep the property names). The function is transpiled into static object and a function which uses brackets to access the object. Turns out, that because the code is using brackets to access the object Closure doesn't optimize the properties away.

I checked performance difference between hasOwnProperty and brackets, and looks like object bracket access is faster: https://jsperf.com/static-object-check-if-prop-exists/1