### PR TITLE
Add envify transform to scheduler package

### DIFF
--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -13,6 +13,7 @@
   },
   "homepage": "https://reactjs.org/",
   "dependencies": {
+    "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1"
   },
   "files": [
@@ -23,5 +24,10 @@
     "tracing-profiling.js",
     "cjs/",
     "umd/"
-  ]
+  ],
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
+  }
 }


### PR DESCRIPTION
This package uses `process.env.NODE_ENV` but does not transform its usage during bundling like the rest of the React libraries do. This causes issues when `process` is not defined globally.
