### PR TITLE
Resume onSelect tracking after dragend

### DIFF
--- a/packages/react-dom/src/events/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/SelectEventPlugin.js
@@ -14,6 +14,7 @@ import shallowEqual from 'shared/shallowEqual';
 import {
   TOP_BLUR,
   TOP_CONTEXT_MENU,
+  TOP_DRAG_END,
   TOP_FOCUS,
   TOP_KEY_DOWN,
   TOP_KEY_UP,
@@ -39,6 +40,7 @@ const eventTypes = {
     dependencies: [
       TOP_BLUR,
       TOP_CONTEXT_MENU,
+      TOP_DRAG_END,
       TOP_FOCUS,
       TOP_KEY_DOWN,
       TOP_KEY_UP,
@@ -200,6 +202,7 @@ const SelectEventPlugin = {
         break;
       case TOP_CONTEXT_MENU:
       case TOP_MOUSE_UP:
+      case TOP_DRAG_END:
         mouseDown = false;
         return constructSelectEvent(nativeEvent, nativeEventTarget);
       // Chrome and IE fire non-standard event when selection is changed (and

--- a/packages/react-dom/src/events/__tests__/SelectEventPlugin-test.js
+++ b/packages/react-dom/src/events/__tests__/SelectEventPlugin-test.js
@@ -108,4 +108,39 @@ describe('SelectEventPlugin', () => {
     node.dispatchEvent(nativeEvent);
     expect(select).toHaveBeenCalledTimes(1);
   });
+
+  // Regression test for https://github.com/facebook/react/issues/11379
+  it('should not wait for `mouseup` after receiving `dragend`', () => {
+    const select = jest.fn();
+    const onSelect = event => {
+      expect(typeof event).toBe('object');
+      expect(event.type).toBe('select');
+      expect(event.target).toBe(node);
+      select(event.currentTarget);
+    };
+
+    const node = ReactDOM.render(
+      <input type="text" onSelect={onSelect} />,
+      container,
+    );
+    node.focus();
+
+    let nativeEvent = new MouseEvent('focus', {
+      bubbles: true,
+      cancelable: true,
+    });
+    node.dispatchEvent(nativeEvent);
+    expect(select).toHaveBeenCalledTimes(0);
+
+    nativeEvent = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    });
+    node.dispatchEvent(nativeEvent);
+    expect(select).toHaveBeenCalledTimes(0);
+
+    nativeEvent = new MouseEvent('dragend', {bubbles: true, cancelable: true});
+    node.dispatchEvent(nativeEvent);
+    expect(select).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/11379.
Verified by the following the original repro instructions (you need to use arrow keys).

Note that listening to `drop` wouldn't be sufficient because it isn't fired on cancelled drag events. So if you didn't end up dropping, you'd still stop getting select events. By listening to `dragend` we handle both successful and unsuccessful drop cases.