### PR TITLE
Drop handling for ms and O prefixes for CSS transition and animation events.

### DIFF
--- a/packages/react-dom/src/events/getVendorPrefixedEventName.js
+++ b/packages/react-dom/src/events/getVendorPrefixedEventName.js
@@ -20,8 +20,6 @@ function makePrefixMap(styleProp, eventName) {
   prefixes[styleProp.toLowerCase()] = eventName.toLowerCase();
   prefixes['Webkit' + styleProp] = 'webkit' + eventName;
   prefixes['Moz' + styleProp] = 'moz' + eventName;
-  prefixes['ms' + styleProp] = 'MS' + eventName;
-  prefixes['O' + styleProp] = 'o' + eventName.toLowerCase();
 
   return prefixes;
 }


### PR DESCRIPTION
- Internet Explorer has never needed these prefixes (see https://caniuse.com/#feat=css-animation and https://caniuse.com/#feat=css-transitions)
- Opera 11.5 was the only release that needed a prefix (for CSS Transitions). Support for that version has already been removed in #11921

I think the `Moz` prefix could be dropped as well. It's only needed by Firefox 15 and older. This could open up a small refactor avoiding building these maps. WDYT?