### PR TITLE
Ensure there are no warnings for getDefaultProps when using createReactClass

### DIFF
--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -224,7 +224,7 @@ function validatePropTypes(element) {
   }
   if (typeof type.getDefaultProps === 'function') {
     warningWithoutStack(
-      type.getDefaultProps.isReactClassApproved,
+      type.prototype.hasOwnProperty('getDefaultProps'),
       'getDefaultProps is only used on classic React.createClass ' +
         'definitions. Use a static property named `defaultProps` instead.',
     );

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -341,32 +341,6 @@ describe('ReactJSXElementValidator', () => {
     );
   });
 
-  it('does not warn when using getDefaultProps with createReactClass', () => {
-    // Set NODE_ENV to 'production' to verify that dev specific flags
-    // are not necessary
-    const ORIGINAL_ENV = process.env;
-    process.env = {
-      ...ORIGINAL_ENV,
-      NODE_ENV: 'production',
-    };
-    const createReactClass = require('create-react-class');
-    const ValidGetDefaultPropsComponent = createReactClass({
-      getDefaultProps: function() {
-        return {
-          prop: 'foo',
-        };
-      },
-      render: function() {
-        return <span>{this.props.prop}</span>;
-      },
-    });
-
-    spyOnDevAndProd(console, 'error');
-    ReactTestUtils.renderIntoDocument(<ValidGetDefaultPropsComponent />);
-    expect(console.error).not.toHaveBeenCalled();
-    process.env = ORIGINAL_ENV;
-  });
-
   it('should warn if component declares PropTypes instead of propTypes', () => {
     class MisspelledPropTypesComponent extends React.Component {
       render() {
@@ -439,6 +413,41 @@ describe('ReactJSXElementValidator', () => {
       ),
     ).toWarnDev('Encountered two children with the same key, `a`.', {
       withoutStack: true,
+    });
+  });
+
+  describe('production build', () => {
+    let originalEnv;
+    beforeAll(() => {
+      // Set NODE_ENV to 'production' to verify that dev specific flags
+      // are not necessary
+      originalEnv = process.env;
+      process.env = {
+        ...originalEnv,
+        NODE_ENV: 'production',
+      };
+    });
+
+    afterAll(() => {
+      process.env = originalEnv;
+    });
+
+    it('does not warn when using getDefaultProps with createReactClass', () => {
+      const createReactClass = require('create-react-class');
+      const ValidGetDefaultPropsComponent = createReactClass({
+        getDefaultProps: function() {
+          return {
+            prop: 'foo',
+          };
+        },
+        render: function() {
+          return <span>{this.props.prop}</span>;
+        },
+      });
+
+      spyOnDevAndProd(console, 'error');
+      ReactTestUtils.renderIntoDocument(<ValidGetDefaultPropsComponent />);
+      expect(console.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -341,6 +341,32 @@ describe('ReactJSXElementValidator', () => {
     );
   });
 
+  it('does not warn when using getDefaultProps with createReactClass', () => {
+    // Set NODE_ENV to 'production' to verify that dev specific flags
+    // are not necessary
+    const ORIGINAL_ENV = process.env;
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: 'production',
+    };
+    const createReactClass = require('create-react-class');
+    const ValidGetDefaultPropsComponent = createReactClass({
+      getDefaultProps: function() {
+        return {
+          prop: 'foo',
+        };
+      },
+      render: function() {
+        return <span>{this.props.prop}</span>;
+      },
+    });
+
+    spyOnDevAndProd(console, 'error');
+    ReactTestUtils.renderIntoDocument(<ValidGetDefaultPropsComponent />);
+    expect(console.error).not.toHaveBeenCalled();
+    process.env = ORIGINAL_ENV;
+  });
+
   it('should warn if component declares PropTypes instead of propTypes', () => {
     class MisspelledPropTypesComponent extends React.Component {
       render() {


### PR DESCRIPTION
This aims to address the issue where there is a false positive warning for getDefaultProps when using the prod version of `createReactClass` with the dev version of React.
Issue: https://github.com/facebook/react/issues/9999

There was a previous PR that attempted to address this by setting flags even in prod: https://github.com/facebook/react/pull/12064 .  However, @gaearon raised a concern about setting those flags unnecessarily in prod.  

This PR resolves that by checking if `getDefaultProps` is on the prototype created by `createReactClass` instead of any of the dev flags.  This seems to work fine to distinguish components from `createReactClass` vs extending the class `Component`.
https://github.com/facebook/react/blob/15-stable/addons/create-react-class/factory.js#L857



