### PR TITLE
Hydration warnings with DOM diff in react-reconciler (#10085)

### DIFF
--- a/fixtures/ssr/server/render.js
+++ b/fixtures/ssr/server/render.js
@@ -14,8 +14,8 @@ if (process.env.NODE_ENV === 'development') {
   assets = require('../build/asset-manifest.json');
 }
 
-export default function render() {
-  var html = renderToString(<App assets={assets} />);
+export default function render(url) {
+  var html = renderToString(<App assets={assets} url={url} />);
   // There's no way to render a doctype in React so prepend manually.
   // Also append a bootstrap script tag.
   return '<!DOCTYPE html>' + html;

--- a/fixtures/ssr/src/components/App.js
+++ b/fixtures/ssr/src/components/App.js
@@ -4,13 +4,14 @@ import Chrome from './Chrome';
 import Page from './Page';
 import Page2 from './Page2';
 import Theme from './Theme';
+import SSRMismatchTest from './SSRMismatchTest';
 
 function LoadingIndicator() {
   let theme = useContext(Theme);
   return <div className={theme + '-loading'}>Loading...</div>;
 }
 
-export default function App({assets}) {
+export default function App({assets, url}) {
   let [CurrentPage, switchPage] = useState(() => Page);
   return (
     <Chrome title="Hello World" assets={assets}>
@@ -26,6 +27,9 @@ export default function App({assets}) {
         <Suspense fallback={<LoadingIndicator />}>
           <CurrentPage />
         </Suspense>
+      </div>
+      <div>
+        <SSRMismatchTest url={url} />
       </div>
     </Chrome>
   );

--- a/fixtures/ssr/src/components/SSRMismatchTest.js
+++ b/fixtures/ssr/src/components/SSRMismatchTest.js
@@ -1,0 +1,450 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+// Helps to test hydration edge cases with the root node.
+// Sets the passed-in `serverHTML` as `innerHTML` and hydrates the passed-in `browserReact` over it.
+function SSRMismatchTestRootHydrate({serverHTML, browserReact}) {
+  return (
+    <div
+      data-ssr-mismatch-test-hydrate-root
+      ref={el => {
+        if (el) {
+          el.innerHTML = serverHTML;
+          ReactDOM.hydrate(browserReact, el);
+        }
+      }}
+    />
+  );
+}
+
+const testCases = [
+  {
+    key: 'ssr-warnForTextDifference',
+    renderServer: () => (
+      <div>
+        <em>SSRMismatchTest server text</em>
+      </div>
+    ),
+    renderBrowser: () => (
+      // The inner element type is the same as the server render, but the inner text differs.
+      <div>
+        <em>SSRMismatchTest client text</em>
+      </div>
+    ),
+  },
+  {
+    key: 'ssr-warnForTextDifference-didNotMatchHydratedContainerTextInstance',
+    render: () => (
+      <SSRMismatchTestRootHydrate
+        serverHTML={'SSRMismatchTest server text'}
+        browserReact={'SSRMismatchTest client text'}
+      />
+    ),
+  },
+  {
+    key: 'ssr-warnForTextDifference-didNotMatchHydratedTextInstance',
+    renderServer: () => (
+      <div>
+        <em>
+          {'SSRMismatchTest static text and '}
+          {'server random text ' + Math.random()}
+        </em>
+      </div>
+    ),
+    renderBrowser: () => (
+      <div>
+        <em>
+          {'SSRMismatchTest static text and '}
+          {'client random text ' + Math.random()}
+        </em>
+      </div>
+    ),
+  },
+  {
+    key: 'ssr-warnForPropDifference',
+    renderServer: () => (
+      <div>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+    renderBrowser: () => (
+      // The inner element type is the same as the server render.
+      // The browser root element has an extra prop with a non-`null` value.
+      <div data-ssr-extra-prop={true} data-ssr-extra-prop-2={true}>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+  },
+  {
+    key: 'ssr-warnForPropDifference-null-no-warning',
+    renderServer: () => (
+      <div>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+    renderBrowser: () => (
+      // The inner element type is the same as the server render.
+      // The browser root element has an extra prop explicitly set to `null`.
+      <div data-ssr-extra-prop={null} data-ssr-extra-prop-2={null}>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+  },
+  {
+    key: 'ssr-warnForExtraAttributes',
+    renderServer: () => (
+      <div data-ssr-extra-prop={true} data-ssr-extra-prop-2={true}>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+    renderBrowser: () => (
+      // The inner element type is the same as the server render.
+      // The root element is missing a server-rendered prop.
+      <div>
+        <em>SSRMismatchTest default text</em>
+      </div>
+    ),
+  },
+  {
+    key: 'ssr-warnForInvalidEventListener-false',
+    renderServer: () => <div onClick={() => {}} />,
+    renderBrowser: () => <div onClick={false} />,
+  },
+  {
+    key: 'ssr-warnForInvalidEventListener-typeof',
+    renderServer: () => <div onClick={() => {}} />,
+    renderBrowser: () => <div onClick={'a string'} />,
+  },
+  {
+    key:
+      'ssr-warnForDeletedHydratableInstance-didNotHydrateContainerInstance-element',
+    render: () => (
+      <SSRMismatchTestRootHydrate
+        serverHTML={
+          'SSRMismatchTest first text' +
+          '<br />' +
+          '<br />' +
+          'SSRMismatchTest second text'
+        }
+        browserReact={[
+          'SSRMismatchTest first text',
+          <br key={1} />,
+          'SSRMismatchTest second text',
+        ]}
+      />
+    ),
+  },
+  {
+    key: 'ssr-warnForDeletedHydratableInstance-didNotHydrateInstance-element',
+    renderServer: () => (
+      <div>
+        <div>SSRMismatchTest default text</div>
+        <span />
+      </div>
+    ),
+    renderBrowser: () => (
+      <div>
+        <span />
+      </div>
+    ),
+  },
+  {
+    key:
+      'ssr-warnForDeletedHydratableInstance-didNotHydrateContainerInstance-text',
+    render: () => (
+      <SSRMismatchTestRootHydrate
+        serverHTML={
+          'SSRMismatchTest server text' +
+          '<br />' +
+          'SSRMismatchTest default text'
+        }
+        browserReact={[<br key={1} />, 'SSRMismatchTest default text']}
+      />
+    ),
+  },
+  {
+    key: 'ssr-warnForDeletedHydratableInstance-didNotHydrateInstance-text',
+    renderServer: () => (
+      <div>
+        SSRMismatchTest server text
+        <span />
+      </div>
+    ),
+    renderBrowser: () => (
+      <div>
+        <span />
+      </div>
+    ),
+  },
+  {
+    key:
+      'ssr-warnForInsertedHydratedInstance-didNotFindHydratableContainerInstance',
+    render: () => (
+      // The root element type is different (text on server, span on client), the inner text is the same.
+      <SSRMismatchTestRootHydrate
+        serverHTML={'SSRMismatchTest default text'}
+        browserReact={<span>SSRMismatchTest default text</span>}
+      />
+    ),
+  },
+  {
+    key: 'ssr-warnForInsertedHydratedInstance-didNotFindHydratableInstance',
+    renderServer: () => (
+      <div className="SSRMismatchTest__wrapper">
+        <span className="SSRMismatchTest__1">1</span>
+        <span className="SSRMismatchTest__2">2</span>
+        <span className="SSRMismatchTest__3">3</span>
+        <span className="SSRMismatchTest__4">4</span>
+        <span className="SSRMismatchTest__5">5</span>
+        <span className="SSRMismatchTest__6">6</span>
+        <strong> SSRMismatchTest default text </strong>
+        <span className="SSRMismatchTest__7">7</span>
+        <span className="SSRMismatchTest__8">8</span>
+        <span className="SSRMismatchTest__9">9</span>
+        <span className="SSRMismatchTest__10">10</span>
+        <span className="SSRMismatchTest__11">11</span>
+        <span className="SSRMismatchTest__12">12</span>
+      </div>
+    ),
+    renderBrowser: () => (
+      // The inner element type is different from the server render, but the inner text is the same.
+      <div className="SSRMismatchTest__wrapper">
+        <span className="SSRMismatchTest__1">1</span>
+        <span className="SSRMismatchTest__2">2</span>
+        <span className="SSRMismatchTest__3">3</span>
+        <span className="SSRMismatchTest__4">4</span>
+        <span className="SSRMismatchTest__5">5</span>
+        <span className="SSRMismatchTest__6">6</span>
+        <em> SSRMismatchTest default text </em>
+        <span className="SSRMismatchTest__7">7</span>
+        <span className="SSRMismatchTest__8">8</span>
+        <span className="SSRMismatchTest__9">9</span>
+        <span className="SSRMismatchTest__10">10</span>
+        <span className="SSRMismatchTest__11">11</span>
+        <span className="SSRMismatchTest__12">12</span>
+      </div>
+    ),
+  },
+  {
+    key:
+      'ssr-warnForInsertedHydratedTextInstance-didNotFindHydratableContainerTextInstance',
+    render: () => (
+      // The root element type is different (span on server, text on client), the inner text is the same.
+      <SSRMismatchTestRootHydrate
+        serverHTML={'<span>SSRMismatchTest default text</span>'}
+        browserReact={'SSRMismatchTest default text'}
+      />
+    ),
+  },
+  {
+    key:
+      'ssr-warnForInsertedHydratedTextInstance-didNotFindHydratableTextInstance-replacement',
+    renderServer: () => (
+      <div>
+        nested{' '}
+        <p>
+          children <b>text</b>
+        </p>
+      </div>
+    ),
+    renderBrowser: () => (
+      <div>
+        nested{' '}
+        <div>
+          children <b>text</b>
+        </div>
+      </div>
+    ),
+  },
+  {
+    key:
+      'ssr-warnForInsertedHydratedTextInstance-didNotFindHydratableTextInstance-insertion',
+    renderServer: () => (
+      <div>
+        nested{' '}
+        <p>
+          children <b>text</b>
+        </p>
+      </div>
+    ),
+    renderBrowser: () => (
+      <div>
+        nested{' '}
+        <p>
+          children <b>text</b>
+        </p>
+        <div>
+          children <b>text</b>
+        </div>
+      </div>
+    ),
+  },
+  {
+    key:
+      'ssr-hydrationWarningHostInstanceIndex-didNotFindHydratableInstance-replacement',
+    render: isServer => {
+      class TestPaddingBeforeInnerComponent extends React.Component {
+        render() {
+          return (
+            <React.Fragment>
+              <div data-ssr-mismatch-padding-before="2" />
+              <div data-ssr-mismatch-padding-before="3" />
+            </React.Fragment>
+          );
+        }
+      }
+      class TestPaddingBeforeComponent extends React.Component {
+        render() {
+          return (
+            <React.Fragment>
+              <div data-ssr-mismatch-padding-before="1" />
+              <TestPaddingBeforeInnerComponent />
+              <div data-ssr-mismatch-padding-before="4" />
+              <div data-ssr-mismatch-padding-before="5" />
+            </React.Fragment>
+          );
+        }
+      }
+      class TestPaddingAfterComponent extends React.Component {
+        render() {
+          return (
+            <React.Fragment>
+              <div data-ssr-mismatch-padding-after="1" />
+              <div data-ssr-mismatch-padding-after="2" />
+              <div data-ssr-mismatch-padding-after="3" />
+              <div data-ssr-mismatch-padding-after="4" />
+              <div data-ssr-mismatch-padding-after="5" />
+            </React.Fragment>
+          );
+        }
+      }
+      class TestNestedComponent extends React.Component {
+        render() {
+          if (this.props.isServer) {
+            return (
+              <div>
+                <TestPaddingBeforeComponent />
+                <h1>SSRMismatchTest default text</h1>
+                <span />
+                <TestPaddingAfterComponent />
+              </div>
+            );
+          }
+          return (
+            <div>
+              <TestPaddingBeforeComponent />
+              <h2>SSRMismatchTest default text</h2>
+              <span />
+              <TestPaddingAfterComponent />
+            </div>
+          );
+        }
+      }
+      class TestComponent extends React.Component {
+        render() {
+          return <TestNestedComponent isServer={this.props.isServer} />;
+        }
+      }
+
+      return <TestComponent isServer={isServer} />;
+    },
+  },
+
+  {
+    key:
+      'ssr-hydrationWarningHostInstanceIndex-didNotFindHydratableInstance-insertion',
+    render(isServer) {
+      class TestPaddingBeforeInnerInnerComponent extends React.Component {
+        render() {
+          return <div data-ssr-mismatch-padding-before="6" />;
+        }
+      }
+      class TestPaddingBeforeInnerComponent extends React.Component {
+        render() {
+          return (
+            <React.Fragment>
+              <div data-ssr-mismatch-padding-before="4" />
+              <div data-ssr-mismatch-padding-before="5" />
+              <TestPaddingBeforeInnerInnerComponent />
+            </React.Fragment>
+          );
+        }
+      }
+      class TestPaddingBeforeComponent extends React.Component {
+        render() {
+          return (
+            <React.Fragment>
+              <div data-ssr-mismatch-padding-before="2" />
+              <div data-ssr-mismatch-padding-before="3" />
+              <TestPaddingBeforeInnerComponent />
+              <div data-ssr-mismatch-padding-before="7" />
+              <div data-ssr-mismatch-padding-before="8" />
+              <div data-ssr-mismatch-padding-before="9" />
+            </React.Fragment>
+          );
+        }
+      }
+
+      return isServer ? (
+        <div>
+          <div data-ssr-mismatch-padding-before="1" />
+          <TestPaddingBeforeComponent />
+          <div data-ssr-mismatch-padding-before="10" />
+          <div data-ssr-mismatch-padding-before="11" />
+          <div data-ssr-mismatch-padding-before="12" />
+        </div>
+      ) : (
+        <div>
+          <div data-ssr-mismatch-padding-before="1" />
+          <TestPaddingBeforeComponent />
+          <div data-ssr-mismatch-padding-before="10" />
+          <div data-ssr-mismatch-padding-before="11" />
+          <div data-ssr-mismatch-padding-before="12" />
+          SSRMismatchTest client text
+        </div>
+      );
+    },
+  },
+];
+
+// Triggers the DOM mismatch warnings if requested via query string.
+export default function SSRMismatchTest({url}) {
+  let content = null;
+  const queryParams = url.replace(/^[^?]+[?]?/, '').split('&');
+  const testCaseFound = testCases.find(
+    testCase => queryParams.indexOf(testCase.key) >= 0
+  );
+  if (testCaseFound) {
+    // In the browser where `window` is available, triggering a DOM mismatch if it's requested.
+    const isServer = typeof window === 'undefined';
+    let render;
+    if (isServer) {
+      render = testCaseFound.renderServer || testCaseFound.render;
+    } else {
+      render = testCaseFound.renderBrowser || testCaseFound.render;
+    }
+    content = render(isServer);
+  }
+
+  return (
+    <div>
+      <div style={{fontSize: '12px'}}>
+        <div>SSRMismatchTest. Open the console, select a test case:</div>
+        <ol>
+          <li style={{paddingBottom: '10px'}}>
+            <a href="/">none</a>
+          </li>
+          {testCases.map(testCase => (
+            <li key={testCase.key} style={{paddingBottom: '10px'}}>
+              <a href={'/?' + testCase.key}>{testCase.key}</a>
+              {testCaseFound && testCaseFound.key === testCase.key
+                ? ' 👈'
+                : ' '}
+            </li>
+          ))}
+        </ol>
+      </div>
+      <div className="SSRMismatchTest__placeholder">{content}</div>
+    </div>
+  );
+}

--- a/fixtures/ssr/src/index.js
+++ b/fixtures/ssr/src/index.js
@@ -3,5 +3,8 @@ import {unstable_createRoot} from 'react-dom';
 
 import App from './components/App';
 
+// No host:port and #hash (fragment identifier) components in the `url` to match the server-side value.
+const url = window.location.pathname + window.location.search;
+
 let root = unstable_createRoot(document, {hydrate: true});
-root.render(<App assets={window.assetManifest} />);
+root.render(<App assets={window.assetManifest} url={url} />);

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -105,9 +105,9 @@ describe('ReactDOMRoot', () => {
         <span />
       </div>,
     );
-    expect(() => Scheduler.flushAll()).toWarnDev('Extra attributes', {
-      withoutStack: true,
-    });
+    expect(() => Scheduler.flushAll()).toWarnDev(
+      'Warning: Extra attributes from the server: class',
+    );
   });
 
   it('does not clear existing children', async () => {

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -123,20 +123,29 @@ describe('ReactMount', () => {
 
   it('should warn if mounting into left padded rendered markup', () => {
     const container = document.createElement('container');
-    container.innerHTML = ReactDOMServer.renderToString(<div />) + ' ';
+    container.innerHTML = ' ' + ReactDOMServer.renderToString(<div />);
 
     expect(() => ReactDOM.hydrate(<div />, container)).toWarnDev(
-      'Did not expect server HTML to contain the text node " " in <container>.',
-      {withoutStack: true},
+      "Warning: Did not expect server HTML to contain the text node {' '} in <container>.\n\n" +
+        '  <container>\n' +
+        "-   {' '}\n" +
+        '    <div data-reactroot=""></div>\n' +
+        '  </container>\n\n' +
+        '    in div (at **)',
     );
   });
 
   it('should warn if mounting into right padded rendered markup', () => {
     const container = document.createElement('container');
-    container.innerHTML = ' ' + ReactDOMServer.renderToString(<div />);
+    container.innerHTML = ReactDOMServer.renderToString(<div />) + ' ';
 
     expect(() => ReactDOM.hydrate(<div />, container)).toWarnDev(
-      'Did not expect server HTML to contain the text node " " in <container>.',
+      "Warning: Did not expect server HTML to contain the text node {' '} in <container>.\n\n" +
+        '  <container>\n' +
+        '    <div data-reactroot=""></div>\n' +
+        "-   {' '}\n" +
+        '  </container>\n',
+      // Without the component stack here because it's empty: found an unexpected text node directly in the root node.
       {withoutStack: true},
     );
   });
@@ -160,6 +169,306 @@ describe('ReactMount', () => {
     );
   });
 
+  it('should warn when a hydrated element has inner text mismatch', () => {
+    // See fixtures/ssr: ssr-warnForTextDifference
+
+    class Component extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <Component>
+        <div>server text</div>
+      </Component>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <Component>
+          <div>client text</div>
+        </Component>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Text content did not match. ' +
+        'Server: "server text" ' +
+        'Client: "client text"\n' +
+        '    in div (at **)\n' +
+        '    in Component (at **)',
+    );
+  });
+
+  it('should warn when hydrating a text node over a mismatching text node', () => {
+    // See fixtures/ssr: ssr-warnForTextDifference-warnForUnmatchedText-didNotMatchHydratedContainerTextInstance
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString('server text');
+    div.innerHTML = markup;
+
+    expect(() => ReactDOM.hydrate('client text', div)).toWarnDev(
+      'Warning: Text content did not match. ' +
+        'Server: "server text" ' +
+        'Client: "client text"',
+      // Without the component stack here because it's empty: rendering a text node directly into the root node.
+      {withoutStack: true},
+    );
+  });
+
+  it('should warn when a hydrated element has first text match but second text mismatch', () => {
+    // See fixtures/ssr: ssr-warnForTextDifference-warnForUnmatchedText-didNotMatchHydratedTextInstance
+
+    class Component extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    const serverRandom = Math.random();
+    const clientRandom = Math.random();
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <Component>
+        <em>
+          {'SSRMismatchTest static text and '}
+          {'server random text ' + serverRandom}
+        </em>
+      </Component>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <Component>
+          <em>
+            {'SSRMismatchTest static text and '}
+            {'client random text ' + clientRandom}
+          </em>
+        </Component>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Text content did not match. ' +
+        'Server: "server random text ' +
+        serverRandom +
+        '" ' +
+        'Client: "client random text ' +
+        clientRandom +
+        '"\n' +
+        '    in em (at **)\n' +
+        '    in Component (at **)',
+    );
+  });
+
+  it('should warn when a hydrated element has children mismatch (replacement diff)', () => {
+    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance-replacement
+
+    class Component extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <Component>
+        nested{'   '}
+        <h1>
+          children <b>text</b>
+        </h1>
+        <div data-ssr-mismatch-padding-after="1" />
+        <div data-ssr-mismatch-padding-after="2" />
+        <div data-ssr-mismatch-padding-after="3" />
+        <div data-ssr-mismatch-padding-after="4" />
+        <div data-ssr-mismatch-padding-after="5" />
+      </Component>,
+    );
+    div.innerHTML = markup;
+
+    expect(div.outerHTML).toEqual(
+      '<div>nested<!-- -->   <h1>children <b>text</b></h1>' +
+        '<div data-ssr-mismatch-padding-after="1"></div>' +
+        '<div data-ssr-mismatch-padding-after="2"></div>' +
+        '<div data-ssr-mismatch-padding-after="3"></div>' +
+        '<div data-ssr-mismatch-padding-after="4"></div>' +
+        '<div data-ssr-mismatch-padding-after="5"></div>' +
+        '</div>',
+    );
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <Component>
+          nested{'   '}
+          <h2>
+            children <b>text</b>
+          </h2>
+        </Component>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <h2> in <div>.\n\n' +
+        '  <div>\n' +
+        "    {'nested'}\n" +
+        '    <!-- -->\n' +
+        "    {'   '}\n" +
+        '-   <h1>children <b>text</b></h1>\n' +
+        "+   <h2>{['children ', ...]}</h2>\n" +
+        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
+        '  </div>\n\n' +
+        '    in h2 (at **)\n' +
+        '    in Component (at **)',
+    );
+  });
+
+  it('should warn when a hydrated element has extra child element (insertion diff)', () => {
+    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableInstance-insertion
+
+    class Component extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <Component>
+        nested{'   '}
+        <h1>
+          children <b>text</b>
+        </h1>
+        <div data-ssr-mismatch-padding="1" />
+        <div data-ssr-mismatch-padding="2" />
+        <div data-ssr-mismatch-padding="3" />
+        <div data-ssr-mismatch-padding="4" />
+        <div data-ssr-mismatch-padding="5" />
+      </Component>,
+    );
+    div.innerHTML = markup;
+
+    expect(div.outerHTML).toEqual(
+      '<div>nested<!-- -->   <h1>children <b>text</b></h1>' +
+        '<div data-ssr-mismatch-padding="1"></div>' +
+        '<div data-ssr-mismatch-padding="2"></div>' +
+        '<div data-ssr-mismatch-padding="3"></div>' +
+        '<div data-ssr-mismatch-padding="4"></div>' +
+        '<div data-ssr-mismatch-padding="5"></div>' +
+        '</div>',
+    );
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <Component>
+          nested{'   '}
+          <h1>
+            children <b>text</b>
+          </h1>
+          <div data-ssr-mismatch-padding="1" />
+          <div data-ssr-mismatch-padding="2" />
+          <div data-ssr-mismatch-padding="3" />
+          <div data-ssr-mismatch-padding="4" />
+          <div data-ssr-mismatch-padding="5" />
+          <h2>
+            extra <b>element</b>
+          </h2>
+        </Component>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <h2> in <div>.\n\n' +
+        '  <div>\n' +
+        "    {'nested'}\n" +
+        '    <!-- -->\n' +
+        "    {'   '}\n" +
+        '    <h1>children <b>text</b></h1>\n' +
+        '    <div data-ssr-mismatch-padding="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding="5"></div>\n' +
+        "+   <h2>{['extra ', ...]}</h2>\n" +
+        '  </div>\n\n' +
+        '    in h2 (at **)\n' +
+        '    in Component (at **)',
+    );
+  });
+
+  it('should warn when a hydrated element has extra child text node (insertion diff)', () => {
+    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance-insertion
+
+    class Component extends React.Component {
+      render() {
+        return this.props.children;
+      }
+    }
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <Component>
+        nested{'   '}
+        <h1>
+          children <b>text</b>
+        </h1>
+        <div data-ssr-mismatch-padding="1" />
+        <div data-ssr-mismatch-padding="2" />
+        <div data-ssr-mismatch-padding="3" />
+        <div data-ssr-mismatch-padding="4" />
+        <div data-ssr-mismatch-padding="5" />
+      </Component>,
+    );
+    div.innerHTML = markup;
+
+    expect(div.outerHTML).toEqual(
+      '<div>nested<!-- -->   <h1>children <b>text</b></h1>' +
+        '<div data-ssr-mismatch-padding="1"></div>' +
+        '<div data-ssr-mismatch-padding="2"></div>' +
+        '<div data-ssr-mismatch-padding="3"></div>' +
+        '<div data-ssr-mismatch-padding="4"></div>' +
+        '<div data-ssr-mismatch-padding="5"></div>' +
+        '</div>',
+    );
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <Component>
+          nested{'   '}
+          <h1>
+            children <b>text</b>
+          </h1>
+          <div data-ssr-mismatch-padding="1" />
+          <div data-ssr-mismatch-padding="2" />
+          <div data-ssr-mismatch-padding="3" />
+          <div data-ssr-mismatch-padding="4" />
+          <div data-ssr-mismatch-padding="5" />
+          {'extra text node'}
+        </Component>,
+        div,
+      ),
+    ).toWarnDev(
+      "Warning: Expected server HTML to contain a matching text node for {'extra text node'} in <div>.\n\n" +
+        '  <div>\n' +
+        "    {'nested'}\n" +
+        '    <!-- -->\n' +
+        "    {'   '}\n" +
+        '    <h1>children <b>text</b></h1>\n' +
+        '    <div data-ssr-mismatch-padding="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding="5"></div>\n' +
+        "+   {'extra text node'}\n" +
+        '  </div>\n\n' +
+        '    in Component (at **)',
+    );
+  });
+
   it('should account for escaping on a checksum mismatch', () => {
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString(
@@ -173,9 +482,629 @@ describe('ReactMount', () => {
         div,
       ),
     ).toWarnDev(
-      'Server: "This markup contains an nbsp entity:   server text" ' +
-        'Client: "This markup contains an nbsp entity:   client text"',
+      'Warning: Text content did not match. ' +
+        'Server: "This markup contains an nbsp entity:   server text" ' +
+        'Client: "This markup contains an nbsp entity:   client text"\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when a hydrated element has extra props with non-null values', () => {
+    // See fixtures/ssr: ssr-warnForPropDifference
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <div>
+        <em>SSRMismatchTest default text</em>
+      </div>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div data-ssr-extra-prop={true} data-ssr-extra-prop-2={true}>
+          <em>SSRMismatchTest default text</em>
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Prop `data-ssr-extra-prop` did not match. ' +
+        'Server: "null" ' +
+        'Client: "true"\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should not warn when a hydrated element has extra props explicitly set to null', () => {
+    // See fixtures/ssr: ssr-warnForPropDifference-null-no-warning
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <div>
+        <em>SSRMismatchTest default text</em>
+      </div>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div data-ssr-extra-prop={null} data-ssr-extra-prop-2={null}>
+          <em>SSRMismatchTest default text</em>
+        </div>,
+        div,
+      ),
+    ).toWarnDev([]);
+  });
+
+  it('should warn when a server element has extra props', () => {
+    // See fixtures/ssr: ssr-warnForExtraAttributes
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <div data-ssr-extra-prop={true} data-ssr-extra-prop-2={true}>
+        <em>SSRMismatchTest default text</em>
+      </div>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div>
+          <em>SSRMismatchTest default text</em>
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Extra attributes from the server: data-ssr-extra-prop,data-ssr-extra-prop-2\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when a browser element has an event handler which is set to false', () => {
+    // See fixtures/ssr: ssr-warnForInvalidEventListener-false
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(<div onClick={() => {}} />);
+    div.innerHTML = markup;
+
+    expect(() => ReactDOM.hydrate(<div onClick={false} />, div)).toWarnDev(
+      'Warning: Expected `onClick` listener to be a function, instead got `false`.\n\n' +
+        'If you used to conditionally omit it with onClick={condition && value}, ' +
+        'pass onClick={condition ? value : undefined} instead.\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when a browser element has an event handler which is set to a non-function, non-false value', () => {
+    // See fixtures/ssr: ssr-warnForInvalidEventListener-typeof
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(<div onClick={() => {}} />);
+    div.innerHTML = markup;
+
+    expect(() => ReactDOM.hydrate(<div onClick={'a string'} />, div)).toWarnDev(
+      'Warning: Expected `onClick` listener to be a function, instead got a value of `string` type.\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when hydrate removes an element within a root container (removal diff)', () => {
+    // See fixtures/ssr: ssr-warnForDeletedHydratableElement-didNotHydrateContainerInstance
+
+    const div = document.createElement('div');
+    div.setAttribute('data-ssr-mismatch-test-hydrate-root', '');
+    const markup =
+      'SSRMismatchTest first text' +
+      '<br />' +
+      '<br />' +
+      'SSRMismatchTest second text';
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        [
+          'SSRMismatchTest first text',
+          <br key={1} />,
+          'SSRMismatchTest second text',
+        ],
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Did not expect server HTML to contain a <br> in <div>.\n\n' +
+        '  <div data-ssr-mismatch-test-hydrate-root="">\n' +
+        "    {'SSRMismatchTest first text'}\n" +
+        '    <br />\n' +
+        '-   <br />\n' +
+        "    {'SSRMismatchTest second text'}\n" +
+        '  </div>\n',
+      // Without the component stack here because it's empty: rendering a text node directly into the root node.
       {withoutStack: true},
+    );
+  });
+
+  it('should warn when hydrate removes an element within an element (removal diff)', () => {
+    // See fixtures/ssr: ssr-warnForDeletedHydratableElement-didNotHydrateInstance
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <div>
+        <div>SSRMismatchTest default text</div>
+        <span />
+        <div data-ssr-mismatch-padding-after="1" />
+        <div data-ssr-mismatch-padding-after="2" />
+        <div data-ssr-mismatch-padding-after="3" />
+        <div data-ssr-mismatch-padding-after="4" />
+        <div data-ssr-mismatch-padding-after="5" />
+      </div>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div>
+          <span />
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Did not expect server HTML to contain a <div> in <div>.\n\n' +
+        '  <div data-reactroot="">\n' +
+        '-   <div>SSRMismatchTest default text</div>\n' +
+        '    <span></span>\n' +
+        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
+        '  </div>\n\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when hydrate replaces an element within server-rendered nested components (replacement diff)', () => {
+    // See fixtures/ssr: ssr-hydrationWarningHostInstanceIndex-didNotFindHydratableInstance-replacement
+
+    class TestPaddingBeforeInnerComponent extends React.Component {
+      render() {
+        return (
+          <React.Fragment>
+            <div data-ssr-mismatch-padding-before="2" />
+            <div data-ssr-mismatch-padding-before="3" />
+          </React.Fragment>
+        );
+      }
+    }
+    class TestPaddingBeforeComponent extends React.Component {
+      render() {
+        return (
+          <React.Fragment>
+            <div data-ssr-mismatch-padding-before="1" />
+            <TestPaddingBeforeInnerComponent />
+            <div data-ssr-mismatch-padding-before="4" />
+            <div data-ssr-mismatch-padding-before="5" />
+          </React.Fragment>
+        );
+      }
+    }
+    class TestPaddingAfterComponent extends React.Component {
+      render() {
+        return (
+          <React.Fragment>
+            <div data-ssr-mismatch-padding-after="1" />
+            <div data-ssr-mismatch-padding-after="2" />
+            <div data-ssr-mismatch-padding-after="3" />
+            <div data-ssr-mismatch-padding-after="4" />
+            <div data-ssr-mismatch-padding-after="5" />
+          </React.Fragment>
+        );
+      }
+    }
+    class TestNestedComponent extends React.Component {
+      render() {
+        if (this.props.isServer) {
+          return (
+            <div>
+              <TestPaddingBeforeComponent />
+              <h1>SSRMismatchTest default text</h1>
+              <span />
+              <TestPaddingAfterComponent />
+            </div>
+          );
+        }
+        return (
+          <div>
+            <TestPaddingBeforeComponent />
+            <h2>SSRMismatchTest default text</h2>
+            <span />
+            <TestPaddingAfterComponent />
+          </div>
+        );
+      }
+    }
+    class TestComponent extends React.Component {
+      render() {
+        return <TestNestedComponent isServer={this.props.isServer} />;
+      }
+    }
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <TestComponent isServer={true} />,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(<TestComponent isServer={false} />, div),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <h2> in <div>.\n\n' +
+        '  <div data-reactroot="">\n' +
+        '    <div data-ssr-mismatch-padding-before="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="5"></div>\n' +
+        '-   <h1>SSRMismatchTest default text</h1>\n' +
+        '+   <h2>SSRMismatchTest default text</h2>\n' +
+        '    <span></span>\n' +
+        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
+        '  </div>\n\n' +
+        '    in h2 (at **)\n' +
+        '    in div (at **)\n' +
+        '    in TestNestedComponent (at **)\n' +
+        '    in TestComponent (at **)',
+    );
+  });
+
+  it('should warn when hydrate removes a text node within a root container (removal diff)', () => {
+    // See fixtures/ssr: ssr-warnForDeletedHydratableText-didNotHydrateContainerInstance
+
+    const div = document.createElement('div');
+    div.setAttribute('data-ssr-mismatch-test-hydrate-root', '');
+    const markup =
+      'SSRMismatchTest server text' +
+      '<br />' +
+      'SSRMismatchTest default text' +
+      '<div data-ssr-mismatch-padding-after="1"></div>' +
+      '<div data-ssr-mismatch-padding-after="2"></div>' +
+      '<div data-ssr-mismatch-padding-after="3"></div>' +
+      '<div data-ssr-mismatch-padding-after="4"></div>' +
+      '<div data-ssr-mismatch-padding-after="5"></div>';
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate([<br key={1} />, 'SSRMismatchTest default text'], div),
+    ).toWarnDev(
+      "Warning: Did not expect server HTML to contain the text node {'SSRMismatchTest server text'} in <div>.\n\n" +
+        '  <div data-ssr-mismatch-test-hydrate-root="">\n' +
+        "-   {'SSRMismatchTest server text'}\n" +
+        '    <br />\n' +
+        "    {'SSRMismatchTest default text'}\n" +
+        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
+        '  </div>\n\n' +
+        '    in br (at **)',
+    );
+  });
+
+  it('should warn when hydrate removes a text node within an element (removal diff)', () => {
+    // See fixtures/ssr: ssr-warnForDeletedHydratableText-didNotHydrateInstance
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <div>
+        SSRMismatchTest server text
+        <span />
+        <div data-ssr-mismatch-padding-after="1" />
+        <div data-ssr-mismatch-padding-after="2" />
+        <div data-ssr-mismatch-padding-after="3" />
+        <div data-ssr-mismatch-padding-after="4" />
+        <div data-ssr-mismatch-padding-after="5" />
+      </div>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div>
+          <span />
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      "Warning: Did not expect server HTML to contain the text node {'SSRMismatchTest server text'} in <div>.\n\n" +
+        '  <div data-reactroot="">\n' +
+        "-   {'SSRMismatchTest server text'}\n" +
+        '    <span></span>\n' +
+        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
+        '  </div>\n\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when hydrate replaces a text node by an element within a root container (replacement diff)', () => {
+    // See fixtures/ssr: ssr-warnForInsertedHydratedElement-didNotFindHydratableContainerInstance
+
+    const div = document.createElement('div');
+    const markup = 'SSRMismatchTest default text';
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(<span>SSRMismatchTest default text</span>, div),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
+        '  <div>\n' +
+        "-   {'SSRMismatchTest default text'}\n" +
+        '+   <span>SSRMismatchTest default text</span>\n' +
+        '  </div>\n\n' +
+        '    in span (at **)',
+    );
+  });
+
+  it('should warn when hydrate replaces an element by a text node within a root container (replacement diff)', () => {
+    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableContainerTextInstance
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <span>SSRMismatchTest default text</span>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate('SSRMismatchTest default text', div),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching text node' +
+        " for {'SSRMismatchTest default text'} in <div>.\n\n" +
+        '  <div>\n' +
+        '-   <span data-reactroot="">SSRMismatchTest default text</span>\n' +
+        "+   {'SSRMismatchTest default text'}\n" +
+        '  </div>\n',
+      // Without the component stack here because it's empty: rendering a text node directly into the root node.
+      {withoutStack: true},
+    );
+  });
+
+  it('should warn when hydrate replaces an element by a different element (replacement diff)', () => {
+    // See fixtures/ssr: ssr-warnForInsertedHydratedElement-didNotFindHydratableInstance
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <div>
+        <em>SSRMismatchTest default text</em>
+      </div>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div>
+          <p>SSRMismatchTest default text</p>
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <p> in <div>.\n\n' +
+        '  <div data-reactroot="">\n' +
+        '-   <em>SSRMismatchTest default text</em>\n' +
+        '+   <p>SSRMismatchTest default text</p>\n' +
+        '  </div>\n\n' +
+        '    in p (at **)\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when hydrate inserts a text node after matching elements (insertion diff)', () => {
+    // See fixtures/ssr: ssr-hydrationWarningHostInstanceIndex-didNotFindHydratableInstance-insertion
+
+    class TestPaddingBeforeInnerInnerComponent extends React.Component {
+      render() {
+        return <div data-ssr-mismatch-padding-before="6" />;
+      }
+    }
+    class TestPaddingBeforeInnerComponent extends React.Component {
+      render() {
+        return (
+          <React.Fragment>
+            <div data-ssr-mismatch-padding-before="4" />
+            <div data-ssr-mismatch-padding-before="5" />
+            <TestPaddingBeforeInnerInnerComponent />
+          </React.Fragment>
+        );
+      }
+    }
+    class TestPaddingBeforeComponent extends React.Component {
+      render() {
+        return (
+          <React.Fragment>
+            <div data-ssr-mismatch-padding-before="2" />
+            <div data-ssr-mismatch-padding-before="3" />
+            <TestPaddingBeforeInnerComponent />
+            <div data-ssr-mismatch-padding-before="7" />
+            <div data-ssr-mismatch-padding-before="8" />
+            <div data-ssr-mismatch-padding-before="9" />
+          </React.Fragment>
+        );
+      }
+    }
+
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <div>
+        <div data-ssr-mismatch-padding-before="1" />
+        <TestPaddingBeforeComponent />
+        <div data-ssr-mismatch-padding-before="10" />
+        <div data-ssr-mismatch-padding-before="11" />
+        <div data-ssr-mismatch-padding-before="12" />
+      </div>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div>
+          <div data-ssr-mismatch-padding-before="1" />
+          <TestPaddingBeforeComponent />
+          <div data-ssr-mismatch-padding-before="10" />
+          <div data-ssr-mismatch-padding-before="11" />
+          <div data-ssr-mismatch-padding-before="12" />
+          SSRMismatchTest client text
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching text node' +
+        " for {'SSRMismatchTest client text'} in <div>.\n\n" +
+        '  <div data-reactroot="">\n' +
+        '    <div data-ssr-mismatch-padding-before="1"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="2"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="3"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="4"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="5"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="6"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="7"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="8"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="9"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="10"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="11"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="12"></div>\n' +
+        "+   {'SSRMismatchTest client text'}\n" +
+        '  </div>\n\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when hydrate inserts an element after a comment node (insertion diff)', () => {
+    const div = document.createElement('div');
+    div.innerHTML = '<div><!-- a comment --></div>';
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div>
+          <span />
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
+        '  <div>\n' +
+        '    <!-- a comment -->\n' +
+        '+   <span></span>\n' +
+        '  </div>\n\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when hydrate replaces an element after a comment node (replacement diff)', () => {
+    const div = document.createElement('div');
+    div.innerHTML = '<div><!-- a comment --><div></div></div>';
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div>
+          <span />
+          <div />
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
+        '  <div>\n' +
+        '    <!-- a comment -->\n' +
+        '-   <div></div>\n' +
+        '+   <span></span>\n' +
+        '  </div>\n\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn when hydrate inserts an element after a non-typical node (insertion diff)', () => {
+    // A non-typical node is a node that is not typically seen in the DOM: not an element, text, or comment.
+    // This is an artificial test case to check how we print non-typical nodes if they somehow end up in the DOM.
+    const xml = document.createElement('xml');
+    xml.appendChild(
+      document.createProcessingInstruction(
+        'dom-processing-instruction',
+        'content',
+      ),
+    );
+
+    expect(() => ReactDOM.hydrate(<div />, xml)).toWarnDev(
+      'Warning: Expected server HTML to contain a matching <div> in <xml>.\n\n' +
+        '  <xml>\n' +
+        '    <?dom-processing-instruction content?>\n' +
+        '+   <div></div>\n' +
+        '  </xml>\n\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn with special characters in the JSX string output', () => {
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <div>{'SSRMismatchTest special characters: \'"\t\n'}</div>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div>
+          <span />
+          {'SSRMismatchTest special characters: \'"\t\n'}
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      // TODO: Currently, the special characters in the JSX string output are not escaped, the output looks invalid.
+      'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
+        '  <div data-reactroot="">\n' +
+        "-   {'SSRMismatchTest special characters: '\"\t\n'}\n" +
+        '+   <span></span>\n' +
+        '  </div>\n\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)',
+    );
+  });
+
+  it('should warn with special characters in the HTML tag output', () => {
+    const div = document.createElement('div');
+    const markup = ReactDOMServer.renderToString(
+      <div data-ssr-mismatch-attribute-with-special-characters={'"'}>
+        <div>{'SSRMismatchTest text'}</div>
+      </div>,
+    );
+    div.innerHTML = markup;
+
+    expect(() =>
+      ReactDOM.hydrate(
+        <div data-ssr-mismatch-attribute-with-special-characters={'"'}>
+          <span>&nbsp;&mdash; &lt;div&gt;</span>
+          <div>{'SSRMismatchTest text'}</div>
+        </div>,
+        div,
+      ),
+    ).toWarnDev(
+      // TODO: Currently, the special characters in the HTML string output are not escaped, the output looks invalid.
+      'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
+        '  <div data-ssr-mismatch-attribute-with-special-characters=""" data-reactroot="">\n' +
+        '-   <div>SSRMismatchTest text</div>\n' +
+        '+   <span> — <div></span>\n' +
+        '  </div>\n\n' +
+        '    in span (at **)\n' +
+        '    in div (at **)',
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -129,7 +129,7 @@ describe('ReactMount', () => {
       "Warning: Did not expect server HTML to contain the text node {' '} in <container>.\n\n" +
         '  <container>\n' +
         "-   {' '}\n" +
-        '    <div data-reactroot=""></div>\n' +
+        '    <div data-reactroot="" />\n' +
         '  </container>\n\n' +
         '    in div (at **)',
     );
@@ -142,7 +142,7 @@ describe('ReactMount', () => {
     expect(() => ReactDOM.hydrate(<div />, container)).toWarnDev(
       "Warning: Did not expect server HTML to contain the text node {' '} in <container>.\n\n" +
         '  <container>\n' +
-        '    <div data-reactroot=""></div>\n' +
+        '    <div data-reactroot="" />\n' +
         "-   {' '}\n" +
         '  </container>\n',
       // Without the component stack here because it's empty: found an unexpected text node directly in the root node.
@@ -203,7 +203,7 @@ describe('ReactMount', () => {
   });
 
   it('should warn when hydrating a text node over a mismatching text node', () => {
-    // See fixtures/ssr: ssr-warnForTextDifference-warnForUnmatchedText-didNotMatchHydratedContainerTextInstance
+    // See fixtures/ssr: ssr-warnForTextDifference-didNotMatchHydratedContainerTextInstance
 
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString('server text');
@@ -219,7 +219,7 @@ describe('ReactMount', () => {
   });
 
   it('should warn when a hydrated element has first text match but second text mismatch', () => {
-    // See fixtures/ssr: ssr-warnForTextDifference-warnForUnmatchedText-didNotMatchHydratedTextInstance
+    // See fixtures/ssr: ssr-warnForTextDifference-didNotMatchHydratedTextInstance
 
     class Component extends React.Component {
       render() {
@@ -265,7 +265,7 @@ describe('ReactMount', () => {
   });
 
   it('should warn when a hydrated element has children mismatch (replacement diff)', () => {
-    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance-replacement
+    // See fixtures/ssr: ssr-warnForInsertedHydratedTextInstance-didNotFindHydratableTextInstance-replacement
 
     class Component extends React.Component {
       render() {
@@ -313,15 +313,14 @@ describe('ReactMount', () => {
       'Warning: Expected server HTML to contain a matching <h2> in <div>.\n\n' +
         '  <div>\n' +
         "    {'nested'}\n" +
-        '    <!-- -->\n' +
         "    {'   '}\n" +
         '-   <h1>children <b>text</b></h1>\n' +
-        "+   <h2>{['children ', ...]}</h2>\n" +
-        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
+        '+   <h2>children <b>text</b></h2>\n' +
+        '    <div data-ssr-mismatch-padding-after="1" />\n' +
+        '    <div data-ssr-mismatch-padding-after="2" />\n' +
+        '    <div data-ssr-mismatch-padding-after="3" />\n' +
+        '    <div data-ssr-mismatch-padding-after="4" />\n' +
+        '    <div data-ssr-mismatch-padding-after="5" />\n' +
         '  </div>\n\n' +
         '    in h2 (at **)\n' +
         '    in Component (at **)',
@@ -329,7 +328,7 @@ describe('ReactMount', () => {
   });
 
   it('should warn when a hydrated element has extra child element (insertion diff)', () => {
-    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableInstance-insertion
+    // See fixtures/ssr: ssr-warnForInsertedHydratedTextInstance-didNotFindHydratableInstance-insertion
 
     class Component extends React.Component {
       render() {
@@ -385,15 +384,14 @@ describe('ReactMount', () => {
       'Warning: Expected server HTML to contain a matching <h2> in <div>.\n\n' +
         '  <div>\n' +
         "    {'nested'}\n" +
-        '    <!-- -->\n' +
         "    {'   '}\n" +
         '    <h1>children <b>text</b></h1>\n' +
-        '    <div data-ssr-mismatch-padding="1"></div>\n' +
-        '    <div data-ssr-mismatch-padding="2"></div>\n' +
-        '    <div data-ssr-mismatch-padding="3"></div>\n' +
-        '    <div data-ssr-mismatch-padding="4"></div>\n' +
-        '    <div data-ssr-mismatch-padding="5"></div>\n' +
-        "+   <h2>{['extra ', ...]}</h2>\n" +
+        '    <div data-ssr-mismatch-padding="1" />\n' +
+        '    <div data-ssr-mismatch-padding="2" />\n' +
+        '    <div data-ssr-mismatch-padding="3" />\n' +
+        '    <div data-ssr-mismatch-padding="4" />\n' +
+        '    <div data-ssr-mismatch-padding="5" />\n' +
+        '+   <h2>extra <b>element</b></h2>\n' +
         '  </div>\n\n' +
         '    in h2 (at **)\n' +
         '    in Component (at **)',
@@ -401,7 +399,7 @@ describe('ReactMount', () => {
   });
 
   it('should warn when a hydrated element has extra child text node (insertion diff)', () => {
-    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableTextInstance-insertion
+    // See fixtures/ssr: ssr-warnForInsertedHydratedTextInstance-didNotFindHydratableTextInstance-insertion
 
     class Component extends React.Component {
       render() {
@@ -455,14 +453,13 @@ describe('ReactMount', () => {
       "Warning: Expected server HTML to contain a matching text node for {'extra text node'} in <div>.\n\n" +
         '  <div>\n' +
         "    {'nested'}\n" +
-        '    <!-- -->\n' +
         "    {'   '}\n" +
         '    <h1>children <b>text</b></h1>\n' +
-        '    <div data-ssr-mismatch-padding="1"></div>\n' +
-        '    <div data-ssr-mismatch-padding="2"></div>\n' +
-        '    <div data-ssr-mismatch-padding="3"></div>\n' +
-        '    <div data-ssr-mismatch-padding="4"></div>\n' +
-        '    <div data-ssr-mismatch-padding="5"></div>\n' +
+        '    <div data-ssr-mismatch-padding="1" />\n' +
+        '    <div data-ssr-mismatch-padding="2" />\n' +
+        '    <div data-ssr-mismatch-padding="3" />\n' +
+        '    <div data-ssr-mismatch-padding="4" />\n' +
+        '    <div data-ssr-mismatch-padding="5" />\n' +
         "+   {'extra text node'}\n" +
         '  </div>\n\n' +
         '    in Component (at **)',
@@ -509,8 +506,8 @@ describe('ReactMount', () => {
       ),
     ).toWarnDev(
       'Warning: Prop `data-ssr-extra-prop` did not match. ' +
-        'Server: "null" ' +
-        'Client: "true"\n' +
+        'Server: null ' +
+        'Client: true\n' +
         '    in div (at **)',
     );
   });
@@ -555,7 +552,7 @@ describe('ReactMount', () => {
         div,
       ),
     ).toWarnDev(
-      'Warning: Extra attributes from the server: data-ssr-extra-prop,data-ssr-extra-prop-2\n' +
+      'Warning: Extra attributes from the server: data-ssr-extra-prop, data-ssr-extra-prop-2\n' +
         '    in div (at **)',
     );
   });
@@ -589,7 +586,7 @@ describe('ReactMount', () => {
   });
 
   it('should warn when hydrate removes an element within a root container (removal diff)', () => {
-    // See fixtures/ssr: ssr-warnForDeletedHydratableElement-didNotHydrateContainerInstance
+    // See fixtures/ssr: ssr-warnForDeletedHydratableInstance-didNotHydrateContainerInstance-element
 
     const div = document.createElement('div');
     div.setAttribute('data-ssr-mismatch-test-hydrate-root', '');
@@ -623,7 +620,7 @@ describe('ReactMount', () => {
   });
 
   it('should warn when hydrate removes an element within an element (removal diff)', () => {
-    // See fixtures/ssr: ssr-warnForDeletedHydratableElement-didNotHydrateInstance
+    // See fixtures/ssr: ssr-warnForDeletedHydratableInstance-didNotHydrateInstance-element
 
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString(
@@ -650,12 +647,12 @@ describe('ReactMount', () => {
       'Warning: Did not expect server HTML to contain a <div> in <div>.\n\n' +
         '  <div data-reactroot="">\n' +
         '-   <div>SSRMismatchTest default text</div>\n' +
-        '    <span></span>\n' +
-        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
+        '    <span />\n' +
+        '    <div data-ssr-mismatch-padding-after="1" />\n' +
+        '    <div data-ssr-mismatch-padding-after="2" />\n' +
+        '    <div data-ssr-mismatch-padding-after="3" />\n' +
+        '    <div data-ssr-mismatch-padding-after="4" />\n' +
+        '    <div data-ssr-mismatch-padding-after="5" />\n' +
         '  </div>\n\n' +
         '    in span (at **)\n' +
         '    in div (at **)',
@@ -739,19 +736,19 @@ describe('ReactMount', () => {
     ).toWarnDev(
       'Warning: Expected server HTML to contain a matching <h2> in <div>.\n\n' +
         '  <div data-reactroot="">\n' +
-        '    <div data-ssr-mismatch-padding-before="1"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="2"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="3"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="4"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="5"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="1" />\n' +
+        '    <div data-ssr-mismatch-padding-before="2" />\n' +
+        '    <div data-ssr-mismatch-padding-before="3" />\n' +
+        '    <div data-ssr-mismatch-padding-before="4" />\n' +
+        '    <div data-ssr-mismatch-padding-before="5" />\n' +
         '-   <h1>SSRMismatchTest default text</h1>\n' +
         '+   <h2>SSRMismatchTest default text</h2>\n' +
-        '    <span></span>\n' +
-        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
+        '    <span />\n' +
+        '    <div data-ssr-mismatch-padding-after="1" />\n' +
+        '    <div data-ssr-mismatch-padding-after="2" />\n' +
+        '    <div data-ssr-mismatch-padding-after="3" />\n' +
+        '    <div data-ssr-mismatch-padding-after="4" />\n' +
+        '    <div data-ssr-mismatch-padding-after="5" />\n' +
         '  </div>\n\n' +
         '    in h2 (at **)\n' +
         '    in div (at **)\n' +
@@ -761,7 +758,7 @@ describe('ReactMount', () => {
   });
 
   it('should warn when hydrate removes a text node within a root container (removal diff)', () => {
-    // See fixtures/ssr: ssr-warnForDeletedHydratableText-didNotHydrateContainerInstance
+    // See fixtures/ssr: ssr-warnForDeletedHydratableInstance-didNotHydrateContainerInstance-text
 
     const div = document.createElement('div');
     div.setAttribute('data-ssr-mismatch-test-hydrate-root', '');
@@ -784,18 +781,18 @@ describe('ReactMount', () => {
         "-   {'SSRMismatchTest server text'}\n" +
         '    <br />\n' +
         "    {'SSRMismatchTest default text'}\n" +
-        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
+        '    <div data-ssr-mismatch-padding-after="1" />\n' +
+        '    <div data-ssr-mismatch-padding-after="2" />\n' +
+        '    <div data-ssr-mismatch-padding-after="3" />\n' +
+        '    <div data-ssr-mismatch-padding-after="4" />\n' +
+        '    <div data-ssr-mismatch-padding-after="5" />\n' +
         '  </div>\n\n' +
         '    in br (at **)',
     );
   });
 
   it('should warn when hydrate removes a text node within an element (removal diff)', () => {
-    // See fixtures/ssr: ssr-warnForDeletedHydratableText-didNotHydrateInstance
+    // See fixtures/ssr: ssr-warnForDeletedHydratableInstance-didNotHydrateInstance-text
 
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString(
@@ -822,12 +819,12 @@ describe('ReactMount', () => {
       "Warning: Did not expect server HTML to contain the text node {'SSRMismatchTest server text'} in <div>.\n\n" +
         '  <div data-reactroot="">\n' +
         "-   {'SSRMismatchTest server text'}\n" +
-        '    <span></span>\n' +
-        '    <div data-ssr-mismatch-padding-after="1"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="2"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="3"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="4"></div>\n' +
-        '    <div data-ssr-mismatch-padding-after="5"></div>\n' +
+        '    <span />\n' +
+        '    <div data-ssr-mismatch-padding-after="1" />\n' +
+        '    <div data-ssr-mismatch-padding-after="2" />\n' +
+        '    <div data-ssr-mismatch-padding-after="3" />\n' +
+        '    <div data-ssr-mismatch-padding-after="4" />\n' +
+        '    <div data-ssr-mismatch-padding-after="5" />\n' +
         '  </div>\n\n' +
         '    in span (at **)\n' +
         '    in div (at **)',
@@ -835,7 +832,7 @@ describe('ReactMount', () => {
   });
 
   it('should warn when hydrate replaces a text node by an element within a root container (replacement diff)', () => {
-    // See fixtures/ssr: ssr-warnForInsertedHydratedElement-didNotFindHydratableContainerInstance
+    // See fixtures/ssr: ssr-warnForInsertedHydratedInstance-didNotFindHydratableContainerInstance
 
     const div = document.createElement('div');
     const markup = 'SSRMismatchTest default text';
@@ -854,7 +851,7 @@ describe('ReactMount', () => {
   });
 
   it('should warn when hydrate replaces an element by a text node within a root container (replacement diff)', () => {
-    // See fixtures/ssr: ssr-warnForInsertedHydratedText-didNotFindHydratableContainerTextInstance
+    // See fixtures/ssr: ssr-warnForInsertedHydratedTextInstance-didNotFindHydratableContainerTextInstance
 
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString(
@@ -877,7 +874,7 @@ describe('ReactMount', () => {
   });
 
   it('should warn when hydrate replaces an element by a different element (replacement diff)', () => {
-    // See fixtures/ssr: ssr-warnForInsertedHydratedElement-didNotFindHydratableInstance
+    // See fixtures/ssr: ssr-warnForInsertedHydratedInstance-didNotFindHydratableInstance
 
     const div = document.createElement('div');
     const markup = ReactDOMServer.renderToString(
@@ -967,18 +964,18 @@ describe('ReactMount', () => {
       'Warning: Expected server HTML to contain a matching text node' +
         " for {'SSRMismatchTest client text'} in <div>.\n\n" +
         '  <div data-reactroot="">\n' +
-        '    <div data-ssr-mismatch-padding-before="1"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="2"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="3"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="4"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="5"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="6"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="7"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="8"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="9"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="10"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="11"></div>\n' +
-        '    <div data-ssr-mismatch-padding-before="12"></div>\n' +
+        '    <div data-ssr-mismatch-padding-before="1" />\n' +
+        '    <div data-ssr-mismatch-padding-before="2" />\n' +
+        '    <div data-ssr-mismatch-padding-before="3" />\n' +
+        '    <div data-ssr-mismatch-padding-before="4" />\n' +
+        '    <div data-ssr-mismatch-padding-before="5" />\n' +
+        '    <div data-ssr-mismatch-padding-before="6" />\n' +
+        '    <div data-ssr-mismatch-padding-before="7" />\n' +
+        '    <div data-ssr-mismatch-padding-before="8" />\n' +
+        '    <div data-ssr-mismatch-padding-before="9" />\n' +
+        '    <div data-ssr-mismatch-padding-before="10" />\n' +
+        '    <div data-ssr-mismatch-padding-before="11" />\n' +
+        '    <div data-ssr-mismatch-padding-before="12" />\n' +
         "+   {'SSRMismatchTest client text'}\n" +
         '  </div>\n\n' +
         '    in div (at **)',
@@ -999,8 +996,7 @@ describe('ReactMount', () => {
     ).toWarnDev(
       'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
         '  <div>\n' +
-        '    <!-- a comment -->\n' +
-        '+   <span></span>\n' +
+        '+   <span />\n' +
         '  </div>\n\n' +
         '    in span (at **)\n' +
         '    in div (at **)',
@@ -1009,7 +1005,7 @@ describe('ReactMount', () => {
 
   it('should warn when hydrate replaces an element after a comment node (replacement diff)', () => {
     const div = document.createElement('div');
-    div.innerHTML = '<div><!-- a comment --><div></div></div>';
+    div.innerHTML = '<div><!-- a comment <-- --&gt; > --><div></div></div>';
 
     expect(() =>
       ReactDOM.hydrate(
@@ -1022,9 +1018,8 @@ describe('ReactMount', () => {
     ).toWarnDev(
       'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
         '  <div>\n' +
-        '    <!-- a comment -->\n' +
-        '-   <div></div>\n' +
-        '+   <span></span>\n' +
+        '-   <div />\n' +
+        '+   <span />\n' +
         '  </div>\n\n' +
         '    in span (at **)\n' +
         '    in div (at **)',
@@ -1038,15 +1033,14 @@ describe('ReactMount', () => {
     xml.appendChild(
       document.createProcessingInstruction(
         'dom-processing-instruction',
-        'content',
+        'content > ',
       ),
     );
 
     expect(() => ReactDOM.hydrate(<div />, xml)).toWarnDev(
       'Warning: Expected server HTML to contain a matching <div> in <xml>.\n\n' +
         '  <xml>\n' +
-        '    <?dom-processing-instruction content?>\n' +
-        '+   <div></div>\n' +
+        '+   <div />\n' +
         '  </xml>\n\n' +
         '    in div (at **)',
     );
@@ -1071,8 +1065,8 @@ describe('ReactMount', () => {
       // TODO: Currently, the special characters in the JSX string output are not escaped, the output looks invalid.
       'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
         '  <div data-reactroot="">\n' +
-        "-   {'SSRMismatchTest special characters: '\"\t\n'}\n" +
-        '+   <span></span>\n' +
+        "-   {'SSRMismatchTest special characters: \\'\"\\t\\n'}\n" +
+        '+   <span />\n' +
         '  </div>\n\n' +
         '    in span (at **)\n' +
         '    in div (at **)',
@@ -1099,9 +1093,9 @@ describe('ReactMount', () => {
     ).toWarnDev(
       // TODO: Currently, the special characters in the HTML string output are not escaped, the output looks invalid.
       'Warning: Expected server HTML to contain a matching <span> in <div>.\n\n' +
-        '  <div data-ssr-mismatch-attribute-with-special-characters=""" data-reactroot="">\n' +
+        `  <div data-ssr-mismatch-attribute-with-special-characters={'"'} data-reactroot="">\n` +
         '-   <div>SSRMismatchTest text</div>\n' +
-        '+   <span> — <div></span>\n' +
+        "+   <span>{'\\xa0\\u2014 <div>'}</span>\n" +
         '  </div>\n\n' +
         '    in span (at **)\n' +
         '    in div (at **)',

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -274,7 +274,6 @@ describe('ReactDOMServerHydration', () => {
       'Warning: Prop `style` did not match. Server: ' +
         '"text-decoration:none;color:black;height:10px" Client: ' +
         '"text-decoration:none;color:white;height:10px"',
-      {withoutStack: true},
     );
   });
 
@@ -322,7 +321,6 @@ describe('ReactDOMServerHydration', () => {
       'Warning: Prop `style` did not match. Server: ' +
         '"text-decoration: none; color: black; height: 10px;" Client: ' +
         '"text-decoration:none;color:black;height:10px"',
-      {withoutStack: true},
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -104,9 +104,7 @@ describe('ReactDOMServerHydration', () => {
       element.innerHTML = lastMarkup;
       expect(() => {
         instance = ReactDOM.render(<TestComponent name="y" />, element);
-      }).toWarnDev('Text content did not match. Server: "x" Client: "y"', {
-        withoutStack: true,
-      });
+      }).toWarnDev('Text content did not match. Server: "x" Client: "y"');
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
       expect(element.innerHTML).not.toEqual(lastMarkup);
@@ -189,9 +187,7 @@ describe('ReactDOMServerHydration', () => {
       element.innerHTML = lastMarkup;
       expect(() => {
         instance = ReactDOM.hydrate(<TestComponent name="y" />, element);
-      }).toWarnDev('Text content did not match. Server: "x" Client: "y"', {
-        withoutStack: true,
-      });
+      }).toWarnDev('Text content did not match. Server: "x" Client: "y"');
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
       expect(element.innerHTML).not.toEqual(lastMarkup);
@@ -254,7 +250,6 @@ describe('ReactDOMServerHydration', () => {
       ReactDOM.hydrate(<button autoFocus={false}>client</button>, element),
     ).toWarnDev(
       'Warning: Text content did not match. Server: "server" Client: "client"',
-      {withoutStack: true},
     );
 
     expect(element.firstChild.focus).not.toHaveBeenCalled();

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -12,7 +12,6 @@ import {getCurrentFiberOwnerNameInDevOrNull} from 'react-reconciler/src/ReactCur
 import {registrationNameModules} from 'events/EventPluginRegistry';
 import warning from 'shared/warning';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import warningWithoutStack from 'shared/warningWithoutStack';
 import type {ReactEventResponderEventType} from 'shared/ReactTypes';
 import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
 import {setListenToResponderEventTypes} from '../events/DOMEventResponderSystem';
@@ -176,7 +175,7 @@ if (__DEV__) {
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Text content did not match. Server: "%s" Client: "%s"',
       normalizedServerText,
@@ -202,7 +201,7 @@ if (__DEV__) {
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Prop `%s` did not match. Server: %s Client: %s',
       propName,
@@ -220,7 +219,7 @@ if (__DEV__) {
     attributeNames.forEach(function(name) {
       names.push(name);
     });
-    warningWithoutStack(false, 'Extra attributes from the server: %s', names);
+    warning(false, 'Extra attributes from the server: %s', names);
   };
 
   warnForInvalidEventListener = function(registrationName, listener) {
@@ -1189,7 +1188,7 @@ export function warnForDeletedHydratableElement(
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Did not expect server HTML to contain a <%s> in <%s>.',
       child.nodeName.toLowerCase(),
@@ -1207,7 +1206,7 @@ export function warnForDeletedHydratableText(
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Did not expect server HTML to contain the text node "%s" in <%s>.',
       child.nodeValue,
@@ -1226,7 +1225,7 @@ export function warnForInsertedHydratedElement(
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Expected server HTML to contain a matching <%s> in <%s>.',
       tag,
@@ -1251,7 +1250,7 @@ export function warnForInsertedHydratedText(
       return;
     }
     didWarnInvalidHydration = true;
-    warningWithoutStack(
+    warning(
       false,
       'Expected server HTML to contain a matching text node for "%s" in <%s>.',
       text,

--- a/packages/react-events/src/__tests__/TouchHitTarget-test.internal.js
+++ b/packages/react-events/src/__tests__/TouchHitTarget-test.internal.js
@@ -534,8 +534,16 @@ describe('TouchHitTarget', () => {
         ReactDOM.hydrate(<Test />, container);
         expect(Scheduler).toFlushWithoutYielding();
       }).toWarnDev(
-        'Warning: Expected server HTML to contain a matching <div> in <div>.',
-        {withoutStack: true},
+        'Warning: Expected server HTML to contain a matching ' +
+          "<div style={{'position': 'absolute', 'zIndex': -1, 'bottom': '-10px', ...}}> in <div>.\n\n" +
+          '  <div style="position: relative; z-index: 0">\n' +
+          "+   <div style={{'position': 'absolute', 'zIndex': -1, 'bottom': '-10px', ...}} />\n" +
+          '  </div>\n\n' +
+          '    in div\n' +
+          '    in TouchHitTarget (at **)\n' +
+          '    in div (at **)\n' +
+          '    in Unknown (at **)\n' +
+          '    in Test (at **)',
       );
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -53,6 +53,7 @@ let nextReactTag = 2;
 type Node = Object;
 export type Type = string;
 export type Props = Object;
+export type Container = number;
 export type Instance = {
   node: Node,
   canonical: ReactFabricHostComponent,
@@ -61,8 +62,8 @@ export type TextInstance = {
   node: Node,
 };
 export type HydratableInstance = Instance | TextInstance;
+export type HostInstance = HydratableInstance | Container;
 export type PublicInstance = ReactFabricHostComponent;
-export type Container = number;
 export type ChildSet = Object;
 export type HostContext = $ReadOnly<{|
   isInAParentText: boolean,

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -35,6 +35,7 @@ export type Instance = {
 };
 export type TextInstance = number;
 export type HydratableInstance = Instance | TextInstance;
+export type HostInstance = HydratableInstance | Container;
 export type PublicInstance = Instance;
 export type HostContext = $ReadOnly<{|
   isInAParentText: boolean,

--- a/packages/react-reconciler/src/ReactFiberHydrationWarning.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationWarning.js
@@ -1,0 +1,1042 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {HostComponent, HostText, HostPortal} from 'shared/ReactWorkTags';
+import warning from 'shared/warning';
+import getComponentName from 'shared/getComponentName';
+
+import type {Fiber} from './ReactFiber';
+import type {
+  Container,
+  Instance,
+  TextInstance,
+  HostInstance,
+  HydratableInstance,
+} from './ReactFiberHostConfig';
+
+import {
+  getNextHydratableSibling,
+  getFirstHydratableChild,
+  getHostInstanceDisplayName,
+  getHostInstanceProps,
+  isTextInstance,
+  getTextInstanceText,
+  isSuspenseInstance,
+  compareTextForHydrationWarning,
+  comparePropValueForHydrationWarning,
+} from './ReactFiberHostConfig';
+
+type Props = Object;
+
+const REACT_SPECIFIC_PROPS = {
+  key: true,
+  ref: true,
+  __self: true,
+  __source: true,
+  children: null,
+  dangerouslySetInnerHTML: null,
+  suppressContentEditableWarning: null,
+  suppressHydrationWarning: null,
+};
+
+let didWarnInvalidHydration = false;
+let SUPPRESS_HYDRATION_WARNING;
+if (__DEV__) {
+  SUPPRESS_HYDRATION_WARNING = 'suppressHydrationWarning';
+}
+export {SUPPRESS_HYDRATION_WARNING};
+
+// TODO: Should PRINT_MAX_STRING_LENGTH remain hardcoded?
+const PRINT_MAX_STRING_LENGTH = 100;
+// TODO: Should PRINT_MAX_ARRAY_ITEMS remain hardcoded?
+const PRINT_MAX_ARRAY_ITEMS = 3;
+// TODO: Should PRINT_MAX_OBJECT_ITEMS remain hardcoded?
+const PRINT_MAX_OBJECT_ITEMS = 3;
+// TODO: Should PRINT_MAX_PROP_ITEMS remain hardcoded?
+const PRINT_MAX_PROP_ITEMS = 3;
+
+type DangerouslySetInnerHTMLString = {
+  __html: string,
+};
+
+const PRINT_ELEMENT_MODE_DEFAULT: 0b0000 = 0b0000;
+const PRINT_ELEMENT_MODE_OPENING_TAG_ONLY: 0b0001 = 0b0001;
+const PRINT_CHILDREN_VALUE_MODE_DEFAULT: 0b0010 = 0b0010;
+const PRINT_CHILDREN_VALUE_MODE_RAW: 0b0100 = 0b0100;
+
+function isReactElement(value: mixed): boolean %checks {
+  return (
+    typeof value === 'object' && value !== null && value.$$typeof !== undefined
+  );
+}
+
+function printReactElement(value: Object): string {
+  const instanceDisplayName = getComponentName(value.type);
+  // Add `key` prop to print it along with regular props if it's defined.
+  const instanceProps = value.props
+    ? value.key !== undefined && value.key !== null
+      ? {key: value.key, ...value.props}
+      : value.props
+    : null;
+  return instanceDisplayName === null
+    ? '<...>'
+    : printElementOrText(
+        instanceDisplayName,
+        instanceProps,
+        null,
+        PRINT_ELEMENT_MODE_DEFAULT,
+        PRINT_CHILDREN_VALUE_MODE_DEFAULT,
+      );
+}
+
+function clipStringWithEllipsis(str: string, clipAtLength: number): string {
+  return (
+    str.substring(0, clipAtLength) + (str.length > clipAtLength ? '...' : '')
+  );
+}
+
+function escapeNonPrintableCharacters(str: string, quote: "'" | '"'): string {
+  return str.replace(/[\s\S]/g, character => {
+    switch (character) {
+      case quote:
+        return '\\' + character;
+      case '\n':
+        return '\\n';
+      case '\t':
+        return '\\t';
+      default: {
+        const charCode = character.charCodeAt(0);
+        // Do not escape if the character is within the ASCII printable range:
+        if (charCode >= 0x20 && charCode <= 0x7e) {
+          return character;
+        }
+        const charCodeHex = charCode.toString(16);
+        const longhand = charCodeHex.length > 2;
+        return (
+          '\\' +
+          (longhand ? 'u' : 'x') +
+          ('0000' + charCodeHex).slice(longhand ? -4 : -2)
+        );
+      }
+    }
+  });
+}
+
+function printQuotedStringValue(str: string, quote: "'" | '"'): string {
+  return (
+    quote +
+    escapeNonPrintableCharacters(
+      clipStringWithEllipsis(str, PRINT_MAX_STRING_LENGTH),
+      quote,
+    ) +
+    quote
+  );
+}
+
+function printValue(value: mixed): string {
+  try {
+    if (value === null) {
+      return 'null';
+    } else if (value === undefined) {
+      return 'undefined';
+    } else if (typeof value === 'number') {
+      return '' + value;
+    } else if (typeof value === 'string') {
+      return printQuotedStringValue(value, "'");
+    } else if (Array.isArray(value)) {
+      let ret = '[';
+      const ic = value.length;
+      for (let i = 0; i < ic; ++i) {
+        ret += i > 0 ? ', ' : '';
+        if (i >= PRINT_MAX_ARRAY_ITEMS) {
+          ret += '...';
+          break;
+        }
+        const item = value[i];
+        ret += printValue(item);
+      }
+      ret += ']';
+      return ret;
+    } else if (isReactElement(value)) {
+      return printReactElement(value);
+    } else if (typeof value === 'function' && typeof value.name === 'string') {
+      return clipStringWithEllipsis(
+        'function ' + value.name,
+        PRINT_MAX_STRING_LENGTH,
+      );
+    } else if (typeof value === 'object') {
+      let ret = '{';
+      const keys = Object.keys(value);
+      const ic = keys.length;
+      for (let i = 0; i < ic; ++i) {
+        ret += i > 0 ? ', ' : '';
+        if (i >= PRINT_MAX_OBJECT_ITEMS) {
+          ret += '...';
+          break;
+        }
+        const item = value[keys[i]];
+        ret += printValue(keys[i]) + ': ' + printValue(item);
+      }
+      ret += '}';
+      return ret;
+    } else {
+      return '...';
+    }
+  } catch (ex) {
+    return '...';
+  }
+}
+
+function printCurlyValue(value: mixed): string {
+  return '{' + printValue(value) + '}';
+}
+
+const SPACE_ONLY_RE = /^\s*$/;
+const NON_EMPTY_WITH_SPACE_FROM_BOTH_SIDES_RE = /^\s+.+\s+$/;
+// The ASCII printable range is from \x20 to \x7E. The tag brackets are '<' (\x3C) and '>' (\x3E).
+const ASCII_PRINTABLE_EXCEPT_TAG_BRACKETS_RE = /^[\x20-\x3B\x3D\x3F-\x7E]*$/;
+
+function shouldPrintStringAsRawUnescapedText(str: string): boolean {
+  return (
+    !SPACE_ONLY_RE.test(str) &&
+    !NON_EMPTY_WITH_SPACE_FROM_BOTH_SIDES_RE.test(str) &&
+    ASCII_PRINTABLE_EXCEPT_TAG_BRACKETS_RE.test(str)
+  );
+}
+
+function printCurlyOrQuotedStringValue(value: mixed): string {
+  if (typeof value === 'string') {
+    if (
+      (value === '' || shouldPrintStringAsRawUnescapedText(value)) &&
+      value.indexOf('"') < 0
+    ) {
+      // Examples: `<meta charset="utf-8" />`, `<div data-reactroot="" />`.
+      return printQuotedStringValue(value, '"');
+    } else {
+      // Examples: `<div>{'Foo\u00a0Bar'}</div>`.
+      return '{' + printQuotedStringValue(value, "'") + '}';
+    }
+  } else {
+    // Examples: `<div>{[object Object]}</div>`.
+    return printCurlyValue(value);
+  }
+}
+
+function printChildrenValueInner(
+  children: mixed,
+  printChildrenMode:
+    | typeof PRINT_CHILDREN_VALUE_MODE_DEFAULT
+    | typeof PRINT_CHILDREN_VALUE_MODE_RAW,
+): string {
+  if (printChildrenMode & PRINT_CHILDREN_VALUE_MODE_RAW && children === null) {
+    return '';
+  } else if (
+    printChildrenMode & PRINT_CHILDREN_VALUE_MODE_RAW &&
+    typeof children === 'string' &&
+    shouldPrintStringAsRawUnescapedText(children)
+  ) {
+    // Print unquoted text content within a parent tag if special-character escaping is not required.
+    // Example: `<div>parsnip</div>` instead of `<div>{'parsnip'}</div>`
+    // Example: `<div>parsnip <span /></div>` instead of `<div>{['parsnip ', <span />]}</div>`
+    return clipStringWithEllipsis(children, PRINT_MAX_STRING_LENGTH);
+  } else if (isReactElement(children)) {
+    return printReactElement(children);
+  } else {
+    return printCurlyValue(children);
+  }
+}
+
+function printChildrenValue(
+  children: mixed,
+  printChildrenMode:
+    | typeof PRINT_CHILDREN_VALUE_MODE_DEFAULT
+    | typeof PRINT_CHILDREN_VALUE_MODE_RAW,
+): string {
+  if (Array.isArray(children)) {
+    let ic = children.length;
+    let isAllStrings = ic > 0;
+    while (--ic > 0) {
+      if (typeof children[ic] !== 'string') {
+        isAllStrings = false;
+        break;
+      }
+    }
+    if (isAllStrings) {
+      return printCurlyValue(children);
+    } else {
+      return children
+        .map(child => printChildrenValueInner(child, printChildrenMode))
+        .join('');
+    }
+  } else {
+    return printChildrenValueInner(children, printChildrenMode);
+  }
+}
+
+function printChildrenDangerouslySetInnerHTMLString(
+  dangerouslySetInnerHTMLString: string,
+): string {
+  // For simplicity, assuming for display purposes that HTML is equivalent to the printed JSX markup.
+  return clipStringWithEllipsis(
+    dangerouslySetInnerHTMLString,
+    PRINT_MAX_STRING_LENGTH,
+  );
+}
+
+function printElementOpeningTag(
+  instanceDisplayName: string,
+  instanceProps: Props | null,
+  selfClosing: boolean,
+) {
+  let ret = '<' + instanceDisplayName;
+  if (instanceProps) {
+    let i = 0;
+    for (const propName in instanceProps) {
+      if (
+        !instanceProps.hasOwnProperty(propName) ||
+        REACT_SPECIFIC_PROPS.hasOwnProperty(propName)
+      ) {
+        continue;
+      }
+      if (i >= PRINT_MAX_PROP_ITEMS) {
+        ret += ' ...';
+        break;
+      }
+      ret +=
+        ' ' +
+        propName +
+        '=' +
+        printCurlyOrQuotedStringValue(instanceProps[propName]);
+      ++i;
+    }
+  }
+  return ret + (selfClosing ? ' />' : '>');
+}
+
+function printElementClosingTag(instanceDisplayName: string): string {
+  return '</' + instanceDisplayName + '>';
+}
+
+function getDangerouslySetInnerHTMLString(something: mixed): string | null {
+  const __html =
+    typeof something === 'object' && something !== null
+      ? something.__html
+      : null;
+  if (
+    __html != null &&
+    // We need to ensure `__html` actually contains a string, as some tests put `false` in there.
+    typeof __html === 'string'
+  ) {
+    return __html;
+  }
+  return null;
+}
+
+function printElementChildren(
+  instanceProps: Props | null,
+  instanceTextOrHTML: string | DangerouslySetInnerHTMLString | null,
+) {
+  const dangerouslySetInnerHTMLStringFromProps = getDangerouslySetInnerHTMLString(
+    instanceProps ? instanceProps.dangerouslySetInnerHTML : null,
+  );
+  const dangerouslySetInnerHTMLStringFromInstanceTextOrHTML = getDangerouslySetInnerHTMLString(
+    instanceTextOrHTML,
+  );
+  if (instanceProps && instanceProps.children != null) {
+    return printChildrenValue(
+      instanceProps.children,
+      PRINT_CHILDREN_VALUE_MODE_RAW,
+    );
+  } else if (dangerouslySetInnerHTMLStringFromProps) {
+    return printChildrenDangerouslySetInnerHTMLString(
+      dangerouslySetInnerHTMLStringFromProps,
+    );
+  } else if (typeof instanceTextOrHTML === 'string') {
+    return printChildrenValue(
+      instanceTextOrHTML,
+      PRINT_CHILDREN_VALUE_MODE_RAW,
+    );
+  } else if (dangerouslySetInnerHTMLStringFromInstanceTextOrHTML) {
+    return printChildrenDangerouslySetInnerHTMLString(
+      dangerouslySetInnerHTMLStringFromInstanceTextOrHTML,
+    );
+  } else if (instanceTextOrHTML != null) {
+    return printCurlyValue(instanceTextOrHTML);
+  } else {
+    return '';
+  }
+}
+
+function printElementOrText(
+  instanceDisplayName: string | null,
+  instanceProps: Props | null,
+  instanceTextOrHTML: string | DangerouslySetInnerHTMLString | null,
+  printElementMode:
+    | typeof PRINT_ELEMENT_MODE_DEFAULT
+    | typeof PRINT_ELEMENT_MODE_OPENING_TAG_ONLY,
+  printChildrenMode:
+    | typeof PRINT_CHILDREN_VALUE_MODE_DEFAULT
+    | typeof PRINT_CHILDREN_VALUE_MODE_RAW,
+): string {
+  if (
+    instanceDisplayName !== null &&
+    printElementMode & PRINT_ELEMENT_MODE_OPENING_TAG_ONLY
+  ) {
+    return printElementOpeningTag(instanceDisplayName, instanceProps, false);
+  } else if (instanceDisplayName !== null) {
+    const printedChildren = printElementChildren(
+      instanceProps,
+      instanceTextOrHTML,
+    );
+    if (printedChildren) {
+      return (
+        printElementOpeningTag(instanceDisplayName, instanceProps, false) +
+        printedChildren +
+        printElementClosingTag(instanceDisplayName)
+      );
+    } else {
+      return printElementOpeningTag(instanceDisplayName, instanceProps, true);
+    }
+  } else {
+    return printChildrenValue(instanceTextOrHTML, printChildrenMode);
+  }
+}
+
+function getHostInstanceDisplayStringForHydrationWarningMessage(
+  instance: HostInstance,
+) {
+  if (isTextInstance(instance)) {
+    const textInstance: TextInstance = (instance: any);
+    return printElementOrText(
+      null,
+      null,
+      getTextInstanceText(textInstance),
+      PRINT_ELEMENT_MODE_OPENING_TAG_ONLY,
+      PRINT_CHILDREN_VALUE_MODE_DEFAULT,
+    );
+  } else if (isSuspenseInstance(instance)) {
+    return printElementOrText(
+      'Suspense',
+      // We don't know Suspense props here.
+      {},
+      null,
+      PRINT_ELEMENT_MODE_OPENING_TAG_ONLY,
+      PRINT_CHILDREN_VALUE_MODE_DEFAULT,
+    );
+  } else {
+    return printElementOrText(
+      getHostInstanceDisplayName(instance),
+      // Do not include props into the warning message.
+      {},
+      null,
+      PRINT_ELEMENT_MODE_OPENING_TAG_ONLY,
+      PRINT_CHILDREN_VALUE_MODE_DEFAULT,
+    );
+  }
+}
+
+function printHostInstance(
+  instance: HostInstance,
+  printChildrenMode:
+    | typeof PRINT_CHILDREN_VALUE_MODE_DEFAULT
+    | typeof PRINT_CHILDREN_VALUE_MODE_RAW,
+) {
+  let ret = '';
+  if (isTextInstance(instance)) {
+    const textInstance: TextInstance = (instance: any);
+    ret += printElementOrText(
+      null,
+      null,
+      getTextInstanceText(textInstance),
+      PRINT_ELEMENT_MODE_DEFAULT,
+      printChildrenMode,
+    );
+  } else if (isSuspenseInstance(instance)) {
+    ret += printElementOrText(
+      'Suspense',
+      // We don't know Suspense props here.
+      {},
+      null,
+      PRINT_ELEMENT_MODE_DEFAULT,
+      printChildrenMode,
+    );
+  } else {
+    const instanceDisplayName = getHostInstanceDisplayName(instance);
+    const instanceProps = getHostInstanceProps(instance);
+    let nextHydratableInstance = getFirstHydratableChild(instance);
+    if (nextHydratableInstance) {
+      ret += printElementOrText(
+        instanceDisplayName,
+        instanceProps,
+        null,
+        PRINT_ELEMENT_MODE_OPENING_TAG_ONLY,
+        printChildrenMode,
+      );
+      while (nextHydratableInstance) {
+        ret += printHostInstance(
+          nextHydratableInstance,
+          PRINT_CHILDREN_VALUE_MODE_RAW,
+        );
+        nextHydratableInstance = getNextHydratableSibling(
+          nextHydratableInstance,
+        );
+      }
+      ret += printElementClosingTag(instanceDisplayName);
+    } else {
+      ret += printElementOrText(
+        instanceDisplayName,
+        instanceProps,
+        null,
+        PRINT_ELEMENT_MODE_DEFAULT,
+        printChildrenMode,
+      );
+    }
+  }
+  return ret;
+}
+
+export function findHydrationWarningHostInstanceIndex(
+  returnFiber: Fiber,
+  fiber: Fiber,
+): number {
+  let hydrationWarningHostInstanceIndex = 0;
+  // Find index of `fiber`, the place where hydration failed, among immediate children host nodes of `returnFiber`.
+  const startNode = returnFiber.child;
+  let node: Fiber | null = startNode;
+  search: while (node && node !== fiber) {
+    if (node.tag === HostComponent || node.tag === HostText) {
+      ++hydrationWarningHostInstanceIndex;
+    } else if (node.tag === HostPortal) {
+      // Do not count HostPortal and do not descend into them as they do not affect the index within the parent.
+    } else if (node.child !== null) {
+      // Do not descend into HostComponent or HostText as they do not affect the index within the parent.
+      node.child.return = node;
+      node = node.child;
+      continue;
+    }
+    while (node && node.sibling === null) {
+      if (node.return === null || node.return === startNode) {
+        break search;
+      }
+      node = node.return;
+    }
+    if (node && node.sibling) {
+      node.sibling.return = node.return;
+      node = node.sibling;
+    }
+  }
+  return hydrationWarningHostInstanceIndex;
+}
+
+function getHydrationDiff(
+  parentInstance: HostInstance,
+  childInstanceDeletedIndex: number,
+  childInstanceInsertedIndex: number,
+  insertedInstanceDisplayName: string | null,
+  insertedInstanceProps: Props | null,
+  insertedText: string | null,
+): string {
+  // Prepending '\n' for readability to separate the diff from the warning message.
+  let ret = '\n';
+  const INDENT = '  ';
+  const DIFF_ADDED = '\n+ ';
+  const DIFF_REMOVED = '\n- ';
+  const DIFF_UNCHANGED = '\n  ';
+  ret +=
+    DIFF_UNCHANGED +
+    printElementOrText(
+      getHostInstanceDisplayName(parentInstance),
+      getHostInstanceProps(parentInstance),
+      null,
+      PRINT_ELEMENT_MODE_OPENING_TAG_ONLY,
+      // TODO: Should we print curly values for top-level text nodes or raw text.
+      PRINT_CHILDREN_VALUE_MODE_DEFAULT,
+    );
+  let inserted = false;
+  const insert = () => {
+    if (!inserted) {
+      if (insertedInstanceDisplayName || typeof insertedText === 'string') {
+        inserted = true;
+        ret +=
+          DIFF_ADDED +
+          INDENT +
+          printElementOrText(
+            insertedInstanceDisplayName,
+            insertedInstanceProps,
+            insertedText,
+            PRINT_ELEMENT_MODE_DEFAULT,
+            // TODO: Should we print curly values for top-level text nodes or raw text.
+            PRINT_CHILDREN_VALUE_MODE_DEFAULT,
+          );
+      }
+    }
+  };
+  let nextHydratableInstance = getFirstHydratableChild(parentInstance);
+  let index = 0;
+  while (nextHydratableInstance) {
+    if (index === childInstanceDeletedIndex) {
+      ret +=
+        DIFF_REMOVED +
+        INDENT +
+        printHostInstance(
+          nextHydratableInstance,
+          PRINT_CHILDREN_VALUE_MODE_DEFAULT,
+        );
+    } else {
+      ret +=
+        DIFF_UNCHANGED +
+        INDENT +
+        printHostInstance(
+          nextHydratableInstance,
+          PRINT_CHILDREN_VALUE_MODE_DEFAULT,
+        );
+    }
+    if (index === childInstanceInsertedIndex) {
+      insert();
+    }
+    ++index;
+    nextHydratableInstance = getNextHydratableSibling(nextHydratableInstance);
+  }
+  insert();
+  // TODO: Cannot tell if more sibling React elements were expected to be hydrated after the current one.
+  ret +=
+    DIFF_UNCHANGED +
+    printElementClosingTag(getHostInstanceDisplayName(parentInstance));
+  // Append '\n' for readability to separate the diff from the component stack that follows.
+  ret += '\n';
+  return ret;
+}
+
+function warnForTextDifference(
+  hostText: string,
+  renderedValue: string | number,
+) {
+  if (didWarnInvalidHydration) {
+    return;
+  }
+  if (compareTextForHydrationWarning(hostText, renderedValue)) {
+    return;
+  }
+  didWarnInvalidHydration = true;
+  // TODO: As we're here in the terminology of universal hydration, should we stop saying 'Server' and 'Client'?
+  warning(
+    false,
+    'Text content did not match. Server: %s Client: %s',
+    JSON.stringify(hostText),
+    JSON.stringify(renderedValue),
+  );
+}
+
+function warnForPropDifference(
+  propName: string,
+  hostValue: mixed,
+  renderedValue: mixed,
+) {
+  if (didWarnInvalidHydration) {
+    return;
+  }
+  if (comparePropValueForHydrationWarning(hostValue, renderedValue)) {
+    return;
+  }
+  didWarnInvalidHydration = true;
+  // TODO: As we're here in the terminology of universal hydration, should we stop saying 'Server' and 'Client'?
+  warning(
+    false,
+    'Prop `%s` did not match. Server: %s Client: %s',
+    propName,
+    JSON.stringify(hostValue),
+    JSON.stringify(renderedValue),
+  );
+}
+
+function warnForExtraAttributes(attributeNames: Set<string>) {
+  if (didWarnInvalidHydration) {
+    return;
+  }
+  didWarnInvalidHydration = true;
+  const names = [];
+  attributeNames.forEach(function(name) {
+    names.push(name);
+  });
+  // TODO: As we're here in the terminology of universal hydration, should we stop saying 'from the server'?
+  warning(false, 'Extra attributes from the server: %s', names.join(', '));
+}
+
+function warnForDeletedHydratableInstance(
+  parentContainer: HostInstance,
+  child: HydratableInstance,
+) {
+  if (__DEV__) {
+    if (didWarnInvalidHydration) {
+      return;
+    }
+    didWarnInvalidHydration = true;
+    let nextHydratableInstance = getFirstHydratableChild(parentContainer);
+    let childInstanceDeletedIndex = -1;
+    let index = 0;
+    while (nextHydratableInstance) {
+      if (nextHydratableInstance === child) {
+        childInstanceDeletedIndex = index;
+        break;
+      }
+      ++index;
+      nextHydratableInstance = getNextHydratableSibling(nextHydratableInstance);
+    }
+    // TODO: As we're here in the terminology of universal hydration, should we stop saying 'server HTML'?
+    if (isTextInstance(child)) {
+      // warnForDeletedHydratableText
+      warning(
+        false,
+        'Did not expect server HTML to contain the text node %s in %s.%s',
+        // $FlowFixMe `HydratableInstance` and `HostInstance` opaque so incompatible in `ReactFiberHostConfig.custom`.
+        getHostInstanceDisplayStringForHydrationWarningMessage(child),
+        getHostInstanceDisplayStringForHydrationWarningMessage(parentContainer),
+        getHydrationDiff(
+          parentContainer,
+          childInstanceDeletedIndex,
+          -1,
+          null,
+          null,
+          null,
+        ),
+      );
+    } else if (isSuspenseInstance(child)) {
+      // warnForDeletedHydratableSuspenseBoundary
+      warning(
+        false,
+        'Did not expect server HTML to contain the Suspense %s in %s.%s',
+        // $FlowFixMe `HydratableInstance` and `HostInstance` opaque so incompatible in `ReactFiberHostConfig.custom`.
+        getHostInstanceDisplayStringForHydrationWarningMessage(child),
+        getHostInstanceDisplayStringForHydrationWarningMessage(parentContainer),
+        getHydrationDiff(
+          parentContainer,
+          childInstanceDeletedIndex,
+          -1,
+          null,
+          null,
+          null,
+        ),
+      );
+    } else {
+      // warnForDeletedHydratableElement
+      warning(
+        false,
+        'Did not expect server HTML to contain a %s in %s.%s',
+        // $FlowFixMe `HydratableInstance` and `HostInstance` opaque so incompatible in `ReactFiberHostConfig.custom`.
+        getHostInstanceDisplayStringForHydrationWarningMessage(child),
+        getHostInstanceDisplayStringForHydrationWarningMessage(parentContainer),
+        getHydrationDiff(
+          parentContainer,
+          childInstanceDeletedIndex,
+          -1,
+          null,
+          null,
+          null,
+        ),
+      );
+    }
+  }
+}
+
+function warnForInsertedHydratedInstance(
+  parentContainer: HostInstance,
+  tag: string,
+  props: Props,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
+) {
+  if (__DEV__) {
+    if (didWarnInvalidHydration) {
+      return;
+    }
+    didWarnInvalidHydration = true;
+    // TODO: As we're here in the terminology of universal hydration, should we stop saying 'server HTML'?
+    warning(
+      false,
+      'Expected server HTML to contain a matching %s in %s.%s',
+      printElementOrText(
+        tag,
+        props,
+        null,
+        PRINT_ELEMENT_MODE_OPENING_TAG_ONLY,
+        PRINT_CHILDREN_VALUE_MODE_DEFAULT,
+      ),
+      getHostInstanceDisplayStringForHydrationWarningMessage(parentContainer),
+      getHydrationDiff(
+        parentContainer,
+        hydrationWarningHostInstanceIsReplaced
+          ? hydrationWarningHostInstanceIndex
+          : -1,
+        hydrationWarningHostInstanceIndex,
+        tag,
+        props,
+        null,
+      ),
+    );
+  }
+}
+
+function warnForInsertedHydratedTextInstance(
+  parentContainer: HostInstance,
+  text: string,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
+) {
+  if (__DEV__) {
+    if (text === '') {
+      // We expect to insert empty text nodes since they're not represented in the HTML.
+      // TODO: Remove this special case if we can just avoid inserting empty text nodes.
+      return;
+    }
+    if (didWarnInvalidHydration) {
+      return;
+    }
+    didWarnInvalidHydration = true;
+    // TODO: As we're here in the terminology of universal hydration, should we stop saying 'server HTML'?
+    warning(
+      false,
+      'Expected server HTML to contain a matching text node for %s in %s.%s',
+      printCurlyValue(text),
+      getHostInstanceDisplayStringForHydrationWarningMessage(parentContainer),
+      getHydrationDiff(
+        parentContainer,
+        hydrationWarningHostInstanceIsReplaced
+          ? hydrationWarningHostInstanceIndex
+          : -1,
+        hydrationWarningHostInstanceIndex,
+        null,
+        null,
+        text,
+      ),
+    );
+  }
+}
+
+function warnForInsertedHydratedSuspense(
+  parentContainer: HostInstance,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
+) {
+  if (__DEV__) {
+    if (didWarnInvalidHydration) {
+      return;
+    }
+    didWarnInvalidHydration = true;
+    // TODO: As we're here in the terminology of universal hydration, should we stop saying 'server HTML'?
+    warning(
+      false,
+      'Expected server HTML to contain a matching Suspense in %s.%s',
+      getHostInstanceDisplayStringForHydrationWarningMessage(parentContainer),
+      getHydrationDiff(
+        parentContainer,
+        hydrationWarningHostInstanceIsReplaced
+          ? hydrationWarningHostInstanceIndex
+          : -1,
+        hydrationWarningHostInstanceIndex,
+        null,
+        null,
+        null,
+      ),
+    );
+  }
+}
+
+export function didNotMatchHydratedContainerTextInstance(
+  parentContainer: Container,
+  textInstance: TextInstance,
+  renderedText: string,
+) {
+  if (__DEV__) {
+    warnForTextDifference(getTextInstanceText(textInstance), renderedText);
+  }
+}
+
+export function didNotMatchHydratedTextInstance(
+  parentType: string,
+  parentProps: Props,
+  parentInstance: Instance,
+  textInstance: TextInstance,
+  renderedText: string,
+) {
+  if (__DEV__ && parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
+    warnForTextDifference(getTextInstanceText(textInstance), renderedText);
+  }
+}
+
+export function didNotMatchHydratedChildrenPropValue(
+  type: string,
+  props: Props,
+  instance: Instance,
+  hostChildrenText: string,
+  renderedChildrenValue: string | number,
+) {
+  if (__DEV__ && props[SUPPRESS_HYDRATION_WARNING] !== true) {
+    warnForTextDifference(hostChildrenText, renderedChildrenValue);
+  }
+}
+
+export function didNotMatchHydratedPropValue(
+  type: string,
+  props: Props,
+  instance: Instance,
+  propKey: string,
+  hostValue: mixed,
+  renderedValue: mixed,
+) {
+  if (__DEV__ && props[SUPPRESS_HYDRATION_WARNING] !== true) {
+    warnForPropDifference(propKey, hostValue, renderedValue);
+  }
+}
+
+export function didNotMatchHydratedPropsHostInstanceHasExtraAttributes(
+  type: string,
+  props: Props,
+  instance: Instance,
+  attributeNames: Set<string>,
+) {
+  if (__DEV__ && props[SUPPRESS_HYDRATION_WARNING] !== true) {
+    warnForExtraAttributes(attributeNames);
+  }
+}
+
+export function didNotHydrateContainerInstance(
+  parentContainer: Container,
+  instance: HydratableInstance,
+) {
+  if (__DEV__) {
+    warnForDeletedHydratableInstance(
+      // $FlowFixMe `Container` and `HostInstance` opaque so incompatible in `ReactFiberHostConfig.custom`.
+      parentContainer,
+      instance,
+    );
+  }
+}
+
+export function didNotHydrateInstance(
+  parentType: string,
+  parentProps: Props,
+  parentInstance: Instance,
+  instance: HydratableInstance,
+) {
+  if (__DEV__ && parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
+    warnForDeletedHydratableInstance(
+      // $FlowFixMe `Instance` and `HostInstance` opaque so incompatible in `ReactFiberHostConfig.custom`.
+      parentInstance,
+      instance,
+    );
+  }
+}
+
+export function didNotFindHydratableContainerInstance(
+  parentContainer: Container,
+  type: string,
+  props: Props,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
+) {
+  if (__DEV__) {
+    warnForInsertedHydratedInstance(
+      // $FlowFixMe `Container` and `HostInstance` opaque so incompatible in `ReactFiberHostConfig.custom`.
+      parentContainer,
+      type,
+      props,
+      hydrationWarningHostInstanceIndex,
+      hydrationWarningHostInstanceIsReplaced,
+    );
+  }
+}
+
+export function didNotFindHydratableContainerTextInstance(
+  parentContainer: Container,
+  text: string,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
+) {
+  if (__DEV__) {
+    warnForInsertedHydratedTextInstance(
+      // $FlowFixMe `Container` and `HostInstance` opaque so incompatible in `ReactFiberHostConfig.custom`.
+      parentContainer,
+      text,
+      hydrationWarningHostInstanceIndex,
+      hydrationWarningHostInstanceIsReplaced,
+    );
+  }
+}
+
+export function didNotFindHydratableContainerSuspenseInstance(
+  parentContainer: Container,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
+) {
+  if (__DEV__) {
+    warnForInsertedHydratedSuspense(
+      // $FlowFixMe `Container` and `HostInstance` opaque so incompatible in `ReactFiberHostConfig.custom`.
+      parentContainer,
+      hydrationWarningHostInstanceIndex,
+      hydrationWarningHostInstanceIsReplaced,
+    );
+  }
+}
+
+export function didNotFindHydratableInstance(
+  parentType: string,
+  parentProps: Props,
+  parentInstance: Instance,
+  type: string,
+  props: Props,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
+) {
+  if (__DEV__ && parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
+    warnForInsertedHydratedInstance(
+      // $FlowFixMe `Instance` and `HostInstance` opaque so incompatible in `ReactFiberHostConfig.custom`.
+      parentInstance,
+      type,
+      props,
+      hydrationWarningHostInstanceIndex,
+      hydrationWarningHostInstanceIsReplaced,
+    );
+  }
+}
+
+export function didNotFindHydratableTextInstance(
+  parentType: string,
+  parentProps: Props,
+  parentInstance: Instance,
+  text: string,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
+) {
+  if (__DEV__ && parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
+    warnForInsertedHydratedTextInstance(
+      // $FlowFixMe `Instance` and `HostInstance` opaque so incompatible in `ReactFiberHostConfig.custom`.
+      parentInstance,
+      text,
+      hydrationWarningHostInstanceIndex,
+      hydrationWarningHostInstanceIsReplaced,
+    );
+  }
+}
+
+export function didNotFindHydratableSuspenseInstance(
+  parentType: string,
+  parentProps: Props,
+  parentInstance: Instance,
+  hydrationWarningHostInstanceIndex: number,
+  hydrationWarningHostInstanceIsReplaced: boolean,
+) {
+  if (__DEV__ && parentProps[SUPPRESS_HYDRATION_WARNING] !== true) {
+    warnForInsertedHydratedSuspense(
+      // $FlowFixMe `Instance` and `HostInstance` opaque so incompatible in `ReactFiberHostConfig.custom`.
+      parentInstance,
+      hydrationWarningHostInstanceIndex,
+      hydrationWarningHostInstanceIsReplaced,
+    );
+  }
+}

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -31,6 +31,7 @@ export opaque type Instance = mixed; // eslint-disable-line no-undef
 export opaque type TextInstance = mixed; // eslint-disable-line no-undef
 export opaque type SuspenseInstance = mixed; // eslint-disable-line no-undef
 export opaque type HydratableInstance = mixed; // eslint-disable-line no-undef
+export opaque type HostInstance = mixed; // eslint-disable-line no-undef
 export opaque type PublicInstance = mixed; // eslint-disable-line no-undef
 export opaque type HostContext = mixed; // eslint-disable-line no-undef
 export opaque type UpdatePayload = mixed; // eslint-disable-line no-undef
@@ -110,6 +111,16 @@ export const cloneHiddenTextInstance = $$$hostConfig.cloneHiddenTextInstance;
 //     Hydration
 //     (optional)
 // -------------------
+export const getHostInstanceDisplayName =
+  $$$hostConfig.getHostInstanceDisplayName;
+export const getHostInstanceProps = $$$hostConfig.getHostInstanceProps;
+export const isTextInstance = $$$hostConfig.isTextInstance;
+export const getTextInstanceText = $$$hostConfig.getTextInstanceText;
+export const isSuspenseInstance = $$$hostConfig.isSuspenseInstance;
+export const compareTextForHydrationWarning =
+  $$$hostConfig.compareTextForHydrationWarning;
+export const comparePropValueForHydrationWarning =
+  $$$hostConfig.comparePropValueForHydrationWarning;
 export const canHydrateInstance = $$$hostConfig.canHydrateInstance;
 export const canHydrateTextInstance = $$$hostConfig.canHydrateTextInstance;
 export const canHydrateSuspenseInstance =
@@ -129,22 +140,3 @@ export const getNextHydratableInstanceAfterSuspenseInstance =
 export const clearSuspenseBoundary = $$$hostConfig.clearSuspenseBoundary;
 export const clearSuspenseBoundaryFromContainer =
   $$$hostConfig.clearSuspenseBoundaryFromContainer;
-export const didNotMatchHydratedContainerTextInstance =
-  $$$hostConfig.didNotMatchHydratedContainerTextInstance;
-export const didNotMatchHydratedTextInstance =
-  $$$hostConfig.didNotMatchHydratedTextInstance;
-export const didNotHydrateContainerInstance =
-  $$$hostConfig.didNotHydrateContainerInstance;
-export const didNotHydrateInstance = $$$hostConfig.didNotHydrateInstance;
-export const didNotFindHydratableContainerInstance =
-  $$$hostConfig.didNotFindHydratableContainerInstance;
-export const didNotFindHydratableContainerTextInstance =
-  $$$hostConfig.didNotFindHydratableContainerTextInstance;
-export const didNotFindHydratableContainerSuspenseInstance =
-  $$$hostConfig.didNotFindHydratableContainerSuspenseInstance;
-export const didNotFindHydratableInstance =
-  $$$hostConfig.didNotFindHydratableInstance;
-export const didNotFindHydratableTextInstance =
-  $$$hostConfig.didNotFindHydratableTextInstance;
-export const didNotFindHydratableSuspenseInstance =
-  $$$hostConfig.didNotFindHydratableSuspenseInstance;

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -47,6 +47,7 @@ export type TextInstance = {|
   tag: 'TEXT',
 |};
 export type HydratableInstance = Instance | TextInstance;
+export type HostInstance = HydratableInstance | Container;
 export type PublicInstance = Instance | TextInstance;
 export type HostContext = Object;
 export type UpdatePayload = Object;

--- a/packages/shared/HostConfigWithNoHydration.js
+++ b/packages/shared/HostConfigWithNoHydration.js
@@ -23,6 +23,13 @@ function shim(...args: any) {
 
 // Hydration (when unsupported)
 export type SuspenseInstance = mixed;
+export const getHostInstanceDisplayName = shim;
+export const getHostInstanceProps = shim;
+export const isTextInstance = shim;
+export const getTextInstanceText = shim;
+export const isSuspenseInstance = shim;
+export const compareTextForHydrationWarning = shim;
+export const comparePropValueForHydrationWarning = shim;
 export const supportsHydration = false;
 export const canHydrateInstance = shim;
 export const canHydrateTextInstance = shim;
@@ -37,15 +44,5 @@ export const hydrateTextInstance = shim;
 export const getNextHydratableInstanceAfterSuspenseInstance = shim;
 export const clearSuspenseBoundary = shim;
 export const clearSuspenseBoundaryFromContainer = shim;
-export const didNotMatchHydratedContainerTextInstance = shim;
-export const didNotMatchHydratedTextInstance = shim;
-export const didNotHydrateContainerInstance = shim;
-export const didNotHydrateInstance = shim;
-export const didNotFindHydratableContainerInstance = shim;
-export const didNotFindHydratableContainerTextInstance = shim;
-export const didNotFindHydratableContainerSuspenseInstance = shim;
-export const didNotFindHydratableInstance = shim;
-export const didNotFindHydratableTextInstance = shim;
-export const didNotFindHydratableSuspenseInstance = shim;
 export const canHydrateTouchHitTargetInstance = shim;
 export const hydrateTouchHitTargetInstance = shim;


### PR DESCRIPTION
An attempt to implement the hydration warning and DOM diff in react-reconciler package as requested by @gaearon here: https://github.com/facebook/react/pull/12063#pullrequestreview-142612751

> What would diffing look like if it was implemented in the reconciler? Feel free to change host config API if necessary — the goal is that all hydratable renderers would get nice warnings, not just DOM.

The tests and fixtures were copied from the original PR: https://github.com/facebook/react/pull/12063 and slightly modified (see my review below).