### PR TITLE
getPeerGlobals should check bundleType instead of moduleType

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -352,10 +352,7 @@ async function createBundle(bundle, bundleType) {
 
   const shouldBundleDependencies =
     bundleType === UMD_DEV || bundleType === UMD_PROD;
-  const peerGlobals = Modules.getPeerGlobals(
-    bundle.externals,
-    bundle.moduleType
-  );
+  const peerGlobals = Modules.getPeerGlobals(bundle.externals, bundleType);
   let externals = Object.keys(peerGlobals);
   if (!shouldBundleDependencies) {
     const deps = Modules.getDependencies(bundleType, bundle.entry);

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -27,12 +27,12 @@ const knownGlobals = Object.freeze({
 });
 
 // Given ['react'] in bundle externals, returns { 'react': 'React' }.
-function getPeerGlobals(externals, moduleType) {
+function getPeerGlobals(externals, bundleType) {
   const peerGlobals = {};
   externals.forEach(name => {
     if (
       !knownGlobals[name] &&
-      (moduleType === UMD_DEV || moduleType === UMD_PROD)
+      (bundleType === UMD_DEV || bundleType === UMD_PROD)
     ) {
       throw new Error('Cannot build UMD without a global name for: ' + name);
     }


### PR DESCRIPTION
There is a mistake in `Modules.getPeerGlobals` of rollup script. `UMD_DEV` and `UMD_PROD` is checked against `moduleType`, actually it should be `bundleType`.