### PR TITLE
Don't try to read child nodes of Text when hydrating

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -248,7 +248,8 @@ export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
       );
     }
     hydrationParentFiber = fiber;
-    nextHydratableInstance = getFirstHydratableChild(nextInstance);
+    nextHydratableInstance =
+      fiber.tag !== HostText ? getFirstHydratableChild(nextInstance) : null;
   }
 
   function prepareToHydrateHostInstance(


### PR DESCRIPTION
Text nodes can't have children. Flow didn't catch this for some reason, but it does in my WIP branch where I run Flow with more specific types.

This doesn't really change the behavior except getting rid of an unnecessary function call and a read from a DOM node. The issue is unobservable but it breaks typing in my future PR.

You can verify this used to happen in old code by applying

```diff
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -419,6 +419,10 @@ const ReactDOMHostConfig = {
     getFirstHydratableChild(
       parentInstance: Container | Instance,
     ): null | Instance | TextInstance {
+      if (parentInstance instanceof Text) {
+        throw new Error('nooo')
+      }
+
```

and running `yarn test`. With this change, it doesn't happen anymore.