### PR TITLE
Inject react-art renderer into react-devtools

### DIFF
--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import ReactVersion from 'shared/ReactVersion';
 import * as ARTRenderer from 'react-reconciler/inline.art';
 import Transform from 'art/core/transform';
 import Mode from 'art/modes/current';
@@ -130,6 +131,13 @@ class Text extends React.Component {
     );
   }
 }
+
+ARTRenderer.injectIntoDevTools({
+  findFiberByHostInstance: () => null,
+  bundleType: __DEV__ ? 1 : 0,
+  version: ReactVersion,
+  rendererPackageName: 'react-art-renderer',
+});
 
 /** API */
 

--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -136,7 +136,7 @@ ARTRenderer.injectIntoDevTools({
   findFiberByHostInstance: () => null,
   bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,
-  rendererPackageName: 'react-art-renderer',
+  rendererPackageName: 'react-art',
 });
 
 /** API */


### PR DESCRIPTION
Now a days, I am creating something using react-art. 
However, I have suffered difficulties to debug my components based on react-art.
Because current react-art renderer isn't injected to react-devtools.
So I have made react-art be injected to devtools, and checked it works well in the browsers.

Could you review this my PR? 
And let me know if I should do something for this PR to be accepted.