### PR TITLE
--save is no longer needed

### DIFF
--- a/packages/react-is/README.md
+++ b/packages/react-is/README.md
@@ -9,7 +9,7 @@ This package allows you to test arbitrary values and see if they're a particular
 yarn add react-is
 
 # NPM
-npm install react-is --save
+npm install react-is
 ```
 
 ## Usage


### PR DESCRIPTION
`--save` is on by default as of [npm 5](https://blog.npmjs.org/post/161081169345/v500), and `npm install aphrodite` is functionally equivalent to `npm install --save aphrodite` now
