### PR TITLE
Preserve state of placeholders by hiding timed-out children instead of deleting them

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -406,3 +406,19 @@ export function commitUpdate(
 ) {
   instance._applyProps(instance, newProps, oldProps);
 }
+
+export function hideInstance(instance: Instance): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function hideTextInstance(textInstance: TextInstance): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function unhideInstance(instance: Instance, props: Props): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function unhideTextInstance(textInstance: TextInstance): void {
+  throw new Error('Not yet implemented.');
+}

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -419,6 +419,9 @@ export function unhideInstance(instance: Instance, props: Props): void {
   throw new Error('Not yet implemented.');
 }
 
-export function unhideTextInstance(textInstance: TextInstance): void {
+export function unhideTextInstance(
+  textInstance: TextInstance,
+  text: string,
+): void {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -407,21 +407,22 @@ export function commitUpdate(
   instance._applyProps(instance, newProps, oldProps);
 }
 
-export function hideInstance(instance: Instance): void {
-  throw new Error('Not yet implemented.');
+export function hideInstance(instance) {
+  instance.hide();
 }
 
-export function hideTextInstance(textInstance: TextInstance): void {
-  throw new Error('Not yet implemented.');
+export function hideTextInstance(textInstance) {
+  // Noop
 }
 
-export function unhideInstance(instance: Instance, props: Props): void {
-  throw new Error('Not yet implemented.');
+export function unhideInstance(instance, props) {
+  if (props.visible == null || props.visible) {
+    instance.show();
+  } else {
+    instance.hide();
+  }
 }
 
-export function unhideTextInstance(
-  textInstance: TextInstance,
-  text: string,
-): void {
-  throw new Error('Not yet implemented.');
+export function unhideTextInstance(textInstance, text): void {
+  // Noop
 }

--- a/packages/react-dom/src/__tests__/ReactDOMPlaceholder-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMPlaceholder-test.internal.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let ReactFeatureFlags;
+let React;
+let ReactDOM;
+let Placeholder;
+let SimpleCacheProvider;
+let cache;
+let TextResource;
+
+describe('ReactDOMPlaceholder', () => {
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableSuspense = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    SimpleCacheProvider = require('simple-cache-provider');
+    Placeholder = React.Placeholder;
+    container = document.createElement('div');
+
+    function invalidateCache() {
+      cache = SimpleCacheProvider.createCache(invalidateCache);
+    }
+    invalidateCache();
+    TextResource = SimpleCacheProvider.createResource(([text, ms = 0]) => {
+      return new Promise((resolve, reject) =>
+        setTimeout(() => {
+          resolve(text);
+        }, ms),
+      );
+    }, ([text, ms]) => text);
+  });
+
+  function advanceTimers(ms) {
+    // Note: This advances Jest's virtual time but not React's. Use
+    // ReactNoop.expire for that.
+    if (typeof ms !== 'number') {
+      throw new Error('Must specify ms');
+    }
+    jest.advanceTimersByTime(ms);
+    // Wait until the end of the current tick
+    return new Promise(resolve => {
+      setImmediate(resolve);
+    });
+  }
+
+  function Text(props) {
+    return props.text;
+  }
+
+  function AsyncText(props) {
+    const text = props.text;
+    TextResource.read(cache, [props.text, props.ms]);
+    return text;
+  }
+
+  it('hides and unhides timed out DOM elements', async () => {
+    let divs = [
+      React.createRef(null),
+      React.createRef(null),
+      React.createRef(null),
+    ];
+    function App() {
+      return (
+        <Placeholder delayMs={500} fallback={<Text text="Loading..." />}>
+          <div ref={divs[0]}>
+            <Text text="A" />
+          </div>
+          <div ref={divs[1]}>
+            <AsyncText ms={1000} text="B" />
+          </div>
+          <div style={{display: 'block'}} ref={divs[2]}>
+            <Text text="C" />
+          </div>
+        </Placeholder>
+      );
+    }
+    ReactDOM.render(<App />, container);
+    expect(divs[0].current.style.display).toEqual('none');
+    expect(divs[1].current.style.display).toEqual('none');
+    expect(divs[2].current.style.display).toEqual('none');
+
+    await advanceTimers(1000);
+
+    expect(divs[0].current.style.display).toEqual('');
+    expect(divs[1].current.style.display).toEqual('');
+    // This div's display was set with a prop.
+    expect(divs[2].current.style.display).toEqual('block');
+  });
+
+  it('hides and unhides timed out text nodes', async () => {
+    function App() {
+      return (
+        <Placeholder delayMs={500} fallback={<Text text="Loading..." />}>
+          <Text text="A" />
+          <AsyncText ms={1000} text="B" />
+          <Text text="C" />
+        </Placeholder>
+      );
+    }
+    ReactDOM.render(<App />, container);
+    expect(container.textContent).toEqual('Loading...');
+
+    await advanceTimers(1000);
+
+    expect(container.textContent).toEqual('ABC');
+  });
+});

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -31,6 +31,9 @@ export type Props = {
   hidden?: boolean,
   suppressHydrationWarning?: boolean,
   dangerouslySetInnerHTML?: mixed,
+  style?: {
+    display?: string,
+  },
 };
 export type Container = Element | Document;
 export type Instance = Element;
@@ -69,6 +72,8 @@ let SUPPRESS_HYDRATION_WARNING;
 if (__DEV__) {
   SUPPRESS_HYDRATION_WARNING = 'suppressHydrationWarning';
 }
+
+const STYLE = 'style';
 
 let eventsEnabled: ?boolean = null;
 let selectionInformation: ?mixed = null;
@@ -395,19 +400,38 @@ export function removeChildFromContainer(
 }
 
 export function hideInstance(instance: Instance): void {
-  throw new Error('TODO');
+  // TODO: Does this work for all element types? What about MathML? Should we
+  // pass host context to this method?
+  instance = ((instance: any): HTMLElement);
+  if (instance.style !== undefined && instance.style !== null) {
+    instance.style.display = 'none';
+  }
 }
 
 export function hideTextInstance(textInstance: TextInstance): void {
-  throw new Error('TODO');
+  textInstance.nodeValue = '';
 }
 
 export function unhideInstance(instance: Instance, props: Props): void {
-  throw new Error('TODO');
+  instance = ((instance: any): HTMLElement);
+  if (instance.style !== undefined && instance.style !== null) {
+    let display = null;
+    if (props[STYLE] !== undefined && props[STYLE] !== null) {
+      const styleProp = props[STYLE];
+      if (styleProp.hasOwnProperty('display')) {
+        display = styleProp.display;
+      }
+    }
+    // $FlowFixMe Setting a style property to null is the valid way to reset it.
+    instance.style.display = display;
+  }
 }
 
-export function unhideTextInstance(textInstance: TextInstance): void {
-  throw new Error('TODO');
+export function unhideTextInstance(
+  textInstance: TextInstance,
+  text: string,
+): void {
+  textInstance.nodeValue = text;
 }
 
 // -------------------

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -394,6 +394,22 @@ export function removeChildFromContainer(
   }
 }
 
+export function hideInstance(instance: Instance): void {
+  throw new Error('TODO');
+}
+
+export function hideTextInstance(textInstance: TextInstance): void {
+  throw new Error('TODO');
+}
+
+export function unhideInstance(instance: Instance, props: Props): void {
+  throw new Error('TODO');
+}
+
+export function unhideTextInstance(textInstance: TextInstance): void {
+  throw new Error('TODO');
+}
+
 // -------------------
 //     Hydration
 // -------------------

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -376,6 +376,33 @@ export function cloneInstance(
   };
 }
 
+export function cloneHiddenInstance(
+  instance: Instance,
+  type: string,
+  props: Props,
+  internalInstanceHandle: Object,
+): Instance {
+  throw new Error('Not yet implemented.');
+}
+
+export function cloneUnhiddenInstance(
+  instance: Instance,
+  type: string,
+  props: Props,
+  internalInstanceHandle: Object,
+): Instance {
+  throw new Error('Not yet implemented.');
+}
+
+export function createHiddenTextInstance(
+  text: string,
+  rootContainerInstance: Container,
+  hostContext: HostContext,
+  internalInstanceHandle: Object,
+): TextInstance {
+  throw new Error('Not yet implemented.');
+}
+
 export function createContainerChildSet(container: Container): ChildSet {
   return createChildNodeSet(container);
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -451,3 +451,19 @@ export function removeChildFromContainer(
 export function resetTextContent(instance: Instance): void {
   // Noop
 }
+
+export function hideInstance(instance: Instance): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function hideTextInstance(textInstance: TextInstance): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function unhideInstance(instance: Instance, props: Props): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function unhideTextInstance(textInstance: TextInstance): void {
+  throw new Error('Not yet implemented.');
+}

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -464,6 +464,9 @@ export function unhideInstance(instance: Instance, props: Props): void {
   throw new Error('Not yet implemented.');
 }
 
-export function unhideTextInstance(textInstance: TextInstance): void {
+export function unhideTextInstance(
+  textInstance: TextInstance,
+  text: string,
+): void {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -386,7 +386,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           }
         },
 
-        unhideTextInstance(textInstance: TextInstance): void {
+        unhideTextInstance(textInstance: TextInstance, text: string): void {
           textInstance.hidden = false;
         },
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -372,6 +372,24 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         removeChild,
         removeChildFromContainer,
 
+        hideInstance(instance: Instance): void {
+          instance.hidden = true;
+        },
+
+        hideTextInstance(textInstance: TextInstance): void {
+          textInstance.hidden = true;
+        },
+
+        unhideInstance(instance: Instance, props: Props): void {
+          if (!props.hidden) {
+            instance.hidden = false;
+          }
+        },
+
+        unhideTextInstance(textInstance: TextInstance): void {
+          textInstance.hidden = false;
+        },
+
         resetTextContent(instance: Instance): void {
           instance.text = null;
         },
@@ -406,6 +424,61 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           newChildren: Array<Instance | TextInstance>,
         ): void {
           container.children = newChildren;
+        },
+
+        cloneHiddenInstance(
+          instance: Instance,
+          type: string,
+          props: Props,
+          internalInstanceHandle: Object,
+        ): Instance {
+          const clone = cloneInstance(
+            instance,
+            null,
+            type,
+            props,
+            props,
+            internalInstanceHandle,
+            true,
+            null,
+          );
+          clone.hidden = true;
+          return clone;
+        },
+
+        cloneUnhiddenInstance(
+          instance: Instance,
+          type: string,
+          props: Props,
+          internalInstanceHandle: Object,
+        ): Instance {
+          const clone = cloneInstance(
+            instance,
+            null,
+            type,
+            props,
+            props,
+            internalInstanceHandle,
+            true,
+            null,
+          );
+          clone.hidden = props.hidden;
+          return clone;
+        },
+
+        createHiddenTextInstance(
+          text: string,
+          rootContainerInstance: Container,
+          hostContext: Object,
+          internalInstanceHandle: Object,
+        ): TextInstance {
+          const inst = {text: text, id: instanceCounter++, hidden: true};
+          // Hide from unit tests
+          Object.defineProperty(inst, 'id', {
+            value: inst.id,
+            enumerable: false,
+          });
+          return inst;
         },
       };
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -20,16 +20,22 @@ import type {ReactNodeList} from 'shared/ReactTypes';
 
 import * as ReactPortal from 'shared/ReactPortal';
 import expect from 'expect';
+import {REACT_FRAGMENT_TYPE, REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 
-type Container = {rootID: string, children: Array<Instance | TextInstance>};
-type Props = {prop: any, hidden?: boolean, children?: mixed};
+type Container = {
+  rootID: string,
+  children: Array<Instance | TextInstance>,
+};
+type Props = {prop: any, hidden: boolean, children?: mixed};
 type Instance = {|
   type: string,
   id: number,
   children: Array<Instance | TextInstance>,
+  text: string | null,
   prop: any,
+  hidden: boolean,
 |};
-type TextInstance = {|text: string, id: number|};
+type TextInstance = {|text: string, id: number, hidden: boolean|};
 
 const NO_CONTEXT = {};
 const UPDATE_SIGNAL = {};
@@ -160,6 +166,46 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     removeChildFromContainerOrInstance(parentInstance, child);
   }
 
+  function cloneInstance(
+    instance: Instance,
+    updatePayload: null | Object,
+    type: string,
+    oldProps: Props,
+    newProps: Props,
+    internalInstanceHandle: Object,
+    keepChildren: boolean,
+    recyclableInstance: null | Instance,
+  ): Instance {
+    const clone = {
+      id: instance.id,
+      type: type,
+      children: keepChildren ? instance.children : [],
+      text: shouldSetTextContent(type, newProps)
+        ? (newProps.children: any) + ''
+        : null,
+      prop: newProps.prop,
+      hidden: newProps.hidden === true,
+    };
+    Object.defineProperty(clone, 'id', {
+      value: clone.id,
+      enumerable: false,
+    });
+    Object.defineProperty(clone, 'text', {
+      value: clone.text,
+      enumerable: false,
+    });
+    return clone;
+  }
+
+  function shouldSetTextContent(type: string, props: Props): boolean {
+    if (type === 'errorInBeginPhase') {
+      throw new Error('Error in host config.');
+    }
+    return (
+      typeof props.children === 'string' || typeof props.children === 'number'
+    );
+  }
+
   let elapsedTimeInMs = 0;
 
   const sharedHostConfig = {
@@ -183,10 +229,18 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         id: instanceCounter++,
         type: type,
         children: [],
+        text: shouldSetTextContent(type, props)
+          ? (props.children: any) + ''
+          : null,
         prop: props.prop,
+        hidden: props.hidden === true,
       };
       // Hide from unit tests
       Object.defineProperty(inst, 'id', {value: inst.id, enumerable: false});
+      Object.defineProperty(inst, 'text', {
+        value: inst.text,
+        enumerable: false,
+      });
       return inst;
     },
 
@@ -223,14 +277,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return UPDATE_SIGNAL;
     },
 
-    shouldSetTextContent(type: string, props: Props): boolean {
-      if (type === 'errorInBeginPhase') {
-        throw new Error('Error in host config.');
-      }
-      return (
-        typeof props.children === 'string' || typeof props.children === 'number'
-      );
-    },
+    shouldSetTextContent,
 
     shouldDeprioritizeSubtree(type: string, props: Props): boolean {
       return !!props.hidden;
@@ -242,7 +289,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       hostContext: Object,
       internalInstanceHandle: Object,
     ): TextInstance {
-      const inst = {text: text, id: instanceCounter++};
+      const inst = {text: text, id: instanceCounter++, hidden: false};
       // Hide from unit tests
       Object.defineProperty(inst, 'id', {value: inst.id, enumerable: false});
       return inst;
@@ -304,6 +351,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
             throw new Error('Should have old props');
           }
           instance.prop = newProps.prop;
+          instance.hidden = newProps.hidden === true;
+          if (shouldSetTextContent(type, newProps)) {
+            instance.text = (newProps.children: any) + '';
+          }
         },
 
         commitTextUpdate(
@@ -321,35 +372,16 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         removeChild,
         removeChildFromContainer,
 
-        resetTextContent(instance: Instance): void {},
+        resetTextContent(instance: Instance): void {
+          instance.text = null;
+        },
       }
     : {
         ...sharedHostConfig,
         supportsMutation: false,
         supportsPersistence: true,
 
-        cloneInstance(
-          instance: Instance,
-          updatePayload: null | Object,
-          type: string,
-          oldProps: Props,
-          newProps: Props,
-          internalInstanceHandle: Object,
-          keepChildren: boolean,
-          recyclableInstance: null | Instance,
-        ): Instance {
-          const clone = {
-            id: instance.id,
-            type: type,
-            children: keepChildren ? instance.children : [],
-            prop: newProps.prop,
-          };
-          Object.defineProperty(clone, 'id', {
-            value: clone.id,
-            enumerable: false,
-          });
-          return clone;
-        },
+        cloneInstance,
 
         createContainerChildSet(
           container: Container,
@@ -418,6 +450,59 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     }
   }
 
+  function childToJSX(child, text) {
+    if (text !== null) {
+      return text;
+    }
+    if (child === null) {
+      return null;
+    }
+    if (typeof child === 'string') {
+      return child;
+    }
+    if (Array.isArray(child)) {
+      if (child.length === 0) {
+        return null;
+      }
+      if (child.length === 1) {
+        return childToJSX(child[0], null);
+      }
+      // $FlowFixMe
+      const children = child.map(c => childToJSX(c, null));
+      if (children.every(c => typeof c === 'string' || typeof c === 'number')) {
+        return children.join('');
+      }
+      return children;
+    }
+    if (Array.isArray(child.children)) {
+      // This is an instance.
+      const instance: Instance = (child: any);
+      const children = childToJSX(instance.children, instance.text);
+      const props = ({prop: instance.prop}: any);
+      if (instance.hidden) {
+        props.hidden = true;
+      }
+      if (children !== null) {
+        props.children = children;
+      }
+      return {
+        $$typeof: REACT_ELEMENT_TYPE,
+        type: instance.type,
+        key: null,
+        ref: null,
+        props: props,
+        _owner: null,
+        _store: __DEV__ ? {} : undefined,
+      };
+    }
+    // This is a text instance
+    const textInstance: TextInstance = (child: any);
+    if (textInstance.hidden) {
+      return '';
+    }
+    return textInstance.text;
+  }
+
   const ReactNoop = {
     getChildren(rootID: string = DEFAULT_ROOT_ID) {
       const container = rootContainers.get(rootID);
@@ -440,6 +525,25 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         roots.set(rootID, root);
       }
       return root.current.stateNode.containerInfo;
+    },
+
+    getChildrenAsJSX(rootID: string = DEFAULT_ROOT_ID) {
+      const children = childToJSX(ReactNoop.getChildren(rootID), null);
+      if (children === null) {
+        return null;
+      }
+      if (Array.isArray(children)) {
+        return {
+          $$typeof: REACT_ELEMENT_TYPE,
+          type: REACT_FRAGMENT_TYPE,
+          key: null,
+          ref: null,
+          props: {children},
+          _owner: null,
+          _store: __DEV__ ? {} : undefined,
+        };
+      }
+      return children;
     },
 
     createPortal(

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -390,7 +390,7 @@ function hideOrUnhideAllChildren(finishedWork, isHidden) {
         if (isHidden) {
           hideTextInstance(instance);
         } else {
-          unhideTextInstance(instance);
+          unhideTextInstance(instance, node.memoizedProps);
         }
       } else if (node.child !== null) {
         node.child.return = node;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -64,6 +64,10 @@ import {
   removeChildFromContainer,
   replaceContainerChildren,
   createContainerChildSet,
+  hideInstance,
+  hideTextInstance,
+  unhideInstance,
+  unhideTextInstance,
 } from './ReactFiberHostConfig';
 import {
   captureCommitPhaseError,
@@ -71,6 +75,7 @@ import {
   scheduleWork,
 } from './ReactFiberScheduler';
 import {StrictMode} from './ReactTypeOfMode';
+import {PlaceholderFallback} from './ReactFiberPlaceholder';
 
 const {
   invokeGuardedCallback,
@@ -324,7 +329,28 @@ function commitLifeCycles(
     }
     case PlaceholderComponent: {
       if (enableSuspense) {
-        if ((finishedWork.mode & StrictMode) === NoEffect) {
+        const isInStrictMode = (finishedWork.mode & StrictMode) !== NoEffect;
+
+        if (isInStrictMode) {
+          // In strict mode, the Update effect is used to record the time at
+          // which the placeholder timed out.
+          const currentTime = requestCurrentTime();
+          finishedWork.stateNode = {timedOutAt: currentTime};
+        }
+
+        const newIsHidden = finishedWork.memoizedState;
+        if (current !== null && current.memoizedState !== newIsHidden) {
+          // The placeholder either just timed out or switched back to the
+          // normal children after having previously timed out. Toggle the
+          // visibility of the direct host children.
+          let child = finishedWork.child;
+          while (child !== null && child.type !== PlaceholderFallback) {
+            // Find the nearest host children and update their visibility. But
+            // skip over the fallback children.
+            hideOrUnhideAllChildren(child, newIsHidden);
+            child = child.sibling;
+          }
+        } else if (!isInStrictMode) {
           // In loose mode, a placeholder times out by scheduling a synchronous
           // update in the commit phase. Use `updateQueue` field to signal that
           // the Timeout needs to switch to the placeholder. We don't need an
@@ -332,11 +358,6 @@ function commitLifeCycles(
           // $FlowFixMe - Intentionally using a value other than an UpdateQueue.
           finishedWork.updateQueue = emptyObject;
           scheduleWork(finishedWork, Sync);
-        } else {
-          // In strict mode, the Update effect is used to record the time at
-          // which the placeholder timed out.
-          const currentTime = requestCurrentTime();
-          finishedWork.stateNode = {timedOutAt: currentTime};
         }
       }
       return;
@@ -347,6 +368,46 @@ function commitLifeCycles(
         'This unit of work tag should not have side-effects. This error is ' +
           'likely caused by a bug in React. Please file an issue.',
       );
+    }
+  }
+}
+
+function hideOrUnhideAllChildren(finishedWork, isHidden) {
+  if (supportsMutation) {
+    // We only have the top Fiber that was inserted but we need recurse down its
+    // children to find all the terminal nodes.
+    let node: Fiber = finishedWork;
+    while (true) {
+      if (node.tag === HostComponent) {
+        const instance = node.stateNode;
+        if (isHidden) {
+          hideInstance(instance);
+        } else {
+          unhideInstance(node.stateNode, node.memoizedProps);
+        }
+      } else if (node.tag === HostText) {
+        const instance = node.stateNode;
+        if (isHidden) {
+          hideTextInstance(instance);
+        } else {
+          unhideTextInstance(instance);
+        }
+      } else if (node.child !== null) {
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
+      if (node === finishedWork) {
+        return;
+      }
+      while (node.sibling === null) {
+        if (node.return === null || node.return === finishedWork) {
+          return;
+        }
+        node = node.return;
+      }
+      node.sibling.return = node.return;
+      node = node.sibling;
     }
   }
 }
@@ -512,6 +573,9 @@ function commitContainer(finishedWork: Fiber) {
         finishedWork.stateNode;
       const {containerInfo, pendingChildren} = portalOrRoot;
       replaceContainerChildren(containerInfo, pendingChildren);
+      return;
+    }
+    case PlaceholderComponent: {
       return;
     }
     default: {

--- a/packages/react-reconciler/src/ReactFiberPlaceholder.js
+++ b/packages/react-reconciler/src/ReactFiberPlaceholder.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactNodeList} from 'shared/ReactTypes';
+
+type Props = {|
+  children: ReactNodeList,
+|};
+
+export function PlaceholderFallback(props: Props): ReactNodeList {
+  return props.children;
+}

--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
@@ -23,7 +23,13 @@ describe('ReactExpiration', () => {
   });
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    const inst = {
+      type: 'span',
+      children: [],
+      prop,
+      hidden: false,
+    };
+    return inst;
   }
 
   it('increases priority of updates as time progresses', () => {

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -20,17 +20,19 @@ describe('ReactFragment', () => {
     ReactNoop = require('react-noop-renderer');
   });
 
-  function span(prop) {
-    return {type: 'span', children: [], prop};
-  }
-
-  function text(val) {
-    return {text: val};
-  }
-
   function div(...children) {
     children = children.map(c => (typeof c === 'string' ? {text: c} : c));
-    return {type: 'div', children, prop: undefined};
+    return {type: 'div', children, prop: undefined, hidden: false};
+  }
+
+  function span(prop) {
+    const inst = {
+      type: 'span',
+      children: [],
+      prop,
+      hidden: false,
+    };
+    return inst;
   }
 
   it('should render a single child via noop renderer', () => {
@@ -43,7 +45,7 @@ describe('ReactFragment', () => {
     ReactNoop.render(element);
     ReactNoop.flush();
 
-    expect(ReactNoop.getChildren()).toEqual([span()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<span>foo</span>);
   });
 
   it('should render zero children via noop renderer', () => {
@@ -65,7 +67,11 @@ describe('ReactFragment', () => {
     ReactNoop.render(element);
     ReactNoop.flush();
 
-    expect(ReactNoop.getChildren()).toEqual([text('hello '), span()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <React.Fragment>
+        hello <span>world</span>
+      </React.Fragment>,
+    );
   });
 
   it('should render an iterable via noop renderer', () => {
@@ -78,7 +84,12 @@ describe('ReactFragment', () => {
     ReactNoop.render(element);
     ReactNoop.flush();
 
-    expect(ReactNoop.getChildren()).toEqual([span(), span()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <React.Fragment>
+        <span>hi</span>
+        <span>bye</span>
+      </React.Fragment>,
+    );
   });
 
   it('should preserve state of children with 1 level nesting', function() {
@@ -112,13 +123,18 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div(), div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <React.Fragment>
+        <div>Hello</div>
+        <div>World</div>
+      </React.Fragment>,
+    );
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should preserve state between top-level fragments', function() {
@@ -153,13 +169,13 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should preserve state of children nested at same level', function() {
@@ -203,13 +219,18 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div(), div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <React.Fragment>
+        <div />
+        <div>Hello</div>
+      </React.Fragment>,
+    );
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should not preserve state in non-top-level fragment nesting', function() {
@@ -246,13 +267,13 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should not preserve state of children if nested 2 levels without siblings', function() {
@@ -287,13 +308,13 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should not preserve state of children if nested 2 levels with siblings', function() {
@@ -329,13 +350,18 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div(), div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <React.Fragment>
+        <div>Hello</div>
+        <div />
+      </React.Fragment>,
+    );
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should preserve state between array nested in fragment and fragment', function() {
@@ -368,13 +394,13 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should preserve state between top level fragment and array', function() {
@@ -407,13 +433,13 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should not preserve state between array nested in fragment and double nested fragment', function() {
@@ -448,13 +474,13 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should not preserve state between array nested in fragment and double nested array', function() {
@@ -485,13 +511,13 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should preserve state between double nested fragment and double nested array', function() {
@@ -526,13 +552,13 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should not preserve state of children when the keys are different', function() {
@@ -568,13 +594,18 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div(), span()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <React.Fragment>
+        <div>Hello</div>
+        <span>World</span>
+      </React.Fragment>,
+    );
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should not preserve state between unkeyed and keyed fragment', function() {
@@ -609,13 +640,13 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div>Hello</div>);
   });
 
   it('should preserve state with reordering in multiple levels', function() {
@@ -662,13 +693,29 @@ describe('ReactFragment', () => {
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div(span(), div(div()), span())]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <span>beep</span>
+        <div>
+          <div>Hello</div>
+        </div>
+        <span>bar</span>
+      </div>,
+    );
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([div(span(), div(div()), span())]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <span>foo</span>
+        <div>
+          <div>Hello</div>
+        </div>
+        <span>boop</span>
+      </div>,
+    );
   });
 
   it('should not preserve state when switching to a keyed fragment to an array', function() {
@@ -711,13 +758,23 @@ describe('ReactFragment', () => {
     );
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <div>Hello</div>
+        <span />
+      </div>,
+    );
 
     ReactNoop.render(<Foo condition={true} />);
     ReactNoop.flush();
 
     expect(ops).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <div>Hello</div>
+        <span />
+      </div>,
+    );
   });
 
   it('should preserve state when it does not change positions', function() {
@@ -760,7 +817,12 @@ describe('ReactFragment', () => {
     );
 
     expect(ops).toEqual(['Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([span(), div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <React.Fragment>
+        <span />
+        <div>Hello</div>
+      </React.Fragment>,
+    );
 
     ReactNoop.render(<Foo condition={true} />);
     expect(ReactNoop.flush).toWarnDev(
@@ -768,6 +830,11 @@ describe('ReactFragment', () => {
     );
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
-    expect(ReactNoop.getChildren()).toEqual([span(), div()]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <React.Fragment>
+        <span />
+        <div>Hello</div>
+      </React.Fragment>,
+    );
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -29,11 +29,17 @@ describe('ReactIncrementalErrorHandling', () => {
 
   function div(...children) {
     children = children.map(c => (typeof c === 'string' ? {text: c} : c));
-    return {type: 'div', children, prop: undefined};
+    return {type: 'div', children, prop: undefined, hidden: false};
   }
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    const inst = {
+      type: 'span',
+      children: [],
+      prop,
+      hidden: false,
+    };
+    return inst;
   }
 
   function normalizeCodeLocInfo(str) {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
@@ -24,7 +24,13 @@ describe('ReactIncrementalScheduling', () => {
   });
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    const inst = {
+      type: 'span',
+      children: [],
+      prop,
+      hidden: false,
+    };
+    return inst;
   }
 
   it('schedules and flushes deferred work', () => {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
@@ -24,16 +24,20 @@ describe('ReactIncrementalSideEffects', () => {
   });
 
   function div(...children) {
-    children = children.map(c => (typeof c === 'string' ? text(c) : c));
-    return {type: 'div', children, prop: undefined};
+    children = children.map(
+      c => (typeof c === 'string' ? {text: c, hidden: false} : c),
+    );
+    return {type: 'div', children, prop: undefined, hidden: false};
   }
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
-  }
-
-  function text(t) {
-    return {text: t};
+    const inst = {
+      type: 'span',
+      children: [],
+      prop,
+      hidden: false,
+    };
+    return inst;
   }
 
   it('can update child nodes of a host instance', () => {
@@ -52,11 +56,20 @@ describe('ReactIncrementalSideEffects', () => {
 
     ReactNoop.render(<Foo text="Hello" />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([div(span())]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <span>Hello</span>
+      </div>,
+    );
 
     ReactNoop.render(<Foo text="World" />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([div(span(), span())]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <span>World</span>
+        <span>World</span>
+      </div>,
+    );
   });
 
   it('can update child nodes of a fragment', function() {
@@ -80,19 +93,34 @@ describe('ReactIncrementalSideEffects', () => {
 
     ReactNoop.render(<Foo text="Hello" />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([div(span(), span('test'))]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <span>Hello</span>
+        <span prop="test" />
+      </div>,
+    );
 
     ReactNoop.render(<Foo text="World" />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([
-      div(span(), span(), div(), span('test')),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <span>World</span>
+        <span>World</span>
+        <div />
+        <span prop="test" />
+      </div>,
+    );
 
     ReactNoop.render(<Foo text="Hi" />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([
-      div(span(), div(), span(), span('test')),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <span>Hi</span>
+        <div />
+        <span>Hi</span>
+        <span prop="test" />
+      </div>,
+    );
   });
 
   it('can update child nodes rendering into text nodes', function() {
@@ -266,12 +294,14 @@ describe('ReactIncrementalSideEffects', () => {
       </div>,
     );
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-    expect(ReactNoop.getChildren('portalContainer')).toEqual([
-      div(),
-      span('Hello'),
-      text('World'),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div />);
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(
+      <React.Fragment>
+        <div />
+        <span prop="Hello" />
+        World
+      </React.Fragment>,
+    );
 
     ReactNoop.render(
       <div>
@@ -279,8 +309,8 @@ describe('ReactIncrementalSideEffects', () => {
       </div>,
     );
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-    expect(ReactNoop.getChildren('portalContainer')).toEqual([]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div />);
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(null);
 
     ReactNoop.render(
       <div>
@@ -288,12 +318,14 @@ describe('ReactIncrementalSideEffects', () => {
       </div>,
     );
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-    expect(ReactNoop.getChildren('portalContainer')).toEqual([
-      div(),
-      span('Hello'),
-      text('World'),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div />);
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(
+      <React.Fragment>
+        <div />
+        <span prop="Hello" />
+        World
+      </React.Fragment>,
+    );
 
     ReactNoop.render(null);
     ReactNoop.flush();
@@ -307,17 +339,19 @@ describe('ReactIncrementalSideEffects', () => {
 
     ReactNoop.render(<Foo show={true} />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([]);
-    expect(ReactNoop.getChildren('portalContainer')).toEqual([
-      div(),
-      span('Hello'),
-      text('World'),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(null);
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(
+      <React.Fragment>
+        <div />
+        <span prop="Hello" />
+        World
+      </React.Fragment>,
+    );
 
     ReactNoop.render(null);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([]);
-    expect(ReactNoop.getChildren('portalContainer')).toEqual([]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(null);
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(null);
   });
 
   it('can delete a child when it unmounts with a portal', () => {
@@ -342,31 +376,35 @@ describe('ReactIncrementalSideEffects', () => {
       </div>,
     );
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([div()]);
-    expect(ReactNoop.getChildren('portalContainer')).toEqual([
-      div(),
-      span('Hello'),
-      text('World'),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(<div />);
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(
+      <React.Fragment>
+        <div />
+        <span prop="Hello" />
+        World
+      </React.Fragment>,
+    );
 
     ReactNoop.render(null);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([]);
-    expect(ReactNoop.getChildren('portalContainer')).toEqual([]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(null);
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(null);
 
     ReactNoop.render(<Foo />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([]);
-    expect(ReactNoop.getChildren('portalContainer')).toEqual([
-      div(),
-      span('Hello'),
-      text('World'),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(null);
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(
+      <React.Fragment>
+        <div />
+        <span prop="Hello" />
+        World
+      </React.Fragment>,
+    );
 
     ReactNoop.render(null);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([]);
-    expect(ReactNoop.getChildren('portalContainer')).toEqual([]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(null);
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(null);
   });
 
   it('does not update child nodes if a flush is aborted', () => {
@@ -417,16 +455,34 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop.render(<Foo text="foo" />);
     ReactNoop.flush();
 
-    expect(ReactNoop.getChildren()).toEqual([div(div(span('foo')))]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <div hidden={true}>
+          <span prop="foo" />
+        </div>
+      </div>,
+    );
 
     ReactNoop.render(<Foo text="bar" />);
     ReactNoop.flushDeferredPri(20);
 
-    expect(ReactNoop.getChildren()).toEqual([div(div(span('foo')))]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <div hidden={true}>
+          <span prop="foo" />
+        </div>
+      </div>,
+    );
 
     ReactNoop.flush();
 
-    expect(ReactNoop.getChildren()).toEqual([div(div(span('bar')))]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <div hidden={true}>
+          <span prop="bar" />
+        </div>
+      </div>,
+    );
   });
 
   it('can reuse side-effects after being preempted', () => {
@@ -460,9 +516,14 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop.render(<Foo text="foo" step={0} />);
     ReactNoop.flush();
 
-    expect(ReactNoop.getChildren()).toEqual([
-      div(div(span('Hi'), span('foo'))),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div hidden={true}>
+        <div>
+          <span prop="Hi" />
+          <span prop="foo" />
+        </div>
+      </div>,
+    );
 
     // Make a quick update which will schedule low priority work to
     // update the middle content.
@@ -470,9 +531,14 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop.flushDeferredPri(30);
 
     // The tree remains unchanged.
-    expect(ReactNoop.getChildren()).toEqual([
-      div(div(span('Hi'), span('foo'))),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div hidden={true}>
+        <div>
+          <span prop="Hi" />
+          <span prop="foo" />
+        </div>
+      </div>,
+    );
 
     // The first Bar has already completed its update but we'll interrupt it to
     // render some higher priority work. The middle content will bailout so
@@ -484,9 +550,14 @@ describe('ReactIncrementalSideEffects', () => {
     // we should be able to reuse the reconciliation work that we already did
     // without restarting. The side-effects should still be replayed.
 
-    expect(ReactNoop.getChildren()).toEqual([
-      div(div(span('Hello'), span('World'))),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div hidden={true}>
+        <div>
+          <span prop="Hello" />
+          <span prop="World" />
+        </div>
+      </div>,
+    );
   });
 
   it('can reuse side-effects after being preempted, if shouldComponentUpdate is false', () => {
@@ -525,9 +596,14 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop.render(<Foo text="foo" step={0} />);
     ReactNoop.flush();
 
-    expect(ReactNoop.getChildren()).toEqual([
-      div(div(span('Hi'), span('foo'))),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div hidden={true}>
+        <div>
+          <span prop="Hi" />
+          <span prop="foo" />
+        </div>
+      </div>,
+    );
 
     // Make a quick update which will schedule low priority work to
     // update the middle content.
@@ -535,9 +611,14 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop.flushDeferredPri(35);
 
     // The tree remains unchanged.
-    expect(ReactNoop.getChildren()).toEqual([
-      div(div(span('Hi'), span('foo'))),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div hidden={true}>
+        <div>
+          <span prop="Hi" />
+          <span prop="foo" />
+        </div>
+      </div>,
+    );
 
     // The first Bar has already completed its update but we'll interrupt it to
     // render some higher priority work. The middle content will bailout so
@@ -549,9 +630,14 @@ describe('ReactIncrementalSideEffects', () => {
     // we should be able to reuse the reconciliation work that we already did
     // without restarting. The side-effects should still be replayed.
 
-    expect(ReactNoop.getChildren()).toEqual([
-      div(div(span('Hello'), span('World'))),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div hidden={true}>
+        <div>
+          <span prop="Hello" />
+          <span prop="World" />
+        </div>
+      </div>,
+    );
   });
 
   it('can update a completed tree before it has a chance to commit', () => {
@@ -597,7 +683,11 @@ describe('ReactIncrementalSideEffects', () => {
 
     ReactNoop.render(<Foo />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([div(span(1))]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div hidden={true}>
+        <span prop={1} />
+      </div>,
+    );
   });
 
   xit('can defer side-effects and resume them later on', () => {
@@ -855,9 +945,16 @@ describe('ReactIncrementalSideEffects', () => {
     }
     ReactNoop.render(<Foo tick={0} idx={0} />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([
-      div(span(0), div(span(0), span(0), span(0))),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <span prop={0} />
+        <div hidden={true}>
+          <span prop={0} />
+          <span prop={0} />
+          <span prop={0} />
+        </div>
+      </div>,
+    );
 
     expect(ops).toEqual(['Foo', 'Bar', 'Bar', 'Bar']);
 
@@ -865,18 +962,18 @@ describe('ReactIncrementalSideEffects', () => {
 
     ReactNoop.render(<Foo tick={1} idx={1} />);
     ReactNoop.flushDeferredPri(70 + 5);
-    expect(ReactNoop.getChildren()).toEqual([
-      div(
-        // Updated.
-        span(1),
-        div(
-          // Still not updated.
-          span(0),
-          span(0),
-          span(0),
-        ),
-      ),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        {/* Updated. */}
+        <span prop={1} />
+        <div hidden={true}>
+          {/* Still not updated. */}
+          <span prop={0} />
+          <span prop={0} />
+          <span prop={0} />
+        </div>
+      </div>,
+    );
 
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
     ops = [];
@@ -888,18 +985,18 @@ describe('ReactIncrementalSideEffects', () => {
     // TODO: The cycles it takes to do this could be lowered with further
     // optimizations.
     ReactNoop.flushDeferredPri(35);
-    expect(ReactNoop.getChildren()).toEqual([
-      div(
-        // Updated.
-        span(1),
-        div(
-          // Still not updated.
-          span(0),
-          span(0),
-          span(0),
-        ),
-      ),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        {/* Updated. */}
+        <span prop={1} />
+        <div hidden={true}>
+          {/* Still not updated. */}
+          <span prop={0} />
+          <span prop={0} />
+          <span prop={0} />
+        </div>
+      </div>,
+    );
 
     expect(ops).toEqual(['Bar']);
     ops = [];
@@ -907,17 +1004,17 @@ describe('ReactIncrementalSideEffects', () => {
     // However, once we render fully, we will have enough time to finish it all
     // at once.
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([
-      div(
-        span(1),
-        div(
-          // Now we had enough time to finish the spans.
-          span('X'),
-          span(1),
-          span(1),
-        ),
-      ),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <span prop={1} />
+        <div hidden={true}>
+          {/* Now we've had enough time to finish the spans. */}
+          <span prop="X" />
+          <span prop={1} />
+          <span prop={1} />
+        </div>
+      </div>,
+    );
 
     expect(ops).toEqual(['Bar', 'Bar', 'Bar']);
   });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -23,8 +23,19 @@ describe('ReactIncrementalUpdates', () => {
     ReactNoop = require('react-noop-renderer');
   });
 
+  function div(...children) {
+    children = children.map(c => (typeof c === 'string' ? {text: c} : c));
+    return {type: 'div', children, prop: undefined, hidden: false};
+  }
+
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    const inst = {
+      type: 'span',
+      children: [],
+      prop,
+      hidden: false,
+    };
+    return inst;
   }
 
   it('applies updates in order of priority', () => {

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -25,18 +25,19 @@ describe('ReactNewContext', () => {
     gen = require('random-seed');
   });
 
-  // function div(...children) {
-  //   children = children.map(c => (typeof c === 'string' ? {text: c} : c));
-  //   return {type: 'div', children, prop: undefined};
-  // }
+  function span(prop) {
+    const inst = {
+      type: 'span',
+      children: [],
+      prop,
+      hidden: false,
+    };
+    return inst;
+  }
 
   function Text(props) {
     ReactNoop.yield(props.text);
     return <span prop={props.text} />;
-  }
-
-  function span(prop) {
-    return {type: 'span', children: [], prop};
   }
 
   // We have several ways of reading from context. sharedContextTests runs

--- a/packages/react-reconciler/src/__tests__/ReactPersistent-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPersistent-test.js
@@ -37,12 +37,20 @@ describe('ReactPersistent', () => {
   }
 
   function div(...children) {
-    children = children.map(c => (typeof c === 'string' ? {text: c} : c));
-    return {type: 'div', children, prop: undefined};
+    children = children.map(
+      c => (typeof c === 'string' ? {text: c, hidden: false} : c),
+    );
+    return {type: 'div', children, prop: undefined, hidden: false};
   }
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    const inst = {
+      type: 'span',
+      children: [],
+      prop,
+      hidden: false,
+    };
+    return inst;
   }
 
   function getChildren() {
@@ -65,15 +73,28 @@ describe('ReactPersistent', () => {
 
     render(<Foo text="Hello" />);
     ReactNoopPersistent.flush();
-    const originalChildren = getChildren();
-    expect(originalChildren).toEqual([div(span())]);
+    const originalChildren = ReactNoopPersistent.getChildrenAsJSX();
+    expect(originalChildren).toEqual(
+      <div>
+        <span>Hello</span>
+      </div>,
+    );
 
     render(<Foo text="World" />);
     ReactNoopPersistent.flush();
-    const newChildren = getChildren();
-    expect(newChildren).toEqual([div(span(), span())]);
+    const newChildren = ReactNoopPersistent.getChildrenAsJSX();
+    expect(newChildren).toEqual(
+      <div>
+        <span>World</span>
+        <span>World</span>
+      </div>,
+    );
 
-    expect(originalChildren).toEqual([div(span())]);
+    expect(originalChildren).toEqual(
+      <div>
+        <span>Hello</span>
+      </div>,
+    );
   });
 
   it('can reuse child nodes between updates', () => {

--- a/packages/react-reconciler/src/__tests__/ReactPlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactPlaceholder-test.internal.js
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+
+runPlaceholderTests('ReactPlaceholder (mutation)', () =>
+  require('react-noop-renderer'),
+);
+runPlaceholderTests('ReactPlaceholder (persistence)', () =>
+  require('react-noop-renderer/persistent'),
+);
+
+function runPlaceholderTests(suiteLabel, loadReactNoop) {
+  let React;
+  let ReactNoop;
+  let ReactFeatureFlags;
+  let Fragment;
+  let SimpleCacheProvider;
+  let Placeholder;
+
+  let cache;
+  let TextResource;
+  let textResourceShouldFail;
+
+  describe(suiteLabel, () => {
+    beforeEach(() => {
+      jest.resetModules();
+      ReactFeatureFlags = require('shared/ReactFeatureFlags');
+      ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+      ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
+      ReactFeatureFlags.enableSuspense = true;
+      React = require('react');
+      Fragment = React.Fragment;
+      ReactNoop = loadReactNoop();
+      SimpleCacheProvider = require('simple-cache-provider');
+      Placeholder = React.Placeholder;
+
+      function invalidateCache() {
+        cache = SimpleCacheProvider.createCache(invalidateCache);
+      }
+      invalidateCache();
+      TextResource = SimpleCacheProvider.createResource(([text, ms = 0]) => {
+        return new Promise((resolve, reject) =>
+          setTimeout(() => {
+            if (textResourceShouldFail) {
+              ReactNoop.yield(`Promise rejected [${text}]`);
+              reject(new Error('Failed to load: ' + text));
+            } else {
+              ReactNoop.yield(`Promise resolved [${text}]`);
+              resolve(text);
+            }
+          }, ms),
+        );
+      }, ([text, ms]) => text);
+      textResourceShouldFail = false;
+    });
+
+    function advanceTimers(ms) {
+      // Note: This advances Jest's virtual time but not React's. Use
+      // ReactNoop.expire for that.
+      if (typeof ms !== 'number') {
+        throw new Error('Must specify ms');
+      }
+      jest.advanceTimersByTime(ms);
+      // Wait until the end of the current tick
+      return new Promise(resolve => {
+        setImmediate(resolve);
+      });
+    }
+
+    function Text(props) {
+      ReactNoop.yield(props.text);
+      return props.text;
+    }
+
+    function AsyncText(props) {
+      const text = props.text;
+      try {
+        TextResource.read(cache, [props.text, props.ms]);
+        ReactNoop.yield(text);
+        return text;
+      } catch (promise) {
+        if (typeof promise.then === 'function') {
+          ReactNoop.yield(`Suspend! [${text}]`);
+        } else {
+          ReactNoop.yield(`Error! [${text}]`);
+        }
+        throw promise;
+      }
+    }
+
+    it('times out children that are already hidden', async () => {
+      class HiddenText extends React.PureComponent {
+        render() {
+          const text = this.props.text;
+          ReactNoop.yield(text);
+          return <span hidden={true}>{text}</span>;
+        }
+      }
+
+      function App(props) {
+        return (
+          <Placeholder delayMs={500} fallback={<Text text="Loading..." />}>
+            <HiddenText text="A" />
+            <span>
+              <AsyncText ms={1000} text={props.middleText} />
+            </span>
+            <span>
+              <Text text="C" />
+            </span>
+          </Placeholder>
+        );
+      }
+
+      // Initial mount
+      ReactNoop.render(<App middleText="B" />);
+      expect(ReactNoop.flush()).toEqual([
+        'A',
+        'Suspend! [B]',
+        'C',
+        'Loading...',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([]);
+      await advanceTimers(1000);
+      ReactNoop.expire(1000);
+      expect(ReactNoop.flush()).toEqual(['A', 'B', 'C']);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <Fragment>
+          <span hidden={true}>A</span>
+          <span>B</span>
+          <span>C</span>
+        </Fragment>,
+      );
+
+      // Update
+      ReactNoop.render(<App middleText="B2" />);
+      expect(ReactNoop.flush()).toEqual(['Suspend! [B2]', 'C', 'Loading...']);
+      // Time out the update
+      await advanceTimers(750);
+      ReactNoop.expire(750);
+      expect(ReactNoop.flush()).toEqual([]);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <Fragment>
+          <span hidden={true}>A</span>
+          <span hidden={true}>B</span>
+          <span hidden={true}>C</span>
+          Loading...
+        </Fragment>,
+      );
+
+      // Resolve the promise
+      await advanceTimers(1000);
+      ReactNoop.expire(1000);
+      expect(ReactNoop.flush()).toEqual(['B2', 'C']);
+
+      // Render the final update. A should still be hidden, because it was
+      // given a `hidden` prop.
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <Fragment>
+          <span hidden={true}>A</span>
+          <span>B2</span>
+          <span>C</span>
+        </Fragment>,
+      );
+    });
+
+    it('times out text nodes', async () => {
+      function App(props) {
+        return (
+          <Placeholder delayMs={500} fallback={<Text text="Loading..." />}>
+            <Text text="A" />
+            <AsyncText ms={1000} text={props.middleText} />
+            <Text text="C" />
+          </Placeholder>
+        );
+      }
+
+      // Initial mount
+      ReactNoop.render(<App middleText="B" />);
+      expect(ReactNoop.flush()).toEqual([
+        'A',
+        'Suspend! [B]',
+        'C',
+        'Loading...',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([]);
+      await advanceTimers(1000);
+      ReactNoop.expire(1000);
+      expect(ReactNoop.flush()).toEqual(['A', 'B', 'C']);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual('ABC');
+
+      // Update
+      ReactNoop.render(<App middleText="B2" />);
+      expect(ReactNoop.flush()).toEqual([
+        'A',
+        'Suspend! [B2]',
+        'C',
+        'Loading...',
+      ]);
+      // Time out the update
+      await advanceTimers(750);
+      ReactNoop.expire(750);
+      expect(ReactNoop.flush()).toEqual([]);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual('Loading...');
+
+      // Resolve the promise
+      await advanceTimers(1000);
+      ReactNoop.expire(1000);
+      expect(ReactNoop.flush()).toEqual(['A', 'B2', 'C']);
+
+      // Render the final update. A should still be hidden, because it was
+      // given a `hidden` prop.
+      expect(ReactNoop.getChildrenAsJSX()).toEqual('AB2C');
+    });
+  });
+}

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+
 let React;
 let ReactFeatureFlags;
 let Fragment;
@@ -48,11 +58,17 @@ describe('ReactSuspense', () => {
 
   function div(...children) {
     children = children.map(c => (typeof c === 'string' ? {text: c} : c));
-    return {type: 'div', children, prop: undefined};
+    return {type: 'div', children, prop: undefined, hidden: false};
   }
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    const inst = {
+      type: 'span',
+      children: [],
+      prop,
+      hidden: false,
+    };
+    return inst;
   }
 
   function advanceTimers(ms) {
@@ -771,13 +787,22 @@ describe('ReactSuspense', () => {
     ReactNoop.expire(2000);
     await advanceTimers(2000);
     expect(ReactNoop.flush()).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div(), span('Loading...')]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <Fragment>
+        <div hidden={true} />
+        <span prop="Loading..." />
+      </Fragment>,
+    );
 
     ReactNoop.expire(1000);
     await advanceTimers(1000);
 
     expect(ReactNoop.flush()).toEqual(['Promise resolved [Async]', 'Async']);
-    expect(ReactNoop.getChildren()).toEqual([div(span('Async'))]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <span prop="Async" />
+      </div>,
+    );
   });
 
   describe('a Delay component', () => {

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -943,22 +943,26 @@ describe('ReactSuspense', () => {
         'Loading (2)',
         'Loading (3)',
       ]);
-      expect(ReactNoop.getChildren()).toEqual([
-        span('Sibling'),
-        span('Loading (1)'),
-        span('Loading (2)'),
-        span('Loading (3)'),
-      ]);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <Fragment>
+          <span hidden={true} prop="Sibling" />
+          <span prop="Loading (1)" />
+          <span prop="Loading (2)" />
+          <span prop="Loading (3)" />
+        </Fragment>,
+      );
 
       await advanceTimers(100);
       expect(ReactNoop.flush()).toEqual([
         'Promise resolved [Step: 2]',
         'Step: 2',
       ]);
-      expect(ReactNoop.getChildren()).toEqual([
-        span('Step: 2'),
-        span('Sibling'),
-      ]);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <Fragment>
+          <span prop="Step: 2" />
+          <span prop="Sibling" />
+        </Fragment>,
+      );
     });
 
     it(
@@ -1080,15 +1084,16 @@ describe('ReactSuspense', () => {
           'Update 2 did commit',
         ]);
 
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Before'),
-          span('Async: 2'),
-          span('After'),
-
-          span('Before'),
-          span('Sync: 2'),
-          span('After'),
-        ]);
+        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+          <Fragment>
+            <span prop="Before" />
+            <span prop="Async: 2" />
+            <span prop="After" />
+            <span prop="Before" />
+            <span prop="Sync: 2" />
+            <span prop="After" />
+          </Fragment>,
+        );
       },
     );
 
@@ -1192,15 +1197,16 @@ describe('ReactSuspense', () => {
           // Switch to the placeholder in a subsequent commit
           'Loading...',
         ]);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Before'),
-          span('After'),
-          span('Loading...'),
-
-          span('Before'),
-          span('Sync: 2'),
-          span('After'),
-        ]);
+        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+          <Fragment>
+            <span hidden={true} prop="Before" />
+            <span hidden={true} prop="After" />
+            <span prop="Loading..." />
+            <span prop="Before" />
+            <span prop="Sync: 2" />
+            <span prop="After" />
+          </Fragment>,
+        );
 
         // The promise pings asynchronsouly
         await advanceTimers(100);
@@ -1209,15 +1215,16 @@ describe('ReactSuspense', () => {
         ]);
         expect(ReactNoop.flush()).toEqual(['Async: 2']);
 
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Before'),
-          span('Async: 2'),
-          span('After'),
-
-          span('Before'),
-          span('Sync: 2'),
-          span('After'),
-        ]);
+        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+          <Fragment>
+            <span prop="Before" />
+            <span prop="Async: 2" />
+            <span prop="After" />
+            <span prop="Before" />
+            <span prop="Sync: 2" />
+            <span prop="After" />
+          </Fragment>,
+        );
       },
     );
 
@@ -1277,20 +1284,24 @@ describe('ReactSuspense', () => {
         // This should be a mount, not an update.
         'Mount [Loading...]',
       ]);
-      expect(ReactNoop.getChildren()).toEqual([
-        span('A'),
-        span('C'),
-        span('Loading...'),
-      ]);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <Fragment>
+          <span hidden={true} prop="A" />
+          <span hidden={true} prop="C" />
+          <span prop="Loading..." />
+        </Fragment>,
+      );
 
       await advanceTimers(1000);
       expect(ReactNoop.expire(1000)).toEqual(['Promise resolved [B]', 'B']);
 
-      expect(ReactNoop.getChildren()).toEqual([
-        span('A'),
-        span('B'),
-        span('C'),
-      ]);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <Fragment>
+          <span prop="A" />
+          <span prop="B" />
+          <span prop="C" />
+        </Fragment>,
+      );
     });
 
     it('suspends inside constructor', async () => {
@@ -1433,11 +1444,13 @@ describe('ReactSuspense', () => {
         // placeholder. This should be a mount, not an update.
         'Mount [Loading...]',
       ]);
-      expect(ReactNoop.getChildren()).toEqual([
-        span('A'),
-        span('C'),
-        span('Loading...'),
-      ]);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <Fragment>
+          <span prop="A" hidden={true} />
+          <span prop="C" hidden={true} />
+          <span prop="Loading..." />
+        </Fragment>,
+      );
     });
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactTopLevelText-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTopLevelText-test.js
@@ -26,13 +26,13 @@ describe('ReactTopLevelText', () => {
     const Text = ({value}) => value;
     ReactNoop.render(<Text value="foo" />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([{text: 'foo'}]);
+    expect(ReactNoop.getChildren()).toEqual([{text: 'foo', hidden: false}]);
   });
 
   it('should render a component returning numbers directly from render', () => {
     const Text = ({value}) => value;
     ReactNoop.render(<Text value={10} />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([{text: '10'}]);
+    expect(ReactNoop.getChildren()).toEqual([{text: '10', hidden: false}]);
   });
 });

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -75,6 +75,10 @@ export const insertInContainerBefore = $$$hostConfig.insertInContainerBefore;
 export const removeChild = $$$hostConfig.removeChild;
 export const removeChildFromContainer = $$$hostConfig.removeChildFromContainer;
 export const resetTextContent = $$$hostConfig.resetTextContent;
+export const hideInstance = $$$hostConfig.hideInstance;
+export const hideTextInstance = $$$hostConfig.hideTextInstance;
+export const unhideInstance = $$$hostConfig.unhideInstance;
+export const unhideTextInstance = $$$hostConfig.unhideTextInstance;
 
 // -------------------
 //     Persistence
@@ -87,6 +91,9 @@ export const appendChildToContainerChildSet =
 export const finalizeContainerChildren =
   $$$hostConfig.finalizeContainerChildren;
 export const replaceContainerChildren = $$$hostConfig.replaceContainerChildren;
+export const cloneHiddenInstance = $$$hostConfig.cloneHiddenInstance;
+export const cloneUnhiddenInstance = $$$hostConfig.cloneUnhiddenInstance;
+export const createHiddenTextInstance = $$$hostConfig.createHiddenTextInstance;
 
 // -------------------
 //     Hydration

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -235,3 +235,19 @@ export function resetTextContent(testElement: Instance): void {
 export const appendChildToContainer = appendChild;
 export const insertInContainerBefore = insertBefore;
 export const removeChildFromContainer = removeChild;
+
+export function hideInstance(instance: Instance): void {
+  throw new Error('TODO');
+}
+
+export function hideTextInstance(textInstance: TextInstance): void {
+  throw new Error('TODO');
+}
+
+export function unhideInstance(instance: Instance, props: Props): void {
+  throw new Error('TODO');
+}
+
+export function unhideTextInstance(textInstance: TextInstance): void {
+  throw new Error('TODO');
+}

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -19,12 +19,14 @@ export type Container = {|
 export type Instance = {|
   type: string,
   props: Object,
+  isHidden: boolean,
   children: Array<Instance | TextInstance>,
   rootContainerInstance: Container,
   tag: 'INSTANCE',
 |};
 export type TextInstance = {|
   text: string,
+  isHidden: boolean,
   tag: 'TEXT',
 |};
 export type HydratableInstance = Instance | TextInstance;
@@ -122,6 +124,7 @@ export function createInstance(
   return {
     type,
     props,
+    isHidden: false,
     children: [],
     rootContainerInstance,
     tag: 'INSTANCE',
@@ -176,6 +179,7 @@ export function createTextInstance(
 ): TextInstance {
   return {
     text,
+    isHidden: false,
     tag: 'TEXT',
   };
 }
@@ -237,20 +241,20 @@ export const insertInContainerBefore = insertBefore;
 export const removeChildFromContainer = removeChild;
 
 export function hideInstance(instance: Instance): void {
-  throw new Error('TODO');
+  instance.isHidden = true;
 }
 
 export function hideTextInstance(textInstance: TextInstance): void {
-  throw new Error('TODO');
+  textInstance.isHidden = true;
 }
 
 export function unhideInstance(instance: Instance, props: Props): void {
-  throw new Error('TODO');
+  instance.isHidden = false;
 }
 
 export function unhideTextInstance(
   textInstance: TextInstance,
   text: string,
 ): void {
-  throw new Error('TODO');
+  textInstance.isHidden = false;
 }

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -248,6 +248,9 @@ export function unhideInstance(instance: Instance, props: Props): void {
   throw new Error('TODO');
 }
 
-export function unhideTextInstance(textInstance: TextInstance): void {
+export function unhideTextInstance(
+  textInstance: TextInstance,
+  text: string,
+): void {
   throw new Error('TODO');
 }

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -102,11 +102,17 @@ describe('forwardRef', () => {
       <RefForwardingComponent ref={ref} optional="foo" required="bar" />,
     );
     ReactNoop.flush();
-    expect(ref.current.children).toEqual([{text: 'foo'}, {text: 'bar'}]);
+    expect(ref.current.children).toEqual([
+      {text: 'foo', hidden: false},
+      {text: 'bar', hidden: false},
+    ]);
 
     ReactNoop.render(<RefForwardingComponent ref={ref} required="foo" />);
     ReactNoop.flush();
-    expect(ref.current.children).toEqual([{text: 'default'}, {text: 'foo'}]);
+    expect(ref.current.children).toEqual([
+      {text: 'default', hidden: false},
+      {text: 'foo', hidden: false},
+    ]);
 
     expect(() =>
       ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />),

--- a/packages/shared/HostConfigWithNoMutation.js
+++ b/packages/shared/HostConfigWithNoMutation.js
@@ -33,3 +33,7 @@ export const insertInContainerBefore = shim;
 export const removeChild = shim;
 export const removeChildFromContainer = shim;
 export const resetTextContent = shim;
+export const hideInstance = shim;
+export const hideTextInstance = shim;
+export const unhideInstance = shim;
+export const unhideTextInstance = shim;

--- a/packages/shared/HostConfigWithNoPersistence.js
+++ b/packages/shared/HostConfigWithNoPersistence.js
@@ -28,3 +28,6 @@ export const createContainerChildSet = shim;
 export const appendChildToContainerChildSet = shim;
 export const finalizeContainerChildren = shim;
 export const replaceContainerChildren = shim;
+export const cloneHiddenInstance = shim;
+export const cloneUnhiddenInstance = shim;
+export const createHiddenTextInstance = shim;


### PR DESCRIPTION
When a placeholder times out, instead of unmounting the current tree, hide it and render the fallback view as a sibling. When the data resolves and the tree resumes rendering, the children are made visible again. Because they remain mounted throughout, the state is preserved.

Adds additional host config methods. For mutation mode:

- hideInstance
- hideTextInstance
- unhideInstance
- unhideTextInstance

For persistent mode:

- cloneHiddenInstance
- cloneUnhiddenInstance
- createHiddenTextInstance

### TODO

- [x] Need more comments.
- [ ] Implement new host config methods for each renderer:
  - [x] Noop
  - [x] DOM
  - [x] ART
  - [ ] Native
  - [ ] Fabric
  - [x] Test
    - Idk how this should be exposed publicly yet so all I did was add an `isHidden` property to the instance types.