### PR TITLE
fork a new FeatureFlags file for test renderer on www

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import invariant from 'shared/invariant';
+
+import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
+import typeof * as PersistentFeatureFlagsType from './ReactFeatureFlags.persistent';
+
+export const debugRenderPhaseSideEffects = false;
+export const debugRenderPhaseSideEffectsForStrictMode = false;
+export const enableUserTimingAPI = __DEV__;
+export const enableGetDerivedStateFromCatch = false;
+export const enableSuspense = true;
+export const warnAboutDeprecatedLifecycles = false;
+export const warnAboutLegacyContextAPI = false;
+export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
+export const enableProfilerTimer = false;
+
+// Only used in www builds.
+export function addUserTimingListener() {
+  invariant(false, 'Not implemented.');
+}
+
+// Flow magic to verify the exports of this file match the original version.
+// eslint-disable-next-line no-unused-vars
+type Check<_X, Y: _X, X: Y = _X> = null;
+// eslint-disable-next-line no-unused-expressions
+(null: Check<PersistentFeatureFlagsType, FeatureFlagsType>);

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -74,6 +74,12 @@ const forks = Object.freeze({
       case 'react-reconciler/persistent':
         return 'shared/forks/ReactFeatureFlags.persistent.js';
       case 'react-test-renderer':
+        switch (bundleType) {
+          case FB_WWW_DEV:
+          case FB_WWW_PROD:
+          case FB_WWW_PROFILING:
+            return 'shared/forks/ReactFeatureFlags.test-renderer.www.js';
+        }
         return 'shared/forks/ReactFeatureFlags.test-renderer.js';
       default:
         switch (bundleType) {


### PR DESCRIPTION
The `enableSuspense` feature flag is off on test-renderer. To turn on the `enableSuspense` feature flag for test renderer on www, I created a fork of the previous file for www only, so that it doesn't affect open source.