### PR TITLE
[ReactElementValidator.js] Remove outdated null element check

### DIFF
--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -307,12 +307,6 @@ export function createElementWithValidation(type, props, children) {
 
   const element = createElement.apply(this, arguments);
 
-  // The result can be nullish if a mock or a custom function is used.
-  // TODO: Drop this when these are no longer allowed as the type argument.
-  if (element == null) {
-    return element;
-  }
-
   // Skip key warning if the type isn't valid since our key validation logic
   // doesn't expect a non-string/function type and can throw confusing errors.
   // We don't want exception behavior to differ between dev and prod.


### PR DESCRIPTION
Since createElement not longer return `null`(It will always return an object), we can remove this check now.