### PR TITLE
Adds ReactScheduler red->green unit test for bug fixed in #12834

### DIFF
--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -18,7 +18,7 @@ describe('ReactScheduler', () => {
 
   function drainPostMessageQueue() {
     if (postMessageCallback) {
-      while(postMessageEvents.length){
+      while (postMessageEvents.length) {
         postMessageCallback(postMessageEvents.shift());
       }
     }
@@ -104,15 +104,17 @@ describe('ReactScheduler', () => {
         // initially waits to call the callback
         expect(callbackLog).toEqual([]);
         jest.runAllTimers();
-        // waits while second callback is passed
+        // this should schedule work *after* the requestAnimationFrame but before the message handler
         scheduleWork(callbackB);
         expect(callbackLog).toEqual([]);
-        // after a delay, calls as many callbacks as it has time for
+        // now it should drain the message queue and do all scheduled work
         drainPostMessageQueue();
         expect(callbackLog).toEqual(['A', 'B']);
 
+        // advances timers, now with an empty queue of work (to ensure they don't deadlock)
         advanceAll();
 
+        // see if more work can be done now.
         scheduleWork(callbackC);
         expect(callbackLog).toEqual(['A', 'B']);
         advanceAll();

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -12,7 +12,6 @@
 let ReactScheduler;
 
 describe('ReactScheduler', () => {
-
   let postMessageCallback;
   let postMessageEvents = [];
 
@@ -94,7 +93,7 @@ describe('ReactScheduler', () => {
         );
       });
 
-      it('accepts callbacks betweeen animationFrame and postMessage and doesn\'t stall', () => {
+      it("accepts callbacks betweeen animationFrame and postMessage and doesn't stall", () => {
         const {scheduleWork} = ReactScheduler;
         const callbackLog = [];
         const callbackA = jest.fn(() => callbackLog.push('A'));


### PR DESCRIPTION
Verifies that work scheduled after the initial rAF but before the postMessage callback still runs and that more work can be scheduled after the fact.