### PR TITLE
Release script updates private package dependencies also

### DIFF
--- a/scripts/release/build.js
+++ b/scripts/release/build.js
@@ -8,7 +8,7 @@ const {exec} = require('child_process');
 const run = async () => {
   const chalk = require('chalk');
   const logUpdate = require('log-update');
-  const {getPublicPackages} = require('./utils');
+  const {getPublicPackages, getPackages} = require('./utils');
 
   const addGitTag = require('./build-commands/add-git-tag');
   const buildArtifacts = require('./build-commands/build-artifacts');
@@ -31,6 +31,7 @@ const run = async () => {
   try {
     const params = parseBuildParameters();
     params.packages = getPublicPackages();
+
     await checkEnvironmentVariables(params);
     await validateVersion(params);
     await checkUncommittedChanges(params);
@@ -41,7 +42,13 @@ const run = async () => {
     await checkPackageDependencies(params);
     await updateYarnDependencies(params);
     await runAutomatedTests(params);
-    await updatePackageVersions(params);
+    // Also update NPM dependencies for private packages (e.g. react-native-renderer)
+    // Even though we don't publish these to NPM,
+    // mismatching dependencies can cause `yarn install` to install duplicate packages.
+    await updatePackageVersions({
+      ...params,
+      packages: getPackages(),
+    });
     await updateNoopRendererDependencies(params);
     await buildArtifacts(params);
     await runAutomatedBundleTests(params);

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -23,6 +23,23 @@ const execUnlessDry = async (command, {cwd, dry}) => {
   }
 };
 
+const getPackages = () => {
+  const packagesRoot = join(__dirname, '..', '..', 'packages');
+
+  return readdirSync(packagesRoot).filter(dir => {
+    const packagePath = join(packagesRoot, dir, 'package.json');
+
+    if (dir.charAt(0) !== '.' && statSync(packagePath).isFile()) {
+      const packageJSON = JSON.parse(readFileSync(packagePath));
+
+      // Skip packages like "shared" and "events" that shouldn't be updated.
+      return packageJSON.version !== '0.0.0';
+    }
+
+    return false;
+  });
+};
+
 const getPublicPackages = () => {
   const packagesRoot = join(__dirname, '..', '..', 'packages');
 
@@ -99,6 +116,7 @@ const runYarnTask = async (cwd, task, errorMessage) => {
 module.exports = {
   execRead,
   execUnlessDry,
+  getPackages,
   getPublicPackages,
   getUnexecutedCommands,
   logPromise,


### PR DESCRIPTION
Follow up to #13609

Running a "dry" build for 16.5.1 with this change made resulted in the following package JSON changes:
```diff
diff --git a/package.json b/package.json
index d13a853c2..a9e90be08 100644
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "16.5.0",
+  "version": "16.5.1",
   "workspaces": [
     "packages/*"
   ],
diff --git a/packages/create-subscription/package.json b/packages/create-subscription/package.json
index 87751232b..8908afd8a 100644
--- a/packages/create-subscription/package.json
+++ b/packages/create-subscription/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-subscription",
   "description": "utility for subscribing to external data sources inside React components",
-  "version": "16.5.0",
+  "version": "16.5.1",
   "repository": "facebook/react",
   "files": [
     "LICENSE",
diff --git a/packages/react-art/package.json b/packages/react-art/package.json
index d97da9fc1..95f424282 100644
--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-art",
   "description": "React ART is a JavaScript library for drawing vector graphics using React. It provides declarative and reactive bindings to the ART library. Using the same declarative API you can render the output to either Canvas, SVG or VML (IE8).",
-  "version": "16.5.0",
+  "version": "16.5.1",
   "main": "index.js",
   "repository": "facebook/react",
   "keywords": [
@@ -23,7 +23,7 @@
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "schedule": "^0.3.0"
+    "schedule": "^0.4.0"
   },
   "peerDependencies": {
     "react": "^16.0.0"
diff --git a/packages/react-dom/package.json b/packages/react-dom/package.json
index 36c5b076f..2ad460879 100644
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dom",
-  "version": "16.5.0",
+  "version": "16.5.1",
   "description": "React package for working with the DOM.",
   "main": "index.js",
   "repository": "facebook/react",
@@ -16,7 +16,7 @@
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "schedule": "^0.3.0"
+    "schedule": "^0.4.0"
   },
   "peerDependencies": {
     "react": "^16.0.0"
diff --git a/packages/react-is/package.json b/packages/react-is/package.json
index b1a76bdf8..195858013 100644
--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-is",
-  "version": "16.5.0",
+  "version": "16.5.1",
   "description": "Brand checking of React Elements.",
   "main": "index.js",
   "repository": "facebook/react",
diff --git a/packages/react-native-renderer/package.json b/packages/react-native-renderer/package.json
index 5168d6eaf..34748f8d2 100644
--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "schedule": "^0.3.0"
+    "schedule": "^0.4.0"
   },
   "peerDependencies": {
     "react": "^16.0.0"
diff --git a/packages/react-reconciler/package.json b/packages/react-reconciler/package.json
index a401cea51..95cd741e3 100644
--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-reconciler",
   "description": "React package for creating custom renderers.",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "keywords": [
     "react"
   ],
@@ -28,7 +28,7 @@
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "schedule": "^0.3.0"
+    "schedule": "^0.4.0"
   },
   "browserify": {
     "transform": [
diff --git a/packages/react-test-renderer/package.json b/packages/react-test-renderer/package.json
index 06fe74c15..5d138c8bf 100644
--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-test-renderer",
-  "version": "16.5.0",
+  "version": "16.5.1",
   "description": "React package for snapshot testing.",
   "main": "index.js",
   "repository": "facebook/react",
@@ -17,8 +17,8 @@
   "dependencies": {
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "react-is": "^16.5.0",
-    "schedule": "^0.3.0"
+    "react-is": "^16.5.1",
+    "schedule": "^0.4.0"
   },
   "peerDependencies": {
     "react": "^16.0.0"
diff --git a/packages/react/package.json b/packages/react/package.json
index 65eb8edef..bcc0b14f9 100644
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "react"
   ],
-  "version": "16.5.0",
+  "version": "16.5.1",
   "homepage": "https://reactjs.org/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "schedule": "^0.3.0"
+    "schedule": "^0.4.0"
   },
   "browserify": {
     "transform": [
diff --git a/packages/schedule/package.json b/packages/schedule/package.json
index f0ce6c2a4..07a8cc94e 100644
--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schedule",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Cooperative scheduler for the browser environment.",
   "main": "index.js",
   "repository": "facebook/react",
diff --git a/packages/shared/ReactVersion.js b/packages/shared/ReactVersion.js
index a0bbbee0a..498f960c2 100644
--- a/packages/shared/ReactVersion.js
+++ b/packages/shared/ReactVersion.js
@@ -8,4 +8,4 @@
 'use strict';
 
 // TODO: this is special because it gets imported during build.
-module.exports = '16.5.0';
+module.exports = '16.5.1';
diff --git a/packages/simple-cache-provider/package.json b/packages/simple-cache-provider/package.json
index 3e2e0261e..b2e556245 100644
--- a/packages/simple-cache-provider/package.json
+++ b/packages/simple-cache-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-cache-provider",
   "description": "A basic cache for React applications",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "repository": "facebook/react",
   "files": [
     "LICENSE",
```