### PR TITLE
[#13171] Needless checkbox warning when using onClick instead of onChange

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -913,14 +913,32 @@ describe('ReactDOMInput', () => {
       <input type="checkbox" checked="false" readOnly={true} />,
     );
 
+    ReactTestUtils.renderIntoDocument(
+      <input
+        type="checkbox"
+        checked="false"
+        onChange={emptyFunction}
+        readOnly={false}
+      />,
+    );
+
+    ReactTestUtils.renderIntoDocument(
+      <input
+        type="checkbox"
+        checked="false"
+        onClick={emptyFunction}
+        readOnly={false}
+      />,
+    );
+
     expect(() =>
       ReactTestUtils.renderIntoDocument(
         <input type="checkbox" checked="false" readOnly={false} />,
       ),
     ).toWarnDev(
-      'Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler. ' +
+      'Failed prop type: You provided a `checked` prop to a form field without an `onChange` or `onClick` handler. ' +
         'This will render a read-only field. If the field should be mutable use `defaultChecked`. ' +
-        'Otherwise, set either `onChange` or `readOnly`.',
+        'Otherwise, set `onChange`, `onClick` or `readOnly`.',
     );
   });
 

--- a/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
+++ b/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
@@ -44,6 +44,7 @@ if (__DEV__) {
       if (
         !props[propName] ||
         props.onChange ||
+        props.onClick ||
         props.readOnly ||
         props.disabled
       ) {
@@ -51,9 +52,9 @@ if (__DEV__) {
       }
       return new Error(
         'You provided a `checked` prop to a form field without an ' +
-          '`onChange` handler. This will render a read-only field. If ' +
+          '`onChange` or `onClick` handler. This will render a read-only field. If ' +
           'the field should be mutable use `defaultChecked`. Otherwise, ' +
-          'set either `onChange` or `readOnly`.',
+          'set `onChange`, `onClick` or `readOnly`.',
       );
     },
   };


### PR DESCRIPTION
Fixes #13171

Adds additional check for `onClick` presence before showing the warning.