### PR TITLE
Add context provider/consumer to getComponentName

### DIFF
--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -12,11 +12,13 @@ import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import {
   REACT_ASYNC_MODE_TYPE,
   REACT_CALL_TYPE,
+  REACT_CONTEXT_TYPE,
   REACT_FORWARD_REF_TYPE,
   REACT_FRAGMENT_TYPE,
-  REACT_RETURN_TYPE,
   REACT_PORTAL_TYPE,
   REACT_PROFILER_TYPE,
+  REACT_PROVIDER_TYPE,
+  REACT_RETURN_TYPE,
   REACT_STRICT_MODE_TYPE,
 } from 'shared/ReactSymbols';
 
@@ -33,12 +35,16 @@ function getComponentName(fiber: Fiber): string | null {
       return 'AsyncMode';
     case REACT_CALL_TYPE:
       return 'ReactCall';
+    case REACT_CONTEXT_TYPE:
+      return 'Context.Consumer';
     case REACT_FRAGMENT_TYPE:
       return 'ReactFragment';
     case REACT_PORTAL_TYPE:
       return 'ReactPortal';
     case REACT_PROFILER_TYPE:
       return `Profiler(${fiber.pendingProps.id})`;
+    case REACT_PROVIDER_TYPE:
+      return 'Context.Provider';
     case REACT_RETURN_TYPE:
       return 'ReactReturn';
     case REACT_STRICT_MODE_TYPE:


### PR DESCRIPTION
RN Inspector uses these.