### PR TITLE
Update scroll restoration logic in suspense fixture

### DIFF
--- a/fixtures/unstable-async/suspense/src/components/App.js
+++ b/fixtures/unstable-async/suspense/src/components/App.js
@@ -20,8 +20,8 @@ export default class App extends PureComponent {
 
   componentDidUpdate(prevProps, prevState) {
     if (
-      prevState.showDetail !== this.state.showDetail ||
-      prevState.currentId !== this.state.currentId
+      prevState.showDetail !== this.state.showDetail &&
+      this.state.showDetail
     ) {
       window.scrollTo(0, 0);
     }

--- a/fixtures/unstable-async/suspense/src/components/App.js
+++ b/fixtures/unstable-async/suspense/src/components/App.js
@@ -20,8 +20,8 @@ export default class App extends PureComponent {
 
   componentDidUpdate(prevProps, prevState) {
     if (
-      prevState.showDetail !== this.state.showDetail &&
-      this.state.showDetail
+      prevState.showDetail !== this.state.showDetail ||
+      (prevState.currentId !== this.state.currentId && this.state.showDetail)
     ) {
       window.scrollTo(0, 0);
     }


### PR DESCRIPTION
This change should fix the issue raised in #13436.

The extra check of ensuring that `showDetail` has changed (i.e. `prevState.showDetail !== this.state.showDetail`) might not be necessary, however I wanted to make sure we don't call `scrollTo` too frequently.



**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
10. If you haven't already, complete the CLA.

**Learn more about contributing:** https://reactjs.org/docs/how-to-contribute.html
