### PR TITLE
Build script correctly bumps prerelease deps (e.g. schedule) for react

### DIFF
--- a/scripts/release/build-commands/update-package-versions.js
+++ b/scripts/release/build-commands/update-package-versions.js
@@ -61,7 +61,22 @@ const update = async ({cwd, dry, packages, version}) => {
       // Unstable package version.
       json.version = getNextVersion(json.version, version);
 
-      if (project !== 'react' && json.peerDependencies) {
+      if (project === 'react') {
+        // Update inter-package dependencies as well.
+        // e.g. react depends on scheduler
+        if (json.dependencies) {
+          Object.keys(json.dependencies).forEach(dependency => {
+            if (packages.indexOf(dependency) >= 0) {
+              const prevVersion = json.dependencies[dependency];
+              const nextVersion = getNextVersion(
+                prevVersion.replace('^', ''),
+                version
+              );
+              json.dependencies[dependency] = `^${nextVersion}`;
+            }
+          });
+        }
+      } else if (json.peerDependencies) {
         let peerVersion = json.peerDependencies.react.replace('^', '');
 
         // If the previous release was a pre-release version,


### PR DESCRIPTION
Whoops. Needed this too:
```diff
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "react"
   ],
-  "version": "16.4.3-alpha.0",
+  "version": "16.5.0",
   "homepage": "https://reactjs.org/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "schedule": "^0.2.0"
+    "schedule": "^0.3.0"
   },
   "browserify": {
     "transform": [
diff --git a/packages/schedule/package.json b/packages/schedule/package.json
index f4379bdad..db052a1ed 100644```