### PR TITLE
Convert react to named exports

### DIFF
--- a/packages/create-subscription/src/createSubscription.js
+++ b/packages/create-subscription/src/createSubscription.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import invariant from 'shared/invariant';
 import warning from 'shared/warning';
 

--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import * as React from 'react';
 import * as ARTRenderer from 'react-reconciler/inline.art';
 import Transform from 'art/core/transform';
 import Mode from 'art/modes/current';

--- a/packages/react-dom/src/client/ReactDOMFiberOption.js
+++ b/packages/react-dom/src/client/ReactDOMFiberOption.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import warning from 'shared/warning';
 
 let didWarnSelectedSetOnOption = false;

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -14,7 +14,7 @@ import type {
   ReactContext,
 } from 'shared/ReactTypes';
 
-import React from 'react';
+import * as React from 'react';
 import invariant from 'shared/invariant';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 import warning from 'shared/warning';

--- a/packages/react-dom/src/shared/checkReact.js
+++ b/packages/react-dom/src/shared/checkReact.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import invariant from 'shared/invariant';
 
 invariant(

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {findCurrentFiberUsingSlowPath} from 'react-reconciler/reflection';
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';

--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -16,7 +16,7 @@ import type {
   ReactNativeBaseComponentViewConfig,
 } from './ReactNativeTypes';
 
-import React from 'react';
+import * as React from 'react';
 // Modules provided by RN:
 import TextInputState from 'TextInputState';
 import UIManager from 'UIManager';

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 export type MeasureOnSuccessCallback = (
   x: number,

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -10,7 +10,7 @@
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
-import React from 'react';
+import * as React from 'react';
 import {Update, Snapshot} from 'shared/ReactTypeOfSideEffect';
 import {
   debugRenderPhaseSideEffects,

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -6,7 +6,7 @@
  *
  */
 
-import React from 'react';
+import * as React from 'react';
 import {isForwardRef} from 'react-is';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import getComponentName from 'shared/getComponentName';

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -7,10 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const React = require('./src/React');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = React.default ? React.default : React;
+export * from './src/React';

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -3,6 +3,7 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ * @flow
  */
 
 import assign from 'object-assign';

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -21,9 +21,9 @@ import {createRef} from './ReactCreateRef';
 import {forEach, map, count, toArray, only} from './ReactChildren';
 import ReactCurrentOwner from './ReactCurrentOwner';
 import {
-  createElement,
-  createFactory,
-  cloneElement,
+  createElement as createElementNormal,
+  createFactory as createFactoryNormal,
+  cloneElement as cloneElementNormal,
   isValidElement,
 } from './ReactElement';
 import {createContext} from './ReactContext';
@@ -35,53 +35,49 @@ import {
 } from './ReactElementValidator';
 import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
 
-const React = {
-  Children: {
-    map,
-    forEach,
-    count,
-    toArray,
-    only,
-  },
+export const Children = {
+  map,
+  forEach,
+  count,
+  toArray,
+  only,
+};
 
+export {
   createRef,
   Component,
   PureComponent,
-
   createContext,
   forwardRef,
-
-  Fragment: REACT_FRAGMENT_TYPE,
-  StrictMode: REACT_STRICT_MODE_TYPE,
-  unstable_AsyncMode: REACT_ASYNC_MODE_TYPE,
-  unstable_Profiler: REACT_PROFILER_TYPE,
-
-  createElement: __DEV__ ? createElementWithValidation : createElement,
-  cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,
-  createFactory: __DEV__ ? createFactoryWithValidation : createFactory,
-  isValidElement: isValidElement,
-
-  version: ReactVersion,
-
-  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
-    ReactCurrentOwner,
-    // Used by renderers to avoid bundling object-assign twice in UMD bundles:
-    assign,
-  },
+  isValidElement,
 };
 
-if (enableSuspense) {
-  React.Timeout = REACT_TIMEOUT_TYPE;
-}
+export const Fragment = REACT_FRAGMENT_TYPE;
+export const StrictMode = REACT_STRICT_MODE_TYPE;
+export const unstable_AsyncMode = REACT_ASYNC_MODE_TYPE;
+export const unstable_Profiler = REACT_PROFILER_TYPE;
 
-if (__DEV__) {
-  Object.assign(React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED, {
-    // These should not be included in production.
-    ReactDebugCurrentFrame,
-    // Shim for React DOM 16.0.0 which still destructured (but not used) this.
-    // TODO: remove in React 17.0.
-    ReactComponentTreeHook: {},
-  });
-}
+export const createElement = __DEV__
+  ? createElementWithValidation
+  : createElementNormal;
+export const cloneElement = __DEV__
+  ? cloneElementWithValidation
+  : cloneElementNormal;
+export const createFactory = __DEV__
+  ? createFactoryWithValidation
+  : createFactoryNormal;
 
-export default React;
+export const version = ReactVersion;
+
+export const __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = {
+  ReactCurrentOwner,
+  // Used by renderers to avoid bundling object-assign twice in UMD bundles:
+  assign,
+  // These should not be included in production.
+  ReactDebugCurrentFrame: __DEV__ ? ReactDebugCurrentFrame : null,
+  // Shim for React DOM 16.0.0 which still destructured (but not used) this.
+  // TODO: remove in React 17.0.
+  ReactComponentTreeHook: __DEV__ ? {} : null,
+};
+
+export const Timeout = enableSuspense ? REACT_TIMEOUT_TYPE : null;

--- a/packages/shared/ReactGlobalSharedState.js
+++ b/packages/shared/ReactGlobalSharedState.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 

--- a/packages/shared/forks/object-assign.umd.js
+++ b/packages/shared/forks/object-assign.umd.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 

--- a/packages/simple-cache-provider/src/SimpleCacheProvider.js
+++ b/packages/simple-cache-provider/src/SimpleCacheProvider.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import warning from 'shared/warning';
 
 function noop() {}

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -275,6 +275,8 @@ function getPlugins(
     bundleType === RN_FB_DEV ||
     bundleType === RN_FB_PROD;
   const shouldStayReadable = isFBBundle || isRNBundle || forcePrettyOutput;
+  const shouldHaveSmoothInterop = packageName === 'react';
+
   return [
     // Extract error codes from invariant() messages into a file.
     shouldExtractErrors && {
@@ -317,6 +319,15 @@ function getPlugins(
         return source
           .replace(/require\(['"]react['"]\)/g, "require('React')")
           .replace(/require\(['"]react-is['"]\)/g, "require('ReactIs')");
+      },
+    },
+    // remove Object.defineProperty(exports, '__esModule', { value: true })
+    // to allow both import React from 'react' and import * as React from 'react'
+    // TODO replace with esModule: false after rollup upgrade with
+    // https://github.com/rollup/rollup/pull/2287
+    shouldHaveSmoothInterop && {
+      transformBundle(source) {
+        return source.replace(/Object\.defineProperty\(.+__esModule.+\n/, '');
       },
     },
     // Apply dead code elimination and/or minification.


### PR DESCRIPTION
In this diff I'm making a step forward to esm support.

Here I export scoped variables instead of object. Conditions are
resolved with with ternary operator.

To solve the problem of using both `import * as React from 'react'`
and `import React from 'react'` I removed `__esModule` field with simple
regexp. In the future rollup release this will be achived with
[new rollup option](https://github.com/rollup/rollup/pull/2287).

New bundles are tested with webpack, rollup and babel-jest. All ways
produce same results.

There was a problem with reexports in https://github.com/facebook/react/issues/11526
and as you can see in examples below it's solved so we can migrate
react-dom to named exports aswell in the next PR.

before

```js
var React = {
  Children: {
    map: mapChildren,
    forEach: forEachChildren,
    count: countChildren,
    toArray: toArray,
    only: onlyChild
  },
  createRef: createRef,
  Component: Component,
  PureComponent: PureComponent,
  createContext: createContext,
  forwardRef: forwardRef,
  Fragment: REACT_FRAGMENT_TYPE,
  StrictMode: REACT_STRICT_MODE_TYPE,
  unstable_AsyncMode: REACT_ASYNC_MODE_TYPE,
  unstable_Profiler: REACT_PROFILER_TYPE,
  createElement: createElementWithValidation,
  cloneElement: cloneElementWithValidation,
  createFactory: createFactoryWithValidation,
  isValidElement: isValidElement,
  version: ReactVersion,
  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
    ReactCurrentOwner: ReactCurrentOwner,
    // Used by renderers to avoid bundling object-assign twice in UMD bundles:
    assign: _assign
  }
};
if (enableSuspense) {
  React.Timeout = REACT_TIMEOUT_TYPE;
}
{
  _assign(React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED, {
    // These should not be included in production.
    ReactDebugCurrentFrame: ReactDebugCurrentFrame,
    // Shim for React DOM 16.0.0 which still destructured (but not used) this.
    // TODO: remove in React 17.0.
    ReactComponentTreeHook: {}
  });
}
var React$2 = Object.freeze({
	default: React
});
var React$3 = ( React$2 && React ) || React$2;
// TODO: decide on the top-level export form.
// This is hacky but makes it work with both Rollup and Jest.
var react = React$3.default ? React$3.default : React$3;
module.exports = react;
```

after

```js
exports.Children = Children;
exports.createRef = createRef;
exports.Component = Component;
exports.PureComponent = PureComponent;
exports.createContext = createContext;
exports.forwardRef = forwardRef;
exports.isValidElement = isValidElement;
exports.Fragment = Fragment;
exports.StrictMode = StrictMode;
exports.unstable_AsyncMode = unstable_AsyncMode;
exports.unstable_Profiler = unstable_Profiler;
exports.createElement = createElement$$1;
exports.cloneElement = cloneElement$$1;
exports.createFactory = createFactory$$1;
exports.version = version;
exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
exports.Timeout = Timeout;
```