### PR TITLE
ShallowRenderer should always call the callback of setState

### DIFF
--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -315,8 +315,10 @@ class Updater {
       );
     }
 
-    // Null and undefined are treated as no-ops.
+    // Skip the update if partialState is null or undefined
     if (partialState === null || partialState === undefined) {
+      // the callback of 2nd arguments should always be called
+      this._invokeCallbacks();
       return;
     }
 

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -1418,4 +1418,25 @@ describe('ReactShallowRenderer', () => {
     shallowRenderer.render(<Foo foo="bar" />);
     expect(logs).toEqual([undefined]);
   });
+
+  it('should callback when setState returns null or undefined', () => {
+    let instance;
+    class Component extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          count: 0,
+        };
+      }
+      render() {
+        instance = this;
+        return null;
+      }
+    }
+    const shallowRenderer = createRenderer();
+    shallowRenderer.render(<Component />);
+    const spy = jest.fn();
+    instance.setState(() => null, spy);
+    expect(spy).toBeCalled();
+  });
 });


### PR DESCRIPTION
Currently, ShallowRenderer doesn't call a callback of `setState`'s 2nd arguments when the `setState` returns `null` or `undefined`. `react-dom` always calls the callback regardless the result of `setState`.
This PR fixes the inconsistency.