### PR TITLE
Inline fbjs/lib/emptyObject

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -14,9 +14,11 @@ import {TYPES, EVENT_TYPES, childrenAsString} from './ReactARTInternals';
 
 const pooledTransform = new Transform();
 
-const emptyObject = {};
+const NO_CONTEXT = {};
+const UPDATE_SIGNAL = {};
 if (__DEV__) {
-  Object.freeze(emptyObject);
+  Object.freeze(NO_CONTEXT);
+  Object.freeze(UPDATE_SIGNAL);
 }
 
 /** Helper Methods */
@@ -304,7 +306,7 @@ export function prepareForCommit() {
 }
 
 export function prepareUpdate(domElement, type, oldProps, newProps) {
-  return emptyObject;
+  return UPDATE_SIGNAL;
 }
 
 export function resetAfterCommit() {
@@ -320,11 +322,11 @@ export function shouldDeprioritizeSubtree(type, props) {
 }
 
 export function getRootHostContext() {
-  return emptyObject;
+  return NO_CONTEXT;
 }
 
 export function getChildHostContext() {
-  return emptyObject;
+  return NO_CONTEXT;
 }
 
 export const scheduleDeferredCallback = ReactScheduler.scheduleWork;

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -9,13 +9,15 @@ import * as ReactScheduler from 'shared/ReactScheduler';
 import Transform from 'art/core/transform';
 import Mode from 'art/modes/current';
 import invariant from 'fbjs/lib/invariant';
-import emptyObject from 'fbjs/lib/emptyObject';
 
 import {TYPES, EVENT_TYPES, childrenAsString} from './ReactARTInternals';
 
 const pooledTransform = new Transform();
 
-const UPDATE_SIGNAL = {};
+const emptyObject = {};
+if (__DEV__) {
+  Object.freeze(emptyObject);
+}
 
 /** Helper Methods */
 
@@ -302,7 +304,7 @@ export function prepareForCommit() {
 }
 
 export function prepareUpdate(domElement, type, oldProps, newProps) {
-  return UPDATE_SIGNAL;
+  return emptyObject;
 }
 
 export function resetAfterCommit() {

--- a/packages/react-art/src/__tests__/ReactART-test.js
+++ b/packages/react-art/src/__tests__/ReactART-test.js
@@ -71,6 +71,8 @@ describe('ReactART', () => {
     Surface = ReactART.Surface;
 
     TestComponent = class extends React.Component {
+      group = React.createRef();
+
       render() {
         const a = (
           <Shape
@@ -104,7 +106,7 @@ describe('ReactART', () => {
 
         return (
           <Surface width={150} height={200}>
-            <Group ref="group">
+            <Group ref={this.group}>
               {this.props.flipped ? [b, a, c] : [a, b, c]}
             </Group>
           </Surface>
@@ -121,7 +123,7 @@ describe('ReactART', () => {
   it('should have the correct lifecycle state', () => {
     let instance = <TestComponent />;
     instance = ReactTestUtils.renderIntoDocument(instance);
-    const group = instance.refs.group;
+    const group = instance.group.current;
     // Duck type test for an ART group
     expect(typeof group.indicate).toBe('function');
   });
@@ -260,15 +262,17 @@ describe('ReactART', () => {
     let ref = null;
 
     class Outer extends React.Component {
+      test = React.createRef();
+
       componentDidMount() {
-        ref = this.refs.test;
+        ref = this.test.current;
       }
 
       render() {
         return (
           <Surface>
             <Group>
-              <CustomShape ref="test" />
+              <CustomShape ref={this.test} />
             </Group>
           </Surface>
         );
@@ -289,26 +293,28 @@ describe('ReactART', () => {
     let ref = {};
 
     class Outer extends React.Component {
+      test = React.createRef();
+
       componentDidMount() {
-        ref = this.refs.test;
+        ref = this.test.current;
       }
 
       componentDidUpdate() {
-        ref = this.refs.test;
+        ref = this.test.current;
       }
 
       render() {
         return (
           <Surface>
             <Group>
-              {this.props.mountCustomShape && <CustomShape ref="test" />}
+              {this.props.mountCustomShape && <CustomShape ref={this.test} />}
             </Group>
           </Surface>
         );
       }
     }
     ReactDOM.render(<Outer />, container);
-    expect(ref).not.toBeDefined();
+    expect(ref).toBe(null);
     ReactDOM.render(<Outer mountCustomShape={true} />, container);
     expect(ref.constructor).toBe(CustomShape);
   });

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -15,7 +15,6 @@ import type {
 } from 'shared/ReactTypes';
 
 import React from 'react';
-import emptyObject from 'fbjs/lib/emptyObject';
 import invariant from 'fbjs/lib/invariant';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 import warning from 'fbjs/lib/warning';
@@ -282,6 +281,11 @@ function flattenOptionChildren(children: mixed): string {
     }
   });
   return content;
+}
+
+const emptyObject = {};
+if (__DEV__) {
+  Object.freeze(emptyObject);
 }
 
 function maskContext(type, context) {

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -15,12 +15,16 @@ import {
 } from 'react-reconciler/reflection';
 import getComponentName from 'shared/getComponentName';
 import {HostComponent} from 'shared/ReactTypeOfWork';
-import emptyObject from 'fbjs/lib/emptyObject';
 import invariant from 'fbjs/lib/invariant';
 // Module provided by RN:
 import UIManager from 'UIManager';
 
 import {getClosestInstanceFromNode} from './ReactNativeComponentTree';
+
+const emptyObject = {};
+if (__DEV__) {
+  Object.freeze(emptyObject);
+}
 
 let getInspectorDataForViewTag;
 

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -9,7 +9,6 @@
 
 import type {ReactNativeBaseComponentViewConfig} from './ReactNativeTypes';
 
-import emptyObject from 'fbjs/lib/emptyObject';
 import invariant from 'fbjs/lib/invariant';
 
 // Modules provided by RN:
@@ -42,6 +41,11 @@ export type HostContext = $ReadOnly<{|
 |}>;
 export type UpdatePayload = Object; // Unused
 export type ChildSet = void; // Unused
+
+const emptyObject = {};
+if (__DEV__) {
+  Object.freeze(emptyObject);
+}
 
 // Counter for uniquely identifying views.
 // % 10 === 1 means it is a rootTag.

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -42,9 +42,9 @@ export type HostContext = $ReadOnly<{|
 export type UpdatePayload = Object; // Unused
 export type ChildSet = void; // Unused
 
-const emptyObject = {};
+const UPDATE_SIGNAL = {};
 if (__DEV__) {
-  Object.freeze(emptyObject);
+  Object.freeze(UPDATE_SIGNAL);
 }
 
 // Counter for uniquely identifying views.
@@ -222,7 +222,7 @@ export function prepareUpdate(
   rootContainerInstance: Container,
   hostContext: HostContext,
 ): null | Object {
-  return emptyObject;
+  return UPDATE_SIGNAL;
 }
 
 export function resetAfterCommit(containerInfo: Container): void {

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -31,13 +31,14 @@ type Instance = {|
 |};
 type TextInstance = {|text: string, id: number|};
 
-const emptyObject = {};
+const NO_CONTEXT = {};
+const UPDATE_SIGNAL = {};
 if (__DEV__) {
-  Object.freeze(emptyObject);
+  Object.freeze(NO_CONTEXT);
+  Object.freeze(UPDATE_SIGNAL);
 }
 
 function createReactNoop(reconciler: Function, useMutation: boolean) {
-  const UPDATE_SIGNAL = {};
   let scheduledCallback = null;
 
   let instanceCounter = 0;
@@ -88,11 +89,11 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       if (failInBeginPhase) {
         throw new Error('Error in host config.');
       }
-      return emptyObject;
+      return NO_CONTEXT;
     },
 
     getChildHostContext() {
-      return emptyObject;
+      return NO_CONTEXT;
     },
 
     getPublicInstance(instance) {

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -19,7 +19,6 @@ import type {UpdateQueue} from 'react-reconciler/src/ReactUpdateQueue';
 import type {ReactNodeList} from 'shared/ReactTypes';
 
 import * as ReactPortal from 'shared/ReactPortal';
-import emptyObject from 'fbjs/lib/emptyObject';
 import expect from 'expect';
 
 type Container = {rootID: string, children: Array<Instance | TextInstance>};
@@ -31,6 +30,11 @@ type Instance = {|
   prop: any,
 |};
 type TextInstance = {|text: string, id: number|};
+
+const emptyObject = {};
+if (__DEV__) {
+  Object.freeze(emptyObject);
+}
 
 function createReactNoop(reconciler: Function, useMutation: boolean) {
   const UPDATE_SIGNAL = {};

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -41,7 +41,7 @@ import {
 import ReactDebugCurrentFiber from './ReactDebugCurrentFiber';
 import {StrictMode} from './ReactTypeOfMode';
 
-function LegacyRefsObject() {}
+function MutableLegacyRefs() {}
 
 const {getCurrentFiberStackAddendum} = ReactDebugCurrentFiber;
 
@@ -159,14 +159,14 @@ function coerceRef(
       }
       const ref = function(value) {
         let refs;
-        if (inst.refs instanceof LegacyRefsObject) {
+        if (inst.refs instanceof MutableLegacyRefs) {
           // We've already assigned legacy refs to this component before.
           refs = inst.refs;
         } else {
           // `this.refs` either points to a pooled empty object,
           // or (very unlikely) an object created by another renderer.
           // Ensure we can mutate it and copy any existing refs over.
-          refs = inst.refs = Object.assign(new LegacyRefsObject(), inst.refs);
+          refs = inst.refs = Object.assign(new MutableLegacyRefs(), inst.refs);
           // This should happen only once per instance.
         }
         if (value === null) {

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -157,12 +157,10 @@ function coerceRef(
         return current.ref;
       }
       const ref = function(value) {
-        let refs;
-        if (inst.refs === emptyRefsObject) {
+        let refs = inst.refs;
+        if (refs === emptyRefsObject) {
           // This is a lazy pooled frozen object, so we need to initialize.
           refs = inst.refs = {};
-        } else {
-          refs = inst.refs;
         }
         if (value === null) {
           delete refs[stringRef];

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -158,14 +158,14 @@ function coerceRef(
       const ref = function(value) {
         let refs;
         // This flag tells us if we need to initialize `this.refs`.
-        if (inst.__reactInternalHasLegacyRefs) {
-          refs = inst.refs;
-        } else {
+        if (inst.__reactInternalHasLegacyRefs === undefined) {
           // `this.refs` points to a pooled empty object.
           // Replace it so we can mutate it.
           inst.refs = refs = {};
           // Remember that now we can mutate it.
           inst.__reactInternalHasLegacyRefs = true;
+        } else {
+          refs = inst.refs;
         }
         if (value === null) {
           delete refs[stringRef];

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -38,10 +38,9 @@ import {
   createFiberFromText,
   createFiberFromPortal,
 } from './ReactFiber';
+import {emptyRefsObject} from './ReactFiberClassComponent';
 import ReactDebugCurrentFiber from './ReactDebugCurrentFiber';
 import {StrictMode} from './ReactTypeOfMode';
-
-function MutableLegacyRefs() {}
 
 const {getCurrentFiberStackAddendum} = ReactDebugCurrentFiber;
 
@@ -159,15 +158,11 @@ function coerceRef(
       }
       const ref = function(value) {
         let refs;
-        if (inst.refs instanceof MutableLegacyRefs) {
-          // We've already assigned legacy refs to this component before.
-          refs = inst.refs;
+        if (inst.refs === emptyRefsObject) {
+          // This is a lazy pooled frozen object, so we need to initialize.
+          refs = inst.refs = {};
         } else {
-          // `this.refs` either points to a pooled empty object,
-          // or (very unlikely) an object created by another renderer.
-          // Ensure we can mutate it and copy any existing refs over.
-          refs = inst.refs = Object.assign(new MutableLegacyRefs(), inst.refs);
-          // This should happen only once per instance.
+          refs = inst.refs;
         }
         if (value === null) {
           delete refs[stringRef];

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -10,6 +10,7 @@
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
+import React from 'react';
 import {Update, Snapshot} from 'shared/ReactTypeOfSideEffect';
 import {
   debugRenderPhaseSideEffects,
@@ -53,10 +54,9 @@ import {
 const fakeInternalInstance = {};
 const isArray = Array.isArray;
 
-const emptyRefsObject = {};
-if (__DEV__) {
-  Object.freeze(emptyRefsObject);
-}
+// React.Component uses a shared frozen object by default.
+// We'll use it to determine whether we need to initialize legacy refs.
+export const emptyRefsObject = new React.Component().refs;
 
 let didWarnAboutStateAssignmentForComponent;
 let didWarnAboutUninitializedState;

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -20,7 +20,6 @@ import ReactStrictModeWarnings from './ReactStrictModeWarnings';
 import {isMounted} from 'react-reconciler/reflection';
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';
 import shallowEqual from 'shared/shallowEqual';
-import emptyObject from 'fbjs/lib/emptyObject';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
@@ -43,6 +42,7 @@ import {
   getUnmaskedContext,
   isContextConsumer,
   hasContextChanged,
+  emptyContextObject,
 } from './ReactFiberContext';
 import {
   recalculateCurrentTime,
@@ -52,6 +52,11 @@ import {
 
 const fakeInternalInstance = {};
 const isArray = Array.isArray;
+
+const emptyRefsObject = {};
+if (__DEV__) {
+  Object.freeze(emptyRefsObject);
+}
 
 let didWarnAboutStateAssignmentForComponent;
 let didWarnAboutUninitializedState;
@@ -469,7 +474,7 @@ function constructClassInstance(
   const needsContext = isContextConsumer(workInProgress);
   const context = needsContext
     ? getMaskedContext(workInProgress, unmaskedContext)
-    : emptyObject;
+    : emptyContextObject;
 
   // Instantiate twice to help detect side-effects.
   if (__DEV__) {
@@ -658,7 +663,7 @@ function mountClassInstance(
 
   instance.props = props;
   instance.state = workInProgress.memoizedState;
-  instance.refs = emptyObject;
+  instance.refs = emptyRefsObject;
   instance.context = getMaskedContext(workInProgress, unmaskedContext);
 
   if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -13,7 +13,6 @@ import type {StackCursor} from './ReactFiberStack';
 import {isFiberMounted} from 'react-reconciler/reflection';
 import {ClassComponent, HostRoot} from 'shared/ReactTypeOfWork';
 import getComponentName from 'shared/getComponentName';
-import emptyObject from 'fbjs/lib/emptyObject';
 import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
 import checkPropTypes from 'prop-types/checkPropTypes';
@@ -28,14 +27,19 @@ if (__DEV__) {
   warnedAboutMissingGetChildContext = {};
 }
 
+export const emptyContextObject = {};
+if (__DEV__) {
+  Object.freeze(emptyContextObject);
+}
+
 // A cursor to the current merged context object on the stack.
-let contextStackCursor: StackCursor<Object> = createCursor(emptyObject);
+let contextStackCursor: StackCursor<Object> = createCursor(emptyContextObject);
 // A cursor to a boolean indicating whether the context has changed.
 let didPerformWorkStackCursor: StackCursor<boolean> = createCursor(false);
 // Keep track of the previous context object that was on the stack.
 // We use this to get access to the parent context after we have already
 // pushed the next context provider, and now need to merge their contexts.
-let previousContext: Object = emptyObject;
+let previousContext: Object = emptyContextObject;
 
 function getUnmaskedContext(workInProgress: Fiber): Object {
   const hasOwnContext = isContextProvider(workInProgress);
@@ -66,7 +70,7 @@ function getMaskedContext(
   const type = workInProgress.type;
   const contextTypes = type.contextTypes;
   if (!contextTypes) {
-    return emptyObject;
+    return emptyContextObject;
   }
 
   // Avoid recreating masked context unless unmasked context has changed.
@@ -137,7 +141,7 @@ function pushTopLevelContextObject(
   didChange: boolean,
 ): void {
   invariant(
-    contextStackCursor.current === emptyObject,
+    contextStackCursor.current === emptyContextObject,
     'Unexpected context found on stack. ' +
       'This error is likely caused by a bug in React. Please file an issue.',
   );
@@ -219,7 +223,7 @@ function pushContextProvider(workInProgress: Fiber): boolean {
   // and replace it on the stack later when invalidating the context.
   const memoizedMergedChildContext =
     (instance && instance.__reactInternalMemoizedMergedChildContext) ||
-    emptyObject;
+    emptyContextObject;
 
   // Remember the parent context so we can merge with it later.
   // Inherit the parent's did-perform-work value to avoid inadvertently blocking updates.

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -24,7 +24,6 @@ import {
 } from 'react-reconciler/reflection';
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';
 import {HostComponent} from 'shared/ReactTypeOfWork';
-import emptyObject from 'fbjs/lib/emptyObject';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'fbjs/lib/invariant';
 import warning from 'fbjs/lib/warning';
@@ -34,6 +33,7 @@ import {
   findCurrentUnmaskedContext,
   isContextProvider,
   processChildContext,
+  emptyContextObject,
 } from './ReactFiberContext';
 import {createFiberRoot} from './ReactFiberRoot';
 import * as ReactFiberDevToolsHook from './ReactFiberDevToolsHook';
@@ -86,7 +86,7 @@ function getContextForSubtree(
   parentComponent: ?React$Component<any, any>,
 ): Object {
   if (!parentComponent) {
-    return emptyObject;
+    return emptyContextObject;
   }
 
   const fiber = ReactInstanceMap.get(parentComponent);

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -11,9 +11,13 @@ import {isForwardRef} from 'react-is';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import getComponentName from 'shared/getComponentName';
 import shallowEqual from 'shared/shallowEqual';
-import emptyObject from 'fbjs/lib/emptyObject';
 import invariant from 'fbjs/lib/invariant';
 import checkPropTypes from 'prop-types/checkPropTypes';
+
+const emptyObject = {};
+if (__DEV__) {
+  Object.freeze(emptyObject);
+}
 
 class ReactShallowRenderer {
   static createRenderer = function() {

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -36,9 +36,11 @@ export type ChildSet = void; // Unused
 export * from 'shared/HostConfigWithNoPersistence';
 export * from 'shared/HostConfigWithNoHydration';
 
-const emptyObject = {};
+const NO_CONTEXT = {};
+const UPDATE_SIGNAL = {};
 if (__DEV__) {
-  Object.freeze(emptyObject);
+  Object.freeze(NO_CONTEXT);
+  Object.freeze(UPDATE_SIGNAL);
 }
 
 export function getPublicInstance(inst: Instance | TextInstance): * {
@@ -89,7 +91,7 @@ export function removeChild(
 export function getRootHostContext(
   rootContainerInstance: Container,
 ): HostContext {
-  return emptyObject;
+  return NO_CONTEXT;
 }
 
 export function getChildHostContext(
@@ -97,7 +99,7 @@ export function getChildHostContext(
   type: string,
   rootContainerInstance: Container,
 ): HostContext {
-  return emptyObject;
+  return NO_CONTEXT;
 }
 
 export function prepareForCommit(containerInfo: Container): void {
@@ -153,7 +155,7 @@ export function prepareUpdate(
   rootContainerInstance: Container,
   hostContext: Object,
 ): null | {} {
-  return emptyObject;
+  return UPDATE_SIGNAL;
 }
 
 export function shouldSetTextContent(type: string, props: Props): boolean {

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -7,8 +7,6 @@
  * @flow
  */
 
-import emptyObject from 'fbjs/lib/emptyObject';
-
 import * as TestRendererScheduling from './ReactTestRendererScheduling';
 
 export type Type = string;
@@ -35,10 +33,13 @@ export type HostContext = Object;
 export type UpdatePayload = Object;
 export type ChildSet = void; // Unused
 
-const UPDATE_SIGNAL = {};
-
 export * from 'shared/HostConfigWithNoPersistence';
 export * from 'shared/HostConfigWithNoHydration';
+
+const emptyObject = {};
+if (__DEV__) {
+  Object.freeze(emptyObject);
+}
 
 export function getPublicInstance(inst: Instance | TextInstance): * {
   switch (inst.tag) {
@@ -152,7 +153,7 @@ export function prepareUpdate(
   rootContainerInstance: Container,
   hostContext: Object,
 ): null | {} {
-  return UPDATE_SIGNAL;
+  return emptyObject;
 }
 
 export function shouldSetTextContent(type: string, props: Props): boolean {

--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -5,11 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import emptyObject from 'fbjs/lib/emptyObject';
 import invariant from 'fbjs/lib/invariant';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 
 import ReactNoopUpdateQueue from './ReactNoopUpdateQueue';
+
+const emptyObject = {};
+if (__DEV__) {
+  Object.freeze(emptyObject);
+}
 
 /**
  * Base class helpers for the updating state of a component.
@@ -17,6 +21,7 @@ import ReactNoopUpdateQueue from './ReactNoopUpdateQueue';
 function Component(props, context, updater) {
   this.props = props;
   this.context = context;
+  // If a component has string refs, we will assign a different object later.
   this.refs = emptyObject;
   // We initialize the default updater but the real one gets injected by the
   // renderer.
@@ -126,6 +131,7 @@ ComponentDummy.prototype = Component.prototype;
 function PureComponent(props, context, updater) {
   this.props = props;
   this.context = context;
+  // If a component has string refs, we will assign a different object later.
   this.refs = emptyObject;
   this.updater = updater || ReactNoopUpdateQueue;
 }

--- a/scripts/jest/setupEnvironment.js
+++ b/scripts/jest/setupEnvironment.js
@@ -46,9 +46,3 @@ if (typeof window !== 'undefined') {
     }
   });
 }
-
-// Preserve the empty object identity across module resets.
-// This is needed for some tests that rely on string refs
-// but reset modules between loading different renderers.
-const obj = require.requireActual('fbjs/lib/emptyObject');
-jest.mock('fbjs/lib/emptyObject', () => obj);


### PR DESCRIPTION
Continuing https://github.com/facebook/react/pull/13046 and https://github.com/facebook/react/pull/13054.

This one was a bit more challenging, but it was nice to uncover the current assumptions. (Which tended to break with module resetting, for example.)

In most places I just inlined the code to create a DEV-frozen object. But a few places relied on reference equality semantics. I will add inline comments to describe what I did to fix those.