### PR TITLE
Adding react is export support

### DIFF
--- a/packages/react-is/index.js
+++ b/packages/react-is/index.js
@@ -10,3 +10,4 @@
 'use strict';
 
 export * from './src/ReactIs';
+export {default} from './src/ReactIs';

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -99,3 +99,26 @@ export function isPortal(object: any) {
 export function isStrictMode(object: any) {
   return typeOf(object) === REACT_STRICT_MODE_TYPE;
 }
+
+export default {
+  typeOf,
+  AsyncMode,
+  ContextConsumer,
+  ContextProvider,
+  Element,
+  ForwardRef,
+  Fragment,
+  Profiler,
+  Portal,
+  StrictMode,
+  isValidElementType,
+  isAsyncMode,
+  isContextConsumer,
+  isContextProvider,
+  isElement,
+  isForwardRef,
+  isFragment,
+  isProfiler,
+  isPortal,
+  isStrictMode,
+};


### PR DESCRIPTION
Adding support so that each function of ReactIs is individually accessible

This solve the issue mentioned in #13250 

And then finally provide a feature requested in #13272 

**What is the issue**
Tree shaking not enabled with react-is.
```
import * as ReactIs from "react-is";
ReactIs.isValidElementType(<div />); // true
```

**Expected behavior**
Allow importing individual modules from the package.
```
import { isValidElementType } from "react-is";
isValidElementType(<div />); // true

```