### PR TITLE
[WIP] Optimize context by using an object for stateNode

### DIFF
--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -39,7 +39,7 @@ export default function(stack: Stack) {
     push(providerCursor, providerFiber, providerFiber);
 
     context._currentValue = providerFiber.pendingProps.value;
-    context._changedBits = providerFiber.stateNode;
+    context._changedBits = providerFiber.stateNode.bits;
 
     if (__DEV__) {
       warning(


### PR DESCRIPTION
I tested a tree view with this, and there appears to be a significant improvement in DEV.

My hypothesis is that `stateNode` being an object prevents some kind of deopt in the propagation loop where `fiber` type switches from one with a number `stateNode` to one with an object `stateNode`.

Details below.

## Self Time

### Before

<img width="745" alt="dev" src="https://user-images.githubusercontent.com/810438/38329659-6c4259c6-3846-11e8-8e8b-49fc4428f2ee.png">

### After

<img width="746" alt="dev" src="https://user-images.githubusercontent.com/810438/38329694-815724c2-3846-11e8-974a-dd2a06e6fccc.png">

## Detailed Breakdown

### Before

<img width="420" alt="hotness_dev" src="https://user-images.githubusercontent.com/810438/38329733-97124e7c-3846-11e8-9a1b-199621ead0c0.png">

### After

<img width="375" alt="hotness_dev" src="https://user-images.githubusercontent.com/810438/38329715-8d4d518e-3846-11e8-8e91-44d853bfdc5f.png">

## Summary

### Before
<img width="168" alt="screen shot 2018-04-04 at 20 36 05" src="https://user-images.githubusercontent.com/810438/38330242-f566e680-3847-11e8-9d61-073dd165e717.png">

### After

<img width="174" alt="screen shot 2018-04-04 at 20 36 54" src="https://user-images.githubusercontent.com/810438/38330253-fa641aa4-3847-11e8-8ae2-ffe006cade73.png">

## Firefox 

### Before
<img width="694" alt="ff_dev" src="https://user-images.githubusercontent.com/810438/38329915-134711a8-3847-11e8-8b96-3da8446998bd.png">


### After

<img width="724" alt="ff_dev" src="https://user-images.githubusercontent.com/810438/38329880-075c71a8-3847-11e8-904b-e19204a5997f.png">

-----

What’s odd is, I haven’t seen a noticeable difference in production builds.
Maybe there’s something GCC does that accidentally mitigates this.

My testing procedure is to make a tree view with 1,000 consumers, and then update the root context 10 times. I tried swapping the bundles here and back a few times, and the difference in DEV consistently reproduces.