### PR TITLE
Fix Prettier "No parser" warning while building

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -350,7 +350,7 @@ function getPlugins(
         })
       ),
     // Add the whitespace back if necessary.
-    shouldStayReadable && prettier(),
+    shouldStayReadable && prettier({parser: 'babylon'}),
     // License and haste headers, top-level `if` blocks.
     {
       transformBundle(source) {


### PR DESCRIPTION
Currently while building React a warning appears:
> No parser and no filepath given, using 'babylon' the parser now but this will throw an error in the future. Please specify a parser or a filepath so one can be inferred.

This occurs because no config has been passed to Prettier invoked in build process.

As a solution I purposed adding `{parser: 'babylon'}` option but you should decide if whole config should be passed here.

I have also tested importing and passing whole Prettier config on my local machine and I stumble across a problem. Parameter `overrides` is not supported from other sources than while reading Prettier config file by Prettier CLI itself (https://github.com/prettier/eslint-plugin-prettier/issues/68#issuecomment-343069185). It means that in this case any overrides should be done manually inside `build.js` file.

So it seems that even when you decide to pass whole config there is no option to have only one version of Prettier config in project (located in `.prettierrc.js`).