### PR TITLE
Remove a element having duplicated key

### DIFF
--- a/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
+++ b/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
@@ -13,6 +13,7 @@
 'use strict';
 
 let React;
+let ReactDOM;
 let ReactTestUtils;
 
 describe('ReactChildReconciler', () => {
@@ -20,6 +21,7 @@ describe('ReactChildReconciler', () => {
     jest.resetModules();
 
     React = require('react');
+    ReactDOM = require('react-dom');
     ReactTestUtils = require('react-dom/test-utils');
   });
 
@@ -133,5 +135,21 @@ describe('ReactChildReconciler', () => {
         '    in Parent (at **)\n' +
         '    in GrandParent (at **)',
     );
+  });
+
+  it('should remove a element having the duplicated key', () => {
+    const container = document.createElement('div');
+    spyOnDev(console, 'error');
+    ReactDOM.render(
+      <ul>{['a', 'b', 'c', 'b'].map(s => <li key={s}>{s}</li>)}</ul>,
+      container,
+    );
+    expect(container.textContent).toEqual('abcb');
+
+    ReactDOM.render(
+      <ul>{['a', 'c', 'b'].map(s => <li key={s}>{s}</li>)}</ul>,
+      container,
+    );
+    expect(container.textContent).toEqual('acb');
   });
 });

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -284,7 +284,13 @@ function ChildReconciler(shouldTrackSideEffects) {
     let existingChild = currentFirstChild;
     while (existingChild !== null) {
       if (existingChild.key !== null) {
-        existingChildren.set(existingChild.key, existingChild);
+        const key = existingChild.key;
+        // If the key is already used, we remove a element having the key.
+        const duplicatedChild = existingChildren.get(key);
+        if (duplicatedChild) {
+          deleteChild(returnFiber, duplicatedChild);
+        }
+        existingChildren.set(key, existingChild);
       } else {
         existingChildren.set(existingChild.index, existingChild);
       }


### PR DESCRIPTION
Currently, there is a case that React doesn't remove a element having a duplicate key.

```js
ReactDOM.render(
  <ul>{['a', 'b', 'c', 'b'].map(s => <li key={s}>{s}</li>)}</ul>,
  container
);

ReactDOM.render(
  <ul>{['a', 'c', 'b'].map(s => <li key={s}>{s}</li>)}</ul>,
  container
);
// Display a b c b
```

https://codepen.io/koba04/pen/YvyOqx?editors=0010

In the above case, the first `b` isn't removed even though the 2nd ReactDOM.render doesn't have it.

I know React doesn't guarantee any behaviors when children have duplicated keys

> Warning: Encountered two children with the same key, `b`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

So feel free to close this if this is not an issue. 