### PR TITLE
Remove flushSync from React Native

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -77,8 +77,6 @@ const ReactFabric: ReactNativeType = {
 
   unstable_batchedUpdates: ReactGenericBatching.batchedUpdates,
 
-  flushSync: ReactFabricRenderer.flushSync,
-
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // Used as a mixin in many createClass-based components
     NativeMethodsMixin,

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -96,8 +96,6 @@ const ReactNativeRenderer: ReactNativeType = {
 
   unstable_batchedUpdates: ReactGenericBatching.batchedUpdates,
 
-  flushSync: ReactNativeFiberRenderer.flushSync,
-
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // Used as a mixin in many createClass-based components
     NativeMethodsMixin,


### PR DESCRIPTION
There are no plans to enable async in the old renderer. In the new renderer
it only really makes sense to do from the main thread and probably from
native since it'll have to yield to native to do the work.

I'm not sure the exact equivalent will exist (and that makes it interesting from a test renderer perspective, should it exist there if it is not universal)?