### PR TITLE
Add deprecation warning for unstable_renderSubtreeIntoContainer

### DIFF
--- a/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
+++ b/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
@@ -17,6 +17,27 @@ const renderSubtreeIntoContainer = require('react-dom')
   .unstable_renderSubtreeIntoContainer;
 
 describe('renderSubtreeIntoContainer', () => {
+  it('should warn about future deprecation of the API', () => {
+    const portal = document.createElement('div');
+
+    class Parent extends React.Component {
+      render() {
+        return null;
+      }
+
+      componentDidMount() {
+        expect(() =>
+          renderSubtreeIntoContainer(this, <div />, portal),
+        ).toLowPriorityWarnDev(
+          'ReactDOM.unstable_renderSubtreeIntoContainer() has been deprecated, ' +
+            'and will be removed in React 17+. Update your code to use ' +
+            'ReactDOM.createPortal() instead.',
+        );
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(<Parent />);
+  });
   it('should pass context when rendering subtree elsewhere', () => {
     const portal = document.createElement('div');
 

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -73,6 +73,7 @@ let SUPPRESS_HYDRATION_WARNING;
 let topLevelUpdateWarnings;
 let warnOnInvalidCallback;
 let didWarnAboutUnstableCreatePortal = false;
+let didWarnAboutUnstableRenderSubtree = false;
 
 if (__DEV__) {
   SUPPRESS_HYDRATION_WARNING = 'suppressHydrationWarning';
@@ -1181,6 +1182,16 @@ const ReactDOM: Object = {
     containerNode: DOMContainer,
     callback: ?Function,
   ) {
+    if (!didWarnAboutUnstableRenderSubtree) {
+      didWarnAboutUnstableRenderSubtree = true;
+      lowPriorityWarning(
+        false,
+        'ReactDOM.unstable_renderSubtreeIntoContainer() has been deprecated, ' +
+          'and will be removed in React 17+. Update your code to use ' +
+          'ReactDOM.createPortal() instead.',
+      );
+    }
+
     invariant(
       parentComponent != null && ReactInstanceMap.has(parentComponent),
       'parentComponent must be a valid React Component',


### PR DESCRIPTION
PR to kick off the issue over at #10143. 

When should the API itself be removed? I currently specified the 17+ version in the deprecation warning, although I'm not sure if that is in alignment with the actual plan.

