### PR TITLE
Synchronously restart when an error is thrown during async rendering

### DIFF
--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -44,6 +44,11 @@ export type FiberRoot = {
   // be retried.
   latestPingedTime: ExpirationTime,
 
+  // If an error is thrown, and there are no more updates in the queue, we try
+  // rendering from the root one more time, synchronously, before handling
+  // the error.
+  didError: boolean,
+
   pendingCommitExpirationTime: ExpirationTime,
   // A finished work-in-progress HostRoot that's ready to be committed.
   // TODO: The reason this is separate from isReadyForCommit is because the
@@ -85,6 +90,8 @@ export function createFiberRoot(
     earliestSuspendedTime: NoWork,
     latestSuspendedTime: NoWork,
     latestPingedTime: NoWork,
+
+    didError: false,
 
     pendingCommitExpirationTime: NoWork,
     finishedWork: null,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -229,6 +229,7 @@ let nextRoot: FiberRoot | null = null;
 // The time at which we're currently rendering work.
 let nextRenderExpirationTime: ExpirationTime = NoWork;
 let nextLatestTimeoutMs: number = -1;
+let nextRenderDidError: boolean = false;
 
 // The next fiber with an effect that we're currently committing.
 let nextEffect: Fiber | null = null;
@@ -343,6 +344,7 @@ function resetStack() {
   nextRoot = null;
   nextRenderExpirationTime = NoWork;
   nextLatestTimeoutMs = -1;
+  nextRenderDidError = false;
   nextUnitOfWork = null;
 }
 
@@ -1007,6 +1009,7 @@ function renderRoot(root: FiberRoot, isYieldy: boolean): void {
     nextRoot = root;
     nextRenderExpirationTime = expirationTime;
     nextLatestTimeoutMs = -1;
+    nextRenderDidError = false;
     nextUnitOfWork = createWorkInProgress(
       nextRoot.current,
       null,
@@ -1113,7 +1116,7 @@ function renderRoot(root: FiberRoot, isYieldy: boolean): void {
       const didCompleteRoot = false;
       stopWorkLoopTimer(interruptedBy, didCompleteRoot);
       interruptedBy = null;
-      markSuspendedPriorityLevel(root, expirationTime);
+      markSuspendedPriorityLevel(root, expirationTime, nextRenderDidError);
       const suspendedExpirationTime = expirationTime;
       const newExpirationTime = root.expirationTime;
       onSuspend(
@@ -1288,6 +1291,10 @@ function markTimeout(
   if (timeoutMs >= 0 && nextLatestTimeoutMs < timeoutMs) {
     nextLatestTimeoutMs = timeoutMs;
   }
+}
+
+function markError(root: FiberRoot) {
+  nextRenderDidError = true;
 }
 
 function retrySuspendedRoot(root: FiberRoot, suspendedTime: ExpirationTime) {
@@ -1975,6 +1982,7 @@ export {
   captureCommitPhaseError,
   onUncaughtError,
   markTimeout,
+  markError,
   retrySuspendedRoot,
   markLegacyErrorBoundaryAsFailed,
   isAlreadyFailedLegacyErrorBoundary,

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
@@ -36,7 +36,7 @@ describe('ReactIncrementalErrorReplay', () => {
     });
   });
 
-  it('should fail gracefully on error that does not reproduce on replay', () => {
+  it("should ignore error if it doesn't throw on retry", () => {
     let didInit = false;
 
     function badLazyInit() {
@@ -54,6 +54,6 @@ describe('ReactIncrementalErrorReplay', () => {
       }
     }
     ReactNoop.render(<App />);
-    expect(() => ReactNoop.flush()).toThrow('Hi');
+    expect(() => ReactNoop.flush()).not.toThrow();
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -14,6 +14,7 @@ describe('ReactSuspense', () => {
     jest.resetModules();
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+    ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
     ReactFeatureFlags.enableSuspense = true;
     React = require('react');
     Fragment = React.Fragment;
@@ -258,6 +259,11 @@ describe('ReactSuspense', () => {
     expect(ReactNoop.flush()).toEqual([
       'Promise rejected [Result]',
       'Error! [Result]',
+
+      // React retries one more time
+      'Error! [Result]',
+
+      // Errored again on retry. Now handle it.
       'Caught error: Failed to load: Result',
     ]);
     expect(ReactNoop.getChildren()).toEqual([
@@ -320,6 +326,12 @@ describe('ReactSuspense', () => {
     expect(ReactNoop.flush()).toEqual([
       'Promise rejected [Result]',
       'Error! [Result]',
+
+      // React retries one more time
+      'Error! [Result]',
+
+      // Errored again on retry. Now handle it.
+
       'Caught error: Failed to load: Result',
     ]);
     expect(ReactNoop.getChildren()).toEqual([

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -288,6 +288,12 @@ exports[`ReactDebugFiberPerf recovers from caught errors 1`] = `
 // Stop on Baddie and restart from Boundary
 ⚛ (React Tree Reconciliation: Yielded)
   ⚛ Parent [mount]
+    ⚛ Boundary [mount]
+      ⚛ Parent [mount]
+        ⚛ Baddie [mount]
+
+⚛ (React Tree Reconciliation: Yielded)
+  ⚛ Parent [mount]
     ⛔ Boundary [mount] Warning: An error was thrown inside this error boundary
       ⚛ Parent [mount]
         ⚛ Baddie [mount]
@@ -316,6 +322,10 @@ exports[`ReactDebugFiberPerf recovers from fatal errors 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5250 ms)
 
 // Will fatal
+⚛ (React Tree Reconciliation: Yielded)
+  ⚛ Parent [mount]
+    ⚛ Baddie [mount]
+
 ⚛ (React Tree Reconciliation: Yielded)
   ⚛ Parent [mount]
     ⚛ Baddie [mount]

--- a/packages/react/src/__tests__/forwardRef-test.internal.js
+++ b/packages/react/src/__tests__/forwardRef-test.internal.js
@@ -18,6 +18,7 @@ describe('forwardRef', () => {
     jest.resetModules();
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+    ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
     React = require('react');
     ReactNoop = require('react-noop-renderer');
   });
@@ -175,6 +176,13 @@ describe('forwardRef', () => {
       'ErrorBoundary.render: try',
       'Wrapper',
       'BadRender throw',
+
+      // React retries one more time
+      'ErrorBoundary.render: try',
+      'Wrapper',
+      'BadRender throw',
+
+      // Errored again on retry. Now handle it.
       'ErrorBoundary.componentDidCatch',
       'ErrorBoundary.render: catch',
     ]);


### PR DESCRIPTION
In async mode, events are interleaved with rendering. If one of those events mutates state that is later accessed during render, it can lead to inconsistencies/tearing.

Restarting the render from the root is often sufficient to fix the inconsistency. We'll flush the restart synchronously to prevent yet another mutation from happening during an interleaved event.

We'll only restart during an async render. Sync renders are already sync, so there's no benefit in restarting. (Unless a mutation happens during the render phase, but we don't support that.)