### PR TITLE
Remove Timeout export on React object unless enableSuspense flag

### DIFF
--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -55,7 +55,6 @@ const React = {
   StrictMode: REACT_STRICT_MODE_TYPE,
   unstable_AsyncMode: REACT_ASYNC_MODE_TYPE,
   unstable_Profiler: REACT_PROFILER_TYPE,
-  Timeout: REACT_TIMEOUT_TYPE,
 
   createElement: __DEV__ ? createElementWithValidation : createElement,
   cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,


### PR DESCRIPTION
`React` includes the `Timeout` component type if the `enableSuspense` feature flag is on:
```js
if (enableSuspense) {
  React.Timeout = REACT_TIMEOUT_TYPE;
}
```

But it also unconditionally includes it a few lines above:
```js
{
  // ...
  Timeout: REACT_TIMEOUT_TYPE,
  // ...
}
```

One of these is a mistake? I'm guessing it's the one I deleted.