### PR TITLE
Fallback to event.srcElement for IE9

### DIFF
--- a/packages/react-dom/src/events/getEventTarget.js
+++ b/packages/react-dom/src/events/getEventTarget.js
@@ -15,7 +15,9 @@ import {TEXT_NODE} from '../shared/HTMLNodeType';
  * @return {DOMEventTarget} Target node.
  */
 function getEventTarget(nativeEvent) {
-  let target = nativeEvent.target || window;
+  // Fallback to nativeEvent.srcElement for IE9
+  // https://github.com/facebook/react/issues/12506
+  let target = nativeEvent.target || nativeEvent.srcElement || window;
 
   // Normalize SVG <use> element events #4963
   if (target.correspondingUseElement) {


### PR DESCRIPTION
It looks like we accidentally removed a fallback condition for the event target in IE9 when we dropped some support for IE8. This commit adds the event target specific support code back to getEventTarget.js

Fixes #12506

**Test Plan**

1. Open IE9
2. Visit http://react-nh-fix-ie9-target.surge.sh/number-inputs
3. Try to enter text into the inputs

**Local Behavior:** Includes this fix. `event.target` falls back to `event.srcElement` and text correctly updates
**16.4.0 Behavior:** Text does not update because event.target.value references the window, which is always undefined.

http://react-nh-fix-ie9-target.surge.sh/number-inputs?version=16.4.0

*Note: It's a bummer that IE9 can't fetch our latest tags... I'll try to do something about that.*