### PR TITLE
remove another couple of redundant lines

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1840,7 +1840,6 @@ function performWorkOnRoot(
       // This root is already complete. We can commit it.
       completeRoot(root, finishedWork, expirationTime);
     } else {
-      root.finishedWork = null;
       renderRoot(root, false);
       finishedWork = root.finishedWork;
       if (finishedWork !== null) {
@@ -1855,7 +1854,6 @@ function performWorkOnRoot(
       // This root is already complete. We can commit it.
       completeRoot(root, finishedWork, expirationTime);
     } else {
-      root.finishedWork = null;
       renderRoot(root, true);
       finishedWork = root.finishedWork;
       if (finishedWork !== null) {


### PR DESCRIPTION
By definition, `root.finishedWork` must already be null at the time both of these lines are executed.