### PR TITLE
Minor simplify childrenAsString

### DIFF
--- a/packages/react-art/src/ReactARTInternals.js
+++ b/packages/react-art/src/ReactARTInternals.js
@@ -26,9 +26,7 @@ export function childrenAsString(children) {
     return '';
   } else if (typeof children === 'string') {
     return children;
-  } else if (children.length) {
-    return children.join('');
   } else {
-    return '';
+    return children.join('');
   }
 }


### PR DESCRIPTION
Removed check for array length, because `join('')` with emty array returns emtpy string anyway.