### PR TITLE
add functional components warning about legacy context api

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -48,6 +48,7 @@ import {
 } from 'shared/ReactFeatureFlags';
 import invariant from 'fbjs/lib/invariant';
 import getComponentName from 'shared/getComponentName';
+import ReactStrictModeWarnings from './ReactStrictModeWarnings';
 import warning from 'fbjs/lib/warning';
 import ReactDebugCurrentFiber from './ReactDebugCurrentFiber';
 import {cancelWorkTimer} from './ReactDebugFiberPerf';
@@ -600,6 +601,11 @@ function mountIndeterminateComponent(
         didWarnAboutBadClass[componentName] = true;
       }
     }
+
+    if (workInProgress.mode & StrictMode) {
+      ReactStrictModeWarnings.recordLegacyContextWarning(workInProgress, null);
+    }
+
     ReactCurrentOwner.current = workInProgress;
     value = fn(props, context);
   } else {

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -319,9 +319,9 @@ if (__DEV__) {
     let warningsForRoot = pendingLegacyContextWarning.get(strictRoot);
 
     if (
-      typeof instance.getChildContext === 'function' ||
       fiber.type.contextTypes != null ||
-      fiber.type.childContextTypes != null
+      fiber.type.childContextTypes != null ||
+      (instance !== null && typeof instance.getChildContext === 'function')
     ) {
       if (warningsForRoot === undefined) {
         warningsForRoot = [];

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -824,8 +824,26 @@ describe('ReactStrictMode', () => {
         }
 
         render() {
-          return <LegacyContextConsumer />;
+          return (
+            <div>
+              <LegacyContextConsumer />
+              <FunctionalLegacyContextConsumer />
+              <FactoryLegacyContextConsumer />
+            </div>
+          );
         }
+      }
+
+      function FunctionalLegacyContextConsumer() {
+        return null;
+      }
+
+      function FactoryLegacyContextConsumer() {
+        return {
+          render() {
+            return null;
+          },
+        };
       }
 
       LegacyContextProvider.childContextTypes = {
@@ -856,6 +874,14 @@ describe('ReactStrictMode', () => {
         color: PropTypes.string,
       };
 
+      FunctionalLegacyContextConsumer.contextTypes = {
+        color: PropTypes.string,
+      };
+
+      FactoryLegacyContextConsumer.contextTypes = {
+        color: PropTypes.string,
+      };
+
       let rendered;
 
       expect(() => {
@@ -864,7 +890,8 @@ describe('ReactStrictMode', () => {
         'Warning: Legacy context API has been detected within a strict-mode tree: ' +
           '\n    in div (at **)' +
           '\n    in Root (at **)' +
-          '\n\nPlease update the following components: LegacyContextConsumer, LegacyContextProvider' +
+          '\n\nPlease update the following components: FactoryLegacyContextConsumer, ' +
+          'FunctionalLegacyContextConsumer, LegacyContextConsumer, LegacyContextProvider' +
           '\n\nLearn more about this warning here:' +
           '\nhttps://fb.me/react-strict-mode-warnings',
       );


### PR DESCRIPTION
> Looks like we're not catching functional components here. They can also have contextTypes and should also be warned about.

As is mentioned by @gaearon in the previous PR, functional components should also be warned if they have `contextTypes`. Previously it only warns in class components.

To reduce extraneous check, the logic is put into `mountIndeterminateComponent`.