### PR TITLE
Do not fire getDerivedStateFromProps unless props or state have changed

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -802,16 +802,6 @@ export default function(
       );
       newState = workInProgress.memoizedState;
     }
-
-    if (typeof getDerivedStateFromProps === 'function') {
-      applyDerivedStateFromProps(
-        workInProgress,
-        getDerivedStateFromProps,
-        newProps,
-      );
-      newState = workInProgress.memoizedState;
-    }
-
     if (
       oldProps === newProps &&
       oldState === newState &&
@@ -827,6 +817,15 @@ export default function(
         workInProgress.effectTag |= Update;
       }
       return false;
+    }
+
+    if (typeof getDerivedStateFromProps === 'function') {
+      applyDerivedStateFromProps(
+        workInProgress,
+        getDerivedStateFromProps,
+        newProps,
+      );
+      newState = workInProgress.memoizedState;
     }
 
     const shouldUpdate = checkShouldComponentUpdate(
@@ -937,17 +936,6 @@ export default function(
       newState = workInProgress.memoizedState;
     }
 
-    if (typeof getDerivedStateFromProps === 'function') {
-      if (fireGetDerivedStateFromPropsOnStateUpdates || oldProps !== newProps) {
-        applyDerivedStateFromProps(
-          workInProgress,
-          getDerivedStateFromProps,
-          newProps,
-        );
-        newState = workInProgress.memoizedState;
-      }
-    }
-
     if (
       oldProps === newProps &&
       oldState === newState &&
@@ -976,6 +964,17 @@ export default function(
         }
       }
       return false;
+    }
+
+    if (typeof getDerivedStateFromProps === 'function') {
+      if (fireGetDerivedStateFromPropsOnStateUpdates || oldProps !== newProps) {
+        applyDerivedStateFromProps(
+          workInProgress,
+          getDerivedStateFromProps,
+          newProps,
+        );
+        newState = workInProgress.memoizedState;
+      }
     }
 
     const shouldUpdate = checkShouldComponentUpdate(


### PR DESCRIPTION
Fixes an oversight from #12600. getDerivedStateFromProps should fire if either props *or* state have changed, but not if *neither* have changed. This prevents a parent from re-rendering if a deep child receives an update.