### PR TITLE
Update devEngines

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "yargs": "^6.3.0"
   },
   "devEngines": {
-    "node": "8.x || 9.x"
+    "node": ">=8",
+    "yarn": "^1.2.0"
   },
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"


### PR DESCRIPTION
This pr updated devEngines to satisfy [the prerequisite requirement](https://reactjs.org/docs/how-to-contribute.html#contribution-prerequisites).

Node 10 has been released for a while, it might be the time to include version 10 in devEngines.
Version check for yarn will take effects after https://github.com/facebook/fbjs/pull/288 is merged.