### PR TITLE
forwardRef() components should not re-render on deep setState()

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -169,12 +169,16 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
   function updateForwardRef(current, workInProgress) {
     const render = workInProgress.type.render;
-    const nextChildren = render(
-      workInProgress.pendingProps,
-      workInProgress.ref,
-    );
+    const nextProps = workInProgress.pendingProps;
+    if (hasLegacyContextChanged()) {
+      // Normally we can bail out on props equality but if context has changed
+      // we don't do the bailout and we have to reuse existing props instead.
+    } else if (workInProgress.memoizedProps === nextProps) {
+      return bailoutOnAlreadyFinishedWork(current, workInProgress);
+    }
+    const nextChildren = render(nextProps, workInProgress.ref);
     reconcileChildren(current, workInProgress, nextChildren);
-    memoizeProps(workInProgress, nextChildren);
+    memoizeProps(workInProgress, nextProps);
     return workInProgress.child;
   }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -170,13 +170,17 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   function updateForwardRef(current, workInProgress) {
     const render = workInProgress.type.render;
     const nextProps = workInProgress.pendingProps;
+    const ref = workInProgress.ref;
     if (hasLegacyContextChanged()) {
       // Normally we can bail out on props equality but if context has changed
       // we don't do the bailout and we have to reuse existing props instead.
     } else if (workInProgress.memoizedProps === nextProps) {
-      return bailoutOnAlreadyFinishedWork(current, workInProgress);
+      const currentRef = current !== null ? current.ref : null;
+      if (ref === currentRef) {
+        return bailoutOnAlreadyFinishedWork(current, workInProgress);
+      }
     }
-    const nextChildren = render(nextProps, workInProgress.ref);
+    const nextChildren = render(nextProps, ref);
     reconcileChildren(current, workInProgress, nextChildren);
     memoizeProps(workInProgress, nextProps);
     return workInProgress.child;

--- a/packages/react/src/__tests__/forwardRef-test.internal.js
+++ b/packages/react/src/__tests__/forwardRef-test.internal.js
@@ -232,6 +232,39 @@ describe('forwardRef', () => {
     expect(ref.current).toBe(null);
   });
 
+  it('should not re-run the render callback on a deep setState', () => {
+    let inst;
+
+    class Inner extends React.Component {
+      render() {
+        ReactNoop.yield('Inner');
+        inst = this;
+        return <div ref={this.props.forwardedRef} />;
+      }
+    }
+
+    function Middle(props) {
+      ReactNoop.yield('Middle');
+      return <Inner {...props} />;
+    }
+
+    const Forward = React.forwardRef((props, ref) => {
+      ReactNoop.yield('Forward');
+      return <Middle {...props} forwardedRef={ref} />;
+    });
+
+    function App() {
+      ReactNoop.yield('App');
+      return <Forward />;
+    }
+
+    ReactNoop.render(<App />);
+    expect(ReactNoop.flush()).toEqual(['App', 'Forward', 'Middle', 'Inner']);
+
+    inst.setState({});
+    expect(ReactNoop.flush()).toEqual(['Inner']);
+  });
+
   it('should warn if not provided a callback during creation', () => {
     expect(() => React.forwardRef(undefined)).toWarnDev(
       'forwardRef requires a render function but was given undefined.',


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/12688. This is not just related to legacy context: as far as I can tell from the test I added, we're currently re-rendering all `forwardRef` components on a deeper `setState`. This seems bad.

I changed memoization to store the `props` instead of the returned child. Not sure if it matters. Maybe for DevTools?

I'm also not sure if what I'm doing here is safe. Can `ref` provided by React ever be different in this scenario and "justify" re-render?