### PR TITLE
test: add test for fragement props

### DIFF
--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -420,6 +420,21 @@ describe('ReactElementValidator', () => {
     );
   });
 
+  it('warns for fragments with illegal attributes', () => {
+    class Foo extends React.Component {
+      render() {
+        return React.createElement(React.Fragment, {a: 1}, '123');
+      }
+    }
+
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(React.createElement(Foo));
+    }).toWarnDev(
+      'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
+        'can only have `key` and `children` props.',
+    );
+  });
+
   it('should warn when accessing .type on an element factory', () => {
     function TestComponent() {
       return <div />;


### PR DESCRIPTION
This test case was added for this part of the code：

https://github.com/facebook/react/blob/master/packages/react/src/ReactElementValidator.js#L243-L248

Although the relevant test case is already included in `ReactJSXElementValidator-test.js`

I think we need to add a test case, which created by `React.createElement`