### PR TITLE
Fix double-firing submit events

### DIFF
--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -13,7 +13,9 @@ import {
   TOP_CANCEL,
   TOP_CLOSE,
   TOP_FOCUS,
+  TOP_RESET,
   TOP_SCROLL,
+  TOP_SUBMIT,
 } from './DOMTopLevelEventTypes';
 import {
   setEnabled,
@@ -147,7 +149,7 @@ export function listenTo(
           trapCapturedEvent(TOP_CLOSE, mountAt);
         }
         isListening[TOP_CLOSE] = true;
-      } else {
+      } else if (dependency !== TOP_SUBMIT && dependency !== TOP_RESET) {
         trapBubbledEvent(dependency, mountAt);
       }
 


### PR DESCRIPTION
We were adding a listener at the root when we weren't meant to. Blames to e96dc140599363029bd05565d58bcd4a432db370.

This now alerts once (at FORM) instead of twice (at FORM, #document):

```
var Hello = class extends React.Component {
  render() {
    return (
      <form onSubmit={(e) => {e.preventDefault(); alert('hi ' + e.nativeEvent.currentTarget.nodeName);}}>
        <button>hi</button>
      </form>
    );
  }
};
```