### PR TITLE
Scheduler depends on common packages

### DIFF
--- a/packages/react-scheduler/package.json
+++ b/packages/react-scheduler/package.json
@@ -13,6 +13,10 @@
     "url": "https://github.com/facebook/react/issues"
   },
   "homepage": "https://reactjs.org/",
+  "dependencies": {
+    "fbjs": "^0.8.16",
+    "object-assign": "^4.1.1"
+  },
   "files": [
     "LICENSE",
     "README.md",


### PR DESCRIPTION
This adds common dependencies to scheduler.

* `fbjs` avoids duplication of invariant/warning between React and the scheduler package. This fixes the FB bundle too so that it doesn't ship a different `invariant` than the one we use normally.
* `object-assign` is not currently used but it will be if we add an `Object.assign()` call. In that case, if we don't specify it in dependencies, the polyfill will be inlined (which we don't want).

We can choose to drop these dependencies later by removing their use, but seems safer to add them now as we're not focused on the code size yet, and React already uses both of them anyway.

Test plan: `yarn build scheduler --type=NODE,FB` shouldn't include `invariant` or `warning` implementations in any bundles.