### PR TITLE
allow non-numeric values of 'cols' and 'rows' attributes (#13645)

### DIFF
--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -199,5 +199,13 @@ describe('DOMPropertyOperations', () => {
       ReactDOM.render(<my-icon size="5px" />, container);
       expect(container.firstChild.getAttribute('size')).toBe('5px');
     });
+
+    it('should not remove non-numeric cols and rows attributes from frameset', () => {
+      const container = document.createElement('div');
+      const frameset = <frameset rows="25%,*,25%" cols="180,11,*" />;
+      ReactDOM.render(frameset, container);
+      expect(container.firstChild.getAttribute('rows')).toBe('25%,*,25%');
+      expect(container.firstChild.getAttribute('cols')).toBe('180,11,*');
+    });
   });
 });

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -355,8 +355,6 @@ const properties = {};
 
 // These are HTML attributes that must be positive numbers.
 [
-  'cols',
-  'rows',
   'size',
   'span',
 


### PR DESCRIPTION
According to HTML spec not only positive numbers are valid values of  'cols' and 'rows' attributes. More information could be found in corresponding issue #13645.

I'm not sure if `DOMPropertyOperations` is the best fitting file to put that test in. Maybe it should be `ReactDOMIframe` since `frameset` tag is fully related to `iframe`?