### PR TITLE
Warn when an empty string is passed to a DOM boolean prop

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -2532,6 +2532,45 @@ describe('ReactDOMComponent', () => {
 
       expect(el.getAttribute('hidden')).toBe('');
     });
+
+    it('warns on the ambiguous string value "" when it means false', function() {
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div hidden="" />);
+      }).toWarnDev(
+        'Received the string "" for the boolean attribute `hidden`. ' +
+          'This value can mean `true` or `false`, depending on the attribute. ' +
+          'Did you mean hidden={false}?',
+      );
+
+      expect(el.hasAttribute('hidden')).toBe(false);
+    });
+
+    it('warns on the ambiguous string value "" when it means true', function() {
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<div spellCheck="" />);
+      }).toWarnDev(
+        'Received the string "" for the boolean attribute `spellCheck`. ' +
+          'This value can mean `true` or `false`, depending on the attribute. ' +
+          'Did you mean spellCheck={true}?',
+      );
+
+      expect(el.getAttribute('spellCheck')).toBe('');
+    });
+
+    it('warns on the ambiguous string value "" in an overloaded boolean prop', function() {
+      let el;
+      expect(() => {
+        el = ReactTestUtils.renderIntoDocument(<input capture="" />);
+      }).toWarnDev(
+        'Received the string "" for the boolean attribute `capture`. ' +
+          'This value can mean `true` or `false`, depending on the attribute. ' +
+          'Did you mean capture={true}?',
+      );
+
+      expect(el.getAttribute('capture')).toBe('');
+    });
   });
 
   describe('Hyphenated SVG elements', function() {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -98,7 +98,7 @@ describe('ReactDOMServerIntegration', () => {
       // that the boolean property is present. however, it is how the current code
       // behaves, so the test is included here.
       itRenders('boolean prop with "" value', async render => {
-        const e = await render(<div hidden="" />);
+        const e = await render(<div hidden="" />, 1);
         expect(e.getAttribute('hidden')).toBe(null);
       });
 

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -14,6 +14,8 @@ import warning from 'shared/warning';
 import {
   ATTRIBUTE_NAME_CHAR,
   BOOLEAN,
+  BOOLEANISH_STRING,
+  OVERLOADED_BOOLEAN,
   RESERVED,
   shouldRemoveAttributeWithWarning,
   getPropertyInfo,
@@ -227,7 +229,7 @@ if (__DEV__) {
       return false;
     }
 
-    // Warn when passing the strings 'false' or 'true' into a boolean prop
+    // Warn about passing the strings 'false' or 'true' into a boolean prop
     if (
       (value === 'false' || value === 'true') &&
       propertyInfo !== null &&
@@ -245,6 +247,30 @@ if (__DEV__) {
           : 'Although this works, it will not work as expected if you pass the string "false".',
         name,
         value,
+      );
+      warnedProperties[name] = true;
+      return true;
+    }
+
+    // Warn about passing an empty string into any kind of boolean prop, except
+    // 'value' which is modeled as a "booleanish string"
+    if (
+      value === '' &&
+      name !== 'value' &&
+      propertyInfo !== null &&
+      (propertyInfo.type === BOOLEAN ||
+        propertyInfo.type === BOOLEANISH_STRING ||
+        propertyInfo.type === OVERLOADED_BOOLEAN)
+    ) {
+      const isBoolean = propertyInfo.type === BOOLEAN;
+      warning(
+        false,
+        'Received the string "" for the boolean attribute `%s`. ' +
+          'This value can mean `true` or `false`, depending on the attribute. ' +
+          'Did you mean %s={%s}?',
+        name,
+        name,
+        isBoolean ? 'false' : 'true',
       );
       warnedProperties[name] = true;
       return true;


### PR DESCRIPTION
This is the more targeted of two possible approaches to resolve #13400, the other being @gaearon's [suggestion](https://github.com/facebook/react/issues/13400#issuecomment-413048688) of warning on _any_ string value passed to a boolean prop (also subsuming #13372).

Apart from my [other reservation](https://github.com/facebook/react/issues/13400#issuecomment-413056690) regarding a blanket warning on string values, the present approach has the advantage of being applicable to `BOOLEAN`, `BOOLEANISH_STRING` _and_ `OVERLOADED_BOOLEAN` props (see [`DOMProperty.js`](https://github.com/facebook/react/blob/master/packages/react-dom/src/shared/DOMProperty.js) for definitions). The latter do legitimately need to accept arbitrary string values alongside booleans; if we did go with a blanket warning, it would only make sense for the first two types, so we'd potentially still want a separate check for `""` to accommodate `OVERLOADED_BOOLEAN`.

The one wrinkle here (that would also affect the other approach) is that I had to special-case `value` and exclude it from the warning, since it's somewhat oddly modelled as a `BOOLEANISH_STRING`, making legitimate uses of `value=""` warn under my initial implementation. This raises a separate question, though: when is `value` ever legitimately a _boolean_? (`<param>`? That's a bit tenuous; `value` is certainly not [specced](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-param-value) as a boolean there.) However, we can't just remove it from the whitelist, as that would break current behaviour.