### PR TITLE
Revert "Do not bind topLevelType to dispatch"

### DIFF
--- a/packages/events/PluginModuleType.js
+++ b/packages/events/PluginModuleType.js
@@ -16,7 +16,7 @@ import type {TopLevelType} from './TopLevelEventTypes';
 
 export type EventTypes = {[key: string]: DispatchConfig};
 
-export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | TouchEvent;
+export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | Touch;
 
 export type PluginName = string;
 

--- a/packages/events/ReactGenericBatching.js
+++ b/packages/events/ReactGenericBatching.js
@@ -20,8 +20,8 @@ import {
 let _batchedUpdatesImpl = function(fn, bookkeeping) {
   return fn(bookkeeping);
 };
-let _interactiveUpdatesImpl = function(fn, a) {
-  return fn(a);
+let _interactiveUpdatesImpl = function(fn, a, b) {
+  return fn(a, b);
 };
 let _flushInteractiveUpdatesImpl = function() {};
 
@@ -52,8 +52,8 @@ export function batchedUpdates(fn, bookkeeping) {
   }
 }
 
-export function interactiveUpdates(fn, a) {
-  return _interactiveUpdatesImpl(fn, a);
+export function interactiveUpdates(fn, a, b) {
+  return _interactiveUpdatesImpl(fn, a, b);
 }
 
 export function flushInteractiveUpdates() {

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -42,9 +42,7 @@ const [
   runEventsInBatch,
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
 
-function Event(type) {
-  this.type = type;
-}
+function Event(suffix) {}
 
 let hasWarnedAboutDeprecatedMockComponent = false;
 
@@ -61,7 +59,7 @@ let hasWarnedAboutDeprecatedMockComponent = false;
  */
 function simulateNativeEventOnNode(topLevelType, node, fakeNativeEvent) {
   fakeNativeEvent.target = node;
-  dispatchEvent(fakeNativeEvent);
+  dispatchEvent(topLevelType, fakeNativeEvent);
 }
 
 /**


### PR DESCRIPTION
Reverts facebook/react#13618

This breaks some tests using SimulateNative :-(.
Don't know what's the cause but if it breaks us, it can break other people too.

We could investigate this more but I think it's not high priority for now so I'll just get this in to unblock syncing (and 16.5.2)