### PR TITLE
Retry on error if there's lower priority pending work

### DIFF
--- a/packages/react-reconciler/src/ReactFiberPendingPriority.js
+++ b/packages/react-reconciler/src/ReactFiberPendingPriority.js
@@ -12,30 +12,26 @@ import type {ExpirationTime} from './ReactFiberExpirationTime';
 
 import {NoWork} from './ReactFiberExpirationTime';
 
-import {enableSuspense} from 'shared/ReactFeatureFlags';
-
 // TODO: Offscreen updates
 
 export function markPendingPriorityLevel(
   root: FiberRoot,
   expirationTime: ExpirationTime,
 ): void {
-  if (enableSuspense) {
-    // Update the latest and earliest pending times
-    const earliestPendingTime = root.earliestPendingTime;
-    if (earliestPendingTime === NoWork) {
-      // No other pending updates.
-      root.earliestPendingTime = root.latestPendingTime = expirationTime;
+  // Update the latest and earliest pending times
+  const earliestPendingTime = root.earliestPendingTime;
+  if (earliestPendingTime === NoWork) {
+    // No other pending updates.
+    root.earliestPendingTime = root.latestPendingTime = expirationTime;
+  } else {
+    if (earliestPendingTime > expirationTime) {
+      // This is the earliest pending update.
+      root.earliestPendingTime = expirationTime;
     } else {
-      if (earliestPendingTime > expirationTime) {
-        // This is the earliest pending update.
-        root.earliestPendingTime = expirationTime;
-      } else {
-        const latestPendingTime = root.latestPendingTime;
-        if (latestPendingTime < expirationTime) {
-          // This is the latest pending update
-          root.latestPendingTime = expirationTime;
-        }
+      const latestPendingTime = root.latestPendingTime;
+      if (latestPendingTime < expirationTime) {
+        // This is the latest pending update
+        root.latestPendingTime = expirationTime;
       }
     }
   }
@@ -46,114 +42,110 @@ export function markCommittedPriorityLevels(
   currentTime: ExpirationTime,
   earliestRemainingTime: ExpirationTime,
 ): void {
-  if (enableSuspense) {
-    if (earliestRemainingTime === NoWork) {
-      // Fast path. There's no remaining work. Clear everything.
-      root.earliestPendingTime = NoWork;
-      root.latestPendingTime = NoWork;
-      root.earliestSuspendedTime = NoWork;
-      root.latestSuspendedTime = NoWork;
-      root.latestPingedTime = NoWork;
-      return;
-    }
+  if (earliestRemainingTime === NoWork) {
+    // Fast path. There's no remaining work. Clear everything.
+    root.earliestPendingTime = NoWork;
+    root.latestPendingTime = NoWork;
+    root.earliestSuspendedTime = NoWork;
+    root.latestSuspendedTime = NoWork;
+    root.latestPingedTime = NoWork;
+    return;
+  }
 
-    // Let's see if the previous latest known pending level was just flushed.
-    const latestPendingTime = root.latestPendingTime;
-    if (latestPendingTime !== NoWork) {
-      if (latestPendingTime < earliestRemainingTime) {
-        // We've flushed all the known pending levels.
-        root.earliestPendingTime = root.latestPendingTime = NoWork;
-      } else {
-        const earliestPendingTime = root.earliestPendingTime;
-        if (earliestPendingTime < earliestRemainingTime) {
-          // We've flushed the earliest known pending level. Set this to the
-          // latest pending time.
-          root.earliestPendingTime = root.latestPendingTime;
-        }
+  // Let's see if the previous latest known pending level was just flushed.
+  const latestPendingTime = root.latestPendingTime;
+  if (latestPendingTime !== NoWork) {
+    if (latestPendingTime < earliestRemainingTime) {
+      // We've flushed all the known pending levels.
+      root.earliestPendingTime = root.latestPendingTime = NoWork;
+    } else {
+      const earliestPendingTime = root.earliestPendingTime;
+      if (earliestPendingTime < earliestRemainingTime) {
+        // We've flushed the earliest known pending level. Set this to the
+        // latest pending time.
+        root.earliestPendingTime = root.latestPendingTime;
       }
     }
-
-    // Now let's handle the earliest remaining level in the whole tree. We need to
-    // decide whether to treat it as a pending level or as suspended. Check
-    // it falls within the range of known suspended levels.
-
-    const earliestSuspendedTime = root.earliestSuspendedTime;
-    if (earliestSuspendedTime === NoWork) {
-      // There's no suspended work. Treat the earliest remaining level as a
-      // pending level.
-      markPendingPriorityLevel(root, earliestRemainingTime);
-      return;
-    }
-
-    const latestSuspendedTime = root.latestSuspendedTime;
-    if (earliestRemainingTime > latestSuspendedTime) {
-      // The earliest remaining level is later than all the suspended work. That
-      // means we've flushed all the suspended work.
-      root.earliestSuspendedTime = NoWork;
-      root.latestSuspendedTime = NoWork;
-      root.latestPingedTime = NoWork;
-
-      // There's no suspended work. Treat the earliest remaining level as a
-      // pending level.
-      markPendingPriorityLevel(root, earliestRemainingTime);
-      return;
-    }
-
-    if (earliestRemainingTime < earliestSuspendedTime) {
-      // The earliest remaining time is earlier than all the suspended work.
-      // Treat it as a pending update.
-      markPendingPriorityLevel(root, earliestRemainingTime);
-      return;
-    }
-
-    // The earliest remaining time falls within the range of known suspended
-    // levels. We should treat this as suspended work.
   }
+
+  // Now let's handle the earliest remaining level in the whole tree. We need to
+  // decide whether to treat it as a pending level or as suspended. Check
+  // it falls within the range of known suspended levels.
+
+  const earliestSuspendedTime = root.earliestSuspendedTime;
+  if (earliestSuspendedTime === NoWork) {
+    // There's no suspended work. Treat the earliest remaining level as a
+    // pending level.
+    markPendingPriorityLevel(root, earliestRemainingTime);
+    return;
+  }
+
+  const latestSuspendedTime = root.latestSuspendedTime;
+  if (earliestRemainingTime > latestSuspendedTime) {
+    // The earliest remaining level is later than all the suspended work. That
+    // means we've flushed all the suspended work.
+    root.earliestSuspendedTime = NoWork;
+    root.latestSuspendedTime = NoWork;
+    root.latestPingedTime = NoWork;
+
+    // There's no suspended work. Treat the earliest remaining level as a
+    // pending level.
+    markPendingPriorityLevel(root, earliestRemainingTime);
+    return;
+  }
+
+  if (earliestRemainingTime < earliestSuspendedTime) {
+    // The earliest remaining time is earlier than all the suspended work.
+    // Treat it as a pending update.
+    markPendingPriorityLevel(root, earliestRemainingTime);
+    return;
+  }
+
+  // The earliest remaining time falls within the range of known suspended
+  // levels. We should treat this as suspended work.
 }
 
 export function markSuspendedPriorityLevel(
   root: FiberRoot,
   suspendedTime: ExpirationTime,
 ): void {
-  if (enableSuspense) {
-    // First, check the known pending levels and update them if needed.
-    const earliestPendingTime = root.earliestPendingTime;
-    const latestPendingTime = root.latestPendingTime;
-    if (earliestPendingTime === suspendedTime) {
-      if (latestPendingTime === suspendedTime) {
-        // Both known pending levels were suspended. Clear them.
-        root.earliestPendingTime = root.latestPendingTime = NoWork;
-      } else {
-        // The earliest pending level was suspended. Clear by setting it to the
-        // latest pending level.
-        root.earliestPendingTime = latestPendingTime;
-      }
-    } else if (latestPendingTime === suspendedTime) {
-      // The latest pending level was suspended. Clear by setting it to the
-      // latest pending level.
-      root.latestPendingTime = earliestPendingTime;
-    }
-
-    // Next, if we're working on the lowest known suspended level, clear the ping.
-    // TODO: What if a promise suspends and pings before the root completes?
-    const latestSuspendedTime = root.latestSuspendedTime;
-    if (latestSuspendedTime === suspendedTime) {
-      root.latestPingedTime = NoWork;
-    }
-
-    // Finally, update the known suspended levels.
-    const earliestSuspendedTime = root.earliestSuspendedTime;
-    if (earliestSuspendedTime === NoWork) {
-      // No other suspended levels.
-      root.earliestSuspendedTime = root.latestSuspendedTime = suspendedTime;
+  // First, check the known pending levels and update them if needed.
+  const earliestPendingTime = root.earliestPendingTime;
+  const latestPendingTime = root.latestPendingTime;
+  if (earliestPendingTime === suspendedTime) {
+    if (latestPendingTime === suspendedTime) {
+      // Both known pending levels were suspended. Clear them.
+      root.earliestPendingTime = root.latestPendingTime = NoWork;
     } else {
-      if (earliestSuspendedTime > suspendedTime) {
-        // This is the earliest suspended level.
-        root.earliestSuspendedTime = suspendedTime;
-      } else if (latestSuspendedTime < suspendedTime) {
-        // This is the latest suspended level
-        root.latestSuspendedTime = suspendedTime;
-      }
+      // The earliest pending level was suspended. Clear by setting it to the
+      // latest pending level.
+      root.earliestPendingTime = latestPendingTime;
+    }
+  } else if (latestPendingTime === suspendedTime) {
+    // The latest pending level was suspended. Clear by setting it to the
+    // latest pending level.
+    root.latestPendingTime = earliestPendingTime;
+  }
+
+  // Next, if we're working on the lowest known suspended level, clear the ping.
+  // TODO: What if a promise suspends and pings before the root completes?
+  const latestSuspendedTime = root.latestSuspendedTime;
+  if (latestSuspendedTime === suspendedTime) {
+    root.latestPingedTime = NoWork;
+  }
+
+  // Finally, update the known suspended levels.
+  const earliestSuspendedTime = root.earliestSuspendedTime;
+  if (earliestSuspendedTime === NoWork) {
+    // No other suspended levels.
+    root.earliestSuspendedTime = root.latestSuspendedTime = suspendedTime;
+  } else {
+    if (earliestSuspendedTime > suspendedTime) {
+      // This is the earliest suspended level.
+      root.earliestSuspendedTime = suspendedTime;
+    } else if (latestSuspendedTime < suspendedTime) {
+      // This is the latest suspended level
+      root.latestSuspendedTime = suspendedTime;
     }
   }
 }
@@ -162,35 +154,29 @@ export function markPingedPriorityLevel(
   root: FiberRoot,
   pingedTime: ExpirationTime,
 ): void {
-  if (enableSuspense) {
-    const latestSuspendedTime = root.latestSuspendedTime;
-    if (latestSuspendedTime !== NoWork && latestSuspendedTime <= pingedTime) {
-      const latestPingedTime = root.latestPingedTime;
-      if (latestPingedTime === NoWork || latestPingedTime < pingedTime) {
-        root.latestPingedTime = pingedTime;
-      }
+  const latestSuspendedTime = root.latestSuspendedTime;
+  if (latestSuspendedTime !== NoWork && latestSuspendedTime <= pingedTime) {
+    const latestPingedTime = root.latestPingedTime;
+    if (latestPingedTime === NoWork || latestPingedTime < pingedTime) {
+      root.latestPingedTime = pingedTime;
     }
   }
 }
 
 export function findNextPendingPriorityLevel(root: FiberRoot): ExpirationTime {
-  if (enableSuspense) {
-    const earliestSuspendedTime = root.earliestSuspendedTime;
-    const earliestPendingTime = root.earliestPendingTime;
-    if (earliestSuspendedTime === NoWork) {
-      // Fast path. There's no suspended work.
-      return earliestPendingTime;
-    }
-
-    // First, check if there's known pending work.
-    if (earliestPendingTime !== NoWork) {
-      return earliestPendingTime;
-    }
-
-    // Finally, if a suspended level was pinged, work on that. Otherwise there's
-    // nothing to work on.
-    return root.latestPingedTime;
-  } else {
-    return root.current.expirationTime;
+  const earliestSuspendedTime = root.earliestSuspendedTime;
+  const earliestPendingTime = root.earliestPendingTime;
+  if (earliestSuspendedTime === NoWork) {
+    // Fast path. There's no suspended work.
+    return earliestPendingTime;
   }
+
+  // First, check if there's known pending work.
+  if (earliestPendingTime !== NoWork) {
+    return earliestPendingTime;
+  }
+
+  // Finally, if a suspended level was pinged, work on that. Otherwise there's
+  // nothing to work on.
+  return root.latestPingedTime;
 }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -237,8 +237,6 @@ let nextEffect: Fiber | null = null;
 
 let isCommitting: boolean = false;
 
-let isRootReadyForCommit: boolean = false;
-
 let legacyErrorBoundariesThatAlreadyFailed: Set<mixed> | null = null;
 
 // Used for performance tracking.
@@ -349,8 +347,6 @@ function resetStack() {
   nextLatestTimeoutMs = -1;
   nextRenderIsExpired = false;
   nextUnitOfWork = null;
-
-  isRootReadyForCommit = false;
 }
 
 function commitAllHostEffects() {
@@ -518,7 +514,12 @@ function commitRoot(finishedWork: Fiber): ExpirationTime {
   );
   root.pendingCommitExpirationTime = NoWork;
 
+  // Update the pending priority levels to account for the work that we are
+  // about to commit. This needs to happen before calling the lifecycles, since
+  // they may schedule additional updates.
+  const earliestRemainingTime = finishedWork.expirationTime;
   const currentTime = recalculateCurrentTime();
+  markCommittedPriorityLevels(root, currentTime, earliestRemainingTime);
 
   // Reset this to null before calling lifecycles
   ReactCurrentOwner.current = null;
@@ -689,14 +690,13 @@ function commitRoot(finishedWork: Fiber): ExpirationTime {
     ReactFiberInstrumentation.debugTool.onCommitWork(finishedWork);
   }
 
-  markCommittedPriorityLevels(root, currentTime, root.current.expirationTime);
-  const remainingTime = findNextPendingPriorityLevel(root);
-  if (remainingTime === NoWork) {
+  const nextPendingPriorityLevel = findNextPendingPriorityLevel(root);
+  if (nextPendingPriorityLevel === NoWork) {
     // If there's no remaining work, we can clear the set of already failed
     // error boundaries.
     legacyErrorBoundariesThatAlreadyFailed = null;
   }
-  return remainingTime;
+  return nextPendingPriorityLevel;
 }
 
 function resetExpirationTime(
@@ -847,7 +847,6 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
         continue;
       } else {
         // We've reached the root.
-        isRootReadyForCommit = true;
         return null;
       }
     } else {
@@ -1097,11 +1096,11 @@ function renderRoot(
   } while (true);
 
   // We're done performing work. Time to clean up.
-  let didCompleteRoot = false;
   isWorking = false;
 
   // Yield back to main thread.
   if (didFatal) {
+    const didCompleteRoot = false;
     stopWorkLoopTimer(interruptedBy, didCompleteRoot);
     interruptedBy = null;
     // There was a fatal error.
@@ -1111,34 +1110,38 @@ function renderRoot(
     return null;
   } else if (nextUnitOfWork === null) {
     // We reached the root.
-    if (isRootReadyForCommit) {
-      didCompleteRoot = true;
+    const rootWorkInProgress = root.current.alternate;
+    invariant(
+      rootWorkInProgress !== null,
+      'Finished root should have a work-in-progress. This error is likely ' +
+        'caused by a bug in React. Please file an issue.',
+    );
+    if ((rootWorkInProgress.effectTag & Incomplete) === NoEffect) {
+      const didCompleteRoot = true;
       stopWorkLoopTimer(interruptedBy, didCompleteRoot);
       interruptedBy = null;
-      // The root successfully completed. It's ready for commit.
+      // The root successfully completed.
       root.pendingCommitExpirationTime = expirationTime;
-      const finishedWork = root.current.alternate;
-      return finishedWork;
+      // Return the completed work-in-progress.
+      return rootWorkInProgress;
     } else {
       // The root did not complete.
+      const didCompleteRoot = false;
       stopWorkLoopTimer(interruptedBy, didCompleteRoot);
       interruptedBy = null;
-      invariant(
-        !nextRenderIsExpired,
-        'Expired work should have completed. This error is likely caused ' +
-          'by a bug in React. Please file an issue.',
-      );
-      markSuspendedPriorityLevel(root, expirationTime);
       if (nextLatestTimeoutMs >= 0) {
         setTimeout(() => {
           retrySuspendedRoot(root, expirationTime);
         }, nextLatestTimeoutMs);
       }
+      markSuspendedPriorityLevel(root, expirationTime);
       const firstUnblockedExpirationTime = findNextPendingPriorityLevel(root);
       onBlock(firstUnblockedExpirationTime);
+      // Return null to indicate that the root did not complete.
       return null;
     }
   } else {
+    const didCompleteRoot = false;
     stopWorkLoopTimer(interruptedBy, didCompleteRoot);
     interruptedBy = null;
     // There's more work to do, but we ran out of time. Yield back to
@@ -1294,8 +1297,7 @@ function computeExpirationForFiber(currentTime: ExpirationTime, fiber: Fiber) {
   return expirationTime;
 }
 
-// TODO: Rename this to scheduleTimeout or something
-function suspendRoot(
+function markTimeout(
   root: FiberRoot,
   thenable: Thenable,
   timeoutMs: number,
@@ -1980,7 +1982,7 @@ export {
   computeExpirationForFiber,
   captureCommitPhaseError,
   onUncaughtError,
-  suspendRoot,
+  markTimeout,
   retrySuspendedRoot,
   markLegacyErrorBoundaryAsFailed,
   isAlreadyFailedLegacyErrorBoundary,


### PR DESCRIPTION
If an error is thrown, and there's lower priority work, it's possible the lower priority work will fix the error. Retry at the lower priority.

If an error is thrown and there's no more work to try, handle the error like we normally do (trigger the nearest error boundary).

This does not handle expiration correctly. If a priority level is suspended due to an error, the lower priority work should expire at the time of the suspended work. I'll work on this in a subsequent PR.