### PR TITLE
Wrap retrySuspendedRoot using SchedulerTracing

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -43,14 +43,12 @@ import {
   Update,
   Ref,
 } from 'shared/ReactSideEffectTags';
-import {captureWillSyncRenderPlaceholder} from './ReactFiberScheduler';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
   enableSuspense,
   debugRenderPhaseSideEffects,
   debugRenderPhaseSideEffectsForStrictMode,
   enableProfilerTimer,
-  enableSchedulerTracing,
 } from 'shared/ReactFeatureFlags';
 import invariant from 'shared/invariant';
 import shallowEqual from 'shared/shallowEqual';
@@ -952,13 +950,6 @@ function updatePlaceholderComponent(
 
     let nextDidTimeout;
     if (current !== null && workInProgress.updateQueue !== null) {
-      if (enableSchedulerTracing) {
-        // Handle special case of rendering a Placeholder for a sync, suspended tree.
-        // We flag this to properly trace and count interactions.
-        // Otherwise interaction pending count will be decremented too many times.
-        captureWillSyncRenderPlaceholder();
-      }
-
       // We're outside strict mode. Something inside this Placeholder boundary
       // suspended during the last commit. Switch to the placholder.
       workInProgress.updateQueue = null;

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -257,11 +257,6 @@ let legacyErrorBoundariesThatAlreadyFailed: Set<mixed> | null = null;
 // Used for performance tracking.
 let interruptedBy: Fiber | null = null;
 
-// Do not decrement interaction counts in the event of suspense timeouts.
-// This would lead to prematurely calling the interaction-complete hook.
-// Instead we wait until the suspended promise has resolved.
-let nextRenderIncludesTimedOutPlaceholder: boolean = false;
-
 let stashedWorkInProgressProperties;
 let replayUnitOfWork;
 let isReplayingFailedUnitOfWork;
@@ -766,42 +761,40 @@ function commitRoot(root: FiberRoot, finishedWork: Fiber): void {
         unhandledError = error;
       }
     } finally {
-      if (!nextRenderIncludesTimedOutPlaceholder) {
-        // Clear completed interactions from the pending Map.
-        // Unless the render was suspended or cascading work was scheduled,
-        // In which case– leave pending interactions until the subsequent render.
-        const pendingInteractionMap = root.pendingInteractionMap;
-        pendingInteractionMap.forEach(
-          (scheduledInteractions, scheduledExpirationTime) => {
-            // Only decrement the pending interaction count if we're done.
-            // If there's still work at the current priority,
-            // That indicates that we are waiting for suspense data.
-            if (
-              earliestRemainingTimeAfterCommit === NoWork ||
-              scheduledExpirationTime < earliestRemainingTimeAfterCommit
-            ) {
-              pendingInteractionMap.delete(scheduledExpirationTime);
+      // Clear completed interactions from the pending Map.
+      // Unless the render was suspended or cascading work was scheduled,
+      // In which case– leave pending interactions until the subsequent render.
+      const pendingInteractionMap = root.pendingInteractionMap;
+      pendingInteractionMap.forEach(
+        (scheduledInteractions, scheduledExpirationTime) => {
+          // Only decrement the pending interaction count if we're done.
+          // If there's still work at the current priority,
+          // That indicates that we are waiting for suspense data.
+          if (
+            earliestRemainingTimeAfterCommit === NoWork ||
+            scheduledExpirationTime < earliestRemainingTimeAfterCommit
+          ) {
+            pendingInteractionMap.delete(scheduledExpirationTime);
 
-              scheduledInteractions.forEach(interaction => {
-                interaction.__count--;
+            scheduledInteractions.forEach(interaction => {
+              interaction.__count--;
 
-                if (subscriber !== null && interaction.__count === 0) {
-                  try {
-                    subscriber.onInteractionScheduledWorkCompleted(interaction);
-                  } catch (error) {
-                    // It's not safe for commitRoot() to throw.
-                    // Store the error for now and we'll re-throw in finishRendering().
-                    if (!hasUnhandledError) {
-                      hasUnhandledError = true;
-                      unhandledError = error;
-                    }
+              if (subscriber !== null && interaction.__count === 0) {
+                try {
+                  subscriber.onInteractionScheduledWorkCompleted(interaction);
+                } catch (error) {
+                  // It's not safe for commitRoot() to throw.
+                  // Store the error for now and we'll re-throw in finishRendering().
+                  if (!hasUnhandledError) {
+                    hasUnhandledError = true;
+                    unhandledError = error;
                   }
                 }
-              });
-            }
-          },
-        );
-      }
+              }
+            });
+          }
+        },
+      );
     }
   }
 }
@@ -1173,11 +1166,6 @@ function renderRoot(
     root.pendingCommitExpirationTime = NoWork;
 
     if (enableSchedulerTracing) {
-      // Reset this flag once we start rendering a new root or at a new priority.
-      // This might indicate that suspended work has completed.
-      // If not, the flag will be reset.
-      nextRenderIncludesTimedOutPlaceholder = false;
-
       // Determine which interactions this batch of work currently includes,
       // So that we can accurately attribute time spent working on it,
       // And so that cascading work triggered during the render phase will be associated with it.
@@ -1388,9 +1376,6 @@ function renderRoot(
 
   if (enableSuspense && !isExpired && nextLatestAbsoluteTimeoutMs !== -1) {
     // The tree was suspended.
-    if (enableSchedulerTracing) {
-      nextRenderIncludesTimedOutPlaceholder = true;
-    }
     const suspendedExpirationTime = expirationTime;
     markSuspendedPriorityLevel(root, suspendedExpirationTime);
 
@@ -1596,6 +1581,13 @@ function retrySuspendedRoot(
       retryTime = computeExpirationForFiber(currentTime, fiber);
       markPendingPriorityLevel(root, retryTime);
     }
+
+    // TODO: If the placeholder fiber has already rendered the primary children
+    // without suspending (that is, all of the promises have already resolved),
+    // we should not trigger another update here. One case this happens is when
+    // we are in sync mode and a single promise is thrown both on initial render
+    // and on update; we attach two .then(retrySuspendedRoot) callbacks and each
+    // one performs Sync work, rerendering the Placeholder.
 
     if ((fiber.mode & ConcurrentMode) !== NoContext) {
       if (root === nextRoot && nextRenderExpirationTime === suspendedTime) {
@@ -1912,15 +1904,7 @@ function onTimeout(root, finishedWork, suspendedExpirationTime) {
     // because we're at the top of a timer event.
     recomputeCurrentRendererTime();
     currentSchedulerTime = currentRendererTime;
-
-    if (enableSchedulerTracing) {
-      // Don't update pending interaction counts for suspense timeouts,
-      // Because we know we still need to do more work in this case.
-      nextRenderIncludesTimedOutPlaceholder = true;
-      flushRoot(root, suspendedExpirationTime);
-    } else {
-      flushRoot(root, suspendedExpirationTime);
-    }
+    flushRoot(root, suspendedExpirationTime);
   }
 }
 
@@ -2488,12 +2472,6 @@ function flushControlled(fn: () => mixed): void {
   }
 }
 
-function captureWillSyncRenderPlaceholder() {
-  if (enableSchedulerTracing) {
-    nextRenderIncludesTimedOutPlaceholder = true;
-  }
-}
-
 export {
   requestCurrentTime,
   computeExpirationForFiber,
@@ -2516,5 +2494,4 @@ export {
   interactiveUpdates,
   flushInteractiveUpdates,
   computeUniqueAsyncExpiration,
-  captureWillSyncRenderPlaceholder,
 };

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -14,6 +14,7 @@ import type {CapturedValue} from './ReactCapturedValue';
 import type {Update} from './ReactUpdateQueue';
 import type {Thenable} from './ReactFiberScheduler';
 
+import {unstable_wrap as Schedule_tracing_wrap} from 'scheduler/tracing';
 import getComponentName from 'shared/getComponentName';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {
@@ -224,12 +225,15 @@ function throwException(
               : renderExpirationTime;
 
           // Attach a listener to the promise to "ping" the root and retry.
-          const onResolveOrReject = retrySuspendedRoot.bind(
+          let onResolveOrReject = retrySuspendedRoot.bind(
             null,
             root,
             workInProgress,
             pingTime,
           );
+          if (enableSchedulerTracing) {
+            onResolveOrReject = Schedule_tracing_wrap(onResolveOrReject);
+          }
           thenable.then(onResolveOrReject, onResolveOrReject);
 
           // If the boundary is outside of strict mode, we should *not* suspend

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -60,7 +60,6 @@ import {
   markLegacyErrorBoundaryAsFailed,
   isAlreadyFailedLegacyErrorBoundary,
   retrySuspendedRoot,
-  captureWillSyncRenderPlaceholder,
 } from './ReactFiberScheduler';
 import {Sync} from './ReactFiberExpirationTime';
 
@@ -246,13 +245,6 @@ function throwException(
           // should *not* suspend the commit.
           if ((workInProgress.mode & StrictMode) === NoEffect) {
             workInProgress.effectTag |= UpdateEffect;
-
-            if (enableSchedulerTracing) {
-              // Handles the special case of unwinding a suspended sync render.
-              // We flag this to properly trace and count interactions.
-              // Otherwise interaction pending count will be decremented too many times.
-              captureWillSyncRenderPlaceholder();
-            }
 
             // Unmount the source fiber's children
             const nextChildren = null;

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -2555,7 +2555,9 @@ describe('Profiler', () => {
 
         expect(onRender).toHaveBeenCalledTimes(2); // Sync null commit, placeholder commit
         expect(onRender.mock.calls[0][6]).toMatchInteractions([
-          initialRenderInteraction,
+          highPriUpdateInteraction,
+        ]);
+        expect(onRender.mock.calls[1][6]).toMatchInteractions([
           highPriUpdateInteraction,
         ]);
         onRender.mockClear();
@@ -2567,9 +2569,12 @@ describe('Profiler', () => {
         await originalPromise;
         expect(renderer.toJSON()).toEqual(['loaded', 'updated']);
 
+        // TODO: Bug. This *should* just be one render tied to both interactions.
         expect(onRender).toHaveBeenCalledTimes(2);
         expect(onRender.mock.calls[0][6]).toMatchInteractions([
           initialRenderInteraction,
+        ]);
+        expect(onRender.mock.calls[1][6]).toMatchInteractions([
           highPriUpdateInteraction,
         ]);
 

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -2219,6 +2219,14 @@ describe('Profiler', () => {
           timestamp: mockNow(),
         };
 
+        const monkey = React.createRef();
+        class Monkey extends React.Component {
+          render() {
+            ReactNoop.yield('Monkey');
+            return null;
+          }
+        }
+
         const onRender = jest.fn();
         SchedulerTracing.unstable_trace(interaction.name, mockNow(), () => {
           ReactNoop.render(
@@ -2227,6 +2235,7 @@ describe('Profiler', () => {
                 <AsyncText text="Async" ms={20000} />
               </React.Placeholder>
               <Text text="Sync" />
+              <Monkey ref={monkey} />
             </React.unstable_Profiler>,
           );
         });
@@ -2243,6 +2252,7 @@ describe('Profiler', () => {
           'Suspend [Async]',
           'Text [Loading...]',
           'Text [Sync]',
+          'Monkey',
         ]);
         // The update hasn't expired yet, so we commit nothing.
         expect(ReactNoop.getChildren()).toEqual([]);
@@ -2271,6 +2281,11 @@ describe('Profiler', () => {
         expect(onInteractionTraced).toHaveBeenCalledTimes(1);
         expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
 
+        // An unrelated update in the middle shouldn't affect things...
+        monkey.current.forceUpdate();
+        expect(ReactNoop.flush()).toEqual(['Monkey']);
+        expect(onRender).toHaveBeenCalledTimes(2);
+
         // Once the promise resolves, we render the suspended view
         await awaitableAdvanceTimers(10000);
         expect(ReactNoop.flush()).toEqual([
@@ -2281,9 +2296,9 @@ describe('Profiler', () => {
           {text: 'Async'},
           {text: 'Sync'},
         ]);
-        expect(onRender).toHaveBeenCalledTimes(2);
+        expect(onRender).toHaveBeenCalledTimes(3);
 
-        call = onRender.mock.calls[1];
+        call = onRender.mock.calls[2];
         expect(call[0]).toEqual('test-profiler');
         expect(call[6]).toMatchInteractions(
           ReactFeatureFlags.enableSchedulerTracing ? [interaction] : [],
@@ -2631,6 +2646,11 @@ describe('Profiler', () => {
             },
           );
         });
+        expect(ReactTestRenderer).toHaveYielded([
+          'Suspend [loaded]',
+          'Text [loading]',
+          'Text [updated]',
+        ]);
         expect(renderer.toJSON()).toEqual(['loading', 'updated']);
 
         expect(onRender).toHaveBeenCalledTimes(1);
@@ -2639,32 +2659,28 @@ describe('Profiler', () => {
         ]);
         onRender.mockClear();
 
-        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-        expect(
-          onInteractionScheduledWorkCompleted,
-        ).toHaveBeenLastNotifiedOfInteraction(highPriUpdateInteraction);
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(0);
 
         advanceTimeBy(500);
         jest.advanceTimersByTime(500);
         await originalPromise;
-        expect(ReactTestRenderer).toHaveYielded([
-          'Suspend [loaded]',
-          'Text [loading]',
-          'Text [updated]',
-          'Promise resolved [loaded]',
-        ]);
+        expect(ReactTestRenderer).toHaveYielded(['Promise resolved [loaded]']);
         expect(renderer).toFlushAndYield(['AsyncText [loaded]']);
         expect(renderer.toJSON()).toEqual(['loaded', 'updated']);
 
         expect(onRender).toHaveBeenCalledTimes(1);
         expect(onRender.mock.calls[0][6]).toMatchInteractions([
           initialRenderInteraction,
+          highPriUpdateInteraction,
         ]);
 
         expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
         expect(
-          onInteractionScheduledWorkCompleted,
-        ).toHaveBeenLastNotifiedOfInteraction(initialRenderInteraction);
+          onInteractionScheduledWorkCompleted.mock.calls[0][0],
+        ).toMatchInteraction(initialRenderInteraction);
+        expect(
+          onInteractionScheduledWorkCompleted.mock.calls[1][0],
+        ).toMatchInteraction(highPriUpdateInteraction);
       });
     });
   });


### PR DESCRIPTION
Previously, we were emptying root.pendingInteractionMap and permanently losing those interactions when applying an unrelated update to a tree that has no scheduled work that is waiting on promise resolution. (That is, one that is showing a fallback and waiting for the suspended content to resolve.)

The logic I'm leaving untouched with `nextRenderIncludesTimedOutPlaceholder` is *not* correct -- what we want is instead to know if *any* placeholder anywhere in the tree is showing its fallback -- but we don't currently have a better replacement, and this should unblock tracing with suspense again.
