### PR TITLE
Configure react-test-renderer as a secondary renderer

### DIFF
--- a/packages/react-art/src/__tests__/ReactART-test.js
+++ b/packages/react-art/src/__tests__/ReactART-test.js
@@ -28,6 +28,10 @@ const Circle = require('react-art/Circle');
 const Rectangle = require('react-art/Rectangle');
 const Wedge = require('react-art/Wedge');
 
+// Isolate the noop renderer
+jest.resetModules();
+const ReactNoop = require('react-noop-renderer');
+
 let Group;
 let Shape;
 let Surface;
@@ -354,7 +358,7 @@ describe('ReactART', () => {
     const CurrentRendererContext = React.createContext(null);
 
     function Yield(props) {
-      testRenderer.unstable_yield(props.value);
+      ReactNoop.yield(props.value);
       return null;
     }
 
@@ -372,19 +376,16 @@ describe('ReactART', () => {
 
     // Using test renderer instead of the DOM renderer here because async
     // testing APIs for the DOM renderer don't exist.
-    const testRenderer = ReactTestRenderer.create(
+    ReactNoop.render(
       <CurrentRendererContext.Provider value="Test">
         <Yield value="A" />
         <Yield value="B" />
         <LogCurrentRenderer />
         <Yield value="C" />
       </CurrentRendererContext.Provider>,
-      {
-        unstable_isAsync: true,
-      },
     );
 
-    testRenderer.unstable_flushThrough(['A']);
+    ReactNoop.flushThrough(['A']);
 
     ReactDOM.render(
       <Surface>
@@ -399,7 +400,7 @@ describe('ReactART', () => {
     expect(ops).toEqual([null, 'ART']);
 
     ops = [];
-    expect(testRenderer.unstable_flushAll()).toEqual(['B', 'C']);
+    expect(ReactNoop.flush()).toEqual(['B', 'C']);
 
     expect(ops).toEqual(['Test']);
   });

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -180,7 +180,7 @@ export function createTextInstance(
   };
 }
 
-export const isPrimaryRenderer = true;
+export const isPrimaryRenderer = false;
 // This approach enables `now` to be mocked by tests,
 // Even after the reconciler has initialized and read host config values.
 export const now = () => TestRendererScheduling.nowImplementation();

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -16,6 +16,10 @@ const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
 const prettyFormat = require('pretty-format');
 
+// Isolate noop renderer
+jest.resetModules();
+const ReactNoop = require('react-noop-renderer');
+
 // Kind of hacky, but we nullify all the instances to test the tree structure
 // with jasmine's deep equality function, and test the instances separate. We
 // also delete children props because testing them is more annoying and not
@@ -999,5 +1003,20 @@ describe('ReactTestRenderer', () => {
         type: App,
       }),
     );
+  });
+
+  it('can concurrently render context with a "primary" renderer', () => {
+    const Context = React.createContext(null);
+    const Indirection = React.Fragment;
+    const App = () => (
+      <Context.Provider>
+        <Indirection>
+          <Context.Consumer>{() => null}</Context.Consumer>
+        </Indirection>
+      </Context.Provider>
+    );
+    ReactNoop.render(<App />);
+    ReactNoop.flush();
+    ReactTestRenderer.create(<App />);
   });
 });


### PR DESCRIPTION
Resolves https://github.com/facebook/react/issues/13150

* Configure `react-test-renderer` as a secondary renderer, so that it can render context instances that were also rendered by `react-dom` (a primary renderer)
* Refactor a ReactART test that relied on the test renderer being a primary renderer.