### PR TITLE
Add failing test for Suspense bug

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -531,6 +531,7 @@ const ReactTestRendererFiber = {
 
   /* eslint-disable camelcase */
   unstable_batchedUpdates: batchedUpdates,
+  unstable_interactiveUpdates: TestRenderer.interactiveUpdates,
   /* eslint-enable camelcase */
 
   unstable_setNowImplementation: TestRendererScheduling.setNowImplementation,


### PR DESCRIPTION
I expect that `maxDuration` that is larger than both the actual waiting time *and* the current expiration context timeout should be equivalent to not specifying `maxDuration` at all. But that doesn't seem like what happens. 

A more concrete example:

```js
import React, { lazy, unstable_Suspense as Suspense } from "react";
import { unstable_createRoot as createRoot } from "react-dom";

let done = false;
let promise;
function Delay({ ms, children }) {
  if (done) {
    return children;
  }
  if (!promise) {
    promise = new Promise(resolve => {
      setTimeout(() => {
        done = true;
        resolve();
      }, ms);
    });
  }
  throw promise;
}

class Spinner extends React.Component {
  componentDidMount() {
    alert("spin");
  }
  render() {
    console.log("spinner");
    return <h1>🌀 'Loading....'</h1>;
  }
}

class App extends React.Component {
  state = {};
  render() {
    return (
      <>
        <h1 onClick={() => this.setState({ showStuff: true })}>Suspense</h1>
        {this.state.showStuff && (
          <Suspense maxDuration={2000} fallback={<Spinner />}>
            <Delay ms={10}>Ready</Delay>
          </Suspense>
        )}
      </>
    );
  }
}

createRoot(document.getElementById("root")).render(<App />);
```

I'd expect `Spinner` to never be shown — or at least the behavior to be consistent between `maxDuration={2000}` and missing `maxDuration`.