### PR TITLE
adding check for mousemove

### DIFF
--- a/packages/react-dom/src/events/SyntheticMouseEvent.js
+++ b/packages/react-dom/src/events/SyntheticMouseEvent.js
@@ -53,7 +53,8 @@ const SyntheticMouseEvent = SyntheticUIEvent.extend({
       return 0;
     }
 
-    return event.screenX - screenX;
+    // movementX/Y must be zero for all mouse events except mousemove.
+    return event.type === 'mousemove' ? event.screenX - screenX : 0;
   },
   movementY: function(event) {
     if ('movementY' in event) {
@@ -68,7 +69,8 @@ const SyntheticMouseEvent = SyntheticUIEvent.extend({
       return 0;
     }
 
-    return event.screenY - screenY;
+    // movementX/Y must be zero for all mouse events except mousemove.
+    return event.type === 'mousemove' ? event.screenY - screenY : 0;
   },
 });
 


### PR DESCRIPTION
@aweary @gaearon this should fix the previous issue introduced by https://github.com/facebook/react/pull/13082

If event type is not mousemove, return 0.
I've left the native event above as it is, as that should already be following the spec.