### PR TITLE
WIP: Don't update state if setState updater returns the state itself

### DIFF
--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -385,7 +385,11 @@ function getStateFromUpdate<State>(
         // Partial state object
         partialState = payload;
       }
-      if (partialState === null || partialState === undefined) {
+      if (
+        partialState === prevState ||
+        partialState === null ||
+        partialState === undefined
+      ) {
         // Null and undefined are treated as no-ops.
         return prevState;
       }


### PR DESCRIPTION
In the current implementation, a state is kept if `updater` returns `null` or `undefined` but it will be updated if `updater` returns the same state. It's inconvenient if a state is updated by functions like `set` or `setIn` from lodash or immutable because we need to compare a new state with a previous one, but nobody cares about it even in such popular libraries like `formik` which causes performance issues.
So, with this small change, it will be possible to use state updaters like `prevState => _.set(prevState, 'touched.field_name', true)` and prevent unnecessary state updates if nothing is changed.