### PR TITLE
Fix sample command in scripts/bench/README.md

### DIFF
--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -5,7 +5,7 @@
 In most cases, the only two commands you might want to use are:
 
 - `yarn start`
-- `yarn build core,dom-client --type=UMD_PROD && yarn start --skip-build`
+- `yarn --cwd=../../ build core,dom-client --type=UMD_PROD && yarn start --skip-build`
 
 The first command will run benchmarks with all the default settings. A local and remote build will occur on React and ReactDOM UMD bundles, both local and remote repos will be run against all benchmarks.
 


### PR DESCRIPTION
This PR fixes an regression from #10424 where the benchmark deps were moved to its own subdir but the build `cwd` in the README wasn't updated accordingly.

