### PR TITLE
Run react-dom SSR import test in jsdom-less environment

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -446,26 +446,4 @@ describe('ReactDOM', () => {
       global.requestAnimationFrame = previousRAF;
     }
   });
-
-  // We're just testing importing, not using it.
-  // It is important because even isomorphic components may import it.
-  it('can import findDOMNode in Node environment', () => {
-    const previousRAF = global.requestAnimationFrame;
-    const previousRIC = global.requestIdleCallback;
-    const prevWindow = global.window;
-    try {
-      global.requestAnimationFrame = undefined;
-      global.requestIdleCallback = undefined;
-      // Simulate the Node environment:
-      delete global.window;
-      jest.resetModules();
-      expect(() => {
-        require('react-dom');
-      }).not.toThrow();
-    } finally {
-      global.requestAnimationFrame = previousRAF;
-      global.requestIdleCallback = previousRIC;
-      global.window = prevWindow;
-    }
-  });
 });

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -643,4 +643,25 @@ describe('ReactDOMServer', () => {
       ReactDOMServer.renderToString(<ClassWithRenderNotExtended />);
     }).toThrow(TypeError);
   });
+
+  // We're just testing importing, not using it.
+  // It is important because even isomorphic components may import it.
+  it('can import react-dom in Node environment', () => {
+    if (
+      typeof requestAnimationFrame !== 'undefined' ||
+      global.hasOwnProperty('requestAnimationFrame') ||
+      typeof requestIdleCallback !== 'undefined' ||
+      global.hasOwnProperty('requestIdleCallback') ||
+      typeof window !== 'undefined' ||
+      global.hasOwnProperty('window')
+    ) {
+      // Don't remove this. This test is specifically checking
+      // what happens when they *don't* exist. It's useless otherwise.
+      throw new Error('Expected this test to run in a Node environment.');
+    }
+    jest.resetModules();
+    expect(() => {
+      require('react-dom');
+    }).not.toThrow();
+  });
 });

--- a/scripts/jest/setupEnvironment.js
+++ b/scripts/jest/setupEnvironment.js
@@ -7,24 +7,6 @@ if (NODE_ENV !== 'development' && NODE_ENV !== 'production') {
 global.__DEV__ = NODE_ENV === 'development';
 global.__PROFILE__ = NODE_ENV === 'development';
 
-global.requestAnimationFrame = function(callback) {
-  setTimeout(callback);
-};
-
-global.requestIdleCallback = function(callback) {
-  return setTimeout(() => {
-    callback({
-      timeRemaining() {
-        return Infinity;
-      },
-    });
-  });
-};
-
-global.cancelIdleCallback = function(callbackID) {
-  clearTimeout(callbackID);
-};
-
 // By default React console.error()'s any errors, caught or uncaught.
 // However it is annoying to assert that a warning fired each time
 // we assert that there is an exception in our tests. This lets us
@@ -34,7 +16,25 @@ global.cancelIdleCallback = function(callbackID) {
 Error.prototype.suppressReactErrorLogging = true;
 
 if (typeof window !== 'undefined') {
-  // Same as above.
+  global.requestAnimationFrame = function(callback) {
+    setTimeout(callback);
+  };
+
+  global.requestIdleCallback = function(callback) {
+    return setTimeout(() => {
+      callback({
+        timeRemaining() {
+          return Infinity;
+        },
+      });
+    });
+  };
+
+  global.cancelIdleCallback = function(callbackID) {
+    clearTimeout(callbackID);
+  };
+
+  // Same as we did with Error.prototype above.
   DOMException.prototype.suppressReactErrorLogging = true;
 
   // Also prevent JSDOM from logging intentionally thrown errors.


### PR DESCRIPTION
I added this test a while ago but I just noticed it is running in jsdom environment (so we have to delete some stuff from a global). However running it in a real jsdom-less environment would be a closer approximation to what it needs to verify.

We already have some tests that specify `@jest-environment node` in the header, including `ReactServerRendering-test`. So this is a better place for this test. I moved it there. I also added precautions in case somebody removes the header in the future.

That uncovered that we still run those "Node environment" tests with our custom shims for rAF and rIC. But we should only set those shims in jsdom environment. So I moved some of our Jest initialization code behind a `if (typeof window !== 'undefined')` condition.

This PR doesn't affect React itself. Only our test setup which is now closer to real conditions.