### PR TITLE
[scheduler] 4/n Allow splitting out `schedule` in fb-www, prepare to fix polyfill issue internally

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as ReactScheduler from 'react-scheduler';
+import * as ReactScheduler from 'shared/ReactScheduler';
 import Transform from 'art/core/transform';
 import Mode from 'art/modes/current';
 import invariant from 'fbjs/lib/invariant';

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import * as ReactScheduler from 'react-scheduler';
+import * as ReactScheduler from 'shared/ReactScheduler';
 
 import * as ReactDOMComponentTree from './ReactDOMComponentTree';
 import * as ReactDOMFiberComponent from './ReactDOMFiberComponent';

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -44,17 +44,25 @@ export type CallbackIdType = CallbackConfigType;
 import requestAnimationFrameForReact from 'shared/requestAnimationFrameForReact';
 import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 
+// We capture a local reference to any global, in case it gets polyfilled after
+// this module is initially evaluated.
+// We want to be using a consistent implementation.
+const localDate = Date;
+const localSetTimeout = setTimeout;
+const localClearTimeout = clearTimeout;
+
 const hasNativePerformanceNow =
   typeof performance === 'object' && typeof performance.now === 'function';
 
 let now;
 if (hasNativePerformanceNow) {
+  const localPerformance = performance;
   now = function() {
-    return performance.now();
+    return localPerformance.now();
   };
 } else {
   now = function() {
-    return Date.now();
+    return localDate.now();
   };
 }
 

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -86,7 +86,7 @@ if (!ExecutionEnvironment.canUseDOM) {
       next: null,
       prev: null,
     };
-    const timeoutId = setTimeout(() => {
+    const timeoutId = localSetTimeout(() => {
       callback({
         timeRemaining() {
           return Infinity;
@@ -101,7 +101,7 @@ if (!ExecutionEnvironment.canUseDOM) {
     const callback = callbackId.scheduledCallback;
     const timeoutId = timeoutIds.get(callback);
     timeoutIds.delete(callbackId);
-    clearTimeout(timeoutId);
+    localClearTimeout(timeoutId);
   };
 } else {
   let headOfPendingCallbacksLinkedList: CallbackConfigType | null = null;

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -47,22 +47,22 @@ import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 // We capture a local reference to any global, in case it gets polyfilled after
 // this module is initially evaluated.
 // We want to be using a consistent implementation.
-const localDate = Date;
-const localSetTimeout = setTimeout;
-const localClearTimeout = clearTimeout;
+const Date = global.Date;
+const setTimeout = global.setTimeout;
+const clearTimeout = global.clearTimeout;
 
 const hasNativePerformanceNow =
   typeof performance === 'object' && typeof performance.now === 'function';
 
 let now;
 if (hasNativePerformanceNow) {
-  const localPerformance = performance;
+  const Performance = performance;
   now = function() {
-    return localPerformance.now();
+    return Performance.now();
   };
 } else {
   now = function() {
-    return localDate.now();
+    return Date.now();
   };
 }
 
@@ -86,7 +86,7 @@ if (!ExecutionEnvironment.canUseDOM) {
       next: null,
       prev: null,
     };
-    const timeoutId = localSetTimeout(() => {
+    const timeoutId = setTimeout(() => {
       callback({
         timeRemaining() {
           return Infinity;
@@ -101,7 +101,7 @@ if (!ExecutionEnvironment.canUseDOM) {
     const callback = callbackId.scheduledCallback;
     const timeoutId = timeoutIds.get(callback);
     timeoutIds.delete(callbackId);
-    localClearTimeout(timeoutId);
+    clearTimeout(timeoutId);
   };
 } else {
   let headOfPendingCallbacksLinkedList: CallbackConfigType | null = null;
@@ -232,7 +232,7 @@ if (!ExecutionEnvironment.canUseDOM) {
   };
   // Assumes that we have addEventListener in this environment. Might need
   // something better for old IE.
-  window.addEventListener('message', idleTick, false);
+  global.addEventListener('message', idleTick, false);
 
   const animationTick = function(rafTime) {
     isAnimationFrameScheduled = false;

--- a/packages/shared/ReactScheduler.js
+++ b/packages/shared/ReactScheduler.js
@@ -8,6 +8,10 @@
  */
 
 'use strict';
-import {now, scheduleWork, cancelScheduledWork} from 'react-scheduler/src/ReactScheduler';
+import {
+  now,
+  scheduleWork,
+  cancelScheduledWork,
+} from 'react-scheduler/src/ReactScheduler';
 
 export {now, scheduleWork, cancelScheduledWork};

--- a/packages/shared/ReactScheduler.js
+++ b/packages/shared/ReactScheduler.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+import {now, scheduleWork, cancelScheduledWork} from 'react-scheduler/src/ReactScheduler';
+
+export {now, scheduleWork, cancelScheduledWork};

--- a/packages/shared/forks/ReactScheduler.www.js
+++ b/packages/shared/forks/ReactScheduler.www.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+const {now, scheduleWork, cancelScheduledWork} = require('customSchedule');
+
+export {now, scheduleWork, cancelScheduledWork};

--- a/packages/shared/requestAnimationFrameForReact.js
+++ b/packages/shared/requestAnimationFrameForReact.js
@@ -15,12 +15,12 @@ import warning from 'fbjs/lib/warning';
 // We capture a local reference to any global, in case it gets polyfilled after
 // this module is initially evaluated.
 // We want to be using a consistent implementation.
-const localRequestAnimationFrame = requestAnimationFrame;
+const requestAnimationFrame = global.requestAnimationFrame;
 
 if (__DEV__) {
   if (
     ExecutionEnvironment.canUseDOM &&
-    typeof localRequestAnimationFrame !== 'function'
+    typeof requestAnimationFrame !== 'function'
   ) {
     warning(
       false,
@@ -30,4 +30,4 @@ if (__DEV__) {
   }
 }
 
-export default localRequestAnimationFrame;
+export default requestAnimationFrame;

--- a/packages/shared/requestAnimationFrameForReact.js
+++ b/packages/shared/requestAnimationFrameForReact.js
@@ -12,10 +12,15 @@
 import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 import warning from 'fbjs/lib/warning';
 
+// We capture a local reference to any global, in case it gets polyfilled after
+// this module is initially evaluated.
+// We want to be using a consistent implementation.
+const localRequestAnimationFrame = requestAnimationFrame;
+
 if (__DEV__) {
   if (
     ExecutionEnvironment.canUseDOM &&
-    typeof requestAnimationFrame !== 'function'
+    typeof localRequestAnimationFrame !== 'function'
   ) {
     warning(
       false,
@@ -25,4 +30,4 @@ if (__DEV__) {
   }
 }
 
-export default requestAnimationFrame;
+export default localRequestAnimationFrame;

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -371,7 +371,14 @@ const bundles = [
   /******* React Scheduler (experimental) *******/
   {
     label: 'react-scheduler',
-    bundleTypes: [NODE_DEV, NODE_PROD, UMD_DEV, UMD_PROD],
+    bundleTypes: [
+      UMD_DEV,
+      UMD_PROD,
+      NODE_DEV,
+      NODE_PROD,
+      FB_WWW_DEV,
+      FB_WWW_PROD,
+    ],
     moduleType: ISOMORPHIC,
     entry: 'react-scheduler',
     global: 'ReactScheduler',

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -79,11 +79,22 @@ const forks = Object.freeze({
   },
 
   // This logic is forked on www to use the 'acrossTransitions' version.
+  // This will be removed soon, see internal task T29442940
   'shared/requestAnimationFrameForReact': (bundleType, entry) => {
     switch (bundleType) {
       case FB_WWW_DEV:
       case FB_WWW_PROD:
         return 'shared/forks/requestAnimationFrameForReact.www.js';
+      default:
+        return null;
+    }
+  },
+
+  'shared/ReactScheduler': (bundleType, entry) => {
+    switch (bundleType) {
+      case FB_WWW_DEV:
+      case FB_WWW_PROD:
+        return 'shared/forks/ReactScheduler.www.js';
       default:
         return null;
     }


### PR DESCRIPTION
**Edit:** This PR has been rebased and no longer has an cruft from previous PRs.
    
---

**what is the change?:**
- Uses references to global APIs instead of directly calling global APIs themselves inside of exported functions.
- Shim the 'schedule' module itself in `www`, planning to use the generated bundle instead of inlining it.
- Create a `react-scheduler` bundle for `fb-www`

**why make this change?:**
Context: internally we polyfill `requestAnimationFrame` and `setTimeout` and other global APIs. These "polyfills" also add and modify the functionality of the APIs, in ways that are not compatible with React.

We need more control over the version of those APIs that is used by the `schedule` module. To manage this, we want to try loading the `schedule` module before the polyfills are loaded, and holding a reference to the original `requestAnimationFrame` API.

To require `schedule` early we need to split it out from React. This diff takes a simple approach to that - we still want `schedule` bundled with React for open source, but internally we want it to be a separate module.

**test plan:**
I'll run the sync next week and verify that this all works. :)

**issue:**
See internal task T29442940