### PR TITLE
adds createTestInstance function to ReactTestRenderer

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -14,6 +14,7 @@ import type {Instance, TextInstance} from './ReactTestHostConfig';
 import * as TestRenderer from 'react-reconciler/inline.test';
 import {batchedUpdates} from 'events/ReactGenericBatching';
 import {findCurrentFiberUsingSlowPath} from 'react-reconciler/reflection';
+import * as ReactInstanceMap from 'shared/ReactInstanceMap';
 import {
   Fragment,
   FunctionalComponent,
@@ -485,6 +486,15 @@ const ReactTestRendererFiber = {
   /* eslint-enable camelcase */
 
   unstable_setNowImplementation: TestRendererScheduling.setNowImplementation,
+
+  createTestInstance(componentRef: React$Component<any>) {
+    invariant(
+      componentRef !== null && ReactInstanceMap.has(componentRef),
+      'Unable to create TestInstance. Ensure createTestInstance is ' +
+        'called with a reference to a React class component.',
+    );
+    return wrapFiber(ReactInstanceMap.get(componentRef));
+  },
 };
 
 export default ReactTestRendererFiber;

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -1001,3 +1001,22 @@ describe('ReactTestRenderer', () => {
     );
   });
 });
+
+describe('createTestInstance', () => {
+  it('should create a ReactTestInstance from class component', () => {
+    class App extends React.Component {
+      render() {
+        return 'hello';
+      }
+    }
+
+    const renderer = ReactTestRenderer.create(<App />);
+    const instance = renderer.root.instance;
+    const testInstance = ReactTestRenderer.createTestInstance(instance);
+    expect(testInstance).toEqual(renderer.root);
+  });
+
+  it('throws an exception when creating a ReactTestInstance from null', () => {
+    expect(() => ReactTestRenderer.createTestInstance(null)).toThrow();
+  });
+});


### PR DESCRIPTION
Hello, I have had a crack at solving #12753. This change gives people the ability to traverse a component tree rendered by ReactDOM in a sanctioned way. Having a public API that provides this ability will be useful for testing libraries like Enzyme.

This is the most straight forward approach I could come up with. Would love opinions on whether this is the right package to expose this functionality.

Some todos:
- Documentation
- A more realistic test that uses ReactDOM