### PR TITLE
Warn about rendering Generators

### DIFF
--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -315,9 +315,29 @@ describe('ReactMultiChild', () => {
     ReactDOM.render(<Foo />, div);
   });
 
-  it('should not warn for using generators in iterables', () => {
+  it('should not warn for using generators in legacy iterables', () => {
     const fooIterable = {
       '@@iterator': function*() {
+        yield <h1 key="1">Hello</h1>;
+        yield <h1 key="2">World</h1>;
+      },
+    };
+
+    function Foo() {
+      return fooIterable;
+    }
+
+    const div = document.createElement('div');
+    ReactDOM.render(<Foo />, div);
+    expect(div.textContent).toBe('HelloWorld');
+
+    ReactDOM.render(<Foo />, div);
+    expect(div.textContent).toBe('HelloWorld');
+  });
+
+  it('should not warn for using generators in modern iterables', () => {
+    const fooIterable = {
+      [Symbol.iterator]: function*() {
         yield <h1 key="1">Hello</h1>;
         yield <h1 key="2">World</h1>;
       },

--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -315,6 +315,26 @@ describe('ReactMultiChild', () => {
     ReactDOM.render(<Foo />, div);
   });
 
+  it('should not warn for using generators in iterables', () => {
+    const fooIterable = {
+      '@@iterator': function*() {
+        yield <h1 key="1">Hello</h1>;
+        yield <h1 key="2">World</h1>;
+      },
+    };
+
+    function Foo() {
+      return fooIterable;
+    }
+
+    const div = document.createElement('div');
+    ReactDOM.render(<Foo />, div);
+    expect(div.textContent).toBe('HelloWorld');
+
+    ReactDOM.render(<Foo />, div);
+    expect(div.textContent).toBe('HelloWorld');
+  });
+
   it('should reorder bailed-out children', () => {
     class LetterInner extends React.Component {
       render() {

--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -294,6 +294,27 @@ describe('ReactMultiChild', () => {
     );
   });
 
+  it('should warn for using generators as children', () => {
+    function* Foo() {
+      yield <h1 key="1">Hello</h1>;
+      yield <h1 key="2">World</h1>;
+    }
+
+    const div = document.createElement('div');
+    expect(() => {
+      ReactDOM.render(<Foo />, div);
+    }).toWarnDev(
+      'Using Generators as children is unsupported and will likely yield ' +
+        'unexpected results because enumerating a generator mutates it. You may ' +
+        'convert it to an array with `Array.from()` or the `[...spread]` operator ' +
+        'before rendering. Keep in mind you might need to polyfill these features for older browsers.\n' +
+        '    in Foo (at **)',
+    );
+
+    // Test de-duplication
+    ReactDOM.render(<Foo />, div);
+  });
+
   it('should reorder bailed-out children', () => {
     class LetterInner extends React.Component {
       render() {

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -46,6 +46,7 @@ import {
 import {StrictMode} from './ReactTypeOfMode';
 
 let didWarnAboutMaps;
+let didWarnAboutGenerators;
 let didWarnAboutStringRefInStrictMode;
 let ownerHasKeyUseWarning;
 let ownerHasFunctionTypeWarning;
@@ -53,6 +54,7 @@ let warnForMissingKey = (child: mixed) => {};
 
 if (__DEV__) {
   didWarnAboutMaps = false;
+  didWarnAboutGenerators = false;
   didWarnAboutStringRefInStrictMode = {};
 
   /**
@@ -903,6 +905,23 @@ function ChildReconciler(shouldTrackSideEffects) {
     );
 
     if (__DEV__) {
+      // We don't support rendering Generators because it's a mutation.
+      // See https://github.com/facebook/react/issues/12995
+      if (
+        typeof Symbol === 'function' &&
+        newChildrenIterable[Symbol.toStringTag] === 'Generator'
+      ) {
+        warning(
+          didWarnAboutGenerators,
+          'Using Generators as children is unsupported and will likely yield ' +
+            'unexpected results because enumerating a generator mutates it. ' +
+            'You may convert it to an array with `Array.from()` or the ' +
+            '`[...spread]` operator before rendering. Keep in mind ' +
+            'you might need to polyfill these features for older browsers.',
+        );
+        didWarnAboutGenerators = true;
+      }
+
       // Warn about using Maps as children
       if ((newChildrenIterable: any).entries === iteratorFn) {
         warning(

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -909,6 +909,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       // See https://github.com/facebook/react/issues/12995
       if (
         typeof Symbol === 'function' &&
+        // $FlowFixMe Flow doesn't know about toStringTag
         newChildrenIterable[Symbol.toStringTag] === 'Generator'
       ) {
         warning(


### PR DESCRIPTION
It might not be obvious but by rendering a Generator you're asking React to perform a mutation during the render phase. This already doesn't work in development because we do key validation, thus consuming the generator. It led to some confusion: https://github.com/facebook/react/issues/11864, https://github.com/facebook/react/issues/12995, https://github.com/facebook/react/issues/11502, https://github.com/facebook/react/issues/7536.

Let's warn about this pattern right as we encounter it. The new warning shouldn't be noisy because the pattern is already broken in development (and as you can see in https://github.com/facebook/react/issues/12995#issuecomment-410010708, it's fragile in production).

I'm not sure how to detect generators in browsers that don't support `toStringTag` but I figured warning in modern browsers is sufficient.