### PR TITLE
Remove ES3-specific transforms

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -18,8 +18,6 @@
     ["transform-es2015-spread", { "loose": true }],
     "transform-es2015-parameters",
     ["transform-es2015-destructuring", { "loose": true }],
-    ["transform-es2015-block-scoping", { "throwIfClosureRequired": true }],
-    "transform-es3-member-expression-literals",
-    "transform-es3-property-literals"
+    ["transform-es2015-block-scoping", { "throwIfClosureRequired": true }]
   ]
 }


### PR DESCRIPTION
We stopped supporting IE8 a long time ago. 
As far as I can tell all other major browsers [support reserved property names](http://kangax.github.io/compat-table/es5/#test-Object/array_literal_extensions_Reserved_words_as_property_names).

By dropping these transforms we ensure the bundles contain `fiber.return` rather than `fiber["return"]` which I'm worried might deopt.

I've seen `["return"]` being "hot" in some line-by-line Chrome traces before.