### PR TITLE
Suspense fixture large placeholder styling improvement

### DIFF
--- a/fixtures/unstable-async/suspense/src/components/Spinner.css
+++ b/fixtures/unstable-async/suspense/src/components/Spinner.css
@@ -2,6 +2,13 @@
   animation: rotate 1.3s linear infinite;
 }
 
+.SpinnerContainer-large {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
 @keyframes rotate {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(270deg); }

--- a/fixtures/unstable-async/suspense/src/components/Spinner.js
+++ b/fixtures/unstable-async/suspense/src/components/Spinner.js
@@ -26,23 +26,26 @@ export default function Spinner({size = 'small'}) {
   const strokeWidth = STROKE_WIDTHS[size];
   const pathRadius = `${baseSize / 2 - strokeWidth}px`;
   const className = PATH_CLASS_NAMES[size];
+  const containerClassName = `SpinnerContainer SpinnerContainer-${size}`;
 
   return (
-    <svg
-      className={className}
-      width={baseSize}
-      height={baseSize}
-      viewBox={`0 0 ${baseSize} ${baseSize}`}>
-      <circle
-        className="SpinnerPath"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth={strokeWidth}
-        strokeLinecap="round"
-        cx={pathSize}
-        cy={pathSize}
-        r={pathRadius}
-      />
-    </svg>
+    <div class={containerClassName}>
+      <svg
+        className={className}
+        width={baseSize}
+        height={baseSize}
+        viewBox={`0 0 ${baseSize} ${baseSize}`}>
+        <circle
+          className="SpinnerPath"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          cx={pathSize}
+          cy={pathSize}
+          r={pathRadius}
+        />
+      </svg>
+    </div>
   );
 }


### PR DESCRIPTION
Vertically and horizontally center 'large' placeholder spinner in suspense demo as per @gaearon's tweet:
https://twitter.com/dan_abramov/status/1025190261784289280

This is my first PR to React, so let me know if something's not right. Have ran prettier, signed the CLA, and ensured all test suites and Flow checks pass.

GIF of the change in action:
![prgif](https://user-images.githubusercontent.com/1315463/43621219-2b8b0812-968b-11e8-9d46-7b1ca796327c.gif)