### PR TITLE
Split Timeout into separate Timeout and Placeholder primitives

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -30,6 +30,7 @@ import {
   Mode,
   ContextProvider,
   ContextConsumer,
+  TimeoutComponent,
 } from 'shared/ReactTypeOfWork';
 import getComponentName from 'shared/getComponentName';
 
@@ -44,6 +45,7 @@ import {
   REACT_PROVIDER_TYPE,
   REACT_CONTEXT_TYPE,
   REACT_ASYNC_MODE_TYPE,
+  REACT_TIMEOUT_TYPE,
 } from 'shared/ReactSymbols';
 
 let hasBadMapPolyfill;
@@ -348,6 +350,9 @@ export function createFiberFromElement(
         break;
       case REACT_RETURN_TYPE:
         fiberTag = ReturnComponent;
+        break;
+      case REACT_TIMEOUT_TYPE:
+        fiberTag = TimeoutComponent;
         break;
       default: {
         if (typeof type === 'object' && type !== null) {

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -30,6 +30,7 @@ import {
   Mode,
   ContextProvider,
   ContextConsumer,
+  PlaceholderComponent,
   TimeoutComponent,
 } from 'shared/ReactTypeOfWork';
 import getComponentName from 'shared/getComponentName';
@@ -46,6 +47,7 @@ import {
   REACT_CONTEXT_TYPE,
   REACT_ASYNC_MODE_TYPE,
   REACT_TIMEOUT_TYPE,
+  REACT_PLACEHOLDER_TYPE,
 } from 'shared/ReactSymbols';
 
 let hasBadMapPolyfill;
@@ -351,11 +353,14 @@ export function createFiberFromElement(
       case REACT_RETURN_TYPE:
         fiberTag = ReturnComponent;
         break;
-      case REACT_TIMEOUT_TYPE:
-        fiberTag = TimeoutComponent;
+      case REACT_PLACEHOLDER_TYPE:
+        fiberTag = PlaceholderComponent;
         // Suspense does not require async, but its children should be strict
         // mode compatible.
         mode |= StrictMode;
+        break;
+      case REACT_TIMEOUT_TYPE:
+        fiberTag = TimeoutComponent;
         break;
       default: {
         if (typeof type === 'object' && type !== null) {

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -353,6 +353,9 @@ export function createFiberFromElement(
         break;
       case REACT_TIMEOUT_TYPE:
         fiberTag = TimeoutComponent;
+        // Suspense does not require async, but its children should be strict
+        // mode compatible.
+        mode |= StrictMode;
         break;
       default: {
         if (typeof type === 'object' && type !== null) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -34,14 +34,15 @@ import {
   Mode,
   ContextProvider,
   ContextConsumer,
+  TimeoutComponent,
 } from 'shared/ReactTypeOfWork';
 import {
   NoEffect,
   PerformedWork,
   Placement,
   ContentReset,
-  Ref,
   DidCapture,
+  Ref,
 } from 'shared/ReactTypeOfSideEffect';
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
 import {
@@ -63,7 +64,12 @@ import {
   reconcileChildFibers,
   cloneChildFibers,
 } from './ReactChildFiber';
-import {processUpdateQueue} from './ReactUpdateQueue';
+import {
+  createUpdate,
+  enqueueCapturedUpdate,
+  processUpdateQueue,
+  ReplaceState,
+} from './ReactUpdateQueue';
 import {NoWork, Never} from './ReactFiberExpirationTime';
 import {AsyncMode, StrictMode} from './ReactTypeOfMode';
 import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
@@ -86,8 +92,16 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   legacyContext: LegacyContext,
   newContext: NewContext,
   hydrationContext: HydrationContext<C, CX>,
-  scheduleWork: (fiber: Fiber, expirationTime: ExpirationTime) => void,
-  computeExpirationForFiber: (fiber: Fiber) => ExpirationTime,
+  scheduleWork: (
+    fiber: Fiber,
+    startTime: ExpirationTime,
+    expirationTime: ExpirationTime,
+  ) => void,
+  computeExpirationForFiber: (
+    startTime: ExpirationTime,
+    fiber: Fiber,
+  ) => ExpirationTime,
+  recalculateCurrentTime: () => ExpirationTime,
 ) {
   const {shouldSetTextContent, shouldDeprioritizeSubtree} = config;
 
@@ -122,6 +136,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     computeExpirationForFiber,
     memoizeProps,
     memoizeState,
+    recalculateCurrentTime,
   );
 
   // TODO: Remove this and use reconcileChildrenAtExpirationTime directly.
@@ -725,6 +740,52 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     return workInProgress.stateNode;
   }
 
+  function updateTimeoutComponent(
+    current,
+    workInProgress,
+    renderExpirationTime,
+  ) {
+    const nextProps = workInProgress.pendingProps;
+    const prevProps = workInProgress.memoizedProps;
+
+    // Unless we already captured a promise during this render, reset the
+    // placeholder state back to false. We always attempt to render the real
+    // children before falling back to the placeholder.
+    if ((workInProgress.effectTag & DidCapture) === NoEffect) {
+      const update = createUpdate(renderExpirationTime);
+      update.tag = ReplaceState;
+      update.payload = false;
+      enqueueCapturedUpdate(workInProgress, update, renderExpirationTime);
+    }
+
+    const prevState = workInProgress.memoizedState;
+    const updateQueue = workInProgress.updateQueue;
+    if (updateQueue !== null) {
+      processUpdateQueue(
+        workInProgress,
+        updateQueue,
+        null,
+        null,
+        renderExpirationTime,
+      );
+    }
+    const nextState = workInProgress.memoizedState;
+
+    if (hasLegacyContextChanged()) {
+      // Normally we can bail out on props equality but if context has changed
+      // we don't do the bailout and we have to reuse existing props instead.
+    } else if (nextProps === prevProps && nextState === prevState) {
+      return bailoutOnAlreadyFinishedWork(current, workInProgress);
+    }
+
+    const didTimeout = nextState;
+    const render = nextProps.children;
+    const nextChildren = render(didTimeout);
+    workInProgress.memoizedProps = nextProps;
+    reconcileChildren(current, workInProgress, nextChildren);
+    return workInProgress.child;
+  }
+
   function updatePortalComponent(
     current,
     workInProgress,
@@ -1159,6 +1220,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         // A return component is just a placeholder, we can just run through the
         // next one immediately.
         return null;
+      case TimeoutComponent:
+        return updateTimeoutComponent(
+          current,
+          workInProgress,
+          renderExpirationTime,
+        );
       case HostPortal:
         return updatePortalComponent(
           current,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -65,12 +65,7 @@ import {
   reconcileChildFibers,
   cloneChildFibers,
 } from './ReactChildFiber';
-import {
-  createUpdate,
-  enqueueCapturedUpdate,
-  processUpdateQueue,
-  ReplaceState,
-} from './ReactUpdateQueue';
+import {processUpdateQueue} from './ReactUpdateQueue';
 import {NoWork, Never} from './ReactFiberExpirationTime';
 import {AsyncMode, StrictMode} from './ReactTypeOfMode';
 import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
@@ -750,17 +745,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       const nextProps = workInProgress.pendingProps;
       const prevProps = workInProgress.memoizedProps;
 
-      // Unless we already captured a promise during this render, reset the
-      // placeholder state back to false. We always attempt to render the real
-      // children before falling back to the placeholder.
-      if ((workInProgress.effectTag & DidCapture) === NoEffect) {
-        const update = createUpdate(renderExpirationTime);
-        update.tag = ReplaceState;
-        update.payload = false;
-        enqueueCapturedUpdate(workInProgress, update, renderExpirationTime);
-      }
+      const prevDidTimeout = workInProgress.memoizedState;
 
-      const prevState = workInProgress.memoizedState;
+      // The update queue is only used to store expired promises, and to
+      // schedule a re-render once an expired promise resolves. It does not
+      // determine whether we should show the placeholder state, because we
+      // always attempt to show the placeholder state on every render.
       const updateQueue = workInProgress.updateQueue;
       if (updateQueue !== null) {
         processUpdateQueue(
@@ -771,19 +761,24 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           renderExpirationTime,
         );
       }
-      const nextState = workInProgress.memoizedState;
+
+      // Check if we already attempted to render the normal state. If we did,
+      // and we timed out, render the placeholder state.
+      const alreadyCaptured =
+        (workInProgress.effectTag & DidCapture) === NoEffect;
+      const nextDidTimeout = !alreadyCaptured;
 
       if (hasLegacyContextChanged()) {
         // Normally we can bail out on props equality but if context has changed
         // we don't do the bailout and we have to reuse existing props instead.
-      } else if (nextProps === prevProps && nextState === prevState) {
+      } else if (nextProps === prevProps && nextDidTimeout === prevDidTimeout) {
         return bailoutOnAlreadyFinishedWork(current, workInProgress);
       }
 
-      const didTimeout = nextState;
       const render = nextProps.children;
-      const nextChildren = render(didTimeout);
+      const nextChildren = render(nextDidTimeout);
       workInProgress.memoizedProps = nextProps;
+      workInProgress.memoizedState = nextDidTimeout;
       reconcileChildren(current, workInProgress, nextChildren);
       return workInProgress.child;
     } else {

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -151,10 +151,18 @@ export function applyDerivedStateFromProps(
 
 export default function(
   legacyContext: LegacyContext,
-  scheduleWork: (fiber: Fiber, expirationTime: ExpirationTime) => void,
-  computeExpirationForFiber: (fiber: Fiber) => ExpirationTime,
+  scheduleWork: (
+    fiber: Fiber,
+    startTime: ExpirationTime,
+    expirationTime: ExpirationTime,
+  ) => void,
+  computeExpirationForFiber: (
+    currentTime: ExpirationTime,
+    fiber: Fiber,
+  ) => ExpirationTime,
   memoizeProps: (workInProgress: Fiber, props: any) => void,
   memoizeState: (workInProgress: Fiber, state: any) => void,
+  recalculateCurrentTime: () => ExpirationTime,
 ) {
   const {
     cacheContext,
@@ -168,7 +176,8 @@ export default function(
     isMounted,
     enqueueSetState(inst, payload, callback) {
       const fiber = ReactInstanceMap.get(inst);
-      const expirationTime = computeExpirationForFiber(fiber);
+      const currentTime = recalculateCurrentTime();
+      const expirationTime = computeExpirationForFiber(currentTime, fiber);
 
       const update = createUpdate(expirationTime);
       update.payload = payload;
@@ -180,11 +189,12 @@ export default function(
       }
 
       enqueueUpdate(fiber, update, expirationTime);
-      scheduleWork(fiber, expirationTime);
+      scheduleWork(fiber, currentTime, expirationTime);
     },
     enqueueReplaceState(inst, payload, callback) {
       const fiber = ReactInstanceMap.get(inst);
-      const expirationTime = computeExpirationForFiber(fiber);
+      const currentTime = recalculateCurrentTime();
+      const expirationTime = computeExpirationForFiber(currentTime, fiber);
 
       const update = createUpdate(expirationTime);
       update.tag = ReplaceState;
@@ -198,11 +208,12 @@ export default function(
       }
 
       enqueueUpdate(fiber, update, expirationTime);
-      scheduleWork(fiber, expirationTime);
+      scheduleWork(fiber, currentTime, expirationTime);
     },
     enqueueForceUpdate(inst, callback) {
       const fiber = ReactInstanceMap.get(inst);
-      const expirationTime = computeExpirationForFiber(fiber);
+      const currentTime = recalculateCurrentTime();
+      const expirationTime = computeExpirationForFiber(currentTime, fiber);
 
       const update = createUpdate(expirationTime);
       update.tag = ForceUpdate;
@@ -215,7 +226,7 @@ export default function(
       }
 
       enqueueUpdate(fiber, update, expirationTime);
-      scheduleWork(fiber, expirationTime);
+      scheduleWork(fiber, currentTime, expirationTime);
     },
   };
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -25,6 +25,7 @@ import {
   HostText,
   HostPortal,
   CallComponent,
+  TimeoutComponent,
 } from 'shared/ReactTypeOfWork';
 import ReactErrorUtils from 'shared/ReactErrorUtils';
 import {
@@ -306,6 +307,18 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       }
       case HostPortal: {
         // We have no life-cycles associated with portals.
+        return;
+      }
+      case TimeoutComponent: {
+        const updateQueue = finishedWork.updateQueue;
+        if (updateQueue !== null) {
+          commitUpdateQueue(
+            finishedWork,
+            updateQueue,
+            null,
+            committedExpirationTime,
+          );
+        }
         return;
       }
       default: {
@@ -812,6 +825,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         return;
       }
       case HostRoot: {
+        return;
+      }
+      case TimeoutComponent: {
         return;
       }
       default: {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -25,6 +25,7 @@ import {
   HostText,
   HostPortal,
   CallComponent,
+  PlaceholderComponent,
   TimeoutComponent,
 } from 'shared/ReactTypeOfWork';
 import ReactErrorUtils from 'shared/ReactErrorUtils';
@@ -309,7 +310,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         // We have no life-cycles associated with portals.
         return;
       }
-      case TimeoutComponent: {
+      case PlaceholderComponent: {
         const updateQueue = finishedWork.updateQueue;
         if (updateQueue !== null) {
           commitUpdateQueue(
@@ -319,6 +320,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
             committedExpirationTime,
           );
         }
+        return;
+      }
+      case TimeoutComponent: {
+        // We have no life-cycles associated with Timeouts.
         return;
       }
       default: {
@@ -827,7 +832,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       case HostRoot: {
         return;
       }
-      case TimeoutComponent: {
+      case PlaceholderComponent: {
         return;
       }
       default: {

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -37,6 +37,7 @@ import {
   ForwardRef,
   Fragment,
   Mode,
+  PlaceholderComponent,
   TimeoutComponent,
 } from 'shared/ReactTypeOfWork';
 import {Placement, Ref, Update} from 'shared/ReactTypeOfSideEffect';
@@ -587,6 +588,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         // Does nothing.
         return null;
       case ForwardRef:
+        return null;
+      case PlaceholderComponent:
         return null;
       case TimeoutComponent:
         return null;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -37,6 +37,7 @@ import {
   ForwardRef,
   Fragment,
   Mode,
+  TimeoutComponent,
 } from 'shared/ReactTypeOfWork';
 import {Placement, Ref, Update} from 'shared/ReactTypeOfSideEffect';
 import invariant from 'fbjs/lib/invariant';
@@ -586,6 +587,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         // Does nothing.
         return null;
       case ForwardRef:
+        return null;
+      case TimeoutComponent:
         return null;
       case Fragment:
         return null;

--- a/packages/react-reconciler/src/ReactFiberPendingWork.js
+++ b/packages/react-reconciler/src/ReactFiberPendingWork.js
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {FiberRoot} from './ReactFiberRoot';
+import type {ExpirationTime} from './ReactFiberExpirationTime';
+
+import {NoWork} from './ReactFiberExpirationTime';
+
+// Because we don't have a global queue of updates, we use this module to keep
+// track of the pending levels of work that have yet to be flushed. You can
+// think of a PendingWork object as representing a batch of work that will
+// all flush at the same time. The actual updates are spread throughout the
+// update queues of all the fibers in the tree, but those updates have
+// priorities that correspond to a PendingWork batch.
+
+export type PendingWork = {
+  // We use `expirationTime` to represent both a priority and a timeout. There's
+  // no inherent reason why they need to be the same, and we may split them
+  // in the future.
+  startTime: ExpirationTime,
+  expirationTime: ExpirationTime,
+  isSuspended: boolean,
+  shouldTryResuming: boolean,
+  isRenderPhaseWork: boolean,
+  next: PendingWork | null,
+};
+
+function insertPendingWorkAtPosition(root, work, insertAfter, insertBefore) {
+  work.next = insertBefore;
+  if (insertAfter === null) {
+    root.firstPendingWork = work;
+  } else {
+    insertAfter.next = work;
+  }
+}
+
+export function addPendingWork(
+  root: FiberRoot,
+  startTime: ExpirationTime,
+  expirationTime: ExpirationTime,
+): void {
+  let match = null;
+  let insertAfter = null;
+  let insertBefore = root.firstPendingWork;
+  while (insertBefore !== null) {
+    if (insertBefore.expirationTime >= expirationTime) {
+      // Retry anything with an equal or lower expiration time
+      insertBefore.shouldTryResuming = true;
+    }
+    if (insertBefore.expirationTime === expirationTime) {
+      // Found a matching bucket. But we'll keep iterating so we can set
+      // `shouldTryResuming` as needed.
+      match = insertBefore;
+      // Update the start time. We always measure from the most recently
+      // added update.
+      match.startTime = startTime;
+    }
+    if (match === null && insertBefore.expirationTime > expirationTime) {
+      // Found the insertion position
+      break;
+    }
+    insertAfter = insertBefore;
+    insertBefore = insertBefore.next;
+  }
+  if (match === null) {
+    const work: PendingWork = {
+      startTime,
+      expirationTime,
+      isSuspended: false,
+      shouldTryResuming: false,
+      isRenderPhaseWork: false,
+      next: null,
+    };
+    insertPendingWorkAtPosition(root, work, insertAfter, insertBefore);
+  }
+}
+export function addRenderPhasePendingWork(
+  root: FiberRoot,
+  startTime: ExpirationTime,
+  expirationTime: ExpirationTime,
+): void {
+  // Render-phase updates are treated differently because, while they
+  // could potentially unblock earlier pending work, we assume that they won't.
+  // They are also coalesced differently (see findNextExpirationTimeToWorkOn).
+  let insertAfter = null;
+  let insertBefore = root.firstPendingWork;
+  while (insertBefore !== null) {
+    if (insertBefore.expirationTime === expirationTime) {
+      // Found a matching bucket
+      return;
+    }
+    if (insertBefore.expirationTime > expirationTime) {
+      // Found the insertion position
+      break;
+    }
+    insertAfter = insertBefore;
+    insertBefore = insertBefore.next;
+  }
+  // No matching level found. Create a new one.
+  const work: PendingWork = {
+    startTime,
+    expirationTime,
+    isSuspended: false,
+    shouldTryResuming: false,
+    isRenderPhaseWork: true,
+    next: null,
+  };
+  insertPendingWorkAtPosition(root, work, insertAfter, insertBefore);
+}
+
+export function flushPendingWork(
+  root: FiberRoot,
+  currentTime: ExpirationTime,
+  remainingExpirationTime: ExpirationTime,
+) {
+  // Pop all work that has higher priority than the remaining priority.
+  let firstUnflushedWork = root.firstPendingWork;
+  while (firstUnflushedWork !== null) {
+    if (
+      remainingExpirationTime !== NoWork &&
+      firstUnflushedWork.expirationTime >= remainingExpirationTime
+    ) {
+      break;
+    }
+    firstUnflushedWork = firstUnflushedWork.next;
+  }
+  root.firstPendingWork = firstUnflushedWork;
+
+  if (firstUnflushedWork === null) {
+    if (remainingExpirationTime !== NoWork) {
+      // There was an update during the render phase that wasn't flushed.
+      addRenderPhasePendingWork(root, currentTime, remainingExpirationTime);
+    }
+  } else if (
+    remainingExpirationTime !== NoWork &&
+    firstUnflushedWork.expirationTime > remainingExpirationTime
+  ) {
+    // There was an update during the render phase that wasn't flushed.
+    addRenderPhasePendingWork(root, currentTime, remainingExpirationTime);
+  }
+}
+
+export function suspendPendingWork(
+  root: FiberRoot,
+  expirationTime: ExpirationTime,
+): void {
+  let work = root.firstPendingWork;
+  while (work !== null) {
+    if (work.expirationTime === expirationTime) {
+      work.isSuspended = true;
+      work.shouldTryResuming = false;
+      return;
+    }
+    if (work.expirationTime > expirationTime) {
+      return;
+    }
+    work = work.next;
+  }
+}
+
+export function resumePendingWork(
+  root: FiberRoot,
+  expirationTime: ExpirationTime,
+): void {
+  // Called when a promise resolves
+  let work = root.firstPendingWork;
+  while (work !== null) {
+    if (work.expirationTime === expirationTime) {
+      work.shouldTryResuming = true;
+    }
+    if (work.expirationTime > expirationTime) {
+      return;
+    }
+    work = work.next;
+  }
+}
+
+export function findNextExpirationTimeToWorkOn(
+  root: FiberRoot,
+): ExpirationTime {
+  // If there's a non-suspended interactive expiration time, return the first
+  // one. If everything is suspended, return the last retry time that's either
+  //   a) a render phase update
+  //   b) later or equal to the last suspended time
+  let lastSuspendedTime = NoWork;
+  let lastRenderPhaseTime = NoWork;
+  let lastRetryTime = NoWork;
+  let work = root.firstPendingWork;
+  while (work !== null) {
+    if (
+      !work.isSuspended &&
+      (!work.isRenderPhaseWork || lastSuspendedTime === NoWork)
+    ) {
+      return work.expirationTime;
+    }
+    if (
+      lastSuspendedTime === NoWork ||
+      lastSuspendedTime < work.expirationTime
+    ) {
+      lastSuspendedTime = work.expirationTime;
+    }
+    if (work.shouldTryResuming) {
+      if (lastRetryTime === NoWork || lastRetryTime < work.expirationTime) {
+        lastRetryTime = work.expirationTime;
+      }
+      if (
+        work.isRenderPhaseWork &&
+        (lastRenderPhaseTime === NoWork ||
+          lastRenderPhaseTime < work.expirationTime)
+      ) {
+        lastRenderPhaseTime = work.expirationTime;
+      }
+    }
+    work = work.next;
+  }
+  // This has the effect of coalescing all async updates that occur while we're
+  // in a suspended state. This prevents us from rendering an intermediate state
+  // that is no longer valid. An example is a tab switching interface: if
+  // switching to a new tab is suspended, we should only switch to the last
+  // tab that was clicked. If the user switches to tab A and then tab B, we
+  // should continue suspending until B is ready.
+  if (lastRetryTime >= lastSuspendedTime) {
+    return lastRetryTime;
+  }
+  return lastRenderPhaseTime;
+}
+
+export function findStartTime(root: FiberRoot, expirationTime: ExpirationTime) {
+  let match = root.firstPendingWork;
+  while (match !== null) {
+    if (match.expirationTime === expirationTime) {
+      return match.startTime;
+    }
+    match = match.next;
+  }
+  return NoWork;
+}

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -356,7 +356,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
     enqueueUpdate(current, update, expirationTime);
 
-    scheduleWork(current, expirationTime);
+    scheduleWork(current, currentTime, expirationTime);
     return expirationTime;
   }
 
@@ -436,7 +436,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     ): ExpirationTime {
       const current = container.current;
       const currentTime = recalculateCurrentTime();
-      const expirationTime = computeExpirationForFiber(current);
+      const expirationTime = computeExpirationForFiber(currentTime, current);
       return updateContainerAtExpirationTime(
         element,
         container,

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -9,6 +9,7 @@
 
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
+import type {PendingWork} from './ReactFiberPendingWork';
 
 import {createHostRootFiber} from './ReactFiber';
 import {NoWork} from './ReactFiberExpirationTime';
@@ -28,6 +29,7 @@ export type FiberRoot = {
   pendingChildren: any,
   // The currently active root fiber. This is the mutable root of the tree.
   current: Fiber,
+  firstPendingWork: PendingWork | null,
   pendingCommitExpirationTime: ExpirationTime,
   // A finished work-in-progress HostRoot that's ready to be committed.
   // TODO: The reason this is separate from isReadyForCommit is because the
@@ -63,6 +65,7 @@ export function createFiberRoot(
     containerInfo: containerInfo,
     pendingChildren: null,
     pendingCommitExpirationTime: NoWork,
+    firstPendingWork: null,
     finishedWork: null,
     context: null,
     pendingContext: null,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -59,7 +59,6 @@ import ReactFiberInstrumentation from './ReactFiberInstrumentation';
 import ReactDebugCurrentFiber from './ReactDebugCurrentFiber';
 import {
   addPendingWork,
-  addRenderPhasePendingWork,
   flushPendingWork,
   findStartTime,
   findNextExpirationTimeToWorkOn,
@@ -1353,12 +1352,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
             interruptedBy = fiber;
             resetStack();
           }
-          if (!isWorking || isCommitting) {
-            addPendingWork(root, startTime, expirationTime);
-          } else {
-            // We're in the render phase.
-            addRenderPhasePendingWork(root, startTime, expirationTime);
-          }
+          addPendingWork(root, startTime, expirationTime);
           if (
             // If we're in the render phase, we don't need to schedule this root
             // for an update, because we'll do it before we exit...

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -12,6 +12,7 @@ import type {Fiber} from './ReactFiber';
 import type {FiberRoot, Batch} from './ReactFiberRoot';
 import type {HydrationContext} from './ReactFiberHydrationContext';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
+import type {SuspenseThenable} from 'shared/SuspenseThenable';
 
 import ReactErrorUtils from 'shared/ReactErrorUtils';
 import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
@@ -1279,7 +1280,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
   function suspendRoot(
     root: FiberRoot,
-    thenable: {then: (() => mixed) => mixed},
+    thenable: SuspenseThenable,
     timeoutMs: number,
     suspendedTime: ExpirationTime,
   ) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -57,6 +57,15 @@ import ReactFiberHydrationContext from './ReactFiberHydrationContext';
 import ReactFiberInstrumentation from './ReactFiberInstrumentation';
 import ReactDebugCurrentFiber from './ReactDebugCurrentFiber';
 import {
+  addPendingWork,
+  addRenderPhasePendingWork,
+  flushPendingWork,
+  findStartTime,
+  findNextExpirationTimeToWorkOn,
+  suspendPendingWork,
+  resumePendingWork,
+} from './ReactFiberPendingWork';
+import {
   recordEffect,
   recordScheduleUpdate,
   startRequestCallbackTimer,
@@ -179,6 +188,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     hydrationContext,
     scheduleWork,
     computeExpirationForFiber,
+    recalculateCurrentTime,
   );
   const {completeWork} = ReactFiberCompleteWork(
     config,
@@ -198,9 +208,13 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     legacyContext,
     newContext,
     scheduleWork,
+    computeExpirationForFiber,
+    recalculateCurrentTime,
     markLegacyErrorBoundaryAsFailed,
     isAlreadyFailedLegacyErrorBoundary,
     onUncaughtError,
+    suspendRoot,
+    retrySuspendedRoot,
   );
   const {
     commitBeforeMutationLifeCycles,
@@ -247,6 +261,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   let nextRoot: FiberRoot | null = null;
   // The time at which we're currently rendering work.
   let nextRenderExpirationTime: ExpirationTime = NoWork;
+  let nextStartTime: ExpirationTime = NoWork;
+  let nextStartTimeMs: number = -1;
+  let nextElapsedTimeMs: number = -1;
+  let nextRemainingTimeMs: number = -1;
+  let nextEarliestTimeoutMs: number = -1;
+  let nextRenderIsExpired: boolean = false;
 
   // The next fiber with an effect that we're currently committing.
   let nextEffect: Fiber | null = null;
@@ -271,9 +291,20 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     originalReplayError = null;
     replayUnitOfWork = (
       failedUnitOfWork: Fiber,
-      error: mixed,
+      thrownValue: mixed,
       isAsync: boolean,
     ) => {
+      if (
+        thrownValue !== null &&
+        typeof thrownValue === 'object' &&
+        typeof thrownValue.then === 'function'
+      ) {
+        // Don't replay promises. Treat everything else like an error.
+        // TODO: Need to figure out a different strategy if/when we add
+        // support for catching other types.
+        return;
+      }
+
       // Restore the original state of the work-in-progress
       assignFiberPropertiesInDEV(
         failedUnitOfWork,
@@ -299,7 +330,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       }
       // Replay the begin phase.
       isReplayingFailedUnitOfWork = true;
-      originalReplayError = error;
+      originalReplayError = thrownValue;
       invokeGuardedCallback(null, workLoop, null, isAsync);
       isReplayingFailedUnitOfWork = false;
       originalReplayError = null;
@@ -332,6 +363,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     nextRoot = null;
     nextRenderExpirationTime = NoWork;
+    nextStartTime = NoWork;
+    nextStartTimeMs = -1;
+    nextElapsedTimeMs = -1;
+    nextRemainingTimeMs = -1;
+    nextEarliestTimeoutMs = -1;
+    nextRenderIsExpired = false;
     nextUnitOfWork = null;
 
     isRootReadyForCommit = false;
@@ -656,7 +693,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       ReactFiberInstrumentation.debugTool.onCommitWork(finishedWork);
     }
 
-    const remainingTime = root.current.expirationTime;
+    flushPendingWork(root, currentTime, root.current.expirationTime);
+    const remainingTime = findNextExpirationTimeToWorkOn(root);
     if (remainingTime === NoWork) {
       // If there's no remaining work, we can clear the set of already failed
       // error boundaries.
@@ -801,7 +839,14 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         // This fiber did not complete because something threw. Pop values off
         // the stack without entering the complete phase. If this is a boundary,
         // capture values if possible.
-        const next = unwindWork(workInProgress);
+        const next = unwindWork(
+          workInProgress,
+          nextElapsedTimeMs,
+          nextRenderIsExpired,
+          nextRemainingTimeMs,
+          nextStartTime,
+          nextRenderExpirationTime,
+        );
         // Because this fiber did not complete, don't reset its expiration time.
         if (workInProgress.effectTag & DidCapture) {
           // Restarting an error boundary
@@ -937,6 +982,18 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       resetStack();
       nextRoot = root;
       nextRenderExpirationTime = expirationTime;
+      nextStartTime = findStartTime(nextRoot, nextRenderExpirationTime);
+      recalculateCurrentTime();
+      if (nextStartTime === NoWork) {
+        nextStartTime = mostRecentCurrentTime;
+        nextStartTimeMs = mostRecentCurrentTimeMs;
+      } else {
+        nextStartTimeMs = expirationTimeToMs(nextStartTime);
+      }
+      nextElapsedTimeMs = mostRecentCurrentTimeMs - nextStartTimeMs;
+      nextRemainingTimeMs =
+        expirationTimeToMs(nextRenderExpirationTime) - mostRecentCurrentTimeMs;
+      nextEarliestTimeoutMs = nextRemainingTimeMs;
       nextUnitOfWork = createWorkInProgress(
         nextRoot.current,
         null,
@@ -946,6 +1003,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
 
     let didFatal = false;
+
+    nextRenderIsExpired =
+      !isAsync || nextRenderExpirationTime <= mostRecentCurrentTime;
 
     startWorkLoopTimer(nextUnitOfWork);
 
@@ -985,9 +1045,14 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
           break;
         }
         throwException(
+          root,
           returnFiber,
           sourceFiber,
           thrownValue,
+          nextRenderIsExpired,
+          nextRemainingTimeMs,
+          nextElapsedTimeMs,
+          nextStartTime,
           nextRenderExpirationTime,
         );
         nextUnitOfWork = completeUnitOfWork(sourceFiber);
@@ -1023,10 +1088,22 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         stopWorkLoopTimer(interruptedBy, didCompleteRoot);
         interruptedBy = null;
         invariant(
-          false,
+          !nextRenderIsExpired,
           'Expired work should have completed. This error is likely caused ' +
             'by a bug in React. Please file an issue.',
         );
+        if (nextEarliestTimeoutMs >= 0) {
+          const ms =
+            nextStartTimeMs + nextEarliestTimeoutMs - mostRecentCurrentTimeMs;
+          setTimeout(() => {
+            retrySuspendedRoot(root, expirationTime);
+          }, ms);
+        }
+        const firstUnblockedExpirationTime = findNextExpirationTimeToWorkOn(
+          root,
+        );
+        onBlock(firstUnblockedExpirationTime);
+        return null;
       }
     } else {
       stopWorkLoopTimer(interruptedBy, didCompleteRoot);
@@ -1040,6 +1117,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   function dispatch(
     sourceFiber: Fiber,
     value: mixed,
+    startTime: ExpirationTime,
     expirationTime: ExpirationTime,
   ) {
     invariant(
@@ -1065,7 +1143,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
               expirationTime,
             );
             enqueueUpdate(fiber, update, expirationTime);
-            scheduleWork(fiber, expirationTime);
+            const currentTime = recalculateCurrentTime();
+            scheduleWork(fiber, currentTime, expirationTime);
             return;
           }
           break;
@@ -1077,7 +1156,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
             expirationTime,
           );
           enqueueUpdate(fiber, update, expirationTime);
-          scheduleWork(fiber, expirationTime);
+          const currentTime = recalculateCurrentTime();
+          scheduleWork(fiber, currentTime, expirationTime);
           return;
         }
       }
@@ -1095,12 +1175,14 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         expirationTime,
       );
       enqueueUpdate(rootFiber, update, expirationTime);
-      scheduleWork(rootFiber, expirationTime);
+      const currentTime = recalculateCurrentTime();
+      scheduleWork(rootFiber, currentTime, expirationTime);
     }
   }
 
   function onCommitPhaseError(fiber: Fiber, error: mixed) {
-    return dispatch(fiber, error, Sync);
+    const startTime = recalculateCurrentTime();
+    return dispatch(fiber, error, startTime, Sync);
   }
 
   function computeAsyncExpiration(currentTime: ExpirationTime) {
@@ -1147,7 +1229,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     return lastUniqueAsyncExpiration;
   }
 
-  function computeExpirationForFiber(fiber: Fiber) {
+  function computeExpirationForFiber(
+    currentTime: ExpirationTime,
+    fiber: Fiber,
+  ) {
     let expirationTime;
     if (expirationContext !== NoWork) {
       // An explicit expiration context was set;
@@ -1168,11 +1253,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       if (fiber.mode & AsyncMode) {
         if (isBatchingInteractiveUpdates) {
           // This is an interactive update
-          const currentTime = recalculateCurrentTime();
           expirationTime = computeInteractiveExpiration(currentTime);
         } else {
           // This is an async update
-          const currentTime = recalculateCurrentTime();
           expirationTime = computeAsyncExpiration(currentTime);
         }
       } else {
@@ -1194,12 +1277,39 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     return expirationTime;
   }
 
-  function scheduleWork(fiber: Fiber, expirationTime: ExpirationTime) {
-    return scheduleWorkImpl(fiber, expirationTime, false);
+  function suspendRoot(
+    root: FiberRoot,
+    thenable: {then: (() => mixed) => mixed},
+    timeoutMs: number,
+    suspendedTime: ExpirationTime,
+  ) {
+    // Mark this root as suspended.
+    suspendPendingWork(root, suspendedTime);
+    // Schedule the timeout.
+    if (timeoutMs >= 0 && timeoutMs < nextEarliestTimeoutMs) {
+      nextEarliestTimeoutMs = timeoutMs;
+    }
+  }
+
+  function retrySuspendedRoot(root, suspendedTime) {
+    resumePendingWork(root, suspendedTime);
+    const retryTime = findNextExpirationTimeToWorkOn(root);
+    if (retryTime !== NoWork) {
+      requestRetry(root, retryTime);
+    }
+  }
+
+  function scheduleWork(
+    fiber: Fiber,
+    startTime: ExpirationTime,
+    expirationTime: ExpirationTime,
+  ) {
+    return scheduleWorkImpl(fiber, startTime, expirationTime, false);
   }
 
   function scheduleWorkImpl(
     fiber: Fiber,
+    startTime: ExpirationTime,
     expirationTime: ExpirationTime,
     isErrorRecovery: boolean,
   ) {
@@ -1242,6 +1352,12 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
             interruptedBy = fiber;
             resetStack();
           }
+          if (!isWorking || isCommitting) {
+            addPendingWork(root, startTime, expirationTime);
+          } else {
+            // We're in the render phase.
+            addRenderPhasePendingWork(root, startTime, expirationTime);
+          }
           if (
             // If we're in the render phase, we don't need to schedule this root
             // for an update, because we'll do it before we exit...
@@ -1250,7 +1366,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
             // ...unless this is a different root than the one we're rendering.
             nextRoot !== root
           ) {
-            // Add this root to the root schedule.
             requestWork(root, expirationTime);
           }
           if (nestedUpdateCount > NESTED_UPDATE_LIMIT) {
@@ -1361,6 +1476,18 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     callbackExpirationTime = expirationTime;
     callbackID = scheduleDeferredCallback(performAsyncWork, {timeout});
+  }
+
+  function requestRetry(root: FiberRoot, expirationTime: ExpirationTime) {
+    if (
+      root.remainingExpirationTime === NoWork ||
+      root.remainingExpirationTime < expirationTime
+    ) {
+      // For a retry, only update the remaining expiration time if it has a
+      // *lower priority* than the existing value. This is because, on a retry,
+      // we should attempt to coalesce as much as possible.
+      requestWork(root, expirationTime);
+    }
   }
 
   // requestWork is called by the scheduler whenever a root receives an update.
@@ -1724,6 +1851,16 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       hasUnhandledError = true;
       unhandledError = error;
     }
+  }
+
+  function onBlock(remainingExpirationTime: ExpirationTime) {
+    invariant(
+      nextFlushedRoot !== null,
+      'Should be working on a root. This error is likely caused by a bug in ' +
+        'React. Please file an issue.',
+    );
+    // This root was blocked. Unschedule it until there's another update.
+    nextFlushedRoot.remainingExpirationTime = remainingExpirationTime;
   }
 
   // TODO: Batching should be implemented at the renderer level, not inside

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -15,6 +15,7 @@ import type {LegacyContext} from './ReactFiberContext';
 import type {NewContext} from './ReactFiberNewContext';
 import type {CapturedValue} from './ReactCapturedValue';
 import type {Update} from './ReactUpdateQueue';
+import type {SuspenseThenable} from 'shared/SuspenseThenable';
 
 import {createCapturedValue} from './ReactCapturedValue';
 import {
@@ -83,7 +84,7 @@ export default function<C, CX>(
   onUncaughtError: (error: mixed) => void,
   suspendRoot: (
     root: FiberRoot,
-    thenable: {then: (() => mixed) => mixed},
+    thenable: SuspenseThenable,
     timeoutMs: number,
     suspendedTime: ExpirationTime,
   ) => void,
@@ -160,7 +161,7 @@ export default function<C, CX>(
 
   function waitForPromiseAndScheduleRecovery(finishedWork, thenable) {
     // Await promise
-    thenable.then(() => {
+    const onResolveOrReject = () => {
       // Once the promise resolves, we should try rendering the non-
       // placeholder state again.
       const startTime = recalculateCurrentTime();
@@ -168,7 +169,8 @@ export default function<C, CX>(
       const recoveryUpdate = createUpdate(expirationTime);
       enqueueUpdate(finishedWork, recoveryUpdate, expirationTime);
       scheduleWork(finishedWork, startTime, expirationTime);
-    });
+    };
+    thenable.then(onResolveOrReject, onResolveOrReject);
   }
 
   function throwException(
@@ -195,7 +197,7 @@ export default function<C, CX>(
       // This is a thenable.
       // Allow var because this is used in a closure.
       // eslint-disable-next-line no-var
-      var thenable: {then: (() => mixed) => mixed} = (value: any);
+      var thenable: SuspenseThenable = (value: any);
 
       // Find the earliest timeout of all the timeouts in the ancestor path.
       // TODO: Alternatively, we could store the earliest timeout on the context
@@ -239,9 +241,10 @@ export default function<C, CX>(
       if (msUntilTimeout > 0) {
         // There's still time remaining.
         suspendRoot(root, thenable, earliestTimeoutMs, renderExpirationTime);
-        thenable.then(() => {
+        const onResolveOrReject = () => {
           retrySuspendedRoot(root, renderExpirationTime);
-        });
+        };
+        thenable.then(onResolveOrReject, onResolveOrReject);
         return;
       } else {
         // No time remaining. Need to fallback to palceholder.

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -23,7 +23,6 @@ import {
   createUpdate,
   enqueueUpdate,
   CaptureUpdate,
-  ReplaceState,
 } from './ReactUpdateQueue';
 import {logError} from './ReactFiberCommitWork';
 
@@ -269,8 +268,6 @@ export default function<C, CX>(
               if ((workInProgress.effectTag & DidCapture) === NoEffect) {
                 workInProgress.effectTag |= ShouldCapture;
                 const update = createUpdate(renderExpirationTime);
-                update.tag = ReplaceState;
-                update.payload = true;
                 // Allow var because this is used in a closure.
                 // eslint-disable-next-line no-var
                 var finishedWork = workInProgress;

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -44,7 +44,10 @@ import {
 
 import {Sync} from './ReactFiberExpirationTime';
 
-import {enableGetDerivedStateFromCatch} from 'shared/ReactFeatureFlags';
+import {
+  enableGetDerivedStateFromCatch,
+  enableSuspense,
+} from 'shared/ReactFeatureFlags';
 
 import invariant from 'fbjs/lib/invariant';
 
@@ -190,6 +193,7 @@ export default function<C, CX>(
     sourceFiber.firstEffect = sourceFiber.lastEffect = null;
 
     if (
+      enableSuspense &&
       value !== null &&
       typeof value === 'object' &&
       typeof value.then === 'function'

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -3,6 +3,7 @@ let ReactFeatureFlags;
 let Fragment;
 let ReactNoop;
 let SimpleCacheProvider;
+let Placeholder;
 let Timeout;
 
 let cache;
@@ -19,6 +20,7 @@ describe('ReactSuspense', () => {
     Fragment = React.Fragment;
     ReactNoop = require('react-noop-renderer');
     SimpleCacheProvider = require('simple-cache-provider');
+    Placeholder = React.Placeholder;
     Timeout = React.Timeout;
 
     function invalidateCache() {
@@ -87,7 +89,9 @@ describe('ReactSuspense', () => {
   function Fallback(props) {
     return (
       <Timeout ms={props.timeout}>
-        {didExpire => (didExpire ? props.placeholder : props.children)}
+        <Placeholder>
+          {didExpire => (didExpire ? props.placeholder : props.children)}
+        </Placeholder>
       </Timeout>
     );
   }
@@ -609,7 +613,9 @@ describe('ReactSuspense', () => {
   it('throws a helpful error when a synchronous update is suspended', () => {
     expect(() => {
       ReactNoop.flushSync(() =>
-        ReactNoop.render(<Timeout>{() => <AsyncText text="Async" />}</Timeout>),
+        ReactNoop.render(
+          <Placeholder>{() => <AsyncText text="Async" />}</Placeholder>,
+        ),
       );
     }).toThrow(
       'A synchronous update was suspended, but no fallback UI was provided.',
@@ -618,7 +624,7 @@ describe('ReactSuspense', () => {
 
   it('throws a helpful error when an expired update is suspended', async () => {
     ReactNoop.render(
-      <Timeout>{() => <AsyncText text="Async" ms={20000} />}</Timeout>,
+      <Placeholder>{() => <AsyncText text="Async" ms={20000} />}</Placeholder>,
     );
     expect(ReactNoop.flush()).toEqual(['Suspend! [Async]']);
     await advanceTimers(10000);
@@ -791,14 +797,16 @@ describe('ReactSuspense', () => {
     function Delay({ms}) {
       return (
         <Timeout ms={ms}>
-          {didTimeout => {
-            if (didTimeout) {
-              // Once ms has elapsed, render null. This allows the rest of the
-              // tree to resume rendering.
-              return null;
-            }
-            return <Never />;
-          }}
+          <Placeholder>
+            {didTimeout => {
+              if (didTimeout) {
+                // Once ms has elapsed, render null. This allows the rest of the
+                // tree to resume rendering.
+                return null;
+              }
+              return <Never />;
+            }}
+          </Placeholder>
         </Timeout>
       );
     }

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -14,6 +14,7 @@ describe('ReactSuspense', () => {
     jest.resetModules();
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+    ReactFeatureFlags.enableSuspense = true;
     React = require('react');
     Fragment = React.Fragment;
     ReactNoop = require('react-noop-renderer');

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -1,0 +1,656 @@
+let React;
+let ReactFeatureFlags;
+let Fragment;
+let ReactNoop;
+let SimpleCacheProvider;
+let Timeout;
+
+let cache;
+let TextResource;
+
+describe('ReactSuspense', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+    React = require('react');
+    Fragment = React.Fragment;
+    ReactNoop = require('react-noop-renderer');
+    SimpleCacheProvider = require('simple-cache-provider');
+    Timeout = React.Timeout;
+
+    cache = SimpleCacheProvider.createCache();
+    TextResource = SimpleCacheProvider.createResource(([text, ms = 0]) => {
+      return new Promise(resolve =>
+        setTimeout(() => {
+          ReactNoop.yield(`Promise resolved [${text}]`);
+          resolve(text);
+        }, ms),
+      );
+    }, ([text, ms]) => text);
+  });
+
+  // function div(...children) {
+  //   children = children.map(c => (typeof c === 'string' ? {text: c} : c));
+  //   return {type: 'div', children, prop: undefined};
+  // }
+
+  function span(prop) {
+    return {type: 'span', children: [], prop};
+  }
+
+  function advanceTimers(ms) {
+    // Note: This advances Jest's virtual time but not React's. Use
+    // ReactNoop.expire for that.
+    if (typeof ms !== 'number') {
+      throw new Error('Must specify ms');
+    }
+    jest.advanceTimersByTime(ms);
+    // Wait until the end of the current tick
+    return new Promise(resolve => {
+      setImmediate(resolve);
+    });
+  }
+
+  function Text(props) {
+    ReactNoop.yield(props.text);
+    return <span prop={props.text} />;
+  }
+
+  function AsyncText(props) {
+    const text = props.text;
+    try {
+      TextResource.read(cache, [props.text, props.ms]);
+      ReactNoop.yield(text);
+      return <span prop={text} />;
+    } catch (promise) {
+      ReactNoop.yield(`Suspend! [${text}]`);
+      throw promise;
+    }
+  }
+
+  function Fallback(props) {
+    return (
+      <Timeout ms={props.timeout}>
+        {didExpire => (didExpire ? props.placeholder : props.children)}
+      </Timeout>
+    );
+  }
+  it('suspends rendering and continues later', async () => {
+    function Bar(props) {
+      ReactNoop.yield('Bar');
+      return props.children;
+    }
+
+    function Foo() {
+      ReactNoop.yield('Foo');
+      return (
+        <Fallback>
+          <Bar>
+            <AsyncText text="A" ms={100} />
+            <Text text="B" />
+          </Bar>
+        </Fallback>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+    expect(ReactNoop.flush()).toEqual([
+      'Foo',
+      'Bar',
+      // A suspends
+      'Suspend! [A]',
+      // But we keep rendering the siblings
+      'B',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flush some of the time
+    await advanceTimers(50);
+    // Still nothing...
+    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flush the promise completely
+    await advanceTimers(50);
+    // Renders successfully
+    expect(ReactNoop.flush()).toEqual([
+      'Promise resolved [A]',
+      'Foo',
+      'Bar',
+      'A',
+      'B',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
+  });
+
+  it('continues rendering siblings after suspending', async () => {
+    ReactNoop.render(
+      <Fallback>
+        <Text text="A" />
+        <AsyncText text="B" />
+        <Text text="C" />
+        <Text text="D" />
+      </Fallback>,
+    );
+    // B suspends. Continue rendering the remaining siblings.
+    expect(ReactNoop.flush()).toEqual(['A', 'Suspend! [B]', 'C', 'D']);
+    // Did not commit yet.
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Wait for data to resolve
+    await advanceTimers(100);
+    // Renders successfully
+    expect(ReactNoop.flush()).toEqual([
+      'Promise resolved [B]',
+      'A',
+      'B',
+      'C',
+      'D',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([
+      span('A'),
+      span('B'),
+      span('C'),
+      span('D'),
+    ]);
+  });
+
+  it('can update at a higher priority while in a suspended state', async () => {
+    function App(props) {
+      return (
+        <Fallback>
+          <Text text={props.highPri} />
+          <AsyncText text={props.lowPri} />
+        </Fallback>
+      );
+    }
+
+    // Initial mount
+    ReactNoop.render(<App highPri="A" lowPri="1" />);
+    ReactNoop.flush();
+    await advanceTimers(0);
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('1')]);
+
+    // Update the low-pri text
+    ReactNoop.render(<App highPri="A" lowPri="2" />);
+    expect(ReactNoop.flush()).toEqual([
+      'A',
+      // Suspends
+      'Suspend! [2]',
+    ]);
+
+    // While we're still waiting for the low-pri update to complete, update the
+    // high-pri text at high priority.
+    ReactNoop.flushSync(() => {
+      ReactNoop.render(<App highPri="B" lowPri="1" />);
+    });
+    expect(ReactNoop.flush()).toEqual(['B', '1']);
+    expect(ReactNoop.getChildren()).toEqual([span('B'), span('1')]);
+
+    // Unblock the low-pri text and finish
+    await advanceTimers(0);
+    expect(ReactNoop.flush()).toEqual(['Promise resolved [2]']);
+    expect(ReactNoop.getChildren()).toEqual([span('B'), span('1')]);
+  });
+
+  it('keeps working on lower priority work after being unblocked', async () => {
+    function App(props) {
+      return (
+        <Fallback>
+          <AsyncText text="A" />
+          {props.showB && <Text text="B" />}
+        </Fallback>
+      );
+    }
+
+    ReactNoop.render(<App showB={false} />);
+    expect(ReactNoop.flush()).toEqual(['Suspend! [A]']);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance React's virtual time by enough to fall into a new async bucket.
+    ReactNoop.expire(1200);
+    ReactNoop.render(<App showB={true} />);
+    expect(ReactNoop.flush()).toEqual(['Suspend! [A]', 'B']);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    await advanceTimers(0);
+    expect(ReactNoop.flush()).toEqual(['Promise resolved [A]', 'A', 'B']);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
+  });
+
+  it('coalesces all async updates when in a suspended state', async () => {
+    ReactNoop.render(
+      <Fallback>
+        <AsyncText text="A" />
+      </Fallback>,
+    );
+    ReactNoop.flush();
+    await advanceTimers(0);
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([span('A')]);
+
+    ReactNoop.render(
+      <Fallback>
+        <AsyncText text="B" ms={50} />
+      </Fallback>,
+    );
+    expect(ReactNoop.flush()).toEqual(['Suspend! [B]']);
+    expect(ReactNoop.getChildren()).toEqual([span('A')]);
+
+    // Advance React's virtual time so that C falls into a new expiration bucket
+    ReactNoop.expire(1000);
+    ReactNoop.render(
+      <Fallback>
+        <AsyncText text="C" ms={100} />
+      </Fallback>,
+    );
+    expect(ReactNoop.flush()).toEqual([
+      // Tries C first, since it has a later expiration time
+      'Suspend! [C]',
+      // Does not retry B, because its promise has not resolved yet.
+    ]);
+
+    expect(ReactNoop.getChildren()).toEqual([span('A')]);
+
+    // Unblock B
+    await advanceTimers(90);
+    // Even though B's promise resolved, the view is still suspended because it
+    // coalesced with C.
+    expect(ReactNoop.flush()).toEqual(['Promise resolved [B]']);
+    expect(ReactNoop.getChildren()).toEqual([span('A')]);
+
+    // Unblock C
+    await advanceTimers(50);
+    expect(ReactNoop.flush()).toEqual(['Promise resolved [C]', 'C']);
+    expect(ReactNoop.getChildren()).toEqual([span('C')]);
+  });
+
+  it('forces an expiration after an update times out', async () => {
+    ReactNoop.render(
+      <Fragment>
+        <Fallback placeholder={<Text text="Loading..." />}>
+          <AsyncText text="Async" ms={20000} />
+        </Fallback>
+        <Text text="Sync" />
+      </Fragment>,
+    );
+
+    expect(ReactNoop.flush()).toEqual([
+      // The async child suspends
+      'Suspend! [Async]',
+      // Continue on the sibling
+      'Sync',
+    ]);
+    // The update hasn't expired yet, so we commit nothing.
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance both React's virtual time and Jest's timers by enough to expire
+    // the update, but not by enough to flush the suspending promise.
+    ReactNoop.expire(10000);
+    await advanceTimers(10000);
+    expect(ReactNoop.flushExpired()).toEqual([
+      // Still suspended.
+      'Suspend! [Async]',
+      // Now that the update has expired, we render the fallback UI
+      'Loading...',
+      'Sync',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...'), span('Sync')]);
+
+    // Once the promise resolves, we render the suspended view
+    await advanceTimers(10000);
+    expect(ReactNoop.flush()).toEqual(['Promise resolved [Async]', 'Async']);
+    expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
+  });
+
+  it('renders an expiration boundary synchronously', async () => {
+    // Synchronously render a tree that suspends
+    ReactNoop.flushSync(() =>
+      ReactNoop.render(
+        <Fragment>
+          <Fallback placeholder={<Text text="Loading..." />}>
+            <AsyncText text="Async" />
+          </Fallback>
+          <Text text="Sync" />
+        </Fragment>,
+      ),
+    );
+    expect(ReactNoop.clearYields()).toEqual([
+      // The async child suspends
+      'Suspend! [Async]',
+      // We immediately render the fallback UI
+      'Loading...',
+      // Continue on the sibling
+      'Sync',
+    ]);
+    // The tree commits synchronously
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...'), span('Sync')]);
+
+    // Once the promise resolves, we render the suspended view
+    await advanceTimers(0);
+    expect(ReactNoop.flush()).toEqual(['Promise resolved [Async]', 'Async']);
+    expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
+  });
+
+  it('suspending inside an expired expiration boundary will bubble to the next one', async () => {
+    ReactNoop.flushSync(() =>
+      ReactNoop.render(
+        <Fragment>
+          <Fallback placeholder={<Text text="Loading (outer)..." />}>
+            <Fallback placeholder={<AsyncText text="Loading (inner)..." />}>
+              <AsyncText text="Async" />
+            </Fallback>
+            <Text text="Sync" />
+          </Fallback>
+        </Fragment>,
+      ),
+    );
+    expect(ReactNoop.clearYields()).toEqual([
+      'Suspend! [Async]',
+      'Suspend! [Loading (inner)...]',
+      'Sync',
+      'Loading (outer)...',
+    ]);
+    // The tree commits synchronously
+    expect(ReactNoop.getChildren()).toEqual([span('Loading (outer)...')]);
+  });
+
+  it('expires early with a `timeout` option', async () => {
+    ReactNoop.render(
+      <Fragment>
+        <Fallback timeout={100} placeholder={<Text text="Loading..." />}>
+          <AsyncText text="Async" ms={1000} />
+        </Fallback>
+        <Text text="Sync" />
+      </Fragment>,
+    );
+
+    expect(ReactNoop.flush()).toEqual([
+      // The async child suspends
+      'Suspend! [Async]',
+      // Continue on the sibling
+      'Sync',
+    ]);
+    // The update hasn't expired yet, so we commit nothing.
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance both React's virtual time and Jest's timers by enough to trigger
+    // the timeout, but not by enough to flush the promise or reach the true
+    // expiration time.
+    ReactNoop.expire(120);
+    await advanceTimers(120);
+    expect(ReactNoop.flush()).toEqual([
+      // Still suspended.
+      'Suspend! [Async]',
+      // Now that the expiration view has timed out, we render the fallback UI
+      'Loading...',
+      'Sync',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...'), span('Sync')]);
+
+    // Once the promise resolves, we render the suspended view
+    await advanceTimers(1000);
+    expect(ReactNoop.flush()).toEqual(['Promise resolved [Async]', 'Async']);
+    expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
+  });
+
+  it('throws a helpful error when a synchronous update is suspended', () => {
+    expect(() => {
+      ReactNoop.flushSync(() =>
+        ReactNoop.render(<Timeout>{() => <AsyncText text="Async" />}</Timeout>),
+      );
+    }).toThrow(
+      'A synchronous update was suspended, but no fallback UI was provided.',
+    );
+  });
+
+  it('throws a helpful error when an expired update is suspended', async () => {
+    ReactNoop.render(
+      <Timeout>{() => <AsyncText text="Async" ms={20000} />}</Timeout>,
+    );
+    expect(ReactNoop.flush()).toEqual(['Suspend! [Async]']);
+    await advanceTimers(10000);
+    ReactNoop.expire(10000);
+    expect(() => {
+      expect(ReactNoop.flush()).toEqual(['Suspend! [Async]']);
+    }).toThrow(
+      'An update was suspended for longer than the timeout, but no fallback ' +
+        'UI was provided.',
+    );
+  });
+
+  it('a Timeout component correctly handles more than one suspended child', async () => {
+    ReactNoop.render(
+      <Fallback timeout={0}>
+        <AsyncText text="A" ms={100} />
+        <AsyncText text="B" ms={100} />
+      </Fallback>,
+    );
+    ReactNoop.expire(10000);
+    expect(ReactNoop.flush()).toEqual(['Suspend! [A]', 'Suspend! [B]']);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    await advanceTimers(100);
+
+    expect(ReactNoop.flush()).toEqual([
+      'Promise resolved [A]',
+      'Promise resolved [B]',
+      'A',
+      'B',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
+  });
+
+  it('can resume rendering earlier than a timeout', async () => {
+    ReactNoop.render(
+      <Fallback timeout={1000} placeholder={<Text text="Loading..." />}>
+        <AsyncText text="Async" ms={100} />
+      </Fallback>,
+    );
+    expect(ReactNoop.flush()).toEqual(['Suspend! [Async]']);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance time by an amount slightly smaller than what's necessary to
+    // resolve the promise
+    await advanceTimers(99);
+
+    // Nothing has rendered yet
+    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Resolve the promise
+    await advanceTimers(1);
+    // We can now resume rendering
+    expect(ReactNoop.flush()).toEqual(['Promise resolved [Async]', 'Async']);
+    expect(ReactNoop.getChildren()).toEqual([span('Async')]);
+  });
+
+  describe('splitting a high-pri update into high and low', () => {
+    React = require('react');
+
+    class AsyncValue extends React.Component {
+      state = {asyncValue: this.props.defaultValue};
+      componentDidMount() {
+        ReactNoop.deferredUpdates(() => {
+          this.setState((state, props) => ({asyncValue: props.value}));
+        });
+      }
+      componentDidUpdate() {
+        if (this.props.value !== this.state.asyncValue) {
+          ReactNoop.deferredUpdates(() => {
+            this.setState((state, props) => ({asyncValue: props.value}));
+          });
+        }
+      }
+      render() {
+        return this.props.children(this.state.asyncValue);
+      }
+    }
+
+    it('coalesces async values when in a suspended state', async () => {
+      function App(props) {
+        const highPriText = props.text;
+        return (
+          <Fallback>
+            <AsyncValue value={highPriText} defaultValue={null}>
+              {lowPriText => (
+                <Fragment>
+                  <Text text={`High-pri: ${highPriText}`} />
+                  {lowPriText && (
+                    <AsyncText text={`Low-pri: ${lowPriText}`} ms={100} />
+                  )}
+                </Fragment>
+              )}
+            </AsyncValue>
+          </Fallback>
+        );
+      }
+
+      function renderAppSync(props) {
+        ReactNoop.flushSync(() => ReactNoop.render(<App {...props} />));
+      }
+
+      // Initial mount
+      renderAppSync({text: 'A'});
+      expect(ReactNoop.flush()).toEqual([
+        // First we render at high priority
+        'High-pri: A',
+        // Then we come back later to render a low priority
+        'High-pri: A',
+        // The low-pri view suspends
+        'Suspend! [Low-pri: A]',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span('High-pri: A')]);
+
+      // Partially flush the promise for 'A', not by enough to resolve it.
+      await advanceTimers(99);
+
+      // Advance React's virtual time so that the next update falls into a new
+      // expiration bucket
+      ReactNoop.expire(2000);
+      // Update to B. At this point, the low-pri view still hasn't updated
+      // to 'A'.
+      renderAppSync({text: 'B'});
+      expect(ReactNoop.flush()).toEqual([
+        // First we render at high priority
+        'High-pri: B',
+        // Then we come back later to render a low priority
+        'High-pri: B',
+        // The low-pri view suspends
+        'Suspend! [Low-pri: B]',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span('High-pri: B')]);
+
+      // Flush the rest of the promise for 'A', without flushing the one
+      // for 'B'.
+      await advanceTimers(1);
+      expect(ReactNoop.flush()).toEqual([
+        // A is unblocked
+        'Promise resolved [Low-pri: A]',
+        // But we don't try to render it, because there's a lower priority
+        // update that is also suspended.
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span('High-pri: B')]);
+
+      // Flush the remaining work.
+      await advanceTimers(99);
+      expect(ReactNoop.flush()).toEqual([
+        // B is unblocked
+        'Promise resolved [Low-pri: B]',
+        // Now we can continue rendering the async view
+        'High-pri: B',
+        'Low-pri: B',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('High-pri: B'),
+        span('Low-pri: B'),
+      ]);
+    });
+  });
+
+  describe('a Delay component', () => {
+    function Never() {
+      // Throws a promise that resolves after some arbitrarily large
+      // number of seconds. The idea is that this component will never
+      // resolve. It's always wrapped by a Timeout.
+      throw new Promise(resolve => setTimeout(() => resolve(), 10000));
+    }
+
+    function Delay({ms}) {
+      return (
+        <Timeout ms={ms}>
+          {didTimeout => {
+            if (didTimeout) {
+              // Once ms has elapsed, render null. This allows the rest of the
+              // tree to resume rendering.
+              return null;
+            }
+            return <Never />;
+          }}
+        </Timeout>
+      );
+    }
+
+    function DebouncedText({text, ms}) {
+      return (
+        <Fragment>
+          <Delay ms={ms} />
+          <Text text={text} />
+        </Fragment>
+      );
+    }
+
+    it('works', async () => {
+      ReactNoop.render(<DebouncedText text="A" ms={1000} />);
+      ReactNoop.flush();
+      expect(ReactNoop.getChildren()).toEqual([]);
+
+      await advanceTimers(999);
+      ReactNoop.expire(999);
+      ReactNoop.flush();
+      expect(ReactNoop.getChildren()).toEqual([]);
+
+      await advanceTimers(1);
+      ReactNoop.expire(1);
+      ReactNoop.flush();
+      expect(ReactNoop.getChildren()).toEqual([span('A')]);
+    });
+
+    it('uses the most recent update as its start time', async () => {
+      ReactNoop.render(<DebouncedText text="A" ms={1000} />);
+      ReactNoop.flush();
+      expect(ReactNoop.getChildren()).toEqual([]);
+
+      // Advance time by a little, but not by enough to move this into a new
+      // expiration bucket.
+      await advanceTimers(10);
+      ReactNoop.expire(10);
+      ReactNoop.flush();
+      expect(ReactNoop.getChildren()).toEqual([]);
+
+      // Schedule an update. It should have the same expiration as the first one.
+      ReactNoop.render(<DebouncedText text="B" ms={1000} />);
+
+      // Advance time by enough that it would have timed-out the first update,
+      // but not enough that it times out the second one.
+      await advanceTimers(999);
+      ReactNoop.expire(999);
+      ReactNoop.flush();
+      expect(ReactNoop.getChildren()).toEqual([]);
+
+      // Advance time by just a bit more to trigger the timeout.
+      await advanceTimers(1);
+      ReactNoop.expire(1);
+      ReactNoop.flush();
+      expect(ReactNoop.getChildren()).toEqual([span('B')]);
+    });
+  });
+
+  // TODO:
+  // Timeout inside an async boundary
+  // Promise rejection
+  // Suspending inside an offscreen tree
+  // Timeout for CPU-bound work (if it makes sense to do this?)
+});

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -11,6 +11,7 @@ import {
   REACT_FRAGMENT_TYPE,
   REACT_STRICT_MODE_TYPE,
   REACT_ASYNC_MODE_TYPE,
+  REACT_TIMEOUT_TYPE,
 } from 'shared/ReactSymbols';
 
 import {Component, PureComponent} from './ReactBaseClasses';
@@ -51,6 +52,7 @@ const React = {
   Fragment: REACT_FRAGMENT_TYPE,
   StrictMode: REACT_STRICT_MODE_TYPE,
   unstable_AsyncMode: REACT_ASYNC_MODE_TYPE,
+  Timeout: REACT_TIMEOUT_TYPE,
 
   createElement: __DEV__ ? createElementWithValidation : createElement,
   cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -13,6 +13,7 @@ import {
   REACT_ASYNC_MODE_TYPE,
   REACT_TIMEOUT_TYPE,
 } from 'shared/ReactSymbols';
+import {enableSuspense} from 'shared/ReactFeatureFlags';
 
 import {Component, PureComponent} from './ReactBaseClasses';
 import {createRef} from './ReactCreateRef';
@@ -52,7 +53,6 @@ const React = {
   Fragment: REACT_FRAGMENT_TYPE,
   StrictMode: REACT_STRICT_MODE_TYPE,
   unstable_AsyncMode: REACT_ASYNC_MODE_TYPE,
-  Timeout: REACT_TIMEOUT_TYPE,
 
   createElement: __DEV__ ? createElementWithValidation : createElement,
   cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,
@@ -67,6 +67,10 @@ const React = {
     assign,
   },
 };
+
+if (enableSuspense) {
+  React.Timeout = REACT_TIMEOUT_TYPE;
+}
 
 if (__DEV__) {
   Object.assign(React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED, {

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -12,6 +12,7 @@ import {
   REACT_STRICT_MODE_TYPE,
   REACT_ASYNC_MODE_TYPE,
   REACT_TIMEOUT_TYPE,
+  REACT_PLACEHOLDER_TYPE,
 } from 'shared/ReactSymbols';
 import {enableSuspense} from 'shared/ReactFeatureFlags';
 
@@ -69,6 +70,7 @@ const React = {
 };
 
 if (enableSuspense) {
+  React.Placeholder = REACT_PLACEHOLDER_TYPE;
   React.Timeout = REACT_TIMEOUT_TYPE;
 }
 

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -21,6 +21,8 @@ export const enablePersistentReconciler = false;
 // Experimental error-boundary API that can recover from errors within a single
 // render phase
 export const enableGetDerivedStateFromCatch = false;
+// Suspense
+export const enableSuspense = false;
 // Helps identify side effects in begin-phase lifecycle hooks and setState reducers:
 export const debugRenderPhaseSideEffects = false;
 

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -39,6 +39,9 @@ export const REACT_ASYNC_MODE_TYPE = hasSymbol
 export const REACT_FORWARD_REF_TYPE = hasSymbol
   ? Symbol.for('react.forward_ref')
   : 0xead0;
+export const REACT_TIMEOUT_TYPE = hasSymbol
+  ? Symbol.for('react.timeout')
+  : 0xead1;
 
 const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -39,9 +39,12 @@ export const REACT_ASYNC_MODE_TYPE = hasSymbol
 export const REACT_FORWARD_REF_TYPE = hasSymbol
   ? Symbol.for('react.forward_ref')
   : 0xead0;
+export const REACT_PLACEHOLDER_TYPE = hasSymbol
+  ? Symbol.for('react.placeholder')
+  : 0xead1;
 export const REACT_TIMEOUT_TYPE = hasSymbol
   ? Symbol.for('react.timeout')
-  : 0xead1;
+  : 0xead2;
 
 const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';

--- a/packages/shared/ReactTypeOfWork.js
+++ b/packages/shared/ReactTypeOfWork.js
@@ -23,7 +23,8 @@ export type TypeOfWork =
   | 12
   | 13
   | 14
-  | 15;
+  | 15
+  | 16;
 
 export const IndeterminateComponent = 0; // Before we know whether it is functional or class
 export const FunctionalComponent = 1;
@@ -40,4 +41,5 @@ export const Mode = 11;
 export const ContextConsumer = 12;
 export const ContextProvider = 13;
 export const ForwardRef = 14;
-export const TimeoutComponent = 15;
+export const PlaceholderComponent = 15;
+export const TimeoutComponent = 16;

--- a/packages/shared/ReactTypeOfWork.js
+++ b/packages/shared/ReactTypeOfWork.js
@@ -22,7 +22,8 @@ export type TypeOfWork =
   | 11
   | 12
   | 13
-  | 14;
+  | 14
+  | 15;
 
 export const IndeterminateComponent = 0; // Before we know whether it is functional or class
 export const FunctionalComponent = 1;
@@ -39,3 +40,4 @@ export const Mode = 11;
 export const ContextConsumer = 12;
 export const ContextProvider = 13;
 export const ForwardRef = 14;
+export const TimeoutComponent = 15;

--- a/packages/shared/SuspenseThenable.js
+++ b/packages/shared/SuspenseThenable.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export type SuspenseThenable = {
+  then(resolve: () => mixed, reject?: () => mixed): mixed,
+};

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric-fb.js
@@ -16,6 +16,7 @@ export const debugRenderPhaseSideEffects = false;
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableUserTimingAPI = __DEV__;
 export const enableGetDerivedStateFromCatch = false;
+export const enableSuspense = false;
 export const warnAboutDeprecatedLifecycles = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
@@ -16,6 +16,7 @@ export const debugRenderPhaseSideEffects = false;
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableUserTimingAPI = __DEV__;
 export const enableGetDerivedStateFromCatch = false;
+export const enableSuspense = false;
 export const warnAboutDeprecatedLifecycles = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -15,6 +15,7 @@ import typeof * as FeatureFlagsShimType from './ReactFeatureFlags.native-fb';
 // Re-export dynamic flags from the fbsource version.
 export const {
   enableGetDerivedStateFromCatch,
+  enableSuspense,
   debugRenderPhaseSideEffects,
   debugRenderPhaseSideEffectsForStrictMode,
   warnAboutDeprecatedLifecycles,

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -15,6 +15,7 @@ import typeof * as FeatureFlagsShimType from './ReactFeatureFlags.native-oss';
 export const debugRenderPhaseSideEffects = false;
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableGetDerivedStateFromCatch = false;
+export const enableSuspense = false;
 export const enableMutatingReconciler = true;
 export const enableNoopReconciler = false;
 export const enablePersistentReconciler = false;

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -16,6 +16,7 @@ export const debugRenderPhaseSideEffects = false;
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableUserTimingAPI = __DEV__;
 export const enableGetDerivedStateFromCatch = false;
+export const enableSuspense = false;
 export const warnAboutDeprecatedLifecycles = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -16,6 +16,7 @@ export const debugRenderPhaseSideEffects = false;
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableUserTimingAPI = __DEV__;
 export const enableGetDerivedStateFromCatch = false;
+export const enableSuspense = false;
 export const warnAboutDeprecatedLifecycles = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableMutatingReconciler = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -13,6 +13,7 @@ import typeof * as FeatureFlagsShimType from './ReactFeatureFlags.www';
 // Re-export dynamic flags from the www version.
 export const {
   enableGetDerivedStateFromCatch,
+  enableSuspense,
   debugRenderPhaseSideEffects,
   debugRenderPhaseSideEffectsForStrictMode,
   warnAboutDeprecatedLifecycles,

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -15,6 +15,7 @@ import {
   REACT_CONTEXT_TYPE,
   REACT_FORWARD_REF_TYPE,
   REACT_TIMEOUT_TYPE,
+  REACT_PLACEHOLDER_TYPE,
 } from 'shared/ReactSymbols';
 
 export default function isValidElementType(type: mixed) {
@@ -25,6 +26,7 @@ export default function isValidElementType(type: mixed) {
     type === REACT_FRAGMENT_TYPE ||
     type === REACT_ASYNC_MODE_TYPE ||
     type === REACT_STRICT_MODE_TYPE ||
+    type === REACT_PLACEHOLDER_TYPE ||
     type === REACT_TIMEOUT_TYPE ||
     (typeof type === 'object' &&
       type !== null &&

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -14,6 +14,7 @@ import {
   REACT_PROVIDER_TYPE,
   REACT_CONTEXT_TYPE,
   REACT_FORWARD_REF_TYPE,
+  REACT_TIMEOUT_TYPE,
 } from 'shared/ReactSymbols';
 
 export default function isValidElementType(type: mixed) {
@@ -24,6 +25,7 @@ export default function isValidElementType(type: mixed) {
     type === REACT_FRAGMENT_TYPE ||
     type === REACT_ASYNC_MODE_TYPE ||
     type === REACT_STRICT_MODE_TYPE ||
+    type === REACT_TIMEOUT_TYPE ||
     (typeof type === 'object' &&
       type !== null &&
       (type.$$typeof === REACT_PROVIDER_TYPE ||


### PR DESCRIPTION
I think this separation makes sense, if for no other reason than it helps with the mental model. A Timeout determines the threshold before a suspend "effect" turns into an error. A Placeholder is like an error boundary that pattern matches on those errors.

Depends on https://github.com/facebook/react/pull/12279. Opening this separately, since it's not needed for the basic functionality and it's debatable whether these are the right primitives.