### PR TITLE
Remove event simulation of onChange events

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -60,7 +60,7 @@ describe('ReactDOMInput', () => {
 
     // This must use the native event dispatching. If we simulate, we will
     // bypass the lazy event attachment system so we won't actually test this.
-    dispatchEventOnNode(node, 'change');
+    dispatchEventOnNode(node, 'input');
 
     expect(node.value).toBe('lion');
   });
@@ -76,7 +76,7 @@ describe('ReactDOMInput', () => {
         // Calling focus here will blur the text box which causes a native
         // change event. Ideally we shouldn't have to fire this ourselves.
         // Don't remove unless you've verified the fix in #8240 is still covered.
-        dispatchEventOnNode(this.a, 'change');
+        dispatchEventOnNode(this.a, 'input');
         this.b.focus();
       }
       blur(currentValue) {
@@ -109,7 +109,7 @@ describe('ReactDOMInput', () => {
     setUntrackedValue.call(instance.a, 'giraffe');
     // This must use the native event dispatching. If we simulate, we will
     // bypass the lazy event attachment system so we won't actually test this.
-    dispatchEventOnNode(instance.a, 'change');
+    dispatchEventOnNode(instance.a, 'input');
     dispatchEventOnNode(instance.a, 'blur');
 
     expect(instance.a.value).toBe('giraffe');
@@ -166,7 +166,7 @@ describe('ReactDOMInput', () => {
 
       setUntrackedValue.call(node, '2.0');
 
-      dispatchEventOnNode(node, 'change');
+      dispatchEventOnNode(node, 'input');
 
       expect(node.getAttribute('value')).toBe('2');
       expect(node.value).toBe('2');
@@ -178,7 +178,7 @@ describe('ReactDOMInput', () => {
 
       setUntrackedValue.call(node, '2.0');
 
-      dispatchEventOnNode(node, 'change');
+      dispatchEventOnNode(node, 'input');
 
       expect(node.getAttribute('value')).toBe('2');
       expect(node.value).toBe('2');
@@ -204,7 +204,7 @@ describe('ReactDOMInput', () => {
 
       setUntrackedValue.call(node, '2.0');
 
-      dispatchEventOnNode(node, 'change');
+      dispatchEventOnNode(node, 'input');
 
       expect(node.getAttribute('value')).toBe('2.0');
       expect(node.value).toBe('2.0');
@@ -567,7 +567,7 @@ describe('ReactDOMInput', () => {
     const node = ReactDOM.render(stub, container);
 
     setUntrackedValue.call(node, 'giraffe');
-    dispatchEventOnNode(node, 'change');
+    dispatchEventOnNode(node, 'input');
     expect(node.value).toBe('0');
   });
 
@@ -576,7 +576,7 @@ describe('ReactDOMInput', () => {
     const node = ReactDOM.render(stub, container);
 
     setUntrackedValue.call(node, '0.0');
-    dispatchEventOnNode(node, 'change');
+    dispatchEventOnNode(node, 'input');
     expect(node.value).toBe('0');
   });
 
@@ -585,7 +585,7 @@ describe('ReactDOMInput', () => {
     const node = ReactDOM.render(stub, container);
 
     setUntrackedValue.call(node, '0.0');
-    dispatchEventOnNode(node, 'change');
+    dispatchEventOnNode(node, 'input');
     expect(node.value).toBe('0.0');
   });
 
@@ -871,7 +871,7 @@ describe('ReactDOMInput', () => {
     const node = ReactDOM.render(stub, container);
 
     setUntrackedValue.call(node, 'giraffe');
-    dispatchEventOnNode(node, 'change');
+    dispatchEventOnNode(node, 'input');
   });
 
   it('should warn with checked and no onChange handler with readOnly specified', () => {
@@ -1377,7 +1377,7 @@ describe('ReactDOMInput', () => {
       const node = ReactDOM.findDOMNode(stub);
 
       setUntrackedValue.call(node, '2');
-      dispatchEventOnNode(node, 'change');
+      dispatchEventOnNode(node, 'input');
 
       expect(node.getAttribute('value')).toBe('2');
     });
@@ -1393,7 +1393,7 @@ describe('ReactDOMInput', () => {
       node.focus();
 
       setUntrackedValue.call(node, '2');
-      dispatchEventOnNode(node, 'change');
+      dispatchEventOnNode(node, 'input');
 
       expect(node.getAttribute('value')).toBe('1');
     });
@@ -1407,7 +1407,7 @@ describe('ReactDOMInput', () => {
       const node = ReactDOM.findDOMNode(stub);
 
       setUntrackedValue.call(node, '2');
-      dispatchEventOnNode(node, 'change');
+      dispatchEventOnNode(node, 'input');
       dispatchEventOnNode(node, 'blur');
 
       expect(node.getAttribute('value')).toBe('2');
@@ -1464,7 +1464,7 @@ describe('ReactDOMInput', () => {
       const stub = ReactDOM.render(<Input />, container);
       input = ReactDOM.findDOMNode(stub);
       setUntrackedValue.call(input, 'latest');
-      dispatchEventOnNode(input, 'change');
+      dispatchEventOnNode(input, 'input');
       setValueToUndefined();
     }
 
@@ -1509,7 +1509,7 @@ describe('ReactDOMInput', () => {
       const stub = ReactDOM.render(<Input />, container);
       input = ReactDOM.findDOMNode(stub);
       setUntrackedValue.call(input, 'latest');
-      dispatchEventOnNode(input, 'change');
+      dispatchEventOnNode(input, 'input');
       setValueToNull();
     }
 

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -15,8 +15,9 @@ describe('ReactDOMInput', () => {
   let React;
   let ReactDOM;
   let ReactDOMServer;
-  let ReactTestUtils;
   let setUntrackedValue;
+  let setUntrackedChecked;
+  let container;
 
   function dispatchEventOnNode(node, type) {
     node.dispatchEvent(new Event(type, {bubbles: true, cancelable: true}));
@@ -29,15 +30,24 @@ describe('ReactDOMInput', () => {
       HTMLInputElement.prototype,
       'value',
     ).set;
+    setUntrackedChecked = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'checked',
+    ).set;
 
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
-    ReactTestUtils = require('react-dom/test-utils');
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
   });
 
   it('should properly control a value even if no event listener exists', () => {
-    const container = document.createElement('div');
     let node;
 
     expect(() => {
@@ -46,19 +56,13 @@ describe('ReactDOMInput', () => {
       'Failed prop type: You provided a `value` prop to a form field without an `onChange` handler.',
     );
 
-    document.body.appendChild(container);
+    setUntrackedValue.call(node, 'giraffe');
 
-    try {
-      setUntrackedValue.call(node, 'giraffe');
+    // This must use the native event dispatching. If we simulate, we will
+    // bypass the lazy event attachment system so we won't actually test this.
+    dispatchEventOnNode(node, 'change');
 
-      // This must use the native event dispatching. If we simulate, we will
-      // bypass the lazy event attachment system so we won't actually test this.
-      dispatchEventOnNode(node, 'change');
-
-      expect(node.value).toBe('lion');
-    } finally {
-      document.body.removeChild(container);
-    }
+    expect(node.value).toBe('lion');
   });
 
   it('should control a value in reentrant events', () => {
@@ -97,11 +101,7 @@ describe('ReactDOMInput', () => {
       }
     }
 
-    const container = document.createElement('div');
     const instance = ReactDOM.render(<ControlledInputs />, container);
-
-    // We need it to be in the body to test native event dispatching.
-    document.body.appendChild(container);
 
     // Focus the field so we can later blur it.
     // Don't remove unless you've verified the fix in #8240 is still covered.
@@ -114,8 +114,6 @@ describe('ReactDOMInput', () => {
 
     expect(instance.a.value).toBe('giraffe');
     expect(instance.switchedFocus).toBe(true);
-
-    document.body.removeChild(container);
   });
 
   it('should control values in reentrant events with different targets', () => {
@@ -150,11 +148,7 @@ describe('ReactDOMInput', () => {
       }
     }
 
-    const container = document.createElement('div');
     const instance = ReactDOM.render(<ControlledInputs />, container);
-
-    // We need it to be in the body to test native event dispatching.
-    document.body.appendChild(container);
 
     setUntrackedValue.call(instance.a, 'giraffe');
     // This must use the native event dispatching. If we simulate, we will
@@ -163,18 +157,16 @@ describe('ReactDOMInput', () => {
 
     expect(instance.a.value).toBe('lion');
     expect(instance.b.checked).toBe(true);
-
-    document.body.removeChild(container);
   });
 
   describe('switching text inputs between numeric and string numbers', () => {
     it('does change the number 2 to "2.0" with no change handler', () => {
       const stub = <input type="text" value={2} onChange={jest.fn()} />;
-      const node = ReactTestUtils.renderIntoDocument(stub);
+      const node = ReactDOM.render(stub, container);
 
-      node.value = '2.0';
+      setUntrackedValue.call(node, '2.0');
 
-      ReactTestUtils.Simulate.change(node);
+      dispatchEventOnNode(node, 'change');
 
       expect(node.getAttribute('value')).toBe('2');
       expect(node.value).toBe('2');
@@ -182,11 +174,11 @@ describe('ReactDOMInput', () => {
 
     it('does change the string "2" to "2.0" with no change handler', () => {
       const stub = <input type="text" value={'2'} onChange={jest.fn()} />;
-      const node = ReactTestUtils.renderIntoDocument(stub);
+      const node = ReactDOM.render(stub, container);
 
-      node.value = '2.0';
+      setUntrackedValue.call(node, '2.0');
 
-      ReactTestUtils.Simulate.change(node);
+      dispatchEventOnNode(node, 'change');
 
       expect(node.getAttribute('value')).toBe('2');
       expect(node.value).toBe('2');
@@ -207,12 +199,12 @@ describe('ReactDOMInput', () => {
         }
       }
 
-      const stub = ReactTestUtils.renderIntoDocument(<Stub />);
+      const stub = ReactDOM.render(<Stub />, container);
       const node = ReactDOM.findDOMNode(stub);
 
-      node.value = '2.0';
+      setUntrackedValue.call(node, '2.0');
 
-      ReactTestUtils.Simulate.change(node);
+      dispatchEventOnNode(node, 'change');
 
       expect(node.getAttribute('value')).toBe('2.0');
       expect(node.value).toBe('2.0');
@@ -231,7 +223,7 @@ describe('ReactDOMInput', () => {
 
     let stub;
     expect(() => {
-      stub = ReactTestUtils.renderIntoDocument(<Stub />);
+      stub = ReactDOM.render(<Stub />, container);
     }).toWarnDev(
       'You provided a `value` prop to a form field ' +
         'without an `onChange` handler.',
@@ -252,7 +244,7 @@ describe('ReactDOMInput', () => {
       }
     }
 
-    const stub = ReactTestUtils.renderIntoDocument(<Stub />);
+    const stub = ReactDOM.render(<Stub />, container);
     const node = ReactDOM.findDOMNode(stub);
     stub.setState({value: 0});
 
@@ -260,7 +252,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('updates the value on radio buttons from "" to 0', function() {
-    const container = document.createElement('div');
     ReactDOM.render(
       <input type="radio" value="" onChange={function() {}} />,
       container,
@@ -274,7 +265,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('updates the value on checkboxes from "" to 0', function() {
-    const container = document.createElement('div');
     ReactDOM.render(
       <input type="checkbox" value="" onChange={function() {}} />,
       container,
@@ -300,7 +290,7 @@ describe('ReactDOMInput', () => {
     let stub;
 
     expect(() => {
-      stub = ReactTestUtils.renderIntoDocument(<Stub />);
+      stub = ReactDOM.render(<Stub />, container);
     }).toWarnDev(
       'You provided a `value` prop to a form field ' +
         'without an `onChange` handler.',
@@ -313,7 +303,7 @@ describe('ReactDOMInput', () => {
 
   it('should display `defaultValue` of number 0', () => {
     let stub = <input type="text" defaultValue={0} />;
-    const node = ReactTestUtils.renderIntoDocument(stub);
+    const node = ReactDOM.render(stub, container);
 
     expect(node.getAttribute('value')).toBe('0');
     expect(node.value).toBe('0');
@@ -326,7 +316,7 @@ describe('ReactDOMInput', () => {
       }
     }
 
-    const component = ReactTestUtils.renderIntoDocument(<Test />);
+    const component = ReactDOM.render(<Test />, container);
     const node = ReactDOM.findDOMNode(component);
 
     Object.defineProperty(node, 'defaultValue', {
@@ -345,21 +335,19 @@ describe('ReactDOMInput', () => {
 
   it('should display "true" for `defaultValue` of `true`', () => {
     let stub = <input type="text" defaultValue={true} />;
-    const node = ReactTestUtils.renderIntoDocument(stub);
+    const node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('true');
   });
 
   it('should display "false" for `defaultValue` of `false`', () => {
     let stub = <input type="text" defaultValue={false} />;
-    const node = ReactTestUtils.renderIntoDocument(stub);
+    const node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('false');
   });
 
   it('should update `defaultValue` for uncontrolled input', () => {
-    const container = document.createElement('div');
-
     const node = ReactDOM.render(
       <input type="text" defaultValue="0" />,
       container,
@@ -374,8 +362,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should update `defaultValue` for uncontrolled date/time input', () => {
-    const container = document.createElement('div');
-
     const node = ReactDOM.render(
       <input type="date" defaultValue="1980-01-01" />,
       container,
@@ -392,7 +378,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should take `defaultValue` when changing to uncontrolled input', () => {
-    const container = document.createElement('div');
     const node = ReactDOM.render(
       <input type="text" value="0" readOnly="true" />,
       container,
@@ -427,7 +412,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should render name attribute if it is supplied', () => {
-    const container = document.createElement('div');
     const node = ReactDOM.render(<input type="text" name="name" />, container);
     expect(node.name).toBe('name');
     expect(container.firstChild.getAttribute('name')).toBe('name');
@@ -442,7 +426,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should not render name attribute if it is not supplied', () => {
-    const container = document.createElement('div');
     ReactDOM.render(<input type="text" />, container);
     expect(container.firstChild.getAttribute('name')).toBe(null);
   });
@@ -463,20 +446,19 @@ describe('ReactDOMInput', () => {
     };
 
     const stub = <input type="text" defaultValue={objToString} />;
-    const node = ReactTestUtils.renderIntoDocument(stub);
+    const node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('foobar');
   });
 
   it('should display `value` of number 0', () => {
     const stub = <input type="text" value={0} />;
-    const node = ReactTestUtils.renderIntoDocument(stub);
+    const node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('0');
   });
 
   it('should allow setting `value` to `true`', () => {
-    const container = document.createElement('div');
     let stub = <input type="text" value="yolo" onChange={emptyFunction} />;
     const node = ReactDOM.render(stub, container);
 
@@ -490,7 +472,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should allow setting `value` to `false`', () => {
-    const container = document.createElement('div');
     let stub = <input type="text" value="yolo" onChange={emptyFunction} />;
     const node = ReactDOM.render(stub, container);
 
@@ -504,7 +485,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should allow setting `value` to `objToString`', () => {
-    const container = document.createElement('div');
     let stub = <input type="text" value="foo" onChange={emptyFunction} />;
     const node = ReactDOM.render(stub, container);
 
@@ -523,7 +503,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should not incur unnecessary DOM mutations', () => {
-    const container = document.createElement('div');
     ReactDOM.render(<input value="a" onChange={() => {}} />, container);
 
     const node = container.firstChild;
@@ -546,7 +525,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should not incur unnecessary DOM mutations for numeric type conversion', () => {
-    const container = document.createElement('div');
     ReactDOM.render(<input value="0" onChange={() => {}} />, container);
 
     const node = container.firstChild;
@@ -566,7 +544,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should not incur unnecessary DOM mutations for the boolean type conversion', () => {
-    const container = document.createElement('div');
     ReactDOM.render(<input value="true" onChange={() => {}} />, container);
 
     const node = container.firstChild;
@@ -587,34 +564,32 @@ describe('ReactDOMInput', () => {
 
   it('should properly control a value of number `0`', () => {
     const stub = <input type="text" value={0} onChange={emptyFunction} />;
-    const node = ReactTestUtils.renderIntoDocument(stub);
+    const node = ReactDOM.render(stub, container);
 
-    node.value = 'giraffe';
-    ReactTestUtils.Simulate.change(node);
+    setUntrackedValue.call(node, 'giraffe');
+    dispatchEventOnNode(node, 'change');
     expect(node.value).toBe('0');
   });
 
   it('should properly control 0.0 for a text input', () => {
     const stub = <input type="text" value={0} onChange={emptyFunction} />;
-    const node = ReactTestUtils.renderIntoDocument(stub);
+    const node = ReactDOM.render(stub, container);
 
-    node.value = '0.0';
-    ReactTestUtils.Simulate.change(node, {target: {value: '0.0'}});
+    setUntrackedValue.call(node, '0.0');
+    dispatchEventOnNode(node, 'change');
     expect(node.value).toBe('0');
   });
 
   it('should properly control 0.0 for a number input', () => {
     const stub = <input type="number" value={0} onChange={emptyFunction} />;
-    const node = ReactTestUtils.renderIntoDocument(stub);
+    const node = ReactDOM.render(stub, container);
 
-    node.value = '0.0';
-    ReactTestUtils.Simulate.change(node, {target: {value: '0.0'}});
+    setUntrackedValue.call(node, '0.0');
+    dispatchEventOnNode(node, 'change');
     expect(node.value).toBe('0.0');
   });
 
   it('should properly transition from an empty value to 0', function() {
-    const container = document.createElement('div');
-
     ReactDOM.render(<input type="text" value="" />, container);
     ReactDOM.render(<input type="text" value={0} />, container);
 
@@ -625,8 +600,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should properly transition from 0 to an empty value', function() {
-    const container = document.createElement('div');
-
     ReactDOM.render(<input type="text" value={0} />, container);
     ReactDOM.render(<input type="text" value="" />, container);
 
@@ -637,8 +610,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should properly transition a text input from 0 to an empty 0.0', function() {
-    const container = document.createElement('div');
-
     ReactDOM.render(<input type="text" value={0} />, container);
     ReactDOM.render(<input type="text" value="0.0" />, container);
 
@@ -649,8 +620,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should properly transition a number input from "" to 0', function() {
-    const container = document.createElement('div');
-
     ReactDOM.render(<input type="number" value="" />, container);
     ReactDOM.render(<input type="number" value={0} />, container);
 
@@ -661,8 +630,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should properly transition a number input from "" to "0"', function() {
-    const container = document.createElement('div');
-
     ReactDOM.render(<input type="number" value="" />, container);
     ReactDOM.render(<input type="number" value="0" />, container);
 
@@ -679,21 +646,18 @@ describe('ReactDOMInput', () => {
       handled = true;
     };
     const stub = <input type="text" value={0} onChange={handler} />;
-    const container = document.createElement('div');
     const node = ReactDOM.render(stub, container);
 
     setUntrackedValue.call(node, 'giraffe');
 
-    ReactTestUtils.SimulateNative.input(node, {
-      path: [node, container],
-    });
+    dispatchEventOnNode(node, 'input');
 
     expect(handled).toBe(true);
   });
 
   it('should not set a value for submit buttons unnecessarily', () => {
     const stub = <input type="submit" />;
-    const node = ReactTestUtils.renderIntoDocument(stub);
+    const node = ReactDOM.render(stub, container);
 
     // The value shouldn't be '', or else the button will have no text; it
     // should have the default "Submit" or "Submit Query" label. Most browsers
@@ -733,7 +697,7 @@ describe('ReactDOMInput', () => {
       }
     }
 
-    const stub = ReactTestUtils.renderIntoDocument(<RadioGroup />);
+    const stub = ReactDOM.render(<RadioGroup />, container);
     const aNode = stub.refs.a;
     const bNode = stub.refs.b;
     const cNode = stub.refs.c;
@@ -746,11 +710,8 @@ describe('ReactDOMInput', () => {
     expect(cNode.checked).toBe(true);
     expect(cNode.hasAttribute('checked')).toBe(true);
 
-    bNode.checked = true;
-    // This next line isn't necessary in a proper browser environment, but
-    // jsdom doesn't uncheck the others in a group (which makes this whole test
-    // a little less effective)
-    aNode.checked = false;
+    setUntrackedChecked.call(bNode, true);
+    expect(aNode.checked).toBe(false);
     expect(cNode.checked).toBe(true);
 
     // The original 'checked' attribute should be unchanged
@@ -759,7 +720,7 @@ describe('ReactDOMInput', () => {
     expect(cNode.hasAttribute('checked')).toBe(true);
 
     // Now let's run the actual ReactDOMInput change event handler
-    ReactTestUtils.Simulate.change(bNode);
+    dispatchEventOnNode(bNode, 'click');
 
     // The original state should have been restored
     expect(aNode.checked).toBe(true);
@@ -797,16 +758,16 @@ describe('ReactDOMInput', () => {
       }
     }
 
-    const stub = ReactTestUtils.renderIntoDocument(<App />);
+    const stub = ReactDOM.render(<App />, container);
     const buttonNode = ReactDOM.findDOMNode(stub).childNodes[0];
     const firstRadioNode = ReactDOM.findDOMNode(stub).childNodes[1];
     expect(firstRadioNode.checked).toBe(false);
-    ReactTestUtils.Simulate.click(buttonNode);
+    dispatchEventOnNode(buttonNode, 'click');
     expect(firstRadioNode.checked).toBe(true);
   });
 
   it('should control radio buttons if the tree updates during render', () => {
-    const sharedParent = document.createElement('div');
+    const sharedParent = container;
     const container1 = document.createElement('div');
     const container2 = document.createElement('div');
 
@@ -815,6 +776,15 @@ describe('ReactDOMInput', () => {
     let aNode;
     let bNode;
     class ComponentA extends React.Component {
+      state = {changed: false};
+      handleChange = () => {
+        this.setState({
+          changed: true,
+        });
+      };
+      componentDidUpdate() {
+        sharedParent.appendChild(container2);
+      }
       componentDidMount() {
         ReactDOM.render(<ComponentB />, container2);
       }
@@ -825,8 +795,8 @@ describe('ReactDOMInput', () => {
               ref={n => (aNode = n)}
               type="radio"
               name="fruit"
-              checked={true}
-              onChange={emptyFunction}
+              checked={false}
+              onChange={this.handleChange}
             />
             A
           </div>
@@ -835,15 +805,6 @@ describe('ReactDOMInput', () => {
     }
 
     class ComponentB extends React.Component {
-      state = {changed: false};
-      handleChange = () => {
-        this.setState({
-          changed: true,
-        });
-      };
-      componentDidUpdate() {
-        sharedParent.appendChild(container2);
-      }
       render() {
         return (
           <div>
@@ -851,8 +812,8 @@ describe('ReactDOMInput', () => {
               ref={n => (bNode = n)}
               type="radio"
               name="fruit"
-              checked={false}
-              onChange={this.handleChange}
+              checked={true}
+              onChange={emptyFunction}
             />
             B
           </div>
@@ -862,31 +823,34 @@ describe('ReactDOMInput', () => {
 
     ReactDOM.render(<ComponentA />, container1);
 
-    expect(aNode.checked).toBe(true);
-    expect(bNode.checked).toBe(false);
+    expect(aNode.checked).toBe(false);
+    expect(bNode.checked).toBe(true);
 
-    bNode.checked = true;
+    setUntrackedChecked.call(aNode, true);
     // This next line isn't necessary in a proper browser environment, but
-    // jsdom doesn't uncheck the others in a group (which makes this whole test
-    // a little less effective)
-    aNode.checked = false;
+    // jsdom doesn't uncheck the others in a group (because they are not yet
+    // sharing a parent), which makes this whole test a little less effective.
+    setUntrackedChecked.call(bNode, false);
 
     // Now let's run the actual ReactDOMInput change event handler
-    ReactTestUtils.Simulate.change(bNode);
+    dispatchEventOnNode(aNode, 'click');
 
     // The original state should have been restored
-    expect(aNode.checked).toBe(true);
-    expect(bNode.checked).toBe(false);
+    expect(aNode.checked).toBe(false);
+    expect(bNode.checked).toBe(true);
   });
 
   it('should warn with value and no onChange handler and readOnly specified', () => {
-    ReactTestUtils.renderIntoDocument(
+    ReactDOM.render(
       <input type="text" value="zoink" readOnly={true} />,
+      container,
     );
+    ReactDOM.unmountComponentAtNode(container);
 
     expect(() =>
-      ReactTestUtils.renderIntoDocument(
+      ReactDOM.render(
         <input type="text" value="zoink" readOnly={false} />,
+        container,
       ),
     ).toWarnDev(
       'Warning: Failed prop type: You provided a `value` prop to a form ' +
@@ -898,24 +862,29 @@ describe('ReactDOMInput', () => {
   });
 
   it('should have a this value of undefined if bind is not used', () => {
+    expect.assertions(1);
     const unboundInputOnChange = function() {
       expect(this).toBe(undefined);
     };
 
-    let instance = <input type="text" onChange={unboundInputOnChange} />;
-    instance = ReactTestUtils.renderIntoDocument(instance);
+    const stub = <input type="text" onChange={unboundInputOnChange} />;
+    const node = ReactDOM.render(stub, container);
 
-    ReactTestUtils.Simulate.change(instance);
+    setUntrackedValue.call(node, 'giraffe');
+    dispatchEventOnNode(node, 'change');
   });
 
   it('should warn with checked and no onChange handler with readOnly specified', () => {
-    ReactTestUtils.renderIntoDocument(
+    ReactDOM.render(
       <input type="checkbox" checked="false" readOnly={true} />,
+      container,
     );
+    ReactDOM.unmountComponentAtNode(container);
 
     expect(() =>
-      ReactTestUtils.renderIntoDocument(
+      ReactDOM.render(
         <input type="checkbox" checked="false" readOnly={false} />,
+        container,
       ),
     ).toWarnDev(
       'Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler. ' +
@@ -925,7 +894,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should update defaultValue to empty string', () => {
-    const container = document.createElement('div');
     ReactDOM.render(<input type="text" defaultValue={'foo'} />, container);
     ReactDOM.render(<input type="text" defaultValue={''} />, container);
     expect(container.firstChild.defaultValue).toBe('');
@@ -933,25 +901,27 @@ describe('ReactDOMInput', () => {
 
   it('should warn if value is null', () => {
     expect(() =>
-      ReactTestUtils.renderIntoDocument(<input type="text" value={null} />),
+      ReactDOM.render(<input type="text" value={null} />, container),
     ).toWarnDev(
       '`value` prop on `input` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` ' +
         'for uncontrolled components.',
     );
+    ReactDOM.unmountComponentAtNode(container);
 
-    ReactTestUtils.renderIntoDocument(<input type="text" value={null} />);
+    ReactDOM.render(<input type="text" value={null} />, container);
   });
 
   it('should warn if checked and defaultChecked props are specified', () => {
     expect(() =>
-      ReactTestUtils.renderIntoDocument(
+      ReactDOM.render(
         <input
           type="radio"
           checked={true}
           defaultChecked={true}
           readOnly={true}
         />,
+        container,
       ),
     ).toWarnDev(
       'A component contains an input of type radio with both checked and defaultChecked props. ' +
@@ -961,21 +931,24 @@ describe('ReactDOMInput', () => {
         'element and remove one of these props. More info: ' +
         'https://fb.me/react-controlled-components',
     );
+    ReactDOM.unmountComponentAtNode(container);
 
-    ReactTestUtils.renderIntoDocument(
+    ReactDOM.render(
       <input
         type="radio"
         checked={true}
         defaultChecked={true}
         readOnly={true}
       />,
+      container,
     );
   });
 
   it('should warn if value and defaultValue props are specified', () => {
     expect(() =>
-      ReactTestUtils.renderIntoDocument(
+      ReactDOM.render(
         <input type="text" value="foo" defaultValue="bar" readOnly={true} />,
+        container,
       ),
     ).toWarnDev(
       'A component contains an input of type text with both value and defaultValue props. ' +
@@ -985,9 +958,11 @@ describe('ReactDOMInput', () => {
         'element and remove one of these props. More info: ' +
         'https://fb.me/react-controlled-components',
     );
+    ReactDOM.unmountComponentAtNode(container);
 
-    ReactTestUtils.renderIntoDocument(
+    ReactDOM.render(
       <input type="text" value="foo" defaultValue="bar" readOnly={true} />,
+      container,
     );
   });
 
@@ -995,7 +970,6 @@ describe('ReactDOMInput', () => {
     const stub = (
       <input type="text" value="controlled" onChange={emptyFunction} />
     );
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() => ReactDOM.render(<input type="text" />, container)).toWarnDev(
       'Warning: A component is changing a controlled input of type text to be uncontrolled. ' +
@@ -1010,7 +984,6 @@ describe('ReactDOMInput', () => {
     const stub = (
       <input type="text" value="controlled" onChange={emptyFunction} />
     );
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="text" value={null} />, container),
@@ -1029,7 +1002,6 @@ describe('ReactDOMInput', () => {
     const stub = (
       <input type="text" value="controlled" onChange={emptyFunction} />
     );
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(
@@ -1047,7 +1019,6 @@ describe('ReactDOMInput', () => {
 
   it('should warn if uncontrolled input (value is undefined) switches to controlled', () => {
     const stub = <input type="text" />;
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="text" value="controlled" />, container),
@@ -1062,7 +1033,6 @@ describe('ReactDOMInput', () => {
 
   it('should warn if uncontrolled input (value is null) switches to controlled', () => {
     const stub = <input type="text" value={null} />;
-    const container = document.createElement('div');
     expect(() => ReactDOM.render(stub, container)).toWarnDev(
       '`value` prop on `input` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` for uncontrolled components.',
@@ -1082,7 +1052,6 @@ describe('ReactDOMInput', () => {
     const stub = (
       <input type="checkbox" checked={true} onChange={emptyFunction} />
     );
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="checkbox" />, container),
@@ -1099,7 +1068,6 @@ describe('ReactDOMInput', () => {
     const stub = (
       <input type="checkbox" checked={true} onChange={emptyFunction} />
     );
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="checkbox" checked={null} />, container),
@@ -1116,7 +1084,6 @@ describe('ReactDOMInput', () => {
     const stub = (
       <input type="checkbox" checked={true} onChange={emptyFunction} />
     );
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(
@@ -1134,7 +1101,6 @@ describe('ReactDOMInput', () => {
 
   it('should warn if uncontrolled checkbox (checked is undefined) switches to controlled', () => {
     const stub = <input type="checkbox" />;
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="checkbox" checked={true} />, container),
@@ -1149,7 +1115,6 @@ describe('ReactDOMInput', () => {
 
   it('should warn if uncontrolled checkbox (checked is null) switches to controlled', () => {
     const stub = <input type="checkbox" checked={null} />;
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="checkbox" checked={true} />, container),
@@ -1164,7 +1129,6 @@ describe('ReactDOMInput', () => {
 
   it('should warn if controlled radio switches to uncontrolled (checked is undefined)', () => {
     const stub = <input type="radio" checked={true} onChange={emptyFunction} />;
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() => ReactDOM.render(<input type="radio" />, container)).toWarnDev(
       'Warning: A component is changing a controlled input of type radio to be uncontrolled. ' +
@@ -1177,7 +1141,6 @@ describe('ReactDOMInput', () => {
 
   it('should warn if controlled radio switches to uncontrolled (checked is null)', () => {
     const stub = <input type="radio" checked={true} onChange={emptyFunction} />;
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="radio" checked={null} />, container),
@@ -1192,7 +1155,6 @@ describe('ReactDOMInput', () => {
 
   it('should warn if controlled radio switches to uncontrolled with defaultChecked', () => {
     const stub = <input type="radio" checked={true} onChange={emptyFunction} />;
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="radio" defaultChecked={true} />, container),
@@ -1207,7 +1169,6 @@ describe('ReactDOMInput', () => {
 
   it('should warn if uncontrolled radio (checked is undefined) switches to controlled', () => {
     const stub = <input type="radio" />;
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="radio" checked={true} />, container),
@@ -1222,7 +1183,6 @@ describe('ReactDOMInput', () => {
 
   it('should warn if uncontrolled radio (checked is null) switches to controlled', () => {
     const stub = <input type="radio" checked={null} />;
-    const container = document.createElement('div');
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="radio" checked={true} />, container),
@@ -1236,7 +1196,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should not warn if radio value changes but never becomes controlled', () => {
-    const container = document.createElement('div');
     ReactDOM.render(<input type="radio" value="value" />, container);
     ReactDOM.render(<input type="radio" />, container);
     ReactDOM.render(
@@ -1251,7 +1210,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should not warn if radio value changes but never becomes uncontrolled', () => {
-    const container = document.createElement('div');
     ReactDOM.render(
       <input type="radio" checked={false} onChange={() => null} />,
       container,
@@ -1269,7 +1227,6 @@ describe('ReactDOMInput', () => {
   });
 
   it('should warn if radio checked false changes to become uncontrolled', () => {
-    const container = document.createElement('div');
     ReactDOM.render(
       <input
         type="radio"
@@ -1314,7 +1271,7 @@ describe('ReactDOMInput', () => {
       return el;
     });
 
-    ReactTestUtils.renderIntoDocument(
+    ReactDOM.render(
       <input
         value="0"
         onChange={() => {}}
@@ -1323,6 +1280,7 @@ describe('ReactDOMInput', () => {
         max="100"
         step="1"
       />,
+      container,
     );
     expect(log).toEqual([
       'set attribute type',
@@ -1336,9 +1294,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('sets value properly with type coming later in props', () => {
-    const input = ReactTestUtils.renderIntoDocument(
-      <input value="hi" type="radio" />,
-    );
+    const input = ReactDOM.render(<input value="hi" type="radio" />, container);
     expect(input.value).toBe('hi');
   });
 
@@ -1352,7 +1308,7 @@ describe('ReactDOMInput', () => {
       }
     }
 
-    const input = ReactTestUtils.renderIntoDocument(<Input />);
+    const input = ReactDOM.render(<Input />, container);
     const node = ReactDOM.findDOMNode(input);
 
     // If the value is set before the type, a validation warning will raise and
@@ -1388,9 +1344,7 @@ describe('ReactDOMInput', () => {
       return el;
     });
 
-    ReactTestUtils.renderIntoDocument(
-      <input type="date" defaultValue="1980-01-01" />,
-    );
+    ReactDOM.render(<input type="date" defaultValue="1980-01-01" />, container);
     expect(log).toEqual([
       'node.setAttribute("type", "date")',
       'node.value = "1980-01-01"',
@@ -1419,61 +1373,68 @@ describe('ReactDOMInput', () => {
 
     it('always sets the attribute when values change on text inputs', function() {
       const Input = getTestInput();
-      const stub = ReactTestUtils.renderIntoDocument(<Input type="text" />);
+      const stub = ReactDOM.render(<Input type="text" />, container);
       const node = ReactDOM.findDOMNode(stub);
 
-      ReactTestUtils.Simulate.change(node, {target: {value: '2'}});
+      setUntrackedValue.call(node, '2');
+      dispatchEventOnNode(node, 'change');
 
       expect(node.getAttribute('value')).toBe('2');
     });
 
     it('does not set the value attribute on number inputs if focused', () => {
       const Input = getTestInput();
-      const stub = ReactTestUtils.renderIntoDocument(
+      const stub = ReactDOM.render(
         <Input type="number" value="1" />,
+        container,
       );
       const node = ReactDOM.findDOMNode(stub);
 
       node.focus();
 
-      ReactTestUtils.Simulate.change(node, {target: {value: '2'}});
+      setUntrackedValue.call(node, '2');
+      dispatchEventOnNode(node, 'change');
 
       expect(node.getAttribute('value')).toBe('1');
     });
 
     it('sets the value attribute on number inputs on blur', () => {
       const Input = getTestInput();
-      const stub = ReactTestUtils.renderIntoDocument(
+      const stub = ReactDOM.render(
         <Input type="number" value="1" />,
+        container,
       );
       const node = ReactDOM.findDOMNode(stub);
 
-      ReactTestUtils.Simulate.change(node, {target: {value: '2'}});
-      ReactTestUtils.SimulateNative.blur(node);
+      setUntrackedValue.call(node, '2');
+      dispatchEventOnNode(node, 'change');
+      dispatchEventOnNode(node, 'blur');
 
       expect(node.getAttribute('value')).toBe('2');
     });
 
     it('an uncontrolled number input will not update the value attribute on blur', () => {
-      const node = ReactTestUtils.renderIntoDocument(
+      const node = ReactDOM.render(
         <input type="number" defaultValue="1" />,
+        container,
       );
 
-      node.value = 4;
+      setUntrackedValue.call(node, 4);
 
-      ReactTestUtils.SimulateNative.blur(node);
+      dispatchEventOnNode(node, 'blur');
 
       expect(node.getAttribute('value')).toBe('1');
     });
 
     it('an uncontrolled text input will not update the value attribute on blur', () => {
-      const node = ReactTestUtils.renderIntoDocument(
+      const node = ReactDOM.render(
         <input type="text" defaultValue="1" />,
+        container,
       );
 
-      node.value = 4;
+      setUntrackedValue.call(node, 4);
 
-      ReactTestUtils.SimulateNative.blur(node);
+      dispatchEventOnNode(node, 'blur');
 
       expect(node.getAttribute('value')).toBe('1');
     });
@@ -1483,7 +1444,12 @@ describe('ReactDOMInput', () => {
     let input;
 
     function renderInputWithStringThenWithUndefined() {
+      let setValueToUndefined;
       class Input extends React.Component {
+        constructor() {
+          super();
+          setValueToUndefined = () => this.setState({value: undefined});
+        }
         state = {value: 'first'};
         render() {
           return (
@@ -1495,10 +1461,11 @@ describe('ReactDOMInput', () => {
         }
       }
 
-      const stub = ReactTestUtils.renderIntoDocument(<Input />);
+      const stub = ReactDOM.render(<Input />, container);
       input = ReactDOM.findDOMNode(stub);
-      ReactTestUtils.Simulate.change(input, {target: {value: 'latest'}});
-      ReactTestUtils.Simulate.change(input, {target: {value: undefined}});
+      setUntrackedValue.call(input, 'latest');
+      dispatchEventOnNode(input, 'change');
+      setValueToUndefined();
     }
 
     it('reverts the value attribute to the initial value', () => {
@@ -1522,7 +1489,12 @@ describe('ReactDOMInput', () => {
     let input;
 
     function renderInputWithStringThenWithNull() {
+      let setValueToNull;
       class Input extends React.Component {
+        constructor() {
+          super();
+          setValueToNull = () => this.setState({value: null});
+        }
         state = {value: 'first'};
         render() {
           return (
@@ -1534,10 +1506,11 @@ describe('ReactDOMInput', () => {
         }
       }
 
-      const stub = ReactTestUtils.renderIntoDocument(<Input />);
+      const stub = ReactDOM.render(<Input />, container);
       input = ReactDOM.findDOMNode(stub);
-      ReactTestUtils.Simulate.change(input, {target: {value: 'latest'}});
-      ReactTestUtils.Simulate.change(input, {target: {value: null}});
+      setUntrackedValue.call(input, 'latest');
+      dispatchEventOnNode(input, 'change');
+      setValueToNull();
     }
 
     it('reverts the value attribute to the initial value', () => {
@@ -1565,7 +1538,6 @@ describe('ReactDOMInput', () => {
 
   describe('When given a Symbol value', function() {
     it('treats initial Symbol value as an empty string', function() {
-      const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(
           <input value={Symbol('foobar')} onChange={() => {}} />,
@@ -1579,7 +1551,6 @@ describe('ReactDOMInput', () => {
     });
 
     it('treats updated Symbol value as an empty string', function() {
-      const container = document.createElement('div');
       ReactDOM.render(<input value="foo" onChange={() => {}} />, container);
       expect(() =>
         ReactDOM.render(
@@ -1594,7 +1565,6 @@ describe('ReactDOMInput', () => {
     });
 
     it('treats initial Symbol defaultValue as an empty string', function() {
-      const container = document.createElement('div');
       ReactDOM.render(<input defaultValue={Symbol('foobar')} />, container);
       const node = container.firstChild;
 
@@ -1604,7 +1574,6 @@ describe('ReactDOMInput', () => {
     });
 
     it('treats updated Symbol defaultValue as an empty string', function() {
-      const container = document.createElement('div');
       ReactDOM.render(<input defaultValue="foo" />, container);
       ReactDOM.render(<input defaultValue={Symbol('foobar')} />, container);
       const node = container.firstChild;
@@ -1617,7 +1586,6 @@ describe('ReactDOMInput', () => {
 
   describe('When given a function value', function() {
     it('treats initial function value as an empty string', function() {
-      const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(
           <input value={() => {}} onChange={() => {}} />,
@@ -1631,7 +1599,6 @@ describe('ReactDOMInput', () => {
     });
 
     it('treats updated function value as an empty string', function() {
-      const container = document.createElement('div');
       ReactDOM.render(<input value="foo" onChange={() => {}} />, container);
       expect(() =>
         ReactDOM.render(
@@ -1646,7 +1613,6 @@ describe('ReactDOMInput', () => {
     });
 
     it('treats initial function defaultValue as an empty string', function() {
-      const container = document.createElement('div');
       ReactDOM.render(<input defaultValue={() => {}} />, container);
       const node = container.firstChild;
 
@@ -1656,7 +1622,6 @@ describe('ReactDOMInput', () => {
     });
 
     it('treats updated function defaultValue as an empty string', function() {
-      const container = document.createElement('div');
       ReactDOM.render(<input defaultValue="foo" />, container);
       ReactDOM.render(<input defaultValue={() => {}} />, container);
       const node = container.firstChild;
@@ -1673,7 +1638,6 @@ describe('ReactDOMInput', () => {
     // value in order to "dettach" it from defaultValue. This had the unfortunate
     // side-effect of assigning value="on" to radio and checkboxes
     it('does not add "on" in absence of value on a checkbox', function() {
-      const container = document.createElement('div');
       ReactDOM.render(
         <input type="checkbox" defaultChecked={true} />,
         container,
@@ -1685,7 +1649,6 @@ describe('ReactDOMInput', () => {
     });
 
     it('does not add "on" in absence of value on a radio', function() {
-      const container = document.createElement('div');
       ReactDOM.render(<input type="radio" defaultChecked={true} />, container);
       const node = container.firstChild;
 

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -615,11 +615,20 @@ describe('ReactDOMSelect', () => {
         <option value="gorilla">A gorilla!</option>
       </select>
     );
-    const node = ReactTestUtils.renderIntoDocument(stub);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
 
-    ReactTestUtils.Simulate.change(node);
+    try {
+      const node = ReactDOM.render(stub, container);
 
-    expect(node.value).toBe('giraffe');
+      node.dispatchEvent(
+        new Event('change', {bubbles: true, cancelable: false}),
+      );
+
+      expect(node.value).toBe('giraffe');
+    } finally {
+      document.body.removeChild(container);
+    }
   });
 
   it('should warn if value and defaultValue props are specified', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
@@ -536,7 +536,7 @@ describe('ReactDOMServerIntegration', () => {
             // simulate a user typing.
             setUntrackedValue.call(e, 'Goodbye');
             e.dispatchEvent(
-              new Event('change', {bubbles: true, cancelable: false}),
+              new Event('input', {bubbles: true, cancelable: false}),
             );
 
             expect(changeCount).toBe(1);
@@ -566,7 +566,7 @@ describe('ReactDOMServerIntegration', () => {
             // simulate a user typing.
             setUntrackedValue.call(e, 'Goodbye');
             e.dispatchEvent(
-              new Event('change', {bubbles: true, cancelable: false}),
+              new Event('input', {bubbles: true, cancelable: false}),
             );
 
             expect(changeCount).toBe(1);

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
@@ -14,14 +14,12 @@ const ReactDOMServerIntegrationUtils = require('./utils/ReactDOMServerIntegratio
 let React;
 let ReactDOM;
 let ReactDOMServer;
-let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
   jest.resetModuleRegistry();
   React = require('react');
   ReactDOM = require('react-dom');
-  ReactTestUtils = require('react-dom/test-utils');
   ReactDOMServer = require('react-dom/server');
 
   // Make them available to the helpers.
@@ -519,35 +517,63 @@ describe('ReactDOMServerIntegration', () => {
 
       describe('user interaction with controlled inputs', function() {
         itClientRenders('a controlled text input', async render => {
+          const setUntrackedValue = Object.getOwnPropertyDescriptor(
+            HTMLInputElement.prototype,
+            'value',
+          ).set;
+
           let changeCount = 0;
           const e = await render(
             <ControlledInput onChange={() => changeCount++} />,
           );
-          expect(changeCount).toBe(0);
-          expect(e.value).toBe('Hello');
+          const container = e.parentNode;
+          document.body.appendChild(container);
 
-          // simulate a user typing.
-          e.value = 'Goodbye';
-          ReactTestUtils.Simulate.change(e);
+          try {
+            expect(changeCount).toBe(0);
+            expect(e.value).toBe('Hello');
 
-          expect(changeCount).toBe(1);
-          expect(e.value).toBe('Goodbye');
+            // simulate a user typing.
+            setUntrackedValue.call(e, 'Goodbye');
+            e.dispatchEvent(
+              new Event('change', {bubbles: true, cancelable: false}),
+            );
+
+            expect(changeCount).toBe(1);
+            expect(e.value).toBe('Goodbye');
+          } finally {
+            document.body.removeChild(container);
+          }
         });
 
         itClientRenders('a controlled textarea', async render => {
+          const setUntrackedValue = Object.getOwnPropertyDescriptor(
+            HTMLTextAreaElement.prototype,
+            'value',
+          ).set;
+
           let changeCount = 0;
           const e = await render(
             <ControlledTextArea onChange={() => changeCount++} />,
           );
-          expect(changeCount).toBe(0);
-          expect(e.value).toBe('Hello');
+          const container = e.parentNode;
+          document.body.appendChild(container);
 
-          // simulate a user typing.
-          e.value = 'Goodbye';
-          ReactTestUtils.Simulate.change(e);
+          try {
+            expect(changeCount).toBe(0);
+            expect(e.value).toBe('Hello');
 
-          expect(changeCount).toBe(1);
-          expect(e.value).toBe('Goodbye');
+            // simulate a user typing.
+            setUntrackedValue.call(e, 'Goodbye');
+            e.dispatchEvent(
+              new Event('change', {bubbles: true, cancelable: false}),
+            );
+
+            expect(changeCount).toBe(1);
+            expect(e.value).toBe('Goodbye');
+          } finally {
+            document.body.removeChild(container);
+          }
         });
 
         itClientRenders('a controlled checkbox', async render => {
@@ -555,31 +581,53 @@ describe('ReactDOMServerIntegration', () => {
           const e = await render(
             <ControlledCheckbox onChange={() => changeCount++} />,
           );
-          expect(changeCount).toBe(0);
-          expect(e.checked).toBe(true);
+          const container = e.parentNode;
+          document.body.appendChild(container);
 
-          // simulate a user typing.
-          e.checked = false;
-          ReactTestUtils.Simulate.change(e);
+          try {
+            expect(changeCount).toBe(0);
+            expect(e.checked).toBe(true);
 
-          expect(changeCount).toBe(1);
-          expect(e.checked).toBe(false);
+            // simulate a user clicking.
+            e.dispatchEvent(
+              new Event('click', {bubbles: true, cancelable: true}),
+            );
+
+            expect(changeCount).toBe(1);
+            expect(e.checked).toBe(false);
+          } finally {
+            document.body.removeChild(container);
+          }
         });
 
         itClientRenders('a controlled select', async render => {
+          const setUntrackedValue = Object.getOwnPropertyDescriptor(
+            HTMLSelectElement.prototype,
+            'value',
+          ).set;
+
           let changeCount = 0;
           const e = await render(
             <ControlledSelect onChange={() => changeCount++} />,
           );
-          expect(changeCount).toBe(0);
-          expect(e.value).toBe('Hello');
+          const container = e.parentNode;
+          document.body.appendChild(container);
 
-          // simulate a user typing.
-          e.value = 'Goodbye';
-          ReactTestUtils.Simulate.change(e);
+          try {
+            expect(changeCount).toBe(0);
+            expect(e.value).toBe('Hello');
 
-          expect(changeCount).toBe(1);
-          expect(e.value).toBe('Goodbye');
+            // simulate a user typing.
+            setUntrackedValue.call(e, 'Goodbye');
+            e.dispatchEvent(
+              new Event('change', {bubbles: true, cancelable: false}),
+            );
+
+            expect(changeCount).toBe(1);
+            expect(e.value).toBe('Goodbye');
+          } finally {
+            document.body.removeChild(container);
+          }
         });
       });
 

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -250,7 +250,7 @@ describe('ReactDOMTextarea', () => {
 
       setUntrackedValue.call(node, 'giraffe');
       node.dispatchEvent(
-        new Event('change', {bubbles: true, cancelable: false}),
+        new Event('input', {bubbles: true, cancelable: false}),
       );
       expect(node.value).toBe('0');
     } finally {

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -237,11 +237,25 @@ describe('ReactDOMTextarea', () => {
 
   it('should properly control a value of number `0`', () => {
     const stub = <textarea value={0} onChange={emptyFunction} />;
-    const node = renderTextarea(stub);
+    const setUntrackedValue = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'value',
+    ).set;
 
-    node.value = 'giraffe';
-    ReactTestUtils.Simulate.change(node);
-    expect(node.value).toBe('0');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    try {
+      const node = renderTextarea(stub, container);
+
+      setUntrackedValue.call(node, 'giraffe');
+      node.dispatchEvent(
+        new Event('change', {bubbles: true, cancelable: false}),
+      );
+      expect(node.value).toBe('0');
+    } finally {
+      document.body.removeChild(container);
+    }
   });
 
   it('should treat children like `defaultValue`', () => {


### PR DESCRIPTION
It’s time to get rid of even more `ReactTestUtils.Simulate`s. In this PR we remove the event simulation from all onChange tests. To do this, we have to get a setter to the untracked value/checked props.

All remaining `ReactTestUtils.Simulate` calls are either testing ReactTestUtils or assert that they do/don't throw.