### PR TITLE
remove some redundant lines

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -999,8 +999,6 @@ function renderRoot(root: FiberRoot, isYieldy: boolean): void {
     resetStack();
     nextRoot = root;
     nextRenderExpirationTime = expirationTime;
-    nextLatestTimeoutMs = -1;
-    nextRenderDidError = false;
     nextUnitOfWork = createWorkInProgress(
       nextRoot.current,
       null,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1840,7 +1840,6 @@ function performWorkOnRoot(
       // This root is already complete. We can commit it.
       completeRoot(root, finishedWork, expirationTime);
     } else {
-      root.finishedWork = null;
       renderRoot(root, false);
       finishedWork = root.finishedWork;
       if (finishedWork !== null) {
@@ -1855,7 +1854,6 @@ function performWorkOnRoot(
       // This root is already complete. We can commit it.
       completeRoot(root, finishedWork, expirationTime);
     } else {
-      root.finishedWork = null;
       renderRoot(root, true);
       finishedWork = root.finishedWork;
       if (finishedWork !== null) {


### PR DESCRIPTION
In `performWorkOnRoot()`, `root.finishedWork` must logically already be null at the time both those lines are run. So no need for the null assignments.

In `renderRoot()`, `nextLatestTimeoutMs` and `nextRenderDidError` have already been set to -1 and false respectively in `resetStack()` so no need to set again.