### PR TITLE
Fix Flow type that event target can be null

### DIFF
--- a/packages/events/EventPluginHub.js
+++ b/packages/events/EventPluginHub.js
@@ -167,7 +167,7 @@ export function getListener(inst: Fiber, registrationName: string) {
  */
 function extractEvents(
   topLevelType: TopLevelType,
-  targetInst: Fiber,
+  targetInst: null | Fiber,
   nativeEvent: AnyNativeEvent,
   nativeEventTarget: EventTarget,
 ): Array<ReactSyntheticEvent> | ReactSyntheticEvent | null {
@@ -229,7 +229,7 @@ export function runEventsInBatch(
 
 export function runExtractedEventsInBatch(
   topLevelType: TopLevelType,
-  targetInst: Fiber,
+  targetInst: null | Fiber,
   nativeEvent: AnyNativeEvent,
   nativeEventTarget: EventTarget,
 ) {

--- a/packages/events/PluginModuleType.js
+++ b/packages/events/PluginModuleType.js
@@ -24,7 +24,7 @@ export type PluginModule<NativeEvent> = {
   eventTypes: EventTypes,
   extractEvents: (
     topLevelType: TopLevelType,
-    targetInst: Fiber,
+    targetInst: null | Fiber,
     nativeTarget: NativeEvent,
     nativeEventTarget: EventTarget,
   ) => ?ReactSyntheticEvent,

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -212,7 +212,7 @@ const SimpleEventPlugin: PluginModule<MouseEvent> & {
 
   extractEvents: function(
     topLevelType: TopLevelType,
-    targetInst: Fiber,
+    targetInst: null | Fiber,
     nativeEvent: MouseEvent,
     nativeEventTarget: EventTarget,
   ): null | ReactSyntheticEvent {

--- a/packages/react-native-renderer/src/ReactFabricEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactFabricEventEmitter.js
@@ -19,11 +19,11 @@ import type {TopLevelType} from 'events/TopLevelEventTypes';
 export {getListener, registrationNameModules as registrationNames};
 
 export function dispatchEvent(
-  target: Object,
+  target: null | Object,
   topLevelType: TopLevelType,
   nativeEvent: AnyNativeEvent,
 ) {
-  const targetFiber = (target: Fiber);
+  const targetFiber = (target: null | Fiber);
   batchedUpdates(function() {
     runExtractedEventsInBatch(
       topLevelType,

--- a/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
+++ b/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
@@ -31,7 +31,7 @@ const ReactNativeBridgeEventPlugin = {
    */
   extractEvents: function(
     topLevelType: TopLevelType,
-    targetInst: Object,
+    targetInst: null | Object,
     nativeEvent: AnyNativeEvent,
     nativeEventTarget: Object,
   ): ?Object {

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -100,7 +100,7 @@ declare module 'FabricUIManager' {
     viewName: string,
     rootTag: number,
     props: ?Object,
-    instanceHandle: Object,
+    eventTarget: Object,
   ): Object;
   declare function cloneNode(node: Object, instanceHandle: Object): Object;
   declare function cloneNodeWithNewChildren(
@@ -124,7 +124,7 @@ declare module 'FabricUIManager' {
   declare function completeRoot(rootTag: number, childSet: Object): void;
   declare function registerEventHandler(
     callback: (
-      instanceHandle: Object,
+      eventTarget: null | Object,
       type: RNTopLevelEventType,
       payload: Object,
     ) => void,


### PR DESCRIPTION
We pass null sometimes when the event target has disappeared. E.g. when touches fires on a deleted node.
