### PR TITLE
Fix Native/Fabric host instance types

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -63,11 +63,9 @@ function findNodeHandle(componentOrHandle: any): ?number {
   if (hostInstance == null) {
     return hostInstance;
   }
-  // TODO: the code is right but the types here are wrong.
-  // https://github.com/facebook/react/pull/12863
   if ((hostInstance: any).canonical) {
     // Fabric
-    return (hostInstance: any).canonical._nativeTag;
+    return hostInstance.canonical._nativeTag;
   }
   return hostInstance._nativeTag;
 }

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -9,6 +9,10 @@
 
 import type {ReactFabricType} from './ReactNativeTypes';
 import type {ReactNodeList} from 'shared/ReactTypes';
+import type {
+  Instance as NativeInstance,
+  TextInstance as NativeTextInstance,
+} from './ReactNativeHostConfig';
 
 import './ReactFabricInjection';
 
@@ -63,11 +67,29 @@ function findNodeHandle(componentOrHandle: any): ?number {
   if (hostInstance == null) {
     return hostInstance;
   }
-  if ((hostInstance: any).canonical) {
-    // Fabric
-    return hostInstance.canonical._nativeTag;
+  if (
+    typeof hostInstance === 'object' &&
+    typeof hostInstance.node !== 'undefined'
+  ) {
+    const fabricHostInstance = hostInstance;
+    if (typeof fabricHostInstance.canonical !== 'undefined') {
+      // Fabric Instance
+      return fabricHostInstance.canonical._nativeTag;
+    } else {
+      // Fabric Text
+      return null;
+    }
   }
-  return hostInstance._nativeTag;
+  const nonFabricInstance = ((hostInstance: any):
+    | NativeInstance
+    | NativeTextInstance);
+  if (typeof nonFabricInstance === 'object') {
+    // Non-Fabric Instance
+    return nonFabricInstance._nativeTag;
+  } else {
+    // Non-Fabric Text
+    return null;
+  }
 }
 
 ReactGenericBatching.injection.injectRenderer(ReactFabricRenderer);

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -50,13 +50,15 @@ let nextReactTag = 2;
 type Node = Object;
 export type Type = string;
 export type Props = Object;
-export type Instance = {
+export type Instance = {|
+  // Note: findNodeHandle() uses presence of `node` to detect Fabric instances.
   node: Node,
   canonical: ReactFabricHostComponent,
-};
-export type TextInstance = {
+|};
+export type TextInstance = {|
+  // Note: findNodeHandle() uses presence of `node` to detect Fabric instances.
   node: Node,
-};
+|};
 export type HydratableInstance = Instance | TextInstance;
 export type PublicInstance = ReactFabricHostComponent;
 export type Container = number;

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -9,7 +9,10 @@
 
 import type {ReactNativeType} from './ReactNativeTypes';
 import type {ReactNodeList} from 'shared/ReactTypes';
-import type {Instance as FabricInstance} from './ReactFabricHostConfig';
+import type {
+  Instance as FabricInstance,
+  TextInstance as FabricTextInstance,
+} from './ReactFabricHostConfig';
 
 import './ReactNativeInjection';
 
@@ -67,12 +70,33 @@ function findNodeHandle(componentOrHandle: any): ?number {
   if (hostInstance == null) {
     return hostInstance;
   }
-  if ((hostInstance: any).canonical) {
-    // Fabric
-    const fabricHostInstance = ((hostInstance: any): FabricInstance);
-    return fabricHostInstance.canonical._nativeTag;
+  if (typeof hostInstance === 'number') {
+    // Non-Fabric text node.
+    return null;
   }
-  return hostInstance._nativeTag;
+  if (
+    typeof hostInstance === 'object' &&
+    typeof (hostInstance: any).node !== 'undefined'
+  ) {
+    const fabricHostInstance = ((hostInstance: any):
+      | FabricInstance
+      | FabricTextInstance);
+    if (typeof fabricHostInstance.canonical !== 'undefined') {
+      // Fabric Instance
+      return fabricHostInstance.canonical._nativeTag;
+    } else {
+      // Fabric Text
+      return null;
+    }
+  }
+  const nonFabricInstance = hostInstance;
+  if (typeof nonFabricInstance === 'object') {
+    // Non-Fabric Instance
+    return nonFabricInstance._nativeTag;
+  } else {
+    // Non-Fabric Text
+    return null;
+  }
 }
 
 ReactGenericBatching.injection.injectRenderer(ReactNativeFiberRenderer);

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -9,6 +9,7 @@
 
 import type {ReactNativeType} from './ReactNativeTypes';
 import type {ReactNodeList} from 'shared/ReactTypes';
+import type {Instance as FabricInstance} from './ReactFabricHostConfig';
 
 import './ReactNativeInjection';
 
@@ -68,7 +69,8 @@ function findNodeHandle(componentOrHandle: any): ?number {
   }
   if ((hostInstance: any).canonical) {
     // Fabric
-    return (hostInstance: any).canonical._nativeTag;
+    const fabricHostInstance = ((hostInstance: any): FabricInstance);
+    return fabricHostInstance.canonical._nativeTag;
   }
   return hostInstance._nativeTag;
 }

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -352,4 +352,28 @@ describe('ReactFabric', () => {
       11,
     );
   });
+
+  it('does not find text nodes with findNodeHandle()', () => {
+    const Text = createReactNativeComponentClass('RCTText', () => ({
+      validAttributes: {},
+      uiViewClassName: 'RCTText',
+    }));
+
+    class Component extends React.Component {
+      render() {
+        return 'hello';
+      }
+    }
+
+    let ref = React.createRef();
+    ReactFabric.render(
+      <Text>
+        <Component ref={ref} />
+      </Text>,
+      11,
+    );
+
+    let handle = ReactFabric.findNodeHandle(ref.current);
+    expect(handle).toBe(null);
+  });
 });

--- a/packages/react-native-renderer/src/__tests__/ReactFabricAndNative-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabricAndNative-test.internal.js
@@ -49,4 +49,29 @@ describe('ReactFabric', () => {
     let handle = ReactNative.findNodeHandle(ref.current);
     expect(handle).toBe(2);
   });
+
+  it('find Fabric text nodes with the RN renderer', () => {
+    const Text = createReactNativeComponentClass('RCTText', () => ({
+      validAttributes: {title: true},
+      uiViewClassName: 'RCTText',
+    }));
+
+    let ref = React.createRef();
+
+    class Component extends React.Component {
+      render() {
+        return 'hello';
+      }
+    }
+
+    ReactFabric.render(
+      <Text>
+        <Component ref={ref} />
+      </Text>,
+      11,
+    );
+
+    let handle = ReactNative.findNodeHandle(ref.current);
+    expect(handle).toBe(2);
+  });
 });

--- a/packages/react-native-renderer/src/__tests__/ReactFabricAndNative-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabricAndNative-test.internal.js
@@ -50,13 +50,11 @@ describe('ReactFabric', () => {
     expect(handle).toBe(2);
   });
 
-  it('find Fabric text nodes with the RN renderer', () => {
+  it('does not find Fabric text nodes with the RN renderer', () => {
     const Text = createReactNativeComponentClass('RCTText', () => ({
-      validAttributes: {title: true},
+      validAttributes: {},
       uiViewClassName: 'RCTText',
     }));
-
-    let ref = React.createRef();
 
     class Component extends React.Component {
       render() {
@@ -64,6 +62,7 @@ describe('ReactFabric', () => {
       }
     }
 
+    let ref = React.createRef();
     ReactFabric.render(
       <Text>
         <Component ref={ref} />
@@ -72,6 +71,6 @@ describe('ReactFabric', () => {
     );
 
     let handle = ReactNative.findNodeHandle(ref.current);
-    expect(handle).toBe(2);
+    expect(handle).toBe(null);
   });
 });

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -258,4 +258,28 @@ describe('ReactNative', () => {
       11,
     );
   });
+
+  it('does not find text nodes with findNodeHandle()', () => {
+    const Text = createReactNativeComponentClass('RCTText', () => ({
+      validAttributes: {},
+      uiViewClassName: 'RCTText',
+    }));
+
+    class Component extends React.Component {
+      render() {
+        return 'hello';
+      }
+    }
+
+    let ref = React.createRef();
+    ReactNative.render(
+      <Text>
+        <Component ref={ref} />
+      </Text>,
+      11,
+    );
+
+    let handle = ReactNative.findNodeHandle(ref.current);
+    expect(handle).toBe(null);
+  });
 });

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -173,7 +173,7 @@ export function updateContainerAtExpirationTime(
   return scheduleRootUpdate(current, element, expirationTime, callback);
 }
 
-function findHostInstance(component: Object): PublicInstance | null {
+function findHostInstance(component: Object): Instance | TextInstance | null {
   const fiber = ReactInstanceMap.get(component);
   if (fiber === undefined) {
     if (typeof component.render === 'function') {
@@ -252,7 +252,7 @@ export {findHostInstance};
 
 export function findHostInstanceWithNoPortals(
   fiber: Fiber,
-): PublicInstance | null {
+): Instance | TextInstance | null {
   const hostFiber = findCurrentHostFiberWithNoPortals(fiber);
   if (hostFiber === null) {
     return null;


### PR DESCRIPTION
I tried removing `any` there and I noticed the types are a bit wrong.

Specifically, `findHostInstance*` reconciler methods return `Instance | TextInstance` rather than `PublicInstance` because they just give you the `stateNode`.

However making that change uncovers that `findNodeHandle` can get a text instance (number in Native, object without a `canonical` field in Fabric). I'm not sure what to do with it; Flow fails.

@sebmarkbage?