### PR TITLE
Re-enable Flow for ReactFiber and fix Flow issues

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -21,6 +21,9 @@
 ./node_modules/fbjs/flow/lib/dev.js
 ./scripts/flow
 
+[lints]
+untyped-type-import=error
+
 [options]
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -54,7 +54,7 @@ function getTopLevelCallbackBookKeeping(
 ): {
   topLevelType: ?DOMTopLevelEventType,
   nativeEvent: ?AnyNativeEvent,
-  targetInst: Fiber,
+  targetInst: Fiber | null,
   ancestors: Array<Fiber>,
 } {
   if (callbackBookkeepingPool.length) {

--- a/packages/react-reconciler/src/ReactCapturedValue.js
+++ b/packages/react-reconciler/src/ReactCapturedValue.js
@@ -29,7 +29,7 @@ export type CapturedError = {
 
 export function createCapturedValue<T>(
   value: T,
-  source: Fiber | null,
+  source: Fiber,
 ): CapturedValue<T> {
   // If the value is an error, call this function immediately after it is thrown
   // so the stack is accurate.

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow
  */
 
 import type {ReactElement, Source} from 'shared/ReactElementType';

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -386,17 +386,10 @@ export function createFiberFromElement(
 }
 
 function getFiberTagFromObjectType(type, owner): TypeOfWork {
-  if (typeof type !== 'object' || type === null) {
-    invariant(
-      false,
-      'Element type is invalid: expected a string (for built-in ' +
-        'components) or a class/function (for composite components) ' +
-        'but got: %s.%s',
-      type == null ? type : typeof type,
-      getInvalidElementTypeErrorInfo(type, owner),
-    );
-  }
-  switch (type.$$typeof) {
+  const $$typeof =
+    typeof type === 'object' && type !== null ? type.$$typeof : null;
+
+  switch ($$typeof) {
     case REACT_PROVIDER_TYPE:
       return ContextProvider;
     case REACT_CONTEXT_TYPE:
@@ -404,38 +397,35 @@ function getFiberTagFromObjectType(type, owner): TypeOfWork {
       return ContextConsumer;
     case REACT_FORWARD_REF_TYPE:
       return ForwardRef;
-    default:
+    default: {
+      let info = '';
+      if (__DEV__) {
+        if (
+          type === undefined ||
+          (typeof type === 'object' &&
+            type !== null &&
+            Object.keys(type).length === 0)
+        ) {
+          info +=
+            ' You likely forgot to export your component from the file ' +
+            "it's defined in, or you might have mixed up default and " +
+            'named imports.';
+        }
+        const ownerName = owner ? getComponentName(owner) : null;
+        if (ownerName) {
+          info += '\n\nCheck the render method of `' + ownerName + '`.';
+        }
+      }
       invariant(
         false,
         'Element type is invalid: expected a string (for built-in ' +
           'components) or a class/function (for composite components) ' +
           'but got: %s.%s',
         type == null ? type : typeof type,
-        getInvalidElementTypeErrorInfo(type, owner),
+        info,
       );
-  }
-}
-
-function getInvalidElementTypeErrorInfo(type, owner): string {
-  let info = '';
-  if (__DEV__) {
-    if (
-      type === undefined ||
-      (typeof type === 'object' &&
-        type !== null &&
-        Object.keys(type).length === 0)
-    ) {
-      info +=
-        ' You likely forgot to export your component from the file ' +
-        "it's defined in, or you might have mixed up default and " +
-        'named imports.';
-    }
-    const ownerName = owner ? getComponentName(owner) : null;
-    if (ownerName) {
-      info += '\n\nCheck the render method of `' + ownerName + '`.';
     }
   }
-  return info;
 }
 
 export function createFiberFromFragment(

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -9,7 +9,7 @@
 
 import type {HostConfig} from 'react-reconciler';
 import type {Fiber} from './ReactFiber';
-import type {FiberRoot} from './ReactFiber';
+import type {FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {CapturedValue, CapturedError} from './ReactCapturedValue';
 
@@ -59,7 +59,7 @@ if (__DEV__) {
 export function logError(boundary: Fiber, errorInfo: CapturedValue<mixed>) {
   const source = errorInfo.source;
   let stack = errorInfo.stack;
-  if (stack === null) {
+  if (stack === null && source !== null) {
     stack = getStackAddendumByWorkInProgressFiber(source);
   }
 
@@ -94,7 +94,7 @@ export function logError(boundary: Fiber, errorInfo: CapturedValue<mixed>) {
 
 export default function<T, P, I, TI, HI, PI, C, CC, CX, PL>(
   config: HostConfig<T, P, I, TI, HI, PI, C, CC, CX, PL>,
-  captureError: (failedFiber: Fiber, error: mixed) => Fiber | null,
+  captureError: (failedFiber: Fiber, error: mixed) => void,
   scheduleWork: (
     fiber: Fiber,
     startTime: ExpirationTime,

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -13,6 +13,7 @@ import getComponentName from 'shared/getComponentName';
 import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
 import {StrictMode} from './ReactTypeOfMode';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
+import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 
 type LIFECYCLE =
@@ -110,14 +111,19 @@ if (__DEV__) {
   const getStrictRoot = (fiber: Fiber): Fiber => {
     let maybeStrictRoot = null;
 
-    while (fiber !== null) {
-      if (fiber.mode & StrictMode) {
-        maybeStrictRoot = fiber;
+    let node = fiber;
+    while (node !== null) {
+      if (node.mode & StrictMode) {
+        maybeStrictRoot = node;
       }
-
-      fiber = fiber.return;
+      node = node.return;
     }
 
+    invariant(
+      maybeStrictRoot !== null,
+      'Expected to find a StrictMode component in a strict mode tree. ' +
+        'This error is likely caused by a bug in React. Please file an issue.',
+    );
     return maybeStrictRoot;
   };
 

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -13,7 +13,6 @@ import getComponentName from 'shared/getComponentName';
 import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
 import {StrictMode} from './ReactTypeOfMode';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
-import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 
 type LIFECYCLE =
@@ -108,7 +107,7 @@ if (__DEV__) {
     pendingUnsafeLifecycleWarnings = new Map();
   };
 
-  const getStrictRoot = (fiber: Fiber): Fiber => {
+  const findStrictRoot = (fiber: Fiber): Fiber | null => {
     let maybeStrictRoot = null;
 
     let node = fiber;
@@ -119,11 +118,6 @@ if (__DEV__) {
       node = node.return;
     }
 
-    invariant(
-      maybeStrictRoot !== null,
-      'Expected to find a StrictMode component in a strict mode tree. ' +
-        'This error is likely caused by a bug in React. Please file an issue.',
-    );
     return maybeStrictRoot;
   };
 
@@ -231,7 +225,15 @@ if (__DEV__) {
     fiber: Fiber,
     instance: any,
   ) => {
-    const strictRoot = getStrictRoot(fiber);
+    const strictRoot = findStrictRoot(fiber);
+    if (strictRoot === null) {
+      warning(
+        false,
+        'Expected to find a StrictMode component in a strict mode tree. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
+      return;
+    }
 
     // Dedup strategy: Warn once per component.
     // This is difficult to track any other way since component names


### PR DESCRIPTION
In October I merged a PR that accidentally removed `@flow` from `ReactFiber.js`.
As a result it resolved to `any`.

In this PR, I'm adding it back, along with a Flow lint rule that prevents importing types from untyped files.
I'm also fixing Flow uncovered violations.

[View without whitespace](https://github.com/facebook/react/pull/12842/files?w=1)