### PR TITLE
[schedule] Use linked list instead of queue and map for storing cbs

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -23,6 +23,7 @@ import getComponentName from 'shared/getComponentName';
 import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 
+import {CallbackConfigType} from 'react-scheduler';
 import {createFiberRoot} from './ReactFiberRoot';
 import * as ReactFiberDevToolsHook from './ReactFiberDevToolsHook';
 import ReactFiberScheduler from './ReactFiberScheduler';
@@ -87,8 +88,8 @@ export type HostConfig<T, P, I, TI, HI, PI, C, CC, CX, PL> = {
   scheduleDeferredCallback(
     callback: (deadline: Deadline) => void,
     options?: {timeout: number},
-  ): number,
-  cancelDeferredCallback(callbackID: number): void,
+  ): CallbackConfigType,
+  cancelDeferredCallback(callbackID: CallbackConfigType): void,
 
   prepareForCommit(containerInfo: C): void,
   resetAfterCommit(containerInfo: C): void,


### PR DESCRIPTION
NOTE: This is mostly done, but I need to figure out how the flow typing
should work for the 'timeoutId' returned from 'scheduleWork'.

Hoping to discuss on the PR.

---

**what is the change?:**
See title

**why make this change?:**
This seems to make the code simpler, and potentially saves space of
having an array and object around holding references to the callbacks.

I'm not actually convinced this will be higher performance, but
@sebastian we can bikeshed that more. Wanted to get this pushed for
early feedback.

**test plan:**
Run existing tests, try a fixture or two.