### PR TITLE
Throw more specific error if passed undefined in React.cloneElement

### DIFF
--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -293,7 +293,7 @@ export function cloneAndReplaceKey(oldElement, newKey) {
  */
 export function cloneElement(element, config, children) {
   invariant(
-    !(element === null || element === undefined),
+    element != null,
     'Cannot clone a null or undefined element.'
   );
 

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -10,9 +10,9 @@ import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 
 import ReactCurrentOwner from './ReactCurrentOwner';
 
-const hasOwnProperty = Object.prototype.hasOwnProperty;
+import invariant from 'fbjs/lib/invariant';
 
-const invariant = require('fbjs/lib/invariant');
+const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 const RESERVED_PROPS = {
   key: true,

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -294,7 +294,8 @@ export function cloneAndReplaceKey(oldElement, newKey) {
 export function cloneElement(element, config, children) {
   invariant(
     !(element === null || element === undefined),
-    'Cannot clone a null or undefined element.',
+    'React.cloneElement(...): The argument must be a React element, but you passed %s.',
+    element,
   );
 
   let propName;

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -291,7 +291,7 @@ export function cloneAndReplaceKey(oldElement, newKey) {
  */
 export function cloneElement(element, config, children) {
   if (element === undefined) {
-    throw new Error("Cannot call 'cloneElement' on undefined.");
+    throw new TypeError("Cannot call 'cloneElement' on undefined.");
   }
 
   let propName;

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -294,7 +294,7 @@ export function cloneAndReplaceKey(oldElement, newKey) {
 export function cloneElement(element, config, children) {
   invariant(
     !(element === null || element === undefined),
-    'Cannot clone a null or undefined element.'
+    'Cannot clone a null or undefined element.',
   );
 
   let propName;

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -290,6 +290,10 @@ export function cloneAndReplaceKey(oldElement, newKey) {
  * See https://reactjs.org/docs/react-api.html#cloneelement
  */
 export function cloneElement(element, config, children) {
+  if (element === undefined) {
+    throw new Error("Cannot call 'cloneElement' on undefined.");
+  }
+
   let propName;
 
   // Original props are copied

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -293,8 +293,8 @@ export function cloneAndReplaceKey(oldElement, newKey) {
  */
 export function cloneElement(element, config, children) {
   invariant(
-      !(element === null || element === undefined),
-      'Cannot clone a null or undefined element.'
+    !(element === null || element === undefined),
+    'Cannot clone a null or undefined element.'
   );
 
   let propName;

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -12,6 +12,8 @@ import ReactCurrentOwner from './ReactCurrentOwner';
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
+const invariant = require('fbjs/lib/invariant');
+
 const RESERVED_PROPS = {
   key: true,
   ref: true,
@@ -290,10 +292,10 @@ export function cloneAndReplaceKey(oldElement, newKey) {
  * See https://reactjs.org/docs/react-api.html#cloneelement
  */
 export function cloneElement(element, config, children) {
-
-  if (!element) {
-    throw new TypeError('Cannot clone null or undefined.');
-  }
+  invariant(
+      !(element === null || element === undefined),
+      'Cannot clone a null or undefined element.'
+  );
 
   let propName;
 

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -5,12 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 
 import ReactCurrentOwner from './ReactCurrentOwner';
-
-import invariant from 'fbjs/lib/invariant';
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -290,8 +290,9 @@ export function cloneAndReplaceKey(oldElement, newKey) {
  * See https://reactjs.org/docs/react-api.html#cloneelement
  */
 export function cloneElement(element, config, children) {
-  if (element === undefined) {
-    throw new TypeError("Cannot call 'cloneElement' on undefined.");
+
+  if (!element) {
+    throw new TypeError('Cannot clone null or undefined.');
   }
 
   let propName;

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -293,7 +293,7 @@ export function cloneAndReplaceKey(oldElement, newKey) {
  */
 export function cloneElement(element, config, children) {
   invariant(
-    element != null,
+    !(element === null || element === undefined),
     'Cannot clone a null or undefined element.'
   );
 

--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -363,14 +363,14 @@ describe('ReactElementClone', () => {
   it('throws an error if passed null', () => {
     const element = null;
     expect(() => React.cloneElement(element)).toThrow(
-        'React.cloneElement(...): The argument must be a React element, but you passed null.'
+      'React.cloneElement(...): The argument must be a React element, but you passed null.',
     );
   });
 
   it('throws an error if passed undefined', () => {
     let element;
     expect(() => React.cloneElement(element)).toThrow(
-        'React.cloneElement(...): The argument must be a React element, but you passed undefined.'
+      'React.cloneElement(...): The argument must be a React element, but you passed undefined.',
     );
   });
 });

--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -359,4 +359,18 @@ describe('ReactElementClone', () => {
     }
     expect(clone.props).toEqual({foo: 'ef'});
   });
+
+  it('throws an error if passed null', () => {
+    const element = null;
+    expect(() => React.cloneElement(element)).toThrow(
+        'React.cloneElement(...): The argument must be a React element, but you passed null.'
+    );
+  });
+
+  it('throws an error if passed undefined', () => {
+    let element;
+    expect(() => React.cloneElement(element)).toThrow(
+        'React.cloneElement(...): The argument must be a React element, but you passed undefined.'
+    );
+  });
 });


### PR DESCRIPTION
References issue: #12491 

Throw a `TypeError` if the element to clone is `undefined`.