### PR TITLE
[React-Linter] Update danger token

### DIFF
--- a/scripts/tasks/danger.js
+++ b/scripts/tasks/danger.js
@@ -12,8 +12,8 @@ const spawn = require('child_process').spawn;
 
 const extension = process.platform === 'win32' ? '.cmd' : '';
 
-// Facebook-Open-Source-Bot public_repo token
-const token = 'b186c9a82bab3b08ec80' + 'c0818117619eec6f281a';
+// React-Linter public_repo token (this is publicly visible on purpose)
+const token = '80aa64c50f38a267e9ba' + '575d41d528f9c234edb8';
 spawn(path.join('node_modules', '.bin', 'danger-ci' + extension), [], {
   // Allow colors to pass through
   stdio: 'inherit',


### PR DESCRIPTION
Use a new `react-linter` access token. This is used by Danger in Circle CI to post `react-linter`'s build size metrics whenever a PR is created or updated.

This token is publicly visible on purpose. As Danger runs on forked pull requests, Danger does not have access to the private environment variables in the Circle CI test environment. We therefore use an access token for a GitHub bot account (`react-linter`) that is, for all intents and purposes, a regular account with no privileged access. 

This token will only allow the bot to interact with public repositories the same way any arbitrary GitHub account might. This allows us to add [build size metrics as a comment on PRs](https://github.com/facebook/react/pull/12944#issuecomment-393366438). Unfortunately, it also means anyone can leave random comments or even [open new issues](https://github.com/facebook/react/issues/12953).

The token was revoked earlier today after it was used to open https://github.com/facebook/react/issues/12953. I'm restoring the token in order to re-enable build size tracking, but further abuse of the token might result in it getting revoked permanently and we'll need to find an alternate means of running the build size tracking script.
