### PR TITLE
[Experimental] API for reading context from within any render phase function

### DIFF
--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -662,7 +662,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
             '- ' +
             // need to explicitly coerce Symbol to a string
             (fiber.type ? fiber.type.name || fiber.type.toString() : '[root]'),
-          '[' + fiber.expirationTime + (fiber.pendingProps ? '*' : '') + ']',
+          '[' +
+            fiber.childExpirationTime +
+            (fiber.pendingProps ? '*' : '') +
+            ']',
         );
         if (fiber.updateQueue) {
           logUpdateQueue(fiber.updateQueue, depth);

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -14,6 +14,7 @@ import type {TypeOfMode} from './ReactTypeOfMode';
 import type {TypeOfSideEffect} from 'shared/ReactTypeOfSideEffect';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {UpdateQueue} from './ReactUpdateQueue';
+import type {ContextDependency} from './ReactFiberNewContext';
 
 import invariant from 'shared/invariant';
 import {enableProfilerTimer} from 'shared/ReactFeatureFlags';
@@ -124,6 +125,9 @@ export type Fiber = {|
   // The state used to create the output
   memoizedState: any,
 
+  // A linked-list of contexts that this fiber depends on
+  firstContextDependency: ContextDependency<mixed> | null,
+
   // Bitfield that describes properties about the fiber and its subtree. E.g.
   // the AsyncMode flag indicates whether the subtree should be async-by-
   // default. When a fiber is created, it inherits the mode of its
@@ -213,6 +217,7 @@ function FiberNode(
   this.memoizedProps = null;
   this.updateQueue = null;
   this.memoizedState = null;
+  this.firstContextDependency = null;
 
   this.mode = mode;
 
@@ -331,6 +336,7 @@ export function createWorkInProgress(
   workInProgress.memoizedProps = current.memoizedProps;
   workInProgress.memoizedState = current.memoizedState;
   workInProgress.updateQueue = current.updateQueue;
+  workInProgress.firstContextDependency = current.firstContextDependency;
 
   // These will be overridden during the parent's reconciliation
   workInProgress.sibling = current.sibling;
@@ -559,6 +565,7 @@ export function assignFiberPropertiesInDEV(
   target.memoizedProps = source.memoizedProps;
   target.updateQueue = source.updateQueue;
   target.memoizedState = source.memoizedState;
+  target.firstContextDependency = source.firstContextDependency;
   target.mode = source.mode;
   target.effectTag = source.effectTag;
   target.nextEffect = source.nextEffect;

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -162,7 +162,7 @@ export function applyDerivedStateFromProps(
   // Once the update queue is empty, persist the derived state onto the
   // base state.
   const updateQueue = workInProgress.updateQueue;
-  if (updateQueue !== null && updateQueue.expirationTime === NoWork) {
+  if (updateQueue !== null && workInProgress.expirationTime === NoWork) {
     updateQueue.baseState = memoizedState;
   }
 }
@@ -183,7 +183,7 @@ const classComponentUpdater = {
       update.callback = callback;
     }
 
-    enqueueUpdate(fiber, update, expirationTime);
+    enqueueUpdate(fiber, update);
     scheduleWork(fiber, expirationTime);
   },
   enqueueReplaceState(inst, payload, callback) {
@@ -202,7 +202,7 @@ const classComponentUpdater = {
       update.callback = callback;
     }
 
-    enqueueUpdate(fiber, update, expirationTime);
+    enqueueUpdate(fiber, update);
     scheduleWork(fiber, expirationTime);
   },
   enqueueForceUpdate(inst, callback) {
@@ -220,7 +220,7 @@ const classComponentUpdater = {
       update.callback = callback;
     }
 
-    enqueueUpdate(fiber, update, expirationTime);
+    enqueueUpdate(fiber, update);
     scheduleWork(fiber, expirationTime);
   },
 };

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -231,7 +231,7 @@ function checkShouldComponentUpdate(
   newProps,
   oldState,
   newState,
-  newContext,
+  nextLegacyContext,
 ) {
   const instance = workInProgress.stateNode;
   const ctor = workInProgress.type;
@@ -240,7 +240,7 @@ function checkShouldComponentUpdate(
     const shouldUpdate = instance.shouldComponentUpdate(
       newProps,
       newState,
-      newContext,
+      nextLegacyContext,
     );
     stopPhaseTimer();
 
@@ -620,15 +620,15 @@ function callComponentWillReceiveProps(
   workInProgress,
   instance,
   newProps,
-  newContext,
+  nextLegacyContext,
 ) {
   const oldState = instance.state;
   startPhaseTimer(workInProgress, 'componentWillReceiveProps');
   if (typeof instance.componentWillReceiveProps === 'function') {
-    instance.componentWillReceiveProps(newProps, newContext);
+    instance.componentWillReceiveProps(newProps, nextLegacyContext);
   }
   if (typeof instance.UNSAFE_componentWillReceiveProps === 'function') {
-    instance.UNSAFE_componentWillReceiveProps(newProps, newContext);
+    instance.UNSAFE_componentWillReceiveProps(newProps, nextLegacyContext);
   }
   stopPhaseTimer();
 
@@ -741,6 +741,7 @@ function mountClassInstance(
 
 function resumeMountClassInstance(
   workInProgress: Fiber,
+  hasPendingNewContext: boolean,
   renderExpirationTime: ExpirationTime,
 ): boolean {
   const ctor = workInProgress.type;
@@ -751,8 +752,11 @@ function resumeMountClassInstance(
   instance.props = oldProps;
 
   const oldContext = instance.context;
-  const newUnmaskedContext = getUnmaskedContext(workInProgress);
-  const newContext = getMaskedContext(workInProgress, newUnmaskedContext);
+  const nextLegacyUnmaskedContext = getUnmaskedContext(workInProgress);
+  const nextLegacyContext = getMaskedContext(
+    workInProgress,
+    nextLegacyUnmaskedContext,
+  );
 
   const getDerivedStateFromProps = ctor.getDerivedStateFromProps;
   const hasNewLifecycles =
@@ -770,12 +774,12 @@ function resumeMountClassInstance(
     (typeof instance.UNSAFE_componentWillReceiveProps === 'function' ||
       typeof instance.componentWillReceiveProps === 'function')
   ) {
-    if (oldProps !== newProps || oldContext !== newContext) {
+    if (oldProps !== newProps || oldContext !== nextLegacyContext) {
       callComponentWillReceiveProps(
         workInProgress,
         instance,
         newProps,
-        newContext,
+        nextLegacyContext,
       );
     }
   }
@@ -799,6 +803,7 @@ function resumeMountClassInstance(
     oldProps === newProps &&
     oldState === newState &&
     !hasContextChanged() &&
+    !hasPendingNewContext &&
     !checkHasForceUpdateAfterProcessing()
   ) {
     // If an update was already in progress, we should schedule an Update
@@ -820,13 +825,14 @@ function resumeMountClassInstance(
 
   const shouldUpdate =
     checkHasForceUpdateAfterProcessing() ||
+    hasPendingNewContext ||
     checkShouldComponentUpdate(
       workInProgress,
       oldProps,
       newProps,
       oldState,
       newState,
-      newContext,
+      nextLegacyContext,
     );
 
   if (shouldUpdate) {
@@ -866,7 +872,7 @@ function resumeMountClassInstance(
   // if shouldComponentUpdate returns false.
   instance.props = newProps;
   instance.state = newState;
-  instance.context = newContext;
+  instance.context = nextLegacyContext;
 
   return shouldUpdate;
 }
@@ -875,6 +881,7 @@ function resumeMountClassInstance(
 function updateClassInstance(
   current: Fiber,
   workInProgress: Fiber,
+  hasPendingNewContext: boolean,
   renderExpirationTime: ExpirationTime,
 ): boolean {
   const ctor = workInProgress.type;
@@ -885,8 +892,11 @@ function updateClassInstance(
   instance.props = oldProps;
 
   const oldContext = instance.context;
-  const newUnmaskedContext = getUnmaskedContext(workInProgress);
-  const newContext = getMaskedContext(workInProgress, newUnmaskedContext);
+  const nextLegacyUnmaskedContext = getUnmaskedContext(workInProgress);
+  const nextLegacyContext = getMaskedContext(
+    workInProgress,
+    nextLegacyUnmaskedContext,
+  );
 
   const getDerivedStateFromProps = ctor.getDerivedStateFromProps;
   const hasNewLifecycles =
@@ -904,12 +914,12 @@ function updateClassInstance(
     (typeof instance.UNSAFE_componentWillReceiveProps === 'function' ||
       typeof instance.componentWillReceiveProps === 'function')
   ) {
-    if (oldProps !== newProps || oldContext !== newContext) {
+    if (oldProps !== newProps || oldContext !== nextLegacyContext) {
       callComponentWillReceiveProps(
         workInProgress,
         instance,
         newProps,
-        newContext,
+        nextLegacyContext,
       );
     }
   }
@@ -934,6 +944,7 @@ function updateClassInstance(
     oldProps === newProps &&
     oldState === newState &&
     !hasContextChanged() &&
+    !hasPendingNewContext &&
     !checkHasForceUpdateAfterProcessing()
   ) {
     // If an update was already in progress, we should schedule an Update
@@ -968,13 +979,14 @@ function updateClassInstance(
 
   const shouldUpdate =
     checkHasForceUpdateAfterProcessing() ||
+    hasPendingNewContext ||
     checkShouldComponentUpdate(
       workInProgress,
       oldProps,
       newProps,
       oldState,
       newState,
-      newContext,
+      nextLegacyContext,
     );
 
   if (shouldUpdate) {
@@ -987,10 +999,14 @@ function updateClassInstance(
     ) {
       startPhaseTimer(workInProgress, 'componentWillUpdate');
       if (typeof instance.componentWillUpdate === 'function') {
-        instance.componentWillUpdate(newProps, newState, newContext);
+        instance.componentWillUpdate(newProps, newState, nextLegacyContext);
       }
       if (typeof instance.UNSAFE_componentWillUpdate === 'function') {
-        instance.UNSAFE_componentWillUpdate(newProps, newState, newContext);
+        instance.UNSAFE_componentWillUpdate(
+          newProps,
+          newState,
+          nextLegacyContext,
+        );
       }
       stopPhaseTimer();
     }
@@ -1030,7 +1046,7 @@ function updateClassInstance(
   // if shouldComponentUpdate returns false.
   instance.props = newProps;
   instance.state = newState;
-  instance.context = newContext;
+  instance.context = nextLegacyContext;
 
   return shouldUpdate;
 }

--- a/packages/react-reconciler/src/ReactFiberDispatcher.js
+++ b/packages/react-reconciler/src/ReactFiberDispatcher.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {readContext} from './ReactFiberNewContext';
+
+export const Dispatcher = {
+  readContext,
+};

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -27,7 +27,6 @@ import {ContextProvider} from 'shared/ReactTypeOfWork';
 
 import invariant from 'shared/invariant';
 
-const providerCursor: StackCursor<Fiber | null> = createCursor(null);
 const valueCursor: StackCursor<mixed> = createCursor(null);
 const changedBitsCursor: StackCursor<number> = createCursor(0);
 
@@ -47,7 +46,6 @@ export function pushProvider(providerFiber: Fiber): void {
   if (isPrimaryRenderer) {
     push(changedBitsCursor, context._changedBits, providerFiber);
     push(valueCursor, context._currentValue, providerFiber);
-    push(providerCursor, providerFiber, providerFiber);
 
     context._currentValue = providerFiber.pendingProps.value;
     context._changedBits = providerFiber.stateNode;
@@ -64,7 +62,6 @@ export function pushProvider(providerFiber: Fiber): void {
   } else {
     push(changedBitsCursor, context._changedBits2, providerFiber);
     push(valueCursor, context._currentValue2, providerFiber);
-    push(providerCursor, providerFiber, providerFiber);
 
     context._currentValue2 = providerFiber.pendingProps.value;
     context._changedBits2 = providerFiber.stateNode;
@@ -85,7 +82,6 @@ export function popProvider(providerFiber: Fiber): void {
   const changedBits = changedBitsCursor.current;
   const currentValue = valueCursor.current;
 
-  pop(providerCursor, providerFiber);
   pop(valueCursor, providerFiber);
   pop(changedBitsCursor, providerFiber);
 

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -118,29 +118,44 @@ export function propagateContextChange(
           dependency.context === context &&
           (dependency.observedBits & changedBits) !== 0
         ) {
-          // Match! Update the expiration time of all the ancestors, including
+          // Match! Schedule an update on this fiber.
+          if (
+            fiber.expirationTime === NoWork ||
+            fiber.expirationTime > renderExpirationTime
+          ) {
+            fiber.expirationTime = renderExpirationTime;
+          }
+          let alternate = fiber.alternate;
+          if (
+            alternate !== null &&
+            (alternate.expirationTime === NoWork ||
+              alternate.expirationTime > renderExpirationTime)
+          ) {
+            alternate.expirationTime = renderExpirationTime;
+          }
+          // Update the child expiration time of all the ancestors, including
           // the alternates.
-          let node = fiber;
+          let node = fiber.return;
           while (node !== null) {
-            const alternate = node.alternate;
+            alternate = node.alternate;
             if (
-              node.expirationTime === NoWork ||
-              node.expirationTime > renderExpirationTime
+              node.childExpirationTime === NoWork ||
+              node.childExpirationTime > renderExpirationTime
             ) {
-              node.expirationTime = renderExpirationTime;
+              node.childExpirationTime = renderExpirationTime;
               if (
                 alternate !== null &&
-                (alternate.expirationTime === NoWork ||
-                  alternate.expirationTime > renderExpirationTime)
+                (alternate.childExpirationTime === NoWork ||
+                  alternate.childExpirationTime > renderExpirationTime)
               ) {
-                alternate.expirationTime = renderExpirationTime;
+                alternate.childExpirationTime = renderExpirationTime;
               }
             } else if (
               alternate !== null &&
-              (alternate.expirationTime === NoWork ||
-                alternate.expirationTime > renderExpirationTime)
+              (alternate.childExpirationTime === NoWork ||
+                alternate.childExpirationTime > renderExpirationTime)
             ) {
-              alternate.expirationTime = renderExpirationTime;
+              alternate.childExpirationTime = renderExpirationTime;
             } else {
               // Neither alternate was updated, which means the rest of the
               // ancestor path already has sufficient priority.

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -7,20 +7,25 @@
  * @flow
  */
 
-import type {Fiber} from './ReactFiber';
 import type {ReactContext} from 'shared/ReactTypes';
+import type {Fiber} from './ReactFiber';
 import type {StackCursor} from './ReactFiberStack';
+import type {ExpirationTime} from './ReactFiberExpirationTime';
 
-export type NewContext = {
-  pushProvider(providerFiber: Fiber): void,
-  popProvider(providerFiber: Fiber): void,
-  getContextCurrentValue(context: ReactContext<any>): any,
-  getContextChangedBits(context: ReactContext<any>): number,
+export type ContextDependency<T> = {
+  context: ReactContext<T>,
+  observedBits: number,
+  next: ContextDependency<mixed> | null,
 };
 
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {isPrimaryRenderer} from './ReactFiberHostConfig';
 import {createCursor, push, pop} from './ReactFiberStack';
+import maxSigned31BitInt from './maxSigned31BitInt';
+import {NoWork} from './ReactFiberExpirationTime';
+import {ContextProvider} from 'shared/ReactTypeOfWork';
+
+import invariant from 'shared/invariant';
 
 const providerCursor: StackCursor<Fiber | null> = createCursor(null);
 const valueCursor: StackCursor<mixed> = createCursor(null);
@@ -32,7 +37,11 @@ if (__DEV__) {
   rendererSigil = {};
 }
 
-function pushProvider(providerFiber: Fiber): void {
+let currentlyRenderingFiber: Fiber | null = null;
+let lastContextDependency: ContextDependency<mixed> | null = null;
+let memoizedFirstContextDependency: ContextDependency<mixed> | null = null;
+
+export function pushProvider(providerFiber: Fiber): void {
   const context: ReactContext<any> = providerFiber.type._context;
 
   if (isPrimaryRenderer) {
@@ -72,7 +81,7 @@ function pushProvider(providerFiber: Fiber): void {
   }
 }
 
-function popProvider(providerFiber: Fiber): void {
+export function popProvider(providerFiber: Fiber): void {
   const changedBits = changedBitsCursor.current;
   const currentValue = valueCursor.current;
 
@@ -90,17 +99,191 @@ function popProvider(providerFiber: Fiber): void {
   }
 }
 
-function getContextCurrentValue(context: ReactContext<any>): any {
+export function propagateContextChange(
+  workInProgress: Fiber,
+  context: ReactContext<mixed>,
+  changedBits: number,
+  renderExpirationTime: ExpirationTime,
+): void {
+  let fiber = workInProgress.child;
+  if (fiber !== null) {
+    // Set the return pointer of the child to the work-in-progress fiber.
+    fiber.return = workInProgress;
+  }
+  while (fiber !== null) {
+    let nextFiber;
+
+    // Visit this fiber.
+    let dependency = fiber.firstContextDependency;
+    if (dependency !== null) {
+      do {
+        // Check if the context matches.
+        if (
+          dependency.context === context &&
+          (dependency.observedBits & changedBits) !== 0
+        ) {
+          // Match! Update the expiration time of all the ancestors, including
+          // the alternates.
+          let node = fiber;
+          while (node !== null) {
+            const alternate = node.alternate;
+            if (
+              node.expirationTime === NoWork ||
+              node.expirationTime > renderExpirationTime
+            ) {
+              node.expirationTime = renderExpirationTime;
+              if (
+                alternate !== null &&
+                (alternate.expirationTime === NoWork ||
+                  alternate.expirationTime > renderExpirationTime)
+              ) {
+                alternate.expirationTime = renderExpirationTime;
+              }
+            } else if (
+              alternate !== null &&
+              (alternate.expirationTime === NoWork ||
+                alternate.expirationTime > renderExpirationTime)
+            ) {
+              alternate.expirationTime = renderExpirationTime;
+            } else {
+              // Neither alternate was updated, which means the rest of the
+              // ancestor path already has sufficient priority.
+              break;
+            }
+            node = node.return;
+          }
+          // Don't scan deeper than a matching consumer. When we render the
+          // consumer, we'll continue scanning from that point. This way the
+          // scanning work is time-sliced.
+          nextFiber = null;
+        } else {
+          nextFiber = fiber.child;
+        }
+        dependency = dependency.next;
+      } while (dependency !== null);
+    } else if (fiber.tag === ContextProvider) {
+      // Don't scan deeper if this is a matching provider
+      nextFiber = fiber.type === workInProgress.type ? null : fiber.child;
+    } else {
+      // Traverse down.
+      nextFiber = fiber.child;
+    }
+
+    if (nextFiber !== null) {
+      // Set the return pointer of the child to the work-in-progress fiber.
+      nextFiber.return = fiber;
+    } else {
+      // No child. Traverse to next sibling.
+      nextFiber = fiber;
+      while (nextFiber !== null) {
+        if (nextFiber === workInProgress) {
+          // We're back to the root of this subtree. Exit.
+          nextFiber = null;
+          break;
+        }
+        let sibling = nextFiber.sibling;
+        if (sibling !== null) {
+          // Set the return pointer of the sibling to the work-in-progress fiber.
+          sibling.return = nextFiber.return;
+          nextFiber = sibling;
+          break;
+        }
+        // No more siblings. Traverse up.
+        nextFiber = nextFiber.return;
+      }
+    }
+    fiber = nextFiber;
+  }
+}
+
+export function prepareToReadContext(
+  workInProgress: Fiber,
+  renderExpirationTime: ExpirationTime,
+): boolean {
+  currentlyRenderingFiber = workInProgress;
+  memoizedFirstContextDependency = workInProgress.firstContextDependency;
+  if (memoizedFirstContextDependency !== null) {
+    // Reset the work-in-progress list
+    workInProgress.firstContextDependency = null;
+
+    // Iterate through the context dependencies and see if there were any
+    // changes. If so, continue propagating the context change by scanning
+    // the child subtree.
+    let dependency = memoizedFirstContextDependency;
+    let hasPendingContext = false;
+    do {
+      const context = dependency.context;
+      const changedBits = isPrimaryRenderer
+        ? context._changedBits
+        : context._changedBits2;
+      if (changedBits !== 0) {
+        // Resume context change propagation. We need to call this even if
+        // this fiber bails out, in case deeply nested consumers observe more
+        // bits than this one.
+        propagateContextChange(
+          workInProgress,
+          context,
+          changedBits,
+          renderExpirationTime,
+        );
+        if ((changedBits & dependency.observedBits) !== 0) {
+          hasPendingContext = true;
+        }
+      }
+      dependency = dependency.next;
+    } while (dependency !== null);
+    return hasPendingContext;
+  } else {
+    return false;
+  }
+}
+
+export function readContext<T>(
+  context: ReactContext<T>,
+  observedBits: void | number | boolean,
+): T {
+  invariant(
+    currentlyRenderingFiber !== null,
+    'Context.unstable_read(): Context can only be read while React is ' +
+      'rendering, e.g. inside the render method or getDerivedStateFromProps.',
+  );
+
+  if (typeof observedBits !== 'number') {
+    if (observedBits === false) {
+      // Do not observe updates
+      observedBits = 0;
+    } else {
+      // Observe all updates
+      observedBits = maxSigned31BitInt;
+    }
+  }
+
+  if (currentlyRenderingFiber.firstContextDependency === null) {
+    // This is the first dependency in the list
+    currentlyRenderingFiber.firstContextDependency = lastContextDependency = {
+      context: ((context: any): ReactContext<mixed>),
+      observedBits,
+      next: null,
+    };
+  } else {
+    invariant(
+      lastContextDependency !== null,
+      'Expected a non-empty list of context dependencies. This is likely a ' +
+        'bug in React. Please file an issue.',
+    );
+    if (lastContextDependency.context === context) {
+      // Fast path. The previous context has the same type. We can reuse
+      // the same node.
+      lastContextDependency.observedBits |= observedBits;
+    } else {
+      // Append a new context item.
+      lastContextDependency = lastContextDependency.next = {
+        context: ((context: any): ReactContext<mixed>),
+        observedBits,
+        next: null,
+      };
+    }
+  }
+
   return isPrimaryRenderer ? context._currentValue : context._currentValue2;
 }
-
-function getContextChangedBits(context: ReactContext<any>): number {
-  return isPrimaryRenderer ? context._changedBits : context._changedBits2;
-}
-
-export {
-  pushProvider,
-  popProvider,
-  getContextCurrentValue,
-  getContextChangedBits,
-};

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -135,7 +135,7 @@ function scheduleRootUpdate(
     );
     update.callback = callback;
   }
-  enqueueUpdate(current, update, expirationTime);
+  enqueueUpdate(current, update);
 
   scheduleWork(current, expirationTime);
   return expirationTime;

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -109,7 +109,7 @@ import {
   popTopLevelContextObject as popTopLevelLegacyContextObject,
   popContextProvider as popLegacyContextProvider,
 } from './ReactFiberContext';
-import {popProvider} from './ReactFiberNewContext';
+import {popProvider, resetContextDependences} from './ReactFiberNewContext';
 import {popHostContext, popHostContainer} from './ReactFiberHostContext';
 import {
   checkActualRenderTimeStackEmpty,
@@ -1131,6 +1131,7 @@ function renderRoot(
   // We're done performing work. Time to clean up.
   isWorking = false;
   ReactCurrentOwner.currentDispatcher = null;
+  resetContextDependences();
 
   // Yield back to main thread.
   if (didFatal) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -533,8 +533,15 @@ function commitRoot(root: FiberRoot, finishedWork: Fiber): void {
   // Update the pending priority levels to account for the work that we are
   // about to commit. This needs to happen before calling the lifecycles, since
   // they may schedule additional updates.
-  const earliestRemainingTime = finishedWork.expirationTime;
-  markCommittedPriorityLevels(root, earliestRemainingTime);
+  const updateExpirationTimeBeforeCommit = finishedWork.expirationTime;
+  const childExpirationTimeBeforeCommit = finishedWork.childExpirationTime;
+  const earliestRemainingTimeBeforeCommit =
+    updateExpirationTimeBeforeCommit === NoWork ||
+    (childExpirationTimeBeforeCommit !== NoWork &&
+      childExpirationTimeBeforeCommit < updateExpirationTimeBeforeCommit)
+      ? childExpirationTimeBeforeCommit
+      : updateExpirationTimeBeforeCommit;
+  markCommittedPriorityLevels(root, earliestRemainingTimeBeforeCommit);
 
   // Reset this to null before calling lifecycles
   ReactCurrentOwner.current = null;
@@ -706,71 +713,85 @@ function commitRoot(root: FiberRoot, finishedWork: Fiber): void {
     ReactFiberInstrumentation.debugTool.onCommitWork(finishedWork);
   }
 
-  const expirationTime = root.expirationTime;
-  if (expirationTime === NoWork) {
+  const updateExpirationTimeAfterCommit = finishedWork.expirationTime;
+  const childExpirationTimeAfterCommit = finishedWork.childExpirationTime;
+  const earliestRemainingTimeAfterCommit =
+    updateExpirationTimeAfterCommit === NoWork ||
+    (childExpirationTimeAfterCommit !== NoWork &&
+      childExpirationTimeAfterCommit < updateExpirationTimeAfterCommit)
+      ? childExpirationTimeAfterCommit
+      : updateExpirationTimeAfterCommit;
+  if (earliestRemainingTimeAfterCommit === NoWork) {
     // If there's no remaining work, we can clear the set of already failed
     // error boundaries.
     legacyErrorBoundariesThatAlreadyFailed = null;
   }
-  onCommit(root, expirationTime);
+  onCommit(root, earliestRemainingTimeAfterCommit);
 }
 
-function resetExpirationTime(
+function resetChildExpirationTime(
   workInProgress: Fiber,
   renderTime: ExpirationTime,
 ) {
-  if (renderTime !== Never && workInProgress.expirationTime === Never) {
+  if (renderTime !== Never && workInProgress.childExpirationTime === Never) {
     // The children of this component are hidden. Don't bubble their
     // expiration times.
     return;
   }
 
-  // Check for pending updates.
-  let newExpirationTime = NoWork;
-  switch (workInProgress.tag) {
-    case HostRoot:
-    case ClassComponent: {
-      const updateQueue = workInProgress.updateQueue;
-      if (updateQueue !== null) {
-        newExpirationTime = updateQueue.expirationTime;
-      }
-    }
-  }
-
-  // TODO: Calls need to visit stateNode
+  let newChildExpirationTime = NoWork;
 
   // Bubble up the earliest expiration time.
-  // (And "base" render timers if that feature flag is enabled)
   if (enableProfilerTimer && workInProgress.mode & ProfileMode) {
+    // We're in profiling mode. Let's use this same traversal to update the
+    // "base" render times.
     let treeBaseDuration = workInProgress.selfBaseDuration;
     let child = workInProgress.child;
     while (child !== null) {
-      treeBaseDuration += child.treeBaseDuration;
+      const childUpdateExpirationTime = child.expirationTime;
+      const childChildExpirationTime = child.childExpirationTime;
       if (
-        child.expirationTime !== NoWork &&
-        (newExpirationTime === NoWork ||
-          newExpirationTime > child.expirationTime)
+        newChildExpirationTime === NoWork ||
+        (childUpdateExpirationTime !== NoWork &&
+          childUpdateExpirationTime < newChildExpirationTime)
       ) {
-        newExpirationTime = child.expirationTime;
+        newChildExpirationTime = childUpdateExpirationTime;
       }
+      if (
+        newChildExpirationTime === NoWork ||
+        (childChildExpirationTime !== NoWork &&
+          childChildExpirationTime < newChildExpirationTime)
+      ) {
+        newChildExpirationTime = childChildExpirationTime;
+      }
+      treeBaseDuration += child.treeBaseDuration;
       child = child.sibling;
     }
     workInProgress.treeBaseDuration = treeBaseDuration;
   } else {
     let child = workInProgress.child;
     while (child !== null) {
+      const childUpdateExpirationTime = child.expirationTime;
+      const childChildExpirationTime = child.childExpirationTime;
       if (
-        child.expirationTime !== NoWork &&
-        (newExpirationTime === NoWork ||
-          newExpirationTime > child.expirationTime)
+        newChildExpirationTime === NoWork ||
+        (childUpdateExpirationTime !== NoWork &&
+          childUpdateExpirationTime < newChildExpirationTime)
       ) {
-        newExpirationTime = child.expirationTime;
+        newChildExpirationTime = childUpdateExpirationTime;
+      }
+      if (
+        newChildExpirationTime === NoWork ||
+        (childChildExpirationTime !== NoWork &&
+          childChildExpirationTime < newChildExpirationTime)
+      ) {
+        newChildExpirationTime = childChildExpirationTime;
       }
       child = child.sibling;
     }
   }
 
-  workInProgress.expirationTime = newExpirationTime;
+  workInProgress.childExpirationTime = newChildExpirationTime;
 }
 
 function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
@@ -799,7 +820,7 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
       );
       let next = nextUnitOfWork;
       stopWorkTimer(workInProgress);
-      resetExpirationTime(workInProgress, nextRenderExpirationTime);
+      resetChildExpirationTime(workInProgress, nextRenderExpirationTime);
       if (__DEV__) {
         ReactCurrentFiber.resetCurrentFiber();
       }
@@ -1270,7 +1291,7 @@ function dispatch(
             errorInfo,
             expirationTime,
           );
-          enqueueUpdate(fiber, update, expirationTime);
+          enqueueUpdate(fiber, update);
           scheduleWork(fiber, expirationTime);
           return;
         }
@@ -1278,7 +1299,7 @@ function dispatch(
       case HostRoot: {
         const errorInfo = createCapturedValue(value, sourceFiber);
         const update = createRootErrorUpdate(fiber, errorInfo, expirationTime);
-        enqueueUpdate(fiber, update, expirationTime);
+        enqueueUpdate(fiber, update);
         scheduleWork(fiber, expirationTime);
         return;
       }
@@ -1292,7 +1313,7 @@ function dispatch(
     const rootFiber = sourceFiber;
     const errorInfo = createCapturedValue(value, rootFiber);
     const update = createRootErrorUpdate(rootFiber, errorInfo, expirationTime);
-    enqueueUpdate(rootFiber, update, expirationTime);
+    enqueueUpdate(rootFiber, update);
     scheduleWork(rootFiber, expirationTime);
   }
 }
@@ -1411,35 +1432,52 @@ function retrySuspendedRoot(
 }
 
 function scheduleWorkToRoot(fiber: Fiber, expirationTime): FiberRoot | null {
-  // Walk the parent path to the root and update each node's
-  // expiration time.
-  let node = fiber;
-  do {
-    const alternate = node.alternate;
+  // Update the source fiber's expiration time
+  if (
+    fiber.expirationTime === NoWork ||
+    fiber.expirationTime > expirationTime
+  ) {
+    fiber.expirationTime = expirationTime;
+  }
+  let alternate = fiber.alternate;
+  if (
+    alternate !== null &&
+    (alternate.expirationTime === NoWork ||
+      alternate.expirationTime > expirationTime)
+  ) {
+    alternate.expirationTime = expirationTime;
+  }
+  // Walk the parent path to the root and update the child expiration time.
+  let node = fiber.return;
+  if (node === null && fiber.tag === HostRoot) {
+    return fiber.stateNode;
+  }
+  while (node !== null) {
+    alternate = node.alternate;
     if (
-      node.expirationTime === NoWork ||
-      node.expirationTime > expirationTime
+      node.childExpirationTime === NoWork ||
+      node.childExpirationTime > expirationTime
     ) {
-      node.expirationTime = expirationTime;
+      node.childExpirationTime = expirationTime;
       if (
         alternate !== null &&
-        (alternate.expirationTime === NoWork ||
-          alternate.expirationTime > expirationTime)
+        (alternate.childExpirationTime === NoWork ||
+          alternate.childExpirationTime > expirationTime)
       ) {
-        alternate.expirationTime = expirationTime;
+        alternate.childExpirationTime = expirationTime;
       }
     } else if (
       alternate !== null &&
-      (alternate.expirationTime === NoWork ||
-        alternate.expirationTime > expirationTime)
+      (alternate.childExpirationTime === NoWork ||
+        alternate.childExpirationTime > expirationTime)
     ) {
-      alternate.expirationTime = expirationTime;
+      alternate.childExpirationTime = expirationTime;
     }
     if (node.return === null && node.tag === HostRoot) {
       return node.stateNode;
     }
     node = node.return;
-  } while (node !== null);
+  }
   return null;
 }
 

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -145,6 +145,7 @@ import {
   commitAttachRef,
   commitDetachRef,
 } from './ReactFiberCommitWork';
+import {Dispatcher} from './ReactFiberDispatcher';
 
 export type Deadline = {
   timeRemaining: () => number,
@@ -1017,6 +1018,7 @@ function renderRoot(
       'by a bug in React. Please file an issue.',
   );
   isWorking = true;
+  ReactCurrentOwner.currentDispatcher = Dispatcher;
 
   const expirationTime = root.nextExpirationTimeToWorkOn;
 
@@ -1107,6 +1109,7 @@ function renderRoot(
 
   // We're done performing work. Time to clean up.
   isWorking = false;
+  ReactCurrentOwner.currentDispatcher = null;
 
   // Yield back to main thread.
   if (didFatal) {

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -70,7 +70,7 @@ import {
   LOW_PRIORITY_EXPIRATION,
 } from './ReactFiberExpirationTime';
 import {findEarliestOutstandingPriorityLevel} from './ReactFiberPendingPriority';
-import {reconcileChildrenAtExpirationTime} from './ReactFiberBeginWork';
+import {reconcileChildren} from './ReactFiberBeginWork';
 
 function NoopComponent() {
   return null;
@@ -238,7 +238,7 @@ function throwException(
 
             // Unmount the source fiber's children
             const nextChildren = null;
-            reconcileChildrenAtExpirationTime(
+            reconcileChildren(
               sourceFiber.alternate,
               sourceFiber,
               nextChildren,
@@ -310,6 +310,7 @@ function throwException(
           renderDidSuspend(root, absoluteTimeoutMs, renderExpirationTime);
 
           workInProgress.effectTag |= ShouldCapture;
+          workInProgress.expirationTime = renderExpirationTime;
           return;
         }
         // This boundary already captured during this render. Continue to the
@@ -334,12 +335,13 @@ function throwException(
       case HostRoot: {
         const errorInfo = value;
         workInProgress.effectTag |= ShouldCapture;
+        workInProgress.expirationTime = renderExpirationTime;
         const update = createRootErrorUpdate(
           workInProgress,
           errorInfo,
           renderExpirationTime,
         );
-        enqueueCapturedUpdate(workInProgress, update, renderExpirationTime);
+        enqueueCapturedUpdate(workInProgress, update);
         return;
       }
       case ClassComponent:
@@ -356,13 +358,14 @@ function throwException(
               !isAlreadyFailedLegacyErrorBoundary(instance)))
         ) {
           workInProgress.effectTag |= ShouldCapture;
+          workInProgress.expirationTime = renderExpirationTime;
           // Schedule the error boundary to re-render using updated state
           const update = createClassErrorUpdate(
             workInProgress,
             errorInfo,
             renderExpirationTime,
           );
-          enqueueCapturedUpdate(workInProgress, update, renderExpirationTime);
+          enqueueCapturedUpdate(workInProgress, update);
           return;
         }
         break;

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -117,7 +117,6 @@ export type Update<State> = {
 };
 
 export type UpdateQueue<State> = {
-  expirationTime: ExpirationTime,
   baseState: State,
 
   firstUpdate: Update<State> | null,
@@ -156,7 +155,6 @@ if (__DEV__) {
 
 export function createUpdateQueue<State>(baseState: State): UpdateQueue<State> {
   const queue: UpdateQueue<State> = {
-    expirationTime: NoWork,
     baseState,
     firstUpdate: null,
     lastUpdate: null,
@@ -174,7 +172,6 @@ function cloneUpdateQueue<State>(
   currentQueue: UpdateQueue<State>,
 ): UpdateQueue<State> {
   const queue: UpdateQueue<State> = {
-    expirationTime: currentQueue.expirationTime,
     baseState: currentQueue.baseState,
     firstUpdate: currentQueue.firstUpdate,
     lastUpdate: currentQueue.lastUpdate,
@@ -209,7 +206,6 @@ export function createUpdate(expirationTime: ExpirationTime): Update<*> {
 function appendUpdateToQueue<State>(
   queue: UpdateQueue<State>,
   update: Update<State>,
-  expirationTime: ExpirationTime,
 ) {
   // Append the update to the end of the list.
   if (queue.lastUpdate === null) {
@@ -219,21 +215,9 @@ function appendUpdateToQueue<State>(
     queue.lastUpdate.next = update;
     queue.lastUpdate = update;
   }
-  if (
-    queue.expirationTime === NoWork ||
-    queue.expirationTime > expirationTime
-  ) {
-    // The incoming update has the earliest expiration of any update in the
-    // queue. Update the queue's expiration time.
-    queue.expirationTime = expirationTime;
-  }
 }
 
-export function enqueueUpdate<State>(
-  fiber: Fiber,
-  update: Update<State>,
-  expirationTime: ExpirationTime,
-) {
+export function enqueueUpdate<State>(fiber: Fiber, update: Update<State>) {
   // Update queues are created lazily.
   const alternate = fiber.alternate;
   let queue1;
@@ -271,19 +255,19 @@ export function enqueueUpdate<State>(
   }
   if (queue2 === null || queue1 === queue2) {
     // There's only a single queue.
-    appendUpdateToQueue(queue1, update, expirationTime);
+    appendUpdateToQueue(queue1, update);
   } else {
     // There are two queues. We need to append the update to both queues,
     // while accounting for the persistent structure of the list — we don't
     // want the same update to be added multiple times.
     if (queue1.lastUpdate === null || queue2.lastUpdate === null) {
       // One of the queues is not empty. We must add the update to both queues.
-      appendUpdateToQueue(queue1, update, expirationTime);
-      appendUpdateToQueue(queue2, update, expirationTime);
+      appendUpdateToQueue(queue1, update);
+      appendUpdateToQueue(queue2, update);
     } else {
       // Both queues are non-empty. The last update is the same in both lists,
       // because of structural sharing. So, only append to one of the lists.
-      appendUpdateToQueue(queue1, update, expirationTime);
+      appendUpdateToQueue(queue1, update);
       // But we still need to update the `lastUpdate` pointer of queue2.
       queue2.lastUpdate = update;
     }
@@ -311,7 +295,6 @@ export function enqueueUpdate<State>(
 export function enqueueCapturedUpdate<State>(
   workInProgress: Fiber,
   update: Update<State>,
-  renderExpirationTime: ExpirationTime,
 ) {
   // Captured updates go into a separate list, and only on the work-in-
   // progress queue.
@@ -337,14 +320,6 @@ export function enqueueCapturedUpdate<State>(
   } else {
     workInProgressQueue.lastCapturedUpdate.next = update;
     workInProgressQueue.lastCapturedUpdate = update;
-  }
-  if (
-    workInProgressQueue.expirationTime === NoWork ||
-    workInProgressQueue.expirationTime > renderExpirationTime
-  ) {
-    // The incoming update has the earliest expiration of any update in the
-    // queue. Update the queue's expiration time.
-    workInProgressQueue.expirationTime = renderExpirationTime;
   }
 }
 
@@ -437,14 +412,6 @@ export function processUpdateQueue<State>(
   renderExpirationTime: ExpirationTime,
 ): void {
   hasForceUpdate = false;
-
-  if (
-    queue.expirationTime === NoWork ||
-    queue.expirationTime > renderExpirationTime
-  ) {
-    // Insufficient priority. Bailout.
-    return;
-  }
 
   queue = ensureWorkInProgressQueueIsAClone(workInProgress, queue);
 
@@ -577,8 +544,15 @@ export function processUpdateQueue<State>(
   queue.baseState = newBaseState;
   queue.firstUpdate = newFirstUpdate;
   queue.firstCapturedUpdate = newFirstCapturedUpdate;
-  queue.expirationTime = newExpirationTime;
 
+  // Set the remaining expiration time to be whatever is remaining in the queue.
+  // This should be fine because the only two other things that contribute to
+  // expiration time are props and context. We're already in the middle of the
+  // begin phase by the time we start processing the queue, so we've already
+  // dealt with the props. Context in components that specify
+  // shouldComponentUpdate is tricky; but we'll have to account for
+  // that regardless.
+  workInProgress.expirationTime = newExpirationTime;
   workInProgress.memoizedState = resultState;
 
   if (__DEV__) {

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -30,1102 +30,1297 @@ describe('ReactNewContext', () => {
   //   return {type: 'div', children, prop: undefined};
   // }
 
+  function Text(props) {
+    ReactNoop.yield(props.text);
+    return <span prop={props.text} />;
+  }
+
   function span(prop) {
     return {type: 'span', children: [], prop};
   }
 
-  it('simple mount and update', () => {
-    const Context = React.createContext(1);
+  // We have several ways of reading from context. sharedContextTests runs
+  // a suite of tests for a given context consumer implementation.
+  sharedContextTests('Context.Consumer', Context => Context.Consumer);
+  sharedContextTests(
+    'Context.unstable_read inside functional component',
+    Context =>
+      function Consumer(props) {
+        const observedBits = props.unstable_observedBits;
+        const contextValue = Context.unstable_read(observedBits);
+        const render = props.children;
+        return render(contextValue);
+      },
+  );
+  sharedContextTests(
+    'Context.unstable_read inside class component',
+    Context =>
+      class Consumer extends React.Component {
+        render() {
+          const observedBits = this.props.unstable_observedBits;
+          const contextValue = Context.unstable_read(observedBits);
+          const render = this.props.children;
+          return render(contextValue);
+        }
+      },
+  );
 
-    function Consumer(props) {
-      return (
-        <Context.Consumer>
-          {value => <span prop={'Result: ' + value} />}
-        </Context.Consumer>
-      );
-    }
+  function sharedContextTests(label, getConsumer) {
+    describe(`reading context with ${label}`, () => {
+      it('simple mount and update', () => {
+        const Context = React.createContext(1);
+        const Consumer = getConsumer(Context);
 
-    const Indirection = React.Fragment;
+        const Indirection = React.Fragment;
 
-    function App(props) {
-      return (
-        <Context.Provider value={props.value}>
-          <Indirection>
-            <Indirection>
-              <Consumer />
-            </Indirection>
-          </Indirection>
-        </Context.Provider>
-      );
-    }
+        function App(props) {
+          return (
+            <Context.Provider value={props.value}>
+              <Indirection>
+                <Indirection>
+                  <Consumer>
+                    {value => <span prop={'Result: ' + value} />}
+                  </Consumer>
+                </Indirection>
+              </Indirection>
+            </Context.Provider>
+          );
+        }
 
-    ReactNoop.render(<App value={2} />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span('Result: 2')]);
+        ReactNoop.render(<App value={2} />);
+        ReactNoop.flush();
+        expect(ReactNoop.getChildren()).toEqual([span('Result: 2')]);
 
-    // Update
-    ReactNoop.render(<App value={3} />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span('Result: 3')]);
-  });
+        // Update
+        ReactNoop.render(<App value={3} />);
+        ReactNoop.flush();
+        expect(ReactNoop.getChildren()).toEqual([span('Result: 3')]);
+      });
 
-  it('propagates through shouldComponentUpdate false', () => {
-    const Context = React.createContext(1);
+      it('propagates through shouldComponentUpdate false', () => {
+        const Context = React.createContext(1);
+        const ContextConsumer = getConsumer(Context);
 
-    function Provider(props) {
-      ReactNoop.yield('Provider');
-      return (
-        <Context.Provider value={props.value}>
-          {props.children}
-        </Context.Provider>
-      );
-    }
-
-    function Consumer(props) {
-      ReactNoop.yield('Consumer');
-      return (
-        <Context.Consumer>
-          {value => {
-            ReactNoop.yield('Consumer render prop');
-            return <span prop={'Result: ' + value} />;
-          }}
-        </Context.Consumer>
-      );
-    }
-
-    class Indirection extends React.Component {
-      shouldComponentUpdate() {
-        return false;
-      }
-      render() {
-        ReactNoop.yield('Indirection');
-        return this.props.children;
-      }
-    }
-
-    function App(props) {
-      ReactNoop.yield('App');
-      return (
-        <Provider value={props.value}>
-          <Indirection>
-            <Indirection>
-              <Consumer />
-            </Indirection>
-          </Indirection>
-        </Provider>
-      );
-    }
-
-    ReactNoop.render(<App value={2} />);
-    expect(ReactNoop.flush()).toEqual([
-      'App',
-      'Provider',
-      'Indirection',
-      'Indirection',
-      'Consumer',
-      'Consumer render prop',
-    ]);
-    expect(ReactNoop.getChildren()).toEqual([span('Result: 2')]);
-
-    // Update
-    ReactNoop.render(<App value={3} />);
-    expect(ReactNoop.flush()).toEqual([
-      'App',
-      'Provider',
-      'Consumer render prop',
-    ]);
-    expect(ReactNoop.getChildren()).toEqual([span('Result: 3')]);
-  });
-
-  it('consumers bail out if context value is the same', () => {
-    const Context = React.createContext(1);
-
-    function Provider(props) {
-      ReactNoop.yield('Provider');
-      return (
-        <Context.Provider value={props.value}>
-          {props.children}
-        </Context.Provider>
-      );
-    }
-
-    function Consumer(props) {
-      ReactNoop.yield('Consumer');
-      return (
-        <Context.Consumer>
-          {value => {
-            ReactNoop.yield('Consumer render prop');
-            return <span prop={'Result: ' + value} />;
-          }}
-        </Context.Consumer>
-      );
-    }
-
-    class Indirection extends React.Component {
-      shouldComponentUpdate() {
-        return false;
-      }
-      render() {
-        ReactNoop.yield('Indirection');
-        return this.props.children;
-      }
-    }
-
-    function App(props) {
-      ReactNoop.yield('App');
-      return (
-        <Provider value={props.value}>
-          <Indirection>
-            <Indirection>
-              <Consumer />
-            </Indirection>
-          </Indirection>
-        </Provider>
-      );
-    }
-
-    ReactNoop.render(<App value={2} />);
-    expect(ReactNoop.flush()).toEqual([
-      'App',
-      'Provider',
-      'Indirection',
-      'Indirection',
-      'Consumer',
-      'Consumer render prop',
-    ]);
-    expect(ReactNoop.getChildren()).toEqual([span('Result: 2')]);
-
-    // Update with the same context value
-    ReactNoop.render(<App value={2} />);
-    expect(ReactNoop.flush()).toEqual([
-      'App',
-      'Provider',
-      // Don't call render prop again
-    ]);
-    expect(ReactNoop.getChildren()).toEqual([span('Result: 2')]);
-  });
-
-  it('nested providers', () => {
-    const Context = React.createContext(1);
-
-    function Provider(props) {
-      return (
-        <Context.Consumer>
-          {contextValue => (
-            // Multiply previous context value by 2, unless prop overrides
-            <Context.Provider value={props.value || contextValue * 2}>
+        function Provider(props) {
+          ReactNoop.yield('Provider');
+          return (
+            <Context.Provider value={props.value}>
               {props.children}
             </Context.Provider>
-          )}
-        </Context.Consumer>
-      );
-    }
+          );
+        }
 
-    function Consumer(props) {
-      return (
-        <Context.Consumer>
-          {value => <span prop={'Result: ' + value} />}
-        </Context.Consumer>
-      );
-    }
+        function Consumer(props) {
+          ReactNoop.yield('Consumer');
+          return (
+            <ContextConsumer>
+              {value => {
+                ReactNoop.yield('Consumer render prop');
+                return <span prop={'Result: ' + value} />;
+              }}
+            </ContextConsumer>
+          );
+        }
 
-    class Indirection extends React.Component {
-      shouldComponentUpdate() {
-        return false;
-      }
-      render() {
-        return this.props.children;
-      }
-    }
+        class Indirection extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          render() {
+            ReactNoop.yield('Indirection');
+            return this.props.children;
+          }
+        }
 
-    function App(props) {
-      return (
-        <Provider value={props.value}>
-          <Indirection>
-            <Provider>
+        function App(props) {
+          ReactNoop.yield('App');
+          return (
+            <Provider value={props.value}>
+              <Indirection>
+                <Indirection>
+                  <Consumer />
+                </Indirection>
+              </Indirection>
+            </Provider>
+          );
+        }
+
+        ReactNoop.render(<App value={2} />);
+        expect(ReactNoop.flush()).toEqual([
+          'App',
+          'Provider',
+          'Indirection',
+          'Indirection',
+          'Consumer',
+          'Consumer render prop',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([span('Result: 2')]);
+
+        // Update
+        ReactNoop.render(<App value={3} />);
+        expect(ReactNoop.flush()).toEqual([
+          'App',
+          'Provider',
+          'Consumer render prop',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([span('Result: 3')]);
+      });
+
+      it('consumers bail out if context value is the same', () => {
+        const Context = React.createContext(1);
+        const ContextConsumer = getConsumer(Context);
+
+        function Provider(props) {
+          ReactNoop.yield('Provider');
+          return (
+            <Context.Provider value={props.value}>
+              {props.children}
+            </Context.Provider>
+          );
+        }
+
+        function Consumer(props) {
+          ReactNoop.yield('Consumer');
+          return (
+            <ContextConsumer>
+              {value => {
+                ReactNoop.yield('Consumer render prop');
+                return <span prop={'Result: ' + value} />;
+              }}
+            </ContextConsumer>
+          );
+        }
+
+        class Indirection extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          render() {
+            ReactNoop.yield('Indirection');
+            return this.props.children;
+          }
+        }
+
+        function App(props) {
+          ReactNoop.yield('App');
+          return (
+            <Provider value={props.value}>
+              <Indirection>
+                <Indirection>
+                  <Consumer />
+                </Indirection>
+              </Indirection>
+            </Provider>
+          );
+        }
+
+        ReactNoop.render(<App value={2} />);
+        expect(ReactNoop.flush()).toEqual([
+          'App',
+          'Provider',
+          'Indirection',
+          'Indirection',
+          'Consumer',
+          'Consumer render prop',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([span('Result: 2')]);
+
+        // Update with the same context value
+        ReactNoop.render(<App value={2} />);
+        expect(ReactNoop.flush()).toEqual([
+          'App',
+          'Provider',
+          // Don't call render prop again
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([span('Result: 2')]);
+      });
+
+      it('nested providers', () => {
+        const Context = React.createContext(1);
+        const Consumer = getConsumer(Context);
+
+        function Provider(props) {
+          return (
+            <Consumer>
+              {contextValue => (
+                // Multiply previous context value by 2, unless prop overrides
+                <Context.Provider value={props.value || contextValue * 2}>
+                  {props.children}
+                </Context.Provider>
+              )}
+            </Consumer>
+          );
+        }
+
+        class Indirection extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          render() {
+            return this.props.children;
+          }
+        }
+
+        function App(props) {
+          return (
+            <Provider value={props.value}>
               <Indirection>
                 <Provider>
                   <Indirection>
-                    <Consumer />
+                    <Provider>
+                      <Indirection>
+                        <Consumer>
+                          {value => <span prop={'Result: ' + value} />}
+                        </Consumer>
+                      </Indirection>
+                    </Provider>
                   </Indirection>
                 </Provider>
               </Indirection>
             </Provider>
-          </Indirection>
-        </Provider>
-      );
-    }
+          );
+        }
 
-    ReactNoop.render(<App value={2} />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span('Result: 8')]);
+        ReactNoop.render(<App value={2} />);
+        ReactNoop.flush();
+        expect(ReactNoop.getChildren()).toEqual([span('Result: 8')]);
 
-    // Update
-    ReactNoop.render(<App value={3} />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span('Result: 12')]);
-  });
+        // Update
+        ReactNoop.render(<App value={3} />);
+        ReactNoop.flush();
+        expect(ReactNoop.getChildren()).toEqual([span('Result: 12')]);
+      });
 
-  it('should provide the correct (default) values to consumers outside of a provider', () => {
-    const FooContext = React.createContext({value: 'foo-initial'});
-    const BarContext = React.createContext({value: 'bar-initial'});
+      it('should provide the correct (default) values to consumers outside of a provider', () => {
+        const FooContext = React.createContext({value: 'foo-initial'});
+        const BarContext = React.createContext({value: 'bar-initial'});
+        const FooConsumer = getConsumer(FooContext);
+        const BarConsumer = getConsumer(BarContext);
 
-    const Verify = ({actual, expected}) => {
-      expect(expected).toBe(actual);
-      return null;
-    };
+        const Verify = ({actual, expected}) => {
+          expect(expected).toBe(actual);
+          return null;
+        };
 
-    ReactNoop.render(
-      <React.Fragment>
-        <BarContext.Provider value={{value: 'bar-updated'}}>
-          <BarContext.Consumer>
-            {({value}) => <Verify actual={value} expected="bar-updated" />}
-          </BarContext.Consumer>
+        ReactNoop.render(
+          <React.Fragment>
+            <BarContext.Provider value={{value: 'bar-updated'}}>
+              <BarConsumer>
+                {({value}) => <Verify actual={value} expected="bar-updated" />}
+              </BarConsumer>
 
-          <FooContext.Provider value={{value: 'foo-updated'}}>
-            <FooContext.Consumer>
-              {({value}) => <Verify actual={value} expected="foo-updated" />}
-            </FooContext.Consumer>
-          </FooContext.Provider>
-        </BarContext.Provider>
+              <FooContext.Provider value={{value: 'foo-updated'}}>
+                <FooConsumer>
+                  {({value}) => (
+                    <Verify actual={value} expected="foo-updated" />
+                  )}
+                </FooConsumer>
+              </FooContext.Provider>
+            </BarContext.Provider>
 
-        <FooContext.Consumer>
-          {({value}) => <Verify actual={value} expected="foo-initial" />}
-        </FooContext.Consumer>
-        <BarContext.Consumer>
-          {({value}) => <Verify actual={value} expected="bar-initial" />}
-        </BarContext.Consumer>
-      </React.Fragment>,
-    );
-    ReactNoop.flush();
-  });
+            <FooConsumer>
+              {({value}) => <Verify actual={value} expected="foo-initial" />}
+            </FooConsumer>
+            <BarConsumer>
+              {({value}) => <Verify actual={value} expected="bar-initial" />}
+            </BarConsumer>
+          </React.Fragment>,
+        );
+        ReactNoop.flush();
+      });
 
-  it('multiple consumers in different branches', () => {
-    const Context = React.createContext(1);
+      it('multiple consumers in different branches', () => {
+        const Context = React.createContext(1);
+        const Consumer = getConsumer(Context);
 
-    function Provider(props) {
-      return (
-        <Context.Consumer>
-          {contextValue => (
-            // Multiply previous context value by 2, unless prop overrides
-            <Context.Provider value={props.value || contextValue * 2}>
+        function Provider(props) {
+          return (
+            <Context.Consumer>
+              {contextValue => (
+                // Multiply previous context value by 2, unless prop overrides
+                <Context.Provider value={props.value || contextValue * 2}>
+                  {props.children}
+                </Context.Provider>
+              )}
+            </Context.Consumer>
+          );
+        }
+
+        class Indirection extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          render() {
+            return this.props.children;
+          }
+        }
+
+        function App(props) {
+          return (
+            <Provider value={props.value}>
+              <Indirection>
+                <Indirection>
+                  <Provider>
+                    <Consumer>
+                      {value => <span prop={'Result: ' + value} />}
+                    </Consumer>
+                  </Provider>
+                </Indirection>
+                <Indirection>
+                  <Consumer>
+                    {value => <span prop={'Result: ' + value} />}
+                  </Consumer>
+                </Indirection>
+              </Indirection>
+            </Provider>
+          );
+        }
+
+        ReactNoop.render(<App value={2} />);
+        ReactNoop.flush();
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Result: 4'),
+          span('Result: 2'),
+        ]);
+
+        // Update
+        ReactNoop.render(<App value={3} />);
+        ReactNoop.flush();
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Result: 6'),
+          span('Result: 3'),
+        ]);
+
+        // Another update
+        ReactNoop.render(<App value={4} />);
+        ReactNoop.flush();
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Result: 8'),
+          span('Result: 4'),
+        ]);
+      });
+
+      it('compares context values with Object.is semantics', () => {
+        const Context = React.createContext(1);
+        const ContextConsumer = getConsumer(Context);
+
+        function Provider(props) {
+          ReactNoop.yield('Provider');
+          return (
+            <Context.Provider value={props.value}>
               {props.children}
             </Context.Provider>
-          )}
-        </Context.Consumer>
-      );
-    }
-
-    function Consumer(props) {
-      return (
-        <Context.Consumer>
-          {value => <span prop={'Result: ' + value} />}
-        </Context.Consumer>
-      );
-    }
-
-    class Indirection extends React.Component {
-      shouldComponentUpdate() {
-        return false;
-      }
-      render() {
-        return this.props.children;
-      }
-    }
-
-    function App(props) {
-      return (
-        <Provider value={props.value}>
-          <Indirection>
-            <Indirection>
-              <Provider>
-                <Consumer />
-              </Provider>
-            </Indirection>
-            <Indirection>
-              <Consumer />
-            </Indirection>
-          </Indirection>
-        </Provider>
-      );
-    }
-
-    ReactNoop.render(<App value={2} />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([
-      span('Result: 4'),
-      span('Result: 2'),
-    ]);
-
-    // Update
-    ReactNoop.render(<App value={3} />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([
-      span('Result: 6'),
-      span('Result: 3'),
-    ]);
-
-    // Another update
-    ReactNoop.render(<App value={4} />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([
-      span('Result: 8'),
-      span('Result: 4'),
-    ]);
-  });
-
-  it('compares context values with Object.is semantics', () => {
-    const Context = React.createContext(1);
-
-    function Provider(props) {
-      ReactNoop.yield('Provider');
-      return (
-        <Context.Provider value={props.value}>
-          {props.children}
-        </Context.Provider>
-      );
-    }
-
-    function Consumer(props) {
-      ReactNoop.yield('Consumer');
-      return (
-        <Context.Consumer>
-          {value => {
-            ReactNoop.yield('Consumer render prop');
-            return <span prop={'Result: ' + value} />;
-          }}
-        </Context.Consumer>
-      );
-    }
-
-    class Indirection extends React.Component {
-      shouldComponentUpdate() {
-        return false;
-      }
-      render() {
-        ReactNoop.yield('Indirection');
-        return this.props.children;
-      }
-    }
-
-    function App(props) {
-      ReactNoop.yield('App');
-      return (
-        <Provider value={props.value}>
-          <Indirection>
-            <Indirection>
-              <Consumer />
-            </Indirection>
-          </Indirection>
-        </Provider>
-      );
-    }
-
-    ReactNoop.render(<App value={NaN} />);
-    expect(ReactNoop.flush()).toEqual([
-      'App',
-      'Provider',
-      'Indirection',
-      'Indirection',
-      'Consumer',
-      'Consumer render prop',
-    ]);
-    expect(ReactNoop.getChildren()).toEqual([span('Result: NaN')]);
-
-    // Update
-    ReactNoop.render(<App value={NaN} />);
-    expect(ReactNoop.flush()).toEqual([
-      'App',
-      'Provider',
-      // Consumer should not re-render again
-      // 'Consumer render prop',
-    ]);
-    expect(ReactNoop.getChildren()).toEqual([span('Result: NaN')]);
-  });
-
-  it('context unwinds when interrupted', () => {
-    const Context = React.createContext('Default');
-
-    function Consumer(props) {
-      return (
-        <Context.Consumer>
-          {value => <span prop={'Result: ' + value} />}
-        </Context.Consumer>
-      );
-    }
-
-    function BadRender() {
-      throw new Error('Bad render');
-    }
-
-    class ErrorBoundary extends React.Component {
-      state = {error: null};
-      componentDidCatch(error) {
-        this.setState({error});
-      }
-      render() {
-        if (this.state.error) {
-          return null;
+          );
         }
-        return this.props.children;
-      }
-    }
 
-    function App(props) {
-      return (
-        <React.Fragment>
-          <Context.Provider value="Does not unwind">
-            <ErrorBoundary>
-              <Context.Provider value="Unwinds after BadRender throws">
-                <BadRender />
-              </Context.Provider>
-            </ErrorBoundary>
-            <Consumer />
-          </Context.Provider>
-        </React.Fragment>
-      );
-    }
+        function Consumer(props) {
+          ReactNoop.yield('Consumer');
+          return (
+            <ContextConsumer>
+              {value => {
+                ReactNoop.yield('Consumer render prop');
+                return <span prop={'Result: ' + value} />;
+              }}
+            </ContextConsumer>
+          );
+        }
 
-    ReactNoop.render(<App value="A" />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([
-      // The second provider should use the default value.
-      span('Result: Does not unwind'),
-    ]);
-  });
+        class Indirection extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          render() {
+            ReactNoop.yield('Indirection');
+            return this.props.children;
+          }
+        }
 
-  it('can skip consumers with bitmask', () => {
-    const Context = React.createContext({foo: 0, bar: 0}, (a, b) => {
-      let result = 0;
-      if (a.foo !== b.foo) {
-        result |= 0b01;
-      }
-      if (a.bar !== b.bar) {
-        result |= 0b10;
-      }
-      return result;
-    });
-
-    function Provider(props) {
-      return (
-        <Context.Provider value={{foo: props.foo, bar: props.bar}}>
-          {props.children}
-        </Context.Provider>
-      );
-    }
-
-    function Foo() {
-      return (
-        <Context.Consumer unstable_observedBits={0b01}>
-          {value => {
-            ReactNoop.yield('Foo');
-            return <span prop={'Foo: ' + value.foo} />;
-          }}
-        </Context.Consumer>
-      );
-    }
-
-    function Bar() {
-      return (
-        <Context.Consumer unstable_observedBits={0b10}>
-          {value => {
-            ReactNoop.yield('Bar');
-            return <span prop={'Bar: ' + value.bar} />;
-          }}
-        </Context.Consumer>
-      );
-    }
-
-    class Indirection extends React.Component {
-      shouldComponentUpdate() {
-        return false;
-      }
-      render() {
-        return this.props.children;
-      }
-    }
-
-    function App(props) {
-      return (
-        <Provider foo={props.foo} bar={props.bar}>
-          <Indirection>
-            <Indirection>
-              <Foo />
-            </Indirection>
-            <Indirection>
-              <Bar />
-            </Indirection>
-          </Indirection>
-        </Provider>
-      );
-    }
-
-    ReactNoop.render(<App foo={1} bar={1} />);
-    expect(ReactNoop.flush()).toEqual(['Foo', 'Bar']);
-    expect(ReactNoop.getChildren()).toEqual([span('Foo: 1'), span('Bar: 1')]);
-
-    // Update only foo
-    ReactNoop.render(<App foo={2} bar={1} />);
-    expect(ReactNoop.flush()).toEqual(['Foo']);
-    expect(ReactNoop.getChildren()).toEqual([span('Foo: 2'), span('Bar: 1')]);
-
-    // Update only bar
-    ReactNoop.render(<App foo={2} bar={2} />);
-    expect(ReactNoop.flush()).toEqual(['Bar']);
-    expect(ReactNoop.getChildren()).toEqual([span('Foo: 2'), span('Bar: 2')]);
-
-    // Update both
-    ReactNoop.render(<App foo={3} bar={3} />);
-    expect(ReactNoop.flush()).toEqual(['Foo', 'Bar']);
-    expect(ReactNoop.getChildren()).toEqual([span('Foo: 3'), span('Bar: 3')]);
-  });
-
-  it('can skip parents with bitmask bailout while updating their children', () => {
-    const Context = React.createContext({foo: 0, bar: 0}, (a, b) => {
-      let result = 0;
-      if (a.foo !== b.foo) {
-        result |= 0b01;
-      }
-      if (a.bar !== b.bar) {
-        result |= 0b10;
-      }
-      return result;
-    });
-
-    function Provider(props) {
-      return (
-        <Context.Provider value={{foo: props.foo, bar: props.bar}}>
-          {props.children}
-        </Context.Provider>
-      );
-    }
-
-    function Foo(props) {
-      return (
-        <Context.Consumer unstable_observedBits={0b01}>
-          {value => {
-            ReactNoop.yield('Foo');
-            return (
-              <React.Fragment>
-                <span prop={'Foo: ' + value.foo} />
-                {props.children && props.children()}
-              </React.Fragment>
-            );
-          }}
-        </Context.Consumer>
-      );
-    }
-
-    function Bar(props) {
-      return (
-        <Context.Consumer unstable_observedBits={0b10}>
-          {value => {
-            ReactNoop.yield('Bar');
-            return (
-              <React.Fragment>
-                <span prop={'Bar: ' + value.bar} />
-                {props.children && props.children()}
-              </React.Fragment>
-            );
-          }}
-        </Context.Consumer>
-      );
-    }
-
-    class Indirection extends React.Component {
-      shouldComponentUpdate() {
-        return false;
-      }
-      render() {
-        return this.props.children;
-      }
-    }
-
-    function App(props) {
-      return (
-        <Provider foo={props.foo} bar={props.bar}>
-          <Indirection>
-            <Foo>
-              {/* Use a render prop so we don't test constant elements. */}
-              {() => (
+        function App(props) {
+          ReactNoop.yield('App');
+          return (
+            <Provider value={props.value}>
+              <Indirection>
                 <Indirection>
-                  <Bar>
-                    {() => (
-                      <Indirection>
-                        <Foo />
-                      </Indirection>
-                    )}
-                  </Bar>
+                  <Consumer />
                 </Indirection>
-              )}
-            </Foo>
-          </Indirection>
-        </Provider>
-      );
-    }
-
-    ReactNoop.render(<App foo={1} bar={1} />);
-    expect(ReactNoop.flush()).toEqual(['Foo', 'Bar', 'Foo']);
-    expect(ReactNoop.getChildren()).toEqual([
-      span('Foo: 1'),
-      span('Bar: 1'),
-      span('Foo: 1'),
-    ]);
-
-    // Update only foo
-    ReactNoop.render(<App foo={2} bar={1} />);
-    expect(ReactNoop.flush()).toEqual(['Foo', 'Foo']);
-    expect(ReactNoop.getChildren()).toEqual([
-      span('Foo: 2'),
-      span('Bar: 1'),
-      span('Foo: 2'),
-    ]);
-
-    // Update only bar
-    ReactNoop.render(<App foo={2} bar={2} />);
-    expect(ReactNoop.flush()).toEqual(['Bar']);
-    expect(ReactNoop.getChildren()).toEqual([
-      span('Foo: 2'),
-      span('Bar: 2'),
-      span('Foo: 2'),
-    ]);
-
-    // Update both
-    ReactNoop.render(<App foo={3} bar={3} />);
-    expect(ReactNoop.flush()).toEqual(['Foo', 'Bar', 'Foo']);
-    expect(ReactNoop.getChildren()).toEqual([
-      span('Foo: 3'),
-      span('Bar: 3'),
-      span('Foo: 3'),
-    ]);
-  });
-
-  it('warns if calculateChangedBits returns larger than a 31-bit integer', () => {
-    const Context = React.createContext(
-      0,
-      (a, b) => Math.pow(2, 32) - 1, // Return 32 bit int
-    );
-
-    function App(props) {
-      return <Context.Provider value={props.value} />;
-    }
-
-    ReactNoop.render(<App value={1} />);
-    ReactNoop.flush();
-
-    // Update
-    ReactNoop.render(<App value={2} />);
-    expect(ReactNoop.flush).toWarnDev(
-      'calculateChangedBits: Expected the return value to be a 31-bit ' +
-        'integer. Instead received: 4294967295',
-    );
-  });
-
-  it('warns if multiple renderers concurrently render the same context', () => {
-    spyOnDev(console, 'error');
-    const Context = React.createContext(0);
-
-    function Foo(props) {
-      ReactNoop.yield('Foo');
-      return null;
-    }
-
-    function App(props) {
-      return (
-        <Context.Provider value={props.value}>
-          <Foo />
-          <Foo />
-        </Context.Provider>
-      );
-    }
-
-    ReactNoop.render(<App value={1} />);
-    // Render past the Provider, but don't commit yet
-    ReactNoop.flushThrough(['Foo']);
-
-    // Get a new copy of ReactNoop
-    jest.resetModules();
-    ReactFeatureFlags = require('shared/ReactFeatureFlags');
-    React = require('react');
-    ReactNoop = require('react-noop-renderer');
-
-    // Render the provider again using a different renderer
-    ReactNoop.render(<App value={1} />);
-    ReactNoop.flush();
-
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Detected multiple renderers concurrently rendering the same ' +
-          'context provider. This is currently unsupported',
-      );
-    }
-  });
-
-  it('warns if consumer child is not a function', () => {
-    spyOnDev(console, 'error');
-    const Context = React.createContext(0);
-    ReactNoop.render(<Context.Consumer />);
-    expect(ReactNoop.flush).toThrow('render is not a function');
-    if (__DEV__) {
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'A context consumer was rendered with multiple children, or a child ' +
-          "that isn't a function",
-      );
-    }
-  });
-
-  it("does not re-render if there's an update in a child", () => {
-    const Context = React.createContext(0);
-
-    let child;
-    class Child extends React.Component {
-      state = {step: 0};
-      render() {
-        ReactNoop.yield('Child');
-        return (
-          <span
-            prop={`Context: ${this.props.context}, Step: ${this.state.step}`}
-          />
-        );
-      }
-    }
-
-    function App(props) {
-      return (
-        <Context.Provider value={props.value}>
-          <Context.Consumer>
-            {value => {
-              ReactNoop.yield('Consumer render prop');
-              return <Child ref={inst => (child = inst)} context={value} />;
-            }}
-          </Context.Consumer>
-        </Context.Provider>
-      );
-    }
-
-    // Initial mount
-    ReactNoop.render(<App value={1} />);
-    expect(ReactNoop.flush()).toEqual(['Consumer render prop', 'Child']);
-    expect(ReactNoop.getChildren()).toEqual([span('Context: 1, Step: 0')]);
-
-    child.setState({step: 1});
-    expect(ReactNoop.flush()).toEqual(['Child']);
-    expect(ReactNoop.getChildren()).toEqual([span('Context: 1, Step: 1')]);
-  });
-
-  it('provider bails out if children and value are unchanged (like sCU)', () => {
-    const Context = React.createContext(0);
-
-    function Child() {
-      ReactNoop.yield('Child');
-      return <span prop="Child" />;
-    }
-
-    const children = <Child />;
-
-    function App(props) {
-      ReactNoop.yield('App');
-      return (
-        <Context.Provider value={props.value}>{children}</Context.Provider>
-      );
-    }
-
-    // Initial mount
-    ReactNoop.render(<App value={1} />);
-    expect(ReactNoop.flush()).toEqual(['App', 'Child']);
-    expect(ReactNoop.getChildren()).toEqual([span('Child')]);
-
-    // Update
-    ReactNoop.render(<App value={1} />);
-    expect(ReactNoop.flush()).toEqual([
-      'App',
-      // Child does not re-render
-    ]);
-    expect(ReactNoop.getChildren()).toEqual([span('Child')]);
-  });
-
-  it('provider does not bail out if legacy context changed above', () => {
-    const Context = React.createContext(0);
-
-    function Child() {
-      ReactNoop.yield('Child');
-      return <span prop="Child" />;
-    }
-
-    const children = <Child />;
-
-    class LegacyProvider extends React.Component {
-      static childContextTypes = {
-        legacyValue: () => {},
-      };
-      state = {legacyValue: 1};
-      getChildContext() {
-        return {legacyValue: this.state.legacyValue};
-      }
-      render() {
-        ReactNoop.yield('LegacyProvider');
-        return this.props.children;
-      }
-    }
-
-    class App extends React.Component {
-      state = {value: 1};
-      render() {
-        ReactNoop.yield('App');
-        return (
-          <Context.Provider value={this.state.value}>
-            {this.props.children}
-          </Context.Provider>
-        );
-      }
-    }
-
-    const legacyProviderRef = React.createRef();
-    const appRef = React.createRef();
-
-    // Initial mount
-    ReactNoop.render(
-      <LegacyProvider ref={legacyProviderRef}>
-        <App ref={appRef} value={1}>
-          {children}
-        </App>
-      </LegacyProvider>,
-    );
-    expect(ReactNoop.flush()).toEqual(['LegacyProvider', 'App', 'Child']);
-    expect(ReactNoop.getChildren()).toEqual([span('Child')]);
-
-    // Update App with same value (should bail out)
-    appRef.current.setState({value: 1});
-    expect(ReactNoop.flush()).toEqual(['App']);
-    expect(ReactNoop.getChildren()).toEqual([span('Child')]);
-
-    // Update LegacyProvider (should not bail out)
-    legacyProviderRef.current.setState({value: 1});
-    expect(ReactNoop.flush()).toEqual(['LegacyProvider', 'App', 'Child']);
-    expect(ReactNoop.getChildren()).toEqual([span('Child')]);
-
-    // Update App with same value (should bail out)
-    appRef.current.setState({value: 1});
-    expect(ReactNoop.flush()).toEqual(['App']);
-    expect(ReactNoop.getChildren()).toEqual([span('Child')]);
-  });
-
-  it('consumer bails out if value is unchanged and something above bailed out', () => {
-    const Context = React.createContext(0);
-
-    function renderChildValue(value) {
-      ReactNoop.yield('Consumer');
-      return <span prop={value} />;
-    }
-
-    function ChildWithInlineRenderCallback() {
-      ReactNoop.yield('ChildWithInlineRenderCallback');
-      // Note: we are intentionally passing an inline arrow. Don't refactor.
-      return (
-        <Context.Consumer>{value => renderChildValue(value)}</Context.Consumer>
-      );
-    }
-
-    function ChildWithCachedRenderCallback() {
-      ReactNoop.yield('ChildWithCachedRenderCallback');
-      return <Context.Consumer>{renderChildValue}</Context.Consumer>;
-    }
-
-    class PureIndirection extends React.PureComponent {
-      render() {
-        ReactNoop.yield('PureIndirection');
-        return (
-          <React.Fragment>
-            <ChildWithInlineRenderCallback />
-            <ChildWithCachedRenderCallback />
-          </React.Fragment>
-        );
-      }
-    }
-
-    class App extends React.Component {
-      render() {
-        ReactNoop.yield('App');
-        return (
-          <Context.Provider value={this.props.value}>
-            <PureIndirection />
-          </Context.Provider>
-        );
-      }
-    }
-
-    // Initial mount
-    ReactNoop.render(<App value={1} />);
-    expect(ReactNoop.flush()).toEqual([
-      'App',
-      'PureIndirection',
-      'ChildWithInlineRenderCallback',
-      'Consumer',
-      'ChildWithCachedRenderCallback',
-      'Consumer',
-    ]);
-    expect(ReactNoop.getChildren()).toEqual([span(1), span(1)]);
-
-    // Update (bailout)
-    ReactNoop.render(<App value={1} />);
-    expect(ReactNoop.flush()).toEqual(['App']);
-    expect(ReactNoop.getChildren()).toEqual([span(1), span(1)]);
-
-    // Update (no bailout)
-    ReactNoop.render(<App value={2} />);
-    expect(ReactNoop.flush()).toEqual(['App', 'Consumer', 'Consumer']);
-    expect(ReactNoop.getChildren()).toEqual([span(2), span(2)]);
-  });
-
-  // Context consumer bails out on propagating "deep" updates when `value` hasn't changed.
-  // However, it doesn't bail out from rendering if the component above it re-rendered anyway.
-  // If we bailed out on referential equality, it would be confusing that you
-  // can call this.setState(), but an autobound render callback "blocked" the update.
-  // https://github.com/facebook/react/pull/12470#issuecomment-376917711
-  it('consumer does not bail out if there were no bailouts above it', () => {
-    const Context = React.createContext(0);
-
-    class App extends React.Component {
-      state = {
-        text: 'hello',
-      };
-
-      renderConsumer = context => {
-        ReactNoop.yield('App#renderConsumer');
-        return <span prop={this.state.text} />;
-      };
-
-      render() {
-        ReactNoop.yield('App');
-        return (
-          <Context.Provider value={this.props.value}>
-            <Context.Consumer>{this.renderConsumer}</Context.Consumer>
-          </Context.Provider>
-        );
-      }
-    }
-
-    // Initial mount
-    let inst;
-    ReactNoop.render(<App value={1} ref={ref => (inst = ref)} />);
-    expect(ReactNoop.flush()).toEqual(['App', 'App#renderConsumer']);
-    expect(ReactNoop.getChildren()).toEqual([span('hello')]);
-
-    // Update
-    inst.setState({text: 'goodbye'});
-    expect(ReactNoop.flush()).toEqual(['App', 'App#renderConsumer']);
-    expect(ReactNoop.getChildren()).toEqual([span('goodbye')]);
-  });
-
-  // This is a regression case for https://github.com/facebook/react/issues/12389.
-  it('does not run into an infinite loop', () => {
-    const Context = React.createContext(null);
-
-    class App extends React.Component {
-      renderItem(id) {
-        return (
-          <span key={id}>
-            <Context.Consumer>{() => <span>inner</span>}</Context.Consumer>
-            <span>outer</span>
-          </span>
-        );
-      }
-      renderList() {
-        const list = [1, 2].map(id => this.renderItem(id));
-        if (this.props.reverse) {
-          list.reverse();
+              </Indirection>
+            </Provider>
+          );
         }
-        return list;
+
+        ReactNoop.render(<App value={NaN} />);
+        expect(ReactNoop.flush()).toEqual([
+          'App',
+          'Provider',
+          'Indirection',
+          'Indirection',
+          'Consumer',
+          'Consumer render prop',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([span('Result: NaN')]);
+
+        // Update
+        ReactNoop.render(<App value={NaN} />);
+        expect(ReactNoop.flush()).toEqual([
+          'App',
+          'Provider',
+          // Consumer should not re-render again
+          // 'Consumer render prop',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([span('Result: NaN')]);
+      });
+
+      it('context unwinds when interrupted', () => {
+        const Context = React.createContext('Default');
+        const ContextConsumer = getConsumer(Context);
+
+        function Consumer(props) {
+          return (
+            <ContextConsumer>
+              {value => <span prop={'Result: ' + value} />}
+            </ContextConsumer>
+          );
+        }
+
+        function BadRender() {
+          throw new Error('Bad render');
+        }
+
+        class ErrorBoundary extends React.Component {
+          state = {error: null};
+          componentDidCatch(error) {
+            this.setState({error});
+          }
+          render() {
+            if (this.state.error) {
+              return null;
+            }
+            return this.props.children;
+          }
+        }
+
+        function App(props) {
+          return (
+            <React.Fragment>
+              <Context.Provider value="Does not unwind">
+                <ErrorBoundary>
+                  <Context.Provider value="Unwinds after BadRender throws">
+                    <BadRender />
+                  </Context.Provider>
+                </ErrorBoundary>
+                <Consumer />
+              </Context.Provider>
+            </React.Fragment>
+          );
+        }
+
+        ReactNoop.render(<App value="A" />);
+        ReactNoop.flush();
+        expect(ReactNoop.getChildren()).toEqual([
+          // The second provider should use the default value.
+          span('Result: Does not unwind'),
+        ]);
+      });
+
+      it('can skip consumers with bitmask', () => {
+        const Context = React.createContext({foo: 0, bar: 0}, (a, b) => {
+          let result = 0;
+          if (a.foo !== b.foo) {
+            result |= 0b01;
+          }
+          if (a.bar !== b.bar) {
+            result |= 0b10;
+          }
+          return result;
+        });
+        const Consumer = getConsumer(Context);
+
+        function Provider(props) {
+          return (
+            <Context.Provider value={{foo: props.foo, bar: props.bar}}>
+              {props.children}
+            </Context.Provider>
+          );
+        }
+
+        function Foo() {
+          return (
+            <Consumer unstable_observedBits={0b01}>
+              {value => {
+                ReactNoop.yield('Foo');
+                return <span prop={'Foo: ' + value.foo} />;
+              }}
+            </Consumer>
+          );
+        }
+
+        function Bar() {
+          return (
+            <Consumer unstable_observedBits={0b10}>
+              {value => {
+                ReactNoop.yield('Bar');
+                return <span prop={'Bar: ' + value.bar} />;
+              }}
+            </Consumer>
+          );
+        }
+
+        class Indirection extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          render() {
+            return this.props.children;
+          }
+        }
+
+        function App(props) {
+          return (
+            <Provider foo={props.foo} bar={props.bar}>
+              <Indirection>
+                <Indirection>
+                  <Foo />
+                </Indirection>
+                <Indirection>
+                  <Bar />
+                </Indirection>
+              </Indirection>
+            </Provider>
+          );
+        }
+
+        ReactNoop.render(<App foo={1} bar={1} />);
+        expect(ReactNoop.flush()).toEqual(['Foo', 'Bar']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Foo: 1'),
+          span('Bar: 1'),
+        ]);
+
+        // Update only foo
+        ReactNoop.render(<App foo={2} bar={1} />);
+        expect(ReactNoop.flush()).toEqual(['Foo']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Foo: 2'),
+          span('Bar: 1'),
+        ]);
+
+        // Update only bar
+        ReactNoop.render(<App foo={2} bar={2} />);
+        expect(ReactNoop.flush()).toEqual(['Bar']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Foo: 2'),
+          span('Bar: 2'),
+        ]);
+
+        // Update both
+        ReactNoop.render(<App foo={3} bar={3} />);
+        expect(ReactNoop.flush()).toEqual(['Foo', 'Bar']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Foo: 3'),
+          span('Bar: 3'),
+        ]);
+      });
+
+      it('can skip parents with bitmask bailout while updating their children', () => {
+        const Context = React.createContext({foo: 0, bar: 0}, (a, b) => {
+          let result = 0;
+          if (a.foo !== b.foo) {
+            result |= 0b01;
+          }
+          if (a.bar !== b.bar) {
+            result |= 0b10;
+          }
+          return result;
+        });
+        const Consumer = getConsumer(Context);
+
+        function Provider(props) {
+          return (
+            <Context.Provider value={{foo: props.foo, bar: props.bar}}>
+              {props.children}
+            </Context.Provider>
+          );
+        }
+
+        function Foo(props) {
+          return (
+            <Consumer unstable_observedBits={0b01}>
+              {value => {
+                ReactNoop.yield('Foo');
+                return (
+                  <React.Fragment>
+                    <span prop={'Foo: ' + value.foo} />
+                    {props.children && props.children()}
+                  </React.Fragment>
+                );
+              }}
+            </Consumer>
+          );
+        }
+
+        function Bar(props) {
+          return (
+            <Consumer unstable_observedBits={0b10}>
+              {value => {
+                ReactNoop.yield('Bar');
+                return (
+                  <React.Fragment>
+                    <span prop={'Bar: ' + value.bar} />
+                    {props.children && props.children()}
+                  </React.Fragment>
+                );
+              }}
+            </Consumer>
+          );
+        }
+
+        class Indirection extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          render() {
+            return this.props.children;
+          }
+        }
+
+        function App(props) {
+          return (
+            <Provider foo={props.foo} bar={props.bar}>
+              <Indirection>
+                <Foo>
+                  {/* Use a render prop so we don't test constant elements. */}
+                  {() => (
+                    <Indirection>
+                      <Bar>
+                        {() => (
+                          <Indirection>
+                            <Foo />
+                          </Indirection>
+                        )}
+                      </Bar>
+                    </Indirection>
+                  )}
+                </Foo>
+              </Indirection>
+            </Provider>
+          );
+        }
+
+        ReactNoop.render(<App foo={1} bar={1} />);
+        expect(ReactNoop.flush()).toEqual(['Foo', 'Bar', 'Foo']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Foo: 1'),
+          span('Bar: 1'),
+          span('Foo: 1'),
+        ]);
+
+        // Update only foo
+        ReactNoop.render(<App foo={2} bar={1} />);
+        expect(ReactNoop.flush()).toEqual(['Foo', 'Foo']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Foo: 2'),
+          span('Bar: 1'),
+          span('Foo: 2'),
+        ]);
+
+        // Update only bar
+        ReactNoop.render(<App foo={2} bar={2} />);
+        expect(ReactNoop.flush()).toEqual(['Bar']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Foo: 2'),
+          span('Bar: 2'),
+          span('Foo: 2'),
+        ]);
+
+        // Update both
+        ReactNoop.render(<App foo={3} bar={3} />);
+        expect(ReactNoop.flush()).toEqual(['Foo', 'Bar', 'Foo']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Foo: 3'),
+          span('Bar: 3'),
+          span('Foo: 3'),
+        ]);
+      });
+
+      it("does not re-render if there's an update in a child", () => {
+        const Context = React.createContext(0);
+        const Consumer = getConsumer(Context);
+
+        let child;
+        class Child extends React.Component {
+          state = {step: 0};
+          render() {
+            ReactNoop.yield('Child');
+            return (
+              <span
+                prop={`Context: ${this.props.context}, Step: ${
+                  this.state.step
+                }`}
+              />
+            );
+          }
+        }
+
+        function App(props) {
+          return (
+            <Context.Provider value={props.value}>
+              <Consumer>
+                {value => {
+                  ReactNoop.yield('Consumer render prop');
+                  return <Child ref={inst => (child = inst)} context={value} />;
+                }}
+              </Consumer>
+            </Context.Provider>
+          );
+        }
+
+        // Initial mount
+        ReactNoop.render(<App value={1} />);
+        expect(ReactNoop.flush()).toEqual(['Consumer render prop', 'Child']);
+        expect(ReactNoop.getChildren()).toEqual([span('Context: 1, Step: 0')]);
+
+        child.setState({step: 1});
+        expect(ReactNoop.flush()).toEqual(['Child']);
+        expect(ReactNoop.getChildren()).toEqual([span('Context: 1, Step: 1')]);
+      });
+
+      it('consumer bails out if value is unchanged and something above bailed out', () => {
+        const Context = React.createContext(0);
+        const Consumer = getConsumer(Context);
+
+        function renderChildValue(value) {
+          ReactNoop.yield('Consumer');
+          return <span prop={value} />;
+        }
+
+        function ChildWithInlineRenderCallback() {
+          ReactNoop.yield('ChildWithInlineRenderCallback');
+          // Note: we are intentionally passing an inline arrow. Don't refactor.
+          return <Consumer>{value => renderChildValue(value)}</Consumer>;
+        }
+
+        function ChildWithCachedRenderCallback() {
+          ReactNoop.yield('ChildWithCachedRenderCallback');
+          return <Consumer>{renderChildValue}</Consumer>;
+        }
+
+        class PureIndirection extends React.PureComponent {
+          render() {
+            ReactNoop.yield('PureIndirection');
+            return (
+              <React.Fragment>
+                <ChildWithInlineRenderCallback />
+                <ChildWithCachedRenderCallback />
+              </React.Fragment>
+            );
+          }
+        }
+
+        class App extends React.Component {
+          render() {
+            ReactNoop.yield('App');
+            return (
+              <Context.Provider value={this.props.value}>
+                <PureIndirection />
+              </Context.Provider>
+            );
+          }
+        }
+
+        // Initial mount
+        ReactNoop.render(<App value={1} />);
+        expect(ReactNoop.flush()).toEqual([
+          'App',
+          'PureIndirection',
+          'ChildWithInlineRenderCallback',
+          'Consumer',
+          'ChildWithCachedRenderCallback',
+          'Consumer',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([span(1), span(1)]);
+
+        // Update (bailout)
+        ReactNoop.render(<App value={1} />);
+        expect(ReactNoop.flush()).toEqual(['App']);
+        expect(ReactNoop.getChildren()).toEqual([span(1), span(1)]);
+
+        // Update (no bailout)
+        ReactNoop.render(<App value={2} />);
+        expect(ReactNoop.flush()).toEqual(['App', 'Consumer', 'Consumer']);
+        expect(ReactNoop.getChildren()).toEqual([span(2), span(2)]);
+      });
+
+      // Context consumer bails out on propagating "deep" updates when `value` hasn't changed.
+      // However, it doesn't bail out from rendering if the component above it re-rendered anyway.
+      // If we bailed out on referential equality, it would be confusing that you
+      // can call this.setState(), but an autobound render callback "blocked" the update.
+      // https://github.com/facebook/react/pull/12470#issuecomment-376917711
+      it('consumer does not bail out if there were no bailouts above it', () => {
+        const Context = React.createContext(0);
+        const Consumer = getConsumer(Context);
+
+        class App extends React.Component {
+          state = {
+            text: 'hello',
+          };
+
+          renderConsumer = context => {
+            ReactNoop.yield('App#renderConsumer');
+            return <span prop={this.state.text} />;
+          };
+
+          render() {
+            ReactNoop.yield('App');
+            return (
+              <Context.Provider value={this.props.value}>
+                <Consumer>{this.renderConsumer}</Consumer>
+              </Context.Provider>
+            );
+          }
+        }
+
+        // Initial mount
+        let inst;
+        ReactNoop.render(<App value={1} ref={ref => (inst = ref)} />);
+        expect(ReactNoop.flush()).toEqual(['App', 'App#renderConsumer']);
+        expect(ReactNoop.getChildren()).toEqual([span('hello')]);
+
+        // Update
+        inst.setState({text: 'goodbye'});
+        expect(ReactNoop.flush()).toEqual(['App', 'App#renderConsumer']);
+        expect(ReactNoop.getChildren()).toEqual([span('goodbye')]);
+      });
+
+      // This is a regression case for https://github.com/facebook/react/issues/12389.
+      it('does not run into an infinite loop', () => {
+        const Context = React.createContext(null);
+        const Consumer = getConsumer(Context);
+
+        class App extends React.Component {
+          renderItem(id) {
+            return (
+              <span key={id}>
+                <Consumer>{() => <span>inner</span>}</Consumer>
+                <span>outer</span>
+              </span>
+            );
+          }
+          renderList() {
+            const list = [1, 2].map(id => this.renderItem(id));
+            if (this.props.reverse) {
+              list.reverse();
+            }
+            return list;
+          }
+          render() {
+            return (
+              <Context.Provider value={{}}>
+                {this.renderList()}
+              </Context.Provider>
+            );
+          }
+        }
+
+        ReactNoop.render(<App reverse={false} />);
+        ReactNoop.flush();
+        ReactNoop.render(<App reverse={true} />);
+        ReactNoop.flush();
+        ReactNoop.render(<App reverse={false} />);
+        ReactNoop.flush();
+      });
+
+      // This is a regression case for https://github.com/facebook/react/issues/12686
+      it('does not skip some siblings', () => {
+        const Context = React.createContext(0);
+        const ContextConsumer = getConsumer(Context);
+
+        class App extends React.Component {
+          state = {
+            step: 0,
+          };
+
+          render() {
+            ReactNoop.yield('App');
+            return (
+              <Context.Provider value={this.state.step}>
+                <StaticContent />
+                {this.state.step > 0 && <Indirection />}
+              </Context.Provider>
+            );
+          }
+        }
+
+        class StaticContent extends React.PureComponent {
+          render() {
+            return (
+              <React.Fragment>
+                <React.Fragment>
+                  <span prop="static 1" />
+                  <span prop="static 2" />
+                </React.Fragment>
+              </React.Fragment>
+            );
+          }
+        }
+
+        class Indirection extends React.PureComponent {
+          render() {
+            return (
+              <ContextConsumer>
+                {value => {
+                  ReactNoop.yield('Consumer');
+                  return <span prop={value} />;
+                }}
+              </ContextConsumer>
+            );
+          }
+        }
+
+        // Initial mount
+        let inst;
+        ReactNoop.render(<App ref={ref => (inst = ref)} />);
+        expect(ReactNoop.flush()).toEqual(['App']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('static 1'),
+          span('static 2'),
+        ]);
+        // Update the first time
+        inst.setState({step: 1});
+        expect(ReactNoop.flush()).toEqual(['App', 'Consumer']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('static 1'),
+          span('static 2'),
+          span(1),
+        ]);
+        // Update the second time
+        inst.setState({step: 2});
+        expect(ReactNoop.flush()).toEqual(['App', 'Consumer']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('static 1'),
+          span('static 2'),
+          span(2),
+        ]);
+      });
+    });
+  }
+
+  describe('Context.Provider', () => {
+    it('warns if calculateChangedBits returns larger than a 31-bit integer', () => {
+      const Context = React.createContext(
+        0,
+        (a, b) => Math.pow(2, 32) - 1, // Return 32 bit int
+      );
+
+      function App(props) {
+        return <Context.Provider value={props.value} />;
       }
-      render() {
-        return (
-          <Context.Provider value={{}}>{this.renderList()}</Context.Provider>
-        );
+
+      ReactNoop.render(<App value={1} />);
+      ReactNoop.flush();
+
+      // Update
+      ReactNoop.render(<App value={2} />);
+      expect(ReactNoop.flush).toWarnDev(
+        'calculateChangedBits: Expected the return value to be a 31-bit ' +
+          'integer. Instead received: 4294967295',
+      );
+    });
+
+    it('warns if multiple renderers concurrently render the same context', () => {
+      spyOnDev(console, 'error');
+      const Context = React.createContext(0);
+
+      function Foo(props) {
+        ReactNoop.yield('Foo');
+        return null;
       }
-    }
 
-    ReactNoop.render(<App reverse={false} />);
-    ReactNoop.flush();
-    ReactNoop.render(<App reverse={true} />);
-    ReactNoop.flush();
-    ReactNoop.render(<App reverse={false} />);
-    ReactNoop.flush();
-  });
-
-  // This is a regression case for https://github.com/facebook/react/issues/12686
-  it('does not skip some siblings', () => {
-    const Context = React.createContext(0);
-
-    class App extends React.Component {
-      state = {
-        step: 0,
-      };
-
-      render() {
-        ReactNoop.yield('App');
+      function App(props) {
         return (
-          <Context.Provider value={this.state.step}>
-            <StaticContent />
-            {this.state.step > 0 && <Indirection />}
+          <Context.Provider value={props.value}>
+            <Foo />
+            <Foo />
           </Context.Provider>
         );
       }
-    }
 
-    class StaticContent extends React.PureComponent {
-      render() {
-        return (
-          <React.Fragment>
-            <React.Fragment>
-              <span prop="static 1" />
-              <span prop="static 2" />
-            </React.Fragment>
-          </React.Fragment>
+      ReactNoop.render(<App value={1} />);
+      // Render past the Provider, but don't commit yet
+      ReactNoop.flushThrough(['Foo']);
+
+      // Get a new copy of ReactNoop
+      jest.resetModules();
+      ReactFeatureFlags = require('shared/ReactFeatureFlags');
+      React = require('react');
+      ReactNoop = require('react-noop-renderer');
+
+      // Render the provider again using a different renderer
+      ReactNoop.render(<App value={1} />);
+      ReactNoop.flush();
+
+      if (__DEV__) {
+        expect(console.error.calls.argsFor(0)[0]).toContain(
+          'Detected multiple renderers concurrently rendering the same ' +
+            'context provider. This is currently unsupported',
         );
       }
-    }
+    });
 
-    class Indirection extends React.PureComponent {
-      render() {
-        return <Consumer />;
+    it('provider bails out if children and value are unchanged (like sCU)', () => {
+      const Context = React.createContext(0);
+
+      function Child() {
+        ReactNoop.yield('Child');
+        return <span prop="Child" />;
       }
-    }
 
-    function Consumer() {
-      return (
-        <Context.Consumer>
-          {value => {
-            ReactNoop.yield('Consumer');
-            return <span prop={value} />;
-          }}
-        </Context.Consumer>
+      const children = <Child />;
+
+      function App(props) {
+        ReactNoop.yield('App');
+        return (
+          <Context.Provider value={props.value}>{children}</Context.Provider>
+        );
+      }
+
+      // Initial mount
+      ReactNoop.render(<App value={1} />);
+      expect(ReactNoop.flush()).toEqual(['App', 'Child']);
+      expect(ReactNoop.getChildren()).toEqual([span('Child')]);
+
+      // Update
+      ReactNoop.render(<App value={1} />);
+      expect(ReactNoop.flush()).toEqual([
+        'App',
+        // Child does not re-render
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span('Child')]);
+    });
+
+    it('provider does not bail out if legacy context changed above', () => {
+      const Context = React.createContext(0);
+
+      function Child() {
+        ReactNoop.yield('Child');
+        return <span prop="Child" />;
+      }
+
+      const children = <Child />;
+
+      class LegacyProvider extends React.Component {
+        static childContextTypes = {
+          legacyValue: () => {},
+        };
+        state = {legacyValue: 1};
+        getChildContext() {
+          return {legacyValue: this.state.legacyValue};
+        }
+        render() {
+          ReactNoop.yield('LegacyProvider');
+          return this.props.children;
+        }
+      }
+
+      class App extends React.Component {
+        state = {value: 1};
+        render() {
+          ReactNoop.yield('App');
+          return (
+            <Context.Provider value={this.state.value}>
+              {this.props.children}
+            </Context.Provider>
+          );
+        }
+      }
+
+      const legacyProviderRef = React.createRef();
+      const appRef = React.createRef();
+
+      // Initial mount
+      ReactNoop.render(
+        <LegacyProvider ref={legacyProviderRef}>
+          <App ref={appRef} value={1}>
+            {children}
+          </App>
+        </LegacyProvider>,
       );
-    }
+      expect(ReactNoop.flush()).toEqual(['LegacyProvider', 'App', 'Child']);
+      expect(ReactNoop.getChildren()).toEqual([span('Child')]);
 
-    // Initial mount
-    let inst;
-    ReactNoop.render(<App ref={ref => (inst = ref)} />);
-    expect(ReactNoop.flush()).toEqual(['App']);
-    expect(ReactNoop.getChildren()).toEqual([
-      span('static 1'),
-      span('static 2'),
-    ]);
-    // Update the first time
-    inst.setState({step: 1});
-    expect(ReactNoop.flush()).toEqual(['App', 'Consumer']);
-    expect(ReactNoop.getChildren()).toEqual([
-      span('static 1'),
-      span('static 2'),
-      span(1),
-    ]);
-    // Update the second time
-    inst.setState({step: 2});
-    expect(ReactNoop.flush()).toEqual(['App', 'Consumer']);
-    expect(ReactNoop.getChildren()).toEqual([
-      span('static 1'),
-      span('static 2'),
-      span(2),
-    ]);
+      // Update App with same value (should bail out)
+      appRef.current.setState({value: 1});
+      expect(ReactNoop.flush()).toEqual(['App']);
+      expect(ReactNoop.getChildren()).toEqual([span('Child')]);
+
+      // Update LegacyProvider (should not bail out)
+      legacyProviderRef.current.setState({value: 1});
+      expect(ReactNoop.flush()).toEqual(['LegacyProvider', 'App', 'Child']);
+      expect(ReactNoop.getChildren()).toEqual([span('Child')]);
+
+      // Update App with same value (should bail out)
+      appRef.current.setState({value: 1});
+      expect(ReactNoop.flush()).toEqual(['App']);
+      expect(ReactNoop.getChildren()).toEqual([span('Child')]);
+    });
+  });
+
+  describe('Context.Consumer', () => {
+    it('warns if child is not a function', () => {
+      spyOnDev(console, 'error');
+      const Context = React.createContext(0);
+      ReactNoop.render(<Context.Consumer />);
+      expect(ReactNoop.flush).toThrow('render is not a function');
+      if (__DEV__) {
+        expect(console.error.calls.argsFor(0)[0]).toContain(
+          'A context consumer was rendered with multiple children, or a child ' +
+            "that isn't a function",
+        );
+      }
+    });
+
+    it('can read other contexts inside consumer render prop', () => {
+      const FooContext = React.createContext(0);
+      const BarContext = React.createContext(0);
+
+      function FooAndBar() {
+        return (
+          <FooContext>
+            {foo => {
+              const bar = BarContext.unstable_read();
+              return <Text text={`Foo: ${foo}, Bar: ${bar}`} />;
+            }}
+          </FooContext>
+        );
+      }
+
+      class Indirection extends React.Component {
+        shouldComponentUpdate() {
+          return false;
+        }
+        render() {
+          return this.props.children;
+        }
+      }
+
+      function App(props) {
+        return (
+          <FooContext.Provider value={props.foo}>
+            <BarContext.Provider value={props.bar}>
+              <Indirection>
+                <FooAndBar />
+              </Indirection>
+            </BarContext.Provider>
+          </FooContext.Provider>
+        );
+      }
+
+      ReactNoop.render(<App foo={1} bar={1} />);
+      expect(ReactNoop.flush()).toEqual(['Foo: 1, Bar: 1']);
+      expect(ReactNoop.getChildren()).toEqual([span('Foo: 1, Bar: 1')]);
+
+      // Update foo
+      ReactNoop.render(<App foo={2} bar={1} />);
+      expect(ReactNoop.flush()).toEqual(['Foo: 2, Bar: 1']);
+      expect(ReactNoop.getChildren()).toEqual([span('Foo: 2, Bar: 1')]);
+
+      // Update bar
+      ReactNoop.render(<App foo={2} bar={2} />);
+      expect(ReactNoop.flush()).toEqual(['Foo: 2, Bar: 2']);
+      expect(ReactNoop.getChildren()).toEqual([span('Foo: 2, Bar: 2')]);
+    });
+  });
+
+  describe('unstable_readContext', () => {
+    it('can use the same context multiple times in the same function', () => {
+      const Context = React.createContext({foo: 0, bar: 0, baz: 0}, (a, b) => {
+        let result = 0;
+        if (a.foo !== b.foo) {
+          result |= 0b001;
+        }
+        if (a.bar !== b.bar) {
+          result |= 0b010;
+        }
+        if (a.baz !== b.baz) {
+          result |= 0b100;
+        }
+        return result;
+      });
+
+      function Provider(props) {
+        return (
+          <Context.Provider
+            value={{foo: props.foo, bar: props.bar, baz: props.baz}}>
+            {props.children}
+          </Context.Provider>
+        );
+      }
+
+      function FooAndBar() {
+        const {foo} = Context.unstable_read(0b001);
+        const {bar} = Context.unstable_read(0b010);
+        return <Text text={`Foo: ${foo}, Bar: ${bar}`} />;
+      }
+
+      function Baz() {
+        const {baz} = Context.unstable_read(0b100);
+        return <Text text={'Baz: ' + baz} />;
+      }
+
+      class Indirection extends React.Component {
+        shouldComponentUpdate() {
+          return false;
+        }
+        render() {
+          return this.props.children;
+        }
+      }
+
+      function App(props) {
+        return (
+          <Provider foo={props.foo} bar={props.bar} baz={props.baz}>
+            <Indirection>
+              <Indirection>
+                <FooAndBar />
+              </Indirection>
+              <Indirection>
+                <Baz />
+              </Indirection>
+            </Indirection>
+          </Provider>
+        );
+      }
+
+      ReactNoop.render(<App foo={1} bar={1} baz={1} />);
+      expect(ReactNoop.flush()).toEqual(['Foo: 1, Bar: 1', 'Baz: 1']);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('Foo: 1, Bar: 1'),
+        span('Baz: 1'),
+      ]);
+
+      // Update only foo
+      ReactNoop.render(<App foo={2} bar={1} baz={1} />);
+      expect(ReactNoop.flush()).toEqual(['Foo: 2, Bar: 1']);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('Foo: 2, Bar: 1'),
+        span('Baz: 1'),
+      ]);
+
+      // Update only bar
+      ReactNoop.render(<App foo={2} bar={2} baz={1} />);
+      expect(ReactNoop.flush()).toEqual(['Foo: 2, Bar: 2']);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('Foo: 2, Bar: 2'),
+        span('Baz: 1'),
+      ]);
+
+      // Update only baz
+      ReactNoop.render(<App foo={2} bar={2} baz={2} />);
+      expect(ReactNoop.flush()).toEqual(['Baz: 2']);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('Foo: 2, Bar: 2'),
+        span('Baz: 2'),
+      ]);
+    });
   });
 
   it('unwinds after errors in complete phase', () => {

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -11,7 +11,23 @@ import {REACT_PROVIDER_TYPE, REACT_CONTEXT_TYPE} from 'shared/ReactSymbols';
 
 import type {ReactContext} from 'shared/ReactTypes';
 
+import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
+
+import ReactCurrentOwner from './ReactCurrentOwner';
+
+export function readContext<T>(
+  context: ReactContext<T>,
+  observedBits: void | number | boolean,
+): T {
+  const dispatcher = ReactCurrentOwner.currentDispatcher;
+  invariant(
+    dispatcher !== null,
+    'Context.unstable_read(): Context can only be read while React is ' +
+      'rendering, e.g. inside the render method or getDerivedStateFromProps.',
+  );
+  return dispatcher.readContext(context, observedBits);
+}
 
 export function createContext<T>(
   defaultValue: T,
@@ -47,6 +63,7 @@ export function createContext<T>(
     // These are circular
     Provider: (null: any),
     Consumer: (null: any),
+    unstable_read: (null: any),
   };
 
   context.Provider = {
@@ -54,6 +71,7 @@ export function createContext<T>(
     _context: context,
   };
   context.Consumer = context;
+  context.unstable_read = readContext.bind(null, context);
 
   if (__DEV__) {
     context._currentRenderer = null;

--- a/packages/react/src/ReactCurrentOwner.js
+++ b/packages/react/src/ReactCurrentOwner.js
@@ -8,6 +8,7 @@
  */
 
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
+import typeof {Dispatcher} from 'react-reconciler/src/ReactFiberDispatcher';
 
 /**
  * Keeps track of the current owner.
@@ -21,6 +22,7 @@ const ReactCurrentOwner = {
    * @type {ReactComponent}
    */
   current: (null: null | Fiber),
+  currentDispatcher: (null: null | Dispatcher),
 };
 
 export default ReactCurrentOwner;

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -79,6 +79,7 @@ export type ReactContext<T> = {
   $$typeof: Symbol | number,
   Consumer: ReactContext<T>,
   Provider: ReactProviderType<T>,
+  unstable_read: () => T,
 
   _calculateChangedBits: ((a: T, b: T) => number) | null,
   _defaultValue: T,


### PR DESCRIPTION
`Context.unstable_read` can be called anywhere within the render phase. That includes the render method, `getDerivedStateFromProps`, constructors, functional components, and context consumer render props.