### PR TITLE
Fix react-dom ReferenceError requestAnimationFrame in non-browser env (#13000)

### DIFF
--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -43,6 +43,7 @@ export type CallbackIdType = CallbackConfigType;
 
 import requestAnimationFrameForReact from 'shared/requestAnimationFrameForReact';
 import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
+import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 
 // We capture a local reference to any global, in case it gets polyfilled after
@@ -119,8 +120,10 @@ if (!ExecutionEnvironment.canUseDOM) {
     typeof requestAnimationFrameForReact === 'function'
       ? requestAnimationFrameForReact
       : function(callback: Function) {
-          throw new Error(
-            'React depends on requestAnimationFrame, but this shim was called.',
+          invariant(
+            false,
+            'React depends on requestAnimationFrame. Make sure that you load a ' +
+              'polyfill in older browsers. https://fb.me/react-polyfills',
           );
         };
 

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -43,6 +43,7 @@ export type CallbackIdType = CallbackConfigType;
 
 import requestAnimationFrameForReact from 'shared/requestAnimationFrameForReact';
 import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
+import warning from 'fbjs/lib/warning';
 
 // We capture a local reference to any global, in case it gets polyfilled after
 // this module is initially evaluated.
@@ -104,6 +105,25 @@ if (!ExecutionEnvironment.canUseDOM) {
     localClearTimeout(timeoutId);
   };
 } else {
+  if (__DEV__) {
+    if (typeof requestAnimationFrameForReact !== 'function') {
+      warning(
+        false,
+        'React depends on requestAnimationFrame. Make sure that you load a ' +
+          'polyfill in older browsers. https://fb.me/react-polyfills',
+      );
+    }
+  }
+
+  let localRequestAnimationFrame =
+    typeof requestAnimationFrameForReact === 'function'
+      ? requestAnimationFrameForReact
+      : function(callback: Function) {
+          throw new Error(
+            'React depends on requestAnimationFrame, but this shim was called.',
+          );
+        };
+
   let headOfPendingCallbacksLinkedList: CallbackConfigType | null = null;
   let tailOfPendingCallbacksLinkedList: CallbackConfigType | null = null;
 
@@ -252,7 +272,7 @@ if (!ExecutionEnvironment.canUseDOM) {
       if (!isAnimationFrameScheduled) {
         // Schedule another animation callback so we retry later.
         isAnimationFrameScheduled = true;
-        requestAnimationFrameForReact(animationTick);
+        localRequestAnimationFrame(animationTick);
       }
     }
   };
@@ -333,7 +353,7 @@ if (!ExecutionEnvironment.canUseDOM) {
       // might want to still have setTimeout trigger scheduleWork as a backup to ensure
       // that we keep performing work.
       isAnimationFrameScheduled = true;
-      requestAnimationFrameForReact(animationTick);
+      localRequestAnimationFrame(animationTick);
     }
     return scheduledCallbackConfig;
   };

--- a/packages/shared/requestAnimationFrameForReact.js
+++ b/packages/shared/requestAnimationFrameForReact.js
@@ -9,9 +9,6 @@
 
 'use strict';
 
-import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
-import warning from 'fbjs/lib/warning';
-
 // We capture a local reference to any global, in case it gets polyfilled after
 // this module is initially evaluated.
 // We want to be using a consistent implementation.
@@ -20,17 +17,8 @@ const localRequestAnimationFrame =
     ? requestAnimationFrame
     : undefined;
 
-if (__DEV__) {
-  if (
-    ExecutionEnvironment.canUseDOM &&
-    typeof localRequestAnimationFrame !== 'function'
-  ) {
-    warning(
-      false,
-      'React depends on requestAnimationFrame. Make sure that you load a ' +
-        'polyfill in older browsers. https://fb.me/react-polyfills',
-    );
-  }
-}
+// The callsites should check if the requestAnimationFrame imported from this module is a function,
+// fire a developer warning if it doesn't exist, and substitute it by a shim in that case
+// (e.g. that throws on call).
 
 export default localRequestAnimationFrame;

--- a/packages/shared/requestAnimationFrameForReact.js
+++ b/packages/shared/requestAnimationFrameForReact.js
@@ -15,7 +15,10 @@ import warning from 'fbjs/lib/warning';
 // We capture a local reference to any global, in case it gets polyfilled after
 // this module is initially evaluated.
 // We want to be using a consistent implementation.
-const localRequestAnimationFrame = requestAnimationFrame;
+const localRequestAnimationFrame =
+  typeof requestAnimationFrame === 'function'
+    ? requestAnimationFrame
+    : undefined;
 
 if (__DEV__) {
   if (


### PR DESCRIPTION
The https://github.com/facebook/react/pull/12931 ( https://github.com/facebook/react/commit/79a740c6e32ca300d4e7ff55ab06de172d4237fd ) broke the server-side rendering: in the `fixtures/ssr` the following error appeared from the server-side when `localhost:3000` is requested:
```
ReferenceError: requestAnimationFrame is not defined
    at /__CENSORED__/react/build/node_modules/react-dom/cjs/react-dom.development.js:5232:34
    at Object.<anonymous> (/__CENSORED__/react/build/node_modules/react-dom/cjs/react-dom.development.js:17632:5)
    at Module._compile (module.js:624:30)
    at Module._extensions..js (module.js:635:10)
    at Object.require.extensions.(anonymous function) [as .js] (/__CENSORED__/react/fixtures/ssr/node_modules/babel-register/lib/node.js:152:7)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
```

The exception pointed to this line:
```js
// We capture a local reference to any global, in case it gets polyfilled after
// this module is initially evaluated.
// We want to be using a consistent implementation.
const localRequestAnimationFrame = requestAnimationFrame;
```

**Test plan**

1. In `react` repo root, `yarn && yarn build`.
2. In `fixtures/ssr`, `yarn && yarn start`,
3. In browser, go to `http://localhost:3000`.
4. Observe the fixture page, not the exception message.
