### PR TITLE
Release script prompts for NPM 2FA code

### DIFF
--- a/scripts/release/build.js
+++ b/scripts/release/build.js
@@ -31,7 +31,6 @@ const run = async () => {
   try {
     const params = parseBuildParameters();
     params.packages = getPublicPackages();
-
     await checkEnvironmentVariables(params);
     await validateVersion(params);
     await checkUncommittedChanges(params);

--- a/scripts/release/package.json
+++ b/scripts/release/package.json
@@ -13,6 +13,7 @@
     "figlet": "^1.2.0",
     "fs-extra": "^4.0.2",
     "log-update": "^2.1.0",
+    "prompt-promise": "^1.0.3",
     "request-promise-json": "^1.0.4",
     "semver": "^5.4.1"
   }

--- a/scripts/release/publish-commands/get-npm-two-factor-auth.js
+++ b/scripts/release/publish-commands/get-npm-two-factor-auth.js
@@ -8,8 +8,8 @@ const prompt = require('prompt-promise');
 
 module.exports = async params => {
   logUpdate(chalk`{green ✓} Npm two-factor auth code {gray (or blank)}: `);
-  const opt = await prompt('');
+  const otp = await prompt('');
   prompt.done();
   logUpdate.clear();
-  return opt.trim() || null;
+  return otp.trim() || null;
 };

--- a/scripts/release/publish-commands/get-npm-two-factor-auth.js
+++ b/scripts/release/publish-commands/get-npm-two-factor-auth.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const chalk = require('chalk');
+const logUpdate = require('log-update');
+const prompt = require('prompt-promise');
+
+module.exports = async params => {
+  logUpdate(chalk`{green ✓} Npm two-factor auth code {gray (or blank)}: `);
+  const opt = await prompt('');
+  prompt.done();
+  logUpdate.clear();
+  return opt.trim() || null;
+};

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -8,7 +8,7 @@ const {join} = require('path');
 const semver = require('semver');
 const {execRead, execUnlessDry, logPromise} = require('../utils');
 
-const push = async ({cwd, dry, packages, version, tag}) => {
+const push = async ({cwd, dry, opt, packages, version, tag}) => {
   const errors = [];
   const isPrerelease = semver.prerelease(version);
   if (tag === undefined) {
@@ -19,10 +19,17 @@ const push = async ({cwd, dry, packages, version, tag}) => {
     throw new Error('The tag `latest` can only be used for stable versions.');
   }
 
+  // Pass two factor auth code if provided:
+  // https://docs.npmjs.com/getting-started/using-two-factor-authentication
+  const twoFactorAuth = opt != null ? `--opt ${opt}` : '';
+
   const publishProject = async project => {
     try {
       const path = join(cwd, 'build', 'node_modules', project);
-      await execUnlessDry(`npm publish --tag ${tag}`, {cwd: path, dry});
+      await execUnlessDry(`npm publish --tag ${tag} ${twoFactorAuth}`, {
+        cwd: path,
+        dry,
+      });
 
       const packagePath = join(
         cwd,

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -8,7 +8,7 @@ const {join} = require('path');
 const semver = require('semver');
 const {execRead, execUnlessDry, logPromise} = require('../utils');
 
-const push = async ({cwd, dry, opt, packages, version, tag}) => {
+const push = async ({cwd, dry, otp, packages, version, tag}) => {
   const errors = [];
   const isPrerelease = semver.prerelease(version);
   if (tag === undefined) {
@@ -21,7 +21,7 @@ const push = async ({cwd, dry, opt, packages, version, tag}) => {
 
   // Pass two factor auth code if provided:
   // https://docs.npmjs.com/getting-started/using-two-factor-authentication
-  const twoFactorAuth = opt != null ? `--opt ${opt}` : '';
+  const twoFactorAuth = otp != null ? `--otp ${otp}` : '';
 
   const publishProject = async project => {
     try {

--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -23,7 +23,7 @@ const run = async () => {
     await checkBuildStatus(params);
     await commitChangelog(params);
     await pushGitRemote(params);
-    params.opt = await getNpmTwoFactorAuth(params);
+    params.otp = await getNpmTwoFactorAuth(params);
     await publishToNpm(params);
     await printPostPublishSummary(params);
   } catch (error) {

--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -8,6 +8,7 @@ const {getPublicPackages} = require('./utils');
 
 const checkBuildStatus = require('./publish-commands/check-build-status');
 const commitChangelog = require('./publish-commands/commit-changelog');
+const getNpmTwoFactorAuth = require('./publish-commands/get-npm-two-factor-auth');
 const parsePublishParams = require('./publish-commands/parse-publish-params');
 const printPostPublishSummary = require('./publish-commands/print-post-publish-summary');
 const pushGitRemote = require('./publish-commands/push-git-remote');
@@ -22,6 +23,7 @@ const run = async () => {
     await checkBuildStatus(params);
     await commitChangelog(params);
     await pushGitRemote(params);
+    params.opt = await getNpmTwoFactorAuth(params);
     await publishToNpm(params);
     await printPostPublishSummary(params);
   } catch (error) {

--- a/scripts/release/yarn.lock
+++ b/scripts/release/yarn.lock
@@ -335,6 +335,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+keypress@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/keypress/-/keypress-0.2.1.tgz#1e80454250018dbad4c3fe94497d6e67b6269c77"
+
 lodash.padend@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
@@ -368,6 +372,16 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
+native-or-another@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/native-or-another/-/native-or-another-2.0.0.tgz#17a567f92beea9cd71acff96a7681a735eca3bff"
+  dependencies:
+    native-or-bluebird "^1.1.2"
+
+native-or-bluebird@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz#39c47bfd7825d1fb9ffad32210ae25daadf101c9"
+
 node-version@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.1.0.tgz#f437d7ba407e65e2c4eaef8887b1718ba523d4f0"
@@ -389,6 +403,13 @@ performance-now@^2.1.0:
 promise-polyfill@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.0.2.tgz#d9c86d3dc4dc2df9016e88946defd69b49b41162"
+
+prompt-promise@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/prompt-promise/-/prompt-promise-1.0.3.tgz#78ce4fcb9a14a108c49174f2d808c440d1bde265"
+  dependencies:
+    keypress "~0.2.1"
+    native-or-another "~2.0.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
I haven't _really_ tested this, but in theory, it prompts you for a 2FA code prior to publishing. If you provide a code, it passes it via the `--opt` flag to `npm publish` which is how the docs specify you should pass it.

Publishing is quick, and hopefully all of the packages can be published with the same token. But it's possible that it will expire in the middle, which would not be ideal. In that case, you would need to re-run the publish command with modifications to skip the already published packages.

I'm opening this PR for discussion purposes. I'll give it a little more thought before marking it ready for review.