### PR TITLE
Use --frozen-lockfile for Yarn in CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run:
           name: Install Packages
-          command: yarn install
+          command: yarn install --frozen-lockfile
 
       - run:
           name: Test Packages


### PR DESCRIPTION
CI builds should always use the `--frozen-lockfile` option. It will fail the build if the lockfile is out-of-date:

> If you need reproducible dependencies, which is usually the case with the continuous integration systems, you should pass --frozen-lockfile flag.

(https://yarnpkg.com/en/docs/cli/install/)