### PR TITLE
Don't search beyond Sync roots for highest priority work

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1841,6 +1841,11 @@ function findHighestPriorityRoot() {
         if (root === lastScheduledRoot) {
           break;
         }
+        if (highestPriorityWork === Sync) {
+          // Sync is highest priority by definition so
+          // we can stop searching.
+          break;
+        }
         previousScheduledRoot = root;
         root = root.nextScheduledRoot;
       }


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/13334 at a cost of one extra comparison per scheduled root.
Not directly observable — verified by manual testing with test cases from https://github.com/facebook/react/issues/13334 and https://github.com/facebook/react/issues/12700.

Unless I'm missing something it's useless to continue searching once we've found sync work since nothing else is going to win.