### PR TITLE
[size: tiny] Rename methods exposed by `ReactScheduler`

### DIFF
--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -468,7 +468,7 @@ const ARTRenderer = ReactFiberReconciler({
     return emptyObject;
   },
 
-  scheduleDeferredCallback: ReactScheduler.rIC,
+  scheduleDeferredCallback: ReactScheduler.scheduleSerialCallback,
 
   shouldSetTextContent(type, props) {
     return (

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -984,8 +984,8 @@ const DOMRenderer = ReactFiberReconciler({
     },
   },
 
-  scheduleDeferredCallback: ReactScheduler.rIC,
-  cancelDeferredCallback: ReactScheduler.cIC,
+  scheduleDeferredCallback: ReactScheduler.scheduleSerialCallback,
+  cancelDeferredCallback: ReactScheduler.cancelScheduledCallback,
 });
 
 ReactGenericBatching.injection.injectRenderer(DOMRenderer);

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -41,10 +41,10 @@ describe('ReactScheduler', () => {
     ReactScheduler = require('react-scheduler');
   });
 
-  it('rIC calls the callback within the frame when not blocked', () => {
-    const {rIC} = ReactScheduler;
+  it('scheduleSerialCallback calls the callback within the frame when not blocked', () => {
+    const {scheduleSerialCallback} = ReactScheduler;
     const cb = jest.fn();
-    rIC(cb);
+    scheduleSerialCallback(cb);
     jest.runAllTimers();
     expect(cb.mock.calls.length).toBe(1);
     // should have ... TODO details on what we expect


### PR DESCRIPTION
Going to make incremental PRs with the changes we discussed. This is a quick and easy one to start with.

**what is the change?:**
`rIC` -> `scheduleSerialCallback`
We will later expose a second method called `scheduleDeferredCallback`,
for different priority levels.

`cIC` -> `cancelScheduledCallback`
This method can be used to cancel callbacks scheduled at either serial
or deferred priority.

**why make this change?:**
Originally this module contained a polyfill for `requestIdleCallback`
and `cancelIdleCallback` but we are changing the behavior so it's no
longer just a polyfill. The new names are more semantic and distinguish
this from the original polyfill functionality.

**test plan:**
Ran the tests