### PR TITLE
[WIP] Remove mount safe callback out ouf react native renderer

### DIFF
--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -89,6 +89,7 @@ export default function(
     measureInWindow: function(callback: MeasureInWindowOnSuccessCallback) {
       UIManager.measureInWindow(
         findNodeHandle(this),
+        // TODO(Tycho): how to supress theese mountSafeCallback
         mountSafeCallback(this, callback),
       );
     },
@@ -109,6 +110,7 @@ export default function(
       UIManager.measureLayout(
         findNodeHandle(this),
         relativeToNativeNode,
+        // TODO(Tycho): how to supress those
         mountSafeCallback(this, onFail),
         mountSafeCallback(this, onSuccess),
       );

--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -53,6 +53,13 @@ export default function(
     props: Props;
     state: State;
 
+    componentWillUnmount() {
+      this._pendingCancelableCallbacks.map(cancelableCallback =>
+        cancelableCallback.cancel(),
+      );
+      delete this._pendingCancelableCallbacks;
+    }
+
     /**
      * Removes focus. This is the opposite of `focus()`.
      */

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -121,6 +121,9 @@ const ReactNativeRenderer: ReactNativeType = {
         roots.delete(containerTag);
       });
     }
+    // TODO(Tycho): how to access the Instance form the container tag ?
+    // I want to do
+    // findHostInstance(containerTag)._pendingCancelableCallbacks.map(cb => cb.cancel());
   },
 
   unmountComponentAtNodeAndRemoveContainer(containerTag: number) {

--- a/packages/shared/__tests__/cancelableCallback-test.internal.js
+++ b/packages/shared/__tests__/cancelableCallback-test.internal.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @flow
+ */
+'use strict';
+
+import makeCancelableCallback from 'shared/cancelableCallback';
+
+jest.useFakeTimers();
+const TIMEOUT_TIME = 5000;
+const DELTA_TIME = 1000;
+
+describe('cancelableCallback', () => {
+  it("call the callback if the callback isn't canceled", done => {
+    // given
+    const callback = jest.fn();
+    const cancelableCallback = makeCancelableCallback(callback);
+    const asyncProcess = () =>
+      setTimeout(cancelableCallback.callback, TIMEOUT_TIME);
+
+    // when
+    asyncProcess();
+    expect(callback).not.toBeCalled();
+
+    // then
+    setTimeout(() => {
+      expect(callback).toHaveBeenCalled();
+      done();
+    }, TIMEOUT_TIME + DELTA_TIME);
+    // calls expect
+    jest.runTimersToTime(TIMEOUT_TIME);
+    // calls done
+    jest.runTimersToTime(DELTA_TIME);
+  });
+  it('short circuit the callback if the callback is canceled', done => {
+    // given
+    const callback = jest.fn();
+    const cancelableCallback = makeCancelableCallback(callback);
+    const asyncProcess = () =>
+      setTimeout(cancelableCallback.callback, TIMEOUT_TIME);
+
+    // when
+    asyncProcess();
+    expect(callback).not.toBeCalled();
+
+    // then
+    setTimeout(() => {
+      expect(callback).not.toHaveBeenCalled();
+      done();
+    }, TIMEOUT_TIME + DELTA_TIME);
+    // calls expect
+    jest.runTimersToTime(DELTA_TIME);
+    cancelableCallback.cancel();
+    jest.runTimersToTime(TIMEOUT_TIME - DELTA_TIME);
+    // calls done
+    jest.runTimersToTime(DELTA_TIME);
+  });
+});

--- a/packages/shared/cancelableCallback.js
+++ b/packages/shared/cancelableCallback.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export type CancelableCallback<A, R> = {
+  callback: (...A) => R,
+  cancel: () => void,
+};
+
+const makeCancelable = <A, R>(
+  callback: (...A) => R,
+): CancelableCallback<A, R> => {
+  let hasCanceled = false;
+
+  const wrappedCallback = (...args: A): R => {
+    if (hasCanceled) {
+      return;
+    }
+    callback(...args);
+  };
+
+  return {
+    callback: wrappedCallback,
+    cancel() {
+      hasCanceled = true;
+    },
+  };
+};
+
+export default makeCancelable;


### PR DESCRIPTION
# Note

This PR is wip but I opened it to get feedback from @gaearon or rest of https://github.com/facebook/react/ team.

# Goals

Look at https://github.com/facebook/react-native/issues/18868 especially https://github.com/facebook/react-native/issues/18868#issuecomment-413609027.

The Goal is to remove mountSafeCallback from react native renderer as it is not safe proof.

> This makes sense. I don't argue with this. My argument is that mountSafeCallback already seems to not do anything for built-in components like RCTView / RCTText (to which normal Text and View forward their refs) because they have neither __isMounted nor isMounted() according to their definition. So the whole premise of mountSafeCallback being "safe" already seems questionable.

> And for ES6 React classes, the method doesn't exist either — just a getter with warnings.

# Open questions

Is the approach I propose in https://github.com/facebook/react-native/issues/18868#issuecomment-413945370 correct ?

Is the start of implementation (this PR) OK ?

How to remove the callpoints of https://github.com/facebook/react/pull/13461/files#diff-4ec7e5798bfcb299da3fc827eb7db07d ?

### How to clear pending callback: 

- For the easy case, the ReactNativeComponent, I tried this https://github.com/facebook/react/pull/13461/files#diff-3899566ffae25dd959157d1e7a9fc8c1R56 (so in cWU, map and cancel, then delete the reference). 

- I have no clue how to do it for `ReactNativeFiberHostComponent` but looking at the code i guess that i can retrieve the instance with `findHostInstance(containerTag)` in ReactNativeRender, in `unmountComponentAtNode` then get the `canonical` property which is the `ReactNativeFiberHostComponent`, right ?

- I also have no clue how to do it in `ReactFabricHostComponent`. My guess it is the same than above, one for `React Fiber` and one for `React stack` but the file seems edited so I must be wrong



