### PR TITLE
Restore global window.event after event dispatching (#13688)

### DIFF
--- a/packages/shared/invokeGuardedCallbackImpl.js
+++ b/packages/shared/invokeGuardedCallbackImpl.js
@@ -98,6 +98,13 @@ if (__DEV__) {
       // browsers that support it.
       let windowEvent = window.event;
 
+      // Keeps track of the descriptor of window.event to restore it after event
+      // dispatching: https://github.com/facebook/react/issues/13688
+      const windowEventDescriptor = Object.getOwnPropertyDescriptor(
+        window,
+        'event',
+      );
+
       // Create an event handler for our fake event. We will synchronously
       // dispatch our fake event using `dispatchEvent`. Inside the handler, we
       // call the user-provided callback.
@@ -171,6 +178,10 @@ if (__DEV__) {
       // errors, it will trigger our global error handler.
       evt.initEvent(evtType, false, false);
       fakeNode.dispatchEvent(evt);
+
+      if (windowEventDescriptor) {
+        Object.defineProperty(window, 'event', windowEventDescriptor);
+      }
 
       if (didError) {
         if (!didSetError) {


### PR DESCRIPTION
Used @ConradIrwin [suggestion](https://github.com/facebook/react/issues/13688#issuecomment-422939757) to fix #13688.