### PR TITLE
Use ReactDebugCurrentFrame.getStackAddendum() in element validator

### DIFF
--- a/packages/react/src/ReactDebugCurrentFrame.js
+++ b/packages/react/src/ReactDebugCurrentFrame.js
@@ -7,18 +7,46 @@
  * @flow
  */
 
+import type {ReactElement} from 'shared/ReactElementType';
+
+import describeComponentFrame from 'shared/describeComponentFrame';
+import getComponentName from 'shared/getComponentName';
+
 const ReactDebugCurrentFrame = {};
 
+let currentlyValidatingElement = (null: null | ReactElement);
+
+export function setCurrentlyValidatingElement(element: null | ReactElement) {
+  if (__DEV__) {
+    currentlyValidatingElement = element;
+  }
+}
+
 if (__DEV__) {
-  // Component that is being worked on
+  // Stack implementation injected by the current renderer.
   ReactDebugCurrentFrame.getCurrentStack = (null: null | (() => string));
 
   ReactDebugCurrentFrame.getStackAddendum = function(): string {
+    let stack = '';
+
+    // Add an extra top frame while an element is being validated
+    if (currentlyValidatingElement) {
+      const name = getComponentName(currentlyValidatingElement.type);
+      const owner = currentlyValidatingElement._owner;
+      stack += describeComponentFrame(
+        name,
+        currentlyValidatingElement._source,
+        owner && getComponentName(owner.type),
+      );
+    }
+
+    // Delegate to the injected renderer-specific implementation
     const impl = ReactDebugCurrentFrame.getCurrentStack;
     if (impl) {
-      return impl() || '';
+      stack += impl() || '';
     }
-    return '';
+
+    return stack;
   };
 }
 


### PR DESCRIPTION
Doesn't change anything functionally, but moves the logic for tracking the currently validated element into a centralized place instead of amending the stack in an ad hoc way.

This moves us closer to making `warning()` calls append the stack automatically without having to think *where* that call happens.