### PR TITLE
 Do not add additional work to a batch that is already rendering

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -163,7 +163,7 @@ describe('ReactIncrementalUpdates', () => {
     ReactNoop.flushThrough(['a', 'b', 'c']);
     expect(ReactNoop.getChildren()).toEqual([span('')]);
 
-    // Schedule some more updates at different priorities{
+    // Schedule some more updates at different priorities
     instance.setState(createUpdate('d'));
     ReactNoop.flushSync(() => {
       instance.setState(createUpdate('e'));
@@ -178,7 +178,22 @@ describe('ReactIncrementalUpdates', () => {
     // they should be processed again, to ensure that the terminal state
     // is deterministic.
     ReactNoop.clearYields();
-    expect(ReactNoop.flush()).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+    expect(ReactNoop.flush()).toEqual([
+      'a',
+      'b',
+      'c',
+
+      // e, f, and g are in a separate batch from a, b, and c because they
+      // were scheduled in the middle of a render
+      'e',
+      'f',
+      'g',
+
+      'd',
+      'e',
+      'f',
+      'g',
+    ]);
     expect(ReactNoop.getChildren()).toEqual([span('abcdefg')]);
   });
 
@@ -237,7 +252,22 @@ describe('ReactIncrementalUpdates', () => {
     // they should be processed again, to ensure that the terminal state
     // is deterministic.
     ReactNoop.clearYields();
-    expect(ReactNoop.flush()).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+    expect(ReactNoop.flush()).toEqual([
+      'a',
+      'b',
+      'c',
+
+      // e, f, and g are in a separate batch from a, b, and c because they
+      // were scheduled in the middle of a render
+      'e',
+      'f',
+      'g',
+
+      'd',
+      'e',
+      'f',
+      'g',
+    ]);
     expect(ReactNoop.getChildren()).toEqual([span('fg')]);
   });
 


### PR DESCRIPTION
## Depends on https://github.com/facebook/react/pull/13071

Otherwise, the part of the tree that hasn't rendered yet will receive the latest state, but the already rendered part will show the state as it was before the intervening update.