### PR TITLE
delete a couple of redundant lines

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1768,7 +1768,6 @@ function performWorkOnRoot(
       // This root is already complete. We can commit it.
       completeRoot(root, finishedWork, expirationTime);
     } else {
-      root.finishedWork = null;
       finishedWork = renderRoot(root, expirationTime, false);
       if (finishedWork !== null) {
         // We've completed the root. Commit it.
@@ -1782,7 +1781,6 @@ function performWorkOnRoot(
       // This root is already complete. We can commit it.
       completeRoot(root, finishedWork, expirationTime);
     } else {
-      root.finishedWork = null;
       finishedWork = renderRoot(root, expirationTime, true);
       if (finishedWork !== null) {
         // We've completed the root. Check the deadline one more time


### PR DESCRIPTION
By definition `root.finishedWork` must already be null at the point that either of these lines are executed. The immediately preceding `if` blocks ensure it. So no need to set to null.