### PR TITLE
Error gracefully for unsupported SSR features

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -566,6 +566,29 @@ describe('ReactDOMServer', () => {
     expect(markup).toBe('<div></div>');
   });
 
+  it('throws for unsupported types on the server', () => {
+    expect(() => {
+      ReactDOMServer.renderToString(<React.unstable_Suspense />);
+    }).toThrow('ReactDOMServer does not yet support Suspense.');
+
+    expect(() => {
+      const LazyFoo = React.lazy(
+        () =>
+          new Promise(resolve =>
+            resolve(function Foo() {
+              return <div />;
+            }),
+          ),
+      );
+      ReactDOMServer.renderToString(<LazyFoo />);
+    }).toThrow('ReactDOMServer does not yet support lazy-loaded components.');
+
+    expect(() => {
+      const FooPromise = {then() {}};
+      ReactDOMServer.renderToString(<FooPromise />);
+    }).toThrow('ReactDOMServer does not yet support lazy-loaded components.');
+  });
+
   it('should throw (in dev) when children are mutated during render', () => {
     function Wrapper(props) {
       props.children[1] = <p key={1} />; // Mutation is illegal

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -935,6 +935,8 @@ class ReactDOMServerRenderer {
             }
             this.stack.push(frame);
             return '';
+          } else {
+            invariant(false, 'ReactDOMServer does not yet support Suspense.');
           }
         }
         // eslint-disable-next-line-no-fallthrough
@@ -1004,6 +1006,12 @@ class ReactDOMServerRenderer {
             return '';
           }
           default:
+            if (typeof elementType.then === 'function') {
+              invariant(
+                false,
+                'ReactDOMServer does not yet support lazy-loaded components.',
+              );
+            }
             break;
         }
       }


### PR DESCRIPTION
While we may plan to make `Suspense` work for some cases for the current SSR (I think?), in the meantime I'm adding coverage for the current behavior and replacing highly unintuitive `Invalid element type` errors that happen today. 

I also added a test for client-only post-hydration use of Suspense, to avoid accidentally regressing this.