### PR TITLE
Deprecate undocumented ReactTestUtils.SimulateNative API

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -35,6 +35,22 @@ describe('ReactTestUtils', () => {
     expect(Object.keys(ReactTestUtils.SimulateNative).sort()).toMatchSnapshot();
   });
 
+  it('SimulateNative should warn about deprecation', () => {
+    const container = document.createElement('div');
+    const node = ReactDOM.render(<div />, container);
+    expect(() =>
+      ReactTestUtils.SimulateNative.click(node),
+    ).toWarnDev(
+      'ReactTestUtils.SimulateNative is an undocumented API that does not match ' +
+        'how the browser dispatches events, and will be removed in a future major ' +
+        'version of React. If you rely on it for testing, consider attaching the root ' +
+        'DOM container to the document during the test, and then dispatching native browser ' +
+        'events by calling `node.dispatchEvent()` on the DOM nodes. Make sure to set ' +
+        'the `bubbles` flag to `true` when creating the native browser event.',
+      {withoutStack: true},
+    );
+  });
+
   it('gives Jest mocks a passthrough implementation with mockComponent()', () => {
     class MockedComponent extends React.Component {
       render() {

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -48,6 +48,7 @@ const [
 function Event(suffix) {}
 
 let hasWarnedAboutDeprecatedMockComponent = false;
+let didWarnSimulateNativeDeprecated = false;
 
 /**
  * @class ReactTestUtils
@@ -622,6 +623,20 @@ buildSimulators();
 
 function makeNativeSimulator(eventType, topLevelType) {
   return function(domComponentOrNode, nativeEventData) {
+    if (__DEV__) {
+      if (!didWarnSimulateNativeDeprecated) {
+        didWarnSimulateNativeDeprecated = true;
+        console.warn(
+          'ReactTestUtils.SimulateNative is an undocumented API that does not match ' +
+            'how the browser dispatches events, and will be removed in a future major ' +
+            'version of React. If you rely on it for testing, consider attaching the root ' +
+            'DOM container to the document during the test, and then dispatching native browser ' +
+            'events by calling `node.dispatchEvent()` on the DOM nodes. Make sure to set ' +
+            'the `bubbles` flag to `true` when creating the native browser event.',
+        );
+      }
+    }
+
     const fakeNativeEvent = new Event(eventType);
     Object.assign(fakeNativeEvent, nativeEventData);
     if (isDOMComponent(domComponentOrNode)) {


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/11656.

This API is counter-intuitive because it only simulates the *React dispatch* of a native event, as opposed to simulating what the *browser* would do on an event. I've seen quite a few people confused by this. It's also completely undocumented.

I think it's a liability to keep this around.