### PR TITLE
Remove fbjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "eslint-plugin-no-for-of-loops": "^1.0.0",
     "eslint-plugin-react": "^6.7.1",
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules/",
-    "fbjs": "^0.8.16",
     "fbjs-scripts": "^0.6.0",
     "filesize": "^3.5.6",
     "flow-bin": "^0.72.0",

--- a/packages/create-subscription/package.json
+++ b/packages/create-subscription/package.json
@@ -9,9 +9,6 @@
     "index.js",
     "cjs/"
   ],
-  "dependencies": {
-    "fbjs": "^0.8.16"
-  },
   "peerDependencies": {
     "react": "^16.3.0"
   },

--- a/packages/create-subscription/src/createSubscription.js
+++ b/packages/create-subscription/src/createSubscription.js
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 type Unsubscribe = () => void;
 

--- a/packages/create-subscription/src/createSubscription.js
+++ b/packages/create-subscription/src/createSubscription.js
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 type Unsubscribe = () => void;

--- a/packages/events/EventPluginHub.js
+++ b/packages/events/EventPluginHub.js
@@ -7,7 +7,7 @@
  */
 
 import ReactErrorUtils from 'shared/ReactErrorUtils';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import {
   injectEventPluginOrder,

--- a/packages/events/EventPluginRegistry.js
+++ b/packages/events/EventPluginRegistry.js
@@ -14,7 +14,7 @@ import type {
   PluginModule,
 } from './PluginModuleType';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 type NamesToPlugins = {[key: PluginName]: PluginModule<AnyNativeEvent>};
 type EventPluginOrder = null | Array<PluginName>;

--- a/packages/events/EventPluginUtils.js
+++ b/packages/events/EventPluginUtils.js
@@ -6,7 +6,7 @@
  */
 
 import ReactErrorUtils from 'shared/ReactErrorUtils';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 export let getFiberCurrentPropsFromNode = null;

--- a/packages/events/EventPluginUtils.js
+++ b/packages/events/EventPluginUtils.js
@@ -7,7 +7,7 @@
 
 import ReactErrorUtils from 'shared/ReactErrorUtils';
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 export let getFiberCurrentPropsFromNode = null;
 export let getInstanceFromNode = null;

--- a/packages/events/EventPropagators.js
+++ b/packages/events/EventPropagators.js
@@ -10,7 +10,7 @@ import {
   traverseTwoPhase,
   traverseEnterLeave,
 } from 'shared/ReactTreeTraversal';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import {getListener} from './EventPluginHub';
 import accumulateInto from './accumulateInto';

--- a/packages/events/ReactControlledComponent.js
+++ b/packages/events/ReactControlledComponent.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import {
   getInstanceFromNode,

--- a/packages/events/ResponderTouchHistoryStore.js
+++ b/packages/events/ResponderTouchHistoryStore.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 import {isStartish, isMoveish, isEndish} from './ResponderTopLevelEventTypes';

--- a/packages/events/ResponderTouchHistoryStore.js
+++ b/packages/events/ResponderTouchHistoryStore.js
@@ -8,7 +8,7 @@
  */
 
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import {isStartish, isMoveish, isEndish} from './ResponderTopLevelEventTypes';
 

--- a/packages/events/SyntheticEvent.js
+++ b/packages/events/SyntheticEvent.js
@@ -8,7 +8,7 @@
 /* eslint valid-typeof: 0 */
 
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 let didWarnForAddedNewProperty = false;
 const EVENT_POOL_SIZE = 10;

--- a/packages/events/SyntheticEvent.js
+++ b/packages/events/SyntheticEvent.js
@@ -7,7 +7,7 @@
 
 /* eslint valid-typeof: 0 */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 let didWarnForAddedNewProperty = false;

--- a/packages/events/accumulate.js
+++ b/packages/events/accumulate.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 /**
  * Accumulates items that must not be null or undefined.

--- a/packages/events/accumulateInto.js
+++ b/packages/events/accumulateInto.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 /**
  * Accumulates items that must not be null or undefined into the first one. This

--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "art": "^0.10.1",
     "create-react-class": "^15.6.2",
-    "fbjs": "^0.8.16",
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0"

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -8,7 +8,7 @@
 import * as ReactScheduler from 'shared/ReactScheduler';
 import Transform from 'art/core/transform';
 import Mode from 'art/modes/current';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import {TYPES, EVENT_TYPES, childrenAsString} from './ReactARTInternals';
 

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -13,7 +13,6 @@
   },
   "homepage": "https://reactjs.org/",
   "dependencies": {
-    "fbjs": "^0.8.16",
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0"

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -17,10 +17,50 @@ let ReactDOMServer;
 let ReactCurrentOwner;
 let ReactTestUtils;
 let PropTypes;
-let shallowEqual;
-let shallowCompare;
 
 describe('ReactCompositeComponent', () => {
+  const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+  /**
+   * Performs equality by iterating through keys on an object and returning false
+   * when any key has values which are not strictly equal between the arguments.
+   * Returns true when the values of all keys are strictly equal.
+   */
+  function shallowEqual(objA: mixed, objB: mixed): boolean {
+    if (Object.is(objA, objB)) {
+      return true;
+    }
+    if (
+      typeof objA !== 'object' ||
+      objA === null ||
+      typeof objB !== 'object' ||
+      objB === null
+    ) {
+      return false;
+    }
+    const keysA = Object.keys(objA);
+    const keysB = Object.keys(objB);
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+    for (let i = 0; i < keysA.length; i++) {
+      if (
+        !hasOwnProperty.call(objB, keysA[i]) ||
+        !Object.is(objA[keysA[i]], objB[keysA[i]])
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function shallowCompare(instance, nextProps, nextState) {
+    return (
+      !shallowEqual(instance.props, nextProps) ||
+      !shallowEqual(instance.state, nextState)
+    );
+  }
+
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
@@ -30,14 +70,6 @@ describe('ReactCompositeComponent', () => {
       .__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner;
     ReactTestUtils = require('react-dom/test-utils');
     PropTypes = require('prop-types');
-    shallowEqual = require('fbjs/lib/shallowEqual');
-
-    shallowCompare = function(instance, nextProps, nextState) {
-      return (
-        !shallowEqual(instance.props, nextProps) ||
-        !shallowEqual(instance.state, nextState)
-      );
-    };
 
     MorphingComponent = class extends React.Component {
       state = {activated: false};

--- a/packages/react-dom/src/__tests__/ReactDOMSelection-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelection-test.internal.js
@@ -12,7 +12,6 @@
 let React;
 let ReactDOM;
 let ReactDOMSelection;
-let invariant;
 
 let getModernOffsetsFromPoints;
 
@@ -21,7 +20,6 @@ describe('ReactDOMSelection', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMSelection = require('../client/ReactDOMSelection');
-    invariant = require('fbjs/lib/invariant');
 
     ({getModernOffsetsFromPoints} = ReactDOMSelection);
   });
@@ -68,10 +66,9 @@ describe('ReactDOMSelection', () => {
     }
     traverse(outerNode);
 
-    invariant(
-      start !== null && end !== null,
-      'Provided anchor/focus nodes were outside of root.',
-    );
+    if (start === null || end === null) {
+      throw new Error('Provided anchor/focus nodes were outside of root.');
+    }
     return {start, end};
   }
 

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -33,7 +33,7 @@ import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import * as ReactDOMComponentTree from './ReactDOMComponentTree';
 import * as ReactDOMFiberComponent from './ReactDOMFiberComponent';

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -31,7 +31,7 @@ import * as ReactInstanceMap from 'shared/ReactInstanceMap';
 import ReactVersion from 'shared/ReactVersion';
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
 import getComponentName from 'shared/getComponentName';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 import warning from 'fbjs/lib/warning';
 

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -6,7 +6,7 @@
  */
 
 import {HostComponent, HostText} from 'shared/ReactTypeOfWork';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 const randomKey = Math.random()
   .toString(36)

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -10,7 +10,7 @@
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import ReactDebugCurrentFiber from 'react-reconciler/src/ReactDebugCurrentFiber';
 import {registrationNameModules} from 'events/EventPluginRegistry';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import * as DOMPropertyOperations from './DOMPropertyOperations';
 import * as ReactDOMFiberInput from './ReactDOMFiberInput';

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -9,7 +9,7 @@
 
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import ReactDebugCurrentFiber from 'react-reconciler/src/ReactDebugCurrentFiber';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 import * as DOMPropertyOperations from './DOMPropertyOperations';

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -10,7 +10,7 @@
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import ReactDebugCurrentFiber from 'react-reconciler/src/ReactDebugCurrentFiber';
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import * as DOMPropertyOperations from './DOMPropertyOperations';
 import {getFiberCurrentPropsFromNode} from './ReactDOMComponentTree';

--- a/packages/react-dom/src/client/ReactDOMFiberOption.js
+++ b/packages/react-dom/src/client/ReactDOMFiberOption.js
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 let didWarnSelectedSetOnOption = false;
 

--- a/packages/react-dom/src/client/ReactDOMFiberSelect.js
+++ b/packages/react-dom/src/client/ReactDOMFiberSelect.js
@@ -9,7 +9,7 @@
 
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import ReactDebugCurrentFiber from 'react-reconciler/src/ReactDebugCurrentFiber';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import ReactControlledValuePropTypes from '../shared/ReactControlledValuePropTypes';
 

--- a/packages/react-dom/src/client/ReactDOMFiberTextarea.js
+++ b/packages/react-dom/src/client/ReactDOMFiberTextarea.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import ReactDebugCurrentFiber from 'react-reconciler/src/ReactDebugCurrentFiber';

--- a/packages/react-dom/src/client/ReactDOMFiberTextarea.js
+++ b/packages/react-dom/src/client/ReactDOMFiberTextarea.js
@@ -8,7 +8,7 @@
  */
 
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import ReactDebugCurrentFiber from 'react-reconciler/src/ReactDebugCurrentFiber';
 

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import ReactDebugCurrentFiber from 'react-reconciler/src/ReactDebugCurrentFiber';
 

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -22,7 +22,7 @@ import {accumulateTwoPhaseDispatches} from 'events/EventPropagators';
 import SyntheticEvent from 'events/SyntheticEvent';
 
 import * as DOMTopLevelEventTypes from './DOMTopLevelEventTypes';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import SyntheticAnimationEvent from './SyntheticAnimationEvent';
 import SyntheticClipboardEvent from './SyntheticClipboardEvent';

--- a/packages/react-dom/src/server/ReactDOMServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMServerBrowser.js
@@ -6,7 +6,7 @@
  */
 
 import ReactVersion from 'shared/ReactVersion';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import {renderToString, renderToStaticMarkup} from './ReactDOMStringRenderer';
 

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -17,7 +17,7 @@ import type {
 import React from 'react';
 import invariant from 'shared/invariant';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 import checkPropTypes from 'prop-types/checkPropTypes';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import {ReactDebugCurrentFrame} from 'shared/ReactGlobalSharedState';

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -15,7 +15,7 @@ import type {
 } from 'shared/ReactTypes';
 
 import React from 'react';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 import warning from 'fbjs/lib/warning';
 import checkPropTypes from 'prop-types/checkPropTypes';

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 type PropertyType = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 

--- a/packages/react-dom/src/shared/ReactDOMInvalidARIAHook.js
+++ b/packages/react-dom/src/shared/ReactDOMInvalidARIAHook.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 import {ReactDebugCurrentFrame} from 'shared/ReactGlobalSharedState';
 
 import {ATTRIBUTE_NAME_CHAR} from './DOMProperty';

--- a/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
+++ b/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
@@ -6,7 +6,7 @@
  */
 
 import {ReactDebugCurrentFrame} from 'shared/ReactGlobalSharedState';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 let didWarnValueNull = false;
 

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -10,7 +10,7 @@ import {
   possibleRegistrationNames,
 } from 'events/EventPluginRegistry';
 import {ReactDebugCurrentFrame} from 'shared/ReactGlobalSharedState';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import {
   ATTRIBUTE_NAME_CHAR,

--- a/packages/react-dom/src/shared/assertValidProps.js
+++ b/packages/react-dom/src/shared/assertValidProps.js
@@ -6,7 +6,7 @@
  */
 
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import voidElementTags from './voidElementTags';
 

--- a/packages/react-dom/src/shared/assertValidProps.js
+++ b/packages/react-dom/src/shared/assertValidProps.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 import voidElementTags from './voidElementTags';

--- a/packages/react-dom/src/shared/checkReact.js
+++ b/packages/react-dom/src/shared/checkReact.js
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 invariant(
   React,

--- a/packages/react-dom/src/shared/warnValidStyle.js
+++ b/packages/react-dom/src/shared/warnValidStyle.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 let warnValidStyle = () => {};
 

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -16,7 +16,7 @@ import {
   HostText,
 } from 'shared/ReactTypeOfWork';
 import SyntheticEvent from 'events/SyntheticEvent';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import * as DOMTopLevelEventTypes from '../events/DOMTopLevelEventTypes';
 

--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "repository": "facebook/react",
   "dependencies": {
-    "fbjs": "^0.8.16",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0"
   },

--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -15,7 +15,7 @@ import type {
   ReactNativeBaseComponentViewConfig,
 } from './ReactNativeTypes';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 // Modules provided by RN:
 import TextInputState from 'TextInputState';
 import UIManager from 'UIManager';

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -25,7 +25,7 @@ import {getInspectorDataForViewTag} from './ReactNativeFiberInspector';
 
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
 import getComponentName from 'shared/getComponentName';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 const findHostInstance = ReactFabricRenderer.findHostInstance;
 

--- a/packages/react-native-renderer/src/ReactFabricComponentTree.js
+++ b/packages/react-native-renderer/src/ReactFabricComponentTree.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 function getInstanceFromInstance(instanceHandle) {
   return instanceHandle;

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -21,7 +21,7 @@ import * as ReactNativeFrameScheduling from './ReactNativeFrameScheduling';
 import * as ReactNativeViewConfigRegistry from 'ReactNativeViewConfigRegistry';
 
 import deepFreezeAndThrowOnMutationInDev from 'deepFreezeAndThrowOnMutationInDev';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import {dispatchEvent} from './ReactFabricEventEmitter';
 

--- a/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
+++ b/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
@@ -15,7 +15,7 @@ import {
 import type {TopLevelType} from 'events/TopLevelEventTypes';
 import * as ReactNativeViewConfigRegistry from 'ReactNativeViewConfigRegistry';
 import SyntheticEvent from 'events/SyntheticEvent';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 const {
   customBubblingEventTypes,

--- a/packages/react-native-renderer/src/ReactNativeComponentTree.js
+++ b/packages/react-native-renderer/src/ReactNativeComponentTree.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 const instanceCache = {};
 const instanceProps = {};

--- a/packages/react-native-renderer/src/ReactNativeEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactNativeEventEmitter.js
@@ -10,7 +10,7 @@
 import {getListener, runExtractedEventsInBatch} from 'events/EventPluginHub';
 import {registrationNameModules} from 'events/EventPluginRegistry';
 import {batchedUpdates} from 'events/ReactGenericBatching';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import {getInstanceFromNode} from './ReactNativeComponentTree';
 

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -15,7 +15,7 @@ import {
 } from 'react-reconciler/reflection';
 import getComponentName from 'shared/getComponentName';
 import {HostComponent} from 'shared/ReactTypeOfWork';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 // Module provided by RN:
 import UIManager from 'UIManager';
 

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -9,7 +9,7 @@
 
 import type {ReactNativeBaseComponentViewConfig} from './ReactNativeTypes';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 // Modules provided by RN:
 import UIManager from 'UIManager';

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -28,7 +28,7 @@ import {getInspectorDataForViewTag} from './ReactNativeFiberInspector';
 
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';
 import getComponentName from 'shared/getComponentName';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 const findHostInstance = ReactNativeFiberRenderer.findHostInstance;
 

--- a/packages/react-native-renderer/src/__mocks__/FabricUIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/FabricUIManager.js
@@ -9,7 +9,7 @@
 
 // Mock of the Native Hooks
 
-const invariant = require('shared/invariant');
+import invariant from 'shared/invariant';
 
 const roots = new Map();
 const allocatedTags = new Set();

--- a/packages/react-native-renderer/src/__mocks__/FabricUIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/FabricUIManager.js
@@ -9,7 +9,7 @@
 
 // Mock of the Native Hooks
 
-const invariant = require('fbjs/lib/invariant');
+const invariant = require('shared/invariant');
 
 const roots = new Map();
 const allocatedTags = new Set();

--- a/packages/react-native-renderer/src/__mocks__/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native-renderer/src/__mocks__/ReactNativeViewConfigRegistry.js
@@ -13,7 +13,7 @@ import type {
   ViewConfigGetter,
 } from './ReactNativeTypes';
 
-const invariant = require('fbjs/lib/invariant');
+const invariant = require('shared/invariant');
 
 // Event configs
 const customBubblingEventTypes = {};

--- a/packages/react-native-renderer/src/__mocks__/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native-renderer/src/__mocks__/ReactNativeViewConfigRegistry.js
@@ -13,7 +13,7 @@ import type {
   ViewConfigGetter,
 } from './ReactNativeTypes';
 
-const invariant = require('shared/invariant');
+import invariant from 'shared/invariant';
 
 // Event configs
 const customBubblingEventTypes = {};

--- a/packages/react-native-renderer/src/__mocks__/UIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/UIManager.js
@@ -9,7 +9,7 @@
 
 // Mock of the Native Hooks
 
-const invariant = require('fbjs/lib/invariant');
+const invariant = require('shared/invariant');
 
 // Map of viewTag -> {children: [childTag], parent: ?parentTag}
 const roots = [];

--- a/packages/react-native-renderer/src/__mocks__/UIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/UIManager.js
@@ -9,7 +9,7 @@
 
 // Mock of the Native Hooks
 
-const invariant = require('shared/invariant');
+import invariant from 'shared/invariant';
 
 // Map of viewTag -> {children: [childTag], parent: ?parentTag}
 const roots = [];

--- a/packages/react-noop-renderer/package.json
+++ b/packages/react-noop-renderer/package.json
@@ -7,7 +7,6 @@
   "repository": "facebook/react",
   "license": "MIT",
   "dependencies": {
-    "fbjs": "^0.8.16",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0",
     "regenerator-runtime": "^0.11.0",

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -25,7 +25,6 @@
     "react": "^16.0.0"
   },
   "dependencies": {
-    "fbjs": "^0.8.16",
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0"

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -29,7 +29,7 @@ import {
 } from 'shared/ReactTypeOfWork';
 import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import {
   createWorkInProgress,

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -28,7 +28,7 @@ import {
   Fragment,
 } from 'shared/ReactTypeOfWork';
 import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 import {

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -15,7 +15,7 @@ import type {TypeOfSideEffect} from 'shared/ReactTypeOfSideEffect';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {UpdateQueue} from './ReactUpdateQueue';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import {enableProfilerTimer} from 'shared/ReactFeatureFlags';
 import {NoEffect} from 'shared/ReactTypeOfSideEffect';
 import {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -46,7 +46,7 @@ import {
   debugRenderPhaseSideEffectsForStrictMode,
   enableProfilerTimer,
 } from 'shared/ReactFeatureFlags';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import getComponentName from 'shared/getComponentName';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings';
 import warning from 'fbjs/lib/warning';

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -49,7 +49,7 @@ import {
 import invariant from 'shared/invariant';
 import getComponentName from 'shared/getComponentName';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 import ReactDebugCurrentFiber from './ReactDebugCurrentFiber';
 import {cancelWorkTimer} from './ReactDebugFiberPerf';
 

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -22,7 +22,7 @@ import {isMounted} from 'react-reconciler/reflection';
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';
 import shallowEqual from 'shared/shallowEqual';
 import getComponentName from 'shared/getComponentName';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -23,7 +23,7 @@ import * as ReactInstanceMap from 'shared/ReactInstanceMap';
 import shallowEqual from 'shared/shallowEqual';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
 import {StrictMode} from './ReactTypeOfMode';

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -39,7 +39,7 @@ import {
 } from 'shared/ReactTypeOfSideEffect';
 import {commitUpdateQueue} from './ReactUpdateQueue';
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import {onCommitUnmount} from './ReactFiberDevToolsHook';
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -38,7 +38,7 @@ import {
   Update,
 } from 'shared/ReactTypeOfSideEffect';
 import {commitUpdateQueue} from './ReactUpdateQueue';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 import {onCommitUnmount} from './ReactFiberDevToolsHook';

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -39,7 +39,7 @@ import {
 } from 'shared/ReactTypeOfWork';
 import {Placement, Ref, Update} from 'shared/ReactTypeOfSideEffect';
 import {ProfileMode} from './ReactTypeOfMode';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import {
   createInstance,

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -13,7 +13,7 @@ import type {StackCursor} from './ReactFiberStack';
 import {isFiberMounted} from 'react-reconciler/reflection';
 import {ClassComponent, HostRoot} from 'shared/ReactTypeOfWork';
 import getComponentName from 'shared/getComponentName';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 import checkPropTypes from 'prop-types/checkPropTypes';
 

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -14,7 +14,7 @@ import {isFiberMounted} from 'react-reconciler/reflection';
 import {ClassComponent, HostRoot} from 'shared/ReactTypeOfWork';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 import checkPropTypes from 'prop-types/checkPropTypes';
 
 import ReactDebugCurrentFiber from './ReactDebugCurrentFiber';

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.js
@@ -10,7 +10,7 @@
 import type {Fiber} from './ReactFiber';
 import type {FiberRoot} from './ReactFiberRoot';
 
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 declare var __REACT_DEVTOOLS_GLOBAL_HOOK__: Object | void;
 

--- a/packages/react-reconciler/src/ReactFiberHostConfig.js
+++ b/packages/react-reconciler/src/ReactFiberHostConfig.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 // We expect that our Rollup, Jest, and Flow configurations
 // always shim this module with the corresponding host config

--- a/packages/react-reconciler/src/ReactFiberHostContext.js
+++ b/packages/react-reconciler/src/ReactFiberHostContext.js
@@ -11,7 +11,7 @@ import type {Fiber} from './ReactFiber';
 import type {StackCursor} from './ReactFiberStack';
 import type {Container, HostContext} from './ReactFiberHostConfig';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import {getChildHostContext, getRootHostContext} from './ReactFiberHostConfig';
 import {createCursor, push, pop} from './ReactFiberStack';

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -18,7 +18,7 @@ import type {
 
 import {HostComponent, HostText, HostRoot} from 'shared/ReactTypeOfWork';
 import {Deletion, Placement} from 'shared/ReactTypeOfSideEffect';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import {createFiberFromHostInstanceForDeletion} from './ReactFiber';
 import {

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -18,7 +18,7 @@ export type NewContext = {
   getContextChangedBits(context: ReactContext<any>): number,
 };
 
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 import {isPrimaryRenderer} from './ReactFiberHostConfig';
 import {createCursor, push, pop} from './ReactFiberStack';
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -26,7 +26,7 @@ import * as ReactInstanceMap from 'shared/ReactInstanceMap';
 import {HostComponent} from 'shared/ReactTypeOfWork';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import {getPublicInstance} from './ReactFiberHostConfig';
 import {

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -25,7 +25,7 @@ import {
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';
 import {HostComponent} from 'shared/ReactTypeOfWork';
 import getComponentName from 'shared/getComponentName';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 import {getPublicInstance} from './ReactFiberHostConfig';

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -45,7 +45,7 @@ import {
   warnAboutLegacyContextAPI,
 } from 'shared/ReactFeatureFlags';
 import getComponentName from 'shared/getComponentName';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 import ReactFiberInstrumentation from './ReactFiberInstrumentation';

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -46,7 +46,7 @@ import {
 } from 'shared/ReactFeatureFlags';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import ReactFiberInstrumentation from './ReactFiberInstrumentation';
 import ReactDebugCurrentFiber from './ReactDebugCurrentFiber';

--- a/packages/react-reconciler/src/ReactFiberStack.js
+++ b/packages/react-reconciler/src/ReactFiberStack.js
@@ -9,7 +9,7 @@
 
 import type {Fiber} from './ReactFiber';
 
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 export type StackCursor<T> = {
   current: T,

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -10,7 +10,7 @@
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';
 import {ReactCurrentOwner} from 'shared/ReactGlobalSharedState';

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -9,7 +9,7 @@
 
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -12,7 +12,7 @@ import type {Fiber} from './ReactFiber';
 import getComponentName from 'shared/getComponentName';
 import {enableProfilerTimer} from 'shared/ReactFeatureFlags';
 
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 import {now} from './ReactFiberHostConfig';
 
 export type ProfilerTimer = {

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -13,7 +13,7 @@ import getComponentName from 'shared/getComponentName';
 import {getStackAddendumByWorkInProgressFiber} from 'shared/ReactFiberComponentTreeHook';
 import {StrictMode} from './ReactTypeOfMode';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 type LIFECYCLE =
   | 'UNSAFE_componentWillMount'

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -103,7 +103,7 @@ import {
 import {StrictMode} from './ReactTypeOfMode';
 
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 export type Update<State> = {
   expirationTime: ExpirationTime,

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -102,7 +102,7 @@ import {
 
 import {StrictMode} from './ReactTypeOfMode';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 
 export type Update<State> = {

--- a/packages/react-reconciler/src/forks/ReactFiberErrorDialog.www.js
+++ b/packages/react-reconciler/src/forks/ReactFiberErrorDialog.www.js
@@ -9,7 +9,7 @@
 
 import type {CapturedError} from '../ReactCapturedValue';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 // Provided by www
 const ReactFiberErrorDialogWWW = require('ReactFiberErrorDialog');

--- a/packages/react-scheduler/package.json
+++ b/packages/react-scheduler/package.json
@@ -14,7 +14,6 @@
   },
   "homepage": "https://reactjs.org/",
   "dependencies": {
-    "fbjs": "^0.8.16",
     "object-assign": "^4.1.1"
   },
   "files": [

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -42,7 +42,7 @@ type CallbackConfigType = {|
 export type CallbackIdType = CallbackConfigType;
 
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 if (__DEV__) {
   if (canUseDOM && typeof requestAnimationFrame !== 'function') {

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -15,7 +15,6 @@
   },
   "homepage": "https://reactjs.org/",
   "dependencies": {
-    "fbjs": "^0.8.16",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0",
     "react-is": "^16.4.1"

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -11,7 +11,7 @@ import {isForwardRef} from 'react-is';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import getComponentName from 'shared/getComponentName';
 import shallowEqual from 'shared/shallowEqual';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import checkPropTypes from 'prop-types/checkPropTypes';
 
 const emptyObject = {};

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -28,7 +28,7 @@ import {
   ForwardRef,
   Profiler,
 } from 'shared/ReactTypeOfWork';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import * as ReactTestHostConfig from './ReactTestHostConfig';
 import * as TestRendererScheduling from './ReactTestRendererScheduling';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,7 +21,6 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "fbjs": "^0.8.16",
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.0"

--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 
 import ReactNoopUpdateQueue from './ReactNoopUpdateQueue';

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -6,7 +6,7 @@
  */
 
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 import {
   getIteratorFn,
   REACT_ELEMENT_TYPE,

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 import {
   getIteratorFn,

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -11,7 +11,7 @@ import {REACT_PROVIDER_TYPE, REACT_CONTEXT_TYPE} from 'shared/ReactSymbols';
 
 import type {ReactContext} from 'shared/ReactTypes';
 
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 export function createContext<T>(
   defaultValue: T,

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -6,7 +6,7 @@
  */
 
 import invariant from 'shared/invariant';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 
 import ReactCurrentOwner from './ReactCurrentOwner';

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import warning from 'fbjs/lib/warning';
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -22,7 +22,7 @@ import {
   REACT_FRAGMENT_TYPE,
 } from 'shared/ReactSymbols';
 import checkPropTypes from 'prop-types/checkPropTypes';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 import ReactCurrentOwner from './ReactCurrentOwner';
 import {isValidElement, createElement, cloneElement} from './ReactElement';

--- a/packages/react/src/ReactNoopUpdateQueue.js
+++ b/packages/react/src/ReactNoopUpdateQueue.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 const didWarnStateUpdateForUnmountedComponent = {};
 

--- a/packages/react/src/forwardRef.js
+++ b/packages/react/src/forwardRef.js
@@ -7,7 +7,7 @@
 
 import {REACT_FORWARD_REF_TYPE} from 'shared/ReactSymbols';
 
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 export default function forwardRef<Props, ElementType: React$ElementType>(
   render: (props: Props, ref: React$ElementRef<ElementType>) => React$Node,

--- a/packages/shared/HostConfigWithNoHydration.js
+++ b/packages/shared/HostConfigWithNoHydration.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 // Renderers that don't support hydration
 // can re-export everything from this module.

--- a/packages/shared/HostConfigWithNoMutation.js
+++ b/packages/shared/HostConfigWithNoMutation.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 // Renderers that don't support mutation
 // can re-export everything from this module.

--- a/packages/shared/HostConfigWithNoPersistence.js
+++ b/packages/shared/HostConfigWithNoPersistence.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 // Renderers that don't support persistence
 // can re-export everything from this module.

--- a/packages/shared/ReactErrorUtils.js
+++ b/packages/shared/ReactErrorUtils.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 import invokeGuardedCallback from './invokeGuardedCallback';
 
 const ReactErrorUtils = {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 // Exports ReactDOM.createRoot
 export const enableUserTimingAPI = __DEV__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric-fb.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as FabricFeatureFlagsType from './ReactFeatureFlags.native-fabric-fb';

--- a/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fabric-oss.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as FabricFeatureFlagsType from './ReactFeatureFlags.native-fabric-oss';

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as FeatureFlagsShimType from './ReactFeatureFlags.native-fb';

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as FeatureFlagsShimType from './ReactFeatureFlags.native-oss';

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as PersistentFeatureFlagsType from './ReactFeatureFlags.persistent';

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as PersistentFeatureFlagsType from './ReactFeatureFlags.persistent';

--- a/packages/shared/forks/invariant.www.js
+++ b/packages/shared/forks/invariant.www.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default require('invariant');

--- a/packages/shared/forks/invokeGuardedCallback.www.js
+++ b/packages/shared/forks/invokeGuardedCallback.www.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 const invokeGuardedCallback = require('ReactFbErrorUtils')
   .invokeGuardedCallback;

--- a/packages/shared/forks/warning.www.js
+++ b/packages/shared/forks/warning.www.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default require('warning');

--- a/packages/shared/invariant.js
+++ b/packages/shared/invariant.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/**
+ * Use invariant() to assert state which your program assumes to be true.
+ *
+ * Provide sprintf-style format (only %s is supported) and arguments
+ * to provide information about what broke and what you were
+ * expecting.
+ *
+ * The invariant message will be stripped in production, but the invariant
+ * will remain to ensure logic does not differ in production.
+ */
+
+let validateFormat = () => {};
+
+if (__DEV__) {
+  validateFormat = function(format) {
+    if (format === undefined) {
+      throw new Error('invariant requires an error message argument');
+    }
+  };
+}
+
+export default function invariant(condition, format, a, b, c, d, e, f) {
+  validateFormat(format);
+
+  if (!condition) {
+    let error;
+    if (format === undefined) {
+      error = new Error(
+        'Minified exception occurred; use the non-minified dev environment ' +
+          'for the full error message and additional helpful warnings.',
+      );
+    } else {
+      const args = [a, b, c, d, e, f];
+      let argIndex = 0;
+      error = new Error(
+        format.replace(/%s/g, function() {
+          return args[argIndex++];
+        }),
+      );
+      error.name = 'Invariant Violation';
+    }
+
+    error.framesToPop = 1; // we don't care about invariant's own frame
+    throw error;
+  }
+}

--- a/packages/shared/invokeGuardedCallback.js
+++ b/packages/shared/invokeGuardedCallback.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 let invokeGuardedCallback = function<A, B, C, D, E, F, Context>(
   name: string | null,

--- a/packages/shared/reactProdInvariant.js
+++ b/packages/shared/reactProdInvariant.js
@@ -9,7 +9,7 @@
 
 // Relying on the `invariant()` implementation lets us
 // have preserve the format and params in the www builds.
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'shared/invariant';
 
 /**
  * WARNING: DO NOT manually require this module.

--- a/packages/shared/warning.js
+++ b/packages/shared/warning.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Similar to invariant but only logs a warning if the condition is not met.
+ * This can be used to log issues in development environments in critical
+ * paths. Removing the logging code for production environments will keep the
+ * same logic and follow the same code paths.
+ */
+
+let warning = () => {};
+
+if (__DEV__) {
+  function printWarning(format, ...args) {
+    var argIndex = 0;
+    var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
+    if (typeof console !== 'undefined') {
+      console.error(message);
+    }
+    try {
+      // --- Welcome to debugging React ---
+      // This error was thrown as a convenience so that you can use this stack
+      // to find the callsite that caused this warning to fire.
+      throw new Error(message);
+    } catch (x) {}
+  }
+
+  warning = function(condition, format, ...args) {
+    if (format === undefined) {
+      throw new Error(
+        '`warning(condition, format, ...args)` requires a warning ' +
+        'message argument'
+      );
+    }
+    if (!condition) {
+      printWarning(format, ...args);
+    }
+  };
+}
+
+export default warning;

--- a/packages/shared/warning.js
+++ b/packages/shared/warning.js
@@ -33,7 +33,7 @@ if (__DEV__) {
     if (format === undefined) {
       throw new Error(
         '`warning(condition, format, ...args)` requires a warning ' +
-        'message argument'
+          'message argument',
       );
     }
     if (!condition) {

--- a/packages/shared/warning.js
+++ b/packages/shared/warning.js
@@ -15,9 +15,9 @@
 let warning = () => {};
 
 if (__DEV__) {
-  function printWarning(format, ...args) {
-    var argIndex = 0;
-    var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
+  const printWarning = function(format, ...args) {
+    let argIndex = 0;
+    const message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
     if (typeof console !== 'undefined') {
       console.error(message);
     }
@@ -27,7 +27,7 @@ if (__DEV__) {
       // to find the callsite that caused this warning to fire.
       throw new Error(message);
     } catch (x) {}
-  }
+  };
 
   warning = function(condition, format, ...args) {
     if (format === undefined) {

--- a/packages/simple-cache-provider/package.json
+++ b/packages/simple-cache-provider/package.json
@@ -9,9 +9,6 @@
     "index.js",
     "cjs/"
   ],
-  "dependencies": {
-    "fbjs": "^0.8.16"
-  },
   "peerDependencies": {
     "react": "^16.3.0-alpha.1"
   }

--- a/packages/simple-cache-provider/src/SimpleCacheProvider.js
+++ b/packages/simple-cache-provider/src/SimpleCacheProvider.js
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import warning from 'fbjs/lib/warning';
+import warning from 'shared/warning';
 
 function noop() {}
 

--- a/scripts/error-codes/__tests__/replace-invariant-error-codes-test.js
+++ b/scripts/error-codes/__tests__/replace-invariant-error-codes-test.js
@@ -35,10 +35,10 @@ describe('error codes transform', () => {
 
   it('should replace simple invariant calls', () => {
     compare(
-      "import invariant from 'shared/reactProdInvariant';\n" +
+      "import invariant from 'shared/invariant';\n" +
         "invariant(condition, 'Do not override existing functions.');",
       "import _prodInvariant from 'shared/reactProdInvariant';\n" +
-        "import invariant from 'shared/reactProdInvariant';\n" +
+        "import invariant from 'shared/invariant';\n" +
         '!condition ? ' +
         '__DEV__ ? ' +
         "invariant(false, 'Do not override existing functions.') : " +
@@ -54,11 +54,11 @@ describe('error codes transform', () => {
       `_prodInvariant('16') : void 0;`;
 
     compare(
-      `import invariant from 'invariant';
+      `import invariant from 'shared/invariant';
 invariant(condition, 'Do not override existing functions.');
 invariant(condition, 'Do not override existing functions.');`,
       `import _prodInvariant from 'shared/reactProdInvariant';
-import invariant from 'invariant';
+import invariant from 'shared/invariant';
 ${expectedInvariantTransformResult}
 ${expectedInvariantTransformResult}`
     );
@@ -66,10 +66,10 @@ ${expectedInvariantTransformResult}`
 
   it('should support invariant calls with args', () => {
     compare(
-      "import invariant from 'shared/reactProdInvariant';\n" +
+      "import invariant from 'shared/invariant';\n" +
         "invariant(condition, 'Expected %s target to be an array; got %s', 'foo', 'bar');",
       "import _prodInvariant from 'shared/reactProdInvariant';\n" +
-        "import invariant from 'shared/reactProdInvariant';\n" +
+        "import invariant from 'shared/invariant';\n" +
         '!condition ? ' +
         '__DEV__ ? ' +
         "invariant(false, 'Expected %s target to be an array; got %s', 'foo', 'bar') : " +
@@ -79,10 +79,10 @@ ${expectedInvariantTransformResult}`
 
   it('should support invariant calls with a concatenated template string and args', () => {
     compare(
-      "import invariant from 'shared/reactProdInvariant';\n" +
+      "import invariant from 'shared/invariant';\n" +
         "invariant(condition, 'Expected a component class, ' + 'got %s.' + '%s', 'Foo', 'Bar');",
       "import _prodInvariant from 'shared/reactProdInvariant';\n" +
-        "import invariant from 'shared/reactProdInvariant';\n" +
+        "import invariant from 'shared/invariant';\n" +
         '!condition ? ' +
         '__DEV__ ? ' +
         "invariant(false, 'Expected a component class, got %s.%s', 'Foo', 'Bar') : " +
@@ -92,10 +92,10 @@ ${expectedInvariantTransformResult}`
 
   it('should correctly transform invariants that are not in the error codes map', () => {
     compare(
-      "import invariant from 'shared/reactProdInvariant';\n" +
+      "import invariant from 'shared/invariant';\n" +
         "invariant(condition, 'This is not a real error message.');",
       "import _prodInvariant from 'shared/reactProdInvariant';\n" +
-        "import invariant from 'shared/reactProdInvariant';\n" +
+        "import invariant from 'shared/invariant';\n" +
         "!condition ? invariant(false, 'This is not a real error message.') : void 0;"
     );
   });

--- a/scripts/release/config.js
+++ b/scripts/release/config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const dependencies = ['fbjs', 'object-assign', 'prop-types'];
+const dependencies = ['object-assign', 'prop-types'];
 
 const paramDefinitions = [
   {

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -237,6 +237,20 @@ function isProfilingBundleType(bundleType) {
   }
 }
 
+function blacklistFBJS() {
+  return {
+    name: 'blacklistFBJS',
+    resolveId(importee) {
+      if (/^fbjs\//.test(importee)) {
+        throw new Error(
+          `Don't import ${importee}. ` +
+            `Check out the utilities in packages/shared/ instead.`
+        );
+      }
+    },
+  };
+}
+
 function getPlugins(
   entry,
   externals,
@@ -271,6 +285,8 @@ function getPlugins(
     },
     // Shim any modules that need forking in this environment.
     useForks(forks),
+    // Ensure we don't bundle any fbjs modules
+    blacklistFBJS(),
     // Use Node resolution mechanism.
     resolve({
       skip: externals,

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -240,11 +240,11 @@ function isProfilingBundleType(bundleType) {
 function blacklistFBJS() {
   return {
     name: 'blacklistFBJS',
-    resolveId(importee) {
+    resolveId(importee, importer) {
       if (/^fbjs\//.test(importee)) {
         throw new Error(
-          `Don't import ${importee}. ` +
-            `Check out the utilities in packages/shared/ instead.`
+          `Don't import ${importee} (found in ${importer}). ` +
+            `Use the utilities in packages/shared/ instead.`
         );
       }
     },
@@ -266,7 +266,7 @@ function getPlugins(
   const forks = Modules.getForks(bundleType, entry, moduleType);
   const isProduction = isProductionBundleType(bundleType);
   const isProfiling = isProfilingBundleType(bundleType);
-  const isInGlobalScope = bundleType === UMD_DEV || bundleType === UMD_PROD;
+  const isUMDBundle = bundleType === UMD_DEV || bundleType === UMD_PROD;
   const isFBBundle = bundleType === FB_WWW_DEV || bundleType === FB_WWW_PROD;
   const isRNBundle =
     bundleType === RN_OSS_DEV ||
@@ -285,8 +285,9 @@ function getPlugins(
     },
     // Shim any modules that need forking in this environment.
     useForks(forks),
-    // Ensure we don't bundle any fbjs modules
-    blacklistFBJS(),
+    // Ensure we don't try to bundle any fbjs modules
+    // unless they're transitive (e.g. through prop-types).
+    !isUMDBundle && blacklistFBJS(),
     // Use Node resolution mechanism.
     resolve({
       skip: externals,
@@ -325,7 +326,7 @@ function getPlugins(
         Object.assign({}, closureOptions, {
           // Don't let it create global variables in the browser.
           // https://github.com/facebook/react/issues/10909
-          assume_function_wrapper: !isInGlobalScope,
+          assume_function_wrapper: !isUMDBundle,
           // Works because `google-closure-compiler-js` is forked in Yarn lockfile.
           // We can remove this if GCC merges my PR:
           // https://github.com/google/closure-compiler/pull/2707

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -91,6 +91,17 @@ const forks = Object.freeze({
     }
   },
 
+  // This logic is forked on www to fork the formatting function.
+  'shared/invariant': (bundleType, entry) => {
+    switch (bundleType) {
+      case FB_WWW_DEV:
+      case FB_WWW_PROD:
+        return 'shared/forks/invariant.www.js';
+      default:
+        return null;
+    }
+  },
+
   // This logic is forked on www to blacklist warnings.
   'shared/lowPriorityWarning': (bundleType, entry) => {
     switch (bundleType) {

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -113,6 +113,17 @@ const forks = Object.freeze({
     }
   },
 
+  // This logic is forked on www to blacklist warnings.
+  'shared/warning': (bundleType, entry) => {
+    switch (bundleType) {
+      case FB_WWW_DEV:
+      case FB_WWW_PROD:
+        return 'shared/forks/warning.www.js';
+      default:
+        return null;
+    }
+  },
+
   // In FB bundles, we preserve an inline require to ReactCurrentOwner.
   // See the explanation in FB version of ReactCurrentOwner in www:
   'react/src/ReactCurrentOwner': (bundleType, entry) => {

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -12,7 +12,6 @@ const UMD_PROD = bundleTypes.UMD_PROD;
 const HAS_NO_SIDE_EFFECTS_ON_IMPORT = false;
 // const HAS_SIDE_EFFECTS_ON_IMPORT = true;
 const importSideEffects = Object.freeze({
-  'fbjs/lib/warning': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   'prop-types/checkPropTypes': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   deepFreezeAndThrowOnMutationInDev: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
 });

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -12,11 +12,8 @@ const UMD_PROD = bundleTypes.UMD_PROD;
 const HAS_NO_SIDE_EFFECTS_ON_IMPORT = false;
 // const HAS_SIDE_EFFECTS_ON_IMPORT = true;
 const importSideEffects = Object.freeze({
-  'fbjs/lib/invariant': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   'fbjs/lib/warning': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   'prop-types/checkPropTypes': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
-  'fbjs/lib/camelizeStyleName': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
-  'fbjs/lib/hyphenateStyleName': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   deepFreezeAndThrowOnMutationInDev: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
 });
 


### PR DESCRIPTION
This removes our runtime dependency on fbjs for a few reasons:

* We didn't get much value from it, the changes are pretty rare
* It obscures what we're bundling and sometimes is more generic than we need
* It drags some runtime dependencies that we don't use

I had to fork www's invariant and warning. Technically they were *already* implicitly forked (because www's CommonJS resolution gave us a different module) so this is just making it implicit. Warning needs to be forked because of blacklists, and invariant needs to be forked because of differences in production argument formatting logic (which goes through `ex` internally).

Note: to fully get rid of it we'd also need to remove it in `prop-types` (https://github.com/facebook/prop-types/pull/194).