### PR TITLE
Add more flexibility in testing errors in begin/complete phases

### DIFF
--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -40,10 +40,7 @@ if (__DEV__) {
 
 function createReactNoop(reconciler: Function, useMutation: boolean) {
   let scheduledCallback = null;
-
   let instanceCounter = 0;
-  let failInBeginPhase = false;
-  let failInCompletePhase = false;
 
   function appendChildToContainerOrInstance(
     parentInstance: Container | Instance,
@@ -167,9 +164,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
   const sharedHostConfig = {
     getRootHostContext() {
-      if (failInBeginPhase) {
-        throw new Error('Error in host config.');
-      }
       return NO_CONTEXT;
     },
 
@@ -182,7 +176,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     },
 
     createInstance(type: string, props: Props): Instance {
-      if (failInCompletePhase) {
+      if (type === 'errorInCompletePhase') {
         throw new Error('Error in host config.');
       }
       const inst = {
@@ -227,6 +221,9 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     },
 
     shouldSetTextContent(type: string, props: Props): boolean {
+      if (type === 'errorInBeginPhase') {
+        throw new Error('Error in host config.');
+      }
       return (
         typeof props.children === 'string' || typeof props.children === 'number'
       );
@@ -693,24 +690,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       logFiber(root.current, 0);
 
       console.log(...bufferedLog);
-    },
-
-    simulateErrorInHostConfigDuringBeginPhase(fn: () => void) {
-      failInBeginPhase = true;
-      try {
-        fn();
-      } finally {
-        failInBeginPhase = false;
-      }
-    },
-
-    simulateErrorInHostConfigDuringCompletePhase(fn: () => void) {
-      failInCompletePhase = true;
-      try {
-        fn();
-      } finally {
-        failInCompletePhase = false;
-      }
     },
 
     flushWithoutCommitting(

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -211,6 +211,9 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       oldProps: Props,
       newProps: Props,
     ): null | {} {
+      if (type === 'errorInCompletePhase') {
+        throw new Error('Error in host config.');
+      }
       if (oldProps === null) {
         throw new Error('Should have old props');
       }

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1212,10 +1212,8 @@ describe('ReactIncrementalErrorHandling', () => {
   });
 
   it('handles error thrown by host config while working on failed root', () => {
-    ReactNoop.simulateErrorInHostConfigDuringBeginPhase(() => {
-      ReactNoop.render(<span />);
-      expect(() => ReactNoop.flush()).toThrow('Error in host config.');
-    });
+    ReactNoop.render(<errorInBeginPhase />);
+    expect(() => ReactNoop.flush()).toThrow('Error in host config.');
   });
 
   it('handles error thrown by top-level callback', () => {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
@@ -21,10 +21,8 @@ describe('ReactIncrementalErrorReplay', () => {
   });
 
   it('should fail gracefully on error in the host environment', () => {
-    ReactNoop.simulateErrorInHostConfigDuringBeginPhase(() => {
-      ReactNoop.render(<span />);
-      expect(() => ReactNoop.flush()).toThrow('Error in host config.');
-    });
+    ReactNoop.render(<errorInBeginPhase />);
+    expect(() => ReactNoop.flush()).toThrow('Error in host config.');
   });
 
   it("should ignore error if it doesn't throw on retry", () => {

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -988,14 +988,12 @@ describe('Profiler', () => {
 
             // Simulate a renderer error during the "complete" phase.
             // This mimics behavior like React Native's View/Text nesting validation.
-            ReactNoop.simulateErrorInHostConfigDuringCompletePhase(() => {
-              ReactNoop.render(
-                <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
-                  <span>hi</span>
-                </React.unstable_Profiler>,
-              );
-              expect(ReactNoop.flush).toThrow('Error in host config.');
-            });
+            ReactNoop.render(
+              <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
+                <errorInCompletePhase>hi</errorInCompletePhase>
+              </React.unstable_Profiler>,
+            );
+            expect(ReactNoop.flush).toThrow('Error in host config.');
 
             // So long as the profiler timer's fiber stack is reset correctly,
             // Subsequent renders should not error.


### PR DESCRIPTION
While debugging an internal issue with stack mismatches, I noticed that our current API for simulating errors is not sufficient to represent some cases. In particular, I want to be able to render a host parent, but then have *its* host node throw. This API is a bit more flexible and allows me to create a repro (will send as a separate PR).