### PR TITLE
De-duplicate ReactUpdateQueue commitUpdateQueue

### DIFF
--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -599,19 +599,17 @@ export function commitUpdateQueue<State>(
   }
 
   // Commit the effects
-  let effect = finishedQueue.firstEffect;
+  commitUpdateEffects(finishedQueue.firstEffect, instance);
   finishedQueue.firstEffect = finishedQueue.lastEffect = null;
-  while (effect !== null) {
-    const callback = effect.callback;
-    if (callback !== null) {
-      effect.callback = null;
-      callCallback(callback, instance);
-    }
-    effect = effect.nextEffect;
-  }
 
-  effect = finishedQueue.firstCapturedEffect;
+  commitUpdateEffects(finishedQueue.firstCapturedEffect, instance);
   finishedQueue.firstCapturedEffect = finishedQueue.lastCapturedEffect = null;
+}
+
+function commitUpdateEffects<State>(
+  effect: Update<State> | null,
+  instance: any,
+): void {
   while (effect !== null) {
     const callback = effect.callback;
     if (callback !== null) {


### PR DESCRIPTION
A small patch to deduplicate a loop inside the commitUpdateQueue. (_And to test the waters on sending PRs to the React codebase_)

There is some of the same (duplicated) code being run for both the effects and the captured effect. I want to pick the duplicated loop in `processUpdateQueue` next
