### PR TITLE
Proof of concept (for safeInContext hook RFC)

### DIFF
--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -16,6 +16,8 @@ import {
   OVERLOADED_BOOLEAN,
 } from '../shared/DOMProperty';
 
+import {getSafeInContext} from './safeInContext';
+
 import type {PropertyInfo} from '../shared/DOMProperty';
 
 /**
@@ -126,6 +128,13 @@ export function setValueForProperty(
   if (shouldRemoveAttribute(name, value, propertyInfo, isCustomComponentTag)) {
     value = null;
   }
+
+  const safeInContext = getSafeInContext();
+  if (value !== null && safeInContext) {
+    // Don't interfere with deletes.
+    value = safeInContext(node, name, value);
+  }
+
   // If the prop isn't in the special list, treat it as a simple attribute.
   if (isCustomComponentTag || propertyInfo === null) {
     if (isAttributeNameSafe(name)) {

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -44,6 +44,8 @@ import {
   DOCUMENT_NODE,
   DOCUMENT_FRAGMENT_NODE,
 } from '../shared/HTMLNodeType';
+import {getSafeInContext, setSafeInContext} from './safeInContext';
+import type {SafeInContext} from './safeInContext';
 import {ROOT_ATTRIBUTE_NAME} from '../shared/DOMProperty';
 
 let topLevelUpdateWarnings;
@@ -735,6 +737,13 @@ const ReactDOM: Object = {
   flushSync: DOMRenderer.flushSync,
 
   unstable_flushControlled: DOMRenderer.flushControlled,
+
+  get safeInContext(): SafeInContext | null {
+    return getSafeInContext();
+  },
+  set safeInContext(x: SafeInContext | null) {
+    setSafeInContext(x);
+  },
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // For TapEventPlugin which is popular in open source

--- a/packages/react-dom/src/client/safeInContext.js
+++ b/packages/react-dom/src/client/safeInContext.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export {getSafeInContext, setSafeInContext};
+export type {SafeInContext};
+
+/**
+ * Called before React uses a value in a non-DOM-structure altering way.
+ *
+ * This function should not manipulate the DOM or have side effects visible
+ * outside the scope of its call except where necessary to log policy violations.
+ *
+ * It is the implementor's responsibility to ensure that repeated calls in
+ * a tight loop do not deny service, including bounding memory and network
+ * usage for frequent policy violations.
+ *
+ * @param node A node such in the scope of `window.customElements`.
+ *    I.e. any implicit adoption ( https://www.w3.org/TR/dom/#dom-core ) should
+ *    happen before calling this function.
+ * @param attributeOrPropertyName The name of the HTML attribute or JS property.
+ *    Null iff value specifies textContent/nodeValue for a character data node.
+ *    If value specifies, for example, the text content of a text node under a
+ *    `<script>` element then node.parentNode should reach that script.
+ * @param value the value before any coercion to DOMString so that safeInContext
+ *    may treat values as privileged based on their runtime type.
+ *
+ * @return value or a suitable alternative.  Should not throw.
+ */
+type SafeInContext = (
+  node: Node,
+  attributeOrPropertyName: string,
+  value: any,
+) => any;
+
+let safeInContext: SafeInContext | null = null;
+
+function getSafeInContext(): SafeInContext | null {
+  return safeInContext;
+}
+
+function setSafeInContext(newSafeInContext: SafeInContext | null) {
+  safeInContext = newSafeInContext;
+}


### PR DESCRIPTION
This is a proof of concept for [RFC: safeInContext hooks](https://github.com/reactjs/rfcs/pull/55/files) that modifies *DOMPropertyOperations.js* to allow a hook to intercept values as they pass from user-space, over the IDL bridge, to browser builtins.

It looks for a callback at `ReactDOM.safeInContext` so running

```jsx
const payload = 'javascript:alert("evil")'

ReactDOM.render(<a href={payload}>...</a>, container)
```

will effectively use the result of

```js
ReactDOM.safeInContext(aElement, href, 'javascript:alert("evil")')
```

if such exists allowing user libraries to mitigate XSS.

-----

The author plans to provide a library that, loaded alongside ReactDOM,
uses this hook point to whitelist URL protocols based on how they load
with type-safe overrides.  https://github.com/Polymer/polymer-resin
is an example of such a hook that works in production and interoperates
with custom elements.

-----

The contract for `ReactDOM.safeInContext` is:

```jsx
/**
 * Called before React uses a value in a non-DOM-structure altering way.
 *
 * This function should not manipulate the DOM or have side effects visible
 * outside the scope of its call except where necessary to log policy violations.
 *
 * It is the implementor's responsibility to ensure that repeated calls in
 * a tight loop do not deny service, including bounding memory and network
 * usage for frequent policy violations.
 *
 * @param node A node such in the scope of `window.customElements`.
 *    I.e. any implicit adoption ( https://www.w3.org/TR/dom/#dom-core ) should
 *    happen before calling this function.
 * @param attributeOrPropertyName The name of the HTML attribute or JS property.
 *    Null iff value specifies textContent/nodeValue for a character data node.
 *    If value specifies, for example, the text content of a text node under a
 *    `<script>` element then node.parentNode should reach that script.
 * @param value the value before any coercion to DOMString so that safeInContext
 *    may treat values as privileged based on their runtime type.
 *
 * @return value or a suitable alternative.  Should not throw.
 */
function safeInContext(node : Node, attributeOrPropertyName : string, value : any) : any
```

-----

If we wished to allow a `rootContainerElement` to specify its own
`isSafeInContext` per then I'd need to push it farther down in the
stack or thread the root through to `updateDOMProperties`.

For reference, the relevant machinery seems to be:

<details>
  <summary>stack of calls involved in {setInitial,update}DOMProperties</summary>

During initial tree construction

| Depth | File | Function | Receives `rootContainerElement` |
| ----- | ---- | -------- | ------------------------------- |
| 0     | DOMPropertyOperations.js | `setValueForProperty` | No |
| 1     | ReactDOMFiberComponent.js | `setInitialDOMProperties` | Yes |
| 2     | ReactDOMFiberComponent.js | `setInitialProperties` | Yes |
| 3     | ReactDOMHostConfig.js     | `finalizeInitialChildren` | Yes

During incremental updates

| Depth | File | Function | Receives `rootContainerElement` |
| ----- | ---- | -------- | ------------------------------- |
| 0     | DOMPropertyOperations.js | `setValueForProperty` | No |
| 1     | ReactDOMFiberComponent.js | `updateDOMProperties` | No |
| 2     | ReactDOMFiberComponent.js | `updateProperties` | No |
| 3     | ReactDOMHostConfig.js     | `prepareUpdate` | Yes |

per

```
at Object.setValueForProperty (packages/react-dom/src/client/DOMPropertyOperations.js:146:202)
at setInitialDOMProperties (packages/react-dom/src/client/ReactDOMFiberComponent.js:1242:308)
at setInitialProperties (packages/react-dom/src/client/ReactDOMFiberComponent.js:1263:145)
at finalizeInitialChildren (packages/react-dom/src/client/ReactDOMHostConfig.js:587:831)
at completeWork (packages/react-reconciler/src/ReactFiberCompleteWork.js:430:63)
```

</details>

[design]: https://gist.github.com/mikesamuel/094d3fe4b1b2f702f543fa0c263ca8ff

