### PR TITLE
Failing test for Context bug in ReactPartialRenderer

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
@@ -191,5 +191,35 @@ describe('ReactDOMServerIntegration', () => {
       expect(e.querySelector('#theme').textContent).toBe('light');
       expect(e.querySelector('#language').textContent).toBe('english');
     });
+
+    itRenders(
+      'unbalanced nested contexts across multiple renders',
+      async render => {
+        const Theme = React.createContext('dark');
+        const Language = React.createContext('french');
+
+        const App = () => (
+          <div>
+            <Theme.Provider value="light">
+              <Language.Consumer>
+                {language => (
+                  <Theme.Consumer>
+                    {theme => (
+                      <Language.Provider>
+                        {language} - {theme}
+                      </Language.Provider>
+                    )}
+                  </Theme.Consumer>
+                )}
+              </Language.Consumer>
+            </Theme.Provider>
+          </div>
+        );
+        let e = await render(<App />);
+        expect(e.textContent).toBe('french - light');
+        e = await render(<App />);
+        expect(e.textContent).toBe('french - light');
+      },
+    );
   });
 });


### PR DESCRIPTION
A failing test for the bug reported in https://github.com/facebook/react/issues/12968

A summary of the issue is that rendering this combination of consumers and providers for multiple contexts causes a bug where the value from one context is being used in the other in subsequent renders.

This is possible because context is stored on the Context element itself, so it's mutated as the components are rendered. In this case, the wrong value is being set on a provider when its being popped:

https://github.com/facebook/react/blob/36546b5137e9012ebdc62fc9ec11e3518c9e0aab/packages/react-dom/src/server/ReactPartialRenderer.js#L692-L700

`previousProvider` ends up being the provider for the other context, so the next time it renders it has the wrong value. The assumption that the context type is correct because of the index check isn't accurate. It's also strange that it's always setting the context value to `previousProvider.props.value`, even if the provider doesn't have a value.

Not sure what the right fix is, but I'd like to figure it out 😄 

cc @acdlite @gaearon 

