### PR TITLE
Call getDerivedStateFromProps even for setState of ShallowRenderer

### DIFF
--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -186,9 +186,8 @@ class ReactShallowRenderer {
           this._instance.UNSAFE_componentWillReceiveProps(props, context);
         }
       }
-
-      this._updateStateFromStaticLifecycle(props);
     }
+    this._updateStateFromStaticLifecycle(props);
 
     // Read state after cWRP in case it calls setState
     const state = this._newState || oldState;

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -94,7 +94,7 @@ describe('ReactShallowRenderer', () => {
     const instance = shallowRenderer.getMountedInstance();
     instance.setState({});
 
-    expect(logs).toEqual(['shouldComponentUpdate']);
+    expect(logs).toEqual(['getDerivedStateFromProps', 'shouldComponentUpdate']);
 
     logs.splice(0);
 


### PR DESCRIPTION
At the following commit, `getDerivedStateFromProps` is now called even for setState.

https://github.com/facebook/react/pull/12600/files#r183196222

This PR is applying this change to ShallowRenderer.
Does it make sense?