### PR TITLE
Fix crash during server render in react 16.4.1.

### DIFF
--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -60,6 +60,11 @@ if (__DEV__) {
 // this module is initially evaluated.
 // We want to be using a consistent implementation.
 const localDate = Date;
+
+// This initialization code may run even on server environments
+// if a component just imports ReactDOM (e.g. for findDOMNode).
+// Some environments might not have setTimeout or clearTimeout.
+// https://github.com/facebook/react/pull/13088
 const localSetTimeout =
   typeof setTimeout === 'function' ? setTimeout : (undefined: any);
 const localClearTimeout =

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -60,8 +60,9 @@ if (__DEV__) {
 // this module is initially evaluated.
 // We want to be using a consistent implementation.
 const localDate = Date;
-const localSetTimeout = setTimeout;
-const localClearTimeout = clearTimeout;
+const localSetTimeout = typeof setTimeout === 'function' ? setTimeout : null;
+const localClearTimeout =
+  typeof clearTimeout === 'function' ? clearTimeout : null;
 
 const hasNativePerformanceNow =
   typeof performance === 'object' && typeof performance.now === 'function';

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -43,7 +43,6 @@ export type CallbackIdType = CallbackConfigType;
 
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import warning from 'shared/warning';
-import invariant from 'shared/invariant';
 
 if (__DEV__) {
   if (canUseDOM && typeof requestAnimationFrame !== 'function') {
@@ -62,9 +61,9 @@ if (__DEV__) {
 // We want to be using a consistent implementation.
 const localDate = Date;
 const localSetTimeout =
-  typeof setTimeout === 'function' ? setTimeout : undefined;
+  typeof setTimeout === 'function' ? setTimeout : (undefined: any);
 const localClearTimeout =
-  typeof clearTimeout === 'function' ? clearTimeout : undefined;
+  typeof clearTimeout === 'function' ? clearTimeout : (undefined: any);
 
 const hasNativePerformanceNow =
   typeof performance === 'object' && typeof performance.now === 'function';
@@ -94,11 +93,6 @@ if (!canUseDOM) {
     callback: FrameCallbackType,
     options?: {timeout: number},
   ): CallbackIdType {
-    invariant(
-      typeof localSetTimeout === 'function',
-      'localSetTimeout is not a function. Please load a polyfill that defines this function.',
-    );
-
     // keeping return type consistent
     const callbackConfig = {
       scheduledCallback: callback,
@@ -118,11 +112,6 @@ if (!canUseDOM) {
     return callbackConfig;
   };
   cancelScheduledWork = function(callbackId: CallbackIdType) {
-    invariant(
-      typeof localClearTimeout === 'function',
-      'localClearTimeout is not a function. Please load a polyfill that defines this function.',
-    );
-
     const callback = callbackId.scheduledCallback;
     const timeoutId = timeoutIds.get(callback);
     timeoutIds.delete(callbackId);

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -60,9 +60,21 @@ if (__DEV__) {
 // this module is initially evaluated.
 // We want to be using a consistent implementation.
 const localDate = Date;
-const localSetTimeout = typeof setTimeout === 'function' ? setTimeout : null;
+const localSetTimeout =
+  typeof setTimeout === 'function'
+    ? setTimeout
+    : warning(
+        false,
+        'setTimeout is not a function. Please load a polyfill that defines this function.',
+      );
+
 const localClearTimeout =
-  typeof clearTimeout === 'function' ? clearTimeout : null;
+  typeof clearTimeout === 'function'
+    ? clearTimeout
+    : warning(
+        false,
+        'clearTimeout is not a function. Please load a polyfill that defines this function.',
+      );
 
 const hasNativePerformanceNow =
   typeof performance === 'object' && typeof performance.now === 'function';

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -43,6 +43,7 @@ export type CallbackIdType = CallbackConfigType;
 
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import warning from 'shared/warning';
+import invariant from 'shared/invariant';
 
 if (__DEV__) {
   if (canUseDOM && typeof requestAnimationFrame !== 'function') {
@@ -61,20 +62,9 @@ if (__DEV__) {
 // We want to be using a consistent implementation.
 const localDate = Date;
 const localSetTimeout =
-  typeof setTimeout === 'function'
-    ? setTimeout
-    : warning(
-        false,
-        'setTimeout is not a function. Please load a polyfill that defines this function.',
-      );
-
+  typeof setTimeout === 'function' ? setTimeout : undefined;
 const localClearTimeout =
-  typeof clearTimeout === 'function'
-    ? clearTimeout
-    : warning(
-        false,
-        'clearTimeout is not a function. Please load a polyfill that defines this function.',
-      );
+  typeof clearTimeout === 'function' ? clearTimeout : undefined;
 
 const hasNativePerformanceNow =
   typeof performance === 'object' && typeof performance.now === 'function';
@@ -104,6 +94,11 @@ if (!canUseDOM) {
     callback: FrameCallbackType,
     options?: {timeout: number},
   ): CallbackIdType {
+    invariant(
+      typeof localSetTimeout === 'function',
+      'localSetTimeout is not a function. Please load a polyfill that defines this function.',
+    );
+
     // keeping return type consistent
     const callbackConfig = {
       scheduledCallback: callback,
@@ -123,6 +118,11 @@ if (!canUseDOM) {
     return callbackConfig;
   };
   cancelScheduledWork = function(callbackId: CallbackIdType) {
+    invariant(
+      typeof localClearTimeout === 'function',
+      'localClearTimeout is not a function. Please load a polyfill that defines this function.',
+    );
+
     const callback = callbackId.scheduledCallback;
     const timeoutId = timeoutIds.get(callback);
     timeoutIds.delete(callbackId);


### PR DESCRIPTION
This fixes a crash that only occurs in react-dom 16.4.1.

setTimeout and clearTimeout may not be available in some server-render environments (such as ChakraCore in React.NET), and loading ReactScheduler.js will cause a crash unless the existence of the variables are checked via a typeof comparison.

https://github.com/reactjs/React.NET/issues/555

The crash did not occur in 16.4.0, and the change appears to have been introduced here: https://github.com/facebook/react/pull/12931/files#diff-bbebc3357e1fb99ab13ad796e04b69a6L47

I tested this by using yarn link and running it with a local copy of React.NET. I am unsure the best way to unit test this change, since assigning null to `setTimeout` causes an immediate crash within the Node REPL.