### PR TITLE
Restart from root if promise pings before end of render phase

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -111,7 +111,7 @@ import {
   computeAsyncExpiration,
   computeInteractiveExpiration,
 } from './ReactFiberExpirationTime';
-import {ConcurrentMode, ProfileMode} from './ReactTypeOfMode';
+import {ConcurrentMode, ProfileMode, NoContext} from './ReactTypeOfMode';
 import {enqueueUpdate, resetCurrentlyProcessingQueue} from './ReactUpdateQueue';
 import {createCapturedValue} from './ReactCapturedValue';
 import {
@@ -1595,6 +1595,14 @@ function retrySuspendedRoot(
       const currentTime = requestCurrentTime();
       retryTime = computeExpirationForFiber(currentTime, fiber);
       markPendingPriorityLevel(root, retryTime);
+    }
+
+    if ((fiber.mode & ConcurrentMode) !== NoContext) {
+      if (root === nextRoot && nextRenderExpirationTime === suspendedTime) {
+        // Received a ping at the same priority level at which we're currently
+        // rendering. Restart from the root.
+        nextRoot = null;
+      }
     }
 
     scheduleWorkToRoot(fiber, retryTime);


### PR DESCRIPTION
Possible alternative to https://github.com/facebook/react/pull/13767

See my comment here: https://github.com/facebook/react/pull/13767#issuecomment-427094770:

> When a ping happens ("ping" means the promise resolves, so we should attempt to render the placeholder again), we mark the fiber as "dirty" by increasing the priority of its `expirationTime` field, and traverse back through to the root. We also set the pending priority on all the ancestors (using `childExpirationTime`).  This part is the same as a typical update.
> 
> Unlike a typical update, we don't add anything to the update queue. We used to, but both for performance and modeling purposes, we moved away from that model. The idea is that a ping doesn't have a payload; it doesn't represent or contain any data, it's only a signal to re-render. In that way, it's kind of like `forceUpdate`: it means some other mutable source, in this case a cache, has been updated.
> 
> I'm not ready to give up on this model, but I don't think we fully thought through the implications of concurrent pings and updates. Some cases to consider:
> 
>  - What if a promise resolves before the end of the current render phase, while React has yielded?
>  - What if a thenable resolves synchronously inside the current render phase? (An edge case, but still important. Even just for modeling purposes.)
>  - What if a thenable resolves synchronously when calling `then`? (We should special case this one.)
>  - What if a placeholder is pinged, but subsequently the placeholder re-renders at a higher priority? Does the priority of the ping get dropped when we complete the placeholder fiber at the higher priority? For a typical update, the lower priority would not get dropped because we read the remaining priority from the update queue, but we don't have an update queue in this case.
>  - What if a placeholder times out, and the original update that suspended the render was part of the primary children, which are then unmounted? Is it possible this priority level gets lost, maybe if combined with the previous case? (If so, storing the two sets of children separately as in https://github.com/facebook/react/pull/13120 would fix it)

Will add more tests