### PR TITLE
[react-test-renderer] Move unstable_yield to main export

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -466,14 +466,14 @@ const ReactTestRendererFiber = {
         }
         return TestRenderer.getPublicRootInstance(root);
       },
+
       unstable_flushAll: TestRendererScheduling.flushAll,
-      unstable_flushSync(fn: Function) {
-        return TestRendererScheduling.withCleanYields(() => {
-          TestRenderer.flushSync(fn);
-        });
+      unstable_flushSync<T>(fn: () => T): T {
+        TestRendererScheduling.clearYields();
+        return TestRenderer.flushSync(fn);
       },
       unstable_flushThrough: TestRendererScheduling.flushThrough,
-      unstable_yield: TestRendererScheduling.yieldValue,
+      unstable_clearYields: TestRendererScheduling.clearYields,
     };
 
     Object.defineProperty(
@@ -503,6 +503,9 @@ const ReactTestRendererFiber = {
 
     return entry;
   },
+
+  unstable_yield: TestRendererScheduling.yieldValue,
+  unstable_clearYields: TestRendererScheduling.clearYields,
 
   /* eslint-disable camelcase */
   unstable_batchedUpdates: batchedUpdates,

--- a/packages/react-test-renderer/src/ReactTestRendererScheduling.js
+++ b/packages/react-test-renderer/src/ReactTestRendererScheduling.js
@@ -112,8 +112,8 @@ export function yieldValue(value: mixed): void {
   yieldedValues.push(value);
 }
 
-export function withCleanYields(fn: Function) {
+export function clearYields(): Array<mixed> {
+  const values = yieldedValues;
   yieldedValues = [];
-  fn();
-  return yieldedValues;
+  return values;
 }

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
@@ -46,7 +46,7 @@ describe('ReactTestRendererAsync', () => {
 
   it('flushAll returns array of yielded values', () => {
     function Child(props) {
-      renderer.unstable_yield(props.children);
+      ReactTestRenderer.unstable_yield(props.children);
       return props.children;
     }
     function Parent(props) {
@@ -72,7 +72,7 @@ describe('ReactTestRendererAsync', () => {
 
   it('flushThrough flushes until the expected values is yielded', () => {
     function Child(props) {
-      renderer.unstable_yield(props.children);
+      ReactTestRenderer.unstable_yield(props.children);
       return props.children;
     }
     function Parent(props) {
@@ -103,7 +103,7 @@ describe('ReactTestRendererAsync', () => {
 
   it('supports high priority interruptions', () => {
     function Child(props) {
-      renderer.unstable_yield(props.children);
+      ReactTestRenderer.unstable_yield(props.children);
       return props.children;
     }
 
@@ -143,7 +143,7 @@ describe('ReactTestRendererAsync', () => {
 
   it('should error if flushThrough params dont match yielded values', () => {
     const Yield = ({id}) => {
-      renderer.unstable_yield(id);
+      ReactTestRenderer.unstable_yield(id);
       return id;
     };
 
@@ -165,7 +165,7 @@ describe('ReactTestRendererAsync', () => {
 
   it('should error if flushAll params dont match yielded values', () => {
     const Yield = ({id}) => {
-      renderer.unstable_yield(id);
+      ReactTestRenderer.unstable_yield(id);
       return id;
     };
 
@@ -199,7 +199,7 @@ describe('ReactTestRendererAsync', () => {
 
   it('should error if flushThrough yields the wrong number of values', () => {
     const Yield = ({id}) => {
-      renderer.unstable_yield(id);
+      ReactTestRenderer.unstable_yield(id);
       return id;
     };
 

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -163,7 +163,7 @@ describe('Profiler', () => {
       const callback = jest.fn();
 
       const Yield = ({value}) => {
-        renderer.unstable_yield(value);
+        ReactTestRenderer.unstable_yield(value);
         return null;
       };
 
@@ -514,7 +514,7 @@ describe('Profiler', () => {
 
         const Yield = ({renderTime}) => {
           advanceTimeBy(renderTime);
-          renderer.unstable_yield('Yield:' + renderTime);
+          ReactTestRenderer.unstable_yield('Yield:' + renderTime);
           return null;
         };
 
@@ -550,7 +550,7 @@ describe('Profiler', () => {
 
         const Yield = ({renderTime}) => {
           advanceTimeBy(renderTime);
-          renderer.unstable_yield('Yield:' + renderTime);
+          ReactTestRenderer.unstable_yield('Yield:' + renderTime);
           return null;
         };
 
@@ -602,7 +602,7 @@ describe('Profiler', () => {
 
         const Yield = ({renderTime}) => {
           advanceTimeBy(renderTime);
-          renderer.unstable_yield('Yield:' + renderTime);
+          ReactTestRenderer.unstable_yield('Yield:' + renderTime);
           return null;
         };
 
@@ -627,15 +627,14 @@ describe('Profiler', () => {
 
         // Interrupt with higher priority work.
         // The interrupted work simulates an additional 5ms of time.
-        expect(
-          renderer.unstable_flushSync(() => {
-            renderer.update(
-              <React.unstable_Profiler id="test" onRender={callback}>
-                <Yield renderTime={5} />
-              </React.unstable_Profiler>,
-            );
-          }),
-        ).toEqual(['Yield:5']);
+        renderer.unstable_flushSync(() => {
+          renderer.update(
+            <React.unstable_Profiler id="test" onRender={callback}>
+              <Yield renderTime={5} />
+            </React.unstable_Profiler>,
+          );
+        });
+        expect(ReactTestRenderer.unstable_clearYields()).toEqual(['Yield:5']);
 
         // The initial work was thrown away in this case,
         // So the actual and base times should only include the final rendered tree times.
@@ -658,7 +657,7 @@ describe('Profiler', () => {
 
         const Yield = ({renderTime}) => {
           advanceTimeBy(renderTime);
-          renderer.unstable_yield('Yield:' + renderTime);
+          ReactTestRenderer.unstable_yield('Yield:' + renderTime);
           return null;
         };
 
@@ -714,15 +713,14 @@ describe('Profiler', () => {
 
         // Interrupt with higher priority work.
         // The interrupted work simulates an additional 11ms of time.
-        expect(
-          renderer.unstable_flushSync(() => {
-            renderer.update(
-              <React.unstable_Profiler id="test" onRender={callback}>
-                <Yield renderTime={11} />
-              </React.unstable_Profiler>,
-            );
-          }),
-        ).toEqual(['Yield:11']);
+        renderer.unstable_flushSync(() => {
+          renderer.update(
+            <React.unstable_Profiler id="test" onRender={callback}>
+              <Yield renderTime={11} />
+            </React.unstable_Profiler>,
+          );
+        });
+        expect(ReactTestRenderer.unstable_clearYields()).toEqual(['Yield:11']);
 
         // The actual time should include only the most recent render,
         // Because this lets us avoid a lot of commit phase reset complexity.
@@ -744,7 +742,7 @@ describe('Profiler', () => {
 
         const Yield = ({renderTime}) => {
           advanceTimeBy(renderTime);
-          renderer.unstable_yield('Yield:' + renderTime);
+          ReactTestRenderer.unstable_yield('Yield:' + renderTime);
           return null;
         };
 
@@ -754,7 +752,9 @@ describe('Profiler', () => {
           render() {
             first = this;
             advanceTimeBy(this.state.renderTime);
-            renderer.unstable_yield('FirstComponent:' + this.state.renderTime);
+            ReactTestRenderer.unstable_yield(
+              'FirstComponent:' + this.state.renderTime,
+            );
             return <Yield renderTime={4} />;
           }
         }
@@ -764,7 +764,9 @@ describe('Profiler', () => {
           render() {
             second = this;
             advanceTimeBy(this.state.renderTime);
-            renderer.unstable_yield('SecondComponent:' + this.state.renderTime);
+            ReactTestRenderer.unstable_yield(
+              'SecondComponent:' + this.state.renderTime,
+            );
             return <Yield renderTime={7} />;
           }
         }
@@ -812,9 +814,11 @@ describe('Profiler', () => {
 
         // Interrupt with higher priority work.
         // This simulates a total of 37ms of actual render time.
-        expect(
-          renderer.unstable_flushSync(() => second.setState({renderTime: 30})),
-        ).toEqual(['SecondComponent:30', 'Yield:7']);
+        renderer.unstable_flushSync(() => second.setState({renderTime: 30}));
+        expect(ReactTestRenderer.unstable_clearYields()).toEqual([
+          'SecondComponent:30',
+          'Yield:7',
+        ]);
 
         // The actual time should include only the most recent render (37ms),
         // Because this lets us avoid a lot of commit phase reset complexity.


### PR DESCRIPTION
The `yield` method isn't tied to any specific root. Putting this on the main export enables test components that are not within scope to yield even if they don't have access to the currently rendering root instance. This follows the pattern established by ReactNoop.

Added a `clearYields` method, too, for reading values that were yielded out of band. This is also based on ReactNoop.