### PR TITLE
Don’t error when returning an empty Fragment

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -171,6 +171,18 @@ describe('ReactDOMFiber', () => {
     expect(firstNode.tagName).toBe('DIV');
   });
 
+  it('renders an empty fragment', () => {
+    const EmptyFragment = () => <React.Fragment />;
+
+    let instance = null;
+    ReactDOM.render(<EmptyFragment />, container);
+
+    expect(container.childNodes.length).toBe(0);
+
+    const firstNode = ReactDOM.findDOMNode(instance);
+    expect(firstNode).toBe(null);
+  });
+
   let svgEls, htmlEls, mathEls;
   const expectSVG = {ref: el => svgEls.push(el)};
   const expectHTML = {ref: el => htmlEls.push(el)};

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -172,15 +172,28 @@ describe('ReactDOMFiber', () => {
   });
 
   it('renders an empty fragment', () => {
+    const Div = () => <div />;
     const EmptyFragment = () => <React.Fragment />;
+    const NonEmptyFragment = () => (
+      <React.Fragment>
+        <Div />
+      </React.Fragment>
+    );
 
-    let instance = null;
     ReactDOM.render(<EmptyFragment />, container);
+    expect(container.firstChild).toBe(null);
 
-    expect(container.childNodes.length).toBe(0);
+    ReactDOM.render(<NonEmptyFragment />, container);
+    expect(container.firstChild.tagName).toBe('DIV');
 
-    const firstNode = ReactDOM.findDOMNode(instance);
-    expect(firstNode).toBe(null);
+    ReactDOM.render(<EmptyFragment />, container);
+    expect(container.firstChild).toBe(null);
+
+    ReactDOM.render(<Div />, container);
+    expect(container.firstChild.tagName).toBe('DIV');
+
+    ReactDOM.render(<EmptyFragment />, container);
+    expect(container.firstChild).toBe(null);
   });
 
   let svgEls, htmlEls, mathEls;

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -1215,6 +1215,12 @@ function ChildReconciler(shouldTrackSideEffects) {
       newChild.key === null
     ) {
       newChild = newChild.props.children;
+
+      // In case of an empty fragment, this is undefined. Since we crash when
+      // undefined is reconciled, we bail out early.
+      if (typeof newChild === 'undefined') {
+        return deleteRemainingChildren(returnFiber, currentFirstChild);
+      }
     }
 
     // Handle object types

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -1215,11 +1215,9 @@ function ChildReconciler(shouldTrackSideEffects) {
       newChild.key === null
     ) {
       newChild = newChild.props.children;
-
-      // In case of an empty fragment, this is undefined. Since we crash when
-      // undefined is reconciled, we bail out early.
-      if (typeof newChild === 'undefined') {
-        return deleteRemainingChildren(returnFiber, currentFirstChild);
+      // Allow empty <Fragment /> without an invariant about top-level undefined.
+      if (newChild === undefined) {
+        newChild = null;
       }
     }
 

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -1208,17 +1208,13 @@ function ChildReconciler(shouldTrackSideEffects) {
     // Handle top level unkeyed fragments as if they were arrays.
     // This leads to an ambiguity between <>{[...]}</> and <>...</>.
     // We treat the ambiguous cases above the same.
-    if (
+    const isUnkeyedTopLevelFragment =
       typeof newChild === 'object' &&
       newChild !== null &&
       newChild.type === REACT_FRAGMENT_TYPE &&
-      newChild.key === null
-    ) {
+      newChild.key === null;
+    if (isUnkeyedTopLevelFragment) {
       newChild = newChild.props.children;
-      // Allow empty <Fragment /> without an invariant about top-level undefined.
-      if (newChild === undefined) {
-        newChild = null;
-      }
     }
 
     // Handle object types
@@ -1285,7 +1281,7 @@ function ChildReconciler(shouldTrackSideEffects) {
         warnOnFunctionType();
       }
     }
-    if (typeof newChild === 'undefined') {
+    if (typeof newChild === 'undefined' && !isUnkeyedTopLevelFragment) {
       // If the new child is undefined, and the return fiber is a composite
       // component, throw an error. If Fiber return types are disabled,
       // we already threw above.


### PR DESCRIPTION
Fixes #12964

When a fragment is reconciled, we directly move onto it’s children. Since an empty `<React.Fragment/>` will have children of `undefined`, this would always throw.

To fix this, we bail out in those cases. This case now behaves like returning `null` directly.