### PR TITLE
Use global state for `hasForceUpdate` instead of persisting to queue

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -33,6 +33,7 @@ import {
   enqueueUpdate,
   processUpdateQueue,
   checkHasForceUpdateAfterProcessing,
+  resetHasForceUpdateBeforeProcessing,
   createUpdate,
   ReplaceState,
   ForceUpdate,
@@ -782,10 +783,11 @@ export default function(
       }
     }
 
+    resetHasForceUpdateBeforeProcessing();
+
     const oldState = workInProgress.memoizedState;
     let newState = (instance.state = oldState);
     let updateQueue = workInProgress.updateQueue;
-    let hasForceUpdate = false;
     if (updateQueue !== null) {
       processUpdateQueue(
         workInProgress,
@@ -794,14 +796,13 @@ export default function(
         instance,
         renderExpirationTime,
       );
-      hasForceUpdate = hasForceUpdate || checkHasForceUpdateAfterProcessing();
       newState = workInProgress.memoizedState;
     }
     if (
       oldProps === newProps &&
       oldState === newState &&
       !hasContextChanged() &&
-      !hasForceUpdate
+      !checkHasForceUpdateAfterProcessing()
     ) {
       // If an update was already in progress, we should schedule an Update
       // effect even though we're bailing out, so that cWU/cDU are called.
@@ -821,7 +822,7 @@ export default function(
     }
 
     const shouldUpdate =
-      hasForceUpdate ||
+      checkHasForceUpdateAfterProcessing() ||
       checkShouldComponentUpdate(
         workInProgress,
         oldProps,
@@ -916,10 +917,11 @@ export default function(
       }
     }
 
+    resetHasForceUpdateBeforeProcessing();
+
     const oldState = workInProgress.memoizedState;
     let newState = (instance.state = oldState);
     let updateQueue = workInProgress.updateQueue;
-    let hasForceUpdate = false;
     if (updateQueue !== null) {
       processUpdateQueue(
         workInProgress,
@@ -928,7 +930,6 @@ export default function(
         instance,
         renderExpirationTime,
       );
-      hasForceUpdate = hasForceUpdate || checkHasForceUpdateAfterProcessing();
       newState = workInProgress.memoizedState;
     }
 
@@ -936,7 +937,7 @@ export default function(
       oldProps === newProps &&
       oldState === newState &&
       !hasContextChanged() &&
-      !hasForceUpdate
+      !checkHasForceUpdateAfterProcessing()
     ) {
       // If an update was already in progress, we should schedule an Update
       // effect even though we're bailing out, so that cWU/cDU are called.
@@ -971,7 +972,7 @@ export default function(
     }
 
     const shouldUpdate =
-      hasForceUpdate ||
+      checkHasForceUpdateAfterProcessing() ||
       checkShouldComponentUpdate(
         workInProgress,
         oldProps,

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -596,6 +596,10 @@ function callCallback(callback, context) {
   callback.call(context);
 }
 
+export function resetHasForceUpdateBeforeProcessing() {
+  hasForceUpdate = false;
+}
+
 export function checkHasForceUpdateAfterProcessing(): boolean {
   return hasForceUpdate;
 }

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -138,7 +138,10 @@ export const ReplaceState = 1;
 export const ForceUpdate = 2;
 export const CaptureUpdate = 3;
 
-let _hasForceUpdate = false;
+// Global state that is reset at the beginning of calling `processUpdateQueue`.
+// It should only be read right after calling `processUpdateQueue`, via
+// `checkHasForceUpdateAfterProcessing`.
+let hasForceUpdate = false;
 
 let didWarnUpdateInsideUpdate;
 let currentlyProcessingQueue;
@@ -419,7 +422,7 @@ function getStateFromUpdate<State>(
       return Object.assign({}, prevState, partialState);
     }
     case ForceUpdate: {
-      _hasForceUpdate = true;
+      hasForceUpdate = true;
       return prevState;
     }
   }
@@ -433,7 +436,7 @@ export function processUpdateQueue<State>(
   instance: any,
   renderExpirationTime: ExpirationTime,
 ): void {
-  _hasForceUpdate = false;
+  hasForceUpdate = false;
 
   if (
     queue.expirationTime === NoWork ||
@@ -594,7 +597,7 @@ function callCallback(callback, context) {
 }
 
 export function checkHasForceUpdateAfterProcessing(): boolean {
-  return _hasForceUpdate;
+  return hasForceUpdate;
 }
 
 export function commitUpdateQueue<State>(

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -1115,6 +1115,29 @@ describe('ReactIncremental', () => {
     expect(ops).toEqual(['Foo', 'Bar', 'Baz', 'Bar', 'Baz']);
   });
 
+  it('should clear forceUpdate after update is flushed', () => {
+    let a = 0;
+
+    class Foo extends React.PureComponent {
+      render() {
+        const msg = `A: ${a}, B: ${this.props.b}`;
+        ReactNoop.yield(msg);
+        return msg;
+      }
+    }
+
+    const foo = React.createRef(null);
+    ReactNoop.render(<Foo ref={foo} b={0} />);
+    expect(ReactNoop.flush()).toEqual(['A: 0, B: 0']);
+
+    a = 1;
+    foo.current.forceUpdate();
+    expect(ReactNoop.flush()).toEqual(['A: 1, B: 0']);
+
+    ReactNoop.render(<Foo ref={foo} b={0} />);
+    expect(ReactNoop.flush()).toEqual([]);
+  });
+
   xit('can call sCU while resuming a partly mounted component', () => {
     let ops = [];
 


### PR DESCRIPTION
Fixes a bug where `hasForceUpdate` was not reset on commit.

Ideally we'd use a tuple and return `hasForceUpdate` from `processUpdateQueue`.