### PR TITLE
Fix a regression that caused us to listen to extra events at the top

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -260,6 +260,14 @@ describe('ReactDOMEventListener', () => {
     );
     expect(handleSubmit).toHaveBeenCalledTimes(1);
 
+    formRef.current.dispatchEvent(
+      new Event('submit', {
+        // Might happen on older browsers.
+        bubbles: true,
+      }),
+    );
+    expect(handleSubmit).toHaveBeenCalledTimes(2); // It already fired in this test.
+
     document.body.removeChild(container);
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -262,4 +262,46 @@ describe('ReactDOMEventListener', () => {
 
     document.body.removeChild(container);
   });
+
+  it('should dispatch loadstart only for media elements', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const imgRef = React.createRef();
+    const videoRef = React.createRef();
+
+    const handleImgLoadStart = jest.fn();
+    const handleVideoLoadStart = jest.fn();
+    ReactDOM.render(
+      <div>
+        <img ref={imgRef} onLoadStart={handleImgLoadStart} />
+        <video ref={videoRef} onLoadStart={handleVideoLoadStart} />
+      </div>,
+      container,
+    );
+
+    // Note for debugging: loadstart currently doesn't fire in Chrome.
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=458851
+    imgRef.current.dispatchEvent(
+      new ProgressEvent('loadstart', {
+        bubbles: false,
+      }),
+    );
+    // Historically, we happened to not support onLoadStart
+    // on <img>, and this test documents that lack of support.
+    // If we decide to support it in the future, we should change
+    // this line to expect 1 call. Note that fixing this would
+    // be simple but would require attaching a handler to each
+    // <img>. So far nobody asked us for it.
+    expect(handleImgLoadStart).toHaveBeenCalledTimes(0);
+
+    videoRef.current.dispatchEvent(
+      new ProgressEvent('loadstart', {
+        bubbles: false,
+      }),
+    );
+    expect(handleVideoLoadStart).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(container);
+  });
 });

--- a/packages/react-dom/src/events/DOMTopLevelEventTypes.js
+++ b/packages/react-dom/src/events/DOMTopLevelEventTypes.js
@@ -148,6 +148,9 @@ export const TOP_VOLUME_CHANGE = unsafeCastStringToDOMTopLevelType(
 export const TOP_WAITING = unsafeCastStringToDOMTopLevelType('waiting');
 export const TOP_WHEEL = unsafeCastStringToDOMTopLevelType('wheel');
 
+// List of events that need to be individually attached to media elements.
+// Note that events in this list will *not* be listened to at the top level
+// unless they're explicitly whitelisted in `ReactBrowserEventEmitter.listenTo`.
 export const mediaEventTypes = [
   TOP_ABORT,
   TOP_CAN_PLAY,

--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -147,13 +147,11 @@ export function listenTo(
           if (isEventSupported('cancel', true)) {
             trapCapturedEvent(TOP_CANCEL, mountAt);
           }
-          isListening[TOP_CANCEL] = true;
           break;
         case TOP_CLOSE:
           if (isEventSupported('close', true)) {
             trapCapturedEvent(TOP_CLOSE, mountAt);
           }
-          isListening[TOP_CLOSE] = true;
           break;
         case TOP_SUBMIT:
         case TOP_RESET:

--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -130,29 +130,39 @@ export function listenTo(
   for (let i = 0; i < dependencies.length; i++) {
     const dependency = dependencies[i];
     if (!(isListening.hasOwnProperty(dependency) && isListening[dependency])) {
-      if (dependency === TOP_SCROLL) {
-        trapCapturedEvent(TOP_SCROLL, mountAt);
-      } else if (dependency === TOP_FOCUS || dependency === TOP_BLUR) {
-        trapCapturedEvent(TOP_FOCUS, mountAt);
-        trapCapturedEvent(TOP_BLUR, mountAt);
-
-        // to make sure blur and focus event listeners are only attached once
-        isListening[TOP_BLUR] = true;
-        isListening[TOP_FOCUS] = true;
-      } else if (dependency === TOP_CANCEL) {
-        if (isEventSupported('cancel', true)) {
-          trapCapturedEvent(TOP_CANCEL, mountAt);
-        }
-        isListening[TOP_CANCEL] = true;
-      } else if (dependency === TOP_CLOSE) {
-        if (isEventSupported('close', true)) {
-          trapCapturedEvent(TOP_CLOSE, mountAt);
-        }
-        isListening[TOP_CLOSE] = true;
-      } else if (dependency !== TOP_SUBMIT && dependency !== TOP_RESET) {
-        trapBubbledEvent(dependency, mountAt);
+      switch (dependency) {
+        case TOP_SCROLL:
+          trapCapturedEvent(TOP_SCROLL, mountAt);
+          break;
+        case TOP_FOCUS:
+        case TOP_BLUR:
+          trapCapturedEvent(TOP_FOCUS, mountAt);
+          trapCapturedEvent(TOP_BLUR, mountAt);
+          // We set the flag for a single dependency later in this function,
+          // but this ensures we mark both as attached rather than just one.
+          isListening[TOP_BLUR] = true;
+          isListening[TOP_FOCUS] = true;
+          break;
+        case TOP_CANCEL:
+          if (isEventSupported('cancel', true)) {
+            trapCapturedEvent(TOP_CANCEL, mountAt);
+          }
+          isListening[TOP_CANCEL] = true;
+          break;
+        case TOP_CLOSE:
+          if (isEventSupported('close', true)) {
+            trapCapturedEvent(TOP_CLOSE, mountAt);
+          }
+          isListening[TOP_CLOSE] = true;
+          break;
+        case TOP_SUBMIT:
+        case TOP_RESET:
+          // No-op: we don't want them to fire twice.
+          break;
+        default:
+          trapBubbledEvent(dependency, mountAt);
+          break;
       }
-
       isListening[dependency] = true;
     }
   }

--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -13,10 +13,13 @@ import {
   TOP_CANCEL,
   TOP_CLOSE,
   TOP_FOCUS,
+  TOP_INVALID,
+  TOP_LOAD_START,
   TOP_RESET,
   TOP_SCROLL,
   TOP_SUBMIT,
   getRawEventName,
+  mediaEventTypes,
 } from './DOMTopLevelEventTypes';
 import {
   setEnabled,
@@ -150,12 +153,23 @@ export function listenTo(
             trapCapturedEvent(dependency, mountAt);
           }
           break;
+        case TOP_INVALID:
         case TOP_SUBMIT:
         case TOP_RESET:
-          // No-op: we don't want them to fire twice.
+          // We listen to them on the target DOM elements.
+          // Some of them bubble so we don't want them to fire twice.
+          break;
+        case TOP_LOAD_START:
+          // Even though it's a media event, it also exists on <img>.
+          // So we need to listen at top level, unlike other media events.
+          trapBubbledEvent(dependency, mountAt);
           break;
         default:
-          trapBubbledEvent(dependency, mountAt);
+          // By default, listen on the top level to all non-media events.
+          const isMediaEvent = mediaEventTypes.indexOf(dependency) !== -1;
+          if (!isMediaEvent) {
+            trapBubbledEvent(dependency, mountAt);
+          }
           break;
       }
       isListening[dependency] = true;

--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -16,6 +16,7 @@ import {
   TOP_RESET,
   TOP_SCROLL,
   TOP_SUBMIT,
+  getRawEventName,
 } from './DOMTopLevelEventTypes';
 import {
   setEnabled,
@@ -144,13 +145,9 @@ export function listenTo(
           isListening[TOP_FOCUS] = true;
           break;
         case TOP_CANCEL:
-          if (isEventSupported('cancel', true)) {
-            trapCapturedEvent(TOP_CANCEL, mountAt);
-          }
-          break;
         case TOP_CLOSE:
-          if (isEventSupported('close', true)) {
-            trapCapturedEvent(TOP_CLOSE, mountAt);
+          if (isEventSupported(getRawEventName(dependency), true)) {
+            trapCapturedEvent(dependency, mountAt);
           }
           break;
         case TOP_SUBMIT:

--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -160,6 +160,7 @@ export function listenTo(
           break;
         default:
           // By default, listen on the top level to all non-media events.
+          // Media events don't bubble so adding the listener wouldn't do anything.
           const isMediaEvent = mediaEventTypes.indexOf(dependency) !== -1;
           if (!isMediaEvent) {
             trapBubbledEvent(dependency, mountAt);

--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -14,7 +14,6 @@ import {
   TOP_CLOSE,
   TOP_FOCUS,
   TOP_INVALID,
-  TOP_LOAD_START,
   TOP_RESET,
   TOP_SCROLL,
   TOP_SUBMIT,
@@ -158,11 +157,6 @@ export function listenTo(
         case TOP_RESET:
           // We listen to them on the target DOM elements.
           // Some of them bubble so we don't want them to fire twice.
-          break;
-        case TOP_LOAD_START:
-          // Even though it's a media event, it also exists on <img>.
-          // So we need to listen at top level, unlike other media events.
-          trapBubbledEvent(dependency, mountAt);
           break;
         default:
           // By default, listen on the top level to all non-media events.


### PR DESCRIPTION
I think this should fix the regression introduced in https://github.com/facebook/react/pull/12629 and that @sophiebits has patched over in https://github.com/facebook/react/pull/12877.

The first three commits are small refactors (I can remove them but I found the final form easier to read with these changes). The last one fixes the logic.

I'll need to work on some way to test this and verify it’s correct. Here’s the methodology with which I arrived at this solution:

1. Take a list of [all DOM event types in master](https://github.com/facebook/react/blob/master/packages/react-dom/src/events/DOMTopLevelEventTypes.js)

2. For each type, record whether it exists [in either of two mappings that were deleted in #12629](https://github.com/facebook/react/blob/1047980dca0830cd55e1622f3fbefc38aeaadb91/packages/react-dom/src/events/BrowserEventConstants.js): `topLevelTypes` or `mediaEventTypes`. Some types were new in master (pointer events) which I treat as if they were in `topLevelTypes`.

After doing this categorization, I ended up with four lists:

### NOT top AND NOT media

* `TOP_INVALID`
* `TOP_RESET`
* `TOP_SUBMIT`

### NOT top AND media

* `TOP_ABORT`
* `TOP_CAN_PLAY`
* `TOP_CAN_PLAY_THROUGH`
* `TOP_DURATION_CHANGE`
* `TOP_EMPTIED`
* `TOP_ENCRYPTED`
* `TOP_ENDED`
* `TOP_ERROR`
* `TOP_LOADED_DATA`
* `TOP_LOADED_METADATA`
* `TOP_PAUSE`
* `TOP_PLAY`
* `TOP_PLAYING`
* `TOP_PROGRESS`
* `TOP_RATE_CHANGE`
* `TOP_SEEKED`
* `TOP_SEEKING`
* `TOP_STALLED`
* `TOP_SUSPEND`
* `TOP_TIME_UPDATE`
* `TOP_VOLUME_CHANGE`
* `TOP_WAITING`

### top AND media

* `TOP_LOAD_START`

### top AND NOT media

* `TOP_ANIMATION_END`
* `TOP_ANIMATION_ITERATION`
* `TOP_ANIMATION_START`
* `TOP_BLUR`
* `TOP_CANCEL`
* `TOP_CHANGE`
* `TOP_CLICK`
* `TOP_CLOSE`
* `TOP_COMPOSITION_END`
* `TOP_COMPOSITION_START`
* `TOP_COMPOSITION_UPDATE`
* `TOP_CONTEXT_MENU`
* `TOP_COPY`
* `TOP_CUT`
* `TOP_DOUBLE_CLICK`
* `TOP_DRAG`
* `TOP_DRAG_END`
* `TOP_DRAG_ENTER`
* `TOP_DRAG_EXIT`
* `TOP_DRAG_LEAVE`
* `TOP_DRAG_OVER`
* `TOP_DRAG_START`
* `TOP_DROP`
* `TOP_FOCUS`
* `TOP_GOT_POINTER_CAPTURE`
* `TOP_INPUT`
* `TOP_KEY_DOWN`
* `TOP_KEY_PRESS`
* `TOP_KEY_UP`
* `TOP_LOAD`
* `TOP_LOST_POINTER_CAPTURE`
* `TOP_MOUSE_DOWN`
* `TOP_MOUSE_MOVE`
* `TOP_MOUSE_OUT`
* `TOP_MOUSE_OVER`
* `TOP_MOUSE_UP`
* `TOP_PASTE`
* `TOP_POINTER_CANCEL`
* `TOP_POINTER_DOWN`
* `TOP_POINTER_ENTER`
* `TOP_POINTER_LEAVE`
* `TOP_POINTER_MOVE`
* `TOP_POINTER_OUT`
* `TOP_POINTER_OVER`
* `TOP_POINTER_UP`
* `TOP_SCROLL`
* `TOP_SELECTION_CHANGE`
* `TOP_TEXT_INPUT`
* `TOP_TOGGLE`
* `TOP_TOUCH_CANCEL`
* `TOP_TOUCH_END`
* `TOP_TOUCH_MOVE`
* `TOP_TOUCH_START`
* `TOP_TRANSITION_END`
* `TOP_WHEEL`

From these lists, it follows that:

* “Media events should not be listened to on top level” is generally true.
* `TOP_LOAD_START` is an exception to the previous rule: even though it’s a media event, we listen to it on the top level.
* There are three additional events (`TOP_INVALID`, `TOP_RESET`, and `TOP_SUBMIT`) that are *neither* in the media nor the top whitelist. So we should exclude them *too*.

That’s reflected in my switch structure:

```js
      switch (dependency) {
        // ... other special cases ...
        case TOP_INVALID:
        case TOP_SUBMIT:
        case TOP_RESET:
          // We listen to them on the target DOM elements.
          // Some of them bubble so we don't want them to fire twice.
          break;
        case TOP_LOAD_START:
          // Even though it's a media event, it also exists on <img>.
          // So we need to listen at top level, unlike other media events.
          trapBubbledEvent(dependency, mountAt);
          break;
        default:
          // By default, listen on the top level to all non-media events.
          const isMediaEvent = mediaEventTypes.indexOf(dependency) !== -1;
          if (!isMediaEvent) {
            trapBubbledEvent(dependency, mountAt);
          }
          break;
      }
```

Note that I’m introducing an `indexOf` lookup there. I think it’s fine because this code only runs once per event, and `indexOf` is very fast on small arrays (`mediaEventTypes` has 23 elements). So I wouldn’t expect this to regress anything. But I can turn it into an object lookup if needed.