### PR TITLE
Removed unused state argument in unsubscribe method of <Subscription />

### DIFF
--- a/packages/create-subscription/src/createSubscription.js
+++ b/packages/create-subscription/src/createSubscription.js
@@ -87,13 +87,13 @@ export function createSubscription<Property, Value>(
 
     componentDidUpdate(prevProps, prevState) {
       if (this.state.source !== prevState.source) {
-        this.unsubscribe(prevState);
+        this.unsubscribe();
         this.subscribe();
       }
     }
 
     componentWillUnmount() {
-      this.unsubscribe(this.state);
+      this.unsubscribe();
 
       // Track mounted to avoid calling setState after unmounting
       // For source like Promises that can't be unsubscribed from.
@@ -147,7 +147,7 @@ export function createSubscription<Property, Value>(
       }
     }
 
-    unsubscribe(state: State) {
+    unsubscribe() {
       if (typeof this._unsubscribe === 'function') {
         this._unsubscribe();
       }


### PR DESCRIPTION
I've noticed that this argument is no longer used after [this refactor](https://github.com/facebook/react/commit/2738e84805820fbf4f7db1a521e22d44272455ab) by @bvaughn .