### PR TITLE
Add forwardRef DEV warning for prop-types on render function

### DIFF
--- a/packages/react/src/__tests__/forwardRef-test.internal.js
+++ b/packages/react/src/__tests__/forwardRef-test.internal.js
@@ -249,4 +249,25 @@ describe('forwardRef', () => {
       'forwardRef requires a render function but was given undefined.',
     );
   });
+
+  it('should warn if the render function provided has propTypes or defaultProps attributes', () => {
+    function renderWithPropTypes() {
+      return null;
+    }
+    renderWithPropTypes.propTypes = {};
+
+    function renderWithDefaultProps() {
+      return null;
+    }
+    renderWithDefaultProps.defaultProps = {};
+
+    expect(() => React.forwardRef(renderWithPropTypes)).toWarnDev(
+      'forwardRef render functions do not support propTypes or defaultProps. ' +
+        'Did you accidentally pass a React component?',
+    );
+    expect(() => React.forwardRef(renderWithDefaultProps)).toWarnDev(
+      'forwardRef render functions do not support propTypes or defaultProps. ' +
+        'Did you accidentally pass a React component?',
+    );
+  });
 });

--- a/packages/react/src/forwardRef.js
+++ b/packages/react/src/forwardRef.js
@@ -18,6 +18,14 @@ export default function forwardRef<Props, ElementType: React$ElementType>(
       'forwardRef requires a render function but was given %s.',
       render === null ? 'null' : typeof render,
     );
+
+    if (render != null) {
+      warning(
+        render.defaultProps == null && render.propTypes == null,
+        'forwardRef render functions do not support propTypes or defaultProps. ' +
+          'Did you accidentally pass a React component?',
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
Someone at FB recently reported a bug that boiled down to the following:
```js
function MyComponent(props, ref) {
  return <p ref={ref}>myProp: {props.myProp}</p>;
}
MyComponent.defaultProps = {
  myProp: "default"
};
MyComponent.propTypes = {
  myProp: React.PropTypes.string.isRequired
};

const MyWrappedComponent = React.forwardRef(MyComponent);
```
This _kind of worked_ but, of course, prop-types didn't work.

What they meant to do was:
```js
function MyComponent(props) {
  return <p ref={props.forwardedRef}>myProp: {props.myProp}</p>;
}
MyComponent.defaultProps = {
  myProp: "default"
};
MyComponent.propTypes = {
  myProp: React.PropTypes.string.isRequired
};

const MyWrappedComponent = React.forwardRef((props, ref) => (
  <MyComponent {...props} forwardedRef={ref} />
));
```

I think it would be nice for us to warn about this in DEV mode. I'm not enamored with this warning message in particular though if someone has better suggestions.