### PR TITLE
Test renderer flushAll method verifies an array of expected yields

### DIFF
--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
@@ -32,7 +32,7 @@ describe('ReactTestRendererAsync', () => {
     expect(renderer.toJSON()).toEqual(null);
 
     // Flush initial mount.
-    renderer.unstable_flushAll();
+    renderer.unstable_flushAll([]);
     expect(renderer.toJSON()).toEqual('Hi');
 
     // Update
@@ -40,7 +40,7 @@ describe('ReactTestRendererAsync', () => {
     // Not yet updated.
     expect(renderer.toJSON()).toEqual('Hi');
     // Flush update.
-    renderer.unstable_flushAll();
+    renderer.unstable_flushAll([]);
     expect(renderer.toJSON()).toEqual('Bye');
   });
 
@@ -62,11 +62,11 @@ describe('ReactTestRendererAsync', () => {
       unstable_isAsync: true,
     });
 
-    expect(renderer.unstable_flushAll()).toEqual(['A:1', 'B:1', 'C:1']);
+    renderer.unstable_flushAll(['A:1', 'B:1', 'C:1']);
     expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
 
     renderer.update(<Parent step={2} />);
-    expect(renderer.unstable_flushAll()).toEqual(['A:2', 'B:2', 'C:2']);
+    renderer.unstable_flushAll(['A:2', 'B:2', 'C:2']);
     expect(renderer.toJSON()).toEqual(['A:2', 'B:2', 'C:2']);
   });
 
@@ -97,7 +97,7 @@ describe('ReactTestRendererAsync', () => {
     expect(renderer.toJSON()).toEqual(null);
 
     // Flush the remaining work
-    expect(renderer.unstable_flushAll()).toEqual(['C:1']);
+    renderer.unstable_flushAll(['C:1']);
     expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
   });
 
@@ -159,7 +159,41 @@ describe('ReactTestRendererAsync', () => {
     );
 
     expect(() => renderer.unstable_flushThrough(['foo', 'baz'])).toThrow(
-      'flushThrough expected to yield "baz", but "bar" was yielded',
+      'Flush expected to yield "baz", but "bar" was yielded',
+    );
+  });
+
+  it('should error if flushAll params dont match yielded values', () => {
+    const Yield = ({id}) => {
+      renderer.unstable_yield(id);
+      return id;
+    };
+
+    const renderer = ReactTestRenderer.create(
+      <div>
+        <Yield id="foo" />
+        <Yield id="bar" />
+        <Yield id="baz" />
+      </div>,
+      {
+        unstable_isAsync: true,
+      },
+    );
+
+    expect(() => renderer.unstable_flushAll([])).toThrow(
+      'Flush expected to yield 0 values, but yielded 3',
+    );
+
+    renderer.update(
+      <div>
+        <Yield id="foo" />
+        <Yield id="bar" />
+        <Yield id="baz" />
+      </div>,
+    );
+
+    expect(() => renderer.unstable_flushAll(['foo', 'baz'])).toThrow(
+      'Flush expected to yield "baz", but "bar" was yielded',
     );
   });
 
@@ -179,7 +213,7 @@ describe('ReactTestRendererAsync', () => {
     );
 
     expect(() => renderer.unstable_flushThrough(['foo', 'bar'])).toThrow(
-      'flushThrough expected to yield "bar", but nothing was yielded',
+      'Flush expected to yield "bar", but nothing was yielded',
     );
   });
 
@@ -189,7 +223,7 @@ describe('ReactTestRendererAsync', () => {
     });
 
     expect(() => renderer.unstable_flushThrough(['foo'])).toThrow(
-      'flushThrough expected to yield "foo", but nothing was yielded',
+      'Flush expected to yield "foo", but nothing was yielded',
     );
   });
 });

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -178,7 +178,7 @@ describe('Profiler', () => {
       // Times are logged until a render is committed.
       renderer.unstable_flushThrough(['first']);
       expect(callback).toHaveBeenCalledTimes(0);
-      expect(renderer.unstable_flushAll()).toEqual(['last']);
+      renderer.unstable_flushAll(['last']);
       expect(callback).toHaveBeenCalledTimes(1);
     });
 
@@ -532,7 +532,7 @@ describe('Profiler', () => {
         expect(callback).toHaveBeenCalledTimes(0);
 
         // Resume render for remaining children.
-        expect(renderer.unstable_flushAll()).toEqual(['Yield:3']);
+        renderer.unstable_flushAll(['Yield:3']);
 
         // Verify that logged times include both durations above.
         expect(callback).toHaveBeenCalledTimes(1);
@@ -576,7 +576,7 @@ describe('Profiler', () => {
 
         // Flush the remaninig work,
         // Which should take an additional 10ms of simulated time.
-        expect(renderer.unstable_flushAll()).toEqual(['Yield:10', 'Yield:17']);
+        renderer.unstable_flushAll(['Yield:10', 'Yield:17']);
         expect(callback).toHaveBeenCalledTimes(2);
 
         const [innerCall, outerCall] = callback.mock.calls;
@@ -647,7 +647,7 @@ describe('Profiler', () => {
         callback.mockReset();
 
         // Verify no more unexpected callbacks from low priority work
-        expect(renderer.unstable_flushAll()).toEqual([]);
+        renderer.unstable_flushAll([]);
         expect(callback).toHaveBeenCalledTimes(0);
       });
 
@@ -672,7 +672,7 @@ describe('Profiler', () => {
 
         // Render everything initially.
         // This should take 21 seconds of actual and base time.
-        expect(renderer.unstable_flushAll()).toEqual(['Yield:6', 'Yield:15']);
+        renderer.unstable_flushAll(['Yield:6', 'Yield:15']);
         expect(callback).toHaveBeenCalledTimes(1);
         let call = callback.mock.calls[0];
         expect(call[2]).toBe(21); // actual time
@@ -733,7 +733,7 @@ describe('Profiler', () => {
         expect(call[5]).toBe(275); // commit time
 
         // Verify no more unexpected callbacks from low priority work
-        expect(renderer.unstable_flushAll()).toEqual([]);
+        renderer.unstable_flushAll([]);
         expect(callback).toHaveBeenCalledTimes(1);
       });
 
@@ -780,7 +780,7 @@ describe('Profiler', () => {
         // Render everything initially.
         // This simulates a total of 14ms of actual render time.
         // The base render time is also 14ms for the initial render.
-        expect(renderer.unstable_flushAll()).toEqual([
+        renderer.unstable_flushAll([
           'FirstComponent:1',
           'Yield:4',
           'SecondComponent:2',
@@ -836,10 +836,7 @@ describe('Profiler', () => {
         // The tree contains 42ms of base render time at this point,
         // Reflecting the most recent (longer) render durations.
         // TODO: This actual time should decrease by 10ms once the scheduler supports resuming.
-        expect(renderer.unstable_flushAll()).toEqual([
-          'FirstComponent:10',
-          'Yield:4',
-        ]);
+        renderer.unstable_flushAll(['FirstComponent:10', 'Yield:4']);
         expect(callback).toHaveBeenCalledTimes(1);
         call = callback.mock.calls[0];
         expect(call[2]).toBe(14); // actual time


### PR DESCRIPTION
I like that the test renderer's `unstable_flushThrough` method requires you to provide the expected yields so that it can verify them. I think the `unstable_flushAll` method should do this too, so it doesn't rely on us remembering to `expect(...).toEqual(...)` outside.

This is also a backwards-breaking change, but since both methods are "unstable_" that might not matter? (The change to `unstable_flushThrough` didn't seem to draw any attention when it was made.)

Thoughts?