### PR TITLE
Enhance get derived state from props state warning - #12670

### DIFF
--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -1003,8 +1003,10 @@ describe('ReactComponentLifeCycle', () => {
 
     const div = document.createElement('div');
     expect(() => ReactDOM.render(<MyComponent />, div)).toWarnDev(
-      'MyComponent: Component state must be properly initialized when using getDerivedStateFromProps. ' +
-        'Expected state to be an object, but it was undefined.',
+      '`MyComponent` uses `getDerivedStateFromProps` but its initial state is ' +
+        'undefined. This is not recommended. Instead, define the initial state by ' +
+        'assigning an object to `this.state` in the constructor of `MyComponent`. ' +
+        'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
       {withoutStack: true},
     );
 

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -1003,7 +1003,7 @@ describe('ReactComponentLifeCycle', () => {
 
     const div = document.createElement('div');
     expect(() => ReactDOM.render(<MyComponent />, div)).toWarnDev(
-      'MyComponent: Did not properly initialize state during construction. ' +
+      'MyComponent: Component state must be properly initialized when using getDerivedStateFromProps. ' +
         'Expected state to be an object, but it was undefined.',
       {withoutStack: true},
     );

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
@@ -201,7 +201,7 @@ describe('ReactDOMServerLifecycles', () => {
     }
 
     expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
-      'Component: Did not properly initialize state during construction. ' +
+      'Component: Component state must be properly initialized when using getDerivedStateFromProps. ' +
         'Expected state to be an object, but it was undefined.',
       {withoutStack: true},
     );

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
@@ -201,8 +201,10 @@ describe('ReactDOMServerLifecycles', () => {
     }
 
     expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
-      'Component: Component state must be properly initialized when using getDerivedStateFromProps. ' +
-        'Expected state to be an object, but it was undefined.',
+      '`Component` uses `getDerivedStateFromProps` but its initial state is ' +
+        'undefined. This is not recommended. Instead, define the initial state by ' +
+        'assigning an object to `this.state` in the constructor of `Component`. ' +
+        'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
       {withoutStack: true},
     );
 

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -476,10 +476,13 @@ function resolve(
             if (!didWarnAboutUninitializedState[componentName]) {
               warningWithoutStack(
                 false,
-                '%s: Component state must be properly initialized when using getDerivedStateFromProps. ' +
-                  'Expected state to be an object, but it was %s.',
+                '`%s` uses `getDerivedStateFromProps` but its initial state is ' +
+                  '%s. This is not recommended. Instead, define the initial state by ' +
+                  'assigning an object to `this.state` in the constructor of `%s`. ' +
+                  'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
                 componentName,
                 inst.state === null ? 'null' : 'undefined',
+                componentName,
               );
               didWarnAboutUninitializedState[componentName] = true;
             }

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -476,7 +476,7 @@ function resolve(
             if (!didWarnAboutUninitializedState[componentName]) {
               warningWithoutStack(
                 false,
-                '%s: Did not properly initialize state during construction. ' +
+                '%s: Component state must be properly initialized when using getDerivedStateFromProps. ' +
                   'Expected state to be an object, but it was %s.',
                 componentName,
                 inst.state === null ? 'null' : 'undefined',

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -505,7 +505,7 @@ function constructClassInstance(
         didWarnAboutUninitializedState.add(componentName);
         warningWithoutStack(
           false,
-          '%s: Did not properly initialize state during construction. ' +
+          '%s: Component state must be properly initialized when using getDerivedStateFromProps. ' +
             'Expected state to be an object, but it was %s.',
           componentName,
           instance.state === null ? 'null' : 'undefined',

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -505,10 +505,13 @@ function constructClassInstance(
         didWarnAboutUninitializedState.add(componentName);
         warningWithoutStack(
           false,
-          '%s: Component state must be properly initialized when using getDerivedStateFromProps. ' +
-            'Expected state to be an object, but it was %s.',
+          '`%s` uses `getDerivedStateFromProps` but its initial state is ' +
+            '%s. This is not recommended. Instead, define the initial state by ' +
+            'assigning an object to `this.state` in the constructor of `%s`. ' +
+            'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
           componentName,
           instance.state === null ? 'null' : 'undefined',
+          componentName,
         );
       }
     }

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -163,7 +163,7 @@ describe 'ReactCoffeeScriptClass', ->
       }
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: Did not properly initialize state during construction. Expected state to be an object, but it was undefined.', {withoutStack: true}
+    ).toWarnDev 'Foo: Component state must be properly initialized when using getDerivedStateFromProps. Expected state to be an object, but it was undefined.', {withoutStack: true}
     undefined
 
   it 'updates initial state with values returned by static getDerivedStateFromProps', ->

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -163,7 +163,12 @@ describe 'ReactCoffeeScriptClass', ->
       }
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: Component state must be properly initialized when using getDerivedStateFromProps. Expected state to be an object, but it was undefined.', {withoutStack: true}
+    ).toWarnDev (
+      '`Foo` uses `getDerivedStateFromProps` but its initial state is ' +
+      'undefined. This is not recommended. Instead, define the initial state by ' +
+      'assigning an object to `this.state` in the constructor of `Foo`. ' +
+      'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.'
+    ), {withoutStack: true}
     undefined
 
   it 'updates initial state with values returned by static getDerivedStateFromProps', ->

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -190,8 +190,10 @@ describe('ReactES6Class', () => {
       }
     }
     expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
-      'Foo: Component state must be properly initialized when using getDerivedStateFromProps. ' +
-        'Expected state to be an object, but it was undefined.',
+      '`Foo` uses `getDerivedStateFromProps` but its initial state is ' +
+        'undefined. This is not recommended. Instead, define the initial state by ' +
+        'assigning an object to `this.state` in the constructor of `Foo`. ' +
+        'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
       {withoutStack: true},
     );
   });

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -190,7 +190,7 @@ describe('ReactES6Class', () => {
       }
     }
     expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
-      'Foo: Did not properly initialize state during construction. ' +
+      'Foo: Component state must be properly initialized when using getDerivedStateFromProps. ' +
         'Expected state to be an object, but it was undefined.',
       {withoutStack: true},
     );

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -448,8 +448,10 @@ describe('ReactTypeScriptClass', function() {
     expect(function() {
       ReactDOM.render(React.createElement(Foo, {foo: 'foo'}), container);
     }).toWarnDev(
-      'Foo: Component state must be properly initialized when using getDerivedStateFromProps. ' +
-        'Expected state to be an object, but it was undefined.',
+      '`Foo` uses `getDerivedStateFromProps` but its initial state is ' +
+      'undefined. This is not recommended. Instead, define the initial state by ' +
+      'assigning an object to `this.state` in the constructor of `Foo`. ' +
+      'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
         {withoutStack: true}
     );
   });

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -448,7 +448,7 @@ describe('ReactTypeScriptClass', function() {
     expect(function() {
       ReactDOM.render(React.createElement(Foo, {foo: 'foo'}), container);
     }).toWarnDev(
-      'Foo: Did not properly initialize state during construction. ' +
+      'Foo: Component state must be properly initialized when using getDerivedStateFromProps. ' +
         'Expected state to be an object, but it was undefined.',
         {withoutStack: true}
     );

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -510,9 +510,12 @@ describe('create-react-class-integration', () => {
     });
     expect(() =>
       ReactDOM.render(<Component />, document.createElement('div')),
-    ).toWarnDev('Component state must be properly initialized when using getDerivedStateFromProps.', {
-      withoutStack: true,
-    });
+    ).toWarnDev(
+      'Component state must be properly initialized when using getDerivedStateFromProps.',
+      {
+        withoutStack: true,
+      },
+    );
   });
 
   it('should not invoke deprecated lifecycles (cWM/cWRP/cWU) if new static gDSFP is present', () => {

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -511,7 +511,10 @@ describe('create-react-class-integration', () => {
     expect(() =>
       ReactDOM.render(<Component />, document.createElement('div')),
     ).toWarnDev(
-      'Component state must be properly initialized when using getDerivedStateFromProps.',
+      '`Component` uses `getDerivedStateFromProps` but its initial state is ' +
+        'undefined. This is not recommended. Instead, define the initial state by ' +
+        'assigning an object to `this.state` in the constructor of `Component`. ' +
+        'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
       {
         withoutStack: true,
       },

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -510,7 +510,7 @@ describe('create-react-class-integration', () => {
     });
     expect(() =>
       ReactDOM.render(<Component />, document.createElement('div')),
-    ).toWarnDev('Did not properly initialize state during construction.', {
+    ).toWarnDev('Component state must be properly initialized when using getDerivedStateFromProps.', {
       withoutStack: true,
     });
   });

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -512,7 +512,7 @@ describe('create-react-class-integration', () => {
       ReactDOM.render(<Component />, document.createElement('div')),
     ).toWarnDev(
       '`Component` uses `getDerivedStateFromProps` but its initial state is ' +
-        'undefined. This is not recommended. Instead, define the initial state by ' +
+        'null. This is not recommended. Instead, define the initial state by ' +
         'assigning an object to `this.state` in the constructor of `Component`. ' +
         'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
       {


### PR DESCRIPTION
The current warning that `getDerivedStateFromProps` produces when called with `state == null` (intentional null or undefined/not declared) is a bit unclear, so this PR adapts this message for the developer to directly recognize that he didn't declare the Component's state before `getDerivedStateFromProps`.

Resolves: #12670.

The updated message is now:
```
Component state must be properly initialized when using getDerivedStateFromProps.
```