### PR TITLE
Remove unused ReactCall & ReactReturn types

### DIFF
--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -9,8 +9,6 @@
 
 export type ReactNode =
   | React$Element<any>
-  | ReactCall<any>
-  | ReactReturn<any>
   | ReactPortal
   | ReactText
   | ReactFragment
@@ -24,29 +22,6 @@ export type ReactNodeList = ReactEmpty | React$Node;
 export type ReactText = string | number;
 
 export type ReactEmpty = null | void | boolean;
-
-export type ReactCall<V> = {
-  $$typeof: Symbol | number,
-  type: Symbol | number,
-  key: null | string,
-  ref: null,
-  props: {
-    props: any,
-    // This should be a more specific CallHandler
-    handler: (props: any, returns: Array<V>) => ReactNodeList,
-    children?: ReactNodeList,
-  },
-};
-
-export type ReactReturn<V> = {
-  $$typeof: Symbol | number,
-  type: Symbol | number,
-  key: null,
-  ref: null,
-  props: {
-    value: V,
-  },
-};
 
 export type ReactProvider<T> = {
   $$typeof: Symbol | number,


### PR DESCRIPTION
These are no longer used after the removal of the `react-call-return` package.