### PR TITLE
Sanitize unknown attribute names for SSR

### DIFF
--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -60,9 +60,10 @@ export function createMarkupForProperty(name: string, value: mixed): string {
     } else {
       return attributeName + '=' + quoteAttributeValueForBrowser(value);
     }
-  } else {
+  } else if (isAttributeNameSafe(name)) {
     return name + '=' + quoteAttributeValueForBrowser(value);
   }
+  return '';
 }
 
 /**


### PR DESCRIPTION
This is a fix for a minor vulnerability we discovered in the server renderer.
The fix has been cherry-picked to every affected minor release:

* `react-dom@16.0.1` (includes the mitigation)
* `react-dom@16.1.2` (includes the mitigation)
* `react-dom@16.2.1` (includes the mitigation)
* `react-dom@16.3.3` (includes the mitigation)
* `react-dom@16.4.2` (includes the mitigation)

We are putting up a blog post with more info in a few minutes.