### PR TITLE
Preserve error codes for invariants on www

### DIFF
--- a/packages/shared/forks/reactProdInvariant.www.js
+++ b/packages/shared/forks/reactProdInvariant.www.js
@@ -7,12 +7,8 @@
  * @flow
  */
 
-/**
- * WARNING: DO NOT manually require this module.
- * This is a replacement for `invariant(...)` used by the error code system
- * and will _only_ be required by the corresponding babel pass.
- * It always throws.
- */
+const invariant = require('invariant');
+
 function reactProdInvariant(code: string): void {
   const argCount = arguments.length - 1;
 
@@ -31,14 +27,12 @@ function reactProdInvariant(code: string): void {
     ' for the full message or use the non-minified dev environment' +
     ' for full errors and additional helpful warnings.';
 
-  // Note: if you update the code above, don't forget
-  // to update the www fork in forks/reactProdInvariant.www.js.
-
-  const error: Error & {framesToPop?: number} = new Error(message);
-  error.name = 'Invariant Violation';
-  error.framesToPop = 1; // we don't care about reactProdInvariant's own frame
-
-  throw error;
+  // www doesn't strip this because we mark the React bundle
+  // with @preserve-invariant-messages docblock.
+  const i = invariant;
+  // However, we call it with a different name to avoid
+  // transforming this file itself as part of React's own build.
+  i(false, message);
 }
 
 export default reactProdInvariant;

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -205,7 +205,7 @@ function getPlugins(
   return [
     // Extract error codes from invariant() messages into a file.
     shouldExtractErrors && {
-      transform(source, opts) {
+      transform(source) {
         findAndRecordErrorCodes(source);
         return source;
       },

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -82,6 +82,14 @@ function getBabelConfig(updateBabelOptions, bundleType, filename) {
   switch (bundleType) {
     case FB_DEV:
     case FB_PROD:
+      return Object.assign({}, options, {
+        plugins: options.plugins.concat([
+          // Minify invariant messages
+          require('../error-codes/replace-invariant-error-codes'),
+          // Wrap warning() calls in a __DEV__ check so they are stripped from production.
+          require('../babel/wrap-warning-with-env-check'),
+        ]),
+      });
     case RN_DEV:
     case RN_PROD:
       return Object.assign({}, options, {
@@ -197,7 +205,7 @@ function getPlugins(
   return [
     // Extract error codes from invariant() messages into a file.
     shouldExtractErrors && {
-      transform(source) {
+      transform(source, opts) {
         findAndRecordErrorCodes(source);
         return source;
       },

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -84,6 +84,17 @@ const forks = Object.freeze({
     }
   },
 
+  // Route production invariants on www through the www invariant module.
+  'shared/reactProdInvariant': (bundleType, entry) => {
+    switch (bundleType) {
+      case FB_DEV:
+      case FB_PROD:
+        return 'shared/forks/reactProdInvariant.www.js';
+      default:
+        return null;
+    }
+  },
+
   // Different dialogs for caught errors.
   'react-reconciler/src/ReactFiberErrorDialog': (bundleType, entry) => {
     switch (bundleType) {

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -94,6 +94,7 @@ ${license}
  *
  * @noflow
  * @preventMunge
+ * @preserve-invariant-messages
  */
 
 'use strict';
@@ -112,6 +113,7 @@ ${license}
  *
  * @noflow
  * @preventMunge
+ * @preserve-invariant-messages
  */
 
 ${source}`;


### PR DESCRIPTION
Currently we don't do any invariant transformation in www. It has its own pipeline which strips invariant messages completely. But that leaves us worse off because we don't have any codes at all.

With this change, prod www bundles will contain the error codes and a special `@preserve-invariant-messages` directive that will prevent stripping their messages (since there’ll only be one in practice).

The downside of this change is that with JS debugging parameter set to true but in PROD mode you'd have to click an extra time to see the error. Maybe that's not too bad if we fix the error dialog to linkify links.