### PR TITLE
Warn when "false" or "true" is the value of a boolean DOM prop

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -2518,6 +2518,18 @@ describe('ReactDOMComponent', () => {
 
       expect(el.getAttribute('hidden')).toBe('');
     });
+
+    it('warns on the potentially-ambiguous string value "true"', function() {
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div hidden="true" />);
+      }).toWarnDev(
+        'Received the string `true` for the boolean attribute `hidden`. ' +
+          'Did you mean hidden={true}?',
+      );
+
+      expect(el.getAttribute('hidden')).toBe('');
+    });
   });
 
   describe('Hyphenated SVG elements', function() {

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -2513,6 +2513,7 @@ describe('ReactDOMComponent', () => {
         el = ReactTestUtils.renderIntoDocument(<div hidden="false" />);
       }).toWarnDev(
         'Received the string `false` for the boolean attribute `hidden`. ' +
+          'The browser will interpret it as a truthy value. ' +
           'Did you mean hidden={false}?',
       );
 
@@ -2525,6 +2526,7 @@ describe('ReactDOMComponent', () => {
         el = ReactTestUtils.renderIntoDocument(<div hidden="true" />);
       }).toWarnDev(
         'Received the string `true` for the boolean attribute `hidden`. ' +
+          'Although this works, it will not work as expected if you pass the string "false". ' +
           'Did you mean hidden={true}?',
       );
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -2518,18 +2518,6 @@ describe('ReactDOMComponent', () => {
 
       expect(el.getAttribute('hidden')).toBe('');
     });
-
-    it('warns on the ambiguous string value "False"', function() {
-      let el;
-      expect(() => {
-        el = ReactTestUtils.renderIntoDocument(<div hidden="False" />);
-      }).toWarnDev(
-        'Received the string `False` for the boolean attribute `hidden`. ' +
-          'Did you mean hidden={false}?',
-      );
-
-      expect(el.getAttribute('hidden')).toBe('');
-    });
   });
 
   describe('Hyphenated SVG elements', function() {

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -2506,6 +2506,32 @@ describe('ReactDOMComponent', () => {
     });
   });
 
+  describe('Boolean attributes', function() {
+    it('warns on the ambiguous string value "false"', function() {
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div hidden="false" />);
+      }).toWarnDev(
+        'Received the string `false` for the boolean attribute `hidden`. ' +
+          'Did you mean hidden={false}?',
+      );
+
+      expect(el.getAttribute('hidden')).toBe('');
+    });
+
+    it('warns on the ambiguous string value "False"', function() {
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div hidden="False" />);
+      }).toWarnDev(
+        'Received the string `False` for the boolean attribute `hidden`. ' +
+          'Did you mean hidden={false}?',
+      );
+
+      expect(el.getAttribute('hidden')).toBe('');
+    });
+  });
+
   describe('Hyphenated SVG elements', function() {
     it('the font-face element is not a custom element', function() {
       let el;

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -444,7 +444,7 @@ describe('ReactDOMInput', () => {
 
   it('should take `defaultValue` when changing to uncontrolled input', () => {
     const node = ReactDOM.render(
-      <input type="text" value="0" readOnly="true" />,
+      <input type="text" value="0" readOnly={true} />,
       container,
     );
     expect(node.value).toBe('0');

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -236,9 +236,13 @@ if (__DEV__) {
       warning(
         false,
         'Received the string `%s` for the boolean attribute `%s`. ' +
+          '%s ' +
           'Did you mean %s={%s}?',
         value,
         name,
+        value === 'false'
+          ? 'The browser will interpret it as a truthy value.'
+          : 'Although this works, it will not work as expected if you pass the string "false".',
         name,
         value,
       );

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -13,6 +13,7 @@ import warning from 'shared/warning';
 
 import {
   ATTRIBUTE_NAME_CHAR,
+  BOOLEAN,
   RESERVED,
   shouldRemoveAttributeWithWarning,
   getPropertyInfo,
@@ -224,6 +225,25 @@ if (__DEV__) {
     if (shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)) {
       warnedProperties[name] = true;
       return false;
+    }
+
+    // Warn when passing the string 'false' into a boolean prop
+    if (
+      propertyInfo !== null &&
+      propertyInfo.type === BOOLEAN &&
+      typeof value === 'string' &&
+      value.toLowerCase() === 'false'
+    ) {
+      warning(
+        false,
+        'Received the string `%s` for the boolean attribute `%s`. ' +
+          'Did you mean %s={false}?',
+        value,
+        name,
+        name,
+      );
+      warnedProperties[name] = true;
+      return true;
     }
 
     return true;

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -227,19 +227,20 @@ if (__DEV__) {
       return false;
     }
 
-    // Warn when passing the string 'false' into a boolean prop
+    // Warn when passing the strings 'false' or 'true' into a boolean prop
     if (
-      value === 'false' &&
+      (value === 'false' || value === 'true') &&
       propertyInfo !== null &&
       propertyInfo.type === BOOLEAN
     ) {
       warning(
         false,
         'Received the string `%s` for the boolean attribute `%s`. ' +
-          'Did you mean %s={false}?',
+          'Did you mean %s={%s}?',
         value,
         name,
         name,
+        value,
       );
       warnedProperties[name] = true;
       return true;

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -229,10 +229,9 @@ if (__DEV__) {
 
     // Warn when passing the string 'false' into a boolean prop
     if (
+      value === 'false' &&
       propertyInfo !== null &&
-      propertyInfo.type === BOOLEAN &&
-      typeof value === 'string' &&
-      value.toLowerCase() === 'false'
+      propertyInfo.type === BOOLEAN
     ) {
       warning(
         false,


### PR DESCRIPTION
Hi! 😄 

This is my first contribution that actually changes runtime behaviour, and involved some guesswork as to _where_ to make _what_ change to get the desired effect - so do take it with a grain of salt. I'm super willing to learn more about how React is written and fix anything that needs to be fixed in this PR, if the functionality is welcome.

---

This PR adds a new DEV-mode warning when the value `"false"` (case-insensitive) is found in a DOM prop of type `BOOLEAN`, recommending the use of the boolean value `false` instead.

While working on https://github.com/facebook/flow/pull/6727 I came across [the different types of boolean DOM props](https://github.com/facebook/react/blob/725e499cfb4da60da46aa5b44c4bad29cad3d08f/packages/react-dom/src/shared/DOMProperty.js#L22-L37), and specifically the fact that `BOOLEAN` props (e.g. `hidden`) treat the string `"false"` as equivalent to boolean _`true`_, whereas `BOOLEANISH_STRING` props (e.g. `spellCheck`) treat it as equivalent to boolean `false` - an inconsistency that follows from the HTML spec, but one that can conceivably trip up developers, hence a warning.

I'm not entirely sure what `OVERLOADED_BOOLEAN` props should do about `"false"` - currently the warning doesn't apply to them.

EDIT: Per feedback below, this now also warns on `"true"`, and only warns on case-sensitive (lowercase) matches.