### PR TITLE
Do not assign node.value on input creation if no change will occur

### DIFF
--- a/fixtures/dom/src/components/fixtures/text-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/text-inputs/index.js
@@ -64,12 +64,24 @@ class TextInputFixtures extends React.Component {
           <Fixture>
             <form className="control-box">
               <fieldset>
-                <legend>Text</legend>
+                <legend>Empty value prop string</legend>
+                <input value="" required={true} />
+              </fieldset>
+              <fieldset>
+                <legend>No value prop</legend>
                 <input required={true} />
               </fieldset>
               <fieldset>
-                <legend>Date</legend>
+                <legend>Empty defaultValue prop string</legend>
+                <input required={true} defaultValue="" />
+              </fieldset>
+              <fieldset>
+                <legend>No value prop date input</legend>
                 <input type="date" required={true} />
+              </fieldset>
+              <fieldset>
+                <legend>Empty value prop date input</legend>
+                <input type="date" value="" required={true} />
               </fieldset>
             </form>
           </Fixture>
@@ -77,8 +89,11 @@ class TextInputFixtures extends React.Component {
           <p className="footnote">
             Checking the date type is also important because of a prior fix for
             iOS Safari that involved assigning over value/defaultValue
-            properties of the input to prevent a display bug. This also
-            triggered input validation.
+            properties of the input to prevent a display bug. This also triggers
+            input validation.
+          </p>
+          <p className="footnote">
+            The date inputs should be blank in iOS. This is not a bug.
           </p>
         </TestCase>
 

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -209,16 +209,24 @@ export function postMountWrapper(element: Element, props: Object) {
   const node = ((element: any): InputWithWrapperState);
 
   if (props.hasOwnProperty('value') || props.hasOwnProperty('defaultValue')) {
+    const initialValue = '' + node._wrapperState.initialValue;
+    const currentValue = node.value;
+
     // Do not assign value if it is already set. This prevents user text input
     // from being lost during SSR hydration.
-    if (node.value === '') {
-      node.value = '' + node._wrapperState.initialValue;
+    if (currentValue === '') {
+      // Do not re-assign the value property if there is no change. This
+      // potentially avoids a DOM write and prevents Firefox (~60.0.1) from
+      // prematurely marking required inputs as invalid
+      if (initialValue !== currentValue) {
+        node.value = initialValue;
+      }
     }
 
     // value must be assigned before defaultValue. This fixes an issue where the
     // visually displayed value of date inputs disappears on mobile Safari and Chrome:
     // https://github.com/facebook/react/issues/7233
-    node.defaultValue = '' + node._wrapperState.initialValue;
+    node.defaultValue = initialValue;
   }
 
   // Normally, we'd just do `node.checked = node.checked` upon initial mount, less this bug


### PR DESCRIPTION
**What**

This commit fixes an issue where assigning an empty string to required text inputs triggers the invalid state in Firefox (~60.0.1).

It does this by first comparing the initial state value to the current value property on the text element. Doing so:

1. Prevents the validation issue
2. Avoids an extra DOM Mutation in some cases

I have also updated the text fixtures to include the empty string test case presented in https://github.com/facebook/react/issues/8395#issuecomment-392724376

**Test Plan**

1. Open http://react-more-required-validation-pass.surge.sh/text-inputs
2. View the Required Input test case
3. All inputs should appear valid
4. On iOS and Android, date inputs should present a value

<img width="870" alt="screen shot 2018-05-29 at 7 47 11 am" src="https://user-images.githubusercontent.com/590904/40657087-9767b6a2-6314-11e8-90ba-60e3aaf02c34.png">

**Tested In**

- [x] Safari 9, 11
- [x] Chrome 49, 66
- [x] Firefox 47, 60
- [x] IE 9, 11
- [x] Edge 16, 17
- [x] iOS 9, 11 Safari 
- [x] Chrome for Android 

---

Related: https://github.com/facebook/react/issues/8395#issuecomment-392724376