### PR TITLE
Warn about HTML within SVG tags

### DIFF
--- a/packages/react-dom/src/__tests__/validateDOMNesting-test.js
+++ b/packages/react-dom/src/__tests__/validateDOMNesting-test.js
@@ -96,6 +96,21 @@ describe('validateDOMNesting', () => {
       ],
     );
     expectWarnings(
+      ['svg', 'div'],
+      [
+        'validateDOMNesting(...): <div> cannot appear as a descendant of <svg>.\n' +
+          '    in div (at **)',
+      ],
+    );
+    expectWarnings(
+      ['svg', 'path', 'span'],
+      [
+        'validateDOMNesting(...): <span> cannot appear as a descendant of <svg>.\n' +
+          '    in span (at **)\n' +
+          '    in path (at **)',
+      ],
+    );
+    expectWarnings(
       ['div', 'html'],
       [
         'validateDOMNesting(...): <html> cannot appear as a child of <div>.\n' +

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -195,6 +195,12 @@ if (__DEV__) {
     if (tag === 'button') {
       ancestorInfo.buttonTagInScope = info;
     }
+    if (tag === 'svg') {
+      ancestorInfo.svgTagInScope = info;
+    }
+    if (tag === 'foreignObject') {
+      ancestorInfo.foreignObjectInScope = info;
+    }
     if (tag === 'nobr') {
       ancestorInfo.nobrTagInScope = info;
     }
@@ -376,25 +382,56 @@ if (__DEV__) {
       case 'h4':
       case 'h5':
       case 'h6':
-        return ancestorInfo.pTagInButtonScope;
+        return (
+          ancestorInfo.pTagInButtonScope ||
+          (!ancestorInfo.foreignObjectInScope
+            ? ancestorInfo.svgTagInScope
+            : null)
+        );
+
+      case 'span':
+        return !ancestorInfo.foreignObjectInScope
+          ? ancestorInfo.svgTagInScope
+          : null;
 
       case 'form':
-        return ancestorInfo.formTag || ancestorInfo.pTagInButtonScope;
+        return (
+          ancestorInfo.formTag ||
+          ancestorInfo.pTagInButtonScope ||
+          (!ancestorInfo.foreignObjectInScope
+            ? ancestorInfo.svgTagInScope
+            : null)
+        );
 
       case 'li':
-        return ancestorInfo.listItemTagAutoclosing;
+        return (
+          ancestorInfo.listItemTagAutoclosing ||
+          (!ancestorInfo.foreignObjectInScope
+            ? ancestorInfo.svgTagInScope
+            : null)
+        );
 
       case 'dd':
       case 'dt':
         return ancestorInfo.dlItemTagAutoclosing;
 
       case 'button':
-        return ancestorInfo.buttonTagInScope;
+        return (
+          ancestorInfo.buttonTagInScope ||
+          (!ancestorInfo.foreignObjectInScope
+            ? ancestorInfo.svgTagInScope
+            : null)
+        );
 
       case 'a':
         // Spec says something about storing a list of markers, but it sounds
         // equivalent to this check.
-        return ancestorInfo.aTagInScope;
+        return (
+          ancestorInfo.aTagInScope ||
+          (!ancestorInfo.foreignObjectInScope
+            ? ancestorInfo.svgTagInScope
+            : null)
+        );
 
       case 'nobr':
         return ancestorInfo.nobrTagInScope;

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -346,9 +346,8 @@ if (__DEV__) {
    * Returns whether
    */
   const findInvalidAncestorForTag = function(tag, ancestorInfo) {
-    const isValidHtmlInSvg = !ancestorInfo.foreignObjectInScope
-      ? ancestorInfo.svgTagInScope
-      : null;
+    const isInSvgScope =
+      !ancestorInfo.foreignObjectInScope && ancestorInfo.svgTagInScope;
 
     switch (tag) {
       case 'address':
@@ -386,32 +385,30 @@ if (__DEV__) {
       case 'h4':
       case 'h5':
       case 'h6':
-        return ancestorInfo.pTagInButtonScope || isValidHtmlInSvg;
+        return ancestorInfo.pTagInButtonScope || isInSvgScope;
 
       case 'span':
-        return isValidHtmlInSvg;
+        return isInSvgScope;
 
       case 'form':
         return (
-          ancestorInfo.formTag ||
-          ancestorInfo.pTagInButtonScope ||
-          isValidHtmlInSvg
+          ancestorInfo.formTag || ancestorInfo.pTagInButtonScope || isInSvgScope
         );
 
       case 'li':
-        return ancestorInfo.listItemTagAutoclosing || isValidHtmlInSvg;
+        return ancestorInfo.listItemTagAutoclosing || isInSvgScope;
 
       case 'dd':
       case 'dt':
         return ancestorInfo.dlItemTagAutoclosing;
 
       case 'button':
-        return ancestorInfo.buttonTagInScope || isValidHtmlInSvg;
+        return ancestorInfo.buttonTagInScope || isInSvgScope;
 
       case 'a':
         // Spec says something about storing a list of markers, but it sounds
         // equivalent to this check.
-        return ancestorInfo.aTagInScope || isValidHtmlInSvg;
+        return ancestorInfo.aTagInScope;
 
       case 'nobr':
         return ancestorInfo.nobrTagInScope;

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -346,6 +346,10 @@ if (__DEV__) {
    * Returns whether
    */
   const findInvalidAncestorForTag = function(tag, ancestorInfo) {
+    const isValidHtmlInSvg = !ancestorInfo.foreignObjectInScope
+      ? ancestorInfo.svgTagInScope
+      : null;
+
     switch (tag) {
       case 'address':
       case 'article':
@@ -382,12 +386,7 @@ if (__DEV__) {
       case 'h4':
       case 'h5':
       case 'h6':
-        return (
-          ancestorInfo.pTagInButtonScope ||
-          (!ancestorInfo.foreignObjectInScope
-            ? ancestorInfo.svgTagInScope
-            : null)
-        );
+        return ancestorInfo.pTagInButtonScope || isValidHtmlInSvg;
 
       case 'span':
         return !ancestorInfo.foreignObjectInScope
@@ -398,40 +397,23 @@ if (__DEV__) {
         return (
           ancestorInfo.formTag ||
           ancestorInfo.pTagInButtonScope ||
-          (!ancestorInfo.foreignObjectInScope
-            ? ancestorInfo.svgTagInScope
-            : null)
+          isValidHtmlInSvg
         );
 
       case 'li':
-        return (
-          ancestorInfo.listItemTagAutoclosing ||
-          (!ancestorInfo.foreignObjectInScope
-            ? ancestorInfo.svgTagInScope
-            : null)
-        );
+        return ancestorInfo.listItemTagAutoclosing || isValidHtmlInSvg;
 
       case 'dd':
       case 'dt':
         return ancestorInfo.dlItemTagAutoclosing;
 
       case 'button':
-        return (
-          ancestorInfo.buttonTagInScope ||
-          (!ancestorInfo.foreignObjectInScope
-            ? ancestorInfo.svgTagInScope
-            : null)
-        );
+        return ancestorInfo.buttonTagInScope || isValidHtmlInSvg;
 
       case 'a':
         // Spec says something about storing a list of markers, but it sounds
         // equivalent to this check.
-        return (
-          ancestorInfo.aTagInScope ||
-          (!ancestorInfo.foreignObjectInScope
-            ? ancestorInfo.svgTagInScope
-            : null)
-        );
+        return ancestorInfo.aTagInScope || isValidHtmlInSvg;
 
       case 'nobr':
         return ancestorInfo.nobrTagInScope;

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -389,9 +389,7 @@ if (__DEV__) {
         return ancestorInfo.pTagInButtonScope || isValidHtmlInSvg;
 
       case 'span':
-        return !ancestorInfo.foreignObjectInScope
-          ? ancestorInfo.svgTagInScope
-          : null;
+        return isValidHtmlInSvg;
 
       case 'form':
         return (


### PR DESCRIPTION
This PR aims to warn about nesting non-SVG HTML tags within SVG (similar to how developers are warned against nesting `<p>` tags within `<p>` tags).

Example:
```jsx
<svg>
  <path>
    <div>
      I'm a nested div!
    </div>
  </path>
</svg>
```
Produces the following warning:
<img width="465" alt="screen shot 2018-08-30 at 09 57 07" src="https://user-images.githubusercontent.com/22820481/44841366-16c72d00-ac3b-11e8-8792-4239a1595a38.png">

However, including the `<div>` within a `<foreignObject>`
```jsx
<svg>
  <path>
    <foreignObject>
      <div>
        I'm a nested div!
      </div>
    </foreignObject>
  </path>
</svg>
```
Produces no errors message.

Ideally, I think the warning should include some messaging about wrapping HTML inside a foreignObject, i.e. '`<div>` cannot appear as a descendant of `<svg>`, consider wrapping it inside a `<foreignObject>`', but I wasn't 100% sure on how to implement this with how `validateDOMNesting.js` currently works.

closes #11013 