### PR TITLE
Refactor multi !== equal expression -> Array.prototype.includes

### DIFF
--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -49,8 +49,7 @@ function getDeclarationErrorAddendum() {
 
 function getSourceInfoErrorAddendum(elementProps) {
   if (
-    elementProps !== null &&
-    elementProps !== undefined &&
+    ![null, undefined].includes(elementProps) &&
     elementProps.__source !== undefined
   ) {
     const source = elementProps.__source;
@@ -239,7 +238,7 @@ function validateFragmentProps(fragment) {
   const keys = Object.keys(fragment.props);
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
-    if (key !== 'children' && key !== 'key') {
+    if (!['children', 'key'].includes(key)) {
       warning(
         false,
         'Invalid prop `%s` supplied to `React.Fragment`. ' +


### PR DESCRIPTION
This PR is a refactoring multi not equal expression.
I changed multi equal expression to Array.prototype.includes.