### PR TITLE
Stringify <option> children

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMOption-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMOption-test.js
@@ -15,6 +15,7 @@ describe('ReactDOMOption', () => {
   let ReactTestUtils;
 
   beforeEach(() => {
+    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
     ReactTestUtils = require('react-dom/test-utils');
@@ -41,9 +42,10 @@ describe('ReactDOMOption', () => {
     expect(() => {
       node = ReactTestUtils.renderIntoDocument(el);
     }).toWarnDev(
-      '<div> cannot appear as a child of <option>.\n' + '    in option (at **)',
+      'Only strings and numbers are supported as <option> children.\n' +
+        '    in option (at **)',
     );
-    expect(node.innerHTML).toBe('1  2');
+    expect(node.innerHTML).toBe('1 [object Object] 2');
     ReactTestUtils.renderIntoDocument(el);
   });
 
@@ -59,6 +61,76 @@ describe('ReactDOMOption', () => {
     const node = ReactTestUtils.renderIntoDocument(stub);
 
     expect(node.innerHTML).toBe('1  2');
+  });
+
+  it('should throw on object children', () => {
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(<option>{{}}</option>);
+    }).toThrow('Objects are not valid as a React child');
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(<option>{[{}]}</option>);
+    }).toThrow('Objects are not valid as a React child');
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(
+        <option>
+          {{}}
+          <span />
+        </option>,
+      );
+    }).toThrow('Objects are not valid as a React child');
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(
+        <option>
+          {'1'}
+          {{}}
+          {2}
+        </option>,
+      );
+    }).toThrow('Objects are not valid as a React child');
+  });
+
+  it('should support element-ish child', () => {
+    // This is similar to <fbt>.
+    // It's important that we toString it.
+    let obj = {
+      $$typeof: Symbol.for('react.element'),
+      type: props => props.content,
+      ref: null,
+      key: null,
+      props: {
+        content: 'hello',
+      },
+      toString() {
+        return this.props.content;
+      },
+    };
+
+    let node = ReactTestUtils.renderIntoDocument(<option>{obj}</option>);
+    expect(node.innerHTML).toBe('hello');
+
+    node = ReactTestUtils.renderIntoDocument(<option>{[obj]}</option>);
+    expect(node.innerHTML).toBe('hello');
+
+    expect(() => {
+      node = ReactTestUtils.renderIntoDocument(
+        <option>
+          {obj}
+          <span />
+        </option>,
+      );
+    }).toWarnDev(
+      'Only strings and numbers are supported as <option> children.',
+    );
+    expect(node.innerHTML).toBe('hello[object Object]');
+
+    node = ReactTestUtils.renderIntoDocument(
+      <option>
+        {'1'}
+        {obj}
+        {2}
+      </option>,
+    );
+    expect(node.innerHTML).toBe('1hello2');
   });
 
   it('should be able to use dangerouslySetInnerHTML on option', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationForms-test.js
@@ -439,7 +439,7 @@ describe('ReactDOMServerIntegration', () => {
           );
           expect(e.getAttribute('value')).toBe(null);
           expect(e.getAttribute('defaultValue')).toBe(null);
-          expect(e.firstChild.innerHTML).toBe('BarFooBaz');
+          expect(e.firstChild.innerHTML).toBe('BarFoo[object Object]Baz');
           expect(e.firstChild.selected).toBe(true);
         },
       );

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -293,17 +293,18 @@ function flattenOptionChildren(children: mixed): ?string {
     if (child == null) {
       return;
     }
-    if (typeof child === 'string' || typeof child === 'number') {
-      content += child;
-    } else {
-      if (__DEV__) {
-        if (!didWarnInvalidOptionChildren) {
-          didWarnInvalidOptionChildren = true;
-          warningWithoutStack(
-            false,
-            'Only strings and numbers are supported as <option> children.',
-          );
-        }
+    content += child;
+    if (__DEV__) {
+      if (
+        !didWarnInvalidOptionChildren &&
+        typeof child !== 'string' &&
+        typeof child !== 'number'
+      ) {
+        didWarnInvalidOptionChildren = true;
+        warning(
+          false,
+          'Only strings and numbers are supported as <option> children.',
+        );
       }
     }
   });


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/13261. We couldn't land this fix internally because we rely on element-like objects (our translation tooling) being stringified inside an `<option>`. That works in other cases (e.g. `textarea` values), and worked in the past for `option` because it used to take the non-`shouldSetTextContent` codepath. But that created other issues.

This changes `<option>` to actually stringify its children. Should be a tiny bit faster to avoid those checks too, and makes it consistent with `<textarea>`. Note that in practice it already errors on objects. So the only thing that would get stringified are other React elements (e.g. a `<span />` inside of an `<option>`). This is not a breaking change because it's already unsupported, and we always showed a warning about that.