### PR TITLE
remove duplicate code in test

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -59,11 +59,6 @@ describe('ReactDOMRoot', () => {
     expire = function(ms) {
       now += ms;
     };
-    global.performance = {
-      now() {
-        return now;
-      },
-    };
 
     jest.resetModules();
     React = require('react');


### PR DESCRIPTION
[here](https://github.com/facebook/react/pull/12620/files#diff-afdcb1c85de47522ad67cc15d801bbcfR49) had defined `global.performance` and I don't see any effect to define this twice. If I'm wrong, please let me know, thanks!