### PR TITLE
Clarify ReactDOM's case warning for html tags

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1001,7 +1001,7 @@ describe('ReactDOMComponent', () => {
       expect(() => {
         returnedValue = ReactDOMServer.renderToString(<Container />);
       }).toWarnDev(
-          '<BR /> is using incorrect casing. ' +
+        '<BR /> is using incorrect casing. ' +
           'Use PascalCase for React components, ' +
           'or lowercase letters and dashes for HTML.',
       );
@@ -1017,7 +1017,7 @@ describe('ReactDOMComponent', () => {
       expect(() =>
         ReactTestUtils.renderIntoDocument(React.createElement('IMG')),
       ).toWarnDev(
-          '<IMG /> is using incorrect casing. ' +
+        '<IMG /> is using incorrect casing. ' +
           'Use PascalCase for React components, ' +
           'or lowercase letters and dashes for HTML.',
       );
@@ -1068,8 +1068,8 @@ describe('ReactDOMComponent', () => {
           ReactTestUtils.renderIntoDocument(<hasOwnProperty />),
         ).toWarnDev([
           '<hasOwnProperty /> is using incorrect casing. ' +
-          'Use PascalCase for React components, ' +
-          'or lowercase letters and dashes for HTML.',
+            'Use PascalCase for React components, ' +
+            'or lowercase letters and dashes for HTML.',
           'The tag <hasOwnProperty> is unrecognized in this browser',
         ]);
       } finally {

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1000,7 +1000,11 @@ describe('ReactDOMComponent', () => {
 
       expect(() => {
         returnedValue = ReactDOMServer.renderToString(<Container />);
-      }).toWarnDev('<BR /> is using uppercase HTML.');
+      }).toWarnDev(
+          '<BR /> is using incorrect casing. ' +
+          'Use PascalCase for React components, ' +
+          'or lowercase letters and dashes for HTML.',
+      );
       expect(returnedValue).not.toContain('</BR>');
     });
 
@@ -1012,7 +1016,11 @@ describe('ReactDOMComponent', () => {
 
       expect(() =>
         ReactTestUtils.renderIntoDocument(React.createElement('IMG')),
-      ).toWarnDev('<IMG /> is using uppercase HTML.');
+      ).toWarnDev(
+          '<IMG /> is using incorrect casing. ' +
+          'Use PascalCase for React components, ' +
+          'or lowercase letters and dashes for HTML.',
+      );
     });
 
     it('should warn on props reserved for future use', () => {
@@ -1059,7 +1067,9 @@ describe('ReactDOMComponent', () => {
         expect(() =>
           ReactTestUtils.renderIntoDocument(<hasOwnProperty />),
         ).toWarnDev([
-          '<hasOwnProperty /> is using uppercase HTML',
+          '<hasOwnProperty /> is using incorrect casing. ' +
+          'Use PascalCase for React components, ' +
+          'or lowercase letters and dashes for HTML.',
           'The tag <hasOwnProperty> is unrecognized in this browser',
         ]);
       } finally {

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.internal.js
@@ -603,12 +603,12 @@ describe('ReactDOMServer', () => {
       ),
     ).toWarnDev([
       'Warning: <inPUT /> is using incorrect casing. ' +
-      'Use PascalCase for React components, ' +
-      'or lowercase letters and dashes for HTML.',
+        'Use PascalCase for React components, ' +
+        'or lowercase letters and dashes for HTML.',
       // linearGradient doesn't warn
       'Warning: <iFrame /> is using incorrect casing. ' +
-      'Use PascalCase for React components, ' +
-      'or lowercase letters and dashes for HTML.',
+        'Use PascalCase for React components, ' +
+        'or lowercase letters and dashes for HTML.',
     ]);
   });
 

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.internal.js
@@ -602,11 +602,13 @@ describe('ReactDOMServer', () => {
         </div>,
       ),
     ).toWarnDev([
-      'Warning: <inPUT /> is using uppercase HTML. Always use lowercase ' +
-        'HTML tags in React.',
+      'Warning: <inPUT /> is using incorrect casing. ' +
+      'Use PascalCase for React components, ' +
+      'or lowercase letters and dashes for HTML.',
       // linearGradient doesn't warn
-      'Warning: <iFrame /> is using uppercase HTML. Always use lowercase ' +
-        'HTML tags in React.',
+      'Warning: <iFrame /> is using incorrect casing. ' +
+      'Use PascalCase for React components, ' +
+      'or lowercase letters and dashes for HTML.',
     ]);
   });
 

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -355,8 +355,9 @@ export function createElement(
       // allow <SVG> or <mATH>.
       warning(
         isCustomComponentTag || type === type.toLowerCase(),
-        '<%s /> is using uppercase HTML. Always use lowercase HTML tags ' +
-          'in React.',
+        '<%s /> is using incorrect casing. ' +
+          'Use PascalCase for React components, ' +
+          'or lowercase letters and dashes for HTML.',
         type,
       );
     }

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -955,8 +955,9 @@ class ReactDOMServerRenderer {
         // allow <SVG> or <mATH>.
         warning(
           tag === element.type,
-          '<%s /> is using uppercase HTML. Always use lowercase HTML tags ' +
-            'in React.',
+          '<%s /> is using incorrect casing. ' +
+            'Use PascalCase for React components, ' +
+            'or lowercase letters and dashes for HTML.',
           element.type,
         );
       }


### PR DESCRIPTION
References git issue: #12527 

Changed the html tag casing warning to be more explicit.