### PR TITLE
[WIP] Falsey PropTypes not triggering “no onChange handler” warning

### DIFF
--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+const emptyFunction = require('fbjs/lib/emptyFunction');
+
 describe('DOMPropertyOperations', () => {
   let React;
   let ReactDOM;
@@ -79,7 +81,7 @@ describe('DOMPropertyOperations', () => {
 
     it('should not remove empty attributes for special properties', () => {
       const container = document.createElement('div');
-      ReactDOM.render(<input value="" />, container);
+      ReactDOM.render(<input value="" onChange={emptyFunction} />, container);
       expect(container.firstChild.getAttribute('value')).toBe('');
       expect(container.firstChild.value).toBe('');
     });

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -625,8 +625,14 @@ describe('ReactDOMInput', () => {
   it('should properly transition from an empty value to 0', function() {
     const container = document.createElement('div');
 
-    ReactDOM.render(<input type="text" value="" onChange={emptyFunction} />, container);
-    ReactDOM.render(<input type="text" value={0} onChange={emptyFunction} />, container);
+    ReactDOM.render(
+      <input type="text" value="" onChange={emptyFunction} />,
+      container,
+    );
+    ReactDOM.render(
+      <input type="text" value={0} onChange={emptyFunction} />,
+      container,
+    );
 
     const node = container.firstChild;
 
@@ -637,8 +643,14 @@ describe('ReactDOMInput', () => {
   it('should properly transition from 0 to an empty value', function() {
     const container = document.createElement('div');
 
-    ReactDOM.render(<input type="text" value={0} onChange={emptyFunction} />, container);
-    ReactDOM.render(<input type="text" value="" onChange={emptyFunction} />, container);
+    ReactDOM.render(
+      <input type="text" value={0} onChange={emptyFunction} />,
+      container,
+    );
+    ReactDOM.render(
+      <input type="text" value="" onChange={emptyFunction} />,
+      container,
+    );
 
     const node = container.firstChild;
 
@@ -649,8 +661,14 @@ describe('ReactDOMInput', () => {
   it('should properly transition a text input from 0 to an empty 0.0', function() {
     const container = document.createElement('div');
 
-    ReactDOM.render(<input type="text" value={0} onChange={emptyFunction} />, container);
-    ReactDOM.render(<input type="text" value="0.0" onChange={emptyFunction} />, container);
+    ReactDOM.render(
+      <input type="text" value={0} onChange={emptyFunction} />,
+      container,
+    );
+    ReactDOM.render(
+      <input type="text" value="0.0" onChange={emptyFunction} />,
+      container,
+    );
 
     const node = container.firstChild;
 
@@ -661,8 +679,14 @@ describe('ReactDOMInput', () => {
   it('should properly transition a number input from "" to 0', function() {
     const container = document.createElement('div');
 
-    ReactDOM.render(<input type="number" value="" onChange={emptyFunction} />, container);
-    ReactDOM.render(<input type="number" value={0} onChange={emptyFunction} />, container);
+    ReactDOM.render(
+      <input type="number" value="" onChange={emptyFunction} />,
+      container,
+    );
+    ReactDOM.render(
+      <input type="number" value={0} onChange={emptyFunction} />,
+      container,
+    );
 
     const node = container.firstChild;
 
@@ -673,8 +697,14 @@ describe('ReactDOMInput', () => {
   it('should properly transition a number input from "" to "0"', function() {
     const container = document.createElement('div');
 
-    ReactDOM.render(<input type="number" value="" onChange={emptyFunction} />, container);
-    ReactDOM.render(<input type="number" value="0" onChange={emptyFunction} />, container);
+    ReactDOM.render(
+      <input type="number" value="" onChange={emptyFunction} />,
+      container,
+    );
+    ReactDOM.render(
+      <input type="number" value="0" onChange={emptyFunction} />,
+      container,
+    );
 
     const node = container.firstChild;
 
@@ -937,14 +967,18 @@ describe('ReactDOMInput', () => {
 
   it('should warn if value is null', () => {
     expect(() =>
-      ReactTestUtils.renderIntoDocument(<input type="text" value={null} onChange={emptyFunction} />),
+      ReactTestUtils.renderIntoDocument(
+        <input type="text" value={null} onChange={emptyFunction} />,
+      ),
     ).toWarnDev(
       '`value` prop on `input` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` ' +
         'for uncontrolled components.',
     );
 
-    ReactTestUtils.renderIntoDocument(<input type="text" value={null} onChange={emptyFunction} />);
+    ReactTestUtils.renderIntoDocument(
+      <input type="text" value={null} onChange={emptyFunction} />,
+    );
   });
 
   it('should warn if checked and defaultChecked props are specified', () => {
@@ -1054,7 +1088,10 @@ describe('ReactDOMInput', () => {
     const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
-      ReactDOM.render(<input type="text" value="controlled" onChange={emptyFunction} />, container),
+      ReactDOM.render(
+        <input type="text" value="controlled" onChange={emptyFunction} />,
+        container,
+      ),
     ).toWarnDev(
       'Warning: A component is changing an uncontrolled input of type text to be controlled. ' +
         'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -475,7 +475,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('should display `value` of number 0', () => {
-    let stub = <input type="text" value={0} />;
+    let stub = <input type="text" value={0} onChange={emptyFunction} />;
     stub = ReactTestUtils.renderIntoDocument(stub);
     const node = ReactDOM.findDOMNode(stub);
 
@@ -625,8 +625,8 @@ describe('ReactDOMInput', () => {
   it('should properly transition from an empty value to 0', function() {
     const container = document.createElement('div');
 
-    ReactDOM.render(<input type="text" value="" />, container);
-    ReactDOM.render(<input type="text" value={0} />, container);
+    ReactDOM.render(<input type="text" value="" onChange={emptyFunction} />, container);
+    ReactDOM.render(<input type="text" value={0} onChange={emptyFunction} />, container);
 
     const node = container.firstChild;
 
@@ -637,8 +637,8 @@ describe('ReactDOMInput', () => {
   it('should properly transition from 0 to an empty value', function() {
     const container = document.createElement('div');
 
-    ReactDOM.render(<input type="text" value={0} />, container);
-    ReactDOM.render(<input type="text" value="" />, container);
+    ReactDOM.render(<input type="text" value={0} onChange={emptyFunction} />, container);
+    ReactDOM.render(<input type="text" value="" onChange={emptyFunction} />, container);
 
     const node = container.firstChild;
 
@@ -649,8 +649,8 @@ describe('ReactDOMInput', () => {
   it('should properly transition a text input from 0 to an empty 0.0', function() {
     const container = document.createElement('div');
 
-    ReactDOM.render(<input type="text" value={0} />, container);
-    ReactDOM.render(<input type="text" value="0.0" />, container);
+    ReactDOM.render(<input type="text" value={0} onChange={emptyFunction} />, container);
+    ReactDOM.render(<input type="text" value="0.0" onChange={emptyFunction} />, container);
 
     const node = container.firstChild;
 
@@ -661,8 +661,8 @@ describe('ReactDOMInput', () => {
   it('should properly transition a number input from "" to 0', function() {
     const container = document.createElement('div');
 
-    ReactDOM.render(<input type="number" value="" />, container);
-    ReactDOM.render(<input type="number" value={0} />, container);
+    ReactDOM.render(<input type="number" value="" onChange={emptyFunction} />, container);
+    ReactDOM.render(<input type="number" value={0} onChange={emptyFunction} />, container);
 
     const node = container.firstChild;
 
@@ -673,8 +673,8 @@ describe('ReactDOMInput', () => {
   it('should properly transition a number input from "" to "0"', function() {
     const container = document.createElement('div');
 
-    ReactDOM.render(<input type="number" value="" />, container);
-    ReactDOM.render(<input type="number" value="0" />, container);
+    ReactDOM.render(<input type="number" value="" onChange={emptyFunction} />, container);
+    ReactDOM.render(<input type="number" value="0" onChange={emptyFunction} />, container);
 
     const node = container.firstChild;
 
@@ -937,14 +937,14 @@ describe('ReactDOMInput', () => {
 
   it('should warn if value is null', () => {
     expect(() =>
-      ReactTestUtils.renderIntoDocument(<input type="text" value={null} />),
+      ReactTestUtils.renderIntoDocument(<input type="text" value={null} onChange={emptyFunction} />),
     ).toWarnDev(
       '`value` prop on `input` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` ' +
         'for uncontrolled components.',
     );
 
-    ReactTestUtils.renderIntoDocument(<input type="text" value={null} />);
+    ReactTestUtils.renderIntoDocument(<input type="text" value={null} onChange={emptyFunction} />);
   });
 
   it('should warn if checked and defaultChecked props are specified', () => {
@@ -1054,7 +1054,7 @@ describe('ReactDOMInput', () => {
     const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
-      ReactDOM.render(<input type="text" value="controlled" />, container),
+      ReactDOM.render(<input type="text" value="controlled" onChange={emptyFunction} />, container),
     ).toWarnDev(
       'Warning: A component is changing an uncontrolled input of type text to be controlled. ' +
         'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
@@ -1065,7 +1065,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('should warn if uncontrolled input (value is null) switches to controlled', () => {
-    const stub = <input type="text" value={null} />;
+    const stub = <input type="text" value={null} onChange={emptyFunction} />;
     const container = document.createElement('div');
     expect(() => ReactDOM.render(stub, container)).toWarnDev(
       '`value` prop on `input` should not be null. ' +

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -589,7 +589,7 @@ describe('ReactDOMSelect', () => {
     );
 
     ReactTestUtils.renderIntoDocument(
-      <select value={null} multiple={true}  onChange={emptyFunction}>
+      <select value={null} multiple={true} onChange={emptyFunction}>
         <option value="test" />
       </select>,
     );

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+const emptyFunction = require('fbjs/lib/emptyFunction');
+
 describe('ReactDOMSelect', () => {
   let React;
   let ReactDOM;
@@ -534,7 +536,7 @@ describe('ReactDOMSelect', () => {
   it('should warn if value is null', () => {
     expect(() =>
       ReactTestUtils.renderIntoDocument(
-        <select value={null}>
+        <select value={null} onChange={emptyFunction}>
           <option value="test" />
         </select>,
       ),
@@ -545,7 +547,7 @@ describe('ReactDOMSelect', () => {
     );
 
     ReactTestUtils.renderIntoDocument(
-      <select value={null}>
+      <select value={null} onChange={emptyFunction}>
         <option value="test" />
       </select>,
     );
@@ -575,7 +577,7 @@ describe('ReactDOMSelect', () => {
   it('should warn if value is null and multiple is true', () => {
     expect(() =>
       ReactTestUtils.renderIntoDocument(
-        <select value={null} multiple={true}>
+        <select value={null} multiple={true} onChange={emptyFunction}>
           <option value="test" />
         </select>,
       ),
@@ -587,7 +589,7 @@ describe('ReactDOMSelect', () => {
     );
 
     ReactTestUtils.renderIntoDocument(
-      <select value={null} multiple={true}>
+      <select value={null} multiple={true}  onChange={emptyFunction}>
         <option value="test" />
       </select>,
     );

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -373,7 +373,9 @@ describe('ReactDOMTextarea', () => {
 
   it('should warn if value is null', () => {
     expect(() =>
-      ReactTestUtils.renderIntoDocument(<textarea value={null} onChange={emptyFunction} />),
+      ReactTestUtils.renderIntoDocument(
+        <textarea value={null} onChange={emptyFunction} />,
+      ),
     ).toWarnDev(
       '`value` prop on `textarea` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` ' +
@@ -381,7 +383,9 @@ describe('ReactDOMTextarea', () => {
     );
 
     // No additional warnings are expected
-    ReactTestUtils.renderIntoDocument(<textarea value={null} onChange={emptyFunction} />);
+    ReactTestUtils.renderIntoDocument(
+      <textarea value={null} onChange={emptyFunction} />,
+    );
   });
 
   it('should warn if value and defaultValue are specified', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -97,7 +97,7 @@ describe('ReactDOMTextarea', () => {
   });
 
   it('should display `value` of number 0', () => {
-    const stub = <textarea value={0} />;
+    const stub = <textarea value={0} onChange={emptyFunction} />;
     const node = renderTextarea(stub);
 
     expect(node.value).toBe('0');
@@ -373,7 +373,7 @@ describe('ReactDOMTextarea', () => {
 
   it('should warn if value is null', () => {
     expect(() =>
-      ReactTestUtils.renderIntoDocument(<textarea value={null} />),
+      ReactTestUtils.renderIntoDocument(<textarea value={null} onChange={emptyFunction} />),
     ).toWarnDev(
       '`value` prop on `textarea` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` ' +
@@ -381,7 +381,7 @@ describe('ReactDOMTextarea', () => {
     );
 
     // No additional warnings are expected
-    ReactTestUtils.renderIntoDocument(<textarea value={null} />);
+    ReactTestUtils.renderIntoDocument(<textarea value={null} onChange={emptyFunction} />);
   });
 
   it('should warn if value and defaultValue are specified', () => {

--- a/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
+++ b/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
@@ -25,7 +25,7 @@ if (__DEV__) {
   const propTypes = {
     value: function(props, propName, componentName) {
       if (
-        !props[propName] ||
+        !(propName in props) ||
         hasReadOnlyValue[props.type] ||
         props.onChange ||
         props.readOnly ||


### PR DESCRIPTION
## Description

What is the current behavior?

(Bug / Inconsistency)
```
<input type="radio" checked={false} />
```
No Warning.

(Feature Request)
```
<input type="radio" checked={true} onChange={undefined} />
```
`Warning: Failed prop type: You provided a 'checked' prop to a form field without an 'onChange' handler. This will render a read-only field. If the field should be mutable use 'defaultChecked'. Otherwise, set either 'onChange' or 'readOnly’.’`

## Steps

- [x] Check for falsey value prop
  - [x] Add onChange handlers to tests

- [ ] Check for falsey checked prop
  - [ ] Add onChange handlers to tests

- [ ] Write new tests expecting warning with falsey value prop

- [ ] Write new tests expecting warning with falsey checked prop