### PR TITLE
enqueueUpdate() - update expiration time of *both* queues in the case where both are non-empty

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1208,7 +1208,7 @@ function captureCommitPhaseError(fiber: Fiber, error: mixed) {
 function computeAsyncExpiration(currentTime: ExpirationTime) {
   // Given the current clock time, returns an expiration time. We use rounding
   // to batch like updates together.
-  // Should complete within ~1000ms. 1200ms max.
+  // Should complete within ~5000ms. 5250ms max.
   const expirationMs = 5000;
   const bucketSizeMs = 250;
   return computeExpirationBucket(currentTime, expirationMs, bucketSizeMs);

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -284,8 +284,17 @@ export function enqueueUpdate<State>(
       // Both queues are non-empty. The last update is the same in both lists,
       // because of structural sharing. So, only append to one of the lists.
       appendUpdateToQueue(queue1, update, expirationTime);
-      // But we still need to update the `lastUpdate` pointer of queue2.
+      // But we still need to update the `lastUpdate` pointer of queue2
       queue2.lastUpdate = update;
+      // and update its expiration
+      if (
+        queue2.expirationTime === NoWork ||
+        queue2.expirationTime > expirationTime
+      ) {
+        // The incoming update has the earliest expiration of any update in the
+        // queue. Update the queue's expiration time.
+        queue2.expirationTime = expirationTime;
+      }
     }
   }
 


### PR DESCRIPTION
I still have a very shallow understanding of everything but just following along with the code as best I can and it seems that `queue2`'s expiration time needs to be updated when a new update is added? At least in the case where only one is non-empty, that is what happens (both `queue1` and `queue2` expiration times are updated). But not when both are non-empty. This PR fixes that.