### PR TITLE
Record "actual" times for all Fibers within a Profiler tree (alt)

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -153,6 +153,8 @@ export type Fiber = {|
   alternate: Fiber | null,
 
   // Profiling metrics
+  actualDuration?: number,
+  actualStartTime?: number,
   selfBaseTime?: number,
   treeBaseTime?: number,
 
@@ -211,6 +213,8 @@ function FiberNode(
   this.alternate = null;
 
   if (enableProfilerTimer) {
+    this.actualDuration = 0;
+    this.actualStartTime = 0;
     this.selfBaseTime = 0;
     this.treeBaseTime = 0;
   }
@@ -310,6 +314,9 @@ export function createWorkInProgress(
   workInProgress.ref = current.ref;
 
   if (enableProfilerTimer) {
+    // We intentionally do not copy actual duration or start times.
+    // This would interfere with time tracking during interruptions.
+
     workInProgress.selfBaseTime = current.selfBaseTime;
     workInProgress.treeBaseTime = current.treeBaseTime;
   }
@@ -460,13 +467,6 @@ export function createFiberFromProfiler(
   const fiber = createFiber(Profiler, pendingProps, key, mode | ProfileMode);
   fiber.type = REACT_PROFILER_TYPE;
   fiber.expirationTime = expirationTime;
-  if (enableProfilerTimer) {
-    fiber.stateNode = {
-      elapsedPauseTimeAtStart: 0,
-      duration: 0,
-      startTime: 0,
-    };
-  }
 
   return fiber;
 }
@@ -541,6 +541,8 @@ export function assignFiberPropertiesInDEV(
   target.expirationTime = source.expirationTime;
   target.alternate = source.alternate;
   if (enableProfilerTimer) {
+    target.actualDuration = source.actualDuration;
+    target.actualStartTime = source.actualStartTime;
     target.selfBaseTime = source.selfBaseTime;
     target.treeBaseTime = source.treeBaseTime;
   }

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -313,6 +313,15 @@ export function createWorkInProgress(
     workInProgress.nextEffect = null;
     workInProgress.firstEffect = null;
     workInProgress.lastEffect = null;
+
+    if (enableProfilerTimer) {
+      // We intentionally reset, rather than copy, actualDuration & actualStartTime.
+      // This prevents time from endlessly accumulating in new commits.
+      // This has the downside of resetting values for different priority renders,
+      // But works for yielding (the common case) and should support resuming.
+      workInProgress.actualDuration = 0;
+      workInProgress.actualStartTime = 0;
+    }
   }
 
   workInProgress.expirationTime = expirationTime;
@@ -328,11 +337,6 @@ export function createWorkInProgress(
   workInProgress.ref = current.ref;
 
   if (enableProfilerTimer) {
-    // We intentionally reset, rather than copy, actualDuration & actualStartTime.
-    // This prevents time from endlessly accumulating in new commits.
-    workInProgress.actualDuration = 0;
-    workInProgress.actualStartTime = 0;
-
     workInProgress.selfBaseTime = current.selfBaseTime;
     workInProgress.treeBaseTime = current.treeBaseTime;
   }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -753,7 +753,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
 
   switch (finishedWork.tag) {
     case ClassComponent: {
-      return;
+      break;
     }
     case HostComponent: {
       const instance: Instance = finishedWork.stateNode;
@@ -779,7 +779,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           );
         }
       }
-      return;
+      break;
     }
     case HostText: {
       invariant(
@@ -795,10 +795,10 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       const oldText: string =
         current !== null ? current.memoizedProps : newText;
       commitTextUpdate(textInstance, oldText, newText);
-      return;
+      break;
     }
     case HostRoot: {
-      return;
+      break;
     }
     case Profiler: {
       if (enableProfilerTimer) {
@@ -811,15 +811,11 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           finishedWork.actualStartTime,
           getCommitTime(),
         );
-
-        // Reset actualTime after successful commit.
-        // By default, we append to this time to account for errors and pauses.
-        finishedWork.actualDuration = 0;
       }
-      return;
+      break;
     }
     case TimeoutComponent: {
-      return;
+      break;
     }
     default: {
       invariant(
@@ -828,6 +824,12 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           'likely caused by a bug in React. Please file an issue.',
       );
     }
+  }
+
+  if (enableProfilerTimer) {
+    // Reset actualTime after successful commit.
+    // By default, we append to this time to account for errors and pauses.
+    finishedWork.actualDuration = 0;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -825,12 +825,6 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       );
     }
   }
-
-  if (enableProfilerTimer) {
-    // Reset actualTime after successful commit.
-    // By default, we append to this time to account for errors and pauses.
-    finishedWork.actualDuration = 0;
-  }
 }
 
 function commitResetTextContent(current: Fiber) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -753,7 +753,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
 
   switch (finishedWork.tag) {
     case ClassComponent: {
-      break;
+      return;
     }
     case HostComponent: {
       const instance: Instance = finishedWork.stateNode;
@@ -779,7 +779,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           );
         }
       }
-      break;
+      return;
     }
     case HostText: {
       invariant(
@@ -795,10 +795,10 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       const oldText: string =
         current !== null ? current.memoizedProps : newText;
       commitTextUpdate(textInstance, oldText, newText);
-      break;
+      return;
     }
     case HostRoot: {
-      break;
+      return;
     }
     case Profiler: {
       if (enableProfilerTimer) {
@@ -812,10 +812,10 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           getCommitTime(),
         );
       }
-      break;
+      return;
     }
     case TimeoutComponent: {
-      break;
+      return;
     }
     default: {
       invariant(

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -806,15 +806,15 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
         onRender(
           finishedWork.memoizedProps.id,
           current === null ? 'mount' : 'update',
-          finishedWork.stateNode.duration,
+          finishedWork.actualDuration,
           finishedWork.treeBaseTime,
-          finishedWork.stateNode.startTime,
+          finishedWork.actualStartTime,
           getCommitTime(),
         );
 
         // Reset actualTime after successful commit.
         // By default, we append to this time to account for errors and pauses.
-        finishedWork.stateNode.duration = 0;
+        finishedWork.actualDuration = 0;
       }
       return;
     }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -38,6 +38,7 @@ import {
   TimeoutComponent,
 } from 'shared/ReactTypeOfWork';
 import {Placement, Ref, Update} from 'shared/ReactTypeOfSideEffect';
+import {ProfileMode} from './ReactTypeOfMode';
 import invariant from 'fbjs/lib/invariant';
 
 import {
@@ -312,6 +313,13 @@ function completeWork(
   renderExpirationTime: ExpirationTime,
 ): Fiber | null {
   const newProps = workInProgress.pendingProps;
+
+  if (enableProfilerTimer) {
+    if (workInProgress.mode & ProfileMode) {
+      recordElapsedActualRenderTime(workInProgress);
+    }
+  }
+
   switch (workInProgress.tag) {
     case FunctionalComponent:
       return null;
@@ -489,9 +497,6 @@ function completeWork(
     case Mode:
       return null;
     case Profiler:
-      if (enableProfilerTimer) {
-        recordElapsedActualRenderTime(workInProgress);
-      }
       return null;
     case HostPortal:
       popHostContainer(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -104,7 +104,6 @@ import {popProvider} from './ReactFiberNewContext';
 import {popHostContext, popHostContainer} from './ReactFiberHostContext';
 import {
   checkActualRenderTimeStackEmpty,
-  incrementCommitBatchId,
   pauseActualRenderTimerIfRunning,
   recordCommitTime,
   recordElapsedActualRenderTime,
@@ -579,11 +578,6 @@ function commitRoot(finishedWork: Fiber): ExpirationTime {
   stopCommitSnapshotEffectsTimer();
 
   if (enableProfilerTimer) {
-    // Batch ID groups profile timings for a given commit.
-    // This allows durations to acculate across interrupts or yields,
-    // And reset between commits.
-    incrementCommitBatchId();
-
     // Mark the current commit time to be shared by all Profilers in this batch.
     // This enables them to be grouped later.
     recordCommitTime();

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -104,6 +104,7 @@ import {popProvider} from './ReactFiberNewContext';
 import {popHostContext, popHostContainer} from './ReactFiberHostContext';
 import {
   checkActualRenderTimeStackEmpty,
+  incrementCommitBatchId,
   pauseActualRenderTimerIfRunning,
   recordCommitTime,
   recordElapsedActualRenderTime,
@@ -578,6 +579,13 @@ function commitRoot(finishedWork: Fiber): ExpirationTime {
   stopCommitSnapshotEffectsTimer();
 
   if (enableProfilerTimer) {
+    // Batch ID groups profile timings for a given commit.
+    // This allows durations to acculate across interrupts or yields,
+    // And reset between commits.
+    incrementCommitBatchId();
+
+    // Mark the current commit time to be shared by all Profilers in this batch.
+    // This enables them to be grouped later.
     recordCommitTime();
   }
 

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -106,6 +106,7 @@ import {
   checkActualRenderTimeStackEmpty,
   pauseActualRenderTimerIfRunning,
   recordCommitTime,
+  recordElapsedActualRenderTime,
   recordElapsedBaseRenderTimeIfRunning,
   resetActualRenderTimer,
   resumeActualRenderTimerIfPaused,
@@ -311,6 +312,10 @@ if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
       clearCaughtError();
 
       if (enableProfilerTimer) {
+        if (failedUnitOfWork.mode & ProfileMode) {
+          recordElapsedActualRenderTime(failedUnitOfWork);
+        }
+
         // Stop "base" render timer again (after the re-thrown error).
         stopBaseRenderTimerIfRunning();
       }

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -18,7 +18,6 @@ import {now} from './ReactFiberHostConfig';
 export type ProfilerTimer = {
   checkActualRenderTimeStackEmpty(): void,
   getCommitTime(): number,
-  incrementCommitBatchId(): void,
   markActualRenderTimeStarted(fiber: Fiber): void,
   pauseActualRenderTimerIfRunning(): void,
   recordElapsedActualRenderTime(fiber: Fiber): void,
@@ -31,14 +30,9 @@ export type ProfilerTimer = {
 };
 
 let commitTime: number = 0;
-let commitBatchId: number = 0;
 
 function getCommitTime(): number {
   return commitTime;
-}
-
-function incrementCommitBatchId(): void {
-  commitBatchId++;
 }
 
 function recordCommitTime(): void {
@@ -82,11 +76,6 @@ function markActualRenderTimeStarted(fiber: Fiber): void {
   }
   if (__DEV__) {
     fiberStack.push(fiber);
-  }
-
-  if (fiber.profilerCommitBatchId !== commitBatchId) {
-    fiber.profilerCommitBatchId = commitBatchId;
-    fiber.actualDuration = 0;
   }
 
   fiber.actualDuration =
@@ -181,7 +170,6 @@ function stopBaseRenderTimerIfRunning(): void {
 export {
   checkActualRenderTimeStackEmpty,
   getCommitTime,
-  incrementCommitBatchId,
   markActualRenderTimeStarted,
   pauseActualRenderTimerIfRunning,
   recordCommitTime,

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -9,6 +9,7 @@
 
 import type {Fiber} from './ReactFiber';
 
+import getComponentName from 'shared/getComponentName';
 import {enableProfilerTimer} from 'shared/ReactFeatureFlags';
 
 import warning from 'fbjs/lib/warning';
@@ -96,7 +97,11 @@ function recordElapsedActualRenderTime(fiber: Fiber): void {
     return;
   }
   if (__DEV__) {
-    warning(fiber === fiberStack.pop(), 'Unexpected Fiber popped.');
+    warning(
+      fiber === fiberStack.pop(),
+      'Unexpected Fiber (%s) popped.',
+      getComponentName(fiber),
+    );
   }
 
   fiber.actualDuration =

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -76,9 +76,10 @@ function markActualRenderTimeStarted(fiber: Fiber): void {
   if (__DEV__) {
     fiberStack.push(fiber);
   }
-  const stateNode = fiber.stateNode;
-  stateNode.elapsedPauseTimeAtStart = totalElapsedPauseTime;
-  stateNode.startTime = now();
+
+  fiber.actualDuration =
+    now() - ((fiber.actualDuration: any): number) - totalElapsedPauseTime;
+  fiber.actualStartTime = now();
 }
 
 function pauseActualRenderTimerIfRunning(): void {
@@ -97,11 +98,9 @@ function recordElapsedActualRenderTime(fiber: Fiber): void {
   if (__DEV__) {
     warning(fiber === fiberStack.pop(), 'Unexpected Fiber popped.');
   }
-  const stateNode = fiber.stateNode;
-  stateNode.duration +=
-    now() -
-    (totalElapsedPauseTime - stateNode.elapsedPauseTimeAtStart) -
-    stateNode.startTime;
+
+  fiber.actualDuration =
+    now() - totalElapsedPauseTime - ((fiber.actualDuration: any): number);
 }
 
 function resetActualRenderTimer(): void {

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -18,6 +18,7 @@ import {now} from './ReactFiberHostConfig';
 export type ProfilerTimer = {
   checkActualRenderTimeStackEmpty(): void,
   getCommitTime(): number,
+  incrementCommitBatchId(): void,
   markActualRenderTimeStarted(fiber: Fiber): void,
   pauseActualRenderTimerIfRunning(): void,
   recordElapsedActualRenderTime(fiber: Fiber): void,
@@ -30,9 +31,14 @@ export type ProfilerTimer = {
 };
 
 let commitTime: number = 0;
+let commitBatchId: number = 0;
 
 function getCommitTime(): number {
   return commitTime;
+}
+
+function incrementCommitBatchId(): void {
+  commitBatchId++;
 }
 
 function recordCommitTime(): void {
@@ -76,6 +82,11 @@ function markActualRenderTimeStarted(fiber: Fiber): void {
   }
   if (__DEV__) {
     fiberStack.push(fiber);
+  }
+
+  if (fiber.profilerCommitBatchId !== commitBatchId) {
+    fiber.profilerCommitBatchId = commitBatchId;
+    fiber.actualDuration = 0;
   }
 
   fiber.actualDuration =
@@ -170,6 +181,7 @@ function stopBaseRenderTimerIfRunning(): void {
 export {
   checkActualRenderTimeStackEmpty,
   getCommitTime,
+  incrementCommitBatchId,
   markActualRenderTimeStarted,
   pauseActualRenderTimerIfRunning,
   recordCommitTime,

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -705,11 +705,12 @@ describe('Profiler', () => {
           }),
         ).toEqual(['Yield:11']);
 
-        // Verify that the actual time includes all three durations above.
-        // And the base time includes only the final rendered tree times.
+        // The actual time should include only the most recent render,
+        // Because this lets us avoid a lot of commit phase reset complexity.
+        // The base time includes only the final rendered tree times.
         expect(callback).toHaveBeenCalledTimes(1);
         call = callback.mock.calls[0];
-        expect(call[2]).toBe(19); // actual time
+        expect(call[2]).toBe(11); // actual time
         expect(call[3]).toBe(11); // base time
         expect(call[4]).toBe(264); // start time
         expect(call[5]).toBe(275); // commit time
@@ -796,12 +797,13 @@ describe('Profiler', () => {
           renderer.unstable_flushSync(() => second.setState({renderTime: 30})),
         ).toEqual(['SecondComponent:30', 'Yield:7']);
 
-        // Verify that the actual time includes time spent in the both renders so far (10ms and 37ms).
+        // The actual time should include only the most recent render (37ms),
+        // Because this lets us avoid a lot of commit phase reset complexity.
         // The base time should include the more recent times for the SecondComponent subtree,
         // As well as the original times for the FirstComponent subtree.
         expect(callback).toHaveBeenCalledTimes(1);
         call = callback.mock.calls[0];
-        expect(call[2]).toBe(47); // actual time
+        expect(call[2]).toBe(37); // actual time
         expect(call[3]).toBe(42); // base time
         expect(call[4]).toBe(229); // start time
         expect(call[5]).toBe(266); // commit time

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -598,7 +598,9 @@ describe('Profiler', () => {
           </React.unstable_Profiler>,
           {unstable_isAsync: true},
         );
-        expect(renderer.unstable_flushThrough(['first'])).toEqual(['Yield:10']);
+        expect(renderer.unstable_flushThrough(['Yield:10'])).toEqual([
+          'Yield:10',
+        ]);
         expect(callback).toHaveBeenCalledTimes(0);
 
         // Simulate time moving forward while frame is paused.

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -228,6 +228,28 @@ describe('Profiler', () => {
       expect(call[3]).toBe(10); // base time
       expect(call[4]).toBe(35); // start time
       expect(call[5]).toBe(45); // commit time
+
+      callback.mockReset();
+
+      advanceTimeBy(20); // 45 -> 65
+
+      renderer.update(
+        <React.unstable_Profiler id="test" onRender={callback}>
+          <AdvanceTime byAmount={4} />
+        </React.unstable_Profiler>,
+      );
+
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      [call] = callback.mock.calls;
+
+      expect(call).toHaveLength(6);
+      expect(call[0]).toBe('test');
+      expect(call[1]).toBe('update');
+      expect(call[2]).toBe(4); // actual time
+      expect(call[3]).toBe(4); // base time
+      expect(call[4]).toBe(65); // start time
+      expect(call[5]).toBe(69); // commit time
     });
 
     it('includes render times of nested Profilers in their parent times', () => {


### PR DESCRIPTION
Alternate implementation of PR #12891

Trades the ability to accumulate "actual" time across renders of different priorities in exchange for simplifying how/when we need to reset times. Theoretically, this approach is also more compatible with future resuming behavior.
