### PR TITLE
Switch React-Linter to SizeBot

### DIFF
--- a/scripts/tasks/danger.js
+++ b/scripts/tasks/danger.js
@@ -12,8 +12,8 @@ const spawn = require('child_process').spawn;
 
 const extension = process.platform === 'win32' ? '.cmd' : '';
 
-// React-Linter public_repo token (this is publicly visible on purpose)
-const token = '80aa64c50f38a267e9ba' + '575d41d528f9c234edb8';
+// sizebot public_repo token (this is publicly visible on purpose)
+const token = '0a7d5c3cad9a6dbec2d9' + '9a5222cf49062a4c1ef7';
 spawn(path.join('node_modules', '.bin', 'danger-ci' + extension), [], {
   // Allow colors to pass through
   stdio: 'inherit',


### PR DESCRIPTION
The token for React-Linter was revoked recently. This PR switches React to use the @sizebot GitHub account for build size tracking.