### PR TITLE
Refactor fiber triangle

### DIFF
--- a/fixtures/fiber-triangle/index.html
+++ b/fixtures/fiber-triangle/index.html
@@ -1,26 +1,29 @@
 <!DOCTYPE html>
 <html style="width: 100%; height: 100%; overflow: hidden">
-  <head>
-    <meta charset="utf-8">
-    <title>Fiber Example</title>
-  </head>
-  <body>
-    <h1>Fiber Example</h1>
-    <div id="container">
-      <p>
-        To install React, follow the instructions on
-        <a href="https://github.com/facebook/react/">GitHub</a>.
-      </p>
-      <p>
-        If you can see this, React is <strong>not</strong> working right.
-        If you checked out the source from GitHub make sure to run <code>npm run build</code>.
-      </p>
-    </div>
-    <script src="../../build/dist/react.development.js"></script>
-    <script src="../../build/dist/react-dom.development.js"></script>
-    <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
-    <script type="text/babel">
-      var dotStyle = {
+
+<head>
+  <meta charset="utf-8">
+  <title>Fiber Example</title>
+</head>
+
+<body>
+  <h1>Fiber Example</h1>
+  <div id="container">
+    <p>
+      To install React, follow the instructions on
+      <a href="https://github.com/facebook/react/">GitHub</a>.
+    </p>
+    <p>
+      If you can see this, React is
+      <strong>not</strong> working right. If you checked out the source from GitHub make sure to run
+      <code>npm run build</code>.
+    </p>
+  </div>
+  <script src="../../build/dist/react.development.js"></script>
+  <script src="../../build/dist/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
+  <script type="text/babel">
+      const dotStyle = {
         position: 'absolute',
         background: '#61dafb',
         font: 'normal 15px sans-serif',
@@ -28,7 +31,7 @@
         cursor: 'pointer',
       };
 
-      var containerStyle = {
+      const containerStyle = {
         position: 'absolute',
         transformOrigin: '0 0',
         left: '50%',
@@ -38,12 +41,14 @@
         background: '#eee',
       };
 
-      var targetSize = 25;
+      const targetSize = 25;
 
       class Dot extends React.Component {
         constructor() {
           super();
           this.state = { hover: false };
+          this.enter = this.enter.bind(this);
+          this.leave = this.leave.bind(this);
         }
         enter() {
           this.setState({
@@ -56,21 +61,22 @@
           });
         }
         render() {
-          var props = this.props;
-          var s = props.size * 1.3;
-          var style = {
+          const { size, x, y, text } = this.props;
+          const { hover } = this.state;
+          const s = size * 1.3;
+          const style = {
             ...dotStyle,
             width: s + 'px',
             height: s + 'px',
-            left: (props.x) + 'px',
-            top: (props.y) + 'px',
-            borderRadius: (s / 2) + 'px',
-            lineHeight: (s) + 'px',
+            left: `${x}px`,
+            top: `${y}px`,
+            borderRadius: `${s / 2}px`,
+            lineHeight: `${s}px`,
             background: this.state.hover ? '#ff0' : dotStyle.background
           };
           return (
-            <div style={style} onMouseEnter={() => this.enter()} onMouseLeave={() => this.leave()}>
-              {this.state.hover ? '*' + props.text + '*' : props.text}
+            <div style={style} onMouseEnter={this.enter} onMouseLeave={this.leave}>
+              {hover ? '*' + text + '*' : text}
             </div>
           );
         }
@@ -78,8 +84,8 @@
 
       class SierpinskiTriangle extends React.Component {
         shouldComponentUpdate(nextProps) {
-          var o = this.props;
-          var n = nextProps;
+          const o = this.props;
+          const n = nextProps;
           return !(
             o.x === n.x &&
             o.y === n.y &&
@@ -88,7 +94,7 @@
           );
         }
         render() {
-          let {x, y, s, children} = this.props;
+          let { x, y, s, children } = this.props;
           if (s <= targetSize) {
             return (
               <Dot
@@ -100,10 +106,10 @@
             );
             return r;
           }
-          var newSize = s / 2;
-          var slowDown = true;
+          const newSize = s / 2;
+          const slowDown = true;
           if (slowDown) {
-            var e = performance.now() + 0.8;
+            const e = performance.now() + 0.8;
             while (performance.now() < e) {
               // Artificially long execution time.
             }
@@ -160,7 +166,7 @@
           const elapsed = this.props.elapsed;
           const t = (elapsed / 1000) % 10;
           const scale = 1 + (t > 5 ? 10 - t : t) / 10;
-          const transform = 'scaleX(' + (scale / 2.1) + ') scaleY(0.7) translateZ(0.1px)';
+          const transform = `scaleX(${scale / 2.1}) scaleY(0.7) translateZ(0.1px)`;
           return (
             <div>
               <div>
@@ -176,7 +182,7 @@
               <div style={{ ...containerStyle, transform }}>
                 <div>
                   <SierpinskiTriangle x={0} y={0} s={1000}>
-                    {this.state.seconds}
+                    {seconds}
                   </SierpinskiTriangle>
                 </div>
               </div>
@@ -194,15 +200,15 @@
           this.props.onChange(event.target.value === 'on');
         }
         render() {
-          const value = this.props.value;
+          const { value, onLabel, offLabel } = this.props;
           return (
             <label onChange={this.onChange}>
               <label>
-                {this.props.onLabel}
+                {onLabel}
                 <input type="radio" name="value" value="on" checked={value} />
               </label>
               <label>
-                {this.props.offLabel}
+                {offLabel}
                 <input type="radio" name="value" value="off" checked={!value} />
               </label>
             </label>
@@ -210,7 +216,7 @@
         }
       }
 
-      var start = new Date().getTime();
+      const start = new Date().getTime();
       function update() {
         ReactDOM.render(
           <ExampleApplication elapsed={new Date().getTime() - start} />,
@@ -220,5 +226,6 @@
       }
       requestAnimationFrame(update);
     </script>
-  </body>
+</body>
+
 </html>

--- a/fixtures/fiber-triangle/index.html
+++ b/fixtures/fiber-triangle/index.html
@@ -16,7 +16,8 @@
     <p>
       If you can see this, React is
       <strong>not</strong> working right. If you checked out the source from GitHub make sure to run
-      <code>npm run build</code>.
+      <code>npm run build</code> or
+      <code>yarn build</code>.
     </p>
   </div>
   <script src="../../build/dist/react.development.js"></script>
@@ -158,8 +159,8 @@
         this.setState(state => ({seconds: state.seconds % 10 + 1}));
       }
     }
-    onTimeSlicingChange({target: {value}}) {
-      this.setState(() => ({useTimeSlicing: value === 'on'}));
+    onTimeSlicingChange(value) {
+      this.setState(() => ({ useTimeSlicing: value }));
     }
     componentWillUnmount() {
       clearInterval(this.intervalID);
@@ -194,30 +195,36 @@
     }
   }
 
-  const Toggle = ({value, onLabel, offLabel, onChange}) => (
-    <label>
-      <label>
-        {onLabel}
-        <input
-          type="radio"
-          name="value"
-          value="on"
-          checked={value}
-          onChange={onChange}
-        />
-      </label>
-      <label>
-        {offLabel}
-        <input
-          type="radio"
-          name="value"
-          value="off"
-          checked={!value}
-          onChange={onChange}
-        />
-      </label>
-    </label>
-  );
+  class Toggle extends React.Component {
+    constructor(props) {
+      super(props);
+      this.onChange = this.onChange.bind(this);
+    }
+    onChange(event) {
+      this.props.onChange(event.target.value === 'on');
+    }
+
+    shouldComponentUpdate(nextProps) {
+      return nextProps.value !== this.props.value;
+    }
+
+    render() {
+      const {value, onLabel, offLabel} = this.props;
+      return (
+        <label>
+          <label style={{fontWeight: value ? 'bold': 'normal'}}>
+            {onLabel}
+            <input type="radio" name="value" value="on" checked={value} onChange={this.onChange}/>
+          </label>
+          <label style={{fontWeight: value ? 'normal': 'bold'}}>
+            {offLabel}
+            <input type="radio" name="value" value="off" checked={!value} onChange={this.onChange}  />
+          </label>
+        </label>
+      );
+    }
+  }
+
   const start = new Date().getTime();
   function update() {
     ReactDOM.render(

--- a/fixtures/fiber-triangle/index.html
+++ b/fixtures/fiber-triangle/index.html
@@ -95,6 +95,7 @@
     }
     render() {
       let {x, y, s, children} = this.props;
+      const {Fragment} = React;
       if (s <= targetSize) {
         return (
           <Dot
@@ -117,17 +118,19 @@
 
       s /= 2;
 
-      return [
-        <SierpinskiTriangle x={x} y={y - s / 2} s={s} key={1}>
-          {children}
-        </SierpinskiTriangle>,
-        <SierpinskiTriangle x={x - s} y={y + s / 2} s={s} key={2}>
-          {children}
-        </SierpinskiTriangle>,
-        <SierpinskiTriangle x={x + s} y={y + s / 2} s={s} key={3}>
-          {children}
-        </SierpinskiTriangle>,
-      ];
+      return (
+        <Fragment>
+          <SierpinskiTriangle x={x} y={y - s / 2} s={s}>
+            {children}
+          </SierpinskiTriangle>
+          <SierpinskiTriangle x={x - s} y={y + s / 2} s={s}>
+            {children}
+          </SierpinskiTriangle>
+          <SierpinskiTriangle x={x + s} y={y + s / 2} s={s}>
+            {children}
+          </SierpinskiTriangle>
+        </Fragment>
+      );
     }
   }
 
@@ -162,8 +165,8 @@
       clearInterval(this.intervalID);
     }
     render() {
-      const seconds = this.state.seconds;
-      const elapsed = this.props.elapsed;
+      const {seconds} = this.state;
+      const {elapsed} = this.props;
       const t = (elapsed / 1000) % 10;
       const scale = 1 + (t > 5 ? 10 - t : t) / 10;
       const transform = `scaleX(${scale / 2.1}) scaleY(0.7) translateZ(0.1px)`;

--- a/fixtures/fiber-triangle/index.html
+++ b/fixtures/fiber-triangle/index.html
@@ -23,209 +23,209 @@
   <script src="../../build/dist/react-dom.development.js"></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
   <script type="text/babel">
-      const dotStyle = {
-        position: 'absolute',
-        background: '#61dafb',
-        font: 'normal 15px sans-serif',
-        textAlign: 'center',
-        cursor: 'pointer',
+  const dotStyle = {
+    position: 'absolute',
+    background: '#61dafb',
+    font: 'normal 15px sans-serif',
+    textAlign: 'center',
+    cursor: 'pointer',
+  };
+
+  const containerStyle = {
+    position: 'absolute',
+    transformOrigin: '0 0',
+    left: '50%',
+    top: '50%',
+    width: '10px',
+    height: '10px',
+    background: '#eee',
+  };
+
+  const targetSize = 25;
+
+  class Dot extends React.Component {
+    constructor() {
+      super();
+      this.state = {hover: false};
+      this.enter = this.enter.bind(this);
+      this.leave = this.leave.bind(this);
+    }
+    enter() {
+      this.setState({
+        hover: true,
+      });
+    }
+    leave() {
+      this.setState({
+        hover: false,
+      });
+    }
+    render() {
+      const {size, x, y, text} = this.props;
+      const {hover} = this.state;
+      const s = size * 1.3;
+      const style = {
+        ...dotStyle,
+        width: s + 'px',
+        height: s + 'px',
+        left: `${x}px`,
+        top: `${y}px`,
+        borderRadius: `${s / 2}px`,
+        lineHeight: `${s}px`,
+        background: this.state.hover ? '#ff0' : dotStyle.background,
       };
+      return (
+        <div style={style} onMouseEnter={this.enter} onMouseLeave={this.leave}>
+          {hover ? '*' + text + '*' : text}
+        </div>
+      );
+    }
+  }
 
-      const containerStyle = {
-        position: 'absolute',
-        transformOrigin: '0 0',
-        left: '50%',
-        top: '50%',
-        width: '10px',
-        height: '10px',
-        background: '#eee',
-      };
-
-      const targetSize = 25;
-
-      class Dot extends React.Component {
-        constructor() {
-          super();
-          this.state = { hover: false };
-          this.enter = this.enter.bind(this);
-          this.leave = this.leave.bind(this);
-        }
-        enter() {
-          this.setState({
-            hover: true
-          });
-        }
-        leave() {
-          this.setState({
-            hover: false
-          });
-        }
-        render() {
-          const { size, x, y, text } = this.props;
-          const { hover } = this.state;
-          const s = size * 1.3;
-          const style = {
-            ...dotStyle,
-            width: s + 'px',
-            height: s + 'px',
-            left: `${x}px`,
-            top: `${y}px`,
-            borderRadius: `${s / 2}px`,
-            lineHeight: `${s}px`,
-            background: this.state.hover ? '#ff0' : dotStyle.background
-          };
-          return (
-            <div style={style} onMouseEnter={this.enter} onMouseLeave={this.leave}>
-              {hover ? '*' + text + '*' : text}
-            </div>
-          );
-        }
-      }
-
-      class SierpinskiTriangle extends React.Component {
-        shouldComponentUpdate(nextProps) {
-          const o = this.props;
-          const n = nextProps;
-          return !(
-            o.x === n.x &&
-            o.y === n.y &&
-            o.s === n.s &&
-            o.children === n.children
-          );
-        }
-        render() {
-          let { x, y, s, children } = this.props;
-          if (s <= targetSize) {
-            return (
-              <Dot
-                x={x - (targetSize / 2)}
-                y={y - (targetSize / 2)}
-                size={targetSize}
-                text={children}
-              />
-            );
-            return r;
-          }
-          const newSize = s / 2;
-          const slowDown = true;
-          if (slowDown) {
-            const e = performance.now() + 0.8;
-            while (performance.now() < e) {
-              // Artificially long execution time.
-            }
-          }
-
-          s /= 2;
-
-          return [
-            <SierpinskiTriangle x={x} y={y - (s / 2)} s={s} key={1}>
-              {children}
-            </SierpinskiTriangle>,
-            <SierpinskiTriangle x={x - s} y={y + (s / 2)} s={s} key={2}>
-              {children}
-            </SierpinskiTriangle>,
-            <SierpinskiTriangle x={x + s} y={y + (s / 2)} s={s} key={3}>
-              {children}
-            </SierpinskiTriangle>,
-          ];
-        }
-      }
-
-      class ExampleApplication extends React.Component {
-        constructor() {
-          super();
-          this.state = {
-            seconds: 0,
-            useTimeSlicing: true,
-          };
-          this.tick = this.tick.bind(this);
-          this.onTimeSlicingChange = this.onTimeSlicingChange.bind(this);
-        }
-        componentDidMount() {
-          this.intervalID = setInterval(this.tick, 1000);
-        }
-        tick() {
-          if (this.state.useTimeSlicing) {
-            // Update is time-sliced.
-            ReactDOM.unstable_deferredUpdates(() => {
-              this.setState(state => ({ seconds: (state.seconds % 10) + 1 }));
-            });
-          } else {
-            // Update is not time-sliced. Causes demo to stutter.
-            this.setState(state => ({ seconds: (state.seconds % 10) + 1 }));
-          }
-        }
-        onTimeSlicingChange(value) {
-          this.setState(() => ({ useTimeSlicing: value }));
-        }
-        componentWillUnmount() {
-          clearInterval(this.intervalID);
-        }
-        render() {
-          const seconds = this.state.seconds;
-          const elapsed = this.props.elapsed;
-          const t = (elapsed / 1000) % 10;
-          const scale = 1 + (t > 5 ? 10 - t : t) / 10;
-          const transform = `scaleX(${scale / 2.1}) scaleY(0.7) translateZ(0.1px)`;
-          return (
-            <div>
-              <div>
-                <h3>Time-slicing</h3>
-                <p>Toggle this and observe the effect</p>
-                <Toggle
-                  onLabel="On"
-                  offLabel="Off"
-                  onChange={this.onTimeSlicingChange}
-                  value={this.state.useTimeSlicing}
-                />
-              </div>
-              <div style={{ ...containerStyle, transform }}>
-                <div>
-                  <SierpinskiTriangle x={0} y={0} s={1000}>
-                    {seconds}
-                  </SierpinskiTriangle>
-                </div>
-              </div>
-            </div>
-          );
-        }
-      }
-
-      class Toggle extends React.Component {
-        constructor(props) {
-          super();
-          this.onChange = this.onChange.bind(this);
-        }
-        onChange(event) {
-          this.props.onChange(event.target.value === 'on');
-        }
-        render() {
-          const { value, onLabel, offLabel } = this.props;
-          return (
-            <label>
-              <label>
-                {onLabel}
-                <input type="radio" name="value" value="on" checked={value} onChange={this.onChange}/>
-              </label>
-              <label>
-                {offLabel}
-                <input type="radio" name="value" value="off" checked={!value} onChange={this.onChange}  />
-              </label>
-            </label>
-          );
-        }
-      }
-
-      const start = new Date().getTime();
-      function update() {
-        ReactDOM.render(
-          <ExampleApplication elapsed={new Date().getTime() - start} />,
-          document.getElementById('container')
+  class SierpinskiTriangle extends React.Component {
+    shouldComponentUpdate(nextProps) {
+      const o = this.props;
+      const n = nextProps;
+      return !(
+        o.x === n.x &&
+        o.y === n.y &&
+        o.s === n.s &&
+        o.children === n.children
+      );
+    }
+    render() {
+      let {x, y, s, children} = this.props;
+      if (s <= targetSize) {
+        return (
+          <Dot
+            x={x - targetSize / 2}
+            y={y - targetSize / 2}
+            size={targetSize}
+            text={children}
+          />
         );
-        requestAnimationFrame(update);
+        return r;
       }
-      requestAnimationFrame(update);
-    </script>
+      const newSize = s / 2;
+      const slowDown = true;
+      if (slowDown) {
+        const e = performance.now() + 0.8;
+        while (performance.now() < e) {
+          // Artificially long execution time.
+        }
+      }
+
+      s /= 2;
+
+      return [
+        <SierpinskiTriangle x={x} y={y - s / 2} s={s} key={1}>
+          {children}
+        </SierpinskiTriangle>,
+        <SierpinskiTriangle x={x - s} y={y + s / 2} s={s} key={2}>
+          {children}
+        </SierpinskiTriangle>,
+        <SierpinskiTriangle x={x + s} y={y + s / 2} s={s} key={3}>
+          {children}
+        </SierpinskiTriangle>,
+      ];
+    }
+  }
+
+  class ExampleApplication extends React.Component {
+    constructor() {
+      super();
+      this.state = {
+        seconds: 0,
+        useTimeSlicing: true,
+      };
+      this.tick = this.tick.bind(this);
+      this.onTimeSlicingChange = this.onTimeSlicingChange.bind(this);
+    }
+    componentDidMount() {
+      this.intervalID = setInterval(this.tick, 1000);
+    }
+    tick() {
+      if (this.state.useTimeSlicing) {
+        // Update is time-sliced.
+        ReactDOM.unstable_deferredUpdates(() => {
+          this.setState(state => ({seconds: state.seconds % 10 + 1}));
+        });
+      } else {
+        // Update is not time-sliced. Causes demo to stutter.
+        this.setState(state => ({seconds: state.seconds % 10 + 1}));
+      }
+    }
+    onTimeSlicingChange({target: {value}}) {
+      this.setState(() => ({useTimeSlicing: value === 'on'}));
+    }
+    componentWillUnmount() {
+      clearInterval(this.intervalID);
+    }
+    render() {
+      const seconds = this.state.seconds;
+      const elapsed = this.props.elapsed;
+      const t = (elapsed / 1000) % 10;
+      const scale = 1 + (t > 5 ? 10 - t : t) / 10;
+      const transform = `scaleX(${scale / 2.1}) scaleY(0.7) translateZ(0.1px)`;
+      return (
+        <div>
+          <div>
+            <h3>Time-slicing</h3>
+            <p>Toggle this and observe the effect</p>
+            <Toggle
+              onLabel="On"
+              offLabel="Off"
+              onChange={this.onTimeSlicingChange}
+              value={this.state.useTimeSlicing}
+            />
+          </div>
+          <div style={{...containerStyle, transform}}>
+            <div>
+              <SierpinskiTriangle x={0} y={0} s={1000}>
+                {seconds}
+              </SierpinskiTriangle>
+            </div>
+          </div>
+        </div>
+      );
+    }
+  }
+
+  const Toggle = ({value, onLabel, offLabel, onChange}) => (
+    <label>
+      <label>
+        {onLabel}
+        <input
+          type="radio"
+          name="value"
+          value="on"
+          checked={value}
+          onChange={onChange}
+        />
+      </label>
+      <label>
+        {offLabel}
+        <input
+          type="radio"
+          name="value"
+          value="off"
+          checked={!value}
+          onChange={onChange}
+        />
+      </label>
+    </label>
+  );
+  const start = new Date().getTime();
+  function update() {
+    ReactDOM.render(
+      <ExampleApplication elapsed={new Date().getTime() - start} />,
+      document.getElementById('container')
+    );
+    requestAnimationFrame(update);
+  }
+  requestAnimationFrame(update);
+
+  </script>
 </body>
 
 </html>

--- a/fixtures/fiber-triangle/index.html
+++ b/fixtures/fiber-triangle/index.html
@@ -118,13 +118,13 @@
           s /= 2;
 
           return [
-            <SierpinskiTriangle x={x} y={y - (s / 2)} s={s}>
+            <SierpinskiTriangle x={x} y={y - (s / 2)} s={s} key={1}>
               {children}
             </SierpinskiTriangle>,
-            <SierpinskiTriangle x={x - s} y={y + (s / 2)} s={s}>
+            <SierpinskiTriangle x={x - s} y={y + (s / 2)} s={s} key={2}>
               {children}
             </SierpinskiTriangle>,
-            <SierpinskiTriangle x={x + s} y={y + (s / 2)} s={s}>
+            <SierpinskiTriangle x={x + s} y={y + (s / 2)} s={s} key={3}>
               {children}
             </SierpinskiTriangle>,
           ];
@@ -202,14 +202,14 @@
         render() {
           const { value, onLabel, offLabel } = this.props;
           return (
-            <label onChange={this.onChange}>
+            <label>
               <label>
                 {onLabel}
-                <input type="radio" name="value" value="on" checked={value} />
+                <input type="radio" name="value" value="on" checked={value} onChange={this.onChange}/>
               </label>
               <label>
                 {offLabel}
-                <input type="radio" name="value" value="off" checked={!value} />
+                <input type="radio" name="value" value="off" checked={!value} onChange={this.onChange}  />
               </label>
             </label>
           );


### PR DESCRIPTION
Improve two things for the fiber triangle example.
1. Update code style to be compatible with lint.
2. Clear the warning message.
3. Increase the contrast to distinguish the triggered radio button(In Chrome 67, **the radio element is invisible**, I don't find the reason, so I bolder the toggled status).

Like this:
<img width="275" alt="image" src="https://user-images.githubusercontent.com/11444431/42437763-a535813c-8390-11e8-943d-9ce40f49e7d9.png">