### PR TITLE
Add @flow directive to findDOMNode shim

### DIFF
--- a/scripts/rollup/shims/facebook-www/findDOMNode.js
+++ b/scripts/rollup/shims/facebook-www/findDOMNode.js
@@ -1,9 +1,12 @@
-/**
- * Copyright (c) 2013-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
+/**	
+ * Copyright (c) 2013-present, Facebook, Inc.	
+ *	
+ * This source code is licensed under the MIT license found in the	
+ * LICENSE file in the root directory of this source tree.	
+ *	
+ * @flow	
+ * @format	
+ */	
 
 'use strict';
 

--- a/scripts/rollup/shims/facebook-www/findDOMNode.js
+++ b/scripts/rollup/shims/facebook-www/findDOMNode.js
@@ -1,12 +1,12 @@
-/**	
- * Copyright (c) 2013-present, Facebook, Inc.	
- *	
- * This source code is licensed under the MIT license found in the	
- * LICENSE file in the root directory of this source tree.	
- *	
- * @flow	
- * @format	
- */	
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
 
 'use strict';
 


### PR DESCRIPTION
An internal diff (D8895394) recently removed a `$FlowFixMe` comment which caused a subsequent Flow error for the `findDOMNode` shim. To fix this error, an FB engineer added the `@flow` directive to this shim.

I'm not sure what the right long term strategy is here, but in order to prevent future syncs from breaking www builds (by causing Flow errors) I'm syncing the change upstream for now.