### PR TITLE
Add flow types in ReactControlledComponent

### DIFF
--- a/packages/events/ReactControlledComponent.js
+++ b/packages/events/ReactControlledComponent.js
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import invariant from 'shared/invariant';
@@ -35,11 +37,13 @@ function restoreStateOfTarget(target) {
   restoreImpl(internalInstance.stateNode, internalInstance.type, props);
 }
 
-export function setRestoreImplementation(impl) {
+export function setRestoreImplementation(
+  impl: (domElement: Element, tag: string, props: Object) => void,
+): void {
   restoreImpl = impl;
 }
 
-export function enqueueStateRestore(target) {
+export function enqueueStateRestore(target: EventTarget): void {
   if (restoreTarget) {
     if (restoreQueue) {
       restoreQueue.push(target);


### PR DESCRIPTION
1. `setRestoreImplementation` is only used in `ReactDOM.js` and takes `restoreControlledState` as input which is of type `(Element, string, Object) => void` (see `ReactDOMComponent.js`)

2. `enqueueStateRestore` takes `DOMEventTarget` as input that's why type `EventTarget` is used