### PR TITLE
Remove duplicate code in EventPluginRegistry

### DIFF
--- a/packages/events/__tests__/EventPluginRegistry-test.internal.js
+++ b/packages/events/__tests__/EventPluginRegistry-test.internal.js
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Facebook, Inc. and xits affiliates.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the Mxit license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
@@ -12,6 +12,23 @@
 describe('EventPluginRegistry', () => {
   let EventPluginRegistry;
   let createPlugin;
+
+  // @TODO: Test more, code reuse to avoid duplicate code
+  const testEventPlugin = (eventPluginOrder, eventPluginsByName) => {
+    EventPluginRegistry.injectEventPluginOrder(eventPluginOrder);
+
+    eventPluginsByName.forEach(pluginByName => {
+      EventPluginRegistry.injectEventPluginsByName(pluginByName);
+    });
+
+    expect(EventPluginRegistry.plugins.length).toBe(eventPluginOrder.length);
+
+    const mergedEventPluginsByName = Object.assign({}, ...eventPluginsByName)
+
+    EventPluginRegistry.plugins.forEach((plugin, index) => {
+      expect(mergedEventPluginsByName[eventPluginOrder[index]]).toBe(plugin);
+    });
+  };
 
   beforeEach(() => {
     jest.resetModuleRegistry();
@@ -26,37 +43,52 @@ describe('EventPluginRegistry', () => {
     };
   });
 
-  it('should be able to inject ordering before plugins', () => {
-    const OnePlugin = createPlugin();
-    const TwoPlugin = createPlugin();
-    const ThreePlugin = createPlugin();
+  xit('should be able to inject ordering before plugins', () => {
+    const [OnePlugin, TwoPlugin, ThreePlugin] = Array.from({length: 3}, () =>
+      createPlugin(),
+    );
 
-    EventPluginRegistry.injectEventPluginOrder(['one', 'two', 'three']);
-    EventPluginRegistry.injectEventPluginsByName({
-      one: OnePlugin,
-      two: TwoPlugin,
-    });
-    EventPluginRegistry.injectEventPluginsByName({
-      three: ThreePlugin,
-    });
-
-    expect(EventPluginRegistry.plugins.length).toBe(3);
-    expect(EventPluginRegistry.plugins[0]).toBe(OnePlugin);
-    expect(EventPluginRegistry.plugins[1]).toBe(TwoPlugin);
-    expect(EventPluginRegistry.plugins[2]).toBe(ThreePlugin);
+    testEventPlugin(
+      ['one', 'two', 'three'],
+      [
+        {
+          one: OnePlugin,
+          two: TwoPlugin,
+          three: ThreePlugin,
+        },
+      ],
+    );
   });
 
-  it('should be able to inject plugins before and after ordering', () => {
+  xit('should be able to inject plugins before and after ordering', () => {
+    const [OnePlugin, TwoPlugin, ThreePlugin] = Array.from({length: 3}, () =>
+      createPlugin(),
+    );
+
+    testEventPlugin(
+      ['one', 'two', 'three'],
+      [
+        {
+          one: OnePlugin,
+          two: TwoPlugin,
+        },
+        {three: ThreePlugin},
+      ],
+    );
+  });
+
+  it('should be able to inject repeated plugins and out-of-order', () => {
     const OnePlugin = createPlugin();
     const TwoPlugin = createPlugin();
     const ThreePlugin = createPlugin();
 
     EventPluginRegistry.injectEventPluginsByName({
       one: OnePlugin,
-      two: TwoPlugin,
+      three: ThreePlugin,
     });
     EventPluginRegistry.injectEventPluginOrder(['one', 'two', 'three']);
     EventPluginRegistry.injectEventPluginsByName({
+      two: TwoPlugin,
       three: ThreePlugin,
     });
 
@@ -87,7 +119,7 @@ describe('EventPluginRegistry', () => {
     expect(EventPluginRegistry.plugins[2]).toBe(ThreePlugin);
   });
 
-  it('should throw if plugin does not implement `extractEvents`', () => {
+  xit('should throw if plugin does not implement `extractEvents`', () => {
     const BadPlugin = {};
 
     EventPluginRegistry.injectEventPluginOrder(['bad']);
@@ -102,7 +134,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  it('should throw if plugin does not exist in ordering', () => {
+  xit('should throw if plugin does not exist in ordering', () => {
     const OnePlugin = createPlugin();
     const RandomPlugin = createPlugin();
 
@@ -119,7 +151,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  it('should throw if ordering is injected more than once', () => {
+  xit('should throw if ordering is injected more than once', () => {
     const pluginOrdering = [];
 
     EventPluginRegistry.injectEventPluginOrder(pluginOrdering);
@@ -132,7 +164,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  it('should throw if different plugins injected using same name', () => {
+  xit('should throw if different plugins injected using same name', () => {
     const OnePlugin = createPlugin();
     const TwoPlugin = createPlugin();
 
@@ -146,7 +178,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  it('should publish registration names of injected plugins', () => {
+  xit('should publish registration names of injected plugins', () => {
     const OnePlugin = createPlugin({
       eventTypes: {
         click: {registrationName: 'onClick'},
@@ -186,7 +218,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  it('should throw if multiple registration names collide', () => {
+  xit('should throw if multiple registration names collide', () => {
     const OnePlugin = createPlugin({
       eventTypes: {
         photoCapture: {registrationName: 'onPhotoCapture'},
@@ -216,7 +248,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  it('should throw if an invalid event is published', () => {
+  xit('should throw if an invalid event is published', () => {
     const OnePlugin = createPlugin({
       eventTypes: {
         badEvent: {

--- a/packages/events/__tests__/EventPluginRegistry-test.internal.js
+++ b/packages/events/__tests__/EventPluginRegistry-test.internal.js
@@ -13,7 +13,7 @@ describe('EventPluginRegistry', () => {
   let EventPluginRegistry;
   let createPlugin;
 
-  // @TODO: Test more, code reuse to avoid duplicate code
+  // Function to perform common tests on top of EventPluginRegistry
   const testEventPlugin = (eventPluginOrder, eventPluginsByName) => {
     EventPluginRegistry.injectEventPluginOrder(eventPluginOrder);
 

--- a/packages/events/__tests__/EventPluginRegistry-test.internal.js
+++ b/packages/events/__tests__/EventPluginRegistry-test.internal.js
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the Mit license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @emails react-core

--- a/packages/events/__tests__/EventPluginRegistry-test.internal.js
+++ b/packages/events/__tests__/EventPluginRegistry-test.internal.js
@@ -21,7 +21,7 @@ describe('EventPluginRegistry', () => {
       EventPluginRegistry.injectEventPluginsByName(pluginByName);
     });
 
-    const mergedEventPluginsByName = Object.assign({}, ...eventPluginsByName)
+    const mergedEventPluginsByName = Object.assign({}, ...eventPluginsByName);
 
     expect(EventPluginRegistry.plugins.length).toBe(eventPluginOrder.length);
 
@@ -43,7 +43,7 @@ describe('EventPluginRegistry', () => {
     };
   });
 
-  xit('should be able to inject ordering before plugins', () => {
+  it('should be able to inject ordering before plugins', () => {
     const [OnePlugin, TwoPlugin, ThreePlugin] = Array.from({length: 3}, () =>
       createPlugin(),
     );
@@ -60,7 +60,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  xit('should be able to inject plugins before and after ordering', () => {
+  it('should be able to inject plugins before and after ordering', () => {
     const [OnePlugin, TwoPlugin, ThreePlugin] = Array.from({length: 3}, () =>
       createPlugin(),
     );
@@ -97,28 +97,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  it('should be able to inject repeated plugins and out-of-order', () => {
-    const OnePlugin = createPlugin();
-    const TwoPlugin = createPlugin();
-    const ThreePlugin = createPlugin();
-
-    EventPluginRegistry.injectEventPluginsByName({
-      one: OnePlugin,
-      three: ThreePlugin,
-    });
-    EventPluginRegistry.injectEventPluginOrder(['one', 'two', 'three']);
-    EventPluginRegistry.injectEventPluginsByName({
-      two: TwoPlugin,
-      three: ThreePlugin,
-    });
-
-    expect(EventPluginRegistry.plugins.length).toBe(3);
-    expect(EventPluginRegistry.plugins[0]).toBe(OnePlugin);
-    expect(EventPluginRegistry.plugins[1]).toBe(TwoPlugin);
-    expect(EventPluginRegistry.plugins[2]).toBe(ThreePlugin);
-  });
-
-  xit('should throw if plugin does not implement `extractEvents`', () => {
+  it('should throw if plugin does not implement `extractEvents`', () => {
     const BadPlugin = {};
 
     EventPluginRegistry.injectEventPluginOrder(['bad']);
@@ -133,9 +112,10 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  xit('should throw if plugin does not exist in ordering', () => {
-    const OnePlugin = createPlugin();
-    const RandomPlugin = createPlugin();
+  it('should throw if plugin does not exist in ordering', () => {
+    const [OnePlugin, RandomPlugin] = Array.from({length: 2}, () =>
+      createPlugin(),
+    );
 
     EventPluginRegistry.injectEventPluginOrder(['one']);
 
@@ -150,7 +130,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  xit('should throw if ordering is injected more than once', () => {
+  it('should throw if ordering is injected more than once', () => {
     const pluginOrdering = [];
 
     EventPluginRegistry.injectEventPluginOrder(pluginOrdering);
@@ -163,9 +143,10 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  xit('should throw if different plugins injected using same name', () => {
-    const OnePlugin = createPlugin();
-    const TwoPlugin = createPlugin();
+  it('should throw if different plugins injected using same name', () => {
+    const [OnePlugin, TwoPlugin] = Array.from({length: 2}, () =>
+      createPlugin(),
+    );
 
     EventPluginRegistry.injectEventPluginsByName({same: OnePlugin});
 
@@ -177,7 +158,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  xit('should publish registration names of injected plugins', () => {
+  it('should publish registration names of injected plugins', () => {
     const OnePlugin = createPlugin({
       eventTypes: {
         click: {registrationName: 'onClick'},
@@ -217,7 +198,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  xit('should throw if multiple registration names collide', () => {
+  it('should throw if multiple registration names collide', () => {
     const OnePlugin = createPlugin({
       eventTypes: {
         photoCapture: {registrationName: 'onPhotoCapture'},
@@ -247,7 +228,7 @@ describe('EventPluginRegistry', () => {
     );
   });
 
-  xit('should throw if an invalid event is published', () => {
+  it('should throw if an invalid event is published', () => {
     const OnePlugin = createPlugin({
       eventTypes: {
         badEvent: {

--- a/packages/events/__tests__/EventPluginRegistry-test.internal.js
+++ b/packages/events/__tests__/EventPluginRegistry-test.internal.js
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) Facebook, Inc. and xits affiliates.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the Mxit license found in the
+ * This source code is licensed under the Mit license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
@@ -21,9 +21,9 @@ describe('EventPluginRegistry', () => {
       EventPluginRegistry.injectEventPluginsByName(pluginByName);
     });
 
-    expect(EventPluginRegistry.plugins.length).toBe(eventPluginOrder.length);
-
     const mergedEventPluginsByName = Object.assign({}, ...eventPluginsByName)
+
+    expect(EventPluginRegistry.plugins.length).toBe(eventPluginOrder.length);
 
     EventPluginRegistry.plugins.forEach((plugin, index) => {
       expect(mergedEventPluginsByName[eventPluginOrder[index]]).toBe(plugin);
@@ -78,24 +78,23 @@ describe('EventPluginRegistry', () => {
   });
 
   it('should be able to inject repeated plugins and out-of-order', () => {
-    const OnePlugin = createPlugin();
-    const TwoPlugin = createPlugin();
-    const ThreePlugin = createPlugin();
+    const [OnePlugin, TwoPlugin, ThreePlugin] = Array.from({length: 3}, () =>
+      createPlugin(),
+    );
 
-    EventPluginRegistry.injectEventPluginsByName({
-      one: OnePlugin,
-      three: ThreePlugin,
-    });
-    EventPluginRegistry.injectEventPluginOrder(['one', 'two', 'three']);
-    EventPluginRegistry.injectEventPluginsByName({
-      two: TwoPlugin,
-      three: ThreePlugin,
-    });
-
-    expect(EventPluginRegistry.plugins.length).toBe(3);
-    expect(EventPluginRegistry.plugins[0]).toBe(OnePlugin);
-    expect(EventPluginRegistry.plugins[1]).toBe(TwoPlugin);
-    expect(EventPluginRegistry.plugins[2]).toBe(ThreePlugin);
+    testEventPlugin(
+      ['one', 'two', 'three'],
+      [
+        {
+          one: OnePlugin,
+          three: ThreePlugin,
+        },
+        {
+          two: TwoPlugin,
+          three: ThreePlugin,
+        },
+      ],
+    );
   });
 
   it('should be able to inject repeated plugins and out-of-order', () => {


### PR DESCRIPTION
I was reading the React core to further study the ecosystem, found some code duplicates, and did a refactor, I would like to mature the code. If PR is useful.

- [x] run yarn;
- [x] remove duplicate codes;
- [x] create testEventPlugin;
- [x] run `yarn test`;
- [x] run `yarn test --watch EventPluginRegistry`;
- [x] run `yarn test-prod`;
- [x] run `yarn prettier`; 
- [x] run `yarn lint`;

## Run tests

```
./node_modules/.bin/cross-env NODE_ENV=development jest --config ./scripts/jest/config.source.js /Users/rodrigooler/projects/react/packages/events/__tests__/EventPluginRegistry-test.internal.js&& yarn prettier && yarn lint
```

![captura de tela 2018-09-14 as 04 52 25](https://user-images.githubusercontent.com/5496931/45537215-0043d880-b7da-11e8-8129-18fc491ba257.png)

