### PR TITLE
Remove addEventListener check in isEventSupported

### DIFF
--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -146,7 +146,7 @@ export function listenTo(
           break;
         case TOP_CANCEL:
         case TOP_CLOSE:
-          if (isEventSupported(getRawEventName(dependency), true)) {
+          if (isEventSupported(getRawEventName(dependency))) {
             trapCapturedEvent(dependency, mountAt);
           }
           break;

--- a/packages/react-dom/src/events/isEventSupported.js
+++ b/packages/react-dom/src/events/isEventSupported.js
@@ -22,7 +22,7 @@ import {canUseDOM} from 'shared/ExecutionEnvironment';
  * @license Modernizr 3.0.0pre (Custom Build) | MIT
  */
 function isEventSupported(eventNameSuffix, capture) {
-  if (!canUseDOM || (capture && !('addEventListener' in document))) {
+  if (!canUseDOM) {
     return false;
   }
 

--- a/packages/react-dom/src/events/isEventSupported.js
+++ b/packages/react-dom/src/events/isEventSupported.js
@@ -16,12 +16,11 @@ import {canUseDOM} from 'shared/ExecutionEnvironment';
  * Borrows from Modernizr.
  *
  * @param {string} eventNameSuffix Event name, e.g. "click".
- * @param {?boolean} capture Check if the capture phase is supported.
  * @return {boolean} True if the event is supported.
  * @internal
  * @license Modernizr 3.0.0pre (Custom Build) | MIT
  */
-function isEventSupported(eventNameSuffix, capture) {
+function isEventSupported(eventNameSuffix) {
   if (!canUseDOM) {
     return false;
   }


### PR DESCRIPTION
[According to caniuse](https://caniuse.com/#search=addEventLIstener) all browsers we support also support addEventListener, so this check is unnecessary