### PR TITLE
Ignore symbols and functions in select tag

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -808,4 +808,268 @@ describe('ReactDOMSelect', () => {
     expect(node.options[1].selected).toBe(false); // b
     expect(node.options[2].selected).toBe(false); // c
   });
+
+  describe('When given a Symbol value', () => {
+    it('treats initial Symbol value as an empty string', () => {
+      let node;
+
+      expect(
+        () =>
+          (node = ReactTestUtils.renderIntoDocument(
+            <select onChange={noop} value={Symbol('foobar')}>
+              <option value={Symbol('foobar')}>A Symbol!</option>
+              <option value="monkey">A monkey!</option>
+              <option value="giraffe">A giraffe!</option>
+            </select>,
+          )),
+      ).toWarnDev('Invalid value for prop `value`');
+
+      expect(node.value).toBe('');
+    });
+
+    it('treats updated Symbol value as an empty string', () => {
+      let node;
+
+      expect(
+        () =>
+          (node = ReactTestUtils.renderIntoDocument(
+            <select onChange={noop} value="monkey">
+              <option value={Symbol('foobar')}>A Symbol!</option>
+              <option value="monkey">A monkey!</option>
+              <option value="giraffe">A giraffe!</option>
+            </select>,
+          )),
+      ).toWarnDev('Invalid value for prop `value`');
+
+      expect(node.value).toBe('monkey');
+
+      node = ReactTestUtils.renderIntoDocument(
+        <select onChange={noop} value={Symbol('foobar')}>
+          <option value={Symbol('foobar')}>A Symbol!</option>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+        </select>,
+      );
+
+      expect(node.value).toBe('');
+    });
+
+    it('treats initial Symbol defaultValue as an empty string', () => {
+      let node;
+
+      expect(
+        () =>
+          (node = ReactTestUtils.renderIntoDocument(
+            <select defaultValue={Symbol('foobar')}>
+              <option value={Symbol('foobar')}>A Symbol!</option>
+              <option value="monkey">A monkey!</option>
+              <option value="giraffe">A giraffe!</option>
+            </select>,
+          )),
+      ).toWarnDev('Invalid value for prop `value`');
+
+      expect(node.value).toBe('');
+    });
+
+    it('treats updated Symbol defaultValue as an empty string', () => {
+      let node;
+
+      expect(
+        () =>
+          (node = ReactTestUtils.renderIntoDocument(
+            <select defaultValue="monkey">
+              <option value={Symbol('foobar')}>A Symbol!</option>
+              <option value="monkey">A monkey!</option>
+              <option value="giraffe">A giraffe!</option>
+            </select>,
+          )),
+      ).toWarnDev('Invalid value for prop `value`');
+
+      expect(node.value).toBe('monkey');
+
+      node = ReactTestUtils.renderIntoDocument(
+        <select defaultValue={Symbol('foobar')}>
+          <option value={Symbol('foobar')}>A Symbol!</option>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+        </select>,
+      );
+
+      expect(node.value).toBe('');
+    });
+  });
+
+  describe('When given a function value', () => {
+    let setUntrackedValue;
+    function dispatchEventOnNode(node, type) {
+      node.dispatchEvent(new Event(type, {bubbles: true, cancelable: true}));
+    }
+
+    beforeEach(() => {
+      setUntrackedValue = Object.getOwnPropertyDescriptor(
+        HTMLSelectElement.prototype,
+        'value',
+      ).set;
+    });
+
+    it('treats initial function value as an empty string', () => {
+      let node;
+
+      expect(
+        () =>
+          (node = ReactTestUtils.renderIntoDocument(
+            <select onChange={noop} value={() => {}}>
+              <option value={() => {}}>A function!</option>
+              <option value="monkey">A monkey!</option>
+              <option value="giraffe">A giraffe!</option>
+            </select>,
+          )),
+      ).toWarnDev('Invalid value for prop `value`');
+
+      expect(node.value).toBe('');
+    });
+
+    it('treats initial function defaultValue as an empty string', () => {
+      let node;
+
+      expect(
+        () =>
+          (node = ReactTestUtils.renderIntoDocument(
+            <select defaultValue={() => {}}>
+              <option value={() => {}}>A function!</option>
+              <option value="monkey">A monkey!</option>
+              <option value="giraffe">A giraffe!</option>
+            </select>,
+          )),
+      ).toWarnDev('Invalid value for prop `value`');
+
+      expect(node.value).toBe('');
+    });
+
+    it('treats updated function value as an empty string', () => {
+      let node;
+
+      expect(
+        () =>
+          (node = ReactTestUtils.renderIntoDocument(
+            <select onChange={noop} value="monkey">
+              <option value={() => {}}>A function!</option>
+              <option value="monkey">A monkey!</option>
+              <option value="giraffe">A giraffe!</option>
+            </select>,
+          )),
+      ).toWarnDev('Invalid value for prop `value`');
+
+      expect(node.value).toBe('monkey');
+
+      node = ReactTestUtils.renderIntoDocument(
+        <select onChange={noop} value={() => {}}>
+          <option value={() => {}}>A function!</option>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+        </select>,
+      );
+
+      expect(node.value).toBe('');
+    });
+
+    it('treats updated function defaultValue as an empty string', () => {
+      let node;
+
+      expect(
+        () =>
+          (node = ReactTestUtils.renderIntoDocument(
+            <select defaultValue="monkey">
+              <option value={() => {}}>A function!</option>
+              <option value="monkey">A monkey!</option>
+              <option value="giraffe">A giraffe!</option>
+            </select>,
+          )),
+      ).toWarnDev('Invalid value for prop `value`');
+
+      expect(node.value).toBe('monkey');
+
+      node = ReactTestUtils.renderIntoDocument(
+        <select defaultValue={() => {}}>
+          <option value={() => {}}>A function!</option>
+          <option value="monkey">A monkey!</option>
+          <option value="giraffe">A giraffe!</option>
+        </select>,
+      );
+
+      expect(node.value).toBe('');
+    });
+
+    it('treats controlled function value as an empty string', () => {
+      let selectNode;
+
+      class Form extends React.Component {
+        state = {
+          value: 'giraffe',
+        };
+
+        handleChange = e => this.setState({value: e.target.value});
+
+        render() {
+          return (
+            <select
+              onChange={this.handleChange}
+              value={this.state.value}
+              ref={x => (selectNode = x)}>
+              <option value={() => {}}>A Function!</option>
+              <option value="monkey">A monkey!</option>
+              <option value="giraffe">A giraffe!</option>
+            </select>
+          );
+        }
+      }
+
+      expect(() => ReactTestUtils.renderIntoDocument(<Form />)).toWarnDev(
+        'Invalid value for prop `value`',
+      );
+
+      expect(selectNode.value).toBe('giraffe');
+
+      setUntrackedValue.call(selectNode, () => {});
+      dispatchEventOnNode(selectNode, 'change');
+
+      expect(selectNode.value).toBe('');
+    });
+
+    it('treats controlled function value as an empty string', () => {
+      let selectNode;
+
+      class Form extends React.Component {
+        state = {
+          value: 'giraffe',
+        };
+
+        handleChange = e => this.setState({value: e.target.value});
+
+        render() {
+          return (
+            <select
+              onChange={this.handleChange}
+              value={this.state.value}
+              ref={x => (selectNode = x)}>
+              <option value={() => {}}>A Function!</option>
+              <option value="monkey">A monkey!</option>
+              <option value="giraffe">A giraffe!</option>
+            </select>
+          );
+        }
+      }
+
+      expect(() => ReactTestUtils.renderIntoDocument(<Form />)).toWarnDev(
+        'Invalid value for prop `value`',
+      );
+
+      expect(selectNode.value).toBe('giraffe');
+
+      setUntrackedValue.call(selectNode, () => {});
+      dispatchEventOnNode(selectNode, 'change');
+
+      expect(selectNode.value).toBe('');
+    });
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -900,18 +900,6 @@ describe('ReactDOMSelect', () => {
   });
 
   describe('When given a function value', () => {
-    let setUntrackedValue;
-    function dispatchEventOnNode(node, type) {
-      node.dispatchEvent(new Event(type, {bubbles: true, cancelable: true}));
-    }
-
-    beforeEach(() => {
-      setUntrackedValue = Object.getOwnPropertyDescriptor(
-        HTMLSelectElement.prototype,
-        'value',
-      ).set;
-    });
-
     it('treats initial function value as an empty string', () => {
       let node;
 
@@ -998,78 +986,6 @@ describe('ReactDOMSelect', () => {
       );
 
       expect(node.value).toBe('');
-    });
-
-    it('treats controlled function value as an empty string', () => {
-      let selectNode;
-
-      class Form extends React.Component {
-        state = {
-          value: 'giraffe',
-        };
-
-        handleChange = e => this.setState({value: e.target.value});
-
-        render() {
-          return (
-            <select
-              onChange={this.handleChange}
-              value={this.state.value}
-              ref={x => (selectNode = x)}>
-              <option value={() => {}}>A Function!</option>
-              <option value="monkey">A monkey!</option>
-              <option value="giraffe">A giraffe!</option>
-            </select>
-          );
-        }
-      }
-
-      expect(() => ReactTestUtils.renderIntoDocument(<Form />)).toWarnDev(
-        'Invalid value for prop `value`',
-      );
-
-      expect(selectNode.value).toBe('giraffe');
-
-      setUntrackedValue.call(selectNode, () => {});
-      dispatchEventOnNode(selectNode, 'change');
-
-      expect(selectNode.value).toBe('');
-    });
-
-    it('treats controlled function value as an empty string', () => {
-      let selectNode;
-
-      class Form extends React.Component {
-        state = {
-          value: 'giraffe',
-        };
-
-        handleChange = e => this.setState({value: e.target.value});
-
-        render() {
-          return (
-            <select
-              onChange={this.handleChange}
-              value={this.state.value}
-              ref={x => (selectNode = x)}>
-              <option value={() => {}}>A Function!</option>
-              <option value="monkey">A monkey!</option>
-              <option value="giraffe">A giraffe!</option>
-            </select>
-          );
-        }
-      }
-
-      expect(() => ReactTestUtils.renderIntoDocument(<Form />)).toWarnDev(
-        'Invalid value for prop `value`',
-      );
-
-      expect(selectNode.value).toBe('giraffe');
-
-      setUntrackedValue.call(selectNode, () => {});
-      dispatchEventOnNode(selectNode, 'change');
-
-      expect(selectNode.value).toBe('');
     });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -813,16 +813,15 @@ describe('ReactDOMSelect', () => {
     it('treats initial Symbol value as an empty string', () => {
       let node;
 
-      expect(
-        () =>
-          (node = ReactTestUtils.renderIntoDocument(
-            <select onChange={noop} value={Symbol('foobar')}>
-              <option value={Symbol('foobar')}>A Symbol!</option>
-              <option value="monkey">A monkey!</option>
-              <option value="giraffe">A giraffe!</option>
-            </select>,
-          )),
-      ).toWarnDev('Invalid value for prop `value`');
+      expect(() => {
+        node = ReactTestUtils.renderIntoDocument(
+          <select onChange={noop} value={Symbol('foobar')}>
+            <option value={Symbol('foobar')}>A Symbol!</option>
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+          </select>,
+        );
+      }).toWarnDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('');
     });
@@ -830,16 +829,15 @@ describe('ReactDOMSelect', () => {
     it('treats updated Symbol value as an empty string', () => {
       let node;
 
-      expect(
-        () =>
-          (node = ReactTestUtils.renderIntoDocument(
-            <select onChange={noop} value="monkey">
-              <option value={Symbol('foobar')}>A Symbol!</option>
-              <option value="monkey">A monkey!</option>
-              <option value="giraffe">A giraffe!</option>
-            </select>,
-          )),
-      ).toWarnDev('Invalid value for prop `value`');
+      expect(() => {
+        node = ReactTestUtils.renderIntoDocument(
+          <select onChange={noop} value="monkey">
+            <option value={Symbol('foobar')}>A Symbol!</option>
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+          </select>,
+        );
+      }).toWarnDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('monkey');
 
@@ -857,16 +855,15 @@ describe('ReactDOMSelect', () => {
     it('treats initial Symbol defaultValue as an empty string', () => {
       let node;
 
-      expect(
-        () =>
-          (node = ReactTestUtils.renderIntoDocument(
-            <select defaultValue={Symbol('foobar')}>
-              <option value={Symbol('foobar')}>A Symbol!</option>
-              <option value="monkey">A monkey!</option>
-              <option value="giraffe">A giraffe!</option>
-            </select>,
-          )),
-      ).toWarnDev('Invalid value for prop `value`');
+      expect(() => {
+        node = ReactTestUtils.renderIntoDocument(
+          <select defaultValue={Symbol('foobar')}>
+            <option value={Symbol('foobar')}>A Symbol!</option>
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+          </select>,
+        );
+      }).toWarnDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('');
     });
@@ -874,16 +871,15 @@ describe('ReactDOMSelect', () => {
     it('treats updated Symbol defaultValue as an empty string', () => {
       let node;
 
-      expect(
-        () =>
-          (node = ReactTestUtils.renderIntoDocument(
-            <select defaultValue="monkey">
-              <option value={Symbol('foobar')}>A Symbol!</option>
-              <option value="monkey">A monkey!</option>
-              <option value="giraffe">A giraffe!</option>
-            </select>,
-          )),
-      ).toWarnDev('Invalid value for prop `value`');
+      expect(() => {
+        node = ReactTestUtils.renderIntoDocument(
+          <select defaultValue="monkey">
+            <option value={Symbol('foobar')}>A Symbol!</option>
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+          </select>,
+        );
+      }).toWarnDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('monkey');
 
@@ -903,16 +899,15 @@ describe('ReactDOMSelect', () => {
     it('treats initial function value as an empty string', () => {
       let node;
 
-      expect(
-        () =>
-          (node = ReactTestUtils.renderIntoDocument(
-            <select onChange={noop} value={() => {}}>
-              <option value={() => {}}>A function!</option>
-              <option value="monkey">A monkey!</option>
-              <option value="giraffe">A giraffe!</option>
-            </select>,
-          )),
-      ).toWarnDev('Invalid value for prop `value`');
+      expect(() => {
+        node = ReactTestUtils.renderIntoDocument(
+          <select onChange={noop} value={() => {}}>
+            <option value={() => {}}>A function!</option>
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+          </select>,
+        );
+      }).toWarnDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('');
     });
@@ -920,16 +915,15 @@ describe('ReactDOMSelect', () => {
     it('treats initial function defaultValue as an empty string', () => {
       let node;
 
-      expect(
-        () =>
-          (node = ReactTestUtils.renderIntoDocument(
-            <select defaultValue={() => {}}>
-              <option value={() => {}}>A function!</option>
-              <option value="monkey">A monkey!</option>
-              <option value="giraffe">A giraffe!</option>
-            </select>,
-          )),
-      ).toWarnDev('Invalid value for prop `value`');
+      expect(() => {
+        node = ReactTestUtils.renderIntoDocument(
+          <select defaultValue={() => {}}>
+            <option value={() => {}}>A function!</option>
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+          </select>,
+        );
+      }).toWarnDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('');
     });
@@ -937,16 +931,15 @@ describe('ReactDOMSelect', () => {
     it('treats updated function value as an empty string', () => {
       let node;
 
-      expect(
-        () =>
-          (node = ReactTestUtils.renderIntoDocument(
-            <select onChange={noop} value="monkey">
-              <option value={() => {}}>A function!</option>
-              <option value="monkey">A monkey!</option>
-              <option value="giraffe">A giraffe!</option>
-            </select>,
-          )),
-      ).toWarnDev('Invalid value for prop `value`');
+      expect(() => {
+        node = ReactTestUtils.renderIntoDocument(
+          <select onChange={noop} value="monkey">
+            <option value={() => {}}>A function!</option>
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+          </select>,
+        );
+      }).toWarnDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('monkey');
 
@@ -964,16 +957,15 @@ describe('ReactDOMSelect', () => {
     it('treats updated function defaultValue as an empty string', () => {
       let node;
 
-      expect(
-        () =>
-          (node = ReactTestUtils.renderIntoDocument(
-            <select defaultValue="monkey">
-              <option value={() => {}}>A function!</option>
-              <option value="monkey">A monkey!</option>
-              <option value="giraffe">A giraffe!</option>
-            </select>,
-          )),
-      ).toWarnDev('Invalid value for prop `value`');
+      expect(() => {
+        node = ReactTestUtils.renderIntoDocument(
+          <select defaultValue="monkey">
+            <option value={() => {}}>A function!</option>
+            <option value="monkey">A monkey!</option>
+            <option value="giraffe">A giraffe!</option>
+          </select>,
+        );
+      }).toWarnDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('monkey');
 

--- a/packages/react-dom/src/client/ReactDOMFiberOption.js
+++ b/packages/react-dom/src/client/ReactDOMFiberOption.js
@@ -10,6 +10,7 @@
 import React from 'react';
 import warning from 'shared/warning';
 import {validateDOMNesting, updatedAncestorInfo} from './validateDOMNesting';
+import {getToStringValue, toString} from './ToStringValue';
 
 let didWarnSelectedSetOnOption = false;
 
@@ -73,7 +74,7 @@ export function validateProps(element: Element, props: Object) {
 export function postMountWrapper(element: Element, props: Object) {
   // value="" should make a value attribute (#6219)
   if (props.value != null) {
-    element.setAttribute('value', props.value);
+    element.setAttribute('value', toString(getToStringValue(props.value)));
   }
 }
 

--- a/packages/react-dom/src/client/ReactDOMFiberSelect.js
+++ b/packages/react-dom/src/client/ReactDOMFiberSelect.js
@@ -12,6 +12,8 @@ import {getCurrentFiberOwnerNameInDevOrNull} from 'react-reconciler/src/ReactCur
 import warning from 'shared/warning';
 
 import ReactControlledValuePropTypes from '../shared/ReactControlledValuePropTypes';
+import {getToStringValue, toString} from './ToStringValue';
+import type {ToStringValue} from './ToStringValue';
 
 let didWarnValueDefaultValue;
 
@@ -21,7 +23,7 @@ if (__DEV__) {
 
 type SelectWithWrapperState = HTMLSelectElement & {
   _wrapperState: {
-    initialValue: ?string,
+    initialValue: ToStringValue | void,
     wasMultiple: boolean,
   },
 };
@@ -98,7 +100,7 @@ function updateOptions(
   } else {
     // Do not set `select.value` as exact behavior isn't consistent across all
     // browsers for all cases.
-    let selectedValue = '' + (propValue: string);
+    let selectedValue = toString(getToStringValue((propValue: any)));
     let defaultSelected = null;
     for (let i = 0; i < options.length; i++) {
       if (options[i].value === selectedValue) {

--- a/packages/react-dom/src/client/ReactDOMFiberSelect.js
+++ b/packages/react-dom/src/client/ReactDOMFiberSelect.js
@@ -23,7 +23,7 @@ if (__DEV__) {
 
 type SelectWithWrapperState = HTMLSelectElement & {
   _wrapperState: {
-    initialValue: ToStringValue | void,
+    initialValue: ?ToStringValue,
     wasMultiple: boolean,
   },
 };


### PR DESCRIPTION
Related to #11734 and #13362.

As expected, the same cases that fail for textarea [seem to fail for select as well](https://codesandbox.io/s/pj40nrp5px).