### PR TITLE
Refactor validateDOMNesting a bit

### DIFF
--- a/packages/react-dom/src/client/ReactDOMFiberOption.js
+++ b/packages/react-dom/src/client/ReactDOMFiberOption.js
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import warning from 'shared/warning';
-import validateDOMNesting from './validateDOMNesting';
+import {validateDOMNesting, updatedAncestorInfo} from './validateDOMNesting';
 
 let didWarnSelectedSetOnOption = false;
 
@@ -53,10 +53,7 @@ export function validateProps(element: Element, props: Object) {
         // We don't have access to the real one because the <option>
         // fiber has already been popped, and threading it through
         // is needlessly annoying.
-        const ancestorInfo = validateDOMNesting.updatedAncestorInfo(
-          null,
-          'option',
-        );
+        const ancestorInfo = updatedAncestorInfo(null, 'option');
         validateDOMNesting(child.type, null, ancestorInfo);
       });
     }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -13,7 +13,7 @@ import * as ReactDOMComponentTree from './ReactDOMComponentTree';
 import * as ReactDOMFiberComponent from './ReactDOMFiberComponent';
 import * as ReactInputSelection from './ReactInputSelection';
 import setTextContent from './setTextContent';
-import validateDOMNesting from './validateDOMNesting';
+import {validateDOMNesting, updatedAncestorInfo} from './validateDOMNesting';
 import * as ReactBrowserEventEmitter from '../events/ReactBrowserEventEmitter';
 import {getChildNamespace} from '../shared/DOMNamespaces';
 import {
@@ -62,7 +62,6 @@ const {
   warnForInsertedHydratedElement,
   warnForInsertedHydratedText,
 } = ReactDOMFiberComponent;
-const {updatedAncestorInfo} = validateDOMNesting;
 const {precacheFiberNode, updateFiberProps} = ReactDOMComponentTree;
 
 let SUPPRESS_HYDRATION_WARNING;
@@ -113,7 +112,7 @@ export function getRootHostContext(
   }
   if (__DEV__) {
     const validatedTag = type.toLowerCase();
-    const ancestorInfo = updatedAncestorInfo(null, validatedTag, null);
+    const ancestorInfo = updatedAncestorInfo(null, validatedTag);
     return {namespace, ancestorInfo};
   }
   return namespace;
@@ -130,7 +129,6 @@ export function getChildHostContext(
     const ancestorInfo = updatedAncestorInfo(
       parentHostContextDev.ancestorInfo,
       type,
-      null,
     );
     return {namespace, ancestorInfo};
   }
@@ -175,7 +173,6 @@ export function createInstance(
       const ownAncestorInfo = updatedAncestorInfo(
         hostContextDev.ancestorInfo,
         type,
-        null,
       );
       validateDOMNesting(null, string, ownAncestorInfo);
     }
@@ -231,7 +228,6 @@ export function prepareUpdate(
       const ownAncestorInfo = updatedAncestorInfo(
         hostContextDev.ancestorInfo,
         type,
-        null,
       );
       validateDOMNesting(null, string, ownAncestorInfo);
     }

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -10,6 +10,7 @@ import warningWithoutStack from 'shared/warningWithoutStack';
 import {getCurrentFiberStackInDev} from 'react-reconciler/src/ReactCurrentFiber';
 
 let validateDOMNesting = () => {};
+let updatedAncestorInfo = () => {};
 
 if (__DEV__) {
   // This validation code was written based on the HTML5 parsing spec:
@@ -158,9 +159,9 @@ if (__DEV__) {
     dlItemTagAutoclosing: null,
   };
 
-  const updatedAncestorInfo = function(oldInfo, tag, instance) {
+  updatedAncestorInfo = function(oldInfo, tag) {
     let ancestorInfo = {...(oldInfo || emptyAncestorInfo)};
-    let info = {tag: tag, instance: instance};
+    let info = {tag};
 
     if (inScopeTags.indexOf(tag) !== -1) {
       ancestorInfo.aTagInScope = null;
@@ -477,9 +478,6 @@ if (__DEV__) {
       );
     }
   };
-
-  // TODO: turn this into a named export
-  validateDOMNesting.updatedAncestorInfo = updatedAncestorInfo;
 }
 
-export default validateDOMNesting;
+export {updatedAncestorInfo, validateDOMNesting};


### PR DESCRIPTION
Very minor cleanup.

* Use named exports instead of attaching one function to another
* Remove unused argument/field from the Stack era