### PR TITLE
Fix typo in a comment

### DIFF
--- a/packages/shared/invariant.js
+++ b/packages/shared/invariant.js
@@ -27,7 +27,7 @@ if (__DEV__) {
   };
 }
 
-export default function invariant(condition, format, a, b, c, d, e, f) {
+export default function invariant(condition, format, ...args) {
   validateFormat(format);
 
   if (!condition) {
@@ -38,7 +38,6 @@ export default function invariant(condition, format, a, b, c, d, e, f) {
           'for the full error message and additional helpful warnings.',
       );
     } else {
-      const args = [a, b, c, d, e, f];
       let argIndex = 0;
       error = new Error(
         format.replace(/%s/g, function() {

--- a/packages/shared/invariant.js
+++ b/packages/shared/invariant.js
@@ -27,7 +27,7 @@ if (__DEV__) {
   };
 }
 
-export default function invariant(condition, format, ...args) {
+export default function invariant(condition, format, a, b, c, d, e, f) {
   validateFormat(format);
 
   if (!condition) {
@@ -38,6 +38,7 @@ export default function invariant(condition, format, ...args) {
           'for the full error message and additional helpful warnings.',
       );
     } else {
+      const args = [a, b, c, d, e, f];
       let argIndex = 0;
       error = new Error(
         format.replace(/%s/g, function() {

--- a/packages/shared/reactProdInvariant.js
+++ b/packages/shared/reactProdInvariant.js
@@ -8,7 +8,7 @@
  */
 
 // Relying on the `invariant()` implementation lets us
-// have preserve the format and params in the www builds.
+// preserve the format and params in the www builds.
 import invariant from 'shared/invariant';
 
 /**

--- a/packages/shared/reactProdInvariant.js
+++ b/packages/shared/reactProdInvariant.js
@@ -17,12 +17,11 @@ import invariant from 'shared/invariant';
  * and will _only_ be required by the corresponding babel pass.
  * It always throws.
  */
-function reactProdInvariant(code: string, ...args: Array<string>): void {
+function reactProdInvariant(code: string): void {
+  const argCount = arguments.length - 1;
   let url = 'https://reactjs.org/docs/error-decoder.html?invariant=' + code;
-  if (args.length > 0) {
-    for (let argIdx = 0; argIdx < args.length; argIdx++) {
-      url += '&args[]=' + encodeURIComponent(args[argIdx]);
-    }
+  for (let argIdx = 0; argIdx < argCount; argIdx++) {
+    url += '&args[]=' + encodeURIComponent(arguments[argIdx + 1]);
   }
   // Rename it so that our build transform doesn't atttempt
   // to replace this invariant() call with reactProdInvariant().

--- a/packages/shared/reactProdInvariant.js
+++ b/packages/shared/reactProdInvariant.js
@@ -17,11 +17,10 @@ import invariant from 'shared/invariant';
  * and will _only_ be required by the corresponding babel pass.
  * It always throws.
  */
-function reactProdInvariant(code: string): void {
-  const argCount = arguments.length - 1;
+function reactProdInvariant(code: string, args: Array<string>): void {
   let url = 'https://reactjs.org/docs/error-decoder.html?invariant=' + code;
-  for (let argIdx = 0; argIdx < argCount; argIdx++) {
-    url += '&args[]=' + encodeURIComponent(arguments[argIdx + 1]);
+  for (let argIdx = 0; argIdx < args.length; argIdx++) {
+    url += '&args[]=' + encodeURIComponent(args[argIdx]);
   }
   // Rename it so that our build transform doesn't atttempt
   // to replace this invariant() call with reactProdInvariant().

--- a/packages/shared/reactProdInvariant.js
+++ b/packages/shared/reactProdInvariant.js
@@ -17,10 +17,12 @@ import invariant from 'shared/invariant';
  * and will _only_ be required by the corresponding babel pass.
  * It always throws.
  */
-function reactProdInvariant(code: string, args: Array<string>): void {
+function reactProdInvariant(code: string, ...args: Array<string>): void {
   let url = 'https://reactjs.org/docs/error-decoder.html?invariant=' + code;
-  for (let argIdx = 0; argIdx < args.length; argIdx++) {
-    url += '&args[]=' + encodeURIComponent(args[argIdx]);
+  if (args.length > 0) {
+    for (let argIdx = 0; argIdx < args.length; argIdx++) {
+      url += '&args[]=' + encodeURIComponent(args[argIdx]);
+    }
   }
   // Rename it so that our build transform doesn't atttempt
   // to replace this invariant() call with reactProdInvariant().


### PR DESCRIPTION
I fixed a typo and changed the code to use the rest parameter to allow the use of more than 6 %s in _invariant_, though I'm not sure if it'll ever be needed.