### PR TITLE
Removed ref-getter methods from "schedule" API

### DIFF
--- a/fixtures/tracking/script.js
+++ b/fixtures/tracking/script.js
@@ -48,8 +48,6 @@ function checkSchedulerTrackingAPI() {
   runTest(document.getElementById('checkSchedulerTrackingAPI'), () => {
     if (
       typeof ScheduleTracking === 'undefined' ||
-      typeof ScheduleTracking.__getInteractionsRef !== 'function' ||
-      typeof ScheduleTracking.__getSubscriberRef !== 'function' ||
       typeof ScheduleTracking.unstable_clear !== 'function' ||
       typeof ScheduleTracking.unstable_getCurrent !== 'function' ||
       typeof ScheduleTracking.unstable_getThreadID !== 'function' ||
@@ -62,7 +60,7 @@ function checkSchedulerTrackingAPI() {
     try {
       let interactionsSet;
       ScheduleTracking.unstable_track('test', 123, () => {
-        interactionsSet = ScheduleTracking.__getInteractionsRef().current;
+        interactionsSet = ScheduleTracking.unstable_getCurrent();
       });
       if (interactionsSet.size !== 1) {
         throw null;

--- a/packages/react/src/ReactSharedInternals.js
+++ b/packages/react/src/ReactSharedInternals.js
@@ -12,8 +12,8 @@ import {
   unstable_scheduleWork,
 } from 'schedule';
 import {
-  __getInteractionsRef,
-  __getSubscriberRef,
+  __interactionsRef,
+  __subscriberRef,
   unstable_clear,
   unstable_getCurrent,
   unstable_getThreadID,
@@ -44,8 +44,8 @@ if (__UMD__) {
       unstable_scheduleWork,
     },
     ScheduleTracking: {
-      __getInteractionsRef,
-      __getSubscriberRef,
+      __interactionsRef,
+      __subscriberRef,
       unstable_clear,
       unstable_getCurrent,
       unstable_getThreadID,

--- a/packages/schedule/npm/umd/schedule-tracking.development.js
+++ b/packages/schedule/npm/umd/schedule-tracking.development.js
@@ -16,20 +16,6 @@
       ? define(['react'], factory) // eslint-disable-line no-undef
       : (global.ScheduleTracking = factory(global));
 })(this, function(global) {
-  function __getInteractionsRef() {
-    return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ScheduleTracking.__getInteractionsRef.apply(
-      this,
-      arguments
-    );
-  }
-
-  function __getSubscriberRef() {
-    return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ScheduleTracking.__getSubscriberRef.apply(
-      this,
-      arguments
-    );
-  }
-
   function unstable_clear() {
     return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ScheduleTracking.unstable_clear.apply(
       this,
@@ -82,8 +68,6 @@
   }
 
   return Object.freeze({
-    __getInteractionsRef: __getInteractionsRef,
-    __getSubscriberRef: __getSubscriberRef,
     unstable_clear: unstable_clear,
     unstable_getCurrent: unstable_getCurrent,
     unstable_getThreadID: unstable_getThreadID,

--- a/packages/schedule/npm/umd/schedule-tracking.production.min.js
+++ b/packages/schedule/npm/umd/schedule-tracking.production.min.js
@@ -16,20 +16,6 @@
       ? define(['react'], factory) // eslint-disable-line no-undef
       : (global.ScheduleTracking = factory(global));
 })(this, function(global) {
-  function __getInteractionsRef() {
-    return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ScheduleTracking.__getInteractionsRef.apply(
-      this,
-      arguments
-    );
-  }
-
-  function __getSubscriberRef() {
-    return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ScheduleTracking.__getSubscriberRef.apply(
-      this,
-      arguments
-    );
-  }
-
   function unstable_clear() {
     return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ScheduleTracking.unstable_clear.apply(
       this,
@@ -82,8 +68,6 @@
   }
 
   return Object.freeze({
-    __getInteractionsRef: __getInteractionsRef,
-    __getSubscriberRef: __getSubscriberRef,
     unstable_clear: unstable_clear,
     unstable_getCurrent: unstable_getCurrent,
     unstable_getThreadID: unstable_getThreadID,

--- a/packages/schedule/src/Tracking.js
+++ b/packages/schedule/src/Tracking.js
@@ -79,15 +79,7 @@ if (enableSchedulerTracking) {
   };
 }
 
-// These values are exported for libraries with advanced use cases (i.e. React).
-// They should not typically be accessed directly.
-export function __getInteractionsRef(): InteractionsRef {
-  return interactionsRef;
-}
-
-export function __getSubscriberRef(): SubscriberRef {
-  return subscriberRef;
-}
+export {interactionsRef as __interactionsRef, subscriberRef as __subscriberRef};
 
 export function unstable_clear(callback: Function): any {
   if (!enableSchedulerTracking) {

--- a/packages/schedule/src/TrackingSubscriptions.js
+++ b/packages/schedule/src/TrackingSubscriptions.js
@@ -7,15 +7,13 @@
  * @flow
  */
 
-import type {Interaction, Subscriber, SubscriberRef} from './Tracking';
+import type {Interaction, Subscriber} from './Tracking';
 
 import {enableSchedulerTracking} from 'shared/ReactFeatureFlags';
-import {__getSubscriberRef} from 'schedule/tracking';
+import {__subscriberRef} from 'schedule/tracking';
 
-let subscriberRef: SubscriberRef = (null: any);
 let subscribers: Set<Subscriber> = (null: any);
 if (enableSchedulerTracking) {
-  subscriberRef = __getSubscriberRef();
   subscribers = new Set();
 }
 
@@ -24,7 +22,7 @@ export function unstable_subscribe(subscriber: Subscriber): void {
     subscribers.add(subscriber);
 
     if (subscribers.size === 1) {
-      subscriberRef.current = {
+      __subscriberRef.current = {
         onInteractionScheduledWorkCompleted,
         onInteractionTracked,
         onWorkCanceled,
@@ -41,7 +39,7 @@ export function unstable_unsubscribe(subscriber: Subscriber): void {
     subscribers.delete(subscriber);
 
     if (subscribers.size === 0) {
-      subscriberRef.current = null;
+      __subscriberRef.current = null;
     }
   }
 }

--- a/packages/schedule/src/__tests__/ScheduleUMDBundle-test.internal.js
+++ b/packages/schedule/src/__tests__/ScheduleUMDBundle-test.internal.js
@@ -16,10 +16,20 @@ describe('Scheduling UMD bundle', () => {
     jest.resetModules();
   });
 
+  function filterPrivateKeys(name) {
+    return !name.startsWith('_');
+  }
+
   function validateForwardedAPIs(api, forwardedAPIs) {
-    const apiKeys = Object.keys(api).sort();
+    const apiKeys = Object.keys(api)
+      .filter(filterPrivateKeys)
+      .sort();
     forwardedAPIs.forEach(forwardedAPI => {
-      expect(Object.keys(forwardedAPI).sort()).toEqual(apiKeys);
+      expect(
+        Object.keys(forwardedAPI)
+          .filter(filterPrivateKeys)
+          .sort(),
+      ).toEqual(apiKeys);
     });
   }
 

--- a/packages/schedule/src/__tests__/Tracking-test.internal.js
+++ b/packages/schedule/src/__tests__/Tracking-test.internal.js
@@ -299,11 +299,11 @@ describe('Tracking', () => {
 
       it('should expose the current set of interactions to be externally manipulated', () => {
         SchedulerTracking.unstable_track('outer event', currentTime, () => {
-          expect(SchedulerTracking.__getInteractionsRef().current).toBe(
+          expect(SchedulerTracking.__interactionsRef.current).toBe(
             SchedulerTracking.unstable_getCurrent(),
           );
 
-          SchedulerTracking.__getInteractionsRef().current = new Set([
+          SchedulerTracking.__interactionsRef.current = new Set([
             {name: 'override event'},
           ]);
 
@@ -315,7 +315,7 @@ describe('Tracking', () => {
 
       it('should expose a subscriber ref to be externally manipulated', () => {
         SchedulerTracking.unstable_track('outer event', currentTime, () => {
-          expect(SchedulerTracking.__getSubscriberRef()).toEqual({
+          expect(SchedulerTracking.__subscriberRef).toEqual({
             current: null,
           });
         });
@@ -368,7 +368,7 @@ describe('Tracking', () => {
 
     describe('advanced integration', () => {
       it('should not create unnecessary objects', () => {
-        expect(SchedulerTracking.__getInteractionsRef()).toBe(null);
+        expect(SchedulerTracking.__interactionsRef).toBe(null);
       });
     });
   });

--- a/packages/schedule/src/__tests__/TrackingSubscriptions-test.internal.js
+++ b/packages/schedule/src/__tests__/TrackingSubscriptions-test.internal.js
@@ -112,15 +112,15 @@ describe('TrackingSubscriptions', () => {
     it('should lazily subscribe to tracking and unsubscribe again if there are no external subscribers', () => {
       loadModules({enableSchedulerTracking: true, autoSubscribe: false});
 
-      expect(SchedulerTracking.__getSubscriberRef().current).toBe(null);
+      expect(SchedulerTracking.__subscriberRef.current).toBe(null);
       SchedulerTracking.unstable_subscribe(firstSubscriber);
-      expect(SchedulerTracking.__getSubscriberRef().current).toBeDefined();
+      expect(SchedulerTracking.__subscriberRef.current).toBeDefined();
       SchedulerTracking.unstable_subscribe(secondSubscriber);
-      expect(SchedulerTracking.__getSubscriberRef().current).toBeDefined();
+      expect(SchedulerTracking.__subscriberRef.current).toBeDefined();
       SchedulerTracking.unstable_unsubscribe(secondSubscriber);
-      expect(SchedulerTracking.__getSubscriberRef().current).toBeDefined();
+      expect(SchedulerTracking.__subscriberRef.current).toBeDefined();
       SchedulerTracking.unstable_unsubscribe(firstSubscriber);
-      expect(SchedulerTracking.__getSubscriberRef().current).toBe(null);
+      expect(SchedulerTracking.__subscriberRef.current).toBe(null);
     });
 
     describe('error handling', () => {

--- a/packages/shared/forks/ScheduleTracking.umd.js
+++ b/packages/shared/forks/ScheduleTracking.umd.js
@@ -12,8 +12,8 @@ import React from 'react';
 const ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 
 const {
-  __getInteractionsRef,
-  __getSubscriberRef,
+  __interactionsRef,
+  __subscriberRef,
   unstable_clear,
   unstable_getCurrent,
   unstable_getThreadID,
@@ -24,8 +24,8 @@ const {
 } = ReactInternals.ScheduleTracking;
 
 export {
-  __getInteractionsRef,
-  __getSubscriberRef,
+  __interactionsRef,
+  __subscriberRef,
   unstable_clear,
   unstable_getCurrent,
   unstable_getThreadID,


### PR DESCRIPTION
First two steps of #13559:
- Replace the [`__getInteractionsRef` and `__getSubscriberRef` methods](https://github.com/facebook/react/blob/fb88fd9d8c9f72b8e2e7e1ae89652d2a6a707562/packages/schedule/src/Tracking.js#L84-L90) with direct exports (`__interactionsRef` and `__subscriberRef`) and [update the `ScheduleTracking` UMD fork](https://github.com/facebook/react/blob/master/packages/shared/forks/ScheduleTracking.umd.js).
- Remove `__getInteractionsRef` and `__getSubscriberRef` from the `schedule/tracking` UMD [dev](https://github.com/facebook/react/blob/master/packages/schedule/npm/umd/schedule-tracking.development.js) and [prod](https://github.com/facebook/react/blob/master/packages/schedule/npm/umd/schedule-tracking.production.min.js) bundles since it's not part of the public API.

I tested the packaging and tracking fixtures, as well as the "suspense" demo app, and hand-inspected the `react`, `react-dom`, and `schedule` NPM bundles. All seemed in order.