### PR TITLE
Add an invariant to createRoot() to validate containers

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -366,4 +366,12 @@ describe('ReactDOMRoot', () => {
     );
     expect(() => batch.commit()).toThrow('Element type is invalid');
   });
+
+  it('throws a good message on invalid containers', () => {
+    expect(() => {
+      ReactDOM.unstable_createRoot(<div>Hi</div>);
+    }).toThrow(
+      'unstable_createRoot(...): Target container is not a DOM element.',
+    );
+  });
 });

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -758,6 +758,10 @@ ReactDOM.unstable_createRoot = function createRoot(
   container: DOMContainer,
   options?: RootOptions,
 ): ReactRoot {
+  invariant(
+    isValidContainer(container),
+    'unstable_createRoot(...): Target container is not a DOM element.',
+  );
   const hydrate = options != null && options.hydrate === true;
   return new ReactRoot(container, true, hydrate);
 };


### PR DESCRIPTION
Every time I use `createRoot` I try to write

```js
createRoot(<Foo />).render(container)
```

but it should be the other way around.

It often fails with confusing errors later on.

This adds a preemptive invariant, like we do elsewhere.