### PR TITLE
Support tangentialPressure and twist fields of pointer events

### DIFF
--- a/packages/react-dom/src/events/SyntheticPointerEvent.js
+++ b/packages/react-dom/src/events/SyntheticPointerEvent.js
@@ -16,8 +16,10 @@ const SyntheticPointerEvent = SyntheticMouseEvent.extend({
   width: null,
   height: null,
   pressure: null,
+  tangentialPressure: null,
   tiltX: null,
   tiltY: null,
+  twist: null,
   pointerType: null,
   isPrimary: null,
 });


### PR DESCRIPTION
While working on https://github.com/facebook/flow/pull/6728 I noticed React's recently-added `SyntheticPointerEvent` was missing the [`tangentialPressure`](https://www.w3.org/TR/pointerevents/#dom-pointerevent-tangentialpressure) and [`twist`](https://www.w3.org/TR/pointerevents/#dom-pointerevent-twist) fields. I couldn't find any reason for their omission in https://github.com/facebook/react/pull/12507 (nor in the spec) so I assume they were meant to be included, like the rest of `PointerEvent`. This PR adds these two fields to `SyntheticPointerEvent`.