### PR TITLE
Allow multiple root children in test renderer traversal API

### DIFF
--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
@@ -199,4 +199,48 @@ describe('ReactTestRendererTraversal', () => {
     expect(nestedViews[1].parent).toBe(expectedParent);
     expect(nestedViews[2].parent).toBe(expectedParent);
   });
+
+  it('can have special nodes as roots', () => {
+    const FR = React.forwardRef(props => <section {...props} />);
+    expect(
+      ReactTestRenderer.create(
+        <FR>
+          <div />
+          <div />
+        </FR>,
+      ).root.findAllByType('div').length,
+    ).toBe(2);
+    expect(
+      ReactTestRenderer.create(
+        <React.Fragment>
+          <div />
+          <div />
+        </React.Fragment>,
+      ).root.findAllByType('div').length,
+    ).toBe(2);
+    expect(
+      ReactTestRenderer.create(
+        <React.Fragment key="foo">
+          <div />
+          <div />
+        </React.Fragment>,
+      ).root.findAllByType('div').length,
+    ).toBe(2);
+    expect(
+      ReactTestRenderer.create(
+        <React.StrictMode>
+          <div />
+          <div />
+        </React.StrictMode>,
+      ).root.findAllByType('div').length,
+    ).toBe(2);
+    expect(
+      ReactTestRenderer.create(
+        <Context.Provider>
+          <div />
+          <div />
+        </Context.Provider>,
+      ).root.findAllByType('div').length,
+    ).toBe(2);
+  });
 });


### PR DESCRIPTION
This should fix some bugs @sahrens was seeing.

Test renderer traversal API currently treats "fragmenty" nodes (fragments, providers, modes) as passthrough. That usually works, but it breaks down at the top level. The `.root` node has to point to a Fiber, so if it's a "passthrough" Fiber, we currently invariant.

Ideally I think the root node should have always been a special kind of "root" whose `type` and `props` don't match the nearest "materialized" node. But that ship has sailed, and changing this would be breaking.

So for now I want to enable those use cases by only "materializing" a special root node (with `type: null, props: null`) when it has multiple children.

It should be mostly additive because that kind of code used to throw. It *does* change the behavior for a top-level non-keyed fragment with many children (we used to ignore all children but the first) but this actually sounds like a bugfix to me, especially given that subsequent children were *not* ignored in the `toJSON()` API.

In the future, we probably should change `.root` to always be a special node, regardless of whether it has one or more children.