### PR TITLE
Fix a portal unmounting crash for renderers with distinct Instance and Container

### DIFF
--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -56,6 +56,18 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     parentInstance.children.push(child);
   }
 
+  function appendChildToContainer(
+    parentInstance: Container,
+    child: Instance | TextInstance,
+  ): void {
+    if (typeof parentInstance.rootID !== 'string') {
+      throw new Error(
+        'appendChildToContainer() first argument is not a container.',
+      );
+    }
+    appendChild(parentInstance, child);
+  }
+
   function insertBefore(
     parentInstance: Instance | Container,
     child: Instance | TextInstance,
@@ -72,6 +84,19 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     parentInstance.children.splice(beforeIndex, 0, child);
   }
 
+  function insertInContainerBefore(
+    parentInstance: Container,
+    child: Instance | TextInstance,
+    beforeChild: Instance | TextInstance,
+  ) {
+    if (typeof parentInstance.rootID !== 'string') {
+      throw new Error(
+        'insertInContainerBefore() first argument is not a container.',
+      );
+    }
+    insertBefore(parentInstance, child, beforeChild);
+  }
+
   function removeChild(
     parentInstance: Instance | Container,
     child: Instance | TextInstance,
@@ -81,6 +106,18 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       throw new Error('This child does not exist.');
     }
     parentInstance.children.splice(index, 1);
+  }
+
+  function removeChildFromContainer(
+    parentInstance: Container,
+    child: Instance | TextInstance,
+  ): void {
+    if (typeof parentInstance.rootID !== 'string') {
+      throw new Error(
+        'removeChildFromContainer() first argument is not a container.',
+      );
+    }
+    removeChild(parentInstance, child);
   }
 
   let elapsedTimeInMs = 0;
@@ -234,12 +271,12 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           textInstance.text = newText;
         },
 
-        appendChild: appendChild,
-        appendChildToContainer: appendChild,
-        insertBefore: insertBefore,
-        insertInContainerBefore: insertBefore,
-        removeChild: removeChild,
-        removeChildFromContainer: removeChild,
+        appendChild,
+        appendChildToContainer,
+        insertBefore,
+        insertInContainerBefore,
+        removeChild,
+        removeChildFromContainer,
 
         resetTextContent(instance: Instance): void {},
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -670,7 +670,7 @@ function commitPlacement(finishedWork: Fiber): void {
 }
 
 function unmountHostComponents(current): void {
-  // We only have the top Fiber that was inserted but we need recurse down its
+  // We only have the top Fiber that was deleted but we need recurse down its
   // children to find all the terminal nodes.
   let node: Fiber = current;
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -722,6 +722,7 @@ function unmountHostComponents(current): void {
       // When we go into a portal, it becomes the parent to remove from.
       // We will reassign it back when we pop the portal on the way up.
       currentParent = node.stateNode.containerInfo;
+      currentParentIsContainer = true;
       // Visit children because portals might contain host components.
       if (node.child !== null) {
         node.child.return = node;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -598,8 +598,11 @@ function commitPlacement(finishedWork: Fiber): void {
 
   // Recursively insert all host nodes into the parent.
   const parentFiber = getHostParentFiber(finishedWork);
+
+  // Note: these two variables *must* always be updated together.
   let parent;
   let isContainer;
+
   switch (parentFiber.tag) {
     case HostComponent:
       parent = parentFiber.stateNode;
@@ -677,6 +680,8 @@ function unmountHostComponents(current): void {
   // Each iteration, currentParent is populated with node's host parent if not
   // currentParentIsValid.
   let currentParentIsValid = false;
+
+  // Note: these two variables *must* always be updated together.
   let currentParent;
   let currentParentIsContainer;
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -539,9 +539,13 @@ describe('ReactDebugFiberPerf', () => {
   });
 
   it('supports portals', () => {
-    const noopContainer = {children: []};
+    const portalContainer = ReactNoop.getOrCreateRootContainer(
+      'portalContainer',
+    );
     ReactNoop.render(
-      <Parent>{ReactNoop.createPortal(<Child />, noopContainer, null)}</Parent>,
+      <Parent>
+        {ReactNoop.createPortal(<Child />, portalContainer, null)}
+      </Parent>,
     );
     ReactNoop.flush();
     expect(getFlameChart()).toMatchSnapshot();


### PR DESCRIPTION
CurrentParent will now be considered as a container node and other renderer than web won't crash when unmounting

*this PR follows this one on the React-native repo https://github.com/facebook/react-native/pull/20233*

fixes https://github.com/facebook/react-native/issues/19084
