### PR TITLE
Fixes children when using dangerouslySetInnerHtml in a selected <option>

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -443,38 +443,35 @@ describe('ReactDOMSelect', () => {
     expect(markup).not.toContain('<option selected="" value="gorilla"');
   });
 
-  [null, undefined].forEach(val => {
-    it(`should support server-side rendering with dangerouslySetInnerHTML and ${val} children`, () => {
-      const stub = (
-        <select defaultValue="giraffe">
-          <option
-            value="monkey"
-            dangerouslySetInnerHTML={{
-              __html: 'A monkey!',
-            }}>
-            {val}
-          </option>
-          <option
-            value="giraffe"
-            dangerouslySetInnerHTML={{
-              __html: 'A giraffe!',
-            }}>
-            {val}
-          </option>
-          <option
-            value="gorilla"
-            dangerouslySetInnerHTML={{
-              __html: 'A gorilla!',
-            }}>
-            {val}
-          </option>
-        </select>
-      );
-      const markup = ReactDOMServer.renderToString(stub);
-      expect(markup).toContain('<option selected="" value="giraffe"');
-      expect(markup).not.toContain('<option selected="" value="monkey"');
-      expect(markup).not.toContain('<option selected="" value="gorilla"');
-    });
+  it('should support server-side rendering with dangerouslySetInnerHTML', () => {
+    const stub = (
+      <select defaultValue="giraffe">
+        <option
+          value="monkey"
+          dangerouslySetInnerHTML={{
+            __html: 'A monkey!',
+          }}>
+          {undefined}
+        </option>
+        <option
+          value="giraffe"
+          dangerouslySetInnerHTML={{
+            __html: 'A giraffe!',
+          }}>
+          {null}
+        </option>
+        <option
+          value="gorilla"
+          dangerouslySetInnerHTML={{
+            __html: 'A gorilla!',
+          }}
+        />
+      </select>
+    );
+    const markup = ReactDOMServer.renderToString(stub);
+    expect(markup).toContain('<option selected="" value="giraffe"');
+    expect(markup).not.toContain('<option selected="" value="monkey"');
+    expect(markup).not.toContain('<option selected="" value="gorilla"');
   });
 
   it('should support server-side rendering with multiple', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -443,6 +443,35 @@ describe('ReactDOMSelect', () => {
     expect(markup).not.toContain('<option selected="" value="gorilla"');
   });
 
+  it('should support server-side rendering with dangerouslySetInnerHTML', () => {
+    const stub = (
+      <select defaultValue="giraffe">
+        <option
+          value="monkey"
+          dangerouslySetInnerHTML={{
+            __html: 'A monkey!',
+          }}
+        />
+        <option
+          value="giraffe"
+          dangerouslySetInnerHTML={{
+            __html: 'A giraffe!',
+          }}
+        />
+        <option
+          value="gorilla"
+          dangerouslySetInnerHTML={{
+            __html: 'A gorilla!',
+          }}
+        />
+      </select>
+    );
+    const markup = ReactDOMServer.renderToString(stub);
+    expect(markup).toContain('<option selected="" value="giraffe"');
+    expect(markup).not.toContain('<option selected="" value="monkey"');
+    expect(markup).not.toContain('<option selected="" value="gorilla"');
+  });
+
   it('should support server-side rendering with multiple', () => {
     const stub = (
       <select multiple={true} value={['giraffe', 'gorilla']} onChange={noop}>

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -443,33 +443,38 @@ describe('ReactDOMSelect', () => {
     expect(markup).not.toContain('<option selected="" value="gorilla"');
   });
 
-  it('should support server-side rendering with dangerouslySetInnerHTML', () => {
-    const stub = (
-      <select defaultValue="giraffe">
-        <option
-          value="monkey"
-          dangerouslySetInnerHTML={{
-            __html: 'A monkey!',
-          }}
-        />
-        <option
-          value="giraffe"
-          dangerouslySetInnerHTML={{
-            __html: 'A giraffe!',
-          }}
-        />
-        <option
-          value="gorilla"
-          dangerouslySetInnerHTML={{
-            __html: 'A gorilla!',
-          }}
-        />
-      </select>
-    );
-    const markup = ReactDOMServer.renderToString(stub);
-    expect(markup).toContain('<option selected="" value="giraffe"');
-    expect(markup).not.toContain('<option selected="" value="monkey"');
-    expect(markup).not.toContain('<option selected="" value="gorilla"');
+  [null, undefined].forEach(val => {
+    it(`should support server-side rendering with dangerouslySetInnerHTML and ${val} children`, () => {
+      const stub = (
+        <select defaultValue="giraffe">
+          <option
+            value="monkey"
+            dangerouslySetInnerHTML={{
+              __html: 'A monkey!',
+            }}>
+            {val}
+          </option>
+          <option
+            value="giraffe"
+            dangerouslySetInnerHTML={{
+              __html: 'A giraffe!',
+            }}>
+            {val}
+          </option>
+          <option
+            value="gorilla"
+            dangerouslySetInnerHTML={{
+              __html: 'A gorilla!',
+            }}>
+            {val}
+          </option>
+        </select>
+      );
+      const markup = ReactDOMServer.renderToString(stub);
+      expect(markup).toContain('<option selected="" value="giraffe"');
+      expect(markup).not.toContain('<option selected="" value="monkey"');
+      expect(markup).not.toContain('<option selected="" value="gorilla"');
+    });
   });
 
   it('should support server-side rendering with multiple', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
@@ -327,38 +327,43 @@ describe('ReactDOMServerIntegration', () => {
         expectSelectValue(e, 'bar');
       });
 
-      itRenders(
-        'a select with options that use dangerouslySetInnerHTML',
-        async render => {
-          const e = await render(
-            <select defaultValue="baz" value="bar" readOnly={true}>
-              <option
-                id="foo"
-                value="foo"
-                dangerouslySetInnerHTML={{
-                  __html: 'Foo',
-                }}
-              />
-              <option
-                id="bar"
-                value="bar"
-                dangerouslySetInnerHTML={{
-                  __html: 'Bar',
-                }}
-              />
-              <option
-                id="baz"
-                value="baz"
-                dangerouslySetInnerHTML={{
-                  __html: 'Baz',
-                }}
-              />
-            </select>,
-            1,
-          );
-          expectSelectValue(e, 'bar');
-        },
-      );
+      [null, undefined].forEach(val => {
+        itRenders(
+          `a select with options that use dangerouslySetInnerHTML and ${val} children`,
+          async render => {
+            const e = await render(
+              <select defaultValue="baz" value="bar" readOnly={true}>
+                <option
+                  id="foo"
+                  value="foo"
+                  dangerouslySetInnerHTML={{
+                    __html: 'Foo',
+                  }}>
+                  {val}
+                </option>
+                <option
+                  id="bar"
+                  value="bar"
+                  dangerouslySetInnerHTML={{
+                    __html: 'Bar',
+                  }}>
+                  {val}
+                </option>
+                <option
+                  id="baz"
+                  value="baz"
+                  dangerouslySetInnerHTML={{
+                    __html: 'Baz',
+                  }}>
+                  {val}
+                </option>
+              </select>,
+              1,
+            );
+            expectSelectValue(e, 'bar');
+          },
+        );
+      });
 
       itRenders(
         'a select value overriding defaultValue no matter the prop order',

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
@@ -327,43 +327,40 @@ describe('ReactDOMServerIntegration', () => {
         expectSelectValue(e, 'bar');
       });
 
-      [null, undefined].forEach(val => {
-        itRenders(
-          `a select with options that use dangerouslySetInnerHTML and ${val} children`,
-          async render => {
-            const e = await render(
-              <select defaultValue="baz" value="bar" readOnly={true}>
-                <option
-                  id="foo"
-                  value="foo"
-                  dangerouslySetInnerHTML={{
-                    __html: 'Foo',
-                  }}>
-                  {val}
-                </option>
-                <option
-                  id="bar"
-                  value="bar"
-                  dangerouslySetInnerHTML={{
-                    __html: 'Bar',
-                  }}>
-                  {val}
-                </option>
-                <option
-                  id="baz"
-                  value="baz"
-                  dangerouslySetInnerHTML={{
-                    __html: 'Baz',
-                  }}>
-                  {val}
-                </option>
-              </select>,
-              1,
-            );
-            expectSelectValue(e, 'bar');
-          },
-        );
-      });
+      itRenders(
+        `a select with options that use dangerouslySetInnerHTML`,
+        async render => {
+          const e = await render(
+            <select defaultValue="baz" value="bar" readOnly={true}>
+              <option
+                id="foo"
+                value="foo"
+                dangerouslySetInnerHTML={{
+                  __html: 'Foo',
+                }}>
+                {undefined}
+              </option>
+              <option
+                id="bar"
+                value="bar"
+                dangerouslySetInnerHTML={{
+                  __html: 'Bar',
+                }}>
+                {null}
+              </option>
+              <option
+                id="baz"
+                value="baz"
+                dangerouslySetInnerHTML={{
+                  __html: 'Baz',
+                }}
+              />
+            </select>,
+            1,
+          );
+          expectSelectValue(e, 'bar');
+        },
+      );
 
       itRenders(
         'a select value overriding defaultValue no matter the prop order',

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
@@ -366,7 +366,7 @@ describe('ReactDOMServerIntegration', () => {
       itThrowsWhenRendering(
         'a select with option that uses dangerouslySetInnerHTML and 0 as child',
         async render => {
-          const e = await render(
+          await render(
             <select defaultValue="baz" value="foo" readOnly={true}>
               <option
                 id="foo"
@@ -386,7 +386,7 @@ describe('ReactDOMServerIntegration', () => {
       itThrowsWhenRendering(
         'a select with option that uses dangerouslySetInnerHTML and empty string as child',
         async render => {
-          const e = await render(
+          await render(
             <select defaultValue="baz" value="foo" readOnly={true}>
               <option
                 id="foo"

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
@@ -35,6 +35,7 @@ const {
   resetModules,
   itRenders,
   itClientRenders,
+  itThrowsWhenRendering,
   renderIntoDom,
   serverRender,
 } = ReactDOMServerIntegrationUtils(initModules);
@@ -328,7 +329,7 @@ describe('ReactDOMServerIntegration', () => {
       });
 
       itRenders(
-        `a select with options that use dangerouslySetInnerHTML`,
+        'a select with options that use dangerouslySetInnerHTML',
         async render => {
           const e = await render(
             <select defaultValue="baz" value="bar" readOnly={true}>
@@ -360,6 +361,46 @@ describe('ReactDOMServerIntegration', () => {
           );
           expectSelectValue(e, 'bar');
         },
+      );
+
+      itThrowsWhenRendering(
+        'a select with option that uses dangerouslySetInnerHTML and 0 as child',
+        async render => {
+          const e = await render(
+            <select defaultValue="baz" value="foo" readOnly={true}>
+              <option
+                id="foo"
+                value="foo"
+                dangerouslySetInnerHTML={{
+                  __html: 'Foo',
+                }}>
+                {0}
+              </option>
+            </select>,
+            1,
+          );
+        },
+        'Can only set one of `children` or `props.dangerouslySetInnerHTML`.',
+      );
+
+      itThrowsWhenRendering(
+        'a select with option that uses dangerouslySetInnerHTML and empty string as child',
+        async render => {
+          const e = await render(
+            <select defaultValue="baz" value="foo" readOnly={true}>
+              <option
+                id="foo"
+                value="foo"
+                dangerouslySetInnerHTML={{
+                  __html: 'Foo',
+                }}>
+                {''}
+              </option>
+            </select>,
+            1,
+          );
+        },
+        'Can only set one of `children` or `props.dangerouslySetInnerHTML`.',
       );
 
       itRenders(

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
@@ -328,6 +328,39 @@ describe('ReactDOMServerIntegration', () => {
       });
 
       itRenders(
+        'a select with options that use dangerouslySetInnerHTML',
+        async render => {
+          const e = await render(
+            <select defaultValue="baz" value="bar" readOnly={true}>
+              <option
+                id="foo"
+                value="foo"
+                dangerouslySetInnerHTML={{
+                  __html: 'Foo',
+                }}
+              />
+              <option
+                id="bar"
+                value="bar"
+                dangerouslySetInnerHTML={{
+                  __html: 'Bar',
+                }}
+              />
+              <option
+                id="baz"
+                value="baz"
+                dangerouslySetInnerHTML={{
+                  __html: 'Baz',
+                }}
+              />
+            </select>,
+            1,
+          );
+          expectSelectValue(e, 'bar');
+        },
+      );
+
+      itRenders(
         'a select value overriding defaultValue no matter the prop order',
         async render => {
           const e = await render(

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1173,7 +1173,9 @@ class ReactDOMServerRenderer {
     } else if (tag === 'option') {
       let selected = null;
       const selectValue = this.currentSelectValue;
-      const optionChildren = flattenOptionChildren(props.children);
+      const optionChildren = Array.isArray(props.children)
+        ? flattenOptionChildren(props.children)
+        : props.children;
       if (selectValue != null) {
         let value;
         if (props.value != null) {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1173,9 +1173,10 @@ class ReactDOMServerRenderer {
     } else if (tag === 'option') {
       let selected = null;
       const selectValue = this.currentSelectValue;
-      const optionChildren = Array.isArray(props.children)
-        ? flattenOptionChildren(props.children)
-        : props.children;
+      const optionChildren =
+        props.children === undefined
+          ? props.children
+          : flattenOptionChildren(props.children);
       if (selectValue != null) {
         let value;
         if (props.value != null) {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -258,7 +258,10 @@ function flattenTopLevelChildren(children: mixed): FlatReactChildren {
   return [fragmentChildElement];
 }
 
-function flattenOptionChildren(children: mixed): string {
+function flattenOptionChildren(children: mixed): ?string {
+  if (children === undefined || children === null) {
+    return children;
+  }
   let content = '';
   // Flatten children and warn if they aren't strings or numbers;
   // invalid types are ignored.
@@ -1173,10 +1176,7 @@ class ReactDOMServerRenderer {
     } else if (tag === 'option') {
       let selected = null;
       const selectValue = this.currentSelectValue;
-      const optionChildren =
-        props.children === undefined
-          ? props.children
-          : flattenOptionChildren(props.children);
+      const optionChildren = flattenOptionChildren(props.children);
       if (selectValue != null) {
         let value;
         if (props.value != null) {


### PR DESCRIPTION
This fixes an inadvertent cast of undefined children to an empty string when creating an option tag that will be selected:

```
  <select defaultValue="test">
    <option value='test' dangerouslySetInnerHTML={{ __html: '&rlm; test'}} />
  </select>
```

This causes an invariant error because both children and dangerouslySetInnerHTML are set.

**What is the current behavior?**

```js
const React = require('react');
const ReactDOM = require('react-dom/server');

ReactDOM.renderToString(
  <select defaultValue="test">
    <option value='test' dangerouslySetInnerHTML={{ __html: '&rlm; test'}} />
  </select>
);
```

```
/Volumes/Projects/shakti/node_modules/fbjs/lib/invariant.js:49
    throw error;
    ^

Invariant Violation: Can only set one of `children` or `props.dangerouslySetInnerHTML`.
    at invariant (/Volumes/Projects/shakti/node_modules/fbjs/lib/invariant.js:42:15)
    at assertValidProps (/Volumes/Projects/shakti/node_modules/react-dom/cjs/react-dom-server.node.development.js:693:33)
    at ReactDOMServerRenderer.renderDOM (/Volumes/Projects/shakti/node_modules/react-dom/cjs/react-dom-server.node.development.js:2674:5)
    at ReactDOMServerRenderer.render (/Volumes/Projects/shakti/node_modules/react-dom/cjs/react-dom-server.node.development.js:2418:21)
    at ReactDOMServerRenderer.read (/Volumes/Projects/shakti/node_modules/react-dom/cjs/react-dom-server.node.development.js:2357:19)
    at Object.renderToString (/Volumes/Projects/shakti/node_modules/react-dom/cjs/react-dom-server.node.development.js:2731:25)
    at Object.<anonymous> (/Volumes/Projects/shakti/test.js:4:22)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
```

**What is the expected behavior?**

```
<select data-reactroot=""><option selected="" value="test">&rlm; test</option></select>
```

**Which versions of React, and which browser / OS are affected by this issue? Did this work in previous versions of React?**

16.4.1 using node 8. This worked in 15.x.
