### PR TITLE
refactor: remove type judgment when defining warning props

### DIFF
--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -229,20 +229,15 @@ export function createElement(type, config, children) {
   }
   if (__DEV__) {
     if (key || ref) {
-      if (
-        typeof props.$$typeof === 'undefined' ||
-        props.$$typeof !== REACT_ELEMENT_TYPE
-      ) {
-        const displayName =
-          typeof type === 'function'
-            ? type.displayName || type.name || 'Unknown'
-            : type;
-        if (key) {
-          defineKeyPropWarningGetter(props, displayName);
-        }
-        if (ref) {
-          defineRefPropWarningGetter(props, displayName);
-        }
+      const displayName =
+        typeof type === 'function'
+          ? type.displayName || type.name || 'Unknown'
+          : type;
+      if (key) {
+        defineKeyPropWarningGetter(props, displayName);
+      }
+      if (ref) {
+        defineRefPropWarningGetter(props, displayName);
       }
     }
   }


### PR DESCRIPTION
The judgment in this code seems to be invalid：

https://github.com/facebook/react/blob/master/packages/react/src/ReactElement.js#L233-L234

Because props.$$typeof is always undefined.

I can't see the effect of this judgment from the unit test.

If he is necessary. Please tell me the special use case. 

I will add a test case here.