### PR TITLE
refactor: remove promise on checkModule

### DIFF
--- a/scripts/release/build-commands/check-package-dependencies.js
+++ b/scripts/release/build-commands/check-package-dependencies.js
@@ -39,7 +39,7 @@ const check = async ({cwd, packages}) => {
     });
   };
 
-  await Promise.all(dependencies.map(checkModule));
+  dependencies.map(checkModule);
 
   if (invalidDependencies.length) {
     throw Error(

--- a/scripts/release/build-commands/check-package-dependencies.js
+++ b/scripts/release/build-commands/check-package-dependencies.js
@@ -39,7 +39,7 @@ const check = async ({cwd, packages}) => {
     });
   };
 
-  dependencies.map(checkModule);
+  dependencies.forEach(checkModule);
 
   if (invalidDependencies.length) {
     throw Error(


### PR DESCRIPTION
The `checkModule` doesn't return any promise object, so it may be better to remove the Promise.all