### PR TITLE
Add a failing test for unnecessary commits

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -472,27 +472,22 @@ describe('ReactIncrementalUpdates', () => {
     expect(updateCommits).toBe(0);
     expect(ReactNoop.getChildren()).toEqual([span('')]);
 
-    ReactNoop.deferredUpdates(() => {
-      ReactNoop.render(<Foo prop="h" />);
-    });
-    ReactNoop.deferredUpdates(() => {
-      ReactNoop.render(<Foo prop="he" />);
-    });
+    ReactNoop.render(<Foo prop="h" />);
+    ReactNoop.expire(200);
+    ReactNoop.render(<Foo prop="he" />);
+    ReactNoop.expire(200);
     // Do some work but not enough for a commit
     expect(updateCommits).toBe(0);
     ReactNoop.flushUnitsOfWork(1);
     expect(updateCommits).toBe(0);
     expect(ReactNoop.getChildren()).toEqual([span('')]);
 
-    ReactNoop.deferredUpdates(() => {
-      ReactNoop.render(<Foo prop="hel" />);
-    });
-    ReactNoop.deferredUpdates(() => {
-      ReactNoop.render(<Foo prop="hell" />);
-    });
-    ReactNoop.deferredUpdates(() => {
-      ReactNoop.render(<Foo prop="hello" />);
-    });
+    ReactNoop.render(<Foo prop="hel" />);
+    ReactNoop.expire(200);
+    ReactNoop.render(<Foo prop="hell" />);
+    ReactNoop.expire(200);
+    ReactNoop.render(<Foo prop="hello" />);
+    ReactNoop.expire(200);
     // We expect a single resulting commit
     expect(updateCommits).toBe(0);
     ReactNoop.flushDeferredPri();


### PR DESCRIPTION
I think this demonstrates what I've been running into with my time slicing demo. Not sure though — maybe it's a different problem. If there is a good explanation for this behavior I can dig further.

The symptom I was seeing is that if I flood the scheduler with enough low pri work, it would make a synchronous long chain of commits during expiration — sometimes locking up the thread for 20 seconds or so. I couldn't find a way to reproduce more than one extra commit in this test, but maybe this is enough to demonstrate the issue?