### PR TITLE
Relax current renderer warning

### DIFF
--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -45,6 +45,7 @@ export default function(stack: Stack, isPrimaryRenderer: boolean) {
       context._changedBits = providerFiber.stateNode;
       if (__DEV__) {
         warning(
+          context._currentRenderer === undefined ||
           context._currentRenderer === null ||
             context._currentRenderer === rendererSigil,
           'Detected multiple renderers concurrently rendering the ' +
@@ -61,6 +62,7 @@ export default function(stack: Stack, isPrimaryRenderer: boolean) {
       context._changedBits2 = providerFiber.stateNode;
       if (__DEV__) {
         warning(
+          context._currentRenderer2 === undefined ||
           context._currentRenderer2 === null ||
             context._currentRenderer2 === rendererSigil,
           'Detected multiple renderers concurrently rendering the ' +

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -46,7 +46,7 @@ export default function(stack: Stack, isPrimaryRenderer: boolean) {
       if (__DEV__) {
         warning(
           context._currentRenderer === undefined ||
-          context._currentRenderer === null ||
+            context._currentRenderer === null ||
             context._currentRenderer === rendererSigil,
           'Detected multiple renderers concurrently rendering the ' +
             'same context provider. This is currently unsupported.',
@@ -63,7 +63,7 @@ export default function(stack: Stack, isPrimaryRenderer: boolean) {
       if (__DEV__) {
         warning(
           context._currentRenderer2 === undefined ||
-          context._currentRenderer2 === null ||
+            context._currentRenderer2 === null ||
             context._currentRenderer2 === rendererSigil,
           'Detected multiple renderers concurrently rendering the ' +
             'same context provider. This is currently unsupported.',


### PR DESCRIPTION
If you use an older version of `react` this won't get initialized to null. We don't really need it to be initialized to work.
