### PR TITLE
When a root expires, flush all expired work in a single batch

### DIFF
--- a/packages/react-reconciler/src/ReactFiberPendingPriority.js
+++ b/packages/react-reconciler/src/ReactFiberPendingPriority.js
@@ -242,6 +242,17 @@ export function findEarliestOutstandingPriorityLevel(
   return earliestExpirationTime;
 }
 
+export function didExpireAtExpirationTime(
+  root: FiberRoot,
+  currentTime: ExpirationTime,
+): void {
+  const expirationTime = root.expirationTime;
+  if (expirationTime !== NoWork && currentTime >= expirationTime) {
+    // The root has expired. Flush all work up to the current time.
+    root.nextExpirationTimeToWorkOn = currentTime;
+  }
+}
+
 function findNextExpirationTimeToWorkOn(completedExpirationTime, root) {
   const earliestSuspendedTime = root.earliestSuspendedTime;
   const latestSuspendedTime = root.latestSuspendedTime;


### PR DESCRIPTION
Still need to add some Suspense tests, and some comments. Pushing so Dan can test if it fixes the issue in the fixture.