### PR TITLE
Fixed an issue with nested contexts unwinding when server rendering. Issue #12984

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
@@ -191,5 +191,33 @@ describe('ReactDOMServerIntegration', () => {
       expect(e.querySelector('#theme').textContent).toBe('light');
       expect(e.querySelector('#language').textContent).toBe('english');
     });
+
+    itRenders(
+      'nested context unwinding',
+      async render => {
+        const Theme = React.createContext('dark');
+        const Language = React.createContext('french');
+
+        const App = () => (
+          <div>
+            <Theme.Provider value="light">
+              <Language.Provider>
+                <Theme.Provider value="dark">
+                  <Theme.Consumer>
+                    {theme => <div id="theme1">{theme}</div>}
+                  </Theme.Consumer>
+                </Theme.Provider>
+                <Theme.Consumer>
+                  {theme => <div id="theme2">{theme}</div>}
+                </Theme.Consumer>
+              </Language.Provider>
+            </Theme.Provider>
+          </div>
+        );
+        let e = await render(<App />);
+        expect(e.querySelector('#theme1').textContent).toBe('dark');
+        expect(e.querySelector('#theme2').textContent).toBe('light');
+      },
+    );
   });
 });

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -689,14 +689,21 @@ class ReactDOMServerRenderer {
     this.providerStack[this.providerIndex] = null;
     this.providerIndex -= 1;
     const context: ReactContext<any> = provider.type._context;
-    if (this.providerIndex < 0) {
-      context._currentValue = context._defaultValue;
-    } else {
-      // We assume this type is correct because of the index check above.
-      const previousProvider: ReactProvider<any> = (this.providerStack[
-        this.providerIndex
-      ]: any);
+    // find the correct previous provider based on type
+    let previousProvider;
+    if (this.providerIndex > -1) {
+      for (let i = 0; i <= this.providerIndex; i += 1) {
+        if (this.providerStack[i] &&
+          (this.providerStack[i]: ReactProvider<any>).type === provider.type) {
+          previousProvider = this.providerStack[i];
+          break;
+        }
+      }
+    }
+    if (previousProvider) {
       context._currentValue = previousProvider.props.value;
+    } else {
+      context._currentValue = context._defaultValue;
     }
   }
 


### PR DESCRIPTION
The key change her is to unwind to the previous provider of the same type as the provider being popped.