### PR TITLE
Add error when running jest directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,9 @@
   "devEngines": {
     "node": "8.x || 9.x"
   },
+  "jest": {
+    "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"
+  },
   "scripts": {
     "build": "npm run version-check && node ./scripts/rollup/build.js",
     "flow-coverage": "flow-coverage-report --config ./.flowcoverage",

--- a/scripts/jest/dont-run-jest-directly.js
+++ b/scripts/jest/dont-run-jest-directly.js
@@ -1,0 +1,3 @@
+'use strict';
+
+throw new Error("Don't run `jest` directly. Run `yarn test` instead.");


### PR DESCRIPTION
```
$ jest
 FAIL  scripts/jest/dont-run-jest-directly.js
  ● Test suite failed to run

    Don't run `jest` directly. Run `yarn test` instead.

    > 1 | throw new Error("Don't run `jest` directly. Run `yarn test` instead.");
      2 |

      at Object.<anonymous> (scripts/jest/dont-run-jest-directly.js:1:96)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.866s
Ran all test suites.
```