### PR TITLE
Don't bail on new context Provider if a legacy provider rendered above

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -893,11 +893,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       // Initial render
       changedBits = MAX_SIGNED_31_BIT_INT;
     } else {
-      const canBailOnChildren =
-        canBailOnProps && oldProps.children === newProps.children;
       if (oldProps.value === newProps.value) {
         // No change. Bailout early if children are the same.
-        if (canBailOnChildren) {
+        if (oldProps.children === newProps.children && canBailOnProps) {
           workInProgress.stateNode = 0;
           pushProvider(workInProgress);
           return bailoutOnAlreadyFinishedWork(current, workInProgress);
@@ -914,7 +912,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           (oldValue !== oldValue && newValue !== newValue) // eslint-disable-line no-self-compare
         ) {
           // No change. Bailout early if children are the same.
-          if (canBailOnChildren) {
+          if (oldProps.children === newProps.children && canBailOnProps) {
             workInProgress.stateNode = 0;
             pushProvider(workInProgress);
             return bailoutOnAlreadyFinishedWork(current, workInProgress);
@@ -937,7 +935,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
           if (changedBits === 0) {
             // No change. Bailout early if children are the same.
-            if (canBailOnChildren) {
+            if (oldProps.children === newProps.children && canBailOnProps) {
               workInProgress.stateNode = 0;
               pushProvider(workInProgress);
               return bailoutOnAlreadyFinishedWork(current, workInProgress);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -859,8 +859,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     const newProps = workInProgress.pendingProps;
     const oldProps = workInProgress.memoizedProps;
+    let canBailOnProps = true;
 
     if (hasLegacyContextChanged()) {
+      canBailOnProps = false;
       // Normally we can bail out on props equality but if context has changed
       // we don't do the bailout and we have to reuse existing props instead.
     } else if (oldProps === newProps) {
@@ -891,9 +893,11 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       // Initial render
       changedBits = MAX_SIGNED_31_BIT_INT;
     } else {
+      const canBailOnChildren =
+        canBailOnProps && oldProps.children === newProps.children;
       if (oldProps.value === newProps.value) {
         // No change. Bailout early if children are the same.
-        if (oldProps.children === newProps.children) {
+        if (canBailOnChildren) {
           workInProgress.stateNode = 0;
           pushProvider(workInProgress);
           return bailoutOnAlreadyFinishedWork(current, workInProgress);
@@ -910,7 +914,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           (oldValue !== oldValue && newValue !== newValue) // eslint-disable-line no-self-compare
         ) {
           // No change. Bailout early if children are the same.
-          if (oldProps.children === newProps.children) {
+          if (canBailOnChildren) {
             workInProgress.stateNode = 0;
             pushProvider(workInProgress);
             return bailoutOnAlreadyFinishedWork(current, workInProgress);
@@ -933,7 +937,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
           if (changedBits === 0) {
             // No change. Bailout early if children are the same.
-            if (oldProps.children === newProps.children) {
+            if (canBailOnChildren) {
               workInProgress.stateNode = 0;
               pushProvider(workInProgress);
               return bailoutOnAlreadyFinishedWork(current, workInProgress);


### PR DESCRIPTION
This fixes https://github.com/facebook/react/issues/12551, https://github.com/ReactTraining/react-router/issues/6072.

Arguably we don't *have to* fix it but it's pretty confusing to debug and I expect this to be a hurdle to libraries adopting new context while the ecosystem hasn't fully migrated yet (for example React Router already has a bug about this: https://github.com/ReactTraining/react-router/issues/6072).

This **only** affects the `Provider` bailout, and relaxes it to not bail out on constant children if there's a legacy provider above. This shouldn't make modern-only code any slower, and I think would help products move to new context sooner. 
