### PR TITLE
Update headers for React Native shims

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -89,7 +89,9 @@ export type NativeMethodsMixinType = {
 
 type SecretInternalsType = {
   NativeMethodsMixin: NativeMethodsMixinType,
+  ReactDebugTool?: any,
   ReactNativeComponentTree: any,
+  ReactPerf?: any,
   computeComponentStackForErrorReporting(tag: number): string,
   // TODO (bvaughn) Decide which additional types to expose here?
   // And how much information to fill in for the above types.

--- a/scripts/rollup/shims/react-native-fb/ReactFeatureFlags.js
+++ b/scripts/rollup/shims/react-native-fb/ReactFeatureFlags.js
@@ -4,7 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule ReactFeatureFlags
+ * @format
+ * @flow
  */
 
 'use strict';

--- a/scripts/rollup/shims/react-native/NativeMethodsMixin.js
+++ b/scripts/rollup/shims/react-native/NativeMethodsMixin.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule NativeMethodsMixin
+ * @format
  * @flow
  */
 

--- a/scripts/rollup/shims/react-native/ReactDebugTool.js
+++ b/scripts/rollup/shims/react-native/ReactDebugTool.js
@@ -4,7 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule ReactDebugTool
+ * @format
+ * @flow
  */
 
 'use strict';

--- a/scripts/rollup/shims/react-native/ReactFabric.js
+++ b/scripts/rollup/shims/react-native/ReactFabric.js
@@ -4,9 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule ReactFabric
+ * @format
  * @flow
  */
+
 'use strict';
 
 const BatchedBridge = require('BatchedBridge');

--- a/scripts/rollup/shims/react-native/ReactNative.js
+++ b/scripts/rollup/shims/react-native/ReactNative.js
@@ -4,9 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule ReactNative
+ * @format
  * @flow
  */
+
 'use strict';
 
 import type {ReactNativeType} from 'ReactNativeTypes';

--- a/scripts/rollup/shims/react-native/ReactNativeComponentTree.js
+++ b/scripts/rollup/shims/react-native/ReactNativeComponentTree.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule ReactNativeComponentTree
+ * @format
  * @flow
  */
 

--- a/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
+++ b/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
@@ -4,9 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule ReactNativeViewConfigRegistry
+ * @format
  * @flow
  */
+
 'use strict';
 
 import type {

--- a/scripts/rollup/shims/react-native/ReactPerf.js
+++ b/scripts/rollup/shims/react-native/ReactPerf.js
@@ -4,7 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule ReactPerf
+ * @format
+ * @flow
  */
 
 'use strict';

--- a/scripts/rollup/shims/react-native/createReactNativeComponentClass.js
+++ b/scripts/rollup/shims/react-native/createReactNativeComponentClass.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule createReactNativeComponentClass
+ * @format
  * @flow
  */
 


### PR DESCRIPTION
Adds `@flow` and `@format` to all of the shims sync'd to React Native. Also, removes `@providesModule`.

**Test Plan:**

Ran `yarn linc` and `yarn flow`.
Applied these changes to React Native and verified Flow checks successfully.