### PR TITLE
Suspending inside a constructor outside of strict mode

### DIFF
--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -71,6 +71,10 @@ import {
 import {findEarliestOutstandingPriorityLevel} from './ReactFiberPendingPriority';
 import {reconcileChildrenAtExpirationTime} from './ReactFiberBeginWork';
 
+function NoopComponent() {
+  return null;
+}
+
 function createRootErrorUpdate(
   fiber: Fiber,
   errorInfo: CapturedValue<mixed>,
@@ -244,6 +248,19 @@ function throwException(
               // Let's just assume it's a functional component. This fiber will
               // be unmounted in the immediate next commit, anyway.
               sourceFiber.tag = FunctionalComponent;
+            }
+
+            if (
+              sourceFiber.tag === ClassComponent &&
+              workInProgress.stateNode === null
+            ) {
+              // We're about to mount a class component that doesn't have an
+              // instance. Turn this into a dummy functional component instead,
+              // to prevent type errors. This is a bit weird but it's an edge
+              // case and we're about to synchronously delete this
+              // component, anyway.
+              sourceFiber.tag = FunctionalComponent;
+              sourceFiber.type = NoopComponent;
             }
 
             // Exit without suspending.


### PR DESCRIPTION
Outside of strict mode, suspended components commit in an incomplete state, then are synchronously deleted in a subsequent commit. If a component suspends inside the constructor, it mounts without an instance.

This breaks at least one invariant: during deletion, we assume that every mounted component has an instance, and check the instance for the existence of `componentWillUnmount`.

Rather than add a redundant check to the deletion of every class component, components that suspend inside their constructor and outside of strict mode are turned into empty functional components before they are mounted. This is a bit weird, but it's an edge case, and the empty component will be synchronously unmounted regardless.