### PR TITLE
Suspended high pri work forces lower priority work to expire early 

### DIFF
--- a/packages/react-reconciler/src/ReactFiberExpirationTime.js
+++ b/packages/react-reconciler/src/ReactFiberExpirationTime.js
@@ -9,7 +9,6 @@
 
 import MAX_SIGNED_31_BIT_INT from './maxSigned31BitInt';
 
-// TODO: Use an opaque type once ESLint et al support the syntax
 export type ExpirationTime = number;
 
 export const NoWork = 0;

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -57,7 +57,7 @@ export type FiberRoot = {
   +hydrate: boolean,
   // Remaining expiration time on this root.
   // TODO: Lift this into the renderer
-  remainingExpirationTime: ExpirationTime,
+  nextExpirationTimeToWorkOn: ExpirationTime,
   // List of top-level batches. This list indicates whether a commit should be
   // deferred. Also contains completion callbacks.
   // TODO: Lift this into the renderer
@@ -90,7 +90,7 @@ export function createFiberRoot(
     context: null,
     pendingContext: null,
     hydrate,
-    remainingExpirationTime: NoWork,
+    nextExpirationTimeToWorkOn: NoWork,
     firstBatch: null,
     nextScheduledRoot: null,
   };

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -58,6 +58,7 @@ export type FiberRoot = {
   // Remaining expiration time on this root.
   // TODO: Lift this into the renderer
   nextExpirationTimeToWorkOn: ExpirationTime,
+  expirationTime: ExpirationTime,
   // List of top-level batches. This list indicates whether a commit should be
   // deferred. Also contains completion callbacks.
   // TODO: Lift this into the renderer
@@ -91,6 +92,7 @@ export function createFiberRoot(
     pendingContext: null,
     hydrate,
     nextExpirationTimeToWorkOn: NoWork,
+    expirationTime: NoWork,
     firstBatch: null,
     nextScheduledRoot: null,
   };

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -142,7 +142,6 @@ function throwException(
   returnFiber: Fiber,
   sourceFiber: Fiber,
   value: mixed,
-  renderIsExpired: boolean,
   renderExpirationTime: ExpirationTime,
   currentTimeMs: number,
 ) {
@@ -174,6 +173,7 @@ function throwException(
     // This is a thenable.
     const thenable: Thenable = (value: any);
 
+    // TODO: Should use the earliest known expiration time
     const expirationTimeMs = expirationTimeToMs(renderExpirationTime);
     const startTimeMs = expirationTimeMs - 5000;
     let elapsedMs = currentTimeMs - startTimeMs;
@@ -312,7 +312,6 @@ function throwException(
 
 function unwindWork(
   workInProgress: Fiber,
-  renderIsExpired: boolean,
   renderExpirationTime: ExpirationTime,
 ) {
   if (enableProfilerTimer) {


### PR DESCRIPTION
If an error is thrown, and there is lower priority pending work, we retry at the lower priority. The lower priority work should expire at the same time at which the high priority work would have expired. Effectively, this increases the priority of the low priority work.

Simple example: If an error is thrown during a synchronous render, and there's an async update, the async update should flush synchronously in case it's able to fix the error. I've added a unit test for this scenario.

User provided timeouts should have the same behavior, but I'll leave that for a future PR.