### PR TITLE
[react-dom] Allow additional text inside of a comment node container

### DIFF
--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -314,35 +314,49 @@ describe('ReactMount', () => {
     let containerDiv;
     let mountPoint;
 
-    beforeEach(() => {
+    const Char = props => props.children;
+    const list = chars => chars.split('').map(c => <Char key={c}>{c}</Char>);
+
+    function initializeMountPoint(commentText) {
       containerDiv = document.createElement('div');
-      containerDiv.innerHTML = 'A<!-- react-mount-point-unstable -->B';
+      containerDiv.innerHTML = 'A<!--' + commentText + '-->B';
       mountPoint = containerDiv.childNodes[1];
       expect(mountPoint.nodeType).toBe(COMMENT_NODE);
+    }
+
+    describe('with proper marker', () => {
+      beforeEach(() => {
+        initializeMountPoint(' ABC react-mount-point-unstable def 123 ');
+      });
+
+      it('renders at a comment node', () => {
+        ReactDOM.render(list('aeiou'), mountPoint);
+        expect(containerDiv.innerHTML).toBe(
+          'Aaeiou<!-- ABC react-mount-point-unstable def 123 -->B',
+        );
+
+        ReactDOM.render(list('yea'), mountPoint);
+        expect(containerDiv.innerHTML).toBe(
+          'Ayea<!-- ABC react-mount-point-unstable def 123 -->B',
+        );
+
+        ReactDOM.render(list(''), mountPoint);
+        expect(containerDiv.innerHTML).toBe(
+          'A<!-- ABC react-mount-point-unstable def 123 -->B',
+        );
+      });
     });
 
-    it('renders at a comment node', () => {
-      function Char(props) {
-        return props.children;
-      }
-      function list(chars) {
-        return chars.split('').map(c => <Char key={c}>{c}</Char>);
-      }
+    describe('without proper marker', () => {
+      beforeEach(() => {
+        initializeMountPoint(' ABC def 123 ');
+      });
 
-      ReactDOM.render(list('aeiou'), mountPoint);
-      expect(containerDiv.innerHTML).toBe(
-        'Aaeiou<!-- react-mount-point-unstable -->B',
-      );
-
-      ReactDOM.render(list('yea'), mountPoint);
-      expect(containerDiv.innerHTML).toBe(
-        'Ayea<!-- react-mount-point-unstable -->B',
-      );
-
-      ReactDOM.render(list(''), mountPoint);
-      expect(containerDiv.innerHTML).toBe(
-        'A<!-- react-mount-point-unstable -->B',
-      );
+      it('throws an error', () => {
+        expect(() => {
+          ReactDOM.render(list('boooom!'), mountPoint);
+        }).toThrow();
+      });
     });
   });
 });

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -425,7 +425,7 @@ function isValidContainer(node) {
       node.nodeType === DOCUMENT_NODE ||
       node.nodeType === DOCUMENT_FRAGMENT_NODE ||
       (node.nodeType === COMMENT_NODE &&
-        node.nodeValue === ' react-mount-point-unstable '))
+        node.nodeValue.indexOf(' react-mount-point-unstable ') !== -1))
   );
 }
 


### PR DESCRIPTION
### Problem
While using `ReactDOM.render` with a comment node as a container it is not possible to have the comment node different then `<!-- react-mount-point-unstable -->`. This makes it hard to identify multiple comment node containers on the page.

### Solution
Make the container check more relaxed, allow an arbitrary string in a comment node container but still require the string to contain ` react-mount-point-unstable ` marker text inside.