### PR TITLE
Deprecate context object as a consumer and add a warning message

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1107,7 +1107,7 @@ function updateContextConsumer(
   let context: ReactContext<any> = workInProgress.type;
   // The logic below for Context differs depending on PROD or DEV mode. In
   // DEV mode, we create a separate object for Context.Consumer that acts
-  // like a proxy to Context. This proxy object adds unecessary code in PROD
+  // like a proxy to Context. This proxy object adds unnecessary code in PROD
   // so we use the old behaviour (Context.Consumer references Context) to
   // reduce size and overhead. The separate object references context via
   // a property called "_context", which also gives us the ability to check

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1105,6 +1105,13 @@ function updateContextConsumer(
   renderExpirationTime: ExpirationTime,
 ) {
   let context: ReactContext<any> = workInProgress.type;
+  // The logic below for Context differs depending on PROD or DEV mode. In
+  // DEV mode, we create a separate object for Context.Consumer that acts
+  // like a proxy to Context. This proxy object adds unecessary code in PROD
+  // so we use the old behaviour (Context.Consumer references Context) to
+  // reduce size and overhead. The separate object references context via
+  // a property called "_context", which also gives us the ability to check
+  // in DEV mode if this property exists or not and warn if it does not.
   if (__DEV__) {
     if (workInProgress.type._context === undefined) {
       if (!hasWarnedAboutUsingContextAsConsumer) {
@@ -1113,12 +1120,10 @@ function updateContextConsumer(
           false,
           'You are using the Context from React.createContext() as a consumer.' +
             'The correct way is to use Context.Consumer as the consumer instead. ' +
-            'This usage is deprecated and will be removed in the next major version.',
+            'This usage is deprecated and will be removed in a future major release.',
         );
       }
     } else {
-      // Context.Consumer is a separate object in DEV, where
-      // _context points back to the original context
       context = workInProgress.type._context;
     }
   }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -8,7 +8,6 @@
  */
 
 import type {ReactProviderType, ReactContext} from 'shared/ReactTypes';
-import lowPriorityWarning from 'shared/lowPriorityWarning';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
@@ -1113,18 +1112,17 @@ function updateContextConsumer(
   // a property called "_context", which also gives us the ability to check
   // in DEV mode if this property exists or not and warn if it does not.
   if (__DEV__) {
-    if (workInProgress.type._context === undefined) {
+    if (context._context === undefined) {
       if (!hasWarnedAboutUsingContextAsConsumer) {
         hasWarnedAboutUsingContextAsConsumer = true;
-        lowPriorityWarning(
+        warning(
           false,
-          'You are using the Context from React.createContext() as a consumer.' +
-            'The correct way is to use Context.Consumer as the consumer instead. ' +
-            'This usage is deprecated and will be removed in a future major release.',
+          'Rendering <Context> directly is not supported and will be removed in ' +
+          'a future major release. Did you mean to render <Context.Consumer> instead?',
         );
       }
     } else {
-      context = workInProgress.type._context;
+      context = context._context;
     }
   }
   const newProps = workInProgress.pendingProps;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1118,7 +1118,7 @@ function updateContextConsumer(
         warning(
           false,
           'Rendering <Context> directly is not supported and will be removed in ' +
-          'a future major release. Did you mean to render <Context.Consumer> instead?',
+            'a future major release. Did you mean to render <Context.Consumer> instead?',
         );
       }
     } else {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1112,7 +1112,7 @@ function updateContextConsumer(
   // a property called "_context", which also gives us the ability to check
   // in DEV mode if this property exists or not and warn if it does not.
   if (__DEV__) {
-    if (context._context === undefined) {
+    if ((context: any)._context === undefined) {
       if (!hasWarnedAboutUsingContextAsConsumer) {
         hasWarnedAboutUsingContextAsConsumer = true;
         warning(
@@ -1122,7 +1122,7 @@ function updateContextConsumer(
         );
       }
     } else {
-      context = context._context;
+      context = (context: any)._context;
     }
   }
   const newProps = workInProgress.pendingProps;

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1578,11 +1578,9 @@ Context fuzz tester error! Copy and paste the following line into the test suite
     expect(() => {
       ReactNoop.render(<Component />);
       ReactNoop.flush();
-    }).toLowPriorityWarnDev(
-      'You are using the Context from React.createContext() as a consumer.' +
-        'The correct way is to use Context.Consumer as the consumer instead. ' +
-        'This usage is deprecated and will be removed in a future major release.',
-      {withoutStack: true},
+    }).toWarnDev(
+      'Rendering <Context> directly is not supported and will be removed in ' +
+      'a future major release. Did you mean to render <Context.Consumer> instead?',
     );
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1190,12 +1190,12 @@ describe('ReactNewContext', () => {
 
       function FooAndBar() {
         return (
-          <FooContext>
+          <FooContext.Consumer>
             {foo => {
               const bar = BarContext.unstable_read();
               return <Text text={`Foo: ${foo}, Bar: ${bar}`} />;
             }}
-          </FooContext>
+          </FooContext.Consumer>
         );
       }
 
@@ -1557,5 +1557,32 @@ Context fuzz tester error! Copy and paste the following line into the test suite
         }
       }
     });
+  });
+
+  it('should warn with an error message when using context as a consumer in DEV', () => {
+    const BarContext = React.createContext({value: 'bar-initial'});
+    const BarConsumer = BarContext;
+
+    function Component() {
+      return (
+        <React.Fragment>
+          <BarContext.Provider value={{value: 'bar-updated'}}>
+            <BarConsumer>
+              {({value}) => <div actual={value} expected="bar-updated" />}
+            </BarConsumer>
+          </BarContext.Provider>
+        </React.Fragment>
+      );
+    }
+
+    expect(() => {
+      ReactNoop.render(<Component />);
+      ReactNoop.flush();
+    }).toLowPriorityWarnDev(
+      'You are using the Context from React.createContext() as a consumer.' +
+        'The correct way is to use Context.Consumer as the consumer instead. ' +
+        'This usage is deprecated and will be removed in the next major version.',
+      {withoutStack: true},
+    );
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1581,7 +1581,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
     }).toLowPriorityWarnDev(
       'You are using the Context from React.createContext() as a consumer.' +
         'The correct way is to use Context.Consumer as the consumer instead. ' +
-        'This usage is deprecated and will be removed in the next major version.',
+        'This usage is deprecated and will be removed in a future major release.',
       {withoutStack: true},
     );
   });

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1656,7 +1656,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
       ReactNoop.flush();
     }).toWarnDev(
       'Rendering <Context.Consumer.Provider> is not supported and will be removed in ' +
-      'a future major release. Did you mean to render <Context.Provider> instead?',
+        'a future major release. Did you mean to render <Context.Provider> instead?',
     );
-  });  
+  });
 });

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1635,4 +1635,28 @@ Context fuzz tester error! Copy and paste the following line into the test suite
         'a future major release. Did you mean to render Context.unstable_read() instead?',
     );
   });
+
+  it('should warn with an error message when using Context.Consumer.Provider DEV', () => {
+    const BarContext = React.createContext({value: 'bar-initial'});
+
+    function Component() {
+      return (
+        <React.Fragment>
+          <BarContext.Consumer.Provider value={{value: 'bar-updated'}}>
+            <BarContext.Consumer>
+              {({value}) => <div actual={value} expected="bar-updated" />}
+            </BarContext.Consumer>
+          </BarContext.Consumer.Provider>
+        </React.Fragment>
+      );
+    }
+
+    expect(() => {
+      ReactNoop.render(<Component />);
+      ReactNoop.flush();
+    }).toWarnDev(
+      'Rendering <Context.Consumer.Provider> is not supported and will be removed in ' +
+      'a future major release. Did you mean to render <Context.Provider> instead?',
+    );
+  });  
 });

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1608,4 +1608,31 @@ Context fuzz tester error! Copy and paste the following line into the test suite
         'a future major release. Did you mean to render <Context.Consumer> instead?',
     );
   });
+
+  it('should warn with an error message when using Context.Consumer.unstable_read() DEV', () => {
+    const BarContext = React.createContext({value: 'bar-initial'});
+
+    function Child() {
+      let value = BarContext.Consumer.unstable_read();
+      return <div actual={value} expected="bar-updated" />;
+    }
+
+    function Component() {
+      return (
+        <React.Fragment>
+          <BarContext.Provider value={{value: 'bar-updated'}}>
+            <Child />
+          </BarContext.Provider>
+        </React.Fragment>
+      );
+    }
+
+    expect(() => {
+      ReactNoop.render(<Component />);
+      ReactNoop.flush();
+    }).toWarnDev(
+      'Calling Context.Consumer.unstable_read() is not supported and will be removed in ' +
+        'a future major release. Did you mean to render Context.unstable_read() instead?',
+    );
+  });
 });

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1580,7 +1580,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
       ReactNoop.flush();
     }).toWarnDev(
       'Rendering <Context> directly is not supported and will be removed in ' +
-      'a future major release. Did you mean to render <Context.Consumer> instead?',
+        'a future major release. Did you mean to render <Context.Consumer> instead?',
     );
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1583,4 +1583,29 @@ Context fuzz tester error! Copy and paste the following line into the test suite
         'a future major release. Did you mean to render <Context.Consumer> instead?',
     );
   });
+
+  it('should warn with an error message when using nested context consumers in DEV', () => {
+    const BarContext = React.createContext({value: 'bar-initial'});
+    const BarConsumer = BarContext;
+
+    function Component() {
+      return (
+        <React.Fragment>
+          <BarContext.Provider value={{value: 'bar-updated'}}>
+            <BarConsumer.Consumer.Consumer>
+              {({value}) => <div actual={value} expected="bar-updated" />}
+            </BarConsumer.Consumer.Consumer>
+          </BarContext.Provider>
+        </React.Fragment>
+      );
+    }
+
+    expect(() => {
+      ReactNoop.render(<Component />);
+      ReactNoop.flush();
+    }).toWarnDev(
+      'Rendering <Context.Consumer.Consumer> is not supported and will be removed in ' +
+        'a future major release. Did you mean to render <Context.Consumer> instead?',
+    );
+  });
 });

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -69,6 +69,8 @@ export function createContext<T>(
     _context: context,
   };
 
+  context.unstable_read = readContext.bind(null, context);
+
   let hasWarnedAboutUsingNestedContextConsumers = false;
 
   if (__DEV__) {
@@ -119,7 +121,6 @@ export function createContext<T>(
   } else {
     context.Consumer = context;
   }
-  context.unstable_read = readContext.bind(null, context);
 
   if (__DEV__) {
     context._currentRenderer = null;

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -72,6 +72,7 @@ export function createContext<T>(
   context.unstable_read = readContext.bind(null, context);
 
   let hasWarnedAboutUsingNestedContextConsumers = false;
+  let hasWarnedAboutUsingConsumerUnstableRead = false;
 
   if (__DEV__) {
     // A separate object, but proxies back to the original context object for
@@ -82,7 +83,17 @@ export function createContext<T>(
       _context: context,
       _calculateChangedBits: context._calculateChangedBits,
       Provider: context.Provider,
-      unstable_read: context.unstable_read,
+      unstable_read() {
+        if (!hasWarnedAboutUsingConsumerUnstableRead) {
+          hasWarnedAboutUsingConsumerUnstableRead = true;
+          warning(
+            false,
+            'Calling Context.Consumer.unstable_read() is not supported and will be removed in ' +
+              'a future major release. Did you mean to render Context.unstable_read() instead?',
+          );
+        }
+        return context.unstable_read();
+      },
     };
     // $FlowFixMe: Flow complains about not setting a value, which is intentional here
     Object.defineProperties(consumer, {

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -79,7 +79,7 @@ export function createContext<T>(
     // A separate object, but proxies back to the original context object for
     // backwards compatibility. It has a different $$typeof, so we can properly
     // warn for the incorrect usage of Context as a Consumer.
-    const consumer = {
+    const Consumer = {
       $$typeof: REACT_CONTEXT_TYPE,
       _context: context,
       _calculateChangedBits: context._calculateChangedBits,
@@ -96,7 +96,7 @@ export function createContext<T>(
       },
     };
     // $FlowFixMe: Flow complains about not setting a value, which is intentional here
-    Object.defineProperties(consumer, {
+    Object.defineProperties(Consumer, {
       Provider: {
         get() {
           if (!hasWarnedAboutUsingConsumerProvider) {
@@ -144,7 +144,7 @@ export function createContext<T>(
       },
     });
     // $FlowFixMe: Flow complains about missing properties because it doesn't understand defineProperty
-    context.Consumer = consumer;
+    context.Consumer = Consumer;
   } else {
     context.Consumer = context;
   }

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -67,7 +67,46 @@ export function createContext<T>(
     $$typeof: REACT_PROVIDER_TYPE,
     _context: context,
   };
-  context.Consumer = context;
+
+  if (__DEV__) {
+    // A separate object, but proxies back to the original context object for
+    // backwards compatibility. It has a different $$typeof, so we can properly
+    // warn for the incorrect usage of Context as a Consumer.
+    context.Consumer = {
+      $$typeof: REACT_CONTEXT_TYPE,
+      _context: context,
+      get _calculateChangedBits() {
+        return context._calculateChangedBits;
+      },
+      set _calculateChangedBits(_calculateChangedBits) {
+        context._calculateChangedBits = _calculateChangedBits;
+      },
+      get _currentValue() {
+        return context._currentValue;
+      },
+      set _currentValue(_currentValue) {
+        context._currentValue = _currentValue;
+      },
+      get _currentValue2() {
+        return context._currentValue2;
+      },
+      set _currentValue2(_currentValue2) {
+        context._currentValue2 = _currentValue2;
+      },
+      Provider: context.Provider,
+      get Consumer() {
+        return context.Consumer;
+      },
+      get unstable_read() {
+        return context.unstable_read;
+      },
+      set unstable_read(unstable_read) {
+        context.unstable_read = unstable_read;
+      },
+    };
+  } else {
+    context.Consumer = context;
+  }
   context.unstable_read = readContext.bind(null, context);
 
   if (__DEV__) {

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -72,38 +72,53 @@ export function createContext<T>(
     // A separate object, but proxies back to the original context object for
     // backwards compatibility. It has a different $$typeof, so we can properly
     // warn for the incorrect usage of Context as a Consumer.
-    context.Consumer = {
+    const consumer = {
       $$typeof: REACT_CONTEXT_TYPE,
       _context: context,
-      get _calculateChangedBits() {
-        return context._calculateChangedBits;
-      },
-      set _calculateChangedBits(_calculateChangedBits) {
-        context._calculateChangedBits = _calculateChangedBits;
-      },
-      get _currentValue() {
-        return context._currentValue;
-      },
-      set _currentValue(_currentValue) {
-        context._currentValue = _currentValue;
-      },
-      get _currentValue2() {
-        return context._currentValue2;
-      },
-      set _currentValue2(_currentValue2) {
-        context._currentValue2 = _currentValue2;
-      },
       Provider: context.Provider,
-      get Consumer() {
-        return context.Consumer;
-      },
-      get unstable_read() {
-        return context.unstable_read;
-      },
-      set unstable_read(unstable_read) {
-        context.unstable_read = unstable_read;
-      },
     };
+    // $FlowFixMe: Flow complains about not setting a value, which is intentional here
+    Object.defineProperties(consumer, {
+      _calculateChangedBits: {
+        get() {
+          return context._calculateChangedBits;
+        },
+        set(_calculateChangedBits) {
+          context._calculateChangedBits = _calculateChangedBits;
+        },
+      },
+      _currentValue: {
+        get() {
+          return context._currentValue;
+        },
+        set(_currentValue) {
+          context._currentValue = _currentValue;
+        },
+      },
+      _currentValue2: {
+        get() {
+          return context._currentValue2;
+        },
+        set(_currentValue2) {
+          context._currentValue2 = _currentValue2;
+        },
+      },
+      Consumer: {
+        get() {
+          return context.Consumer;
+        },
+      },
+      unstable_read: {
+        get() {
+          return context.unstable_read;
+        },
+        set(unstable_read) {
+          context.unstable_read = unstable_read;
+        },
+      },
+    });
+    // $FlowFixMe: Flow complains about missing properties because it doesn't understand defineProperty
+    context.Consumer = consumer;
   } else {
     context.Consumer = context;
   }

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -73,6 +73,7 @@ export function createContext<T>(
 
   let hasWarnedAboutUsingNestedContextConsumers = false;
   let hasWarnedAboutUsingConsumerUnstableRead = false;
+  let hasWarnedAboutUsingConsumerProvider = false;
 
   if (__DEV__) {
     // A separate object, but proxies back to the original context object for
@@ -82,7 +83,6 @@ export function createContext<T>(
       $$typeof: REACT_CONTEXT_TYPE,
       _context: context,
       _calculateChangedBits: context._calculateChangedBits,
-      Provider: context.Provider,
       unstable_read() {
         if (!hasWarnedAboutUsingConsumerUnstableRead) {
           hasWarnedAboutUsingConsumerUnstableRead = true;
@@ -97,6 +97,22 @@ export function createContext<T>(
     };
     // $FlowFixMe: Flow complains about not setting a value, which is intentional here
     Object.defineProperties(consumer, {
+      Provider: {
+        get() {
+          if (!hasWarnedAboutUsingConsumerProvider) {
+            hasWarnedAboutUsingConsumerProvider = true;
+            warning(
+              false,
+              'Rendering <Context.Consumer.Provider> is not supported and will be removed in ' +
+                'a future major release. Did you mean to render <Context.Provider> instead?',
+            );
+          }
+          return context.Provider;
+        },
+        set(_Provider) {
+          context.Provider = _Provider;
+        },
+      },
       _currentValue: {
         get() {
           return context._currentValue;

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -78,18 +78,12 @@ export function createContext<T>(
     const consumer = {
       $$typeof: REACT_CONTEXT_TYPE,
       _context: context,
+      _calculateChangedBits: context._calculateChangedBits,
       Provider: context.Provider,
+      unstable_read: context.unstable_read,
     };
     // $FlowFixMe: Flow complains about not setting a value, which is intentional here
     Object.defineProperties(consumer, {
-      _calculateChangedBits: {
-        get() {
-          return context._calculateChangedBits;
-        },
-        set(_calculateChangedBits) {
-          context._calculateChangedBits = _calculateChangedBits;
-        },
-      },
       _currentValue: {
         get() {
           return context._currentValue;
@@ -117,14 +111,6 @@ export function createContext<T>(
             );
           }
           return context.Consumer;
-        },
-      },
-      unstable_read: {
-        get() {
-          return context.unstable_read;
-        },
-        set(unstable_read) {
-          context.unstable_read = unstable_read;
         },
       },
     });

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -13,6 +13,7 @@ import type {ReactContext} from 'shared/ReactTypes';
 
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
+import warning from 'shared/warning';
 
 import ReactCurrentOwner from './ReactCurrentOwner';
 
@@ -68,6 +69,8 @@ export function createContext<T>(
     _context: context,
   };
 
+  let hasWarnedAboutUsingNestedContextConsumers = false;
+
   if (__DEV__) {
     // A separate object, but proxies back to the original context object for
     // backwards compatibility. It has a different $$typeof, so we can properly
@@ -105,6 +108,14 @@ export function createContext<T>(
       },
       Consumer: {
         get() {
+          if (!hasWarnedAboutUsingNestedContextConsumers) {
+            hasWarnedAboutUsingNestedContextConsumers = true;
+            warning(
+              false,
+              'Rendering <Context.Consumer.Consumer> is not supported and will be removed in ' +
+                'a future major release. Did you mean to render <Context.Consumer> instead?',
+            );
+          }
           return context.Consumer;
         },
       },


### PR DESCRIPTION
This PR deprecates usage of React context as a consumer in DEV mode, along with a warning message informing the user of this change. Under the hood, we create a new object for `context.consumer` rather than having a cyclic reference to `context`. This object proxies values from the original context so it remains backwards compatible in React 16.

## dev when using consumer: 

- Before: When using `Context.Consumer`, it's the same as `Context` so nothing special is handled.

- After: When `Context.Consumer` is used the at the beginning of reconciliation, the fiber is given the `_context` field from the `Consumer`, that references to `Context`.

## dev when using context:

- Before: When using `Context`, it's the same as the previous case (but the wrong behaviour).

- After: When `Context` we check if `_context` field exists on it (which we added to the new proxy object) and because it won't (only Context.Consumer does) we trigger a new warning.

## prod when using consumer:

- Before & After: When using `Context.Consumer`, it's the same as `Context` so nothing special is handled.

## prod when using context:

- Before & After: When using `Context`, it's the same as the previous case so nothing special is handled.