### PR TITLE
React.Timeout -> React.Placeholder

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -31,7 +31,7 @@ import {
   ContextProvider,
   ContextConsumer,
   Profiler,
-  TimeoutComponent,
+  PlaceholderComponent,
 } from 'shared/ReactTypeOfWork';
 import getComponentName from 'shared/getComponentName';
 
@@ -46,7 +46,7 @@ import {
   REACT_PROVIDER_TYPE,
   REACT_CONTEXT_TYPE,
   REACT_ASYNC_MODE_TYPE,
-  REACT_TIMEOUT_TYPE,
+  REACT_PLACEHOLDER_TYPE,
 } from 'shared/ReactSymbols';
 
 let hasBadMapPolyfill;
@@ -397,8 +397,8 @@ export function createFiberFromElement(
         break;
       case REACT_PROFILER_TYPE:
         return createFiberFromProfiler(pendingProps, mode, expirationTime, key);
-      case REACT_TIMEOUT_TYPE:
-        fiberTag = TimeoutComponent;
+      case REACT_PLACEHOLDER_TYPE:
+        fiberTag = PlaceholderComponent;
         break;
       default:
         fiberTag = getFiberTagFromObjectType(type, owner);

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -28,7 +28,7 @@ import {
   HostText,
   HostPortal,
   Profiler,
-  TimeoutComponent,
+  PlaceholderComponent,
 } from 'shared/ReactTypeOfWork';
 import ReactErrorUtils from 'shared/ReactErrorUtils';
 import {
@@ -322,7 +322,7 @@ function commitLifeCycles(
       // We have no life-cycles associated with Profiler.
       return;
     }
-    case TimeoutComponent: {
+    case PlaceholderComponent: {
       if (enableSuspense) {
         if ((finishedWork.mode & StrictMode) === NoEffect) {
           // In loose mode, a placeholder times out by scheduling a synchronous
@@ -837,7 +837,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       }
       return;
     }
-    case TimeoutComponent: {
+    case PlaceholderComponent: {
       return;
     }
     default: {

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -35,7 +35,7 @@ import {
   Fragment,
   Mode,
   Profiler,
-  TimeoutComponent,
+  PlaceholderComponent,
 } from 'shared/ReactTypeOfWork';
 import {Placement, Ref, Update} from 'shared/ReactTypeOfSideEffect';
 import {ProfileMode} from './ReactTypeOfMode';
@@ -490,7 +490,7 @@ function completeWork(
     }
     case ForwardRef:
       return null;
-    case TimeoutComponent:
+    case PlaceholderComponent:
       return null;
     case Fragment:
       return null;

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -12,7 +12,7 @@ import {
   REACT_FRAGMENT_TYPE,
   REACT_PROFILER_TYPE,
   REACT_STRICT_MODE_TYPE,
-  REACT_TIMEOUT_TYPE,
+  REACT_PLACEHOLDER_TYPE,
 } from 'shared/ReactSymbols';
 import {enableSuspense} from 'shared/ReactFeatureFlags';
 
@@ -71,7 +71,7 @@ const React = {
 };
 
 if (enableSuspense) {
-  React.Timeout = REACT_TIMEOUT_TYPE;
+  React.Placeholder = REACT_PLACEHOLDER_TYPE;
 }
 
 if (__DEV__) {

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -38,8 +38,8 @@ export const REACT_ASYNC_MODE_TYPE = hasSymbol
 export const REACT_FORWARD_REF_TYPE = hasSymbol
   ? Symbol.for('react.forward_ref')
   : 0xead0;
-export const REACT_TIMEOUT_TYPE = hasSymbol
-  ? Symbol.for('react.timeout')
+export const REACT_PLACEHOLDER_TYPE = hasSymbol
+  ? Symbol.for('react.placeholder')
   : 0xead1;
 
 const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;

--- a/packages/shared/ReactTypeOfWork.js
+++ b/packages/shared/ReactTypeOfWork.js
@@ -42,4 +42,4 @@ export const ContextConsumer = 12;
 export const ContextProvider = 13;
 export const ForwardRef = 14;
 export const Profiler = 15;
-export const TimeoutComponent = 16;
+export const PlaceholderComponent = 16;

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -18,7 +18,7 @@ import {
   REACT_PROFILER_TYPE,
   REACT_PROVIDER_TYPE,
   REACT_STRICT_MODE_TYPE,
-  REACT_TIMEOUT_TYPE,
+  REACT_PLACEHOLDER_TYPE,
 } from 'shared/ReactSymbols';
 
 function getComponentName(fiber: Fiber): string | null {
@@ -44,8 +44,8 @@ function getComponentName(fiber: Fiber): string | null {
       return 'Context.Provider';
     case REACT_STRICT_MODE_TYPE:
       return 'StrictMode';
-    case REACT_TIMEOUT_TYPE:
-      return 'Timeout';
+    case REACT_PLACEHOLDER_TYPE:
+      return 'Placeholder';
   }
   if (typeof type === 'object' && type !== null) {
     switch (type.$$typeof) {

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -15,7 +15,7 @@ import {
   REACT_PROFILER_TYPE,
   REACT_PROVIDER_TYPE,
   REACT_STRICT_MODE_TYPE,
-  REACT_TIMEOUT_TYPE,
+  REACT_PLACEHOLDER_TYPE,
 } from 'shared/ReactSymbols';
 
 export default function isValidElementType(type: mixed) {
@@ -27,7 +27,7 @@ export default function isValidElementType(type: mixed) {
     type === REACT_ASYNC_MODE_TYPE ||
     type === REACT_PROFILER_TYPE ||
     type === REACT_STRICT_MODE_TYPE ||
-    type === REACT_TIMEOUT_TYPE ||
+    type === REACT_PLACEHOLDER_TYPE ||
     (typeof type === 'object' &&
       type !== null &&
       (type.$$typeof === REACT_PROVIDER_TYPE ||


### PR DESCRIPTION
## Depends on #13092 and #13098

Changed the API to match what we've been using in our latest discussions.

Our tentative plans are for <Placeholder> to automatically hide the timed-out children, instead of removing them, so their state is not lost. This part is not yet implemented. We'll likely have a lower level API that does not include the hiding behavior. This is also not yet implemented.