### PR TITLE
Set current fiber during before-mutation traversal

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -428,8 +428,11 @@ function commitAllHostEffects() {
 
 function commitBeforeMutationLifecycles() {
   while (nextEffect !== null) {
-    const effectTag = nextEffect.effectTag;
+    if (__DEV__) {
+      ReactCurrentFiber.setCurrentFiber(nextEffect);
+    }
 
+    const effectTag = nextEffect.effectTag;
     if (effectTag & Snapshot) {
       recordEffect();
       const current = nextEffect.alternate;
@@ -439,6 +442,10 @@ function commitBeforeMutationLifecycles() {
     // Don't cleanup effects yet;
     // This will be done by commitAllLifeCycles()
     nextEffect = nextEffect.nextEffect;
+  }
+
+  if (__DEV__) {
+    ReactCurrentFiber.resetCurrentFiber();
   }
 }
 


### PR DESCRIPTION
This sets current fiber during the `getSnapshot` traversal in the commit phase.

It's not currently observable because we don't have any warnings with stacks during that phase. But if we did, the stack would end up empty. With this change, we'd get the correct stack.

Verified this by changing a stack-less warning that occurs in this phase to have a stack (I didn't commit it though because I'm not sure we'd want a stack there).

The purpose of this PR isn't to fix anything, but to avoid future confusion in case we *do* add warnings with stacks during that phase. As far as I'm aware this was the only point in reconciliation where the stack is currently missing.