### PR TITLE
Add support for multiple callbacks in ReactScheduler

### DIFF
--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -34,6 +34,11 @@
 // The frame rate is dynamically adjusted.
 
 import type {Deadline} from 'react-reconciler';
+type CallbackConfigType = {|
+  scheduledCallback: (Deadline) => void,
+  timeoutTime: number,
+  // id: string, // used for cancelling
+|};
 
 import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 import warning from 'fbjs/lib/warning';
@@ -90,12 +95,19 @@ if (!ExecutionEnvironment.canUseDOM) {
 } else {
   // Always polyfill requestIdleCallback and cancelIdleCallback
 
-  let scheduledCallback = null;
+  let scheduledCallbackConfig: CallbackConfigType | null = null;
+  const getCallbackId = function(): string {
+    const callbackId =
+      '__scheduledCallbackId$' +
+      Math.random()
+        .toString(36)
+        .slice(2);
+    return callbackId;
+  };
   let isIdleScheduled = false;
-  let timeoutTime = -1;
   let isCurrentlyRunningCallback = false;
   // We keep a queue of pending callbacks
-  let pendingCallbacks = [];
+  let pendingCallbacks: Array<CallbackConfigType> = [];
 
   let isAnimationFrameScheduled = false;
 
@@ -106,7 +118,15 @@ if (!ExecutionEnvironment.canUseDOM) {
   let previousFrameTime = 33;
   let activeFrameTime = 33;
 
-  const frameDeadlineObject = {
+  // When a callback is scheduled, we register it by adding it's id to this
+  // object.
+  // If the user calls 'cIC' with the id of that callback, it will be
+  // unregistered by removing the id from this object.
+  // Then we skip calling any callback which is not registered.
+  // This means cancelling is an O(1) time complexity instead of O(n).
+  const registeredCallbackIds: { [number]: boolean } = {};
+
+  const frameDeadlineObject: Deadline = {
     didTimeout: false,
     timeRemaining() {
       const remaining = frameDeadline - now();
@@ -122,7 +142,9 @@ if (!ExecutionEnvironment.canUseDOM) {
     } catch (e) {
       isCurrentlyRunningCallback = false;
       // Still throw it, but not in this frame.
-      setTimeout(() => {throw e;});
+      setTimeout(() => {
+        throw e;
+      });
     }
   };
 
@@ -137,9 +159,14 @@ if (!ExecutionEnvironment.canUseDOM) {
       return;
     }
 
+    if (scheduledCallbackConfig === null) {
+      return;
+    }
+
     isIdleScheduled = false;
 
     const currentTime = now();
+    const timeoutTime = scheduledCallbackConfig.timeoutTime;
     let didTimeout = false;
     if (frameDeadline - currentTime <= 0) {
       // There's no time left in this idle period. Check if the callback has
@@ -163,9 +190,8 @@ if (!ExecutionEnvironment.canUseDOM) {
       didTimeout = false;
     }
 
-    const callback = scheduledCallback;
-    timeoutTime = -1;
-    scheduledCallback = null;
+    const callback = scheduledCallbackConfig.scheduledCallback;
+    scheduledCallbackConfig = null;
     if (callback !== null) {
       frameDeadlineObject.didTimeout = didTimeout;
       safelyCallScheduledCallback(callback);
@@ -216,44 +242,44 @@ if (!ExecutionEnvironment.canUseDOM) {
     // having been called before it runs.
     // So we call anything in the queue before the latest callback
 
-    let previousCallback;
-    let timeoutTimeFromPreviousCallback;
-    if (scheduledCallback !== null) {
-      // If we have previous callback, save it and handle it below
-      timeoutTimeFromPreviousCallback = timeoutTime;
-      previousCallback = scheduledCallback;
+    let previouslyScheduledCallbackConfig;
+    if (scheduledCallbackConfig !== null) {
+      // If we have previous callback config, save it and handle it below
+      previouslyScheduledCallbackConfig = scheduledCallbackConfig;
     }
-    // Then set up the next callback, and update timeoutTime
-    scheduledCallback = callback;
+    // Then set up the next callback config
+    let timeoutTime = -1;
     if (options != null && typeof options.timeout === 'number') {
       timeoutTime = now() + options.timeout;
-    } else {
-      timeoutTime = -1;
     }
+    scheduledCallbackConfig = {
+      scheduledCallback: callback,
+      timeoutTime,
+    };
     // If we have previousCallback, call it. This may trigger recursion.
     if (
-      previousCallback &&
-      typeof timeoutTimeFromPreviousCallback === 'number'
+      previouslyScheduledCallbackConfig &&
+      // make flow happy
+      typeof previouslyScheduledCallbackConfig.timeoutTime === 'number'
     ) {
-      const prevCallbackTimeout: number = timeoutTimeFromPreviousCallback;
+      const previousCallbackTimeout: number =
+        previouslyScheduledCallbackConfig.timeoutTime;
+      const previousCallback =
+        previouslyScheduledCallbackConfig.scheduledCallback;
       if (isCurrentlyRunningCallback) {
         // we are inside a recursive call to rIC
         // add this callback to a pending queue and run after we exit
-        pendingCallbacks.push({
-          pendingCallback: previousCallback,
-          pendingCallbackTimeout: prevCallbackTimeout,
-        });
+        pendingCallbacks.push(previouslyScheduledCallbackConfig);
       } else {
         frameDeadlineObject.didTimeout =
-          timeoutTimeFromPreviousCallback !== -1 &&
-          timeoutTimeFromPreviousCallback <= now();
+          previousCallbackTimeout !== -1 &&
+          previousCallbackTimeout <= now();
         safelyCallScheduledCallback(previousCallback);
         while (pendingCallbacks.length) {
           // the callback recursively called rIC and new callbacks are pending
           const callbackConfig = pendingCallbacks.shift();
-          const pendingCallback = callbackConfig.pendingCallback;
-          const pendingCallbackTimeout = callbackConfig.pendingCallbackTimeout;
-          // TODO: pull this into helper method
+          const pendingCallback = callbackConfig.scheduledCallback;
+          const pendingCallbackTimeout = callbackConfig.timeoutTime;
           frameDeadlineObject.didTimeout =
             pendingCallbackTimeout !== -1 && pendingCallbackTimeout <= now();
           safelyCallScheduledCallback(pendingCallback);
@@ -268,15 +294,14 @@ if (!ExecutionEnvironment.canUseDOM) {
       // might want to still have setTimeout trigger rIC as a backup to ensure
       // that we keep performing work.
       isAnimationFrameScheduled = true;
-      return requestAnimationFrame(animationTick);
+      requestAnimationFrame(animationTick);
     }
     return 0;
   };
 
   cIC = function() {
     isIdleScheduled = false;
-    scheduledCallback = null;
-    timeoutTime = -1;
+    scheduledCallbackConfig = null;
   };
 }
 

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -249,29 +249,37 @@ if (!ExecutionEnvironment.canUseDOM) {
     // having been called before it runs.
     // So we call anything in the queue before the latest callback
 
-    let previouslyScheduledCallbackConfig;
-    if (scheduledCallbackConfig !== null) {
-      // If we have previous callback config, save it and handle it below
-      previouslyScheduledCallbackConfig = scheduledCallbackConfig;
-    }
-    // Then set up the next callback config
-    let timeoutTime = -1;
-    if (options != null && typeof options.timeout === 'number') {
-      timeoutTime = now() + options.timeout;
-    }
     const latestCallbackId = getCallbackId();
-    scheduledCallbackConfig = {
-      scheduledCallback: callback,
-      timeoutTime,
-      callbackId: latestCallbackId,
-    };
-    registeredCallbackIds.set(latestCallbackId, true);
-    // If we have previousCallback, call it. This may trigger recursion.
-    if (
-      previouslyScheduledCallbackConfig &&
-      // make flow happy
-      typeof previouslyScheduledCallbackConfig.timeoutTime === 'number'
-    ) {
+    if (scheduledCallbackConfig === null) {
+      // Set up the next callback config
+      let timeoutTime = -1;
+      if (options != null && typeof options.timeout === 'number') {
+        timeoutTime = now() + options.timeout;
+      }
+      scheduledCallbackConfig = {
+        scheduledCallback: callback,
+        timeoutTime,
+        callbackId: latestCallbackId,
+      };
+      registeredCallbackIds.set(latestCallbackId, true);
+    } else {
+      // If we have a previous callback config, we call that and then schedule
+      // the latest callback.
+      const previouslyScheduledCallbackConfig = scheduledCallbackConfig;
+
+      // Then set up the next callback config
+      let timeoutTime = -1;
+      if (options != null && typeof options.timeout === 'number') {
+        timeoutTime = now() + options.timeout;
+      }
+      scheduledCallbackConfig = {
+        scheduledCallback: callback,
+        timeoutTime,
+        callbackId: latestCallbackId,
+      };
+      registeredCallbackIds.set(latestCallbackId, true);
+
+      // If we have previousCallback, call it. This may trigger recursion.
       const previousCallbackTimeout: number =
         previouslyScheduledCallbackConfig.timeoutTime;
       const previousCallback =

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -242,10 +242,9 @@ if (!ExecutionEnvironment.canUseDOM) {
         isCurrentlyRunningCallback = false;
         while (pendingCallbacks.length) {
           // the callback recursively called rIC and new callbacks are pending
-          const {
-            pendingCallback,
-            pendingCallbackTimeout,
-          } = pendingCallbacks.shift();
+          const callbackConfig = pendingCallbacks.shift();
+          const pendingCallback = callbackConfig.pendingCallback;
+          const pendingCallbackTimeout = callbackConfig.pendingCallbackTimeout;
           // TODO: pull this into helper method
           frameDeadlineObject.didTimeout =
             pendingCallbackTimeout !== -1 && pendingCallbackTimeout <= now();

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -94,7 +94,7 @@ if (!ExecutionEnvironment.canUseDOM) {
   let isIdleScheduled = false;
   let timeoutTime = -1;
   let isCurrentlyRunningCallback = false;
-  // We may need to keep a queue of pending callbacks
+  // We keep a queue of pending callbacks
   let pendingCallbacks = [];
 
   let isAnimationFrameScheduled = false;

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -124,7 +124,7 @@ if (!ExecutionEnvironment.canUseDOM) {
   // unregistered by removing the id from this object.
   // Then we skip calling any callback which is not registered.
   // This means cancelling is an O(1) time complexity instead of O(n).
-  const registeredCallbackIds: {[number]: boolean} = {};
+  const registeredCallbackIds: Map<number, boolean> = new Map();
 
   const frameDeadlineObject: Deadline = {
     didTimeout: false,
@@ -135,17 +135,17 @@ if (!ExecutionEnvironment.canUseDOM) {
   };
 
   const safelyCallScheduledCallback = function(callback, callbackId) {
-    if (!registeredCallbackIds[callbackId]) {
+    if (!registeredCallbackIds.get(callbackId)) {
       // ignore cancelled callbacks
       return;
     }
     isCurrentlyRunningCallback = true;
     try {
       callback(frameDeadlineObject);
-      delete registeredCallbackIds[callbackId];
+      registeredCallbackIds.delete(callbackId);
       isCurrentlyRunningCallback = false;
     } catch (e) {
-      delete registeredCallbackIds[callbackId];
+      registeredCallbackIds.delete(callbackId);
       isCurrentlyRunningCallback = false;
       // Still throw it, but not in this frame.
       setTimeout(() => {
@@ -265,7 +265,7 @@ if (!ExecutionEnvironment.canUseDOM) {
       timeoutTime,
       callbackId: latestCallbackId,
     };
-    registeredCallbackIds[latestCallbackId] = true;
+    registeredCallbackIds.set(latestCallbackId, true);
     // If we have previousCallback, call it. This may trigger recursion.
     if (
       previouslyScheduledCallbackConfig &&
@@ -313,7 +313,7 @@ if (!ExecutionEnvironment.canUseDOM) {
   };
 
   cIC = function(callbackId: number) {
-    delete registeredCallbackIds[callbackId];
+    registeredCallbackIds.delete(callbackId);
   };
 }
 

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -103,14 +103,12 @@ if (!ExecutionEnvironment.canUseDOM) {
   let previousFrameTime = 33;
   let activeFrameTime = 33;
 
-  const buildFrameDeadlineObject = function(didTimeout: boolean) {
-    return {
-      didTimeout,
-      timeRemaining() {
-        const remaining = frameDeadline - now();
-        return remaining > 0 ? remaining : 0;
-      },
-    };
+  const frameDeadlineObject = {
+    didTimeout: false,
+    timeRemaining() {
+      const remaining = frameDeadline - now();
+      return remaining > 0 ? remaining : 0;
+    },
   };
 
   // define a helper for this because they should usually happen together
@@ -159,7 +157,8 @@ if (!ExecutionEnvironment.canUseDOM) {
     const callback = scheduledRICCallback;
     clearTimeoutTimeAndScheduledCallback();
     if (callback !== null) {
-      callback(buildFrameDeadlineObject(didTimeout));
+      frameDeadlineObject.didTimeout = didTimeout;
+      callback(frameDeadlineObject);
     }
   };
   // Assumes that we have addEventListener in this environment. Might need
@@ -206,8 +205,9 @@ if (!ExecutionEnvironment.canUseDOM) {
       // For now we implement the behavior expected when the callbacks are
       // serial updates, such that each update relies on the previous ones
       // having been called before it runs.
-      const didTimeout = (timeoutTime !== -1) && (timeoutTime <= now());
-      scheduledRICCallback(buildFrameDeadlineObject(didTimeout));
+      frameDeadlineObject.didTimeout =
+        (timeoutTime !== -1) && (timeoutTime <= now());
+      scheduledRICCallback(frameDeadlineObject);
     }
     scheduledRICCallback = callback;
     if (options != null && typeof options.timeout === 'number') {

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -112,7 +112,7 @@ if (!ExecutionEnvironment.canUseDOM) {
   };
 
   // define a helper for this because they should usually happen together
-  const clearTimeoutTimeAndScheduledCallback = function() {
+  const resetScheduledCallback = function() {
     timeoutTime = -1;
     scheduledRICCallback = null;
   };
@@ -155,7 +155,7 @@ if (!ExecutionEnvironment.canUseDOM) {
     }
 
     const callback = scheduledRICCallback;
-    clearTimeoutTimeAndScheduledCallback();
+    resetScheduledCallback();
     if (callback !== null) {
       frameDeadlineObject.didTimeout = didTimeout;
       callback(frameDeadlineObject);
@@ -228,7 +228,7 @@ if (!ExecutionEnvironment.canUseDOM) {
 
   cIC = function() {
     isIdleScheduled = false;
-    clearTimeoutTimeAndScheduledCallback();
+    resetScheduledCallback();
   };
 }
 

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -47,10 +47,32 @@ describe('ReactScheduler', () => {
     rIC(cb);
     jest.runAllTimers();
     expect(cb.mock.calls.length).toBe(1);
-    // should have ... TODO details on what we expect
+    // should not have timed out and should include a timeRemaining method
     expect(cb.mock.calls[0][0].didTimeout).toBe(false);
     expect(typeof cb.mock.calls[0][0].timeRemaining()).toBe('number');
   });
 
+  it('rIC with multiple callbacks flushes previous cb when new one is passed', () => {
+    const {rIC} = ReactScheduler;
+    const callbackA = jest.fn();
+    const callbackB = jest.fn();
+    rIC(callbackA);
+    // initially waits to call the callback
+    expect(callbackA.mock.calls.length).toBe(0);
+    // when second callback is passed, flushes first one
+    rIC(callbackB);
+    expect(callbackA.mock.calls.length).toBe(1);
+    expect(callbackB.mock.calls.length).toBe(0);
+    // after a delay, calls the latest callback passed
+    jest.runAllTimers();
+    expect(callbackA.mock.calls.length).toBe(1);
+    expect(callbackB.mock.calls.length).toBe(1);
+    // callbackA should not have timed out and should include a timeRemaining method
+    expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
+    expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe('number');
+    // callbackA should not have timed out and should include a timeRemaining method
+    expect(callbackB.mock.calls[0][0].didTimeout).toBe(false);
+    expect(typeof callbackB.mock.calls[0][0].timeRemaining()).toBe('number');
+  });
   // TODO: test cIC and now
 });

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -248,33 +248,35 @@ describe('ReactScheduler', () => {
   });
 
   describe('cIC', () => {
-    // TODO: return an id from rIC and use in cIC
-    // and test this.
     it('cancels the scheduled callback', () => {
       const {rIC, cIC} = ReactScheduler;
       const cb = jest.fn();
-      rIC(cb);
+      const callbackId = rIC(cb);
       expect(cb.mock.calls.length).toBe(0);
-      cIC();
+      cIC(callbackId);
       jest.runAllTimers();
       expect(cb.mock.calls.length).toBe(0);
     });
 
+    // TODO: this test will be easier to implement once we support deferred
+    /**
     it('when one callback cancels the next one', () => {
       const {rIC, cIC} = ReactScheduler;
       const cbA = jest.fn(() => {
+        // How to get the callback id?
         cIC();
       });
       const cbB = jest.fn();
       rIC(cbA);
       expect(cbA.mock.calls.length).toBe(0);
-      rIC(cbB);
+      callbackBId = rIC(cbB);
       expect(cbA.mock.calls.length).toBe(1);
       expect(cbB.mock.calls.length).toBe(0);
       jest.runAllTimers();
       // B should not get called because A cancelled B
       expect(cbB.mock.calls.length).toBe(0);
     });
+    */
   });
 
   // TODO: test 'now'

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -54,19 +54,21 @@ describe('ReactScheduler', () => {
 
   it('rIC with multiple callbacks flushes previous cb when new one is passed', () => {
     const {rIC} = ReactScheduler;
-    const callbackA = jest.fn();
-    const callbackB = jest.fn();
+    const callbackLog = [];
+    const callbackA = jest.fn(() => callbackLog.push('A'));
+    const callbackB = jest.fn(() => callbackLog.push('B'));
     rIC(callbackA);
     // initially waits to call the callback
-    expect(callbackA.mock.calls.length).toBe(0);
+    expect(callbackLog.length).toBe(0);
     // when second callback is passed, flushes first one
     rIC(callbackB);
-    expect(callbackA.mock.calls.length).toBe(1);
-    expect(callbackB.mock.calls.length).toBe(0);
+    expect(callbackLog.length).toBe(1);
+    expect(callbackLog[0]).toBe('A');
     // after a delay, calls the latest callback passed
     jest.runAllTimers();
-    expect(callbackA.mock.calls.length).toBe(1);
-    expect(callbackB.mock.calls.length).toBe(1);
+    expect(callbackLog.length).toBe(2);
+    expect(callbackLog[0]).toBe('A');
+    expect(callbackLog[1]).toBe('B');
     // callbackA should not have timed out and should include a timeRemaining method
     expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
     expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe('number');

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -60,16 +60,13 @@ describe('ReactScheduler', () => {
       const callbackB = jest.fn(() => callbackLog.push('B'));
       rIC(callbackA);
       // initially waits to call the callback
-      expect(callbackLog.length).toBe(0);
+      expect(callbackLog).toEqual([]);
       // when second callback is passed, flushes first one
       rIC(callbackB);
-      expect(callbackLog.length).toBe(1);
-      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog).toEqual(['A']);
       // after a delay, calls the latest callback passed
       jest.runAllTimers();
-      expect(callbackLog.length).toBe(2);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog).toEqual(['A', 'B']);
       // callbackA should not have timed out and should include a timeRemaining method
       expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
       expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe('number');
@@ -98,15 +95,10 @@ describe('ReactScheduler', () => {
       // when second callback is passed, flushes first one
       // callbackA scheduled callbackC, which flushes callbackB
       rIC(callbackB);
-      expect(callbackLog.length).toBe(2);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog).toEqual(['A', 'B']);
       // after a delay, calls the latest callback passed
       jest.runAllTimers();
-      expect(callbackLog.length).toBe(3);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
-      expect(callbackLog[2]).toBe('C');
+      expect(callbackLog).toEqual(['A', 'B', 'C']);
     });
 
     it('schedules callbacks in correct order when callbacks have many nested rIC calls', () => {
@@ -141,16 +133,10 @@ describe('ReactScheduler', () => {
       // when second callback is passed, flushes first one
       // callbackA scheduled callbackC, which flushes callbackB
       rIC(callbackB);
-      expect(callbackLog.length).toBe(5);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
-      expect(callbackLog[2]).toBe('C');
-      expect(callbackLog[3]).toBe('D');
-      expect(callbackLog[4]).toBe('E');
+      expect(callbackLog).toEqual(['A', 'B', 'C', 'D', 'E']);
       // after a delay, calls the latest callback passed
       jest.runAllTimers();
-      expect(callbackLog.length).toBe(6);
-      expect(callbackLog[5]).toBe('F');
+      expect(callbackLog).toEqual(['A', 'B', 'C', 'D', 'E', 'F']);
     });
 
     it('allows each callback finish running before flushing others', () => {
@@ -170,15 +156,10 @@ describe('ReactScheduler', () => {
       // when second callback is passed, flushes first one
       // callbackA scheduled callbackC, which flushes callbackB
       rIC(callbackB);
-      expect(callbackLog.length).toBe(2);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog).toEqual(['A', 'B']);
       // after a delay, calls the latest callback passed
       jest.runAllTimers();
-      expect(callbackLog.length).toBe(3);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
-      expect(callbackLog[2]).toBe('C');
+      expect(callbackLog).toEqual(['A', 'B', 'C']);
     });
 
     it('schedules callbacks in correct order when they use rIC to schedule themselves', () => {
@@ -200,15 +181,10 @@ describe('ReactScheduler', () => {
       // when second callback is passed, flushes first one
       // callbackA scheduled callbackA again, which flushes callbackB
       rIC(callbackB);
-      expect(callbackLog.length).toBe(2);
-      expect(callbackLog[0]).toBe('A0');
-      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog).toEqual(['A0', 'B']);
       // after a delay, calls the latest callback passed
       jest.runAllTimers();
-      expect(callbackLog.length).toBe(3);
-      expect(callbackLog[0]).toBe('A0');
-      expect(callbackLog[1]).toBe('B');
-      expect(callbackLog[2]).toBe('A1');
+      expect(callbackLog).toEqual(['A0', 'B', 'A1']);
     });
 
     describe('handling errors', () => {
@@ -234,15 +210,10 @@ describe('ReactScheduler', () => {
         // callbackA scheduled callbackC, which flushes callbackB
         // even when callbackA throws an error, we successfully call callbackB
         rIC(callbackB);
-        expect(callbackLog.length).toBe(2);
-        expect(callbackLog[0]).toBe('A');
-        expect(callbackLog[1]).toBe('B');
+        expect(callbackLog).toEqual(['A', 'B']);
         // after a delay, throws the error and calls the latest callback passed
         expect(() => jest.runAllTimers()).toThrowError('dummy error A');
-        expect(callbackLog.length).toBe(3);
-        expect(callbackLog[0]).toBe('A');
-        expect(callbackLog[1]).toBe('B');
-        expect(callbackLog[2]).toBe('C');
+        expect(callbackLog).toEqual(['A', 'B', 'C']);
       });
     });
   });

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -52,29 +52,165 @@ describe('ReactScheduler', () => {
     expect(typeof cb.mock.calls[0][0].timeRemaining()).toBe('number');
   });
 
-  it('rIC with multiple callbacks flushes previous cb when new one is passed', () => {
-    const {rIC} = ReactScheduler;
-    const callbackLog = [];
-    const callbackA = jest.fn(() => callbackLog.push('A'));
-    const callbackB = jest.fn(() => callbackLog.push('B'));
-    rIC(callbackA);
-    // initially waits to call the callback
-    expect(callbackLog.length).toBe(0);
-    // when second callback is passed, flushes first one
-    rIC(callbackB);
-    expect(callbackLog.length).toBe(1);
-    expect(callbackLog[0]).toBe('A');
-    // after a delay, calls the latest callback passed
-    jest.runAllTimers();
-    expect(callbackLog.length).toBe(2);
-    expect(callbackLog[0]).toBe('A');
-    expect(callbackLog[1]).toBe('B');
-    // callbackA should not have timed out and should include a timeRemaining method
-    expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
-    expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe('number');
-    // callbackA should not have timed out and should include a timeRemaining method
-    expect(callbackB.mock.calls[0][0].didTimeout).toBe(false);
-    expect(typeof callbackB.mock.calls[0][0].timeRemaining()).toBe('number');
+  describe('with multiple callbacks', () => {
+    it('flushes previous cb when new one is passed', () => {
+      const {rIC} = ReactScheduler;
+      const callbackLog = [];
+      const callbackA = jest.fn(() => callbackLog.push('A'));
+      const callbackB = jest.fn(() => callbackLog.push('B'));
+      rIC(callbackA);
+      // initially waits to call the callback
+      expect(callbackLog.length).toBe(0);
+      // when second callback is passed, flushes first one
+      rIC(callbackB);
+      expect(callbackLog.length).toBe(1);
+      expect(callbackLog[0]).toBe('A');
+      // after a delay, calls the latest callback passed
+      jest.runAllTimers();
+      expect(callbackLog.length).toBe(2);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      // callbackA should not have timed out and should include a timeRemaining method
+      expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
+      expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe('number');
+      // callbackA should not have timed out and should include a timeRemaining method
+      expect(callbackB.mock.calls[0][0].didTimeout).toBe(false);
+      expect(typeof callbackB.mock.calls[0][0].timeRemaining()).toBe('number');
+    });
+
+    it('schedules callbacks in correct order when a callback uses rIC before its own logic', () => {
+      const {rIC} = ReactScheduler;
+      const callbackLog = [];
+      const callbackA = jest.fn(() => {
+        callbackLog.push('A');
+        rIC(callbackC);
+      });
+      const callbackB = jest.fn(() => {
+        callbackLog.push('B');
+      });
+      const callbackC = jest.fn(() => {
+        callbackLog.push('C');
+      });
+
+      rIC(callbackA);
+      // initially waits to call the callback
+      expect(callbackLog.length).toBe(0);
+      // when second callback is passed, flushes first one
+      // callbackA scheduled callbackC, which flushes callbackB
+      rIC(callbackB);
+      expect(callbackLog.length).toBe(2);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      // after a delay, calls the latest callback passed
+      jest.runAllTimers();
+      expect(callbackLog.length).toBe(3);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog[2]).toBe('C');
+    });
+
+    it('schedules callbacks in correct order when callbacks have many nested rIC calls', () => {
+      const {rIC} = ReactScheduler;
+      const callbackLog = [];
+      const callbackA = jest.fn(() => {
+        callbackLog.push('A');
+        rIC(callbackC);
+        rIC(callbackD);
+      });
+      const callbackB = jest.fn(() => {
+        callbackLog.push('B');
+        rIC(callbackE);
+        rIC(callbackF);
+      });
+      const callbackC = jest.fn(() => {
+        callbackLog.push('C');
+      });
+      const callbackD = jest.fn(() => {
+        callbackLog.push('D');
+      });
+      const callbackE = jest.fn(() => {
+        callbackLog.push('E');
+      });
+      const callbackF = jest.fn(() => {
+        callbackLog.push('F');
+      });
+
+      rIC(callbackA);
+      // initially waits to call the callback
+      expect(callbackLog.length).toBe(0);
+      // when second callback is passed, flushes first one
+      // callbackA scheduled callbackC, which flushes callbackB
+      rIC(callbackB);
+      expect(callbackLog.length).toBe(5);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog[2]).toBe('C');
+      expect(callbackLog[3]).toBe('D');
+      expect(callbackLog[4]).toBe('E');
+      // after a delay, calls the latest callback passed
+      jest.runAllTimers();
+      expect(callbackLog.length).toBe(6);
+      expect(callbackLog[5]).toBe('F');
+    });
+
+    it('allows each callback finish running before flushing others', () => {
+      const {rIC} = ReactScheduler;
+      const callbackLog = [];
+      const callbackA = jest.fn(() => {
+        // rIC should wait to flush any more until this callback finishes
+        rIC(callbackC);
+        callbackLog.push('A');
+      });
+      const callbackB = jest.fn(() => callbackLog.push('B'));
+      const callbackC = jest.fn(() => callbackLog.push('C'));
+
+      rIC(callbackA);
+      // initially waits to call the callback
+      expect(callbackLog.length).toBe(0);
+      // when second callback is passed, flushes first one
+      // callbackA scheduled callbackC, which flushes callbackB
+      rIC(callbackB);
+      expect(callbackLog.length).toBe(2);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      // after a delay, calls the latest callback passed
+      jest.runAllTimers();
+      expect(callbackLog.length).toBe(3);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog[2]).toBe('C');
+    });
+
+    it('schedules callbacks in correct order when they use rIC to schedule themselves', () => {
+      const {rIC} = ReactScheduler;
+      const callbackLog = [];
+      let callbackAIterations = 0;
+      const callbackA = jest.fn(() => {
+        if (callbackAIterations < 1) {
+          rIC(callbackA);
+        }
+        callbackLog.push('A' + callbackAIterations);
+        callbackAIterations++;
+      });
+      const callbackB = jest.fn(() => callbackLog.push('B'));
+
+      rIC(callbackA);
+      // initially waits to call the callback
+      expect(callbackLog.length).toBe(0);
+      // when second callback is passed, flushes first one
+      // callbackA scheduled callbackA again, which flushes callbackB
+      rIC(callbackB);
+      expect(callbackLog.length).toBe(2);
+      expect(callbackLog[0]).toBe('A0');
+      expect(callbackLog[1]).toBe('B');
+      // after a delay, calls the latest callback passed
+      jest.runAllTimers();
+      expect(callbackLog.length).toBe(3);
+      expect(callbackLog[0]).toBe('A0');
+      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog[2]).toBe('A1');
+    });
   });
+
   // TODO: test cIC and now
 });

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -247,5 +247,35 @@ describe('ReactScheduler', () => {
     });
   });
 
-  // TODO: test cIC and now
+  describe('cIC', () => {
+    // TODO: return an id from rIC and use in cIC
+    // and test this.
+    it('cancels the scheduled callback', () => {
+      const {rIC, cIC} = ReactScheduler;
+      const cb = jest.fn();
+      rIC(cb);
+      expect(cb.mock.calls.length).toBe(0);
+      cIC();
+      jest.runAllTimers();
+      expect(cb.mock.calls.length).toBe(0);
+    });
+
+    it('when one callback cancels the next one', () => {
+      const {rIC, cIC} = ReactScheduler;
+      const cbA = jest.fn(() => {
+        cIC();
+      });
+      const cbB = jest.fn();
+      rIC(cbA);
+      expect(cbA.mock.calls.length).toBe(0);
+      rIC(cbB);
+      expect(cbA.mock.calls.length).toBe(1);
+      expect(cbB.mock.calls.length).toBe(0);
+      jest.runAllTimers();
+      // B should not get called because A cancelled B
+      expect(cbB.mock.calls.length).toBe(0);
+    });
+  });
+
+  // TODO: test 'now'
 });


### PR DESCRIPTION
**what is the change?:**
We want to support calling ReactScheduler multiple times with different
callbacks, even if the initial callback hasn't been called yet.

There are two possible ways ReactScheduler can handle multiple
callbacks, and in one case we know that callbackA depends on callbackB
having been called already. For example;
callbackA -> updates SelectionState in a textArea
callbackB -> processes the deletion of the text currently selected.

We want to ensure that callbackA happens before callbackB. For now we
will flush callbackB as soon as callbackA is added.

In the next commit we'll split this into two methods, which support two
different behaviors here. We will support the usual behavior, which
would defer both callbackA and callbackB.

One issue with this is that we now create a new object to pass to the
callback for every use of the scheduler, while before we reused the same
object and mutated the 'didExpire' before passing it to each new
callback. With multiple callbacks, I think this leads to a risk of
mutating the object which is being used by multiple callbacks.

**why make this change?:**
We want to use this scheduling helper to coordinate between React and
non-React scripts.

**test plan:**
Added and ran a unit test.