### PR TITLE
Revert "Extract common logic"

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1601,13 +1601,14 @@ function retrySuspendedRoot(
     if (isPriorityLevelSuspended(root, suspendedTime)) {
       // Ping at the original level
       retryTime = suspendedTime;
+      markPingedPriorityLevel(root, retryTime);
     } else {
       // Placeholder already timed out. Compute a new expiration time
       const currentTime = requestCurrentTime();
       retryTime = computeExpirationForFiber(currentTime, fiber);
+      markPendingPriorityLevel(root, retryTime);
     }
 
-    markPingedPriorityLevel(root, retryTime);
     scheduleWorkToRoot(fiber, retryTime);
     const rootExpirationTime = root.expirationTime;
     if (rootExpirationTime !== NoWork) {


### PR DESCRIPTION
Reverts facebook/react#13535

I think this broke master. I’ve been staying it for a minute and can’t see why but I’ll revert for now. 

Sorry I merged without checking closer. CI has been falling last few days and I checked status of another PR by mistake.  