### PR TITLE
Keep consistency in the comment

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -88,7 +88,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
   function markUpdate(workInProgress: Fiber) {
     // Tag the fiber with an update effect. This turns a Placement into
-    // an UpdateAndPlacement.
+    // an PlacementAndUpdate.
     workInProgress.effectTag |= Update;
   }
 


### PR DESCRIPTION
I think this should keep consistency with the [ReactTypeOfSideEffect.js](https://github.com/facebook/react/blob/master/packages/shared/ReactTypeOfSideEffect.js#L19), but I am not sure whether it's intentional
