### PR TITLE
Record "actual" times for all Fibers within a Profiler tree

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -153,6 +153,8 @@ export type Fiber = {|
   alternate: Fiber | null,
 
   // Profiling metrics
+  actualDuration?: number,
+  actualStartTime?: number,
   selfBaseTime?: number,
   treeBaseTime?: number,
 
@@ -211,6 +213,8 @@ function FiberNode(
   this.alternate = null;
 
   if (enableProfilerTimer) {
+    this.actualDuration = 0;
+    this.actualStartTime = 0;
     this.selfBaseTime = 0;
     this.treeBaseTime = 0;
   }
@@ -310,6 +314,9 @@ export function createWorkInProgress(
   workInProgress.ref = current.ref;
 
   if (enableProfilerTimer) {
+    // We intentionally do not copy actual duration or start times.
+    // This would interfere with time tracking during interruptions.
+
     workInProgress.selfBaseTime = current.selfBaseTime;
     workInProgress.treeBaseTime = current.treeBaseTime;
   }
@@ -460,13 +467,6 @@ export function createFiberFromProfiler(
   const fiber = createFiber(Profiler, pendingProps, key, mode | ProfileMode);
   fiber.type = REACT_PROFILER_TYPE;
   fiber.expirationTime = expirationTime;
-  if (enableProfilerTimer) {
-    fiber.stateNode = {
-      elapsedPauseTimeAtStart: 0,
-      duration: 0,
-      startTime: 0,
-    };
-  }
 
   return fiber;
 }
@@ -541,6 +541,8 @@ export function assignFiberPropertiesInDEV(
   target.expirationTime = source.expirationTime;
   target.alternate = source.alternate;
   if (enableProfilerTimer) {
+    target.actualDuration = source.actualDuration;
+    target.actualStartTime = source.actualStartTime;
     target.selfBaseTime = source.selfBaseTime;
     target.treeBaseTime = source.treeBaseTime;
   }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -753,7 +753,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
 
   switch (finishedWork.tag) {
     case ClassComponent: {
-      return;
+      break;
     }
     case HostComponent: {
       const instance: Instance = finishedWork.stateNode;
@@ -779,7 +779,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           );
         }
       }
-      return;
+      break;
     }
     case HostText: {
       invariant(
@@ -795,10 +795,10 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       const oldText: string =
         current !== null ? current.memoizedProps : newText;
       commitTextUpdate(textInstance, oldText, newText);
-      return;
+      break;
     }
     case HostRoot: {
-      return;
+      break;
     }
     case Profiler: {
       if (enableProfilerTimer) {
@@ -811,15 +811,11 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           finishedWork.actualStartTime,
           getCommitTime(),
         );
-
-        // Reset actualTime after successful commit.
-        // By default, we append to this time to account for errors and pauses.
-        finishedWork.actualDuration = 0;
       }
-      return;
+      break;
     }
     case TimeoutComponent: {
-      return;
+      break;
     }
     default: {
       invariant(
@@ -828,6 +824,12 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           'likely caused by a bug in React. Please file an issue.',
       );
     }
+  }
+
+  if (enableProfilerTimer) {
+    // Reset actualTime after successful commit.
+    // By default, we append to this time to account for errors and pauses.
+    finishedWork.actualDuration = 0;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -825,12 +825,6 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       );
     }
   }
-
-  if (enableProfilerTimer) {
-    // Reset actualTime after successful commit.
-    // By default, we append to this time to account for errors and pauses.
-    finishedWork.actualDuration = 0;
-  }
 }
 
 function commitResetTextContent(current: Fiber) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -753,7 +753,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
 
   switch (finishedWork.tag) {
     case ClassComponent: {
-      break;
+      return;
     }
     case HostComponent: {
       const instance: Instance = finishedWork.stateNode;
@@ -779,7 +779,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           );
         }
       }
-      break;
+      return;
     }
     case HostText: {
       invariant(
@@ -795,10 +795,10 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       const oldText: string =
         current !== null ? current.memoizedProps : newText;
       commitTextUpdate(textInstance, oldText, newText);
-      break;
+      return;
     }
     case HostRoot: {
-      break;
+      return;
     }
     case Profiler: {
       if (enableProfilerTimer) {
@@ -812,10 +812,10 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           getCommitTime(),
         );
       }
-      break;
+      return;
     }
     case TimeoutComponent: {
-      break;
+      return;
     }
     default: {
       invariant(

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -806,15 +806,15 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
         onRender(
           finishedWork.memoizedProps.id,
           current === null ? 'mount' : 'update',
-          finishedWork.stateNode.duration,
+          finishedWork.actualDuration,
           finishedWork.treeBaseTime,
-          finishedWork.stateNode.startTime,
+          finishedWork.actualStartTime,
           getCommitTime(),
         );
 
         // Reset actualTime after successful commit.
         // By default, we append to this time to account for errors and pauses.
-        finishedWork.stateNode.duration = 0;
+        finishedWork.actualDuration = 0;
       }
       return;
     }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -38,6 +38,7 @@ import {
   TimeoutComponent,
 } from 'shared/ReactTypeOfWork';
 import {Placement, Ref, Update} from 'shared/ReactTypeOfSideEffect';
+import {ProfileMode} from './ReactTypeOfMode';
 import invariant from 'fbjs/lib/invariant';
 
 import {
@@ -312,6 +313,13 @@ function completeWork(
   renderExpirationTime: ExpirationTime,
 ): Fiber | null {
   const newProps = workInProgress.pendingProps;
+
+  if (enableProfilerTimer) {
+    if (workInProgress.mode & ProfileMode) {
+      recordElapsedActualRenderTime(workInProgress);
+    }
+  }
+
   switch (workInProgress.tag) {
     case FunctionalComponent:
       return null;
@@ -489,9 +497,6 @@ function completeWork(
     case Mode:
       return null;
     case Profiler:
-      if (enableProfilerTimer) {
-        recordElapsedActualRenderTime(workInProgress);
-      }
       return null;
     case HostPortal:
       popHostContainer(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -104,6 +104,7 @@ import {popProvider} from './ReactFiberNewContext';
 import {popHostContext, popHostContainer} from './ReactFiberHostContext';
 import {
   checkActualRenderTimeStackEmpty,
+  incrementCommitBatchId,
   pauseActualRenderTimerIfRunning,
   recordCommitTime,
   recordElapsedActualRenderTime,
@@ -578,6 +579,13 @@ function commitRoot(finishedWork: Fiber): ExpirationTime {
   stopCommitSnapshotEffectsTimer();
 
   if (enableProfilerTimer) {
+    // Batch ID groups profile timings for a given commit.
+    // This allows durations to acculate across interrupts or yields,
+    // And reset between commits.
+    incrementCommitBatchId();
+
+    // Mark the current commit time to be shared by all Profilers in this batch.
+    // This enables them to be grouped later.
     recordCommitTime();
   }
 

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -106,6 +106,7 @@ import {
   checkActualRenderTimeStackEmpty,
   pauseActualRenderTimerIfRunning,
   recordCommitTime,
+  recordElapsedActualRenderTime,
   recordElapsedBaseRenderTimeIfRunning,
   resetActualRenderTimer,
   resumeActualRenderTimerIfPaused,
@@ -311,6 +312,10 @@ if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
       clearCaughtError();
 
       if (enableProfilerTimer) {
+        if (failedUnitOfWork.mode & ProfileMode) {
+          recordElapsedActualRenderTime(failedUnitOfWork);
+        }
+
         // Stop "base" render timer again (after the re-thrown error).
         stopBaseRenderTimerIfRunning();
       }

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -9,6 +9,7 @@
 
 import type {Fiber} from './ReactFiber';
 
+import getComponentName from 'shared/getComponentName';
 import {enableProfilerTimer} from 'shared/ReactFeatureFlags';
 
 import warning from 'fbjs/lib/warning';
@@ -96,7 +97,11 @@ function recordElapsedActualRenderTime(fiber: Fiber): void {
     return;
   }
   if (__DEV__) {
-    warning(fiber === fiberStack.pop(), 'Unexpected Fiber popped.');
+    warning(
+      fiber === fiberStack.pop(),
+      'Unexpected Fiber (%s) popped.',
+      getComponentName(fiber),
+    );
   }
 
   fiber.actualDuration =

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -76,9 +76,10 @@ function markActualRenderTimeStarted(fiber: Fiber): void {
   if (__DEV__) {
     fiberStack.push(fiber);
   }
-  const stateNode = fiber.stateNode;
-  stateNode.elapsedPauseTimeAtStart = totalElapsedPauseTime;
-  stateNode.startTime = now();
+
+  fiber.actualDuration =
+    now() - ((fiber.actualDuration: any): number) - totalElapsedPauseTime;
+  fiber.actualStartTime = now();
 }
 
 function pauseActualRenderTimerIfRunning(): void {
@@ -97,11 +98,9 @@ function recordElapsedActualRenderTime(fiber: Fiber): void {
   if (__DEV__) {
     warning(fiber === fiberStack.pop(), 'Unexpected Fiber popped.');
   }
-  const stateNode = fiber.stateNode;
-  stateNode.duration +=
-    now() -
-    (totalElapsedPauseTime - stateNode.elapsedPauseTimeAtStart) -
-    stateNode.startTime;
+
+  fiber.actualDuration =
+    now() - totalElapsedPauseTime - ((fiber.actualDuration: any): number);
 }
 
 function resetActualRenderTimer(): void {

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -18,6 +18,7 @@ import {now} from './ReactFiberHostConfig';
 export type ProfilerTimer = {
   checkActualRenderTimeStackEmpty(): void,
   getCommitTime(): number,
+  incrementCommitBatchId(): void,
   markActualRenderTimeStarted(fiber: Fiber): void,
   pauseActualRenderTimerIfRunning(): void,
   recordElapsedActualRenderTime(fiber: Fiber): void,
@@ -30,9 +31,14 @@ export type ProfilerTimer = {
 };
 
 let commitTime: number = 0;
+let commitBatchId: number = 0;
 
 function getCommitTime(): number {
   return commitTime;
+}
+
+function incrementCommitBatchId(): void {
+  commitBatchId++;
 }
 
 function recordCommitTime(): void {
@@ -76,6 +82,11 @@ function markActualRenderTimeStarted(fiber: Fiber): void {
   }
   if (__DEV__) {
     fiberStack.push(fiber);
+  }
+
+  if (fiber.profilerCommitBatchId !== commitBatchId) {
+    fiber.profilerCommitBatchId = commitBatchId;
+    fiber.actualDuration = 0;
   }
 
   fiber.actualDuration =
@@ -170,6 +181,7 @@ function stopBaseRenderTimerIfRunning(): void {
 export {
   checkActualRenderTimeStackEmpty,
   getCommitTime,
+  incrementCommitBatchId,
   markActualRenderTimeStarted,
   pauseActualRenderTimerIfRunning,
   recordCommitTime,

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -598,7 +598,9 @@ describe('Profiler', () => {
           </React.unstable_Profiler>,
           {unstable_isAsync: true},
         );
-        expect(renderer.unstable_flushThrough(['first'])).toEqual(['Yield:10']);
+        expect(renderer.unstable_flushThrough(['Yield:10'])).toEqual([
+          'Yield:10',
+        ]);
         expect(callback).toHaveBeenCalledTimes(0);
 
         // Simulate time moving forward while frame is paused.

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -228,6 +228,28 @@ describe('Profiler', () => {
       expect(call[3]).toBe(10); // base time
       expect(call[4]).toBe(35); // start time
       expect(call[5]).toBe(45); // commit time
+
+      callback.mockReset();
+
+      advanceTimeBy(20); // 45 -> 65
+
+      renderer.update(
+        <React.unstable_Profiler id="test" onRender={callback}>
+          <AdvanceTime byAmount={4} />
+        </React.unstable_Profiler>,
+      );
+
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      [call] = callback.mock.calls;
+
+      expect(call).toHaveLength(6);
+      expect(call[0]).toBe('test');
+      expect(call[1]).toBe('update');
+      expect(call[2]).toBe(4); // actual time
+      expect(call[3]).toBe(4); // base time
+      expect(call[4]).toBe(65); // start time
+      expect(call[5]).toBe(69); // commit time
     });
 
     it('includes render times of nested Profilers in their parent times', () => {


### PR DESCRIPTION
Move "actual" time tracking attributes onto the `Fiber` object and track for every `Fiber` within a `Profiler` tree. This change is being made so that DevTools has the ability to display timing info for all components in an application (or a subtree) simply by flipping the root `Fiber` and its alternate to `ProfileMode`.

This change should have no impact on the production bundle since the newly added fields are stripped out if `enableProfilerTimer` is disabled. It should have minimal impact on the dev and [production profiling](https://github.com/facebook/react/pull/12886) bundles since measurements are only recorded if `ProfileMode` is active.

### Checklist
- [x] All existing unit tests pass.
- [x] Bundle size isn't impacted for non-profiling builds. (See below.)
- [x] Reset "actual" time durations for all Fibers after commit- even ones that didn't update due to bailouts. (Otherwise their durations will accumulate for the next eventual re-render.)
- [x] Don't reset durations before DevTools commit hook is called. (Otherwise DevTools will be unable to read these values for profiling mode.)

### Bundle sizes
Built after rebasing on master:
![screen shot 2018-05-25 at 9 52 24 am](https://user-images.githubusercontent.com/29597/40556403-5e31b330-6001-11e8-8e56-663d84187475.png)