### PR TITLE
Remove helper object from FallbackCompositionState

### DIFF
--- a/packages/react-dom/src/events/FallbackCompositionState.js
+++ b/packages/react-dom/src/events/FallbackCompositionState.js
@@ -8,7 +8,7 @@
 import getTextContentAccessor from '../client/getTextContentAccessor';
 
 /**
- * This helper object stores information about text content of a target node,
+ * These variables store information about text content of a target node,
  * allowing comparison of content before and after a given event.
  *
  * Identify the node where selection currently begins, then observe
@@ -18,31 +18,30 @@ import getTextContentAccessor from '../client/getTextContentAccessor';
  *
  *
  */
-const compositionState = {
-  _root: null,
-  _startText: null,
-  _fallbackText: null,
-};
+
+let root = null;
+let startText = null;
+let fallbackText = null;
 
 export function initialize(nativeEventTarget) {
-  compositionState._root = nativeEventTarget;
-  compositionState._startText = getText();
+  root = nativeEventTarget;
+  startText = getText();
   return true;
 }
 
 export function reset() {
-  compositionState._root = null;
-  compositionState._startText = null;
-  compositionState._fallbackText = null;
+  root = null;
+  startText = null;
+  fallbackText = null;
 }
 
 export function getData() {
-  if (compositionState._fallbackText) {
-    return compositionState._fallbackText;
+  if (fallbackText) {
+    return fallbackText;
   }
 
   let start;
-  const startValue = compositionState._startText;
+  const startValue = startText;
   const startLength = startValue.length;
   let end;
   const endValue = getText();
@@ -62,13 +61,13 @@ export function getData() {
   }
 
   const sliceTail = end > 1 ? 1 - end : undefined;
-  compositionState._fallbackText = endValue.slice(start, sliceTail);
-  return compositionState._fallbackText;
+  fallbackText = endValue.slice(start, sliceTail);
+  return fallbackText;
 }
 
 export function getText() {
-  if ('value' in compositionState._root) {
-    return compositionState._root.value;
+  if ('value' in root) {
+    return root.value;
   }
-  return compositionState._root[getTextContentAccessor()];
+  return root[getTextContentAccessor()];
 }


### PR DESCRIPTION
There's no good reason for this to be an object. This refactors it so
that we just use three variables instead. We can avoid the property reads/writes and also minify better, since property names don't get mangled but variables do.
