### PR TITLE
Tweak ReactTypeOfWork order

### DIFF
--- a/packages/shared/ReactTypeOfWork.js
+++ b/packages/shared/ReactTypeOfWork.js
@@ -26,11 +26,11 @@ export type TypeOfWork =
   | 15
   | 16;
 
-export const IndeterminateComponent = 0; // Before we know whether it is functional or class
-export const FunctionalComponent = 1;
-export const FunctionalComponentLazy = 2;
-export const ClassComponent = 3;
-export const ClassComponentLazy = 4;
+export const FunctionalComponent = 0;
+export const FunctionalComponentLazy = 1;
+export const ClassComponent = 2;
+export const ClassComponentLazy = 3;
+export const IndeterminateComponent = 4; // Before we know whether it is functional or class
 export const HostRoot = 5; // Root of a host tree. Could be nested inside another node.
 export const HostPortal = 6; // A subtree. Could be an entry point to a different renderer.
 export const HostComponent = 7;


### PR DESCRIPTION
I empathize with @sebmarkbage's concerns and I did the work of updating DevTools in https://github.com/facebook/react-devtools/pull/1101.

But it turns RN's hot reloading transform also depends on this. It doesn't know the React version. We already have three forks of this transform (one forked by metro, and the original one has two versions that different tools depend on). That transform only depends on a single constant — `ClassComponent` being `2`. Please don't make me re-release all of those. It's a huge timesink. It'll go away by itself when we have a better strategy for hot reloading, but for now let me keep this one constant.