### PR TITLE
Remove injectComponentTree from unstable-native-dependencies, add EventPluginHub

### DIFF
--- a/packages/events/__tests__/ResponderEventPlugin-test.internal.js
+++ b/packages/events/__tests__/ResponderEventPlugin-test.internal.js
@@ -12,11 +12,20 @@
 const {HostComponent} = require('shared/ReactWorkTags');
 
 let EventPluginHub;
+let EventPluginUtils;
 let ResponderEventPlugin;
 
 const touch = function(nodeHandle, i) {
   return {target: nodeHandle, identifier: i};
 };
+
+function injectComponentTree(ComponentTree) {
+  EventPluginUtils.setComponentTree(
+    ComponentTree.getFiberCurrentPropsFromNode,
+    ComponentTree.getInstanceFromNode,
+    ComponentTree.getNodeFromInstance,
+  );
+}
 
 /**
  * @param {NodeHandle} nodeHandle @see NodeHandle. Handle of target.
@@ -395,8 +404,7 @@ describe('ResponderEventPlugin', () => {
 
     const ReactDOMUnstableNativeDependencies = require('react-dom/unstable-native-dependencies');
     EventPluginHub = require('events/EventPluginHub');
-    const injectComponentTree =
-      ReactDOMUnstableNativeDependencies.injectComponentTree;
+    EventPluginUtils = require('events/EventPluginUtils');
     ResponderEventPlugin =
       ReactDOMUnstableNativeDependencies.ResponderEventPlugin;
 

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -745,6 +745,7 @@ const ReactDOM: Object = {
       ReactDOMComponentTree.getInstanceFromNode,
       ReactDOMComponentTree.getNodeFromInstance,
       ReactDOMComponentTree.getFiberCurrentPropsFromNode,
+      EventPluginHub.injection.injectEventPluginsByName,
       EventPluginRegistry.eventNameDispatchConfigs,
       EventPropagators.accumulateTwoPhaseDispatches,
       EventPropagators.accumulateDirectDispatches,

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -31,6 +31,7 @@ const [
   /* eslint-disable no-unused-vars */
   getNodeFromInstance,
   getFiberCurrentPropsFromNode,
+  injectEventPluginsByName,
   /* eslint-enable no-unused-vars */
   eventNameDispatchConfigs,
   accumulateTwoPhaseDispatches,

--- a/packages/react-dom/src/unstable-native-dependencies/ReactDOMUnstableNativeDependencies.js
+++ b/packages/react-dom/src/unstable-native-dependencies/ReactDOMUnstableNativeDependencies.js
@@ -6,20 +6,12 @@
  */
 
 import ReactDOM from 'react-dom';
+import * as EventPluginHub from 'events/EventPluginHub';
 import * as EventPluginUtils from 'events/EventPluginUtils';
 import ResponderEventPlugin from 'events/ResponderEventPlugin';
 import ResponderTouchHistoryStore from 'events/ResponderTouchHistoryStore';
 
-// This is used by react-native-web.
-export function injectComponentTree(ComponentTree) {
-  EventPluginUtils.setComponentTree(
-    ComponentTree.getFiberCurrentPropsFromNode,
-    ComponentTree.getInstanceFromNode,
-    ComponentTree.getNodeFromInstance,
-  );
-}
-
-export {ResponderEventPlugin, ResponderTouchHistoryStore};
+export {ResponderEventPlugin, ResponderTouchHistoryStore, EventPluginHub};
 
 // Inject react-dom's ComponentTree into this module.
 // Keep in sync with ReactDOM.js and ReactTestUtils.js:

--- a/packages/react-dom/src/unstable-native-dependencies/ReactDOMUnstableNativeDependencies.js
+++ b/packages/react-dom/src/unstable-native-dependencies/ReactDOMUnstableNativeDependencies.js
@@ -6,12 +6,9 @@
  */
 
 import ReactDOM from 'react-dom';
-import * as EventPluginHub from 'events/EventPluginHub';
 import * as EventPluginUtils from 'events/EventPluginUtils';
 import ResponderEventPlugin from 'events/ResponderEventPlugin';
 import ResponderTouchHistoryStore from 'events/ResponderTouchHistoryStore';
-
-export {ResponderEventPlugin, ResponderTouchHistoryStore, EventPluginHub};
 
 // Inject react-dom's ComponentTree into this module.
 // Keep in sync with ReactDOM.js and ReactTestUtils.js:
@@ -19,9 +16,17 @@ const [
   getInstanceFromNode,
   getNodeFromInstance,
   getFiberCurrentPropsFromNode,
+  injectEventPluginsByName,
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
+
 EventPluginUtils.setComponentTree(
   getFiberCurrentPropsFromNode,
   getInstanceFromNode,
   getNodeFromInstance,
 );
+
+export {
+  ResponderEventPlugin,
+  ResponderTouchHistoryStore,
+  injectEventPluginsByName,
+};

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -4,29 +4,29 @@
       "filename": "react.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react",
-      "size": 85453,
-      "gzip": 23171
+      "size": 85459,
+      "gzip": 23174
     },
     {
       "filename": "react.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react",
-      "size": 9760,
-      "gzip": 4049
+      "size": 9766,
+      "gzip": 4050
     },
     {
       "filename": "react.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react",
-      "size": 54965,
-      "gzip": 15202
+      "size": 54971,
+      "gzip": 15207
     },
     {
       "filename": "react.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react",
-      "size": 6118,
-      "gzip": 2620
+      "size": 6124,
+      "gzip": 2621
     },
     {
       "filename": "React-dev.js",
@@ -46,29 +46,29 @@
       "filename": "react-dom.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 661338,
-      "gzip": 154989
+      "size": 661344,
+      "gzip": 154987
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 94506,
-      "gzip": 30800
+      "size": 94512,
+      "gzip": 30805
     },
     {
       "filename": "react-dom.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 656572,
-      "gzip": 153559
+      "size": 656578,
+      "gzip": 153557
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 94446,
-      "gzip": 30409
+      "size": 94452,
+      "gzip": 30412
     },
     {
       "filename": "ReactDOM-dev.js",
@@ -88,28 +88,28 @@
       "filename": "react-dom-test-utils.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 45663,
-      "gzip": 12468
+      "size": 45669,
+      "gzip": 12470
     },
     {
       "filename": "react-dom-test-utils.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 10217,
-      "gzip": 3797
+      "size": 10223,
+      "gzip": 3796
     },
     {
       "filename": "react-dom-test-utils.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 45377,
-      "gzip": 12403
+      "size": 45383,
+      "gzip": 12405
     },
     {
       "filename": "react-dom-test-utils.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 9987,
+      "size": 9993,
       "gzip": 3733
     },
     {
@@ -123,29 +123,29 @@
       "filename": "react-dom-unstable-native-dependencies.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 61858,
-      "gzip": 16199
+      "size": 77985,
+      "gzip": 20025
     },
     {
       "filename": "react-dom-unstable-native-dependencies.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 11337,
-      "gzip": 3918
+      "size": 13186,
+      "gzip": 4606
     },
     {
       "filename": "react-dom-unstable-native-dependencies.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 61522,
-      "gzip": 16065
+      "size": 77649,
+      "gzip": 19889
     },
     {
       "filename": "react-dom-unstable-native-dependencies.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 11082,
-      "gzip": 3822
+      "size": 12925,
+      "gzip": 4482
     },
     {
       "filename": "ReactDOMUnstableNativeDependencies-dev.js",
@@ -165,29 +165,29 @@
       "filename": "react-dom-server.browser.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 107276,
-      "gzip": 28619
+      "size": 107282,
+      "gzip": 28637
     },
     {
       "filename": "react-dom-server.browser.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 15693,
-      "gzip": 6004
+      "size": 15699,
+      "gzip": 6005
     },
     {
       "filename": "react-dom-server.browser.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 103314,
-      "gzip": 27617
+      "size": 103320,
+      "gzip": 27620
     },
     {
       "filename": "react-dom-server.browser.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 15593,
-      "gzip": 5948
+      "size": 15599,
+      "gzip": 5950
     },
     {
       "filename": "ReactDOMServer-dev.js",
@@ -207,43 +207,43 @@
       "filename": "react-dom-server.node.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 105282,
-      "gzip": 28164
+      "size": 105288,
+      "gzip": 28167
     },
     {
       "filename": "react-dom-server.node.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 16418,
-      "gzip": 6261
+      "size": 16424,
+      "gzip": 6262
     },
     {
       "filename": "react-art.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-art",
-      "size": 450050,
-      "gzip": 100876
+      "size": 450056,
+      "gzip": 100892
     },
     {
       "filename": "react-art.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-art",
-      "size": 86733,
-      "gzip": 26615
+      "size": 86739,
+      "gzip": 26617
     },
     {
       "filename": "react-art.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-art",
-      "size": 380162,
-      "gzip": 83356
+      "size": 380168,
+      "gzip": 83359
     },
     {
       "filename": "react-art.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-art",
-      "size": 50851,
-      "gzip": 15633
+      "size": 50857,
+      "gzip": 15635
     },
     {
       "filename": "ReactART-dev.js",
@@ -291,29 +291,29 @@
       "filename": "react-test-renderer.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-test-renderer",
-      "size": 392449,
-      "gzip": 85988
+      "size": 392455,
+      "gzip": 86004
     },
     {
       "filename": "react-test-renderer.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-test-renderer",
-      "size": 52087,
-      "gzip": 15902
+      "size": 52093,
+      "gzip": 15903
     },
     {
       "filename": "react-test-renderer.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-test-renderer",
-      "size": 387932,
-      "gzip": 84838
+      "size": 387938,
+      "gzip": 84840
     },
     {
       "filename": "react-test-renderer.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-test-renderer",
-      "size": 51793,
-      "gzip": 15749
+      "size": 51799,
+      "gzip": 15751
     },
     {
       "filename": "ReactTestRenderer-dev.js",
@@ -326,28 +326,28 @@
       "filename": "react-test-renderer-shallow.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-test-renderer",
-      "size": 24864,
-      "gzip": 6763
+      "size": 24870,
+      "gzip": 6782
     },
     {
       "filename": "react-test-renderer-shallow.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-test-renderer",
-      "size": 7334,
-      "gzip": 2397
+      "size": 7340,
+      "gzip": 2398
     },
     {
       "filename": "react-test-renderer-shallow.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-test-renderer",
-      "size": 19940,
-      "gzip": 5548
+      "size": 19946,
+      "gzip": 5551
     },
     {
       "filename": "react-test-renderer-shallow.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-test-renderer",
-      "size": 8050,
+      "size": 8056,
       "gzip": 2670
     },
     {
@@ -361,57 +361,57 @@
       "filename": "react-noop-renderer.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-noop-renderer",
-      "size": 24160,
-      "gzip": 5471
+      "size": 24166,
+      "gzip": 5472
     },
     {
       "filename": "react-noop-renderer.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-noop-renderer",
-      "size": 9066,
-      "gzip": 3147
+      "size": 9072,
+      "gzip": 3150
     },
     {
       "filename": "react-reconciler.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-reconciler",
-      "size": 375968,
-      "gzip": 81425
+      "size": 375974,
+      "gzip": 81428
     },
     {
       "filename": "react-reconciler.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-reconciler",
-      "size": 50418,
-      "gzip": 15128
+      "size": 50424,
+      "gzip": 15131
     },
     {
       "filename": "react-reconciler-persistent.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-reconciler",
-      "size": 374472,
-      "gzip": 80837
+      "size": 374478,
+      "gzip": 80840
     },
     {
       "filename": "react-reconciler-persistent.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-reconciler",
-      "size": 50429,
-      "gzip": 15134
+      "size": 50435,
+      "gzip": 15137
     },
     {
       "filename": "react-reconciler-reflection.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-reconciler",
-      "size": 15105,
-      "gzip": 4719
+      "size": 15111,
+      "gzip": 4723
     },
     {
       "filename": "react-reconciler-reflection.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-reconciler",
-      "size": 2608,
-      "gzip": 1153
+      "size": 2614,
+      "gzip": 1154
     },
     {
       "filename": "react-call-return.development.js",
@@ -431,29 +431,29 @@
       "filename": "react-is.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-is",
-      "size": 4832,
+      "size": 4838,
       "gzip": 1330
     },
     {
       "filename": "react-is.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-is",
-      "size": 1965,
-      "gzip": 796
+      "size": 1971,
+      "gzip": 800
     },
     {
       "filename": "react-is.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-is",
-      "size": 4643,
-      "gzip": 1272
+      "size": 4649,
+      "gzip": 1273
     },
     {
       "filename": "react-is.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-is",
-      "size": 1914,
-      "gzip": 729
+      "size": 1920,
+      "gzip": 731
     },
     {
       "filename": "ReactIs-dev.js",
@@ -473,190 +473,190 @@
       "filename": "simple-cache-provider.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "simple-cache-provider",
-      "size": 9095,
-      "gzip": 2927
+      "size": 9101,
+      "gzip": 2929
     },
     {
       "filename": "simple-cache-provider.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "simple-cache-provider",
-      "size": 1667,
-      "gzip": 826
+      "size": 1673,
+      "gzip": 829
     },
     {
       "filename": "create-subscription.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "create-subscription",
-      "size": 8182,
-      "gzip": 2833
+      "size": 8188,
+      "gzip": 2836
     },
     {
       "filename": "create-subscription.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "create-subscription",
-      "size": 2880,
-      "gzip": 1346
+      "size": 2886,
+      "gzip": 1347
     },
     {
       "filename": "React-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react",
-      "size": 52534,
-      "gzip": 14540
+      "size": 52540,
+      "gzip": 14542
     },
     {
       "filename": "React-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react",
-      "size": 14239,
-      "gzip": 3975
+      "size": 14245,
+      "gzip": 3977
     },
     {
       "filename": "ReactDOM-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-dom",
-      "size": 679493,
-      "gzip": 155978
+      "size": 679499,
+      "gzip": 155980
     },
     {
       "filename": "ReactDOM-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-dom",
-      "size": 294422,
-      "gzip": 54458
+      "size": 294428,
+      "gzip": 54460
     },
     {
       "filename": "ReactTestUtils-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-dom",
-      "size": 42399,
-      "gzip": 11431
+      "size": 42405,
+      "gzip": 11428
     },
     {
       "filename": "ReactDOMUnstableNativeDependencies-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-dom",
-      "size": 59167,
-      "gzip": 14995
+      "size": 69916,
+      "gzip": 17129
     },
     {
       "filename": "ReactDOMUnstableNativeDependencies-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-dom",
-      "size": 27162,
-      "gzip": 5454
+      "size": 33515,
+      "gzip": 6691
     },
     {
       "filename": "ReactDOMServer-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-dom",
-      "size": 104420,
-      "gzip": 27274
+      "size": 104426,
+      "gzip": 27277
     },
     {
       "filename": "ReactDOMServer-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-dom",
-      "size": 34365,
-      "gzip": 8245
+      "size": 34371,
+      "gzip": 8247
     },
     {
       "filename": "ReactART-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-art",
-      "size": 385286,
-      "gzip": 82096
+      "size": 385292,
+      "gzip": 82097
     },
     {
       "filename": "ReactART-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-art",
-      "size": 164067,
-      "gzip": 27804
+      "size": 164073,
+      "gzip": 27807
     },
     {
       "filename": "ReactNativeRenderer-dev.js",
       "bundleType": "RN_FB_DEV",
       "packageName": "react-native-renderer",
-      "size": 510511,
-      "gzip": 113050
+      "size": 510517,
+      "gzip": 113049
     },
     {
       "filename": "ReactNativeRenderer-prod.js",
       "bundleType": "RN_FB_PROD",
       "packageName": "react-native-renderer",
-      "size": 220289,
-      "gzip": 38377
+      "size": 220295,
+      "gzip": 38378
     },
     {
       "filename": "ReactNativeRenderer-dev.js",
       "bundleType": "RN_OSS_DEV",
       "packageName": "react-native-renderer",
-      "size": 510238,
-      "gzip": 112979
+      "size": 510244,
+      "gzip": 112977
     },
     {
       "filename": "ReactNativeRenderer-prod.js",
       "bundleType": "RN_OSS_PROD",
       "packageName": "react-native-renderer",
-      "size": 209866,
-      "gzip": 36697
+      "size": 209872,
+      "gzip": 36698
     },
     {
       "filename": "ReactFabric-dev.js",
       "bundleType": "RN_FB_DEV",
       "packageName": "react-native-renderer",
-      "size": 500459,
-      "gzip": 110576
+      "size": 500465,
+      "gzip": 110574
     },
     {
       "filename": "ReactFabric-prod.js",
       "bundleType": "RN_FB_PROD",
       "packageName": "react-native-renderer",
-      "size": 202061,
-      "gzip": 35159
+      "size": 202067,
+      "gzip": 35161
     },
     {
       "filename": "ReactFabric-dev.js",
       "bundleType": "RN_OSS_DEV",
       "packageName": "react-native-renderer",
-      "size": 500495,
-      "gzip": 110592
+      "size": 500501,
+      "gzip": 110590
     },
     {
       "filename": "ReactFabric-prod.js",
       "bundleType": "RN_OSS_PROD",
       "packageName": "react-native-renderer",
-      "size": 202097,
+      "size": 202103,
       "gzip": 35175
     },
     {
       "filename": "ReactTestRenderer-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-test-renderer",
-      "size": 393178,
-      "gzip": 83848
+      "size": 393184,
+      "gzip": 83849
     },
     {
       "filename": "ReactShallowRenderer-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-test-renderer",
-      "size": 18219,
+      "size": 18225,
       "gzip": 4802
     },
     {
       "filename": "ReactIs-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-is",
-      "size": 4728,
-      "gzip": 1301
+      "size": 4734,
+      "gzip": 1302
     },
     {
       "filename": "ReactIs-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-is",
-      "size": 3811,
-      "gzip": 1012
+      "size": 3817,
+      "gzip": 1013
     },
     {
       "filename": "schedule.development.js",
@@ -676,155 +676,155 @@
       "filename": "schedule.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "schedule",
-      "size": 15705,
-      "gzip": 4716
+      "size": 15711,
+      "gzip": 4717
     },
     {
       "filename": "schedule.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "schedule",
-      "size": 2838,
-      "gzip": 1241
+      "size": 2844,
+      "gzip": 1244
     },
     {
       "filename": "SimpleCacheProvider-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "simple-cache-provider",
-      "size": 8106,
-      "gzip": 2455
+      "size": 8112,
+      "gzip": 2454
     },
     {
       "filename": "SimpleCacheProvider-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "simple-cache-provider",
-      "size": 3734,
-      "gzip": 1137
+      "size": 3740,
+      "gzip": 1139
     },
     {
       "filename": "react-noop-renderer-persistent.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-noop-renderer",
-      "size": 24279,
-      "gzip": 5484
+      "size": 24285,
+      "gzip": 5486
     },
     {
       "filename": "react-noop-renderer-persistent.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-noop-renderer",
-      "size": 9088,
-      "gzip": 3156
+      "size": 9094,
+      "gzip": 3158
     },
     {
       "filename": "react-dom.profiling.min.js",
       "bundleType": "NODE_PROFILING",
       "packageName": "react-dom",
-      "size": 97467,
-      "gzip": 31083
+      "size": 97473,
+      "gzip": 31084
     },
     {
       "filename": "ReactNativeRenderer-profiling.js",
       "bundleType": "RN_OSS_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 217335,
+      "size": 217341,
       "gzip": 38083
     },
     {
       "filename": "ReactFabric-profiling.js",
       "bundleType": "RN_OSS_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 208782,
-      "gzip": 36550
+      "size": 208788,
+      "gzip": 36549
     },
     {
       "filename": "Schedule-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "schedule",
-      "size": 15944,
-      "gzip": 4767
+      "size": 15950,
+      "gzip": 4768
     },
     {
       "filename": "Schedule-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "schedule",
-      "size": 7903,
-      "gzip": 1950
+      "size": 7909,
+      "gzip": 1952
     },
     {
       "filename": "react.profiling.min.js",
       "bundleType": "NODE_PROFILING",
       "packageName": "react",
-      "size": 6117,
+      "size": 6123,
       "gzip": 2621
     },
     {
       "filename": "React-profiling.js",
       "bundleType": "FB_WWW_PROFILING",
       "packageName": "react",
-      "size": 14239,
-      "gzip": 3975
+      "size": 14245,
+      "gzip": 3977
     },
     {
       "filename": "ReactDOM-profiling.js",
       "bundleType": "FB_WWW_PROFILING",
       "packageName": "react-dom",
-      "size": 301137,
-      "gzip": 55838
+      "size": 301143,
+      "gzip": 55840
     },
     {
       "filename": "ReactNativeRenderer-profiling.js",
       "bundleType": "RN_FB_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 226018,
-      "gzip": 39609
+      "size": 226024,
+      "gzip": 39610
     },
     {
       "filename": "ReactFabric-profiling.js",
       "bundleType": "RN_FB_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 208741,
-      "gzip": 36531
+      "size": 208747,
+      "gzip": 36532
     },
     {
       "filename": "schedule-tracking.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "schedule",
-      "size": 10887,
-      "gzip": 2573
+      "size": 10893,
+      "gzip": 2574
     },
     {
       "filename": "schedule-tracking.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "schedule",
-      "size": 713,
-      "gzip": 375
+      "size": 719,
+      "gzip": 374
     },
     {
       "filename": "schedule-tracking.profiling.min.js",
       "bundleType": "NODE_PROFILING",
       "packageName": "schedule",
-      "size": 3331,
+      "size": 3337,
       "gzip": 991
     },
     {
       "filename": "ScheduleTracking-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "schedule",
-      "size": 10528,
-      "gzip": 2304
+      "size": 10534,
+      "gzip": 2307
     },
     {
       "filename": "ScheduleTracking-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "schedule",
-      "size": 893,
+      "size": 899,
       "gzip": 425
     },
     {
       "filename": "ScheduleTracking-profiling.js",
       "bundleType": "FB_WWW_PROFILING",
       "packageName": "schedule",
-      "size": 6978,
-      "gzip": 1256
+      "size": 6984,
+      "gzip": 1258
     }
   ]
 }


### PR DESCRIPTION
Resolves https://github.com/facebook/react/issues/13589

`injectComponentTree` was exposed for react-native-web, but [wasn't actually being used by the project](https://github.com/necolas/react-native-web/search?q=injectComponentTree&unscoped_q=injectComponentTree). There don't appear to be [any call sites for `injectComponentTree` in www either](https://fburl.com/biggrep/a7rpw73t) (FB Internal).

RNW *is* using `EventPluginHub` through ReactDOM's secret internals, but that was removed in https://github.com/facebook/react/pull/13539

This removes the unused `injectComponentTree` export, refactors the `ResponderEventPlugin` test so it doesn't depend on it, and also adds `EventPluginHub` to the exports to unbreak RNW with 16.5

cc @necolas 
