### PR TITLE
ReactRootContainer should not be set to null if root has been rerender

### DIFF
--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -1,102 +1,14 @@
 <html>
-
-<body>
-  <script src="../../../build/dist/react.development.js"></script>
-  <script src="../../../build/dist/react-dom.development.js"></script>
-  <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
-  <div id="root"></div>
-  <hr/>
-  <div id="root1"></div>
-  <script type="text/babel">
-    class Page1 extends React.Component {
-      componentWillUnmount() {
-        console.error("died 1");
-      }
-
-      render() {
-        return <div>Page1</div>;
-      }
-    }
-
-    class Page2 extends React.Component {
-      constructor(props) {
-        super(props);
-        console.log("mount 2");
-      }
-
-      componentDidMount() {
-        // this.yolo = setInterval(() => console.log("I am alive"), 1000);
-      }
-
-      componentWillUnmount() {
-        console.error("died 2");
-      }
-      //   if (this.yolo) {
-      //     window.clearInterval(this.yolo);
-      //   }
-      // }
-
-      render() {
-        console.log("render 2");
-        return <div>Page2</div>;
-      }
-    }
-
-
-    class App extends React.Component {
-      state = {
-        page: 1
-      };
-      componentDidUpdate(prevProps, prevState) {
-        const page = this.state.page;
-        if (prevState.page !== page) {
-          // when everything is run in async context,
-          // the component are unmount in correct order
-          // and so _reactRootContainer will not be null
-          // setTimeout(() => {
-            const ele = document.getElementById("root1");
-            console.warn("before unmount", ele._reactRootContainer);
-            const successUnmount = ReactDOM.unmountComponentAtNode(ele);
-            console.warn("after unmount", ele._reactRootContainer, successUnmount);
-            // then render another Component on the same dom element
-            // run render sync, then unmountComponentAtNode will be failed
-            // and there will be some waining in console logout
-            if (page % 2 === 0) {
-              ReactDOM.render(<Page1 />, ele);
-            } else {
-              ReactDOM.render(<Page2 />, ele);
-            }
-            console.warn("after rendering", ele._reactRootContainer);
-
-            setTimeout(() => {
-              console.warn("after rendering + timeout", ele._reactRootContainer);
-            }, 100);
-          // });
-
-
-        }
-      }
-      handleSwitchPage = () => {
-        this.setState({
-          page: this.state.page + 1
-        });
-      };
-      render() {
-        return (
-          <button onClick={this.handleSwitchPage}>
-            Test unmountCmponentAtNode
-          </button>
-        );
-      }
-    }
-
-    const rootElement = document.getElementById("root");
-    ReactDOM.render(<App />, rootElement);
-      // ReactDOM.render(
-      //   <h1>Hello World!</h1>,
-      //   document.getElementById('container')
-      // );
+  <body>
+    <script src="../../../build/dist/react.development.js"></script>
+    <script src="../../../build/dist/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
+    <div id="container"></div>
+    <script type="text/babel">
+      ReactDOM.render(
+        <h1>Hello World!</h1>,
+        document.getElementById('container')
+      );
     </script>
-</body>
-
+  </body>
 </html>

--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -1,14 +1,102 @@
 <html>
-  <body>
-    <script src="../../../build/dist/react.development.js"></script>
-    <script src="../../../build/dist/react-dom.development.js"></script>
-    <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
-    <div id="container"></div>
-    <script type="text/babel">
-      ReactDOM.render(
-        <h1>Hello World!</h1>,
-        document.getElementById('container')
-      );
+
+<body>
+  <script src="../../../build/dist/react.development.js"></script>
+  <script src="../../../build/dist/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
+  <div id="root"></div>
+  <hr/>
+  <div id="root1"></div>
+  <script type="text/babel">
+    class Page1 extends React.Component {
+      componentWillUnmount() {
+        console.error("died 1");
+      }
+
+      render() {
+        return <div>Page1</div>;
+      }
+    }
+
+    class Page2 extends React.Component {
+      constructor(props) {
+        super(props);
+        console.log("mount 2");
+      }
+
+      componentDidMount() {
+        // this.yolo = setInterval(() => console.log("I am alive"), 1000);
+      }
+
+      componentWillUnmount() {
+        console.error("died 2");
+      }
+      //   if (this.yolo) {
+      //     window.clearInterval(this.yolo);
+      //   }
+      // }
+
+      render() {
+        console.log("render 2");
+        return <div>Page2</div>;
+      }
+    }
+
+
+    class App extends React.Component {
+      state = {
+        page: 1
+      };
+      componentDidUpdate(prevProps, prevState) {
+        const page = this.state.page;
+        if (prevState.page !== page) {
+          // when everything is run in async context,
+          // the component are unmount in correct order
+          // and so _reactRootContainer will not be null
+          // setTimeout(() => {
+            const ele = document.getElementById("root1");
+            console.warn("before unmount", ele._reactRootContainer);
+            const successUnmount = ReactDOM.unmountComponentAtNode(ele);
+            console.warn("after unmount", ele._reactRootContainer, successUnmount);
+            // then render another Component on the same dom element
+            // run render sync, then unmountComponentAtNode will be failed
+            // and there will be some waining in console logout
+            if (page % 2 === 0) {
+              ReactDOM.render(<Page1 />, ele);
+            } else {
+              ReactDOM.render(<Page2 />, ele);
+            }
+            console.warn("after rendering", ele._reactRootContainer);
+
+            setTimeout(() => {
+              console.warn("after rendering + timeout", ele._reactRootContainer);
+            }, 100);
+          // });
+
+
+        }
+      }
+      handleSwitchPage = () => {
+        this.setState({
+          page: this.state.page + 1
+        });
+      };
+      render() {
+        return (
+          <button onClick={this.handleSwitchPage}>
+            Test unmountCmponentAtNode
+          </button>
+        );
+      }
+    }
+
+    const rootElement = document.getElementById("root");
+    ReactDOM.render(<App />, rootElement);
+      // ReactDOM.render(
+      //   <h1>Hello World!</h1>,
+      //   document.getElementById('container')
+      // );
     </script>
-  </body>
+</body>
+
 </html>

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -525,4 +525,33 @@ describe('ReactDOM', () => {
         '    in App (at **)',
     ]);
   });
+
+  it('should not remove _reactRootContainer from a root if unmountComponentAtNode is follow by a render', () => {
+    const containerParent = document.createElement('div');
+    const containerApp = document.createElement('div');
+
+    function App1() {
+      return (
+        <div id="app1" />
+      );
+    }
+    function App2() {
+      return (
+        <div id="app2" />
+      );
+    }
+
+    function Parent() {
+      ReactDOM.render(<App1 />, containerApp);
+      ReactDOM.unmountComponentAtNode(containerApp);
+      ReactDOM.render(<App2 />, containerApp);
+      return (
+        <div />
+      );
+    }
+
+    ReactDOM.render(<Parent />, containerParent);
+    expect(containerApp._reactRootContainer).not.toBeNull();
+    expect(containerApp.innerHTML).toEqual('<div id=\"app2\"></div>');
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -531,27 +531,23 @@ describe('ReactDOM', () => {
     const containerApp = document.createElement('div');
 
     function App1() {
-      return (
-        <div id="app1" />
-      );
+      return <div id="app1" />;
     }
     function App2() {
-      return (
-        <div id="app2" />
-      );
+      return <div id="app2" />;
     }
 
     function Parent() {
       ReactDOM.render(<App1 />, containerApp);
       ReactDOM.unmountComponentAtNode(containerApp);
       ReactDOM.render(<App2 />, containerApp);
-      return (
-        <div />
-      );
+      return <div />;
     }
 
     ReactDOM.render(<Parent />, containerParent);
+    // if null, the next unmountComponentAtNode / render might not behave correctly
+    // skipping some life cycle like componentWillUnmount of App2 etc.
     expect(containerApp._reactRootContainer).not.toBeNull();
-    expect(containerApp.innerHTML).toEqual('<div id=\"app2\"></div>');
+    expect(containerApp.innerHTML).toEqual('<div id="app2"></div>');
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -537,11 +537,16 @@ describe('ReactDOM', () => {
       return <div id="app2" />;
     }
 
-    function Parent() {
-      ReactDOM.render(<App1 />, containerApp);
-      ReactDOM.unmountComponentAtNode(containerApp);
-      ReactDOM.render(<App2 />, containerApp);
-      return <div />;
+    class Parent extends React.Component {
+      render() {
+        return <div />;
+      }
+
+      componentDidMount() {
+        ReactDOM.render(<App1 />, containerApp);
+        ReactDOM.unmountComponentAtNode(containerApp);
+        ReactDOM.render(<App2 />, containerApp);
+      }
     }
 
     ReactDOM.render(<Parent />, containerParent);

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -564,6 +564,9 @@ function legacyRenderSubtreeIntoContainer(
         callback,
       );
     } else {
+      if (root.shouldBeUnMount && children != null) {
+        root.shouldBeUnMount = false;
+      }
       root.render(children, callback);
     }
   }
@@ -679,9 +682,10 @@ const ReactDOM: Object = {
       }
 
       // Unmount should not be batched.
+      container._reactRootContainer.shouldBeUnMount = true;
       DOMRenderer.unbatchedUpdates(() => {
         legacyRenderSubtreeIntoContainer(null, null, container, false, () => {
-          if (!container._reactRootContainer._internalRoot.containerInfo.firstChild) {
+          if (container._reactRootContainer.shouldBeUnMount) {
             container._reactRootContainer = null;
           }
         });

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -681,7 +681,9 @@ const ReactDOM: Object = {
       // Unmount should not be batched.
       DOMRenderer.unbatchedUpdates(() => {
         legacyRenderSubtreeIntoContainer(null, null, container, false, () => {
-          container._reactRootContainer = null;
+          if (!container._reactRootContainer._internalRoot.containerInfo.firstChild) {
+            container._reactRootContainer = null;
+          }
         });
       });
       // If you call unmountComponentAtNode twice in quick succession, you'll


### PR DESCRIPTION
Follow up to https://github.com/facebook/react/issues/13690

- [x] add unit test to reproduce the issues
- [x] implement quick/dirty fix in order to have a first iteration
- [ ] implement proper fix

Detail about the issue:

- When we call `render/unmountComponentAtNode` inside an other life cycle that accept side effect like `ComponentDidMount`, it is queue in order to prevent reentrancy from https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberScheduler.js#L1982
- if for the same `DOMContainer`, we have, an `unmountComponentAtNode` follow by a `render`, they will be queue correctly (as explain just before)
- when we process the queue, it will be done in correct order and so `render` will be correctly executed after the `unmount`. However because **callback** are executed at the end of the `commitLifeCycles` we will execute the `unmountComponentAtNode` even if a render has been executed, and so we will set the `_reactRootContainer` to null. Obviously there is multiple side effect, like next `unmountComponentAtNode` might fail or we will not execute correctly all the lifecycle etc.

Proposal of fix:

As far as I know, the life cycle seems to be fine, the only problem is because callback are call in the end, we need a way to "invalidate" the `unmountComponentAtNode` callback

- solution 1 https://github.com/facebook/react/commit/2ee1335f02469a16166e27e89f09efb9e17ded5b -> just a big hack -> because we are just checking if the container has a child element -> just made for fix purpose and can be easily broken (if component return null)

- solution 2 current commit -> one way to do could be to mutate `_internalRoot` with a boolean like `rootShouldBeUnmount`(need bettername) and then if a render happen after the unmount call we set the boolean to false again -> still feel hacky

- solution 3 could be just better to remove the callback if unmount root ? but for now we don't track if the function is the unMount one or not. (we can add property isUnmountRoot etc but doesn't know if it is better)

- any better idea to experiment ?
