### PR TITLE
refactor: remove unnecessary judgment when check fragment props

### DIFF
--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -239,7 +239,7 @@ function validateFragmentProps(fragment) {
   const keys = Object.keys(fragment.props);
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
-    if (key !== 'children' && key !== 'key') {
+    if (key !== 'children') {
       warning(
         false,
         'Invalid prop `%s` supplied to `React.Fragment`. ' +


### PR DESCRIPTION
There is a small problem with the judgment here.

**When we define `key` in props we use the descriptor like this**
```javascript
  Object.defineProperty(props, 'key', {
    get: warnAboutAccessingKey,
    configurable: true,
  });
```
When `enumerable` is not defined, the default value is false.
doc: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty

So when we use `Object.keys` to get the fragement props, we will never get the `key`.
code: https://github.com/facebook/react/blob/master/packages/react/src/ReactElementValidator.js#L239


