### PR TITLE
Fix Type for ReactNative.NativeComponent

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -4,9 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @format
  * @flow
- * @providesModule ReactNativeTypes
  */
+
+import React from 'react';
 
 export type MeasureOnSuccessCallback = (
   x: number,
@@ -53,6 +55,22 @@ export type ReactNativeBaseComponentViewConfig = {
 export type ViewConfigGetter = () => ReactNativeBaseComponentViewConfig;
 
 /**
+ * Class only exists for its Flow type.
+ */
+class ReactNativeComponent<Props> extends React.Component<Props> {
+  blur(): void {}
+  focus(): void {}
+  measure(callback: MeasureOnSuccessCallback): void {}
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void {}
+  measureLayout(
+    relativeToNativeNode: number,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void,
+  ): void {}
+  setNativeProps(nativeProps: Object): void {}
+}
+
+/**
  * This type keeps ReactNativeFiberHostComponent and NativeMethodsMixin in sync.
  * It can also provide types for ReactNative applications that use NMM or refs.
  */
@@ -87,7 +105,7 @@ type SecretInternalsFabricType = {
  * Provide minimal Flow typing for the high-level RN API and call it a day.
  */
 export type ReactNativeType = {
-  NativeComponent: any,
+  NativeComponent: typeof ReactNativeComponent,
   findNodeHandle(componentOrHandle: any): ?number,
   render(
     element: React$Element<any>,
@@ -102,7 +120,7 @@ export type ReactNativeType = {
 };
 
 export type ReactFabricType = {
-  NativeComponent: any,
+  NativeComponent: typeof ReactNativeComponent,
   findNodeHandle(componentOrHandle: any): ?number,
   render(
     element: React$Element<any>,

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule ReactTypes
  */
 
 export type ReactNode =

--- a/scripts/circleci/check_modules.sh
+++ b/scripts/circleci/check_modules.sh
@@ -3,9 +3,7 @@
 set -e
 
 # Make sure we don't introduce accidental @providesModule annotations.
-EXPECTED='packages/react-native-renderer/src/ReactNativeTypes.js
-packages/shared/ReactTypes.js
-scripts/rollup/wrappers.js'
+EXPECTED='scripts/rollup/wrappers.js'
 ACTUAL=$(git grep -l @providesModule -- './*.js' ':!scripts/rollup/shims/*.js')
 
 # Colors


### PR DESCRIPTION
Fixes the Flow type for `ReactNative.NativeComponent`.

This makes it so that `View`, `Text`, and a few other components are properly typed.