### PR TITLE
Mark React Native and Fabric renderers as @generated

### DIFF
--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -129,7 +129,7 @@ ${license}
  * @noflow
  * @providesModule ${globalName}-dev
  * @preventMunge
- * @generated
+ * ${'@gen' + 'erated'}
  */
 
 'use strict';
@@ -149,7 +149,7 @@ ${license}
  * @noflow
  * @providesModule ${globalName}-prod
  * @preventMunge
- * @generated
+ * ${'@gen' + 'erated'}
  */
 
 ${source}`;
@@ -162,7 +162,7 @@ ${license}
  *
  * @noflow
  * @preventMunge
- * @generated
+ * ${'@gen' + 'erated'}
  */
 
 'use strict';
@@ -181,7 +181,7 @@ ${license}
  *
  * @noflow
  * @preventMunge
- * @generated
+ * ${'@gen' + 'erated'}
  */
 
 ${source}`;

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -129,6 +129,7 @@ ${license}
  * @noflow
  * @providesModule ${globalName}-dev
  * @preventMunge
+ * @generated
  */
 
 'use strict';
@@ -148,6 +149,7 @@ ${license}
  * @noflow
  * @providesModule ${globalName}-prod
  * @preventMunge
+ * @generated
  */
 
 ${source}`;
@@ -160,6 +162,7 @@ ${license}
  *
  * @noflow
  * @preventMunge
+ * @generated
  */
 
 'use strict';
@@ -178,6 +181,7 @@ ${license}
  *
  * @noflow
  * @preventMunge
+ * @generated
  */
 
 ${source}`;


### PR DESCRIPTION
The generated RN and fabric renderers were interfering with internal quality metrics that track the usage of `var` (vs `let`/`const`). Marking the renderer as `@generated` is more accurate anyway, and blacklists it for these metrics.

I could only do this for the `RN_FB_*` bundle, but I added it to the OSS ones as well. Thoughts?