### PR TITLE
Remove ad-hoc forks of getComponentName() and fix it

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -595,7 +595,7 @@ const ReactDOM: Object = {
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
             'componentDidUpdate instead.',
-          getComponentName(owner) || 'A component',
+          getComponentName(owner.type) || 'A component',
         );
         owner.stateNode._warnedAboutRefsInRender = true;
       }

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -16,6 +16,7 @@ import type {
 
 import React from 'react';
 import invariant from 'shared/invariant';
+import getComponentName from 'shared/getComponentName';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 import warning from 'shared/warning';
 import checkPropTypes from 'prop-types/checkPropTypes';
@@ -165,12 +166,6 @@ const newlineEatingTags = {
   pre: true,
   textarea: true,
 };
-
-function getComponentName(type) {
-  return typeof type === 'string'
-    ? type
-    : typeof type === 'function' ? type.displayName || type.name : null;
-}
 
 // We accept any tag to be rendered but since this gets injected into arbitrary
 // HTML, we want to make sure that it's a safe tag.

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -40,7 +40,7 @@ function findNodeHandle(componentOrHandle: any): ?number {
           'never access something that requires stale data from the previous ' +
           'render, such as refs. Move this logic to componentDidMount and ' +
           'componentDidUpdate instead.',
-        getComponentName(owner) || 'A component',
+        getComponentName(owner.type) || 'A component',
       );
 
       owner.stateNode._warnedAboutRefsInRender = true;

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -79,7 +79,7 @@ if (__DEV__) {
 
   const createHierarchy = function(fiberHierarchy) {
     return fiberHierarchy.map(fiber => ({
-      name: getComponentName(fiber),
+      name: getComponentName(fiber.type),
       getInspectorData: findNodeHandle => ({
         measure: callback =>
           UIManager.measure(getHostNode(fiber, findNodeHandle), callback),

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -43,7 +43,7 @@ function findNodeHandle(componentOrHandle: any): ?number {
           'never access something that requires stale data from the previous ' +
           'render, such as refs. Move this logic to componentDidMount and ' +
           'componentDidUpdate instead.',
-        getComponentName(owner) || 'A component',
+        getComponentName(owner.type) || 'A component',
       );
 
       owner.stateNode._warnedAboutRefsInRender = true;

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -111,7 +111,7 @@ function coerceRef(
   ) {
     if (__DEV__) {
       if (returnFiber.mode & StrictMode) {
-        const componentName = getComponentName(returnFiber) || 'Component';
+        const componentName = getComponentName(returnFiber.type) || 'Component';
         if (!didWarnAboutStringRefInStrictMode[componentName]) {
           warning(
             false,

--- a/packages/react-reconciler/src/ReactCurrentFiber.js
+++ b/packages/react-reconciler/src/ReactCurrentFiber.js
@@ -29,10 +29,10 @@ function describeFiber(fiber: Fiber): string {
     case HostComponent:
       const owner = fiber._debugOwner;
       const source = fiber._debugSource;
-      const name = getComponentName(fiber);
+      const name = getComponentName(fiber.type);
       let ownerName = null;
       if (owner) {
-        ownerName = getComponentName(owner);
+        ownerName = getComponentName(owner.type);
       }
       return describeComponentFrame(name, source, ownerName);
     default:
@@ -60,7 +60,7 @@ export function getCurrentFiberOwnerNameInDevOrNull(): string | null {
     }
     const owner = current._debugOwner;
     if (owner !== null && typeof owner !== 'undefined') {
-      return getComponentName(owner);
+      return getComponentName(owner.type);
     }
   }
   return null;

--- a/packages/react-reconciler/src/ReactDebugFiberPerf.js
+++ b/packages/react-reconciler/src/ReactDebugFiberPerf.js
@@ -121,7 +121,7 @@ const beginFiberMark = (
   fiber: Fiber,
   phase: MeasurementPhase | null,
 ): boolean => {
-  const componentName = getComponentName(fiber) || 'Unknown';
+  const componentName = getComponentName(fiber.type) || 'Unknown';
   const debugID = ((fiber._debugID: any): number);
   const isMounted = fiber.alternate !== null;
   const label = getFiberLabel(componentName, isMounted, phase);
@@ -140,7 +140,7 @@ const beginFiberMark = (
 };
 
 const clearFiberMark = (fiber: Fiber, phase: MeasurementPhase | null) => {
-  const componentName = getComponentName(fiber) || 'Unknown';
+  const componentName = getComponentName(fiber.type) || 'Unknown';
   const debugID = ((fiber._debugID: any): number);
   const isMounted = fiber.alternate !== null;
   const label = getFiberLabel(componentName, isMounted, phase);
@@ -153,7 +153,7 @@ const endFiberMark = (
   phase: MeasurementPhase | null,
   warning: string | null,
 ) => {
-  const componentName = getComponentName(fiber) || 'Unknown';
+  const componentName = getComponentName(fiber.type) || 'Unknown';
   const debugID = ((fiber._debugID: any): number);
   const isMounted = fiber.alternate !== null;
   const label = getFiberLabel(componentName, isMounted, phase);
@@ -378,7 +378,7 @@ export function stopWorkLoopTimer(
       if (interruptedBy.tag === HostRoot) {
         warning = 'A top-level update interrupted the previous render';
       } else {
-        const componentName = getComponentName(interruptedBy) || 'Unknown';
+        const componentName = getComponentName(interruptedBy.type) || 'Unknown';
         warning = `An update to ${componentName} interrupted the previous render`;
       }
     } else if (commitCountInCurrentWorkLoop > 1) {

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -444,7 +444,7 @@ function getFiberTagFromObjectType(type, owner): TypeOfWork {
             "it's defined in, or you might have mixed up default and " +
             'named imports.';
         }
-        const ownerName = owner ? getComponentName(owner) : null;
+        const ownerName = owner ? getComponentName(owner.type) : null;
         if (ownerName) {
           info += '\n\nCheck the render method of `' + ownerName + '`.';
         }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -581,7 +581,7 @@ function mountIndeterminateComponent(
 
   if (__DEV__) {
     if (fn.prototype && typeof fn.prototype.render === 'function') {
-      const componentName = getComponentName(workInProgress.type) || 'Unknown';
+      const componentName = getComponentName(fn) || 'Unknown';
 
       if (!didWarnAboutBadClass[componentName]) {
         warning(
@@ -681,8 +681,7 @@ function mountIndeterminateComponent(
       }
 
       if (typeof fn.getDerivedStateFromProps === 'function') {
-        const componentName =
-          getComponentName(workInProgress.type) || 'Unknown';
+        const componentName = getComponentName(fn) || 'Unknown';
 
         if (!didWarnAboutGetDerivedStateOnFunctionalComponent[componentName]) {
           warning(

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -581,7 +581,7 @@ function mountIndeterminateComponent(
 
   if (__DEV__) {
     if (fn.prototype && typeof fn.prototype.render === 'function') {
-      const componentName = getComponentName(workInProgress) || 'Unknown';
+      const componentName = getComponentName(workInProgress.type) || 'Unknown';
 
       if (!didWarnAboutBadClass[componentName]) {
         warning(
@@ -681,7 +681,8 @@ function mountIndeterminateComponent(
       }
 
       if (typeof fn.getDerivedStateFromProps === 'function') {
-        const componentName = getComponentName(workInProgress) || 'Unknown';
+        const componentName =
+          getComponentName(workInProgress.type) || 'Unknown';
 
         if (!didWarnAboutGetDerivedStateOnFunctionalComponent[componentName]) {
           warning(

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -92,10 +92,9 @@ if (__DEV__) {
     }
   };
 
-  warnOnUndefinedDerivedState = function(workInProgress, partialState) {
+  warnOnUndefinedDerivedState = function(type, partialState) {
     if (partialState === undefined) {
-      const componentName =
-        getComponentName(workInProgress.type) || 'Component';
+      const componentName = getComponentName(type) || 'Component';
       if (!didWarnAboutUndefinedDerivedState.has(componentName)) {
         didWarnAboutUndefinedDerivedState.add(componentName);
         warning(
@@ -151,7 +150,7 @@ export function applyDerivedStateFromProps(
   const partialState = getDerivedStateFromProps(nextProps, prevState);
 
   if (__DEV__) {
-    warnOnUndefinedDerivedState(workInProgress, partialState);
+    warnOnUndefinedDerivedState(workInProgress.type, partialState);
   }
   // Merge the partial state and the previous state.
   const memoizedState =
@@ -250,7 +249,7 @@ function checkShouldComponentUpdate(
         shouldUpdate !== undefined,
         '%s.shouldComponentUpdate(): Returned undefined instead of a ' +
           'boolean value. Make sure to return true or false.',
-        getComponentName(workInProgress.type) || 'Component',
+        getComponentName(ctor) || 'Component',
       );
     }
 
@@ -270,7 +269,7 @@ function checkClassInstance(workInProgress: Fiber) {
   const instance = workInProgress.stateNode;
   const type = workInProgress.type;
   if (__DEV__) {
-    const name = getComponentName(workInProgress.type) || 'Component';
+    const name = getComponentName(type) || 'Component';
     const renderPresent = instance.render;
 
     if (!renderPresent) {
@@ -346,7 +345,7 @@ function checkClassInstance(workInProgress: Fiber) {
         '%s has a method called shouldComponentUpdate(). ' +
           'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
           'Please extend React.Component if shouldComponentUpdate is used.',
-        getComponentName(workInProgress.type) || 'A pure component',
+        getComponentName(type) || 'A pure component',
       );
     }
     const noComponentDidUnmount =
@@ -412,7 +411,7 @@ function checkClassInstance(workInProgress: Fiber) {
         false,
         '%s: getSnapshotBeforeUpdate() should be used with componentDidUpdate(). ' +
           'This component defines getSnapshotBeforeUpdate() only.',
-        getComponentName(workInProgress.type),
+        getComponentName(type),
       );
     }
 
@@ -497,8 +496,7 @@ function constructClassInstance(
 
   if (__DEV__) {
     if (typeof ctor.getDerivedStateFromProps === 'function' && state === null) {
-      const componentName =
-        getComponentName(workInProgress.type) || 'Component';
+      const componentName = getComponentName(ctor) || 'Component';
       if (!didWarnAboutUninitializedState.has(componentName)) {
         didWarnAboutUninitializedState.add(componentName);
         warning(
@@ -552,8 +550,7 @@ function constructClassInstance(
         foundWillReceivePropsName !== null ||
         foundWillUpdateName !== null
       ) {
-        const componentName =
-          getComponentName(workInProgress.type) || 'Component';
+        const componentName = getComponentName(ctor) || 'Component';
         const newApiName =
           typeof ctor.getDerivedStateFromProps === 'function'
             ? 'getDerivedStateFromProps()'
@@ -703,7 +700,7 @@ function mountClassInstance(
     instance.state = workInProgress.memoizedState;
   }
 
-  const getDerivedStateFromProps = workInProgress.type.getDerivedStateFromProps;
+  const getDerivedStateFromProps = ctor.getDerivedStateFromProps;
   if (typeof getDerivedStateFromProps === 'function') {
     applyDerivedStateFromProps(workInProgress, getDerivedStateFromProps, props);
     instance.state = workInProgress.memoizedState;

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -94,7 +94,8 @@ if (__DEV__) {
 
   warnOnUndefinedDerivedState = function(workInProgress, partialState) {
     if (partialState === undefined) {
-      const componentName = getComponentName(workInProgress) || 'Component';
+      const componentName =
+        getComponentName(workInProgress.type) || 'Component';
       if (!didWarnAboutUndefinedDerivedState.has(componentName)) {
         didWarnAboutUndefinedDerivedState.add(componentName);
         warning(
@@ -249,7 +250,7 @@ function checkShouldComponentUpdate(
         shouldUpdate !== undefined,
         '%s.shouldComponentUpdate(): Returned undefined instead of a ' +
           'boolean value. Make sure to return true or false.',
-        getComponentName(workInProgress) || 'Component',
+        getComponentName(workInProgress.type) || 'Component',
       );
     }
 
@@ -269,7 +270,7 @@ function checkClassInstance(workInProgress: Fiber) {
   const instance = workInProgress.stateNode;
   const type = workInProgress.type;
   if (__DEV__) {
-    const name = getComponentName(workInProgress) || 'Component';
+    const name = getComponentName(workInProgress.type) || 'Component';
     const renderPresent = instance.render;
 
     if (!renderPresent) {
@@ -345,7 +346,7 @@ function checkClassInstance(workInProgress: Fiber) {
         '%s has a method called shouldComponentUpdate(). ' +
           'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
           'Please extend React.Component if shouldComponentUpdate is used.',
-        getComponentName(workInProgress) || 'A pure component',
+        getComponentName(workInProgress.type) || 'A pure component',
       );
     }
     const noComponentDidUnmount =
@@ -411,7 +412,7 @@ function checkClassInstance(workInProgress: Fiber) {
         false,
         '%s: getSnapshotBeforeUpdate() should be used with componentDidUpdate(). ' +
           'This component defines getSnapshotBeforeUpdate() only.',
-        getComponentName(workInProgress),
+        getComponentName(workInProgress.type),
       );
     }
 
@@ -496,7 +497,8 @@ function constructClassInstance(
 
   if (__DEV__) {
     if (typeof ctor.getDerivedStateFromProps === 'function' && state === null) {
-      const componentName = getComponentName(workInProgress) || 'Component';
+      const componentName =
+        getComponentName(workInProgress.type) || 'Component';
       if (!didWarnAboutUninitializedState.has(componentName)) {
         didWarnAboutUninitializedState.add(componentName);
         warning(
@@ -550,7 +552,8 @@ function constructClassInstance(
         foundWillReceivePropsName !== null ||
         foundWillUpdateName !== null
       ) {
-        const componentName = getComponentName(workInProgress) || 'Component';
+        const componentName =
+          getComponentName(workInProgress.type) || 'Component';
         const newApiName =
           typeof ctor.getDerivedStateFromProps === 'function'
             ? 'getDerivedStateFromProps()'
@@ -605,7 +608,7 @@ function callComponentWillMount(workInProgress, instance) {
         '%s.componentWillMount(): Assigning directly to this.state is ' +
           "deprecated (except inside a component's " +
           'constructor). Use setState instead.',
-        getComponentName(workInProgress) || 'Component',
+        getComponentName(workInProgress.type) || 'Component',
       );
     }
     classComponentUpdater.enqueueReplaceState(instance, instance.state, null);
@@ -630,7 +633,8 @@ function callComponentWillReceiveProps(
 
   if (instance.state !== oldState) {
     if (__DEV__) {
-      const componentName = getComponentName(workInProgress) || 'Component';
+      const componentName =
+        getComponentName(workInProgress.type) || 'Component';
       if (!didWarnAboutStateAssignmentForComponent.has(componentName)) {
         didWarnAboutStateAssignmentForComponent.add(componentName);
         warning(

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -93,7 +93,7 @@ export function logError(boundary: Fiber, errorInfo: CapturedValue<mixed>) {
   }
 
   const capturedError: CapturedError = {
-    componentName: source !== null ? getComponentName(source) : null,
+    componentName: source !== null ? getComponentName(source.type) : null,
     componentStack: stack !== null ? stack : '',
     error: errorInfo.value,
     errorBoundary: null,
@@ -104,7 +104,7 @@ export function logError(boundary: Fiber, errorInfo: CapturedValue<mixed>) {
 
   if (boundary !== null && boundary.tag === ClassComponent) {
     capturedError.errorBoundary = boundary.stateNode;
-    capturedError.errorBoundaryName = getComponentName(boundary);
+    capturedError.errorBoundaryName = getComponentName(boundary.type);
     capturedError.errorBoundaryFound = true;
     capturedError.willRetry = true;
   }
@@ -203,7 +203,7 @@ function commitBeforeMutationLifeCycles(
                 false,
                 '%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' +
                   'must be returned. You have returned undefined.',
-                getComponentName(finishedWork),
+                getComponentName(finishedWork.type),
               );
             }
           }
@@ -372,7 +372,7 @@ function commitAttachRef(finishedWork: Fiber) {
             false,
             'Unexpected ref object provided for %s. ' +
               'Use either a ref-setter function or React.createRef().%s',
-            getComponentName(finishedWork),
+            getComponentName(finishedWork.type),
             getStackByFiberInDevAndProd(finishedWork),
           );
         }

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -90,7 +90,7 @@ function getMaskedContext(
   }
 
   if (__DEV__) {
-    const name = getComponentName(workInProgress.type) || 'Unknown';
+    const name = getComponentName(type) || 'Unknown';
     checkPropTypes(
       contextTypes,
       context,
@@ -152,13 +152,14 @@ function pushTopLevelContextObject(
 
 function processChildContext(fiber: Fiber, parentContext: Object): Object {
   const instance = fiber.stateNode;
-  const childContextTypes = fiber.type.childContextTypes;
+  const type = fiber.type;
+  const childContextTypes = type.childContextTypes;
 
   // TODO (bvaughn) Replace this behavior with an invariant() in the future.
   // It has only been added in Fiber to match the (unintentional) behavior in Stack.
   if (typeof instance.getChildContext !== 'function') {
     if (__DEV__) {
-      const componentName = getComponentName(fiber.type) || 'Unknown';
+      const componentName = getComponentName(type) || 'Unknown';
 
       if (!warnedAboutMissingGetChildContext[componentName]) {
         warnedAboutMissingGetChildContext[componentName] = true;
@@ -189,12 +190,12 @@ function processChildContext(fiber: Fiber, parentContext: Object): Object {
     invariant(
       contextKey in childContextTypes,
       '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
-      getComponentName(fiber.type) || 'Unknown',
+      getComponentName(type) || 'Unknown',
       contextKey,
     );
   }
   if (__DEV__) {
-    const name = getComponentName(fiber.type) || 'Unknown';
+    const name = getComponentName(type) || 'Unknown';
     checkPropTypes(
       childContextTypes,
       childContext,

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -90,7 +90,7 @@ function getMaskedContext(
   }
 
   if (__DEV__) {
-    const name = getComponentName(workInProgress) || 'Unknown';
+    const name = getComponentName(workInProgress.type) || 'Unknown';
     checkPropTypes(
       contextTypes,
       context,
@@ -158,7 +158,7 @@ function processChildContext(fiber: Fiber, parentContext: Object): Object {
   // It has only been added in Fiber to match the (unintentional) behavior in Stack.
   if (typeof instance.getChildContext !== 'function') {
     if (__DEV__) {
-      const componentName = getComponentName(fiber) || 'Unknown';
+      const componentName = getComponentName(fiber.type) || 'Unknown';
 
       if (!warnedAboutMissingGetChildContext[componentName]) {
         warnedAboutMissingGetChildContext[componentName] = true;
@@ -189,12 +189,12 @@ function processChildContext(fiber: Fiber, parentContext: Object): Object {
     invariant(
       contextKey in childContextTypes,
       '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
-      getComponentName(fiber) || 'Unknown',
+      getComponentName(fiber.type) || 'Unknown',
       contextKey,
     );
   }
   if (__DEV__) {
-    const name = getComponentName(fiber) || 'Unknown';
+    const name = getComponentName(fiber.type) || 'Unknown';
     checkPropTypes(
       childContextTypes,
       childContext,

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -115,7 +115,7 @@ function scheduleRootUpdate(
           'triggering nested component updates from render is not allowed. ' +
           'If necessary, trigger nested updates in componentDidUpdate.\n\n' +
           'Check the render method of %s.',
-        getComponentName(ReactCurrentFiber.current) || 'Unknown',
+        getComponentName(ReactCurrentFiber.current.type) || 'Unknown',
       );
     }
   }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -174,7 +174,7 @@ if (__DEV__) {
   warnAboutUpdateOnUnmounted = function(fiber: Fiber) {
     // We show the whole stack but dedupe on the top component's name because
     // the problematic code almost always lies inside that component.
-    const componentName = getComponentName(fiber) || 'ReactClass';
+    const componentName = getComponentName(fiber.type) || 'ReactClass';
     if (didWarnStateUpdateForUnmountedComponent[componentName]) {
       return;
     }

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -74,7 +74,7 @@ export function isMounted(component: React$Component<any, any>): boolean {
           'never access something that requires stale data from the previous ' +
           'render, such as refs. Move this logic to componentDidMount and ' +
           'componentDidUpdate instead.',
-        getComponentName(ownerFiber) || 'A component',
+        getComponentName(ownerFiber.type) || 'A component',
       );
       instance._warnedAboutRefsInRender = true;
     }

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -109,7 +109,7 @@ function recordElapsedActualRenderTime(fiber: Fiber): void {
     warning(
       fiber === fiberStack.pop(),
       'Unexpected Fiber (%s) popped.',
-      getComponentName(fiber),
+      getComponentName(fiber.type),
     );
   }
 

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -79,7 +79,7 @@ if (__DEV__) {
           if (lifecycleWarnings.length > 0) {
             const componentNames = new Set();
             lifecycleWarnings.forEach(fiber => {
-              componentNames.add(getComponentName(fiber) || 'Component');
+              componentNames.add(getComponentName(fiber.type) || 'Component');
               didWarnAboutUnsafeLifecycles.add(fiber.type);
             });
 
@@ -133,7 +133,7 @@ if (__DEV__) {
     if (pendingComponentWillMountWarnings.length > 0) {
       const uniqueNames = new Set();
       pendingComponentWillMountWarnings.forEach(fiber => {
-        uniqueNames.add(getComponentName(fiber) || 'Component');
+        uniqueNames.add(getComponentName(fiber.type) || 'Component');
         didWarnAboutDeprecatedLifecycles.add(fiber.type);
       });
 
@@ -156,7 +156,7 @@ if (__DEV__) {
     if (pendingComponentWillReceivePropsWarnings.length > 0) {
       const uniqueNames = new Set();
       pendingComponentWillReceivePropsWarnings.forEach(fiber => {
-        uniqueNames.add(getComponentName(fiber) || 'Component');
+        uniqueNames.add(getComponentName(fiber.type) || 'Component');
         didWarnAboutDeprecatedLifecycles.add(fiber.type);
       });
 
@@ -178,7 +178,7 @@ if (__DEV__) {
     if (pendingComponentWillUpdateWarnings.length > 0) {
       const uniqueNames = new Set();
       pendingComponentWillUpdateWarnings.forEach(fiber => {
-        uniqueNames.add(getComponentName(fiber) || 'Component');
+        uniqueNames.add(getComponentName(fiber.type) || 'Component');
         didWarnAboutDeprecatedLifecycles.add(fiber.type);
       });
 
@@ -337,7 +337,7 @@ if (__DEV__) {
       (fiberArray: FiberArray, strictRoot) => {
         const uniqueNames = new Set();
         fiberArray.forEach(fiber => {
-          uniqueNames.add(getComponentName(fiber) || 'Component');
+          uniqueNames.add(getComponentName(fiber.type) || 'Component');
           didWarnAboutLegacyContext.add(fiber.type);
         });
 

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -96,7 +96,7 @@ exports[`ReactDebugFiberPerf does not include AsyncMode, StrictMode, or Profiler
 
 // Mount
 ⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ Profiler(test) [mount]
+  ⚛ Profiler [mount]
     ⚛ Parent [mount]
       ⚛ Child [mount]
 

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -349,7 +349,7 @@ function getStackAddendum() {
     stack += describeComponentFrame(
       name,
       currentlyValidatingElement._source,
-      owner && getComponentName(owner),
+      owner && getComponentName(owner.type),
     );
   }
   return stack;

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -31,7 +31,6 @@ import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
 let currentlyValidatingElement;
 let propTypesMisspellWarningShown;
 
-let getDisplayName = () => {};
 let getStackAddendum = () => {};
 
 if (__DEV__) {
@@ -39,34 +38,10 @@ if (__DEV__) {
 
   propTypesMisspellWarningShown = false;
 
-  getDisplayName = function(element): string {
-    if (element == null) {
-      return '#empty';
-    } else if (typeof element === 'string' || typeof element === 'number') {
-      return '#text';
-    } else if (typeof element.type === 'string') {
-      return element.type;
-    }
-
-    const type = element.type;
-    if (type === REACT_FRAGMENT_TYPE) {
-      return 'React.Fragment';
-    } else if (
-      typeof type === 'object' &&
-      type !== null &&
-      type.$$typeof === REACT_FORWARD_REF_TYPE
-    ) {
-      const functionName = type.render.displayName || type.render.name || '';
-      return functionName !== '' ? `ForwardRef(${functionName})` : 'ForwardRef';
-    } else {
-      return type.displayName || type.name || 'Unknown';
-    }
-  };
-
   getStackAddendum = function(): string {
     let stack = '';
     if (currentlyValidatingElement) {
-      const name = getDisplayName(currentlyValidatingElement);
+      const name = getComponentName(currentlyValidatingElement.type);
       const owner = currentlyValidatingElement._owner;
       stack += describeComponentFrame(
         name,

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -71,7 +71,7 @@ if (__DEV__) {
       stack += describeComponentFrame(
         name,
         currentlyValidatingElement._source,
-        owner && getComponentName(owner),
+        owner && getComponentName(owner.type),
       );
     }
     stack += ReactDebugCurrentFrame.getStackAddendum();
@@ -81,7 +81,7 @@ if (__DEV__) {
 
 function getDeclarationErrorAddendum() {
   if (ReactCurrentOwner.current) {
-    const name = getComponentName(ReactCurrentOwner.current);
+    const name = getComponentName(ReactCurrentOwner.current.type);
     if (name) {
       return '\n\nCheck the render method of `' + name + '`.';
     }
@@ -159,7 +159,7 @@ function validateExplicitKey(element, parentType) {
   ) {
     // Give the component that originally created this child.
     childOwner = ` It was passed a child from ${getComponentName(
-      element._owner,
+      element._owner.type,
     )}.`;
   }
 

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -37,7 +37,7 @@ function getComponentName(fiber: Fiber): string | null {
     case REACT_PORTAL_TYPE:
       return 'Portal';
     case REACT_PROFILER_TYPE:
-      return `Profiler(${fiber.pendingProps.id})`;
+      return `Profiler`;
     case REACT_STRICT_MODE_TYPE:
       return 'StrictMode';
     case REACT_PLACEHOLDER_TYPE:

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -32,16 +32,12 @@ function getComponentName(fiber: Fiber): string | null {
   switch (type) {
     case REACT_ASYNC_MODE_TYPE:
       return 'AsyncMode';
-    case REACT_CONTEXT_TYPE:
-      return 'Context.Consumer';
     case REACT_FRAGMENT_TYPE:
-      return 'ReactFragment';
+      return 'Fragment';
     case REACT_PORTAL_TYPE:
-      return 'ReactPortal';
+      return 'Portal';
     case REACT_PROFILER_TYPE:
       return `Profiler(${fiber.pendingProps.id})`;
-    case REACT_PROVIDER_TYPE:
-      return 'Context.Provider';
     case REACT_STRICT_MODE_TYPE:
       return 'StrictMode';
     case REACT_PLACEHOLDER_TYPE:
@@ -49,6 +45,10 @@ function getComponentName(fiber: Fiber): string | null {
   }
   if (typeof type === 'object' && type !== null) {
     switch (type.$$typeof) {
+      case REACT_CONTEXT_TYPE:
+        return 'Context.Consumer';
+      case REACT_PROVIDER_TYPE:
+        return 'Context.Provider';
       case REACT_FORWARD_REF_TYPE:
         const functionName = type.render.displayName || type.render.name || '';
         return functionName !== ''

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -7,8 +7,6 @@
  * @flow
  */
 
-import type {Fiber} from 'react-reconciler/src/ReactFiber';
-
 import warning from 'shared/warning';
 import {
   REACT_ASYNC_MODE_TYPE,


### PR DESCRIPTION
1. Fixes `getComponentName()` for a few cases where it was incorrectly reading the type (https://github.com/facebook/react/commit/a482fb41c35448cc1f2cc2e1e7b655a11e8f8957). We didn't notice because we rarely call it for anything other than user-defined components.
2. Changes its signature to require just the `type` alone rather than the Fiber. This might seem like it makes the calling code longer. However we often *already* have the type destructured anyway when we call it. I also remember from writing some of that code that it was awkward to always *have to* pass a Fiber around when I only needed a type.
3. This lets us remove two ad-hoc forks of `getComponentName()` that don't handle all the cases it does.