### PR TITLE
Remove useless code

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -1097,7 +1097,6 @@ function ChildReconciler(shouldTrackSideEffects) {
     }
     // The existing first child is not a text node so we need to create one
     // and delete the existing ones.
-    deleteRemainingChildren(returnFiber, currentFirstChild);
     const created = createFiberFromText(
       textContent,
       returnFiber.mode,

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -1095,8 +1095,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       existing.return = returnFiber;
       return existing;
     }
-    // The existing first child is not a text node so we need to create one
-    // and delete the existing ones.
+    // The existing first child is not a text node so we need to create one.
     const created = createFiberFromText(
       textContent,
       returnFiber.mode,


### PR DESCRIPTION
Because only when `currentFirstChild !== null` we will do the `deleteRemainingChildren(returnFiber, currentFirstChild);` line which I delete in this PR. But delete a `null` child for a fiber is a no-op operation, so we can just remove this.