### PR TITLE
Remove some statefulness from SSR stack handling

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -664,4 +664,60 @@ describe('ReactDOMServer', () => {
       require('react-dom');
     }).not.toThrow();
   });
+
+  it('includes a useful stack in warnings', () => {
+    function A() {
+      return null;
+    }
+
+    function B() {
+      return (
+        <font>
+          <C>
+            <span ariaTypo="no" />
+          </C>
+        </font>
+      );
+    }
+
+    class C extends React.Component {
+      render() {
+        return <b>{this.props.children}</b>;
+      }
+    }
+
+    function Child() {
+      return [<A key="1" />, <B key="2" />, <span ariaTypo2="no" />];
+    }
+
+    function App() {
+      return (
+        <div>
+          <section />
+          <span>
+            <Child />
+          </span>
+        </div>
+      );
+    }
+
+    expect(() => ReactDOMServer.renderToString(<App />)).toWarnDev([
+      'Invalid ARIA attribute `ariaTypo`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
+        '    in span (at **)\n' +
+        '    in b (at **)\n' +
+        '    in C (at **)\n' +
+        '    in font (at **)\n' +
+        '    in B (at **)\n' +
+        '    in Child (at **)\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)\n' +
+        '    in App (at **)',
+      'Invalid ARIA attribute `ariaTypo2`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
+        '    in span (at **)\n' +
+        '    in Child (at **)\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)\n' +
+        '    in App (at **)',
+    ]);
+  });
 });


### PR DESCRIPTION
I started looking into fixing https://github.com/facebook/react/issues/10188 (which I think would be good before we do https://github.com/facebook/react/issues/13149), but it was really hard to understand what's going on in the SSR stack handling because of the unnecessary mutable state.

I added a detailed test to capture regressions to this part of the code, and then refactored it to remove the stateful `currentDebugElementStack`. We could already get it from the frame if we only passed it down, which is what I’m doing. This also makes the `!== null` check [motivated in this comment](https://github.com/facebook/react/pull/10187#discussion_r127573702) unnecessary because even if it's re-entrant, we're going to access the right reference from the argument.

In a follow up, I'll try to fix reentrancy for SSR (and add test coverage around that).