### PR TITLE
[Fabric] setJSResponder using correct reactTag

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
+++ b/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Module provided by RN:
+import UIManager from 'UIManager';
+
+const ReactFabricGlobalResponderHandler = {
+  onChange: function(from: any, to: any, blockNativeResponder: boolean) {
+    if (to !== null) {
+      const tag = to.stateNode.canonical._nativeTag;
+      UIManager.setJSResponder(tag, blockNativeResponder);
+    } else {
+      UIManager.clearJSResponder();
+    }
+  },
+};
+
+export default ReactFabricGlobalResponderHandler;

--- a/packages/react-native-renderer/src/ReactFabricInjection.js
+++ b/packages/react-native-renderer/src/ReactFabricInjection.js
@@ -11,5 +11,11 @@ import './ReactNativeInjectionShared';
 
 import * as ReactFabricComponentTree from './ReactFabricComponentTree';
 import * as EventPluginUtils from 'events/EventPluginUtils';
+import ReactFabricGlobalResponderHandler from './ReactFabricGlobalResponderHandler';
+import ResponderEventPlugin from 'events/ResponderEventPlugin';
 
 EventPluginUtils.injection.injectComponentTree(ReactFabricComponentTree);
+
+ResponderEventPlugin.injection.injectGlobalResponderHandler(
+  ReactFabricGlobalResponderHandler,
+);

--- a/packages/react-native-renderer/src/ReactNativeInjection.js
+++ b/packages/react-native-renderer/src/ReactNativeInjection.js
@@ -12,6 +12,8 @@ import './ReactNativeInjectionShared';
 import * as ReactNativeComponentTree from './ReactNativeComponentTree';
 import * as EventPluginUtils from 'events/EventPluginUtils';
 import * as ReactNativeEventEmitter from './ReactNativeEventEmitter';
+import ReactNativeGlobalResponderHandler from './ReactNativeGlobalResponderHandler';
+import ResponderEventPlugin from 'events/ResponderEventPlugin';
 
 // Module provided by RN:
 import RCTEventEmitter from 'RCTEventEmitter';
@@ -22,3 +24,7 @@ import RCTEventEmitter from 'RCTEventEmitter';
 RCTEventEmitter.register(ReactNativeEventEmitter);
 
 EventPluginUtils.injection.injectComponentTree(ReactNativeComponentTree);
+
+ResponderEventPlugin.injection.injectGlobalResponderHandler(
+  ReactNativeGlobalResponderHandler,
+);

--- a/packages/react-native-renderer/src/ReactNativeInjectionShared.js
+++ b/packages/react-native-renderer/src/ReactNativeInjectionShared.js
@@ -21,16 +21,11 @@ import ResponderEventPlugin from 'events/ResponderEventPlugin';
 
 import ReactNativeBridgeEventPlugin from './ReactNativeBridgeEventPlugin';
 import ReactNativeEventPluginOrder from './ReactNativeEventPluginOrder';
-import ReactNativeGlobalResponderHandler from './ReactNativeGlobalResponderHandler';
 
 /**
  * Inject module for resolving DOM hierarchy and plugin ordering.
  */
 EventPluginHub.injection.injectEventPluginOrder(ReactNativeEventPluginOrder);
-
-ResponderEventPlugin.injection.injectGlobalResponderHandler(
-  ReactNativeGlobalResponderHandler,
-);
 
 /**
  * Some important event plugins included by default (without having to require


### PR DESCRIPTION
Stacked on #13024

Forks the Fabric global responder thingy and sets the JS responder using the correct reactTag.

It's a bit unclear what this really means since that call is async atm and the responder can change on a different thread. Will probably have to be redesigned slightly in the future and perhaps use FabricUIManager instead.