### PR TITLE
Enable warnings for the defaultValue prop

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -1640,23 +1640,29 @@ describe('ReactDOMInput', () => {
       expect(node.getAttribute('value')).toBe('');
     });
 
-    it('treats initial Symbol defaultValue as an empty string', function() {
-      ReactDOM.render(<input defaultValue={Symbol('foobar')} />, container);
+    fit('treats initial Symbol defaultValue as an empty string', function() {
+      expect(() =>
+        ReactDOM.render(
+          <input defaultValue={Symbol('foobar')} />,
+          container
+        ),
+      ).toWarnDev('Invalid value for prop `defaultValue`');
+
       const node = container.firstChild;
 
       expect(node.value).toBe('');
       expect(node.getAttribute('value')).toBe('');
-      // TODO: we should warn here.
     });
 
     it('treats updated Symbol defaultValue as an empty string', function() {
       ReactDOM.render(<input defaultValue="foo" />, container);
-      ReactDOM.render(<input defaultValue={Symbol('foobar')} />, container);
+      expect(() =>
+        ReactDOM.render(<input defaultValue={Symbol('foobar')} />, container),
+      ).toWarnDev('Invalid value for prop `defaultValue`');
       const node = container.firstChild;
 
       expect(node.value).toBe('foo');
       expect(node.getAttribute('value')).toBe('');
-      // TODO: we should warn here.
     });
   });
 
@@ -1689,22 +1695,24 @@ describe('ReactDOMInput', () => {
     });
 
     it('treats initial function defaultValue as an empty string', function() {
-      ReactDOM.render(<input defaultValue={() => {}} />, container);
+      expect(() =>
+        ReactDOM.render(<input defaultValue={() => {}} />, container),
+      ).toWarnDev('Invalid value for prop `defaultValue`');
       const node = container.firstChild;
 
       expect(node.value).toBe('');
       expect(node.getAttribute('value')).toBe('');
-      // TODO: we should warn here.
     });
 
     it('treats updated function defaultValue as an empty string', function() {
       ReactDOM.render(<input defaultValue="foo" />, container);
-      ReactDOM.render(<input defaultValue={() => {}} />, container);
+      expect(() =>
+        ReactDOM.render(<input defaultValue={() => {}} />, container),
+      ).toWarnDev('Invalid value for prop `defaultValue`');
       const node = container.firstChild;
 
       expect(node.value).toBe('foo');
       expect(node.getAttribute('value')).toBe('');
-      // TODO: we should warn here.
     });
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -1640,7 +1640,7 @@ describe('ReactDOMInput', () => {
       expect(node.getAttribute('value')).toBe('');
     });
 
-    fit('treats initial Symbol defaultValue as an empty string', function() {
+    it('treats initial Symbol defaultValue as an empty string', function() {
       expect(() =>
         ReactDOM.render(
           <input defaultValue={Symbol('foobar')} />,

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -1642,10 +1642,7 @@ describe('ReactDOMInput', () => {
 
     it('treats initial Symbol defaultValue as an empty string', function() {
       expect(() =>
-        ReactDOM.render(
-          <input defaultValue={Symbol('foobar')} />,
-          container
-        ),
+        ReactDOM.render(<input defaultValue={Symbol('foobar')} />, container),
       ).toWarnDev('Invalid value for prop `defaultValue`');
 
       const node = container.firstChild;

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -400,14 +400,20 @@ describe('ReactDOMInput', () => {
 
   it('should display "true" for `defaultValue` of `true`', () => {
     let stub = <input type="text" defaultValue={true} />;
-    const node = ReactDOM.render(stub, container);
+    let node;
+    expect(() => (node = ReactDOM.render(stub, container))).toWarnDev(
+      'Received `true` for a non-boolean attribute `defaultValue`',
+    );
 
     expect(node.value).toBe('true');
   });
 
   it('should display "false" for `defaultValue` of `false`', () => {
     let stub = <input type="text" defaultValue={false} />;
-    const node = ReactDOM.render(stub, container);
+    let node;
+    expect(() => (node = ReactDOM.render(stub, container))).toWarnDev(
+      'Received `false` for a non-boolean attribute `defaultValue`',
+    );
 
     expect(node.value).toBe('false');
   });

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -63,7 +63,10 @@ describe('ReactDOMTextarea', () => {
 
   it('should display "false" for `defaultValue` of `false`', () => {
     const stub = <textarea defaultValue={false} />;
-    const node = renderTextarea(stub);
+    let node;
+    expect(() => (node = renderTextarea(stub))).toWarnDev(
+      'Received `false` for a non-boolean attribute `defaultValue`',
+    );
 
     expect(node.value).toBe('false');
   });

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -115,7 +115,13 @@ export function shouldRemoveAttributeWithWarning(
   propertyInfo: PropertyInfo | null,
   isCustomComponentTag: boolean,
 ): boolean {
-  if (propertyInfo !== null && propertyInfo.type === RESERVED) {
+  // Do not validate data types for reserved props
+  // (excluding defaultValue)
+  if (
+    propertyInfo !== null &&
+    propertyInfo.type === RESERVED &&
+    propertyInfo.attributeName !== 'defaultValue'
+  ) {
     return false;
   }
   switch (typeof value) {

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -51,6 +51,7 @@ export type PropertyInfo = {|
   +mustUseProperty: boolean,
   +propertyName: string,
   +type: PropertyType,
+  +shouldWarnInDev: boolean,
 |};
 
 /* eslint-disable max-len */
@@ -120,7 +121,7 @@ export function shouldRemoveAttributeWithWarning(
   if (
     propertyInfo !== null &&
     propertyInfo.type === RESERVED &&
-    propertyInfo.attributeName !== 'defaultValue'
+    !propertyInfo.shouldWarnInDev
   ) {
     return false;
   }
@@ -192,6 +193,7 @@ function PropertyInfoRecord(
   mustUseProperty: boolean,
   attributeName: string,
   attributeNamespace: string | null,
+  shouldWarnInDev: boolean = false,
 ) {
   this.acceptsBooleans =
     type === BOOLEANISH_STRING ||
@@ -202,6 +204,7 @@ function PropertyInfoRecord(
   this.mustUseProperty = mustUseProperty;
   this.propertyName = name;
   this.type = type;
+  this.shouldWarnInDev = shouldWarnInDev;
 }
 
 // When adding attributes to this list, be sure to also add them to
@@ -229,6 +232,7 @@ const properties = {};
     false, // mustUseProperty
     name, // attributeName
     null, // attributeNamespace
+    name === 'defaultValue', // shouldWarnInDev
   );
 });
 

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -214,6 +214,16 @@ if (__DEV__) {
       return true;
     }
 
+    // Ignore the reservation of the `defaultValue` prop for warnings
+    if (
+      typeof value === 'symbol' || typeof value === 'function' &&
+      tagName === 'input' &&
+      name === 'defaultValue'
+    ) {
+      warnedProperties[name] = true;
+      return false;
+    }
+
     // Now that we've validated casing, do not validate
     // data types for reserved props
     if (isReserved) {

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -214,23 +214,6 @@ if (__DEV__) {
       return true;
     }
 
-    // Ignore the reservation of the `defaultValue` prop for warnings
-    if (
-      typeof value === 'symbol' ||
-      (typeof value === 'function' &&
-        tagName === 'input' &&
-        name === 'defaultValue')
-    ) {
-      warnedProperties[name] = true;
-      return false;
-    }
-
-    // Now that we've validated casing, do not validate
-    // data types for reserved props
-    if (isReserved) {
-      return true;
-    }
-
     // Warn when a known attribute is a bad type
     if (shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)) {
       warnedProperties[name] = true;

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -216,9 +216,10 @@ if (__DEV__) {
 
     // Ignore the reservation of the `defaultValue` prop for warnings
     if (
-      typeof value === 'symbol' || typeof value === 'function' &&
-      tagName === 'input' &&
-      name === 'defaultValue'
+      typeof value === 'symbol' ||
+      (typeof value === 'function' &&
+        tagName === 'input' &&
+        name === 'defaultValue')
     ) {
       warnedProperties[name] = true;
       return false;


### PR DESCRIPTION
Somewhat related to #11734.

I started off with adding warnings for assigning symbols and functions to the defaultValue prop (ultimately resolving TODOs in `ReactDOMInput-test.js`), then quickly realized that there are a few cases that don't currently warn, so I decided to go ahead and cover those as well. For i.e, assigning a boolean to defaultValue currently does not warn, but could, in order to prevent potential pitfalls or misconceptions.