### PR TITLE
[scheduler] 3/n Use a linked list instead of map and queue for callback storage

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -10,7 +10,6 @@
 import type {Fiber} from './ReactFiber';
 import type {FiberRoot, Batch} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
-import type {CallbackIdType} from 'react-scheduler';
 
 import ReactErrorUtils from 'shared/ReactErrorUtils';
 import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
@@ -1431,7 +1430,7 @@ let firstScheduledRoot: FiberRoot | null = null;
 let lastScheduledRoot: FiberRoot | null = null;
 
 let callbackExpirationTime: ExpirationTime = NoWork;
-let callbackID: CallbackIdType | number | null = null;
+let callbackID: *;
 let isRendering: boolean = false;
 let nextFlushedRoot: FiberRoot | null = null;
 let nextFlushedExpirationTime: ExpirationTime = NoWork;

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -10,6 +10,7 @@
 import type {Fiber} from './ReactFiber';
 import type {FiberRoot, Batch} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
+import type {CallbackIdType} from 'react-scheduler';
 
 import ReactErrorUtils from 'shared/ReactErrorUtils';
 import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
@@ -1430,7 +1431,7 @@ let firstScheduledRoot: FiberRoot | null = null;
 let lastScheduledRoot: FiberRoot | null = null;
 
 let callbackExpirationTime: ExpirationTime = NoWork;
-let callbackID: number = -1;
+let callbackID: CallbackIdType | number | null = null;
 let isRendering: boolean = false;
 let nextFlushedRoot: FiberRoot | null = null;
 let nextFlushedExpirationTime: ExpirationTime = NoWork;
@@ -1459,9 +1460,11 @@ function scheduleCallbackWithExpiration(expirationTime) {
       // Existing callback has sufficient timeout. Exit.
       return;
     } else {
-      // Existing callback has insufficient timeout. Cancel and schedule a
-      // new one.
-      cancelDeferredCallback(callbackID);
+      if (callbackID !== null) {
+        // Existing callback has insufficient timeout. Cancel and schedule a
+        // new one.
+        cancelDeferredCallback(callbackID);
+      }
     }
     // The request callback timer is already running. Don't start a new one.
   } else {
@@ -1687,7 +1690,7 @@ function performWork(
   // If we're inside a callback, set this to false since we just completed it.
   if (deadline !== null) {
     callbackExpirationTime = NoWork;
-    callbackID = -1;
+    callbackID = null;
   }
   // If there's work left over, schedule a new callback.
   if (nextFlushedExpirationTime !== NoWork) {

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -35,8 +35,8 @@ type FrameCallbackType = Deadline => void;
 type CallbackConfigType = {|
   scheduledCallback: FrameCallbackType,
   timeoutTime: number,
-  nextCallbackConfig: CallbackConfigType | null, // creating a linked list
-  previousCallbackConfig: CallbackConfigType | null, // creating a linked list
+  next: CallbackConfigType | null, // creating a linked list
+  prev: CallbackConfigType | null, // creating a linked list
 |};
 
 export type CallbackIdType = CallbackConfigType;
@@ -75,8 +75,8 @@ if (!ExecutionEnvironment.canUseDOM) {
     const callbackConfig = {
       scheduledCallback: callback,
       timeoutTime: 0,
-      nextCallbackConfig: null,
-      previousCallbackConfig: null,
+      next: null,
+      prev: null,
     };
     const timeoutId = setTimeout(() => {
       callback({
@@ -168,7 +168,7 @@ if (!ExecutionEnvironment.canUseDOM) {
           nextSoonestTimeoutTime = timeoutTime;
         }
       }
-      currentCallbackConfig = currentCallbackConfig.nextCallbackConfig;
+      currentCallbackConfig = currentCallbackConfig.next;
     }
   };
 
@@ -200,9 +200,9 @@ if (!ExecutionEnvironment.canUseDOM) {
       const latestCallbackConfig = headOfPendingCallbacksLinkedList;
       // move head of list to next callback
       headOfPendingCallbacksLinkedList =
-        latestCallbackConfig.nextCallbackConfig;
+        latestCallbackConfig.next;
       if (headOfPendingCallbacksLinkedList !== null) {
-        headOfPendingCallbacksLinkedList.previousCallbackConfig = null;
+        headOfPendingCallbacksLinkedList.prev = null;
       } else {
         // if headOfPendingCallbacksLinkedList is null,
         // then the list must be empty.
@@ -276,8 +276,8 @@ if (!ExecutionEnvironment.canUseDOM) {
     const scheduledCallbackConfig: CallbackConfigType = {
       scheduledCallback: callback,
       timeoutTime,
-      previousCallbackConfig: null,
-      nextCallbackConfig: null,
+      prev: null,
+      next: null,
     };
     if (headOfPendingCallbacksLinkedList === null) {
       // Make this callback the head and tail of our list
@@ -285,11 +285,11 @@ if (!ExecutionEnvironment.canUseDOM) {
       tailOfPendingCallbacksLinkedList = scheduledCallbackConfig;
     } else {
       // Add latest callback as the new tail of the list
-      scheduledCallbackConfig.previousCallbackConfig = tailOfPendingCallbacksLinkedList;
+      scheduledCallbackConfig.prev = tailOfPendingCallbacksLinkedList;
       // renaming for clarity
       const oldTailOfPendingCallbacksLinkedList = tailOfPendingCallbacksLinkedList;
       if (oldTailOfPendingCallbacksLinkedList !== null) {
-        oldTailOfPendingCallbacksLinkedList.nextCallbackConfig = scheduledCallbackConfig;
+        oldTailOfPendingCallbacksLinkedList.next = scheduledCallbackConfig;
       }
       tailOfPendingCallbacksLinkedList = scheduledCallbackConfig;
     }
@@ -322,35 +322,35 @@ if (!ExecutionEnvironment.canUseDOM) {
      *   In this case we point the Head.next to the Tail and the Tail.prev to
      *   the Head.
      */
-    if (callbackConfig.nextCallbackConfig !== null) {
-      // we have a nextCallbackConfig
-      const nextCallbackConfig = callbackConfig.nextCallbackConfig;
+    if (callbackConfig.next !== null) {
+      // we have a next
+      const next = callbackConfig.next;
 
-      if (callbackConfig.previousCallbackConfig !== null) {
-        // we have a previousCallbackConfig
-        const previousCallbackConfig = callbackConfig.previousCallbackConfig;
+      if (callbackConfig.prev !== null) {
+        // we have a prev
+        const prev = callbackConfig.prev;
 
         // callbackConfig is somewhere in the middle of a list of 3 or more nodes.
-        previousCallbackConfig.nextCallbackConfig = nextCallbackConfig;
-        nextCallbackConfig.previousCallbackConfig = previousCallbackConfig;
+        prev.next = next;
+        next.prev = prev;
         return;
       } else {
-        // there is a nextCallbackConfig but not a previous one;
+        // there is a next but not a previous one;
         // callbackConfig is the head of a list of 2 or more other nodes.
-        nextCallbackConfig.previousCallbackConfig = null;
-        headOfPendingCallbacksLinkedList = nextCallbackConfig;
+        next.prev = null;
+        headOfPendingCallbacksLinkedList = next;
         return;
       }
     } else {
       // there is no next callback config; this must the tail of the list
 
-      if (callbackConfig.previousCallbackConfig !== null) {
-        // we have a previousCallbackConfig
-        const previousCallbackConfig = callbackConfig.previousCallbackConfig;
+      if (callbackConfig.prev !== null) {
+        // we have a prev
+        const prev = callbackConfig.prev;
 
         // callbackConfig is the tail of a list of 2 or more other nodes.
-        previousCallbackConfig.nextCallbackConfig = null;
-        tailOfPendingCallbacksLinkedList = previousCallbackConfig;
+        prev.next = null;
+        tailOfPendingCallbacksLinkedList = prev;
         return;
       } else {
         // there is no previous callback config;

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -197,10 +197,12 @@ if (!ExecutionEnvironment.canUseDOM) {
       // move head of list to next callback
       headOfPendingCallbacksLinkedList =
         latestCallbackConfig.nextCallbackConfig;
-      if (headOfPendingCallbacksLinkedList) {
+      if (headOfPendingCallbacksLinkedList !== null) {
         headOfPendingCallbacksLinkedList.previousCallbackConfig = null;
-      }
-      if (tailOfPendingCallbacksLinkedList === latestCallbackConfig) {
+      } else {
+        // if headOfPendingCallbacksLinkedList is null,
+        // then the list must be empty.
+        // make sure we set the tail to null as well.
         tailOfPendingCallbacksLinkedList = null;
       }
       frameDeadlineObject.didTimeout = false;
@@ -318,10 +320,10 @@ if (!ExecutionEnvironment.canUseDOM) {
      */
     const previousCallbackConfig = callbackConfig.previousCallbackConfig;
     const nextCallbackConfig = callbackConfig.nextCallbackConfig;
-    if (previousCallbackConfig) {
+    if (previousCallbackConfig !== null) {
       previousCallbackConfig.nextCallbackConfig = nextCallbackConfig;
     }
-    if (nextCallbackConfig) {
+    if (nextCallbackConfig !== null) {
       nextCallbackConfig.previousCallbackConfig = previousCallbackConfig;
     }
     if (headOfPendingCallbacksLinkedList === callbackConfig) {

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -288,36 +288,43 @@ cancelScheduledWork = function(
    *   In this case we point the Head.next to the Tail and the Tail.prev to
    *   the Head.
    */
+  if (callbackConfig.nextCallbackConfig !== null) {
+    // we have a nextCallbackConfig
+    const nextCallbackConfig = callbackConfig.nextCallbackConfig;
 
-  if (headOfPendingCallbacksLinkedList === callbackConfig) {
-    // this callbackConfig is at the head of the list.
-    if (tailOfPendingCallbacksLinkedList === callbackConfig) {
-      // callbackConfig is the only thing in the linked list,
-      // so both head and tail point to it.
-      headOfPendingCallbacksLinkedList = null;
-      tailOfPendingCallbacksLinkedList = null;
+    if (callbackConfig.previousCallbackConfig !== null) {
+      // we have a previousCallbackConfig
+      const previousCallbackConfig = callbackConfig.previousCallbackConfig;
+
+      // callbackConfig is somewhere in the middle of a list of 3 or more nodes.
+      previousCallbackConfig.nextCallbackConfig = nextCallbackConfig;
+      nextCallbackConfig.previousCallbackConfig = previousCallbackConfig;
       return;
+
     } else {
+      // there is a nextCallbackConfig but not a previous one;
       // callbackConfig is the head of a list of 2 or more other nodes.
-      const nextCallbackConfig = callbackConfig.nextCallbackConfig;
       nextCallbackConfig.previousCallbackConfig = null;
       headOfPendingCallbacksLinkedList = nextCallbackConfig;
       return;
     }
   } else {
-    // this callbackConfig is not at the head of the list.
-    if (tailOfPendingCallbacksLinkedList === callbackConfig) {
-      // callbackConfig is the tail of a list of 2 or more other nodes.
+    // there is no next callback config; this must the tail of the list
+
+    if (callbackConfig.previousCallbackConfig !== null) {
+      // we have a previousCallbackConfig
       const previousCallbackConfig = callbackConfig.previousCallbackConfig;
+
+      // callbackConfig is the tail of a list of 2 or more other nodes.
       previousCallbackConfig.nextCallbackConfig = null;
       tailOfPendingCallbacksLinkedList = previousCallbackConfig;
       return;
     } else {
-      // callbackConfig is somewhere in the middle of a list of 3 or more nodes.
-      const nextCallbackConfig = callbackConfig.nextCallbackConfig;
-      const previousCallbackConfig = callbackConfig.previousCallbackConfig;
-      previousCallbackConfig.nextCallbackConfig = nextCallbackConfig;
-      nextCallbackConfig.previousCallbackConfig = previousCallbackConfig;
+      // there is no previous callback config;
+      // callbackConfig is the only thing in the linked list,
+      // so both head and tail point to it.
+      headOfPendingCallbacksLinkedList = null;
+      tailOfPendingCallbacksLinkedList = null;
       return;
     }
   }

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -128,8 +128,7 @@ const callTimedOutCallbacks = function() {
     } else {
       if (
         timeoutTime !== -1 &&
-        (nextSoonestTimeoutTime === -1 ||
-          timeoutTime < nextSoonestTimeoutTime)
+        (nextSoonestTimeoutTime === -1 || timeoutTime < nextSoonestTimeoutTime)
       ) {
         nextSoonestTimeoutTime = timeoutTime;
       }
@@ -165,8 +164,7 @@ const idleTick = function(event) {
   ) {
     const latestCallbackConfig = headOfPendingCallbacksLinkedList;
     // move head of list to next callback
-    headOfPendingCallbacksLinkedList =
-      latestCallbackConfig.nextCallbackConfig;
+    headOfPendingCallbacksLinkedList = latestCallbackConfig.nextCallbackConfig;
     if (headOfPendingCallbacksLinkedList !== null) {
       headOfPendingCallbacksLinkedList.previousCallbackConfig = null;
     } else {
@@ -196,10 +194,7 @@ window.addEventListener('message', idleTick, false);
 const animationTick = function(rafTime) {
   isAnimationFrameScheduled = false;
   let nextFrameTime = rafTime - frameDeadline + activeFrameTime;
-  if (
-    nextFrameTime < activeFrameTime &&
-    previousFrameTime < activeFrameTime
-  ) {
+  if (nextFrameTime < activeFrameTime && previousFrameTime < activeFrameTime) {
     if (nextFrameTime < 8) {
       // Defensive coding. We don't support higher frame rates than 120hz.
       // If we get lower than that, it is probably a bug.
@@ -300,7 +295,6 @@ cancelScheduledWork = function(
       previousCallbackConfig.nextCallbackConfig = nextCallbackConfig;
       nextCallbackConfig.previousCallbackConfig = previousCallbackConfig;
       return;
-
     } else {
       // there is a nextCallbackConfig but not a previous one;
       // callbackConfig is the head of a list of 2 or more other nodes.

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -39,9 +39,8 @@ type CallbackConfigType = {|
   previousCallbackConfig: CallbackConfigType | null, // creating a linked list
 |};
 
-export type CallbackIdType = any;
+export type CallbackIdType = CallbackConfigType;
 
-import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 import requestAnimationFrameForReact from 'shared/requestAnimationFrameForReact';
 
 const hasNativePerformanceNow =
@@ -63,295 +62,265 @@ let scheduleWork: (
   options?: {timeout: number},
 ) => CallbackIdType;
 let cancelScheduledWork: (callbackId: CallbackIdType) => void;
+let headOfPendingCallbacksLinkedList: CallbackConfigType | null = null;
+let tailOfPendingCallbacksLinkedList: CallbackConfigType | null = null;
 
-if (!ExecutionEnvironment.canUseDOM) {
-  let callbackIdCounter = 0;
-  // Timeouts are objects in Node.
-  // For consistency, we'll use numbers in the public API anyway.
-  const timeoutIds: {[number]: TimeoutID} = {};
+// We track what the next soonest timeoutTime is, to be able to quickly tell
+// if none of the scheduled callbacks have timed out.
+let nextSoonestTimeoutTime = -1;
 
-  scheduleWork = function(
-    callback: FrameCallbackType,
-    options?: {timeout: number},
-  ): CallbackIdType {
-    const callbackId = callbackIdCounter++;
-    const timeoutId = setTimeout(() => {
-      callback({
-        timeRemaining() {
-          return Infinity;
-        },
-        didTimeout: false,
-      });
-    });
-    timeoutIds[callbackId] = timeoutId;
-    return callbackId;
-  };
-  cancelScheduledWork = function(callbackId: CallbackIdType) {
-    const timeoutId = timeoutIds[callbackId];
-    delete timeoutIds[callbackId];
-    clearTimeout(timeoutId);
-  };
-} else {
-  let headOfPendingCallbacksLinkedList: CallbackConfigType | null = null;
-  let tailOfPendingCallbacksLinkedList: CallbackConfigType | null = null;
+let isIdleScheduled = false;
+let isAnimationFrameScheduled = false;
 
-  // We track what the next soonest timeoutTime is, to be able to quickly tell
-  // if none of the scheduled callbacks have timed out.
-  let nextSoonestTimeoutTime = -1;
+let frameDeadline = 0;
+// We start out assuming that we run at 30fps but then the heuristic tracking
+// will adjust this value to a faster fps if we get more frequent animation
+// frames.
+let previousFrameTime = 33;
+let activeFrameTime = 33;
 
-  let isIdleScheduled = false;
-  let isAnimationFrameScheduled = false;
+const frameDeadlineObject: Deadline = {
+  didTimeout: false,
+  timeRemaining() {
+    const remaining = frameDeadline - now();
+    return remaining > 0 ? remaining : 0;
+  },
+};
 
-  let frameDeadline = 0;
-  // We start out assuming that we run at 30fps but then the heuristic tracking
-  // will adjust this value to a faster fps if we get more frequent animation
-  // frames.
-  let previousFrameTime = 33;
-  let activeFrameTime = 33;
+/**
+ * Checks for timed out callbacks, runs them, and then checks again to see if
+ * any more have timed out.
+ * Keeps doing this until there are none which have currently timed out.
+ */
+const callTimedOutCallbacks = function() {
+  if (headOfPendingCallbacksLinkedList === null) {
+    return;
+  }
 
-  const frameDeadlineObject: Deadline = {
-    didTimeout: false,
-    timeRemaining() {
-      const remaining = frameDeadline - now();
-      return remaining > 0 ? remaining : 0;
-    },
-  };
+  const currentTime = now();
+  // TODO: this would be more efficient if deferred callbacks are stored in
+  // min heap.
+  // Or in a linked list with links for both timeoutTime order and insertion
+  // order.
+  // For now an easy compromise is the current approach:
+  // Keep a pointer to the soonest timeoutTime, and check that first.
+  // If it has not expired, we can skip traversing the whole list.
+  // If it has expired, then we step through all the callbacks.
+  if (nextSoonestTimeoutTime === -1 || nextSoonestTimeoutTime > currentTime) {
+    // We know that none of them have timed out yet.
+    return;
+  }
+  nextSoonestTimeoutTime = -1; // we will reset it below
 
-  /**
-   * Checks for timed out callbacks, runs them, and then checks again to see if
-   * any more have timed out.
-   * Keeps doing this until there are none which have currently timed out.
-   */
-  const callTimedOutCallbacks = function() {
-    if (headOfPendingCallbacksLinkedList === null) {
-      return;
-    }
-
-    const currentTime = now();
-    // TODO: this would be more efficient if deferred callbacks are stored in
-    // min heap.
-    // Or in a linked list with links for both timeoutTime order and insertion
-    // order.
-    // For now an easy compromise is the current approach:
-    // Keep a pointer to the soonest timeoutTime, and check that first.
-    // If it has not expired, we can skip traversing the whole list.
-    // If it has expired, then we step through all the callbacks.
-    if (nextSoonestTimeoutTime === -1 || nextSoonestTimeoutTime > currentTime) {
-      // We know that none of them have timed out yet.
-      return;
-    }
-    nextSoonestTimeoutTime = -1; // we will reset it below
-
-    // keep checking until we don't find any more timed out callbacks
-    frameDeadlineObject.didTimeout = true;
-    let currentCallbackConfig = headOfPendingCallbacksLinkedList;
-    while (currentCallbackConfig !== null) {
-      const timeoutTime = currentCallbackConfig.timeoutTime;
-      if (timeoutTime !== -1 && timeoutTime <= currentTime) {
-        // it has timed out!
-        // call it
-        const callback = currentCallbackConfig.scheduledCallback;
-        // TODO: error handling
-        callback(frameDeadlineObject);
-        // remove it from linked list
-        cancelScheduledWork(currentCallbackConfig);
-      } else {
-        if (
-          timeoutTime !== -1 &&
-          (nextSoonestTimeoutTime === -1 ||
-            timeoutTime < nextSoonestTimeoutTime)
-        ) {
-          nextSoonestTimeoutTime = timeoutTime;
-        }
+  // keep checking until we don't find any more timed out callbacks
+  frameDeadlineObject.didTimeout = true;
+  let currentCallbackConfig = headOfPendingCallbacksLinkedList;
+  while (currentCallbackConfig !== null) {
+    const timeoutTime = currentCallbackConfig.timeoutTime;
+    if (timeoutTime !== -1 && timeoutTime <= currentTime) {
+      // it has timed out!
+      // call it
+      const callback = currentCallbackConfig.scheduledCallback;
+      // TODO: error handling
+      callback(frameDeadlineObject);
+      // remove it from linked list
+      cancelScheduledWork(currentCallbackConfig);
+    } else {
+      if (
+        timeoutTime !== -1 &&
+        (nextSoonestTimeoutTime === -1 ||
+          timeoutTime < nextSoonestTimeoutTime)
+      ) {
+        nextSoonestTimeoutTime = timeoutTime;
       }
-      currentCallbackConfig = currentCallbackConfig.nextCallbackConfig;
     }
-  };
+    currentCallbackConfig = currentCallbackConfig.nextCallbackConfig;
+  }
+};
 
-  // We use the postMessage trick to defer idle work until after the repaint.
-  const messageKey =
-    '__reactIdleCallback$' +
-    Math.random()
-      .toString(36)
-      .slice(2);
-  const idleTick = function(event) {
-    if (event.source !== window || event.data !== messageKey) {
-      return;
-    }
-    isIdleScheduled = false;
+// We use the postMessage trick to defer idle work until after the repaint.
+const messageKey =
+  '__reactIdleCallback$' +
+  Math.random()
+    .toString(36)
+    .slice(2);
+const idleTick = function(event) {
+  if (event.source !== window || event.data !== messageKey) {
+    return;
+  }
+  isIdleScheduled = false;
 
-    if (headOfPendingCallbacksLinkedList === null) {
-      return;
-    }
+  if (headOfPendingCallbacksLinkedList === null) {
+    return;
+  }
 
-    // First call anything which has timed out, until we have caught up.
-    callTimedOutCallbacks();
+  // First call anything which has timed out, until we have caught up.
+  callTimedOutCallbacks();
 
-    let currentTime = now();
-    // Next, as long as we have idle time, try calling more callbacks.
-    while (
-      frameDeadline - currentTime > 0 &&
-      headOfPendingCallbacksLinkedList !== null
-    ) {
-      const latestCallbackConfig = headOfPendingCallbacksLinkedList;
-      // move head of list to next callback
-      headOfPendingCallbacksLinkedList =
-        latestCallbackConfig.nextCallbackConfig;
-      if (headOfPendingCallbacksLinkedList !== null) {
-        headOfPendingCallbacksLinkedList.previousCallbackConfig = null;
-      } else {
-        // if headOfPendingCallbacksLinkedList is null,
-        // then the list must be empty.
-        // make sure we set the tail to null as well.
-        tailOfPendingCallbacksLinkedList = null;
-      }
-      frameDeadlineObject.didTimeout = false;
-      const latestCallback = latestCallbackConfig.scheduledCallback;
-      // TODO: before using this outside of React we need to add error handling
-      latestCallback(frameDeadlineObject);
-      currentTime = now();
-    }
+  let currentTime = now();
+  // Next, as long as we have idle time, try calling more callbacks.
+  while (
+    frameDeadline - currentTime > 0 &&
+    headOfPendingCallbacksLinkedList !== null
+  ) {
+    const latestCallbackConfig = headOfPendingCallbacksLinkedList;
+    // move head of list to next callback
+    headOfPendingCallbacksLinkedList =
+      latestCallbackConfig.nextCallbackConfig;
     if (headOfPendingCallbacksLinkedList !== null) {
-      if (!isAnimationFrameScheduled) {
-        // Schedule another animation callback so we retry later.
-        isAnimationFrameScheduled = true;
-        requestAnimationFrameForReact(animationTick);
-      }
-    }
-  };
-  // Assumes that we have addEventListener in this environment. Might need
-  // something better for old IE.
-  window.addEventListener('message', idleTick, false);
-
-  const animationTick = function(rafTime) {
-    isAnimationFrameScheduled = false;
-    let nextFrameTime = rafTime - frameDeadline + activeFrameTime;
-    if (
-      nextFrameTime < activeFrameTime &&
-      previousFrameTime < activeFrameTime
-    ) {
-      if (nextFrameTime < 8) {
-        // Defensive coding. We don't support higher frame rates than 120hz.
-        // If we get lower than that, it is probably a bug.
-        nextFrameTime = 8;
-      }
-      // If one frame goes long, then the next one can be short to catch up.
-      // If two frames are short in a row, then that's an indication that we
-      // actually have a higher frame rate than what we're currently optimizing.
-      // We adjust our heuristic dynamically accordingly. For example, if we're
-      // running on 120hz display or 90hz VR display.
-      // Take the max of the two in case one of them was an anomaly due to
-      // missed frame deadlines.
-      activeFrameTime =
-        nextFrameTime < previousFrameTime ? previousFrameTime : nextFrameTime;
+      headOfPendingCallbacksLinkedList.previousCallbackConfig = null;
     } else {
-      previousFrameTime = nextFrameTime;
+      // if headOfPendingCallbacksLinkedList is null,
+      // then the list must be empty.
+      // make sure we set the tail to null as well.
+      tailOfPendingCallbacksLinkedList = null;
     }
-    frameDeadline = rafTime + activeFrameTime;
-    if (!isIdleScheduled) {
-      isIdleScheduled = true;
-      window.postMessage(messageKey, '*');
-    }
-  };
-
-  scheduleWork = function(
-    callback: FrameCallbackType,
-    options?: {timeout: number},
-  ): CallbackIdType /* CallbackConfigType */ {
-    let timeoutTime = -1;
-    if (options != null && typeof options.timeout === 'number') {
-      timeoutTime = now() + options.timeout;
-    }
-    if (
-      nextSoonestTimeoutTime === -1 ||
-      (timeoutTime !== -1 && timeoutTime < nextSoonestTimeoutTime)
-    ) {
-      nextSoonestTimeoutTime = timeoutTime;
-    }
-
-    const scheduledCallbackConfig: CallbackConfigType = {
-      scheduledCallback: callback,
-      timeoutTime,
-      previousCallbackConfig: null,
-      nextCallbackConfig: null,
-    };
-    if (headOfPendingCallbacksLinkedList === null) {
-      // Make this callback the head and tail of our list
-      headOfPendingCallbacksLinkedList = scheduledCallbackConfig;
-      tailOfPendingCallbacksLinkedList = scheduledCallbackConfig;
-    } else {
-      // Add latest callback as the new tail of the list
-      scheduledCallbackConfig.previousCallbackConfig = tailOfPendingCallbacksLinkedList;
-      // renaming for clarity
-      const oldTailOfPendingCallbacksLinkedList = tailOfPendingCallbacksLinkedList;
-      if (oldTailOfPendingCallbacksLinkedList !== null) {
-        oldTailOfPendingCallbacksLinkedList.nextCallbackConfig = scheduledCallbackConfig;
-      }
-      tailOfPendingCallbacksLinkedList = scheduledCallbackConfig;
-    }
-
+    frameDeadlineObject.didTimeout = false;
+    const latestCallback = latestCallbackConfig.scheduledCallback;
+    // TODO: before using this outside of React we need to add error handling
+    latestCallback(frameDeadlineObject);
+    currentTime = now();
+  }
+  if (headOfPendingCallbacksLinkedList !== null) {
     if (!isAnimationFrameScheduled) {
-      // If rAF didn't already schedule one, we need to schedule a frame.
-      // TODO: If this rAF doesn't materialize because the browser throttles, we
-      // might want to still have setTimeout trigger scheduleWork as a backup to ensure
-      // that we keep performing work.
+      // Schedule another animation callback so we retry later.
       isAnimationFrameScheduled = true;
       requestAnimationFrameForReact(animationTick);
     }
-    return scheduledCallbackConfig;
-  };
+  }
+};
+// Assumes that we have addEventListener in this environment. Might need
+// something better for old IE.
+window.addEventListener('message', idleTick, false);
 
-  cancelScheduledWork = function(
-    callbackConfig: CallbackIdType /* CallbackConfigType */,
+const animationTick = function(rafTime) {
+  isAnimationFrameScheduled = false;
+  let nextFrameTime = rafTime - frameDeadline + activeFrameTime;
+  if (
+    nextFrameTime < activeFrameTime &&
+    previousFrameTime < activeFrameTime
   ) {
-    /**
-     * There are four possible cases:
-     * - Head/nodeToRemove/Tail -> null
-     *   In this case we set Head and Tail to null.
-     * - Head -> ... middle nodes... -> Tail/nodeToRemove
-     *   In this case we point the middle.next to null and put middle as the new
-     *   Tail.
-     * - Head/nodeToRemove -> ...middle nodes... -> Tail
-     *   In this case we point the middle.prev at null and move the Head to
-     *   middle.
-     * - Head -> ... ?some nodes ... -> nodeToRemove -> ... ?some nodes ... -> Tail
-     *   In this case we point the Head.next to the Tail and the Tail.prev to
-     *   the Head.
-     */
-
-    if (headOfPendingCallbacksLinkedList === callbackConfig) {
-      // this callbackConfig is at the head of the list.
-      if (tailOfPendingCallbacksLinkedList === callbackConfig) {
-        // callbackConfig is the only thing in the linked list,
-        // so both head and tail point to it.
-        headOfPendingCallbacksLinkedList = null;
-        tailOfPendingCallbacksLinkedList = null;
-        return;
-      } else {
-        // callbackConfig is the head of a list of 2 or more other nodes.
-        const nextCallbackConfig = callbackConfig.nextCallbackConfig;
-        nextCallbackConfig.previousCallbackConfig = null;
-        headOfPendingCallbacksLinkedList = nextCallbackConfig;
-        return;
-      }
-    } else {
-      // this callbackConfig is not at the head of the list.
-      if (tailOfPendingCallbacksLinkedList === callbackConfig) {
-        // callbackConfig is the tail of a list of 2 or more other nodes.
-        const previousCallbackConfig = callbackConfig.previousCallbackConfig;
-        previousCallbackConfig.nextCallbackConfig = null;
-        tailOfPendingCallbacksLinkedList = previousCallbackConfig;
-        return;
-      } else {
-        // callbackConfig is somewhere in the middle of a list of 3 or more nodes.
-        const nextCallbackConfig = callbackConfig.nextCallbackConfig;
-        const previousCallbackConfig = callbackConfig.previousCallbackConfig;
-        previousCallbackConfig.nextCallbackConfig = nextCallbackConfig;
-        nextCallbackConfig.previousCallbackConfig = previousCallbackConfig;
-        return;
-      }
+    if (nextFrameTime < 8) {
+      // Defensive coding. We don't support higher frame rates than 120hz.
+      // If we get lower than that, it is probably a bug.
+      nextFrameTime = 8;
     }
+    // If one frame goes long, then the next one can be short to catch up.
+    // If two frames are short in a row, then that's an indication that we
+    // actually have a higher frame rate than what we're currently optimizing.
+    // We adjust our heuristic dynamically accordingly. For example, if we're
+    // running on 120hz display or 90hz VR display.
+    // Take the max of the two in case one of them was an anomaly due to
+    // missed frame deadlines.
+    activeFrameTime =
+      nextFrameTime < previousFrameTime ? previousFrameTime : nextFrameTime;
+  } else {
+    previousFrameTime = nextFrameTime;
+  }
+  frameDeadline = rafTime + activeFrameTime;
+  if (!isIdleScheduled) {
+    isIdleScheduled = true;
+    window.postMessage(messageKey, '*');
+  }
+};
+
+scheduleWork = function(
+  callback: FrameCallbackType,
+  options?: {timeout: number},
+): CallbackIdType /* CallbackConfigType */ {
+  let timeoutTime = -1;
+  if (options != null && typeof options.timeout === 'number') {
+    timeoutTime = now() + options.timeout;
+  }
+  if (
+    nextSoonestTimeoutTime === -1 ||
+    (timeoutTime !== -1 && timeoutTime < nextSoonestTimeoutTime)
+  ) {
+    nextSoonestTimeoutTime = timeoutTime;
+  }
+
+  const scheduledCallbackConfig: CallbackConfigType = {
+    scheduledCallback: callback,
+    timeoutTime,
+    previousCallbackConfig: null,
+    nextCallbackConfig: null,
   };
-}
+  if (headOfPendingCallbacksLinkedList === null) {
+    // Make this callback the head and tail of our list
+    headOfPendingCallbacksLinkedList = scheduledCallbackConfig;
+    tailOfPendingCallbacksLinkedList = scheduledCallbackConfig;
+  } else {
+    // Add latest callback as the new tail of the list
+    scheduledCallbackConfig.previousCallbackConfig = tailOfPendingCallbacksLinkedList;
+    // renaming for clarity
+    const oldTailOfPendingCallbacksLinkedList = tailOfPendingCallbacksLinkedList;
+    if (oldTailOfPendingCallbacksLinkedList !== null) {
+      oldTailOfPendingCallbacksLinkedList.nextCallbackConfig = scheduledCallbackConfig;
+    }
+    tailOfPendingCallbacksLinkedList = scheduledCallbackConfig;
+  }
+
+  if (!isAnimationFrameScheduled) {
+    // If rAF didn't already schedule one, we need to schedule a frame.
+    // TODO: If this rAF doesn't materialize because the browser throttles, we
+    // might want to still have setTimeout trigger scheduleWork as a backup to ensure
+    // that we keep performing work.
+    isAnimationFrameScheduled = true;
+    requestAnimationFrameForReact(animationTick);
+  }
+  return scheduledCallbackConfig;
+};
+
+cancelScheduledWork = function(
+  callbackConfig: CallbackIdType /* CallbackConfigType */,
+) {
+  /**
+   * There are four possible cases:
+   * - Head/nodeToRemove/Tail -> null
+   *   In this case we set Head and Tail to null.
+   * - Head -> ... middle nodes... -> Tail/nodeToRemove
+   *   In this case we point the middle.next to null and put middle as the new
+   *   Tail.
+   * - Head/nodeToRemove -> ...middle nodes... -> Tail
+   *   In this case we point the middle.prev at null and move the Head to
+   *   middle.
+   * - Head -> ... ?some nodes ... -> nodeToRemove -> ... ?some nodes ... -> Tail
+   *   In this case we point the Head.next to the Tail and the Tail.prev to
+   *   the Head.
+   */
+
+  if (headOfPendingCallbacksLinkedList === callbackConfig) {
+    // this callbackConfig is at the head of the list.
+    if (tailOfPendingCallbacksLinkedList === callbackConfig) {
+      // callbackConfig is the only thing in the linked list,
+      // so both head and tail point to it.
+      headOfPendingCallbacksLinkedList = null;
+      tailOfPendingCallbacksLinkedList = null;
+      return;
+    } else {
+      // callbackConfig is the head of a list of 2 or more other nodes.
+      const nextCallbackConfig = callbackConfig.nextCallbackConfig;
+      nextCallbackConfig.previousCallbackConfig = null;
+      headOfPendingCallbacksLinkedList = nextCallbackConfig;
+      return;
+    }
+  } else {
+    // this callbackConfig is not at the head of the list.
+    if (tailOfPendingCallbacksLinkedList === callbackConfig) {
+      // callbackConfig is the tail of a list of 2 or more other nodes.
+      const previousCallbackConfig = callbackConfig.previousCallbackConfig;
+      previousCallbackConfig.nextCallbackConfig = null;
+      tailOfPendingCallbacksLinkedList = previousCallbackConfig;
+      return;
+    } else {
+      // callbackConfig is somewhere in the middle of a list of 3 or more nodes.
+      const nextCallbackConfig = callbackConfig.nextCallbackConfig;
+      const previousCallbackConfig = callbackConfig.previousCallbackConfig;
+      previousCallbackConfig.nextCallbackConfig = nextCallbackConfig;
+      nextCallbackConfig.previousCallbackConfig = previousCallbackConfig;
+      return;
+    }
+  }
+};
 
 export {now, scheduleWork, cancelScheduledWork};

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -199,8 +199,7 @@ if (!ExecutionEnvironment.canUseDOM) {
     ) {
       const latestCallbackConfig = headOfPendingCallbacksLinkedList;
       // move head of list to next callback
-      headOfPendingCallbacksLinkedList =
-        latestCallbackConfig.next;
+      headOfPendingCallbacksLinkedList = latestCallbackConfig.next;
       if (headOfPendingCallbacksLinkedList !== null) {
         headOfPendingCallbacksLinkedList.prev = null;
       } else {
@@ -322,13 +321,13 @@ if (!ExecutionEnvironment.canUseDOM) {
      *   In this case we point the Head.next to the Tail and the Tail.prev to
      *   the Head.
      */
-    if (callbackConfig.next !== null) {
+    const next = callbackConfig.next;
+    const prev = callbackConfig.prev;
+    if (next !== null) {
       // we have a next
-      const next = callbackConfig.next;
 
-      if (callbackConfig.prev !== null) {
+      if (prev !== null) {
         // we have a prev
-        const prev = callbackConfig.prev;
 
         // callbackConfig is somewhere in the middle of a list of 3 or more nodes.
         prev.next = next;
@@ -344,9 +343,8 @@ if (!ExecutionEnvironment.canUseDOM) {
     } else {
       // there is no next callback config; this must the tail of the list
 
-      if (callbackConfig.prev !== null) {
+      if (prev !== null) {
         // we have a prev
-        const prev = callbackConfig.prev;
 
         // callbackConfig is the tail of a list of 2 or more other nodes.
         prev.next = null;

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -42,6 +42,7 @@ type CallbackConfigType = {|
 export type CallbackIdType = CallbackConfigType;
 
 import requestAnimationFrameForReact from 'shared/requestAnimationFrameForReact';
+import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 
 const hasNativePerformanceNow =
   typeof performance === 'object' && typeof performance.now === 'function';
@@ -62,266 +63,305 @@ let scheduleWork: (
   options?: {timeout: number},
 ) => CallbackIdType;
 let cancelScheduledWork: (callbackId: CallbackIdType) => void;
-let headOfPendingCallbacksLinkedList: CallbackConfigType | null = null;
-let tailOfPendingCallbacksLinkedList: CallbackConfigType | null = null;
 
-// We track what the next soonest timeoutTime is, to be able to quickly tell
-// if none of the scheduled callbacks have timed out.
-let nextSoonestTimeoutTime = -1;
+if (!ExecutionEnvironment.canUseDOM) {
+  const timeoutIds = new Map();
 
-let isIdleScheduled = false;
-let isAnimationFrameScheduled = false;
+  scheduleWork = function(
+    callback: FrameCallbackType,
+    options?: {timeout: number},
+  ): CallbackIdType {
+    // keeping return type consistent
+    const callbackConfig = {
+      scheduledCallback: callback,
+      timeoutTime: 0,
+      nextCallbackConfig: null,
+      previousCallbackConfig: null,
+    };
+    const timeoutId = setTimeout(() => {
+      callback({
+        timeRemaining() {
+          return Infinity;
+        },
+        didTimeout: false,
+      });
+    });
+    timeoutIds.set(callback, timeoutId);
+    return callbackConfig;
+  };
+  cancelScheduledWork = function(callbackId: CallbackIdType) {
+    const callback = callbackId.scheduledCallback;
+    const timeoutId = timeoutIds.get(callback);
+    timeoutIds.delete(callbackId);
+    clearTimeout(timeoutId);
+  };
+} else {
+  let headOfPendingCallbacksLinkedList: CallbackConfigType | null = null;
+  let tailOfPendingCallbacksLinkedList: CallbackConfigType | null = null;
 
-let frameDeadline = 0;
-// We start out assuming that we run at 30fps but then the heuristic tracking
-// will adjust this value to a faster fps if we get more frequent animation
-// frames.
-let previousFrameTime = 33;
-let activeFrameTime = 33;
+  // We track what the next soonest timeoutTime is, to be able to quickly tell
+  // if none of the scheduled callbacks have timed out.
+  let nextSoonestTimeoutTime = -1;
 
-const frameDeadlineObject: Deadline = {
-  didTimeout: false,
-  timeRemaining() {
-    const remaining = frameDeadline - now();
-    return remaining > 0 ? remaining : 0;
-  },
-};
+  let isIdleScheduled = false;
+  let isAnimationFrameScheduled = false;
 
-/**
- * Checks for timed out callbacks, runs them, and then checks again to see if
- * any more have timed out.
- * Keeps doing this until there are none which have currently timed out.
- */
-const callTimedOutCallbacks = function() {
-  if (headOfPendingCallbacksLinkedList === null) {
-    return;
-  }
+  let frameDeadline = 0;
+  // We start out assuming that we run at 30fps but then the heuristic tracking
+  // will adjust this value to a faster fps if we get more frequent animation
+  // frames.
+  let previousFrameTime = 33;
+  let activeFrameTime = 33;
 
-  const currentTime = now();
-  // TODO: this would be more efficient if deferred callbacks are stored in
-  // min heap.
-  // Or in a linked list with links for both timeoutTime order and insertion
-  // order.
-  // For now an easy compromise is the current approach:
-  // Keep a pointer to the soonest timeoutTime, and check that first.
-  // If it has not expired, we can skip traversing the whole list.
-  // If it has expired, then we step through all the callbacks.
-  if (nextSoonestTimeoutTime === -1 || nextSoonestTimeoutTime > currentTime) {
-    // We know that none of them have timed out yet.
-    return;
-  }
-  nextSoonestTimeoutTime = -1; // we will reset it below
+  const frameDeadlineObject: Deadline = {
+    didTimeout: false,
+    timeRemaining() {
+      const remaining = frameDeadline - now();
+      return remaining > 0 ? remaining : 0;
+    },
+  };
 
-  // keep checking until we don't find any more timed out callbacks
-  frameDeadlineObject.didTimeout = true;
-  let currentCallbackConfig = headOfPendingCallbacksLinkedList;
-  while (currentCallbackConfig !== null) {
-    const timeoutTime = currentCallbackConfig.timeoutTime;
-    if (timeoutTime !== -1 && timeoutTime <= currentTime) {
-      // it has timed out!
-      // call it
-      const callback = currentCallbackConfig.scheduledCallback;
-      // TODO: error handling
-      callback(frameDeadlineObject);
-      // remove it from linked list
-      cancelScheduledWork(currentCallbackConfig);
-    } else {
-      if (
-        timeoutTime !== -1 &&
-        (nextSoonestTimeoutTime === -1 || timeoutTime < nextSoonestTimeoutTime)
-      ) {
-        nextSoonestTimeoutTime = timeoutTime;
+  /**
+   * Checks for timed out callbacks, runs them, and then checks again to see if
+   * any more have timed out.
+   * Keeps doing this until there are none which have currently timed out.
+   */
+  const callTimedOutCallbacks = function() {
+    if (headOfPendingCallbacksLinkedList === null) {
+      return;
+    }
+
+    const currentTime = now();
+    // TODO: this would be more efficient if deferred callbacks are stored in
+    // min heap.
+    // Or in a linked list with links for both timeoutTime order and insertion
+    // order.
+    // For now an easy compromise is the current approach:
+    // Keep a pointer to the soonest timeoutTime, and check that first.
+    // If it has not expired, we can skip traversing the whole list.
+    // If it has expired, then we step through all the callbacks.
+    if (nextSoonestTimeoutTime === -1 || nextSoonestTimeoutTime > currentTime) {
+      // We know that none of them have timed out yet.
+      return;
+    }
+    nextSoonestTimeoutTime = -1; // we will reset it below
+
+    // keep checking until we don't find any more timed out callbacks
+    frameDeadlineObject.didTimeout = true;
+    let currentCallbackConfig = headOfPendingCallbacksLinkedList;
+    while (currentCallbackConfig !== null) {
+      const timeoutTime = currentCallbackConfig.timeoutTime;
+      if (timeoutTime !== -1 && timeoutTime <= currentTime) {
+        // it has timed out!
+        // call it
+        const callback = currentCallbackConfig.scheduledCallback;
+        // TODO: error handling
+        callback(frameDeadlineObject);
+        // remove it from linked list
+        cancelScheduledWork(currentCallbackConfig);
+      } else {
+        if (
+          timeoutTime !== -1 &&
+          (nextSoonestTimeoutTime === -1 ||
+            timeoutTime < nextSoonestTimeoutTime)
+        ) {
+          nextSoonestTimeoutTime = timeoutTime;
+        }
+      }
+      currentCallbackConfig = currentCallbackConfig.nextCallbackConfig;
+    }
+  };
+
+  // We use the postMessage trick to defer idle work until after the repaint.
+  const messageKey =
+    '__reactIdleCallback$' +
+    Math.random()
+      .toString(36)
+      .slice(2);
+  const idleTick = function(event) {
+    if (event.source !== window || event.data !== messageKey) {
+      return;
+    }
+    isIdleScheduled = false;
+
+    if (headOfPendingCallbacksLinkedList === null) {
+      return;
+    }
+
+    // First call anything which has timed out, until we have caught up.
+    callTimedOutCallbacks();
+
+    let currentTime = now();
+    // Next, as long as we have idle time, try calling more callbacks.
+    while (
+      frameDeadline - currentTime > 0 &&
+      headOfPendingCallbacksLinkedList !== null
+    ) {
+      const latestCallbackConfig = headOfPendingCallbacksLinkedList;
+      // move head of list to next callback
+      headOfPendingCallbacksLinkedList =
+        latestCallbackConfig.nextCallbackConfig;
+      if (headOfPendingCallbacksLinkedList !== null) {
+        headOfPendingCallbacksLinkedList.previousCallbackConfig = null;
+      } else {
+        // if headOfPendingCallbacksLinkedList is null,
+        // then the list must be empty.
+        // make sure we set the tail to null as well.
+        tailOfPendingCallbacksLinkedList = null;
+      }
+      frameDeadlineObject.didTimeout = false;
+      const latestCallback = latestCallbackConfig.scheduledCallback;
+      // TODO: before using this outside of React we need to add error handling
+      latestCallback(frameDeadlineObject);
+      currentTime = now();
+    }
+    if (headOfPendingCallbacksLinkedList !== null) {
+      if (!isAnimationFrameScheduled) {
+        // Schedule another animation callback so we retry later.
+        isAnimationFrameScheduled = true;
+        requestAnimationFrameForReact(animationTick);
       }
     }
-    currentCallbackConfig = currentCallbackConfig.nextCallbackConfig;
-  }
-};
+  };
+  // Assumes that we have addEventListener in this environment. Might need
+  // something better for old IE.
+  window.addEventListener('message', idleTick, false);
 
-// We use the postMessage trick to defer idle work until after the repaint.
-const messageKey =
-  '__reactIdleCallback$' +
-  Math.random()
-    .toString(36)
-    .slice(2);
-const idleTick = function(event) {
-  if (event.source !== window || event.data !== messageKey) {
-    return;
-  }
-  isIdleScheduled = false;
-
-  if (headOfPendingCallbacksLinkedList === null) {
-    return;
-  }
-
-  // First call anything which has timed out, until we have caught up.
-  callTimedOutCallbacks();
-
-  let currentTime = now();
-  // Next, as long as we have idle time, try calling more callbacks.
-  while (
-    frameDeadline - currentTime > 0 &&
-    headOfPendingCallbacksLinkedList !== null
-  ) {
-    const latestCallbackConfig = headOfPendingCallbacksLinkedList;
-    // move head of list to next callback
-    headOfPendingCallbacksLinkedList = latestCallbackConfig.nextCallbackConfig;
-    if (headOfPendingCallbacksLinkedList !== null) {
-      headOfPendingCallbacksLinkedList.previousCallbackConfig = null;
+  const animationTick = function(rafTime) {
+    isAnimationFrameScheduled = false;
+    let nextFrameTime = rafTime - frameDeadline + activeFrameTime;
+    if (
+      nextFrameTime < activeFrameTime &&
+      previousFrameTime < activeFrameTime
+    ) {
+      if (nextFrameTime < 8) {
+        // Defensive coding. We don't support higher frame rates than 120hz.
+        // If we get lower than that, it is probably a bug.
+        nextFrameTime = 8;
+      }
+      // If one frame goes long, then the next one can be short to catch up.
+      // If two frames are short in a row, then that's an indication that we
+      // actually have a higher frame rate than what we're currently optimizing.
+      // We adjust our heuristic dynamically accordingly. For example, if we're
+      // running on 120hz display or 90hz VR display.
+      // Take the max of the two in case one of them was an anomaly due to
+      // missed frame deadlines.
+      activeFrameTime =
+        nextFrameTime < previousFrameTime ? previousFrameTime : nextFrameTime;
     } else {
-      // if headOfPendingCallbacksLinkedList is null,
-      // then the list must be empty.
-      // make sure we set the tail to null as well.
-      tailOfPendingCallbacksLinkedList = null;
+      previousFrameTime = nextFrameTime;
     }
-    frameDeadlineObject.didTimeout = false;
-    const latestCallback = latestCallbackConfig.scheduledCallback;
-    // TODO: before using this outside of React we need to add error handling
-    latestCallback(frameDeadlineObject);
-    currentTime = now();
-  }
-  if (headOfPendingCallbacksLinkedList !== null) {
+    frameDeadline = rafTime + activeFrameTime;
+    if (!isIdleScheduled) {
+      isIdleScheduled = true;
+      window.postMessage(messageKey, '*');
+    }
+  };
+
+  scheduleWork = function(
+    callback: FrameCallbackType,
+    options?: {timeout: number},
+  ): CallbackIdType /* CallbackConfigType */ {
+    let timeoutTime = -1;
+    if (options != null && typeof options.timeout === 'number') {
+      timeoutTime = now() + options.timeout;
+    }
+    if (
+      nextSoonestTimeoutTime === -1 ||
+      (timeoutTime !== -1 && timeoutTime < nextSoonestTimeoutTime)
+    ) {
+      nextSoonestTimeoutTime = timeoutTime;
+    }
+
+    const scheduledCallbackConfig: CallbackConfigType = {
+      scheduledCallback: callback,
+      timeoutTime,
+      previousCallbackConfig: null,
+      nextCallbackConfig: null,
+    };
+    if (headOfPendingCallbacksLinkedList === null) {
+      // Make this callback the head and tail of our list
+      headOfPendingCallbacksLinkedList = scheduledCallbackConfig;
+      tailOfPendingCallbacksLinkedList = scheduledCallbackConfig;
+    } else {
+      // Add latest callback as the new tail of the list
+      scheduledCallbackConfig.previousCallbackConfig = tailOfPendingCallbacksLinkedList;
+      // renaming for clarity
+      const oldTailOfPendingCallbacksLinkedList = tailOfPendingCallbacksLinkedList;
+      if (oldTailOfPendingCallbacksLinkedList !== null) {
+        oldTailOfPendingCallbacksLinkedList.nextCallbackConfig = scheduledCallbackConfig;
+      }
+      tailOfPendingCallbacksLinkedList = scheduledCallbackConfig;
+    }
+
     if (!isAnimationFrameScheduled) {
-      // Schedule another animation callback so we retry later.
+      // If rAF didn't already schedule one, we need to schedule a frame.
+      // TODO: If this rAF doesn't materialize because the browser throttles, we
+      // might want to still have setTimeout trigger scheduleWork as a backup to ensure
+      // that we keep performing work.
       isAnimationFrameScheduled = true;
       requestAnimationFrameForReact(animationTick);
     }
-  }
-};
-// Assumes that we have addEventListener in this environment. Might need
-// something better for old IE.
-window.addEventListener('message', idleTick, false);
-
-const animationTick = function(rafTime) {
-  isAnimationFrameScheduled = false;
-  let nextFrameTime = rafTime - frameDeadline + activeFrameTime;
-  if (nextFrameTime < activeFrameTime && previousFrameTime < activeFrameTime) {
-    if (nextFrameTime < 8) {
-      // Defensive coding. We don't support higher frame rates than 120hz.
-      // If we get lower than that, it is probably a bug.
-      nextFrameTime = 8;
-    }
-    // If one frame goes long, then the next one can be short to catch up.
-    // If two frames are short in a row, then that's an indication that we
-    // actually have a higher frame rate than what we're currently optimizing.
-    // We adjust our heuristic dynamically accordingly. For example, if we're
-    // running on 120hz display or 90hz VR display.
-    // Take the max of the two in case one of them was an anomaly due to
-    // missed frame deadlines.
-    activeFrameTime =
-      nextFrameTime < previousFrameTime ? previousFrameTime : nextFrameTime;
-  } else {
-    previousFrameTime = nextFrameTime;
-  }
-  frameDeadline = rafTime + activeFrameTime;
-  if (!isIdleScheduled) {
-    isIdleScheduled = true;
-    window.postMessage(messageKey, '*');
-  }
-};
-
-scheduleWork = function(
-  callback: FrameCallbackType,
-  options?: {timeout: number},
-): CallbackIdType /* CallbackConfigType */ {
-  let timeoutTime = -1;
-  if (options != null && typeof options.timeout === 'number') {
-    timeoutTime = now() + options.timeout;
-  }
-  if (
-    nextSoonestTimeoutTime === -1 ||
-    (timeoutTime !== -1 && timeoutTime < nextSoonestTimeoutTime)
-  ) {
-    nextSoonestTimeoutTime = timeoutTime;
-  }
-
-  const scheduledCallbackConfig: CallbackConfigType = {
-    scheduledCallback: callback,
-    timeoutTime,
-    previousCallbackConfig: null,
-    nextCallbackConfig: null,
+    return scheduledCallbackConfig;
   };
-  if (headOfPendingCallbacksLinkedList === null) {
-    // Make this callback the head and tail of our list
-    headOfPendingCallbacksLinkedList = scheduledCallbackConfig;
-    tailOfPendingCallbacksLinkedList = scheduledCallbackConfig;
-  } else {
-    // Add latest callback as the new tail of the list
-    scheduledCallbackConfig.previousCallbackConfig = tailOfPendingCallbacksLinkedList;
-    // renaming for clarity
-    const oldTailOfPendingCallbacksLinkedList = tailOfPendingCallbacksLinkedList;
-    if (oldTailOfPendingCallbacksLinkedList !== null) {
-      oldTailOfPendingCallbacksLinkedList.nextCallbackConfig = scheduledCallbackConfig;
-    }
-    tailOfPendingCallbacksLinkedList = scheduledCallbackConfig;
-  }
 
-  if (!isAnimationFrameScheduled) {
-    // If rAF didn't already schedule one, we need to schedule a frame.
-    // TODO: If this rAF doesn't materialize because the browser throttles, we
-    // might want to still have setTimeout trigger scheduleWork as a backup to ensure
-    // that we keep performing work.
-    isAnimationFrameScheduled = true;
-    requestAnimationFrameForReact(animationTick);
-  }
-  return scheduledCallbackConfig;
-};
+  cancelScheduledWork = function(
+    callbackConfig: CallbackIdType /* CallbackConfigType */,
+  ) {
+    /**
+     * There are four possible cases:
+     * - Head/nodeToRemove/Tail -> null
+     *   In this case we set Head and Tail to null.
+     * - Head -> ... middle nodes... -> Tail/nodeToRemove
+     *   In this case we point the middle.next to null and put middle as the new
+     *   Tail.
+     * - Head/nodeToRemove -> ...middle nodes... -> Tail
+     *   In this case we point the middle.prev at null and move the Head to
+     *   middle.
+     * - Head -> ... ?some nodes ... -> nodeToRemove -> ... ?some nodes ... -> Tail
+     *   In this case we point the Head.next to the Tail and the Tail.prev to
+     *   the Head.
+     */
+    if (callbackConfig.nextCallbackConfig !== null) {
+      // we have a nextCallbackConfig
+      const nextCallbackConfig = callbackConfig.nextCallbackConfig;
 
-cancelScheduledWork = function(
-  callbackConfig: CallbackIdType /* CallbackConfigType */,
-) {
-  /**
-   * There are four possible cases:
-   * - Head/nodeToRemove/Tail -> null
-   *   In this case we set Head and Tail to null.
-   * - Head -> ... middle nodes... -> Tail/nodeToRemove
-   *   In this case we point the middle.next to null and put middle as the new
-   *   Tail.
-   * - Head/nodeToRemove -> ...middle nodes... -> Tail
-   *   In this case we point the middle.prev at null and move the Head to
-   *   middle.
-   * - Head -> ... ?some nodes ... -> nodeToRemove -> ... ?some nodes ... -> Tail
-   *   In this case we point the Head.next to the Tail and the Tail.prev to
-   *   the Head.
-   */
-  if (callbackConfig.nextCallbackConfig !== null) {
-    // we have a nextCallbackConfig
-    const nextCallbackConfig = callbackConfig.nextCallbackConfig;
+      if (callbackConfig.previousCallbackConfig !== null) {
+        // we have a previousCallbackConfig
+        const previousCallbackConfig = callbackConfig.previousCallbackConfig;
 
-    if (callbackConfig.previousCallbackConfig !== null) {
-      // we have a previousCallbackConfig
-      const previousCallbackConfig = callbackConfig.previousCallbackConfig;
-
-      // callbackConfig is somewhere in the middle of a list of 3 or more nodes.
-      previousCallbackConfig.nextCallbackConfig = nextCallbackConfig;
-      nextCallbackConfig.previousCallbackConfig = previousCallbackConfig;
-      return;
+        // callbackConfig is somewhere in the middle of a list of 3 or more nodes.
+        previousCallbackConfig.nextCallbackConfig = nextCallbackConfig;
+        nextCallbackConfig.previousCallbackConfig = previousCallbackConfig;
+        return;
+      } else {
+        // there is a nextCallbackConfig but not a previous one;
+        // callbackConfig is the head of a list of 2 or more other nodes.
+        nextCallbackConfig.previousCallbackConfig = null;
+        headOfPendingCallbacksLinkedList = nextCallbackConfig;
+        return;
+      }
     } else {
-      // there is a nextCallbackConfig but not a previous one;
-      // callbackConfig is the head of a list of 2 or more other nodes.
-      nextCallbackConfig.previousCallbackConfig = null;
-      headOfPendingCallbacksLinkedList = nextCallbackConfig;
-      return;
-    }
-  } else {
-    // there is no next callback config; this must the tail of the list
+      // there is no next callback config; this must the tail of the list
 
-    if (callbackConfig.previousCallbackConfig !== null) {
-      // we have a previousCallbackConfig
-      const previousCallbackConfig = callbackConfig.previousCallbackConfig;
+      if (callbackConfig.previousCallbackConfig !== null) {
+        // we have a previousCallbackConfig
+        const previousCallbackConfig = callbackConfig.previousCallbackConfig;
 
-      // callbackConfig is the tail of a list of 2 or more other nodes.
-      previousCallbackConfig.nextCallbackConfig = null;
-      tailOfPendingCallbacksLinkedList = previousCallbackConfig;
-      return;
-    } else {
-      // there is no previous callback config;
-      // callbackConfig is the only thing in the linked list,
-      // so both head and tail point to it.
-      headOfPendingCallbacksLinkedList = null;
-      tailOfPendingCallbacksLinkedList = null;
-      return;
+        // callbackConfig is the tail of a list of 2 or more other nodes.
+        previousCallbackConfig.nextCallbackConfig = null;
+        tailOfPendingCallbacksLinkedList = previousCallbackConfig;
+        return;
+      } else {
+        // there is no previous callback config;
+        // callbackConfig is the only thing in the linked list,
+        // so both head and tail point to it.
+        headOfPendingCallbacksLinkedList = null;
+        tailOfPendingCallbacksLinkedList = null;
+        return;
+      }
     }
-  }
-};
+  };
+}
 
 export {now, scheduleWork, cancelScheduledWork};

--- a/packages/react-test-renderer/src/ReactTestRendererScheduling.js
+++ b/packages/react-test-renderer/src/ReactTestRendererScheduling.js
@@ -8,6 +8,7 @@
  */
 
 import type {Deadline} from 'react-reconciler/src/ReactFiberScheduler';
+import type {CallbackIdType} from 'react-scheduler';
 
 // Current virtual time
 export let nowImplementation = () => 0;
@@ -19,10 +20,11 @@ export function scheduleDeferredCallback(
   options?: {timeout: number},
 ): number {
   scheduledCallback = callback;
-  return 0;
+  const fakeCallbackId = (0: CallbackIdType);
+  return fakeCallbackId;
 }
 
-export function cancelDeferredCallback(timeoutID: number): void {
+export function cancelDeferredCallback(timeoutID: CallbackIdType): void {
   scheduledCallback = null;
 }
 

--- a/packages/react-test-renderer/src/ReactTestRendererScheduling.js
+++ b/packages/react-test-renderer/src/ReactTestRendererScheduling.js
@@ -8,7 +8,6 @@
  */
 
 import type {Deadline} from 'react-reconciler/src/ReactFiberScheduler';
-import type {CallbackIdType} from 'react-scheduler';
 
 // Current virtual time
 export let nowImplementation = () => 0;
@@ -20,11 +19,11 @@ export function scheduleDeferredCallback(
   options?: {timeout: number},
 ): number {
   scheduledCallback = callback;
-  const fakeCallbackId = (0: CallbackIdType);
+  const fakeCallbackId = 0;
   return fakeCallbackId;
 }
 
-export function cancelDeferredCallback(timeoutID: CallbackIdType): void {
+export function cancelDeferredCallback(timeoutID: number): void {
   scheduledCallback = null;
 }
 


### PR DESCRIPTION
**Edit:** Rebased and now there is no cruft on this PR. :)
    
---
    
**what is the change?:**
See title
    
**why make this change?:**
This seems to make the code simpler, and potentially saves space of
having an array and object around holding references to the callbacks.
    
**test plan:**
Run existing the new and improved tests, from the previous PR.