### PR TITLE
Decrease nested update limit from 1000 to 50

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1544,7 +1544,7 @@ let currentRendererTime: ExpirationTime = msToExpirationTime(
 let currentSchedulerTime: ExpirationTime = currentRendererTime;
 
 // Use these to prevent an infinite loop of nested updates
-const NESTED_UPDATE_LIMIT = 1000;
+const NESTED_UPDATE_LIMIT = 50;
 let nestedUpdateCount: number = 0;
 let lastCommittedRootDuringThisBatch: FiberRoot | null = null;
 


### PR DESCRIPTION
An infinite update loop can occur when an update is scheduled inside a lifecycle method, which causes a re-render, which schedules another update, and so on. Before the Fiber rewrite, this scenario resulted in a stack overflow.

Because Fiber does not use the JavaScript stack, we maintain our own counter to track the number of nested, synchronous updates. We throw an error if the limit is exceeded.

The nested update limit is currently 1000. I chose this number arbitrarily, certain that there was no valid reason for a component to schedule so many synchronous re-renders.

I think we can go much lower. This commit decreases the limit to 50. I believe this is still comfortably above the reasonable number of synchronous re-renders a component may perform.

This will make it easier for developers to debug infinite update bugs when they occur.