### PR TITLE
[react-is] export individual modules to enable tree-shaking capabilities

### DIFF
--- a/packages/react-is/index.js
+++ b/packages/react-is/index.js
@@ -9,4 +9,25 @@
 
 'use strict';
 
-export * from './src/ReactIs';
+export {
+  typeOf,
+  AsyncMode,
+  ContextConsumer,
+  ContextProvider,
+  Element,
+  ForwardRef,
+  Fragment,
+  Profiler,
+  Portal,
+  StrictMode,
+  isValidElementType,
+  isAsyncMode,
+  isContextConsumer,
+  isContextProvider,
+  isElement,
+  isForwardRef,
+  isFragment,
+  isProfiler,
+  isPortal,
+  isStrictMode,
+} from './src/ReactIs';


### PR DESCRIPTION
### What is the issue

Tree shaking not enabled with react-is.

```jsx
import * as ReactIs from "react-is";
ReactIs.isValidElementType(<div />); // true
```

### Expected behavior

Allow importing individual modules from the package.

```js
import { isValidElementType } from "react-is";
isElement(<div />); // true
```

### Checklist

- [x] fix bug
- [x] `yarn`
- [x] `yarn test`
- [x] `yarn test-prod`
- [x] `yarn prettier`
- [x] `yarn lint`
- [x] `yarn flow dom && yarn flow test`
- [x] complete the CLA