### PR TITLE
Fix concatenation of null to a warning message

### DIFF
--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -10,7 +10,7 @@
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import {
   getCurrentFiberOwnerNameInDevOrNull,
-  getCurrentFiberStackInDevOrNull,
+  getCurrentFiberStackInDev,
 } from 'react-reconciler/src/ReactCurrentFiber';
 import {registrationNameModules} from 'events/EventPluginRegistry';
 import warning from 'shared/warning';
@@ -61,7 +61,7 @@ const HTML = '__html';
 
 const {html: HTML_NAMESPACE} = Namespaces;
 
-let getStackInDevOrNull = () => '';
+let getStackInDev = () => '';
 
 let warnedUnknownTags;
 let suppressHydrationWarning;
@@ -76,7 +76,7 @@ let normalizeMarkupForTextOrAttribute;
 let normalizeHTML;
 
 if (__DEV__) {
-  getStackInDevOrNull = getCurrentFiberStackInDevOrNull;
+  getStackInDev = getCurrentFiberStackInDev;
 
   warnedUnknownTags = {
     // Chrome is the only major browser not shipping <time>. But as of July
@@ -180,7 +180,7 @@ if (__DEV__) {
         registrationName,
         registrationName,
         registrationName,
-        getCurrentFiberStackInDevOrNull(),
+        getCurrentFiberStackInDev(),
       );
     } else {
       warning(
@@ -188,7 +188,7 @@ if (__DEV__) {
         'Expected `%s` listener to be a function, instead got a value of `%s` type.%s',
         registrationName,
         typeof listener,
-        getCurrentFiberStackInDevOrNull(),
+        getCurrentFiberStackInDev(),
       );
     }
   };
@@ -269,7 +269,7 @@ function setInitialDOMProperties(
       CSSPropertyOperations.setValueForStyles(
         domElement,
         nextProp,
-        getStackInDevOrNull,
+        getStackInDev,
       );
     } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
       const nextHtml = nextProp ? nextProp[HTML] : undefined;
@@ -329,7 +329,7 @@ function updateDOMProperties(
       CSSPropertyOperations.setValueForStyles(
         domElement,
         propValue,
-        getStackInDevOrNull,
+        getStackInDev,
       );
     } else if (propKey === DANGEROUSLY_SET_INNER_HTML) {
       setInnerHTML(domElement, propValue);
@@ -523,7 +523,7 @@ export function setInitialProperties(
       props = rawProps;
   }
 
-  assertValidProps(tag, props, getStackInDevOrNull);
+  assertValidProps(tag, props, getStackInDev);
 
   setInitialDOMProperties(
     tag,
@@ -611,7 +611,7 @@ export function diffProperties(
       break;
   }
 
-  assertValidProps(tag, nextProps, getStackInDevOrNull);
+  assertValidProps(tag, nextProps, getStackInDev);
 
   let propKey;
   let styleName;
@@ -902,7 +902,7 @@ export function diffHydratedProperties(
       break;
   }
 
-  assertValidProps(tag, rawProps, getStackInDevOrNull);
+  assertValidProps(tag, rawProps, getStackInDev);
 
   if (__DEV__) {
     extraAttributeNames = new Set();

--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -10,7 +10,7 @@
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import {
   getCurrentFiberOwnerNameInDevOrNull,
-  getCurrentFiberStackInDevOrNull,
+  getCurrentFiberStackInDev,
 } from 'react-reconciler/src/ReactCurrentFiber';
 import invariant from 'shared/invariant';
 import warning from 'shared/warning';
@@ -74,7 +74,7 @@ export function initWrapperState(element: Element, props: Object) {
     ReactControlledValuePropTypes.checkPropTypes(
       'input',
       props,
-      getCurrentFiberStackInDevOrNull,
+      getCurrentFiberStackInDev,
     );
 
     if (
@@ -153,7 +153,7 @@ export function updateWrapper(element: Element, props: Object) {
           'Decide between using a controlled or uncontrolled input ' +
           'element for the lifetime of the component. More info: https://fb.me/react-controlled-components%s',
         props.type,
-        getCurrentFiberStackInDevOrNull(),
+        getCurrentFiberStackInDev(),
       );
       didWarnUncontrolledToControlled = true;
     }
@@ -169,7 +169,7 @@ export function updateWrapper(element: Element, props: Object) {
           'Decide between using a controlled or uncontrolled input ' +
           'element for the lifetime of the component. More info: https://fb.me/react-controlled-components%s',
         props.type,
-        getCurrentFiberStackInDevOrNull(),
+        getCurrentFiberStackInDev(),
       );
       didWarnControlledToUncontrolled = true;
     }

--- a/packages/react-dom/src/client/ReactDOMFiberSelect.js
+++ b/packages/react-dom/src/client/ReactDOMFiberSelect.js
@@ -10,7 +10,7 @@
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import {
   getCurrentFiberOwnerNameInDevOrNull,
-  getCurrentFiberStackInDevOrNull,
+  getCurrentFiberStackInDev,
 } from 'react-reconciler/src/ReactCurrentFiber';
 import warning from 'shared/warning';
 
@@ -46,7 +46,7 @@ function checkSelectPropTypes(props) {
   ReactControlledValuePropTypes.checkPropTypes(
     'select',
     props,
-    getCurrentFiberStackInDevOrNull,
+    getCurrentFiberStackInDev,
   );
 
   for (let i = 0; i < valuePropNames.length; i++) {

--- a/packages/react-dom/src/client/ReactDOMFiberTextarea.js
+++ b/packages/react-dom/src/client/ReactDOMFiberTextarea.js
@@ -10,7 +10,7 @@
 import invariant from 'shared/invariant';
 import warning from 'shared/warning';
 // TODO: direct imports like some-package/src/* are bad. Fix me.
-import {getCurrentFiberStackInDevOrNull} from 'react-reconciler/src/ReactCurrentFiber';
+import {getCurrentFiberStackInDev} from 'react-reconciler/src/ReactCurrentFiber';
 
 import ReactControlledValuePropTypes from '../shared/ReactControlledValuePropTypes';
 
@@ -67,7 +67,7 @@ export function initWrapperState(element: Element, props: Object) {
     ReactControlledValuePropTypes.checkPropTypes(
       'textarea',
       props,
-      getCurrentFiberStackInDevOrNull,
+      getCurrentFiberStackInDev,
     );
     if (
       props.value !== undefined &&

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -7,7 +7,7 @@
 
 import warning from 'shared/warning';
 // TODO: direct imports like some-package/src/* are bad. Fix me.
-import {getCurrentFiberStackInDevOrNull} from 'react-reconciler/src/ReactCurrentFiber';
+import {getCurrentFiberStackInDev} from 'react-reconciler/src/ReactCurrentFiber';
 
 let validateDOMNesting = () => {};
 
@@ -426,7 +426,7 @@ if (__DEV__) {
     }
 
     const ancestorTag = invalidParentOrAncestor.tag;
-    const addendum = getCurrentFiberStackInDevOrNull();
+    const addendum = getCurrentFiberStackInDev();
 
     const warnKey =
       !!invalidParent + '|' + childTag + '|' + ancestorTag + '|' + addendum;

--- a/packages/react-dom/src/shared/ReactDOMInvalidARIAHook.js
+++ b/packages/react-dom/src/shared/ReactDOMInvalidARIAHook.js
@@ -18,11 +18,6 @@ const rARIACamel = new RegExp('^(aria)[A-Z][' + ATTRIBUTE_NAME_CHAR + ']*$');
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
-function getStackAddendum() {
-  const stack = ReactDebugCurrentFrame.getStackAddendum();
-  return stack != null ? stack : '';
-}
-
 function validateProperty(tagName, name) {
   if (hasOwnProperty.call(warnedProperties, name) && warnedProperties[name]) {
     return true;
@@ -41,7 +36,7 @@ function validateProperty(tagName, name) {
         false,
         'Invalid ARIA attribute `%s`. ARIA attributes follow the pattern aria-* and must be lowercase.%s',
         name,
-        getStackAddendum(),
+        ReactDebugCurrentFrame.getStackAddendum(),
       );
       warnedProperties[name] = true;
       return true;
@@ -53,7 +48,7 @@ function validateProperty(tagName, name) {
         'Invalid ARIA attribute `%s`. Did you mean `%s`?%s',
         name,
         correctName,
-        getStackAddendum(),
+        ReactDebugCurrentFrame.getStackAddendum(),
       );
       warnedProperties[name] = true;
       return true;
@@ -79,7 +74,7 @@ function validateProperty(tagName, name) {
         'Unknown ARIA attribute `%s`. Did you mean `%s`?%s',
         name,
         standardName,
-        getStackAddendum(),
+        ReactDebugCurrentFrame.getStackAddendum(),
       );
       warnedProperties[name] = true;
       return true;
@@ -110,7 +105,7 @@ function warnInvalidARIAProps(type, props) {
         'For details, see https://fb.me/invalid-aria-prop%s',
       unknownPropString,
       type,
-      getStackAddendum(),
+      ReactDebugCurrentFrame.getStackAddendum(),
     );
   } else if (invalidProps.length > 1) {
     warning(
@@ -119,7 +114,7 @@ function warnInvalidARIAProps(type, props) {
         'For details, see https://fb.me/invalid-aria-prop%s',
       unknownPropString,
       type,
-      getStackAddendum(),
+      ReactDebugCurrentFrame.getStackAddendum(),
     );
   }
 }

--- a/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
+++ b/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
@@ -10,11 +10,6 @@ import warning from 'shared/warning';
 
 let didWarnValueNull = false;
 
-function getStackAddendum() {
-  const stack = ReactDebugCurrentFrame.getStackAddendum();
-  return stack != null ? stack : '';
-}
-
 export function validateProperties(type, props) {
   if (type !== 'input' && type !== 'textarea' && type !== 'select') {
     return;
@@ -29,7 +24,7 @@ export function validateProperties(type, props) {
           'Consider using an empty array when `multiple` is set to `true` ' +
           'to clear the component or `undefined` for uncontrolled components.%s',
         type,
-        getStackAddendum(),
+        ReactDebugCurrentFrame.getStackAddendum(),
       );
     } else {
       warning(
@@ -38,7 +33,7 @@ export function validateProperties(type, props) {
           'Consider using an empty string to clear the component or `undefined` ' +
           'for uncontrolled components.%s',
         type,
-        getStackAddendum(),
+        ReactDebugCurrentFrame.getStackAddendum(),
       );
     }
   }

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -21,11 +21,6 @@ import {
 import isCustomComponent from './isCustomComponent';
 import possibleStandardNames from './possibleStandardNames';
 
-function getStackAddendum() {
-  const stack = ReactDebugCurrentFrame.getStackAddendum();
-  return stack != null ? stack : '';
-}
-
 let validateProperty = () => {};
 
 if (__DEV__) {
@@ -69,7 +64,7 @@ if (__DEV__) {
           'Invalid event handler property `%s`. Did you mean `%s`?%s',
           name,
           registrationName,
-          getStackAddendum(),
+          ReactDebugCurrentFrame.getStackAddendum(),
         );
         warnedProperties[name] = true;
         return true;
@@ -79,7 +74,7 @@ if (__DEV__) {
           false,
           'Unknown event handler property `%s`. It will be ignored.%s',
           name,
-          getStackAddendum(),
+          ReactDebugCurrentFrame.getStackAddendum(),
         );
         warnedProperties[name] = true;
         return true;
@@ -94,7 +89,7 @@ if (__DEV__) {
           'Invalid event handler property `%s`. ' +
             'React events use the camelCase naming convention, for example `onClick`.%s',
           name,
-          getStackAddendum(),
+          ReactDebugCurrentFrame.getStackAddendum(),
         );
       }
       warnedProperties[name] = true;
@@ -137,7 +132,7 @@ if (__DEV__) {
         'Received a `%s` for a string attribute `is`. If this is expected, cast ' +
           'the value to a string.%s',
         typeof value,
-        getStackAddendum(),
+        ReactDebugCurrentFrame.getStackAddendum(),
       );
       warnedProperties[name] = true;
       return true;
@@ -149,7 +144,7 @@ if (__DEV__) {
         'Received NaN for the `%s` attribute. If this is expected, cast ' +
           'the value to a string.%s',
         name,
-        getStackAddendum(),
+        ReactDebugCurrentFrame.getStackAddendum(),
       );
       warnedProperties[name] = true;
       return true;
@@ -167,7 +162,7 @@ if (__DEV__) {
           'Invalid DOM property `%s`. Did you mean `%s`?%s',
           name,
           standardName,
-          getStackAddendum(),
+          ReactDebugCurrentFrame.getStackAddendum(),
         );
         warnedProperties[name] = true;
         return true;
@@ -184,7 +179,7 @@ if (__DEV__) {
           'it from the DOM element.%s',
         name,
         lowerCasedName,
-        getStackAddendum(),
+        ReactDebugCurrentFrame.getStackAddendum(),
       );
       warnedProperties[name] = true;
       return true;
@@ -205,7 +200,7 @@ if (__DEV__) {
           name,
           value,
           name,
-          getStackAddendum(),
+          ReactDebugCurrentFrame.getStackAddendum(),
         );
       } else {
         warning(
@@ -222,7 +217,7 @@ if (__DEV__) {
           name,
           name,
           name,
-          getStackAddendum(),
+          ReactDebugCurrentFrame.getStackAddendum(),
         );
       }
       warnedProperties[name] = true;
@@ -265,7 +260,7 @@ const warnUnknownProperties = function(type, props, canUseEventSystem) {
         'For details, see https://fb.me/react-attribute-behavior%s',
       unknownPropString,
       type,
-      getStackAddendum(),
+      ReactDebugCurrentFrame.getStackAddendum(),
     );
   } else if (unknownProps.length > 1) {
     warning(
@@ -275,7 +270,7 @@ const warnUnknownProperties = function(type, props, canUseEventSystem) {
         'For details, see https://fb.me/react-attribute-behavior%s',
       unknownPropString,
       type,
-      getStackAddendum(),
+      ReactDebugCurrentFrame.getStackAddendum(),
     );
   }
 };

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -39,7 +39,7 @@ import {
 } from './ReactFiber';
 import {emptyRefsObject} from './ReactFiberClassComponent';
 import {
-  getCurrentFiberStackInDevOrNull,
+  getCurrentFiberStackInDev,
   getStackByFiberInDevAndProd,
 } from './ReactCurrentFiber';
 import {StrictMode} from './ReactTypeOfMode';
@@ -80,7 +80,7 @@ if (__DEV__) {
       'Each child in an array or iterator should have a unique ' +
       '"key" prop. See https://fb.me/react-warning-keys for ' +
       'more information.' +
-      (getCurrentFiberStackInDevOrNull() || '');
+      getCurrentFiberStackInDev();
     if (ownerHasKeyUseWarning[currentComponentErrorInfo]) {
       return;
     }
@@ -91,7 +91,7 @@ if (__DEV__) {
       'Each child in an array or iterator should have a unique ' +
         '"key" prop. See https://fb.me/react-warning-keys for ' +
         'more information.%s',
-      getCurrentFiberStackInDevOrNull(),
+      getCurrentFiberStackInDev(),
     );
   };
 }
@@ -197,7 +197,7 @@ function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
       addendum =
         ' If you meant to render a collection of children, use an array ' +
         'instead.' +
-        (getCurrentFiberStackInDevOrNull() || '');
+        getCurrentFiberStackInDev();
     }
     invariant(
       false,
@@ -215,7 +215,7 @@ function warnOnFunctionType() {
     'Functions are not valid as a React child. This may happen if ' +
     'you return a Component instead of <Component /> from render. ' +
     'Or maybe you meant to call this function rather than return it.' +
-    (getCurrentFiberStackInDevOrNull() || '');
+    getCurrentFiberStackInDev();
 
   if (ownerHasFunctionTypeWarning[currentComponentErrorInfo]) {
     return;
@@ -227,7 +227,7 @@ function warnOnFunctionType() {
     'Functions are not valid as a React child. This may happen if ' +
       'you return a Component instead of <Component /> from render. ' +
       'Or maybe you meant to call this function rather than return it.%s',
-    getCurrentFiberStackInDevOrNull() || '',
+    getCurrentFiberStackInDev(),
   );
 }
 
@@ -719,7 +719,7 @@ function ChildReconciler(shouldTrackSideEffects) {
               'duplicated and/or omitted — the behavior is unsupported and ' +
               'could change in a future version.%s',
             key,
-            getCurrentFiberStackInDevOrNull(),
+            getCurrentFiberStackInDev(),
           );
           break;
         default:
@@ -912,7 +912,7 @@ function ChildReconciler(shouldTrackSideEffects) {
           'Using Maps as children is unsupported and will likely yield ' +
             'unexpected results. Convert it to a sequence/iterable of keyed ' +
             'ReactElements instead.%s',
-          getCurrentFiberStackInDevOrNull(),
+          getCurrentFiberStackInDev(),
         );
         didWarnAboutMaps = true;
       }

--- a/packages/react-reconciler/src/ReactCurrentFiber.js
+++ b/packages/react-reconciler/src/ReactCurrentFiber.js
@@ -66,16 +66,16 @@ export function getCurrentFiberOwnerNameInDevOrNull(): string | null {
   return null;
 }
 
-export function getCurrentFiberStackInDevOrNull(): string | null {
+export function getCurrentFiberStackInDev(): string {
   if (__DEV__) {
     if (current === null) {
-      return null;
+      return '';
     }
     // Safe because if current fiber exists, we are reconciling,
     // and it is guaranteed to be the work-in-progress version.
     return getStackByFiberInDevAndProd(current);
   }
-  return null;
+  return '';
 }
 
 export function resetCurrentFiber() {
@@ -88,7 +88,7 @@ export function resetCurrentFiber() {
 
 export function setCurrentFiber(fiber: Fiber) {
   if (__DEV__) {
-    ReactDebugCurrentFrame.getCurrentStack = getCurrentFiberStackInDevOrNull;
+    ReactDebugCurrentFrame.getCurrentStack = getCurrentFiberStackInDev;
     current = fiber;
     phase = null;
   }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -675,7 +675,7 @@ function mountIndeterminateComponent(
             'Stateless function components cannot be given refs. ' +
               'Attempts to access this ref will fail.%s%s',
             info,
-            ReactCurrentFiber.getCurrentFiberStackInDevOrNull(),
+            ReactCurrentFiber.getCurrentFiberStackInDev(),
           );
         }
       }
@@ -933,7 +933,7 @@ function updateContextProvider(current, workInProgress, renderExpirationTime) {
         newProps,
         'prop',
         'Context.Provider',
-        ReactCurrentFiber.getCurrentFiberStackInDevOrNull,
+        ReactCurrentFiber.getCurrentFiberStackInDev,
       );
     }
   }

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -96,7 +96,7 @@ function getMaskedContext(
       context,
       'context',
       name,
-      ReactCurrentFiber.getCurrentFiberStackInDevOrNull,
+      ReactCurrentFiber.getCurrentFiberStackInDev,
     );
   }
 
@@ -205,7 +205,7 @@ function processChildContext(fiber: Fiber, parentContext: Object): Object {
       // context from the parent component instance. The stack will be missing
       // because it's outside of the reconciliation, and so the pointer has not
       // been set. This is rare and doesn't matter. We'll also remove that API.
-      ReactCurrentFiber.getCurrentFiberStackInDevOrNull,
+      ReactCurrentFiber.getCurrentFiberStackInDev,
     );
   }
 

--- a/packages/react/src/ReactDebugCurrentFrame.js
+++ b/packages/react/src/ReactDebugCurrentFrame.js
@@ -11,14 +11,14 @@ const ReactDebugCurrentFrame = {};
 
 if (__DEV__) {
   // Component that is being worked on
-  ReactDebugCurrentFrame.getCurrentStack = (null: null | (() => string | null));
+  ReactDebugCurrentFrame.getCurrentStack = (null: null | (() => string));
 
-  ReactDebugCurrentFrame.getStackAddendum = function(): string | null {
+  ReactDebugCurrentFrame.getStackAddendum = function(): string {
     const impl = ReactDebugCurrentFrame.getCurrentStack;
     if (impl) {
-      return impl();
+      return impl() || '';
     }
-    return null;
+    return '';
   };
 }
 

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -74,7 +74,7 @@ if (__DEV__) {
         owner && getComponentName(owner),
       );
     }
-    stack += ReactDebugCurrentFrame.getStackAddendum() || '';
+    stack += ReactDebugCurrentFrame.getStackAddendum();
     return stack;
   };
 }
@@ -324,7 +324,7 @@ export function createElementWithValidation(type, props, children) {
       info += getDeclarationErrorAddendum();
     }
 
-    info += getStackAddendum() || '';
+    info += getStackAddendum();
 
     let typeString;
     if (type === null) {


### PR DESCRIPTION
Thanks to the renaming in #13165, I noticed a bunch of cases where we could accidentally concatenate `null` to a warning message if the stack was missing.

I changed `getCurrentFiberStackInDevOrNull` to always return a string, and renamed it to `getCurrentFiberStackInDev`. This fixed existing callsites that *already relied* on it being a string (which wasn't always the case). Then I removed a few `|| ''` that now became unnecessary.

I also changed the "isomorphic" type of `ReactDebugCurrentFrame.getStackAddendum()` to be tighter since we know both SSR and Fiber implementation return a string now. This is a bit optimistic because in practice `ReactDebugCurrentFrame` could be from an old React version that didn't have the `|| ''` isomorphic fallback, and its `getStackAddendum` could be pointing to another renderer that has a version before this change (e.g. maybe something like React 16.4 + React DOM 16.5 + ReactDOMServer 16.4). In that case you could potentially see the `null` bug in the warning message. I don't think this matters because (a) we recommend to keep versions in sync, (b) we *already have* this bug in a bunch of places, and I'd prefer tightening it up now than worrying about what happens in an edge case where you mix past and present versions.