### PR TITLE
Failing test for removing nodes with dupe keys

### DIFF
--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -387,6 +387,27 @@ describe('ReactMultiChild', () => {
     expect(container.textContent).toBe('EHCjpdTUuiybDvhRJwZt');
   });
 
+  it('should reorder children with duplicate keys', () => {
+    class Letters extends React.Component {
+      render() {
+        const letters = this.props.letters.split('');
+        return <div>{letters.map(c => <span key={c}>{c}</span>)}</div>;
+      }
+    }
+
+    // Ignore warnings about duplicate keys
+    spyOnDev(console, 'error');
+    const container = document.createElement('div');
+
+    // Two random strings *with duplicates* -- we don't guarantee the ways in
+    // which state is preserved but it would be nice if we don't give totally
+    // wrong output (like by failing to remove old elements)
+    ReactDOM.render(<Letters letters="uhimxkxtsnsdakapkeam" />, container);
+    expect(container.textContent).toBe('uhimxkxtsnsdakapkeam');
+    ReactDOM.render(<Letters letters="jqvrhtlpxjhpeuyolwnr" />, container);
+    expect(container.textContent).toBe('jqvrhtlpxjhpeuyolwnr');
+  });
+
   it('prepares new children before unmounting old', () => {
     const log = [];
 


### PR DESCRIPTION
We don't really support duplicate keys, but the fact that we don't means you can get totally inconsistent output -- where your component thinks it is rendering one thing but is actually rendering another. The simplest manifestation of this is:

```js
function Foo(props) {
  if (props.step === 1) {
    return <>
      <div key="bar" />
      <div key="bar" />
    </>;
  } else {
    return <>
      <div key="baz" />
    </>;
  }
}
```

If you render step=1 then step=2, you'll end up with a DOM containing `bar` then `baz` even though that's "logically impossible".

People who see a dupe key warning in DEV should heed it, but this is still pretty odd behavior (that can be caused by fluke unreliable server data), so maybe we can do better?