### PR TITLE
Rollup freeze: false

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -129,6 +129,7 @@ function getRollupOutputOptions(outputPath, format, globals, globalName) {
       file: outputPath,
       format,
       globals,
+      freeze: false,
       interop: false,
       name: globalName,
       sourcemap: false,


### PR DESCRIPTION
Maybe this is unnecessary? Posting for consideration. Feel free to close the PR if there's any concern.

### `react-dom.development.js` diff
```diff
409c409
< var EventPluginRegistry = Object.freeze({
---
> var EventPluginRegistry = ({
735c735
< var EventPluginHub = Object.freeze({
---
> var EventPluginHub = ({
836c836
< var ReactDOMComponentTree = Object.freeze({
---
> var ReactDOMComponentTree = ({
1078c1078
< var EventPropagators = Object.freeze({
---
> var EventPropagators = ({
2097c2097
< var ReactControlledComponent = Object.freeze({
---
> var ReactControlledComponent = ({
4552c4552
< var ReactDOMEventListener = Object.freeze({
---
> var ReactDOMEventListener = ({
7946c7946
< var ReactDOMFiberComponent = Object.freeze({
---
> var ReactDOMFiberComponent = ({
16694c16694
< var DOMRenderer = Object.freeze({
---
> var DOMRenderer = ({
17221c17221
< var ReactDOM$2 = Object.freeze({
---
> var ReactDOM$2 = ({
```