### PR TITLE
Added production profiling bundle type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,5 @@ module.exports = {
     spyOnDev: true,
     spyOnDevAndProd: true,
     spyOnProd: true,
-    __PROFILER__: true,
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,6 @@ module.exports = {
     spyOnDev: true,
     spyOnDevAndProd: true,
     spyOnProd: true,
-    __PROFILER__: true,
+    __PROFILE__: true,
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,5 +81,6 @@ module.exports = {
     spyOnDev: true,
     spyOnDevAndProd: true,
     spyOnProd: true,
+    __PROFILER__: true,
   },
 };

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -37,7 +37,8 @@ export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 
 // Gather advanced timing metrics for Profiler subtrees.
-export const enableProfilerTimer = __DEV__ || __PROFILER__;
+export const enableProfilerTimer =
+  __DEV__ || process.env.REACT_ENABLE_PROFILING === true;
 
 // Fires getDerivedStateFromProps for state *or* props changes
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -37,7 +37,7 @@ export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 
 // Gather advanced timing metrics for Profiler subtrees.
-export const enableProfilerTimer = __DEV__;
+export const enableProfilerTimer = __DEV__ || __PROFILER__;
 
 // Fires getDerivedStateFromProps for state *or* props changes
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -37,7 +37,7 @@ export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 
 // Gather advanced timing metrics for Profiler subtrees.
-export const enableProfilerTimer = __DEV__ || __PROFILER__;
+export const enableProfilerTimer = __DEV__ || __PROFILE__;
 
 // Fires getDerivedStateFromProps for state *or* props changes
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -37,8 +37,7 @@ export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 
 // Gather advanced timing metrics for Profiler subtrees.
-export const enableProfilerTimer =
-  __DEV__ || process.env.REACT_ENABLE_PROFILING === true;
+export const enableProfilerTimer = __DEV__ || __PROFILER__;
 
 // Fires getDerivedStateFromProps for state *or* props changes
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -37,7 +37,7 @@ export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 
 // Gather advanced timing metrics for Profiler subtrees.
-export const enableProfilerTimer = __DEV__ || __PROFILE__;
+export const enableProfilerTimer = __PROFILE__;
 
 // Fires getDerivedStateFromProps for state *or* props changes
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
@@ -20,8 +20,7 @@ export const enableSuspense = false;
 export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
-export const enableProfilerTimer =
-  __DEV__ || process.env.REACT_ENABLE_PROFILING;
+export const enableProfilerTimer = __DEV__ || __PROFILER__;
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
@@ -20,7 +20,7 @@ export const enableSuspense = false;
 export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
-export const enableProfilerTimer = __DEV__ || __PROFILE__;
+export const enableProfilerTimer = __PROFILE__;
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
@@ -20,7 +20,7 @@ export const enableSuspense = false;
 export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
-export const enableProfilerTimer = false;
+export const enableProfilerTimer = __DEV__ || __PROFILER__;
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
@@ -20,7 +20,8 @@ export const enableSuspense = false;
 export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
-export const enableProfilerTimer = __DEV__ || __PROFILER__;
+export const enableProfilerTimer =
+  __DEV__ || process.env.REACT_ENABLE_PROFILING;
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
@@ -20,7 +20,7 @@ export const enableSuspense = false;
 export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
-export const enableProfilerTimer = __DEV__ || __PROFILER__;
+export const enableProfilerTimer = __DEV__ || __PROFILE__;
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -20,7 +20,7 @@ export const enableUserTimingAPI = __DEV__;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
-export const enableProfilerTimer = __DEV__ || __PROFILE__;
+export const enableProfilerTimer = __PROFILE__;
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -20,7 +20,8 @@ export const enableUserTimingAPI = __DEV__;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
-export const enableProfilerTimer = __DEV__ || __PROFILER__;
+export const enableProfilerTimer =
+  __DEV__ || process.env.REACT_ENABLE_PROFILING;
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -20,8 +20,7 @@ export const enableUserTimingAPI = __DEV__;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
-export const enableProfilerTimer =
-  __DEV__ || process.env.REACT_ENABLE_PROFILING;
+export const enableProfilerTimer = __DEV__ || __PROFILER__;
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -20,7 +20,7 @@ export const enableUserTimingAPI = __DEV__;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
-export const enableProfilerTimer = __DEV__;
+export const enableProfilerTimer = __DEV__ || __PROFILER__;
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -20,7 +20,7 @@ export const enableUserTimingAPI = __DEV__;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
-export const enableProfilerTimer = __DEV__ || __PROFILER__;
+export const enableProfilerTimer = __DEV__ || __PROFILE__;
 export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -9,6 +9,8 @@
 
 /* eslint-disable */
 
+declare var __PROFILER__: boolean;
+
 declare var __REACT_DEVTOOLS_GLOBAL_HOOK__: any; /*?{
   inject: ?((stuff: Object) => void)
 };*/

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -9,7 +9,7 @@
 
 /* eslint-disable */
 
-declare var __PROFILER__: boolean;
+declare var __PROFILE__: boolean;
 
 declare var __REACT_DEVTOOLS_GLOBAL_HOOK__: any; /*?{
   inject: ?((stuff: Object) => void)

--- a/scripts/jest/setupEnvironment.js
+++ b/scripts/jest/setupEnvironment.js
@@ -5,6 +5,7 @@ if (NODE_ENV !== 'development' && NODE_ENV !== 'production') {
   throw new Error('NODE_ENV must either be set to development or production.');
 }
 global.__DEV__ = NODE_ENV === 'development';
+global.__PROFILE__ = NODE_ENV === 'development';
 
 global.requestAnimationFrame = function(callback) {
   setTimeout(callback);

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -290,7 +290,7 @@ function getPlugins(
     // Turn __DEV__ and process.env checks into constants.
     replace({
       __DEV__: isProduction ? 'false' : 'true',
-      __PROFILE__: isProfiling ? 'true' : 'false',
+      __PROFILE__: isProfiling || !isProduction ? 'true' : 'false',
       'process.env.NODE_ENV': isProduction ? "'production'" : "'development'",
     }),
     // We still need CommonJS for external deps like object-assign.

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -290,7 +290,7 @@ function getPlugins(
     // Turn __DEV__ and process.env checks into constants.
     replace({
       __DEV__: isProduction ? 'false' : 'true',
-      'process.env.REACT_ENABLE_PROFILING': isProfiling ? 'true' : 'false',
+      __PROFILER__: isProfiling ? 'true' : 'false',
       'process.env.NODE_ENV': isProduction ? "'production'" : "'development'",
     }),
     // We still need CommonJS for external deps like object-assign.

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -39,10 +39,12 @@ const {
   UMD_PROD,
   NODE_DEV,
   NODE_PROD,
+  NODE_PROFILING,
   FB_WWW_DEV,
   FB_WWW_PROD,
   RN_OSS_DEV,
   RN_OSS_PROD,
+  RN_OSS_PROFILING,
   RN_FB_DEV,
   RN_FB_PROD,
 } = Bundles.bundleTypes;
@@ -95,6 +97,7 @@ function getBabelConfig(updateBabelOptions, bundleType, filename) {
       });
     case RN_OSS_DEV:
     case RN_OSS_PROD:
+    case RN_OSS_PROFILING:
     case RN_FB_DEV:
     case RN_FB_PROD:
       return Object.assign({}, options, {
@@ -107,6 +110,7 @@ function getBabelConfig(updateBabelOptions, bundleType, filename) {
     case UMD_PROD:
     case NODE_DEV:
     case NODE_PROD:
+    case NODE_PROFILING:
       return Object.assign({}, options, {
         plugins: options.plugins.concat([
           // Use object-assign polyfill in open source
@@ -152,10 +156,12 @@ function getFormat(bundleType) {
       return `umd`;
     case NODE_DEV:
     case NODE_PROD:
+    case NODE_PROFILING:
     case FB_WWW_DEV:
     case FB_WWW_PROD:
     case RN_OSS_DEV:
     case RN_OSS_PROD:
+    case RN_OSS_PROFILING:
     case RN_FB_DEV:
     case RN_FB_PROD:
       return `cjs`;
@@ -174,6 +180,8 @@ function getFilename(name, globalName, bundleType) {
       return `${name}.development.js`;
     case NODE_PROD:
       return `${name}.production.min.js`;
+    case NODE_PROFILING:
+      return `${name}.profiling.min.js`;
     case FB_WWW_DEV:
     case RN_OSS_DEV:
     case RN_FB_DEV:
@@ -182,6 +190,8 @@ function getFilename(name, globalName, bundleType) {
     case RN_OSS_PROD:
     case RN_FB_PROD:
       return `${globalName}-prod.js`;
+    case RN_OSS_PROFILING:
+      return `${globalName}-profiling.js`;
   }
 }
 
@@ -195,9 +205,32 @@ function isProductionBundleType(bundleType) {
       return false;
     case UMD_PROD:
     case NODE_PROD:
+    case NODE_PROFILING:
     case FB_WWW_PROD:
     case RN_OSS_PROD:
+    case RN_OSS_PROFILING:
     case RN_FB_PROD:
+      return true;
+    default:
+      throw new Error(`Unknown type: ${bundleType}`);
+  }
+}
+
+function isProfilingBundleType(bundleType) {
+  switch (bundleType) {
+    case FB_WWW_DEV:
+    case FB_WWW_PROD:
+    case NODE_DEV:
+    case NODE_PROD:
+    case RN_FB_DEV:
+    case RN_FB_PROD:
+    case RN_OSS_DEV:
+    case RN_OSS_PROD:
+    case UMD_DEV:
+    case UMD_PROD:
+      return false;
+    case NODE_PROFILING:
+    case RN_OSS_PROFILING:
       return true;
     default:
       throw new Error(`Unknown type: ${bundleType}`);
@@ -218,11 +251,13 @@ function getPlugins(
   const findAndRecordErrorCodes = extractErrorCodes(errorCodeOpts);
   const forks = Modules.getForks(bundleType, entry, moduleType);
   const isProduction = isProductionBundleType(bundleType);
+  const isProfiling = isProfilingBundleType(bundleType);
   const isInGlobalScope = bundleType === UMD_DEV || bundleType === UMD_PROD;
   const isFBBundle = bundleType === FB_WWW_DEV || bundleType === FB_WWW_PROD;
   const isRNBundle =
     bundleType === RN_OSS_DEV ||
     bundleType === RN_OSS_PROD ||
+    bundleType === RN_OSS_PROFILING ||
     bundleType === RN_FB_DEV ||
     bundleType === RN_FB_PROD;
   const shouldStayReadable = isFBBundle || isRNBundle || forcePrettyOutput;
@@ -255,6 +290,7 @@ function getPlugins(
     // Turn __DEV__ and process.env checks into constants.
     replace({
       __DEV__: isProduction ? 'false' : 'true',
+      __PROFILER__: isProfiling ? 'true' : 'false',
       'process.env.NODE_ENV': isProduction ? "'production'" : "'development'",
     }),
     // We still need CommonJS for external deps like object-assign.
@@ -508,10 +544,12 @@ async function buildEverything() {
     await createBundle(bundle, UMD_PROD);
     await createBundle(bundle, NODE_DEV);
     await createBundle(bundle, NODE_PROD);
+    await createBundle(bundle, NODE_PROFILING);
     await createBundle(bundle, FB_WWW_DEV);
     await createBundle(bundle, FB_WWW_PROD);
     await createBundle(bundle, RN_OSS_DEV);
     await createBundle(bundle, RN_OSS_PROD);
+    await createBundle(bundle, RN_OSS_PROFILING);
     await createBundle(bundle, RN_FB_DEV);
     await createBundle(bundle, RN_FB_PROD);
   }

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -290,7 +290,7 @@ function getPlugins(
     // Turn __DEV__ and process.env checks into constants.
     replace({
       __DEV__: isProduction ? 'false' : 'true',
-      __PROFILER__: isProfiling ? 'true' : 'false',
+      'process.env.REACT_ENABLE_PROFILING': isProfiling ? 'true' : 'false',
       'process.env.NODE_ENV': isProduction ? "'production'" : "'development'",
     }),
     // We still need CommonJS for external deps like object-assign.

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -290,7 +290,7 @@ function getPlugins(
     // Turn __DEV__ and process.env checks into constants.
     replace({
       __DEV__: isProduction ? 'false' : 'true',
-      __PROFILER__: isProfiling ? 'true' : 'false',
+      __PROFILE__: isProfiling ? 'true' : 'false',
       'process.env.NODE_ENV': isProduction ? "'production'" : "'development'",
     }),
     // We still need CommonJS for external deps like object-assign.

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -5,10 +5,12 @@ const bundleTypes = {
   UMD_PROD: 'UMD_PROD',
   NODE_DEV: 'NODE_DEV',
   NODE_PROD: 'NODE_PROD',
+  NODE_PROFILING: 'NODE_PROFILING',
   FB_WWW_DEV: 'FB_WWW_DEV',
   FB_WWW_PROD: 'FB_WWW_PROD',
   RN_OSS_DEV: 'RN_OSS_DEV',
   RN_OSS_PROD: 'RN_OSS_PROD',
+  RN_OSS_PROFILING: 'RN_OSS_PROFILING',
   RN_FB_DEV: 'RN_FB_DEV',
   RN_FB_PROD: 'RN_FB_PROD',
 };
@@ -17,10 +19,12 @@ const UMD_DEV = bundleTypes.UMD_DEV;
 const UMD_PROD = bundleTypes.UMD_PROD;
 const NODE_DEV = bundleTypes.NODE_DEV;
 const NODE_PROD = bundleTypes.NODE_PROD;
+const NODE_PROFILING = bundleTypes.NODE_PROFILING;
 const FB_WWW_DEV = bundleTypes.FB_WWW_DEV;
 const FB_WWW_PROD = bundleTypes.FB_WWW_PROD;
 const RN_OSS_DEV = bundleTypes.RN_OSS_DEV;
 const RN_OSS_PROD = bundleTypes.RN_OSS_PROD;
+const RN_OSS_PROFILING = bundleTypes.RN_OSS_PROFILING;
 const RN_FB_DEV = bundleTypes.RN_FB_DEV;
 const RN_FB_PROD = bundleTypes.RN_FB_PROD;
 
@@ -69,6 +73,7 @@ const bundles = [
       UMD_PROD,
       NODE_DEV,
       NODE_PROD,
+      NODE_PROFILING,
       FB_WWW_DEV,
       FB_WWW_PROD,
     ],
@@ -175,7 +180,7 @@ const bundles = [
 
   {
     label: 'native',
-    bundleTypes: [RN_OSS_DEV, RN_OSS_PROD],
+    bundleTypes: [RN_OSS_DEV, RN_OSS_PROD, RN_OSS_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer',
     global: 'ReactNativeRenderer',
@@ -217,7 +222,7 @@ const bundles = [
 
   {
     label: 'native-fabric',
-    bundleTypes: [RN_OSS_DEV, RN_OSS_PROD],
+    bundleTypes: [RN_OSS_DEV, RN_OSS_PROD, RN_OSS_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer/fabric',
     global: 'ReactFabric',

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -10,6 +10,7 @@ const FB_WWW_DEV = bundleTypes.FB_WWW_DEV;
 const FB_WWW_PROD = bundleTypes.FB_WWW_PROD;
 const RN_OSS_DEV = bundleTypes.RN_OSS_DEV;
 const RN_OSS_PROD = bundleTypes.RN_OSS_PROD;
+const RN_OSS_PROFILING = bundleTypes.RN_OSS_PROFILING;
 const RN_FB_DEV = bundleTypes.RN_FB_DEV;
 const RN_FB_PROD = bundleTypes.RN_FB_PROD;
 const RENDERER = moduleTypes.RENDERER;
@@ -45,6 +46,7 @@ const forks = Object.freeze({
             return 'shared/forks/ReactFeatureFlags.native-fb.js';
           case RN_OSS_DEV:
           case RN_OSS_PROD:
+          case RN_OSS_PROFILING:
             return 'shared/forks/ReactFeatureFlags.native-oss.js';
           default:
             throw Error(
@@ -58,6 +60,7 @@ const forks = Object.freeze({
             return 'shared/forks/ReactFeatureFlags.native-fabric-fb.js';
           case RN_OSS_DEV:
           case RN_OSS_PROD:
+          case RN_OSS_PROFILING:
             return 'shared/forks/ReactFeatureFlags.native-fabric-oss.js';
           default:
             throw Error(
@@ -143,6 +146,7 @@ const forks = Object.freeze({
         return 'react-reconciler/src/forks/ReactFiberErrorDialog.www.js';
       case RN_OSS_DEV:
       case RN_OSS_PROD:
+      case RN_OSS_PROFILING:
       case RN_FB_DEV:
       case RN_FB_PROD:
         switch (entry) {

--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -14,10 +14,12 @@ const {
   UMD_PROD,
   NODE_DEV,
   NODE_PROD,
+  NODE_PROFILING,
   FB_WWW_DEV,
   FB_WWW_PROD,
   RN_OSS_DEV,
   RN_OSS_PROD,
+  RN_OSS_PROFILING,
   RN_FB_DEV,
   RN_FB_PROD,
 } = Bundles.bundleTypes;
@@ -33,6 +35,7 @@ function getBundleOutputPaths(bundleType, filename, packageName) {
   switch (bundleType) {
     case NODE_DEV:
     case NODE_PROD:
+    case NODE_PROFILING:
       return [`build/node_modules/${packageName}/cjs/${filename}`];
     case UMD_DEV:
     case UMD_PROD:
@@ -45,6 +48,7 @@ function getBundleOutputPaths(bundleType, filename, packageName) {
       return [`build/facebook-www/${filename}`];
     case RN_OSS_DEV:
     case RN_OSS_PROD:
+    case RN_OSS_PROFILING:
       switch (packageName) {
         case 'react-native-renderer':
           return [`build/react-native/oss/${filename}`];

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -7,10 +7,12 @@ const UMD_DEV = Bundles.bundleTypes.UMD_DEV;
 const UMD_PROD = Bundles.bundleTypes.UMD_PROD;
 const NODE_DEV = Bundles.bundleTypes.NODE_DEV;
 const NODE_PROD = Bundles.bundleTypes.NODE_PROD;
+const NODE_PROFILING = Bundles.bundleTypes.NODE_PROFILING;
 const FB_WWW_DEV = Bundles.bundleTypes.FB_WWW_DEV;
 const FB_WWW_PROD = Bundles.bundleTypes.FB_WWW_PROD;
 const RN_OSS_DEV = Bundles.bundleTypes.RN_OSS_DEV;
 const RN_OSS_PROD = Bundles.bundleTypes.RN_OSS_PROD;
+const RN_OSS_PROFILING = Bundles.bundleTypes.RN_OSS_PROFILING;
 const RN_FB_DEV = Bundles.bundleTypes.RN_FB_DEV;
 const RN_FB_PROD = Bundles.bundleTypes.RN_FB_PROD;
 
@@ -91,6 +93,25 @@ ${
 ${source}`;
   },
 
+  /***************** NODE_PROFILING *****************/
+  [NODE_PROFILING](source, globalName, filename, moduleType) {
+    return `/** @license React v${reactVersion}
+ * ${filename}
+ *
+${license}
+ */
+${
+      globalName === 'ReactNoopRenderer' ||
+      globalName === 'ReactNoopRendererPersistent'
+        ? // React Noop needs regenerator runtime because it uses
+          // generators but GCC doesn't handle them in the output.
+          // So we use Babel for them.
+          `const regeneratorRuntime = require("regenerator-runtime");`
+        : ``
+    }
+${source}`;
+  },
+
   /****************** FB_WWW_DEV ******************/
   [FB_WWW_DEV](source, globalName, filename, moduleType) {
     return `/**
@@ -150,6 +171,20 @@ ${license}
  *
  * @noflow
  * @providesModule ${globalName}-prod
+ * @preventMunge
+ * ${'@gen' + 'erated'}
+ */
+
+${source}`;
+  },
+
+  /****************** RN_OSS_PROFILING ******************/
+  [RN_OSS_PROFILING](source, globalName, filename, moduleType) {
+    return `/**
+${license}
+ *
+ * @noflow
+ * @providesModule ${globalName}-profiling
  * @preventMunge
  * ${'@gen' + 'erated'}
  */


### PR DESCRIPTION
Adds a new "profiling" target to ReactDOM (cjs) and ReactNative (oss) bundles. This is a production build (`process.env.NODE_ENV === "production"`) but has the profiling timing flag enabled (via a new env variable `process.env.REACT_ENABLE_PROFILING`).

I don't believe that other bundles need this new build type, but it would be easy enough to add if we decided it did.

```
┌──────────────────────────────────┬──────────────────┬───────────┬───────────┐
│ Bundle                           │ Type             │ Size      │ Gzip      │
├──────────────────────────────────┼──────────────────┼───────────┼───────────┤
│ react-dom.development.js         │ NODE_DEV         │ 603.67 KB │ 140.49 KB │
├──────────────────────────────────┼──────────────────┼───────────┼───────────┤
│ react-dom.production.min.js      │ NODE_PROD        │ 92.33 KB  │ 29.41 KB  │
├──────────────────────────────────┼──────────────────┼───────────┼───────────┤
│ react-dom.profiling.min.js       │ NODE_PROFILING   │ 93.28 KB  │ 29.77 KB  │
├──────────────────────────────────┼──────────────────┼───────────┼───────────┤
│ ReactNativeRenderer-dev.js       │ RN_OSS_DEV       │ 454.67 KB │ 99.65 KB  │
├──────────────────────────────────┼──────────────────┼───────────┼───────────┤
│ ReactNativeRenderer-prod.js      │ RN_OSS_PROD      │ 193.62 KB │ 33.9 KB   │
├──────────────────────────────────┼──────────────────┼───────────┼───────────┤
│ ReactNativeRenderer-profiling.js │ RN_OSS_PROFILING │ 196.27 KB │ 34.47 KB  │
├──────────────────────────────────┼──────────────────┼───────────┼───────────┤
│ ReactFabric-dev.js               │ RN_OSS_DEV       │ 445.96 KB │ 97.5 KB   │
├──────────────────────────────────┼──────────────────┼───────────┼───────────┤
│ ReactFabric-prod.js              │ RN_OSS_PROD      │ 185.91 KB │ 32.56 KB  │
├──────────────────────────────────┼──────────────────┼───────────┼───────────┤
│ ReactFabric-profiling.js         │ RN_OSS_PROFILING │ 188.19 KB │ 33.06 KB  │
└──────────────────────────────────┴──────────────────┴───────────┴───────────┘
```