### PR TITLE
Remove feature flag around 'getDerivedStateFromProps' bug fix

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -15,7 +15,6 @@ import {
   debugRenderPhaseSideEffects,
   debugRenderPhaseSideEffectsForStrictMode,
   warnAboutDeprecatedLifecycles,
-  fireGetDerivedStateFromPropsOnStateUpdates,
 } from 'shared/ReactFeatureFlags';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings';
 import {isMounted} from 'react-reconciler/reflection';
@@ -949,14 +948,12 @@ function updateClassInstance(
   }
 
   if (typeof getDerivedStateFromProps === 'function') {
-    if (fireGetDerivedStateFromPropsOnStateUpdates || oldProps !== newProps) {
-      applyDerivedStateFromProps(
-        workInProgress,
-        getDerivedStateFromProps,
-        newProps,
-      );
-      newState = workInProgress.memoizedState;
-    }
+    applyDerivedStateFromProps(
+      workInProgress,
+      getDerivedStateFromProps,
+      newProps,
+    );
+    newState = workInProgress.memoizedState;
   }
 
   const shouldUpdate =

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -1520,51 +1520,6 @@ describe('ReactIncremental', () => {
     expect(ReactNoop.flush()).toEqual(['Child']);
   });
 
-  it('does not call getDerivedStateFromProps for state-only updates if feature flag is disabled', () => {
-    jest.resetModules();
-    ReactFeatureFlags = require('shared/ReactFeatureFlags');
-    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
-    ReactFeatureFlags.fireGetDerivedStateFromPropsOnStateUpdates = false;
-    React = require('react');
-    ReactNoop = require('react-noop-renderer');
-
-    let ops = [];
-    let instance;
-
-    class LifeCycle extends React.Component {
-      state = {};
-      static getDerivedStateFromProps(props, prevState) {
-        ops.push('getDerivedStateFromProps');
-        return {foo: 'foo'};
-      }
-      changeState() {
-        this.setState({foo: 'bar'});
-      }
-      componentDidUpdate() {
-        ops.push('componentDidUpdate');
-      }
-      render() {
-        ops.push('render');
-        instance = this;
-        return null;
-      }
-    }
-
-    ReactNoop.render(<LifeCycle />);
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['getDerivedStateFromProps', 'render']);
-    expect(instance.state).toEqual({foo: 'foo'});
-
-    ops = [];
-
-    instance.changeState();
-    ReactNoop.flush();
-
-    expect(ops).toEqual(['render', 'componentDidUpdate']);
-    expect(instance.state).toEqual({foo: 'bar'});
-  });
-
   xit('does not call componentWillReceiveProps for state-only updates', () => {
     let ops = [];
 

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -39,9 +39,6 @@ export const warnAboutLegacyContextAPI = false;
 // Gather advanced timing metrics for Profiler subtrees.
 export const enableProfilerTimer = __PROFILE__;
 
-// Fires getDerivedStateFromProps for state *or* props changes
-export const fireGetDerivedStateFromPropsOnStateUpdates = true;
-
 // Only used in www builds.
 export function addUserTimingListener() {
   invariant(false, 'Not implemented.');

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric-fb.js
@@ -21,7 +21,6 @@ export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = __DEV__;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const enableProfilerTimer = __DEV__;
-export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
@@ -21,7 +21,6 @@ export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const enableProfilerTimer = __PROFILE__;
-export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -21,7 +21,6 @@ export const {
   warnAboutDeprecatedLifecycles,
   replayFailedUnitOfWorkWithInvokeGuardedCallback,
   enableProfilerTimer,
-  fireGetDerivedStateFromPropsOnStateUpdates,
 } = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -21,7 +21,6 @@ export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 export const enableProfilerTimer = __PROFILE__;
-export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -21,7 +21,6 @@ export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const enableProfilerTimer = false;
-export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -21,7 +21,6 @@ export const warnAboutDeprecatedLifecycles = false;
 export const warnAboutLegacyContextAPI = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = false;
-export const fireGetDerivedStateFromPropsOnStateUpdates = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -19,7 +19,6 @@ export const {
   replayFailedUnitOfWorkWithInvokeGuardedCallback,
   warnAboutDeprecatedLifecycles,
   enableProfilerTimer,
-  fireGetDerivedStateFromPropsOnStateUpdates,
 } = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.


### PR DESCRIPTION
**what is the change?:**
Basically undoes https://github.com/facebook/react/commit/4b2e65d32e3adec7d4ef5ddd5fcb35e617e0cde6#diff-904ceabd8a1e9a07ab1d876d843d62e1

**why make this change?:**
We rolled out this fix internally and in open source weeks ago, and now
we're cleaning up.

**test plan:**
Ran tests and lint, and really we have been testing this because the
flag is open internally as of last week or so.

**issue:**
Internal task T29948812 has some info.

Will follow up by removing internal code which uses this flag, after syncing this. Probably this Tues./Weds. or early next week.