### PR TITLE
Perform null check on sourceFiber

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -962,7 +962,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         }
 
         const sourceFiber: Fiber = nextUnitOfWork;
-        let returnFiber = sourceFiber.return;
+        let returnFiber = sourceFiber ? sourceFiber.return : null;
         if (returnFiber === null) {
           // This is the root. The root could capture its own errors. However,
           // we don't know if it errors before or after we pushed the host


### PR DESCRIPTION
Similar to issue presented in https://github.com/facebook/react/issues/12449, the "Cannot read property 'return' of null" of error can still be thrown due to a possible null value. This PR adds a nullcheck.

Error: 
![](https://user-images.githubusercontent.com/7062515/39015394-e4bdce6a-43e2-11e8-909a-1120d36d8a30.png)
