### PR TITLE
Warn when `static propTypes/static defaultProps` is a function fix #9620

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -312,6 +312,20 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         'Use a static property to define defaultProps instead.',
       name,
     );
+    const noDefaultPropsFunction = typeof ctor.defaultProps !== 'function';
+    warningWithoutStack(
+      noDefaultPropsFunction,
+      'defaultProps was defined as a static function on %s. ' +
+        'Use a static property instead.',
+      name,
+    );
+    const noPropTypesFunction = typeof ctor.propTypes !== 'function';
+    warningWithoutStack(
+      noPropTypesFunction,
+      'propTypes was defined as a static function on %s. ' +
+        'Use a static property instead.',
+      name,
+    );
     const noInstancePropTypes = !instance.propTypes;
     warningWithoutStack(
       noInstancePropTypes,

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -418,6 +418,24 @@ describe 'ReactCoffeeScriptClass', ->
     expect(getDefaultPropsWasCalled).toBe false
     undefined
 
+  it 'should warn when defaultProps/propTypes is defined as function.', ->
+    class Foo extends React.Component
+      render: ->
+        span
+          className: ''
+    Foo.defaultProps = -> {}
+    Foo.propTypes = -> {}
+
+    expect(->
+      test React.createElement(Foo), 'SPAN', ''
+    ).toWarnDev(
+      [
+        'defaultProps was defined as a static function on Foo. Use a static property instead.',
+        'propTypes was defined as a static function on Foo. Use a static property instead.',
+      ],
+      {withoutStack: true},
+    )
+
   it 'does not warn about getInitialState() on class components
       if state is also defined.', ->
     class Foo extends React.Component

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -463,6 +463,30 @@ describe('ReactES6Class', () => {
     expect(getDefaultPropsWasCalled).toBe(false);
   });
 
+  it('should warn when defaultProps/propTypes is defined as function.', () => {
+    class Foo extends React.Component {
+      static defaultProps() {
+        return {};
+      }
+
+      static propTypes() {
+        return {};
+      }
+
+      render() {
+        return <span />;
+      }
+    }
+
+    expect(() => test(<Foo />, 'SPAN', '')).toWarnDev(
+      [
+        'defaultProps was defined as a static function on Foo. Use a static property instead.',
+        'propTypes was defined as a static function on Foo. Use a static property instead.',
+      ],
+      {withoutStack: true},
+    );
+  });
+
   it('does not warn about getInitialState() on class components if state is also defined.', () => {
     class Foo extends React.Component {
       state = this.getInitialState();

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -600,6 +600,30 @@ describe('ReactTypeScriptClass', function() {
     }
   );
 
+  it('should warn when defaultProps/propTypes is defined as function.', () => {
+    class Foo extends React.Component {
+      static defaultProps() {
+        return {};
+      }
+
+      static propTypes() {
+        return {};
+      }
+
+      render() {
+        return React.createElement('span', { className: '' });
+      }
+    }
+
+    expect(() => test(React.createElement(Foo), 'SPAN', '')).toWarnDev(
+      [
+        'defaultProps was defined as a static function on Foo. Use a static property instead.',
+        'propTypes was defined as a static function on Foo. Use a static property instead.'
+      ],
+      {withoutStack: true}
+    );
+  })
+
   it(
     'does not warn about getInitialState() on class components ' +
       'if state is also defined.',


### PR DESCRIPTION
  This check might be helpful for newcomers since default props can only be returned from factory functions in vue.