### PR TITLE
Replace CSS vendor prefix Object.keys with for..in

### DIFF
--- a/packages/react-dom/src/shared/CSSProperty.js
+++ b/packages/react-dom/src/shared/CSSProperty.js
@@ -70,10 +70,8 @@ function prefixKey(prefix, key) {
  */
 const prefixes = ['Webkit', 'ms', 'Moz', 'O'];
 
-// Using Object.keys here, or else the vanilla for-in loop makes IE8 go into an
-// infinite loop, because it iterates over the newly added props too.
-Object.keys(isUnitlessNumber).forEach(function(prop) {
-  prefixes.forEach(function(prefix) {
-    isUnitlessNumber[prefixKey(prefix, prop)] = isUnitlessNumber[prop];
-  });
-});
+for (let prop in isUnitlessNumber) {
+  for (let i = 0; i < prefixes.length; i++) {
+    isUnitlessNumber[prefixKey(prefixes[i], prop)] = isUnitlessNumber[prop];
+  }
+}


### PR DESCRIPTION
This PR replaces the Object.keys loop used to avoid an IE8 infinite loop bug with a regular for..in loop. According to [React docs](https://reactjs.org/blog/2016/01/12/discontinuing-ie8-support.html) IE8 is not supported anymore so technically this workaround isn't needed anymore.

I also removed the forEach in the inner loop and replaced it with a regular for since it's still the fastest way to loop in an Array.