### PR TITLE
Remove transitive dependency on fbjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "object-assign": "^4.1.1",
     "platform": "^1.1.0",
     "prettier": "1.11.1",
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.6.2",
     "random-seed": "^0.3.0",
     "react-lifecycles-compat": "^3.0.2",
     "rimraf": "^2.6.1",

--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -22,7 +22,7 @@
     "create-react-class": "^15.6.2",
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.2"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.2"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -5,7 +5,7 @@
   "repository": "facebook/react",
   "dependencies": {
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.2"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/packages/react-noop-renderer/package.json
+++ b/packages/react-noop-renderer/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.6.2",
     "regenerator-runtime": "^0.11.0",
     "react-reconciler": "*"
   },

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.2"
   },
   "browserify": {
     "transform": [

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://reactjs.org/",
   "dependencies": {
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.6.2",
     "react-is": "^16.4.1"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.2"
   },
   "browserify": {
     "transform": [

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -285,9 +285,8 @@ function getPlugins(
     },
     // Shim any modules that need forking in this environment.
     useForks(forks),
-    // Ensure we don't try to bundle any fbjs modules
-    // unless they're transitive (e.g. through prop-types).
-    !isUMDBundle && blacklistFBJS(),
+    // Ensure we don't try to bundle any fbjs modules.
+    blacklistFBJS(),
     // Use Node resolution mechanism.
     resolve({
       skip: externals,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4603,11 +4603,18 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7, prop-types@^15.6.0:
+prop-types@^15.5.7:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
     fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 


### PR DESCRIPTION
This bumps to include https://github.com/facebook/prop-types/pull/194, making it possible to remove even transitive deps on `fbjs` in the next release.