### PR TITLE
Fix User Timing oddities with Suspense, pure, and lazy

### DIFF
--- a/packages/react-reconciler/src/ReactDebugFiberPerf.js
+++ b/packages/react-reconciler/src/ReactDebugFiberPerf.js
@@ -20,6 +20,7 @@ import {
   ContextProvider,
   ContextConsumer,
   Mode,
+  SuspenseComponent,
 } from 'shared/ReactWorkTags';
 
 type MeasurementPhase =
@@ -315,7 +316,10 @@ export function stopFailedWorkTimer(fiber: Fiber): void {
       return;
     }
     fiber._debugIsCurrentlyTiming = false;
-    const warning = 'An error was thrown inside this error boundary';
+    const warning =
+      fiber.tag === SuspenseComponent
+        ? 'Rendering has been suspended'
+        : 'An error was thrown inside this error boundary';
     endFiberMark(fiber, null, warning);
   }
 }

--- a/packages/react-reconciler/src/ReactDebugFiberPerf.js
+++ b/packages/react-reconciler/src/ReactDebugFiberPerf.js
@@ -318,7 +318,7 @@ export function stopFailedWorkTimer(fiber: Fiber): void {
     fiber._debugIsCurrentlyTiming = false;
     const warning =
       fiber.tag === SuspenseComponent
-        ? 'Rendering has been suspended'
+        ? 'Rendering was suspended'
         : 'An error was thrown inside this error boundary';
     endFiberMark(fiber, null, warning);
   }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -56,7 +56,7 @@ import ReactStrictModeWarnings from './ReactStrictModeWarnings';
 import warning from 'shared/warning';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import * as ReactCurrentFiber from './ReactCurrentFiber';
-import {cancelWorkTimer} from './ReactDebugFiberPerf';
+import {startWorkTimer, cancelWorkTimer} from './ReactDebugFiberPerf';
 
 import {
   mountChildFibers,
@@ -719,11 +719,15 @@ function mountIndeterminateComponent(
     Component !== null &&
     typeof Component.then === 'function'
   ) {
+    // We can't start a User Timing measurement with correct label yet.
+    // Cancel and resume right after we know the tag.
+    cancelWorkTimer(workInProgress);
     Component = readLazyComponentType(Component);
     const resolvedTag = (workInProgress.tag = resolveLazyComponentTag(
       workInProgress,
       Component,
     ));
+    startWorkTimer(workInProgress);
     const resolvedProps = resolveDefaultProps(Component, props);
     let child;
     switch (resolvedTag) {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -568,6 +568,45 @@ describe('ReactDebugFiberPerf', () => {
     expect(getFlameChart()).toMatchSnapshot();
   });
 
+  it('supports Suspense and lazy', async () => {
+    function Spinner() {
+      return <span />;
+    }
+
+    let resolve;
+    const LazyFoo = React.lazy(
+      () =>
+        new Promise(r => {
+          resolve = r;
+        }),
+    );
+
+    ReactNoop.render(
+      <Parent>
+        <React.unstable_Suspense fallback={<Spinner />}>
+          <LazyFoo />
+        </React.unstable_Suspense>
+      </Parent>,
+    );
+    ReactNoop.flush();
+    expect(getFlameChart()).toMatchSnapshot();
+
+    resolve(function Foo() {
+      return <div />;
+    });
+    await LazyFoo;
+
+    ReactNoop.render(
+      <Parent>
+        <React.unstable_Suspense>
+          <LazyFoo />
+        </React.unstable_Suspense>
+      </Parent>,
+    );
+    ReactNoop.flush();
+    expect(getFlameChart()).toMatchSnapshot();
+  });
+
   it('does not schedule an extra callback if setState is called during a synchronous commit phase', () => {
     class Component extends React.Component {
       state = {step: 1};

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -555,6 +555,19 @@ describe('ReactDebugFiberPerf', () => {
     expect(getFlameChart()).toMatchSnapshot();
   });
 
+  it('supports pure', () => {
+    const PureFoo = React.pure(function Foo() {
+      return <div />;
+    });
+    ReactNoop.render(
+      <Parent>
+        <PureFoo />
+      </Parent>,
+    );
+    ReactNoop.flush();
+    expect(getFlameChart()).toMatchSnapshot();
+  });
+
   it('does not schedule an extra callback if setState is called during a synchronous commit phase', () => {
     class Component extends React.Component {
       state = {step: 1};

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -362,6 +362,40 @@ exports[`ReactDebugFiberPerf skips parents during setState 1`] = `
 "
 `;
 
+exports[`ReactDebugFiberPerf supports Suspense and lazy 1`] = `
+"⚛ (Waiting for async callback... will force flush in 5250 ms)
+
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [mount]
+    ⛔ Suspense [mount] Warning: Rendering has been suspended
+    ⚛ Suspense [mount]
+      ⚛ Spinner [mount]
+"
+`;
+
+exports[`ReactDebugFiberPerf supports Suspense and lazy 2`] = `
+"⚛ (Waiting for async callback... will force flush in 5250 ms)
+
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [mount]
+    ⛔ Suspense [mount] Warning: Rendering has been suspended
+    ⚛ Suspense [mount]
+      ⚛ Spinner [mount]
+
+⚛ (Waiting for async callback... will force flush in 5250 ms)
+
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [mount]
+    ⚛ Suspense [mount]
+      ⚛ Foo [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
+"
+`;
+
 exports[`ReactDebugFiberPerf supports portals 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5250 ms)
 

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -367,7 +367,7 @@ exports[`ReactDebugFiberPerf supports Suspense and lazy 1`] = `
 
 ⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
-    ⛔ Suspense [mount] Warning: Rendering has been suspended
+    ⛔ Suspense [mount] Warning: Rendering was suspended
     ⚛ Suspense [mount]
       ⚛ Spinner [mount]
 "
@@ -378,7 +378,7 @@ exports[`ReactDebugFiberPerf supports Suspense and lazy 2`] = `
 
 ⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
-    ⛔ Suspense [mount] Warning: Rendering has been suspended
+    ⛔ Suspense [mount] Warning: Rendering was suspended
     ⚛ Suspense [mount]
       ⚛ Spinner [mount]
 
@@ -415,7 +415,7 @@ exports[`ReactDebugFiberPerf supports pure 1`] = `
 
 ⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
-    ⚛ Foo [mount]
+    ⚛ Pure(Foo) [mount]
 
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -376,6 +376,20 @@ exports[`ReactDebugFiberPerf supports portals 1`] = `
 "
 `;
 
+exports[`ReactDebugFiberPerf supports pure 1`] = `
+"⚛ (Waiting for async callback... will force flush in 5250 ms)
+
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [mount]
+    ⚛ Foo [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
+"
+`;
+
 exports[`ReactDebugFiberPerf warns if an in-progress update is interrupted 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5250 ms)
 

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -24,11 +24,14 @@ import {
 } from 'shared/ReactSymbols';
 import {refineResolvedThenable} from 'shared/ReactLazyComponent';
 
-function getWrappedName(type: mixed, wrapperName: string): string {
-  const renderFn = (type.render: any);
-  const functionName = renderFn.displayName || renderFn.name || '';
+function getWrappedName(
+  outerType: mixed,
+  innerType: any,
+  wrapperName: string,
+): string {
+  const functionName = innerType.displayName || innerType.name || '';
   return (
-    (type: any).displayName ||
+    (outerType: any).displayName ||
     (functionName !== '' ? `${wrapperName}(${functionName})` : wrapperName)
   );
 }
@@ -74,9 +77,9 @@ function getComponentName(type: mixed): string | null {
       case REACT_PROVIDER_TYPE:
         return 'Context.Provider';
       case REACT_FORWARD_REF_TYPE:
-        return getWrappedName(type, 'ForwardRef');
+        return getWrappedName(type, type.render, 'ForwardRef');
       case REACT_PURE_TYPE:
-        return getWrappedName(type, 'Pure');
+        return getWrappedName(type, type.render, 'Pure');
     }
     if (typeof type.then === 'function') {
       const thenable: Thenable<mixed> = (type: any);

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -24,6 +24,15 @@ import {
 } from 'shared/ReactSymbols';
 import {refineResolvedThenable} from 'shared/ReactLazyComponent';
 
+function getWrappedName(type: mixed, wrapperName: string): string {
+  const renderFn = (type.render: any);
+  const functionName = renderFn.displayName || renderFn.name || '';
+  return (
+    (type: any).displayName ||
+    (functionName !== '' ? `${wrapperName}(${functionName})` : wrapperName)
+  );
+}
+
 function getComponentName(type: mixed): string | null {
   if (type == null) {
     // Host root, text node or just invalid type.
@@ -64,23 +73,10 @@ function getComponentName(type: mixed): string | null {
         return 'Context.Consumer';
       case REACT_PROVIDER_TYPE:
         return 'Context.Provider';
-      case REACT_FORWARD_REF_TYPE: {
-        const renderFn = (type.render: any);
-        const functionName = renderFn.displayName || renderFn.name || '';
-        return (
-          (type: any).displayName ||
-          (functionName !== '' ? `ForwardRef(${functionName})` : 'ForwardRef')
-        );
-      }
-      case REACT_PURE_TYPE: {
-        const renderFn = (type.render: any);
-        return (
-          (type: any).displayName ||
-          renderFn.displayName ||
-          renderFn.name ||
-          'Pure'
-        );
-      }
+      case REACT_FORWARD_REF_TYPE:
+        return getWrappedName(type, 'ForwardRef');
+      case REACT_PURE_TYPE:
+        return getWrappedName(type, 'Pure');
     }
     if (typeof type.then === 'function') {
       const thenable: Thenable<mixed> = (type: any);

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -16,6 +16,7 @@ import {
   REACT_FORWARD_REF_TYPE,
   REACT_FRAGMENT_TYPE,
   REACT_PORTAL_TYPE,
+  REACT_PURE_TYPE,
   REACT_PROFILER_TYPE,
   REACT_PROVIDER_TYPE,
   REACT_STRICT_MODE_TYPE,
@@ -63,13 +64,23 @@ function getComponentName(type: mixed): string | null {
         return 'Context.Consumer';
       case REACT_PROVIDER_TYPE:
         return 'Context.Provider';
-      case REACT_FORWARD_REF_TYPE:
+      case REACT_FORWARD_REF_TYPE: {
         const renderFn = (type.render: any);
         const functionName = renderFn.displayName || renderFn.name || '';
         return (
           (type: any).displayName ||
           (functionName !== '' ? `ForwardRef(${functionName})` : 'ForwardRef')
         );
+      }
+      case REACT_PURE_TYPE: {
+        const renderFn = (type.render: any);
+        return (
+          (type: any).displayName ||
+          renderFn.displayName ||
+          renderFn.name ||
+          'Pure'
+        );
+      }
     }
     if (typeof type.then === 'function') {
       const thenable: Thenable<mixed> = (type: any);


### PR DESCRIPTION
This is for User Timings perf interation. We've been neglecting testing it when adding new features — let's try to keep it working in the future.

* `pure` components now show their name instead of `Unknown`
* There was a naming mismatch because `lazy` components began work as `Unknown` but completed with real name. I fix this by canceling immediately and restarting right after they get the right tag. Seems a bit odd but probably okay for this corner case?
* Suspense printed error boundary message which seemed misleading.