### PR TITLE
Quick fix for minor typo in ReactScheduler

### DIFF
--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -209,11 +209,11 @@ if (!ExecutionEnvironment.canUseDOM) {
     if (event.source !== window || event.data !== messageKey) {
       return;
     }
+    isIdleScheduled = false;
 
     if (pendingCallbacks.length === 0) {
       return;
     }
-    isIdleScheduled = false;
 
     // First call anything which has timed out, until we have caught up.
     callTimedOutCallbacks();


### PR DESCRIPTION
**what is the change?:**
We were setting a flag after some early returns, should have set it
right away.

To be fair, it's not clear how you can hit a problem with the current
state of things. Even if a callback is cancelled, it's still in the
'pendingCallbacks' queue until the rAF runs, and we only schedule a rAF
when there are pendingCallbacks in the queue.

But since this is obviously wrong, going to fix it.

We will be adding a regression test in a follow-up PR.

**why make this change?:**
To fix a random bug which was popping up.

**test plan:**
Adding a regression unit test in a follow-up PR.