### PR TITLE
Shallow renderer: pass component instance to setState updater as `this`

### DIFF
--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -298,7 +298,7 @@ class Updater {
     const currentState = this._renderer._newState || publicInstance.state;
 
     if (typeof partialState === 'function') {
-      partialState = partialState(currentState, publicInstance.props);
+      partialState = partialState.call(publicInstance, currentState, publicInstance.props);
     }
 
     // Null and undefined are treated as no-ops.

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -945,6 +945,27 @@ describe('ReactShallowRenderer', () => {
     expect(result.props.children).toEqual(2);
   });
 
+  it('can access component instance from setState updater function', done => {
+    let instance;
+
+    class SimpleComponent extends React.Component {
+      state = {};
+
+      render() {
+        instance = this;
+        return null;
+      }
+    }
+
+    const shallowRenderer = createRenderer();
+    shallowRenderer.render(<SimpleComponent />);
+
+    instance.setState(function updater(state, props) {
+      expect(this).toBe(instance);
+      done();
+    });
+  });
+
   it('can setState with a callback', () => {
     let instance;
 


### PR DESCRIPTION
This makes react-test-renderer behaviour aligned with one of react-reconciler, see
https://github.com/facebook/react/blob/b548b3cd640dbd515f5d67dafc0216bb7ee0d796/packages/react-reconciler/src/ReactUpdateQueue.js#L413

