### PR TITLE
Update GCC

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -68,6 +68,7 @@ const closureOptions = {
   applyInputSourceMaps: false,
   useTypesForOptimization: false,
   processCommonJsModules: false,
+  rewritePolyfills: false,
 };
 
 function getBabelConfig(updateBabelOptions, bundleType, filename) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2561,8 +2561,8 @@ glogg@^1.0.0:
     sparkles "^1.0.0"
 
 google-closure-compiler-js@>20170000:
-  version "20170910.0.1"
-  resolved "https://registry.yarnpkg.com/@gaearon/google-closure-compiler-js/-/google-closure-compiler-js-20170910.0.1.tgz#b0cf7ef408219a19c390375a76bf0a82ccf65eea"
+  version "20180402.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20180402.0.0.tgz#b90ee11c597030b90ed1c6a054dd728aba81ab2d"
   dependencies:
     minimist "^1.2.0"
     vinyl "^2.0.1"


### PR DESCRIPTION
No significant changes as far as I can see. I had to add `rewritePolyfills: false` because of https://github.com/google/closure-compiler/issues/2448. That’s what we want anyway.

This “unforks” GCC because I point it at the official package now.

<details>

```diff
diff --git a/dist/react-art.production.min.js b/dist/react-art.production.min.js
index a05da7b..16fcf28 100644
--- a/dist/react-art.production.min.js
+++ b/dist/react-art.production.min.js
@@ -1159,15 +1159,17 @@
                 currentFirstChild,
                 newChild,
                 expirationTime
-              )))
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild))
             : (deleteRemainingChildren(returnFiber, currentFirstChild),
               (currentFirstChild = createFiberFromText(
                 newChild,
                 returnFiber.mode,
                 expirationTime
-              ))),
-          (currentFirstChild["return"] = returnFiber),
-          (returnFiber = currentFirstChild),
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild)),
           placeSingleChild(returnFiber)
         );
       if (isArray$1(newChild))
@@ -5520,7 +5522,7 @@
       }
       this.isColor = !0;
     },
-    listMatch = /([-.\d]+\%?)\s*,\s*([-.\d]+\%?)\s*,\s*([-.\d]+\%?)\s*,?\s*([-.\d]*\%?)/,
+    listMatch = /([-.\d]+%?)\s*,\s*([-.\d]+%?)\s*,\s*([-.\d]+%?)\s*,?\s*([-.\d]*%?)/,
     hexMatch = /^#?([a-f0-9]{1,2})([a-f0-9]{1,2})([a-f0-9]{1,2})([a-f0-9]{0,2})$/i;
   Color.parseRGB = function(color) {
     return map(color.match(listMatch).slice(1), function(bit, i) {
@@ -5964,7 +5966,14 @@
             (this._layer = layer = canvas.getContext("2d"));
         isDirty &&
           (this.renderLayerTo(layer, xx, yx, xy, yy, x, y),
-          (this._layerCache = { xx: xx, yx: yx, xy: xy, yy: yy, x: x, y: y }));
+          (this._layerCache = {
+            xx: xx,
+            yx: yx,
+            xy: xy,
+            yy: yy,
+            x: x,
+            y: y
+          }));
         context.globalAlpha = opacity;
         context.setTransform(1, 0, 0, 1, 0, 0);
         context.drawImage(canvas, 0, 0, w, h, 0, 0, w, h);
diff --git a/dist/react-dom-server.browser.production.min.js b/dist/react-dom-server.browser.production.min.js
index ed20d16..ca3efa5 100644
--- a/dist/react-dom-server.browser.production.min.js
+++ b/dist/react-dom-server.browser.production.min.js
@@ -436,7 +436,7 @@
       null
     );
   });
-  var CAMELIZE = /[\-\:]([a-z])/g,
+  var CAMELIZE = /[\-:]([a-z])/g,
     capitalize = function(token) {
       return token[1].toUpperCase();
     };
diff --git a/dist/react-dom.production.min.js b/dist/react-dom.production.min.js
index 70669da..301a61d 100644
--- a/dist/react-dom.production.min.js
+++ b/dist/react-dom.production.min.js
@@ -2216,15 +2216,17 @@
                 currentFirstChild,
                 newChild,
                 expirationTime
-              )))
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild))
             : (deleteRemainingChildren(returnFiber, currentFirstChild),
               (currentFirstChild = createFiberFromText(
                 newChild,
                 returnFiber.mode,
                 expirationTime
-              ))),
-          (currentFirstChild["return"] = returnFiber),
-          (returnFiber = currentFirstChild),
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild)),
           placeSingleChild(returnFiber)
         );
       if (isArray$1(newChild))
@@ -3541,7 +3543,7 @@
       null
     );
   });
-  var CAMELIZE = /[\-\:]([a-z])/g,
+  var CAMELIZE = /[\-:]([a-z])/g,
     capitalize = function(token) {
       return token[1].toUpperCase();
     };
@@ -3627,12 +3629,10 @@
               ? (getTargetInstFunc = getTargetInstForInputOrChangeEvent)
               : ((getTargetInstFunc = getTargetInstForInputEventPolyfill),
                 (handleEventFunc = handleEventsForInputEventPolyfill))
-            : ((nodeName = targetNode.nodeName),
-              !nodeName ||
-                "input" !== nodeName.toLowerCase() ||
-                ("checkbox" !== targetNode.type &&
-                  "radio" !== targetNode.type) ||
-                (getTargetInstFunc = getTargetInstForClickEvent));
+            : (nodeName = targetNode.nodeName) &&
+              "input" === nodeName.toLowerCase() &&
+              ("checkbox" === targetNode.type || "radio" === targetNode.type) &&
+              (getTargetInstFunc = getTargetInstForClickEvent);
         if (
           getTargetInstFunc &&
           (getTargetInstFunc = getTargetInstFunc(topLevelType, targetInst))
diff --git a/dist/react-test-renderer.production.min.js b/dist/react-test-renderer.production.min.js
index c4d3d29..b298f79 100644
--- a/dist/react-test-renderer.production.min.js
+++ b/dist/react-test-renderer.production.min.js
@@ -1159,15 +1159,17 @@
                 currentFirstChild,
                 newChild,
                 expirationTime
-              )))
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild))
             : (deleteRemainingChildren(returnFiber, currentFirstChild),
               (currentFirstChild = createFiberFromText(
                 newChild,
                 returnFiber.mode,
                 expirationTime
-              ))),
-          (currentFirstChild["return"] = returnFiber),
-          (returnFiber = currentFirstChild),
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild)),
           placeSingleChild(returnFiber)
         );
       if (isArray$1(newChild))
@@ -1259,11 +1261,7 @@
         inst.children &&
           inst.children.length &&
           (_inst$props = inst.children.map(toJSON));
-        inst = {
-          type: inst.type,
-          props: target,
-          children: _inst$props
-        };
+        inst = { type: inst.type, props: target, children: _inst$props };
         Object.defineProperty(inst, "$$typeof", {
           value: Symbol["for"]("react.test.json")
         });
diff --git a/facebook-www/ReactART-prod.js b/facebook-www/ReactART-prod.js
index 8fd377d..e6f63d8 100644
--- a/facebook-www/ReactART-prod.js
+++ b/facebook-www/ReactART-prod.js
@@ -1630,15 +1630,17 @@ function ChildReconciler(shouldTrackSideEffects) {
               currentFirstChild,
               newChild,
               expirationTime
-            )))
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild))
           : (deleteRemainingChildren(returnFiber, currentFirstChild),
             (currentFirstChild = createFiberFromText(
               newChild,
               returnFiber.mode,
               expirationTime
-            ))),
-        (currentFirstChild["return"] = returnFiber),
-        (returnFiber = currentFirstChild),
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild)),
         placeSingleChild(returnFiber)
       );
     if (isArray$1(newChild))
@@ -4948,7 +4950,7 @@ var slice = Array.prototype.slice,
       }
     }
   }),
-  reactArt = (Object.freeze || Object)({
+  ReactART = (Object.freeze || Object)({
     ClippingRectangle: TYPES.CLIPPING_RECTANGLE,
     Group: TYPES.GROUP,
     Shape: TYPES.SHAPE,
@@ -4960,4 +4962,4 @@ var slice = Array.prototype.slice,
     Text: Text,
     Transform: Transform
   });
-module.exports = reactArt;
+module.exports = ReactART;
diff --git a/facebook-www/ReactDOM-prod.js b/facebook-www/ReactDOM-prod.js
index 9308d8e..5f82272 100644
--- a/facebook-www/ReactDOM-prod.js
+++ b/facebook-www/ReactDOM-prod.js
@@ -1041,6 +1041,11 @@ var BeforeInputEventPlugin = {
     }
   },
   fiberHostComponent = null,
+  ReactControlledComponentInjection = {
+    injectFiberControlledHostComponent: function(hostComponentImpl) {
+      fiberHostComponent = hostComponentImpl;
+    }
+  },
   restoreTarget = null,
   restoreQueue = null;
 function restoreStateOfTarget(target) {
@@ -1057,11 +1062,6 @@ function restoreStateOfTarget(target) {
     );
   }
 }
-var injection$2 = {
-  injectFiberControlledHostComponent: function(hostComponentImpl) {
-    fiberHostComponent = hostComponentImpl;
-  }
-};
 function enqueueStateRestore(target) {
   restoreTarget
     ? restoreQueue ? restoreQueue.push(target) : (restoreQueue = [target])
@@ -1082,7 +1082,7 @@ function restoreStateIfNeeded() {
   }
 }
 var ReactControlledComponent = (Object.freeze || Object)({
-  injection: injection$2,
+  injection: ReactControlledComponentInjection,
   enqueueStateRestore: enqueueStateRestore,
   needsStateRestore: needsStateRestore,
   restoreStateIfNeeded: restoreStateIfNeeded
@@ -1397,7 +1397,7 @@ var properties = {};
     null
   );
 });
-var CAMELIZE = /[\-\:]([a-z])/g;
+var CAMELIZE = /[\-:]([a-z])/g;
 function capitalize(token) {
   return token[1].toUpperCase();
 }
@@ -1643,11 +1643,10 @@ var ChangeEventPlugin = {
             ? (getTargetInstFunc = getTargetInstForInputOrChangeEvent)
             : ((getTargetInstFunc = getTargetInstForInputEventPolyfill),
               (handleEventFunc = handleEventsForInputEventPolyfill))
-          : ((nodeName = targetNode.nodeName),
-            !nodeName ||
-              "input" !== nodeName.toLowerCase() ||
-              ("checkbox" !== targetNode.type && "radio" !== targetNode.type) ||
-              (getTargetInstFunc = getTargetInstForClickEvent));
+          : (nodeName = targetNode.nodeName) &&
+            "input" === nodeName.toLowerCase() &&
+            ("checkbox" === targetNode.type || "radio" === targetNode.type) &&
+            (getTargetInstFunc = getTargetInstForClickEvent);
       if (
         getTargetInstFunc &&
         (getTargetInstFunc = getTargetInstFunc(topLevelType, targetInst))
@@ -2617,7 +2616,6 @@ function beginMark(markName) {
 function endMark(label, markName, warning) {
   markName = "\u269b " + markName;
   label =
-    "" +
     (warning ? "\u26d4 " : "\u269b ") +
     label +
     (warning ? " Warning: " + warning : "");
@@ -3977,15 +3975,17 @@ function ChildReconciler(shouldTrackSideEffects) {
               currentFirstChild,
               newChild,
               expirationTime
-            )))
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild))
           : (deleteRemainingChildren(returnFiber, currentFirstChild),
             (currentFirstChild = createFiberFromText(
               newChild,
               returnFiber.mode,
               expirationTime
-            ))),
-        (currentFirstChild["return"] = returnFiber),
-        (returnFiber = currentFirstChild),
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild)),
         placeSingleChild(returnFiber)
       );
     if (isArray$1(newChild))
@@ -7298,8 +7298,7 @@ function isCustomComponent(tagName, props) {
       return !0;
   }
 }
-var HTML_NAMESPACE = Namespaces.html,
-  getStack = emptyFunction.thatReturns("");
+var getStack = emptyFunction.thatReturns("");
 function ensureListeningTo(rootContainerElement, registrationName) {
   listenTo(
     registrationName,
@@ -7313,9 +7312,9 @@ function createElement$1(type, props, rootContainerElement, parentNamespace) {
     9 === rootContainerElement.nodeType
       ? rootContainerElement
       : rootContainerElement.ownerDocument;
-  parentNamespace === HTML_NAMESPACE &&
+  parentNamespace === Namespaces.html &&
     (parentNamespace = getIntrinsicNamespace(type));
-  parentNamespace === HTML_NAMESPACE
+  parentNamespace === Namespaces.html
     ? "script" === type
       ? ((type = rootContainerElement.createElement("div")),
         (type.innerHTML = "\x3cscript\x3e\x3c/script\x3e"),
@@ -7761,7 +7760,9 @@ var ReactDOMFiberComponent = (Object.freeze || Object)({
     }
   }),
   didWarnAboutUnstableCreatePortal = !1;
-injection$2.injectFiberControlledHostComponent(ReactDOMFiberComponent);
+ReactControlledComponentInjection.injectFiberControlledHostComponent(
+  ReactDOMFiberComponent
+);
 var eventsEnabled = null,
   selectionInformation = null;
 function ReactBatch(root) {
diff --git a/facebook-www/ReactDOMServer-prod.js b/facebook-www/ReactDOMServer-prod.js
index eb37a69..c0b342e 100644
--- a/facebook-www/ReactDOMServer-prod.js
+++ b/facebook-www/ReactDOMServer-prod.js
@@ -200,7 +200,7 @@ var properties = {};
     null
   );
 });
-var CAMELIZE = /[\-\:]([a-z])/g;
+var CAMELIZE = /[\-:]([a-z])/g;
 function capitalize(token) {
   return token[1].toUpperCase();
 }
diff --git a/facebook-www/ReactDOMUnstableNativeDependencies-prod.js b/facebook-www/ReactDOMUnstableNativeDependencies-prod.js
index 0fa0914..41097bc 100644
--- a/facebook-www/ReactDOMUnstableNativeDependencies-prod.js
+++ b/facebook-www/ReactDOMUnstableNativeDependencies-prod.js
@@ -35,7 +35,14 @@ function reactProdInvariant(code) {
   : void 0;
 var getFiberCurrentPropsFromNode = null,
   getInstanceFromNode = null,
-  getNodeFromInstance = null;
+  getNodeFromInstance = null,
+  injection = {
+    injectComponentTree: function(Injected) {
+      getFiberCurrentPropsFromNode = Injected.getFiberCurrentPropsFromNode;
+      getInstanceFromNode = Injected.getInstanceFromNode;
+      getNodeFromInstance = Injected.getNodeFromInstance;
+    }
+  };
 function isEndish(topLevelType) {
   return (
     "topMouseUp" === topLevelType ||
@@ -732,18 +739,13 @@ var eventTypes = {
       }
     }
   };
-function injectComponentTree(Injected) {
-  getFiberCurrentPropsFromNode = Injected.getFiberCurrentPropsFromNode;
-  getInstanceFromNode = Injected.getInstanceFromNode;
-  getNodeFromInstance = Injected.getNodeFromInstance;
-}
-injectComponentTree(
+(0, injection.injectComponentTree)(
   ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
     .ReactDOMComponentTree
 );
-var unstableNativeDependencies = (Object.freeze || Object)({
-  injectComponentTree: injectComponentTree,
+var ReactDOMUnstableNativeDependencies = (Object.freeze || Object)({
+  injectComponentTree: injection.injectComponentTree,
   ResponderEventPlugin: ResponderEventPlugin,
   ResponderTouchHistoryStore: ResponderTouchHistoryStore
 });
-module.exports = unstableNativeDependencies;
+module.exports = ReactDOMUnstableNativeDependencies;
diff --git a/node_modules/react-art/cjs/react-art.production.min.js b/node_modules/react-art/cjs/react-art.production.min.js
index 742ae9f..816efd3 100644
--- a/node_modules/react-art/cjs/react-art.production.min.js
+++ b/node_modules/react-art/cjs/react-art.production.min.js
@@ -1550,15 +1550,17 @@ function ChildReconciler(shouldTrackSideEffects) {
               currentFirstChild,
               newChild,
               expirationTime
-            )))
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild))
           : (deleteRemainingChildren(returnFiber, currentFirstChild),
             (currentFirstChild = createFiberFromText(
               newChild,
               returnFiber.mode,
               expirationTime
-            ))),
-        (currentFirstChild["return"] = returnFiber),
-        (returnFiber = currentFirstChild),
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild)),
         placeSingleChild(returnFiber)
       );
     if (isArray$1(newChild))
@@ -4834,7 +4836,7 @@ var slice = Array.prototype.slice,
       }
     }
   }),
-  reactArt = Object.freeze({
+  ReactART = Object.freeze({
     ClippingRectangle: TYPES.CLIPPING_RECTANGLE,
     Group: TYPES.GROUP,
     Shape: TYPES.SHAPE,
@@ -4846,4 +4848,4 @@ var slice = Array.prototype.slice,
     Text: Text,
     Transform: Transform
   });
-module.exports = reactArt;
+module.exports = ReactART;
diff --git a/node_modules/react-art/umd/react-art.production.min.js b/node_modules/react-art/umd/react-art.production.min.js
index a05da7b..16fcf28 100644
--- a/node_modules/react-art/umd/react-art.production.min.js
+++ b/node_modules/react-art/umd/react-art.production.min.js
@@ -1159,15 +1159,17 @@
                 currentFirstChild,
                 newChild,
                 expirationTime
-              )))
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild))
             : (deleteRemainingChildren(returnFiber, currentFirstChild),
               (currentFirstChild = createFiberFromText(
                 newChild,
                 returnFiber.mode,
                 expirationTime
-              ))),
-          (currentFirstChild["return"] = returnFiber),
-          (returnFiber = currentFirstChild),
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild)),
           placeSingleChild(returnFiber)
         );
       if (isArray$1(newChild))
@@ -5520,7 +5522,7 @@
       }
       this.isColor = !0;
     },
-    listMatch = /([-.\d]+\%?)\s*,\s*([-.\d]+\%?)\s*,\s*([-.\d]+\%?)\s*,?\s*([-.\d]*\%?)/,
+    listMatch = /([-.\d]+%?)\s*,\s*([-.\d]+%?)\s*,\s*([-.\d]+%?)\s*,?\s*([-.\d]*%?)/,
     hexMatch = /^#?([a-f0-9]{1,2})([a-f0-9]{1,2})([a-f0-9]{1,2})([a-f0-9]{0,2})$/i;
   Color.parseRGB = function(color) {
     return map(color.match(listMatch).slice(1), function(bit, i) {
@@ -5964,7 +5966,14 @@
             (this._layer = layer = canvas.getContext("2d"));
         isDirty &&
           (this.renderLayerTo(layer, xx, yx, xy, yy, x, y),
-          (this._layerCache = { xx: xx, yx: yx, xy: xy, yy: yy, x: x, y: y }));
+          (this._layerCache = {
+            xx: xx,
+            yx: yx,
+            xy: xy,
+            yy: yy,
+            x: x,
+            y: y
+          }));
         context.globalAlpha = opacity;
         context.setTransform(1, 0, 0, 1, 0, 0);
         context.drawImage(canvas, 0, 0, w, h, 0, 0, w, h);
diff --git a/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js b/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js
index 246b49a..2a3b0ba 100644
--- a/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js
+++ b/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js
@@ -197,7 +197,7 @@ var properties = {};
     null
   );
 });
-var CAMELIZE = /[\-\:]([a-z])/g;
+var CAMELIZE = /[\-:]([a-z])/g;
 function capitalize(token) {
   return token[1].toUpperCase();
 }
diff --git a/node_modules/react-dom/cjs/react-dom-server.node.production.min.js b/node_modules/react-dom/cjs/react-dom-server.node.production.min.js
index 08b7005..7502d55 100644
--- a/node_modules/react-dom/cjs/react-dom-server.node.production.min.js
+++ b/node_modules/react-dom/cjs/react-dom-server.node.production.min.js
@@ -198,7 +198,7 @@ var properties = {};
     null
   );
 });
-var CAMELIZE = /[\-\:]([a-z])/g;
+var CAMELIZE = /[\-:]([a-z])/g;
 function capitalize(token) {
   return token[1].toUpperCase();
 }
diff --git a/node_modules/react-dom/cjs/react-dom-unstable-native-dependencies.production.min.js b/node_modules/react-dom/cjs/react-dom-unstable-native-dependencies.production.min.js
index 8ea2a7d..e5083f9 100644
--- a/node_modules/react-dom/cjs/react-dom-unstable-native-dependencies.production.min.js
+++ b/node_modules/react-dom/cjs/react-dom-unstable-native-dependencies.production.min.js
@@ -31,7 +31,14 @@ function reactProdInvariant(code) {
 }
 var getFiberCurrentPropsFromNode = null,
   getInstanceFromNode = null,
-  getNodeFromInstance = null;
+  getNodeFromInstance = null,
+  injection = {
+    injectComponentTree: function(Injected) {
+      getFiberCurrentPropsFromNode = Injected.getFiberCurrentPropsFromNode;
+      getInstanceFromNode = Injected.getInstanceFromNode;
+      getNodeFromInstance = Injected.getNodeFromInstance;
+    }
+  };
 function isEndish(topLevelType) {
   return (
     "topMouseUp" === topLevelType ||
@@ -728,18 +735,13 @@ var eventTypes = {
       }
     }
   };
-function injectComponentTree(Injected) {
-  getFiberCurrentPropsFromNode = Injected.getFiberCurrentPropsFromNode;
-  getInstanceFromNode = Injected.getInstanceFromNode;
-  getNodeFromInstance = Injected.getNodeFromInstance;
-}
-injectComponentTree(
+(0, injection.injectComponentTree)(
   ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
     .ReactDOMComponentTree
 );
-var unstableNativeDependencies = Object.freeze({
-  injectComponentTree: injectComponentTree,
+var ReactDOMUnstableNativeDependencies = Object.freeze({
+  injectComponentTree: injection.injectComponentTree,
   ResponderEventPlugin: ResponderEventPlugin,
   ResponderTouchHistoryStore: ResponderTouchHistoryStore
 });
-module.exports = unstableNativeDependencies;
+module.exports = ReactDOMUnstableNativeDependencies;
diff --git a/node_modules/react-dom/cjs/react-dom.production.min.js b/node_modules/react-dom/cjs/react-dom.production.min.js
index e42a6b6..03deefa 100644
--- a/node_modules/react-dom/cjs/react-dom.production.min.js
+++ b/node_modules/react-dom/cjs/react-dom.production.min.js
@@ -826,6 +826,11 @@ var BeforeInputEventPlugin = {
     }
   },
   fiberHostComponent = null,
+  ReactControlledComponentInjection = {
+    injectFiberControlledHostComponent: function(hostComponentImpl) {
+      fiberHostComponent = hostComponentImpl;
+    }
+  },
   restoreTarget = null,
   restoreQueue = null;
 function restoreStateOfTarget(target) {
@@ -842,11 +847,6 @@ function restoreStateOfTarget(target) {
     );
   }
 }
-var injection$2 = {
-  injectFiberControlledHostComponent: function(hostComponentImpl) {
-    fiberHostComponent = hostComponentImpl;
-  }
-};
 function enqueueStateRestore(target) {
   restoreTarget
     ? restoreQueue ? restoreQueue.push(target) : (restoreQueue = [target])
@@ -867,7 +867,7 @@ function restoreStateIfNeeded() {
   }
 }
 var ReactControlledComponent = Object.freeze({
-  injection: injection$2,
+  injection: ReactControlledComponentInjection,
   enqueueStateRestore: enqueueStateRestore,
   needsStateRestore: needsStateRestore,
   restoreStateIfNeeded: restoreStateIfNeeded
@@ -1232,7 +1232,7 @@ var properties = {};
     null
   );
 });
-var CAMELIZE = /[\-\:]([a-z])/g;
+var CAMELIZE = /[\-:]([a-z])/g;
 function capitalize(token) {
   return token[1].toUpperCase();
 }
@@ -1478,11 +1478,10 @@ var ChangeEventPlugin = {
             ? (getTargetInstFunc = getTargetInstForInputOrChangeEvent)
             : ((getTargetInstFunc = getTargetInstForInputEventPolyfill),
               (handleEventFunc = handleEventsForInputEventPolyfill))
-          : ((nodeName = targetNode.nodeName),
-            !nodeName ||
-              "input" !== nodeName.toLowerCase() ||
-              ("checkbox" !== targetNode.type && "radio" !== targetNode.type) ||
-              (getTargetInstFunc = getTargetInstForClickEvent));
+          : (nodeName = targetNode.nodeName) &&
+            "input" === nodeName.toLowerCase() &&
+            ("checkbox" === targetNode.type || "radio" === targetNode.type) &&
+            (getTargetInstFunc = getTargetInstForClickEvent);
       if (
         getTargetInstFunc &&
         (getTargetInstFunc = getTargetInstFunc(topLevelType, targetInst))
@@ -3673,15 +3672,17 @@ function ChildReconciler(shouldTrackSideEffects) {
               currentFirstChild,
               newChild,
               expirationTime
-            )))
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild))
           : (deleteRemainingChildren(returnFiber, currentFirstChild),
             (currentFirstChild = createFiberFromText(
               newChild,
               returnFiber.mode,
               expirationTime
-            ))),
-        (currentFirstChild["return"] = returnFiber),
-        (returnFiber = currentFirstChild),
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild)),
         placeSingleChild(returnFiber)
       );
     if (isArray$1(newChild))
@@ -6820,8 +6821,7 @@ function isCustomComponent(tagName, props) {
       return !0;
   }
 }
-var HTML_NAMESPACE = Namespaces.html,
-  getStack = emptyFunction.thatReturns("");
+var getStack = emptyFunction.thatReturns("");
 function ensureListeningTo(rootContainerElement, registrationName) {
   rootContainerElement =
     9 === rootContainerElement.nodeType || 11 === rootContainerElement.nodeType
@@ -6861,9 +6861,9 @@ function createElement$1(type, props, rootContainerElement, parentNamespace) {
     9 === rootContainerElement.nodeType
       ? rootContainerElement
       : rootContainerElement.ownerDocument;
-  parentNamespace === HTML_NAMESPACE &&
+  parentNamespace === Namespaces.html &&
     (parentNamespace = getIntrinsicNamespace(type));
-  parentNamespace === HTML_NAMESPACE
+  parentNamespace === Namespaces.html
     ? "script" === type
       ? ((type = rootContainerElement.createElement("div")),
         (type.innerHTML = "\x3cscript\x3e\x3c/script\x3e"),
@@ -7307,7 +7307,9 @@ var ReactDOMFiberComponent = Object.freeze({
     }
   }
 });
-injection$2.injectFiberControlledHostComponent(ReactDOMFiberComponent);
+ReactControlledComponentInjection.injectFiberControlledHostComponent(
+  ReactDOMFiberComponent
+);
 var eventsEnabled = null,
   selectionInformation = null;
 function ReactBatch(root) {
diff --git a/node_modules/react-dom/umd/react-dom-server.browser.production.min.js b/node_modules/react-dom/umd/react-dom-server.browser.production.min.js
index ed20d16..ca3efa5 100644
--- a/node_modules/react-dom/umd/react-dom-server.browser.production.min.js
+++ b/node_modules/react-dom/umd/react-dom-server.browser.production.min.js
@@ -436,7 +436,7 @@
       null
     );
   });
-  var CAMELIZE = /[\-\:]([a-z])/g,
+  var CAMELIZE = /[\-:]([a-z])/g,
     capitalize = function(token) {
       return token[1].toUpperCase();
     };
diff --git a/node_modules/react-dom/umd/react-dom.production.min.js b/node_modules/react-dom/umd/react-dom.production.min.js
index 70669da..301a61d 100644
--- a/node_modules/react-dom/umd/react-dom.production.min.js
+++ b/node_modules/react-dom/umd/react-dom.production.min.js
@@ -2216,15 +2216,17 @@
                 currentFirstChild,
                 newChild,
                 expirationTime
-              )))
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild))
             : (deleteRemainingChildren(returnFiber, currentFirstChild),
               (currentFirstChild = createFiberFromText(
                 newChild,
                 returnFiber.mode,
                 expirationTime
-              ))),
-          (currentFirstChild["return"] = returnFiber),
-          (returnFiber = currentFirstChild),
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild)),
           placeSingleChild(returnFiber)
         );
       if (isArray$1(newChild))
@@ -3541,7 +3543,7 @@
       null
     );
   });
-  var CAMELIZE = /[\-\:]([a-z])/g,
+  var CAMELIZE = /[\-:]([a-z])/g,
     capitalize = function(token) {
       return token[1].toUpperCase();
     };
@@ -3627,12 +3629,10 @@
               ? (getTargetInstFunc = getTargetInstForInputOrChangeEvent)
               : ((getTargetInstFunc = getTargetInstForInputEventPolyfill),
                 (handleEventFunc = handleEventsForInputEventPolyfill))
-            : ((nodeName = targetNode.nodeName),
-              !nodeName ||
-                "input" !== nodeName.toLowerCase() ||
-                ("checkbox" !== targetNode.type &&
-                  "radio" !== targetNode.type) ||
-                (getTargetInstFunc = getTargetInstForClickEvent));
+            : (nodeName = targetNode.nodeName) &&
+              "input" === nodeName.toLowerCase() &&
+              ("checkbox" === targetNode.type || "radio" === targetNode.type) &&
+              (getTargetInstFunc = getTargetInstForClickEvent);
         if (
           getTargetInstFunc &&
           (getTargetInstFunc = getTargetInstFunc(topLevelType, targetInst))
diff --git a/node_modules/react-reconciler/cjs/react-reconciler-persistent.production.min.js b/node_modules/react-reconciler/cjs/react-reconciler-persistent.production.min.js
index 19cb85a..0a02e6e 100644
--- a/node_modules/react-reconciler/cjs/react-reconciler-persistent.production.min.js
+++ b/node_modules/react-reconciler/cjs/react-reconciler-persistent.production.min.js
@@ -1547,15 +1547,17 @@ function ChildReconciler(shouldTrackSideEffects) {
               currentFirstChild,
               newChild,
               expirationTime
-            )))
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild))
           : (deleteRemainingChildren(returnFiber, currentFirstChild),
             (currentFirstChild = createFiberFromText(
               newChild,
               returnFiber.mode,
               expirationTime
-            ))),
-        (currentFirstChild["return"] = returnFiber),
-        (returnFiber = currentFirstChild),
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild)),
         placeSingleChild(returnFiber)
       );
     if (isArray$1(newChild))
diff --git a/node_modules/react-reconciler/cjs/react-reconciler.production.min.js b/node_modules/react-reconciler/cjs/react-reconciler.production.min.js
index 094e7d2..2aca99b 100644
--- a/node_modules/react-reconciler/cjs/react-reconciler.production.min.js
+++ b/node_modules/react-reconciler/cjs/react-reconciler.production.min.js
@@ -1547,15 +1547,17 @@ function ChildReconciler(shouldTrackSideEffects) {
               currentFirstChild,
               newChild,
               expirationTime
-            )))
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild))
           : (deleteRemainingChildren(returnFiber, currentFirstChild),
             (currentFirstChild = createFiberFromText(
               newChild,
               returnFiber.mode,
               expirationTime
-            ))),
-        (currentFirstChild["return"] = returnFiber),
-        (returnFiber = currentFirstChild),
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild)),
         placeSingleChild(returnFiber)
       );
     if (isArray$1(newChild))
diff --git a/node_modules/react-test-renderer/cjs/react-test-renderer.production.min.js b/node_modules/react-test-renderer/cjs/react-test-renderer.production.min.js
index b53216a..93c432d 100644
--- a/node_modules/react-test-renderer/cjs/react-test-renderer.production.min.js
+++ b/node_modules/react-test-renderer/cjs/react-test-renderer.production.min.js
@@ -1546,15 +1546,17 @@ function ChildReconciler(shouldTrackSideEffects) {
               currentFirstChild,
               newChild,
               expirationTime
-            )))
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild))
           : (deleteRemainingChildren(returnFiber, currentFirstChild),
             (currentFirstChild = createFiberFromText(
               newChild,
               returnFiber.mode,
               expirationTime
-            ))),
-        (currentFirstChild["return"] = returnFiber),
-        (returnFiber = currentFirstChild),
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild)),
         placeSingleChild(returnFiber)
       );
     if (isArray$1(newChild))
diff --git a/node_modules/react-test-renderer/umd/react-test-renderer.production.min.js b/node_modules/react-test-renderer/umd/react-test-renderer.production.min.js
index c4d3d29..b298f79 100644
--- a/node_modules/react-test-renderer/umd/react-test-renderer.production.min.js
+++ b/node_modules/react-test-renderer/umd/react-test-renderer.production.min.js
@@ -1159,15 +1159,17 @@
                 currentFirstChild,
                 newChild,
                 expirationTime
-              )))
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild))
             : (deleteRemainingChildren(returnFiber, currentFirstChild),
               (currentFirstChild = createFiberFromText(
                 newChild,
                 returnFiber.mode,
                 expirationTime
-              ))),
-          (currentFirstChild["return"] = returnFiber),
-          (returnFiber = currentFirstChild),
+              )),
+              (currentFirstChild["return"] = returnFiber),
+              (returnFiber = currentFirstChild)),
           placeSingleChild(returnFiber)
         );
       if (isArray$1(newChild))
@@ -1259,11 +1261,7 @@
         inst.children &&
           inst.children.length &&
           (_inst$props = inst.children.map(toJSON));
-        inst = {
-          type: inst.type,
-          props: target,
-          children: _inst$props
-        };
+        inst = { type: inst.type, props: target, children: _inst$props };
         Object.defineProperty(inst, "$$typeof", {
           value: Symbol["for"]("react.test.json")
         });
diff --git a/react-native/ReactFabric-prod.js b/react-native/ReactFabric-prod.js
index 4b18437..18bd5b4 100644
--- a/react-native/ReactFabric-prod.js
+++ b/react-native/ReactFabric-prod.js
@@ -2761,15 +2761,17 @@ function ChildReconciler(shouldTrackSideEffects) {
               currentFirstChild,
               newChild,
               expirationTime
-            )))
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild))
           : (deleteRemainingChildren(returnFiber, currentFirstChild),
             (currentFirstChild = createFiberFromText(
               newChild,
               returnFiber.mode,
               expirationTime
-            ))),
-        (currentFirstChild["return"] = returnFiber),
-        (returnFiber = currentFirstChild),
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild)),
         placeSingleChild(returnFiber)
       );
     if (isArray$1(newChild))
diff --git a/react-native/ReactNativeRenderer-prod.js b/react-native/ReactNativeRenderer-prod.js
index 31f0962..77a999e 100644
--- a/react-native/ReactNativeRenderer-prod.js
+++ b/react-native/ReactNativeRenderer-prod.js
@@ -3017,15 +3017,17 @@ function ChildReconciler(shouldTrackSideEffects) {
               currentFirstChild,
               newChild,
               expirationTime
-            )))
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild))
           : (deleteRemainingChildren(returnFiber, currentFirstChild),
             (currentFirstChild = createFiberFromText(
               newChild,
               returnFiber.mode,
               expirationTime
-            ))),
-        (currentFirstChild["return"] = returnFiber),
-        (returnFiber = currentFirstChild),
+            )),
+            (currentFirstChild["return"] = returnFiber),
+            (returnFiber = currentFirstChild)),
         placeSingleChild(returnFiber)
       );
     if (isArray$1(newChild))
```

</details>