### PR TITLE
Treat Rollup "warnings" as errors

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -420,10 +420,6 @@ async function createBundle(bundle, bundleType) {
 }
 
 function handleRollupWarning(warning) {
-  if (warning.code === 'UNRESOLVED_IMPORT') {
-    console.error(warning.message);
-    process.exit(1);
-  }
   if (warning.code === 'UNUSED_EXTERNAL_IMPORT') {
     const match = warning.message.match(/external module '([^']+)'/);
     if (!match || typeof match[1] !== 'string') {
@@ -445,7 +441,20 @@ function handleRollupWarning(warning) {
     // Don't warn. We will remove side effectless require() in a later pass.
     return;
   }
-  console.warn(warning.message || warning);
+
+  if (typeof warning.code === 'string') {
+    // This is a warning coming from Rollup itself.
+    // These tend to be important (e.g. clashes in namespaced exports)
+    // so we'll fail the build on any of them.
+    console.error();
+    console.error(warning.message || warning);
+    console.error();
+    process.exit(1);
+  } else {
+    // The warning is from one of the plugins.
+    // Maybe it's not important, so just print it.
+    console.warn(warning.message || warning);
+  }
 }
 
 function handleRollupError(error) {


### PR DESCRIPTION
Rollup has a bunch of warnings (like unresolved import, or different values for the same export) which really are errors in the sense that we never want them in our code. However, plugins also use the same system for stuff that isn't as important (e.g. Babel helpers duplication).

Now that we rely on ES modules more heavily, I'm making Rollup's own warnings fail the build. This ensures we can't miss a regression like this in the console output, but can still ignore warnings from plugins.