### PR TITLE
Fix ambiguity in doc comment for isValidElement

### DIFF
--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -365,7 +365,7 @@ export function cloneElement(element, config, children) {
  * Verifies the object is a ReactElement.
  * See https://reactjs.org/docs/react-api.html#isvalidelement
  * @param {?object} object
- * @return {boolean} True if `object` is a valid component.
+ * @return {boolean} True if `object` is a ReactElement.
  * @final
  */
 export function isValidElement(object) {


### PR DESCRIPTION
`isValidElement(object)` checks if object is a ReactElement.

`@return {boolean} True if object is a valid component` is leading to confusion which was described in several blog posts:
- https://reactjs.org/blog/2015/12/18/react-components-elements-and-instances.html
- https://medium.com/@fay_jai/react-elements-vs-react-components-vs-component-backing-instances-14d42729f62