### PR TITLE
 honor displayName set on ForwardRef if available

### DIFF
--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -197,7 +197,9 @@ function validatePropTypes(element) {
   ) {
     // ForwardRef
     const functionName = type.render.displayName || type.render.name || '';
-    name = functionName !== '' ? `ForwardRef(${functionName})` : 'ForwardRef';
+    name =
+      type.displayName ||
+      (functionName !== '' ? `ForwardRef(${functionName})` : 'ForwardRef');
     propTypes = type.propTypes;
   } else {
     return;

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -181,4 +181,33 @@ describe('forwardRef', () => {
       {withoutStack: true},
     );
   });
+
+  it('should honor a displayName if set on the forwardRef wrapper in warnings', () => {
+    const Component = props => <div {...props} />;
+
+    const RefForwardingComponent = React.forwardRef((props, ref) => (
+      <Component {...props} forwardedRef={ref} />
+    ));
+
+    RefForwardingComponent.displayName = 'Foo';
+
+    RefForwardingComponent.propTypes = {
+      optional: PropTypes.string,
+      required: PropTypes.string.isRequired,
+    };
+
+    RefForwardingComponent.defaultProps = {
+      optional: 'default',
+    };
+
+    const ref = React.createRef();
+
+    expect(() =>
+      ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />),
+    ).toWarnDev(
+      'Warning: Failed prop type: The prop `required` is marked as required in ' +
+        '`Foo`, but its value is `undefined`.\n' +
+        '    in Foo (at **)',
+    );
+  });
 });

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -66,9 +66,10 @@ function getComponentName(type: mixed): string | null {
       case REACT_FORWARD_REF_TYPE:
         const renderFn = (type.render: any);
         const functionName = renderFn.displayName || renderFn.name || '';
-        return functionName !== ''
-          ? `ForwardRef(${functionName})`
-          : 'ForwardRef';
+        return (
+          type.displayName ||
+          (functionName !== '' ? `ForwardRef(${functionName})` : 'ForwardRef')
+        );
     }
     if (typeof type.then === 'function') {
       const thenable: Thenable<mixed> = (type: any);

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -23,7 +23,7 @@ import {
 } from 'shared/ReactSymbols';
 import {refineResolvedThenable} from 'shared/ReactLazyComponent';
 
-function getComponentName(type: mixed): string | null {
+function getComponentName(type: any): string | null {
   if (type == null) {
     // Host root, text node or just invalid type.
     return null;

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -23,7 +23,7 @@ import {
 } from 'shared/ReactSymbols';
 import {refineResolvedThenable} from 'shared/ReactLazyComponent';
 
-function getComponentName(type: any): string | null {
+function getComponentName(type: mixed): string | null {
   if (type == null) {
     // Host root, text node or just invalid type.
     return null;
@@ -67,7 +67,7 @@ function getComponentName(type: any): string | null {
         const renderFn = (type.render: any);
         const functionName = renderFn.displayName || renderFn.name || '';
         return (
-          type.displayName ||
+          (type: any).displayName ||
           (functionName !== '' ? `ForwardRef(${functionName})` : 'ForwardRef')
         );
     }


### PR DESCRIPTION
Since React.forwardRef returns a component object, some users
(including styled-components and react-native) are starting to
decorate it with various statics including displayName.

This adjusts React's various name-getters to honor this if set and
surface the name in warnings and hopefully DevTools.