### PR TITLE
maybe using logical or expressions is better

### DIFF
--- a/packages/react-dom/src/client/getActiveElement.js
+++ b/packages/react-dom/src/client/getActiveElement.js
@@ -8,7 +8,7 @@
  */
 
 export default function getActiveElement(doc: ?Document): ?Element {
-  doc = doc || (typeof document !== 'undefined' ? document : undefined);
+  doc = doc || (document || undefined);
   if (typeof doc === 'undefined') {
     return null;
   }


### PR DESCRIPTION
logical operators take precedence over conditional operators, and more concise.
reference link: 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence