### PR TITLE
TestRenderer warns if flushThrough is passed the wrong params

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRendererScheduling.js
+++ b/packages/react-test-renderer/src/ReactTestRendererScheduling.js
@@ -82,24 +82,13 @@ export function flushThrough(expectedValues: Array<mixed>): Array<mixed> {
     // Always return an array.
     yieldedValues = [];
   }
-  if (yieldedValues.length !== expectedValues.length) {
-    const error = new Error(
-      `flushThrough expected to yield ${
-        expectedValues.length
-      } values, but yielded ${yieldedValues.length}`,
-    );
-    // Attach expected and yielded arrays,
-    // So the caller could pretty print the diff (if desired).
-    (error: any).expectedValues = expectedValues;
-    (error: any).yieldedValues = yieldedValues;
-    throw error;
-  }
   for (let i = 0; i < expectedValues.length; i++) {
-    if (yieldedValues[i] !== expectedValues[i]) {
+    const expectedValue = `"${(expectedValues[i]: any)}"`;
+    const yieldedValue =
+      i < yieldedValues.length ? `"${(yieldedValues[i]: any)}"` : 'nothing';
+    if (yieldedValue !== expectedValue) {
       const error = new Error(
-        `flushThrough expected to "${(expectedValues[
-          i
-        ]: any)}", but "${(yieldedValues[i]: any)}" was yielded`,
+        `flushThrough expected to yield ${(expectedValue: any)}, but ${(yieldedValue: any)} was yielded`,
       );
       // Attach expected and yielded arrays,
       // So the caller could pretty print the diff (if desired).

--- a/packages/react-test-renderer/src/ReactTestRendererScheduling.js
+++ b/packages/react-test-renderer/src/ReactTestRendererScheduling.js
@@ -93,7 +93,7 @@ export function flushThrough(expectedValues: Array<mixed>): Array<mixed> {
       // Attach expected and yielded arrays,
       // So the caller could pretty print the diff (if desired).
       (error: any).expectedValues = expectedValues;
-      (error: any).yieldedValues = yieldedValues;
+      (error: any).actualValues = yieldedValues;
       throw error;
     }
   }

--- a/packages/react-test-renderer/src/ReactTestRendererScheduling.js
+++ b/packages/react-test-renderer/src/ReactTestRendererScheduling.js
@@ -80,7 +80,33 @@ export function flushThrough(expectedValues: Array<mixed>): Array<mixed> {
   }
   if (yieldedValues === null) {
     // Always return an array.
-    return [];
+    yieldedValues = [];
+  }
+  if (yieldedValues.length !== expectedValues.length) {
+    const error = new Error(
+      `flushThrough expected to yield ${
+        expectedValues.length
+      } values, but yielded ${yieldedValues.length}`,
+    );
+    // Attach expected and yielded arrays,
+    // So the caller could pretty print the diff (if desired).
+    (error: any).expectedValues = expectedValues;
+    (error: any).yieldedValues = yieldedValues;
+    throw error;
+  }
+  for (let i = 0; i < expectedValues.length; i++) {
+    if (yieldedValues[i] !== expectedValues[i]) {
+      const error = new Error(
+        `flushThrough expected to "${(expectedValues[
+          i
+        ]: any)}", but "${(yieldedValues[i]: any)}" was yielded`,
+      );
+      // Attach expected and yielded arrays,
+      // So the caller could pretty print the diff (if desired).
+      (error: any).expectedValues = expectedValues;
+      (error: any).yieldedValues = yieldedValues;
+      throw error;
+    }
   }
   return yieldedValues;
 }

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
@@ -159,7 +159,7 @@ describe('ReactTestRendererAsync', () => {
     );
 
     expect(() => renderer.unstable_flushThrough(['foo', 'baz'])).toThrow(
-      'flushThrough expected to "baz", but "bar" was yielded',
+      'flushThrough expected to yield "baz", but "bar" was yielded',
     );
   });
 
@@ -179,7 +179,7 @@ describe('ReactTestRendererAsync', () => {
     );
 
     expect(() => renderer.unstable_flushThrough(['foo', 'bar'])).toThrow(
-      'flushThrough expected to yield 2 values, but yielded 1',
+      'flushThrough expected to yield "bar", but nothing was yielded',
     );
   });
 
@@ -189,7 +189,7 @@ describe('ReactTestRendererAsync', () => {
     });
 
     expect(() => renderer.unstable_flushThrough(['foo'])).toThrow(
-      'flushThrough expected to yield 1 values, but yielded 0',
+      'flushThrough expected to yield "foo", but nothing was yielded',
     );
   });
 });

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
@@ -10,10 +10,16 @@
 
 'use strict';
 
-const React = require('react');
-const ReactTestRenderer = require('react-test-renderer');
+let React;
+let ReactTestRenderer;
 
 describe('ReactTestRendererAsync', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactTestRenderer = require('react-test-renderer');
+  });
+
   it('flushAll flushes all work', () => {
     function Foo(props) {
       return props.children;
@@ -133,5 +139,57 @@ describe('ReactTestRendererAsync', () => {
 
     // Only the higher priority properties have been committed
     expect(renderer.toJSON()).toEqual(['A:2', 'B:2']);
+  });
+
+  it('should error if flushThrough params dont match yielded values', () => {
+    const Yield = ({id}) => {
+      renderer.unstable_yield(id);
+      return id;
+    };
+
+    const renderer = ReactTestRenderer.create(
+      <div>
+        <Yield id="foo" />
+        <Yield id="bar" />
+        <Yield id="baz" />
+      </div>,
+      {
+        unstable_isAsync: true,
+      },
+    );
+
+    expect(() => renderer.unstable_flushThrough(['foo', 'baz'])).toThrow(
+      'flushThrough expected to "baz", but "bar" was yielded',
+    );
+  });
+
+  it('should error if flushThrough yields the wrong number of values', () => {
+    const Yield = ({id}) => {
+      renderer.unstable_yield(id);
+      return id;
+    };
+
+    const renderer = ReactTestRenderer.create(
+      <div>
+        <Yield id="foo" />
+      </div>,
+      {
+        unstable_isAsync: true,
+      },
+    );
+
+    expect(() => renderer.unstable_flushThrough(['foo', 'bar'])).toThrow(
+      'flushThrough expected to yield 2 values, but yielded 1',
+    );
+  });
+
+  it('should error if flushThrough yields no values', () => {
+    const renderer = ReactTestRenderer.create(null, {
+      unstable_isAsync: true,
+    });
+
+    expect(() => renderer.unstable_flushThrough(['foo'])).toThrow(
+      'flushThrough expected to yield 1 values, but yielded 0',
+    );
   });
 });

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -576,7 +576,9 @@ describe('Profiler', () => {
           </React.unstable_Profiler>,
           {unstable_isAsync: true},
         );
-        expect(renderer.unstable_flushThrough(['first'])).toEqual(['Yield:10']);
+        expect(renderer.unstable_flushThrough(['Yield:10'])).toEqual([
+          'Yield:10',
+        ]);
         expect(callback).toHaveBeenCalledTimes(0);
 
         // Simulate time moving forward while frame is paused.


### PR DESCRIPTION
This was silently passing before, when it probably should have failed harder (in case we forgot to expect-to-equal).

The resulting test failures now will not be as pretty (wrt diff highlighting) but it's more foolproof.