### PR TITLE
Remove the use of proxies for synthetic events in DEV

### DIFF
--- a/packages/events/SyntheticEvent.js
+++ b/packages/events/SyntheticEvent.js
@@ -70,6 +70,8 @@ function SyntheticEvent(
     delete this.nativeEvent;
     delete this.preventDefault;
     delete this.stopPropagation;
+    delete this.isDefaultPrevented;
+    delete this.isPropagationStopped;
   }
 
   this.dispatchConfig = dispatchConfig;
@@ -180,8 +182,8 @@ Object.assign(SyntheticEvent.prototype, {
     this.dispatchConfig = null;
     this._targetInst = null;
     this.nativeEvent = null;
-    this.isDefaultPrevented = null;
-    this.isPropagationStopped = null;
+    this.isDefaultPrevented = functionThatReturnsFalse;
+    this.isPropagationStopped = functionThatReturnsFalse;
     this._dispatchListeners = null;
     this._dispatchInstances = null;
     if (__DEV__) {
@@ -189,6 +191,16 @@ Object.assign(SyntheticEvent.prototype, {
         this,
         'nativeEvent',
         getPooledWarningPropertyDefinition('nativeEvent', null),
+      );
+      Object.defineProperty(
+        this,
+        'isDefaultPrevented',
+        getPooledWarningPropertyDefinition('isDefaultPrevented', functionThatReturnsFalse),
+      );
+      Object.defineProperty(
+        this,
+        'isPropagationStopped',
+        getPooledWarningPropertyDefinition('isPropagationStopped', functionThatReturnsFalse),
       );
       Object.defineProperty(
         this,

--- a/packages/events/SyntheticEvent.js
+++ b/packages/events/SyntheticEvent.js
@@ -10,18 +10,7 @@
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 
-let didWarnForAddedNewProperty = false;
 const EVENT_POOL_SIZE = 10;
-
-const shouldBeReleasedProperties = [
-  'dispatchConfig',
-  '_targetInst',
-  'nativeEvent',
-  'isDefaultPrevented',
-  'isPropagationStopped',
-  '_dispatchListeners',
-  '_dispatchInstances',
-];
 
 /**
  * @interface Event
@@ -188,9 +177,13 @@ Object.assign(SyntheticEvent.prototype, {
         this[propName] = null;
       }
     }
-    for (let i = 0; i < shouldBeReleasedProperties.length; i++) {
-      this[shouldBeReleasedProperties[i]] = null;
-    }
+    this.dispatchConfig = null;
+    this._targetInst = null;
+    this.nativeEvent = null;
+    this.isDefaultPrevented = null;
+    this.isPropagationStopped = null;
+    this._dispatchListeners = null;
+    this._dispatchInstances = null;
     if (__DEV__) {
       Object.defineProperty(
         this,
@@ -236,49 +229,6 @@ SyntheticEvent.extend = function(Interface) {
 
   return Class;
 };
-
-/** Proxying after everything set on SyntheticEvent
- * to resolve Proxy issue on some WebKit browsers
- * in which some Event properties are set to undefined (GH#10010)
- */
-if (__DEV__) {
-  const isProxySupported =
-    typeof Proxy === 'function' &&
-    // https://github.com/facebook/react/issues/12011
-    !Object.isSealed(new Proxy({}, {}));
-
-  if (isProxySupported) {
-    /*eslint-disable no-func-assign */
-    SyntheticEvent = new Proxy(SyntheticEvent, {
-      construct: function(target, args) {
-        return this.apply(target, Object.create(target.prototype), args);
-      },
-      apply: function(constructor, that, args) {
-        return new Proxy(constructor.apply(that, args), {
-          set: function(target, prop, value) {
-            if (
-              prop !== 'isPersistent' &&
-              !target.constructor.Interface.hasOwnProperty(prop) &&
-              shouldBeReleasedProperties.indexOf(prop) === -1
-            ) {
-              warningWithoutStack(
-                didWarnForAddedNewProperty || target.isPersistent(),
-                "This synthetic event is reused for performance reasons. If you're " +
-                  "seeing this, you're adding a new property in the synthetic event object. " +
-                  'The property is never released. See ' +
-                  'https://fb.me/react-event-pooling for more information.',
-              );
-              didWarnForAddedNewProperty = true;
-            }
-            target[prop] = value;
-            return true;
-          },
-        });
-      },
-    });
-    /*eslint-enable no-func-assign */
-  }
-}
 
 addEventPoolingTo(SyntheticEvent);
 
@@ -354,7 +304,7 @@ function releasePooledEvent(event) {
   const EventConstructor = this;
   invariant(
     event instanceof EventConstructor,
-    'Trying to release an event instance  into a pool of a different type.',
+    'Trying to release an event instance into a pool of a different type.',
   );
   event.destructor();
   if (EventConstructor.eventPool.length < EVENT_POOL_SIZE) {

--- a/packages/events/SyntheticEvent.js
+++ b/packages/events/SyntheticEvent.js
@@ -195,12 +195,18 @@ Object.assign(SyntheticEvent.prototype, {
       Object.defineProperty(
         this,
         'isDefaultPrevented',
-        getPooledWarningPropertyDefinition('isDefaultPrevented', functionThatReturnsFalse),
+        getPooledWarningPropertyDefinition(
+          'isDefaultPrevented',
+          functionThatReturnsFalse,
+        ),
       );
       Object.defineProperty(
         this,
         'isPropagationStopped',
-        getPooledWarningPropertyDefinition('isPropagationStopped', functionThatReturnsFalse),
+        getPooledWarningPropertyDefinition(
+          'isPropagationStopped',
+          functionThatReturnsFalse,
+        ),
       );
       Object.defineProperty(
         this,

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -249,6 +249,58 @@ describe('SyntheticEvent', () => {
     expect(expectedCount).toBe(1);
   });
 
+  it('should warn when calling `isPropagationStopped` if the synthetic event has not been persisted', () => {
+    let node;
+    let expectedCount = 0;
+    let syntheticEvent;
+
+    const eventHandler = e => {
+      syntheticEvent = e;
+      expectedCount++;
+    };
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+
+    const event = document.createEvent('Event');
+    event.initEvent('click', true, true);
+    node.dispatchEvent(event);
+
+    expect(() => expect(syntheticEvent.isPropagationStopped()).toBe(false)).toWarnDev(
+      'Warning: This synthetic event is reused for performance reasons. If ' +
+        "you're seeing this, you're accessing the method `isPropagationStopped` on a " +
+        'released/nullified synthetic event. This is a no-op function. If you must ' +
+        'keep the original synthetic event around, use event.persist(). ' +
+        'See https://fb.me/react-event-pooling for more information.',
+      {withoutStack: true},
+    );
+    expect(expectedCount).toBe(1);
+  });
+
+  it('should warn when calling `isDefaultPrevented` if the synthetic event has not been persisted', () => {
+    let node;
+    let expectedCount = 0;
+    let syntheticEvent;
+
+    const eventHandler = e => {
+      syntheticEvent = e;
+      expectedCount++;
+    };
+    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+
+    const event = document.createEvent('Event');
+    event.initEvent('click', true, true);
+    node.dispatchEvent(event);
+
+    expect(() => expect(syntheticEvent.isDefaultPrevented()).toBe(false)).toWarnDev(
+      'Warning: This synthetic event is reused for performance reasons. If ' +
+        "you're seeing this, you're accessing the method `isDefaultPrevented` on a " +
+        'released/nullified synthetic event. This is a no-op function. If you must ' +
+        'keep the original synthetic event around, use event.persist(). ' +
+        'See https://fb.me/react-event-pooling for more information.',
+      {withoutStack: true},
+    );
+    expect(expectedCount).toBe(1);
+  });
+
   it('should properly log warnings when events simulated with rendered components', () => {
     let event;
     function assignEvent(e) {

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -322,6 +322,10 @@ describe('SyntheticEvent', () => {
     );
   });
 
+  // TODO: we might want to re-add a warning like this in the future,
+  // but it shouldn't use Proxies because they making debugging difficult.
+  // Or we might disallow this pattern altogether:
+  // https://github.com/facebook/react/issues/13224
   xit('should warn if synthetic event is added a property', () => {
     let node;
     let expectedCount = 0;

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -327,10 +327,10 @@ describe('SyntheticEvent', () => {
   });
 
   // TODO: we might want to re-add a warning like this in the future,
-  // but it shouldn't use Proxies because they making debugging difficult.
+  // but it shouldn't use Proxies because they make debugging difficult.
   // Or we might disallow this pattern altogether:
   // https://github.com/facebook/react/issues/13224
-  xit('should warn if synthetic event is added a property', () => {
+  xit('should warn if a property is added to the synthetic event', () => {
     let node;
     let expectedCount = 0;
     let syntheticEvent;

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -270,25 +270,21 @@ describe('SyntheticEvent', () => {
     );
   });
 
-  it('should warn if Proxy is supported and the synthetic event is added a property', () => {
+  xit('should warn if synthetic event is added a property', () => {
     let node;
     let expectedCount = 0;
     let syntheticEvent;
 
     const eventHandler = e => {
-      if (typeof Proxy === 'function') {
-        expect(() => {
-          e.foo = 'bar';
-        }).toWarnDev(
-          'Warning: This synthetic event is reused for performance reasons. If ' +
-            "you're seeing this, you're adding a new property in the synthetic " +
-            'event object. The property is never released. ' +
-            'See https://fb.me/react-event-pooling for more information.',
-          {withoutStack: true},
-        );
-      } else {
+      expect(() => {
         e.foo = 'bar';
-      }
+      }).toWarnDev(
+        'Warning: This synthetic event is reused for performance reasons. If ' +
+          "you're seeing this, you're adding a new property in the synthetic " +
+          'event object. The property is never released. ' +
+          'See https://fb.me/react-event-pooling for more information.',
+        {withoutStack: true},
+      );
       syntheticEvent = e;
       expectedCount++;
     };

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -264,7 +264,9 @@ describe('SyntheticEvent', () => {
     event.initEvent('click', true, true);
     node.dispatchEvent(event);
 
-    expect(() => expect(syntheticEvent.isPropagationStopped()).toBe(false)).toWarnDev(
+    expect(() =>
+      expect(syntheticEvent.isPropagationStopped()).toBe(false),
+    ).toWarnDev(
       'Warning: This synthetic event is reused for performance reasons. If ' +
         "you're seeing this, you're accessing the method `isPropagationStopped` on a " +
         'released/nullified synthetic event. This is a no-op function. If you must ' +
@@ -290,7 +292,9 @@ describe('SyntheticEvent', () => {
     event.initEvent('click', true, true);
     node.dispatchEvent(event);
 
-    expect(() => expect(syntheticEvent.isDefaultPrevented()).toBe(false)).toWarnDev(
+    expect(() =>
+      expect(syntheticEvent.isDefaultPrevented()).toBe(false),
+    ).toWarnDev(
       'Warning: This synthetic event is reused for performance reasons. If ' +
         "you're seeing this, you're accessing the method `isDefaultPrevented` on a " +
         'released/nullified synthetic event. This is a no-op function. If you must ' +


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/12171.

Motivation: [this is very confusing](https://mobile.twitter.com/ReactStudent/status/1018749513572368384). I've seen quite a few complaints about this and also bumped into it myself when I played with React occasionally. The warning is just not worth it.

The first commit (https://github.com/facebook/react/commit/ac71c2987b93a89b1101c617a74a4a78771dd0e7) is pretty much a revert of https://github.com/facebook/react/pull/5947. https://github.com/facebook/react/pull/5947 cleared a few more properties than the code before it (which is nice) so I kept the current behavior (but removed the key list indirection).

The second commit (https://github.com/facebook/react/commit/3c9768046eee4866ad63f6aa1dda0539fe0772ba) fixes a bug that was introduced by https://github.com/facebook/react/pull/5947. Specifically, it was nulling out `isPropagationStopped()` and `isDefaultPrevented()`. While you shouldn't access them, nulling them out can lead to confusing crashes. So I just changed them to behave similarly to `preventDefault()` and `stopPropagation()` (which get shimmed with noops while the event is pooled). I consider it a bugfix — can't imagine somebody relying on whether it's nulled out or not in a way that isn't broken for some other reason.

I considered adding some kind of warning instead of this one (e.g. by counting the keys on every release). But it just seemed too complicated and not worth it. I imagine the situation is pretty rare anyway. And we can fix it in 17 for good with https://github.com/facebook/react/issues/13224.