### PR TITLE
[ReactFiberScheduler.js] Remove redundant if else branch

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1691,13 +1691,8 @@ function scheduleWorkToRoot(fiber: Fiber, expirationTime): FiberRoot | null {
       alternate = node.alternate;
       if (node.childExpirationTime < expirationTime) {
         node.childExpirationTime = expirationTime;
-        if (
-          alternate !== null &&
-          alternate.childExpirationTime < expirationTime
-        ) {
-          alternate.childExpirationTime = expirationTime;
-        }
-      } else if (
+      }
+      if (
         alternate !== null &&
         alternate.childExpirationTime < expirationTime
       ) {


### PR DESCRIPTION
The codes of [this if statement](https://github.com/facebook/react/blob/4bcee56210bd3ab3f6440ff7313a255148e22107/packages/react-reconciler/src/ReactFiberScheduler.js#L1661-L1667) is same with the [else if statement](https://github.com/facebook/react/blob/4bcee56210bd3ab3f6440ff7313a255148e22107/packages/react-reconciler/src/ReactFiberScheduler.js#L1668-L1674), so we merge them as one branch