### PR TITLE
Profiler actualDuration bugfix

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -162,6 +162,7 @@ export type Fiber = {|
 
   // Time spent rendering this Fiber and its descendants for the current update.
   // This tells us how well the tree makes use of sCU for memoization.
+  // It is reset to 0 each time we render and only updated when we don't bailout.
   // This field is only set when the enableProfilerTimer flag is enabled.
   actualDuration?: number,
 
@@ -238,7 +239,7 @@ function FiberNode(
 
   if (enableProfilerTimer) {
     this.actualDuration = 0;
-    this.actualStartTime = 0;
+    this.actualStartTime = -1;
     this.selfBaseDuration = 0;
     this.treeBaseDuration = 0;
   }
@@ -330,7 +331,7 @@ export function createWorkInProgress(
       // This has the downside of resetting values for different priority renders,
       // But works for yielding (the common case) and should support resuming.
       workInProgress.actualDuration = 0;
-      workInProgress.actualStartTime = 0;
+      workInProgress.actualStartTime = -1;
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -62,7 +62,7 @@ import {
 } from './ReactChildFiber';
 import {processUpdateQueue} from './ReactUpdateQueue';
 import {NoWork, Never} from './ReactFiberExpirationTime';
-import {AsyncMode, ProfileMode, StrictMode} from './ReactTypeOfMode';
+import {AsyncMode, StrictMode} from './ReactTypeOfMode';
 import {
   shouldSetTextContent,
   shouldDeprioritizeSubtree,
@@ -75,10 +75,7 @@ import {
   prepareToReadContext,
   calculateChangedBits,
 } from './ReactFiberNewContext';
-import {
-  markActualRenderTimeStarted,
-  stopBaseRenderTimerIfRunning,
-} from './ReactProfilerTimer';
+import {stopProfilerTimerIfRunning} from './ReactProfilerTimer';
 import {
   getMaskedContext,
   getUnmaskedContext,
@@ -379,7 +376,7 @@ function finishClassComponent(
     nextChildren = null;
 
     if (enableProfilerTimer) {
-      stopBaseRenderTimerIfRunning();
+      stopProfilerTimerIfRunning(workInProgress);
     }
   } else {
     if (__DEV__) {
@@ -954,7 +951,7 @@ function bailoutOnAlreadyFinishedWork(
 
   if (enableProfilerTimer) {
     // Don't update "base" render times for bailouts.
-    stopBaseRenderTimerIfRunning();
+    stopProfilerTimerIfRunning(workInProgress);
   }
 
   // Check if the children have any pending work.
@@ -991,12 +988,6 @@ function beginWork(
   workInProgress: Fiber,
   renderExpirationTime: ExpirationTime,
 ): Fiber | null {
-  if (enableProfilerTimer) {
-    if (workInProgress.mode & ProfileMode) {
-      markActualRenderTimeStarted(workInProgress);
-    }
-  }
-
   const updateExpirationTime = workInProgress.expirationTime;
   if (
     !hasLegacyContextChanged() &&

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -20,7 +20,6 @@ import type {
   HostContext,
 } from './ReactFiberHostConfig';
 
-import {enableProfilerTimer} from 'shared/ReactFeatureFlags';
 import {
   IndeterminateComponent,
   FunctionalComponent,
@@ -38,7 +37,6 @@ import {
   PlaceholderComponent,
 } from 'shared/ReactTypeOfWork';
 import {Placement, Ref, Update} from 'shared/ReactTypeOfSideEffect';
-import {ProfileMode} from './ReactTypeOfMode';
 import invariant from 'shared/invariant';
 
 import {
@@ -60,7 +58,6 @@ import {
   getHostContext,
   popHostContainer,
 } from './ReactFiberHostContext';
-import {recordElapsedActualRenderTime} from './ReactProfilerTimer';
 import {
   popContextProvider as popLegacyContextProvider,
   popTopLevelContextObject as popTopLevelLegacyContextObject,
@@ -516,16 +513,6 @@ function completeWork(
         'Unknown unit of work tag. This error is likely caused by a bug in ' +
           'React. Please file an issue.',
       );
-  }
-
-  if (enableProfilerTimer) {
-    if (workInProgress.mode & ProfileMode) {
-      // Don't record elapsed time unless the "complete" phase has succeeded.
-      // Certain renderers may error during this phase (i.e. ReactNative View/Text nesting validation).
-      // If an error occurs, we'll mark the time while unwinding.
-      // This simplifies the unwinding logic and ensures consistency.
-      recordElapsedActualRenderTime(workInProgress);
-    }
   }
 
   return null;

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -34,10 +34,9 @@ import {
 } from 'shared/ReactTypeOfSideEffect';
 import {
   enableGetDerivedStateFromCatch,
-  enableProfilerTimer,
   enableSuspense,
 } from 'shared/ReactFeatureFlags';
-import {ProfileMode, StrictMode, AsyncMode} from './ReactTypeOfMode';
+import {StrictMode, AsyncMode} from './ReactTypeOfMode';
 
 import {createCapturedValue} from './ReactCapturedValue';
 import {
@@ -52,7 +51,6 @@ import {
   popTopLevelContextObject as popTopLevelLegacyContextObject,
 } from './ReactFiberContext';
 import {popProvider} from './ReactFiberNewContext';
-import {recordElapsedActualRenderTime} from './ReactProfilerTimer';
 import {
   renderDidSuspend,
   renderDidError,
@@ -380,12 +378,6 @@ function unwindWork(
   workInProgress: Fiber,
   renderExpirationTime: ExpirationTime,
 ) {
-  if (enableProfilerTimer) {
-    if (workInProgress.mode & ProfileMode) {
-      recordElapsedActualRenderTime(workInProgress);
-    }
-  }
-
   switch (workInProgress.tag) {
     case ClassComponent: {
       popLegacyContextProvider(workInProgress);
@@ -432,12 +424,6 @@ function unwindWork(
 }
 
 function unwindInterruptedWork(interruptedWork: Fiber) {
-  if (enableProfilerTimer) {
-    if (interruptedWork.mode & ProfileMode) {
-      recordElapsedActualRenderTime(interruptedWork);
-    }
-  }
-
   switch (interruptedWork.tag) {
     case ClassComponent: {
       popLegacyContextProvider(interruptedWork);

--- a/packages/react-reconciler/src/ReactProfilerTimer.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.js
@@ -9,27 +9,20 @@
 
 import type {Fiber} from './ReactFiber';
 
-import getComponentName from 'shared/getComponentName';
 import {enableProfilerTimer} from 'shared/ReactFeatureFlags';
 
-import warningWithoutStack from 'shared/warningWithoutStack';
 import {now} from './ReactFiberHostConfig';
 
 export type ProfilerTimer = {
-  checkActualRenderTimeStackEmpty(): void,
   getCommitTime(): number,
-  markActualRenderTimeStarted(fiber: Fiber): void,
-  pauseActualRenderTimerIfRunning(): void,
-  recordElapsedActualRenderTime(fiber: Fiber): void,
-  resumeActualRenderTimerIfPaused(isProcessingBatchCommit: boolean): void,
   recordCommitTime(): void,
-  recordElapsedBaseRenderTimeIfRunning(fiber: Fiber): void,
-  resetActualRenderTimerStackAfterFatalErrorInDev(): void,
-  startBaseRenderTimer(): void,
-  stopBaseRenderTimerIfRunning(): void,
+  startProfilerTimer(fiber: Fiber): void,
+  stopProfilerTimerIfRunning(fiber: Fiber): void,
+  stopProfilerTimerIfRunningAndRecordDelta(fiber: Fiber): void,
 };
 
 let commitTime: number = 0;
+let profilerStartTime: number = -1;
 
 function getCommitTime(): number {
   return commitTime;
@@ -42,155 +35,47 @@ function recordCommitTime(): void {
   commitTime = now();
 }
 
-/**
- * The "actual" render time is total time required to render the descendants of a Profiler component.
- * This time is stored as a stack, since Profilers can be nested.
- * This time is started during the "begin" phase and stopped during the "complete" phase.
- * It is paused (and accumulated) in the event of an interruption or an aborted render.
- */
-
-let fiberStack: Array<Fiber | null>;
-
-if (__DEV__) {
-  fiberStack = [];
-}
-
-let syncCommitStartTime: number = 0;
-let timerPausedAt: number = 0;
-let totalElapsedPauseTime: number = 0;
-
-function checkActualRenderTimeStackEmpty(): void {
+function startProfilerTimer(fiber: Fiber): void {
   if (!enableProfilerTimer) {
     return;
   }
-  if (__DEV__) {
-    warningWithoutStack(
-      fiberStack.length === 0,
-      'Expected an empty stack. Something was not reset properly.',
-    );
+
+  profilerStartTime = now();
+
+  if (((fiber.actualStartTime: any): number) < 0) {
+    fiber.actualStartTime = now();
   }
 }
 
-function markActualRenderTimeStarted(fiber: Fiber): void {
+function stopProfilerTimerIfRunning(fiber: Fiber): void {
   if (!enableProfilerTimer) {
     return;
   }
-  if (__DEV__) {
-    fiberStack.push(fiber);
-  }
-
-  fiber.actualDuration =
-    now() - ((fiber.actualDuration: any): number) - totalElapsedPauseTime;
-  fiber.actualStartTime = now();
+  profilerStartTime = -1;
 }
 
-function pauseActualRenderTimerIfRunning(): void {
+function stopProfilerTimerIfRunningAndRecordDelta(
+  fiber: Fiber,
+  overrideBaseTime: boolean,
+): void {
   if (!enableProfilerTimer) {
     return;
   }
-  if (timerPausedAt === 0) {
-    timerPausedAt = now();
-  }
-  if (syncCommitStartTime > 0) {
-    // Don't count the time spent processing sycn work,
-    // Against yielded async work that will be resumed later.
-    totalElapsedPauseTime += now() - syncCommitStartTime;
-    syncCommitStartTime = 0;
-  } else {
-    totalElapsedPauseTime = 0;
-  }
-}
 
-function recordElapsedActualRenderTime(fiber: Fiber): void {
-  if (!enableProfilerTimer) {
-    return;
-  }
-  if (__DEV__) {
-    warningWithoutStack(
-      fiber === fiberStack.pop(),
-      'Unexpected Fiber (%s) popped.',
-      getComponentName(fiber.type),
-    );
-  }
-
-  fiber.actualDuration =
-    now() - totalElapsedPauseTime - ((fiber.actualDuration: any): number);
-}
-
-function resumeActualRenderTimerIfPaused(isProcessingSyncWork: boolean): void {
-  if (!enableProfilerTimer) {
-    return;
-  }
-  if (isProcessingSyncWork && syncCommitStartTime === 0) {
-    syncCommitStartTime = now();
-  }
-  if (timerPausedAt > 0) {
-    totalElapsedPauseTime += now() - timerPausedAt;
-    timerPausedAt = 0;
-  }
-}
-
-function resetActualRenderTimerStackAfterFatalErrorInDev(): void {
-  if (!enableProfilerTimer) {
-    return;
-  }
-  if (__DEV__) {
-    fiberStack.length = 0;
-  }
-}
-
-/**
- * The "base" render time is the duration of the “begin” phase of work for a particular fiber.
- * This time is measured and stored on each fiber.
- * The time for all sibling fibers are accumulated and stored on their parent during the "complete" phase.
- * If a fiber bails out (sCU false) then its "base" timer is cancelled and the fiber is not updated.
- */
-
-let baseStartTime: number = -1;
-
-function recordElapsedBaseRenderTimeIfRunning(fiber: Fiber): void {
-  if (!enableProfilerTimer) {
-    return;
-  }
-  if (baseStartTime !== -1) {
-    fiber.selfBaseDuration = now() - baseStartTime;
-  }
-}
-
-function startBaseRenderTimer(): void {
-  if (!enableProfilerTimer) {
-    return;
-  }
-  if (__DEV__) {
-    if (baseStartTime !== -1) {
-      warningWithoutStack(
-        false,
-        'Cannot start base timer that is already running. ' +
-          'This error is likely caused by a bug in React. ' +
-          'Please file an issue.',
-      );
+  if (profilerStartTime >= 0) {
+    const elapsedTime = now() - profilerStartTime;
+    fiber.actualDuration += elapsedTime;
+    if (overrideBaseTime) {
+      fiber.selfBaseDuration = elapsedTime;
     }
+    profilerStartTime = -1;
   }
-  baseStartTime = now();
-}
-
-function stopBaseRenderTimerIfRunning(): void {
-  if (!enableProfilerTimer) {
-    return;
-  }
-  baseStartTime = -1;
 }
 
 export {
-  checkActualRenderTimeStackEmpty,
   getCommitTime,
-  markActualRenderTimeStarted,
-  pauseActualRenderTimerIfRunning,
   recordCommitTime,
-  recordElapsedActualRenderTime,
-  resetActualRenderTimerStackAfterFatalErrorInDev,
-  resumeActualRenderTimerIfPaused,
-  recordElapsedBaseRenderTimeIfRunning,
-  startBaseRenderTimer,
-  stopBaseRenderTimerIfRunning,
+  startProfilerTimer,
+  stopProfilerTimerIfRunning,
+  stopProfilerTimerIfRunningAndRecordDelta,
 };

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -57,7 +57,7 @@ describe('Profiler', () => {
 
         // This will throw in production too,
         // But the test is only interested in verifying the DEV error message.
-        if (__PROFILE__) {
+        if (__DEV__ && flagEnabled) {
           it('should warn if required params are missing', () => {
             expect(() => {
               ReactTestRenderer.create(<React.unstable_Profiler />);
@@ -902,7 +902,7 @@ describe('Profiler', () => {
             expect(mountCall[4]).toBe(5);
             // commit time: 5 initially + 14 of work
             // Add an additional 3 (ThrowsError) if we replaced the failed work
-            expect(mountCall[5]).toBe(flagEnabled && __PROFILE__ ? 22 : 19);
+            expect(mountCall[5]).toBe(__DEV__ && flagEnabled ? 22 : 19);
 
             // The update includes the ErrorBoundary and its fallback child
             expect(updateCall[1]).toBe('update');
@@ -911,10 +911,10 @@ describe('Profiler', () => {
             // base time includes: 2 (ErrorBoundary) + 20 (AdvanceTime)
             expect(updateCall[3]).toBe(22);
             // start time
-            expect(updateCall[4]).toBe(flagEnabled && __PROFILE__ ? 22 : 19);
+            expect(updateCall[4]).toBe(__DEV__ && flagEnabled ? 22 : 19);
             // commit time: 19 (startTime) + 2 (ErrorBoundary) + 20 (AdvanceTime)
             // Add an additional 3 (ThrowsError) if we replaced the failed work
-            expect(updateCall[5]).toBe(flagEnabled && __PROFILE__ ? 44 : 41);
+            expect(updateCall[5]).toBe(__DEV__ && flagEnabled ? 44 : 41);
           });
 
           it('should accumulate actual time after an error handled by getDerivedStateFromCatch()', () => {
@@ -968,7 +968,7 @@ describe('Profiler', () => {
             // start time
             expect(mountCall[4]).toBe(5);
             // commit time
-            expect(mountCall[5]).toBe(flagEnabled && __PROFILE__ ? 54 : 44);
+            expect(mountCall[5]).toBe(__DEV__ && flagEnabled ? 54 : 44);
           });
 
           it('should reset the fiber stack correct after a "complete" phase error', () => {

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -894,7 +894,7 @@ describe('Profiler', () => {
             // But it spends time rendering all of the failed subtree also.
             expect(mountCall[1]).toBe('mount');
             // actual time includes: 2 (ErrorBoundary) + 9 (AdvanceTime) + 3 (ThrowsError)
-            // If replayFailedUnitOfWorkWithInvokeGuardedCallback is enbaled, ThrowsError is replayed.
+            // We don't count the time spent in replaying the failed unit of work (ThrowsError)
             expect(mountCall[2]).toBe(14);
             // base time includes: 2 (ErrorBoundary)
             expect(mountCall[3]).toBe(2);


### PR DESCRIPTION
While testing the new DevTools profiler, I noticed that sometimes– in larger, more complicated applications– an incorrect value was being reported for `actualDuration` (often too large, occasionally negative).

Unfortunately I was unable to capture the problem in a test, but I believe it has something to do with the way I was tracking render times across different priorities and roots. So this PR replaces the old approach with a simpler one that I believe is more robust.

Anecdotally, the timing problems I was able to reproduce before in my test app(s) are no longer happening after this change. I think the code is also easier to read and reason about now.

Resolves #13309