### PR TITLE
Fix unwinding starting with a wrong Fiber on error in the complete phase

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -791,11 +791,12 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
 
     if ((workInProgress.effectTag & Incomplete) === NoEffect) {
       // This fiber completed.
-      let next = completeWork(
+      nextUnitOfWork = completeWork(
         current,
         workInProgress,
         nextRenderExpirationTime,
       );
+      let next = nextUnitOfWork;
       stopWorkTimer(workInProgress);
       resetExpirationTime(workInProgress, nextRenderExpirationTime);
       if (__DEV__) {

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1128,6 +1128,27 @@ describe('ReactNewContext', () => {
     ]);
   });
 
+  it('unwinds after errors in complete phase', () => {
+    const Context = React.createContext(0);
+
+    // This is a regression test for stack misalignment
+    // caused by unwinding the context from wrong point.
+    ReactNoop.render(
+      <errorInCompletePhase>
+        <Context.Provider />
+      </errorInCompletePhase>,
+    );
+    expect(ReactNoop.flush).toThrow('Error in host config.');
+
+    ReactNoop.render(
+      <Context.Provider value={10}>
+        <Context.Consumer>{value => <span prop={value} />}</Context.Consumer>
+      </Context.Provider>,
+    );
+    ReactNoop.flush();
+    expect(ReactNoop.getChildren()).toEqual([span(10)]);
+  });
+
   describe('fuzz test', () => {
     const Fragment = React.Fragment;
     const contextKeys = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -999,6 +999,22 @@ describe('Profiler', () => {
             );
             expect(ReactNoop.flush).toThrow('Error in host config.');
 
+            // A similar case we've seen caused by an invariant in ReactDOM.
+            // It didn't reproduce without this specific nesting pattern.
+            ReactNoop.render(
+              <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
+                <div>
+                  <errorInCompletePhase>
+                    <div />
+                  </errorInCompletePhase>
+                  <errorInCompletePhase>
+                    <div />
+                  </errorInCompletePhase>
+                </div>
+              </React.unstable_Profiler>,
+            );
+            expect(ReactNoop.flush).toThrow('Error in host config.');
+
             // So long as the profiler timer's fiber stack is reset correctly,
             // Subsequent renders should not error.
             ReactNoop.render(

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -1000,17 +1000,12 @@ describe('Profiler', () => {
             expect(ReactNoop.flush).toThrow('Error in host config.');
 
             // A similar case we've seen caused by an invariant in ReactDOM.
-            // It didn't reproduce without this specific nesting pattern.
+            // It didn't reproduce without a host component inside.
             ReactNoop.render(
               <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
-                <div>
-                  <errorInCompletePhase>
-                    <div />
-                  </errorInCompletePhase>
-                  <errorInCompletePhase>
-                    <div />
-                  </errorInCompletePhase>
-                </div>
+                <errorInCompletePhase>
+                  <span>hi</span>
+                </errorInCompletePhase>
               </React.unstable_Profiler>,
             );
             expect(ReactNoop.flush).toThrow('Error in host config.');


### PR DESCRIPTION
Adds two regression tests (one for profiler stack and one for context stack). Also fixes the bug.

The bug was caused by a structure like this:

```
    </Provider>
  </div>
</errorInCompletePhase>
```

We forgot to update `nextUnitOfWork` (see the fix in the last commit). So it was still pointing at `Provider` when `errorInCompletePhase` threw. Normally we would update it right after so it wouldn't be noticeable, but in case of exception its value at the moment of throwing matters.

As a result, we would try to unwind from `Provider` (rather than from `errorInCompletePhase`), and thus pop the `Provider` twice. It has already been popped at the beginning of the complete phase.

This was easy to miss because a throwing complete phase is uncommon. But it can happen in host configs (e.g. RN nesting or DOM invalid style invariants).

I verified this fixes the original internal issue too.