### PR TITLE
Refactoring. Remove unnecessary else with return

### DIFF
--- a/fixtures/attribute-behavior/src/App.js
+++ b/fixtures/attribute-behavior/src/App.js
@@ -232,11 +232,11 @@ function getRenderedAttributeValue(
   function createContainer() {
     if (containerTagName === 'svg') {
       return document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    } else if (containerTagName === 'document') {
-      return document.implementation.createHTMLDocument('');
-    } else {
-      return document.createElement(containerTagName);
     }
+    if (containerTagName === 'document') {
+      return document.implementation.createHTMLDocument('');
+    }
+    return document.createElement(containerTagName);
   }
 
   const read = attribute.read;

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -81,37 +81,37 @@ function destroyEventListeners(instance) {
 function getScaleX(props) {
   if (props.scaleX != null) {
     return props.scaleX;
-  } else if (props.scale != null) {
-    return props.scale;
-  } else {
-    return 1;
   }
+  if (props.scale != null) {
+    return props.scale;
+  }
+  return 1;
 }
 
 function getScaleY(props) {
   if (props.scaleY != null) {
     return props.scaleY;
-  } else if (props.scale != null) {
-    return props.scale;
-  } else {
-    return 1;
   }
+  if (props.scale != null) {
+    return props.scale;
+  }
+  return 1;
 }
 
 function isSameFont(oldFont, newFont) {
   if (oldFont === newFont) {
     return true;
-  } else if (typeof newFont === 'string' || typeof oldFont === 'string') {
-    return false;
-  } else {
-    return (
-      newFont.fontSize === oldFont.fontSize &&
-      newFont.fontStyle === oldFont.fontStyle &&
-      newFont.fontVariant === oldFont.fontVariant &&
-      newFont.fontWeight === oldFont.fontWeight &&
-      newFont.fontFamily === oldFont.fontFamily
-    );
   }
+  if (typeof newFont === 'string' || typeof oldFont === 'string') {
+    return false;
+  }
+  return (
+    newFont.fontSize === oldFont.fontSize &&
+    newFont.fontStyle === oldFont.fontStyle &&
+    newFont.fontVariant === oldFont.fontVariant &&
+    newFont.fontWeight === oldFont.fontWeight &&
+    newFont.fontFamily === oldFont.fontFamily
+  );
 }
 
 /** Render Methods */

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -275,9 +275,8 @@ export function getChildHostContext(
 
   if (prevIsInAParentText !== isInAParentText) {
     return {isInAParentText};
-  } else {
-    return parentHostContext;
   }
+  return parentHostContext;
 }
 
 export function getPublicInstance(instance: Instance): * {

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -204,9 +204,8 @@ export function getChildHostContext(
 
   if (prevIsInAParentText !== isInAParentText) {
     return {isInAParentText};
-  } else {
-    return parentHostContext;
   }
+  return parentHostContext;
 }
 
 export function getPublicInstance(instance: Instance): * {

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -334,13 +334,14 @@ let currentlyValidatingElement = null;
 function getDisplayName(element) {
   if (element == null) {
     return '#empty';
-  } else if (typeof element === 'string' || typeof element === 'number') {
-    return '#text';
-  } else if (typeof element.type === 'string') {
-    return element.type;
-  } else {
-    return element.type.displayName || element.type.name || 'Unknown';
   }
+  if (typeof element === 'string' || typeof element === 'number') {
+    return '#text';
+  }
+  if (typeof element.type === 'string') {
+    return element.type;
+  }
+  return element.type.displayName || element.type.name || 'Unknown';
 }
 
 function getStackAddendum() {

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -285,9 +285,8 @@ class ReactTestInstance {
   get instance() {
     if (this._fiber.tag === HostComponent) {
       return ReactTestHostConfig.getPublicInstance(this._fiber.stateNode);
-    } else {
-      return this._fiber.stateNode;
     }
+    return this._fiber.stateNode;
   }
 
   get type() {

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -532,14 +532,13 @@ describe('ReactShallowRenderer', () => {
               Test link
             </a>
           );
-        } else {
-          return (
-            <div>
-              <span className="child1" />
-              <span className="child2" />
-            </div>
-          );
         }
+        return (
+          <div>
+            <span className="child1"/>
+            <span className="child2"/>
+          </div>
+        );
       }
     }
 


### PR DESCRIPTION
We can delete last `else` because this no necessary.

For example, if we have code like this:

```javascript
if (typeof child === 'number') {
  return child
} else {
  return this.nodes.indexOf(child)
}
```

And variable `child` has type `number` then the function always return `child` and never goes on the lines after if-statment. So we can delete `else`-branch:

```javascript
if (typeof child === 'number') {
  return child
}
return this.nodes.indexOf(child)
``` 

I think this part of code more readable then first one.