### PR TITLE
Enable no-use-before-define rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     'no-shadow': ERROR,
     'no-unused-expressions': ERROR,
     'no-unused-vars': [ERROR, {args: 'none'}],
+    'no-use-before-define': [ERROR, {functions: false, variables: false}],
     'no-useless-concat': OFF,
     'quotes': [ERROR, 'single', {avoidEscape: true, allowTemplateLiterals: true }],
     'space-before-blocks': ERROR,

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -126,6 +126,7 @@ if (__DEV__) {
 
 ReactControlledComponent.setRestoreImplementation(restoreControlledState);
 
+/* eslint-disable no-use-before-define */
 type DOMContainer =
   | (Element & {
       _reactRootContainer: ?Root,
@@ -149,6 +150,20 @@ type Batch = FiberRootBatch & {
   _callbacks: Array<() => mixed> | null,
   _didComplete: boolean,
 };
+
+type Root = {
+  render(children: ReactNodeList, callback: ?() => mixed): Work,
+  unmount(callback: ?() => mixed): Work,
+  legacy_renderSubtreeIntoContainer(
+    parentComponent: ?React$Component<any, any>,
+    children: ReactNodeList,
+    callback: ?() => mixed,
+  ): Work,
+  createBatch(): Batch,
+
+  _internalRoot: FiberRoot,
+};
+/* eslint-enable no-use-before-define */
 
 function ReactBatch(root: ReactRoot) {
   const expirationTime = DOMRenderer.computeUniqueAsyncExpiration();
@@ -315,19 +330,6 @@ ReactWork.prototype._onCommit = function(): void {
     );
     callback();
   }
-};
-
-type Root = {
-  render(children: ReactNodeList, callback: ?() => mixed): Work,
-  unmount(callback: ?() => mixed): Work,
-  legacy_renderSubtreeIntoContainer(
-    parentComponent: ?React$Component<any, any>,
-    children: ReactNodeList,
-    callback: ?() => mixed,
-  ): Work,
-  createBatch(): Batch,
-
-  _internalRoot: FiberRoot,
 };
 
 function ReactRoot(container: Container, isAsync: boolean, hydrate: boolean) {

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -50,6 +50,7 @@ import UIManager from 'UIManager';
 // This means that they never overlap.
 let nextReactTag = 2;
 
+/* eslint-disable no-use-before-define */
 type Node = Object;
 export type Type = string;
 export type Props = Object;
@@ -71,6 +72,7 @@ export type UpdatePayload = Object;
 
 export type TimeoutHandle = TimeoutID;
 export type NoTimeout = -1;
+/* eslint-enable no-use-before-define */
 
 // TODO: Remove this conditional once all changes have propagated.
 if (registerEventHandler) {

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -21,6 +21,7 @@ import type {ReactNodeList} from 'shared/ReactTypes';
 import * as ReactPortal from 'shared/ReactPortal';
 import expect from 'expect';
 
+/* eslint-disable no-use-before-define */
 type Container = {rootID: string, children: Array<Instance | TextInstance>};
 type Props = {prop: any, hidden?: boolean, children?: mixed};
 type Instance = {|
@@ -30,6 +31,7 @@ type Instance = {|
   prop: any,
 |};
 type TextInstance = {|text: string, id: number|};
+/* eslint-enable no-use-before-define */
 
 const NO_CONTEXT = {};
 const UPDATE_SIGNAL = {};

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -18,6 +18,7 @@ import {NoWork} from './ReactFiberExpirationTime';
 import {enableSchedulerTracking} from 'shared/ReactFeatureFlags';
 import {unstable_getThreadID} from 'schedule/tracking';
 
+/* eslint-disable no-use-before-define */
 // TODO: This should be lifted into the renderer.
 export type Batch = {
   _defer: boolean,
@@ -98,6 +99,7 @@ export type FiberRoot = {
   ...BaseFiberRootProperties,
   ...ProfilingOnlyFiberRootProperties,
 };
+/* eslint-enable no-use-before-define */
 
 export function createFiberRoot(
   containerInfo: any,

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -10,6 +10,7 @@
 import warning from 'shared/warning';
 import * as TestRendererScheduling from './ReactTestRendererScheduling';
 
+/* eslint-disable no-use-before-define */
 export type Type = string;
 export type Props = Object;
 export type Container = {|
@@ -35,6 +36,7 @@ export type UpdatePayload = Object;
 export type ChildSet = void; // Unused
 export type TimeoutHandle = TimeoutID;
 export type NoTimeout = -1;
+/* eslint-enable no-use-before-define */
 
 export * from 'shared/HostConfigWithNoPersistence';
 export * from 'shared/HostConfigWithNoHydration';

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -37,6 +37,7 @@ import ReactVersion from 'shared/ReactVersion';
 import * as ReactTestHostConfig from './ReactTestHostConfig';
 import * as TestRendererScheduling from './ReactTestRendererScheduling';
 
+/* eslint-disable no-use-before-define */
 type TestRendererOptions = {
   createNodeMock: (element: React$Element<any>) => any,
   unstable_isAsync: boolean,
@@ -57,6 +58,7 @@ type FindOptions = $Shape<{
 }>;
 
 export type Predicate = (node: ReactTestInstance) => ?boolean;
+/* eslint-enable no-use-before-define */
 
 const defaultTestOptions = {
   createNodeMock: function() {
@@ -207,19 +209,6 @@ function toTree(node: ?Fiber) {
         node.tag,
       );
   }
-}
-
-const fiberToWrapper = new WeakMap();
-function wrapFiber(fiber: Fiber): ReactTestInstance {
-  let wrapper = fiberToWrapper.get(fiber);
-  if (wrapper === undefined && fiber.alternate !== null) {
-    wrapper = fiberToWrapper.get(fiber.alternate);
-  }
-  if (wrapper === undefined) {
-    wrapper = new ReactTestInstance(fiber);
-    fiberToWrapper.set(fiber, wrapper);
-  }
-  return wrapper;
 }
 
 const validWrapperTypes = new Set([
@@ -542,6 +531,19 @@ const ReactTestRendererFiber = {
 
   unstable_setNowImplementation: TestRendererScheduling.setNowImplementation,
 };
+
+const fiberToWrapper = new WeakMap();
+function wrapFiber(fiber: Fiber): ReactTestInstance {
+  let wrapper = fiberToWrapper.get(fiber);
+  if (wrapper === undefined && fiber.alternate !== null) {
+    wrapper = fiberToWrapper.get(fiber.alternate);
+  }
+  if (wrapper === undefined) {
+    wrapper = new ReactTestInstance(fiber);
+    fiberToWrapper.set(fiber, wrapper);
+  }
+  return wrapper;
+}
 
 // Enable ReactTestRenderer to be used to test DevTools integration.
 TestRenderer.injectIntoDevTools({

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+/* eslint-disable no-use-before-define */
 export type ReactNode =
   | React$Element<any>
   | ReactPortal
@@ -14,14 +15,15 @@ export type ReactNode =
   | ReactFragment
   | ReactProvider<any>
   | ReactConsumer<any>;
+/* eslint-enable no-use-before-define */
+
+export type ReactEmpty = null | void | boolean;
 
 export type ReactFragment = ReactEmpty | Iterable<React$Node>;
 
 export type ReactNodeList = ReactEmpty | React$Node;
 
 export type ReactText = string | number;
-
-export type ReactEmpty = null | void | boolean;
 
 export type ReactProvider<T> = {
   $$typeof: Symbol | number,


### PR DESCRIPTION
This would have caught https://github.com/facebook/react/pull/13582#discussion_r216163970.

For now, I had to add suppressions for cyclical Flow references but we can remove this after https://github.com/babel/babel-eslint/pull/584 is merged and released.

I also enabled it for classes. Maybe this is excessive but I figured it doesn't hurt since classes aren't hoisted. I had to reorder two places because of that but it's just copy paste.