### PR TITLE
fix test case title

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
@@ -47,7 +47,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildren('c')).toEqual([span('c:1')]);
   });
 
-  it('schedules top-level updates in order of priority', () => {
+  it('schedules top-level updates in order of scheduled', () => {
     // Initial render.
     ReactNoop.render(<span prop={1} />);
     ReactNoop.flush();


### PR DESCRIPTION
Because the update queue depend on the insert order rather than priority level, I think the title should be adjusted? It seems that [#10175](https://github.com/facebook/react/pull/10715) forgot to do this, but I'm not sure. 