### PR TITLE
Fail tests if toWarnDev() does not wrap warnings in array

### DIFF
--- a/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
+++ b/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
@@ -80,8 +80,8 @@ describe('ReactChildReconciler', () => {
         'Keys should be unique so that components maintain their identity ' +
         'across updates. Non-unique keys may cause children to be ' +
         'duplicated and/or omitted — the behavior is unsupported and ' +
-        'could change in a future version.',
-      '    in div (at **)\n' +
+        'could change in a future version.\n' +
+        '    in div (at **)\n' +
         '    in Component (at **)\n' +
         '    in Parent (at **)\n' +
         '    in GrandParent (at **)',
@@ -127,8 +127,8 @@ describe('ReactChildReconciler', () => {
         'Keys should be unique so that components maintain their identity ' +
         'across updates. Non-unique keys may cause children to be ' +
         'duplicated and/or omitted — the behavior is unsupported and ' +
-        'could change in a future version.',
-      '    in div (at **)\n' +
+        'could change in a future version.\n' +
+        '    in div (at **)\n' +
         '    in Component (at **)\n' +
         '    in Parent (at **)\n' +
         '    in GrandParent (at **)',

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -980,8 +980,9 @@ describe('ReactDOMFiber', () => {
     expect(() => ReactDOM.render(<Example />, container)).toWarnDev(
       'Expected `onClick` listener to be a function, instead got `false`.\n\n' +
         'If you used to conditionally omit it with onClick={condition && value}, ' +
-        'pass onClick={condition ? value : undefined} instead.\n',
-      '    in div (at **)\n' + '    in Example (at **)',
+        'pass onClick={condition ? value : undefined} instead.\n' +
+        '    in div (at **)\n' +
+        '    in Example (at **)',
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -209,8 +209,8 @@ describe('ReactMultiChild', () => {
           'Keys should be unique so that components maintain their identity ' +
           'across updates. Non-unique keys may cause children to be ' +
           'duplicated and/or omitted — the behavior is unsupported and ' +
-          'could change in a future version.',
-        '    in div (at **)\n' +
+          'could change in a future version.\n' +
+          '    in div (at **)\n' +
           '    in WrapperComponent (at **)\n' +
           '    in div (at **)\n' +
           '    in Parent (at **)',
@@ -269,8 +269,8 @@ describe('ReactMultiChild', () => {
           'Keys should be unique so that components maintain their identity ' +
           'across updates. Non-unique keys may cause children to be ' +
           'duplicated and/or omitted — the behavior is unsupported and ' +
-          'could change in a future version.',
-        '    in div (at **)\n' +
+          'could change in a future version.\n' +
+          '    in div (at **)\n' +
           '    in WrapperComponent (at **)\n' +
           '    in div (at **)\n' +
           '    in Parent (at **)',

--- a/scripts/jest/matchers/__tests__/toWarnDev-test.js
+++ b/scripts/jest/matchers/__tests__/toWarnDev-test.js
@@ -169,5 +169,51 @@ describe('toWarnDev', () => {
         }).toWarnDev('Hi');
       }).toThrow('Received more than one component stack for a warning');
     });
+
+    it('fails if multiple strings are passed without an array wrapper', () => {
+      expect(() => {
+        expect(() => {
+          console.error('Hi \n    in div');
+        }).toWarnDev('Hi', 'Bye');
+      }).toThrow(
+        'toWarnDev() second argument, when present, should be an object'
+      );
+      expect(() => {
+        expect(() => {
+          console.error('Hi \n    in div');
+          console.error('Bye \n    in div');
+        }).toWarnDev('Hi', 'Bye');
+      }).toThrow(
+        'toWarnDev() second argument, when present, should be an object'
+      );
+      expect(() => {
+        expect(() => {
+          console.error('Hi \n    in div');
+          console.error('Wow \n    in div');
+          console.error('Bye \n    in div');
+        }).toWarnDev('Hi', 'Bye');
+      }).toThrow(
+        'toWarnDev() second argument, when present, should be an object'
+      );
+      expect(() => {
+        expect(() => {
+          console.error('Hi \n    in div');
+          console.error('Wow \n    in div');
+          console.error('Bye \n    in div');
+        }).toWarnDev('Hi', 'Wow', 'Bye');
+      }).toThrow(
+        'toWarnDev() second argument, when present, should be an object'
+      );
+    });
+
+    it('fails on more than two arguments', () => {
+      expect(() => {
+        expect(() => {
+          console.error('Hi \n    in div');
+          console.error('Wow \n    in div');
+          console.error('Bye \n    in div');
+        }).toWarnDev('Hi', undefined, 'Bye');
+      }).toThrow('toWarnDev() received more than two arguments.');
+    });
   }
 });

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -19,6 +19,22 @@ const createMatcherFor = consoleMethod =>
             `but was given ${typeof expectedMessages}.`
         );
       }
+      if (
+        options != null &&
+        (typeof options !== 'object' || Array.isArray(options))
+      ) {
+        throw new Error(
+          'toWarnDev() second argument, when present, should be an object. ' +
+            'Did you forget to wrap messages into an array?'
+        );
+      }
+      if (arguments.length > 3) {
+        // `matcher` comes from Jest, so it's more than 2 in practice
+        throw new Error(
+          'toWarnDev() received more than two arguments. ' +
+            'Did you forget to wrap the messages into an array?'
+        );
+      }
 
       const withoutStack = options.withoutStack;
       const warningsWithoutComponentStack = [];

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -25,7 +25,7 @@ const createMatcherFor = consoleMethod =>
       ) {
         throw new Error(
           'toWarnDev() second argument, when present, should be an object. ' +
-            'Did you forget to wrap messages into an array?'
+            'Did you forget to wrap the messages into an array?'
         );
       }
       if (arguments.length > 3) {


### PR DESCRIPTION
It was too easy to do

```js
toWarnDev(msg1, msg2)
```

and not notice that you're actually validating just `msg1`.

This also leads to confusion when you *do* expect to get both but matcher claims you only expected one.

The correct way is:

```js
toWarnDev([msg1, msg2])
```

This PR adds assertions that would fail the test that passes messages without an array. Also includes regression tests.

In the second commit, I fix the only five violations. They weren't surfacing any bugs — we were essentially ignoring assertions about the component stack because it was accidentally passed as a second argument to `toWarnDev()` instead of being concatenated. Now we check it.