### PR TITLE
fixed a typo in a comment out in ReactFiberUnwindWork.js

### DIFF
--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -250,7 +250,7 @@ function throwException(
             return;
           }
 
-          // Confirmed that the bounary is in a strict mode tree. Continue with
+          // Confirmed that the boundary is in a strict mode tree. Continue with
           // the normal suspend path.
 
           let absoluteTimeoutMs;


### PR DESCRIPTION
fixed a typo `bounary` -> `boundary` which was found in https://github.com/facebook/react/pull/13105