### PR TITLE
Enable Profiler timing for DOM and RN dev bundles

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -115,6 +115,7 @@ describe('ReactDebugFiberPerf', () => {
     global.performance = createUserTimingPolyfill();
 
     require('shared/ReactFeatureFlags').enableUserTimingAPI = true;
+    require('shared/ReactFeatureFlags').enableProfilerTimer = false;
     require('shared/ReactFeatureFlags').replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 
     // Import after the polyfill is set up:

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -40,7 +40,7 @@ export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = false;
 
 // Gather advanced timing metrics for Profiler subtrees.
-export const enableProfilerTimer = false;
+export const enableProfilerTimer = __DEV__;
 
 // Fires getDerivedStateFromProps for state *or* props changes
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -22,7 +22,7 @@ export const enablePersistentReconciler = false;
 export const enableUserTimingAPI = __DEV__;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = false;
-export const enableProfilerTimer = false;
+export const enableProfilerTimer = __DEV__;
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.


### PR DESCRIPTION
Enabling timing for DEV mode only so people can experiment with it in 16.4.

We'll add a profiling production mode bundle in the future.