### PR TITLE
Make REACT_PROFILER_TYPE numeric value unique

### DIFF
--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -24,8 +24,8 @@ export const REACT_STRICT_MODE_TYPE = hasSymbol
   ? Symbol.for('react.strict_mode')
   : 0xeacc;
 export const REACT_PROFILER_TYPE = hasSymbol
-  ? Symbol.for('react.profile_root')
-  : 0xeacc;
+  ? Symbol.for('react.profiler')
+  : 0xead2;
 export const REACT_PROVIDER_TYPE = hasSymbol
   ? Symbol.for('react.provider')
   : 0xeacd;


### PR DESCRIPTION
The `REACT_PROFILER_TYPE ` had the same numeric/non-symbol value as `REACT_STRICT_MODE_TYPE` 🤡 