### PR TITLE
Quick fix for grabbing wrong rAF polyfill in ReactScheduler

### DIFF
--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -38,21 +38,9 @@ type CallbackConfigType = {|
   callbackId: number, // used for cancelling
 |};
 
-import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
-import warning from 'fbjs/lib/warning';
 
-if (__DEV__) {
-  if (
-    ExecutionEnvironment.canUseDOM &&
-    typeof requestAnimationFrame !== 'function'
-  ) {
-    warning(
-      false,
-      'React depends on requestAnimationFrame. Make sure that you load a ' +
-        'polyfill in older browsers. https://fb.me/react-polyfills',
-    );
-  }
-}
+import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
+import requestAnimationFrameForReact from 'shared/requestAnimationFrameForReact';
 
 const hasNativePerformanceNow =
   typeof performance === 'object' && typeof performance.now === 'function';
@@ -232,7 +220,7 @@ if (!ExecutionEnvironment.canUseDOM) {
       if (!isAnimationFrameScheduled) {
         // Schedule another animation callback so we retry later.
         isAnimationFrameScheduled = true;
-        requestAnimationFrame(animationTick);
+        requestAnimationFrameForReact(animationTick);
       }
     }
   };
@@ -298,7 +286,7 @@ if (!ExecutionEnvironment.canUseDOM) {
       // might want to still have setTimeout trigger scheduleWork as a backup to ensure
       // that we keep performing work.
       isAnimationFrameScheduled = true;
-      requestAnimationFrame(animationTick);
+      requestAnimationFrameForReact(animationTick);
     }
     return newCallbackId;
   };

--- a/packages/shared/forks/requestAnimationFrameForReact.www.js
+++ b/packages/shared/forks/requestAnimationFrameForReact.www.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 'use strict';

--- a/packages/shared/forks/requestAnimationFrameForReact.www.js
+++ b/packages/shared/forks/requestAnimationFrameForReact.www.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+export default require('requestAnimationFrameForReact');

--- a/packages/shared/requestAnimationFrameForReact.js
+++ b/packages/shared/requestAnimationFrameForReact.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
+import warning from 'fbjs/lib/warning';
+
+if (__DEV__) {
+  if (
+    ExecutionEnvironment.canUseDOM &&
+    typeof requestAnimationFrame !== 'function'
+  ) {
+    warning(
+      false,
+      'React depends on requestAnimationFrame. Make sure that you load a ' +
+        'polyfill in older browsers. https://fb.me/react-polyfills',
+    );
+  }
+}
+
+export default requestAnimationFrame;

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -74,6 +74,17 @@ const forks = Object.freeze({
     return null;
   },
 
+  // This logic is forked on www to use the 'acrossTransitions' version.
+  'shared/requestAnimationFrameForReact': (bundleType, entry) => {
+    switch (bundleType) {
+      case FB_WWW_DEV:
+      case FB_WWW_PROD:
+        return 'shared/forks/requestAnimationFrameForReact.www.js';
+      default:
+        return null;
+    }
+  },
+
   // This logic is forked on www to blacklist warnings.
   'shared/lowPriorityWarning': (bundleType, entry) => {
     switch (bundleType) {


### PR DESCRIPTION
**what is the change?:**
We need to grab a slightly different implementation of rAF internally at
FB than in Open Source. Making rAF a dependency of the ReactScheduler
module allows us to fork the dependency at FB.

**why make this change?:**
This fixes a problem we're running into when experimenting with
ReactScheduler internally at Facebook, **and* it's part of our long term
plan to use dependency injection with the scheduler to make it easier to
test and adjust.

**test plan:**
Ran tests, lint, flow, and will manually test when syncing into
Facebook's codebase.

**issue:**
See internal task T29442940