### PR TITLE
Bump expiration for interactive updates to 150ms in production

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1094,8 +1094,14 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   }
 
   function computeInteractiveExpiration(currentTime: ExpirationTime) {
-    // Should complete within ~500ms. 600ms max.
-    const expirationMs = 500;
+    let expirationMs;
+    if (__DEV__) {
+      // Should complete within ~500ms. 600ms max.
+      expirationMs = 500;
+    } else {
+      // In production things should be more responsive, 150ms max.
+      expirationMs = 150;
+    }
     const bucketSizeMs = 100;
     return computeExpirationBucket(currentTime, expirationMs, bucketSizeMs);
   }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1095,6 +1095,14 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
   function computeInteractiveExpiration(currentTime: ExpirationTime) {
     let expirationMs;
+    // We intentionally set a higher expiration time for interactive updates in
+    // dev than in production.
+    // If the main thread is being blocked so long that you hit the expiration,
+    // it's a problem that could be solved with better scheduling.
+    // People will be more likely to notice this and fix it with the long
+    // expiration time in development.
+    // In production we opt for better UX at the risk of masking scheduling
+    // problems, by expiring fast.
     if (__DEV__) {
       // Should complete within ~500ms. 600ms max.
       expirationMs = 500;


### PR DESCRIPTION
**what is the change?:**
Changes the expiration deadline from 500ms to 150ms, only in production.
In development it will still be 500ms.

I'm thinking we may want to change the 'bucket size' too, will look into
that a bit.

**why make this change?:**
We need to ensure interactions are responsive enough in order to gather
more test data on async. mode.

Hoping to land and sync this into FB asap.

**test plan:**
No tests failed - where shall we add a test for this?
