### PR TITLE
Ensure arguments are coerced to strings in warnings

### DIFF
--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -165,11 +165,7 @@ if (__DEV__) {
     attributeNames.forEach(function(name) {
       names.push(name);
     });
-    warningWithoutStack(
-      false,
-      'Extra attributes from the server: %s',
-      names.join(', '),
-    );
+    warningWithoutStack(false, 'Extra attributes from the server: %s', names);
   };
 
   warnForInvalidEventListener = function(registrationName, listener) {

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -165,7 +165,7 @@ if (__DEV__) {
     attributeNames.forEach(function(name) {
       names.push(name);
     });
-    warningWithoutStack(false, 'Extra attributes from the server: %s', names);
+    warningWithoutStack(false, 'Extra attributes from the server: %s', names.join(', '));
   };
 
   warnForInvalidEventListener = function(registrationName, listener) {

--- a/packages/react-dom/src/client/ReactDOMFiberComponent.js
+++ b/packages/react-dom/src/client/ReactDOMFiberComponent.js
@@ -165,7 +165,11 @@ if (__DEV__) {
     attributeNames.forEach(function(name) {
       names.push(name);
     });
-    warningWithoutStack(false, 'Extra attributes from the server: %s', names.join(', '));
+    warningWithoutStack(
+      false,
+      'Extra attributes from the server: %s',
+      names.join(', '),
+    );
   };
 
   warnForInvalidEventListener = function(registrationName, listener) {

--- a/packages/shared/warningWithoutStack.js
+++ b/packages/shared/warningWithoutStack.js
@@ -25,16 +25,18 @@ if (__DEV__) {
     if (condition) {
       return;
     }
+
+    let argIndex = 0;
+    const message =
+      'Warning: ' + format.replace(/%s/g, () => `${args[argIndex++]}`);
+
     if (typeof console !== 'undefined') {
-      console.error('Warning: ' + format, ...args);
+      console.error(message);
     }
     try {
       // --- Welcome to debugging React ---
       // This error was thrown as a convenience so that you can use this stack
       // to find the callsite that caused this warning to fire.
-      let argIndex = 0;
-      const message =
-        'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
       throw new Error(message);
     } catch (x) {}
   };

--- a/packages/shared/warningWithoutStack.js
+++ b/packages/shared/warningWithoutStack.js
@@ -25,17 +25,17 @@ if (__DEV__) {
     if (condition) {
       return;
     }
-
-    let argIndex = 0;
-    const message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
-
     if (typeof console !== 'undefined') {
-      console.error(message);
+      const strings = args.map(item => '' + item);
+      console.error('Warning: ' + format, ...strings);
     }
     try {
       // --- Welcome to debugging React ---
       // This error was thrown as a convenience so that you can use this stack
       // to find the callsite that caused this warning to fire.
+      let argIndex = 0;
+      const message =
+        'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
       throw new Error(message);
     } catch (x) {}
   };

--- a/packages/shared/warningWithoutStack.js
+++ b/packages/shared/warningWithoutStack.js
@@ -27,8 +27,7 @@ if (__DEV__) {
     }
 
     let argIndex = 0;
-    const message =
-      'Warning: ' + format.replace(/%s/g, () => `${args[argIndex++]}`);
+    const message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
 
     if (typeof console !== 'undefined') {
       console.error(message);

--- a/packages/shared/warningWithoutStack.js
+++ b/packages/shared/warningWithoutStack.js
@@ -26,8 +26,8 @@ if (__DEV__) {
       return;
     }
     if (typeof console !== 'undefined') {
-      const strings = args.map(item => '' + item);
-      console.error('Warning: ' + format, ...strings);
+      const stringArgs = args.map(item => '' + item);
+      console.error('Warning: ' + format, ...stringArgs);
     }
     try {
       // --- Welcome to debugging React ---


### PR DESCRIPTION
I noticed this working on the [Hydration fixture](http://react-hydration.surge.sh/hydration). It looks like we have a warning that depends on the `%s` replacement to stringify an array into a list of words. Instead it reports `Array(n)`:

![image](https://user-images.githubusercontent.com/590904/44059823-755560da-9f07-11e8-80b3-a16aabd9dd04.png)

I use the 1Password browser extension, which adds some data attributes when you engage with a form.

### Steps to reproduce

Using the 1Password browser extension (I've added some extra steps if you don't have this):

1. Open http://react-hydration.surge.sh/hydration
2. Uncheck "Hydrate" to render markup without executing React
3. Type into the input (anything, and really only necessary for 1password )
4. If you do not have the browser extension, add some data attributes to the input in the JS console
5. Click "hydrate"

**Expected** `Warning: Extra attributes from the server: data-com.onepassword.iv, data-com.agilebits.onepassword.user-edited` (Or whatever attributes you added)

**Actual**: `Warning: Extra attributes from the server: Array(2)`