### PR TITLE
Render charset instead of charSet on SSR

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMMeta-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMMeta-test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+describe('ReactDOMMeta', () => {
+  let React;
+  let ReactDOM;
+  let ReactDOMServer;
+
+  beforeEach(() => {
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMServer = require('react-dom/server');
+  });
+
+  it('should render charSet', () => {
+    const container = document.createElement('head');
+    const node = ReactDOM.render(<meta charSet="utf-8" />, container);
+    expect(node.getAttribute('charset')).toBe('utf-8');
+  });
+
+  it('should render charSet for SSR', () => {
+    const markup = ReactDOMServer.renderToString(<meta charSet="utf-8" />);
+    expect(markup).toBe('<meta charset="utf-8" data-reactroot=""/>');
+  });
+});

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -229,6 +229,7 @@ const properties = {};
 // This is a mapping from React prop names to the attribute names.
 [
   ['acceptCharset', 'accept-charset'],
+  ['charSet', 'charset'],
   ['className', 'class'],
   ['htmlFor', 'for'],
   ['httpEquiv', 'http-equiv'],


### PR DESCRIPTION
## Summary

On SSR, I found the bug that it renders `charSet` attribute on `meta` element:

Expected:
  `"<meta charset=\"utf-8\" data-reactroot=\"\"/>"`

Received:
  `"<meta charSet=\"utf-8\" data-reactroot=\"\"/>"`

So I've fixed it.