### PR TITLE
docs: update comments

### DIFF
--- a/packages/create-subscription/src/createSubscription.js
+++ b/packages/create-subscription/src/createSubscription.js
@@ -21,7 +21,7 @@ export function createSubscription<Property, Value>(
     getCurrentValue: (source: Property) => Value | void,
 
     // Setup a subscription for the subscribable value in props, and return an unsubscribe function.
-    // Return false to indicate the property cannot be unsubscribed from (e.g. native Promises).
+    // Return empty function if the property cannot be unsubscribed from (e.g. native Promises).
     // Due to the variety of change event types, subscribers should provide their own handlers.
     // Those handlers should not attempt to update state though;
     // They should call the callback() instead when a subscription changes.


### PR DESCRIPTION
according to this line https://github.com/facebook/react/blob/bc963f353dc23a6c84c4d2b4daa51a4fdb12a6bc/packages/create-subscription/src/createSubscription.js#L132 an `unsubscribe` function should always be returned