### PR TITLE
added Flow types to setInnerHTML

### DIFF
--- a/packages/react-dom/src/client/setInnerHTML.js
+++ b/packages/react-dom/src/client/setInnerHTML.js
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import {Namespaces} from '../shared/DOMNamespaces';
@@ -18,25 +20,27 @@ let reusableSVGContainer;
  * @param {string} html
  * @internal
  */
-const setInnerHTML = createMicrosoftUnsafeLocalFunction(function(node, html) {
-  // IE does not have innerHTML for SVG nodes, so instead we inject the
-  // new markup in a temp node and then move the child nodes across into
-  // the target node
+const setInnerHTML = createMicrosoftUnsafeLocalFunction(
+  function(node: Element, html: string): void {
+    // IE does not have innerHTML for SVG nodes, so instead we inject the
+    // new markup in a temp node and then move the child nodes across into
+    // the target node
 
-  if (node.namespaceURI === Namespaces.svg && !('innerHTML' in node)) {
-    reusableSVGContainer =
-      reusableSVGContainer || document.createElement('div');
-    reusableSVGContainer.innerHTML = '<svg>' + html + '</svg>';
-    const svgNode = reusableSVGContainer.firstChild;
-    while (node.firstChild) {
-      node.removeChild(node.firstChild);
+    if (node.namespaceURI === Namespaces.svg && !('innerHTML' in node)) {
+      reusableSVGContainer =
+        reusableSVGContainer || document.createElement('div');
+      reusableSVGContainer.innerHTML = '<svg>' + html + '</svg>';
+      const svgNode = reusableSVGContainer.firstChild;
+      while (node.firstChild) {
+        node.removeChild(node.firstChild);
+      }
+      while (svgNode.firstChild) {
+        node.appendChild(svgNode.firstChild);
+      }
+    } else {
+      node.innerHTML = html;
     }
-    while (svgNode.firstChild) {
-      node.appendChild(svgNode.firstChild);
-    }
-  } else {
-    node.innerHTML = html;
   }
-});
+);
 
 export default setInnerHTML;


### PR DESCRIPTION
Hi,

This change adds flow types to `setInnerHTML` to be consistent to a similar module [`setTextContent`](https://github.com/facebook/react/blob/master/packages/react-dom/src/client/setTextContent.js)
