### PR TITLE
Fixed debug performance labels for new component types

### DIFF
--- a/packages/react-reconciler/src/ReactDebugFiberPerf.js
+++ b/packages/react-reconciler/src/ReactDebugFiberPerf.js
@@ -21,6 +21,8 @@ import {
   Fragment,
   ContextProvider,
   ContextConsumer,
+  Mode,
+  ForwardRef,
 } from 'shared/ReactTypeOfWork';
 
 type MeasurementPhase =
@@ -175,6 +177,8 @@ const shouldIgnoreFiber = (fiber: Fiber): boolean => {
     case Fragment:
     case ContextProvider:
     case ContextConsumer:
+    case Mode:
+    case ForwardRef:
       return true;
     default:
       return false;

--- a/packages/react-reconciler/src/ReactDebugFiberPerf.js
+++ b/packages/react-reconciler/src/ReactDebugFiberPerf.js
@@ -22,7 +22,6 @@ import {
   ContextProvider,
   ContextConsumer,
   Mode,
-  ForwardRef,
 } from 'shared/ReactTypeOfWork';
 
 type MeasurementPhase =
@@ -178,7 +177,6 @@ const shouldIgnoreFiber = (fiber: Fiber): boolean => {
     case ContextProvider:
     case ContextConsumer:
     case Mode:
-    case ForwardRef:
       return true;
     default:
       return false;

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -161,7 +161,7 @@ describe('ReactDebugFiberPerf', () => {
     expect(getFlameChart()).toMatchSnapshot();
   });
 
-  it('does not include forwardRef component in measurements', () => {
+  it('properly displays the forwardRef component in measurements', () => {
     const ForwardRef = React.forwardRef(function refForwarder(props, ref) {
       return <Child {...props} ref={ref} />;
     });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -161,6 +161,34 @@ describe('ReactDebugFiberPerf', () => {
     expect(getFlameChart()).toMatchSnapshot();
   });
 
+  it('measures and identifies a forwardRef component correctly', () => {
+    const ForwardRef = React.forwardRef(function refForwarder(props, ref) {
+      return <Child {...props} ref={ref} />;
+    });
+
+    ReactNoop.render(<ForwardRef />);
+    addComment('Mount');
+    ReactNoop.flush();
+
+    expect(getFlameChart()).toMatchSnapshot();
+  });
+
+  it('measures and identifies StrictMode and AsyncMode components correctly', () => {
+    ReactNoop.render(
+      <React.StrictMode>
+        <Parent>
+          <React.unstable_AsyncMode>
+            <Child />
+          </React.unstable_AsyncMode>
+        </Parent>
+      </React.StrictMode>,
+    );
+    addComment('Mount');
+    ReactNoop.flush();
+
+    expect(getFlameChart()).toMatchSnapshot();
+  });
+
   it('skips parents during setState', () => {
     class A extends React.Component {
       render() {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -161,7 +161,7 @@ describe('ReactDebugFiberPerf', () => {
     expect(getFlameChart()).toMatchSnapshot();
   });
 
-  it('measures and identifies a forwardRef component correctly', () => {
+  it('does not include forwardRef component in measurements', () => {
     const ForwardRef = React.forwardRef(function refForwarder(props, ref) {
       return <Child {...props} ref={ref} />;
     });
@@ -173,7 +173,7 @@ describe('ReactDebugFiberPerf', () => {
     expect(getFlameChart()).toMatchSnapshot();
   });
 
-  it('measures and identifies StrictMode and AsyncMode components correctly', () => {
+  it('does not include StrictMode or AsyncMode components in measurements', () => {
     ReactNoop.render(
       <React.StrictMode>
         <Parent>
@@ -182,6 +182,22 @@ describe('ReactDebugFiberPerf', () => {
           </React.unstable_AsyncMode>
         </Parent>
       </React.StrictMode>,
+    );
+    addComment('Mount');
+    ReactNoop.flush();
+
+    expect(getFlameChart()).toMatchSnapshot();
+  });
+
+  it('does not include context provider or consumer in measurements', () => {
+    const {Consumer, Provider} = React.createContext(true);
+
+    ReactNoop.render(
+      <Provider value={false}>
+        <Parent>
+          <Consumer>{value => <Child value={value} />}</Consumer>
+        </Parent>
+      </Provider>,
     );
     addComment('Mount');
     ReactNoop.flush();

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -162,11 +162,25 @@ describe('ReactDebugFiberPerf', () => {
   });
 
   it('properly displays the forwardRef component in measurements', () => {
-    const ForwardRef = React.forwardRef(function refForwarder(props, ref) {
+    const AnonymousForwardRef = React.forwardRef((props, ref) => (
+      <Child {...props} ref={ref} />
+    ));
+    const NamedForwardRef = React.forwardRef(function refForwarder(props, ref) {
       return <Child {...props} ref={ref} />;
     });
+    function notImportant(props, ref) {
+      return <Child {...props} ref={ref} />;
+    }
+    notImportant.displayName = 'OverriddenName';
+    const DisplayNamedForwardRef = React.forwardRef(notImportant);
 
-    ReactNoop.render(<ForwardRef />);
+    ReactNoop.render(
+      <Parent>
+        <AnonymousForwardRef />
+        <NamedForwardRef />
+        <DisplayNamedForwardRef />
+      </Parent>,
+    );
     addComment('Mount');
     ReactNoop.flush();
 

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -182,9 +182,9 @@ exports[`ReactDebugFiberPerf measures and identifies StrictMode and AsyncMode co
 
 // Mount
 ⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ Unknown [mount]
+  ⚛ StrictMode [mount]
     ⚛ Parent [mount]
-      ⚛ Unknown [mount]
+      ⚛ AsyncMode [mount]
         ⚛ Child [mount]
 
 ⚛ (Committing Changes)
@@ -199,7 +199,7 @@ exports[`ReactDebugFiberPerf measures and identifies a forwardRef component corr
 
 // Mount
 ⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ Unknown [mount]
+  ⚛ ForwardRef [mount]
     ⚛ Child [mount]
 
 ⚛ (Committing Changes)

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -266,8 +266,13 @@ exports[`ReactDebugFiberPerf properly displays the forwardRef component in measu
 
 // Mount
 ⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ ForwardRef [mount]
-    ⚛ Child [mount]
+  ⚛ Parent [mount]
+    ⚛ ForwardRef [mount]
+      ⚛ Child [mount]
+    ⚛ ForwardRef(refForwarder) [mount]
+      ⚛ Child [mount]
+    ⚛ ForwardRef(OverriddenName) [mount]
+      ⚛ Child [mount]
 
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -121,20 +121,6 @@ exports[`ReactDebugFiberPerf does not include context provider or consumer in me
 "
 `;
 
-exports[`ReactDebugFiberPerf does not include forwardRef component in measurements 1`] = `
-"⚛ (Waiting for async callback... will force flush in 5230 ms)
-
-// Mount
-⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ Child [mount]
-
-⚛ (Committing Changes)
-  ⚛ (Committing Snapshot Effects: 0 Total)
-  ⚛ (Committing Host Effects: 1 Total)
-  ⚛ (Calling Lifecycle Methods: 0 Total)
-"
-`;
-
 exports[`ReactDebugFiberPerf does not schedule an extra callback if setState is called during a synchronous commit phase 1`] = `
 "⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Component [mount]
@@ -272,6 +258,21 @@ exports[`ReactDebugFiberPerf measures deprioritized work 1`] = `
   ⚛ (Committing Snapshot Effects: 0 Total)
   ⚛ (Committing Host Effects: 3 Total)
   ⚛ (Calling Lifecycle Methods: 2 Total)
+"
+`;
+
+exports[`ReactDebugFiberPerf properly displays the forwardRef component in measurements 1`] = `
+"⚛ (Waiting for async callback... will force flush in 5230 ms)
+
+// Mount
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ ForwardRef [mount]
+    ⚛ Child [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
 "
 `;
 

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -91,6 +91,50 @@ exports[`ReactDebugFiberPerf deduplicates lifecycle names during commit to reduc
 "
 `;
 
+exports[`ReactDebugFiberPerf does not include StrictMode or AsyncMode components in measurements 1`] = `
+"⚛ (Waiting for async callback... will force flush in 5230 ms)
+
+// Mount
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [mount]
+    ⚛ Child [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
+"
+`;
+
+exports[`ReactDebugFiberPerf does not include context provider or consumer in measurements 1`] = `
+"⚛ (Waiting for async callback... will force flush in 5230 ms)
+
+// Mount
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [mount]
+    ⚛ Child [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
+"
+`;
+
+exports[`ReactDebugFiberPerf does not include forwardRef component in measurements 1`] = `
+"⚛ (Waiting for async callback... will force flush in 5230 ms)
+
+// Mount
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Child [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
+"
+`;
+
 exports[`ReactDebugFiberPerf does not schedule an extra callback if setState is called during a synchronous commit phase 1`] = `
 "⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Component [mount]
@@ -169,38 +213,6 @@ exports[`ReactDebugFiberPerf measures a simple reconciliation 1`] = `
 
 // Unmount
 ⚛ (React Tree Reconciliation: Completed Root)
-
-⚛ (Committing Changes)
-  ⚛ (Committing Snapshot Effects: 0 Total)
-  ⚛ (Committing Host Effects: 1 Total)
-  ⚛ (Calling Lifecycle Methods: 0 Total)
-"
-`;
-
-exports[`ReactDebugFiberPerf measures and identifies StrictMode and AsyncMode components correctly 1`] = `
-"⚛ (Waiting for async callback... will force flush in 5230 ms)
-
-// Mount
-⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ StrictMode [mount]
-    ⚛ Parent [mount]
-      ⚛ AsyncMode [mount]
-        ⚛ Child [mount]
-
-⚛ (Committing Changes)
-  ⚛ (Committing Snapshot Effects: 0 Total)
-  ⚛ (Committing Host Effects: 1 Total)
-  ⚛ (Calling Lifecycle Methods: 0 Total)
-"
-`;
-
-exports[`ReactDebugFiberPerf measures and identifies a forwardRef component correctly 1`] = `
-"⚛ (Waiting for async callback... will force flush in 5230 ms)
-
-// Mount
-⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ ForwardRef [mount]
-    ⚛ Child [mount]
 
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -177,6 +177,38 @@ exports[`ReactDebugFiberPerf measures a simple reconciliation 1`] = `
 "
 `;
 
+exports[`ReactDebugFiberPerf measures and identifies StrictMode and AsyncMode components correctly 1`] = `
+"⚛ (Waiting for async callback... will force flush in 5230 ms)
+
+// Mount
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Unknown [mount]
+    ⚛ Parent [mount]
+      ⚛ Unknown [mount]
+        ⚛ Child [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
+"
+`;
+
+exports[`ReactDebugFiberPerf measures and identifies a forwardRef component correctly 1`] = `
+"⚛ (Waiting for async callback... will force flush in 5230 ms)
+
+// Mount
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Unknown [mount]
+    ⚛ Child [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
+"
+`;
+
 exports[`ReactDebugFiberPerf measures deferred work in chunks 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5230 ms)
 

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -38,8 +38,7 @@ function getComponentName(fiber: Fiber): string | null {
   if (typeof type === 'object' && type !== null) {
     switch (type.$$typeof) {
       case REACT_FORWARD_REF_TYPE:
-        const functionName =
-          type.render.displayName || type.render.name || '';
+        const functionName = type.render.displayName || type.render.name || '';
         return functionName !== ''
           ? `ForwardRef(${functionName})`
           : 'ForwardRef';

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -38,7 +38,11 @@ function getComponentName(fiber: Fiber): string | null {
   if (typeof type === 'object' && type !== null) {
     switch (type.$$typeof) {
       case REACT_FORWARD_REF_TYPE:
-        return 'ForwardRef';
+        const functionName =
+          type.render.displayName || type.render.name || '';
+        return functionName !== ''
+          ? `ForwardRef(${functionName})`
+          : 'ForwardRef';
     }
   }
   return null;

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -10,10 +10,13 @@
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
 import {
+  REACT_ASYNC_MODE_TYPE,
   REACT_CALL_TYPE,
+  REACT_FORWARD_REF_TYPE,
   REACT_FRAGMENT_TYPE,
   REACT_RETURN_TYPE,
   REACT_PORTAL_TYPE,
+  REACT_STRICT_MODE_TYPE,
 } from 'shared/ReactSymbols';
 
 function getComponentName(fiber: Fiber): string | null {
@@ -25,15 +28,26 @@ function getComponentName(fiber: Fiber): string | null {
     return type;
   }
   switch (type) {
+    case REACT_ASYNC_MODE_TYPE:
+      return 'AsyncMode';
+    case REACT_CALL_TYPE:
+      return 'ReactCall';
     case REACT_FRAGMENT_TYPE:
       return 'ReactFragment';
     case REACT_PORTAL_TYPE:
       return 'ReactPortal';
-    case REACT_CALL_TYPE:
-      return 'ReactCall';
     case REACT_RETURN_TYPE:
       return 'ReactReturn';
+    case REACT_STRICT_MODE_TYPE:
+      return 'StrictMode';
   }
+  if (typeof type === 'object' && type !== null) {
+    switch (type.$$typeof) {
+      case REACT_FORWARD_REF_TYPE:
+        return 'ForwardRef';
+    }
+  }
+
   return null;
 }
 

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -14,6 +14,7 @@ import {
   REACT_FRAGMENT_TYPE,
   REACT_RETURN_TYPE,
   REACT_PORTAL_TYPE,
+  REACT_FORWARD_REF_TYPE,
 } from 'shared/ReactSymbols';
 
 function getComponentName(fiber: Fiber): string | null {
@@ -33,6 +34,12 @@ function getComponentName(fiber: Fiber): string | null {
       return 'ReactCall';
     case REACT_RETURN_TYPE:
       return 'ReactReturn';
+  }
+  if (typeof type === 'object' && type !== null) {
+    switch (type.$$typeof) {
+      case REACT_FORWARD_REF_TYPE:
+        return 'ForwardRef';
+    }
   }
   return null;
 }

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -10,13 +10,10 @@
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
 import {
-  REACT_ASYNC_MODE_TYPE,
   REACT_CALL_TYPE,
-  REACT_FORWARD_REF_TYPE,
   REACT_FRAGMENT_TYPE,
   REACT_RETURN_TYPE,
   REACT_PORTAL_TYPE,
-  REACT_STRICT_MODE_TYPE,
 } from 'shared/ReactSymbols';
 
 function getComponentName(fiber: Fiber): string | null {
@@ -28,26 +25,15 @@ function getComponentName(fiber: Fiber): string | null {
     return type;
   }
   switch (type) {
-    case REACT_ASYNC_MODE_TYPE:
-      return 'AsyncMode';
-    case REACT_CALL_TYPE:
-      return 'ReactCall';
     case REACT_FRAGMENT_TYPE:
       return 'ReactFragment';
     case REACT_PORTAL_TYPE:
       return 'ReactPortal';
+    case REACT_CALL_TYPE:
+      return 'ReactCall';
     case REACT_RETURN_TYPE:
       return 'ReactReturn';
-    case REACT_STRICT_MODE_TYPE:
-      return 'StrictMode';
   }
-  if (typeof type === 'object' && type !== null) {
-    switch (type.$$typeof) {
-      case REACT_FORWARD_REF_TYPE:
-        return 'ForwardRef';
-    }
-  }
-
   return null;
 }
 


### PR DESCRIPTION
We shouldn't show "Unknown" in the performance tab:
![screen shot 2018-04-12 at 9 05 29 am](https://user-images.githubusercontent.com/29597/38689492-ada70296-3e30-11e8-87f5-10226aae78cf.png)

The perf labels will now exclude `StrictMode` and `unstable_AsyncMode` components. `forwardRef` components will display as "_ForwardRef_".