### PR TITLE
Fix deadline judgement bug

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -2371,7 +2371,7 @@ function shouldYield() {
   }
   if (
     deadline === null ||
-    deadline.timeRemaining() > timeHeuristicForUnitOfWork
+    (deadline !== null && deadline.timeRemaining() > timeHeuristicForUnitOfWork)
   ) {
     // Disregard deadline.didTimeout. Only expired work should be flushed
     // during a timeout. This path is only hit for non-expired work.


### PR DESCRIPTION
When `deadline === null`, the expression `deadline.timeRemaining() > timeHeuristicForUnitOfWork` will still will be executed, it will throw error.

The reason it doesn't throw currently is `deadline` always won't be `null` in the `shouldYield` function.

If this needs to add a test, I will try(though I think it doesn't need and I don't know how to test just for this expression for now).

Of course we can just remove the `deadline === null` check, but I think it is useful in the future?