### PR TITLE
Reset profiler timer correctly after errors

### DIFF
--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -627,6 +627,28 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         failInCompletePhase = false;
       }
     },
+
+    unstable_flushWithoutCommitting(
+      expectedFlush: Array<mixed>,
+      rootID: string = DEFAULT_ROOT_ID,
+    ) {
+      const batch = {
+        _expirationTime: 1,
+        _defer: true,
+      };
+      const root = roots.get(rootID);
+      root.firstBatch = batch;
+      batch._onComplete = () => {
+        root.firstBatch = null;
+      };
+      const actual = ReactNoop.flush(rootID);
+      expect(actual).toEqual(expectedFlush);
+      return expectedCommit => {
+        batch._defer = false;
+        NoopRenderer.flushRoot(root, 1);
+        expect(yieldedValues).toEqual(expectedCommit);
+      };
+    },
   };
 
   return ReactNoop;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -632,18 +632,19 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       expectedFlush: Array<mixed>,
       rootID: string = DEFAULT_ROOT_ID,
     ) {
+      const root: any = roots.get(rootID);
       const batch = {
-        _expirationTime: 1,
         _defer: true,
+        _expirationTime: 1,
+        _onComplete: () => {
+          root.firstBatch = null;
+        },
+        _next: null,
       };
-      const root = roots.get(rootID);
       root.firstBatch = batch;
-      batch._onComplete = () => {
-        root.firstBatch = null;
-      };
-      const actual = ReactNoop.flush(rootID);
+      const actual = ReactNoop.flush();
       expect(actual).toEqual(expectedFlush);
-      return expectedCommit => {
+      return (expectedCommit: Array<mixed>) => {
         batch._defer = false;
         NoopRenderer.flushRoot(root, 1);
         expect(yieldedValues).toEqual(expectedCommit);
@@ -652,7 +653,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
     getRoot(rootID: string = DEFAULT_ROOT_ID) {
       return roots.get(rootID);
-    }
+    },
   };
 
   return ReactNoop;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -43,6 +43,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
   let instanceCounter = 0;
   let failInBeginPhase = false;
+  let failInCompletePhase = false;
 
   function appendChild(
     parentInstance: Instance | Container,
@@ -101,6 +102,9 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     },
 
     createInstance(type: string, props: Props): Instance {
+      if (failInCompletePhase) {
+        throw new Error('Error in host config.');
+      }
       const inst = {
         id: instanceCounter++,
         type: type,
@@ -606,12 +610,21 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       console.log(...bufferedLog);
     },
 
-    simulateErrorInHostConfig(fn: () => void) {
+    simulateErrorInHostConfigDuringBeginPhase(fn: () => void) {
       failInBeginPhase = true;
       try {
         fn();
       } finally {
         failInBeginPhase = false;
+      }
+    },
+
+    simulateErrorInHostConfigDuringCompletePhase(fn: () => void) {
+      failInCompletePhase = true;
+      try {
+        fn();
+      } finally {
+        failInCompletePhase = false;
       }
     },
   };

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -628,7 +628,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       }
     },
 
-    unstable_flushWithoutCommitting(
+    flushWithoutCommitting(
       expectedFlush: Array<mixed>,
       rootID: string = DEFAULT_ROOT_ID,
     ) {
@@ -649,6 +649,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         expect(yieldedValues).toEqual(expectedCommit);
       };
     },
+
+    getRoot(rootID: string = DEFAULT_ROOT_ID) {
+      return roots.get(rootID);
+    }
   };
 
   return ReactNoop;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -314,19 +314,13 @@ function completeWork(
 ): Fiber | null {
   const newProps = workInProgress.pendingProps;
 
-  if (enableProfilerTimer) {
-    if (workInProgress.mode & ProfileMode) {
-      recordElapsedActualRenderTime(workInProgress);
-    }
-  }
-
   switch (workInProgress.tag) {
     case FunctionalComponent:
-      return null;
+      break;
     case ClassComponent: {
       // We are leaving this subtree, so pop context if any.
       popLegacyContextProvider(workInProgress);
-      return null;
+      break;
     }
     case HostRoot: {
       popHostContainer(workInProgress);
@@ -345,7 +339,7 @@ function completeWork(
         workInProgress.effectTag &= ~Placement;
       }
       updateHostContainer(workInProgress);
-      return null;
+      break;
     }
     case HostComponent: {
       popHostContext(workInProgress);
@@ -395,7 +389,7 @@ function completeWork(
               'caused by a bug in React. Please file an issue.',
           );
           // This can happen when we abort work.
-          return null;
+          break;
         }
 
         const currentHostContext = getHostContext();
@@ -451,7 +445,7 @@ function completeWork(
           markRef(workInProgress);
         }
       }
-      return null;
+      break;
     }
     case HostText: {
       let newText = newProps;
@@ -468,7 +462,6 @@ function completeWork(
               'caused by a bug in React. Please file an issue.',
           );
           // This can happen when we abort work.
-          return null;
         }
         const rootContainerInstance = getRootHostContainer();
         const currentHostContext = getHostContext();
@@ -486,28 +479,28 @@ function completeWork(
           );
         }
       }
-      return null;
+      break;
     }
     case ForwardRef:
-      return null;
+      break;
     case PlaceholderComponent:
-      return null;
+      break;
     case Fragment:
-      return null;
+      break;
     case Mode:
-      return null;
+      break;
     case Profiler:
-      return null;
+      break;
     case HostPortal:
       popHostContainer(workInProgress);
       updateHostContainer(workInProgress);
-      return null;
+      break;
     case ContextProvider:
       // Pop provider fiber
       popProvider(workInProgress);
-      return null;
+      break;
     case ContextConsumer:
-      return null;
+      break;
     // Error cases
     case IndeterminateComponent:
       invariant(
@@ -524,6 +517,18 @@ function completeWork(
           'React. Please file an issue.',
       );
   }
+
+  if (enableProfilerTimer) {
+    if (workInProgress.mode & ProfileMode) {
+      // Don't record elapsed time unless the "complete" phase has succeeded.
+      // Certain renderers may error during this phase (i.e. ReactNative View/Text nesting validation).
+      // If an error occurs, we'll mark the time while unwinding.
+      // This simplifies the unwinding logic and ensures consistency.
+      recordElapsedActualRenderTime(workInProgress);
+    }
+  }
+
+  return null;
 }
 
 export {completeWork};

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -863,7 +863,6 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
       // This fiber did not complete because something threw. Pop values off
       // the stack without entering the complete phase. If this is a boundary,
       // capture values if possible.
-
       const next = unwindWork(workInProgress, nextRenderExpirationTime);
       // Because this fiber did not complete, don't reset its expiration time.
       if (workInProgress.effectTag & DidCapture) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -119,6 +119,7 @@ import {
   recordElapsedActualRenderTime,
   recordElapsedBaseRenderTimeIfRunning,
   resetActualRenderTimer,
+  resetActualRenderTimerStackAfterFatalErrorInDev,
   resumeActualRenderTimerIfPaused,
   startBaseRenderTimer,
   stopBaseRenderTimerIfRunning,
@@ -1100,6 +1101,7 @@ function renderRoot(
     // There was a fatal error.
     if (__DEV__) {
       resetStackAfterFatalErrorInDev();
+      resetActualRenderTimerStackAfterFatalErrorInDev();
     }
     // `nextRoot` points to the in-progress root. A non-null value indicates
     // that we're in the middle of an async render. Set it to null to indicate

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -675,6 +675,9 @@ function commitRoot(root: FiberRoot, finishedWork: Fiber): void {
 
   if (enableProfilerTimer) {
     if (__DEV__) {
+      // TODO Rather than checking that the stack is empty,
+      // Maybe change this check to assert that it matches an expected length,
+      // Which we explicitly mark at the start of a chunk of work.
       checkActualRenderTimeStackEmpty();
     }
     resetActualRenderTimer();

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -253,7 +253,6 @@ let replayUnitOfWork;
 let isReplayingFailedUnitOfWork;
 let originalReplayError;
 let rethrowOriginalError;
-let recordElapsedActualRenderTimeWhileUnwinding;
 if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
   stashedWorkInProgressProperties = null;
   isReplayingFailedUnitOfWork = false;
@@ -777,18 +776,12 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
     const siblingFiber = workInProgress.sibling;
 
     if ((workInProgress.effectTag & Incomplete) === NoEffect) {
-      if (enableProfilerTimer) {
-        recordElapsedActualRenderTimeWhileUnwinding = false;
-      }
       // This fiber completed.
       let next = completeWork(
         current,
         workInProgress,
         nextRenderExpirationTime,
       );
-      if (enableProfilerTimer) {
-        recordElapsedActualRenderTimeWhileUnwinding = true;
-      }
       stopWorkTimer(workInProgress);
       resetExpirationTime(workInProgress, nextRenderExpirationTime);
       if (__DEV__) {
@@ -861,18 +854,6 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
       // This fiber did not complete because something threw. Pop values off
       // the stack without entering the complete phase. If this is a boundary,
       // capture values if possible.
-
-      if (enableProfilerTimer) {
-        // In case an error was thrown while completing work,
-        // We should record elapsed time while unwinding.
-        // Doing this would result in us recording time twice.
-        if (recordElapsedActualRenderTimeWhileUnwinding) {
-          if (workInProgress.mode & ProfileMode) {
-            recordElapsedActualRenderTime(workInProgress);
-          }
-        }
-        recordElapsedActualRenderTimeWhileUnwinding = true;
-      }
 
       const next = unwindWork(workInProgress, nextRenderExpirationTime);
       // Because this fiber did not complete, don't reset its expiration time.

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -340,7 +340,7 @@ function resetStack() {
       if (enableProfilerTimer) {
         if (interruptedWork.mode & ProfileMode) {
           // Resume in case we're picking up on work that was paused.
-          resumeActualRenderTimerIfPaused(nextRoot);
+          resumeActualRenderTimerIfPaused(false);
         }
       }
       unwindInterruptedWork(interruptedWork);
@@ -996,7 +996,7 @@ function workLoop(isYieldy) {
     if (enableProfilerTimer) {
       // If we didn't finish, pause the "actual" render timer.
       // We'll restart it when we resume work.
-      pauseActualRenderTimerIfRunning(nextRoot);
+      pauseActualRenderTimerIfRunning();
     }
   }
 }
@@ -1832,7 +1832,7 @@ function performWork(minExpirationTime: ExpirationTime, dl: Deadline | null) {
   findHighestPriorityRoot();
 
   if (enableProfilerTimer) {
-    resumeActualRenderTimerIfPaused(nextRoot);
+    resumeActualRenderTimerIfPaused(minExpirationTime === Sync);
   }
 
   if (deadline !== null) {
@@ -1907,7 +1907,7 @@ function flushRoot(root: FiberRoot, expirationTime: ExpirationTime) {
   performWorkOnRoot(root, expirationTime, true);
   // Flush any sync work that was scheduled by lifecycles
   performSyncWork();
-  pauseActualRenderTimerIfRunning(root);
+  pauseActualRenderTimerIfRunning();
 }
 
 function finishRendering() {
@@ -2012,7 +2012,7 @@ function performWorkOnRoot(
           if (enableProfilerTimer) {
             // If we didn't finish, pause the "actual" render timer.
             // We'll restart it when we resume work.
-            pauseActualRenderTimerIfRunning(root);
+            pauseActualRenderTimerIfRunning();
           }
         }
       }

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -51,10 +51,7 @@ import {
   popTopLevelContextObject as popTopLevelLegacyContextObject,
 } from './ReactFiberContext';
 import {popProvider} from './ReactFiberNewContext';
-import {
-  resumeActualRenderTimerIfPaused,
-  recordElapsedActualRenderTime,
-} from './ReactProfilerTimer';
+import {recordElapsedActualRenderTime} from './ReactProfilerTimer';
 import {
   renderDidSuspend,
   renderDidError,
@@ -413,8 +410,6 @@ function unwindWork(
 function unwindInterruptedWork(interruptedWork: Fiber) {
   if (enableProfilerTimer) {
     if (interruptedWork.mode & ProfileMode) {
-      // Resume in case we're picking up on work that was paused.
-      resumeActualRenderTimerIfPaused();
       recordElapsedActualRenderTime(interruptedWork);
     }
   }

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -359,6 +359,12 @@ function unwindWork(
   workInProgress: Fiber,
   renderExpirationTime: ExpirationTime,
 ) {
+  if (enableProfilerTimer) {
+    if (workInProgress.mode & ProfileMode) {
+      recordElapsedActualRenderTime(workInProgress);
+    }
+  }
+
   switch (workInProgress.tag) {
     case ClassComponent: {
       popLegacyContextProvider(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -359,12 +359,6 @@ function unwindWork(
   workInProgress: Fiber,
   renderExpirationTime: ExpirationTime,
 ) {
-  if (enableProfilerTimer) {
-    if (workInProgress.mode & ProfileMode) {
-      recordElapsedActualRenderTime(workInProgress);
-    }
-  }
-
   switch (workInProgress.tag) {
     case ClassComponent: {
       popLegacyContextProvider(workInProgress);

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -25,6 +25,7 @@ export type ProfilerTimer = {
   resumeActualRenderTimerIfPaused(): void,
   recordCommitTime(): void,
   recordElapsedBaseRenderTimeIfRunning(fiber: Fiber): void,
+  resetActualRenderTimerStackAfterFatalErrorInDev(): void,
   startBaseRenderTimer(): void,
   stopBaseRenderTimerIfRunning(): void,
 };
@@ -125,6 +126,15 @@ function resumeActualRenderTimerIfPaused(): void {
   }
 }
 
+function resetActualRenderTimerStackAfterFatalErrorInDev(): void {
+  if (!enableProfilerTimer) {
+    return;
+  }
+  if (__DEV__) {
+    fiberStack.length = 0;
+  }
+}
+
 /**
  * The "base" render time is the duration of the “begin” phase of work for a particular fiber.
  * This time is measured and stored on each fiber.
@@ -175,6 +185,7 @@ export {
   recordCommitTime,
   recordElapsedActualRenderTime,
   resetActualRenderTimer,
+  resetActualRenderTimerStackAfterFatalErrorInDev,
   resumeActualRenderTimerIfPaused,
   recordElapsedBaseRenderTimeIfRunning,
   startBaseRenderTimer,

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -79,6 +79,9 @@ function markActualRenderTimeStarted(fiber: Fiber): void {
     fiberStack.push(fiber);
   }
 
+  // TODO Offset accumulated total run time (like with pause time) to handle overlapping roots
+  // TODO If this doesn't work, deopt to force-flush of in-progress times when batch+committing?
+
   fiber.actualDuration =
     now() - ((fiber.actualDuration: any): number) - totalElapsedPauseTime;
   fiber.actualStartTime = now();

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -80,9 +80,6 @@ function markActualRenderTimeStarted(fiber: Fiber): void {
     fiberStack.push(fiber);
   }
 
-  // TODO Offset accumulated total run time (like with pause time) to handle overlapping roots
-  // TODO If this doesn't work, deopt to force-flush of in-progress times when batch+committing?
-
   fiber.actualDuration =
     now() - ((fiber.actualDuration: any): number) - totalElapsedPauseTime;
   fiber.actualStartTime = now();

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1211,7 +1211,7 @@ describe('ReactIncrementalErrorHandling', () => {
   });
 
   it('handles error thrown by host config while working on failed root', () => {
-    ReactNoop.simulateErrorInHostConfig(() => {
+    ReactNoop.simulateErrorInHostConfigDuringBeginPhase(() => {
       ReactNoop.render(<span />);
       expect(() => ReactNoop.flush()).toThrow('Error in host config.');
     });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
@@ -20,17 +20,8 @@ describe('ReactIncrementalErrorReplay', () => {
     ReactNoop = require('react-noop-renderer');
   });
 
-  function div(...children) {
-    children = children.map(c => (typeof c === 'string' ? {text: c} : c));
-    return {type: 'div', children, prop: undefined};
-  }
-
-  function span(prop) {
-    return {type: 'span', children: [], prop};
-  }
-
   it('should fail gracefully on error in the host environment', () => {
-    ReactNoop.simulateErrorInHostConfig(() => {
+    ReactNoop.simulateErrorInHostConfigDuringBeginPhase(() => {
       ReactNoop.render(<span />);
       expect(() => ReactNoop.flush()).toThrow('Error in host config.');
     });

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -193,10 +193,10 @@ describe('Profiler', () => {
         </div>,
       );
 
-      // Should be called three times:
+      // Should be called two times:
       // 1. To mark the start (resuming) of work
-      // 1. To compute the update expiration time,
-      // 2. To record the commit time.
+      // 2. To compute the update expiration time,
+      // 3. To record the commit time.
       // No additional calls from ProfilerTimer are expected.
       expect(mockNow).toHaveBeenCalledTimes(3);
     });

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -992,7 +992,7 @@ describe('Profiler', () => {
             ReactNoop.render(
               <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
                 <span>hi</span>
-              </React.unstable_Profiler>
+              </React.unstable_Profiler>,
             );
             ReactNoop.flush();
           });

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -108,4 +108,13 @@ describe('ReactProfiler DevTools integration', () => {
     // The updated 6ms for the component that does.
     expect(rendered.root.findByType(App)._currentFiber().treeBaseTime).toBe(15);
   });
+
+  it('should reset the DEV mode fiber stack correct after an error', () => {
+    expect(() => {
+      ReactTestRenderer.create(<div ref="this-will-cause-an-error" />);
+    }).toThrow();
+
+    // But this should render correctly, if the profiler's fiber stack has been reset.
+    ReactTestRenderer.create(<div />);
+  });
 });

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -112,23 +112,37 @@ describe('ReactProfiler DevTools integration', () => {
   it('should reset the fiber stack correctly after an error when profiling host roots', () => {
     advanceTimeBy(20);
 
-    const rendered = ReactTestRenderer.create(<div><AdvanceTime byAmount={2} /></div>);
+    const rendered = ReactTestRenderer.create(
+      <div>
+        <AdvanceTime byAmount={2} />
+      </div>,
+    );
 
     advanceTimeBy(20);
 
     expect(() => {
-      rendered.update(<div ref="this-will-cause-an-error"><AdvanceTime byAmount={3} /></div>);
+      rendered.update(
+        <div ref="this-will-cause-an-error">
+          <AdvanceTime byAmount={3} />
+        </div>,
+      );
     }).toThrow();
 
     advanceTimeBy(20);
 
     // But this should render correctly, if the profiler's fiber stack has been reset.
-    rendered.update(<div><AdvanceTime byAmount={7} /></div>);
+    rendered.update(
+      <div>
+        <AdvanceTime byAmount={7} />
+      </div>,
+    );
 
     // Measure unobservable timing required by the DevTools profiler.
     // At this point, the base time should include only the most recent (not failed) render.
     // It should not include time spent on the initial render,
     // Or time that elapsed between any of the above renders.
-    expect(rendered.root.findByType('div')._currentFiber().treeBaseTime).toBe(7);
+    expect(rendered.root.findByType('div')._currentFiber().treeBaseTime).toBe(
+      7,
+    );
   });
 });

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -110,11 +110,25 @@ describe('ReactProfiler DevTools integration', () => {
   });
 
   it('should reset the fiber stack correctly after an error when profiling host roots', () => {
+    advanceTimeBy(20);
+
+    const rendered = ReactTestRenderer.create(<div><AdvanceTime byAmount={2} /></div>);
+
+    advanceTimeBy(20);
+
     expect(() => {
-      ReactTestRenderer.create(<div ref="this-will-cause-an-error" />);
+      rendered.update(<div ref="this-will-cause-an-error"><AdvanceTime byAmount={3} /></div>);
     }).toThrow();
 
+    advanceTimeBy(20);
+
     // But this should render correctly, if the profiler's fiber stack has been reset.
-    ReactTestRenderer.create(<div />);
+    rendered.update(<div><AdvanceTime byAmount={7} /></div>);
+
+    // Measure unobservable timing required by the DevTools profiler.
+    // At this point, the base time should include only the most recent (not failed) render.
+    // It should not include time spent on the initial render,
+    // Or time that elapsed between any of the above renders.
+    expect(rendered.root.findByType('div')._currentFiber().treeBaseTime).toBe(7);
   });
 });

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -109,7 +109,7 @@ describe('ReactProfiler DevTools integration', () => {
     expect(rendered.root.findByType(App)._currentFiber().treeBaseTime).toBe(15);
   });
 
-  it('should reset the DEV mode fiber stack correct after an error', () => {
+  it('should reset the fiber stack correctly after an error when profiling host roots', () => {
     expect(() => {
       ReactTestRenderer.create(<div ref="this-will-cause-an-error" />);
     }).toThrow();


### PR DESCRIPTION
I discovered a couple of problems with the profiler timer "unwinding" behavior while testing the DevTools profiler.

It's probably worth noting that the first issue below was the result of #13058, but the other two are present when using the `unstable_Profiler` component (even without the root-profiling changes from #13058).

### 1: An error while profiling the host root

When the DevTools hook is present, [host roots are automatically opted into profiling mode](https://github.com/facebook/react/blob/183aefa51f5b7b18bde05dccdd417b8983d741d0/packages/react-reconciler/src/ReactFiber.js#L351-L356) in order to support the DevTools profiler UI.

However, in the event of an error, [the in-progress root is just nulled out](https://github.com/facebook/react/blob/183aefa51f5b7b18bde05dccdd417b8983d741d0/packages/react-reconciler/src/ReactFiberScheduler.js#L1076-L1088) without its render timer being stopped. In DEV mode, this will cause the subsequent render to [warn about a non-empty stack](https://github.com/facebook/react/blob/183aefa51f5b7b18bde05dccdd417b8983d741d0/packages/react-reconciler/src/ReactFiberScheduler.js#L664-L669).

I think the most straight forward solution here is to just add an explicit, DEV-only reset method (similar to what we do in `ReactFiberStack`). See commit a94b1b7.

### 2: Failures during "complete" phase

React Native does special `View`/`Text` nesting validation during the "complete" phase. If this fails, our unwinding logic previously recorded the elapsed duration twice– once at the start of the "complete" phase (before the error) and once while unwinding (after the error).

I've updated the noop renderer to support triggering this behavior intentionally, and I've added a new test for it as well. Initially, I tried tracking completion in the scheduler but this felt hacky. I think the best solution here is to move the actual time recording to the end of `completeWork` so that it won't be called twice in the event of an error. See commit 0b40c11.

### 3: Interleaved batched and yielded async work

There is one additional case in which the profiler stack isn't being emptied correctly:
1. Batched work on one root is completed, but yields before committing.
2. Async work on another root begins and yields before completing.
3. Work on the initial, batched root is committed.

At this point, the profiler's DEV fiber stack contains the in-progress fibers (from the yielded async render), so we shouldn't assert that the stack is empty. The in-progress time measurements for the yielded fibers are also incorrect because they include the time spent finishing up the batched commit.

I believe the appropriate way to fix the first issue is to only check for an empty stack when we don't have any remaining, yielded async fibers. I think the best way to fix the second issue is to explicitly not count time spent processing batch work (or any sync work) against yielded async fibers. See commit 08febda.

### Other changes

I also added a couple of new APIs to the noop renderer to support new tests:
* The ability to trigger an error during the "complete" phase (to mimic RN's `Text`/`View` nesting logic) - ca91139
* A new `flushWithoutCommitting` API to mimic React DOM's batched commits - 2aa075d