### PR TITLE
Addressed @TODO to refactor direct * imports to property import syntax

### DIFF
--- a/packages/react-dom/src/client/ReactDOMFiberInput.js
+++ b/packages/react-dom/src/client/ReactDOMFiberInput.js
@@ -12,10 +12,10 @@ import {getCurrentFiberOwnerNameInDevOrNull} from 'react-reconciler/src/ReactCur
 import invariant from 'shared/invariant';
 import warning from 'shared/warning';
 
-import * as DOMPropertyOperations from './DOMPropertyOperations';
+import {setValueForProperty} from './DOMPropertyOperations';
 import {getFiberCurrentPropsFromNode} from './ReactDOMComponentTree';
 import ReactControlledValuePropTypes from '../shared/ReactControlledValuePropTypes';
-import * as inputValueTracking from './inputValueTracking';
+import {updateValueIfChanged} from './inputValueTracking';
 
 type InputWithWrapperState = HTMLInputElement & {
   _wrapperState: {
@@ -125,7 +125,7 @@ export function updateChecked(element: Element, props: Object) {
   const node = ((element: any): InputWithWrapperState);
   const checked = props.checked;
   if (checked != null) {
-    DOMPropertyOperations.setValueForProperty(node, 'checked', checked, false);
+    setValueForProperty(node, 'checked', checked, false);
   }
 }
 
@@ -283,7 +283,7 @@ function updateNamedCousins(rootNode, props) {
 
       // We need update the tracked value on the named cousin since the value
       // was changed but the input saw no event or value set
-      inputValueTracking.updateValueIfChanged(otherNode);
+      updateValueIfChanged(otherNode);
 
       // If this is a controlled radio button group, forcing the input that
       // was previously checked to update will cause it to be come re-checked


### PR DESCRIPTION
Hi,

While taking a look at issue #11827 I noticed a `TODO` in [ReactDOMFiberInput](https://github.com/facebook/react/blob/master/packages/react-dom/src/client/ReactDOMFiberInput.js#L10) that reads `TODO: direct imports like some-package/src/* are bad. Fix me.`.

I addressed the `TODO` message and converted the imports from direct import syntax to property import syntax.
