### PR TITLE
Fix stack reporting with re-entrant ReactDOMServer calls

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -9,11 +9,20 @@
 
 'use strict';
 
-let React = require('react');
-let ReactDOM = require('react-dom');
-const ReactTestUtils = require('react-dom/test-utils');
+let React;
+let ReactDOM;
+let ReactDOMServer;
+let ReactTestUtils;
 
 describe('ReactDOM', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMServer = require('react-dom/server');
+    ReactTestUtils = require('react-dom/test-utils');
+  });
+
   // TODO: uncomment this test once we can run in phantom, which
   // supports real submit events.
   /*
@@ -445,5 +454,65 @@ describe('ReactDOM', () => {
     } finally {
       global.requestAnimationFrame = previousRAF;
     }
+  });
+
+  it('reports stacks with re-entrant renderToString() calls on the client', () => {
+    function Child2(props) {
+      return <span ariaTypo3="no">{props.children}</span>;
+    }
+
+    function App2() {
+      return (
+        <Child2>
+          {ReactDOMServer.renderToString(<blink ariaTypo2="no" />)}
+        </Child2>
+      );
+    }
+
+    function Child() {
+      return (
+        <span ariaTypo4="no">{ReactDOMServer.renderToString(<App2 />)}</span>
+      );
+    }
+
+    function ServerEntry() {
+      return ReactDOMServer.renderToString(<Child />);
+    }
+
+    function App() {
+      return (
+        <div>
+          <span ariaTypo="no" />
+          <ServerEntry />
+          <font ariaTypo5="no" />
+        </div>
+      );
+    }
+
+    const container = document.createElement('div');
+    expect(() => ReactDOM.render(<App />, container)).toWarnDev([
+      // ReactDOM(App > div > span)
+      'Invalid ARIA attribute `ariaTypo`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)\n' +
+        '    in App (at **)',
+      // ReactDOM(App > div > ServerEntry) >>> ReactDOMServer(Child) >>> ReactDOMServer(App2) >>> ReactDOMServer(blink)
+      'Invalid ARIA attribute `ariaTypo2`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
+        '    in blink (at **)',
+      // ReactDOM(App > div > ServerEntry) >>> ReactDOMServer(Child) >>> ReactDOMServer(App2 > Child2 > span)
+      'Invalid ARIA attribute `ariaTypo3`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
+        '    in span (at **)\n' +
+        '    in Child2 (at **)\n' +
+        '    in App2 (at **)',
+      // ReactDOM(App > div > ServerEntry) >>> ReactDOMServer(Child > span)
+      'Invalid ARIA attribute `ariaTypo4`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
+        '    in span (at **)\n' +
+        '    in Child (at **)',
+      // ReactDOM(App > div > font)
+      'Invalid ARIA attribute `ariaTypo5`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
+        '    in font (at **)\n' +
+        '    in div (at **)\n' +
+        '    in App (at **)',
+    ]);
   });
 });

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -664,4 +664,60 @@ describe('ReactDOMServer', () => {
       require('react-dom');
     }).not.toThrow();
   });
+
+  it('includes a useful stack in warnings', () => {
+    function A() {
+      return null;
+    }
+
+    function B() {
+      return (
+        <font>
+          <C>
+            <span ariaTypo="no" />
+          </C>
+        </font>
+      );
+    }
+
+    class C extends React.Component {
+      render() {
+        return <b>{this.props.children}</b>;
+      }
+    }
+
+    function Child() {
+      return [<A key="1" />, <B key="2" />, <span ariaTypo2="no" />];
+    }
+
+    function App() {
+      return (
+        <div>
+          <section />
+          <span>
+            <Child />
+          </span>
+        </div>
+      );
+    }
+
+    expect(() => ReactDOMServer.renderToString(<App />)).toWarnDev([
+      'Invalid ARIA attribute `ariaTypo`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
+        '    in span (at **)\n' +
+        '    in b (at **)\n' +
+        '    in C (at **)\n' +
+        '    in font (at **)\n' +
+        '    in B (at **)\n' +
+        '    in Child (at **)\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)\n' +
+        '    in App (at **)',
+      'Invalid ARIA attribute `ariaTypo2`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
+        '    in span (at **)\n' +
+        '    in Child (at **)\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)\n' +
+        '    in App (at **)',
+    ]);
+  });
 });

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -61,13 +61,13 @@ type FlatReactChildren = Array<null | ReactNode>;
 type toArrayType = (children: mixed) => FlatReactChildren;
 const toArray = ((React.Children.toArray: any): toArrayType);
 
-let getStackAddendum = () => '';
+let getStackAddendum: () => string = () => '';
 let describeStackFrame = element => '';
 
 let validatePropertiesInDevelopment = (type, props) => {};
 
 if (__DEV__) {
-  getStackAddendum = () => ReactDebugCurrentFrame.getCurrentStack() || '';
+  getStackAddendum = () => ReactDebugCurrentFrame.getStackAddendum() || '';
   describeStackFrame = function(element): string {
     const source = element._source;
     const type = element.type;

--- a/packages/react/src/ReactDebugCurrentFrame.js
+++ b/packages/react/src/ReactDebugCurrentFrame.js
@@ -7,13 +7,17 @@
  * @flow
  */
 
+export type ReactDebugCurrentFrameDev = {|
+  getCurrentStack: null | (() => string),
+  getStackAddendum: () => string,
+|};
+
 const ReactDebugCurrentFrame = {};
 
 if (__DEV__) {
   // Component that is being worked on
-  ReactDebugCurrentFrame.getCurrentStack = (null: null | (() => string));
-
-  ReactDebugCurrentFrame.getStackAddendum = function(): string {
+  ((ReactDebugCurrentFrame: any): ReactDebugCurrentFrameDev).getCurrentStack = null;
+  ((ReactDebugCurrentFrame: any): ReactDebugCurrentFrameDev).getStackAddendum = function() {
     const impl = ReactDebugCurrentFrame.getCurrentStack;
     if (impl) {
       return impl() || '';

--- a/packages/shared/ReactGlobalSharedState.js
+++ b/packages/shared/ReactGlobalSharedState.js
@@ -3,13 +3,17 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import React from 'react';
 
+import type {ReactDebugCurrentFrameDev} from 'react/src/ReactDebugCurrentFrame';
+
 const ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 
 export const ReactCurrentOwner = ReactInternals.ReactCurrentOwner;
-export const ReactDebugCurrentFrame = __DEV__
+export const ReactDebugCurrentFrame = (((__DEV__
   ? ReactInternals.ReactDebugCurrentFrame
-  : null;
+  : null): any): ReactDebugCurrentFrameDev);


### PR DESCRIPTION
### Depends on https://github.com/facebook/react/pull/13155

### (Mostly) fixes https://github.com/facebook/react/issues/10188

This ensures that `(ReactDOM | ReactDOMServer) > ReactDOMServer > ... > ReactDOMServer` calls don't lose stacks when we exit the inner `ReactDOMServer`. We do this by keeping a reference to the previous implementation, and restoring it. I added tests that were failing before this change due to the missing stacks.

Since we already need to replace and restore the inner reference to make `ReactDOM > ReactDOMServer` work, I reused the same mechanism for nested `ReactDOMServer` calls. Instead of tracking the "current" stack (or pushing and popping it), I'm using a closure to capture the relevant `this.stack`.

I considered changing `ReactDebugCurrentFrame`'s API to expose `push` / `pop` for stack implementations instead of direct assignment. But it lives in `react` so relying on it would break usage of `react-dom@16.x` with `react@16.0`. We could maybe detect presence of `push` / `pop` and use them when they exist. For now I didn't see the benefit since Fiber isn't reentrant, and just restoring the value in `ReactDOMServer` is sufficient for most cases. But maybe I'll add this later as I work more on the warnings.

Note: This doesn't currently handle the case where `ReactDOMServer` errors. I think that's okay given we didn't handle this case before either. I didn't want to try/finally it since it would make it more difficult to split DEV-only code.