### PR TITLE
Validate props on context providers

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -891,7 +891,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         workInProgress.type.propTypes,
         newProps,
         'prop',
-        'ReactContext',
+        'ReactProvider',
       );
     }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -891,7 +891,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         workInProgress.type.propTypes,
         newProps,
         'prop',
-        'ReactProvider',
+        'Context.Provider',
       );
     }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -16,7 +16,6 @@ import type {NewContext} from './ReactFiberNewContext';
 import type {HydrationContext} from './ReactFiberHydrationContext';
 import type {FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
-import emptyFunction from 'fbjs/lib/emptyFunction';
 import checkPropTypes from 'prop-types/checkPropTypes';
 
 import {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -16,6 +16,7 @@ import type {NewContext} from './ReactFiberNewContext';
 import type {HydrationContext} from './ReactFiberHydrationContext';
 import type {FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
+import checkPropTypes from 'prop-types/checkPropTypes';
 
 import {
   IndeterminateComponent,
@@ -884,6 +885,15 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     const newValue = newProps.value;
     workInProgress.memoizedProps = newProps;
+
+    if (__DEV__ && workInProgress.types) {
+      checkPropTypes(
+        workInProgress.types.propTypes,
+        newProps,
+        'context',
+        'ReactContext',
+      );
+    }
 
     let changedBits: number;
     if (oldProps === null) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -891,16 +891,17 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     const newValue = newProps.value;
     workInProgress.memoizedProps = newProps;
 
-    const providerPropTypes = workInProgress.type.propTypes;
-
-    if (__DEV__ && providerPropTypes) {
-      checkPropTypes(
-        providerPropTypes,
-        newProps,
-        'prop',
-        'Context.Provider',
-        getStack,
-      );
+    if (__DEV__) {
+      const providerPropTypes = workInProgress.type.propTypes;
+      if (providerPropTypes) {
+        checkPropTypes(
+          providerPropTypes,
+          newProps,
+          'prop',
+          'Context.Provider',
+          getStack,
+        );
+      }
     }
 
     let changedBits: number;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -64,6 +64,8 @@ import {NoWork, Never} from './ReactFiberExpirationTime';
 import {AsyncMode, StrictMode} from './ReactTypeOfMode';
 import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
 
+const {getCurrentFiberStackAddendum} = ReactDebugCurrentFiber;
+
 let didWarnAboutBadClass;
 let didWarnAboutGetDerivedStateOnFunctionalComponent;
 let didWarnAboutStatelessRefs;
@@ -888,7 +890,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     if (__DEV__) {
       const providerPropTypes = workInProgress.type.propTypes;
-      const {getCurrentFiberStackAddendum} = ReactDebugCurrentFiber;
+
       if (providerPropTypes) {
         checkPropTypes(
           providerPropTypes,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -886,9 +886,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     const newValue = newProps.value;
     workInProgress.memoizedProps = newProps;
 
-    if (__DEV__ && workInProgress.types) {
+    if (__DEV__ && workInProgress.type) {
       checkPropTypes(
-        workInProgress.types.propTypes,
+        workInProgress.type.propTypes,
         newProps,
         'prop',
         'ReactContext',

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -890,7 +890,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       checkPropTypes(
         workInProgress.types.propTypes,
         newProps,
-        'context',
+        'prop',
         'ReactContext',
       );
     }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -65,18 +65,14 @@ import {NoWork, Never} from './ReactFiberExpirationTime';
 import {AsyncMode, StrictMode} from './ReactTypeOfMode';
 import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
 
-const {getCurrentFiberStackAddendum} = ReactDebugCurrentFiber;
-
 let didWarnAboutBadClass;
 let didWarnAboutGetDerivedStateOnFunctionalComponent;
 let didWarnAboutStatelessRefs;
-let getStack = emptyFunction.thatReturns('');
 
 if (__DEV__) {
   didWarnAboutBadClass = {};
   didWarnAboutGetDerivedStateOnFunctionalComponent = {};
   didWarnAboutStatelessRefs = {};
-  getStack = getCurrentFiberStackAddendum;
 }
 
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
@@ -893,13 +889,14 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     if (__DEV__) {
       const providerPropTypes = workInProgress.type.propTypes;
+      const {getCurrentFiberStackAddendum} = ReactDebugCurrentFiber;
       if (providerPropTypes) {
         checkPropTypes(
           providerPropTypes,
           newProps,
           'prop',
           'Context.Provider',
-          getStack,
+          getCurrentFiberStackAddendum,
         );
       }
     }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -886,7 +886,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     const newValue = newProps.value;
     workInProgress.memoizedProps = newProps;
 
-    if (__DEV__ && workInProgress.type) {
+    if (__DEV__) {
       checkPropTypes(
         workInProgress.type.propTypes,
         newProps,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -16,6 +16,7 @@ import type {NewContext} from './ReactFiberNewContext';
 import type {HydrationContext} from './ReactFiberHydrationContext';
 import type {FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
+import emptyFunction from 'fbjs/lib/emptyFunction';
 import checkPropTypes from 'prop-types/checkPropTypes';
 
 import {
@@ -64,14 +65,18 @@ import {NoWork, Never} from './ReactFiberExpirationTime';
 import {AsyncMode, StrictMode} from './ReactTypeOfMode';
 import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
 
+const {getCurrentFiberStackAddendum} = ReactDebugCurrentFiber;
+
 let didWarnAboutBadClass;
 let didWarnAboutGetDerivedStateOnFunctionalComponent;
 let didWarnAboutStatelessRefs;
+let getStack = emptyFunction.thatReturns('');
 
 if (__DEV__) {
   didWarnAboutBadClass = {};
   didWarnAboutGetDerivedStateOnFunctionalComponent = {};
   didWarnAboutStatelessRefs = {};
+  getStack = getCurrentFiberStackAddendum;
 }
 
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
@@ -886,12 +891,15 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     const newValue = newProps.value;
     workInProgress.memoizedProps = newProps;
 
-    if (__DEV__) {
+    const providerPropTypes = workInProgress.type.propTypes;
+
+    if (__DEV__ && providerPropTypes) {
       checkPropTypes(
-        workInProgress.type.propTypes,
+        providerPropTypes,
         newProps,
         'prop',
         'Context.Provider',
+        getStack,
       );
     }
 

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -234,7 +234,9 @@ describe('ReactContextValidator', () => {
 
     ReactTestUtils.renderIntoDocument(<TestContext.Provider value="val" />);
 
-    expect(() => ReactTestUtils.renderIntoDocument(<TestContext.Provider />)).toWarnDev(
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<TestContext.Provider />),
+    ).toWarnDev(
       'Warning: Failed prop type: The prop `value` is marked as required in ' +
         '`ReactProvider`, but its value is `undefined`.',
     );

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -234,11 +234,20 @@ describe('ReactContextValidator', () => {
 
     ReactTestUtils.renderIntoDocument(<TestContext.Provider value="val" />);
 
+    class Component extends React.Component {
+      render () {
+        return (
+            <TestContext.Provider />
+        );
+      }
+    }
+
     expect(() =>
-      ReactTestUtils.renderIntoDocument(<TestContext.Provider />),
+      ReactTestUtils.renderIntoDocument(<Component />),
     ).toWarnDev(
       'Warning: Failed prop type: The prop `value` is marked as required in ' +
-        '`Context.Provider`, but its value is `undefined`.',
+        '`Context.Provider`, but its value is `undefined`.\n' +
+        '    in Component (at **)',
     );
   });
 

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -239,7 +239,7 @@ describe('ReactContextValidator', () => {
 
     expect(() => ReactTestUtils.renderIntoDocument(<TestContext />)).toWarnDev(
       'Warning: Failed prop type: The prop `value` is marked as required in ' +
-        '`ReactContext`, but its value is `undefined`.',
+        '`ReactProvider`, but its value is `undefined`.',
     );
   });
 

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -238,7 +238,7 @@ describe('ReactContextValidator', () => {
       ReactTestUtils.renderIntoDocument(<TestContext.Provider />),
     ).toWarnDev(
       'Warning: Failed prop type: The prop `value` is marked as required in ' +
-        '`ReactProvider`, but its value is `undefined`.',
+        '`Context.Provider`, but its value is `undefined`.',
     );
   });
 

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -226,18 +226,15 @@ describe('ReactContextValidator', () => {
   });
 
   it('warns of incorrect prop types on context provider', () => {
-    class TestContext extends React.Component {
-      render() {
-        return <MyContext.Provider />;
-      }
-    }
     const MyContext = React.createContext();
 
     MyContext.Provider.propTypes = {
       value: PropTypes.string.isRequired,
     };
 
-    expect(() => ReactTestUtils.renderIntoDocument(<TestContext />)).toWarnDev(
+    ReactTestUtils.renderIntoDocument(<MyContext.Provider value="val" />);
+
+    expect(() => ReactTestUtils.renderIntoDocument(<MyContext.Provider />)).toWarnDev(
       'Warning: Failed prop type: The prop `value` is marked as required in ' +
         '`ReactProvider`, but its value is `undefined`.',
     );

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -226,15 +226,15 @@ describe('ReactContextValidator', () => {
   });
 
   it('warns of incorrect prop types on context provider', () => {
-    const MyContext = React.createContext();
+    const TestContext = React.createContext();
 
-    MyContext.Provider.propTypes = {
+    TestContext.Provider.propTypes = {
       value: PropTypes.string.isRequired,
     };
 
-    ReactTestUtils.renderIntoDocument(<MyContext.Provider value="val" />);
+    ReactTestUtils.renderIntoDocument(<TestContext.Provider value="val" />);
 
-    expect(() => ReactTestUtils.renderIntoDocument(<MyContext.Provider />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<TestContext.Provider />)).toWarnDev(
       'Warning: Failed prop type: The prop `value` is marked as required in ' +
         '`ReactProvider`, but its value is `undefined`.',
     );

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -235,16 +235,12 @@ describe('ReactContextValidator', () => {
     ReactTestUtils.renderIntoDocument(<TestContext.Provider value="val" />);
 
     class Component extends React.Component {
-      render () {
-        return (
-            <TestContext.Provider />
-        );
+      render() {
+        return <TestContext.Provider />;
       }
     }
 
-    expect(() =>
-      ReactTestUtils.renderIntoDocument(<Component />),
-    ).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toWarnDev(
       'Warning: Failed prop type: The prop `value` is marked as required in ' +
         '`Context.Provider`, but its value is `undefined`.\n' +
         '    in Component (at **)',

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -225,6 +225,24 @@ describe('ReactContextValidator', () => {
     ReactTestUtils.renderIntoDocument(<Component testContext={{foo: 'foo'}} />);
   });
 
+  it('warns of incorrect prop types on context provider', () => {
+    class TestContext extends React.Component {
+      render() {
+        return <MyContext.Provider />;
+      }
+    }
+    const MyContext = React.createContext();
+
+    MyContext.Provider.propTypes = {
+      value: PropTypes.string.isRequired,
+    };
+
+    expect(() => ReactTestUtils.renderIntoDocument(<TestContext />)).toWarnDev(
+      'Warning: Failed prop type: The prop `value` is marked as required in ' +
+        '`ReactContext`, but its value is `undefined`.',
+    );
+  });
+
   // TODO (bvaughn) Remove this test and the associated behavior in the future.
   // It has only been added in Fiber to match the (unintentional) behavior in Stack.
   it('should warn (but not error) if getChildContext method is missing', () => {


### PR DESCRIPTION
## Description

Prop types aren’t being checked on context providers, resulting in no dev warning in situations like the following:

![38910612-fe7cc032-427e-11e8-92dd-568849ccb4b3](https://user-images.githubusercontent.com/24465189/39029352-50e50694-4429-11e8-9fdb-181a5ce71f70.png)

References issue: #12636 

## Changes

- [x] Added `checkPropTypes` call to `updateContextProvider`
- [x] Added a test to make sure prop types are being checked on providers

## Notes

I only added one test as I thought multiple tests with different propType specification would just be testing the underlying prop-types library instead of react. If this needs to be moved or I’ve missed something let me know! 😄 