### PR TITLE
Ignore noscript content on the client

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -36,6 +36,7 @@ const {
   itThrowsWhenRendering,
   serverRender,
   streamRender,
+  clientCleanRender,
   clientRenderOnServerString,
 } = ReactDOMServerIntegrationUtils(initModules);
 
@@ -575,6 +576,24 @@ describe('ReactDOMServerIntegration', () => {
         expect(e.childNodes.length).toBe(0);
       },
     );
+
+    itRenders('a noscript with children', async render => {
+      const e = await render(
+        <noscript>
+          <div>Enable JavaScript to run this app.</div>
+        </noscript>,
+      );
+      if (render === clientCleanRender) {
+        // On the client we ignore the contents of a noscript
+        expect(e.childNodes.length).toBe(0);
+      } else {
+        // On the server or when hydrating the content should be correct
+        expect(e.childNodes.length).toBe(1);
+        expect(e.firstChild.textContent).toBe(
+          '<div>Enable JavaScript to run this app.</div>',
+        );
+      }
+    });
 
     describe('newline-eating elements', function() {
       itRenders(

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration.js
@@ -341,4 +341,37 @@ describe('ReactDOMServerHydration', () => {
       expect(callback).toHaveBeenCalledTimes(0);
     }
   });
+
+  // Regression test for https://github.com/facebook/react/issues/11423
+  it('should ignore noscript content on the client and not warn about mismatches', () => {
+    const callback = jest.fn();
+    const TestComponent = ({onRender}) => {
+      onRender();
+      return <div>Enable JavaScript to run this app.</div>;
+    };
+    const markup = (
+      <noscript>
+        <TestComponent onRender={callback} />
+      </noscript>
+    );
+
+    const element = document.createElement('div');
+    element.innerHTML = ReactDOMServer.renderToString(markup);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(element.textContent).toBe(
+      '<div>Enable JavaScript to run this app.</div>',
+    );
+
+    // On the client we want to keep the existing markup, but not render the
+    // actual elements for performance reasons and to avoid for example
+    // downloading images. This should also not warn for hydration mismatches.
+    expect(() => ReactDOM.hydrate(markup, element)).not.toWarnDev(
+      'Expected server HTML to contain a matching <div> in <noscript>.',
+      {withoutStack: true},
+    );
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(element.textContent).toBe(
+      '<div>Enable JavaScript to run this app.</div>',
+    );
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration.js
@@ -365,10 +365,7 @@ describe('ReactDOMServerHydration', () => {
     // On the client we want to keep the existing markup, but not render the
     // actual elements for performance reasons and to avoid for example
     // downloading images. This should also not warn for hydration mismatches.
-    expect(() => ReactDOM.hydrate(markup, element)).not.toWarnDev(
-      'Expected server HTML to contain a matching <div> in <noscript>.',
-      {withoutStack: true},
-    );
+    ReactDOM.hydrate(markup, element);
     expect(callback).toHaveBeenCalledTimes(1);
     expect(element.textContent).toBe(
       '<div>Enable JavaScript to run this app.</div>',

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -247,6 +247,7 @@ export function shouldSetTextContent(type: string, props: Props): boolean {
   return (
     type === 'textarea' ||
     type === 'option' ||
+    type === 'noscript' ||
     typeof props.children === 'string' ||
     typeof props.children === 'number' ||
     (typeof props.dangerouslySetInnerHTML === 'object' &&


### PR DESCRIPTION
Fixes #11423

First PR, CLA is signed.

Before this PR `<noscript><img src="..." /></noscript>` would:

* Warn about a server/client mismatch
* Download the img
* (Run any lifecycles for components inside the noscript)

I tried fixing this by only touching ReactDOM and found that by treating `<noscript>` as an element that only supports text it achieved the desired effects. This also keeps the markup in the DOM on the client which is desirable as per the issue.

Questions:

* Is this a hacky way to do it? In a sense `shouldSetTextContent` is true for noscript-elements on the client, but could it have any unintended side-effects now or in the future?
* Solving it this way means that the content inside a noscript could still be updated on the client as long as children is a string, is the desirable or confusing?
* Is the test a sane and robust way to test for this?