### PR TITLE
Allow reading default feature flags from bundle tests

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -7,8 +7,6 @@
  * @flow strict
  */
 
-import invariant from 'shared/invariant';
-
 // Exports ReactDOM.createRoot
 export const enableUserTimingAPI = __DEV__;
 
@@ -47,5 +45,5 @@ export const enableSuspenseServerRenderer = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {
-  invariant(false, 'Not implemented.');
+  throw new Error('Not implemented.');
 }

--- a/packages/shared/forks/ReactFeatureFlags.readonly.js
+++ b/packages/shared/forks/ReactFeatureFlags.readonly.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// This is only used by bundle tests so they can *read* the default feature flags.
+// It lets us determine whether we're running in Fire mode without making tests internal.
+const ReactFeatureFlags = require('../ReactFeatureFlags');
+// Forbid writes because this wouldn't work with bundle tests.
+module.exports = Object.freeze({...ReactFeatureFlags});

--- a/scripts/jest/config.build.js
+++ b/scripts/jest/config.build.js
@@ -18,8 +18,18 @@ const packages = readdirSync(packagesRoot).filter(dir => {
   const packagePath = join(packagesRoot, dir, 'package.json');
   return statSync(packagePath).isFile();
 });
+
 // Create a module map to point React packages to the build output
 const moduleNameMapper = {};
+
+// Allow bundle tests to read (but not write!) default feature flags.
+// This lets us determine whether we're running in Fire mode
+// without making relevant tests internal-only.
+moduleNameMapper[
+  '^shared/ReactFeatureFlags'
+] = `<rootDir>/packages/shared/forks/ReactFeatureFlags.readonly`;
+
+// Map packages to bundles
 packages.forEach(name => {
   // Root entry point
   moduleNameMapper[`^${name}$`] = `<rootDir>/build/node_modules/${name}`;


### PR DESCRIPTION
I want to run some tests both in Fire and normal modes (https://github.com/facebook/react/pull/13628).

But for that I need tests to switch on `ReactFeatureFlags` and determine the expected behavior based on that. And this doesn't work in bundle tests so I'd have to make them internal.

I don't want to make those tests internal. So instead I'm making a readonly version of `ReactFeatureFlags` available to bundle tests. That's sufficient to know in which mode we're running. If you attempt to write to it (as some our tests which need to stay internal do), this will throw.

I could have used something like `process.env` for this instead. But it felt more confusing to me to have different ways to read a feature flag.