### PR TITLE
Support class component static contextType attribute

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -109,11 +109,13 @@ import {resolveLazyComponentTag} from './ReactFiber';
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
 let didWarnAboutBadClass;
+let didWarnAboutContextTypeOnFunctionalComponent;
 let didWarnAboutGetDerivedStateOnFunctionalComponent;
 let didWarnAboutStatelessRefs;
 
 if (__DEV__) {
   didWarnAboutBadClass = {};
+  didWarnAboutContextTypeOnFunctionalComponent = {};
   didWarnAboutGetDerivedStateOnFunctionalComponent = {};
   didWarnAboutStatelessRefs = {};
 }
@@ -803,6 +805,22 @@ function mountIndeterminateComponent(
           didWarnAboutGetDerivedStateOnFunctionalComponent[
             componentName
           ] = true;
+        }
+      }
+
+      if (
+        typeof Component.contextType === 'object' &&
+        Component.contextType !== null
+      ) {
+        const componentName = getComponentName(Component) || 'Unknown';
+
+        if (!didWarnAboutContextTypeOnFunctionalComponent[componentName]) {
+          warningWithoutStack(
+            false,
+            '%s: Stateless functional components do not support contextType.',
+            componentName,
+          );
+          didWarnAboutContextTypeOnFunctionalComponent[componentName] = true;
         }
       }
     }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -59,7 +59,6 @@ import warningWithoutStack from 'shared/warningWithoutStack';
 import * as ReactCurrentFiber from './ReactCurrentFiber';
 import {cancelWorkTimer} from './ReactDebugFiberPerf';
 
-import {applyDerivedStateFromProps} from './ReactFiberClassComponent';
 import {
   mountChildFibers,
   reconcileChildFibers,
@@ -97,6 +96,7 @@ import {
 } from './ReactFiberHydrationContext';
 import {
   adoptClassInstance,
+  applyDerivedStateFromProps,
   constructClassInstance,
   mountClassInstance,
   resumeMountClassInstance,

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -516,7 +516,7 @@ function constructClassInstance(
   props: any,
   renderExpirationTime: ExpirationTime,
 ): any {
-  let isContextConsumer = false;
+  let isLegacyContextConsumer = false;
   let unmaskedContext = emptyContextObject;
   let context = null;
   const contextType = ctor.contextType;
@@ -529,8 +529,9 @@ function constructClassInstance(
   } else {
     unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
     const contextTypes = ctor.contextTypes;
-    isContextConsumer = contextTypes !== null && contextTypes !== undefined;
-    context = isContextConsumer
+    isLegacyContextConsumer =
+      contextTypes !== null && contextTypes !== undefined;
+    context = isLegacyContextConsumer
       ? getMaskedContext(workInProgress, unmaskedContext)
       : emptyContextObject;
   }
@@ -640,7 +641,7 @@ function constructClassInstance(
 
   // Cache unmasked context so we can avoid recreating masked context unless necessary.
   // ReactFiberContext usually updates this cache but can't for newly-created instances.
-  if (isContextConsumer) {
+  if (isLegacyContextConsumer) {
     cacheContext(workInProgress, unmaskedContext, context);
   }
 

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -65,6 +65,8 @@ let didWarnAboutUndefinedDerivedState;
 let warnOnUndefinedDerivedState;
 let warnOnInvalidCallback;
 let didWarnAboutDirectlyAssigningPropsToState;
+let didWarnAboutContextTypeAndContextTypes;
+let didWarnAboutInvalidateContextType;
 
 if (__DEV__) {
   didWarnAboutStateAssignmentForComponent = new Set();
@@ -73,6 +75,8 @@ if (__DEV__) {
   didWarnAboutLegacyLifecyclesAndDerivedState = new Set();
   didWarnAboutDirectlyAssigningPropsToState = new Set();
   didWarnAboutUndefinedDerivedState = new Set();
+  didWarnAboutContextTypeAndContextTypes = new Set();
+  didWarnAboutInvalidateContextType = new Set();
 
   const didWarnOnInvalidCallback = new Set();
 
@@ -234,7 +238,7 @@ function checkShouldComponentUpdate(
   newProps,
   oldState,
   newState,
-  nextLegacyContext,
+  nextContext,
 ) {
   const instance = workInProgress.stateNode;
   if (typeof instance.shouldComponentUpdate === 'function') {
@@ -242,7 +246,7 @@ function checkShouldComponentUpdate(
     const shouldUpdate = instance.shouldComponentUpdate(
       newProps,
       newState,
-      nextLegacyContext,
+      nextContext,
     );
     stopPhaseTimer();
 
@@ -319,6 +323,13 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         'property to define propTypes instead.',
       name,
     );
+    const noInstanceContextType = !instance.contextType;
+    warningWithoutStack(
+      noInstanceContextType,
+      'contextType was defined as an instance property on %s. Use a static ' +
+        'property to define contextType instead.',
+      name,
+    );
     const noInstanceContextTypes = !instance.contextTypes;
     warningWithoutStack(
       noInstanceContextTypes,
@@ -326,6 +337,36 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         'property to define contextTypes instead.',
       name,
     );
+
+    if (
+      ctor.contextType &&
+      ctor.contextTypes &&
+      !didWarnAboutContextTypeAndContextTypes.has(ctor)
+    ) {
+      didWarnAboutContextTypeAndContextTypes.add(ctor);
+      warningWithoutStack(
+        false,
+        '%s declares both contextTypes and contextType static properties. ' +
+          'The legacy contextTypes property will be ignored.',
+        name,
+      );
+    }
+
+    if (
+      ctor.contextType &&
+      typeof ctor.contextType.unstable_read !== 'function' &&
+      !didWarnAboutInvalidateContextType.has(ctor)
+    ) {
+      didWarnAboutInvalidateContextType.add(ctor);
+      warningWithoutStack(
+        false,
+        '%s defines an invalid contextType. ' +
+          'contextType should point to the Context object returned by React.createContext(). ' +
+          'Did you accidentally pass the Context.Provider instead?',
+        name,
+      );
+    }
+
     const noComponentShouldUpdate =
       typeof instance.componentShouldUpdate !== 'function';
     warningWithoutStack(
@@ -475,12 +516,24 @@ function constructClassInstance(
   props: any,
   renderExpirationTime: ExpirationTime,
 ): any {
-  const unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
-  const contextTypes = ctor.contextTypes;
-  const isContextConsumer = contextTypes !== null && contextTypes !== undefined;
-  const context = isContextConsumer
-    ? getMaskedContext(workInProgress, unmaskedContext)
-    : emptyContextObject;
+  let isContextConsumer = false;
+  let unmaskedContext = emptyContextObject;
+  let context = null;
+  const contextType = ctor.contextType;
+  if (
+    typeof contextType === 'object' &&
+    contextType !== null &&
+    typeof contextType.unstable_read === 'function'
+  ) {
+    context = (contextType: any).unstable_read();
+  } else {
+    unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
+    const contextTypes = ctor.contextTypes;
+    isContextConsumer = contextTypes !== null && contextTypes !== undefined;
+    context = isContextConsumer
+      ? getMaskedContext(workInProgress, unmaskedContext)
+      : emptyContextObject;
+  }
 
   // Instantiate twice to help detect side-effects.
   if (__DEV__) {
@@ -625,15 +678,15 @@ function callComponentWillReceiveProps(
   workInProgress,
   instance,
   newProps,
-  nextLegacyContext,
+  nextContext,
 ) {
   const oldState = instance.state;
   startPhaseTimer(workInProgress, 'componentWillReceiveProps');
   if (typeof instance.componentWillReceiveProps === 'function') {
-    instance.componentWillReceiveProps(newProps, nextLegacyContext);
+    instance.componentWillReceiveProps(newProps, nextContext);
   }
   if (typeof instance.UNSAFE_componentWillReceiveProps === 'function') {
-    instance.UNSAFE_componentWillReceiveProps(newProps, nextLegacyContext);
+    instance.UNSAFE_componentWillReceiveProps(newProps, nextContext);
   }
   stopPhaseTimer();
 
@@ -668,12 +721,21 @@ function mountClassInstance(
   }
 
   const instance = workInProgress.stateNode;
-  const unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
-
   instance.props = newProps;
   instance.state = workInProgress.memoizedState;
   instance.refs = emptyRefsObject;
-  instance.context = getMaskedContext(workInProgress, unmaskedContext);
+
+  const contextType = ctor.contextType;
+  if (
+    typeof contextType === 'object' &&
+    contextType !== null &&
+    typeof contextType.unstable_read === 'function'
+  ) {
+    instance.context = (contextType: any).unstable_read();
+  } else {
+    const unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
+    instance.context = getMaskedContext(workInProgress, unmaskedContext);
+  }
 
   if (__DEV__) {
     if (instance.state === newProps) {
@@ -774,15 +836,22 @@ function resumeMountClassInstance(
   instance.props = oldProps;
 
   const oldContext = instance.context;
-  const nextLegacyUnmaskedContext = getUnmaskedContext(
-    workInProgress,
-    ctor,
-    true,
-  );
-  const nextLegacyContext = getMaskedContext(
-    workInProgress,
-    nextLegacyUnmaskedContext,
-  );
+  const contextType = ctor.contextType;
+  let nextContext;
+  if (
+    typeof contextType === 'object' &&
+    contextType !== null &&
+    typeof contextType.unstable_read === 'function'
+  ) {
+    nextContext = (contextType: any).unstable_read();
+  } else {
+    const nextLegacyUnmaskedContext = getUnmaskedContext(
+      workInProgress,
+      ctor,
+      true,
+    );
+    nextContext = getMaskedContext(workInProgress, nextLegacyUnmaskedContext);
+  }
 
   const getDerivedStateFromProps = ctor.getDerivedStateFromProps;
   const hasNewLifecycles =
@@ -800,12 +869,12 @@ function resumeMountClassInstance(
     (typeof instance.UNSAFE_componentWillReceiveProps === 'function' ||
       typeof instance.componentWillReceiveProps === 'function')
   ) {
-    if (oldProps !== newProps || oldContext !== nextLegacyContext) {
+    if (oldProps !== newProps || oldContext !== nextContext) {
       callComponentWillReceiveProps(
         workInProgress,
         instance,
         newProps,
-        nextLegacyContext,
+        nextContext,
       );
     }
   }
@@ -858,7 +927,7 @@ function resumeMountClassInstance(
       newProps,
       oldState,
       newState,
-      nextLegacyContext,
+      nextContext,
     );
 
   if (shouldUpdate) {
@@ -898,7 +967,7 @@ function resumeMountClassInstance(
   // if shouldComponentUpdate returns false.
   instance.props = newProps;
   instance.state = newState;
-  instance.context = nextLegacyContext;
+  instance.context = nextContext;
 
   return shouldUpdate;
 }
@@ -917,15 +986,18 @@ function updateClassInstance(
   instance.props = oldProps;
 
   const oldContext = instance.context;
-  const nextLegacyUnmaskedContext = getUnmaskedContext(
-    workInProgress,
-    ctor,
-    true,
-  );
-  const nextLegacyContext = getMaskedContext(
-    workInProgress,
-    nextLegacyUnmaskedContext,
-  );
+  const contextType = ctor.contextType;
+  let nextContext;
+  if (
+    typeof contextType === 'object' &&
+    contextType !== null &&
+    typeof contextType.unstable_read === 'function'
+  ) {
+    nextContext = (contextType: any).unstable_read();
+  } else {
+    const nextUnmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
+    nextContext = getMaskedContext(workInProgress, nextUnmaskedContext);
+  }
 
   const getDerivedStateFromProps = ctor.getDerivedStateFromProps;
   const hasNewLifecycles =
@@ -943,12 +1015,12 @@ function updateClassInstance(
     (typeof instance.UNSAFE_componentWillReceiveProps === 'function' ||
       typeof instance.componentWillReceiveProps === 'function')
   ) {
-    if (oldProps !== newProps || oldContext !== nextLegacyContext) {
+    if (oldProps !== newProps || oldContext !== nextContext) {
       callComponentWillReceiveProps(
         workInProgress,
         instance,
         newProps,
-        nextLegacyContext,
+        nextContext,
       );
     }
   }
@@ -1015,7 +1087,7 @@ function updateClassInstance(
       newProps,
       oldState,
       newState,
-      nextLegacyContext,
+      nextContext,
     );
 
   if (shouldUpdate) {
@@ -1028,14 +1100,10 @@ function updateClassInstance(
     ) {
       startPhaseTimer(workInProgress, 'componentWillUpdate');
       if (typeof instance.componentWillUpdate === 'function') {
-        instance.componentWillUpdate(newProps, newState, nextLegacyContext);
+        instance.componentWillUpdate(newProps, newState, nextContext);
       }
       if (typeof instance.UNSAFE_componentWillUpdate === 'function') {
-        instance.UNSAFE_componentWillUpdate(
-          newProps,
-          newState,
-          nextLegacyContext,
-        );
+        instance.UNSAFE_componentWillUpdate(newProps, newState, nextContext);
       }
       stopPhaseTimer();
     }
@@ -1075,7 +1143,7 @@ function updateClassInstance(
   // if shouldComponentUpdate returns false.
   instance.props = newProps;
   instance.state = newState;
-  instance.context = nextLegacyContext;
+  instance.context = nextContext;
 
   return shouldUpdate;
 }

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -392,6 +392,7 @@ describe 'ReactCoffeeScriptClass', ->
     class Foo extends React.Component
       constructor: ->
         @contextTypes = {}
+        @contextType = {}
         @propTypes = {}
 
       getInitialState: ->
@@ -413,6 +414,7 @@ describe 'ReactCoffeeScriptClass', ->
       'getDefaultProps was defined on Foo, a plain JavaScript class.',
       'propTypes was defined as an instance property on Foo.',
       'contextTypes was defined as an instance property on Foo.',
+      'contextType was defined as an instance property on Foo.',
     ], {withoutStack: true})
     expect(getInitialStateWasCalled).toBe false
     expect(getDefaultPropsWasCalled).toBe false

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -539,4 +539,31 @@ describe('ReactContextValidator', () => {
       {withoutStack: true},
     );
   });
+
+  it('should warn if you define contextType on a functional component', () => {
+    const Context = React.createContext();
+
+    function ComponentA() {
+      return <div />;
+    }
+    ComponentA.contextType = Context;
+
+    function ComponentB() {
+      return <div />;
+    }
+    ComponentB.contextType = Context;
+
+    expect(() => ReactTestUtils.renderIntoDocument(<ComponentA />)).toWarnDev(
+      'Warning: ComponentA: Stateless functional components do not support contextType.',
+      {withoutStack: true},
+    );
+
+    // Warnings should be deduped by component type
+    ReactTestUtils.renderIntoDocument(<ComponentA />);
+
+    expect(() => ReactTestUtils.renderIntoDocument(<ComponentB />)).toWarnDev(
+      'Warning: ComponentB: Stateless functional components do not support contextType.',
+      {withoutStack: true},
+    );
+  });
 });

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -67,9 +67,16 @@ describe('ReactContextValidator', () => {
   });
 
   it('should pass next context to lifecycles', () => {
-    let actualComponentWillReceiveProps;
-    let actualShouldComponentUpdate;
-    let actualComponentWillUpdate;
+    let componentDidMountContext;
+    let componentDidUpdateContext;
+    let componentWillReceivePropsContext;
+    let componentWillReceivePropsNextContext;
+    let componentWillUpdateContext;
+    let componentWillUpdateNextContext;
+    let constructorContext;
+    let renderContext;
+    let shouldComponentUpdateContext;
+    let shouldComponentUpdateNextContext;
 
     class Parent extends React.Component {
       getChildContext() {
@@ -78,7 +85,6 @@ describe('ReactContextValidator', () => {
           bar: 'bar',
         };
       }
-
       render() {
         return <Component />;
       }
@@ -89,22 +95,33 @@ describe('ReactContextValidator', () => {
     };
 
     class Component extends React.Component {
+      constructor(props, context) {
+        super(props, context);
+        constructorContext = context;
+      }
       UNSAFE_componentWillReceiveProps(nextProps, nextContext) {
-        actualComponentWillReceiveProps = nextContext;
+        componentWillReceivePropsContext = this.context;
+        componentWillReceivePropsNextContext = nextContext;
         return true;
       }
-
       shouldComponentUpdate(nextProps, nextState, nextContext) {
-        actualShouldComponentUpdate = nextContext;
+        shouldComponentUpdateContext = this.context;
+        shouldComponentUpdateNextContext = nextContext;
         return true;
       }
-
       UNSAFE_componentWillUpdate(nextProps, nextState, nextContext) {
-        actualComponentWillUpdate = nextContext;
+        componentWillUpdateContext = this.context;
+        componentWillUpdateNextContext = nextContext;
       }
-
       render() {
+        renderContext = this.context;
         return <div />;
+      }
+      componentDidMount() {
+        componentDidMountContext = this.context;
+      }
+      componentDidUpdate() {
+        componentDidUpdateContext = this.context;
       }
     }
     Component.contextTypes = {
@@ -113,10 +130,18 @@ describe('ReactContextValidator', () => {
 
     const container = document.createElement('div');
     ReactDOM.render(<Parent foo="abc" />, container);
+    expect(constructorContext).toEqual({foo: 'abc'});
+    expect(renderContext).toEqual({foo: 'abc'});
+    expect(componentDidMountContext).toEqual({foo: 'abc'});
     ReactDOM.render(<Parent foo="def" />, container);
-    expect(actualComponentWillReceiveProps).toEqual({foo: 'def'});
-    expect(actualShouldComponentUpdate).toEqual({foo: 'def'});
-    expect(actualComponentWillUpdate).toEqual({foo: 'def'});
+    expect(componentWillReceivePropsContext).toEqual({foo: 'abc'});
+    expect(componentWillReceivePropsNextContext).toEqual({foo: 'def'});
+    expect(shouldComponentUpdateContext).toEqual({foo: 'abc'});
+    expect(shouldComponentUpdateNextContext).toEqual({foo: 'def'});
+    expect(componentWillUpdateContext).toEqual({foo: 'abc'});
+    expect(componentWillUpdateNextContext).toEqual({foo: 'def'});
+    expect(renderContext).toEqual({foo: 'def'});
+    expect(componentDidUpdateContext).toEqual({foo: 'def'});
   });
 
   it('should check context types', () => {
@@ -337,5 +362,181 @@ describe('ReactContextValidator', () => {
     );
     expect(childContext.bar).toBeUndefined();
     expect(childContext.foo).toBe('FOO');
+  });
+
+  it('should pass next context to lifecycles', () => {
+    let componentDidMountContext;
+    let componentDidUpdateContext;
+    let componentWillReceivePropsContext;
+    let componentWillReceivePropsNextContext;
+    let componentWillUpdateContext;
+    let componentWillUpdateNextContext;
+    let constructorContext;
+    let renderContext;
+    let shouldComponentUpdateWasCalled = false;
+
+    const Context = React.createContext();
+
+    class Component extends React.Component {
+      static contextType = Context;
+      constructor(props, context) {
+        super(props, context);
+        constructorContext = context;
+      }
+      UNSAFE_componentWillReceiveProps(nextProps, nextContext) {
+        componentWillReceivePropsContext = this.context;
+        componentWillReceivePropsNextContext = nextContext;
+        return true;
+      }
+      shouldComponentUpdate(nextProps, nextState, nextContext) {
+        shouldComponentUpdateWasCalled = true;
+        return true;
+      }
+      UNSAFE_componentWillUpdate(nextProps, nextState, nextContext) {
+        componentWillUpdateContext = this.context;
+        componentWillUpdateNextContext = nextContext;
+      }
+      render() {
+        renderContext = this.context;
+        return <div />;
+      }
+      componentDidMount() {
+        componentDidMountContext = this.context;
+      }
+      componentDidUpdate() {
+        componentDidUpdateContext = this.context;
+      }
+    }
+
+    const firstContext = {foo: 123};
+    const secondContext = {bar: 456};
+
+    const container = document.createElement('div');
+    ReactDOM.render(
+      <Context.Provider value={firstContext}>
+        <Component />
+      </Context.Provider>,
+      container,
+    );
+    expect(constructorContext).toBe(firstContext);
+    expect(renderContext).toBe(firstContext);
+    expect(componentDidMountContext).toBe(firstContext);
+    ReactDOM.render(
+      <Context.Provider value={secondContext}>
+        <Component />
+      </Context.Provider>,
+      container,
+    );
+    expect(componentWillReceivePropsContext).toBe(firstContext);
+    expect(componentWillReceivePropsNextContext).toBe(secondContext);
+    expect(componentWillUpdateContext).toBe(firstContext);
+    expect(componentWillUpdateNextContext).toBe(secondContext);
+    expect(renderContext).toBe(secondContext);
+    expect(componentDidUpdateContext).toBe(secondContext);
+
+    // sCU is not called in this case because React force updates when a provider re-renders
+    expect(shouldComponentUpdateWasCalled).toBe(false);
+  });
+
+  it('should warn if both contextType and contextTypes are defined', () => {
+    const Context = React.createContext();
+
+    class ParentContextProvider extends React.Component {
+      static childContextTypes = {
+        foo: PropTypes.string,
+      };
+      getChildContext() {
+        return {
+          foo: 'FOO',
+        };
+      }
+      render() {
+        return this.props.children;
+      }
+    }
+
+    class ComponentA extends React.Component {
+      static contextTypes = {
+        foo: PropTypes.string.isRequired,
+      };
+      static contextType = Context;
+      render() {
+        return <div />;
+      }
+    }
+    class ComponentB extends React.Component {
+      static contextTypes = {
+        foo: PropTypes.string.isRequired,
+      };
+      static contextType = Context;
+      render() {
+        return <div />;
+      }
+    }
+
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(
+        <ParentContextProvider>
+          <ComponentA />
+        </ParentContextProvider>,
+      ),
+    ).toWarnDev(
+      'Warning: ComponentA declares both contextTypes and contextType static properties. ' +
+        'The legacy contextTypes property will be ignored.',
+      {withoutStack: true},
+    );
+
+    // Warnings should be deduped by component type
+    ReactTestUtils.renderIntoDocument(
+      <ParentContextProvider>
+        <ComponentA />
+      </ParentContextProvider>,
+    );
+
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(
+        <ParentContextProvider>
+          <ComponentB />
+        </ParentContextProvider>,
+      ),
+    ).toWarnDev(
+      'Warning: ComponentB declares both contextTypes and contextType static properties. ' +
+        'The legacy contextTypes property will be ignored.',
+      {withoutStack: true},
+    );
+  });
+
+  it('should warn if an invalid contextType is defined', () => {
+    const Context = React.createContext();
+
+    class ComponentA extends React.Component {
+      static contextType = Context.Provider;
+      render() {
+        return <div />;
+      }
+    }
+    class ComponentB extends React.Component {
+      static contextType = Context.Provider;
+      render() {
+        return <div />;
+      }
+    }
+
+    expect(() => ReactTestUtils.renderIntoDocument(<ComponentA />)).toWarnDev(
+      'Warning: ComponentA defines an invalid contextType. ' +
+        'contextType should point to the Context object returned by React.createContext(). ' +
+        'Did you accidentally pass the Context.Provider instead?',
+      {withoutStack: true},
+    );
+
+    // Warnings should be deduped by component type
+    ReactTestUtils.renderIntoDocument(<ComponentA />);
+
+    expect(() => ReactTestUtils.renderIntoDocument(<ComponentB />)).toWarnDev(
+      'Warning: ComponentB defines an invalid contextType. ' +
+        'contextType should point to the Context object returned by React.createContext(). ' +
+        'Did you accidentally pass the Context.Provider instead?',
+      {withoutStack: true},
+    );
   });
 });

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -435,6 +435,7 @@ describe('ReactES6Class', () => {
       constructor() {
         super();
         this.contextTypes = {};
+        this.contextType = {};
         this.propTypes = {};
       }
       getInitialState() {
@@ -455,6 +456,7 @@ describe('ReactES6Class', () => {
         'getInitialState was defined on Foo, a plain JavaScript class.',
         'getDefaultProps was defined on Foo, a plain JavaScript class.',
         'propTypes was defined as an instance property on Foo.',
+        'contextType was defined as an instance property on Foo.',
         'contextTypes was defined as an instance property on Foo.',
       ],
       {withoutStack: true},

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -239,6 +239,7 @@ let getInitialStateWasCalled = false;
 let getDefaultPropsWasCalled = false;
 class ClassicProperties extends React.Component {
   contextTypes = {};
+  contextType = {};
   propTypes = {};
   getDefaultProps() {
     getDefaultPropsWasCalled = true;
@@ -594,6 +595,7 @@ describe('ReactTypeScriptClass', function() {
           'a plain JavaScript class.',
         'propTypes was defined as an instance property on ClassicProperties.',
         'contextTypes was defined as an instance property on ClassicProperties.',
+        'contextType was defined as an instance property on ClassicProperties.',
       ], {withoutStack: true});
       expect(getInitialStateWasCalled).toBe(false);
       expect(getDefaultPropsWasCalled).toBe(false);


### PR DESCRIPTION
**Note**: This is an experimental proposal and we haven't published an RFC for it yet. The main motivation is that continuing to support legacy context makes React slower and larger, and we'd like to be able to help everyone migrate to the new context API as soon as possible. Since the new context API is currently too low-level and/or verbose when used in classes, we are considering adding this higher-level API that feels more familiar and will simplify the migration.

-----

New static `contextType` property is supported for class components. This property can be set to the value returned by `React.createContext()` in order to consume the context value via `this.context`, e.g.:
```js
const LocaleContext = React.createContext('blue');

class LocalizedComponent extends React.Component {
  static contextType = LocaleContext;

  render() {
    return <div>The locale is: {this.context}</div>
  }
}
```

Resolves #13336

DEV warnings have been added for the following cases:
* Class component has `contextType` instance property.
* Class component has both `contextType` and `contextTypes` static properties.
* Class component has an invalid `contextType` static property (e.g. mistaken `contextType = Context.Provider`).
* Stateless functional component has an (unsupported) `contextType` property.

New tests have been added to verify the following:
* Class lifecycle `nextContext` params.
* Class lifecycle `this.context` values.
* Class is forcefully updated (without `shouldComponentUpdate` being called) when context provider updates.
* All of the above DEV warnings.