### PR TITLE
Remove 'warning' module from the JS scheduler

### DIFF
--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -122,20 +122,22 @@ if (!canUseDOM) {
     localClearTimeout(timeoutId);
   };
 } else {
-  if (__DEV__ && typeof console !== 'undefined') {
-    if (typeof localRequestAnimationFrame !== 'function') {
-      console.error(
-        "This browser doesn't support requestAnimationFrame. " +
-          'Make sure that you load a ' +
-          'polyfill in older browsers. https://fb.me/react-polyfills',
-      );
-    }
-    if (typeof localCancelAnimationFrame !== 'function') {
-      console.error(
-        "This browser doesn't support cancelAnimationFrame. " +
-          'Make sure that you load a ' +
-          'polyfill in older browsers. https://fb.me/react-polyfills',
-      );
+  if (__DEV__) {
+    if (typeof console !== 'undefined') {
+      if (typeof localRequestAnimationFrame !== 'function') {
+        console.error(
+          "This browser doesn't support requestAnimationFrame. " +
+            'Make sure that you load a ' +
+            'polyfill in older browsers. https://fb.me/react-polyfills',
+        );
+      }
+      if (typeof localCancelAnimationFrame !== 'function') {
+        console.error(
+          "This browser doesn't support cancelAnimationFrame. " +
+            'Make sure that you load a ' +
+            'polyfill in older browsers. https://fb.me/react-polyfills',
+        );
+      }
     }
   }
 

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -42,7 +42,6 @@ type CallbackConfigType = {|
 export type CallbackIdType = CallbackConfigType;
 
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import warningWithoutStack from 'shared/warningWithoutStack';
 
 // We capture a local reference to any global, in case it gets polyfilled after
 // this module is initially evaluated.
@@ -123,17 +122,15 @@ if (!canUseDOM) {
     localClearTimeout(timeoutId);
   };
 } else {
-  if (typeof localRequestAnimationFrame !== 'function') {
-    warningWithoutStack(
-      false,
+  if (__DEV__ && typeof localRequestAnimationFrame !== 'function') {
+    console.error(
       "This browser doesn't support requestAnimationFrame. " +
         'Make sure that you load a ' +
         'polyfill in older browsers. https://fb.me/react-polyfills',
     );
   }
-  if (typeof localCancelAnimationFrame !== 'function') {
-    warningWithoutStack(
-      false,
+  if (__DEV__ && typeof localCancelAnimationFrame !== 'function') {
+    console.error(
       "This browser doesn't support cancelAnimationFrame. " +
         'Make sure that you load a ' +
         'polyfill in older browsers. https://fb.me/react-polyfills',

--- a/packages/react-scheduler/src/ReactScheduler.js
+++ b/packages/react-scheduler/src/ReactScheduler.js
@@ -122,19 +122,21 @@ if (!canUseDOM) {
     localClearTimeout(timeoutId);
   };
 } else {
-  if (__DEV__ && typeof localRequestAnimationFrame !== 'function') {
-    console.error(
-      "This browser doesn't support requestAnimationFrame. " +
-        'Make sure that you load a ' +
-        'polyfill in older browsers. https://fb.me/react-polyfills',
-    );
-  }
-  if (__DEV__ && typeof localCancelAnimationFrame !== 'function') {
-    console.error(
-      "This browser doesn't support cancelAnimationFrame. " +
-        'Make sure that you load a ' +
-        'polyfill in older browsers. https://fb.me/react-polyfills',
-    );
+  if (__DEV__ && typeof console !== 'undefined') {
+    if (typeof localRequestAnimationFrame !== 'function') {
+      console.error(
+        "This browser doesn't support requestAnimationFrame. " +
+          'Make sure that you load a ' +
+          'polyfill in older browsers. https://fb.me/react-polyfills',
+      );
+    }
+    if (typeof localCancelAnimationFrame !== 'function') {
+      console.error(
+        "This browser doesn't support cancelAnimationFrame. " +
+          'Make sure that you load a ' +
+          'polyfill in older browsers. https://fb.me/react-polyfills',
+      );
+    }
   }
 
   let headOfPendingCallbacksLinkedList: CallbackConfigType | null = null;


### PR DESCRIPTION
**what is the change?:**
See title

**why make this change?:**
Internally the 'warning' module has some dependencies which we want to
avoid pulling in during the very early stages of initial pageload. It is
creating a cyclical dependency.

And we wanted to remove this dependency anyway, because this module
should be kept small and decoupled.

**test plan:**
- Tested the exact same change internally in Facebook.com
- Ran unit tests
- Tried out the fixture

**issue:**
Internal task T31831021

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
10. If you haven't already, complete the CLA.

**Learn more about contributing:** https://reactjs.org/docs/how-to-contribute.html
