### PR TITLE
Only measure "base" times within ProfileMode

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -71,7 +71,7 @@ import {
 } from './ReactChildFiber';
 import {processUpdateQueue} from './ReactUpdateQueue';
 import {NoWork, Never} from './ReactFiberExpirationTime';
-import {AsyncMode, ProfileMode, StrictMode} from './ReactTypeOfMode';
+import {AsyncMode, StrictMode} from './ReactTypeOfMode';
 import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
 
 const {getCurrentFiberStackAddendum} = ReactDebugCurrentFiber;
@@ -396,9 +396,7 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       nextChildren = null;
 
       if (enableProfilerTimer) {
-        if (workInProgress.mode & ProfileMode) {
-          stopBaseRenderTimerIfRunning();
-        }
+        stopBaseRenderTimerIfRunning();
       }
     } else {
       if (__DEV__) {
@@ -1155,10 +1153,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     cancelWorkTimer(workInProgress);
 
     if (enableProfilerTimer) {
-      if (workInProgress.mode & ProfileMode) {
-        // Don't update "base" render times for bailouts.
-        stopBaseRenderTimerIfRunning();
-      }
+      // Don't update "base" render times for bailouts.
+      stopBaseRenderTimerIfRunning();
     }
 
     // TODO: We should ideally be able to bail out early if the children have no
@@ -1183,10 +1179,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     cancelWorkTimer(workInProgress);
 
     if (enableProfilerTimer) {
-      if (workInProgress.mode & ProfileMode) {
-        // Don't update "base" render times for bailouts.
-        stopBaseRenderTimerIfRunning();
-      }
+      // Don't update "base" render times for bailouts.
+      stopBaseRenderTimerIfRunning();
     }
 
     // TODO: Handle HostComponent tags here as well and call pushHostContext()?

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -71,7 +71,7 @@ import {
 } from './ReactChildFiber';
 import {processUpdateQueue} from './ReactUpdateQueue';
 import {NoWork, Never} from './ReactFiberExpirationTime';
-import {AsyncMode, StrictMode} from './ReactTypeOfMode';
+import {AsyncMode, ProfileMode, StrictMode} from './ReactTypeOfMode';
 import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
 
 const {getCurrentFiberStackAddendum} = ReactDebugCurrentFiber;
@@ -396,7 +396,9 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       nextChildren = null;
 
       if (enableProfilerTimer) {
-        stopBaseRenderTimerIfRunning();
+        if (workInProgress.mode & ProfileMode) {
+          stopBaseRenderTimerIfRunning();
+        }
       }
     } else {
       if (__DEV__) {
@@ -1153,8 +1155,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     cancelWorkTimer(workInProgress);
 
     if (enableProfilerTimer) {
-      // Don't update "base" render times for bailouts.
-      stopBaseRenderTimerIfRunning();
+      if (workInProgress.mode & ProfileMode) {
+        // Don't update "base" render times for bailouts.
+        stopBaseRenderTimerIfRunning();
+      }
     }
 
     // TODO: We should ideally be able to bail out early if the children have no
@@ -1179,8 +1183,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
     cancelWorkTimer(workInProgress);
 
     if (enableProfilerTimer) {
-      // Don't update "base" render times for bailouts.
-      stopBaseRenderTimerIfRunning();
+      if (workInProgress.mode & ProfileMode) {
+        // Don't update "base" render times for bailouts.
+        stopBaseRenderTimerIfRunning();
+      }
     }
 
     // TODO: Handle HostComponent tags here as well and call pushHostContext()?

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -962,12 +962,17 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
 
     let next;
     if (enableProfilerTimer) {
-      startBaseRenderTimer();
+      if (workInProgress.mode & ProfileMode) {
+        startBaseRenderTimer();
+      }
+
       next = beginWork(current, workInProgress, nextRenderExpirationTime);
 
-      // Update "base" time if the render wasn't bailed out on.
-      recordElapsedBaseRenderTimeIfRunning(workInProgress);
-      stopBaseRenderTimerIfRunning();
+      if (workInProgress.mode & ProfileMode) {
+        // Update "base" time if the render wasn't bailed out on.
+        recordElapsedBaseRenderTimeIfRunning(workInProgress);
+        stopBaseRenderTimerIfRunning();
+      }
     } else {
       next = beginWork(current, workInProgress, nextRenderExpirationTime);
     }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -353,8 +353,10 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         clearCaughtError();
 
         if (enableProfilerTimer) {
-          // Stop "base" render timer again (after the re-thrown error).
-          stopBaseRenderTimerIfRunning();
+          if (failedUnitOfWork.mode & ProfileMode) {
+            // Stop "base" render timer again (after the re-thrown error).
+            stopBaseRenderTimerIfRunning();
+          }
         }
       } else {
         // If the begin phase did not fail the second time, set this pointer
@@ -1064,16 +1066,18 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       try {
         workLoop(isAsync);
       } catch (thrownValue) {
-        if (enableProfilerTimer) {
-          // Stop "base" render timer in the event of an error.
-          stopBaseRenderTimerIfRunning();
-        }
-
         if (nextUnitOfWork === null) {
           // This is a fatal error.
           didFatal = true;
           onUncaughtError(thrownValue);
           break;
+        } else {
+          if (enableProfilerTimer) {
+            if (nextUnitOfWork.mode & ProfileMode) {
+              // Stop "base" render timer in the event of an error.
+              stopBaseRenderTimerIfRunning();
+            }
+          }
         }
 
         if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -353,10 +353,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
         clearCaughtError();
 
         if (enableProfilerTimer) {
-          if (failedUnitOfWork.mode & ProfileMode) {
-            // Stop "base" render timer again (after the re-thrown error).
-            stopBaseRenderTimerIfRunning();
-          }
+          // Stop "base" render timer again (after the re-thrown error).
+          stopBaseRenderTimerIfRunning();
         }
       } else {
         // If the begin phase did not fail the second time, set this pointer
@@ -1066,18 +1064,16 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       try {
         workLoop(isAsync);
       } catch (thrownValue) {
+        if (enableProfilerTimer) {
+          // Stop "base" render timer in the event of an error.
+          stopBaseRenderTimerIfRunning();
+        }
+
         if (nextUnitOfWork === null) {
           // This is a fatal error.
           didFatal = true;
           onUncaughtError(thrownValue);
           break;
-        } else {
-          if (enableProfilerTimer) {
-            if (nextUnitOfWork.mode & ProfileMode) {
-              // Stop "base" render timer in the event of an error.
-              stopBaseRenderTimerIfRunning();
-            }
-          }
         }
 
         if (__DEV__) {


### PR DESCRIPTION
Follow up for [this comment](https://github.com/facebook/react/pull/12745/files#r186276940) on PR #12745. Previously I was tracking base time for all fibers, regardless of whether they were inside of a `Profiler`, because the place where I started the timer didn't yet know if it was in a `ProfileMode`.

I could move where I start/stop the timer somewhere else- where it would know- but this approach seemed simpler. It has a small potential downside of not measuring "base" time for the `Profiler` component itself- but I think this is okay because (1) that time should be minimal and (2) it isn't really actionable for a developer.

### Questions
* ~~Should I remove the conditionals around `stopBaseRenderTimerIfRunning`? (Is it worth having them?)~~

### Caveats
* We pause/resume the global render timer even outside of a `ProfileMode` tree. This only updates a single numeric value though; it doesn't modify any attributes on a fiber.