### PR TITLE
[RFC] Schedule supports two priorities

### DIFF
--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -468,7 +468,7 @@ const ARTRenderer = ReactFiberReconciler({
     return emptyObject;
   },
 
-  scheduleDeferredCallback: ReactScheduler.rIC,
+  scheduleDeferredCallback: ReactScheduler.scheduleSerialCallback,
 
   shouldSetTextContent(type, props) {
     return (

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -984,7 +984,7 @@ const DOMRenderer = ReactFiberReconciler({
     },
   },
 
-  scheduleDeferredCallback: ReactScheduler.rIC,
+  scheduleDeferredCallback: ReactScheduler.scheduleSerialCallback,
   cancelDeferredCallback: ReactScheduler.cIC,
 });
 

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -985,7 +985,7 @@ const DOMRenderer = ReactFiberReconciler({
   },
 
   scheduleDeferredCallback: ReactScheduler.scheduleSerialCallback,
-  cancelDeferredCallback: ReactScheduler.cIC,
+  cancelDeferredCallback: ReactScheduler.cancelSerialCallback,
 });
 
 ReactGenericBatching.injection.injectRenderer(DOMRenderer);

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -69,7 +69,7 @@ if (hasNativePerformanceNow) {
 let scheduleSerialCallback: (
   callback: (deadline: Deadline, options?: {timeout: number}) => void,
 ) => number;
-let cIC: (callbackID: number) => void;
+let cancelSerialCallback: (callbackID: number) => void;
 
 if (!ExecutionEnvironment.canUseDOM) {
   scheduleSerialCallback = function(
@@ -84,7 +84,7 @@ if (!ExecutionEnvironment.canUseDOM) {
       });
     });
   };
-  cIC = function(timeoutID: number) {
+  cancelSerialCallback = function(timeoutID: number) {
     clearTimeout(timeoutID);
   };
 } else {
@@ -276,11 +276,11 @@ if (!ExecutionEnvironment.canUseDOM) {
     return 0;
   };
 
-  cIC = function() {
+  cancelSerialCallback = function() {
     isIdleScheduled = false;
     scheduledCallback = null;
     timeoutTime = -1;
   };
 }
 
-export {now, scheduleSerialCallback, cIC};
+export {now, scheduleSerialCallback, cancelSerialCallback};

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -103,14 +103,12 @@ if (!ExecutionEnvironment.canUseDOM) {
   let previousFrameTime = 33;
   let activeFrameTime = 33;
 
-  const buildFrameDeadlineObject = function(didTimeout: boolean) {
-    return {
-      didTimeout,
-      timeRemaining() {
-        const remaining = frameDeadline - now();
-        return remaining > 0 ? remaining : 0;
-      },
-    };
+  const frameDeadlineObject = {
+    didTimeout: false,
+    timeRemaining() {
+      const remaining = frameDeadline - now();
+      return remaining > 0 ? remaining : 0;
+    },
   };
 
   // define a helper for this because they should usually happen together
@@ -159,7 +157,8 @@ if (!ExecutionEnvironment.canUseDOM) {
     const callback = scheduledRICCallback;
     clearTimeoutTimeAndScheduledCallback();
     if (callback !== null) {
-      callback(buildFrameDeadlineObject(didTimeout));
+      frameDeadlineObject.didTimeout = didTimeout;
+      callback(frameDeadlineObject);
     }
   };
   // Assumes that we have addEventListener in this environment. Might need
@@ -206,8 +205,9 @@ if (!ExecutionEnvironment.canUseDOM) {
       // For now we implement the behavior expected when the callbacks are
       // serial updates, such that each update relies on the previous ones
       // having been called before it runs.
-      const didTimeout = (timeoutTime !== -1) && (timeoutTime <= now());
-      scheduledRICCallback(buildFrameDeadlineObject(didTimeout));
+      frameDeadlineObject.didTimeout =
+        (timeoutTime !== -1) && (timeoutTime <= now());
+      scheduledRICCallback(frameDeadlineObject);
     }
     scheduledRICCallback = callback;
     if (options != null && typeof options.timeout === 'number') {

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -112,7 +112,7 @@ if (!ExecutionEnvironment.canUseDOM) {
   };
 
   // define a helper for this because they should usually happen together
-  const clearTimeoutTimeAndScheduledCallback = function() {
+  const resetScheduledCallback = function() {
     timeoutTime = -1;
     scheduledRICCallback = null;
   };
@@ -155,7 +155,7 @@ if (!ExecutionEnvironment.canUseDOM) {
     }
 
     const callback = scheduledRICCallback;
-    clearTimeoutTimeAndScheduledCallback();
+    resetScheduledCallback();
     if (callback !== null) {
       frameDeadlineObject.didTimeout = didTimeout;
       callback(frameDeadlineObject);
@@ -228,7 +228,7 @@ if (!ExecutionEnvironment.canUseDOM) {
 
   cIC = function() {
     isIdleScheduled = false;
-    clearTimeoutTimeAndScheduledCallback();
+    resetScheduledCallback();
   };
 }
 

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -47,10 +47,32 @@ describe('ReactScheduler', () => {
     rIC(cb);
     jest.runAllTimers();
     expect(cb.mock.calls.length).toBe(1);
-    // should have ... TODO details on what we expect
+    // should not have timed out and should include a timeRemaining method
     expect(cb.mock.calls[0][0].didTimeout).toBe(false);
     expect(typeof cb.mock.calls[0][0].timeRemaining()).toBe('number');
   });
 
+  it('rIC with multiple callbacks flushes previous cb when new one is passed', () => {
+    const {rIC} = ReactScheduler;
+    const callbackA = jest.fn();
+    const callbackB = jest.fn();
+    rIC(callbackA);
+    // initially waits to call the callback
+    expect(callbackA.mock.calls.length).toBe(0);
+    // when second callback is passed, flushes first one
+    rIC(callbackB);
+    expect(callbackA.mock.calls.length).toBe(1);
+    expect(callbackB.mock.calls.length).toBe(0);
+    // after a delay, calls the latest callback passed
+    jest.runAllTimers();
+    expect(callbackA.mock.calls.length).toBe(1);
+    expect(callbackB.mock.calls.length).toBe(1);
+    // callbackA should not have timed out and should include a timeRemaining method
+    expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
+    expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe('number');
+    // callbackA should not have timed out and should include a timeRemaining method
+    expect(callbackB.mock.calls[0][0].didTimeout).toBe(false);
+    expect(typeof callbackB.mock.calls[0][0].timeRemaining()).toBe('number');
+  });
   // TODO: test cIC and now
 });

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -54,19 +54,21 @@ describe('ReactScheduler', () => {
 
   it('rIC with multiple callbacks flushes previous cb when new one is passed', () => {
     const {rIC} = ReactScheduler;
-    const callbackA = jest.fn();
-    const callbackB = jest.fn();
+    const callbackLog = [];
+    const callbackA = jest.fn(() => callbackLog.push('A'));
+    const callbackB = jest.fn(() => callbackLog.push('B'));
     rIC(callbackA);
     // initially waits to call the callback
-    expect(callbackA.mock.calls.length).toBe(0);
+    expect(callbackLog.length).toBe(0);
     // when second callback is passed, flushes first one
     rIC(callbackB);
-    expect(callbackA.mock.calls.length).toBe(1);
-    expect(callbackB.mock.calls.length).toBe(0);
+    expect(callbackLog.length).toBe(1);
+    expect(callbackLog[0]).toBe('A');
     // after a delay, calls the latest callback passed
     jest.runAllTimers();
-    expect(callbackA.mock.calls.length).toBe(1);
-    expect(callbackB.mock.calls.length).toBe(1);
+    expect(callbackLog.length).toBe(2);
+    expect(callbackLog[0]).toBe('A');
+    expect(callbackLog[1]).toBe('B');
     // callbackA should not have timed out and should include a timeRemaining method
     expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
     expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe('number');

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -41,174 +41,180 @@ describe('ReactScheduler', () => {
     ReactScheduler = require('react-scheduler');
   });
 
-  it('calls the callback within the frame when not blocked', () => {
-    const {scheduleSerialCallback} = ReactScheduler;
-    const cb = jest.fn();
-    scheduleSerialCallback(cb);
-    jest.runAllTimers();
-    expect(cb.mock.calls.length).toBe(1);
-    // should not have timed out and should include a timeRemaining method
-    expect(cb.mock.calls[0][0].didTimeout).toBe(false);
-    expect(typeof cb.mock.calls[0][0].timeRemaining()).toBe('number');
-  });
-
-  describe('with multiple callbacks', () => {
-    it('flushes previous cb when new one is passed', () => {
+  describe('scheduleSerialCallback', () => {
+    it('calls the callback within the frame when not blocked', () => {
       const {scheduleSerialCallback} = ReactScheduler;
-      const callbackLog = [];
-      const callbackA = jest.fn(() => callbackLog.push('A'));
-      const callbackB = jest.fn(() => callbackLog.push('B'));
-      scheduleSerialCallback(callbackA);
-      // initially waits to call the callback
-      expect(callbackLog.length).toBe(0);
-      // when second callback is passed, flushes first one
-      scheduleSerialCallback(callbackB);
-      expect(callbackLog.length).toBe(1);
-      expect(callbackLog[0]).toBe('A');
-      // after a delay, calls the latest callback passed
+      const cb = jest.fn();
+      scheduleSerialCallback(cb);
       jest.runAllTimers();
-      expect(callbackLog.length).toBe(2);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
-      // callbackA should not have timed out and should include a timeRemaining method
-      expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
-      expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe('number');
-      // callbackA should not have timed out and should include a timeRemaining method
-      expect(callbackB.mock.calls[0][0].didTimeout).toBe(false);
-      expect(typeof callbackB.mock.calls[0][0].timeRemaining()).toBe('number');
+      expect(cb.mock.calls.length).toBe(1);
+      // should not have timed out and should include a timeRemaining method
+      expect(cb.mock.calls[0][0].didTimeout).toBe(false);
+      expect(typeof cb.mock.calls[0][0].timeRemaining()).toBe('number');
     });
 
-    it('schedules callbacks in correct order when a callback uses scheduleSerialCallback before its own logic', () => {
-      const {scheduleSerialCallback} = ReactScheduler;
-      const callbackLog = [];
-      const callbackA = jest.fn(() => {
-        callbackLog.push('A');
-        scheduleSerialCallback(callbackC);
-      });
-      const callbackB = jest.fn(() => {
-        callbackLog.push('B');
-      });
-      const callbackC = jest.fn(() => {
-        callbackLog.push('C');
-      });
-
-      scheduleSerialCallback(callbackA);
-      // initially waits to call the callback
-      expect(callbackLog.length).toBe(0);
-      // when second callback is passed, flushes first one
-      // callbackA scheduled callbackC, which flushes callbackB
-      scheduleSerialCallback(callbackB);
-      expect(callbackLog.length).toBe(2);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
-      // after a delay, calls the latest callback passed
-      jest.runAllTimers();
-      expect(callbackLog.length).toBe(3);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
-      expect(callbackLog[2]).toBe('C');
-    });
-
-    it('schedules callbacks in correct order when callbacks have many nested scheduleSerialCallback calls', () => {
-      const {scheduleSerialCallback} = ReactScheduler;
-      const callbackLog = [];
-      const callbackA = jest.fn(() => {
-        callbackLog.push('A');
-        scheduleSerialCallback(callbackC);
-        scheduleSerialCallback(callbackD);
-      });
-      const callbackB = jest.fn(() => {
-        callbackLog.push('B');
-        scheduleSerialCallback(callbackE);
-        scheduleSerialCallback(callbackF);
-      });
-      const callbackC = jest.fn(() => {
-        callbackLog.push('C');
-      });
-      const callbackD = jest.fn(() => {
-        callbackLog.push('D');
-      });
-      const callbackE = jest.fn(() => {
-        callbackLog.push('E');
-      });
-      const callbackF = jest.fn(() => {
-        callbackLog.push('F');
+    describe('with multiple callbacks', () => {
+      it('flushes previous cb when new one is passed', () => {
+        const {scheduleSerialCallback} = ReactScheduler;
+        const callbackLog = [];
+        const callbackA = jest.fn(() => callbackLog.push('A'));
+        const callbackB = jest.fn(() => callbackLog.push('B'));
+        scheduleSerialCallback(callbackA);
+        // initially waits to call the callback
+        expect(callbackLog.length).toBe(0);
+        // when second callback is passed, flushes first one
+        scheduleSerialCallback(callbackB);
+        expect(callbackLog.length).toBe(1);
+        expect(callbackLog[0]).toBe('A');
+        // after a delay, calls the latest callback passed
+        jest.runAllTimers();
+        expect(callbackLog.length).toBe(2);
+        expect(callbackLog[0]).toBe('A');
+        expect(callbackLog[1]).toBe('B');
+        // callbackA should not have timed out and should include a timeRemaining method
+        expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
+        expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe(
+          'number',
+        );
+        // callbackA should not have timed out and should include a timeRemaining method
+        expect(callbackB.mock.calls[0][0].didTimeout).toBe(false);
+        expect(typeof callbackB.mock.calls[0][0].timeRemaining()).toBe(
+          'number',
+        );
       });
 
-      scheduleSerialCallback(callbackA);
-      // initially waits to call the callback
-      expect(callbackLog.length).toBe(0);
-      // when second callback is passed, flushes first one
-      // callbackA scheduled callbackC, which flushes callbackB
-      scheduleSerialCallback(callbackB);
-      expect(callbackLog.length).toBe(5);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
-      expect(callbackLog[2]).toBe('C');
-      expect(callbackLog[3]).toBe('D');
-      expect(callbackLog[4]).toBe('E');
-      // after a delay, calls the latest callback passed
-      jest.runAllTimers();
-      expect(callbackLog.length).toBe(6);
-      expect(callbackLog[5]).toBe('F');
-    });
+      it('schedules callbacks in correct order when a callback uses scheduleSerialCallback before its own logic', () => {
+        const {scheduleSerialCallback} = ReactScheduler;
+        const callbackLog = [];
+        const callbackA = jest.fn(() => {
+          callbackLog.push('A');
+          scheduleSerialCallback(callbackC);
+        });
+        const callbackB = jest.fn(() => {
+          callbackLog.push('B');
+        });
+        const callbackC = jest.fn(() => {
+          callbackLog.push('C');
+        });
 
-    it('allows each callback finish running before flushing others', () => {
-      const {scheduleSerialCallback} = ReactScheduler;
-      const callbackLog = [];
-      const callbackA = jest.fn(() => {
-        // scheduleSerialCallback should wait to flush any more until this callback finishes
-        scheduleSerialCallback(callbackC);
-        callbackLog.push('A');
+        scheduleSerialCallback(callbackA);
+        // initially waits to call the callback
+        expect(callbackLog.length).toBe(0);
+        // when second callback is passed, flushes first one
+        // callbackA scheduled callbackC, which flushes callbackB
+        scheduleSerialCallback(callbackB);
+        expect(callbackLog.length).toBe(2);
+        expect(callbackLog[0]).toBe('A');
+        expect(callbackLog[1]).toBe('B');
+        // after a delay, calls the latest callback passed
+        jest.runAllTimers();
+        expect(callbackLog.length).toBe(3);
+        expect(callbackLog[0]).toBe('A');
+        expect(callbackLog[1]).toBe('B');
+        expect(callbackLog[2]).toBe('C');
       });
-      const callbackB = jest.fn(() => callbackLog.push('B'));
-      const callbackC = jest.fn(() => callbackLog.push('C'));
 
-      scheduleSerialCallback(callbackA);
-      // initially waits to call the callback
-      expect(callbackLog.length).toBe(0);
-      // when second callback is passed, flushes first one
-      // callbackA scheduled callbackC, which flushes callbackB
-      scheduleSerialCallback(callbackB);
-      expect(callbackLog.length).toBe(2);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
-      // after a delay, calls the latest callback passed
-      jest.runAllTimers();
-      expect(callbackLog.length).toBe(3);
-      expect(callbackLog[0]).toBe('A');
-      expect(callbackLog[1]).toBe('B');
-      expect(callbackLog[2]).toBe('C');
-    });
+      it('schedules callbacks in correct order when callbacks have many nested scheduleSerialCallback calls', () => {
+        const {scheduleSerialCallback} = ReactScheduler;
+        const callbackLog = [];
+        const callbackA = jest.fn(() => {
+          callbackLog.push('A');
+          scheduleSerialCallback(callbackC);
+          scheduleSerialCallback(callbackD);
+        });
+        const callbackB = jest.fn(() => {
+          callbackLog.push('B');
+          scheduleSerialCallback(callbackE);
+          scheduleSerialCallback(callbackF);
+        });
+        const callbackC = jest.fn(() => {
+          callbackLog.push('C');
+        });
+        const callbackD = jest.fn(() => {
+          callbackLog.push('D');
+        });
+        const callbackE = jest.fn(() => {
+          callbackLog.push('E');
+        });
+        const callbackF = jest.fn(() => {
+          callbackLog.push('F');
+        });
 
-    it('schedules callbacks in correct order when they use scheduleSerialCallback to schedule themselves', () => {
-      const {scheduleSerialCallback} = ReactScheduler;
-      const callbackLog = [];
-      let callbackAIterations = 0;
-      const callbackA = jest.fn(() => {
-        if (callbackAIterations < 1) {
-          scheduleSerialCallback(callbackA);
-        }
-        callbackLog.push('A' + callbackAIterations);
-        callbackAIterations++;
+        scheduleSerialCallback(callbackA);
+        // initially waits to call the callback
+        expect(callbackLog.length).toBe(0);
+        // when second callback is passed, flushes first one
+        // callbackA scheduled callbackC, which flushes callbackB
+        scheduleSerialCallback(callbackB);
+        expect(callbackLog.length).toBe(5);
+        expect(callbackLog[0]).toBe('A');
+        expect(callbackLog[1]).toBe('B');
+        expect(callbackLog[2]).toBe('C');
+        expect(callbackLog[3]).toBe('D');
+        expect(callbackLog[4]).toBe('E');
+        // after a delay, calls the latest callback passed
+        jest.runAllTimers();
+        expect(callbackLog.length).toBe(6);
+        expect(callbackLog[5]).toBe('F');
       });
-      const callbackB = jest.fn(() => callbackLog.push('B'));
 
-      scheduleSerialCallback(callbackA);
-      // initially waits to call the callback
-      expect(callbackLog.length).toBe(0);
-      // when second callback is passed, flushes first one
-      // callbackA scheduled callbackA again, which flushes callbackB
-      scheduleSerialCallback(callbackB);
-      expect(callbackLog.length).toBe(2);
-      expect(callbackLog[0]).toBe('A0');
-      expect(callbackLog[1]).toBe('B');
-      // after a delay, calls the latest callback passed
-      jest.runAllTimers();
-      expect(callbackLog.length).toBe(3);
-      expect(callbackLog[0]).toBe('A0');
-      expect(callbackLog[1]).toBe('B');
-      expect(callbackLog[2]).toBe('A1');
+      it('allows each callback finish running before flushing others', () => {
+        const {scheduleSerialCallback} = ReactScheduler;
+        const callbackLog = [];
+        const callbackA = jest.fn(() => {
+          // scheduleSerialCallback should wait to flush any more until this callback finishes
+          scheduleSerialCallback(callbackC);
+          callbackLog.push('A');
+        });
+        const callbackB = jest.fn(() => callbackLog.push('B'));
+        const callbackC = jest.fn(() => callbackLog.push('C'));
+
+        scheduleSerialCallback(callbackA);
+        // initially waits to call the callback
+        expect(callbackLog.length).toBe(0);
+        // when second callback is passed, flushes first one
+        // callbackA scheduled callbackC, which flushes callbackB
+        scheduleSerialCallback(callbackB);
+        expect(callbackLog.length).toBe(2);
+        expect(callbackLog[0]).toBe('A');
+        expect(callbackLog[1]).toBe('B');
+        // after a delay, calls the latest callback passed
+        jest.runAllTimers();
+        expect(callbackLog.length).toBe(3);
+        expect(callbackLog[0]).toBe('A');
+        expect(callbackLog[1]).toBe('B');
+        expect(callbackLog[2]).toBe('C');
+      });
+
+      it('schedules callbacks in correct order when they use scheduleSerialCallback to schedule themselves', () => {
+        const {scheduleSerialCallback} = ReactScheduler;
+        const callbackLog = [];
+        let callbackAIterations = 0;
+        const callbackA = jest.fn(() => {
+          if (callbackAIterations < 1) {
+            scheduleSerialCallback(callbackA);
+          }
+          callbackLog.push('A' + callbackAIterations);
+          callbackAIterations++;
+        });
+        const callbackB = jest.fn(() => callbackLog.push('B'));
+
+        scheduleSerialCallback(callbackA);
+        // initially waits to call the callback
+        expect(callbackLog.length).toBe(0);
+        // when second callback is passed, flushes first one
+        // callbackA scheduled callbackA again, which flushes callbackB
+        scheduleSerialCallback(callbackB);
+        expect(callbackLog.length).toBe(2);
+        expect(callbackLog[0]).toBe('A0');
+        expect(callbackLog[1]).toBe('B');
+        // after a delay, calls the latest callback passed
+        jest.runAllTimers();
+        expect(callbackLog.length).toBe(3);
+        expect(callbackLog[0]).toBe('A0');
+        expect(callbackLog[1]).toBe('B');
+        expect(callbackLog[2]).toBe('A1');
+      });
     });
   });
 

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -41,7 +41,7 @@ describe('ReactScheduler', () => {
     ReactScheduler = require('react-scheduler');
   });
 
-  it('scheduleSerialCallback calls the callback within the frame when not blocked', () => {
+  it('calls the callback within the frame when not blocked', () => {
     const {scheduleSerialCallback} = ReactScheduler;
     const cb = jest.fn();
     scheduleSerialCallback(cb);
@@ -212,5 +212,33 @@ describe('ReactScheduler', () => {
     });
   });
 
-  // TODO: test cIC and now
+  describe('cancelSerialCallback', () => {
+    it('cancels the scheduled callback', () => {
+      const {scheduleSerialCallback, cancelSerialCallback} = ReactScheduler;
+      const cb = jest.fn();
+      scheduleSerialCallback(cb);
+      expect(cb.mock.calls.length).toBe(0);
+      cancelSerialCallback();
+      jest.runAllTimers();
+      expect(cb.mock.calls.length).toBe(0);
+    });
+
+    it('when one callback cancels the next one', () => {
+      const {scheduleSerialCallback, cancelSerialCallback} = ReactScheduler;
+      const cbA = jest.fn(() => {
+        cancelSerialCallback();
+      });
+      const cbB = jest.fn();
+      scheduleSerialCallback(cbA);
+      expect(cbA.mock.calls.length).toBe(0);
+      scheduleSerialCallback(cbB);
+      expect(cbA.mock.calls.length).toBe(1);
+      expect(cbB.mock.calls.length).toBe(0);
+      jest.runAllTimers();
+      // B should not get called because A cancelled B
+      expect(cbB.mock.calls.length).toBe(0);
+    });
+  });
+
+  // TODO: test schedule.now
 });

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -41,10 +41,10 @@ describe('ReactScheduler', () => {
     ReactScheduler = require('react-scheduler');
   });
 
-  it('rIC calls the callback within the frame when not blocked', () => {
-    const {rIC} = ReactScheduler;
+  it('scheduleSerialCallback calls the callback within the frame when not blocked', () => {
+    const {scheduleSerialCallback} = ReactScheduler;
     const cb = jest.fn();
-    rIC(cb);
+    scheduleSerialCallback(cb);
     jest.runAllTimers();
     expect(cb.mock.calls.length).toBe(1);
     // should not have timed out and should include a timeRemaining method
@@ -52,29 +52,165 @@ describe('ReactScheduler', () => {
     expect(typeof cb.mock.calls[0][0].timeRemaining()).toBe('number');
   });
 
-  it('rIC with multiple callbacks flushes previous cb when new one is passed', () => {
-    const {rIC} = ReactScheduler;
-    const callbackLog = [];
-    const callbackA = jest.fn(() => callbackLog.push('A'));
-    const callbackB = jest.fn(() => callbackLog.push('B'));
-    rIC(callbackA);
-    // initially waits to call the callback
-    expect(callbackLog.length).toBe(0);
-    // when second callback is passed, flushes first one
-    rIC(callbackB);
-    expect(callbackLog.length).toBe(1);
-    expect(callbackLog[0]).toBe('A');
-    // after a delay, calls the latest callback passed
-    jest.runAllTimers();
-    expect(callbackLog.length).toBe(2);
-    expect(callbackLog[0]).toBe('A');
-    expect(callbackLog[1]).toBe('B');
-    // callbackA should not have timed out and should include a timeRemaining method
-    expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
-    expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe('number');
-    // callbackA should not have timed out and should include a timeRemaining method
-    expect(callbackB.mock.calls[0][0].didTimeout).toBe(false);
-    expect(typeof callbackB.mock.calls[0][0].timeRemaining()).toBe('number');
+  describe('with multiple callbacks', () => {
+    it('flushes previous cb when new one is passed', () => {
+      const {scheduleSerialCallback} = ReactScheduler;
+      const callbackLog = [];
+      const callbackA = jest.fn(() => callbackLog.push('A'));
+      const callbackB = jest.fn(() => callbackLog.push('B'));
+      scheduleSerialCallback(callbackA);
+      // initially waits to call the callback
+      expect(callbackLog.length).toBe(0);
+      // when second callback is passed, flushes first one
+      scheduleSerialCallback(callbackB);
+      expect(callbackLog.length).toBe(1);
+      expect(callbackLog[0]).toBe('A');
+      // after a delay, calls the latest callback passed
+      jest.runAllTimers();
+      expect(callbackLog.length).toBe(2);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      // callbackA should not have timed out and should include a timeRemaining method
+      expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
+      expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe('number');
+      // callbackA should not have timed out and should include a timeRemaining method
+      expect(callbackB.mock.calls[0][0].didTimeout).toBe(false);
+      expect(typeof callbackB.mock.calls[0][0].timeRemaining()).toBe('number');
+    });
+
+    it('schedules callbacks in correct order when a callback uses scheduleSerialCallback before its own logic', () => {
+      const {scheduleSerialCallback} = ReactScheduler;
+      const callbackLog = [];
+      const callbackA = jest.fn(() => {
+        callbackLog.push('A');
+        scheduleSerialCallback(callbackC);
+      });
+      const callbackB = jest.fn(() => {
+        callbackLog.push('B');
+      });
+      const callbackC = jest.fn(() => {
+        callbackLog.push('C');
+      });
+
+      scheduleSerialCallback(callbackA);
+      // initially waits to call the callback
+      expect(callbackLog.length).toBe(0);
+      // when second callback is passed, flushes first one
+      // callbackA scheduled callbackC, which flushes callbackB
+      scheduleSerialCallback(callbackB);
+      expect(callbackLog.length).toBe(2);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      // after a delay, calls the latest callback passed
+      jest.runAllTimers();
+      expect(callbackLog.length).toBe(3);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog[2]).toBe('C');
+    });
+
+    it('schedules callbacks in correct order when callbacks have many nested scheduleSerialCallback calls', () => {
+      const {scheduleSerialCallback} = ReactScheduler;
+      const callbackLog = [];
+      const callbackA = jest.fn(() => {
+        callbackLog.push('A');
+        scheduleSerialCallback(callbackC);
+        scheduleSerialCallback(callbackD);
+      });
+      const callbackB = jest.fn(() => {
+        callbackLog.push('B');
+        scheduleSerialCallback(callbackE);
+        scheduleSerialCallback(callbackF);
+      });
+      const callbackC = jest.fn(() => {
+        callbackLog.push('C');
+      });
+      const callbackD = jest.fn(() => {
+        callbackLog.push('D');
+      });
+      const callbackE = jest.fn(() => {
+        callbackLog.push('E');
+      });
+      const callbackF = jest.fn(() => {
+        callbackLog.push('F');
+      });
+
+      scheduleSerialCallback(callbackA);
+      // initially waits to call the callback
+      expect(callbackLog.length).toBe(0);
+      // when second callback is passed, flushes first one
+      // callbackA scheduled callbackC, which flushes callbackB
+      scheduleSerialCallback(callbackB);
+      expect(callbackLog.length).toBe(5);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog[2]).toBe('C');
+      expect(callbackLog[3]).toBe('D');
+      expect(callbackLog[4]).toBe('E');
+      // after a delay, calls the latest callback passed
+      jest.runAllTimers();
+      expect(callbackLog.length).toBe(6);
+      expect(callbackLog[5]).toBe('F');
+    });
+
+    it('allows each callback finish running before flushing others', () => {
+      const {scheduleSerialCallback} = ReactScheduler;
+      const callbackLog = [];
+      const callbackA = jest.fn(() => {
+        // scheduleSerialCallback should wait to flush any more until this callback finishes
+        scheduleSerialCallback(callbackC);
+        callbackLog.push('A');
+      });
+      const callbackB = jest.fn(() => callbackLog.push('B'));
+      const callbackC = jest.fn(() => callbackLog.push('C'));
+
+      scheduleSerialCallback(callbackA);
+      // initially waits to call the callback
+      expect(callbackLog.length).toBe(0);
+      // when second callback is passed, flushes first one
+      // callbackA scheduled callbackC, which flushes callbackB
+      scheduleSerialCallback(callbackB);
+      expect(callbackLog.length).toBe(2);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      // after a delay, calls the latest callback passed
+      jest.runAllTimers();
+      expect(callbackLog.length).toBe(3);
+      expect(callbackLog[0]).toBe('A');
+      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog[2]).toBe('C');
+    });
+
+    it('schedules callbacks in correct order when they use scheduleSerialCallback to schedule themselves', () => {
+      const {scheduleSerialCallback} = ReactScheduler;
+      const callbackLog = [];
+      let callbackAIterations = 0;
+      const callbackA = jest.fn(() => {
+        if (callbackAIterations < 1) {
+          scheduleSerialCallback(callbackA);
+        }
+        callbackLog.push('A' + callbackAIterations);
+        callbackAIterations++;
+      });
+      const callbackB = jest.fn(() => callbackLog.push('B'));
+
+      scheduleSerialCallback(callbackA);
+      // initially waits to call the callback
+      expect(callbackLog.length).toBe(0);
+      // when second callback is passed, flushes first one
+      // callbackA scheduled callbackA again, which flushes callbackB
+      scheduleSerialCallback(callbackB);
+      expect(callbackLog.length).toBe(2);
+      expect(callbackLog[0]).toBe('A0');
+      expect(callbackLog[1]).toBe('B');
+      // after a delay, calls the latest callback passed
+      jest.runAllTimers();
+      expect(callbackLog.length).toBe(3);
+      expect(callbackLog[0]).toBe('A0');
+      expect(callbackLog[1]).toBe('B');
+      expect(callbackLog[2]).toBe('A1');
+    });
   });
+
   // TODO: test cIC and now
 });


### PR DESCRIPTION
This depends on https://github.com/facebook/react/pull/12682 which still needs review, but I wanted to keep pushing forward so submitting this anyway.

Would love early feedback on this, and for now I'll shift to working on test coverage, which is the last significant piece.

To write the unit and fixture test coverage for this new complex behavior, we need to allow configuring 'schedule' with dependency injection. Something like this - pseudocode - : 
```
scheduleFactory(config: {requestAnimationFrame: Function, ...other dependencies}) {
  // ... schedule logic defining requestSerialCallback and requestDeferredCallback
  return {
    requestSerialCallback,
    requestDeferredCallback,
  };
};

// in schedule.js
// check to ensure global.requestAnimationFrame is defined
export scheduleFactory({requestAnimationFrame: global.requestAnimationFrame});

// in noopSchedule.js
// ... define mockRequestAnimationFrame and a 'flushFrame' method you could use to flush callbacks.
export scheduleFactory({requestAnimationFrame: mockRequestAnimationFrame});

// in our fixture
const wrappedRequestAnimationFrame = function(callback) {
  // record something to a log which can be displayed in the fixture later
  const wrappedCallback = function() {
    // record something to a log which can be displayed in the fixture later
    callback(...arguments);
  };
  requestAnimationFrame(wrappedCallback);
};
export scheduleFactory({requestAnimationFrame: wrappedRequestAnimationFrame});
```