### PR TITLE
Add a build step to hoist warning conditions

### DIFF
--- a/scripts/babel/__tests__/wrap-warning-with-env-check-test.js
+++ b/scripts/babel/__tests__/wrap-warning-with-env-check-test.js
@@ -36,7 +36,7 @@ describe('wrap-warning-with-env-check', () => {
   it('should wrap warning calls', () => {
     compare(
       "warning(condition, 'a %s b', 'c');",
-      "__DEV__ ? warning(condition, 'a %s b', 'c') : void 0;"
+      "__DEV__ ? !condition ? warning(false, 'a %s b', 'c') : void 0 : void 0;"
     );
   });
 

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -17,6 +17,9 @@ const pathToBabel = path.join(
 const pathToBabelPluginDevWithCode = require.resolve(
   '../error-codes/replace-invariant-error-codes'
 );
+const pathToBabelPluginWrapWarning = require.resolve(
+  '../babel/wrap-warning-with-env-check'
+);
 const pathToBabelPluginAsyncToGenerator = require.resolve(
   'babel-plugin-transform-async-to-generator'
 );
@@ -29,6 +32,8 @@ const babelOptions = {
     require.resolve('babel-plugin-transform-es2015-modules-commonjs'),
 
     pathToBabelPluginDevWithCode,
+    pathToBabelPluginWrapWarning,
+
     // Keep stacks detailed in tests.
     // Don't put this in .babelrc so that we don't embed filenames
     // into ReactART builds that include JSX.
@@ -75,6 +80,7 @@ module.exports = {
     pathToBabel,
     pathToBabelrc,
     pathToBabelPluginDevWithCode,
+    pathToBabelPluginWrapWarning,
     pathToErrorCodes,
   ]),
 };

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -87,7 +87,7 @@ function getBabelConfig(updateBabelOptions, bundleType, filename) {
       return Object.assign({}, options, {
         plugins: options.plugins.concat([
           // Wrap warning() calls in a __DEV__ check so they are stripped from production.
-          require('./plugins/wrap-warning-with-env-check'),
+          require('../babel/wrap-warning-with-env-check'),
         ]),
       });
     case UMD_DEV:
@@ -101,7 +101,7 @@ function getBabelConfig(updateBabelOptions, bundleType, filename) {
           // Minify invariant messages
           require('../error-codes/replace-invariant-error-codes'),
           // Wrap warning() calls in a __DEV__ check so they are stripped from production.
-          require('./plugins/wrap-warning-with-env-check'),
+          require('../babel/wrap-warning-with-env-check'),
         ]),
       });
     default:


### PR DESCRIPTION
I was recently profiling a DEV build of React and noticed this:

<img width="728" alt="screen shot 2018-04-04 at 15 48 53" src="https://user-images.githubusercontent.com/810438/38317573-3e36d3fc-3825-11e8-8777-6b65079bf38f.png">

So almost 10% of the time was spent building component stacks for a warning that doesn't fire once. This is because the code looks like

```js
warning(condition, message, getStack())
```

and so we evaluate `getStack()` regardless of whether it fires.

We already have a build step that "hoists" invariant conditions to prevent unnecessary work for invariants. In this PR, I extend an existing warning build step to do the same thing.

Essentially it turns the above code into

```js
if (!condition) {
  warning(false, message, getStack());
}
```

This is nice both because it delays evaluating the arguments for the common case, and because we don't even have to step into `warning` at all.

I enabled it in tests too for parity.

One potential pitfall is that it's easier to introduce a mistake into the argument calculation, and if it's never evaluated in tests, we'll never know. But we generally don't add warnings without tests so that seems like it won't be a big problem in practice.

Full bundle diff: https://gist.github.com/gaearon/0bc2fd23d957e2ddc3939ef7425b3afd

This has no effect on production bundles because they don't contain warning calls.