### PR TITLE
Mark context consumers with PerformedWork effect on render

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -181,8 +181,6 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       }
     }
     const nextChildren = render(nextProps, ref);
-    // React DevTools reads this flag.
-    workInProgress.effectTag |= PerformedWork;
     reconcileChildren(current, workInProgress, nextChildren);
     memoizeProps(workInProgress, nextProps);
     return workInProgress.child;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -181,6 +181,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       }
     }
     const nextChildren = render(nextProps, ref);
+    // React DevTools reads this flag.
+    workInProgress.effectTag |= PerformedWork;
     reconcileChildren(current, workInProgress, nextChildren);
     memoizeProps(workInProgress, nextProps);
     return workInProgress.child;
@@ -1023,6 +1025,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     }
 
     const newChildren = render(newValue);
+    // React DevTools reads this flag.
+    workInProgress.effectTag |= PerformedWork;
     reconcileChildren(current, workInProgress, newChildren);
     return workInProgress.child;
   }


### PR DESCRIPTION
It's used by DevTools for "Highlight Updates" feature.
We already mark both classes and functions with it.

It was only used for classes by DevTools, which treated context consumers as always changing. But that turned out to be subtly wrong in some cases (see https://github.com/facebook/react/issues/12715).
