### PR TITLE
Remove useless checks

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -49,7 +49,6 @@ import {
   debugRenderPhaseSideEffects,
   debugRenderPhaseSideEffectsForStrictMode,
   enableProfilerTimer,
-  enableSchedulerTracing,
 } from 'shared/ReactFeatureFlags';
 import invariant from 'shared/invariant';
 import getComponentName from 'shared/getComponentName';
@@ -845,12 +844,10 @@ function updatePlaceholderComponent(
 
     let nextDidTimeout;
     if (current !== null && workInProgress.updateQueue !== null) {
-      if (enableSchedulerTracing) {
-        // Handle special case of rendering a Placeholder for a sync, suspended tree.
-        // We flag this to properly trace and count interactions.
-        // Otherwise interaction pending count will be decremented too many times.
-        captureWillSyncRenderPlaceholder();
-      }
+      // Handle special case of rendering a Placeholder for a sync, suspended tree.
+      // We flag this to properly trace and count interactions.
+      // Otherwise interaction pending count will be decremented too many times.
+      captureWillSyncRenderPlaceholder();
 
       // We're outside strict mode. Something inside this Placeholder boundary
       // suspended during the last commit. Switch to the placholder.

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -35,7 +35,7 @@ import {
   Update as UpdateEffect,
   LifecycleEffectMask,
 } from 'shared/ReactSideEffectTags';
-import {enableSuspense, enableSchedulerTracing} from 'shared/ReactFeatureFlags';
+import {enableSuspense} from 'shared/ReactFeatureFlags';
 import {StrictMode, ConcurrentMode} from './ReactTypeOfMode';
 
 import {createCapturedValue} from './ReactCapturedValue';

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -36,7 +36,6 @@ import {
 import {
   enableGetDerivedStateFromCatch,
   enableSuspense,
-  enableSchedulerTracing,
 } from 'shared/ReactFeatureFlags';
 import {StrictMode, AsyncMode} from './ReactTypeOfMode';
 
@@ -238,12 +237,10 @@ function throwException(
           if ((workInProgress.mode & StrictMode) === NoEffect) {
             workInProgress.effectTag |= UpdateEffect;
 
-            if (enableSchedulerTracing) {
-              // Handles the special case of unwinding a suspended sync render.
-              // We flag this to properly trace and count interactions.
-              // Otherwise interaction pending count will be decremented too many times.
-              captureWillSyncRenderPlaceholder();
-            }
+            // Handles the special case of unwinding a suspended sync render.
+            // We flag this to properly trace and count interactions.
+            // Otherwise interaction pending count will be decremented too many times.
+            captureWillSyncRenderPlaceholder();
 
             // Unmount the source fiber's children
             const nextChildren = null;


### PR DESCRIPTION
We can skip this check as it already checked in `captureWillSyncRenderPlaceholder` function

https://github.com/facebook/react/blob/7601c3765457a4ec7b2d48c0ca75fccf7fecf917/packages/react-reconciler/src/ReactFiberScheduler.js#L2490-L2494