### PR TITLE
Provide the class context to getDerivedStateFromProps

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -445,8 +445,7 @@ function resolve(
           }
         }
 
-        let partialState = Component.getDerivedStateFromProps.call(
-          null,
+        let partialState = Component.getDerivedStateFromProps(
           element.props,
           inst.state,
         );

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -650,14 +650,10 @@ export default function(
           workInProgress.mode & StrictMode)
       ) {
         // Invoke method an extra time to help detect side-effects.
-        type.getDerivedStateFromProps.call(null, nextProps, prevState);
+        type.getDerivedStateFromProps(nextProps, prevState);
       }
 
-      const partialState = type.getDerivedStateFromProps.call(
-        null,
-        nextProps,
-        prevState,
-      );
+      const partialState = type.getDerivedStateFromProps(nextProps, prevState);
 
       if (__DEV__) {
         if (partialState === undefined) {

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -118,6 +118,27 @@ describe 'ReactCoffeeScriptClass', ->
     test React.createElement(Foo, foo: 'foo'), 'DIV', 'foo bar'
     undefined
 
+  it 'can access other class methods and properties from getDerivedStateFromProps', ->
+    class Foo extends React.Component
+      constructor: (props) ->
+        super props
+        @state =
+          foo: null
+          bar: null
+      render: ->
+        div
+          className: "#{@state.foo} #{@state.bar}"
+    Foo.foo = 'foo'
+    Foo.getBar = () ->
+      'bar'
+    Foo.getDerivedStateFromProps = () ->
+      {
+        foo: this.foo
+        bar: this.getBar()
+      }
+    test React.createElement(Foo, foo: 'foo'), 'DIV', 'foo bar'
+    undefined
+
   it 'warns if getDerivedStateFromProps is not static', ->
     class Foo extends React.Component
       render: ->

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -128,6 +128,26 @@ describe('ReactES6Class', () => {
     test(<Foo foo="foo" />, 'DIV', 'foo bar');
   });
 
+  it('can access other class methods and properties from getDerivedStateFromProps', () => {
+    class Foo extends React.Component {
+      state = {};
+      static foo = 'foo';
+      static getBar() {
+        return 'bar';
+      }
+      static getDerivedStateFromProps() {
+        return {
+          foo: this.foo,
+          bar: this.getBar(),
+        };
+      }
+      render() {
+        return <div className={`${this.state.foo} ${this.state.bar}`} />;
+      }
+    }
+    test(<Foo foo="foo" />, 'DIV', 'foo bar');
+  });
+
   it('warns if getDerivedStateFromProps is not static', () => {
     class Foo extends React.Component {
       getDerivedStateFromProps() {

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -378,6 +378,31 @@ describe('ReactTypeScriptClass', function() {
     test(React.createElement(Foo, {foo: 'foo'}), 'DIV', 'foo bar');
   });
 
+  it('can access other class methods and properties from getDerivedStateFromProps', () => {
+    class Foo extends React.Component {
+      state = {
+        foo: null,
+        bar: null,
+      };
+      static foo = 'foo';
+      static getBar() {
+        return 'bar';
+      }
+      static getDerivedStateFromProps() {
+        return {
+          foo: this.foo,
+          bar: this.getBar()
+        };
+      }
+      render() {
+        return React.createElement('div', {
+          className: `${this.state.foo} ${this.state.bar}`,
+        });
+      }
+    }
+    test(React.createElement(Foo, {foo: 'foo'}), 'DIV', 'foo bar');
+  });
+
   it('warns if getDerivedStateFromProps is not static', function() {
     class Foo extends React.Component {
       getDerivedStateFromProps() {


### PR DESCRIPTION
Currently `null` is passed as the context to `getDerivedStateFromProps`, this PR makes sure the context of the class isn't lost, allowing other class methods/properties to be accessed through `this`. (fixes https://github.com/facebook/react/issues/12612)