### PR TITLE
Fix a regression related to isReactComponent prototype check

### DIFF
--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -1762,4 +1762,18 @@ describe('ReactCompositeComponent', () => {
       {withoutStack: true},
     );
   });
+
+  // Regression test for accidental breaking change
+  // https://github.com/facebook/react/issues/13580
+  it('should support classes shadowing isReactComponent', () => {
+    class Shadow extends React.Component {
+      isReactComponent() {}
+      render() {
+        return <div />;
+      }
+    }
+    const container = document.createElement('div');
+    ReactDOM.render(<Shadow />, container);
+    expect(container.firstChild.tagName).toBe('DIV');
+  });
 });

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -284,12 +284,7 @@ const createFiber = function(
 
 function shouldConstruct(Component: Function) {
   const prototype = Component.prototype;
-  return (
-    typeof prototype === 'object' &&
-    prototype !== null &&
-    typeof prototype.isReactComponent === 'object' &&
-    prototype.isReactComponent !== null
-  );
+  return !!(prototype && prototype.isReactComponent);
 }
 
 export function resolveLazyComponentTag(


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/13580.

I didn't bother to add a warning since it would only point out legitimate problems for *functional* components that happen to have a prototype *and* `isReactComponent` on it... which seems like very low probability. So we might as well allow shadowing.