### PR TITLE
Skip special nodes when reading TestInstance.parent

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -245,10 +245,14 @@ class ReactTestInstance {
   }
 
   get parent(): ?ReactTestInstance {
-    const parent = this._fiber.return;
-    return parent === null || parent.tag === HostRoot
-      ? null
-      : wrapFiber(parent);
+    let parent = this._fiber.return;
+    while (parent !== null) {
+      if (validWrapperTypes.has(parent.tag)) {
+        return wrapFiber(parent);
+      }
+      parent = parent.return;
+    }
+    return null;
   }
 
   get children(): Array<ReactTestInstance | string> {
@@ -262,30 +266,12 @@ class ReactTestInstance {
     node = node.child;
     outer: while (true) {
       let descend = false;
-      switch (node.tag) {
-        case FunctionalComponent:
-        case ClassComponent:
-        case HostComponent:
-        case ForwardRef:
-          children.push(wrapFiber(node));
-          break;
-        case HostText:
-          children.push('' + node.memoizedProps);
-          break;
-        case Fragment:
-        case ContextProvider:
-        case ContextConsumer:
-        case Mode:
-        case Profiler:
-          descend = true;
-          break;
-        default:
-          invariant(
-            false,
-            'Unsupported component type %s in test renderer. ' +
-              'This is probably a bug in React.',
-            node.tag,
-          );
+      if (validWrapperTypes.has(node.tag)) {
+        children.push(wrapFiber(node));
+      } else if (node.tag === HostText) {
+        children.push('' + node.memoizedProps);
+      } else {
+        descend = true;
       }
       if (descend && node.child !== null) {
         node.child.return = node;


### PR DESCRIPTION
Fixes `Unexpected object passed to ReactTestInstance constructor (tag: 10)` when reading `.parent` of test instances whose parents are fragments. We currently skip fragments and similar nodes when reading children, so I made the `parent` getter also skip over them.

I got rid of the `switch` because we already have a whitelist of node types that we want to materialize. I’m just reusing that now so we don’t have to remember to keep this logic in sync.

Added some test coverage.