### PR TITLE
Remove function hoisting dependency

### DIFF
--- a/packages/events/SyntheticEvent.js
+++ b/packages/events/SyntheticEvent.js
@@ -259,11 +259,6 @@ addEventPoolingTo(SyntheticEvent);
  */
 function getPooledWarningPropertyDefinition(propName, getVal) {
   const isFunction = typeof getVal === 'function';
-  return {
-    configurable: true,
-    set: set,
-    get: get,
-  };
 
   function set(val) {
     const action = isFunction ? 'setting the method' : 'setting the property';
@@ -295,6 +290,12 @@ function getPooledWarningPropertyDefinition(propName, getVal) {
       result,
     );
   }
+
+  return {
+    configurable: true,
+    set: set,
+    get: get,
+  };
 }
 
 function getPooledEvent(dispatchConfig, targetInst, nativeEvent, nativeInst) {


### PR DESCRIPTION
Move `return` statement below all function declaration