### PR TITLE
Temporarily disable the DevTools auto-profiling behavior

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -352,7 +352,8 @@ export function createHostRootFiber(isAsync: boolean): Fiber {
     // Always collect profile timings when DevTools are present.
     // This enables DevTools to start capturing timing at any point–
     // Without some nodes in the tree having empty base times.
-    mode |= ProfileMode;
+    // TODO (bvaughn) Re-enable as part of PR #13123
+    // mode |= ProfileMode;
   }
 
   return createFiber(HostRoot, null, null, mode);

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -62,7 +62,8 @@ describe('ReactProfiler DevTools integration', () => {
     };
   });
 
-  it('should auto-Profile all fibers if the DevTools hook is detected', () => {
+  // TODO (bvaughn) Re-enable as part of PR #13123
+  xit('should auto-Profile all fibers if the DevTools hook is detected', () => {
     const App = ({multiplier}) => {
       advanceTimeBy(2);
       return (


### PR DESCRIPTION
Disable root profiling until #13123 has landed. Merge this PR if we need to unblock a sync and I'll revert it later. Otherwise, feel free to leave it unmerged and I'll close it if #13123 lands first.