### PR TITLE
Treat focusable as enumerated boolean SVG attribute

### DIFF
--- a/fixtures/attribute-behavior/AttributeTableSnapshot.md
+++ b/fixtures/attribute-behavior/AttributeTableSnapshot.md
@@ -3587,8 +3587,8 @@
 | `focusable=(integer)`| (changed)| `"1"` |
 | `focusable=(NaN)`| (changed, warning)| `"NaN"` |
 | `focusable=(float)`| (changed)| `"99.99"` |
-| `focusable=(true)`| (initial, warning)| `<null>` |
-| `focusable=(false)`| (initial, warning)| `<null>` |
+| `focusable=(true)`| (changed)| `"true"` |
+| `focusable=(false)`| (changed)| `"false"` |
 | `focusable=(string 'true')`| (changed)| `"true"` |
 | `focusable=(string 'false')`| (changed)| `"false"` |
 | `focusable=(string 'on')`| (changed)| `"on"` |

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -260,7 +260,12 @@ const properties = {};
 // In React, we let users pass `true` and `false` even though technically
 // these aren't boolean attributes (they are coerced to strings).
 // Since these are SVG attributes, their attribute names are case-sensitive.
-['autoReverse', 'externalResourcesRequired', 'preserveAlpha'].forEach(name => {
+[
+  'autoReverse',
+  'externalResourcesRequired',
+  'focusable',
+  'preserveAlpha',
+].forEach(name => {
   properties[name] = new PropertyInfoRecord(
     name,
     BOOLEANISH_STRING,


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/12481.

It's a small behavior change but the old behavior both had a warning (in which case we don't provide strong guarantees) *and* was inconsistent with other similar attributes. The old behavior was also unintuitive.

Particularly, this relaxes the restriction on `<svg focusable>` to accept booleans. It's an enumerated attribute with `'true'`, `'false'`, and `'auto'` values. This makes it consistent with how we already handle the HTML `draggable` attribute (which also has `'true'`, `'false'`, and `'auto'` values).

Before:

<img width="836" alt="screen shot 2018-08-07 at 10 07 58 am" src="https://user-images.githubusercontent.com/810438/43766663-fbe1b2de-9a2a-11e8-8583-dca9ae28d1ca.png">
<img width="843" alt="screen shot 2018-08-07 at 10 08 19 am" src="https://user-images.githubusercontent.com/810438/43766665-fc1ac3b2-9a2a-11e8-9e5f-a5c8817554ee.png">

After:

<img width="434" alt="screen shot 2018-08-07 at 10 09 06 am" src="https://user-images.githubusercontent.com/810438/43766677-0207d526-9a2b-11e8-83ed-2d0edb194f26.png">
<img width="452" alt="screen shot 2018-08-07 at 10 08 58 am" src="https://user-images.githubusercontent.com/810438/43766683-06576e3e-9a2b-11e8-892c-7901c34425af.png">

There's no behavior change for cases that didn't warn.

I couldn't find other attributes like this except `syncMaster` (which seems very niche?) so I'm not worried about this list growing.