### PR TITLE
Fix circular dependency in TracingSubscriptions

### DIFF
--- a/packages/scheduler/src/TracingSubscriptions.js
+++ b/packages/scheduler/src/TracingSubscriptions.js
@@ -10,7 +10,7 @@
 import type {Interaction, Subscriber} from './Tracing';
 
 import {enableSchedulerTracing} from 'shared/ReactFeatureFlags';
-import {__subscriberRef} from 'scheduler/tracing';
+import {__subscriberRef} from './Tracing';
 
 let subscribers: Set<Subscriber> = (null: any);
 if (enableSchedulerTracing) {


### PR DESCRIPTION
Fixed Circular dependency warning in new version of Rollup.
It will cause build failure