### PR TITLE
[react-test-renderer] toJSX

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -30,6 +30,7 @@ import {
 } from 'shared/ReactTypeOfWork';
 import invariant from 'shared/invariant';
 import ReactVersion from 'shared/ReactVersion';
+import {REACT_ELEMENT_TYPE, REACT_FRAGMENT_TYPE} from 'shared/ReactSymbols';
 
 import * as ReactTestHostConfig from './ReactTestHostConfig';
 import * as TestRendererScheduling from './ReactTestRendererScheduling';
@@ -86,6 +87,47 @@ function toJSON(inst: Instance | TextInstance): ReactTestRendererNode {
       return json;
     default:
       throw new Error(`Unexpected node type in toJSON: ${inst.tag}`);
+  }
+}
+
+function toJSXChildren(
+  children: Array<Instance | TextInstance>,
+): null | string | React$Element<any> | Array<React$Element<any> | string> {
+  if (children != null) {
+    if (children.length === 1) {
+      return toJSX(children[0]);
+    } else if (children.length > 1) {
+      return children.map(toJSX);
+    }
+  }
+  return null;
+}
+
+function toJSX(child: Instance | TextInstance): string | React$Element<any> {
+  switch (child.tag) {
+    case 'TEXT':
+      return child.text;
+    case 'INSTANCE': {
+      // eslint-disable-next-line no-unused-vars
+      const {children: ignoredChildrenProp, ...props} = child.props;
+      const elementProps = {...props};
+      const elementChildren = toJSXChildren(child.children);
+      if (elementChildren !== null) {
+        elementProps.children = elementChildren;
+      }
+      const element = {
+        $$typeof: REACT_ELEMENT_TYPE,
+        type: child.type,
+        key: null,
+        ref: null,
+        props: elementProps,
+        _owner: null,
+        _store: __DEV__ ? {} : undefined,
+      };
+      return ((element: any): React$Element<any>);
+    }
+    default:
+      throw new Error(`Unexpected node type in child: ${child.tag}`);
   }
 }
 
@@ -439,6 +481,31 @@ const ReactTestRendererFiber = {
           return toJSON(container.children[0]);
         }
         return container.children.map(toJSON);
+      },
+      toJSX(): React$Element<any> | string | null {
+        if (root == null || root.current == null || container == null) {
+          return null;
+        }
+        if (container.children.length === 1) {
+          return toJSX(container.children[0]);
+        }
+        const jsxChildren = toJSXChildren(container.children);
+        if (jsxChildren === null) {
+          return null;
+        }
+        // Return a React.Fragment element
+        const fragmentElement = {
+          $$typeof: REACT_ELEMENT_TYPE,
+          type: REACT_FRAGMENT_TYPE,
+          key: null,
+          ref: null,
+          props: {
+            children: jsxChildren,
+          },
+          _owner: null,
+          _store: __DEV__ ? {} : undefined,
+        };
+        return ((fragmentElement: any): React$Element<any>);
       },
       toTree() {
         if (root == null || root.current == null) {

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -754,6 +754,102 @@ describe('ReactTestRenderer', () => {
     );
   });
 
+  it('toJSX() renders simple components returning host components', () => {
+    const Qoo = () => <span className="Qoo">Hello World!</span>;
+    const renderer = ReactTestRenderer.create(<Qoo />);
+    expect(renderer.toJSX()).toEqual(<span className="Qoo">Hello World!</span>);
+  });
+
+  it('toJSX() handles nested Fragments', () => {
+    const Foo = () => (
+      <React.Fragment>
+        <React.Fragment>foo</React.Fragment>
+      </React.Fragment>
+    );
+    const renderer = ReactTestRenderer.create(<Foo />);
+    expect(renderer.toJSX()).toEqual('foo');
+  });
+
+  it('toJSX() handles null rendering components', () => {
+    class Foo extends React.Component {
+      render() {
+        return null;
+      }
+    }
+
+    const renderer = ReactTestRenderer.create(<Foo />);
+    expect(renderer.toJSX()).toEqual(null);
+  });
+
+  it('toJSX() handles simple components that return arrays', () => {
+    const Foo = ({children}) => children;
+    const renderer = ReactTestRenderer.create(
+      <Foo>
+        <div>One</div>
+        <div>Two</div>
+      </Foo>,
+    );
+    expect(renderer.toJSX()).toEqual(
+      <React.Fragment>
+        <div>One</div>
+        <div>Two</div>
+      </React.Fragment>,
+    );
+  });
+
+  it('toJSX() handles complicated tree of arrays', () => {
+    class Foo extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    const renderer = ReactTestRenderer.create(
+      <div>
+        <Foo>
+          <div>One</div>
+          <div>Two</div>
+          <Foo>
+            <div>Three</div>
+          </Foo>
+        </Foo>
+        <div>Four</div>
+      </div>,
+    );
+
+    expect(renderer.toJSX()).toEqual(
+      <div>
+        <div>One</div>
+        <div>Two</div>
+        <div>Three</div>
+        <div>Four</div>
+      </div>,
+    );
+  });
+
+  it('toJSX() handles complicated tree of fragments', () => {
+    const renderer = ReactTestRenderer.create(
+      <React.Fragment>
+        <React.Fragment>
+          <div>One</div>
+          <div>Two</div>
+          <React.Fragment>
+            <div>Three</div>
+          </React.Fragment>
+        </React.Fragment>
+        <div>Four</div>
+      </React.Fragment>,
+    );
+    expect(renderer.toJSX()).toEqual(
+      <React.Fragment>
+        <div>One</div>
+        <div>Two</div>
+        <div>Three</div>
+        <div>Four</div>
+      </React.Fragment>,
+    );
+  });
+
   it('root instance and createNodeMock ref return the same value', () => {
     const createNodeMock = ref => ({node: ref});
     let refInst = null;


### PR DESCRIPTION
Adds a toJSX method to react-test-renderer. Like toJSON, it returns the current tree of host instances, but in the form of React elements. This is a convenient output format for unit tests. E.g. Jest formats JSX diffs nicely.

The larger goal I'm working toward is to bring the test renderer closer to parity with the noop renderer for writing async tests.