### PR TITLE
[schedule 1/n] Support cancelling scheduled callback with an id

### DIFF
--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -89,7 +89,6 @@ if (!ExecutionEnvironment.canUseDOM) {
 
   const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || 9007199254740991;
   let callbackIdCounter = 1;
-  let scheduledCallbackConfig: CallbackConfigType | null = null;
   const getCallbackId = function(): number {
     callbackIdCounter =
       callbackIdCounter >= MAX_SAFE_INTEGER ? 1 : callbackIdCounter + 1;

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -31,6 +31,11 @@
 // The frame rate is dynamically adjusted.
 
 import type {Deadline} from 'react-reconciler';
+type CallbackConfigType = {|
+  scheduledCallback: Deadline => void,
+  timeoutTime: number,
+  callbackId: number, // used for cancelling
+|};
 
 import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 import warning from 'fbjs/lib/warning';
@@ -85,8 +90,9 @@ if (!ExecutionEnvironment.canUseDOM) {
     clearTimeout(timeoutID);
   };
 } else {
-  // Number.MAX_SAFE_INTEGER is not supported in IE
+  let scheduledCallbackConfig: CallbackConfigType | null = null;
 
+  // Number.MAX_SAFE_INTEGER is not supported in IE
   const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || 9007199254740991;
   let callbackIdCounter = 1;
   const getCallbackId = function(): number {
@@ -103,11 +109,7 @@ if (!ExecutionEnvironment.canUseDOM) {
   // This means cancelling is an O(1) time complexity instead of O(n).
   const registeredCallbackIds: {[number]: boolean} = {};
 
-  let latestCallbackId = -1;
-  let scheduledRICCallback = null;
   let isIdleScheduled = false;
-  let timeoutTime = -1;
-
   let isAnimationFrameScheduled = false;
 
   let frameDeadline = 0;
@@ -117,12 +119,26 @@ if (!ExecutionEnvironment.canUseDOM) {
   let previousFrameTime = 33;
   let activeFrameTime = 33;
 
-  const frameDeadlineObject = {
+  const frameDeadlineObject: Deadline = {
     didTimeout: false,
     timeRemaining() {
       const remaining = frameDeadline - now();
       return remaining > 0 ? remaining : 0;
     },
+  };
+
+  const safelyCallScheduledCallback = function(callback, callbackId) {
+    if (!registeredCallbackIds[callbackId]) {
+      // ignore cancelled callbacks
+      return;
+    }
+    try {
+      callback(frameDeadlineObject);
+      // Avoid using 'catch' to keep errors easy to debug
+    } finally {
+      // always clean up the callbackId, even if the callback throws
+      delete registeredCallbackIds[callbackId];
+    }
   };
 
   // We use the postMessage trick to defer idle work until after the repaint.
@@ -135,11 +151,13 @@ if (!ExecutionEnvironment.canUseDOM) {
     if (event.source !== window || event.data !== messageKey) {
       return;
     }
-
-    if (!registeredCallbackIds[latestCallbackId]) {
-      // ignore cancelled callbacks
+    if (scheduledCallbackConfig === null) {
       return;
     }
+
+    const callback = scheduledCallbackConfig.scheduledCallback;
+    const callbackId = scheduledCallbackConfig.callbackId;
+    const timeoutTime = scheduledCallbackConfig.timeoutTime;
 
     isIdleScheduled = false;
 
@@ -166,13 +184,8 @@ if (!ExecutionEnvironment.canUseDOM) {
       frameDeadlineObject.didTimeout = false;
     }
 
-    timeoutTime = -1;
-    const callback = scheduledRICCallback;
-    scheduledRICCallback = null;
-    if (callback !== null) {
-      callback(frameDeadlineObject);
-      delete registeredCallbackIds[latestCallbackId];
-    }
+    scheduledCallbackConfig = null;
+    safelyCallScheduledCallback(callback, callbackId);
   };
   // Assumes that we have addEventListener in this environment. Might need
   // something better for old IE.
@@ -213,14 +226,19 @@ if (!ExecutionEnvironment.canUseDOM) {
     callback: (deadline: Deadline) => void,
     options?: {timeout: number},
   ): number {
-    // This assumes that we only schedule one callback at a time because that's
-    // how Fiber uses it.
-    latestCallbackId = getCallbackId();
-    scheduledRICCallback = callback;
-    registeredCallbackIds[latestCallbackId] = true;
+    let timeoutTime = -1;
     if (options != null && typeof options.timeout === 'number') {
       timeoutTime = now() + options.timeout;
     }
+    // This assumes that we only schedule one callback at a time because that's
+    // how Fiber uses it.
+    const latestCallbackId = getCallbackId();
+    scheduledCallbackConfig = {
+      scheduledCallback: callback,
+      callbackId: latestCallbackId,
+      timeoutTime,
+    };
+    registeredCallbackIds[latestCallbackId] = true;
     if (!isAnimationFrameScheduled) {
       // If rAF didn't already schedule one, we need to schedule a frame.
       // TODO: If this rAF doesn't materialize because the browser throttles, we

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -102,7 +102,7 @@ if (!ExecutionEnvironment.canUseDOM) {
   // unregistered by removing the id from this object.
   // Then we skip calling any callback which is not registered.
   // This means cancelling is an O(1) time complexity instead of O(n).
-  const registeredCallbackIds: { [number]: boolean } = {};
+  const registeredCallbackIds: {[number]: boolean} = {};
 
   let latestCallbackId = -1;
   let scheduledRICCallback = null;

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -66,6 +66,5 @@ describe('ReactScheduler', () => {
     // TODO: this test when one callback cancels another in the queue
   });
 
-
   // TODO: test now
 });

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -52,5 +52,20 @@ describe('ReactScheduler', () => {
     expect(typeof cb.mock.calls[0][0].timeRemaining()).toBe('number');
   });
 
-  // TODO: test cIC and now
+  describe('cIC', () => {
+    it('cancels the scheduled callback', () => {
+      const {rIC, cIC} = ReactScheduler;
+      const cb = jest.fn();
+      const callbackId = rIC(cb);
+      expect(cb.mock.calls.length).toBe(0);
+      cIC(callbackId);
+      jest.runAllTimers();
+      expect(cb.mock.calls.length).toBe(0);
+    });
+
+    // TODO: this test when one callback cancels another in the queue
+  });
+
+
+  // TODO: test now
 });


### PR DESCRIPTION
**what is the change?:**
-> Stores an id for each callback, removes it after callback is cancelled or called.
-> We don't use 'Map' because this library is intended for use outside of React, don't want to add dependency on a polyfill if we can avoid it.
-> We may eventually just use a linked list, but I still like the simplicity of being able to cancel the callback in O(1) time using some kind of key/value storage with the id.
-> Since we have a callback, timeout, and id which are always used together, makes sense to store them in an object. Also once we store multiple callbacks will need to create objects to store these pieces of data for each. If we really want to avoid creating objects, could use arrays with data for a given callback at the same index, or we could use object pooling. Would explore that in a later PR, seems like a premature optimization though.
    
**why make this change?:**
Once we support multiple callbacks you will need to use the id to
specify which callback you mean.

Also storing the callback data in an object sets us up nicely for storing an array of pending callback configs.
    
**test plan:**
Added a new test for `cIC` and ran all tests.