### PR TITLE
Allocate by using `new Array(n)`

### DIFF
--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -206,7 +206,7 @@ export function createElement(type, config, children) {
   if (childrenLength === 1) {
     props.children = children;
   } else if (childrenLength > 1) {
-    const childArray = Array(childrenLength);
+    const childArray = new Array(childrenLength);
     for (let i = 0; i < childrenLength; i++) {
       childArray[i] = arguments[i + 2];
     }
@@ -351,7 +351,7 @@ export function cloneElement(element, config, children) {
   if (childrenLength === 1) {
     props.children = children;
   } else if (childrenLength > 1) {
-    const childArray = Array(childrenLength);
+    const childArray = new Array(childrenLength);
     for (let i = 0; i < childrenLength; i++) {
       childArray[i] = arguments[i + 2];
     }


### PR DESCRIPTION
`Array(n)` is causing deopts in v8 - https://github.com/babel/babel/issues/6233#issuecomment-329055890
