### PR TITLE
[WIP] Allow dev to acknowledge ‘onChange’ warning by passing undefined/null

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -61,6 +61,18 @@ describe('ReactDOMInput', () => {
     document.body.removeChild(container);
   });
 
+  it('should not warn with value and onChange handler specified as undefined', () => {
+    ReactTestUtils.renderIntoDocument(
+      <input type="checkbox" value="lion" onChange={undefined} />,
+    );
+  });
+
+  it('should not warn with value and onChange handler specified as null', () => {
+    ReactTestUtils.renderIntoDocument(
+      <input type="checkbox" value="lion" onChange={null} />,
+    );
+  });
+
   it('should control a value in reentrant events', () => {
     class ControlledInputs extends React.Component {
       state = {value: 'lion'};
@@ -925,6 +937,18 @@ describe('ReactDOMInput', () => {
       'Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler. ' +
         'This will render a read-only field. If the field should be mutable use `defaultChecked`. ' +
         'Otherwise, set either `onChange` or `readOnly`.',
+    );
+  });
+
+  it('should not warn with checked and onChange handler specified as undefined', () => {
+    ReactTestUtils.renderIntoDocument(
+      <input type="checkbox" checked="false" onChange={undefined} />,
+    );
+  });
+
+  it('should not warn with checked and onChange handler specified as null', () => {
+    ReactTestUtils.renderIntoDocument(
+      <input type="checkbox" checked="false" onChange={null} />,
     );
   });
 

--- a/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
+++ b/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
@@ -27,7 +27,7 @@ if (__DEV__) {
       if (
         !props[propName] ||
         hasReadOnlyValue[props.type] ||
-        props.onChange ||
+        props.hasOwnProperty('onChange') ||
         props.readOnly ||
         props.disabled
       ) {
@@ -43,7 +43,7 @@ if (__DEV__) {
     checked: function(props, propName, componentName) {
       if (
         !props[propName] ||
-        props.onChange ||
+        props.hasOwnProperty('onChange') ||
         props.readOnly ||
         props.disabled
       ) {


### PR DESCRIPTION
## Description

### Problem 1 - pushed

When explicitly setting onChange prop to undefined or null, a warning is still presented
```
<input type="radio" checked={true} onChange={undefined} />
```
### Problem 2

Warning is not shown unless `checked` has a truthy value, ie this does not prompt a warning:
```
<input type="radio" checked={false} />
```

References issue #12477 