### PR TITLE
remove-useless-assign

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -2303,7 +2303,6 @@ function performWorkOnRoot(
       // This root is already complete. We can commit it.
       completeRoot(root, finishedWork, expirationTime);
     } else {
-      root.finishedWork = null;
       // If this root previously suspended, clear its existing timeout, since
       // we're about to try rendering again.
       const timeoutHandle = root.timeoutHandle;


### PR DESCRIPTION
```js    
   let finishedWork = root.finishedWork;
    if (finishedWork !== null) {
    } else {
        root.finishedWork = null; //  should delete
    }
```
when enter else logic, root.finishedWork muse be null, so assignment is redundant


