### PR TITLE
Renamed *BaseTime Fiber attributes to *baseDuration

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -166,12 +166,12 @@ export type Fiber = {|
   // Duration of the most recent render time for this Fiber.
   // This value is not updated when we bailout for memoization purposes.
   // This field is only set when the enableProfilerTimer flag is enabled.
-  selfBaseTime?: number,
+  selfBaseDuration?: number,
 
   // Sum of base times for all descedents of this Fiber.
   // This value bubbles up during the "complete" phase.
   // This field is only set when the enableProfilerTimer flag is enabled.
-  treeBaseTime?: number,
+  treeBaseDuration?: number,
 
   // Conceptual aliases
   // workInProgress : Fiber ->  alternate The alternate used for reuse happens
@@ -230,8 +230,8 @@ function FiberNode(
   if (enableProfilerTimer) {
     this.actualDuration = 0;
     this.actualStartTime = 0;
-    this.selfBaseTime = 0;
-    this.treeBaseTime = 0;
+    this.selfBaseDuration = 0;
+    this.treeBaseDuration = 0;
   }
 
   if (__DEV__) {
@@ -338,8 +338,8 @@ export function createWorkInProgress(
   workInProgress.ref = current.ref;
 
   if (enableProfilerTimer) {
-    workInProgress.selfBaseTime = current.selfBaseTime;
-    workInProgress.treeBaseTime = current.treeBaseTime;
+    workInProgress.selfBaseDuration = current.selfBaseDuration;
+    workInProgress.treeBaseDuration = current.treeBaseDuration;
   }
 
   return workInProgress;
@@ -569,8 +569,8 @@ export function assignFiberPropertiesInDEV(
   if (enableProfilerTimer) {
     target.actualDuration = source.actualDuration;
     target.actualStartTime = source.actualStartTime;
-    target.selfBaseTime = source.selfBaseTime;
-    target.treeBaseTime = source.treeBaseTime;
+    target.selfBaseDuration = source.selfBaseDuration;
+    target.treeBaseDuration = source.treeBaseDuration;
   }
   target._debugID = source._debugID;
   target._debugSource = source._debugSource;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -830,7 +830,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           finishedWork.memoizedProps.id,
           current === null ? 'mount' : 'update',
           finishedWork.actualDuration,
-          finishedWork.treeBaseTime,
+          finishedWork.treeBaseDuration,
           finishedWork.actualStartTime,
           getCommitTime(),
         );

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -736,10 +736,10 @@ function resetExpirationTime(
   // Bubble up the earliest expiration time.
   // (And "base" render timers if that feature flag is enabled)
   if (enableProfilerTimer && workInProgress.mode & ProfileMode) {
-    let treeBaseTime = workInProgress.selfBaseTime;
+    let treeBaseDuration = workInProgress.selfBaseDuration;
     let child = workInProgress.child;
     while (child !== null) {
-      treeBaseTime += child.treeBaseTime;
+      treeBaseDuration += child.treeBaseDuration;
       if (
         child.expirationTime !== NoWork &&
         (newExpirationTime === NoWork ||
@@ -749,7 +749,7 @@ function resetExpirationTime(
       }
       child = child.sibling;
     }
-    workInProgress.treeBaseTime = treeBaseTime;
+    workInProgress.treeBaseDuration = treeBaseDuration;
   } else {
     let child = workInProgress.child;
     while (child !== null) {

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -153,7 +153,7 @@ function recordElapsedBaseRenderTimeIfRunning(fiber: Fiber): void {
     return;
   }
   if (baseStartTime !== -1) {
-    fiber.selfBaseTime = now() - baseStartTime;
+    fiber.selfBaseDuration = now() - baseStartTime;
   }
 }
 

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -92,7 +92,9 @@ describe('ReactProfiler DevTools integration', () => {
     // At this point, the base time should include both:
     // The time 2ms in the App component itself, and
     // The 10ms spend in the Profiler sub-tree beneath.
-    expect(rendered.root.findByType(App)._currentFiber().treeBaseTime).toBe(12);
+    expect(rendered.root.findByType(App)._currentFiber().treeBaseDuration).toBe(
+      12,
+    );
 
     rendered.update(<App multiplier={2} />);
 
@@ -106,7 +108,9 @@ describe('ReactProfiler DevTools integration', () => {
     // At this point, the base time should include both:
     // The initial 9ms for the components that do not re-render, and
     // The updated 6ms for the component that does.
-    expect(rendered.root.findByType(App)._currentFiber().treeBaseTime).toBe(15);
+    expect(rendered.root.findByType(App)._currentFiber().treeBaseDuration).toBe(
+      15,
+    );
   });
 
   it('should reset the fiber stack correctly after an error when profiling host roots', () => {
@@ -141,8 +145,8 @@ describe('ReactProfiler DevTools integration', () => {
     // At this point, the base time should include only the most recent (not failed) render.
     // It should not include time spent on the initial render,
     // Or time that elapsed between any of the above renders.
-    expect(rendered.root.findByType('div')._currentFiber().treeBaseTime).toBe(
-      7,
-    );
+    expect(
+      rendered.root.findByType('div')._currentFiber().treeBaseDuration,
+    ).toBe(7);
   });
 });


### PR DESCRIPTION
Resolves issue #13148

This is an unobservable change to all but the (under development) DevTools Profiler plugin. It is being done so that the plugin can safely feature detect a version of React that supports it. The profiler API has existed since the 16.4.0 release, but it did not support the DevTools plugin prior to PR #13058.

I chose to rename "time" to "duration" because it's more descriptive of what the field contains. That being said, the terms "actual duration" and "base duration" are pretty vague. If anyone has suggestions for better names– this is the best time to bikeshed about them.