### PR TITLE
Hide timed-out children instead of deleting them so their state is preserved

### DIFF
--- a/fixtures/dom/src/components/Header.js
+++ b/fixtures/dom/src/components/Header.js
@@ -68,6 +68,7 @@ class Header extends React.Component {
                 <option value="/pointer-events">Pointer Events</option>
                 <option value="/mouse-events">Mouse Events</option>
                 <option value="/selection-events">Selection Events</option>
+                <option value="/suspense">Suspense</option>
               </select>
             </label>
             <label htmlFor="react_version">

--- a/fixtures/dom/src/components/fixtures/suspense/index.js
+++ b/fixtures/dom/src/components/fixtures/suspense/index.js
@@ -1,0 +1,321 @@
+import Fixture from '../../Fixture';
+import FixtureSet from '../../FixtureSet';
+import TestCase from '../../TestCase';
+
+const React = window.React;
+const ReactDOM = window.ReactDOM;
+
+const Suspense = React.unstable_Suspense;
+
+let cache = new Set();
+
+function AsyncStep({text, ms}) {
+  if (!cache.has(text)) {
+    throw new Promise(resolve =>
+      setTimeout(() => {
+        cache.add(text);
+        resolve();
+      }, ms)
+    );
+  }
+  return null;
+}
+
+let suspendyTreeIdCounter = 0;
+class SuspendyTreeChild extends React.Component {
+  id = suspendyTreeIdCounter++;
+  state = {
+    step: 1,
+    isHidden: false,
+  };
+  increment = () => this.setState(s => ({step: s.step + 1}));
+
+  componentDidMount() {
+    document.addEventListener('keydown', this.onKeydown);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.onKeydown);
+  }
+
+  onKeydown = event => {
+    if (event.metaKey && event.key === 'Enter') {
+      this.increment();
+    }
+  };
+
+  render() {
+    return (
+      <React.Fragment>
+        <Suspense fallback={<div>(display: none)</div>}>
+          <div>
+            <AsyncStep text={`${this.state.step} + ${this.id}`} ms={500} />
+            {this.props.children}
+          </div>
+        </Suspense>
+        <button onClick={this.increment}>Hide</button>
+      </React.Fragment>
+    );
+  }
+}
+
+class SuspendyTree extends React.Component {
+  parentContainer = React.createRef(null);
+  container = React.createRef(null);
+  componentDidMount() {
+    this.setState({});
+    document.addEventListener('keydown', this.onKeydown);
+  }
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.onKeydown);
+  }
+  onKeydown = event => {
+    if (event.metaKey && event.key === '/') {
+      this.removeAndRestore();
+    }
+  };
+  removeAndRestore = () => {
+    const parentContainer = this.parentContainer.current;
+    const container = this.container.current;
+    parentContainer.removeChild(container);
+    parentContainer.textContent = '(removed from DOM)';
+    setTimeout(() => {
+      parentContainer.textContent = '';
+      parentContainer.appendChild(container);
+    }, 500);
+  };
+  render() {
+    return (
+      <React.Fragment>
+        <div ref={this.parentContainer}>
+          <div ref={this.container} />
+        </div>
+        <div>
+          {this.container.current !== null
+            ? ReactDOM.createPortal(
+                <React.Fragment>
+                  <SuspendyTreeChild>{this.props.children}</SuspendyTreeChild>
+                  <button onClick={this.removeAndRestore}>Remove</button>
+                </React.Fragment>,
+                this.container.current
+              )
+            : null}
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+
+class TextInputFixtures extends React.Component {
+  render() {
+    return (
+      <FixtureSet
+        title="Suspense"
+        description="Preserving the state of timed-out children">
+        <p>
+          Clicking "Hide" will hide the fixture context using{' '}
+          <code>display: none</code> for 0.5 seconds, then restore. This is the
+          built-in behavior for timed-out children. Each fixture tests whether
+          the state of the DOM is preserved. Clicking "Remove" will remove the
+          fixture content from the DOM for 0.5 seconds, then restore. This is{' '}
+          <strong>not</strong> how timed-out children are hidden, but is
+          included for comparison purposes.
+        </p>
+        <div className="footnote">
+          As a shortcut, you can use Command + Enter (or Control + Enter on
+          Windows, Linux) to "Hide" all the fixtures, or Command + / to "Remove"
+          them.
+        </div>
+        <TestCase title="Text selection where entire range times out">
+          <TestCase.Steps>
+            <li>Use your cursor to select the text below.</li>
+            <li>Click "Hide" or "Remove".</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            Text selection is preserved when hiding, but not when removing.
+          </TestCase.ExpectedResult>
+
+          <Fixture>
+            <SuspendyTree>
+              Select this entire sentence (and only this sentence).
+            </SuspendyTree>
+          </Fixture>
+        </TestCase>
+        <TestCase title="Text selection that extends outside timed-out subtree">
+          <TestCase.Steps>
+            <li>
+              Use your cursor to select a range that includes both the text and
+              the "Go" button.
+            </li>
+            <li>Click "Hide" or "Remove".</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            Text selection is preserved when hiding, but not when removing.
+          </TestCase.ExpectedResult>
+
+          <Fixture>
+            <SuspendyTree>
+              Select a range that includes both this sentence and the "Go"
+              button.
+            </SuspendyTree>
+          </Fixture>
+        </TestCase>
+        <TestCase title="Focus">
+          <TestCase.Steps>
+            <li>
+              Use your cursor to select a range that includes both the text and
+              the "Go" button.
+            </li>
+            <li>
+              Intead of clicking "Go", which switches focus, press Command +
+              Enter (or Control + Enter on Windows, Linux).
+            </li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The ideal behavior is that the focus would not be lost, but
+            currently it is (both when hiding and removing).
+          </TestCase.ExpectedResult>
+
+          <Fixture>
+            <SuspendyTree>
+              <button>Focus me</button>
+            </SuspendyTree>
+          </Fixture>
+        </TestCase>
+        <TestCase title="Uncontrolled form input">
+          <TestCase.Steps>
+            <li>Type something ("Hello") into the text input.</li>
+            <li>Click "Hide" or "Remove".</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            Input is preserved when hiding, but not when removing.
+          </TestCase.ExpectedResult>
+
+          <Fixture>
+            <SuspendyTree>
+              <input type="text" />
+            </SuspendyTree>
+          </Fixture>
+        </TestCase>
+        <TestCase title="Image flicker">
+          <TestCase.Steps>
+            <li>Click "Hide" or "Remove".</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The image should reappear without flickering. The text should not
+            reflow.
+          </TestCase.ExpectedResult>
+
+          <Fixture>
+            <SuspendyTree>
+              <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/Atom_%282%29.png" />React
+              is cool
+            </SuspendyTree>
+          </Fixture>
+        </TestCase>
+        <TestCase title="Iframe">
+          <TestCase.Steps>
+            <li>
+              The iframe shows a nested version of this fixtures app. Navigate
+              to the "Text inputs" page.
+            </li>
+            <li>Select one of the checkboxes.</li>
+            <li>Click "Hide" or "Remove".</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            When removing, the iframe is reloaded. When hiding, the iframe
+            should still be on the "Text inputs" page. The checkbox should still
+            be checked. (Unfortunately, scroll position is lost.)
+          </TestCase.ExpectedResult>
+
+          <Fixture>
+            <SuspendyTree>
+              <iframe width="500" height="300" src="/" />
+            </SuspendyTree>
+          </Fixture>
+        </TestCase>
+        <TestCase title="Video playback">
+          <TestCase.Steps>
+            <li>Start playing the video, or seek to a specific position.</li>
+            <li>Click "Hide" or "Remove".</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The playback position should stay the same. When hiding, the video
+            plays in the background for the entire duration. When removing, the
+            video stops playing, but the position is not lost.
+          </TestCase.ExpectedResult>
+
+          <Fixture>
+            <SuspendyTree>
+              <video controls>
+                <source
+                  src="http://techslides.com/demos/sample-videos/small.webm"
+                  type="video/webm"
+                />
+                <source
+                  src="http://techslides.com/demos/sample-videos/small.ogv"
+                  type="video/ogg"
+                />
+                <source
+                  src="http://techslides.com/demos/sample-videos/small.mp4"
+                  type="video/mp4"
+                />
+                <source
+                  src="http://techslides.com/demos/sample-videos/small.3gp"
+                  type="video/3gp"
+                />
+              </video>
+            </SuspendyTree>
+          </Fixture>
+        </TestCase>
+        <TestCase title="Audio playback">
+          <TestCase.Steps>
+            <li>Start playing the audio, or seek to a specific position.</li>
+            <li>Click "Hide" or "Remove".</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            The playback position should stay the same. When hiding, the audio
+            plays in the background for the entire duration. When removing, the
+            audio stops playing, but the position is not lost.
+          </TestCase.ExpectedResult>
+          <Fixture>
+            <SuspendyTree>
+              <audio controls={true}>
+                <source src="https://upload.wikimedia.org/wikipedia/commons/e/ec/Mozart_K448.ogg" />
+              </audio>
+            </SuspendyTree>
+          </Fixture>
+        </TestCase>
+        <TestCase title="Scroll position">
+          <TestCase.Steps>
+            <li>Scroll to a position in the list.</li>
+            <li>Click "Hide" or "Remove".</li>
+          </TestCase.Steps>
+
+          <TestCase.ExpectedResult>
+            Scroll position is preserved when hiding, but not when removing.
+          </TestCase.ExpectedResult>
+          <Fixture>
+            <SuspendyTree>
+              <div style={{height: 200, overflow: 'scroll'}}>
+                {Array(20)
+                  .fill()
+                  .map((_, i) => <h2 key={i}>{i + 1}</h2>)}
+              </div>
+            </SuspendyTree>
+          </Fixture>
+        </TestCase>
+      </FixtureSet>
+    );
+  }
+}
+
+export default TextInputFixtures;

--- a/packages/jest-react/src/JestReact.js
+++ b/packages/jest-react/src/JestReact.js
@@ -85,6 +85,7 @@ export function toFlushAndThrow(root, ...rest) {
 }
 
 export function toMatchRenderedOutput(root, expectedJSX) {
+  assertYieldsWereCleared(root);
   const actualJSON = root.toJSON();
 
   let actualJSX;

--- a/packages/jest-react/src/JestReact.js
+++ b/packages/jest-react/src/JestReact.js
@@ -151,7 +151,7 @@ function jsonChildrenToJSXChildren(jsonChildren) {
       let allJSXChildrenAreStrings = true;
       let jsxChildrenString = '';
       for (let i = 0; i < jsonChildren.length; i++) {
-        const jsxChild = jsonChildrenToJSXChildren(jsonChildren[i]);
+        const jsxChild = jsonChildToJSXChild(jsonChildren[i]);
         jsxChildren.push(jsxChild);
         if (allJSXChildrenAreStrings) {
           if (typeof jsxChild === 'string') {

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -405,3 +405,19 @@ export function commitUpdate(
 ) {
   instance._applyProps(instance, newProps, oldProps);
 }
+
+export function hideInstance(instance: Instance): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function hideTextInstance(textInstance: TextInstance): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function unhideInstance(instance: Instance, props: Props): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function unhideTextInstance(textInstance: TextInstance): void {
+  throw new Error('Not yet implemented.');
+}

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -406,21 +406,20 @@ export function commitUpdate(
   instance._applyProps(instance, newProps, oldProps);
 }
 
-export function hideInstance(instance: Instance): void {
-  throw new Error('Not yet implemented.');
+export function hideInstance(instance) {
+  instance.hide();
 }
 
-export function hideTextInstance(textInstance: TextInstance): void {
-  throw new Error('Not yet implemented.');
+export function hideTextInstance(textInstance) {
+  // Noop
 }
 
-export function unhideInstance(instance: Instance, props: Props): void {
-  throw new Error('Not yet implemented.');
+export function unhideInstance(instance, props) {
+  if (props.visible == null || props.visible) {
+    instance.show();
+  }
 }
 
-export function unhideTextInstance(
-  textInstance: TextInstance,
-  text: string,
-): void {
-  throw new Error('Not yet implemented.');
+export function unhideTextInstance(textInstance, text): void {
+  // Noop
 }

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -418,6 +418,9 @@ export function unhideInstance(instance: Instance, props: Props): void {
   throw new Error('Not yet implemented.');
 }
 
-export function unhideTextInstance(textInstance: TextInstance): void {
+export function unhideTextInstance(
+  textInstance: TextInstance,
+  text: string,
+): void {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.internal.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let ReactFeatureFlags;
+let React;
+let ReactDOM;
+let Suspense;
+let ReactCache;
+let cache;
+let TextResource;
+
+describe('ReactDOMSuspensePlaceholder', () => {
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableSuspense = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactCache = require('react-cache');
+    Suspense = React.unstable_Suspense;
+    container = document.createElement('div');
+
+    function invalidateCache() {
+      cache = ReactCache.createCache(invalidateCache);
+    }
+    invalidateCache();
+    TextResource = ReactCache.createResource(([text, ms = 0]) => {
+      return new Promise((resolve, reject) =>
+        setTimeout(() => {
+          resolve(text);
+        }, ms),
+      );
+    }, ([text, ms]) => text);
+  });
+
+  function advanceTimers(ms) {
+    // Note: This advances Jest's virtual time but not React's. Use
+    // ReactNoop.expire for that.
+    if (typeof ms !== 'number') {
+      throw new Error('Must specify ms');
+    }
+    jest.advanceTimersByTime(ms);
+    // Wait until the end of the current tick
+    return new Promise(resolve => {
+      setImmediate(resolve);
+    });
+  }
+
+  function Text(props) {
+    return props.text;
+  }
+
+  function AsyncText(props) {
+    const text = props.text;
+    TextResource.read(cache, [props.text, props.ms]);
+    return text;
+  }
+
+  it('hides and unhides timed out DOM elements', async () => {
+    let divs = [
+      React.createRef(null),
+      React.createRef(null),
+      React.createRef(null),
+    ];
+    function App() {
+      return (
+        <Suspense maxDuration={500} fallback={<Text text="Loading..." />}>
+          <div ref={divs[0]}>
+            <Text text="A" />
+          </div>
+          <div ref={divs[1]}>
+            <AsyncText ms={1000} text="B" />
+          </div>
+          <div style={{display: 'block'}} ref={divs[2]}>
+            <Text text="C" />
+          </div>
+        </Suspense>
+      );
+    }
+    ReactDOM.render(<App />, container);
+    expect(divs[0].current.style.display).toEqual('none');
+    expect(divs[1].current.style.display).toEqual('none');
+    expect(divs[2].current.style.display).toEqual('none');
+
+    await advanceTimers(1000);
+
+    expect(divs[0].current.style.display).toEqual('');
+    expect(divs[1].current.style.display).toEqual('');
+    // This div's display was set with a prop.
+    expect(divs[2].current.style.display).toEqual('block');
+  });
+
+  it('hides and unhides timed out text nodes', async () => {
+    function App() {
+      return (
+        <Suspense maxDuration={500} fallback={<Text text="Loading..." />}>
+          <Text text="A" />
+          <AsyncText ms={1000} text="B" />
+          <Text text="C" />
+        </Suspense>
+      );
+    }
+    ReactDOM.render(<App />, container);
+    expect(container.textContent).toEqual('Loading...');
+
+    await advanceTimers(1000);
+
+    expect(container.textContent).toEqual('ABC');
+  });
+});

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -411,6 +411,22 @@ export function removeChildFromContainer(
   }
 }
 
+export function hideInstance(instance: Instance): void {
+  throw new Error('TODO');
+}
+
+export function hideTextInstance(textInstance: TextInstance): void {
+  throw new Error('TODO');
+}
+
+export function unhideInstance(instance: Instance, props: Props): void {
+  throw new Error('TODO');
+}
+
+export function unhideTextInstance(textInstance: TextInstance): void {
+  throw new Error('TODO');
+}
+
 // -------------------
 //     Hydration
 // -------------------

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -420,9 +420,7 @@ export function hideInstance(instance: Instance): void {
   // TODO: Does this work for all element types? What about MathML? Should we
   // pass host context to this method?
   instance = ((instance: any): HTMLElement);
-  if (instance.style !== undefined && instance.style !== null) {
-    instance.style.display = 'none';
-  }
+  instance.style.display = 'none';
 }
 
 export function hideTextInstance(textInstance: TextInstance): void {
@@ -431,17 +429,15 @@ export function hideTextInstance(textInstance: TextInstance): void {
 
 export function unhideInstance(instance: Instance, props: Props): void {
   instance = ((instance: any): HTMLElement);
-  if (instance.style !== undefined && instance.style !== null) {
-    let display = null;
-    if (props[STYLE] !== undefined && props[STYLE] !== null) {
-      const styleProp = props[STYLE];
-      if (styleProp.hasOwnProperty('display')) {
-        display = styleProp.display;
-      }
-    }
-    // $FlowFixMe Setting a style property to null is the valid way to reset it.
-    instance.style.display = display;
-  }
+  const styleProp = props[STYLE];
+  const display =
+    styleProp !== undefined &&
+    styleProp !== null &&
+    styleProp.hasOwnProperty('display')
+      ? styleProp.display
+      : null;
+  // $FlowFixMe Setting a style property to null is the valid way to reset it.
+  instance.style.display = display;
 }
 
 export function unhideTextInstance(

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -45,6 +45,9 @@ export type Props = {
   hidden?: boolean,
   suppressHydrationWarning?: boolean,
   dangerouslySetInnerHTML?: mixed,
+  style?: {
+    display?: string,
+  },
 };
 export type Container = Element | Document;
 export type Instance = Element;
@@ -72,6 +75,8 @@ let SUPPRESS_HYDRATION_WARNING;
 if (__DEV__) {
   SUPPRESS_HYDRATION_WARNING = 'suppressHydrationWarning';
 }
+
+const STYLE = 'style';
 
 let eventsEnabled: ?boolean = null;
 let selectionInformation: ?mixed = null;
@@ -412,19 +417,38 @@ export function removeChildFromContainer(
 }
 
 export function hideInstance(instance: Instance): void {
-  throw new Error('TODO');
+  // TODO: Does this work for all element types? What about MathML? Should we
+  // pass host context to this method?
+  instance = ((instance: any): HTMLElement);
+  if (instance.style !== undefined && instance.style !== null) {
+    instance.style.display = 'none';
+  }
 }
 
 export function hideTextInstance(textInstance: TextInstance): void {
-  throw new Error('TODO');
+  textInstance.nodeValue = '';
 }
 
 export function unhideInstance(instance: Instance, props: Props): void {
-  throw new Error('TODO');
+  instance = ((instance: any): HTMLElement);
+  if (instance.style !== undefined && instance.style !== null) {
+    let display = null;
+    if (props[STYLE] !== undefined && props[STYLE] !== null) {
+      const styleProp = props[STYLE];
+      if (styleProp.hasOwnProperty('display')) {
+        display = styleProp.display;
+      }
+    }
+    // $FlowFixMe Setting a style property to null is the valid way to reset it.
+    instance.style.display = display;
+  }
 }
 
-export function unhideTextInstance(textInstance: TextInstance): void {
-  throw new Error('TODO');
+export function unhideTextInstance(
+  textInstance: TextInstance,
+  text: string,
+): void {
+  textInstance.nodeValue = text;
 }
 
 // -------------------

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -374,6 +374,33 @@ export function cloneInstance(
   };
 }
 
+export function cloneHiddenInstance(
+  instance: Instance,
+  type: string,
+  props: Props,
+  internalInstanceHandle: Object,
+): Instance {
+  throw new Error('Not yet implemented.');
+}
+
+export function cloneUnhiddenInstance(
+  instance: Instance,
+  type: string,
+  props: Props,
+  internalInstanceHandle: Object,
+): Instance {
+  throw new Error('Not yet implemented.');
+}
+
+export function createHiddenTextInstance(
+  text: string,
+  rootContainerInstance: Container,
+  hostContext: HostContext,
+  internalInstanceHandle: Object,
+): TextInstance {
+  throw new Error('Not yet implemented.');
+}
+
 export function createContainerChildSet(container: Container): ChildSet {
   return createChildNodeSet(container);
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -451,3 +451,19 @@ export function removeChildFromContainer(
 export function resetTextContent(instance: Instance): void {
   // Noop
 }
+
+export function hideInstance(instance: Instance): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function hideTextInstance(textInstance: TextInstance): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function unhideInstance(instance: Instance, props: Props): void {
+  throw new Error('Not yet implemented.');
+}
+
+export function unhideTextInstance(textInstance: TextInstance): void {
+  throw new Error('Not yet implemented.');
+}

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -464,6 +464,9 @@ export function unhideInstance(instance: Instance, props: Props): void {
   throw new Error('Not yet implemented.');
 }
 
-export function unhideTextInstance(textInstance: TextInstance): void {
+export function unhideTextInstance(
+  textInstance: TextInstance,
+  text: string,
+): void {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -408,7 +408,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           }
         },
 
-        unhideTextInstance(textInstance: TextInstance): void {
+        unhideTextInstance(textInstance: TextInstance, text: string): void {
           textInstance.hidden = false;
         },
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -394,6 +394,24 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         removeChild,
         removeChildFromContainer,
 
+        hideInstance(instance: Instance): void {
+          instance.hidden = true;
+        },
+
+        hideTextInstance(textInstance: TextInstance): void {
+          textInstance.hidden = true;
+        },
+
+        unhideInstance(instance: Instance, props: Props): void {
+          if (!props.hidden) {
+            instance.hidden = false;
+          }
+        },
+
+        unhideTextInstance(textInstance: TextInstance): void {
+          textInstance.hidden = false;
+        },
+
         resetTextContent(instance: Instance): void {
           instance.text = null;
         },
@@ -428,6 +446,61 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           newChildren: Array<Instance | TextInstance>,
         ): void {
           container.children = newChildren;
+        },
+
+        cloneHiddenInstance(
+          instance: Instance,
+          type: string,
+          props: Props,
+          internalInstanceHandle: Object,
+        ): Instance {
+          const clone = cloneInstance(
+            instance,
+            null,
+            type,
+            props,
+            props,
+            internalInstanceHandle,
+            true,
+            null,
+          );
+          clone.hidden = true;
+          return clone;
+        },
+
+        cloneUnhiddenInstance(
+          instance: Instance,
+          type: string,
+          props: Props,
+          internalInstanceHandle: Object,
+        ): Instance {
+          const clone = cloneInstance(
+            instance,
+            null,
+            type,
+            props,
+            props,
+            internalInstanceHandle,
+            true,
+            null,
+          );
+          clone.hidden = props.hidden;
+          return clone;
+        },
+
+        createHiddenTextInstance(
+          text: string,
+          rootContainerInstance: Container,
+          hostContext: Object,
+          internalInstanceHandle: Object,
+        ): TextInstance {
+          const inst = {text: text, id: instanceCounter++, hidden: true};
+          // Hide from unit tests
+          Object.defineProperty(inst, 'id', {
+            value: inst.id,
+            enumerable: false,
+          });
+          return inst;
         },
       };
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -20,16 +20,22 @@ import type {ReactNodeList} from 'shared/ReactTypes';
 
 import * as ReactPortal from 'shared/ReactPortal';
 import expect from 'expect';
+import {REACT_FRAGMENT_TYPE, REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 
-type Container = {rootID: string, children: Array<Instance | TextInstance>};
-type Props = {prop: any, hidden?: boolean, children?: mixed};
+type Container = {
+  rootID: string,
+  children: Array<Instance | TextInstance>,
+};
+type Props = {prop: any, hidden: boolean, children?: mixed};
 type Instance = {|
   type: string,
   id: number,
   children: Array<Instance | TextInstance>,
+  text: string | null,
   prop: any,
+  hidden: boolean,
 |};
-type TextInstance = {|text: string, id: number|};
+type TextInstance = {|text: string, id: number, hidden: boolean|};
 
 const NO_CONTEXT = {};
 const UPDATE_SIGNAL = {};
@@ -164,6 +170,47 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     removeChildFromContainerOrInstance(parentInstance, child);
   }
 
+  function cloneInstance(
+    instance: Instance,
+    updatePayload: null | Object,
+    type: string,
+    oldProps: Props,
+    newProps: Props,
+    internalInstanceHandle: Object,
+    keepChildren: boolean,
+    recyclableInstance: null | Instance,
+  ): Instance {
+    const clone = {
+      id: instance.id,
+      type: type,
+      children: keepChildren ? instance.children : [],
+      text: shouldSetTextContent(type, newProps)
+        ? (newProps.children: any) + ''
+        : null,
+      prop: newProps.prop,
+      hidden: newProps.hidden === true,
+    };
+    Object.defineProperty(clone, 'id', {
+      value: clone.id,
+      enumerable: false,
+    });
+    Object.defineProperty(clone, 'text', {
+      value: clone.text,
+      enumerable: false,
+    });
+    hostCloneCounter++;
+    return clone;
+  }
+
+  function shouldSetTextContent(type: string, props: Props): boolean {
+    if (type === 'errorInBeginPhase') {
+      throw new Error('Error in host config.');
+    }
+    return (
+      typeof props.children === 'string' || typeof props.children === 'number'
+    );
+  }
+
   let elapsedTimeInMs = 0;
 
   const sharedHostConfig = {
@@ -187,10 +234,18 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         id: instanceCounter++,
         type: type,
         children: [],
+        text: shouldSetTextContent(type, props)
+          ? (props.children: any) + ''
+          : null,
         prop: props.prop,
+        hidden: props.hidden === true,
       };
       // Hide from unit tests
       Object.defineProperty(inst, 'id', {value: inst.id, enumerable: false});
+      Object.defineProperty(inst, 'text', {
+        value: inst.text,
+        enumerable: false,
+      });
       return inst;
     },
 
@@ -228,14 +283,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return UPDATE_SIGNAL;
     },
 
-    shouldSetTextContent(type: string, props: Props): boolean {
-      if (type === 'errorInBeginPhase') {
-        throw new Error('Error in host config.');
-      }
-      return (
-        typeof props.children === 'string' || typeof props.children === 'number'
-      );
-    },
+    shouldSetTextContent,
 
     shouldDeprioritizeSubtree(type: string, props: Props): boolean {
       return !!props.hidden;
@@ -247,7 +295,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       hostContext: Object,
       internalInstanceHandle: Object,
     ): TextInstance {
-      const inst = {text: text, id: instanceCounter++};
+      const inst = {text: text, id: instanceCounter++, hidden: false};
       // Hide from unit tests
       Object.defineProperty(inst, 'id', {value: inst.id, enumerable: false});
       return inst;
@@ -324,6 +372,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           }
           hostUpdateCounter++;
           instance.prop = newProps.prop;
+          instance.hidden = newProps.hidden === true;
+          if (shouldSetTextContent(type, newProps)) {
+            instance.text = (newProps.children: any) + '';
+          }
         },
 
         commitTextUpdate(
@@ -342,36 +394,16 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         removeChild,
         removeChildFromContainer,
 
-        resetTextContent(instance: Instance): void {},
+        resetTextContent(instance: Instance): void {
+          instance.text = null;
+        },
       }
     : {
         ...sharedHostConfig,
         supportsMutation: false,
         supportsPersistence: true,
 
-        cloneInstance(
-          instance: Instance,
-          updatePayload: null | Object,
-          type: string,
-          oldProps: Props,
-          newProps: Props,
-          internalInstanceHandle: Object,
-          keepChildren: boolean,
-          recyclableInstance: null | Instance,
-        ): Instance {
-          const clone = {
-            id: instance.id,
-            type: type,
-            children: keepChildren ? instance.children : [],
-            prop: newProps.prop,
-          };
-          Object.defineProperty(clone, 'id', {
-            value: clone.id,
-            enumerable: false,
-          });
-          hostCloneCounter++;
-          return clone;
-        },
+        cloneInstance,
 
         createContainerChildSet(
           container: Container,
@@ -439,6 +471,59 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     }
   }
 
+  function childToJSX(child, text) {
+    if (text !== null) {
+      return text;
+    }
+    if (child === null) {
+      return null;
+    }
+    if (typeof child === 'string') {
+      return child;
+    }
+    if (Array.isArray(child)) {
+      if (child.length === 0) {
+        return null;
+      }
+      if (child.length === 1) {
+        return childToJSX(child[0], null);
+      }
+      // $FlowFixMe
+      const children = child.map(c => childToJSX(c, null));
+      if (children.every(c => typeof c === 'string' || typeof c === 'number')) {
+        return children.join('');
+      }
+      return children;
+    }
+    if (Array.isArray(child.children)) {
+      // This is an instance.
+      const instance: Instance = (child: any);
+      const children = childToJSX(instance.children, instance.text);
+      const props = ({prop: instance.prop}: any);
+      if (instance.hidden) {
+        props.hidden = true;
+      }
+      if (children !== null) {
+        props.children = children;
+      }
+      return {
+        $$typeof: REACT_ELEMENT_TYPE,
+        type: instance.type,
+        key: null,
+        ref: null,
+        props: props,
+        _owner: null,
+        _store: __DEV__ ? {} : undefined,
+      };
+    }
+    // This is a text instance
+    const textInstance: TextInstance = (child: any);
+    if (textInstance.hidden) {
+      return '';
+    }
+    return textInstance.text;
+  }
+
   const ReactNoop = {
     getChildren(rootID: string = DEFAULT_ROOT_ID) {
       const container = rootContainers.get(rootID);
@@ -461,6 +546,25 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         roots.set(rootID, root);
       }
       return root.current.stateNode.containerInfo;
+    },
+
+    getChildrenAsJSX(rootID: string = DEFAULT_ROOT_ID) {
+      const children = childToJSX(ReactNoop.getChildren(rootID), null);
+      if (children === null) {
+        return null;
+      }
+      if (Array.isArray(children)) {
+        return {
+          $$typeof: REACT_ELEMENT_TYPE,
+          type: REACT_FRAGMENT_TYPE,
+          key: null,
+          ref: null,
+          props: {children},
+          _owner: null,
+          _store: __DEV__ ? {} : undefined,
+        };
+      }
+      return children;
     },
 
     createPortal(

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -708,20 +708,19 @@ function resolveDefaultProps(Component, baseProps) {
 }
 
 function mountIndeterminateComponent(
-  current,
+  _current,
   workInProgress,
   Component,
   updateExpirationTime,
   renderExpirationTime,
 ) {
-  if (current !== null) {
+  if (_current !== null) {
     // An indeterminate component only mounts if it suspended inside a non-
     // concurrent tree, in an inconsistent state. We want to tree it like
     // a new mount, even though an empty version of it already committed.
     // Disconnect the alternate pointers.
-    current.alternate = null;
+    _current.alternate = null;
     workInProgress.alternate = null;
-    current = null;
     // Since this is conceptually a new fiber, schedule a Placement effect
     workInProgress.effectTag |= Placement;
   }
@@ -746,7 +745,7 @@ function mountIndeterminateComponent(
     switch (resolvedTag) {
       case FunctionComponentLazy: {
         child = updateFunctionComponent(
-          current,
+          null,
           workInProgress,
           Component,
           resolvedProps,
@@ -756,7 +755,7 @@ function mountIndeterminateComponent(
       }
       case ClassComponentLazy: {
         child = updateClassComponent(
-          current,
+          null,
           workInProgress,
           Component,
           resolvedProps,
@@ -766,7 +765,7 @@ function mountIndeterminateComponent(
       }
       case ForwardRefLazy: {
         child = updateForwardRef(
-          current,
+          null,
           workInProgress,
           Component,
           resolvedProps,
@@ -776,7 +775,7 @@ function mountIndeterminateComponent(
       }
       case PureComponentLazy: {
         child = updatePureComponent(
-          current,
+          null,
           workInProgress,
           Component,
           resolvedProps,
@@ -875,7 +874,7 @@ function mountIndeterminateComponent(
     adoptClassInstance(workInProgress, value);
     mountClassInstance(workInProgress, Component, props, renderExpirationTime);
     return finishClassComponent(
-      current,
+      null,
       workInProgress,
       Component,
       true,
@@ -945,7 +944,7 @@ function mountIndeterminateComponent(
         }
       }
     }
-    reconcileChildren(current, workInProgress, value, renderExpirationTime);
+    reconcileChildren(null, workInProgress, value, renderExpirationTime);
     memoizeProps(workInProgress, props);
     return workInProgress.child;
   }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -976,9 +976,6 @@ function updateSuspenseComponent(
         nextState.alreadyCaptured = true;
         nextState.didTimeout = true;
       }
-      // If this render commits, schedule an update effect to record the timed-
-      // out time.
-      workInProgress.effectTag |= Update;
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -39,7 +39,6 @@ import {
   clearCaughtError,
 } from 'shared/ReactErrorUtils';
 import {
-  NoEffect,
   ContentReset,
   Placement,
   Snapshot,
@@ -78,7 +77,7 @@ import {
   requestCurrentTime,
   scheduleWork,
 } from './ReactFiberScheduler';
-import {StrictMode} from './ReactTypeOfMode';
+import {NoContext, StrictMode} from './ReactTypeOfMode';
 
 const emptyObject = {};
 
@@ -352,19 +351,19 @@ function commitLifeCycles(
       return;
     }
     case SuspenseComponent: {
-      if ((finishedWork.mode & StrictMode) === NoEffect) {
-        // In loose mode, a placeholder times out by scheduling a synchronous
-        // update in the commit phase. Use `updateQueue` field to signal that
-        // the Timeout needs to switch to the placeholder. We don't need an
-        // entire queue. Any non-null value works.
+      if ((finishedWork.mode & StrictMode) === NoContext) {
+        // In loose mode, a suspense boundary times out by scheduling a
+        // synchronous update in the commit phase. Use `updateQueue` field to
+        // signal that the Timeout needs to switch to the placeholder. We don't
+        // need an entire queue. Any non-null value works.
         // $FlowFixMe - Intentionally using a value other than an UpdateQueue.
         finishedWork.updateQueue = emptyObject;
         scheduleWork(finishedWork, Sync);
       } else {
         // In strict mode, the Update effect is used to record the time at
-        // which the placeholder timed out.
-        const currentTime = requestCurrentTime();
-        finishedWork.stateNode = {timedOutAt: currentTime};
+        // which the children timed out.
+        // $FlowFixMe - Intentionally using a value other than an UpdateQueue.
+        finishedWork.updateQueue = {timedOutAt: requestCurrentTime()};
       }
       return;
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -424,7 +424,7 @@ function hideOrUnhideAllChildren(finishedWork, isHidden) {
         if (isHidden) {
           hideTextInstance(instance);
         } else {
-          unhideTextInstance(instance);
+          unhideTextInstance(instance, node.memoizedProps);
         }
       } else if (node.child !== null) {
         node.child.return = node;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -17,6 +17,7 @@ import type {
   Container,
   ChildSet,
 } from './ReactFiberHostConfig';
+import type {SuspenseState} from './ReactFiberSuspenseComponent';
 
 import {
   IndeterminateComponent,
@@ -46,12 +47,15 @@ import {getResultFromResolvedThenable} from 'shared/ReactLazyComponent';
 import {
   createInstance,
   createTextInstance,
+  createHiddenTextInstance,
   appendInitialChild,
   finalizeInitialChildren,
   prepareUpdate,
   supportsMutation,
   supportsPersistence,
   cloneInstance,
+  cloneHiddenInstance,
+  cloneUnhiddenInstance,
   createContainerChildSet,
   appendChildToContainerChildSet,
   finalizeContainerChildren,
@@ -84,22 +88,94 @@ function markRef(workInProgress: Fiber) {
   workInProgress.effectTag |= Ref;
 }
 
-function appendAllChildren(parent: Instance, workInProgress: Fiber) {
+function appendAllChildren(
+  parent: Instance,
+  workInProgress: Fiber,
+  needsVisibilityToggle: boolean,
+  isHidden: boolean,
+) {
   // We only have the top Fiber that was created but we need recurse down its
   // children to find all the terminal nodes.
   let node = workInProgress.child;
   while (node !== null) {
-    if (node.tag === HostComponent || node.tag === HostText) {
-      appendInitialChild(parent, node.stateNode);
+    // eslint-disable-next-line no-labels
+    branches: if (node.tag === HostComponent) {
+      let instance = node.stateNode;
+      if (supportsPersistence && needsVisibilityToggle) {
+        const props = node.memoizedProps;
+        const type = node.type;
+        if (isHidden) {
+          // This child is inside a timed out tree. Hide it.
+          instance = cloneHiddenInstance(instance, type, props, node);
+        } else {
+          // This child was previously inside a timed out tree. If it was not
+          // updated during this render, it may need to be unhidden. Clone
+          // again to be sure.
+          instance = cloneUnhiddenInstance(instance, type, props, node);
+        }
+        node.stateNode = instance;
+      }
+      appendInitialChild(parent, instance);
+    } else if (node.tag === HostText) {
+      let instance = node.stateNode;
+      if (supportsPersistence && needsVisibilityToggle) {
+        const text = node.memoizedProps;
+        const rootContainerInstance = getRootHostContainer();
+        const currentHostContext = getHostContext();
+        if (isHidden) {
+          instance = createHiddenTextInstance(
+            text,
+            rootContainerInstance,
+            currentHostContext,
+            workInProgress,
+          );
+        } else {
+          instance = createTextInstance(
+            text,
+            rootContainerInstance,
+            currentHostContext,
+            workInProgress,
+          );
+        }
+        node.stateNode = instance;
+      }
+      appendInitialChild(parent, instance);
     } else if (node.tag === HostPortal) {
       // If we have a portal child, then we don't want to traverse
       // down its children. Instead, we'll get insertions from each child in
       // the portal directly.
+    } else if (node.tag === SuspenseComponent) {
+      const current = node.alternate;
+      if (current !== null) {
+        const oldState: SuspenseState = current.memoizedState;
+        const newState: SuspenseState = node.memoizedState;
+        const oldIsHidden = oldState !== null && oldState.didTimeout;
+        const newIsHidden = newState !== null && newState.didTimeout;
+        if (oldIsHidden !== newIsHidden) {
+          // The placeholder either just timed out or switched back to the normal
+          // children after having previously timed out. Toggle the visibility of
+          // the direct host children.
+          const primaryChildParent = newIsHidden ? node.child : node;
+          if (primaryChildParent !== null) {
+            appendAllChildren(parent, primaryChildParent, true, newIsHidden);
+          }
+          // eslint-disable-next-line no-labels
+          break branches;
+        }
+      }
+      if (node.child !== null) {
+        // Continue traversing like normal
+        node.child.return = node;
+        node = node.child;
+        continue;
+      }
     } else if (node.child !== null) {
       node.child.return = node;
       node = node.child;
       continue;
     }
+    // $FlowFixMe This is correct but Flow is confused by the labeled break.
+    node = (node: Fiber);
     if (node === workInProgress) {
       return;
     }
@@ -182,22 +258,96 @@ if (supportsMutation) {
   const appendAllChildrenToContainer = function(
     containerChildSet: ChildSet,
     workInProgress: Fiber,
+    needsVisibilityToggle: boolean,
+    isHidden: boolean,
   ) {
     // We only have the top Fiber that was created but we need recurse down its
     // children to find all the terminal nodes.
     let node = workInProgress.child;
     while (node !== null) {
-      if (node.tag === HostComponent || node.tag === HostText) {
-        appendChildToContainerChildSet(containerChildSet, node.stateNode);
+      // eslint-disable-next-line no-labels
+      branches: if (node.tag === HostComponent) {
+        let instance = node.stateNode;
+        if (supportsPersistence && needsVisibilityToggle) {
+          const props = node.memoizedProps;
+          const type = node.type;
+          if (isHidden) {
+            // This child is inside a timed out tree. Hide it.
+            instance = cloneHiddenInstance(instance, type, props, node);
+          } else {
+            // This child was previously inside a timed out tree. If it was not
+            // updated during this render, it may need to be unhidden. Clone
+            // again to be sure.
+            instance = cloneUnhiddenInstance(instance, type, props, node);
+          }
+          node.stateNode = instance;
+        }
+        appendChildToContainerChildSet(containerChildSet, instance);
+      } else if (node.tag === HostText) {
+        let instance = node.stateNode;
+        if (supportsPersistence && needsVisibilityToggle) {
+          const text = node.memoizedProps;
+          const rootContainerInstance = getRootHostContainer();
+          const currentHostContext = getHostContext();
+          if (isHidden) {
+            instance = createHiddenTextInstance(
+              text,
+              rootContainerInstance,
+              currentHostContext,
+              workInProgress,
+            );
+          } else {
+            instance = createTextInstance(
+              text,
+              rootContainerInstance,
+              currentHostContext,
+              workInProgress,
+            );
+          }
+          node.stateNode = instance;
+        }
+        appendChildToContainerChildSet(containerChildSet, instance);
       } else if (node.tag === HostPortal) {
         // If we have a portal child, then we don't want to traverse
         // down its children. Instead, we'll get insertions from each child in
         // the portal directly.
+      } else if (node.tag === SuspenseComponent) {
+        const current = node.alternate;
+        if (current !== null) {
+          const oldState: SuspenseState = current.memoizedState;
+          const newState: SuspenseState = node.memoizedState;
+          const oldIsHidden = oldState !== null && oldState.didTimeout;
+          const newIsHidden = newState !== null && newState.didTimeout;
+          if (oldIsHidden !== newIsHidden) {
+            // The placeholder either just timed out or switched back to the normal
+            // children after having previously timed out. Toggle the visibility of
+            // the direct host children.
+            const primaryChildParent = newIsHidden ? node.child : node;
+            if (primaryChildParent !== null) {
+              appendAllChildrenToContainer(
+                containerChildSet,
+                primaryChildParent,
+                true,
+                newIsHidden,
+              );
+            }
+            // eslint-disable-next-line no-labels
+            break branches;
+          }
+        }
+        if (node.child !== null) {
+          // Continue traversing like normal
+          node.child.return = node;
+          node = node.child;
+          continue;
+        }
       } else if (node.child !== null) {
         node.child.return = node;
         node = node.child;
         continue;
       }
+      // $FlowFixMe This is correct but Flow is confused by the labeled break.
+      node = (node: Fiber);
       if (node === workInProgress) {
         return;
       }
@@ -224,7 +374,7 @@ if (supportsMutation) {
       const container = portalOrRoot.containerInfo;
       let newChildSet = createContainerChildSet(container);
       // If children might have changed, we have to add them all to the set.
-      appendAllChildrenToContainer(newChildSet, workInProgress);
+      appendAllChildrenToContainer(newChildSet, workInProgress, false, false);
       portalOrRoot.pendingChildren = newChildSet;
       // Schedule an update on the container to swap out the container.
       markUpdate(workInProgress);
@@ -297,7 +447,7 @@ if (supportsMutation) {
       markUpdate(workInProgress);
     } else {
       // If children might have changed, we have to add them all to the set.
-      appendAllChildren(newInstance, workInProgress);
+      appendAllChildren(newInstance, workInProgress, false, false);
     }
   };
   updateHostText = function(
@@ -447,7 +597,7 @@ function completeWork(
             workInProgress,
           );
 
-          appendAllChildren(instance, workInProgress);
+          appendAllChildren(instance, workInProgress, false, false);
 
           // Certain renderers require commit-time effects for initial mount.
           // (eg DOM renderer supports auto-focus for certain elements).
@@ -510,8 +660,18 @@ function completeWork(
     case ForwardRef:
     case ForwardRefLazy:
       break;
-    case SuspenseComponent:
+    case SuspenseComponent: {
+      const nextState = workInProgress.memoizedState;
+      const prevState = current !== null ? current.memoizedState : null;
+      const nextDidTimeout = nextState !== null && nextState.didTimeout;
+      const prevDidTimeout = prevState !== null && prevState.didTimeout;
+      if (nextDidTimeout !== prevDidTimeout) {
+        // If this render commits, and it switches between the normal state
+        // and the timed-out state, schedule an effect.
+        workInProgress.effectTag |= Update;
+      }
       break;
+    }
     case Fragment:
       break;
     case Mode:

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -353,6 +353,8 @@ function completeWork(
   const newProps = workInProgress.pendingProps;
 
   switch (workInProgress.tag) {
+    case IndeterminateComponent:
+      break;
     case FunctionComponent:
     case FunctionComponentLazy:
       break;
@@ -529,15 +531,6 @@ function completeWork(
     case PureComponent:
     case PureComponentLazy:
       break;
-    // Error cases
-    case IndeterminateComponent:
-      invariant(
-        false,
-        'An indeterminate component should have become determinate before ' +
-          'completing. This error is likely caused by a bug in React. Please ' +
-          'file an issue.',
-      );
-    // eslint-disable-next-line no-fallthrough
     default:
       invariant(
         false,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1604,7 +1604,8 @@ function retrySuspendedRoot(
   scheduleWorkToRoot(boundaryFiber, retryTime);
   if ((boundaryFiber.mode & StrictMode) === NoContext) {
     // Outside of strict mode, we must schedule an update on the source fiber,
-    // too, since it already committed.
+    // too, since it already committed in an inconsistent state and therefore
+    // does not have any pending work.
     scheduleWorkToRoot(sourceFiber, retryTime);
   }
 

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -110,7 +110,12 @@ import {
   computeAsyncExpiration,
   computeInteractiveExpiration,
 } from './ReactFiberExpirationTime';
-import {ConcurrentMode, ProfileMode, NoContext} from './ReactTypeOfMode';
+import {
+  ConcurrentMode,
+  ProfileMode,
+  NoContext,
+  StrictMode,
+} from './ReactTypeOfMode';
 import {enqueueUpdate, resetCurrentlyProcessingQueue} from './ReactUpdateQueue';
 import {createCapturedValue} from './ReactCapturedValue';
 import {
@@ -1563,7 +1568,8 @@ function renderDidError() {
 
 function retrySuspendedRoot(
   root: FiberRoot,
-  fiber: Fiber,
+  boundaryFiber: Fiber,
+  sourceFiber: Fiber,
   suspendedTime: ExpirationTime,
 ) {
   let retryTime;
@@ -1576,18 +1582,18 @@ function retrySuspendedRoot(
   } else {
     // Suspense already timed out. Compute a new expiration time
     const currentTime = requestCurrentTime();
-    retryTime = computeExpirationForFiber(currentTime, fiber);
+    retryTime = computeExpirationForFiber(currentTime, boundaryFiber);
     markPendingPriorityLevel(root, retryTime);
   }
 
-  // TODO: If the placeholder fiber has already rendered the primary children
+  // TODO: If the suspense fiber has already rendered the primary children
   // without suspending (that is, all of the promises have already resolved),
   // we should not trigger another update here. One case this happens is when
   // we are in sync mode and a single promise is thrown both on initial render
   // and on update; we attach two .then(retrySuspendedRoot) callbacks and each
   // one performs Sync work, rerendering the Suspense.
 
-  if ((fiber.mode & ConcurrentMode) !== NoContext) {
+  if ((boundaryFiber.mode & ConcurrentMode) !== NoContext) {
     if (root === nextRoot && nextRenderExpirationTime === suspendedTime) {
       // Received a ping at the same priority level at which we're currently
       // rendering. Restart from the root.
@@ -1595,7 +1601,13 @@ function retrySuspendedRoot(
     }
   }
 
-  scheduleWorkToRoot(fiber, retryTime);
+  scheduleWorkToRoot(boundaryFiber, retryTime);
+  if ((boundaryFiber.mode & StrictMode) === NoContext) {
+    // Outside of strict mode, we must schedule an update on the source fiber,
+    // too, since it already committed.
+    scheduleWorkToRoot(sourceFiber, retryTime);
+  }
+
   const rootExpirationTime = root.expirationTime;
   if (rootExpirationTime !== NoWork) {
     requestWork(root, rootExpirationTime);

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ExpirationTime} from './ReactFiberExpirationTime';
+
+export type SuspenseState = {|
+  // Whether a component in the child subtree already suspended. If true,
+  // subsequent suspends should bubble up to the next boundary.
+  alreadyCaptured: boolean,
+  // Whether the boundary renders the primary or fallback children. This is
+  // separate from `alreadyCaptured` because outside of strict mode, when a
+  // boundary times out, the first commit renders the primary children in an
+  // incomplete state, then performs a second commit to switch the fallback.
+  // In that first commit, `alreadyCaptured` is false and `didTimeout` is true.
+  didTimeout: boolean,
+  // The time at which the boundary timed out. This is separate from
+  // `didTimeout` because it's not set unless the boundary actually commits.
+  timedOutAt: ExpirationTime,
+|};

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -32,7 +32,7 @@ import {
   Incomplete,
   NoEffect,
   ShouldCapture,
-  Update as UpdateEffect,
+  Callback as CallbackEffect,
   LifecycleEffectMask,
 } from 'shared/ReactSideEffectTags';
 import {enableSchedulerTracing} from 'shared/ReactFeatureFlags';
@@ -239,7 +239,7 @@ function throwException(
           // inside a strict mode tree. If the Suspense is outside of it, we
           // should *not* suspend the commit.
           if ((workInProgress.mode & StrictMode) === NoEffect) {
-            workInProgress.effectTag |= UpdateEffect;
+            workInProgress.effectTag |= CallbackEffect;
 
             // Unmount the source fiber's children
             const nextChildren = null;

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -176,17 +176,16 @@ function throwException(
     do {
       if (workInProgress.tag === SuspenseComponent) {
         const current = workInProgress.alternate;
-        if (
-          current !== null &&
-          current.memoizedState === true &&
-          current.stateNode !== null
-        ) {
+        if (current !== null && current.updateQueue !== null) {
           // Reached a placeholder that already timed out. Each timed out
           // placeholder acts as the root of a new suspense boundary.
 
           // Use the time at which the placeholder timed out as the start time
           // for the current render.
-          const timedOutAt = current.stateNode.timedOutAt;
+          const suspenseInfo: {|
+            timedOutAt: ExpirationTime,
+          |} = (current.updateQueue: any);
+          const timedOutAt = suspenseInfo.timedOutAt;
           startTimeMs = expirationTimeToMs(timedOutAt);
 
           // Do not search any further.

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -18,7 +18,6 @@ import {unstable_wrap as Schedule_tracing_wrap} from 'scheduler/tracing';
 import getComponentName from 'shared/getComponentName';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {
-  IndeterminateComponent,
   FunctionComponent,
   ClassComponent,
   ClassComponentLazy,
@@ -226,6 +225,7 @@ function throwException(
             null,
             root,
             workInProgress,
+            sourceFiber,
             pingTime,
           );
           if (enableSchedulerTracing) {
@@ -253,11 +253,6 @@ function throwException(
               renderExpirationTime,
             );
             sourceFiber.effectTag &= ~Incomplete;
-            if (sourceFiber.tag === IndeterminateComponent) {
-              // Let's just assume it's a function component. This fiber will
-              // be unmounted in the immediate next commit, anyway.
-              sourceFiber.tag = FunctionComponent;
-            }
 
             if (
               sourceFiber.tag === ClassComponent ||

--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
@@ -23,7 +23,7 @@ describe('ReactExpiration', () => {
   });
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    return {type: 'span', children: [], prop, hidden: false};
   }
 
   it('increases priority of updates as time progresses', () => {

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -20,17 +20,19 @@ describe('ReactFragment', () => {
     ReactNoop = require('react-noop-renderer');
   });
 
-  function span(prop) {
-    return {type: 'span', children: [], prop};
-  }
-
-  function text(val) {
-    return {text: val};
-  }
-
   function div(...children) {
-    children = children.map(c => (typeof c === 'string' ? {text: c} : c));
-    return {type: 'div', children, prop: undefined};
+    children = children.map(
+      c => (typeof c === 'string' ? {text: c, hidden: false} : c),
+    );
+    return {type: 'div', children, prop: undefined, hidden: false};
+  }
+
+  function span(prop) {
+    return {type: 'span', children: [], prop, hidden: false};
+  }
+
+  function text(t) {
+    return {text: t, hidden: false};
   }
 
   it('should render a single child via noop renderer', () => {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -28,11 +28,11 @@ describe('ReactIncrementalErrorHandling', () => {
 
   function div(...children) {
     children = children.map(c => (typeof c === 'string' ? {text: c} : c));
-    return {type: 'div', children, prop: undefined};
+    return {type: 'div', children, prop: undefined, hidden: false};
   }
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    return {type: 'span', children: [], prop, hidden: false};
   }
 
   function normalizeCodeLocInfo(str) {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
@@ -24,7 +24,7 @@ describe('ReactIncrementalScheduling', () => {
   });
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    return {type: 'span', children: [], prop, hidden: false};
   }
 
   it('schedules and flushes deferred work', () => {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
@@ -24,7 +24,7 @@ describe('ReactIncrementalTriangle', () => {
   });
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    return {type: 'span', children: [], prop, hidden: false};
   }
 
   const FLUSH = 'FLUSH';

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -24,7 +24,7 @@ describe('ReactIncrementalUpdates', () => {
   });
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    return {type: 'span', children: [], prop, hidden: false};
   }
 
   it('applies updates in order of priority', () => {

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -25,18 +25,13 @@ describe('ReactNewContext', () => {
     gen = require('random-seed');
   });
 
-  // function div(...children) {
-  //   children = children.map(c => (typeof c === 'string' ? {text: c} : c));
-  //   return {type: 'div', children, prop: undefined};
-  // }
-
   function Text(props) {
     ReactNoop.yield(props.text);
     return <span prop={props.text} />;
   }
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    return {type: 'span', children: [], prop, hidden: false};
   }
 
   // We have several ways of reading from context. sharedContextTests runs

--- a/packages/react-reconciler/src/__tests__/ReactPersistent-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPersistent-test.js
@@ -37,12 +37,14 @@ describe('ReactPersistent', () => {
   }
 
   function div(...children) {
-    children = children.map(c => (typeof c === 'string' ? {text: c} : c));
-    return {type: 'div', children, prop: undefined};
+    children = children.map(
+      c => (typeof c === 'string' ? {text: c, hidden: false} : c),
+    );
+    return {type: 'div', children, prop: undefined, hidden: false};
   }
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    return {type: 'span', children: [], prop, hidden: false};
   }
 
   function getChildren() {

--- a/packages/react-reconciler/src/__tests__/ReactPure-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactPure-test.internal.js
@@ -26,7 +26,7 @@ describe('pure', () => {
   });
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    return {type: 'span', children: [], prop, hidden: false};
   }
 
   function Text(props) {

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+
+runPlaceholderTests('ReactSuspensePlaceholder (mutation)', () =>
+  require('react-noop-renderer'),
+);
+runPlaceholderTests('ReactSuspensePlaceholder (persistence)', () =>
+  require('react-noop-renderer/persistent'),
+);
+
+function runPlaceholderTests(suiteLabel, loadReactNoop) {
+  let React;
+  let ReactTestRenderer;
+  let ReactFeatureFlags;
+  let ReactCache;
+  let Suspense;
+
+  let cache;
+  let TextResource;
+  let textResourceShouldFail;
+
+  describe(suiteLabel, () => {
+    beforeEach(() => {
+      jest.resetModules();
+      ReactFeatureFlags = require('shared/ReactFeatureFlags');
+      ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+      ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
+      React = require('react');
+      ReactTestRenderer = require('react-test-renderer');
+      // JestReact = require('jest-react');
+      ReactCache = require('react-cache');
+
+      Suspense = React.unstable_Suspense;
+
+      function invalidateCache() {
+        cache = ReactCache.createCache(invalidateCache);
+      }
+      invalidateCache();
+      TextResource = ReactCache.createResource(([text, ms = 0]) => {
+        let listeners = null;
+        let status = 'pending';
+        let value = null;
+        return {
+          then(resolve, reject) {
+            switch (status) {
+              case 'pending': {
+                if (listeners === null) {
+                  listeners = [{resolve, reject}];
+                  setTimeout(() => {
+                    if (textResourceShouldFail) {
+                      ReactTestRenderer.unstable_yield(
+                        `Promise rejected [${text}]`,
+                      );
+                      status = 'rejected';
+                      value = new Error('Failed to load: ' + text);
+                      listeners.forEach(listener => listener.reject(value));
+                    } else {
+                      ReactTestRenderer.unstable_yield(
+                        `Promise resolved [${text}]`,
+                      );
+                      status = 'resolved';
+                      value = text;
+                      listeners.forEach(listener => listener.resolve(value));
+                    }
+                  }, ms);
+                } else {
+                  listeners.push({resolve, reject});
+                }
+                break;
+              }
+              case 'resolved': {
+                resolve(value);
+                break;
+              }
+              case 'rejected': {
+                reject(value);
+                break;
+              }
+            }
+          },
+        };
+      }, ([text, ms]) => text);
+      textResourceShouldFail = false;
+    });
+
+    function Text(props) {
+      ReactTestRenderer.unstable_yield(props.text);
+      return props.text;
+    }
+
+    function AsyncText(props) {
+      const text = props.text;
+      try {
+        TextResource.read(cache, [props.text, props.ms]);
+        ReactTestRenderer.unstable_yield(text);
+        return text;
+      } catch (promise) {
+        if (typeof promise.then === 'function') {
+          ReactTestRenderer.unstable_yield(`Suspend! [${text}]`);
+        } else {
+          ReactTestRenderer.unstable_yield(`Error! [${text}]`);
+        }
+        throw promise;
+      }
+    }
+
+    it('times out children that are already hidden', () => {
+      class HiddenText extends React.PureComponent {
+        render() {
+          const text = this.props.text;
+          ReactTestRenderer.unstable_yield(text);
+          return <span hidden={true}>{text}</span>;
+        }
+      }
+
+      function App(props) {
+        return (
+          <Suspense maxDuration={500} fallback={<Text text="Loading..." />}>
+            <HiddenText text="A" />
+            <span>
+              <AsyncText ms={1000} text={props.middleText} />
+            </span>
+            <span>
+              <Text text="C" />
+            </span>
+          </Suspense>
+        );
+      }
+
+      // Initial mount
+      const root = ReactTestRenderer.create(<App middleText="B" />, {
+        unstable_isConcurrent: true,
+      });
+
+      expect(root).toFlushAndYield(['A', 'Suspend! [B]', 'C', 'Loading...']);
+      expect(root).toMatchRenderedOutput(null);
+
+      jest.advanceTimersByTime(1000);
+      expect(ReactTestRenderer).toHaveYielded(['Promise resolved [B]']);
+
+      expect(root).toFlushAndYield(['A', 'B', 'C']);
+
+      expect(root).toMatchRenderedOutput(
+        <React.Fragment>
+          <span hidden={true}>A</span>
+          <span>B</span>
+          <span>C</span>
+        </React.Fragment>,
+      );
+
+      // Update
+      root.update(<App middleText="B2" />);
+      expect(root).toFlushAndYield(['Suspend! [B2]', 'C', 'Loading...']);
+
+      // Time out the update
+      jest.advanceTimersByTime(750);
+      expect(root).toFlushAndYield([]);
+      expect(root).toMatchRenderedOutput('Loading...');
+
+      // Resolve the promise
+      jest.advanceTimersByTime(1000);
+      expect(ReactTestRenderer).toHaveYielded(['Promise resolved [B2]']);
+      expect(root).toFlushAndYield(['B2', 'C']);
+
+      // Render the final update. A should still be hidden, because it was
+      // given a `hidden` prop.
+      expect(root).toMatchRenderedOutput(
+        <React.Fragment>
+          <span hidden={true}>A</span>
+          <span>B2</span>
+          <span>C</span>
+        </React.Fragment>,
+      );
+    });
+
+    it('times out text nodes', async () => {
+      function App(props) {
+        return (
+          <Suspense maxDuration={500} fallback={<Text text="Loading..." />}>
+            <Text text="A" />
+            <AsyncText ms={1000} text={props.middleText} />
+            <Text text="C" />
+          </Suspense>
+        );
+      }
+
+      // Initial mount
+      const root = ReactTestRenderer.create(<App middleText="B" />, {
+        unstable_isConcurrent: true,
+      });
+
+      expect(root).toFlushAndYield(['A', 'Suspend! [B]', 'C', 'Loading...']);
+
+      expect(root).toMatchRenderedOutput(null);
+
+      jest.advanceTimersByTime(1000);
+      expect(ReactTestRenderer).toHaveYielded(['Promise resolved [B]']);
+      expect(root).toFlushAndYield(['A', 'B', 'C']);
+      expect(root).toMatchRenderedOutput('ABC');
+
+      // Update
+      root.update(<App middleText="B2" />);
+      expect(root).toFlushAndYield(['A', 'Suspend! [B2]', 'C', 'Loading...']);
+      // Time out the update
+      jest.advanceTimersByTime(750);
+      expect(root).toFlushAndYield([]);
+      expect(root).toMatchRenderedOutput('Loading...');
+
+      // Resolve the promise
+      jest.advanceTimersByTime(1000);
+      expect(ReactTestRenderer).toHaveYielded(['Promise resolved [B2]']);
+      expect(root).toFlushAndYield(['A', 'B2', 'C']);
+
+      // Render the final update. A should still be hidden, because it was
+      // given a `hidden` prop.
+      expect(root).toMatchRenderedOutput('AB2C');
+    });
+  });
+}

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -51,12 +51,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   });
 
   function div(...children) {
-    children = children.map(c => (typeof c === 'string' ? {text: c} : c));
-    return {type: 'div', children, prop: undefined};
+    children = children.map(
+      c => (typeof c === 'string' ? {text: c, hidden: false} : c),
+    );
+    return {type: 'div', children, prop: undefined, hidden: false};
   }
 
   function span(prop) {
-    return {type: 'span', children: [], prop};
+    return {type: 'span', children: [], prop, hidden: false};
   }
 
   function advanceTimers(ms) {
@@ -788,18 +790,27 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     ReactNoop.render(<App />);
     expect(ReactNoop.flush()).toEqual(['Suspend! [Async]', 'Loading...']);
-    expect(ReactNoop.getChildren()).toEqual([]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(null);
 
     ReactNoop.expire(2000);
     await advanceTimers(2000);
     expect(ReactNoop.flush()).toEqual([]);
-    expect(ReactNoop.getChildren()).toEqual([div(), span('Loading...')]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <React.Fragment>
+        <div hidden={true} />
+        <span prop="Loading..." />
+      </React.Fragment>,
+    );
 
     ReactNoop.expire(1000);
     await advanceTimers(1000);
 
     expect(ReactNoop.flush()).toEqual(['Promise resolved [Async]', 'Async']);
-    expect(ReactNoop.getChildren()).toEqual([div(span('Async'))]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <div>
+        <span prop="Async" />
+      </div>,
+    );
   });
 
   it('flushes all expired updates in a single batch', async () => {

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -978,10 +978,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         'Promise resolved [Step: 1]',
         'Step: 1',
       ]);
-      expect(ReactNoop.getChildren()).toEqual([
-        span('Step: 1'),
-        span('Sibling'),
-      ]);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <React.Fragment>
+          <span prop="Step: 1" />
+          <span prop="Sibling" />
+        </React.Fragment>,
+      );
 
       // Update. This starts out asynchronously.
       text.current.setState({step: 2}, () =>
@@ -997,22 +999,26 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         'Loading (2)',
         'Loading (3)',
       ]);
-      expect(ReactNoop.getChildren()).toEqual([
-        span('Sibling'),
-        span('Loading (1)'),
-        span('Loading (2)'),
-        span('Loading (3)'),
-      ]);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <React.Fragment>
+          <span hidden={true} prop="Sibling" />
+          <span prop="Loading (1)" />
+          <span prop="Loading (2)" />
+          <span prop="Loading (3)" />
+        </React.Fragment>,
+      );
 
       await advanceTimers(100);
       expect(ReactNoop.flush()).toEqual([
         'Promise resolved [Step: 2]',
         'Step: 2',
       ]);
-      expect(ReactNoop.getChildren()).toEqual([
-        span('Step: 2'),
-        span('Sibling'),
-      ]);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <React.Fragment>
+          <span prop="Step: 2" />
+          <span prop="Sibling" />
+        </React.Fragment>,
+      );
     });
 
     it(
@@ -1213,15 +1219,17 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           'Promise resolved [Async: 1]',
           'Async: 1',
         ]);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Before'),
-          span('Async: 1'),
-          span('After'),
+        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+          <React.Fragment>
+            <span prop="Before" />
+            <span prop="Async: 1" />
+            <span prop="After" />
 
-          span('Before'),
-          span('Sync: 1'),
-          span('After'),
-        ]);
+            <span prop="Before" />
+            <span prop="Sync: 1" />
+            <span prop="After" />
+          </React.Fragment>,
+        );
 
         // Update. This starts out asynchronously.
         text1.current.setState({text: 'Async: 2'}, () =>
@@ -1250,15 +1258,17 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           // Switch to the placeholder in a subsequent commit
           'Loading...',
         ]);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Before'),
-          span('After'),
-          span('Loading...'),
+        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+          <React.Fragment>
+            <span hidden={true} prop="Before" />
+            <span hidden={true} prop="After" />
+            <span prop="Loading..." />
 
-          span('Before'),
-          span('Sync: 2'),
-          span('After'),
-        ]);
+            <span prop="Before" />
+            <span prop="Sync: 2" />
+            <span prop="After" />
+          </React.Fragment>,
+        );
 
         // When the placeholder is pinged, the boundary must be re-rendered
         // synchronously.
@@ -1268,15 +1278,17 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           'Async: 2',
         ]);
 
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Before'),
-          span('Async: 2'),
-          span('After'),
+        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+          <React.Fragment>
+            <span prop="Before" />
+            <span prop="Async: 2" />
+            <span prop="After" />
 
-          span('Before'),
-          span('Sync: 2'),
-          span('After'),
-        ]);
+            <span prop="Before" />
+            <span prop="Sync: 2" />
+            <span prop="After" />
+          </React.Fragment>,
+        );
       },
     );
 
@@ -1336,21 +1348,25 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         // placeholder. This should be a mount, not an update.
         'Mount [Loading...]',
       ]);
-      expect(ReactNoop.getChildren()).toEqual([
-        span('A'),
-        span('C'),
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <React.Fragment>
+          <span hidden={true} prop="A" />
+          <span hidden={true} prop="C" />
 
-        span('Loading...'),
-      ]);
+          <span prop="Loading..." />
+        </React.Fragment>,
+      );
 
       await advanceTimers(1000);
       expect(ReactNoop.expire(1000)).toEqual(['Promise resolved [B]', 'B']);
 
-      expect(ReactNoop.getChildren()).toEqual([
-        span('A'),
-        span('B'),
-        span('C'),
-      ]);
+      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        <React.Fragment>
+          <span prop="A" />
+          <span prop="B" />
+          <span prop="C" />
+        </React.Fragment>,
+      );
     });
 
     it('suspends inside constructor', async () => {
@@ -1779,11 +1795,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'Loading...',
       'Mount [Loading...]',
     ]);
-    expect(ReactNoop.getChildren()).toEqual([
-      span('A'),
-      span('C'),
-      span('Loading...'),
-    ]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      <React.Fragment>
+        <span hidden={true} prop="A" />
+        <span hidden={true} prop="C" />
+        <span prop="Loading..." />
+      </React.Fragment>,
+    );
   });
 });
 

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -966,7 +966,6 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         'Loading (3)',
         'Promise resolved [Step: 1]',
         'Step: 1',
-        'Sibling',
       ]);
       expect(ReactNoop.getChildren()).toEqual([
         span('Step: 1'),
@@ -988,6 +987,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         'Loading (3)',
       ]);
       expect(ReactNoop.getChildren()).toEqual([
+        span('Sibling'),
         span('Loading (1)'),
         span('Loading (2)'),
         span('Loading (3)'),
@@ -996,13 +996,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await advanceTimers(100);
       expect(ReactNoop.flush()).toEqual([
         'Promise resolved [Step: 2]',
-        // TODO: The state of the children is lost when switching back. Revisit
-        // this in the follow up PR.
-        'Step: 1',
-        'Sibling',
+        'Step: 2',
       ]);
       expect(ReactNoop.getChildren()).toEqual([
-        span('Step: 1'),
+        span('Step: 2'),
         span('Sibling'),
       ]);
     });
@@ -1203,9 +1200,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           // The placeholder is rendered in a subsequent commit
           'Loading...',
           'Promise resolved [Async: 1]',
-          'Before',
           'Async: 1',
-          'After',
         ]);
         expect(ReactNoop.getChildren()).toEqual([
           span('Before'),
@@ -1245,6 +1240,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           'Loading...',
         ]);
         expect(ReactNoop.getChildren()).toEqual([
+          span('Before'),
+          span('After'),
           span('Loading...'),
 
           span('Before'),
@@ -1257,16 +1254,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         await advanceTimers(100);
         expect(ReactNoop.clearYields()).toEqual([
           'Promise resolved [Async: 2]',
-          'Before',
-          'Async: 1',
-          'After',
+          'Async: 2',
         ]);
 
         expect(ReactNoop.getChildren()).toEqual([
           span('Before'),
-          // TODO: The state of the children is lost when switching back. Revisit
-          // this in the follow up PR.
-          span('Async: 1'),
+          span('Async: 2'),
           span('After'),
 
           span('Before'),
@@ -1332,18 +1325,15 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         // placeholder. This should be a mount, not an update.
         'Mount [Loading...]',
       ]);
-      expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('A'),
+        span('C'),
+
+        span('Loading...'),
+      ]);
 
       await advanceTimers(1000);
-      expect(ReactNoop.expire(1000)).toEqual([
-        'Promise resolved [B]',
-        'A',
-        'B',
-        'C',
-        'Mount [A]',
-        'Mount [B]',
-        'Mount [C]',
-      ]);
+      expect(ReactNoop.expire(1000)).toEqual(['Promise resolved [B]', 'B']);
 
       expect(ReactNoop.getChildren()).toEqual([
         span('A'),
@@ -1776,16 +1766,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // In a subsequent commit, render a placeholder
       'Loading...',
-
-      // A, B, and C are unmounted, but we skip calling B's componentWillUnmount
-      'Unmount [A]',
-      'Unmount [C]',
-
-      // Force delete all the existing children when switching to the
-      // placeholder. This should be a mount, not an update.
       'Mount [Loading...]',
     ]);
-    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+    expect(ReactNoop.getChildren()).toEqual([
+      span('A'),
+      span('C'),
+      span('Loading...'),
+    ]);
   });
 });
 

--- a/packages/react-reconciler/src/__tests__/ReactTopLevelText-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTopLevelText-test.js
@@ -26,13 +26,13 @@ describe('ReactTopLevelText', () => {
     const Text = ({value}) => value;
     ReactNoop.render(<Text value="foo" />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([{text: 'foo'}]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual('foo');
   });
 
   it('should render a component returning numbers directly from render', () => {
     const Text = ({value}) => value;
     ReactNoop.render(<Text value={10} />);
     ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([{text: '10'}]);
+    expect(ReactNoop.getChildrenAsJSX()).toEqual('10');
   });
 });

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -75,6 +75,10 @@ export const insertInContainerBefore = $$$hostConfig.insertInContainerBefore;
 export const removeChild = $$$hostConfig.removeChild;
 export const removeChildFromContainer = $$$hostConfig.removeChildFromContainer;
 export const resetTextContent = $$$hostConfig.resetTextContent;
+export const hideInstance = $$$hostConfig.hideInstance;
+export const hideTextInstance = $$$hostConfig.hideTextInstance;
+export const unhideInstance = $$$hostConfig.unhideInstance;
+export const unhideTextInstance = $$$hostConfig.unhideTextInstance;
 
 // -------------------
 //     Persistence
@@ -87,6 +91,9 @@ export const appendChildToContainerChildSet =
 export const finalizeContainerChildren =
   $$$hostConfig.finalizeContainerChildren;
 export const replaceContainerChildren = $$$hostConfig.replaceContainerChildren;
+export const cloneHiddenInstance = $$$hostConfig.cloneHiddenInstance;
+export const cloneUnhiddenInstance = $$$hostConfig.cloneUnhiddenInstance;
+export const createHiddenTextInstance = $$$hostConfig.createHiddenTextInstance;
 
 // -------------------
 //     Hydration

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -20,12 +20,14 @@ export type Container = {|
 export type Instance = {|
   type: string,
   props: Object,
+  isHidden: boolean,
   children: Array<Instance | TextInstance>,
   rootContainerInstance: Container,
   tag: 'INSTANCE',
 |};
 export type TextInstance = {|
   text: string,
+  isHidden: boolean,
   tag: 'TEXT',
 |};
 export type HydratableInstance = Instance | TextInstance;
@@ -132,6 +134,7 @@ export function createInstance(
   return {
     type,
     props,
+    isHidden: false,
     children: [],
     rootContainerInstance,
     tag: 'INSTANCE',
@@ -186,6 +189,7 @@ export function createTextInstance(
 ): TextInstance {
   return {
     text,
+    isHidden: false,
     tag: 'TEXT',
   };
 }
@@ -245,3 +249,22 @@ export function resetTextContent(testElement: Instance): void {
 export const appendChildToContainer = appendChild;
 export const insertInContainerBefore = insertBefore;
 export const removeChildFromContainer = removeChild;
+
+export function hideInstance(instance: Instance): void {
+  instance.isHidden = true;
+}
+
+export function hideTextInstance(textInstance: TextInstance): void {
+  textInstance.isHidden = true;
+}
+
+export function unhideInstance(instance: Instance, props: Props): void {
+  instance.isHidden = false;
+}
+
+export function unhideTextInstance(
+  textInstance: TextInstance,
+  text: string,
+): void {
+  textInstance.isHidden = false;
+}

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -2252,7 +2252,7 @@ describe('Profiler', () => {
           'Monkey',
         ]);
         // The update hasn't expired yet, so we commit nothing.
-        expect(ReactNoop.getChildren()).toEqual([]);
+        expect(ReactNoop.getChildrenAsJSX()).toEqual(null);
         expect(onRender).not.toHaveBeenCalled();
 
         // Advance both React's virtual time and Jest's timers by enough to expire
@@ -2263,10 +2263,7 @@ describe('Profiler', () => {
         // the placeholder.
         expect(ReactNoop.flushExpired()).toEqual([]);
         // Should have committed the placeholder.
-        expect(ReactNoop.getChildren()).toEqual([
-          {text: 'Loading...'},
-          {text: 'Sync'},
-        ]);
+        expect(ReactNoop.getChildrenAsJSX()).toEqual('Loading...Sync');
         expect(onRender).toHaveBeenCalledTimes(1);
 
         let call = onRender.mock.calls[0];
@@ -2289,10 +2286,7 @@ describe('Profiler', () => {
           'Promise resolved [Async]',
           'AsyncText [Async]',
         ]);
-        expect(ReactNoop.getChildren()).toEqual([
-          {text: 'Async'},
-          {text: 'Sync'},
-        ]);
+        expect(ReactNoop.getChildrenAsJSX()).toEqual('AsyncSync');
         expect(onRender).toHaveBeenCalledTimes(3);
 
         call = onRender.mock.calls[2];

--- a/packages/react/src/__tests__/ReactProfilerDOM-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDOM-test.internal.js
@@ -107,7 +107,9 @@ describe('ProfilerDOM', () => {
 
   const Text = ({text}) => text;
 
-  it('should correctly trace interactions for async roots', async done => {
+  // TODO: I'll re-enable this in the next commit, which implements new host
+  // config methods in React DOM.
+  xit('should correctly trace interactions for async roots', async done => {
     let batch, element, interaction;
 
     SchedulerTracing.unstable_trace('initial_event', performance.now(), () => {

--- a/packages/react/src/__tests__/ReactProfilerDOM-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDOM-test.internal.js
@@ -107,9 +107,7 @@ describe('ProfilerDOM', () => {
 
   const Text = ({text}) => text;
 
-  // TODO: I'll re-enable this in the next commit, which implements new host
-  // config methods in React DOM.
-  xit('should correctly trace interactions for async roots', async done => {
+  it('should correctly trace interactions for async roots', async done => {
     let batch, element, interaction;
 
     SchedulerTracing.unstable_trace('initial_event', performance.now(), () => {

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -102,11 +102,17 @@ describe('forwardRef', () => {
       <RefForwardingComponent ref={ref} optional="foo" required="bar" />,
     );
     ReactNoop.flush();
-    expect(ref.current.children).toEqual([{text: 'foo'}, {text: 'bar'}]);
+    expect(ref.current.children).toEqual([
+      {text: 'foo', hidden: false},
+      {text: 'bar', hidden: false},
+    ]);
 
     ReactNoop.render(<RefForwardingComponent ref={ref} required="foo" />);
     ReactNoop.flush();
-    expect(ref.current.children).toEqual([{text: 'default'}, {text: 'foo'}]);
+    expect(ref.current.children).toEqual([
+      {text: 'default', hidden: false},
+      {text: 'foo', hidden: false},
+    ]);
 
     expect(() =>
       ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />),

--- a/packages/shared/HostConfigWithNoMutation.js
+++ b/packages/shared/HostConfigWithNoMutation.js
@@ -33,3 +33,7 @@ export const insertInContainerBefore = shim;
 export const removeChild = shim;
 export const removeChildFromContainer = shim;
 export const resetTextContent = shim;
+export const hideInstance = shim;
+export const hideTextInstance = shim;
+export const unhideInstance = shim;
+export const unhideTextInstance = shim;

--- a/packages/shared/HostConfigWithNoPersistence.js
+++ b/packages/shared/HostConfigWithNoPersistence.js
@@ -28,3 +28,6 @@ export const createContainerChildSet = shim;
 export const appendChildToContainerChildSet = shim;
 export const finalizeContainerChildren = shim;
 export const replaceContainerChildren = shim;
+export const cloneHiddenInstance = shim;
+export const cloneUnhiddenInstance = shim;
+export const createHiddenTextInstance = shim;


### PR DESCRIPTION
If the children timeout, we switch to showing the fallback children in place of the "primary" children. However, we don't want to delete the primary children because then their state will be lost (both the React state and the host state, e.g. uncontrolled form inputs). Instead we keep them mounted and hide them. Both the fallback children AND the primary children are rendered at the same time. Once the primary children are un-suspended, we can delete the fallback children — don't need to preserve their state.

The two sets of children are siblings in the host environment, but semantically, for purposes of reconciliation, they are two separate sets. So we store them using two fragment fibers.

However, we want to avoid allocating two extra fibers for every Suspense fiber. They're only necessary when the children time out, because that's the only time when both sets are mounted.

So, the extra fragment fibers are only used if the children time out. Otherwise, we render the primary children directly. This requires some custom reconciliation logic to preserve the state of the primary children. It's essentially a very basic form of re-parenting.

- [x] Reconcile fallback and primary children separately.
- [x] Consolidate various pieces of Suspense state into a single type stored on `memoizedState`.
- [x] Hide timed-out children by toggling their top-most host nodes.
- [ ] React Native?