### PR TITLE
[RN] Remove unstable_batchedUpdates and unmountComponentAtNodeAndRemoveContainer from Fabric

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ReactNativeType} from './ReactNativeTypes';
+import type {ReactFabricType} from './ReactNativeTypes';
 import type {ReactNodeList} from 'shared/ReactTypes';
 
 import './ReactFabricInjection';
@@ -34,7 +34,7 @@ ReactGenericBatching.injection.injectRenderer(ReactFabricRenderer);
 
 const roots = new Map();
 
-const ReactFabric: ReactNativeType = {
+const ReactFabric: ReactFabricType = {
   NativeComponent: ReactNativeComponent,
 
   findNodeHandle: findNumericNodeHandle,
@@ -63,10 +63,6 @@ const ReactFabric: ReactNativeType = {
     }
   },
 
-  unmountComponentAtNodeAndRemoveContainer(containerTag: number) {
-    ReactFabric.unmountComponentAtNode(containerTag);
-  },
-
   createPortal(
     children: ReactNodeList,
     containerTag: number,
@@ -74,8 +70,6 @@ const ReactFabric: ReactNativeType = {
   ) {
     return ReactPortal.createPortal(children, containerTag, null, key);
   },
-
-  unstable_batchedUpdates: ReactGenericBatching.batchedUpdates,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // Used as a mixin in many createClass-based components

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -104,3 +104,16 @@ export type ReactNativeType = {
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: SecretInternalsType,
 };
+
+export type ReactFabricType = {
+  NativeComponent: any,
+  findNodeHandle(componentOrHandle: any): ?number,
+  render(
+    element: React$Element<any>,
+    containerTag: any,
+    callback: ?Function,
+  ): any,
+  unmountComponentAtNode(containerTag: number): any,
+
+  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: SecretInternalsType,
+};


### PR DESCRIPTION
These don't make much sense in Fabric, since Fabric will be async by default only.

And unmount+remove container is a sketchy API we should remove so we might as well make sure modern containers enforce that. It's not functional in Fabric anyway.
