### PR TITLE
Add gridArea to unitless CSS properties

### DIFF
--- a/packages/react-dom/src/shared/CSSProperty.js
+++ b/packages/react-dom/src/shared/CSSProperty.js
@@ -24,6 +24,7 @@ export const isUnitlessNumber = {
   flexShrink: true,
   flexNegative: true,
   flexOrder: true,
+  gridArea: true,
   gridRow: true,
   gridRowEnd: true,
   gridRowSpan: true,


### PR DESCRIPTION
Ref #9185

Based on https://github.com/jquery/jquery/commit/f997241f0011ed728be71002bc703c7a0d3f01e5

`grid-area` accepts a numeric value which then translates to `grid-row-start`, setting `grid-row-end`, `grid-column-start` & `grid-column-end` to `auto`.

I thought about adding a test but I don't understand how the ones in `CSSPropertyOperations-test.js` are supposed to work. For example, setting `grid-row` to `10` will result in a normalized `gridRow` style property with a value `"10 / auto"`. It seems they work just because they use `ms`-prefixed properties in format not actually used in IE as IE's grid properties were named differently?

Another remark - in jQuery we have been auto-appending `px` to most numerical values as well but we decided it was a bad decision. It doesn't scale as it requires us to add more & more properties to the list. We've actually exposed the list at [jQuery.cssNumber](https://api.jquery.com/jQuery.cssNumber/) so that people don't always have to wait for us to add support for a property and do a release. What's more confusing, some of them would work both with & without the `px` suffix and that changes the meaning.

That's why we decided that in jQuery 4 we'll drop the auto-prefixing blacklist and turn to a whitelist that lists only a few most common properties to which we want to auto-append `px` (mostly because they're extremely common and we don't want to break the world too much); we plan to _not_ expand that list. You can see the current plan in my PR: https://github.com/jquery/jquery/pull/4055. In particular, see the proposed whitelist in a (visualized) regexp in:
https://github.com/jquery/jquery/blob/03e9dba3882868e1ee79f1fb0504326da925644f/src/css/isAutoPx.js.
Something to consider for a future React version.