### PR TITLE
Do not bind topLevelType to dispatch

### DIFF
--- a/packages/events/PluginModuleType.js
+++ b/packages/events/PluginModuleType.js
@@ -16,7 +16,7 @@ import type {TopLevelType} from './TopLevelEventTypes';
 
 export type EventTypes = {[key: string]: DispatchConfig};
 
-export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | Touch;
+export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | TouchEvent;
 
 export type PluginName = string;
 

--- a/packages/events/ReactGenericBatching.js
+++ b/packages/events/ReactGenericBatching.js
@@ -20,8 +20,8 @@ import {
 let _batchedUpdatesImpl = function(fn, bookkeeping) {
   return fn(bookkeeping);
 };
-let _interactiveUpdatesImpl = function(fn, a, b) {
-  return fn(a, b);
+let _interactiveUpdatesImpl = function(fn, a) {
+  return fn(a);
 };
 let _flushInteractiveUpdatesImpl = function() {};
 
@@ -52,8 +52,8 @@ export function batchedUpdates(fn, bookkeeping) {
   }
 }
 
-export function interactiveUpdates(fn, a, b) {
-  return _interactiveUpdatesImpl(fn, a, b);
+export function interactiveUpdates(fn, a) {
+  return _interactiveUpdatesImpl(fn, a);
 }
 
 export function flushInteractiveUpdates() {

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -57,6 +57,7 @@ function getTopLevelCallbackBookKeeping(
   targetInst: Fiber | null,
   ancestors: Array<Fiber>,
 } {
+  // This is safe because DOMTopLevelTypes are always native event type strings
   const topLevelType = unsafeCastStringToDOMTopLevelType(nativeEvent.type);
 
   if (callbackBookkeepingPool.length) {

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -144,16 +144,13 @@ export function trapBubbledEvent(
   if (!element) {
     return null;
   }
+
+  // Check if interactive and wrap in interactiveUpdates
   const dispatch = isInteractiveTopLevelEventType(topLevelType)
     ? dispatchInteractiveEvent
     : dispatchEvent;
 
-  addEventBubbleListener(
-    element,
-    getRawEventName(topLevelType),
-    // Check if interactive and wrap in interactiveUpdates
-    dispatch,
-  );
+  addEventBubbleListener(element, getRawEventName(topLevelType), dispatch);
 }
 
 /**
@@ -172,16 +169,13 @@ export function trapCapturedEvent(
   if (!element) {
     return null;
   }
+
+  // Check if interactive and wrap in interactiveUpdates
   const dispatch = isInteractiveTopLevelEventType(topLevelType)
     ? dispatchInteractiveEvent
     : dispatchEvent;
 
-  addEventCaptureListener(
-    element,
-    getRawEventName(topLevelType),
-    // Check if interactive and wrap in interactiveUpdates
-    dispatch,
-  );
+  addEventCaptureListener(element, getRawEventName(topLevelType), dispatch);
 }
 
 function dispatchInteractiveEvent(nativeEvent) {

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -42,7 +42,9 @@ const [
   runEventsInBatch,
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
 
-function Event(suffix) {}
+function Event(type) {
+  this.type = type;
+}
 
 let hasWarnedAboutDeprecatedMockComponent = false;
 
@@ -59,7 +61,7 @@ let hasWarnedAboutDeprecatedMockComponent = false;
  */
 function simulateNativeEventOnNode(topLevelType, node, fakeNativeEvent) {
   fakeNativeEvent.target = node;
-  dispatchEvent(topLevelType, fakeNativeEvent);
+  dispatchEvent(fakeNativeEvent);
 }
 
 /**


### PR DESCRIPTION
This PR is exploratory, but it's been on my mind a long time and I wanted to get others' thoughts.

A previous change (https://github.com/facebook/react/pull/12629) made it such that all top level event types correspond to their associated native event string values. That means we don't need to bind that event name into `dispatchEvent`, letting all event listener code use either the standard dispatch function, or the variant for interactive updates.

### Why

My primary motivation with this PR isn't to necessarily merge this, but to talk about a few event system things.

#### Why drop bind()

Dropping this `.bind()` is attractive to me because I believe we could eventually remove the logic in`ReactDOMBrowserEventEmitter` to track what events have already attached:

https://github.com/facebook/react/blob/f6fb03edffcc5918ad2f37ed45bdc7c0c3b3d199/packages/react-dom/src/events/ReactBrowserEventEmitter.js#L95-L103

https://github.com/facebook/react/blob/f6fb03edffcc5918ad2f37ed45bdc7c0c3b3d199/packages/react-dom/src/events/ReactBrowserEventEmitter.js#L130-L135

When working on the scroll-jank PR (https://github.com/facebook/react/pull/9333), tracking needs to happen per-element for touch, wheel, and scroll events. That means saving state on each DOM node, and doing a lot of property access.

#### Could it be faster?

I'm curious about the performance characteristics of naively attaching the same event. It could avoid a lot of DOM storage and property access (event listener attachment tracking) if we start to attach listeners locally, since `addEventListener` is idempotent:

```javascript
let button = document.createElement('button')
let callback = () => console.log("click!")

button.addEventListener('click', callback)
button.addEventListener('click', callback)

button.click()
```

### Challenges

We can't remove event listener tracking because SelectEventPlugin depends on this tracking to see if it should fire:

https://github.com/facebook/react/blob/f6fb03edffcc5918ad2f37ed45bdc7c0c3b3d199/packages/react-dom/src/events/SelectEventPlugin.js#L173-L177

But we might be able to come up with another way to determine when SelectEventPlugin should fire. Maybe, **instead of enumerating all plugins at dispatch time, they could be eagerly applied on mount**. Then we also wouldn't have to run through all event plugins on every dispatch because the event plugins would have the context to know that their behavior was specifically applied.

---

Still, it's an interesting series of changes to me, and I wanted to get the thoughts of others.