### PR TITLE
Remove unreachable code in ReactFiberCommitWork

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -740,7 +740,6 @@ function unmountHostComponents(current): void {
         }
         parent = parent.return;
       }
-      currentParentIsValid = true;
     }
 
     if (node.tag === HostComponent || node.tag === HostText) {


### PR DESCRIPTION
`while(true)` will run forever and so the code after it will never be executed.