### PR TITLE
Ensure "addEventListener" exists on "window" for "scheduler" package

### DIFF
--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -470,7 +470,7 @@ var getFrameDeadline;
 
 // "addEventListener" might not be available on the window object
 // if this is a mocked "window" object. So we need to validate that too.
-if (typeof window === 'undefined' || typeof window.addEventListener === 'function') {
+if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') {
   // If this accidentally gets imported in a non-browser environment, fallback
   // to a naive implementation.
   var timeoutID = -1;

--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -470,7 +470,10 @@ var getFrameDeadline;
 
 // "addEventListener" might not be available on the window object
 // if this is a mocked "window" object. So we need to validate that too.
-if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') {
+if (
+  typeof window === 'undefined' ||
+  typeof window.addEventListener !== 'function'
+) {
   // If this accidentally gets imported in a non-browser environment, fallback
   // to a naive implementation.
   var timeoutID = -1;

--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -468,7 +468,9 @@ var requestHostCallback;
 var cancelHostCallback;
 var getFrameDeadline;
 
-if (typeof window === 'undefined') {
+// "addEventListener" might not be available on the window object
+// if this is a mocked "window" object. So we need to validate that too.
+if (typeof window === 'undefined' || typeof window.addEventListener === 'function') {
   // If this accidentally gets imported in a non-browser environment, fallback
   // to a naive implementation.
   var timeoutID = -1;
@@ -573,12 +575,8 @@ if (typeof window === 'undefined') {
     }
   };
   // Assumes that we have addEventListener in this environment. Might need
-  // something better for old IE. Furthermore, "addEventListener" might not
-  // be available on the window object (if this is a RN mocked window),
-  // so we should check that it's a function before attaching the listener.
-  if (typeof window.addEventListener === 'function') {
-    window.addEventListener('message', idleTick, false);
-  }
+  // something better for old IE.
+  window.addEventListener('message', idleTick, false);
 
   var animationTick = function(rafTime) {
     isAnimationFrameScheduled = false;

--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -573,8 +573,12 @@ if (typeof window === 'undefined') {
     }
   };
   // Assumes that we have addEventListener in this environment. Might need
-  // something better for old IE.
-  window.addEventListener('message', idleTick, false);
+  // something better for old IE. Furthermore, "addEventListener" might not
+  // be available on the window object (if this is a RN mocked window),
+  // so we should check that it's a function before attaching the listener.
+  if (typeof window.addEventListener === 'function') {
+    window.addEventListener('message', idleTick, false);
+  }
 
   var animationTick = function(rafTime) {
     isAnimationFrameScheduled = false;


### PR DESCRIPTION
This fixes #13694.

When the scheduler package initializes, it tries to attach an event listener to `window` via `addEventListener`. In some environments, the `window` object might be mocked and thus `addEventListener` might be missing. This PR adds a check to ensure that this function does exist before trying to attach the event.