### PR TITLE
[scheduler] 5/n Error handling in scheduler

### DIFF
--- a/fixtures/schedule/index.html
+++ b/fixtures/schedule/index.html
@@ -74,6 +74,11 @@
         <p><b>IMPORTANT:</b> Open the console when you run this! Inspect the logs there!</p>
         <button onClick="runTestFive()">Run Test 5</button>
       </li>
+      <li>
+        <p>When some callbacks throw errors <b> and some also time out</b>, still calls them all within the same frame</p>
+        <p><b>IMPORTANT:</b> Open the console when you run this! Inspect the logs there!</p>
+        <button onClick="runTestSix()">Run Test 6</button>
+      </li>
     </ol>
     <script src="../../build/dist/react-scheduler.development.js"></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
@@ -378,6 +383,84 @@ function runTestFive() {
     scheduleWork(cbD); // will throw error
     console.log('scheduled cbD');
     scheduleWork(cbE);
+    console.log('scheduled cbE');
+  };
+}
+
+function runTestSix() {
+  // Test 6
+  // When some callbacks throw errors, still calls them all within the same frame
+  const cbA = (x) => {
+    console.log('cbA called with argument of ' + JSON.stringify(x));
+    console.log('cbA is about to throw an error!');
+    throw new Error('error A');
+  }
+  const cbB = (x) => {
+    console.log('cbB called with argument of ' + JSON.stringify(x));
+  }
+  const cbC = (x) => {
+    console.log('cbC called with argument of ' + JSON.stringify(x));
+  }
+  const cbD = (x) => {
+    console.log('cbD called with argument of ' + JSON.stringify(x));
+    console.log('cbD is about to throw an error!');
+    throw new Error('error D');
+  }
+  const cbE = (x) => {
+    console.log('cbE called with argument of ' + JSON.stringify(x));
+    console.log('This was the last callback! ------------------');
+  }
+
+  console.log('We are aiming to roughly emulate the way ' +
+  '`requestAnimationFrame` handles errors from callbacks.');
+
+  console.log('about to run the simulation of what it should look like...:');
+
+  requestAnimationFrame(() => {
+    console.log('frame 1 started');
+    requestAnimationFrame(() => {
+      console.log('frame 2 started');
+      requestAnimationFrame(() => {
+        console.log('frame 3 started... we stop counting now.');
+        console.log('about to wait a moment and start this again but ' +
+        'with the scheduler instead of requestAnimationFrame');
+        setTimeout(runSchedulerCode, 1000);
+      });
+    });
+  });
+  requestAnimationFrame(cbC);
+  console.log('scheduled cbC first; simulating timing out');
+  requestAnimationFrame(cbD); // will throw error
+  console.log('scheduled cbD first; simulating timing out');
+  requestAnimationFrame(cbE);
+  console.log('scheduled cbE first; simulating timing out');
+  requestAnimationFrame(cbA);
+  console.log('scheduled cbA'); // will throw error
+  requestAnimationFrame(cbB);
+  console.log('scheduled cbB');
+
+
+  function runSchedulerCode() {
+    console.log('-------------------------------------------------------------');
+    console.log('now lets see what it looks like using the scheduler...:');
+    requestAnimationFrame(() => {
+      console.log('frame 1 started');
+      requestAnimationFrame(() => {
+        console.log('frame 2 started');
+        requestAnimationFrame(() => {
+          console.log('frame 3 started... we stop counting now.');
+        });
+      });
+    });
+    scheduleWork(cbA);
+    console.log('scheduled cbA');
+    scheduleWork(cbB); // will throw error
+    console.log('scheduled cbB');
+    scheduleWork(cbC, {timeout: 1});
+    console.log('scheduled cbC');
+    scheduleWork(cbD, {timeout: 1}); // will throw error
+    console.log('scheduled cbD');
+    scheduleWork(cbE, {timeout: 1});
     console.log('scheduled cbE');
   };
 }

--- a/fixtures/schedule/index.html
+++ b/fixtures/schedule/index.html
@@ -293,7 +293,7 @@ function runTestFour() {
   updateTestResult(4, 'scheduled cbA');
   scheduleWork(cbB, {timeout: 100}); // times out later
   updateTestResult(4, 'scheduled cbB');
-  scheduleWork(cbC, {timeout: 2}); // will time out fast
+  scheduleWork(cbC, {timeout: 1}); // will time out fast
   updateTestResult(4, 'scheduled cbC');
   scheduleWork(cbD); // won't time out
   updateTestResult(4, 'scheduled cbD');

--- a/fixtures/schedule/index.html
+++ b/fixtures/schedule/index.html
@@ -69,6 +69,11 @@
         <div><b>Actual:</b></div>
         <div id="test-4"></div>
       </li>
+      <li>
+        <p>When some callbacks throw errors, still calls them all within the same frame</p>
+        <p><b>IMPORTANT:</b> Open the console when you run this! Inspect the logs there!</p>
+        <button onClick="runTestFive()">Run Test 5</button>
+      </li>
     </ol>
     <script src="../../build/dist/react-scheduler.development.js"></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
@@ -134,6 +139,9 @@ const latestResults = [
   // test 4
   [
   ],
+  // test 5
+  [
+  ],
 ];
 
 const expectedResults = [
@@ -181,6 +189,10 @@ const expectedResults = [
     'cbB called with argument of {"didTimeout":false}',
     'cbD called with argument of {"didTimeout":false}',
     'frame 3 started... we stop counting now.',
+  ],
+  // test 5
+  [
+    // ... TODO
   ],
 ];
 function runTestOne() {
@@ -287,6 +299,87 @@ function runTestFour() {
     displayTestResult(4);
     checkTestResult(4);
   });
+
+}
+
+// Error handling
+
+function runTestFive() {
+  // Test 5
+  // When some callbacks throw errors, still calls them all within the same frame
+  const cbA = (x) => {
+    console.log('cbA called with argument of ' + JSON.stringify(x));
+  }
+  const cbB = (x) => {
+    console.log('cbB called with argument of ' + JSON.stringify(x));
+    console.log('cbB is about to throw an error!');
+    throw new Error('error B');
+  }
+  const cbC = (x) => {
+    console.log('cbC called with argument of ' + JSON.stringify(x));
+  }
+  const cbD = (x) => {
+    console.log('cbD called with argument of ' + JSON.stringify(x));
+    console.log('cbD is about to throw an error!');
+    throw new Error('error D');
+  }
+  const cbE = (x) => {
+    console.log('cbE called with argument of ' + JSON.stringify(x));
+    console.log('This was the last callback! ------------------');
+  }
+
+  console.log('We are aiming to roughly emulate the way ' +
+  '`requestAnimationFrame` handles errors from callbacks.');
+
+  console.log('about to run the simulation of what it should look like...:');
+
+  requestAnimationFrame(() => {
+    console.log('frame 1 started');
+    requestAnimationFrame(() => {
+      console.log('frame 2 started');
+      requestAnimationFrame(() => {
+        console.log('frame 3 started... we stop counting now.');
+        console.log('about to wait a moment and start this again but ' +
+        'with the scheduler instead of requestAnimationFrame');
+        setTimeout(runSchedulerCode, 1000);
+      });
+    });
+  });
+  requestAnimationFrame(cbA);
+  console.log('scheduled cbA');
+  requestAnimationFrame(cbB); // will throw error
+  console.log('scheduled cbB');
+  requestAnimationFrame(cbC);
+  console.log('scheduled cbC');
+  requestAnimationFrame(cbD); // will throw error
+  console.log('scheduled cbD');
+  requestAnimationFrame(cbE);
+  console.log('scheduled cbE');
+
+
+  function runSchedulerCode() {
+    console.log('-------------------------------------------------------------');
+    console.log('now lets see what it looks like using the scheduler...:');
+    requestAnimationFrame(() => {
+      console.log('frame 1 started');
+      requestAnimationFrame(() => {
+        console.log('frame 2 started');
+        requestAnimationFrame(() => {
+          console.log('frame 3 started... we stop counting now.');
+        });
+      });
+    });
+    scheduleWork(cbA);
+    console.log('scheduled cbA');
+    scheduleWork(cbB); // will throw error
+    console.log('scheduled cbB');
+    scheduleWork(cbC);
+    console.log('scheduled cbC');
+    scheduleWork(cbD); // will throw error
+    console.log('scheduled cbD');
+    scheduleWork(cbE);
+    console.log('scheduled cbE');
+  };
 }
     </script type="text/babel">
   </body>

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -138,7 +138,10 @@ if (!ExecutionEnvironment.canUseDOM) {
    * - do start a new postMessage callback, to call any remaining callbacks,
    * - but only if there is an error, so there is not extra overhead.
    */
-  const callUnsafely = function(callbackConfig: CallbackConfigType, arg: Deadline) {
+  const callUnsafely = function(
+    callbackConfig: CallbackConfigType,
+    arg: Deadline,
+  ) {
     const callback = callbackConfig.scheduledCallback;
     let finishedCalling = false;
     try {

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -135,7 +135,7 @@ if (!ExecutionEnvironment.canUseDOM) {
    * - do start a new postMessage callback, to call any remaining callbacks,
    * - but only if there is an error, so there is not extra overhead.
    */
-  const callSafely = function(callback, arg) {
+  const callUnsafely = function(callback, arg) {
     let finishedCalling = false;
     try {
       callback(arg);
@@ -183,7 +183,7 @@ if (!ExecutionEnvironment.canUseDOM) {
         // it has timed out!
         // call it
         const callback = currentCallbackConfig.scheduledCallback;
-        callSafely(callback, frameDeadlineObject);
+        callUnsafely(callback, frameDeadlineObject);
         // remove it from linked list
         cancelScheduledWork(currentCallbackConfig);
       } else {
@@ -237,7 +237,7 @@ if (!ExecutionEnvironment.canUseDOM) {
       }
       frameDeadlineObject.didTimeout = false;
       const latestCallback = latestCallbackConfig.scheduledCallback;
-      callSafely(latestCallback, frameDeadlineObject);
+      callUnsafely(latestCallback, frameDeadlineObject);
       currentTime = now();
     }
     if (headOfPendingCallbacksLinkedList !== null) {

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -86,6 +86,7 @@ if (!ExecutionEnvironment.canUseDOM) {
       timeoutTime: 0,
       next: null,
       prev: null,
+      cancelled: false,
     };
     const timeoutId = localSetTimeout(() => {
       callback({
@@ -96,6 +97,7 @@ if (!ExecutionEnvironment.canUseDOM) {
       });
     });
     timeoutIds.set(callback, timeoutId);
+    callbackConfig.cancelled = true;
     return callbackConfig;
   };
   cancelScheduledWork = function(callbackId: CallbackIdType) {

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -354,7 +354,6 @@ describe('ReactScheduler', () => {
       it('when called more than once', () => {
         const {scheduleWork, cancelScheduledWork} = ReactScheduler;
         const callbackLog = [];
-        let callbackBId;
         const callbackA = jest.fn(() => callbackLog.push('A'));
         const callbackB = jest.fn(() => callbackLog.push('B'));
         const callbackC = jest.fn(() => callbackLog.push('C'));

--- a/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
+++ b/packages/react-scheduler/src/__tests__/ReactScheduler-test.js
@@ -351,6 +351,28 @@ describe('ReactScheduler', () => {
     });
 
     describe('with multiple callbacks', () => {
+      it('when called more than once', () => {
+        const {scheduleWork, cancelScheduledWork} = ReactScheduler;
+        const callbackLog = [];
+        let callbackBId;
+        const callbackA = jest.fn(() => callbackLog.push('A'));
+        const callbackB = jest.fn(() => callbackLog.push('B'));
+        const callbackC = jest.fn(() => callbackLog.push('C'));
+        scheduleWork(callbackA);
+        const callbackId = scheduleWork(callbackB);
+        scheduleWork(callbackC);
+        cancelScheduledWork(callbackId);
+        cancelScheduledWork(callbackId);
+        cancelScheduledWork(callbackId);
+        // Initially doesn't call anything
+        expect(callbackLog).toEqual([]);
+        advanceOneFrame({timeLeftInFrame: 15});
+
+        // Should still call A and C
+        expect(callbackLog).toEqual(['A', 'C']);
+        expect(callbackB).toHaveBeenCalledTimes(0);
+      });
+
       it('when one callback cancels the next one', () => {
         const {scheduleWork, cancelScheduledWork} = ReactScheduler;
         const callbackLog = [];


### PR DESCRIPTION
**what is the change?:**
We set a flag before calling any callback, and then use a 'try/finally'
block to wrap it. Note that we *do not* catch the error, if one is
thrown. But, we only unset the flag after the callback successfully
finishes.

If we reach the 'finally' block and the flag was not unset, then it
means an error was thrown.

In that case we start a new postMessage callback, to finish calling any
other pending callbacks if there is time.

**why make this change?:**
We need to make sure that an error thrown from one callback doesn't stop
other callbacks from firing, but we also don't want to catch or swallow
the error because we want engineers to still be able to log and debug
errors. And we don't want to push errors into the wrong frame or change their timing - this simulates almost exactly how it would work with 'requestAnimationFrame' if the callback throws an error.

**test plan:**
New tests added are passing, and we verified that they fail without this
change.

In particular, the fixture shows how errors and callbacks act in a real browser and compares the 'schedule.scheduleWork' method to 'requestAnimationFrame'. In Chrome the results are the same:

<img width="1058" alt="screen shot 2018-05-27 at 7 14 55 am" src="https://user-images.githubusercontent.com/1114467/40625596-5638daa0-6268-11e8-8a5e-c39e295d122a.png">

**Edit:** In Firefox they are also the same;
<img width="750" alt="screen shot 2018-05-29 at 6 11 32 pm" src="https://user-images.githubusercontent.com/1114467/40693363-d3d61780-636b-11e8-893d-ecb6ba8aebc2.png">
<img width="809" alt="screen shot 2018-05-29 at 6 11 53 pm" src="https://user-images.githubusercontent.com/1114467/40693364-d3fc4be4-636b-11e8-84ea-de2a09e379c6.png">

Haven't tested IE/Edge yet but I will, not expecting problems there.