### PR TITLE
[Fabric] Wire up event emitters

### DIFF
--- a/packages/events/TopLevelEventTypes.js
+++ b/packages/events/TopLevelEventTypes.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-type RNTopLevelEventType =
+export type RNTopLevelEventType =
   | 'topMouseDown'
   | 'topMouseMove'
   | 'topMouseUp'

--- a/packages/react-native-renderer/src/ReactFabricEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactFabricEventEmitter.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
+
+import {getListener, runExtractedEventsInBatch} from 'events/EventPluginHub';
+import {registrationNameModules} from 'events/EventPluginRegistry';
+import {batchedUpdates} from 'events/ReactGenericBatching';
+
+import type {AnyNativeEvent} from 'events/PluginModuleType';
+import type {TopLevelType} from 'events/TopLevelEventTypes';
+
+export {getListener, registrationNameModules as registrationNames};
+
+/**
+ * Publicly exposed method on module for native objc to invoke when a top
+ * level event is extracted.
+ * @param {rootNodeID} rootNodeID React root node ID that event occurred on.
+ * @param {TopLevelType} topLevelType Top level type of event.
+ * @param {object} nativeEventParam Object passed from native.
+ */
+export function dispatchEvent(
+  target: Object,
+  topLevelType: TopLevelType,
+  nativeEvent: AnyNativeEvent,
+) {
+  const targetFiber = (target: Fiber);
+  batchedUpdates(function() {
+    runExtractedEventsInBatch(
+      topLevelType,
+      targetFiber,
+      nativeEvent,
+      nativeEvent.target,
+    );
+  });
+  // React Native doesn't use ReactControlledComponent but if it did, here's
+  // where it would do it.
+}

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -23,6 +23,8 @@ import * as ReactNativeViewConfigRegistry from 'ReactNativeViewConfigRegistry';
 import deepFreezeAndThrowOnMutationInDev from 'deepFreezeAndThrowOnMutationInDev';
 import invariant from 'fbjs/lib/invariant';
 
+import {dispatchEvent} from './ReactFabricEventEmitter';
+
 // Modules provided by RN:
 import TextInputState from 'TextInputState';
 import {
@@ -35,6 +37,7 @@ import {
   appendChild,
   appendChildToSet,
   completeRoot,
+  registerEventHandler,
 } from 'FabricUIManager';
 import UIManager from 'UIManager';
 
@@ -47,6 +50,14 @@ let nextReactTag = 2;
 type HostContext = $ReadOnly<{|
   isInAParentText: boolean,
 |}>;
+
+// TODO: Remove this conditional once all changes have propagated.
+if (registerEventHandler) {
+  /**
+   * Register the event emitter with the native bridge
+   */
+  registerEventHandler(dispatchEvent);
+}
 
 /**
  * This is used for refs on host components.

--- a/packages/react-native-renderer/src/__mocks__/FabricUIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/FabricUIManager.js
@@ -125,6 +125,8 @@ const RCTFabricUIManager = {
   completeRoot: jest.fn(function completeRoot(rootTag, newChildSet) {
     roots.set(rootTag, newChildSet);
   }),
+
+  registerEventHandler: jest.fn(function registerEventHandler(callback) {}),
 };
 
 module.exports = RCTFabricUIManager;

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -13,6 +13,7 @@ import type {
   ReactNativeBaseComponentViewConfig,
   ViewConfigGetter,
 } from 'react-native-renderer/src/ReactNativeTypes';
+import type {RNTopLevelEventType} from 'events/TopLevelEventTypes';
 
 declare module 'deepDiffer' {
   declare module.exports: (one: any, two: any) => boolean;
@@ -121,6 +122,13 @@ declare module 'FabricUIManager' {
   declare function createChildSet(rootTag: number): Object;
   declare function appendChildToSet(childSet: Object, childNode: Object): void;
   declare function completeRoot(rootTag: number, childSet: Object): void;
+  declare function registerEventHandler(
+    callback: (
+      instanceHandle: Object,
+      type: RNTopLevelEventType,
+      payload: Object,
+    ) => void,
+  ): void;
 }
 
 declare module 'View' {


### PR DESCRIPTION
I'm exposing a new native method to wire up the event emitter. This will
use a straight fiber pointer instead of react tags to do the dispatching.
