### PR TITLE
Deprecate ReactTestUtils.mockComponent()

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -53,7 +53,12 @@ describe('ReactTestUtils', () => {
     MockedComponent.prototype.render = jest.fn();
 
     // Patch it up so it returns its children.
-    ReactTestUtils.mockComponent(MockedComponent);
+    expect(() =>
+      ReactTestUtils.mockComponent(MockedComponent),
+    ).toLowPriorityWarnDev(
+      'ReactTestUtils.mockComponent() is deprecated. ' +
+        'We recommend using shallow rendering or jest.mock() instead.',
+    );
 
     const container = document.createElement('div');
     ReactDOM.render(<MockedComponent>Hello</MockedComponent>, container);

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -57,7 +57,7 @@ describe('ReactTestUtils', () => {
       ReactTestUtils.mockComponent(MockedComponent),
     ).toLowPriorityWarnDev(
       'ReactTestUtils.mockComponent() is deprecated. ' +
-        'We recommend using shallow rendering or jest.mock() instead.',
+        'Use shallow rendering or jest.mock() instead.',
     );
 
     const container = document.createElement('div');

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -313,7 +313,7 @@ const ReactTestUtils = {
     lowPriorityWarning(
       false,
       'ReactTestUtils.mockComponent() is deprecated. ' +
-        'We recommend using shallow rendering or jest.mock() instead.',
+        'Use shallow rendering or jest.mock() instead.',
     );
 
     mockTagName = mockTagName || module.mockTagName || 'div';

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -17,6 +17,7 @@ import {
 } from 'shared/ReactTypeOfWork';
 import SyntheticEvent from 'events/SyntheticEvent';
 import invariant from 'shared/invariant';
+import lowPriorityWarning from 'shared/lowPriorityWarning';
 
 import * as DOMTopLevelEventTypes from '../events/DOMTopLevelEventTypes';
 
@@ -309,6 +310,12 @@ const ReactTestUtils = {
    * @return {object} the ReactTestUtils object (for chaining)
    */
   mockComponent: function(module, mockTagName) {
+    lowPriorityWarning(
+      false,
+      'ReactTestUtils.mockComponent() is deprecated. ' +
+        'We recommend using shallow rendering or jest.mock() instead.',
+    );
+
     mockTagName = mockTagName || module.mockTagName || 'div';
 
     module.prototype.render.mockImplementation(function() {


### PR DESCRIPTION
Resolves #11019. Replaces #13192.