### PR TITLE
fix: do not reconcile children that are iterable functions

### DIFF
--- a/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
+++ b/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
@@ -55,7 +55,7 @@ describe('ReactChildReconciler', () => {
     return fn;
   }
 
-  fit('does not treat functions as iterables', () => {
+  it('does not treat functions as iterables', () => {
     let node;
     const iterableFunction = makeIterableFunction('foo');
 
@@ -68,15 +68,6 @@ describe('ReactChildReconciler', () => {
     }).toWarnDev('Functions are not valid as a React child');
 
     expect(node.innerHTML).toContain(''); // h1
-  });
-
-  it('renders iterable functions', () => {
-    class Component extends React.Component {
-      render() {
-        return <div>{createIterable([<div key="1" />, <div key="2" />])}</div>;
-      }
-    }
-    ReactTestUtils.renderIntoDocument(<Component />);
   });
 
   it('warns for duplicated array keys', () => {

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -46,7 +46,11 @@ const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';
 
 export function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<*> {
-  if (maybeIterable === null || typeof maybeIterable === 'undefined') {
+  if (
+    maybeIterable === null ||
+    typeof maybeIterable === 'undefined' ||
+    typeof maybeIterable === 'function'
+  ) {
     return null;
   }
   const maybeIterator =

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -46,11 +46,7 @@ const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';
 
 export function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<*> {
-  if (
-    maybeIterable === null ||
-    typeof maybeIterable === 'undefined' ||
-    typeof maybeIterable !== 'object'
-  ) {
+  if (maybeIterable === null || typeof maybeIterable !== 'object') {
     return null;
   }
   const maybeIterator =

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -49,7 +49,7 @@ export function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<*> {
   if (
     maybeIterable === null ||
     typeof maybeIterable === 'undefined' ||
-    typeof maybeIterable === 'function'
+    typeof maybeIterable !== 'object'
   ) {
     return null;
   }


### PR DESCRIPTION
#11396.

Does this seem reasonable? Should we also add a warning?
