### PR TITLE
Rename internal property to fix React DevTools

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -417,7 +417,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     if (updateQueue !== null) {
       const nextProps = workInProgress.pendingProps;
       const prevState = workInProgress.memoizedState;
-      const prevChildren = prevState !== null ? prevState.children : null;
+      const prevChildren = prevState !== null ? prevState.element : null;
       processUpdateQueue(
         workInProgress,
         updateQueue,
@@ -426,7 +426,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         renderExpirationTime,
       );
       const nextState = workInProgress.memoizedState;
-      const nextChildren = nextState.children;
+      // Caution: React DevTools currently depends on this property
+      // being called "element".
+      const nextChildren = nextState.element;
 
       if (nextChildren === prevChildren) {
         // If the state is the same as before, that's a bailout because we had

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -340,7 +340,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
 
     const update = createUpdate(expirationTime);
-    update.payload = {children: element};
+    // Caution: React DevTools currently depends on this property
+    // being called "element".
+    update.payload = {element};
 
     callback = callback === undefined ? null : callback;
     if (callback !== null) {

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -67,7 +67,9 @@ export default function<C, CX>(
     const update = createUpdate(expirationTime);
     // Unmount the root by rendering null.
     update.tag = CaptureUpdate;
-    update.payload = {children: null};
+    // Caution: React DevTools currently depends on this property
+    // being called "element".
+    update.payload = {element: null};
     const error = errorInfo.value;
     update.callback = () => {
       onUncaughtError(error);


### PR DESCRIPTION
It's broken on master because of this:

https://github.com/facebook/react-devtools/blob/f0cde12e3531aae203f8a685f5e74ead58019b0a/backend/attachRendererFiber.js#L239-L241

Longer term we should check the backend into this monorepo.