### PR TITLE
ReactTestRenderer and ReactDOM portals

### DIFF
--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import warning from 'shared/warning';
 import * as TestRendererScheduling from './ReactTestRendererScheduling';
 
 export type Type = string;
@@ -62,6 +63,15 @@ export function appendChild(
   parentInstance: Instance | Container,
   child: Instance | TextInstance,
 ): void {
+  if (__DEV__) {
+    warning(
+      Array.isArray(parentInstance.children),
+      'An invalid container has been provided. ' +
+        'This may indicate that another render is being used in addition to the test renderer. ' +
+        '(For example, ReactDOM.createPortal inside of a ReactTestRenderer tree.) ' +
+        'This is not supported.',
+    );
+  }
   const index = parentInstance.children.indexOf(child);
   if (index !== -1) {
     parentInstance.children.splice(index, 1);

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+const ReactDOM = require('react-dom');
+
+// Isolate test renderer.
+jest.resetModules();
+const ReactTestRenderer = require('react-test-renderer');
+
+describe('ReactTestRenderer', () => {
+  it('should warn if used to render a ReactDOM portal', () => {
+    const container = document.createElement('div');
+    expect(() => {
+      expect(() => {
+        ReactTestRenderer.create(ReactDOM.createPortal('foo', container));
+      }).toThrow();
+    }).toWarnDev('An invalid container has been provided.', {
+      withoutStack: true,
+    });
+  });
+});


### PR DESCRIPTION
Resolves issue #11565

Adds a warning when a React DOM portal is passed to ReactTestRenderer.

---

**The behavior described below was reverted via 807e623 + 963ed6b + 444619b + db42945.**

---

`ReactTestRenderer` should not runtime error when rendering content that includes a portal created by `ReactDOM.createPortal()`. This PR introduces a new feature flag- used only by the test renderer- that converts portals to fragments, enabling them to be rendered and represented as JSON by the test renderer.

## Before
This test fails:
```js
ReactTestRenderer.create(ReactDOM.createPortal('foo', container));
```
With a confusing error:
> TypeError: parentInstance.children.indexOf is not a function

I think we should either provide a more helpful warning (see 7d57c8a) or support it enough to at least render a JSON representation of the tree (see current implementation).

## After
### Test
```js
const container = document.createElement('div');
let rendered = ReactTestRenderer.create(
  <div>
    {ReactDOM.createPortal(<span>ReactDOM portal</span>, container)}
  </div>,
);
expect(rendered.toJSON()).toMatchSnapshot();

rendered.update(
  <div>
    <span>ReactTestRenderer span</span>
    {ReactDOM.createPortal(<span>ReactDOM portal</span>, container)}
  </div>,
);
expect(rendered.toJSON()).toMatchSnapshot();
```

### Snapshot
```js
// Jest Snapshot v1, https://goo.gl/fbAQLP

exports[`ReactTestRenderer should support ReactDOM.createPortal 1`] = `
<div>
  <span>
    ReactDOM portal
  </span>
</div>
`;

exports[`ReactTestRenderer should support ReactDOM.createPortal 2`] = `
<div>
  <span>
    ReactTestRenderer span
  </span>
  <span>
    ReactDOM portal
  </span>
</div>
`;
```