### PR TITLE
Remove Flow typings from Schedule.js

### DIFF
--- a/packages/schedule/src/Schedule.js
+++ b/packages/schedule/src/Schedule.js
@@ -186,7 +186,7 @@ function unstable_scheduleWork(callback, options) {
   return newNode;
 }
 
-function unstable_cancelScheduledWork(callbackNode: CallbackNode): void {
+function unstable_cancelScheduledWork(callbackNode) {
   var next = callbackNode.next;
   if (next === null) {
     // Already cancelled.


### PR DESCRIPTION
As described in https://github.com/facebook/react/pull/13582, this file needs to be as close to ES5 as possible. Flow pragma (`@flow`) was deleted but there was still a single function signature. Removing it in this PR.

Not sure about what should be done to the `export` statement in the end though.