### PR TITLE
Add non-standard allowing variants of ReactDOMServer render methods (fixes #10064)

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -32,6 +32,7 @@ function initModules() {
 const {
   resetModules,
   itRenders,
+  itRendersNonStandard,
   clientCleanRender,
 } = ReactDOMServerIntegrationUtils(initModules);
 
@@ -603,6 +604,16 @@ describe('ReactDOMServerIntegration', () => {
         const e = await render(<nonstandard foo="bar" />);
         expect(e.getAttribute('foo')).toBe('bar');
       });
+
+      itRendersNonStandard(
+        'non-standard attributes for non-standard elements',
+        async render => {
+          const e = await render(
+            <non-standard {...{'[non-standard]': 'test'}} />,
+          );
+          expect(e.getAttribute('[non-standard]')).toBe('test');
+        },
+      );
 
       itRenders('SVG tags with dashes in them', async render => {
         const e = await render(

--- a/packages/react-dom/src/__tests__/ReactServerRenderingBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingBrowser-test.js
@@ -52,6 +52,40 @@ describe('ReactServerRenderingBrowser', () => {
     );
   });
 
+  it('returns the same non-standard results as react-dom/server', () => {
+    class NiceNonStandard extends React.Component {
+      render() {
+        return (
+          <greeting-answer {...{'[type]': 'nice'}}>
+            I am feeling very good today, thanks, how are you?
+          </greeting-answer>
+        );
+      }
+    }
+    function GreetingNonStandard() {
+      return (
+        <div>
+          <greeting-question {...{'[type]': 'inquisitive'}}>
+            How are you?
+          </greeting-question>
+          <NiceNonStandard />
+        </div>
+      );
+    }
+    expect(
+      ReactDOMServerBrowser.renderToStringNonStandard(<GreetingNonStandard />),
+    ).toEqual(
+      ReactDOMServer.renderToStringNonStandard(<GreetingNonStandard />),
+    );
+    expect(
+      ReactDOMServerBrowser.renderToStaticMarkupNonStandard(
+        <GreetingNonStandard />,
+      ),
+    ).toEqual(
+      ReactDOMServer.renderToStaticMarkupNonStandard(<GreetingNonStandard />),
+    );
+  });
+
   it('throws meaningfully for server-only APIs', () => {
     expect(() => ReactDOMServerBrowser.renderToNodeStream(<div />)).toThrow(
       'ReactDOMServer.renderToNodeStream(): The streaming API is not available ' +
@@ -62,6 +96,18 @@ describe('ReactServerRenderingBrowser', () => {
     ).toThrow(
       'ReactDOMServer.renderToStaticNodeStream(): The streaming API is not available ' +
         'in the browser. Use ReactDOMServer.renderToStaticMarkup() instead.',
+    );
+    expect(() =>
+      ReactDOMServerBrowser.renderToNodeStreamNonStandard(<div />),
+    ).toThrow(
+      'ReactDOMServer.renderToNodeStreamNonStandard(): The streaming API is not available ' +
+        'in the browser. Use ReactDOMServer.renderToStringNonStandard() instead.',
+    );
+    expect(() =>
+      ReactDOMServerBrowser.renderToStaticNodeStreamNonStandard(<div />),
+    ).toThrow(
+      'ReactDOMServer.renderToStaticNodeStreamNonStandard(): The streaming API is not available ' +
+        'in the browser. Use ReactDOMServer.renderToStaticMarkupNonStandard() instead.',
     );
   });
 });

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -75,8 +75,9 @@ export function createMarkupForProperty(name: string, value: mixed): string {
 export function createMarkupForCustomAttribute(
   name: string,
   value: mixed,
+  allowNonStandard: boolean,
 ): string {
-  if (!isAttributeNameSafe(name) || value == null) {
+  if ((!allowNonStandard && !isAttributeNameSafe(name)) || value == null) {
     return '';
   }
   return name + '=' + quoteAttributeValueForBrowser(value);

--- a/packages/react-dom/src/server/ReactDOMNodeStreamRenderer.js
+++ b/packages/react-dom/src/server/ReactDOMNodeStreamRenderer.js
@@ -11,11 +11,15 @@ import ReactPartialRenderer from './ReactPartialRenderer';
 
 // This is a Readable Node.js stream which wraps the ReactDOMPartialRenderer.
 class ReactMarkupReadableStream extends Readable {
-  constructor(element, makeStaticMarkup) {
+  constructor(element, makeStaticMarkup, allowNonStandard) {
     // Calls the stream.Readable(options) constructor. Consider exposing built-in
     // features like highWaterMark in the future.
     super({});
-    this.partialRenderer = new ReactPartialRenderer(element, makeStaticMarkup);
+    this.partialRenderer = new ReactPartialRenderer(
+      element,
+      makeStaticMarkup,
+      allowNonStandard,
+    );
   }
 
   _read(size) {
@@ -32,7 +36,7 @@ class ReactMarkupReadableStream extends Readable {
  * See https://reactjs.org/docs/react-dom-stream.html#rendertonodestream
  */
 export function renderToNodeStream(element) {
-  return new ReactMarkupReadableStream(element, false);
+  return new ReactMarkupReadableStream(element, false, false);
 }
 
 /**
@@ -41,5 +45,23 @@ export function renderToNodeStream(element) {
  * See https://reactjs.org/docs/react-dom-stream.html#rendertostaticnodestream
  */
 export function renderToStaticNodeStream(element) {
-  return new ReactMarkupReadableStream(element, true);
+  return new ReactMarkupReadableStream(element, true, false);
+}
+
+/**
+ * Render a ReactElement to its initial non-standard HTML. This should only be
+ * used on the server.
+ * See https://reactjs.org/docs/react-dom-stream.html#rendertonodestream
+ */
+export function renderToNodeStreamNonStandard(element) {
+  return new ReactMarkupReadableStream(element, false, true);
+}
+
+/**
+ * Similar to renderToNodeStreamNonStandard, except this doesn't create extra
+ * DOM attributes such as data-react-id that React uses internally.
+ * See https://reactjs.org/docs/react-dom-stream.html#rendertostaticnodestream
+ */
+export function renderToStaticNodeStreamNonStandard(element) {
+  return new ReactMarkupReadableStream(element, true, true);
 }

--- a/packages/react-dom/src/server/ReactDOMServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMServerBrowser.js
@@ -8,7 +8,12 @@
 import ReactVersion from 'shared/ReactVersion';
 import invariant from 'fbjs/lib/invariant';
 
-import {renderToString, renderToStaticMarkup} from './ReactDOMStringRenderer';
+import {
+  renderToString,
+  renderToStaticMarkup,
+  renderToStringNonStandard,
+  renderToStaticMarkupNonStandard,
+} from './ReactDOMStringRenderer';
 
 function renderToNodeStream() {
   invariant(
@@ -26,11 +31,31 @@ function renderToStaticNodeStream() {
   );
 }
 
+function renderToNodeStreamNonStandard() {
+  invariant(
+    false,
+    'ReactDOMServer.renderToNodeStreamNonStandard(): The streaming API is not available ' +
+      'in the browser. Use ReactDOMServer.renderToStringNonStandard() instead.',
+  );
+}
+
+function renderToStaticNodeStreamNonStandard() {
+  invariant(
+    false,
+    'ReactDOMServer.renderToStaticNodeStreamNonStandard(): The streaming API is not available ' +
+      'in the browser. Use ReactDOMServer.renderToStaticMarkupNonStandard() instead.',
+  );
+}
+
 // Note: when changing this, also consider https://github.com/facebook/react/issues/11526
 export default {
   renderToString,
   renderToStaticMarkup,
+  renderToStringNonStandard,
+  renderToStaticMarkupNonStandard,
   renderToNodeStream,
   renderToStaticNodeStream,
+  renderToNodeStreamNonStandard,
+  renderToStaticNodeStreamNonStandard,
   version: ReactVersion,
 };

--- a/packages/react-dom/src/server/ReactDOMServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMServerNode.js
@@ -7,17 +7,28 @@
 
 import ReactVersion from 'shared/ReactVersion';
 
-import {renderToString, renderToStaticMarkup} from './ReactDOMStringRenderer';
+import {
+  renderToString,
+  renderToStaticMarkup,
+  renderToStringNonStandard,
+  renderToStaticMarkupNonStandard,
+} from './ReactDOMStringRenderer';
 import {
   renderToNodeStream,
   renderToStaticNodeStream,
+  renderToNodeStreamNonStandard,
+  renderToStaticNodeStreamNonStandard,
 } from './ReactDOMNodeStreamRenderer';
 
 // Note: when changing this, also consider https://github.com/facebook/react/issues/11526
 export default {
   renderToString,
   renderToStaticMarkup,
+  renderToStringNonStandard,
+  renderToStaticMarkupNonStandard,
   renderToNodeStream,
   renderToStaticNodeStream,
+  renderToNodeStreamNonStandard,
+  renderToStaticNodeStreamNonStandard,
   version: ReactVersion,
 };

--- a/packages/react-dom/src/server/ReactDOMStringRenderer.js
+++ b/packages/react-dom/src/server/ReactDOMStringRenderer.js
@@ -13,7 +13,7 @@ import ReactPartialRenderer from './ReactPartialRenderer';
  * See https://reactjs.org/docs/react-dom-server.html#rendertostring
  */
 export function renderToString(element) {
-  const renderer = new ReactPartialRenderer(element, false);
+  const renderer = new ReactPartialRenderer(element, false, false);
   const markup = renderer.read(Infinity);
   return markup;
 }
@@ -24,7 +24,29 @@ export function renderToString(element) {
  * See https://reactjs.org/docs/react-dom-server.html#rendertostaticmarkup
  */
 export function renderToStaticMarkup(element) {
-  const renderer = new ReactPartialRenderer(element, true);
+  const renderer = new ReactPartialRenderer(element, true, false);
+  const markup = renderer.read(Infinity);
+  return markup;
+}
+
+/**
+ * Render a ReactElement to its initial non-standard HTML. This should only be
+ * used on the server.
+ * See https://reactjs.org/docs/react-dom-server.html#rendertostring
+ */
+export function renderToStringNonStandard(element) {
+  const renderer = new ReactPartialRenderer(element, false, true);
+  const markup = renderer.read(Infinity);
+  return markup;
+}
+
+/**
+ * Similar to renderToStringNonStandard, except this doesn't create extra DOM
+ * attributes such as data-react-id that React uses internally.
+ * See https://reactjs.org/docs/react-dom-server.html#rendertostaticmarkup
+ */
+export function renderToStaticMarkupNonStandard(element) {
+  const renderer = new ReactPartialRenderer(element, true, true);
   const markup = renderer.read(Infinity);
   return markup;
 }

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -324,6 +324,7 @@ function createOpenTagMarkup(
   namespace: string,
   makeStaticMarkup: boolean,
   isRootElement: boolean,
+  allowNonStandard: boolean,
 ): string {
   let ret = '<' + tagVerbatim;
 
@@ -341,7 +342,11 @@ function createOpenTagMarkup(
     let markup = null;
     if (isCustomComponent(tagLowercase, props)) {
       if (!RESERVED_PROPS.hasOwnProperty(propKey)) {
-        markup = createMarkupForCustomAttribute(propKey, propValue);
+        markup = createMarkupForCustomAttribute(
+          propKey,
+          propValue,
+          allowNonStandard,
+        );
       }
     } else {
       markup = createMarkupForProperty(propKey, propValue);
@@ -645,7 +650,11 @@ class ReactDOMServerRenderer {
   providerStack: Array<?ReactProvider<any>>;
   providerIndex: number;
 
-  constructor(children: mixed, makeStaticMarkup: boolean) {
+  constructor(
+    children: mixed,
+    makeStaticMarkup: boolean,
+    allowNonStandard: boolean,
+  ) {
     const flatChildren = flattenTopLevelChildren(children);
 
     const topFrame: Frame = {
@@ -666,6 +675,7 @@ class ReactDOMServerRenderer {
     this.currentSelectValue = null;
     this.previousWasTextNode = false;
     this.makeStaticMarkup = makeStaticMarkup;
+    this.allowNonStandard = allowNonStandard;
 
     // Context (new API)
     this.providerStack = []; // Stack of provider objects
@@ -1190,6 +1200,7 @@ class ReactDOMServerRenderer {
       namespace,
       this.makeStaticMarkup,
       this.stack.length === 1,
+      this.allowNonStandard,
     );
     let footer = '';
     if (omittedCloseTags.hasOwnProperty(tag)) {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -646,6 +646,7 @@ class ReactDOMServerRenderer {
   currentSelectValue: any;
   previousWasTextNode: boolean;
   makeStaticMarkup: boolean;
+  allowNonStandard: boolean;
 
   providerStack: Array<?ReactProvider<any>>;
   providerIndex: number;


### PR DESCRIPTION
Adds 4 new methods to ReactDOMServer:
*   `renderToStringNonStandard`
*   `renderToStaticMarkupNonStandard`
*	`renderToNodeStreamNonStandard`
*	`renderToStaticNodeStreamNonStandard`

Each mirrors the existing:
*   `renderToString`
*   `renderToStaticMarkup`
*	`renderToNodeStream`
*	`renderToStaticNodeStream`

This allows for rendering markup that may not adhere to W3C standards, yet still works in browsers (like [AMP html](https://www.ampproject.org/learn/overview/)).