### PR TITLE
Fixes language in error message.

### DIFF
--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -133,7 +133,7 @@ let SharedHostConfig = {
       throw new Error('Should have old props');
     }
     if (newProps === null) {
-      throw new Error('Should have old props');
+      throw new Error('Should have new props');
     }
     return UPDATE_SIGNAL;
   },


### PR DESCRIPTION
# Fixes error message language

I was reading over this doc and noticed an error message that is seemingly a copy/paste typo that could lead to user confusion.

*The fix*

I changed the message to be relative to the errant prop.
