### PR TITLE
React.lazy

### DIFF
--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -25,6 +25,7 @@ import {
   isValidElement,
 } from './ReactElement';
 import {createContext} from './ReactContext';
+import {lazy} from './ReactLazy';
 import forwardRef from './forwardRef';
 import {
   createElementWithValidation,
@@ -66,6 +67,7 @@ const React = {
 
 if (enableSuspense) {
   React.Placeholder = REACT_PLACEHOLDER_TYPE;
+  React.lazy = lazy;
 }
 
 export default React;

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+type Thenable<T, R> = {
+  then(resolve: (T) => mixed, reject: (mixed) => mixed): R,
+};
+
+export function lazy<T, R>(ctor: () => Thenable<T, R>) {
+  let thenable = null;
+  return {
+    then(resolve, reject) {
+      if (thenable === null) {
+        // Lazily create thenable by wrapping in an extra thenable.
+        thenable = ctor();
+        ctor = null;
+      }
+      return thenable.then(resolve, reject);
+    },
+    // React uses these fields to store the result.
+    _reactStatus: -1,
+    _reactResult: null,
+  };
+}


### PR DESCRIPTION
## Based on https://github.com/facebook/react/pull/13397

Lazily starts loading a component the first time it's rendered. The implementation is fairly simple and could be left to userspace, but since this is an important use case, there's value in standardization.

Final name is TBD. I went with `lazy` for now because it's short and descriptive.

I put it on the main React export because it's small and importing this at the top of every file will get old really quickly.