### PR TITLE
Kepp calling peformWork consistent

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -2494,7 +2494,7 @@ function flushControlled(fn: () => mixed): void {
   } finally {
     isBatchingUpdates = previousIsBatchingUpdates;
     if (!isBatchingUpdates && !isRendering) {
-      performWork(Sync, null);
+      performSyncWork();
     }
   }
 }


### PR DESCRIPTION
Because we use [performSyncWork](https://github.com/facebook/react/blob/4bcee56210bd3ab3f6440ff7313a255148e22107/packages/react-reconciler/src/ReactFiberScheduler.js#L2144) to process the Sync work, so we can just replace it here like others do