### PR TITLE
Remove event pooling

### DIFF
--- a/fixtures/dom/.gitignore
+++ b/fixtures/dom/.gitignore
@@ -9,7 +9,9 @@ coverage
 # production
 build
 public/react.development.js
+public/react.production.min.js
 public/react-dom.development.js
+public/react-dom.production.min.js
 
 # misc
 .DS_Store

--- a/fixtures/dom/package.json
+++ b/fixtures/dom/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "prestart": "cp ../../build/dist/react.development.js public/ && cp ../../build/dist/react-dom.development.js public/",
+    "prestart": "cp ../../build/dist/react.development.js public/ && cp ../../build/dist/react-dom.development.js public/ && cp ../../build/dist/react.production.min.js public/ && cp ../../build/dist/react-dom.production.min.js public/",
     "build": "react-scripts build && cp build/index.html build/200.html",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/fixtures/dom/src/components/Header.js
+++ b/fixtures/dom/src/components/Header.js
@@ -7,8 +7,9 @@ class Header extends React.Component {
     super(props, context);
     const query = parse(window.location.search);
     const version = query.version || 'local';
+    const production = query.production || false;
     const versions = [version];
-    this.state = {version, versions};
+    this.state = {version, versions, production};
   }
   componentWillMount() {
     getVersionTags().then(tags => {
@@ -22,6 +23,14 @@ class Header extends React.Component {
     query.version = event.target.value;
     if (query.version === 'local') {
       delete query.version;
+    }
+    window.location.search = stringify(query);
+  }
+  handleProductionChange(event) {
+    const query = parse(window.location.search);
+    query.production = event.target.checked;
+    if (!query.production) {
+      delete query.production;
     }
     window.location.search = stringify(query);
   }
@@ -80,6 +89,15 @@ class Header extends React.Component {
                   </option>
                 ))}
               </select>
+            </label>
+            <input
+              id="react_production"
+              type="checkbox"
+              checked={this.state.production}
+              onChange={this.handleProductionChange}
+            />
+            <label htmlFor="react_production">
+              <span className="header__label">Production</span>
             </label>
           </div>
         </div>

--- a/fixtures/dom/src/react-loader.js
+++ b/fixtures/dom/src/react-loader.js
@@ -42,23 +42,27 @@ export default function loadReact() {
 
   let query = parseQuery(window.location.search);
   let version = query.version || 'local';
+  let production = query.production === 'true';
 
-  if (version !== 'local') {
+  if (version === 'local' && production) {
+    REACT_PATH = 'react.production.min.js';
+    DOM_PATH = 'react-dom.production.min.js';
+  } else if (version !== 'local') {
     const {major, minor, prerelease} = semver(version);
     const [preReleaseStage] = prerelease;
     // The file structure was updated in 16. This wasn't the case for alphas.
     // Load the old module location for anything less than 16 RC
     if (major >= 16 && !(minor === 0 && preReleaseStage === 'alpha')) {
-      REACT_PATH =
-        'https://unpkg.com/react@' + version + '/umd/react.development.js';
+      const suffix = production ? '.production.min.js' : '.development.js';
+      REACT_PATH = 'https://unpkg.com/react@' + version + '/umd/react' + suffix;
       DOM_PATH =
-        'https://unpkg.com/react-dom@' +
-        version +
-        '/umd/react-dom.development.js';
+        'https://unpkg.com/react-dom@' + version + '/umd/react-dom' + suffix;
     } else {
-      REACT_PATH = 'https://unpkg.com/react@' + version + '/dist/react.js';
+      const suffix = production ? '.min.js' : '.js';
+      REACT_PATH =
+        'https://unpkg.com/react@' + version + '/dist/react' + suffix;
       DOM_PATH =
-        'https://unpkg.com/react-dom@' + version + '/dist/react-dom.js';
+        'https://unpkg.com/react-dom@' + version + '/dist/react-dom' + suffix;
     }
   }
 

--- a/fixtures/dom/src/style.css
+++ b/fixtures/dom/src/style.css
@@ -128,6 +128,11 @@ textarea {
   width: 100%;
 }
 
+.header__label {
+  font-size: 12px;
+  color: #ccc;
+}
+
 .sr-only {
   clip: rect(0, 0, 0, 0);
   height: 0;

--- a/packages/events/EventPluginHub.js
+++ b/packages/events/EventPluginHub.js
@@ -33,30 +33,11 @@ import type {TopLevelType} from './TopLevelEventTypes';
  */
 let eventQueue: ?(Array<ReactSyntheticEvent> | ReactSyntheticEvent) = null;
 
-/**
- * Dispatches an event and releases it back into the pool, unless persistent.
- *
- * @param {?object} event Synthetic event to be dispatched.
- * @param {boolean} simulated If the event is simulated (changes exn behavior)
- * @private
- */
-const executeDispatchesAndRelease = function(
-  event: ReactSyntheticEvent,
-  simulated: boolean,
-) {
-  if (event) {
-    executeDispatchesInOrder(event, simulated);
-
-    if (!event.isPersistent()) {
-      event.constructor.release(event);
-    }
-  }
+const executeDispatchesSimulated = function(e) {
+  return executeDispatchesInOrder(e, true);
 };
-const executeDispatchesAndReleaseSimulated = function(e) {
-  return executeDispatchesAndRelease(e, true);
-};
-const executeDispatchesAndReleaseTopLevel = function(e) {
-  return executeDispatchesAndRelease(e, false);
+const executeDispatchesTopLevel = function(e) {
+  return executeDispatchesInOrder(e, false);
 };
 
 function isInteractive(tag) {
@@ -208,15 +189,9 @@ export function runEventsInBatch(
   }
 
   if (simulated) {
-    forEachAccumulated(
-      processingEventQueue,
-      executeDispatchesAndReleaseSimulated,
-    );
+    forEachAccumulated(processingEventQueue, executeDispatchesSimulated);
   } else {
-    forEachAccumulated(
-      processingEventQueue,
-      executeDispatchesAndReleaseTopLevel,
-    );
+    forEachAccumulated(processingEventQueue, executeDispatchesTopLevel);
   }
   invariant(
     !eventQueue,

--- a/packages/events/ResponderEventPlugin.js
+++ b/packages/events/ResponderEventPlugin.js
@@ -365,7 +365,7 @@ function setResponderAndExtractTransfer(
   // It's strange to get an `onMoveShouldSetResponder` when you're *already*
   // the responder.
   const skipOverBubbleShouldSetFrom = bubbleShouldSetFrom === responderInst;
-  const shouldSetEvent = ResponderSyntheticEvent.getPooled(
+  const shouldSetEvent = new ResponderSyntheticEvent(
     shouldSetEventType,
     bubbleShouldSetFrom,
     nativeEvent,
@@ -378,15 +378,12 @@ function setResponderAndExtractTransfer(
     accumulateTwoPhaseDispatches(shouldSetEvent);
   }
   const wantsResponderInst = executeDispatchesInOrderStopAtTrue(shouldSetEvent);
-  if (!shouldSetEvent.isPersistent()) {
-    shouldSetEvent.constructor.release(shouldSetEvent);
-  }
 
   if (!wantsResponderInst || wantsResponderInst === responderInst) {
     return null;
   }
   let extracted;
-  const grantEvent = ResponderSyntheticEvent.getPooled(
+  const grantEvent = new ResponderSyntheticEvent(
     eventTypes.responderGrant,
     wantsResponderInst,
     nativeEvent,
@@ -397,7 +394,7 @@ function setResponderAndExtractTransfer(
   accumulateDirectDispatches(grantEvent);
   const blockHostResponder = executeDirectDispatch(grantEvent) === true;
   if (responderInst) {
-    const terminationRequestEvent = ResponderSyntheticEvent.getPooled(
+    const terminationRequestEvent = new ResponderSyntheticEvent(
       eventTypes.responderTerminationRequest,
       responderInst,
       nativeEvent,
@@ -409,12 +406,9 @@ function setResponderAndExtractTransfer(
     const shouldSwitch =
       !hasDispatches(terminationRequestEvent) ||
       executeDirectDispatch(terminationRequestEvent);
-    if (!terminationRequestEvent.isPersistent()) {
-      terminationRequestEvent.constructor.release(terminationRequestEvent);
-    }
 
     if (shouldSwitch) {
-      const terminateEvent = ResponderSyntheticEvent.getPooled(
+      const terminateEvent = new ResponderSyntheticEvent(
         eventTypes.responderTerminate,
         responderInst,
         nativeEvent,
@@ -425,7 +419,7 @@ function setResponderAndExtractTransfer(
       extracted = accumulate(extracted, [grantEvent, terminateEvent]);
       changeResponder(wantsResponderInst, blockHostResponder);
     } else {
-      const rejectEvent = ResponderSyntheticEvent.getPooled(
+      const rejectEvent = new ResponderSyntheticEvent(
         eventTypes.responderReject,
         wantsResponderInst,
         nativeEvent,
@@ -553,7 +547,7 @@ const ResponderEventPlugin = {
           : null;
 
     if (incrementalTouch) {
-      const gesture = ResponderSyntheticEvent.getPooled(
+      const gesture = new ResponderSyntheticEvent(
         incrementalTouch,
         responderInst,
         nativeEvent,
@@ -577,7 +571,7 @@ const ResponderEventPlugin = {
         ? eventTypes.responderRelease
         : null;
     if (finalTouch) {
-      const finalEvent = ResponderSyntheticEvent.getPooled(
+      const finalEvent = new ResponderSyntheticEvent(
         finalTouch,
         responderInst,
         nativeEvent,

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -340,9 +340,7 @@ describe('ReactTestUtils', () => {
   describe('Simulate', () => {
     it('should change the value of an input field', () => {
       const obj = {
-        handler: function(e) {
-          e.persist();
-        },
+        handler: function() {},
       };
       spyOnDevAndProd(obj, 'handler').and.callThrough();
       const container = document.createElement('div');
@@ -375,9 +373,7 @@ describe('ReactTestUtils', () => {
       }
 
       const obj = {
-        handler: function(e) {
-          e.persist();
-        },
+        handler: function() {},
       };
       spyOnDevAndProd(obj, 'handler').and.callThrough();
       const container = document.createElement('div');
@@ -460,7 +456,6 @@ describe('ReactTestUtils', () => {
     it('should set the type of the event', () => {
       let event;
       const stub = jest.fn().mockImplementation(e => {
-        e.persist();
         event = e;
       });
 

--- a/packages/react-dom/src/events/BeforeInputEventPlugin.js
+++ b/packages/react-dom/src/events/BeforeInputEventPlugin.js
@@ -254,7 +254,7 @@ function extractCompositionEvent(
     }
   }
 
-  const event = SyntheticCompositionEvent.getPooled(
+  const event = new SyntheticCompositionEvent(
     eventType,
     targetInst,
     nativeEvent,
@@ -425,7 +425,7 @@ function extractBeforeInputEvent(
     return null;
   }
 
-  const event = SyntheticInputEvent.getPooled(
+  const event = new SyntheticInputEvent(
     eventTypes.beforeInput,
     targetInst,
     nativeEvent,

--- a/packages/react-dom/src/events/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/ChangeEventPlugin.js
@@ -49,7 +49,7 @@ const eventTypes = {
 };
 
 function createAndAccumulateChangeEvent(inst, nativeEvent, target) {
-  const event = SyntheticEvent.getPooled(
+  const event = new SyntheticEvent(
     eventTypes.change,
     inst,
     nativeEvent,

--- a/packages/react-dom/src/events/EnterLeaveEventPlugin.js
+++ b/packages/react-dom/src/events/EnterLeaveEventPlugin.js
@@ -120,7 +120,7 @@ const EnterLeaveEventPlugin = {
     const fromNode = from == null ? win : getNodeFromInstance(from);
     const toNode = to == null ? win : getNodeFromInstance(to);
 
-    const leave = eventInterface.getPooled(
+    const leave = new eventInterface(
       leaveEventType,
       from,
       nativeEvent,
@@ -130,7 +130,7 @@ const EnterLeaveEventPlugin = {
     leave.target = fromNode;
     leave.relatedTarget = toNode;
 
-    const enter = eventInterface.getPooled(
+    const enter = new eventInterface(
       enterEventType,
       to,
       nativeEvent,

--- a/packages/react-dom/src/events/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/SelectEventPlugin.js
@@ -128,7 +128,7 @@ function constructSelectEvent(nativeEvent, nativeEventTarget) {
   if (!lastSelection || !shallowEqual(lastSelection, currentSelection)) {
     lastSelection = currentSelection;
 
-    const syntheticEvent = SyntheticEvent.getPooled(
+    const syntheticEvent = new SyntheticEvent(
       eventTypes.select,
       activeElementInst,
       nativeEvent,

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -319,7 +319,7 @@ const SimpleEventPlugin: PluginModule<MouseEvent> & {
         EventConstructor = SyntheticEvent;
         break;
     }
-    const event = EventConstructor.getPooled(
+    const event = new EventConstructor(
       dispatchConfig,
       targetInst,
       nativeEvent,

--- a/packages/react-dom/src/events/TapEventPlugin.js
+++ b/packages/react-dom/src/events/TapEventPlugin.js
@@ -181,7 +181,7 @@ const TapEventPlugin = {
     let event = null;
     const distance = getDistance(startCoords, nativeEvent);
     if (isEndish(topLevelType) && distance < tapMoveThreshold) {
-      event = SyntheticUIEvent.getPooled(
+      event = new SyntheticUIEvent(
         eventTypes.touchTap,
         targetInst,
         nativeEvent,

--- a/packages/react-dom/src/events/__tests__/EnterLeaveEventPlugin-test.js
+++ b/packages/react-dom/src/events/__tests__/EnterLeaveEventPlugin-test.js
@@ -44,7 +44,6 @@ describe('EnterLeaveEventPlugin', () => {
     const node = ReactDOM.render(
       <div
         onMouseLeave={e => {
-          e.persist();
           leaveEvents.push(e);
         }}
       />,
@@ -77,7 +76,6 @@ describe('EnterLeaveEventPlugin', () => {
     const node = ReactDOM.render(
       <div
         onMouseEnter={e => {
-          e.persist();
           enterEvents.push(e);
         }}
       />,

--- a/packages/react-dom/src/events/__tests__/SyntheticClipboardEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticClipboardEvent-test.js
@@ -116,42 +116,5 @@ describe('SyntheticClipboardEvent', () => {
 
       expect(expectedCount).toBe(3);
     });
-
-    it('is able to `persist`', () => {
-      const persistentEvents = [];
-      const eventHandler = event => {
-        expect(event.isPersistent()).toBe(false);
-        event.persist();
-        expect(event.isPersistent()).toBe(true);
-        persistentEvents.push(event);
-      };
-
-      const div = ReactDOM.render(
-        <div
-          onCopy={eventHandler}
-          onCut={eventHandler}
-          onPaste={eventHandler}
-        />,
-        container,
-      );
-
-      let event;
-      event = document.createEvent('Event');
-      event.initEvent('copy', true, true);
-      div.dispatchEvent(event);
-
-      event = document.createEvent('Event');
-      event.initEvent('cut', true, true);
-      div.dispatchEvent(event);
-
-      event = document.createEvent('Event');
-      event.initEvent('paste', true, true);
-      div.dispatchEvent(event);
-
-      expect(persistentEvents.length).toBe(3);
-      expect(persistentEvents[0].type).toBe('copy');
-      expect(persistentEvents[1].type).toBe('cut');
-      expect(persistentEvents[2].type).toBe('paste');
-    });
   });
 });

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -102,18 +102,18 @@ describe('SyntheticEvent', () => {
     expect(expectedCount).toBe(1);
   });
 
-  it('should be able to `persist`', () => {
+  it('should indicate that it is persisted and warn when calling `persist`', () => {
     let node;
-    let expectedCount = 0;
     let syntheticEvent;
 
     const eventHandler = e => {
-      expect(e.isPersistent()).toBe(false);
-      e.persist();
+      expect(e.isPersistent()).toBe(true);
+      expect(() => e.persist()).toWarnDev(
+        'Deprecated SyntheticEvent.persist called for click event',
+        {withoutStack: true},
+      );
       syntheticEvent = e;
       expect(e.isPersistent()).toBe(true);
-
-      expectedCount++;
     };
     node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
@@ -122,208 +122,6 @@ describe('SyntheticEvent', () => {
     node.dispatchEvent(event);
 
     expect(syntheticEvent.type).toBe('click');
-    expect(syntheticEvent.bubbles).toBe(true);
-    expect(syntheticEvent.cancelable).toBe(true);
-    expect(expectedCount).toBe(1);
-  });
-
-  it('should be nullified and log warnings if the synthetic event has not been persisted', () => {
-    let node;
-    let expectedCount = 0;
-    let syntheticEvent;
-
-    const eventHandler = e => {
-      syntheticEvent = e;
-
-      expectedCount++;
-    };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
-
-    const event = document.createEvent('Event');
-    event.initEvent('click', true, true);
-    node.dispatchEvent(event);
-
-    const getExpectedWarning = property =>
-      'Warning: This synthetic event is reused for performance reasons. If ' +
-      `you're seeing this, you're accessing the property \`${property}\` on a ` +
-      'released/nullified synthetic event. This is set to null. If you must ' +
-      'keep the original synthetic event around, use event.persist(). ' +
-      'See https://fb.me/react-event-pooling for more information.';
-
-    // once for each property accessed
-    expect(() => expect(syntheticEvent.type).toBe(null)).toWarnDev(
-      getExpectedWarning('type'),
-      {withoutStack: true},
-    );
-    expect(() => expect(syntheticEvent.nativeEvent).toBe(null)).toWarnDev(
-      getExpectedWarning('nativeEvent'),
-      {withoutStack: true},
-    );
-    expect(() => expect(syntheticEvent.target).toBe(null)).toWarnDev(
-      getExpectedWarning('target'),
-      {withoutStack: true},
-    );
-
-    expect(expectedCount).toBe(1);
-  });
-
-  it('should warn when setting properties of a synthetic event that has not been persisted', () => {
-    let node;
-    let expectedCount = 0;
-    let syntheticEvent;
-
-    const eventHandler = e => {
-      syntheticEvent = e;
-
-      expectedCount++;
-    };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
-
-    const event = document.createEvent('Event');
-    event.initEvent('click', true, true);
-    node.dispatchEvent(event);
-
-    expect(() => {
-      syntheticEvent.type = 'MouseEvent';
-    }).toWarnDev(
-      'Warning: This synthetic event is reused for performance reasons. If ' +
-        "you're seeing this, you're setting the property `type` on a " +
-        'released/nullified synthetic event. This is effectively a no-op. If you must ' +
-        'keep the original synthetic event around, use event.persist(). ' +
-        'See https://fb.me/react-event-pooling for more information.',
-      {withoutStack: true},
-    );
-    expect(expectedCount).toBe(1);
-  });
-
-  it('should warn when calling `preventDefault` if the synthetic event has not been persisted', () => {
-    let node;
-    let expectedCount = 0;
-    let syntheticEvent;
-
-    const eventHandler = e => {
-      syntheticEvent = e;
-      expectedCount++;
-    };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
-
-    const event = document.createEvent('Event');
-    event.initEvent('click', true, true);
-    node.dispatchEvent(event);
-
-    expect(() => syntheticEvent.preventDefault()).toWarnDev(
-      'Warning: This synthetic event is reused for performance reasons. If ' +
-        "you're seeing this, you're accessing the method `preventDefault` on a " +
-        'released/nullified synthetic event. This is a no-op function. If you must ' +
-        'keep the original synthetic event around, use event.persist(). ' +
-        'See https://fb.me/react-event-pooling for more information.',
-      {withoutStack: true},
-    );
-    expect(expectedCount).toBe(1);
-  });
-
-  it('should warn when calling `stopPropagation` if the synthetic event has not been persisted', () => {
-    let node;
-    let expectedCount = 0;
-    let syntheticEvent;
-
-    const eventHandler = e => {
-      syntheticEvent = e;
-      expectedCount++;
-    };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
-
-    const event = document.createEvent('Event');
-    event.initEvent('click', true, true);
-
-    node.dispatchEvent(event);
-
-    expect(() => syntheticEvent.stopPropagation()).toWarnDev(
-      'Warning: This synthetic event is reused for performance reasons. If ' +
-        "you're seeing this, you're accessing the method `stopPropagation` on a " +
-        'released/nullified synthetic event. This is a no-op function. If you must ' +
-        'keep the original synthetic event around, use event.persist(). ' +
-        'See https://fb.me/react-event-pooling for more information.',
-      {withoutStack: true},
-    );
-    expect(expectedCount).toBe(1);
-  });
-
-  it('should warn when calling `isPropagationStopped` if the synthetic event has not been persisted', () => {
-    let node;
-    let expectedCount = 0;
-    let syntheticEvent;
-
-    const eventHandler = e => {
-      syntheticEvent = e;
-      expectedCount++;
-    };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
-
-    const event = document.createEvent('Event');
-    event.initEvent('click', true, true);
-    node.dispatchEvent(event);
-
-    expect(() =>
-      expect(syntheticEvent.isPropagationStopped()).toBe(false),
-    ).toWarnDev(
-      'Warning: This synthetic event is reused for performance reasons. If ' +
-        "you're seeing this, you're accessing the method `isPropagationStopped` on a " +
-        'released/nullified synthetic event. This is a no-op function. If you must ' +
-        'keep the original synthetic event around, use event.persist(). ' +
-        'See https://fb.me/react-event-pooling for more information.',
-      {withoutStack: true},
-    );
-    expect(expectedCount).toBe(1);
-  });
-
-  it('should warn when calling `isDefaultPrevented` if the synthetic event has not been persisted', () => {
-    let node;
-    let expectedCount = 0;
-    let syntheticEvent;
-
-    const eventHandler = e => {
-      syntheticEvent = e;
-      expectedCount++;
-    };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
-
-    const event = document.createEvent('Event');
-    event.initEvent('click', true, true);
-    node.dispatchEvent(event);
-
-    expect(() =>
-      expect(syntheticEvent.isDefaultPrevented()).toBe(false),
-    ).toWarnDev(
-      'Warning: This synthetic event is reused for performance reasons. If ' +
-        "you're seeing this, you're accessing the method `isDefaultPrevented` on a " +
-        'released/nullified synthetic event. This is a no-op function. If you must ' +
-        'keep the original synthetic event around, use event.persist(). ' +
-        'See https://fb.me/react-event-pooling for more information.',
-      {withoutStack: true},
-    );
-    expect(expectedCount).toBe(1);
-  });
-
-  it('should properly log warnings when events simulated with rendered components', () => {
-    let event;
-    function assignEvent(e) {
-      event = e;
-    }
-    const node = ReactDOM.render(<div onClick={assignEvent} />, container);
-    node.click();
-
-    // access a property to cause the warning
-    expect(() => {
-      event.nativeEvent; // eslint-disable-line no-unused-expressions
-    }).toWarnDev(
-      'Warning: This synthetic event is reused for performance reasons. If ' +
-        "you're seeing this, you're accessing the property `nativeEvent` on a " +
-        'released/nullified synthetic event. This is set to null. If you must ' +
-        'keep the original synthetic event around, use event.persist(). ' +
-        'See https://fb.me/react-event-pooling for more information.',
-      {withoutStack: true},
-    );
   });
 
   // TODO: we might want to re-add a warning like this in the future,

--- a/packages/react-dom/src/events/__tests__/SyntheticKeyboardEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticKeyboardEvent-test.js
@@ -499,50 +499,5 @@ describe('SyntheticKeyboardEvent', () => {
       );
       expect(expectedCount).toBe(3);
     });
-
-    it('is able to `persist`', () => {
-      const persistentEvents = [];
-      const eventHandler = event => {
-        expect(event.isPersistent()).toBe(false);
-        event.persist();
-        expect(event.isPersistent()).toBe(true);
-        persistentEvents.push(event);
-      };
-      let div = ReactDOM.render(
-        <div
-          onKeyDown={eventHandler}
-          onKeyUp={eventHandler}
-          onKeyPress={eventHandler}
-        />,
-        container,
-      );
-
-      div.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          keyCode: 40,
-          bubbles: true,
-          cancelable: true,
-        }),
-      );
-      div.dispatchEvent(
-        new KeyboardEvent('keyup', {
-          keyCode: 40,
-          bubbles: true,
-          cancelable: true,
-        }),
-      );
-      div.dispatchEvent(
-        new KeyboardEvent('keypress', {
-          charCode: 40,
-          keyCode: 40,
-          bubbles: true,
-          cancelable: true,
-        }),
-      );
-      expect(persistentEvents.length).toBe(3);
-      expect(persistentEvents[0].type).toBe('keydown');
-      expect(persistentEvents[1].type).toBe('keyup');
-      expect(persistentEvents[2].type).toBe('keypress');
-    });
   });
 });

--- a/packages/react-dom/src/events/__tests__/SyntheticWheelEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticWheelEvent-test.js
@@ -32,7 +32,6 @@ describe('SyntheticWheelEvent', () => {
   it('should normalize properties from the MouseEvent interface', () => {
     const events = [];
     const onWheel = event => {
-      event.persist();
       events.push(event);
     };
     ReactDOM.render(<div onWheel={onWheel} />, container);
@@ -51,7 +50,6 @@ describe('SyntheticWheelEvent', () => {
   it('should normalize properties from the WheelEvent interface', () => {
     const events = [];
     const onWheel = event => {
-      event.persist();
       events.push(event);
     };
     ReactDOM.render(<div onWheel={onWheel} />, container);
@@ -89,7 +87,6 @@ describe('SyntheticWheelEvent', () => {
       expect(event.isDefaultPrevented()).toBe(false);
       event.preventDefault();
       expect(event.isDefaultPrevented()).toBe(true);
-      event.persist();
       events.push(event);
     };
     ReactDOM.render(<div onWheel={onWheel} />, container);
@@ -111,25 +108,5 @@ describe('SyntheticWheelEvent', () => {
     );
 
     expect(events.length).toBe(2);
-  });
-
-  it('should be able to `persist`', () => {
-    const events = [];
-    const onWheel = event => {
-      expect(event.isPersistent()).toBe(false);
-      event.persist();
-      expect(event.isPersistent()).toBe(true);
-      events.push(event);
-    };
-    ReactDOM.render(<div onWheel={onWheel} />, container);
-
-    container.firstChild.dispatchEvent(
-      new MouseEvent('wheel', {
-        bubbles: true,
-      }),
-    );
-
-    expect(events.length).toBe(1);
-    expect(events[0].type).toBe('wheel');
   });
 });

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -424,9 +424,6 @@ function makeSimulator(eventType) {
       domNode,
     );
 
-    // Since we aren't using pooling, always persist the event. This will make
-    // sure it's marked and won't warn when setting additional properties.
-    event.persist();
     Object.assign(event, eventData);
 
     if (dispatchConfig.phasedRegistrationNames) {

--- a/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
+++ b/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
@@ -46,7 +46,7 @@ const ReactNativeBridgeEventPlugin = {
       'Unsupported top level event type "%s" dispatched',
       topLevelType,
     );
-    const event = SyntheticEvent.getPooled(
+    const event = new SyntheticEvent(
       bubbleDispatchConfig || directDispatchConfig,
       targetInst,
       nativeEvent,


### PR DESCRIPTION
I started working on this idea by @philipp-spiess during a joint programming session at the React Vienna meetup. It's my first pull request for React, so please go easy on me. :-)

The idea is to get rid of the event object pooling mechanism and instead just create new instances whenever needed. I kept the methods `persist` (issueing a warning for now) and `isPersistent` (just always returning `true` now) on `SyntheticEvent` since at least [persist is documented](https://reactjs.org/docs/events.html#event-pooling). That whole section in the documention would still have to be updated (or removed).

Main benefits:
* reduced code complexity
* smaller bundle size (`react-dom.production.min.js`: 92.2 KB -> 91.54 KB, gzipped 30.01 KB -> 29.81 KB; that's -0.7%)

I removed quite a few tests that were mostly concerned with checking the persistence of events, since that's not really needed anymore. Instead, I added a single test that checks the result from `isPersistent` being `true` and that `persist` issues a warning (which would still need to be finalized, if we want it at all).

The hope is that modern JS engines are optimizing object creation & release enough so that not maintaining a pool does not make a significant difference. (Longer-term, maybe JS engines could make this even faster than the pool implemented in user land?)

So far, I quickly tested the performance using the "Event Pooling" fixture in Mac Chrome 69 (moving the mouse around for a few seconds, creating a few hundred events) and did not notice a significant effect, certainly not visually and also not when glancing at Chrome's Performance flamechart (also tried with 6x CPU slowdown); I did not notice significant garbage collection activity either. But these are just some very preliminary observations (in a rather simple scenario), so the performance side would still need to be analyzed much more carefully, also across different operating systems and browsers.

To make the quick performance check using the fixture UI a bit more meaningful, I added a checkbox to choose the React production build instead of the development build (which remains the default). Please let me know if this should rather go into a separate PR (or if it's not desired at all).

This would take care of #13224 (where the idea of getting rid of object pooling is also mentioned).

I realize that this is quite a big change, so maybe it should have started as an RFC or so. But even if there's more discussion needed, I guess having the code along with it doesn't hurt. Just let me know and I could continue trying to measure the performance impact more carefully (suggestions welcome). But no hard feelings if this is rejected for whatever reason.

Thanks to @philipp-spiess for the introduction to the React code base and kicking off this idea!