### PR TITLE
Enforce presence or absence of component stack in tests

### DIFF
--- a/packages/create-subscription/src/__tests__/createSubscription-test.internal.js
+++ b/packages/create-subscription/src/__tests__/createSubscription-test.internal.js
@@ -450,7 +450,9 @@ describe('createSubscription', () => {
           },
           () => null,
         );
-      }).toWarnDev('Subscription must specify a getCurrentValue function');
+      }).toWarnDev('Subscription must specify a getCurrentValue function', {
+        expectNoStack: true,
+      });
     });
 
     it('should warn for invalid missing subscribe', () => {
@@ -461,7 +463,9 @@ describe('createSubscription', () => {
           },
           () => null,
         );
-      }).toWarnDev('Subscription must specify a subscribe function');
+      }).toWarnDev('Subscription must specify a subscribe function', {
+        expectNoStack: true,
+      });
     });
 
     it('should warn if subscribe does not return an unsubscribe method', () => {

--- a/packages/create-subscription/src/__tests__/createSubscription-test.internal.js
+++ b/packages/create-subscription/src/__tests__/createSubscription-test.internal.js
@@ -451,7 +451,7 @@ describe('createSubscription', () => {
           () => null,
         );
       }).toWarnDev('Subscription must specify a getCurrentValue function', {
-        expectNoStack: true,
+        withoutStack: true,
       });
     });
 
@@ -464,7 +464,7 @@ describe('createSubscription', () => {
           () => null,
         );
       }).toWarnDev('Subscription must specify a subscribe function', {
-        expectNoStack: true,
+        withoutStack: true,
       });
     });
 

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.internal.js
@@ -57,7 +57,7 @@ describe('ReactComponentLifeCycle', () => {
           'you can rename to UNSAFE_componentWillUpdate.' +
           '\n\nPlease update the following components: MyComponent',
       ],
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // Dedupe check (update and instantiate new

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.internal.js
@@ -43,19 +43,22 @@ describe('ReactComponentLifeCycle', () => {
     const container = document.createElement('div');
     expect(() =>
       ReactDOM.render(<MyComponent x={1} />, container),
-    ).toLowPriorityWarnDev([
-      'componentWillMount is deprecated and will be removed in the next major version. ' +
-        'Use componentDidMount instead. As a temporary workaround, ' +
-        'you can rename to UNSAFE_componentWillMount.' +
-        '\n\nPlease update the following components: MyComponent',
-      'componentWillReceiveProps is deprecated and will be removed in the next major version. ' +
-        'Use static getDerivedStateFromProps instead.' +
-        '\n\nPlease update the following components: MyComponent',
-      'componentWillUpdate is deprecated and will be removed in the next major version. ' +
-        'Use componentDidUpdate instead. As a temporary workaround, ' +
-        'you can rename to UNSAFE_componentWillUpdate.' +
-        '\n\nPlease update the following components: MyComponent',
-    ]);
+    ).toLowPriorityWarnDev(
+      [
+        'componentWillMount is deprecated and will be removed in the next major version. ' +
+          'Use componentDidMount instead. As a temporary workaround, ' +
+          'you can rename to UNSAFE_componentWillMount.' +
+          '\n\nPlease update the following components: MyComponent',
+        'componentWillReceiveProps is deprecated and will be removed in the next major version. ' +
+          'Use static getDerivedStateFromProps instead.' +
+          '\n\nPlease update the following components: MyComponent',
+        'componentWillUpdate is deprecated and will be removed in the next major version. ' +
+          'Use componentDidUpdate instead. As a temporary workaround, ' +
+          'you can rename to UNSAFE_componentWillUpdate.' +
+          '\n\nPlease update the following components: MyComponent',
+      ],
+      {expectNoStack: true},
+    );
 
     // Dedupe check (update and instantiate new
     ReactDOM.render(<MyComponent x={2} />, container);

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -218,6 +218,7 @@ describe('ReactComponentLifeCycle', () => {
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
         'class property with the desired state in the StatefulComponent component.',
+      {expectNoStack: true},
     );
 
     // Check deduplication; (no extra warnings should be logged).
@@ -248,7 +249,9 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => {
       const instance = ReactTestUtils.renderIntoDocument(element);
       expect(instance._isMounted()).toBeTruthy();
-    }).toWarnDev('Component is accessing isMounted inside its render()');
+    }).toWarnDev('Component is accessing isMounted inside its render()', {
+      expectNoStack: true,
+    });
   });
 
   it('should correctly determine if a null component is mounted', () => {
@@ -275,7 +278,9 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => {
       const instance = ReactTestUtils.renderIntoDocument(element);
       expect(instance._isMounted()).toBeTruthy();
-    }).toWarnDev('Component is accessing isMounted inside its render()');
+    }).toWarnDev('Component is accessing isMounted inside its render()', {
+      expectNoStack: true,
+    });
   });
 
   it('isMounted should return false when unmounted', () => {
@@ -313,7 +318,9 @@ describe('ReactComponentLifeCycle', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(<Component />);
-    }).toWarnDev('Component is accessing findDOMNode inside its render()');
+    }).toWarnDev('Component is accessing findDOMNode inside its render()', {
+      expectNoStack: true,
+    });
   });
 
   it('should carry through each of the phases of setup', () => {
@@ -379,6 +386,7 @@ describe('ReactComponentLifeCycle', () => {
       instance = ReactDOM.render(<LifeCycleComponent />, container);
     }).toWarnDev(
       'LifeCycleComponent is accessing isMounted inside its render() function',
+      {expectNoStack: true},
     );
 
     // getInitialState
@@ -674,6 +682,7 @@ describe('ReactComponentLifeCycle', () => {
     const container = document.createElement('div');
     expect(() => ReactDOM.render(<Component />, container)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using new component APIs.',
+      {expectNoStack: true},
     );
   });
 
@@ -701,6 +710,7 @@ describe('ReactComponentLifeCycle', () => {
     const container = document.createElement('div');
     expect(() => ReactDOM.render(<Component value={1} />, container)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using new component APIs.',
+      {expectNoStack: true},
     );
     ReactDOM.render(<Component value={2} />, container);
   });
@@ -728,6 +738,7 @@ describe('ReactComponentLifeCycle', () => {
     const container = document.createElement('div');
     expect(() => ReactDOM.render(<Component value={1} />, container)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using new component APIs.',
+      {expectNoStack: true},
     );
     ReactDOM.render(<Component value={2} />, container);
   });
@@ -756,6 +767,7 @@ describe('ReactComponentLifeCycle', () => {
         '  componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
+      {expectNoStack: true},
     );
 
     class WillMount extends React.Component {
@@ -775,6 +787,7 @@ describe('ReactComponentLifeCycle', () => {
         '  UNSAFE_componentWillMount\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
+      {expectNoStack: true},
     );
 
     class WillMountAndUpdate extends React.Component {
@@ -796,6 +809,7 @@ describe('ReactComponentLifeCycle', () => {
         '  UNSAFE_componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
+      {expectNoStack: true},
     );
 
     class WillReceiveProps extends React.Component {
@@ -815,6 +829,7 @@ describe('ReactComponentLifeCycle', () => {
         '  componentWillReceiveProps\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
+      {expectNoStack: true},
     );
   });
 
@@ -841,6 +856,7 @@ describe('ReactComponentLifeCycle', () => {
         '  componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
+      {expectNoStack: true},
     );
 
     class WillMount extends React.Component {
@@ -859,6 +875,7 @@ describe('ReactComponentLifeCycle', () => {
         '  UNSAFE_componentWillMount\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
+      {expectNoStack: true},
     );
 
     class WillMountAndUpdate extends React.Component {
@@ -879,6 +896,7 @@ describe('ReactComponentLifeCycle', () => {
         '  UNSAFE_componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
+      {expectNoStack: true},
     );
 
     class WillReceiveProps extends React.Component {
@@ -897,6 +915,7 @@ describe('ReactComponentLifeCycle', () => {
         '  componentWillReceiveProps\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
+      {expectNoStack: true},
     );
   });
 
@@ -964,6 +983,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => ReactDOM.render(<MyComponent />, div)).toWarnDev(
       'MyComponent.getDerivedStateFromProps(): A valid state object (or null) must ' +
         'be returned. You have returned undefined.',
+      {expectNoStack: true},
     );
 
     // De-duped
@@ -984,6 +1004,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => ReactDOM.render(<MyComponent />, div)).toWarnDev(
       'MyComponent: Did not properly initialize state during construction. ' +
         'Expected state to be an object, but it was undefined.',
+      {expectNoStack: true},
     );
 
     // De-duped
@@ -1209,6 +1230,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => ReactDOM.render(<MyComponent value="bar" />, div)).toWarnDev(
       'MyComponent.getSnapshotBeforeUpdate(): A snapshot value (or null) must ' +
         'be returned. You have returned undefined.',
+      {expectNoStack: true},
     );
 
     // De-duped
@@ -1229,6 +1251,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => ReactDOM.render(<MyComponent />, div)).toWarnDev(
       'MyComponent: getSnapshotBeforeUpdate() should be used with componentDidUpdate(). ' +
         'This component defines getSnapshotBeforeUpdate() only.',
+      {expectNoStack: true},
     );
 
     // De-duped

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -218,7 +218,7 @@ describe('ReactComponentLifeCycle', () => {
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
         'class property with the desired state in the StatefulComponent component.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // Check deduplication; (no extra warnings should be logged).
@@ -250,7 +250,7 @@ describe('ReactComponentLifeCycle', () => {
       const instance = ReactTestUtils.renderIntoDocument(element);
       expect(instance._isMounted()).toBeTruthy();
     }).toWarnDev('Component is accessing isMounted inside its render()', {
-      expectNoStack: true,
+      withoutStack: true,
     });
   });
 
@@ -279,7 +279,7 @@ describe('ReactComponentLifeCycle', () => {
       const instance = ReactTestUtils.renderIntoDocument(element);
       expect(instance._isMounted()).toBeTruthy();
     }).toWarnDev('Component is accessing isMounted inside its render()', {
-      expectNoStack: true,
+      withoutStack: true,
     });
   });
 
@@ -319,7 +319,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => {
       ReactTestUtils.renderIntoDocument(<Component />);
     }).toWarnDev('Component is accessing findDOMNode inside its render()', {
-      expectNoStack: true,
+      withoutStack: true,
     });
   });
 
@@ -386,7 +386,7 @@ describe('ReactComponentLifeCycle', () => {
       instance = ReactDOM.render(<LifeCycleComponent />, container);
     }).toWarnDev(
       'LifeCycleComponent is accessing isMounted inside its render() function',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // getInitialState
@@ -682,7 +682,7 @@ describe('ReactComponentLifeCycle', () => {
     const container = document.createElement('div');
     expect(() => ReactDOM.render(<Component />, container)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using new component APIs.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -710,7 +710,7 @@ describe('ReactComponentLifeCycle', () => {
     const container = document.createElement('div');
     expect(() => ReactDOM.render(<Component value={1} />, container)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using new component APIs.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     ReactDOM.render(<Component value={2} />, container);
   });
@@ -738,7 +738,7 @@ describe('ReactComponentLifeCycle', () => {
     const container = document.createElement('div');
     expect(() => ReactDOM.render(<Component value={1} />, container)).toWarnDev(
       'Unsafe legacy lifecycles will not be called for components using new component APIs.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     ReactDOM.render(<Component value={2} />, container);
   });
@@ -767,7 +767,7 @@ describe('ReactComponentLifeCycle', () => {
         '  componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     class WillMount extends React.Component {
@@ -787,7 +787,7 @@ describe('ReactComponentLifeCycle', () => {
         '  UNSAFE_componentWillMount\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     class WillMountAndUpdate extends React.Component {
@@ -809,7 +809,7 @@ describe('ReactComponentLifeCycle', () => {
         '  UNSAFE_componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     class WillReceiveProps extends React.Component {
@@ -829,7 +829,7 @@ describe('ReactComponentLifeCycle', () => {
         '  componentWillReceiveProps\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -856,7 +856,7 @@ describe('ReactComponentLifeCycle', () => {
         '  componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     class WillMount extends React.Component {
@@ -875,7 +875,7 @@ describe('ReactComponentLifeCycle', () => {
         '  UNSAFE_componentWillMount\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     class WillMountAndUpdate extends React.Component {
@@ -896,7 +896,7 @@ describe('ReactComponentLifeCycle', () => {
         '  UNSAFE_componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     class WillReceiveProps extends React.Component {
@@ -915,7 +915,7 @@ describe('ReactComponentLifeCycle', () => {
         '  componentWillReceiveProps\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -983,7 +983,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => ReactDOM.render(<MyComponent />, div)).toWarnDev(
       'MyComponent.getDerivedStateFromProps(): A valid state object (or null) must ' +
         'be returned. You have returned undefined.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // De-duped
@@ -1004,7 +1004,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => ReactDOM.render(<MyComponent />, div)).toWarnDev(
       'MyComponent: Did not properly initialize state during construction. ' +
         'Expected state to be an object, but it was undefined.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // De-duped
@@ -1230,7 +1230,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => ReactDOM.render(<MyComponent value="bar" />, div)).toWarnDev(
       'MyComponent.getSnapshotBeforeUpdate(): A snapshot value (or null) must ' +
         'be returned. You have returned undefined.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // De-duped
@@ -1251,7 +1251,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => ReactDOM.render(<MyComponent />, div)).toWarnDev(
       'MyComponent: getSnapshotBeforeUpdate() should be used with componentDidUpdate(). ' +
         'This component defines getSnapshotBeforeUpdate() only.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // De-duped

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -163,6 +163,7 @@ describe('ReactCompositeComponent', () => {
       'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
         'will stop working in React v17. Replace the ReactDOM.render() call ' +
         'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+      {expectNoStack: true},
     );
 
     // New explicit API
@@ -279,6 +280,7 @@ describe('ReactCompositeComponent', () => {
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
         'class property with the desired state in the MyComponent component.',
+      {expectNoStack: true},
     );
 
     // No additional warning should be recorded
@@ -303,6 +305,7 @@ describe('ReactCompositeComponent', () => {
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
         'class property with the desired state in the MyComponent component.',
+      {expectNoStack: true},
     );
 
     // No additional warning should be recorded
@@ -466,6 +469,7 @@ describe('ReactCompositeComponent', () => {
         "`render` or another component's constructor). Render methods should " +
         'be a pure function of props and state; constructor side-effects are ' +
         'an anti-pattern, but can be moved to `componentWillMount`.',
+      {expectNoStack: true},
     );
 
     // The setState call is queued and then executed as a second pass. This
@@ -513,6 +517,7 @@ describe('ReactCompositeComponent', () => {
       instance = ReactDOM.render(<Component />, container);
     }).toWarnDev(
       'Warning: setState(...): Cannot call setState() inside getChildContext()',
+      {expectNoStack: true},
     );
 
     expect(renderPasses).toBe(2);
@@ -589,6 +594,7 @@ describe('ReactCompositeComponent', () => {
     expect(() => instance.setState({bogus: true})).toWarnDev(
       'Warning: Component.shouldComponentUpdate(): Returned undefined instead of a ' +
         'boolean value. Make sure to return true or false.',
+      {expectNoStack: true},
     );
   });
 
@@ -605,6 +611,7 @@ describe('ReactCompositeComponent', () => {
       'Warning: Component has a method called ' +
         'componentDidUnmount(). But there is no such lifecycle method. ' +
         'Did you mean componentWillUnmount()?',
+      {expectNoStack: true},
     );
   });
 
@@ -623,6 +630,7 @@ describe('ReactCompositeComponent', () => {
         'If you meant to update the state in response to changing props, ' +
         'use componentWillReceiveProps(). If you meant to fetch data or ' +
         'run side-effects or mutations after React has updated the UI, use componentDidUpdate().',
+      {expectNoStack: true},
     );
   });
 
@@ -641,6 +649,7 @@ describe('ReactCompositeComponent', () => {
     expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toWarnDev(
       'Warning: Setting defaultProps as an instance property on Component is not supported ' +
         'and will be ignored. Instead, define defaultProps as a static property on Component.',
+      {expectNoStack: true},
     );
   });
 
@@ -1131,6 +1140,7 @@ describe('ReactCompositeComponent', () => {
         'triggering nested component updates from render is not allowed. If ' +
         'necessary, trigger nested updates in componentDidUpdate.\n\nCheck the ' +
         'render method of Outer.',
+      {expectNoStack: true},
     );
   });
 
@@ -1422,6 +1432,7 @@ describe('ReactCompositeComponent', () => {
     expect(() => ReactDOM.render(<Foo idx="qwe" />, container)).toWarnDev(
       'Foo(...): When calling super() in `Foo`, make sure to pass ' +
         "up the same props that your component's constructor was passed.",
+      {expectNoStack: true},
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -163,7 +163,7 @@ describe('ReactCompositeComponent', () => {
       'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
         'will stop working in React v17. Replace the ReactDOM.render() call ' +
         'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // New explicit API
@@ -280,7 +280,7 @@ describe('ReactCompositeComponent', () => {
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
         'class property with the desired state in the MyComponent component.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // No additional warning should be recorded
@@ -305,7 +305,7 @@ describe('ReactCompositeComponent', () => {
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
         'class property with the desired state in the MyComponent component.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // No additional warning should be recorded
@@ -469,7 +469,7 @@ describe('ReactCompositeComponent', () => {
         "`render` or another component's constructor). Render methods should " +
         'be a pure function of props and state; constructor side-effects are ' +
         'an anti-pattern, but can be moved to `componentWillMount`.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // The setState call is queued and then executed as a second pass. This
@@ -517,7 +517,7 @@ describe('ReactCompositeComponent', () => {
       instance = ReactDOM.render(<Component />, container);
     }).toWarnDev(
       'Warning: setState(...): Cannot call setState() inside getChildContext()',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     expect(renderPasses).toBe(2);
@@ -594,7 +594,7 @@ describe('ReactCompositeComponent', () => {
     expect(() => instance.setState({bogus: true})).toWarnDev(
       'Warning: Component.shouldComponentUpdate(): Returned undefined instead of a ' +
         'boolean value. Make sure to return true or false.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -611,7 +611,7 @@ describe('ReactCompositeComponent', () => {
       'Warning: Component has a method called ' +
         'componentDidUnmount(). But there is no such lifecycle method. ' +
         'Did you mean componentWillUnmount()?',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -630,7 +630,7 @@ describe('ReactCompositeComponent', () => {
         'If you meant to update the state in response to changing props, ' +
         'use componentWillReceiveProps(). If you meant to fetch data or ' +
         'run side-effects or mutations after React has updated the UI, use componentDidUpdate().',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -649,7 +649,7 @@ describe('ReactCompositeComponent', () => {
     expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toWarnDev(
       'Warning: Setting defaultProps as an instance property on Component is not supported ' +
         'and will be ignored. Instead, define defaultProps as a static property on Component.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -1140,7 +1140,7 @@ describe('ReactCompositeComponent', () => {
         'triggering nested component updates from render is not allowed. If ' +
         'necessary, trigger nested updates in componentDidUpdate.\n\nCheck the ' +
         'render method of Outer.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -1432,7 +1432,7 @@ describe('ReactCompositeComponent', () => {
     expect(() => ReactDOM.render(<Foo idx="qwe" />, container)).toWarnDev(
       'Foo(...): When calling super() in `Foo`, make sure to pass ' +
         "up the same props that your component's constructor was passed.",
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
@@ -410,6 +410,7 @@ describe('ReactCompositeComponent-state', () => {
       'Warning: Test.componentWillReceiveProps(): Assigning directly to ' +
         "this.state is deprecated (except inside a component's constructor). " +
         'Use setState instead.',
+      {expectNoStack: true},
     );
 
     expect(ops).toEqual([
@@ -451,6 +452,7 @@ describe('ReactCompositeComponent-state', () => {
       'Warning: Test.componentWillMount(): Assigning directly to ' +
         "this.state is deprecated (except inside a component's constructor). " +
         'Use setState instead.',
+      {expectNoStack: true},
     );
 
     expect(ops).toEqual([

--- a/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
@@ -410,7 +410,7 @@ describe('ReactCompositeComponent-state', () => {
       'Warning: Test.componentWillReceiveProps(): Assigning directly to ' +
         "this.state is deprecated (except inside a component's constructor). " +
         'Use setState instead.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     expect(ops).toEqual([
@@ -452,7 +452,7 @@ describe('ReactCompositeComponent-state', () => {
       'Warning: Test.componentWillMount(): Assigning directly to ' +
         "this.state is deprecated (except inside a component's constructor). " +
         'Use setState instead.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     expect(ops).toEqual([

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -450,7 +450,7 @@ describe('ReactDOM', () => {
       jest.resetModules();
       expect(() => require('react-dom')).toWarnDev(
         "This browser doesn't support requestAnimationFrame.",
-        {expectNoStack: true},
+        {withoutStack: true},
       );
     } finally {
       global.requestAnimationFrame = previousRAF;

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -450,6 +450,7 @@ describe('ReactDOM', () => {
       jest.resetModules();
       expect(() => require('react-dom')).toWarnDev(
         "This browser doesn't support requestAnimationFrame.",
+        {expectNoStack: true},
       );
     } finally {
       global.requestAnimationFrame = previousRAF;

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -567,7 +567,7 @@ describe('ReactDOMComponent', () => {
         }
       }).toWarnDev(
         'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
     });
 
@@ -587,7 +587,7 @@ describe('ReactDOMComponent', () => {
         }
       }).toWarnDev(
         'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
     });
 
@@ -1006,7 +1006,7 @@ describe('ReactDOMComponent', () => {
         '<BR /> is using incorrect casing. ' +
           'Use PascalCase for React components, ' +
           'or lowercase for HTML elements.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
       expect(returnedValue).not.toContain('</BR>');
     });
@@ -1023,7 +1023,7 @@ describe('ReactDOMComponent', () => {
         '<IMG /> is using incorrect casing. ' +
           'Use PascalCase for React components, ' +
           'or lowercase for HTML elements.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
     });
 
@@ -1033,7 +1033,7 @@ describe('ReactDOMComponent', () => {
       ).toWarnDev(
         'The `aria` attribute is reserved for future use in React. ' +
           'Pass individual `aria-` attributes instead.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
     });
 
@@ -1056,12 +1056,12 @@ describe('ReactDOMComponent', () => {
 
         expect(() => ReactTestUtils.renderIntoDocument(<bar />)).toWarnDev(
           'The tag <bar> is unrecognized in this browser',
-          {expectNoStack: true}, // TODO: add a stack
+          {withoutStack: true}, // TODO: add a stack
         );
         // Test deduplication
         expect(() => ReactTestUtils.renderIntoDocument(<foo />)).toWarnDev(
           'The tag <foo> is unrecognized in this browser',
-          {expectNoStack: true}, // TODO: add a stack
+          {withoutStack: true}, // TODO: add a stack
         );
         ReactTestUtils.renderIntoDocument(<foo />);
         // This is a funny case.
@@ -1080,7 +1080,7 @@ describe('ReactDOMComponent', () => {
               'or lowercase for HTML elements.',
             'The tag <hasOwnProperty> is unrecognized in this browser',
           ],
-          {expectNoStack: true}, // TODO: add a stack
+          {withoutStack: true}, // TODO: add a stack
         );
       } finally {
         Object.prototype.toString = realToString; // eslint-disable-line no-extend-native
@@ -1140,7 +1140,7 @@ describe('ReactDOMComponent', () => {
         expect(() => ReactDOM.render(<ShadyComponent />, node)).toWarnDev(
           'ShadyComponent is using shady DOM. Using shady DOM with React can ' +
             'cause things to break subtly.',
-          {expectNoStack: true}, // TODO: add a stack
+          {withoutStack: true}, // TODO: add a stack
         );
         mountComponent({is: 'custom-shady-div2'});
       } finally {
@@ -1161,7 +1161,7 @@ describe('ReactDOMComponent', () => {
         expect(() => mountComponent({is: 'custom-shady-div'})).toWarnDev(
           'A component is using shady DOM. Using shady DOM with React can ' +
             'cause things to break subtly.',
-          {expectNoStack: true}, // TODO: add a stack
+          {withoutStack: true}, // TODO: add a stack
         );
 
         // No additional warnings are expected
@@ -1210,7 +1210,7 @@ describe('ReactDOMComponent', () => {
       expect(() =>
         mountComponent({innerHTML: '<span>Hi Jim!</span>'}),
       ).toWarnDev('Directly setting property `innerHTML` is not permitted. ', {
-        expectNoStack: true, // TODO: add a stack
+        withoutStack: true, // TODO: add a stack
       });
     });
 
@@ -1218,7 +1218,7 @@ describe('ReactDOMComponent', () => {
       expect(() =>
         mountComponent({innerhtml: '<span>Hi Jim!</span>'}),
       ).toWarnDev('Directly setting property `innerHTML` is not permitted. ', {
-        expectNoStack: true, // TODO: add a stack
+        withoutStack: true, // TODO: add a stack
       });
     });
 
@@ -1812,13 +1812,13 @@ describe('ReactDOMComponent', () => {
         ReactTestUtils.renderIntoDocument(<div onFocusIn={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
       expect(() =>
         ReactTestUtils.renderIntoDocument(<div onFocusOut={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
     });
 
@@ -1828,13 +1828,13 @@ describe('ReactDOMComponent', () => {
         ReactTestUtils.renderIntoDocument(<div onfocusin={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
       expect(() =>
         ReactTestUtils.renderIntoDocument(<div onfocusout={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
     });
 
@@ -1844,13 +1844,13 @@ describe('ReactDOMComponent', () => {
         ReactDOMServer.renderToString(<div onFocusIn={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
       expect(() =>
         ReactDOMServer.renderToString(<div onFocusOut={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
     });
 
@@ -1860,13 +1860,13 @@ describe('ReactDOMComponent', () => {
         ReactDOMServer.renderToString(<div onfocusin={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
       expect(() =>
         ReactDOMServer.renderToString(<div onfocusout={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
     });
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -567,6 +567,7 @@ describe('ReactDOMComponent', () => {
         }
       }).toWarnDev(
         'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
+        {expectNoStack: true}, // TODO: add a stack
       );
     });
 
@@ -586,6 +587,7 @@ describe('ReactDOMComponent', () => {
         }
       }).toWarnDev(
         'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
+        {expectNoStack: true}, // TODO: add a stack
       );
     });
 
@@ -1004,6 +1006,7 @@ describe('ReactDOMComponent', () => {
         '<BR /> is using incorrect casing. ' +
           'Use PascalCase for React components, ' +
           'or lowercase for HTML elements.',
+        {expectNoStack: true}, // TODO: add a stack
       );
       expect(returnedValue).not.toContain('</BR>');
     });
@@ -1020,6 +1023,7 @@ describe('ReactDOMComponent', () => {
         '<IMG /> is using incorrect casing. ' +
           'Use PascalCase for React components, ' +
           'or lowercase for HTML elements.',
+        {expectNoStack: true}, // TODO: add a stack
       );
     });
 
@@ -1029,6 +1033,7 @@ describe('ReactDOMComponent', () => {
       ).toWarnDev(
         'The `aria` attribute is reserved for future use in React. ' +
           'Pass individual `aria-` attributes instead.',
+        {expectNoStack: true}, // TODO: add a stack
       );
     });
 
@@ -1051,10 +1056,12 @@ describe('ReactDOMComponent', () => {
 
         expect(() => ReactTestUtils.renderIntoDocument(<bar />)).toWarnDev(
           'The tag <bar> is unrecognized in this browser',
+          {expectNoStack: true}, // TODO: add a stack
         );
         // Test deduplication
         expect(() => ReactTestUtils.renderIntoDocument(<foo />)).toWarnDev(
           'The tag <foo> is unrecognized in this browser',
+          {expectNoStack: true}, // TODO: add a stack
         );
         ReactTestUtils.renderIntoDocument(<foo />);
         // This is a funny case.
@@ -1066,12 +1073,15 @@ describe('ReactDOMComponent', () => {
         // Corner case. Make sure out deduplication logic doesn't break with weird tag.
         expect(() =>
           ReactTestUtils.renderIntoDocument(<hasOwnProperty />),
-        ).toWarnDev([
-          '<hasOwnProperty /> is using incorrect casing. ' +
-            'Use PascalCase for React components, ' +
-            'or lowercase for HTML elements.',
-          'The tag <hasOwnProperty> is unrecognized in this browser',
-        ]);
+        ).toWarnDev(
+          [
+            '<hasOwnProperty /> is using incorrect casing. ' +
+              'Use PascalCase for React components, ' +
+              'or lowercase for HTML elements.',
+            'The tag <hasOwnProperty> is unrecognized in this browser',
+          ],
+          {expectNoStack: true}, // TODO: add a stack
+        );
       } finally {
         Object.prototype.toString = realToString; // eslint-disable-line no-extend-native
       }
@@ -1130,6 +1140,7 @@ describe('ReactDOMComponent', () => {
         expect(() => ReactDOM.render(<ShadyComponent />, node)).toWarnDev(
           'ShadyComponent is using shady DOM. Using shady DOM with React can ' +
             'cause things to break subtly.',
+          {expectNoStack: true}, // TODO: add a stack
         );
         mountComponent({is: 'custom-shady-div2'});
       } finally {
@@ -1150,6 +1161,7 @@ describe('ReactDOMComponent', () => {
         expect(() => mountComponent({is: 'custom-shady-div'})).toWarnDev(
           'A component is using shady DOM. Using shady DOM with React can ' +
             'cause things to break subtly.',
+          {expectNoStack: true}, // TODO: add a stack
         );
 
         // No additional warnings are expected
@@ -1197,13 +1209,17 @@ describe('ReactDOMComponent', () => {
     it('should validate against use of innerHTML', () => {
       expect(() =>
         mountComponent({innerHTML: '<span>Hi Jim!</span>'}),
-      ).toWarnDev('Directly setting property `innerHTML` is not permitted. ');
+      ).toWarnDev('Directly setting property `innerHTML` is not permitted. ', {
+        expectNoStack: true, // TODO: add a stack
+      });
     });
 
     it('should validate against use of innerHTML without case sensitivity', () => {
       expect(() =>
         mountComponent({innerhtml: '<span>Hi Jim!</span>'}),
-      ).toWarnDev('Directly setting property `innerHTML` is not permitted. ');
+      ).toWarnDev('Directly setting property `innerHTML` is not permitted. ', {
+        expectNoStack: true, // TODO: add a stack
+      });
     });
 
     it('should validate use of dangerouslySetInnerHTML', () => {
@@ -1796,11 +1812,13 @@ describe('ReactDOMComponent', () => {
         ReactTestUtils.renderIntoDocument(<div onFocusIn={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+        {expectNoStack: true}, // TODO: add a stack
       );
       expect(() =>
         ReactTestUtils.renderIntoDocument(<div onFocusOut={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+        {expectNoStack: true}, // TODO: add a stack
       );
     });
 
@@ -1810,11 +1828,13 @@ describe('ReactDOMComponent', () => {
         ReactTestUtils.renderIntoDocument(<div onfocusin={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+        {expectNoStack: true}, // TODO: add a stack
       );
       expect(() =>
         ReactTestUtils.renderIntoDocument(<div onfocusout={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+        {expectNoStack: true}, // TODO: add a stack
       );
     });
 
@@ -1824,11 +1844,13 @@ describe('ReactDOMComponent', () => {
         ReactDOMServer.renderToString(<div onFocusIn={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+        {expectNoStack: true}, // TODO: add a stack
       );
       expect(() =>
         ReactDOMServer.renderToString(<div onFocusOut={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+        {expectNoStack: true}, // TODO: add a stack
       );
     });
 
@@ -1838,11 +1860,13 @@ describe('ReactDOMComponent', () => {
         ReactDOMServer.renderToString(<div onfocusin={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+        {expectNoStack: true}, // TODO: add a stack
       );
       expect(() =>
         ReactDOMServer.renderToString(<div onfocusout={() => {}} />),
       ).toWarnDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
+        {expectNoStack: true}, // TODO: add a stack
       );
     });
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
@@ -195,7 +195,7 @@ describe('ReactDOMComponentTree', () => {
         'was rendered by React and is not a top-level container. You may ' +
         'have accidentally passed in a React root node instead of its ' +
         'container.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -212,7 +212,7 @@ describe('ReactDOMComponentTree', () => {
         'component. If you intended to update the children of this node, ' +
         'you should instead have the existing children update their state ' +
         'and render the new components instead of calling ReactDOM.render.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
@@ -195,6 +195,7 @@ describe('ReactDOMComponentTree', () => {
         'was rendered by React and is not a top-level container. You may ' +
         'have accidentally passed in a React root node instead of its ' +
         'container.',
+      {expectNoStack: true},
     );
   });
 
@@ -211,6 +212,7 @@ describe('ReactDOMComponentTree', () => {
         'component. If you intended to update the children of this node, ' +
         'you should instead have the existing children update their state ' +
         'and render the new components instead of calling ReactDOM.render.',
+      {expectNoStack: true},
     );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -256,7 +256,7 @@ describe('ReactDOMFiber', () => {
         'and will be removed in React 17+. Update your code to use ' +
         'ReactDOM.createPortal() instead. It has the exact same API, ' +
         'but without the "unstable_" prefix.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(portalContainer.innerHTML).toBe('<div>portal</div>');
     expect(container.innerHTML).toBe('<div></div>');
@@ -1101,7 +1101,7 @@ describe('ReactDOMFiber', () => {
           'removed without using React. This is not supported and will ' +
           'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
           'to empty a container.',
-        {expectNoStack: true},
+        {withoutStack: true},
       );
     }).toThrowError();
   });
@@ -1119,7 +1119,7 @@ describe('ReactDOMFiber', () => {
         'removed without using React. This is not supported and will ' +
         'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
         'to empty a container.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -1136,7 +1136,7 @@ describe('ReactDOMFiber', () => {
         'removed without using React. This is not supported and will ' +
         'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
         'to empty a container.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -256,6 +256,7 @@ describe('ReactDOMFiber', () => {
         'and will be removed in React 17+. Update your code to use ' +
         'ReactDOM.createPortal() instead. It has the exact same API, ' +
         'but without the "unstable_" prefix.',
+      {expectNoStack: true},
     );
     expect(portalContainer.innerHTML).toBe('<div>portal</div>');
     expect(container.innerHTML).toBe('<div></div>');
@@ -1100,6 +1101,7 @@ describe('ReactDOMFiber', () => {
           'removed without using React. This is not supported and will ' +
           'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
           'to empty a container.',
+        {expectNoStack: true},
       );
     }).toThrowError();
   });
@@ -1117,6 +1119,7 @@ describe('ReactDOMFiber', () => {
         'removed without using React. This is not supported and will ' +
         'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
         'to empty a container.',
+      {expectNoStack: true},
     );
   });
 
@@ -1133,6 +1136,7 @@ describe('ReactDOMFiber', () => {
         'removed without using React. This is not supported and will ' +
         'cause errors. Instead, call ReactDOM.unmountComponentAtNode ' +
         'to empty a container.',
+      {expectNoStack: true},
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -930,7 +930,7 @@ describe('ReactDOMInput', () => {
         'both). Decide between using a controlled or uncontrolled input ' +
         'element and remove one of these props. More info: ' +
         'https://fb.me/react-controlled-components',
-      {expectNoStack: true}, // TODO: add a stack
+      {withoutStack: true}, // TODO: add a stack
     );
     ReactDOM.unmountComponentAtNode(container);
 
@@ -958,7 +958,7 @@ describe('ReactDOMInput', () => {
         'both). Decide between using a controlled or uncontrolled input ' +
         'element and remove one of these props. More info: ' +
         'https://fb.me/react-controlled-components',
-      {expectNoStack: true}, // TODO: add a stack
+      {withoutStack: true}, // TODO: add a stack
     );
     ReactDOM.unmountComponentAtNode(container);
 

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -930,6 +930,7 @@ describe('ReactDOMInput', () => {
         'both). Decide between using a controlled or uncontrolled input ' +
         'element and remove one of these props. More info: ' +
         'https://fb.me/react-controlled-components',
+      {expectNoStack: true}, // TODO: add a stack
     );
     ReactDOM.unmountComponentAtNode(container);
 
@@ -957,6 +958,7 @@ describe('ReactDOMInput', () => {
         'both). Decide between using a controlled or uncontrolled input ' +
         'element and remove one of these props. More info: ' +
         'https://fb.me/react-controlled-components',
+      {expectNoStack: true}, // TODO: add a stack
     );
     ReactDOM.unmountComponentAtNode(container);
 

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -144,7 +144,7 @@ describe('ReactDOMRoot', () => {
       </div>,
     );
     expect(jest.runAllTimers).toWarnDev('Extra attributes', {
-      expectNoStack: true,
+      withoutStack: true,
     });
   });
 
@@ -362,7 +362,7 @@ describe('ReactDOMRoot', () => {
     const InvalidType = undefined;
     expect(() => batch.render(<InvalidType />)).toWarnDev(
       ['React.createElement: type is invalid'],
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(() => batch.commit()).toThrow('Element type is invalid');
   });

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -143,7 +143,9 @@ describe('ReactDOMRoot', () => {
         <span />
       </div>,
     );
-    expect(jest.runAllTimers).toWarnDev('Extra attributes');
+    expect(jest.runAllTimers).toWarnDev('Extra attributes', {
+      expectNoStack: true,
+    });
   });
 
   it('does not clear existing children', async () => {
@@ -358,9 +360,10 @@ describe('ReactDOMRoot', () => {
     const root = ReactDOM.unstable_createRoot(container);
     const batch = root.createBatch();
     const InvalidType = undefined;
-    expect(() => batch.render(<InvalidType />)).toWarnDev([
-      'React.createElement: type is invalid',
-    ]);
+    expect(() => batch.render(<InvalidType />)).toWarnDev(
+      ['React.createElement: type is invalid'],
+      {expectNoStack: true},
+    );
     expect(() => batch.commit()).toThrow('Element type is invalid');
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -576,6 +576,7 @@ describe('ReactDOMSelect', () => {
     ).toWarnDev(
       'Use the `defaultValue` or `value` props on <select> instead of ' +
         'setting `selected` on <option>.',
+      {expectNoStack: true}, // TODO: add a stack
     );
 
     ReactTestUtils.renderIntoDocument(
@@ -646,6 +647,7 @@ describe('ReactDOMSelect', () => {
         'both). Decide between using a controlled or uncontrolled select ' +
         'element and remove one of these props. More info: ' +
         'https://fb.me/react-controlled-components',
+      {expectNoStack: true}, // TODO: add a stack
     );
 
     ReactTestUtils.renderIntoDocument(

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -576,7 +576,7 @@ describe('ReactDOMSelect', () => {
     ).toWarnDev(
       'Use the `defaultValue` or `value` props on <select> instead of ' +
         'setting `selected` on <option>.',
-      {expectNoStack: true}, // TODO: add a stack
+      {withoutStack: true}, // TODO: add a stack
     );
 
     ReactTestUtils.renderIntoDocument(
@@ -647,7 +647,7 @@ describe('ReactDOMSelect', () => {
         'both). Decide between using a controlled or uncontrolled select ' +
         'element and remove one of these props. More info: ' +
         'https://fb.me/react-controlled-components',
-      {expectNoStack: true}, // TODO: add a stack
+      {withoutStack: true}, // TODO: add a stack
     );
 
     ReactTestUtils.renderIntoDocument(

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -599,7 +599,7 @@ describe('ReactDOMServerIntegration', () => {
         expect(() => {
           ReactDOM.render(<nonstandard />, document.createElement('div'));
         }).toWarnDev('The tag <nonstandard> is unrecognized in this browser.', {
-          expectNoStack: true, // TODO: add a stack
+          withoutStack: true, // TODO: add a stack
         });
 
         const e = await render(<nonstandard foo="bar" />);

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -598,7 +598,9 @@ describe('ReactDOMServerIntegration', () => {
         // so that it gets deduplicated later, and doesn't fail the test.
         expect(() => {
           ReactDOM.render(<nonstandard />, document.createElement('div'));
-        }).toWarnDev('The tag <nonstandard> is unrecognized in this browser.');
+        }).toWarnDev('The tag <nonstandard> is unrecognized in this browser.', {
+          expectNoStack: true, // TODO: add a stack
+        });
 
         const e = await render(<nonstandard foo="bar" />);
         expect(e.getAttribute('foo')).toBe('bar');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -143,7 +143,7 @@ describe('ReactDOMServerIntegration', () => {
         expect(() => {
           ReactDOM.render(<nonstandard />, document.createElement('div'));
         }).toWarnDev('The tag <nonstandard> is unrecognized in this browser.', {
-          expectNoStack: true, // TODO: add a stack
+          withoutStack: true, // TODO: add a stack
         });
 
         const e = await render(<nonstandard>Text</nonstandard>);
@@ -887,7 +887,7 @@ describe('ReactDOMServerIntegration', () => {
               'components) but got: object. You likely forgot to export your ' +
               "component from the file it's defined in, or you might have mixed up " +
               'default and named imports.',
-            {expectNoStack: true},
+            {withoutStack: true},
           );
           await render(EmptyComponent);
         },
@@ -909,7 +909,7 @@ describe('ReactDOMServerIntegration', () => {
             'Warning: React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: null.',
-            {expectNoStack: true},
+            {withoutStack: true},
           );
           await render(NullComponent);
         },
@@ -929,7 +929,7 @@ describe('ReactDOMServerIntegration', () => {
               'components) but got: undefined. You likely forgot to export your ' +
               "component from the file it's defined in, or you might have mixed up " +
               'default and named imports.',
-            {expectNoStack: true},
+            {withoutStack: true},
           );
 
           await render(UndefinedComponent);

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -142,7 +142,9 @@ describe('ReactDOMServerIntegration', () => {
         // so that it gets deduplicated later, and doesn't fail the test.
         expect(() => {
           ReactDOM.render(<nonstandard />, document.createElement('div'));
-        }).toWarnDev('The tag <nonstandard> is unrecognized in this browser.');
+        }).toWarnDev('The tag <nonstandard> is unrecognized in this browser.', {
+          expectNoStack: true, // TODO: add a stack
+        });
 
         const e = await render(<nonstandard>Text</nonstandard>);
         expect(e.tagName).toBe('NONSTANDARD');
@@ -885,6 +887,7 @@ describe('ReactDOMServerIntegration', () => {
               'components) but got: object. You likely forgot to export your ' +
               "component from the file it's defined in, or you might have mixed up " +
               'default and named imports.',
+            {expectNoStack: true},
           );
           await render(EmptyComponent);
         },
@@ -906,6 +909,7 @@ describe('ReactDOMServerIntegration', () => {
             'Warning: React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: null.',
+            {expectNoStack: true},
           );
           await render(NullComponent);
         },
@@ -925,6 +929,7 @@ describe('ReactDOMServerIntegration', () => {
               'components) but got: undefined. You likely forgot to export your ' +
               "component from the file it's defined in, or you might have mixed up " +
               'default and named imports.',
+            {expectNoStack: true},
           );
 
           await render(UndefinedComponent);

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.internal.js
@@ -44,7 +44,7 @@ describe('ReactDOMServerLifecycles', () => {
       ReactDOMServer.renderToString(<Component />),
     ).toLowPriorityWarnDev(
       'Component: componentWillMount() is deprecated and will be removed in the next major version.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -63,7 +63,7 @@ describe('ReactDOMServerLifecycles', () => {
     ).toLowPriorityWarnDev(
       'Warning: Component: componentWillMount() is deprecated and will be removed ' +
         'in the next major version.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // De-duped

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.internal.js
@@ -44,6 +44,7 @@ describe('ReactDOMServerLifecycles', () => {
       ReactDOMServer.renderToString(<Component />),
     ).toLowPriorityWarnDev(
       'Component: componentWillMount() is deprecated and will be removed in the next major version.',
+      {expectNoStack: true},
     );
   });
 
@@ -62,6 +63,7 @@ describe('ReactDOMServerLifecycles', () => {
     ).toLowPriorityWarnDev(
       'Warning: Component: componentWillMount() is deprecated and will be removed ' +
         'in the next major version.',
+      {expectNoStack: true},
     );
 
     // De-duped

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
@@ -183,6 +183,7 @@ describe('ReactDOMServerLifecycles', () => {
     expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
       'Component.getDerivedStateFromProps(): A valid state object (or null) must ' +
         'be returned. You have returned undefined.',
+      {expectNoStack: true},
     );
 
     // De-duped
@@ -202,6 +203,7 @@ describe('ReactDOMServerLifecycles', () => {
     expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
       'Component: Did not properly initialize state during construction. ' +
         'Expected state to be an object, but it was undefined.',
+      {expectNoStack: true},
     );
 
     // De-duped
@@ -258,6 +260,7 @@ describe('ReactDOMServerLifecycles', () => {
         'usually means you called setState() outside componentWillMount() on ' +
         'the server. This is a no-op.\n\n' +
         'Please check the code for the Outer component.',
+      {expectNoStack: true},
     );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
@@ -183,7 +183,7 @@ describe('ReactDOMServerLifecycles', () => {
     expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
       'Component.getDerivedStateFromProps(): A valid state object (or null) must ' +
         'be returned. You have returned undefined.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // De-duped
@@ -203,7 +203,7 @@ describe('ReactDOMServerLifecycles', () => {
     expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
       'Component: Did not properly initialize state during construction. ' +
         'Expected state to be an object, but it was undefined.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // De-duped
@@ -260,7 +260,7 @@ describe('ReactDOMServerLifecycles', () => {
         'usually means you called setState() outside componentWillMount() on ' +
         'the server. This is a no-op.\n\n' +
         'Please check the code for the Outer component.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -267,7 +267,7 @@ describe('ReactDOMTextarea', () => {
       node = renderTextarea(stub, container);
     }).toWarnDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
-      {expectNoStack: true}, // TODO: add a stack
+      {withoutStack: true}, // TODO: add a stack
     );
 
     expect(node.value).toBe('giraffe');
@@ -320,7 +320,7 @@ describe('ReactDOMTextarea', () => {
       node = renderTextarea(<textarea>{17}</textarea>);
     }).toWarnDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
-      {expectNoStack: true}, // TODO: add a stack
+      {withoutStack: true}, // TODO: add a stack
     );
     expect(node.value).toBe('17');
   });
@@ -331,7 +331,7 @@ describe('ReactDOMTextarea', () => {
       node = renderTextarea(<textarea>{false}</textarea>);
     }).toWarnDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
-      {expectNoStack: true}, // TODO: add a stack
+      {withoutStack: true}, // TODO: add a stack
     );
     expect(node.value).toBe('false');
   });
@@ -347,7 +347,7 @@ describe('ReactDOMTextarea', () => {
       node = renderTextarea(<textarea>{obj}</textarea>);
     }).toWarnDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
-      {expectNoStack: true}, // TODO: add a stack
+      {withoutStack: true}, // TODO: add a stack
     );
     expect(node.value).toBe('sharkswithlasers');
   });
@@ -363,7 +363,7 @@ describe('ReactDOMTextarea', () => {
         ),
       ).toWarnDev(
         'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
     }).toThrow();
 
@@ -378,7 +378,7 @@ describe('ReactDOMTextarea', () => {
           )),
       ).toWarnDev(
         'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
     }).not.toThrow();
 
@@ -415,7 +415,7 @@ describe('ReactDOMTextarea', () => {
         'both). Decide between using a controlled or uncontrolled textarea ' +
         'and remove one of these props. More info: ' +
         'https://fb.me/react-controlled-components',
-      {expectNoStack: true}, // TODO: add a stack
+      {withoutStack: true}, // TODO: add a stack
     );
 
     // No additional warnings are expected

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -267,6 +267,7 @@ describe('ReactDOMTextarea', () => {
       node = renderTextarea(stub, container);
     }).toWarnDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+      {expectNoStack: true}, // TODO: add a stack
     );
 
     expect(node.value).toBe('giraffe');
@@ -319,6 +320,7 @@ describe('ReactDOMTextarea', () => {
       node = renderTextarea(<textarea>{17}</textarea>);
     }).toWarnDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+      {expectNoStack: true}, // TODO: add a stack
     );
     expect(node.value).toBe('17');
   });
@@ -329,6 +331,7 @@ describe('ReactDOMTextarea', () => {
       node = renderTextarea(<textarea>{false}</textarea>);
     }).toWarnDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+      {expectNoStack: true}, // TODO: add a stack
     );
     expect(node.value).toBe('false');
   });
@@ -344,6 +347,7 @@ describe('ReactDOMTextarea', () => {
       node = renderTextarea(<textarea>{obj}</textarea>);
     }).toWarnDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+      {expectNoStack: true}, // TODO: add a stack
     );
     expect(node.value).toBe('sharkswithlasers');
   });
@@ -359,6 +363,7 @@ describe('ReactDOMTextarea', () => {
         ),
       ).toWarnDev(
         'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+        {expectNoStack: true}, // TODO: add a stack
       );
     }).toThrow();
 
@@ -373,6 +378,7 @@ describe('ReactDOMTextarea', () => {
           )),
       ).toWarnDev(
         'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
+        {expectNoStack: true}, // TODO: add a stack
       );
     }).not.toThrow();
 
@@ -409,6 +415,7 @@ describe('ReactDOMTextarea', () => {
         'both). Decide between using a controlled or uncontrolled textarea ' +
         'and remove one of these props. More info: ' +
         'https://fb.me/react-controlled-components',
+      {expectNoStack: true}, // TODO: add a stack
     );
 
     // No additional warnings are expected

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -63,6 +63,7 @@ describe('ReactMount', () => {
       'Functions are not valid as a React child. ' +
         'This may happen if you return a Component instead of <Component /> from render. ' +
         'Or maybe you meant to call this function rather than return it.',
+      {expectNoStack: true},
     );
   });
 
@@ -126,6 +127,7 @@ describe('ReactMount', () => {
 
     expect(() => ReactDOM.hydrate(<div />, container)).toWarnDev(
       'Did not expect server HTML to contain the text node " " in <container>.',
+      {expectNoStack: true},
     );
   });
 
@@ -135,6 +137,7 @@ describe('ReactMount', () => {
 
     expect(() => ReactDOM.hydrate(<div />, container)).toWarnDev(
       'Did not expect server HTML to contain the text node " " in <container>.',
+      {expectNoStack: true},
     );
   });
 
@@ -153,6 +156,7 @@ describe('ReactMount', () => {
       ReactDOM.render(<div />, iFrame.contentDocument.body),
     ).toWarnDev(
       'Rendering components directly into document.body is discouraged',
+      {expectNoStack: true},
     );
   });
 
@@ -171,6 +175,7 @@ describe('ReactMount', () => {
     ).toWarnDev(
       'Server: "This markup contains an nbsp entity:   server text" ' +
         'Client: "This markup contains an nbsp entity:   client text"',
+      {expectNoStack: true},
     );
   });
 
@@ -197,6 +202,7 @@ describe('ReactMount', () => {
         'root component. If you intended to update the children of this node, ' +
         'you should instead have the existing children update their state and ' +
         'render the new components instead of calling ReactDOM.render.',
+      {expectNoStack: true},
     );
   });
 
@@ -222,6 +228,7 @@ describe('ReactMount', () => {
     expect(() => ReactDOMOther.unmountComponentAtNode(container)).toWarnDev(
       "Warning: unmountComponentAtNode(): The node you're attempting to unmount " +
         'was rendered by another copy of React.',
+      {expectNoStack: true},
     );
 
     // Don't throw a warning if the correct React copy unmounts the node

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -63,7 +63,7 @@ describe('ReactMount', () => {
       'Functions are not valid as a React child. ' +
         'This may happen if you return a Component instead of <Component /> from render. ' +
         'Or maybe you meant to call this function rather than return it.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -127,7 +127,7 @@ describe('ReactMount', () => {
 
     expect(() => ReactDOM.hydrate(<div />, container)).toWarnDev(
       'Did not expect server HTML to contain the text node " " in <container>.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -137,7 +137,7 @@ describe('ReactMount', () => {
 
     expect(() => ReactDOM.hydrate(<div />, container)).toWarnDev(
       'Did not expect server HTML to contain the text node " " in <container>.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -156,7 +156,7 @@ describe('ReactMount', () => {
       ReactDOM.render(<div />, iFrame.contentDocument.body),
     ).toWarnDev(
       'Rendering components directly into document.body is discouraged',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -175,7 +175,7 @@ describe('ReactMount', () => {
     ).toWarnDev(
       'Server: "This markup contains an nbsp entity:   server text" ' +
         'Client: "This markup contains an nbsp entity:   client text"',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -202,7 +202,7 @@ describe('ReactMount', () => {
         'root component. If you intended to update the children of this node, ' +
         'you should instead have the existing children update their state and ' +
         'render the new components instead of calling ReactDOM.render.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -228,7 +228,7 @@ describe('ReactMount', () => {
     expect(() => ReactDOMOther.unmountComponentAtNode(container)).toWarnDev(
       "Warning: unmountComponentAtNode(): The node you're attempting to unmount " +
         'was rendered by another copy of React.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // Don't throw a warning if the correct React copy unmounts the node

--- a/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
+++ b/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
@@ -55,7 +55,7 @@ describe('ReactMount', () => {
         'unmount was rendered by React and is not a top-level container. You ' +
         'may have accidentally passed in a React root node instead of its ' +
         'container.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -78,7 +78,7 @@ describe('ReactMount', () => {
         'unmount was rendered by React and is not a top-level container. ' +
         'Instead, have the parent component update its state and rerender in ' +
         'order to remove this component.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
+++ b/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
@@ -55,6 +55,7 @@ describe('ReactMount', () => {
         'unmount was rendered by React and is not a top-level container. You ' +
         'may have accidentally passed in a React root node instead of its ' +
         'container.',
+      {expectNoStack: true},
     );
   });
 
@@ -77,6 +78,7 @@ describe('ReactMount', () => {
         'unmount was rendered by React and is not a top-level container. ' +
         'Instead, have the parent component update its state and rerender in ' +
         'order to remove this component.',
+      {expectNoStack: true},
     );
   });
 });

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -39,7 +39,7 @@ describe('rendering React components at document', () => {
         'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
           'will stop working in React v17. Replace the ReactDOM.render() call ' +
           'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
-        {expectNoStack: true},
+        {withoutStack: true},
       );
     }
 
@@ -201,10 +201,10 @@ describe('rendering React components at document', () => {
           'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
             'will stop working in React v17. Replace the ReactDOM.render() call ' +
             'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
-          {expectNoStack: true},
+          {withoutStack: true},
         );
       }).toWarnDev('Warning: Text content did not match.', {
-        expectNoStack: true,
+        withoutStack: true,
       });
     });
 
@@ -373,7 +373,7 @@ describe('rendering React components at document', () => {
       container.textContent = 'potato';
       expect(() => ReactDOM.hydrate(<div>parsnip</div>, container)).toWarnDev(
         'Expected server HTML to contain a matching <div> in <div>.',
-        {expectNoStack: true},
+        {withoutStack: true},
       );
       expect(container.textContent).toBe('parsnip');
     });
@@ -400,7 +400,7 @@ describe('rendering React components at document', () => {
       expect(() =>
         ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
       ).toWarnDev('Warning: Text content did not match.', {
-        expectNoStack: true,
+        withoutStack: true,
       });
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });
@@ -425,7 +425,7 @@ describe('rendering React components at document', () => {
       expect(() =>
         ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
       ).toWarnDev('Did not expect server HTML to contain a <meta> in <head>.', {
-        expectNoStack: true,
+        withoutStack: true,
       });
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -39,6 +39,7 @@ describe('rendering React components at document', () => {
         'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
           'will stop working in React v17. Replace the ReactDOM.render() call ' +
           'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+        {expectNoStack: true},
       );
     }
 
@@ -200,8 +201,11 @@ describe('rendering React components at document', () => {
           'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
             'will stop working in React v17. Replace the ReactDOM.render() call ' +
             'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+          {expectNoStack: true},
         );
-      }).toWarnDev('Warning: Text content did not match.');
+      }).toWarnDev('Warning: Text content did not match.', {
+        expectNoStack: true,
+      });
     });
 
     it('should throw on full document render w/ no markup', () => {
@@ -369,6 +373,7 @@ describe('rendering React components at document', () => {
       container.textContent = 'potato';
       expect(() => ReactDOM.hydrate(<div>parsnip</div>, container)).toWarnDev(
         'Expected server HTML to contain a matching <div> in <div>.',
+        {expectNoStack: true},
       );
       expect(container.textContent).toBe('parsnip');
     });
@@ -394,7 +399,9 @@ describe('rendering React components at document', () => {
 
       expect(() =>
         ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
-      ).toWarnDev('Warning: Text content did not match.');
+      ).toWarnDev('Warning: Text content did not match.', {
+        expectNoStack: true,
+      });
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });
 
@@ -417,7 +424,9 @@ describe('rendering React components at document', () => {
       // getTestDocument() has an extra <meta> that we didn't render.
       expect(() =>
         ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
-      ).toWarnDev('Did not expect server HTML to contain a <meta> in <head>.');
+      ).toWarnDev('Did not expect server HTML to contain a <meta> in <head>.', {
+        expectNoStack: true,
+      });
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });
 

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -519,6 +519,7 @@ describe('ReactDOMServer', () => {
       'Warning: setState(...): Can only update a mounting component.' +
         ' This usually means you called setState() outside componentWillMount() on the server.' +
         ' This is a no-op.\n\nPlease check the code for the Foo component.',
+      {expectNoStack: true},
     );
 
     const markup = ReactDOMServer.renderToStaticMarkup(<Foo />);
@@ -546,6 +547,7 @@ describe('ReactDOMServer', () => {
       'Warning: forceUpdate(...): Can only update a mounting component. ' +
         'This usually means you called forceUpdate() outside componentWillMount() on the server. ' +
         'This is a no-op.\n\nPlease check the code for the Baz component.',
+      {expectNoStack: true},
     );
     const markup = ReactDOMServer.renderToStaticMarkup(<Baz />);
     expect(markup).toBe('<div></div>');
@@ -599,15 +601,18 @@ describe('ReactDOMServer', () => {
           </svg>
         </div>,
       ),
-    ).toWarnDev([
-      'Warning: <inPUT /> is using incorrect casing. ' +
-        'Use PascalCase for React components, ' +
-        'or lowercase for HTML elements.',
-      // linearGradient doesn't warn
-      'Warning: <iFrame /> is using incorrect casing. ' +
-        'Use PascalCase for React components, ' +
-        'or lowercase for HTML elements.',
-    ]);
+    ).toWarnDev(
+      [
+        'Warning: <inPUT /> is using incorrect casing. ' +
+          'Use PascalCase for React components, ' +
+          'or lowercase for HTML elements.',
+        // linearGradient doesn't warn
+        'Warning: <iFrame /> is using incorrect casing. ' +
+          'Use PascalCase for React components, ' +
+          'or lowercase for HTML elements.',
+      ],
+      {expectNoStack: true},
+    );
   });
 
   it('should warn about contentEditable and children', () => {

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -519,7 +519,7 @@ describe('ReactDOMServer', () => {
       'Warning: setState(...): Can only update a mounting component.' +
         ' This usually means you called setState() outside componentWillMount() on the server.' +
         ' This is a no-op.\n\nPlease check the code for the Foo component.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     const markup = ReactDOMServer.renderToStaticMarkup(<Foo />);
@@ -547,7 +547,7 @@ describe('ReactDOMServer', () => {
       'Warning: forceUpdate(...): Can only update a mounting component. ' +
         'This usually means you called forceUpdate() outside componentWillMount() on the server. ' +
         'This is a no-op.\n\nPlease check the code for the Baz component.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     const markup = ReactDOMServer.renderToStaticMarkup(<Baz />);
     expect(markup).toBe('<div></div>');
@@ -611,7 +611,7 @@ describe('ReactDOMServer', () => {
           'Use PascalCase for React components, ' +
           'or lowercase for HTML elements.',
       ],
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration.js
@@ -83,6 +83,7 @@ describe('ReactDOMServerHydration', () => {
         'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
           'will stop working in React v17. Replace the ReactDOM.render() call ' +
           'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+        {expectNoStack: true},
       );
       expect(mountCount).toEqual(3);
       expect(element.innerHTML).toBe(lastMarkup);
@@ -101,7 +102,9 @@ describe('ReactDOMServerHydration', () => {
       element.innerHTML = lastMarkup;
       expect(() => {
         instance = ReactDOM.render(<TestComponent name="y" />, element);
-      }).toWarnDev('Text content did not match. Server: "x" Client: "y"');
+      }).toWarnDev('Text content did not match. Server: "x" Client: "y"', {
+        expectNoStack: true,
+      });
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
       expect(element.innerHTML).not.toEqual(lastMarkup);
@@ -184,7 +187,9 @@ describe('ReactDOMServerHydration', () => {
       element.innerHTML = lastMarkup;
       expect(() => {
         instance = ReactDOM.hydrate(<TestComponent name="y" />, element);
-      }).toWarnDev('Text content did not match. Server: "x" Client: "y"');
+      }).toWarnDev('Text content did not match. Server: "x" Client: "y"', {
+        expectNoStack: true,
+      });
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
       expect(element.innerHTML).not.toEqual(lastMarkup);
@@ -247,6 +252,7 @@ describe('ReactDOMServerHydration', () => {
       ReactDOM.hydrate(<button autoFocus={false}>client</button>, element),
     ).toWarnDev(
       'Warning: Text content did not match. Server: "server" Client: "client"',
+      {expectNoStack: true},
     );
 
     expect(element.firstChild.focus).not.toHaveBeenCalled();
@@ -286,6 +292,7 @@ describe('ReactDOMServerHydration', () => {
 
     expect(() => ReactDOM.hydrate(markup, element)).toWarnDev(
       'Please update the following components to use componentDidMount instead: ComponentWithWarning',
+      {expectNoStack: true},
     );
     expect(element.textContent).toBe('Hi');
   });

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration.js
@@ -83,7 +83,7 @@ describe('ReactDOMServerHydration', () => {
         'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
           'will stop working in React v17. Replace the ReactDOM.render() call ' +
           'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
-        {expectNoStack: true},
+        {withoutStack: true},
       );
       expect(mountCount).toEqual(3);
       expect(element.innerHTML).toBe(lastMarkup);
@@ -103,7 +103,7 @@ describe('ReactDOMServerHydration', () => {
       expect(() => {
         instance = ReactDOM.render(<TestComponent name="y" />, element);
       }).toWarnDev('Text content did not match. Server: "x" Client: "y"', {
-        expectNoStack: true,
+        withoutStack: true,
       });
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
@@ -188,7 +188,7 @@ describe('ReactDOMServerHydration', () => {
       expect(() => {
         instance = ReactDOM.hydrate(<TestComponent name="y" />, element);
       }).toWarnDev('Text content did not match. Server: "x" Client: "y"', {
-        expectNoStack: true,
+        withoutStack: true,
       });
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
@@ -252,7 +252,7 @@ describe('ReactDOMServerHydration', () => {
       ReactDOM.hydrate(<button autoFocus={false}>client</button>, element),
     ).toWarnDev(
       'Warning: Text content did not match. Server: "server" Client: "client"',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     expect(element.firstChild.focus).not.toHaveBeenCalled();
@@ -292,7 +292,7 @@ describe('ReactDOMServerHydration', () => {
 
     expect(() => ReactDOM.hydrate(markup, element)).toWarnDev(
       'Please update the following components to use componentDidMount instead: ComponentWithWarning',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(element.textContent).toBe('Hi');
   });

--- a/packages/react-dom/src/__tests__/ReactStatelessComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactStatelessComponent-test.js
@@ -111,7 +111,7 @@ describe('ReactStatelessComponent', () => {
     ).toWarnDev(
       'StatelessComponentWithChildContext: Stateless ' +
         'functional components do not support getDerivedStateFromProps.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -134,7 +134,7 @@ describe('ReactStatelessComponent', () => {
     ).toWarnDev(
       'StatelessComponentWithChildContext(...): childContextTypes cannot ' +
         'be defined on a functional component.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactStatelessComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactStatelessComponent-test.js
@@ -111,6 +111,7 @@ describe('ReactStatelessComponent', () => {
     ).toWarnDev(
       'StatelessComponentWithChildContext: Stateless ' +
         'functional components do not support getDerivedStateFromProps.',
+      {expectNoStack: true},
     );
   });
 
@@ -133,6 +134,7 @@ describe('ReactStatelessComponent', () => {
     ).toWarnDev(
       'StatelessComponentWithChildContext(...): childContextTypes cannot ' +
         'be defined on a functional component.',
+      {expectNoStack: true},
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -59,6 +59,7 @@ describe('ReactTestUtils', () => {
       'ReactTestUtils.mockComponent() is deprecated. ' +
         'Use shallow rendering or jest.mock() instead.\n\n' +
         'See https://fb.me/test-utils-mock-component for more information.',
+      {expectNoStack: true},
     );
 
     // De-duplication check

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -59,7 +59,7 @@ describe('ReactTestUtils', () => {
       'ReactTestUtils.mockComponent() is deprecated. ' +
         'Use shallow rendering or jest.mock() instead.\n\n' +
         'See https://fb.me/test-utils-mock-component for more information.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // De-duplication check

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1226,6 +1226,7 @@ describe('ReactUpdates', () => {
     const container = document.createElement('div');
     expect(() => ReactDOM.render(<Foo />, container)).toWarnDev(
       'Cannot update during an existing state transition',
+      {expectNoStack: true},
     );
     expect(ops).toEqual(['base: 0, memoized: 0', 'base: 1, memoized: 1']);
   });

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1226,7 +1226,7 @@ describe('ReactUpdates', () => {
     const container = document.createElement('div');
     expect(() => ReactDOM.render(<Foo />, container)).toWarnDev(
       'Cannot update during an existing state transition',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(ops).toEqual(['base: 0, memoized: 0', 'base: 1, memoized: 1']);
   });

--- a/packages/react-dom/src/__tests__/validateDOMNesting-test.js
+++ b/packages/react-dom/src/__tests__/validateDOMNesting-test.js
@@ -12,7 +12,7 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 
-function expectWarnings(tags, warnings = []) {
+function expectWarnings(tags, warnings = [], expectNoStack = 0) {
   tags = [...tags];
   warnings = [...warnings];
 
@@ -28,7 +28,9 @@ function expectWarnings(tags, warnings = []) {
     element = <Tag>{element}</Tag>;
   }
 
-  expect(() => ReactDOM.render(element, container)).toWarnDev(warnings);
+  expect(() => ReactDOM.render(element, container)).toWarnDev(warnings, {
+    expectNoStack: expectNoStack,
+  });
 }
 
 describe('validateDOMNesting', () => {
@@ -39,6 +41,7 @@ describe('validateDOMNesting', () => {
       [
         'render(): Rendering components directly into document.body is discouraged',
       ],
+      1,
     );
     expectWarnings(['div', 'a', 'object', 'a']);
     expectWarnings(['div', 'p', 'button', 'p']);
@@ -106,6 +109,7 @@ describe('validateDOMNesting', () => {
         'validateDOMNesting(...): <body> cannot appear as a child of <body>.\n' +
           '    in body (at **)',
       ],
+      1,
     );
     expectWarnings(
       ['svg', 'foreignObject', 'body', 'p'],

--- a/packages/react-dom/src/__tests__/validateDOMNesting-test.js
+++ b/packages/react-dom/src/__tests__/validateDOMNesting-test.js
@@ -12,7 +12,7 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 
-function expectWarnings(tags, warnings = [], expectNoStack = 0) {
+function expectWarnings(tags, warnings = [], withoutStack = 0) {
   tags = [...tags];
   warnings = [...warnings];
 
@@ -29,7 +29,7 @@ function expectWarnings(tags, warnings = [], expectNoStack = 0) {
   }
 
   expect(() => ReactDOM.render(element, container)).toWarnDev(warnings, {
-    expectNoStack: expectNoStack,
+    withoutStack,
   });
 }
 

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -153,15 +153,15 @@ describe('SyntheticEvent', () => {
     // once for each property accessed
     expect(() => expect(syntheticEvent.type).toBe(null)).toWarnDev(
       getExpectedWarning('type'),
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(() => expect(syntheticEvent.nativeEvent).toBe(null)).toWarnDev(
       getExpectedWarning('nativeEvent'),
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(() => expect(syntheticEvent.target).toBe(null)).toWarnDev(
       getExpectedWarning('target'),
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     expect(expectedCount).toBe(1);
@@ -191,7 +191,7 @@ describe('SyntheticEvent', () => {
         'released/nullified synthetic event. This is effectively a no-op. If you must ' +
         'keep the original synthetic event around, use event.persist(). ' +
         'See https://fb.me/react-event-pooling for more information.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(expectedCount).toBe(1);
   });
@@ -217,7 +217,7 @@ describe('SyntheticEvent', () => {
         'released/nullified synthetic event. This is a no-op function. If you must ' +
         'keep the original synthetic event around, use event.persist(). ' +
         'See https://fb.me/react-event-pooling for more information.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(expectedCount).toBe(1);
   });
@@ -244,7 +244,7 @@ describe('SyntheticEvent', () => {
         'released/nullified synthetic event. This is a no-op function. If you must ' +
         'keep the original synthetic event around, use event.persist(). ' +
         'See https://fb.me/react-event-pooling for more information.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(expectedCount).toBe(1);
   });
@@ -266,7 +266,7 @@ describe('SyntheticEvent', () => {
         'released/nullified synthetic event. This is set to null. If you must ' +
         'keep the original synthetic event around, use event.persist(). ' +
         'See https://fb.me/react-event-pooling for more information.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -284,7 +284,7 @@ describe('SyntheticEvent', () => {
             "you're seeing this, you're adding a new property in the synthetic " +
             'event object. The property is never released. ' +
             'See https://fb.me/react-event-pooling for more information.',
-          {expectNoStack: true},
+          {withoutStack: true},
         );
       } else {
         e.foo = 'bar';

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -153,12 +153,15 @@ describe('SyntheticEvent', () => {
     // once for each property accessed
     expect(() => expect(syntheticEvent.type).toBe(null)).toWarnDev(
       getExpectedWarning('type'),
+      {expectNoStack: true},
     );
     expect(() => expect(syntheticEvent.nativeEvent).toBe(null)).toWarnDev(
       getExpectedWarning('nativeEvent'),
+      {expectNoStack: true},
     );
     expect(() => expect(syntheticEvent.target).toBe(null)).toWarnDev(
       getExpectedWarning('target'),
+      {expectNoStack: true},
     );
 
     expect(expectedCount).toBe(1);
@@ -188,6 +191,7 @@ describe('SyntheticEvent', () => {
         'released/nullified synthetic event. This is effectively a no-op. If you must ' +
         'keep the original synthetic event around, use event.persist(). ' +
         'See https://fb.me/react-event-pooling for more information.',
+      {expectNoStack: true},
     );
     expect(expectedCount).toBe(1);
   });
@@ -213,6 +217,7 @@ describe('SyntheticEvent', () => {
         'released/nullified synthetic event. This is a no-op function. If you must ' +
         'keep the original synthetic event around, use event.persist(). ' +
         'See https://fb.me/react-event-pooling for more information.',
+      {expectNoStack: true},
     );
     expect(expectedCount).toBe(1);
   });
@@ -239,6 +244,7 @@ describe('SyntheticEvent', () => {
         'released/nullified synthetic event. This is a no-op function. If you must ' +
         'keep the original synthetic event around, use event.persist(). ' +
         'See https://fb.me/react-event-pooling for more information.',
+      {expectNoStack: true},
     );
     expect(expectedCount).toBe(1);
   });
@@ -260,6 +266,7 @@ describe('SyntheticEvent', () => {
         'released/nullified synthetic event. This is set to null. If you must ' +
         'keep the original synthetic event around, use event.persist(). ' +
         'See https://fb.me/react-event-pooling for more information.',
+      {expectNoStack: true},
     );
   });
 
@@ -277,6 +284,7 @@ describe('SyntheticEvent', () => {
             "you're seeing this, you're adding a new property in the synthetic " +
             'event object. The property is never released. ' +
             'See https://fb.me/react-event-pooling for more information.',
+          {expectNoStack: true},
         );
       } else {
         e.foo = 'bar';

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -2403,6 +2403,7 @@ describe('ReactIncremental', () => {
     expect(ReactNoop.flush).toWarnDev(
       'componentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: MyComponent',
+      {expectNoStack: true},
     );
 
     expect(ops).toEqual([

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -2403,7 +2403,7 @@ describe('ReactIncremental', () => {
     expect(ReactNoop.flush).toWarnDev(
       'componentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: MyComponent',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     expect(ops).toEqual([

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1100,7 +1100,7 @@ describe('ReactIncrementalErrorHandling', () => {
     const InvalidType = undefined;
     expect(() => ReactNoop.render(<InvalidType />)).toWarnDev(
       'Warning: React.createElement: type is invalid -- expected a string',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(ReactNoop.flush).toThrowError(
       'Element type is invalid: expected a string (for built-in components) or ' +

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1100,6 +1100,7 @@ describe('ReactIncrementalErrorHandling', () => {
     const InvalidType = undefined;
     expect(() => ReactNoop.render(<InvalidType />)).toWarnDev(
       'Warning: React.createElement: type is invalid -- expected a string',
+      {expectNoStack: true},
     );
     expect(ReactNoop.flush).toThrowError(
       'Element type is invalid: expected a string (for built-in components) or ' +

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -314,12 +314,15 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Should not print a warning');
-    expect(ReactNoop.flush).toWarnDev([
-      'componentWillMount: Please update the following components ' +
-        'to use componentDidMount instead: NotCascading' +
-        '\n\ncomponentWillReceiveProps: Please update the following components ' +
-        'to use static getDerivedStateFromProps instead: NotCascading',
-    ]);
+    expect(ReactNoop.flush).toWarnDev(
+      [
+        'componentWillMount: Please update the following components ' +
+          'to use componentDidMount instead: NotCascading' +
+          '\n\ncomponentWillReceiveProps: Please update the following components ' +
+          'to use static getDerivedStateFromProps instead: NotCascading',
+      ],
+      {expectNoStack: true},
+    );
     ReactNoop.render(
       <Parent>
         <NotCascading />
@@ -360,6 +363,7 @@ describe('ReactDebugFiberPerf', () => {
         'to use static getDerivedStateFromProps instead: AllLifecycles' +
         '\n\ncomponentWillUpdate: Please update the following components ' +
         'to use componentDidUpdate instead: AllLifecycles',
+      {expectNoStack: true},
     );
     ReactNoop.render(<AllLifecycles />);
     addComment('Update');

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -321,7 +321,7 @@ describe('ReactDebugFiberPerf', () => {
           '\n\ncomponentWillReceiveProps: Please update the following components ' +
           'to use static getDerivedStateFromProps instead: NotCascading',
       ],
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     ReactNoop.render(
       <Parent>
@@ -363,7 +363,7 @@ describe('ReactDebugFiberPerf', () => {
         'to use static getDerivedStateFromProps instead: AllLifecycles' +
         '\n\ncomponentWillUpdate: Please update the following components ' +
         'to use componentDidUpdate instead: AllLifecycles',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     ReactNoop.render(<AllLifecycles />);
     addComment('Update');

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
@@ -65,7 +65,7 @@ describe('ReactIncrementalReflection', () => {
     expect(ReactNoop.flush).toWarnDev(
       'componentWillMount: Please update the following components ' +
         'to use componentDidMount instead: Component',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     expect(ops).toEqual(['componentDidMount', true]);
@@ -107,7 +107,7 @@ describe('ReactIncrementalReflection', () => {
     expect(ReactNoop.flush).toWarnDev(
       'componentWillMount: Please update the following components ' +
         'to use componentDidMount instead: Component',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     expect(ops).toEqual(['Component']);
@@ -200,7 +200,7 @@ describe('ReactIncrementalReflection', () => {
         'to use componentDidMount instead: Component' +
         '\n\ncomponentWillUpdate: Please update the following components ' +
         'to use componentDidUpdate instead: Component',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     const hostSpan = classInstance.span;

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
@@ -65,6 +65,7 @@ describe('ReactIncrementalReflection', () => {
     expect(ReactNoop.flush).toWarnDev(
       'componentWillMount: Please update the following components ' +
         'to use componentDidMount instead: Component',
+      {expectNoStack: true},
     );
 
     expect(ops).toEqual(['componentDidMount', true]);
@@ -106,6 +107,7 @@ describe('ReactIncrementalReflection', () => {
     expect(ReactNoop.flush).toWarnDev(
       'componentWillMount: Please update the following components ' +
         'to use componentDidMount instead: Component',
+      {expectNoStack: true},
     );
 
     expect(ops).toEqual(['Component']);
@@ -198,6 +200,7 @@ describe('ReactIncrementalReflection', () => {
         'to use componentDidMount instead: Component' +
         '\n\ncomponentWillUpdate: Please update the following components ' +
         'to use componentDidUpdate instead: Component',
+      {expectNoStack: true},
     );
 
     const hostSpan = classInstance.span;

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
@@ -353,7 +353,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.flush).toWarnDev(
       'componentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: Foo',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     ReactNoop.render(<Foo step={2} />);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
@@ -353,6 +353,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.flush).toWarnDev(
       'componentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: Foo',
+      {expectNoStack: true},
     );
 
     ReactNoop.render(<Foo step={2} />);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -345,6 +345,7 @@ describe('ReactIncrementalUpdates', () => {
     expect(ReactNoop.flush).toWarnDev(
       'componentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: Foo',
+      {expectNoStack: true},
     );
 
     ops = [];
@@ -385,6 +386,7 @@ describe('ReactIncrementalUpdates', () => {
         'from inside an update function. Update functions should be pure, ' +
         'with zero side-effects. Consider using componentDidUpdate or a ' +
         'callback.',
+      {expectNoStack: true},
     );
     expect(ops).toEqual([
       // Initial render

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -345,7 +345,7 @@ describe('ReactIncrementalUpdates', () => {
     expect(ReactNoop.flush).toWarnDev(
       'componentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: Foo',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     ops = [];
@@ -386,7 +386,7 @@ describe('ReactIncrementalUpdates', () => {
         'from inside an update function. Update functions should be pure, ' +
         'with zero side-effects. Consider using componentDidUpdate or a ' +
         'callback.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(ops).toEqual([
       // Initial render

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -720,6 +720,7 @@ describe('ReactNewContext', () => {
       expect(console.error.calls.argsFor(0)[0]).toContain(
         'calculateChangedBits: Expected the return value to be a 31-bit ' +
           'integer. Instead received: 4294967295',
+        {expectNoStack: true}, // TODO: add a stack
       );
     }
   });

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -720,7 +720,7 @@ describe('ReactNewContext', () => {
       expect(console.error.calls.argsFor(0)[0]).toContain(
         'calculateChangedBits: Expected the return value to be a 31-bit ' +
           'integer. Instead received: 4294967295',
-        {expectNoStack: true}, // TODO: add a stack
+        {withoutStack: true}, // TODO: add a stack
       );
     }
   });

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -928,7 +928,7 @@ describe('ReactChildren', () => {
         'Warning: ' +
           'Each child in an array or iterator should have a unique "key" prop.' +
           ' See https://fb.me/react-warning-keys for more information.',
-        {expectNoStack: true}, // There's nothing on the stack
+        {withoutStack: true}, // There's nothing on the stack
       );
     });
   });

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -928,6 +928,7 @@ describe('ReactChildren', () => {
         'Warning: ' +
           'Each child in an array or iterator should have a unique "key" prop.' +
           ' See https://fb.me/react-warning-keys for more information.',
+        {expectNoStack: true}, // There's nothing on the stack
       );
     });
   });

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -55,7 +55,7 @@ describe 'ReactCoffeeScriptClass', ->
       # A failed component renders twice in DEV
       'No `render` method found on the returned component instance',
       'No `render` method found on the returned component instance',
-    ], {expectNoStack: true})
+    ], {withoutStack: true})
     undefined
 
   it 'renders a simple stateless component with prop', ->
@@ -126,7 +126,7 @@ describe 'ReactCoffeeScriptClass', ->
         {}
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: getDerivedStateFromProps() is defined as an instance method and will be ignored. Instead, declare it as a static method.', {expectNoStack: true}
+    ).toWarnDev 'Foo: getDerivedStateFromProps() is defined as an instance method and will be ignored. Instead, declare it as a static method.', {withoutStack: true}
     undefined
 
   it 'warns if getDerivedStateFromCatch is not static', ->
@@ -137,7 +137,7 @@ describe 'ReactCoffeeScriptClass', ->
         {}
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: getDerivedStateFromCatch() is defined as an instance method and will be ignored. Instead, declare it as a static method.', {expectNoStack: true}
+    ).toWarnDev 'Foo: getDerivedStateFromCatch() is defined as an instance method and will be ignored. Instead, declare it as a static method.', {withoutStack: true}
     undefined
 
   it 'warns if getSnapshotBeforeUpdate is static', ->
@@ -148,7 +148,7 @@ describe 'ReactCoffeeScriptClass', ->
       {}
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: getSnapshotBeforeUpdate() is defined as a static method and will be ignored. Instead, declare it as an instance method.', {expectNoStack: true}
+    ).toWarnDev 'Foo: getSnapshotBeforeUpdate() is defined as a static method and will be ignored. Instead, declare it as an instance method.', {withoutStack: true}
     undefined
 
   it 'warns if state not initialized before static getDerivedStateFromProps', ->
@@ -163,7 +163,7 @@ describe 'ReactCoffeeScriptClass', ->
       }
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: Did not properly initialize state during construction. Expected state to be an object, but it was undefined.', {expectNoStack: true}
+    ).toWarnDev 'Foo: Did not properly initialize state during construction. Expected state to be an object, but it was undefined.', {withoutStack: true}
     undefined
 
   it 'updates initial state with values returned by static getDerivedStateFromProps', ->
@@ -262,7 +262,7 @@ describe 'ReactCoffeeScriptClass', ->
 
       expect(->
         test React.createElement(Foo), 'SPAN', ''
-      ).toWarnDev('Foo.state: must be set to an object or null', {expectNoStack: true})
+      ).toWarnDev('Foo.state: must be set to an object or null', {withoutStack: true})
     undefined
 
   it 'should render with null in the initial state property', ->
@@ -408,7 +408,7 @@ describe 'ReactCoffeeScriptClass', ->
       'getDefaultProps was defined on Foo, a plain JavaScript class.',
       'propTypes was defined as an instance property on Foo.',
       'contextTypes was defined as an instance property on Foo.',
-    ], {expectNoStack: true})
+    ], {withoutStack: true})
     expect(getInitialStateWasCalled).toBe false
     expect(getDefaultPropsWasCalled).toBe false
     undefined
@@ -445,7 +445,7 @@ describe 'ReactCoffeeScriptClass', ->
       'Warning: NamedComponent has a method called componentShouldUpdate().
        Did you mean shouldComponentUpdate()? The name is phrased as a
        question because the function is expected to return a value.',
-       {expectNoStack: true}
+       {withoutStack: true}
     )
     undefined
 
@@ -463,7 +463,7 @@ describe 'ReactCoffeeScriptClass', ->
     ).toWarnDev(
       'Warning: NamedComponent has a method called componentWillRecieveProps().
        Did you mean componentWillReceiveProps()?',
-       {expectNoStack: true}
+       {withoutStack: true}
     )
     undefined
 
@@ -481,7 +481,7 @@ describe 'ReactCoffeeScriptClass', ->
     ).toWarnDev(
       'Warning: NamedComponent has a method called UNSAFE_componentWillRecieveProps().
        Did you mean UNSAFE_componentWillReceiveProps()?',
-       {expectNoStack: true}
+       {withoutStack: true}
     )
     undefined
 
@@ -492,13 +492,13 @@ describe 'ReactCoffeeScriptClass', ->
       expect(-> instance.replaceState {}).toThrow()
     ).toLowPriorityWarnDev(
       'replaceState(...) is deprecated in plain JavaScript React classes',
-      {expectNoStack: true}
+      {withoutStack: true}
     )
     expect(->
       expect(-> instance.isMounted()).toThrow()
     ).toLowPriorityWarnDev(
       'isMounted(...) is deprecated in plain JavaScript React classes',
-      {expectNoStack: true}
+      {withoutStack: true}
     )
     undefined
 

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -55,7 +55,7 @@ describe 'ReactCoffeeScriptClass', ->
       # A failed component renders twice in DEV
       'No `render` method found on the returned component instance',
       'No `render` method found on the returned component instance',
-    ])
+    ], {expectNoStack: true})
     undefined
 
   it 'renders a simple stateless component with prop', ->
@@ -126,7 +126,7 @@ describe 'ReactCoffeeScriptClass', ->
         {}
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: getDerivedStateFromProps() is defined as an instance method and will be ignored. Instead, declare it as a static method.',
+    ).toWarnDev 'Foo: getDerivedStateFromProps() is defined as an instance method and will be ignored. Instead, declare it as a static method.', {expectNoStack: true}
     undefined
 
   it 'warns if getDerivedStateFromCatch is not static', ->
@@ -137,7 +137,7 @@ describe 'ReactCoffeeScriptClass', ->
         {}
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: getDerivedStateFromCatch() is defined as an instance method and will be ignored. Instead, declare it as a static method.',
+    ).toWarnDev 'Foo: getDerivedStateFromCatch() is defined as an instance method and will be ignored. Instead, declare it as a static method.', {expectNoStack: true}
     undefined
 
   it 'warns if getSnapshotBeforeUpdate is static', ->
@@ -148,7 +148,7 @@ describe 'ReactCoffeeScriptClass', ->
       {}
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: getSnapshotBeforeUpdate() is defined as a static method and will be ignored. Instead, declare it as an instance method.',
+    ).toWarnDev 'Foo: getSnapshotBeforeUpdate() is defined as a static method and will be ignored. Instead, declare it as an instance method.', {expectNoStack: true}
     undefined
 
   it 'warns if state not initialized before static getDerivedStateFromProps', ->
@@ -163,7 +163,7 @@ describe 'ReactCoffeeScriptClass', ->
       }
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: Did not properly initialize state during construction. Expected state to be an object, but it was undefined.'
+    ).toWarnDev 'Foo: Did not properly initialize state during construction. Expected state to be an object, but it was undefined.', {expectNoStack: true}
     undefined
 
   it 'updates initial state with values returned by static getDerivedStateFromProps', ->
@@ -262,7 +262,7 @@ describe 'ReactCoffeeScriptClass', ->
 
       expect(->
         test React.createElement(Foo), 'SPAN', ''
-      ).toWarnDev('Foo.state: must be set to an object or null')
+      ).toWarnDev('Foo.state: must be set to an object or null', {expectNoStack: true})
     undefined
 
   it 'should render with null in the initial state property', ->
@@ -408,7 +408,7 @@ describe 'ReactCoffeeScriptClass', ->
       'getDefaultProps was defined on Foo, a plain JavaScript class.',
       'propTypes was defined as an instance property on Foo.',
       'contextTypes was defined as an instance property on Foo.',
-    ])
+    ], {expectNoStack: true})
     expect(getInitialStateWasCalled).toBe false
     expect(getDefaultPropsWasCalled).toBe false
     undefined
@@ -444,7 +444,8 @@ describe 'ReactCoffeeScriptClass', ->
     ).toWarnDev(
       'Warning: NamedComponent has a method called componentShouldUpdate().
        Did you mean shouldComponentUpdate()? The name is phrased as a
-       question because the function is expected to return a value.'
+       question because the function is expected to return a value.',
+       {expectNoStack: true}
     )
     undefined
 
@@ -461,7 +462,8 @@ describe 'ReactCoffeeScriptClass', ->
       test React.createElement(NamedComponent), 'SPAN', 'foo'
     ).toWarnDev(
       'Warning: NamedComponent has a method called componentWillRecieveProps().
-       Did you mean componentWillReceiveProps()?'
+       Did you mean componentWillReceiveProps()?',
+       {expectNoStack: true}
     )
     undefined
 
@@ -478,7 +480,8 @@ describe 'ReactCoffeeScriptClass', ->
       test React.createElement(NamedComponent), 'SPAN', 'foo'
     ).toWarnDev(
       'Warning: NamedComponent has a method called UNSAFE_componentWillRecieveProps().
-       Did you mean UNSAFE_componentWillReceiveProps()?'
+       Did you mean UNSAFE_componentWillReceiveProps()?',
+       {expectNoStack: true}
     )
     undefined
 
@@ -488,12 +491,14 @@ describe 'ReactCoffeeScriptClass', ->
     expect(->
       expect(-> instance.replaceState {}).toThrow()
     ).toLowPriorityWarnDev(
-      'replaceState(...) is deprecated in plain JavaScript React classes'
+      'replaceState(...) is deprecated in plain JavaScript React classes',
+      {expectNoStack: true}
     )
     expect(->
       expect(-> instance.isMounted()).toThrow()
     ).toLowPriorityWarnDev(
-      'isMounted(...) is deprecated in plain JavaScript React classes'
+      'isMounted(...) is deprecated in plain JavaScript React classes',
+      {expectNoStack: true}
     )
     undefined
 

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -271,6 +271,7 @@ describe('ReactContextValidator', () => {
       'Warning: ComponentA.childContextTypes is specified but there is no ' +
         'getChildContext() method on the instance. You can either define ' +
         'getChildContext() on ComponentA or remove childContextTypes from it.',
+      {expectNoStack: true},
     );
 
     // Warnings should be deduped by component type
@@ -280,6 +281,7 @@ describe('ReactContextValidator', () => {
       'Warning: ComponentB.childContextTypes is specified but there is no ' +
         'getChildContext() method on the instance. You can either define ' +
         'getChildContext() on ComponentB or remove childContextTypes from it.',
+      {expectNoStack: true},
     );
   });
 
@@ -323,13 +325,16 @@ describe('ReactContextValidator', () => {
 
     expect(() =>
       ReactTestUtils.renderIntoDocument(<ParentContextProvider />),
-    ).toWarnDev([
-      'Warning: MiddleMissingContext.childContextTypes is specified but there is no getChildContext() method on the ' +
-        'instance. You can either define getChildContext() on MiddleMissingContext or remove childContextTypes from ' +
-        'it.',
-      'Warning: Failed context type: The context `bar` is marked as required in `ChildContextConsumer`, but its ' +
-        'value is `undefined`.',
-    ]);
+    ).toWarnDev(
+      [
+        'Warning: MiddleMissingContext.childContextTypes is specified but there is no getChildContext() method on the ' +
+          'instance. You can either define getChildContext() on MiddleMissingContext or remove childContextTypes from ' +
+          'it.',
+        'Warning: Failed context type: The context `bar` is marked as required in `ChildContextConsumer`, but its ' +
+          'value is `undefined`.',
+      ],
+      {expectNoStack: 1},
+    );
     expect(childContext.bar).toBeUndefined();
     expect(childContext.foo).toBe('FOO');
   });

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -271,7 +271,7 @@ describe('ReactContextValidator', () => {
       'Warning: ComponentA.childContextTypes is specified but there is no ' +
         'getChildContext() method on the instance. You can either define ' +
         'getChildContext() on ComponentA or remove childContextTypes from it.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // Warnings should be deduped by component type
@@ -281,7 +281,7 @@ describe('ReactContextValidator', () => {
       'Warning: ComponentB.childContextTypes is specified but there is no ' +
         'getChildContext() method on the instance. You can either define ' +
         'getChildContext() on ComponentB or remove childContextTypes from it.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -333,7 +333,7 @@ describe('ReactContextValidator', () => {
         'Warning: Failed context type: The context `bar` is marked as required in `ChildContextConsumer`, but its ' +
           'value is `undefined`.',
       ],
-      {expectNoStack: 1},
+      {withoutStack: 1},
     );
     expect(childContext.bar).toBeUndefined();
     expect(childContext.foo).toBe('FOO');

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -327,11 +327,11 @@ describe('ReactContextValidator', () => {
       ReactTestUtils.renderIntoDocument(<ParentContextProvider />),
     ).toWarnDev(
       [
-        'Warning: MiddleMissingContext.childContextTypes is specified but there is no getChildContext() method on the ' +
-          'instance. You can either define getChildContext() on MiddleMissingContext or remove childContextTypes from ' +
-          'it.',
-        'Warning: Failed context type: The context `bar` is marked as required in `ChildContextConsumer`, but its ' +
-          'value is `undefined`.',
+        'Warning: MiddleMissingContext.childContextTypes is specified but there is no ' +
+          'getChildContext() method on the instance. You can either define getChildContext() ' +
+          'on MiddleMissingContext or remove childContextTypes from it.',
+        'Warning: Failed context type: The context `bar` is marked as required ' +
+          'in `ChildContextConsumer`, but its value is `undefined`.',
       ],
       {withoutStack: 1},
     );

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -67,7 +67,7 @@ describe('ReactES6Class', () => {
         'Warning: Foo(...): No `render` method found on the returned component ' +
           'instance: you may have forgotten to define `render`.',
       ],
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -143,7 +143,7 @@ describe('ReactES6Class', () => {
     expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
       'Foo: getDerivedStateFromProps() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -159,7 +159,7 @@ describe('ReactES6Class', () => {
     expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
       'Foo: getDerivedStateFromCatch() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -173,7 +173,7 @@ describe('ReactES6Class', () => {
     expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
       'Foo: getSnapshotBeforeUpdate() is defined as a static method ' +
         'and will be ignored. Instead, declare it as an instance method.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -192,7 +192,7 @@ describe('ReactES6Class', () => {
     expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
       'Foo: Did not properly initialize state during construction. ' +
         'Expected state to be an object, but it was undefined.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -298,7 +298,7 @@ describe('ReactES6Class', () => {
       }
       expect(() => test(<Foo />, 'SPAN', '')).toWarnDev(
         'Foo.state: must be set to an object or null',
-        {expectNoStack: true},
+        {withoutStack: true},
       );
     });
   });
@@ -455,7 +455,7 @@ describe('ReactES6Class', () => {
         'propTypes was defined as an instance property on Foo.',
         'contextTypes was defined as an instance property on Foo.',
       ],
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(getInitialStateWasCalled).toBe(false);
     expect(getDefaultPropsWasCalled).toBe(false);
@@ -489,7 +489,7 @@ describe('ReactES6Class', () => {
         'NamedComponent has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -507,7 +507,7 @@ describe('ReactES6Class', () => {
       'Warning: ' +
         'NamedComponent has a method called componentWillRecieveProps(). Did ' +
         'you mean componentWillReceiveProps()?',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -525,7 +525,7 @@ describe('ReactES6Class', () => {
       'Warning: ' +
         'NamedComponent has a method called UNSAFE_componentWillRecieveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -535,13 +535,13 @@ describe('ReactES6Class', () => {
       expect(() => instance.replaceState({})).toThrow(),
     ).toLowPriorityWarnDev(
       'replaceState(...) is deprecated in plain JavaScript React classes',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(() =>
       expect(() => instance.isMounted()).toThrow(),
     ).toLowPriorityWarnDev(
       'isMounted(...) is deprecated in plain JavaScript React classes',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -59,13 +59,16 @@ describe('ReactES6Class', () => {
     class Foo extends React.Component {}
     expect(() =>
       expect(() => ReactDOM.render(<Foo />, container)).toThrow(),
-    ).toWarnDev([
-      // A failed component renders twice in DEV
-      'Warning: Foo(...): No `render` method found on the returned component ' +
-        'instance: you may have forgotten to define `render`.',
-      'Warning: Foo(...): No `render` method found on the returned component ' +
-        'instance: you may have forgotten to define `render`.',
-    ]);
+    ).toWarnDev(
+      [
+        // A failed component renders twice in DEV
+        'Warning: Foo(...): No `render` method found on the returned component ' +
+          'instance: you may have forgotten to define `render`.',
+        'Warning: Foo(...): No `render` method found on the returned component ' +
+          'instance: you may have forgotten to define `render`.',
+      ],
+      {expectNoStack: true},
+    );
   });
 
   it('renders a simple stateless component with prop', () => {
@@ -140,6 +143,7 @@ describe('ReactES6Class', () => {
     expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
       'Foo: getDerivedStateFromProps() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
+      {expectNoStack: true},
     );
   });
 
@@ -155,6 +159,7 @@ describe('ReactES6Class', () => {
     expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
       'Foo: getDerivedStateFromCatch() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
+      {expectNoStack: true},
     );
   });
 
@@ -168,6 +173,7 @@ describe('ReactES6Class', () => {
     expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
       'Foo: getSnapshotBeforeUpdate() is defined as a static method ' +
         'and will be ignored. Instead, declare it as an instance method.',
+      {expectNoStack: true},
     );
   });
 
@@ -186,6 +192,7 @@ describe('ReactES6Class', () => {
     expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
       'Foo: Did not properly initialize state during construction. ' +
         'Expected state to be an object, but it was undefined.',
+      {expectNoStack: true},
     );
   });
 
@@ -291,6 +298,7 @@ describe('ReactES6Class', () => {
       }
       expect(() => test(<Foo />, 'SPAN', '')).toWarnDev(
         'Foo.state: must be set to an object or null',
+        {expectNoStack: true},
       );
     });
   });
@@ -440,12 +448,15 @@ describe('ReactES6Class', () => {
       }
     }
 
-    expect(() => test(<Foo />, 'SPAN', 'foo')).toWarnDev([
-      'getInitialState was defined on Foo, a plain JavaScript class.',
-      'getDefaultProps was defined on Foo, a plain JavaScript class.',
-      'propTypes was defined as an instance property on Foo.',
-      'contextTypes was defined as an instance property on Foo.',
-    ]);
+    expect(() => test(<Foo />, 'SPAN', 'foo')).toWarnDev(
+      [
+        'getInitialState was defined on Foo, a plain JavaScript class.',
+        'getDefaultProps was defined on Foo, a plain JavaScript class.',
+        'propTypes was defined as an instance property on Foo.',
+        'contextTypes was defined as an instance property on Foo.',
+      ],
+      {expectNoStack: true},
+    );
     expect(getInitialStateWasCalled).toBe(false);
     expect(getDefaultPropsWasCalled).toBe(false);
   });
@@ -478,6 +489,7 @@ describe('ReactES6Class', () => {
         'NamedComponent has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
+      {expectNoStack: true},
     );
   });
 
@@ -495,6 +507,7 @@ describe('ReactES6Class', () => {
       'Warning: ' +
         'NamedComponent has a method called componentWillRecieveProps(). Did ' +
         'you mean componentWillReceiveProps()?',
+      {expectNoStack: true},
     );
   });
 
@@ -512,6 +525,7 @@ describe('ReactES6Class', () => {
       'Warning: ' +
         'NamedComponent has a method called UNSAFE_componentWillRecieveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?',
+      {expectNoStack: true},
     );
   });
 
@@ -521,11 +535,13 @@ describe('ReactES6Class', () => {
       expect(() => instance.replaceState({})).toThrow(),
     ).toLowPriorityWarnDev(
       'replaceState(...) is deprecated in plain JavaScript React classes',
+      {expectNoStack: true},
     );
     expect(() =>
       expect(() => instance.isMounted()).toThrow(),
     ).toLowPriorityWarnDev(
       'isMounted(...) is deprecated in plain JavaScript React classes',
+      {expectNoStack: true},
     );
   });
 

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -80,7 +80,7 @@ describe('ReactElement', () => {
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +
         'prop. (https://fb.me/react-special-props)',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -91,7 +91,7 @@ describe('ReactElement', () => {
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +
         'prop. (https://fb.me/react-special-props)',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -116,7 +116,7 @@ describe('ReactElement', () => {
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +
         'prop. (https://fb.me/react-special-props)',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -80,6 +80,7 @@ describe('ReactElement', () => {
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +
         'prop. (https://fb.me/react-special-props)',
+      {expectNoStack: true},
     );
   });
 
@@ -90,6 +91,7 @@ describe('ReactElement', () => {
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +
         'prop. (https://fb.me/react-special-props)',
+      {expectNoStack: true},
     );
   });
 
@@ -114,6 +116,7 @@ describe('ReactElement', () => {
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +
         'prop. (https://fb.me/react-special-props)',
+      {expectNoStack: true},
     );
   });
 

--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -235,27 +235,30 @@ describe('ReactElementValidator', () => {
       React.createElement(true);
       React.createElement({x: 17});
       React.createElement({});
-    }).toWarnDev([
-      'Warning: React.createElement: type is invalid -- expected a string ' +
-        '(for built-in components) or a class/function (for composite ' +
-        'components) but got: undefined. You likely forgot to export your ' +
-        "component from the file it's defined in, or you might have mixed up " +
-        'default and named imports.',
-      'Warning: React.createElement: type is invalid -- expected a string ' +
-        '(for built-in components) or a class/function (for composite ' +
-        'components) but got: null.',
-      'Warning: React.createElement: type is invalid -- expected a string ' +
-        '(for built-in components) or a class/function (for composite ' +
-        'components) but got: boolean.',
-      'Warning: React.createElement: type is invalid -- expected a string ' +
-        '(for built-in components) or a class/function (for composite ' +
-        'components) but got: object.',
-      'Warning: React.createElement: type is invalid -- expected a string ' +
-        '(for built-in components) or a class/function (for composite ' +
-        'components) but got: object. You likely forgot to export your ' +
-        "component from the file it's defined in, or you might have mixed up " +
-        'default and named imports.',
-    ]);
+    }).toWarnDev(
+      [
+        'Warning: React.createElement: type is invalid -- expected a string ' +
+          '(for built-in components) or a class/function (for composite ' +
+          'components) but got: undefined. You likely forgot to export your ' +
+          "component from the file it's defined in, or you might have mixed up " +
+          'default and named imports.',
+        'Warning: React.createElement: type is invalid -- expected a string ' +
+          '(for built-in components) or a class/function (for composite ' +
+          'components) but got: null.',
+        'Warning: React.createElement: type is invalid -- expected a string ' +
+          '(for built-in components) or a class/function (for composite ' +
+          'components) but got: boolean.',
+        'Warning: React.createElement: type is invalid -- expected a string ' +
+          '(for built-in components) or a class/function (for composite ' +
+          'components) but got: object.',
+        'Warning: React.createElement: type is invalid -- expected a string ' +
+          '(for built-in components) or a class/function (for composite ' +
+          'components) but got: object. You likely forgot to export your ' +
+          "component from the file it's defined in, or you might have mixed up " +
+          'default and named imports.',
+      ],
+      {expectNoStack: true},
+    );
 
     // Should not log any additional warnings
     React.createElement('div');
@@ -372,6 +375,7 @@ describe('ReactElementValidator', () => {
         'returned a function. You may have forgotten to pass an argument to ' +
         'the type checker creator (arrayOf, instanceOf, objectOf, oneOf, ' +
         'oneOfType, and shape all require an argument).',
+      {expectNoStack: true},
     );
   });
 
@@ -392,6 +396,7 @@ describe('ReactElementValidator', () => {
     }).toWarnDev(
       'Warning: Component MisspelledPropTypesComponent declared `PropTypes` ' +
         'instead of `propTypes`. Did you misspell the property assignment?',
+      {expectNoStack: true},
     );
   });
 
@@ -404,6 +409,7 @@ describe('ReactElementValidator', () => {
     expect(() => TestFactory.type).toLowPriorityWarnDev(
       'Warning: Factory.type is deprecated. Access the class directly before ' +
         'passing it to createFactory.',
+      {expectNoStack: true},
     );
 
     // Warn once, not again
@@ -471,6 +477,7 @@ describe('ReactElementValidator', () => {
         'components) but got: undefined. You likely forgot to export your ' +
         "component from the file it's defined in, or you might have mixed up " +
         'default and named imports.\n\nCheck your code at **.',
+      {expectNoStack: true},
     );
   });
 });

--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -257,7 +257,7 @@ describe('ReactElementValidator', () => {
           "component from the file it's defined in, or you might have mixed up " +
           'default and named imports.',
       ],
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // Should not log any additional warnings
@@ -375,7 +375,7 @@ describe('ReactElementValidator', () => {
         'returned a function. You may have forgotten to pass an argument to ' +
         'the type checker creator (arrayOf, instanceOf, objectOf, oneOf, ' +
         'oneOfType, and shape all require an argument).',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -396,7 +396,7 @@ describe('ReactElementValidator', () => {
     }).toWarnDev(
       'Warning: Component MisspelledPropTypesComponent declared `PropTypes` ' +
         'instead of `propTypes`. Did you misspell the property assignment?',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -409,7 +409,7 @@ describe('ReactElementValidator', () => {
     expect(() => TestFactory.type).toLowPriorityWarnDev(
       'Warning: Factory.type is deprecated. Access the class directly before ' +
         'passing it to createFactory.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // Warn once, not again
@@ -477,7 +477,7 @@ describe('ReactElementValidator', () => {
         'components) but got: undefined. You likely forgot to export your ' +
         "component from the file it's defined in, or you might have mixed up " +
         'default and named imports.\n\nCheck your code at **.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 });

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -221,18 +221,21 @@ describe('ReactJSXElementValidator', () => {
         "component from the file it's defined in, or you might have mixed up " +
         'default and named imports.' +
         '\n\nCheck your code at **.',
+      {expectNoStack: true},
     );
     expect(() => void <Null />).toWarnDev(
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: null.' +
         '\n\nCheck your code at **.',
+      {expectNoStack: true},
     );
     expect(() => void <True />).toWarnDev(
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: boolean.' +
         '\n\nCheck your code at **.',
+      {expectNoStack: true},
     );
     // No error expected
     void <Div />;
@@ -334,6 +337,7 @@ describe('ReactJSXElementValidator', () => {
     ).toWarnDev(
       'getDefaultProps is only used on classic React.createClass definitions.' +
         ' Use a static property named `defaultProps` instead.',
+      {expectNoStack: true},
     );
   });
 
@@ -353,6 +357,7 @@ describe('ReactJSXElementValidator', () => {
     ).toWarnDev(
       'Warning: Component MisspelledPropTypesComponent declared `PropTypes` ' +
         'instead of `propTypes`. Did you misspell the property assignment?',
+      {expectNoStack: true},
     );
   });
 
@@ -406,6 +411,8 @@ describe('ReactJSXElementValidator', () => {
           <span key="b">3</span>
         </React.Fragment>,
       ),
-    ).toWarnDev('Encountered two children with the same key, `a`.');
+    ).toWarnDev('Encountered two children with the same key, `a`.', {
+      expectNoStack: true,
+    });
   });
 });

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -221,21 +221,21 @@ describe('ReactJSXElementValidator', () => {
         "component from the file it's defined in, or you might have mixed up " +
         'default and named imports.' +
         '\n\nCheck your code at **.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(() => void <Null />).toWarnDev(
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: null.' +
         '\n\nCheck your code at **.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(() => void <True />).toWarnDev(
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: boolean.' +
         '\n\nCheck your code at **.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     // No error expected
     void <Div />;
@@ -337,7 +337,7 @@ describe('ReactJSXElementValidator', () => {
     ).toWarnDev(
       'getDefaultProps is only used on classic React.createClass definitions.' +
         ' Use a static property named `defaultProps` instead.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -357,7 +357,7 @@ describe('ReactJSXElementValidator', () => {
     ).toWarnDev(
       'Warning: Component MisspelledPropTypesComponent declared `PropTypes` ' +
         'instead of `propTypes`. Did you misspell the property assignment?',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -412,7 +412,7 @@ describe('ReactJSXElementValidator', () => {
         </React.Fragment>,
       ),
     ).toWarnDev('Encountered two children with the same key, `a`.', {
-      expectNoStack: true,
+      withoutStack: true,
     });
   });
 });

--- a/packages/react/src/__tests__/ReactPureComponent-test.js
+++ b/packages/react/src/__tests__/ReactPureComponent-test.js
@@ -79,6 +79,7 @@ describe('ReactPureComponent', () => {
         'Component has a method called shouldComponentUpdate(). ' +
         'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
         'Please extend React.Component if shouldComponentUpdate is used.',
+      {expectNoStack: true},
     );
     ReactDOM.render(<Component />, container);
     expect(renders).toBe(2);
@@ -113,6 +114,7 @@ describe('ReactPureComponent', () => {
         'PureComponent has a method called shouldComponentUpdate(). ' +
         'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
         'Please extend React.Component if shouldComponentUpdate is used.',
+      {expectNoStack: true},
     );
   });
 });

--- a/packages/react/src/__tests__/ReactPureComponent-test.js
+++ b/packages/react/src/__tests__/ReactPureComponent-test.js
@@ -79,7 +79,7 @@ describe('ReactPureComponent', () => {
         'Component has a method called shouldComponentUpdate(). ' +
         'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
         'Please extend React.Component if shouldComponentUpdate is used.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     ReactDOM.render(<Component />, container);
     expect(renders).toBe(2);
@@ -114,7 +114,7 @@ describe('ReactPureComponent', () => {
         'PureComponent has a method called shouldComponentUpdate(). ' +
         'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
         'Please extend React.Component if shouldComponentUpdate is used.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 });

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -331,7 +331,7 @@ describe('ReactTypeScriptClass', function() {
         'component instance: you may have forgotten to define `render`.',
       'Warning: Empty(...): No `render` method found on the returned ' +
         'component instance: you may have forgotten to define `render`.',
-    ]);
+    ], {expectNoStack: true});
   });
 
   it('renders a simple stateless component with prop', function() {
@@ -391,7 +391,8 @@ describe('ReactTypeScriptClass', function() {
       ReactDOM.render(React.createElement(Foo, {foo: 'foo'}), container);
     }).toWarnDev(
       'Foo: getDerivedStateFromProps() is defined as an instance method ' +
-        'and will be ignored. Instead, declare it as a static method.'
+        'and will be ignored. Instead, declare it as a static method.',
+        {expectNoStack: true}
     );
   });
 
@@ -408,7 +409,8 @@ describe('ReactTypeScriptClass', function() {
       ReactDOM.render(React.createElement(Foo, {foo: 'foo'}), container);
     }).toWarnDev(
       'Foo: getDerivedStateFromCatch() is defined as an instance method ' +
-        'and will be ignored. Instead, declare it as a static method.'
+        'and will be ignored. Instead, declare it as a static method.',
+        {expectNoStack: true}
     );
   });
 
@@ -424,7 +426,8 @@ describe('ReactTypeScriptClass', function() {
       ReactDOM.render(React.createElement(Foo, {foo: 'foo'}), container);
     }).toWarnDev(
       'Foo: getSnapshotBeforeUpdate() is defined as a static method ' +
-        'and will be ignored. Instead, declare it as an instance method.'
+        'and will be ignored. Instead, declare it as an instance method.',
+        {expectNoStack: true}
     );
   });
 
@@ -446,7 +449,8 @@ describe('ReactTypeScriptClass', function() {
       ReactDOM.render(React.createElement(Foo, {foo: 'foo'}), container);
     }).toWarnDev(
       'Foo: Did not properly initialize state during construction. ' +
-        'Expected state to be an object, but it was undefined.'
+        'Expected state to be an object, but it was undefined.',
+        {expectNoStack: true}
     );
   });
 
@@ -503,13 +507,16 @@ describe('ReactTypeScriptClass', function() {
 
   it('should warn with non-object in the initial state property', function() {
     expect(() => test(React.createElement(ArrayState), 'SPAN', '')).toWarnDev(
-      'ArrayState.state: must be set to an object or null'
+      'ArrayState.state: must be set to an object or null',
+      {expectNoStack: true}
     );
     expect(() => test(React.createElement(StringState), 'SPAN', '')).toWarnDev(
-      'StringState.state: must be set to an object or null'
+      'StringState.state: must be set to an object or null',
+      {expectNoStack: true}
     );
     expect(() => test(React.createElement(NumberState), 'SPAN', '')).toWarnDev(
-      'NumberState.state: must be set to an object or null'
+      'NumberState.state: must be set to an object or null',
+      {expectNoStack: true}
     );
   });
 
@@ -585,7 +592,7 @@ describe('ReactTypeScriptClass', function() {
           'a plain JavaScript class.',
         'propTypes was defined as an instance property on ClassicProperties.',
         'contextTypes was defined as an instance property on ClassicProperties.',
-      ]);
+      ], {expectNoStack: true});
       expect(getInitialStateWasCalled).toBe(false);
       expect(getDefaultPropsWasCalled).toBe(false);
     }
@@ -616,7 +623,8 @@ describe('ReactTypeScriptClass', function() {
       'Warning: ' +
         'MisspelledComponent1 has a method called componentShouldUpdate(). Did ' +
         'you mean shouldComponentUpdate()? The name is phrased as a question ' +
-        'because the function is expected to return a value.'
+        'because the function is expected to return a value.',
+        {expectNoStack: true}
     );
   });
 
@@ -626,7 +634,8 @@ describe('ReactTypeScriptClass', function() {
     ).toWarnDev(
       'Warning: ' +
         'MisspelledComponent2 has a method called componentWillRecieveProps(). ' +
-        'Did you mean componentWillReceiveProps()?'
+        'Did you mean componentWillReceiveProps()?',
+        {expectNoStack: true}
     );
   });
 
@@ -636,7 +645,8 @@ describe('ReactTypeScriptClass', function() {
     ).toWarnDev(
       'Warning: ' +
         'MisspelledComponent3 has a method called UNSAFE_componentWillRecieveProps(). ' +
-        'Did you mean UNSAFE_componentWillReceiveProps()?'
+        'Did you mean UNSAFE_componentWillReceiveProps()?',
+        {expectNoStack: true}
     );
   });
 
@@ -649,12 +659,14 @@ describe('ReactTypeScriptClass', function() {
     expect(() =>
       expect(() => instance.replaceState({})).toThrow()
     ).toLowPriorityWarnDev(
-      'replaceState(...) is deprecated in plain JavaScript React classes'
+      'replaceState(...) is deprecated in plain JavaScript React classes',
+      {expectNoStack: true}
     );
     expect(() =>
       expect(() => instance.isMounted()).toThrow()
     ).toLowPriorityWarnDev(
-      'isMounted(...) is deprecated in plain JavaScript React classes'
+      'isMounted(...) is deprecated in plain JavaScript React classes',
+      {expectNoStack: true}
     );
   });
 

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -331,7 +331,7 @@ describe('ReactTypeScriptClass', function() {
         'component instance: you may have forgotten to define `render`.',
       'Warning: Empty(...): No `render` method found on the returned ' +
         'component instance: you may have forgotten to define `render`.',
-    ], {expectNoStack: true});
+    ], {withoutStack: true});
   });
 
   it('renders a simple stateless component with prop', function() {
@@ -392,7 +392,7 @@ describe('ReactTypeScriptClass', function() {
     }).toWarnDev(
       'Foo: getDerivedStateFromProps() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
-        {expectNoStack: true}
+        {withoutStack: true}
     );
   });
 
@@ -410,7 +410,7 @@ describe('ReactTypeScriptClass', function() {
     }).toWarnDev(
       'Foo: getDerivedStateFromCatch() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
-        {expectNoStack: true}
+        {withoutStack: true}
     );
   });
 
@@ -427,7 +427,7 @@ describe('ReactTypeScriptClass', function() {
     }).toWarnDev(
       'Foo: getSnapshotBeforeUpdate() is defined as a static method ' +
         'and will be ignored. Instead, declare it as an instance method.',
-        {expectNoStack: true}
+        {withoutStack: true}
     );
   });
 
@@ -450,7 +450,7 @@ describe('ReactTypeScriptClass', function() {
     }).toWarnDev(
       'Foo: Did not properly initialize state during construction. ' +
         'Expected state to be an object, but it was undefined.',
-        {expectNoStack: true}
+        {withoutStack: true}
     );
   });
 
@@ -508,15 +508,15 @@ describe('ReactTypeScriptClass', function() {
   it('should warn with non-object in the initial state property', function() {
     expect(() => test(React.createElement(ArrayState), 'SPAN', '')).toWarnDev(
       'ArrayState.state: must be set to an object or null',
-      {expectNoStack: true}
+      {withoutStack: true}
     );
     expect(() => test(React.createElement(StringState), 'SPAN', '')).toWarnDev(
       'StringState.state: must be set to an object or null',
-      {expectNoStack: true}
+      {withoutStack: true}
     );
     expect(() => test(React.createElement(NumberState), 'SPAN', '')).toWarnDev(
       'NumberState.state: must be set to an object or null',
-      {expectNoStack: true}
+      {withoutStack: true}
     );
   });
 
@@ -592,7 +592,7 @@ describe('ReactTypeScriptClass', function() {
           'a plain JavaScript class.',
         'propTypes was defined as an instance property on ClassicProperties.',
         'contextTypes was defined as an instance property on ClassicProperties.',
-      ], {expectNoStack: true});
+      ], {withoutStack: true});
       expect(getInitialStateWasCalled).toBe(false);
       expect(getDefaultPropsWasCalled).toBe(false);
     }
@@ -624,7 +624,7 @@ describe('ReactTypeScriptClass', function() {
         'MisspelledComponent1 has a method called componentShouldUpdate(). Did ' +
         'you mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
-        {expectNoStack: true}
+        {withoutStack: true}
     );
   });
 
@@ -635,7 +635,7 @@ describe('ReactTypeScriptClass', function() {
       'Warning: ' +
         'MisspelledComponent2 has a method called componentWillRecieveProps(). ' +
         'Did you mean componentWillReceiveProps()?',
-        {expectNoStack: true}
+        {withoutStack: true}
     );
   });
 
@@ -646,7 +646,7 @@ describe('ReactTypeScriptClass', function() {
       'Warning: ' +
         'MisspelledComponent3 has a method called UNSAFE_componentWillRecieveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?',
-        {expectNoStack: true}
+        {withoutStack: true}
     );
   });
 
@@ -660,13 +660,13 @@ describe('ReactTypeScriptClass', function() {
       expect(() => instance.replaceState({})).toThrow()
     ).toLowPriorityWarnDev(
       'replaceState(...) is deprecated in plain JavaScript React classes',
-      {expectNoStack: true}
+      {withoutStack: true}
     );
     expect(() =>
       expect(() => instance.isMounted()).toThrow()
     ).toLowPriorityWarnDev(
       'isMounted(...) is deprecated in plain JavaScript React classes',
-      {expectNoStack: true}
+      {withoutStack: true}
     );
   });
 

--- a/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
@@ -91,6 +91,7 @@ describe('create-react-class-integration', () => {
       'Warning: MyComponent: isMounted is deprecated. Instead, make sure to ' +
         'clean up subscriptions and pending requests in componentWillUnmount ' +
         'to prevent memory leaks.',
+      {expectNoStack: true},
     );
 
     // Dedupe
@@ -149,6 +150,7 @@ describe('create-react-class-integration', () => {
           'Use componentDidMount instead. As a temporary workaround, ' +
           'you can rename to UNSAFE_componentWillMount.' +
           '\n\nPlease update the following components: MyNativeComponent',
+        {expectNoStack: true},
       );
     });
 
@@ -164,6 +166,7 @@ describe('create-react-class-integration', () => {
         'componentWillReceiveProps is deprecated and will be removed in the next major version. ' +
           'Use static getDerivedStateFromProps instead.' +
           '\n\nPlease update the following components: MyNativeComponent',
+        {expectNoStack: true},
       );
     });
   });

--- a/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
@@ -91,7 +91,7 @@ describe('create-react-class-integration', () => {
       'Warning: MyComponent: isMounted is deprecated. Instead, make sure to ' +
         'clean up subscriptions and pending requests in componentWillUnmount ' +
         'to prevent memory leaks.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     // Dedupe
@@ -150,7 +150,7 @@ describe('create-react-class-integration', () => {
           'Use componentDidMount instead. As a temporary workaround, ' +
           'you can rename to UNSAFE_componentWillMount.' +
           '\n\nPlease update the following components: MyNativeComponent',
-        {expectNoStack: true},
+        {withoutStack: true},
       );
     });
 
@@ -166,7 +166,7 @@ describe('create-react-class-integration', () => {
         'componentWillReceiveProps is deprecated and will be removed in the next major version. ' +
           'Use static getDerivedStateFromProps instead.' +
           '\n\nPlease update the following components: MyNativeComponent',
-        {expectNoStack: true},
+        {withoutStack: true},
       );
     });
   });

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -66,7 +66,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Warning: Component: prop type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -84,7 +84,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Warning: Component: context type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -102,7 +102,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Warning: Component: child context type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -120,7 +120,7 @@ describe('create-react-class-integration', () => {
       'Warning: A component has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     expect(() =>
@@ -137,7 +137,7 @@ describe('create-react-class-integration', () => {
       'Warning: NamedComponent has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -154,7 +154,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Warning: A component has a method called componentWillRecieveProps(). Did you ' +
         'mean componentWillReceiveProps()?',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -171,7 +171,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Warning: A component has a method called UNSAFE_componentWillRecieveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -364,7 +364,7 @@ describe('create-react-class-integration', () => {
     expect(() => expect(() => Component()).toThrow()).toWarnDev(
       'Warning: Something is calling a React component directly. Use a ' +
         'factory or JSX instead. See: https://fb.me/react-legacyfactory',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -455,7 +455,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Component: getDerivedStateFromProps() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -473,7 +473,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Component: getDerivedStateFromCatch() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -493,7 +493,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Component: getSnapshotBeforeUpdate() is defined as a static method ' +
         'and will be ignored. Instead, declare it as an instance method.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -511,7 +511,7 @@ describe('create-react-class-integration', () => {
     expect(() =>
       ReactDOM.render(<Component />, document.createElement('div')),
     ).toWarnDev('Did not properly initialize state during construction.', {
-      expectNoStack: true,
+      withoutStack: true,
     });
   });
 
@@ -549,7 +549,7 @@ describe('create-react-class-integration', () => {
         '  componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     ReactDOM.render(<Component foo={1} />, document.createElement('div'));
   });
@@ -584,7 +584,7 @@ describe('create-react-class-integration', () => {
         '  componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     ReactDOM.render(<Component foo={1} />, document.createElement('div'));
   });

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -66,6 +66,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Warning: Component: prop type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
+      {expectNoStack: true},
     );
   });
 
@@ -83,6 +84,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Warning: Component: context type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
+      {expectNoStack: true},
     );
   });
 
@@ -100,6 +102,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Warning: Component: child context type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
+      {expectNoStack: true},
     );
   });
 
@@ -117,6 +120,7 @@ describe('create-react-class-integration', () => {
       'Warning: A component has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
+      {expectNoStack: true},
     );
 
     expect(() =>
@@ -133,6 +137,7 @@ describe('create-react-class-integration', () => {
       'Warning: NamedComponent has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
+      {expectNoStack: true},
     );
   });
 
@@ -149,6 +154,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Warning: A component has a method called componentWillRecieveProps(). Did you ' +
         'mean componentWillReceiveProps()?',
+      {expectNoStack: true},
     );
   });
 
@@ -165,6 +171,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Warning: A component has a method called UNSAFE_componentWillRecieveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?',
+      {expectNoStack: true},
     );
   });
 
@@ -357,6 +364,7 @@ describe('create-react-class-integration', () => {
     expect(() => expect(() => Component()).toThrow()).toWarnDev(
       'Warning: Something is calling a React component directly. Use a ' +
         'factory or JSX instead. See: https://fb.me/react-legacyfactory',
+      {expectNoStack: true},
     );
   });
 
@@ -447,6 +455,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Component: getDerivedStateFromProps() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
+      {expectNoStack: true},
     );
   });
 
@@ -464,6 +473,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Component: getDerivedStateFromCatch() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
+      {expectNoStack: true},
     );
   });
 
@@ -483,6 +493,7 @@ describe('create-react-class-integration', () => {
     ).toWarnDev(
       'Component: getSnapshotBeforeUpdate() is defined as a static method ' +
         'and will be ignored. Instead, declare it as an instance method.',
+      {expectNoStack: true},
     );
   });
 
@@ -499,7 +510,9 @@ describe('create-react-class-integration', () => {
     });
     expect(() =>
       ReactDOM.render(<Component />, document.createElement('div')),
-    ).toWarnDev('Did not properly initialize state during construction.');
+    ).toWarnDev('Did not properly initialize state during construction.', {
+      expectNoStack: true,
+    });
   });
 
   it('should not invoke deprecated lifecycles (cWM/cWRP/cWU) if new static gDSFP is present', () => {
@@ -536,6 +549,7 @@ describe('create-react-class-integration', () => {
         '  componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
+      {expectNoStack: true},
     );
     ReactDOM.render(<Component foo={1} />, document.createElement('div'));
   });
@@ -570,6 +584,7 @@ describe('create-react-class-integration', () => {
         '  componentWillUpdate\n\n' +
         'The above lifecycles should be removed. Learn more about this warning here:\n' +
         'https://fb.me/react-async-component-lifecycle-hooks',
+      {expectNoStack: true},
     );
     ReactDOM.render(<Component foo={1} />, document.createElement('div'));
   });

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -120,18 +120,22 @@ describe('forwardRef', () => {
   it('should warn if not provided a callback during creation', () => {
     expect(() => React.forwardRef(undefined)).toWarnDev(
       'forwardRef requires a render function but was given undefined.',
+      {expectNoStack: true},
     );
     expect(() => React.forwardRef(null)).toWarnDev(
       'forwardRef requires a render function but was given null.',
+      {expectNoStack: true},
     );
     expect(() => React.forwardRef('foo')).toWarnDev(
       'forwardRef requires a render function but was given string.',
+      {expectNoStack: true},
     );
   });
 
   it('should warn if no render function is provided', () => {
     expect(React.forwardRef).toWarnDev(
       'forwardRef requires a render function but was given undefined.',
+      {expectNoStack: true},
     );
   });
 
@@ -149,10 +153,12 @@ describe('forwardRef', () => {
     expect(() => React.forwardRef(renderWithPropTypes)).toWarnDev(
       'forwardRef render functions do not support propTypes or defaultProps. ' +
         'Did you accidentally pass a React component?',
+      {expectNoStack: true},
     );
     expect(() => React.forwardRef(renderWithDefaultProps)).toWarnDev(
       'forwardRef render functions do not support propTypes or defaultProps. ' +
         'Did you accidentally pass a React component?',
+      {expectNoStack: true},
     );
   });
 
@@ -166,11 +172,13 @@ describe('forwardRef', () => {
     expect(() => React.forwardRef(arityOfZero)).toWarnDev(
       'forwardRef render functions accept two parameters: props and ref. ' +
         'Did you forget to use the ref parameter?',
+      {expectNoStack: true},
     );
 
     expect(() => React.forwardRef(arityOfOne)).toWarnDev(
       'forwardRef render functions accept two parameters: props and ref. ' +
         'Did you forget to use the ref parameter?',
+      {expectNoStack: true},
     );
   });
 });

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -120,22 +120,22 @@ describe('forwardRef', () => {
   it('should warn if not provided a callback during creation', () => {
     expect(() => React.forwardRef(undefined)).toWarnDev(
       'forwardRef requires a render function but was given undefined.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(() => React.forwardRef(null)).toWarnDev(
       'forwardRef requires a render function but was given null.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(() => React.forwardRef('foo')).toWarnDev(
       'forwardRef requires a render function but was given string.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
   it('should warn if no render function is provided', () => {
     expect(React.forwardRef).toWarnDev(
       'forwardRef requires a render function but was given undefined.',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -153,12 +153,12 @@ describe('forwardRef', () => {
     expect(() => React.forwardRef(renderWithPropTypes)).toWarnDev(
       'forwardRef render functions do not support propTypes or defaultProps. ' +
         'Did you accidentally pass a React component?',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
     expect(() => React.forwardRef(renderWithDefaultProps)).toWarnDev(
       'forwardRef render functions do not support propTypes or defaultProps. ' +
         'Did you accidentally pass a React component?',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 
@@ -172,13 +172,13 @@ describe('forwardRef', () => {
     expect(() => React.forwardRef(arityOfZero)).toWarnDev(
       'forwardRef render functions accept two parameters: props and ref. ' +
         'Did you forget to use the ref parameter?',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
 
     expect(() => React.forwardRef(arityOfOne)).toWarnDev(
       'forwardRef render functions accept two parameters: props and ref. ' +
         'Did you forget to use the ref parameter?',
-      {expectNoStack: true},
+      {withoutStack: true},
     );
   });
 });

--- a/packages/shared/__tests__/ReactDOMFrameScheduling-test.js
+++ b/packages/shared/__tests__/ReactDOMFrameScheduling-test.js
@@ -17,6 +17,7 @@ describe('ReactDOMFrameScheduling', () => {
       jest.resetModules();
       expect(() => require('react-dom')).toWarnDev(
         "This browser doesn't support requestAnimationFrame.",
+        {expectNoStack: true},
       );
     } finally {
       global.requestAnimationFrame = previousRAF;

--- a/packages/shared/__tests__/ReactDOMFrameScheduling-test.js
+++ b/packages/shared/__tests__/ReactDOMFrameScheduling-test.js
@@ -17,7 +17,7 @@ describe('ReactDOMFrameScheduling', () => {
       jest.resetModules();
       expect(() => require('react-dom')).toWarnDev(
         "This browser doesn't support requestAnimationFrame.",
-        {expectNoStack: true},
+        {withoutStack: true},
       );
     } finally {
       global.requestAnimationFrame = previousRAF;

--- a/packages/simple-cache-provider/src/__tests__/SimpleCacheProvider-test.js
+++ b/packages/simple-cache-provider/src/__tests__/SimpleCacheProvider-test.js
@@ -149,14 +149,17 @@ describe('SimpleCacheProvider', () => {
     }
 
     if (__DEV__) {
-      expect(fn).toWarnDev([
-        'Invalid resourceType: Expected a symbol, object, or function, but ' +
-          'instead received: foo. Strings and numbers are not permitted as ' +
-          'resource types.',
-        'Invalid resourceType: Expected a symbol, object, or function, but ' +
-          'instead received: 123. Strings and numbers are not permitted as ' +
-          'resource types.',
-      ]);
+      expect(fn).toWarnDev(
+        [
+          'Invalid resourceType: Expected a symbol, object, or function, but ' +
+            'instead received: foo. Strings and numbers are not permitted as ' +
+            'resource types.',
+          'Invalid resourceType: Expected a symbol, object, or function, but ' +
+            'instead received: 123. Strings and numbers are not permitted as ' +
+            'resource types.',
+        ],
+        {expectNoStack: true},
+      );
     } else {
       fn();
     }
@@ -179,12 +182,15 @@ describe('SimpleCacheProvider', () => {
     }
 
     if (__DEV__) {
-      expect(fn).toWarnDev([
-        'preload: Invalid key type. Expected a string, number, symbol, or ' +
-          'boolean, but instead received: 5,5\n\n' +
-          'To use non-primitive values as keys, you must pass a hash ' +
-          'function as the second argument to createResource().',
-      ]);
+      expect(fn).toWarnDev(
+        [
+          'preload: Invalid key type. Expected a string, number, symbol, or ' +
+            'boolean, but instead received: 5,5\n\n' +
+            'To use non-primitive values as keys, you must pass a hash ' +
+            'function as the second argument to createResource().',
+        ],
+        {expectNoStack: true},
+      );
     } else {
       fn();
     }

--- a/packages/simple-cache-provider/src/__tests__/SimpleCacheProvider-test.js
+++ b/packages/simple-cache-provider/src/__tests__/SimpleCacheProvider-test.js
@@ -158,7 +158,7 @@ describe('SimpleCacheProvider', () => {
             'instead received: 123. Strings and numbers are not permitted as ' +
             'resource types.',
         ],
-        {expectNoStack: true},
+        {withoutStack: true},
       );
     } else {
       fn();
@@ -189,7 +189,7 @@ describe('SimpleCacheProvider', () => {
             'To use non-primitive values as keys, you must pass a hash ' +
             'function as the second argument to createResource().',
         ],
-        {expectNoStack: true},
+        {withoutStack: true},
       );
     } else {
       fn();

--- a/scripts/jest/matchers/__tests__/toWarnDev-test.js
+++ b/scripts/jest/matchers/__tests__/toWarnDev-test.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+describe('toWarnDev', () => {
+  it('does not fail if a warning contains a stack', () => {
+    expect(() => {
+      console.error('Hello\n    in div');
+    }).toWarnDev('Hello');
+  });
+
+  it('does not fail if all warnings contain a stack', () => {
+    expect(() => {
+      console.error('Hello\n    in div');
+      console.error('Good day\n    in div');
+      console.error('Bye\n    in div');
+    }).toWarnDev(['Hello', 'Good day', 'Bye']);
+  });
+
+  it('does not fail if warnings without stack explicitly opt out', () => {
+    expect(() => {
+      console.error('Hello');
+    }).toWarnDev('Hello', {withoutStack: true});
+    expect(() => {
+      console.error('Hello');
+      console.error('Good day');
+      console.error('Bye');
+    }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: true});
+  });
+
+  it('does not fail when expected stack-less warning number matches the actual one', () => {
+    expect(() => {
+      console.error('Hello\n    in div');
+      console.error('Good day');
+      console.error('Bye\n    in div');
+    }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: 1});
+  });
+
+  it('fails if a warning does not contain a stack', () => {
+    expect(() => {
+      expect(() => {
+        console.error('Hello');
+      }).toWarnDev('Hello');
+    }).toThrow(
+      'Received warning unexpectedly does not include a component stack'
+    );
+  });
+
+  it('fails if some warnings do not contain a stack', () => {
+    expect(() => {
+      expect(() => {
+        console.error('Hello\n    in div');
+        console.error('Good day\n    in div');
+        console.error('Bye');
+      }).toWarnDev(['Hello', 'Good day', 'Bye']);
+    }).toThrow(
+      'Received warning unexpectedly does not include a component stack'
+    );
+    expect(() => {
+      expect(() => {
+        console.error('Hello');
+        console.error('Good day\n    in div');
+        console.error('Bye\n    in div');
+      }).toWarnDev(['Hello', 'Good day', 'Bye']);
+    }).toThrow(
+      'Received warning unexpectedly does not include a component stack'
+    );
+    expect(() => {
+      expect(() => {
+        console.error('Hello\n    in div');
+        console.error('Good day');
+        console.error('Bye\n    in div');
+      }).toWarnDev(['Hello', 'Good day', 'Bye']);
+    }).toThrow(
+      'Received warning unexpectedly does not include a component stack'
+    );
+    expect(() => {
+      expect(() => {
+        console.error('Hello');
+        console.error('Good day');
+        console.error('Bye');
+      }).toWarnDev(['Hello', 'Good day', 'Bye']);
+    }).toThrow(
+      'Received warning unexpectedly does not include a component stack'
+    );
+  });
+
+  it('fails if warning is expected to not have a stack, but does', () => {
+    expect(() => {
+      expect(() => {
+        console.error('Hello\n    in div');
+      }).toWarnDev('Hello', {withoutStack: true});
+    }).toThrow('Received warning unexpectedly includes a component stack');
+    expect(() => {
+      expect(() => {
+        console.error('Hello\n    in div');
+        console.error('Good day');
+        console.error('Bye\n    in div');
+      }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: true});
+    }).toThrow('Received warning unexpectedly includes a component stack');
+  });
+
+  it('fails if expected stack-less warning number does not match the actual one', () => {
+    expect(() => {
+      expect(() => {
+        console.error('Hello\n    in div');
+        console.error('Good day');
+        console.error('Bye\n    in div');
+      }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: 4});
+    }).toThrow('Expected 4 warnings without a component stack but received 1');
+  });
+
+  it('fails if withoutStack is invalid', () => {
+    expect(() => {
+      expect(() => {
+        console.error('Hi');
+      }).toWarnDev('Hi', {withoutStack: null});
+    }).toThrow('Instead received object');
+    expect(() => {
+      expect(() => {
+        console.error('Hi');
+      }).toWarnDev('Hi', {withoutStack: {}});
+    }).toThrow('Instead received object');
+    expect(() => {
+      expect(() => {
+        console.error('Hi');
+      }).toWarnDev('Hi', {withoutStack: 'haha'});
+    }).toThrow('Instead received string');
+  });
+});

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -116,7 +116,7 @@ const createMatcherFor = consoleMethod =>
           if (withoutStack !== warningsWithoutComponentStack.length) {
             return {
               message: () =>
-                `Expected ${withoutStack} warnings without the component stack but received ${
+                `Expected ${withoutStack} warnings without a component stack but received ${
                   warningsWithoutComponentStack.length
                 }:\n` +
                 warningsWithoutComponentStack.map(warning =>
@@ -131,7 +131,7 @@ const createMatcherFor = consoleMethod =>
           if (warningsWithComponentStack.length > 0) {
             return {
               message: () =>
-                `Received warning unexpectedly includes the component stack:\n  ${this.utils.printReceived(
+                `Received warning unexpectedly includes a component stack:\n  ${this.utils.printReceived(
                   warningsWithComponentStack[0]
                 )}\nIf this warning intentionally includes the component stack, remove ` +
                 `{withoutStack: true} from the toWarnDev() call. If you have a mix of ` +
@@ -146,7 +146,7 @@ const createMatcherFor = consoleMethod =>
           if (warningsWithoutComponentStack.length > 0) {
             return {
               message: () =>
-                `Received warning unexpectedly does not include component stack:\n  ${this.utils.printReceived(
+                `Received warning unexpectedly does not include a component stack:\n  ${this.utils.printReceived(
                   warningsWithoutComponentStack[0]
                 )}\nIf this warning intentionally omits the component stack, add ` +
                 `{withoutStack: true} to the toWarnDev() call.`,
@@ -155,8 +155,8 @@ const createMatcherFor = consoleMethod =>
           }
         } else {
           throw Error(
-            `The options toWarnDev() argument passed to toWarnDev() may include ` +
-              `an option called "withoutStack" which may be undefined, boolean, or a number. ` +
+            `The second argument for toWarnDev(), when specified, must be an object. It may have a ` +
+              `property called "withoutStack" whose value may be undefined, boolean, or a number. ` +
               `Instead received ${typeof withoutStack}.`
           );
         }

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -19,7 +19,7 @@ const createMatcherFor = consoleMethod =>
         );
       }
 
-      const expectNoStack = options.expectNoStack;
+      const withoutStack = options.withoutStack;
       const warningsWithoutComponentStack = [];
       const warningsWithComponentStack = [];
       const unexpectedWarnings = [];
@@ -111,12 +111,12 @@ const createMatcherFor = consoleMethod =>
           };
         }
 
-        if (typeof expectNoStack === 'number') {
+        if (typeof withoutStack === 'number') {
           // We're expecting a particular number of warnings without stacks.
-          if (expectNoStack !== warningsWithoutComponentStack.length) {
+          if (withoutStack !== warningsWithoutComponentStack.length) {
             return {
               message: () =>
-                `Expected ${expectNoStack} warnings without the component stack but received ${
+                `Expected ${withoutStack} warnings without the component stack but received ${
                   warningsWithoutComponentStack.length
                 }:\n` +
                 warningsWithoutComponentStack.map(warning =>
@@ -125,7 +125,7 @@ const createMatcherFor = consoleMethod =>
               pass: false,
             };
           }
-        } else if (expectNoStack === true) {
+        } else if (withoutStack === true) {
           // We're expecting that all warnings won't have the stack.
           // If some warnings have it, it's an error.
           if (warningsWithComponentStack.length > 0) {
@@ -134,13 +134,13 @@ const createMatcherFor = consoleMethod =>
                 `Received warning unexpectedly includes the component stack:\n  ${this.utils.printReceived(
                   warningsWithComponentStack[0]
                 )}\nIf this warning intentionally includes the component stack, remove ` +
-                `{expectNoStack: true} from the toWarnDev() call. If you have a mix of ` +
+                `{withoutStack: true} from the toWarnDev() call. If you have a mix of ` +
                 `warnings with and without stack in one toWarnDev() call, pass ` +
-                `{expectNoStack: N} where N is the number of warnings without stacks.`,
+                `{withoutStack: N} where N is the number of warnings without stacks.`,
               pass: false,
             };
           }
-        } else if (expectNoStack === false || expectNoStack === undefined) {
+        } else if (withoutStack === false || withoutStack === undefined) {
           // We're expecting that all warnings *do* have the stack (default).
           // If some warnings don't have it, it's an error.
           if (warningsWithoutComponentStack.length > 0) {
@@ -149,15 +149,15 @@ const createMatcherFor = consoleMethod =>
                 `Received warning unexpectedly does not include component stack:\n  ${this.utils.printReceived(
                   warningsWithoutComponentStack[0]
                 )}\nIf this warning intentionally omits the component stack, add ` +
-                `{expectNoStack: true} to the toWarnDev() call.`,
+                `{withoutStack: true} to the toWarnDev() call.`,
               pass: false,
             };
           }
         } else {
           throw Error(
             `The options toWarnDev() argument passed to toWarnDev() may include ` +
-              `an option called "expectNoStack" which may be undefined, boolean, or a number. ` +
-              `Instead received ${typeof expectNoStack}.`
+              `an option called "withoutStack" which may be undefined, boolean, or a number. ` +
+              `Instead received ${typeof withoutStack}.`
           );
         }
         return {pass: true};

--- a/scripts/jest/typescript/jest.d.ts
+++ b/scripts/jest/typescript/jest.d.ts
@@ -21,8 +21,8 @@ interface Expect {
   not: Expect
   toThrow(message?: string): void
   toThrowError(message?: string): void
-  toWarnDev(message?: string | Array<string>): void
-  toLowPriorityWarnDev(message?: string | Array<string>): void
+  toWarnDev(message?: string | Array<string>, options?: any): void
+  toLowPriorityWarnDev(message?: string | Array<string>, options?: any): void
   toBe(value: any): void
   toEqual(value: any): void
   toBeFalsy(): void


### PR DESCRIPTION
Currently, the way we test component stacks is ad-hoc. Sometimes we include it in the expected warning message, sometimes we don't. Sometimes we *mean* to not include a stack in the warning, and sometimes we just forget to.

As we're moving towards including component stacks by default for any `warning` call when it exists, I want to make the tests stricter. Specifically, **I want the tests to fail if a warning doesn't contain a stack, unless you explicitly opted out in the `toWarnDev()` call**.

With this change, calls like

```js
expect(() => something()).toWarnDev(message);
expect(() => something()).toWarnDev([messages]);
```

will expect that all messages include a stack (we check for `\n   in ` which is accurate enough).

If the stack is missing, the test will fail. Here, we don't check the stack *content* itself — just that it exists. Any test that needs to verify the stack contents is welcome to keep doing it the same way we do today, in case where it's valuable.

Some warnings are expected to *not* have a stack. In this case, you can pass:

```js
expect(() => something()).toWarnDev(
  message,
  {withoutStack: true}
)
```

It is intentionally somewhat verbose so that you think twice before doing it.

For the edge case where a single `toWarnDev()` call contains both warnings with and without a stack, you can pass a number as `withoutStack`. That number is interpreted as how many messages you expect to not have stacks. This is rare. We only use this in two places in our entire test suite.

----

### Give Me Some Stats

We have 404 calls of `toWarnDev()`, and 193 (a slight minority) of them will contain `withoutStack` with this PR. Note that many of these calls are testing the same messages (e.g. the strict mode message which doesn't have a stack) so this isn't necessarily representative of the real warning distribution.

Our of those 193 stack-less messages, 34 seem to be missing stacks by accident. I added a TODO comments to them so we can fix them.

### Why Not a Shorter Name?

I want to make it a little bit more annoying to add new warnings without stacks. I also think we might want to reconsider whether warnings for the class itself (e.g. bad static methods) should get a stack or not. Currently they don't but I think maybe it could be helpful.

### Why Options Object Instead Of a Boolean Argument?

I want to make it very easy to find all warnings with missing stacks by doing a project-wide search of `withoutStack` at any point in time. I also want all missing stacks to be highly visible since in the future I think we'll want to increase our stack coverage for warnings.

### Why Not a Positive Name?

Why not `withStack: false`? I want the stack to be checked by default, and I find options that are `true` by default a bit confusing. When you see

```js
expect(() => something).toWarn(message, {withStack: false})
```

it's not clear whether you need `{withStack: true}` when you *do* want to check it. I think `withoutStack: true` is a bit more obviously a non-default case.

### What If I Add a Stack?

The matcher will intentionally fail the test if you add a stack but the test doesn't expect it. This is so that the tests always reflect the reality. This might become more important when we automate adding stacks as we then might accidentally include a wrong stack in case where we shouldn't have any. This check would catch such an issue.

## Does This Change the Behavior

No, I only changed the tests. I'll add missing stacks in follow-up PRs.