### PR TITLE
Rename Scheduler methods more accurately

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -319,7 +319,7 @@ const ReactARTHostConfig = {
     return emptyObject;
   },
 
-  scheduleDeferredCallback: ReactScheduler.rIC,
+  scheduleDeferredCallback: ReactScheduler.scheduleWork,
 
   shouldSetTextContent(type, props) {
     return (

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -1,4 +1,4 @@
-/**
+**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
  * This source code is licensed under the MIT license found in the

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -1,4 +1,4 @@
-**
+/**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
  * This source code is licensed under the MIT license found in the

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -561,8 +561,8 @@ const ReactDOMHostConfig = {
     },
   },
 
-  scheduleDeferredCallback: ReactScheduler.rIC,
-  cancelDeferredCallback: ReactScheduler.cIC,
+  scheduleDeferredCallback: ReactScheduler.scheduleWork,
+  cancelDeferredCallback: ReactScheduler.cancelScheduledWork,
 };
 
 export default ReactDOMHostConfig;

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -13,7 +13,7 @@
  * A scheduling library to allow scheduling work with more granular priority and
  * control than requestAnimationFrame and requestIdleCallback.
  * Current TODO items:
- * X- Pull out the rIC polyfill built into React
+ * X- Pull out the scheduleCallback polyfill built into React
  * X- Initial test coverage
  * X- Support for multiple callbacks
  * - Support for two priorities; serial and deferred
@@ -68,13 +68,13 @@ if (hasNativePerformanceNow) {
 }
 
 // TODO: There's no way to cancel, because Fiber doesn't atm.
-let rIC: (
+let scheduleCallback: (
   callback: (deadline: Deadline, options?: {timeout: number}) => void,
 ) => number;
-let cIC: (callbackID: number) => void;
+let cancelScheduledCallback: (callbackID: number) => void;
 
 if (!ExecutionEnvironment.canUseDOM) {
-  rIC = function(
+  scheduleCallback = function(
     frameCallback: (deadline: Deadline, options?: {timeout: number}) => void,
   ): number {
     return setTimeout(() => {
@@ -86,12 +86,12 @@ if (!ExecutionEnvironment.canUseDOM) {
       });
     });
   };
-  cIC = function(timeoutID: number) {
+  cancelScheduledCallback = function(timeoutID: number) {
     clearTimeout(timeoutID);
   };
 } else {
   // We keep callbacks in a queue.
-  // Calling rIC will push in a new callback at the end of the queue.
+  // Calling scheduleCallback will push in a new callback at the end of the queue.
   // When we get idle time, callbacks are removed from the front of the queue
   // and called.
   const pendingCallbacks: Array<CallbackConfigType> = [];
@@ -104,7 +104,7 @@ if (!ExecutionEnvironment.canUseDOM) {
 
   // When a callback is scheduled, we register it by adding it's id to this
   // object.
-  // If the user calls 'cIC' with the id of that callback, it will be
+  // If the user calls 'cancelScheduledCallback' with the id of that callback, it will be
   // unregistered by removing the id from this object.
   // Then we skip calling any callback which is not registered.
   // This means cancelling is an O(1) time complexity instead of O(n).
@@ -265,7 +265,7 @@ if (!ExecutionEnvironment.canUseDOM) {
     }
   };
 
-  rIC = function(
+  scheduleCallback = function(
     callback: (deadline: Deadline) => void,
     options?: {timeout: number},
   ): number {
@@ -289,7 +289,7 @@ if (!ExecutionEnvironment.canUseDOM) {
     if (!isAnimationFrameScheduled) {
       // If rAF didn't already schedule one, we need to schedule a frame.
       // TODO: If this rAF doesn't materialize because the browser throttles, we
-      // might want to still have setTimeout trigger rIC as a backup to ensure
+      // might want to still have setTimeout trigger scheduleCallback as a backup to ensure
       // that we keep performing work.
       isAnimationFrameScheduled = true;
       requestAnimationFrame(animationTick);
@@ -297,9 +297,9 @@ if (!ExecutionEnvironment.canUseDOM) {
     return newCallbackId;
   };
 
-  cIC = function(callbackId: number) {
+  cancelScheduledCallback = function(callbackId: number) {
     delete registeredCallbackIds[callbackId];
   };
 }
 
-export {now, rIC, cIC};
+export {now, scheduleCallback, cancelScheduledCallback};

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -13,7 +13,7 @@
  * A scheduling library to allow scheduling work with more granular priority and
  * control than requestAnimationFrame and requestIdleCallback.
  * Current TODO items:
- * X- Pull out the scheduleCallback polyfill built into React
+ * X- Pull out the scheduleWork polyfill built into React
  * X- Initial test coverage
  * X- Support for multiple callbacks
  * - Support for two priorities; serial and deferred
@@ -68,13 +68,13 @@ if (hasNativePerformanceNow) {
 }
 
 // TODO: There's no way to cancel, because Fiber doesn't atm.
-let scheduleCallback: (
+let scheduleWork: (
   callback: (deadline: Deadline, options?: {timeout: number}) => void,
 ) => number;
-let cancelScheduledCallback: (callbackID: number) => void;
+let cancelScheduledWork: (callbackID: number) => void;
 
 if (!ExecutionEnvironment.canUseDOM) {
-  scheduleCallback = function(
+  scheduleWork = function(
     frameCallback: (deadline: Deadline, options?: {timeout: number}) => void,
   ): number {
     return setTimeout(() => {
@@ -86,12 +86,12 @@ if (!ExecutionEnvironment.canUseDOM) {
       });
     });
   };
-  cancelScheduledCallback = function(timeoutID: number) {
+  cancelScheduledWork = function(timeoutID: number) {
     clearTimeout(timeoutID);
   };
 } else {
   // We keep callbacks in a queue.
-  // Calling scheduleCallback will push in a new callback at the end of the queue.
+  // Calling scheduleWork will push in a new callback at the end of the queue.
   // When we get idle time, callbacks are removed from the front of the queue
   // and called.
   const pendingCallbacks: Array<CallbackConfigType> = [];
@@ -104,7 +104,7 @@ if (!ExecutionEnvironment.canUseDOM) {
 
   // When a callback is scheduled, we register it by adding it's id to this
   // object.
-  // If the user calls 'cancelScheduledCallback' with the id of that callback, it will be
+  // If the user calls 'cancelScheduledWork' with the id of that callback, it will be
   // unregistered by removing the id from this object.
   // Then we skip calling any callback which is not registered.
   // This means cancelling is an O(1) time complexity instead of O(n).
@@ -265,7 +265,7 @@ if (!ExecutionEnvironment.canUseDOM) {
     }
   };
 
-  scheduleCallback = function(
+  scheduleWork = function(
     callback: (deadline: Deadline) => void,
     options?: {timeout: number},
   ): number {
@@ -289,7 +289,7 @@ if (!ExecutionEnvironment.canUseDOM) {
     if (!isAnimationFrameScheduled) {
       // If rAF didn't already schedule one, we need to schedule a frame.
       // TODO: If this rAF doesn't materialize because the browser throttles, we
-      // might want to still have setTimeout trigger scheduleCallback as a backup to ensure
+      // might want to still have setTimeout trigger scheduleWork as a backup to ensure
       // that we keep performing work.
       isAnimationFrameScheduled = true;
       requestAnimationFrame(animationTick);
@@ -297,9 +297,9 @@ if (!ExecutionEnvironment.canUseDOM) {
     return newCallbackId;
   };
 
-  cancelScheduledCallback = function(callbackId: number) {
+  cancelScheduledWork = function(callbackId: number) {
     delete registeredCallbackIds[callbackId];
   };
 }
 
-export {now, scheduleCallback, cancelScheduledCallback};
+export {now, scheduleWork, cancelScheduledWork};

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -41,11 +41,11 @@ describe('ReactScheduler', () => {
     ReactScheduler = require('react-scheduler');
   });
 
-  describe('rIC', () => {
+  describe('scheduleCallback', () => {
     it('calls the callback within the frame when not blocked', () => {
-      const {rIC} = ReactScheduler;
+      const {scheduleCallback} = ReactScheduler;
       const cb = jest.fn();
-      rIC(cb);
+      scheduleCallback(cb);
       jest.runAllTimers();
       expect(cb.mock.calls.length).toBe(1);
       // should not have timed out and should include a timeRemaining method
@@ -55,15 +55,15 @@ describe('ReactScheduler', () => {
 
     describe('with multiple callbacks', () => {
       it('accepts multiple callbacks and calls within frame when not blocked', () => {
-        const {rIC} = ReactScheduler;
+        const {scheduleCallback} = ReactScheduler;
         const callbackLog = [];
         const callbackA = jest.fn(() => callbackLog.push('A'));
         const callbackB = jest.fn(() => callbackLog.push('B'));
-        rIC(callbackA);
+        scheduleCallback(callbackA);
         // initially waits to call the callback
         expect(callbackLog).toEqual([]);
         // waits while second callback is passed
-        rIC(callbackB);
+        scheduleCallback(callbackB);
         expect(callbackLog).toEqual([]);
         // after a delay, calls as many callbacks as it has time for
         jest.runAllTimers();
@@ -84,11 +84,11 @@ describe('ReactScheduler', () => {
         'schedules callbacks in correct order and' +
           'keeps calling them if there is time',
         () => {
-          const {rIC} = ReactScheduler;
+          const {scheduleCallback} = ReactScheduler;
           const callbackLog = [];
           const callbackA = jest.fn(() => {
             callbackLog.push('A');
-            rIC(callbackC);
+            scheduleCallback(callbackC);
           });
           const callbackB = jest.fn(() => {
             callbackLog.push('B');
@@ -97,11 +97,11 @@ describe('ReactScheduler', () => {
             callbackLog.push('C');
           });
 
-          rIC(callbackA);
+          scheduleCallback(callbackA);
           // initially waits to call the callback
           expect(callbackLog).toEqual([]);
           // continues waiting while B is scheduled
-          rIC(callbackB);
+          scheduleCallback(callbackB);
           expect(callbackLog).toEqual([]);
           // after a delay, calls the scheduled callbacks,
           // and also calls new callbacks scheduled by current callbacks
@@ -110,18 +110,18 @@ describe('ReactScheduler', () => {
         },
       );
 
-      it('schedules callbacks in correct order when callbacks have many nested rIC calls', () => {
-        const {rIC} = ReactScheduler;
+      it('schedules callbacks in correct order when callbacks have many nested scheduleCallback calls', () => {
+        const {scheduleCallback} = ReactScheduler;
         const callbackLog = [];
         const callbackA = jest.fn(() => {
           callbackLog.push('A');
-          rIC(callbackC);
-          rIC(callbackD);
+          scheduleCallback(callbackC);
+          scheduleCallback(callbackD);
         });
         const callbackB = jest.fn(() => {
           callbackLog.push('B');
-          rIC(callbackE);
-          rIC(callbackF);
+          scheduleCallback(callbackE);
+          scheduleCallback(callbackF);
         });
         const callbackC = jest.fn(() => {
           callbackLog.push('C');
@@ -136,8 +136,8 @@ describe('ReactScheduler', () => {
           callbackLog.push('F');
         });
 
-        rIC(callbackA);
-        rIC(callbackB);
+        scheduleCallback(callbackA);
+        scheduleCallback(callbackB);
         // initially waits to call the callback
         expect(callbackLog).toEqual([]);
         // while flushing callbacks, calls as many as it has time for
@@ -145,23 +145,23 @@ describe('ReactScheduler', () => {
         expect(callbackLog).toEqual(['A', 'B', 'C', 'D', 'E', 'F']);
       });
 
-      it('schedules callbacks in correct order when they use rIC to schedule themselves', () => {
-        const {rIC} = ReactScheduler;
+      it('schedules callbacks in correct order when they use scheduleCallback to schedule themselves', () => {
+        const {scheduleCallback} = ReactScheduler;
         const callbackLog = [];
         let callbackAIterations = 0;
         const callbackA = jest.fn(() => {
           if (callbackAIterations < 1) {
-            rIC(callbackA);
+            scheduleCallback(callbackA);
           }
           callbackLog.push('A' + callbackAIterations);
           callbackAIterations++;
         });
         const callbackB = jest.fn(() => callbackLog.push('B'));
 
-        rIC(callbackA);
+        scheduleCallback(callbackA);
         // initially waits to call the callback
         expect(callbackLog).toEqual([]);
-        rIC(callbackB);
+        scheduleCallback(callbackB);
         expect(callbackLog).toEqual([]);
         // after a delay, calls the latest callback passed
         jest.runAllTimers();
@@ -170,29 +170,29 @@ describe('ReactScheduler', () => {
     });
   });
 
-  describe('cIC', () => {
+  describe('cancelScheduledCallback', () => {
     it('cancels the scheduled callback', () => {
-      const {rIC, cIC} = ReactScheduler;
+      const {scheduleCallback, cancelScheduledCallback} = ReactScheduler;
       const cb = jest.fn();
-      const callbackId = rIC(cb);
+      const callbackId = scheduleCallback(cb);
       expect(cb.mock.calls.length).toBe(0);
-      cIC(callbackId);
+      cancelScheduledCallback(callbackId);
       jest.runAllTimers();
       expect(cb.mock.calls.length).toBe(0);
     });
 
     describe('with multiple callbacks', () => {
       it('when one callback cancels the next one', () => {
-        const {rIC, cIC} = ReactScheduler;
+        const {scheduleCallback, cancelScheduledCallback} = ReactScheduler;
         const callbackLog = [];
         let callbackBId;
         const callbackA = jest.fn(() => {
           callbackLog.push('A');
-          cIC(callbackBId);
+          cancelScheduledCallback(callbackBId);
         });
         const callbackB = jest.fn(() => callbackLog.push('B'));
-        rIC(callbackA);
-        callbackBId = rIC(callbackB);
+        scheduleCallback(callbackA);
+        callbackBId = scheduleCallback(callbackB);
         // Initially doesn't call anything
         expect(callbackLog).toEqual([]);
         jest.runAllTimers();

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -41,11 +41,11 @@ describe('ReactScheduler', () => {
     ReactScheduler = require('react-scheduler');
   });
 
-  describe('scheduleCallback', () => {
+  describe('scheduleWork', () => {
     it('calls the callback within the frame when not blocked', () => {
-      const {scheduleCallback} = ReactScheduler;
+      const {scheduleWork} = ReactScheduler;
       const cb = jest.fn();
-      scheduleCallback(cb);
+      scheduleWork(cb);
       jest.runAllTimers();
       expect(cb.mock.calls.length).toBe(1);
       // should not have timed out and should include a timeRemaining method
@@ -55,15 +55,15 @@ describe('ReactScheduler', () => {
 
     describe('with multiple callbacks', () => {
       it('accepts multiple callbacks and calls within frame when not blocked', () => {
-        const {scheduleCallback} = ReactScheduler;
+        const {scheduleWork} = ReactScheduler;
         const callbackLog = [];
         const callbackA = jest.fn(() => callbackLog.push('A'));
         const callbackB = jest.fn(() => callbackLog.push('B'));
-        scheduleCallback(callbackA);
+        scheduleWork(callbackA);
         // initially waits to call the callback
         expect(callbackLog).toEqual([]);
         // waits while second callback is passed
-        scheduleCallback(callbackB);
+        scheduleWork(callbackB);
         expect(callbackLog).toEqual([]);
         // after a delay, calls as many callbacks as it has time for
         jest.runAllTimers();
@@ -84,11 +84,11 @@ describe('ReactScheduler', () => {
         'schedules callbacks in correct order and' +
           'keeps calling them if there is time',
         () => {
-          const {scheduleCallback} = ReactScheduler;
+          const {scheduleWork} = ReactScheduler;
           const callbackLog = [];
           const callbackA = jest.fn(() => {
             callbackLog.push('A');
-            scheduleCallback(callbackC);
+            scheduleWork(callbackC);
           });
           const callbackB = jest.fn(() => {
             callbackLog.push('B');
@@ -97,11 +97,11 @@ describe('ReactScheduler', () => {
             callbackLog.push('C');
           });
 
-          scheduleCallback(callbackA);
+          scheduleWork(callbackA);
           // initially waits to call the callback
           expect(callbackLog).toEqual([]);
           // continues waiting while B is scheduled
-          scheduleCallback(callbackB);
+          scheduleWork(callbackB);
           expect(callbackLog).toEqual([]);
           // after a delay, calls the scheduled callbacks,
           // and also calls new callbacks scheduled by current callbacks
@@ -110,18 +110,18 @@ describe('ReactScheduler', () => {
         },
       );
 
-      it('schedules callbacks in correct order when callbacks have many nested scheduleCallback calls', () => {
-        const {scheduleCallback} = ReactScheduler;
+      it('schedules callbacks in correct order when callbacks have many nested scheduleWork calls', () => {
+        const {scheduleWork} = ReactScheduler;
         const callbackLog = [];
         const callbackA = jest.fn(() => {
           callbackLog.push('A');
-          scheduleCallback(callbackC);
-          scheduleCallback(callbackD);
+          scheduleWork(callbackC);
+          scheduleWork(callbackD);
         });
         const callbackB = jest.fn(() => {
           callbackLog.push('B');
-          scheduleCallback(callbackE);
-          scheduleCallback(callbackF);
+          scheduleWork(callbackE);
+          scheduleWork(callbackF);
         });
         const callbackC = jest.fn(() => {
           callbackLog.push('C');
@@ -136,8 +136,8 @@ describe('ReactScheduler', () => {
           callbackLog.push('F');
         });
 
-        scheduleCallback(callbackA);
-        scheduleCallback(callbackB);
+        scheduleWork(callbackA);
+        scheduleWork(callbackB);
         // initially waits to call the callback
         expect(callbackLog).toEqual([]);
         // while flushing callbacks, calls as many as it has time for
@@ -145,23 +145,23 @@ describe('ReactScheduler', () => {
         expect(callbackLog).toEqual(['A', 'B', 'C', 'D', 'E', 'F']);
       });
 
-      it('schedules callbacks in correct order when they use scheduleCallback to schedule themselves', () => {
-        const {scheduleCallback} = ReactScheduler;
+      it('schedules callbacks in correct order when they use scheduleWork to schedule themselves', () => {
+        const {scheduleWork} = ReactScheduler;
         const callbackLog = [];
         let callbackAIterations = 0;
         const callbackA = jest.fn(() => {
           if (callbackAIterations < 1) {
-            scheduleCallback(callbackA);
+            scheduleWork(callbackA);
           }
           callbackLog.push('A' + callbackAIterations);
           callbackAIterations++;
         });
         const callbackB = jest.fn(() => callbackLog.push('B'));
 
-        scheduleCallback(callbackA);
+        scheduleWork(callbackA);
         // initially waits to call the callback
         expect(callbackLog).toEqual([]);
-        scheduleCallback(callbackB);
+        scheduleWork(callbackB);
         expect(callbackLog).toEqual([]);
         // after a delay, calls the latest callback passed
         jest.runAllTimers();
@@ -170,29 +170,29 @@ describe('ReactScheduler', () => {
     });
   });
 
-  describe('cancelScheduledCallback', () => {
+  describe('cancelScheduledWork', () => {
     it('cancels the scheduled callback', () => {
-      const {scheduleCallback, cancelScheduledCallback} = ReactScheduler;
+      const {scheduleWork, cancelScheduledWork} = ReactScheduler;
       const cb = jest.fn();
-      const callbackId = scheduleCallback(cb);
+      const callbackId = scheduleWork(cb);
       expect(cb.mock.calls.length).toBe(0);
-      cancelScheduledCallback(callbackId);
+      cancelScheduledWork(callbackId);
       jest.runAllTimers();
       expect(cb.mock.calls.length).toBe(0);
     });
 
     describe('with multiple callbacks', () => {
       it('when one callback cancels the next one', () => {
-        const {scheduleCallback, cancelScheduledCallback} = ReactScheduler;
+        const {scheduleWork, cancelScheduledWork} = ReactScheduler;
         const callbackLog = [];
         let callbackBId;
         const callbackA = jest.fn(() => {
           callbackLog.push('A');
-          cancelScheduledCallback(callbackBId);
+          cancelScheduledWork(callbackBId);
         });
         const callbackB = jest.fn(() => callbackLog.push('B'));
-        scheduleCallback(callbackA);
-        callbackBId = scheduleCallback(callbackB);
+        scheduleWork(callbackA);
+        callbackBId = scheduleWork(callbackB);
         // Initially doesn't call anything
         expect(callbackLog).toEqual([]);
         jest.runAllTimers();


### PR DESCRIPTION
**what is the change?:**
```
rIC -> scheduleCallback
```
We will later expose a second method for different priority level, name
TBD. Since we only have one priority right now we can delay the
bikeshedding about the priority names.

```
cIC -> cancelScheduledCallback
```
This method can be used to cancel callbacks scheduled at any priority
level, and will remain named this way.

why make this change?:
Originally this module contained a polyfill for requestIdleCallback
and cancelIdleCallback but we are changing the behavior so it's no
longer just a polyfill. The new names are more semantic and distinguish
this from the original polyfill functionality.

**test plan:**
Ran the tests

**why make this change?:**
Getting this out of the way so things are more clear.

**Coming Up Next:**
- Switching from a Map of ids and an array to a linked list for storing
callbacks.
- Error handling