### PR TITLE
[Fabric] Don't pass instanceHandle to clones

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -344,23 +344,15 @@ export function cloneInstance(
   let clone;
   if (keepChildren) {
     if (updatePayload !== null) {
-      clone = cloneNodeWithNewProps(
-        node,
-        updatePayload,
-        internalInstanceHandle,
-      );
+      clone = cloneNodeWithNewProps(node, updatePayload);
     } else {
-      clone = cloneNode(node, internalInstanceHandle);
+      clone = cloneNode(node);
     }
   } else {
     if (updatePayload !== null) {
-      clone = cloneNodeWithNewChildrenAndProps(
-        node,
-        updatePayload,
-        internalInstanceHandle,
-      );
+      clone = cloneNodeWithNewChildrenAndProps(node, updatePayload);
     } else {
-      clone = cloneNodeWithNewChildren(node, internalInstanceHandle);
+      clone = cloneNodeWithNewChildren(node);
     }
   }
   return {

--- a/packages/react-native-renderer/src/__mocks__/FabricUIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/FabricUIManager.js
@@ -50,7 +50,7 @@ const RCTFabricUIManager = {
     viewName,
     rootTag,
     props,
-    instanceHandle,
+    eventTarget,
   ) {
     invariant(
       !allocatedTags.has(reactTag),
@@ -65,7 +65,7 @@ const RCTFabricUIManager = {
       children: [],
     };
   }),
-  cloneNode: jest.fn(function cloneNode(node, instanceHandle) {
+  cloneNode: jest.fn(function cloneNode(node) {
     return {
       reactTag: node.reactTag,
       viewName: node.viewName,
@@ -73,10 +73,7 @@ const RCTFabricUIManager = {
       children: node.children,
     };
   }),
-  cloneNodeWithNewChildren: jest.fn(function cloneNodeWithNewChildren(
-    node,
-    instanceHandle,
-  ) {
+  cloneNodeWithNewChildren: jest.fn(function cloneNodeWithNewChildren(node) {
     return {
       reactTag: node.reactTag,
       viewName: node.viewName,
@@ -87,7 +84,6 @@ const RCTFabricUIManager = {
   cloneNodeWithNewProps: jest.fn(function cloneNodeWithNewProps(
     node,
     newPropsDiff,
-    instanceHandle,
   ) {
     return {
       reactTag: node.reactTag,
@@ -97,11 +93,7 @@ const RCTFabricUIManager = {
     };
   }),
   cloneNodeWithNewChildrenAndProps: jest.fn(
-    function cloneNodeWithNewChildrenAndProps(
-      node,
-      newPropsDiff,
-      instanceHandle,
-    ) {
+    function cloneNodeWithNewChildrenAndProps(node, newPropsDiff) {
       return {
         reactTag: node.reactTag,
         viewName: node.viewName,

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -102,20 +102,15 @@ declare module 'FabricUIManager' {
     props: ?Object,
     instanceHandle: Object,
   ): Object;
-  declare function cloneNode(node: Object, instanceHandle: Object): Object;
-  declare function cloneNodeWithNewChildren(
-    node: Object,
-    instanceHandle: Object,
-  ): Object;
+  declare function cloneNode(node: Object): Object;
+  declare function cloneNodeWithNewChildren(node: Object): Object;
   declare function cloneNodeWithNewProps(
     node: Object,
     newProps: ?Object,
-    instanceHandle: Object,
   ): Object;
   declare function cloneNodeWithNewChildrenAndProps(
     node: Object,
     newProps: ?Object,
-    instanceHandle: Object,
   ): Object;
   declare function appendChild(node: Object, childNode: Object): void;
 


### PR DESCRIPTION
I changed my mind from #12824. We will instead just reuse the first one.

It turns out that this is kind of costly to do cross-VMs. Additionally, we can't really safely use this mechanism to extract the props since we pool the Fibers (so it's not safe to read from an old Fiber's memoizedProps to extract event listeners). To make it safe we'd also have to pass props which are immutable but then that is even more costly.

Finally, in the cases where this matters - async dispatching of events - it doesn't really matter which one we use since the async dispatching nature means that they have to be resilient regardless.

NOTE: We can't actually land this until the native changes has fully propagated everywhere.
