### PR TITLE
Manually update schedule dep in react-native-renderer

### DIFF
--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "schedule": "^0.2.0"
+    "schedule": "^0.3.0"
   },
   "peerDependencies": {
     "react": "^16.0.0"


### PR DESCRIPTION
The build script didn't update this `package.json` because of the `private: true` flag. Running `yarn install` in the React repo will complain now though because of the mismatch.