### PR TITLE
Password inputs do not synchronize the value attribute

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -1433,6 +1433,40 @@ describe('ReactDOMInput', () => {
       expect(node.getAttribute('value')).toBe('2');
     });
 
+    it('does not set the value attribute on password inputs', () => {
+      const Input = getTestInput();
+      const stub = ReactTestUtils.renderIntoDocument(
+        <Input type="password" value="1" />,
+      );
+      const node = ReactDOM.findDOMNode(stub);
+
+      expect(node.hasAttribute('value')).toBe(false);
+      expect(node.value).toBe('1');
+    });
+
+    it('does not update the value attribute on password inputs', () => {
+      const Input = getTestInput();
+      const stub = ReactTestUtils.renderIntoDocument(
+        <Input type="password" value="1" />,
+      );
+      const node = ReactDOM.findDOMNode(stub);
+
+      ReactTestUtils.Simulate.change(node, {target: {value: '2'}});
+
+      expect(node.hasAttribute('value')).toBe(false);
+      expect(node.value).toBe('2');
+    });
+
+    it('does not set the defaultValue attribute on password inputs', () => {
+      const stub = ReactTestUtils.renderIntoDocument(
+        <input type="password" defaultValue="1" />,
+      );
+      const node = ReactDOM.findDOMNode(stub);
+
+      expect(node.hasAttribute('value')).toBe(false);
+      expect(node.value).toBe('1');
+    });
+
     it('does not set the value attribute on number inputs if focused', () => {
       const Input = getTestInput();
       const stub = ReactTestUtils.renderIntoDocument(

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
@@ -96,6 +96,50 @@ describe('ReactDOMServerIntegration', () => {
           expect(e.getAttribute('defaultValue')).toBe(null);
         },
       );
+
+      itClientRenders(
+        'a password input hydrates client-side with the value prop',
+        async render => {
+          const e = await render(
+            <input type="password" value="foo" readOnly={true} />,
+            0,
+          );
+
+          expect(e.value).toBe('foo');
+          expect(e.hasAttribute('value')).toBe(false);
+        },
+      );
+
+      itClientRenders(
+        'a password input hydrates client-side with the defaultValue prop',
+        async render => {
+          const e = await render(
+            <input type="password" defaultValue="foo" readOnly={true} />,
+            0,
+          );
+
+          expect(e.value).toBe('foo');
+          expect(e.hasAttribute('value')).toBe(false);
+        },
+      );
+
+      it('will not render the value prop server-side', async () => {
+        const e = await serverRender(
+          <input type="password" value="foo" readOnly={true} />,
+        );
+
+        expect(e.value).toBe('');
+        expect(e.hasAttribute('value')).toBe(false);
+      });
+
+      it('will not render the defaultValue prop server-side', async () => {
+        const e = await serverRender(
+          <input type="password" defaultValue="foo" readOnly={true} />,
+        );
+
+        expect(e.value).toBe('');
+        expect(e.hasAttribute('value')).toBe(false);
+      });
     });
 
     describe('checkboxes', function() {
@@ -538,6 +582,20 @@ describe('ReactDOMServerIntegration', () => {
         it('should not blow away user-entered text on successful reconnect to an uncontrolled input', () =>
           testUserInteractionBeforeClientRender(
             <input defaultValue="Hello" />,
+          ));
+
+        it('should not blow away user-entered text on successful reconnect to an uncontrolled password input', () =>
+          testUserInteractionBeforeClientRender(
+            <input type="password" defaultValue="Hello" />,
+            '',
+            'Hello',
+          ));
+
+        it('should not blow away user-entered text on successful reconnect to an controlled password input', () =>
+          testUserInteractionBeforeClientRender(
+            <input type="password" value="Hello" readOnly={true} />,
+            '',
+            'Hello',
           ));
 
         it('should not blow away user-entered text on successful reconnect to a controlled input', async () => {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -326,6 +326,7 @@ function createOpenTagMarkup(
   isRootElement: boolean,
 ): string {
   let ret = '<' + tagVerbatim;
+  const isPasswordInput = tagLowercase === 'input' && props.type === 'password';
 
   for (const propKey in props) {
     if (!props.hasOwnProperty(propKey)) {
@@ -333,6 +334,13 @@ function createOpenTagMarkup(
     }
     let propValue = props[propKey];
     if (propValue == null) {
+      continue;
+    }
+    // Do not render values for password inputs
+    if (
+      isPasswordInput &&
+      (propKey === 'value' || propKey === 'defaultValue')
+    ) {
       continue;
     }
     if (propKey === STYLE) {


### PR DESCRIPTION
**On hold until 17.0.0**

In order to prevent passwords from showing up in the markup React generates, this commit adds exceptions for password inputs such that `defaultValue` synchronization is omitted.

**When rendered server-side, password inputs no longer render the value attribute markup**, however the value attribute is restored upon hydration. This is probably a design decision that we should clamp down, and something we'll need to respect if we remove value attribute syncing generally.

This should fix https://github.com/facebook/react/issues/11896, as it pertains to password inputs.