### PR TITLE
Correct type of `ref` in forwardRef render()

### DIFF
--- a/packages/react/src/forwardRef.js
+++ b/packages/react/src/forwardRef.js
@@ -10,7 +10,7 @@ import {REACT_FORWARD_REF_TYPE} from 'shared/ReactSymbols';
 import warning from 'shared/warning';
 
 export default function forwardRef<Props, ElementType: React$ElementType>(
-  render: (props: Props, ref: React$ElementRef<ElementType>) => React$Node,
+  render: (props: Props, ref: React$Ref<ElementType>) => React$Node,
 ) {
   if (__DEV__) {
     warning(


### PR DESCRIPTION
`React$ElementRef<T>` is the type of the ref _instance_ for a component of type T, whereas `React$Ref<T>` is the type of the ref _prop_ for a component of type T, which seems to be the intended type here.

As a side note, `React$Ref<T>` also encompasses string refs, which (unsurprisingly) don't seem to actually work with `forwardRef`. Not sure if we care that much, because presumably refs are intended to be pretty opaque in this context?