### PR TITLE
Separate `yarn flow` and `yarn flow-ci`

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "test-build": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.build.js",
     "test-build-prod": "cross-env NODE_ENV=production jest --config ./scripts/jest/config.build.js",
     "flow": "node ./scripts/tasks/flow.js",
+    "flow-ci": "node ./scripts/tasks/flow-ci.js",
     "prettier": "node ./scripts/prettier/index.js write-changed",
     "prettier-all": "node ./scripts/prettier/index.js write",
     "version-check": "node ./scripts/tasks/version-check.js"

--- a/scripts/circleci/test_entry_point.sh
+++ b/scripts/circleci/test_entry_point.sh
@@ -8,7 +8,7 @@ COMMANDS_TO_RUN=()
 
 if [ $((0 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('node ./scripts/prettier/index')
-  COMMANDS_TO_RUN+=('node ./scripts/tasks/flow')
+  COMMANDS_TO_RUN+=('node ./scripts/tasks/flow-ci')
   COMMANDS_TO_RUN+=('node ./scripts/tasks/eslint')
   COMMANDS_TO_RUN+=('yarn test --maxWorkers=2')
   COMMANDS_TO_RUN+=('./scripts/circleci/check_license.sh')

--- a/scripts/release/build-commands/run-automated-tests.js
+++ b/scripts/release/build-commands/run-automated-tests.js
@@ -7,7 +7,7 @@ const {logPromise, runYarnTask} = require('../utils');
 module.exports = async ({cwd}) => {
   await logPromise(runYarnTask(cwd, 'lint', 'Lint failed'), 'Running ESLint');
   await logPromise(
-    runYarnTask(cwd, 'flow', 'Flow failed'),
+    runYarnTask(cwd, 'flow-ci', 'Flow failed'),
     'Running Flow checks'
   );
   await logPromise(

--- a/scripts/tasks/flow-ci.js
+++ b/scripts/tasks/flow-ci.js
@@ -12,10 +12,10 @@ const spawn = require('child_process').spawn;
 
 const extension = process.platform === 'win32' ? '.cmd' : '';
 
-// This script is using `flow status` for a quick check with a server.
-// Use it for local development.
+// This script forces a complete check.
+// Use it for the CI.
 
-spawn(path.join('node_modules', '.bin', 'flow' + extension), ['status', '.'], {
+spawn(path.join('node_modules', '.bin', 'flow' + extension), ['check', '.'], {
   // Allow colors to pass through
   stdio: 'inherit',
 }).on('close', function(code) {


### PR DESCRIPTION
We keep using `yarn flow` for local development. Now it uses `flow server` so it's fast on rechecks. We add `yarn flow-ci` to force a complete Flow run with no previous state. We use it on CI and in the release script.

I have further more extensive changes coming up later. So I don't bother to share code between them because it will change more.