### PR TITLE
Deprecate findDOMNode in StrictMode

### DIFF
--- a/packages/react-dom/src/__tests__/findDOMNode-test.js
+++ b/packages/react-dom/src/__tests__/findDOMNode-test.js
@@ -154,6 +154,7 @@ describe('findDOMNode', () => {
         'findDOMNode was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
+        '\n    in div (at **)' +
         '\n    in IsInStrictMode (at **)' +
         '\n    in StrictMode (at **)' +
         '\n' +

--- a/packages/react-dom/src/__tests__/findDOMNode-test.js
+++ b/packages/react-dom/src/__tests__/findDOMNode-test.js
@@ -12,6 +12,7 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 const ReactTestUtils = require('react-dom/test-utils');
+const StrictMode = React.StrictMode;
 
 describe('findDOMNode', () => {
   it('findDOMNode should return null if passed null', () => {
@@ -94,7 +95,72 @@ describe('findDOMNode', () => {
         return <div />;
       }
     }
-
     expect(() => ReactTestUtils.renderIntoDocument(<Bar />)).not.toThrow();
+  });
+
+  it('findDOMNode should warn if used to find a host component inside StrictMode', () => {
+    let parent = undefined;
+    let child = undefined;
+
+    class ContainsStrictModeChild extends React.Component {
+      render() {
+        return (
+          <StrictMode>
+            <div ref={n => (child = n)} />
+          </StrictMode>
+        );
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(
+      <ContainsStrictModeChild ref={n => (parent = n)} />,
+    );
+
+    let match;
+    expect(() => (match = ReactDOM.findDOMNode(parent))).toWarnDev([
+      'Warning: findDOMNode is deprecated in StrictMode. ' +
+        'findDOMNode was passed an instance of ContainsStrictModeChild which renders a StrictMode subtree. ' +
+        'The nearest child is in StrictMode. ' +
+        'Use an explicit ref directly on the element you want to get a handle on.' +
+        '\n' +
+        '\n    in div (at **)' +
+        '\n    in StrictMode (at **)' +
+        '\n    in ContainsStrictModeChild (at **)' +
+        '\n' +
+        '\nLearn more about using refs safely here:' +
+        '\nhttps://fb.me/react-strict-mode-find-node',
+    ]);
+    expect(match).toBe(child);
+  });
+
+  it('findDOMNode should warn if passed a component that is inside StrictMode', () => {
+    let parent = undefined;
+    let child = undefined;
+
+    class IsInStrictMode extends React.Component {
+      render() {
+        return <div ref={n => (child = n)} />;
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(
+      <StrictMode>
+        <IsInStrictMode ref={n => (parent = n)} />
+      </StrictMode>,
+    );
+
+    let match;
+    expect(() => (match = ReactDOM.findDOMNode(parent))).toWarnDev([
+      'Warning: findDOMNode is deprecated in StrictMode. ' +
+        'findDOMNode was passed an instance of IsInStrictMode which is in a StrictMode subtree. ' +
+        'Use an explicit ref directly on the element you want to get a handle on.' +
+        '\n' +
+        '\n    in IsInStrictMode (at **)' +
+        '\n    in StrictMode (at **)' +
+        '\n' +
+        '\nLearn more about using refs safely here:' +
+        '\nhttps://fb.me/react-strict-mode-find-node',
+    ]);
+    expect(match).toBe(child);
   });
 });

--- a/packages/react-dom/src/__tests__/findDOMNode-test.js
+++ b/packages/react-dom/src/__tests__/findDOMNode-test.js
@@ -119,9 +119,8 @@ describe('findDOMNode', () => {
     let match;
     expect(() => (match = ReactDOM.findDOMNode(parent))).toWarnDev([
       'Warning: findDOMNode is deprecated in StrictMode. ' +
-        'findDOMNode was passed an instance of ContainsStrictModeChild which renders a StrictMode subtree. ' +
-        'The nearest child is in StrictMode. ' +
-        'Use an explicit ref directly on the element you want to get a handle on.' +
+        'findDOMNode was passed an instance of ContainsStrictModeChild which renders a StrictMode children. ' +
+        'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
         '\n    in div (at **)' +
         '\n    in StrictMode (at **)' +
@@ -152,8 +151,8 @@ describe('findDOMNode', () => {
     let match;
     expect(() => (match = ReactDOM.findDOMNode(parent))).toWarnDev([
       'Warning: findDOMNode is deprecated in StrictMode. ' +
-        'findDOMNode was passed an instance of IsInStrictMode which is in a StrictMode subtree. ' +
-        'Use an explicit ref directly on the element you want to get a handle on.' +
+        'findDOMNode was passed an instance of IsInStrictMode which is inside StrictMode. ' +
+        'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
         '\n    in IsInStrictMode (at **)' +
         '\n    in StrictMode (at **)' +

--- a/packages/react-dom/src/__tests__/findDOMNode-test.js
+++ b/packages/react-dom/src/__tests__/findDOMNode-test.js
@@ -119,7 +119,7 @@ describe('findDOMNode', () => {
     let match;
     expect(() => (match = ReactDOM.findDOMNode(parent))).toWarnDev([
       'Warning: findDOMNode is deprecated in StrictMode. ' +
-        'findDOMNode was passed an instance of ContainsStrictModeChild which renders a StrictMode children. ' +
+        'findDOMNode was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
         '\n    in div (at **)' +

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -614,7 +614,12 @@ const ReactDOM: Object = {
     if ((componentOrElement: any).nodeType === ELEMENT_NODE) {
       return (componentOrElement: any);
     }
-
+    if (__DEV__) {
+      return DOMRenderer.findHostInstanceWithWarning(
+        componentOrElement,
+        'findDOMNode',
+      );
+    }
     return DOMRenderer.findHostInstance(componentOrElement);
   },
 

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -29,6 +29,8 @@ import warningWithoutStack from 'shared/warningWithoutStack';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 const findHostInstance = ReactFabricRenderer.findHostInstance;
+const findHostInstanceWithWarning =
+  ReactFabricRenderer.findHostInstanceWithWarning;
 
 function findNodeHandle(componentOrHandle: any): ?number {
   if (__DEV__) {
@@ -60,7 +62,16 @@ function findNodeHandle(componentOrHandle: any): ?number {
   if (componentOrHandle.canonical && componentOrHandle.canonical._nativeTag) {
     return componentOrHandle.canonical._nativeTag;
   }
-  const hostInstance = findHostInstance(componentOrHandle);
+  let hostInstance;
+  if (__DEV__) {
+    hostInstance = findHostInstanceWithWarning(
+      componentOrHandle,
+      'findNodeHandle',
+    );
+  } else {
+    hostInstance = findHostInstance(componentOrHandle);
+  }
+
   if (hostInstance == null) {
     return hostInstance;
   }

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -32,6 +32,8 @@ import warningWithoutStack from 'shared/warningWithoutStack';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 const findHostInstance = ReactNativeFiberRenderer.findHostInstance;
+const findHostInstanceWithWarning =
+  ReactNativeFiberRenderer.findHostInstanceWithWarning;
 
 function findNodeHandle(componentOrHandle: any): ?number {
   if (__DEV__) {
@@ -63,7 +65,16 @@ function findNodeHandle(componentOrHandle: any): ?number {
   if (componentOrHandle.canonical && componentOrHandle.canonical._nativeTag) {
     return componentOrHandle.canonical._nativeTag;
   }
-  const hostInstance = findHostInstance(componentOrHandle);
+  let hostInstance;
+  if (__DEV__) {
+    hostInstance = findHostInstanceWithWarning(
+      componentOrHandle,
+      'findNodeHandle',
+    );
+  } else {
+    hostInstance = findHostInstance(componentOrHandle);
+  }
+
   if (hostInstance == null) {
     return hostInstance;
   }

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -15,6 +15,7 @@ let ReactFabric;
 let createReactNativeComponentClass;
 let UIManager;
 let FabricUIManager;
+let StrictMode;
 
 jest.mock('shared/ReactFeatureFlags', () =>
   require('shared/forks/ReactFeatureFlags.native-fabric-oss'),
@@ -25,6 +26,7 @@ describe('ReactFabric', () => {
     jest.resetModules();
 
     React = require('react');
+    StrictMode = React.StrictMode;
     ReactFabric = require('react-native-renderer/fabric');
     FabricUIManager = require('FabricUIManager');
     UIManager = require('UIManager');
@@ -435,5 +437,80 @@ describe('ReactFabric', () => {
     // props even though the actual scheduling of the event could have happened earlier.
     // This could change in the future.
     expect(touchStart2).toBeCalled();
+  });
+
+  it('findNodeHandle should warn if used to find a host component inside StrictMode', () => {
+    const View = createReactNativeComponentClass('RCTView', () => ({
+      validAttributes: {foo: true},
+      uiViewClassName: 'RCTView',
+    }));
+
+    let parent = undefined;
+    let child = undefined;
+
+    class ContainsStrictModeChild extends React.Component {
+      render() {
+        return (
+          <StrictMode>
+            <View ref={n => (child = n)} />
+          </StrictMode>
+        );
+      }
+    }
+
+    ReactFabric.render(<ContainsStrictModeChild ref={n => (parent = n)} />, 11);
+
+    let match;
+    expect(() => (match = ReactFabric.findNodeHandle(parent))).toWarnDev([
+      'Warning: findNodeHandle is deprecated in StrictMode. ' +
+        'findNodeHandle was passed an instance of ContainsStrictModeChild which renders a StrictMode subtree. ' +
+        'The nearest child is in StrictMode. ' +
+        'Use an explicit ref directly on the element you want to get a handle on.' +
+        '\n' +
+        '\n    in RCTView (at **)' +
+        '\n    in StrictMode (at **)' +
+        '\n    in ContainsStrictModeChild (at **)' +
+        '\n' +
+        '\nLearn more about using refs safely here:' +
+        '\nhttps://fb.me/react-strict-mode-find-node',
+    ]);
+    expect(match).toBe(child._nativeTag);
+  });
+
+  it('findNodeHandle should warn if passed a component that is inside StrictMode', () => {
+    const View = createReactNativeComponentClass('RCTView', () => ({
+      validAttributes: {foo: true},
+      uiViewClassName: 'RCTView',
+    }));
+
+    let parent = undefined;
+    let child = undefined;
+
+    class IsInStrictMode extends React.Component {
+      render() {
+        return <View ref={n => (child = n)} />;
+      }
+    }
+
+    ReactFabric.render(
+      <StrictMode>
+        <IsInStrictMode ref={n => (parent = n)} />
+      </StrictMode>,
+      11,
+    );
+
+    let match;
+    expect(() => (match = ReactFabric.findNodeHandle(parent))).toWarnDev([
+      'Warning: findNodeHandle is deprecated in StrictMode. ' +
+        'findNodeHandle was passed an instance of IsInStrictMode which is in a StrictMode subtree. ' +
+        'Use an explicit ref directly on the element you want to get a handle on.' +
+        '\n' +
+        '\n    in IsInStrictMode (at **)' +
+        '\n    in StrictMode (at **)' +
+        '\n' +
+        '\nLearn more about using refs safely here:' +
+        '\nhttps://fb.me/react-strict-mode-find-node',
+    ]);
+    expect(match).toBe(child._nativeTag);
   });
 });

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -463,9 +463,8 @@ describe('ReactFabric', () => {
     let match;
     expect(() => (match = ReactFabric.findNodeHandle(parent))).toWarnDev([
       'Warning: findNodeHandle is deprecated in StrictMode. ' +
-        'findNodeHandle was passed an instance of ContainsStrictModeChild which renders a StrictMode subtree. ' +
-        'The nearest child is in StrictMode. ' +
-        'Use an explicit ref directly on the element you want to get a handle on.' +
+        'findNodeHandle was passed an instance of ContainsStrictModeChild which renders a StrictMode children. ' +
+        'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
         '\n    in RCTView (at **)' +
         '\n    in StrictMode (at **)' +
@@ -502,8 +501,8 @@ describe('ReactFabric', () => {
     let match;
     expect(() => (match = ReactFabric.findNodeHandle(parent))).toWarnDev([
       'Warning: findNodeHandle is deprecated in StrictMode. ' +
-        'findNodeHandle was passed an instance of IsInStrictMode which is in a StrictMode subtree. ' +
-        'Use an explicit ref directly on the element you want to get a handle on.' +
+        'findNodeHandle was passed an instance of IsInStrictMode which is inside StrictMode. ' +
+        'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
         '\n    in IsInStrictMode (at **)' +
         '\n    in StrictMode (at **)' +

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -463,7 +463,7 @@ describe('ReactFabric', () => {
     let match;
     expect(() => (match = ReactFabric.findNodeHandle(parent))).toWarnDev([
       'Warning: findNodeHandle is deprecated in StrictMode. ' +
-        'findNodeHandle was passed an instance of ContainsStrictModeChild which renders a StrictMode children. ' +
+        'findNodeHandle was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
         '\n    in RCTView (at **)' +

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -504,6 +504,7 @@ describe('ReactFabric', () => {
         'findNodeHandle was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
+        '\n    in RCTView (at **)' +
         '\n    in IsInStrictMode (at **)' +
         '\n    in StrictMode (at **)' +
         '\n' +

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -285,7 +285,7 @@ describe('ReactNative', () => {
     let match;
     expect(() => (match = ReactNative.findNodeHandle(parent))).toWarnDev([
       'Warning: findNodeHandle is deprecated in StrictMode. ' +
-        'findNodeHandle was passed an instance of ContainsStrictModeChild which renders a StrictMode children. ' +
+        'findNodeHandle was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
         '\n    in RCTView (at **)' +

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -326,6 +326,7 @@ describe('ReactNative', () => {
         'findNodeHandle was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
+        '\n    in RCTView (at **)' +
         '\n    in IsInStrictMode (at **)' +
         '\n    in StrictMode (at **)' +
         '\n' +

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -11,6 +11,7 @@
 'use strict';
 
 let React;
+let StrictMode;
 let ReactNative;
 let createReactNativeComponentClass;
 let UIManager;
@@ -20,6 +21,7 @@ describe('ReactNative', () => {
     jest.resetModules();
 
     React = require('react');
+    StrictMode = React.StrictMode;
     ReactNative = require('react-native-renderer');
     UIManager = require('UIManager');
     createReactNativeComponentClass = require('ReactNativeViewConfigRegistry')
@@ -257,5 +259,80 @@ describe('ReactNative', () => {
       </Text>,
       11,
     );
+  });
+
+  it('findNodeHandle should warn if used to find a host component inside StrictMode', () => {
+    const View = createReactNativeComponentClass('RCTView', () => ({
+      validAttributes: {foo: true},
+      uiViewClassName: 'RCTView',
+    }));
+
+    let parent = undefined;
+    let child = undefined;
+
+    class ContainsStrictModeChild extends React.Component {
+      render() {
+        return (
+          <StrictMode>
+            <View ref={n => (child = n)} />
+          </StrictMode>
+        );
+      }
+    }
+
+    ReactNative.render(<ContainsStrictModeChild ref={n => (parent = n)} />, 11);
+
+    let match;
+    expect(() => (match = ReactNative.findNodeHandle(parent))).toWarnDev([
+      'Warning: findNodeHandle is deprecated in StrictMode. ' +
+        'findNodeHandle was passed an instance of ContainsStrictModeChild which renders a StrictMode subtree. ' +
+        'The nearest child is in StrictMode. ' +
+        'Use an explicit ref directly on the element you want to get a handle on.' +
+        '\n' +
+        '\n    in RCTView (at **)' +
+        '\n    in StrictMode (at **)' +
+        '\n    in ContainsStrictModeChild (at **)' +
+        '\n' +
+        '\nLearn more about using refs safely here:' +
+        '\nhttps://fb.me/react-strict-mode-find-node',
+    ]);
+    expect(match).toBe(child._nativeTag);
+  });
+
+  it('findNodeHandle should warn if passed a component that is inside StrictMode', () => {
+    const View = createReactNativeComponentClass('RCTView', () => ({
+      validAttributes: {foo: true},
+      uiViewClassName: 'RCTView',
+    }));
+
+    let parent = undefined;
+    let child = undefined;
+
+    class IsInStrictMode extends React.Component {
+      render() {
+        return <View ref={n => (child = n)} />;
+      }
+    }
+
+    ReactNative.render(
+      <StrictMode>
+        <IsInStrictMode ref={n => (parent = n)} />
+      </StrictMode>,
+      11,
+    );
+
+    let match;
+    expect(() => (match = ReactNative.findNodeHandle(parent))).toWarnDev([
+      'Warning: findNodeHandle is deprecated in StrictMode. ' +
+        'findNodeHandle was passed an instance of IsInStrictMode which is in a StrictMode subtree. ' +
+        'Use an explicit ref directly on the element you want to get a handle on.' +
+        '\n' +
+        '\n    in IsInStrictMode (at **)' +
+        '\n    in StrictMode (at **)' +
+        '\n' +
+        '\nLearn more about using refs safely here:' +
+        '\nhttps://fb.me/react-strict-mode-find-node',
+    ]);
+    expect(match).toBe(child._nativeTag);
   });
 });

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -285,9 +285,8 @@ describe('ReactNative', () => {
     let match;
     expect(() => (match = ReactNative.findNodeHandle(parent))).toWarnDev([
       'Warning: findNodeHandle is deprecated in StrictMode. ' +
-        'findNodeHandle was passed an instance of ContainsStrictModeChild which renders a StrictMode subtree. ' +
-        'The nearest child is in StrictMode. ' +
-        'Use an explicit ref directly on the element you want to get a handle on.' +
+        'findNodeHandle was passed an instance of ContainsStrictModeChild which renders a StrictMode children. ' +
+        'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
         '\n    in RCTView (at **)' +
         '\n    in StrictMode (at **)' +
@@ -324,8 +323,8 @@ describe('ReactNative', () => {
     let match;
     expect(() => (match = ReactNative.findNodeHandle(parent))).toWarnDev([
       'Warning: findNodeHandle is deprecated in StrictMode. ' +
-        'findNodeHandle was passed an instance of IsInStrictMode which is in a StrictMode subtree. ' +
-        'Use an explicit ref directly on the element you want to get a handle on.' +
+        'findNodeHandle was passed an instance of IsInStrictMode which is inside StrictMode. ' +
+        'Instead, add a ref directly to the element you want to reference.' +
         '\n' +
         '\n    in IsInStrictMode (at **)' +
         '\n    in StrictMode (at **)' +

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -522,6 +522,12 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       if (typeof component.id === 'number') {
         return component;
       }
+      if (__DEV__) {
+        return NoopRenderer.findHostInstanceWithWarning(
+          component,
+          'findInstance',
+        );
+      }
       return NoopRenderer.findHostInstance(component);
     },
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -250,7 +250,7 @@ function findHostInstanceWithWarning(
             methodName,
             methodName,
             componentName,
-            getStackByFiberInDevAndProd(fiber),
+            getStackByFiberInDevAndProd(hostFiber),
           );
         } else {
           warningWithoutStack(

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -242,8 +242,8 @@ function findHostInstanceWithWarning(
           warningWithoutStack(
             false,
             '%s is deprecated in StrictMode. ' +
-              '%s was passed an instance of %s which is in a StrictMode subtree. ' +
-              'Use an explicit ref directly on the element you want to get a handle on.' +
+              '%s was passed an instance of %s which is inside StrictMode. ' +
+              'Instead, add a ref directly to the element you want to reference.' +
               '\n%s' +
               '\n\nLearn more about using refs safely here:' +
               '\nhttps://fb.me/react-strict-mode-find-node',
@@ -256,9 +256,8 @@ function findHostInstanceWithWarning(
           warningWithoutStack(
             false,
             '%s is deprecated in StrictMode. ' +
-              '%s was passed an instance of %s which renders a StrictMode subtree. ' +
-              'The nearest child is in StrictMode. ' +
-              'Use an explicit ref directly on the element you want to get a handle on.' +
+              '%s was passed an instance of %s which renders a StrictMode children. ' +
+              'Instead, add a ref directly to the element you want to reference.' +
               '\n%s' +
               '\n\nLearn more about using refs safely here:' +
               '\nhttps://fb.me/react-strict-mode-find-node',

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -256,7 +256,7 @@ function findHostInstanceWithWarning(
           warningWithoutStack(
             false,
             '%s is deprecated in StrictMode. ' +
-              '%s was passed an instance of %s which renders a StrictMode children. ' +
+              '%s was passed an instance of %s which renders StrictMode children. ' +
               'Instead, add a ref directly to the element you want to reference.' +
               '\n%s' +
               '\n\nLearn more about using refs safely here:' +

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -61,6 +61,8 @@ import {
 import {createUpdate, enqueueUpdate} from './ReactUpdateQueue';
 import ReactFiberInstrumentation from './ReactFiberInstrumentation';
 import * as ReactCurrentFiber from './ReactCurrentFiber';
+import {getStackByFiberInDevAndProd} from './ReactCurrentFiber';
+import {StrictMode} from './ReactTypeOfMode';
 
 type OpaqueRoot = FiberRoot;
 
@@ -82,9 +84,11 @@ type DevToolsConfig = {|
 |};
 
 let didWarnAboutNestedUpdates;
+let didWarnAboutFindNodeInStrictMode;
 
 if (__DEV__) {
   didWarnAboutNestedUpdates = false;
+  didWarnAboutFindNodeInStrictMode = {};
 }
 
 function getContextForSubtree(
@@ -209,6 +213,68 @@ function findHostInstance(component: Object): PublicInstance | null {
   return hostFiber.stateNode;
 }
 
+function findHostInstanceWithWarning(
+  component: Object,
+  methodName: string,
+): PublicInstance | null {
+  if (__DEV__) {
+    const fiber = ReactInstanceMap.get(component);
+    if (fiber === undefined) {
+      if (typeof component.render === 'function') {
+        invariant(false, 'Unable to find node on an unmounted component.');
+      } else {
+        invariant(
+          false,
+          'Argument appears to not be a ReactComponent. Keys: %s',
+          Object.keys(component),
+        );
+      }
+    }
+    const hostFiber = findCurrentHostFiber(fiber);
+    if (hostFiber === null) {
+      return null;
+    }
+    if (hostFiber.mode & StrictMode) {
+      const componentName = getComponentName(fiber.type) || 'Component';
+      if (!didWarnAboutFindNodeInStrictMode[componentName]) {
+        didWarnAboutFindNodeInStrictMode[componentName] = true;
+        if (fiber.mode & StrictMode) {
+          warningWithoutStack(
+            false,
+            '%s is deprecated in StrictMode. ' +
+              '%s was passed an instance of %s which is in a StrictMode subtree. ' +
+              'Use an explicit ref directly on the element you want to get a handle on.' +
+              '\n%s' +
+              '\n\nLearn more about using refs safely here:' +
+              '\nhttps://fb.me/react-strict-mode-find-node',
+            methodName,
+            methodName,
+            componentName,
+            getStackByFiberInDevAndProd(fiber),
+          );
+        } else {
+          warningWithoutStack(
+            false,
+            '%s is deprecated in StrictMode. ' +
+              '%s was passed an instance of %s which renders a StrictMode subtree. ' +
+              'The nearest child is in StrictMode. ' +
+              'Use an explicit ref directly on the element you want to get a handle on.' +
+              '\n%s' +
+              '\n\nLearn more about using refs safely here:' +
+              '\nhttps://fb.me/react-strict-mode-find-node',
+            methodName,
+            methodName,
+            componentName,
+            getStackByFiberInDevAndProd(hostFiber),
+          );
+        }
+      }
+    }
+    return hostFiber.stateNode;
+  }
+  return findHostInstance(component);
+}
+
 export function createContainer(
   containerInfo: Container,
   isConcurrent: boolean,
@@ -265,6 +331,8 @@ export function getPublicRootInstance(
 }
 
 export {findHostInstance};
+
+export {findHostInstanceWithWarning};
 
 export function findHostInstanceWithNoPortals(
   fiber: Fiber,

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
@@ -138,22 +138,35 @@ describe('ReactIncrementalReflection', () => {
 
     let classInstance = null;
 
+    function findInstance(inst) {
+      // We ignore warnings fired by findInstance because we are testing
+      // that the actual behavior still works as expected even though it
+      // is deprecated.
+      let oldConsoleError = console.error;
+      console.error = jest.fn();
+      try {
+        return ReactNoop.findInstance(inst);
+      } finally {
+        console.error = oldConsoleError;
+      }
+    }
+
     class Component extends React.Component {
       UNSAFE_componentWillMount() {
         classInstance = this;
-        ops.push('componentWillMount', ReactNoop.findInstance(this));
+        ops.push('componentWillMount', findInstance(this));
       }
       componentDidMount() {
-        ops.push('componentDidMount', ReactNoop.findInstance(this));
+        ops.push('componentDidMount', findInstance(this));
       }
       UNSAFE_componentWillUpdate() {
-        ops.push('componentWillUpdate', ReactNoop.findInstance(this));
+        ops.push('componentWillUpdate', findInstance(this));
       }
       componentDidUpdate() {
-        ops.push('componentDidUpdate', ReactNoop.findInstance(this));
+        ops.push('componentDidUpdate', findInstance(this));
       }
       componentWillUnmount() {
-        ops.push('componentWillUnmount', ReactNoop.findInstance(this));
+        ops.push('componentWillUnmount', findInstance(this));
       }
       render() {
         ops.push('render');
@@ -193,7 +206,7 @@ describe('ReactIncrementalReflection', () => {
     expect(classInstance).toBeDefined();
     // The instance has been complete but is still not committed so it should
     // not find any host nodes in it.
-    expect(ReactNoop.findInstance(classInstance)).toBe(null);
+    expect(findInstance(classInstance)).toBe(null);
 
     expect(ReactNoop.flush).toWarnDev(
       'componentWillMount: Please update the following components ' +
@@ -206,7 +219,7 @@ describe('ReactIncrementalReflection', () => {
     const hostSpan = classInstance.span;
     expect(hostSpan).toBeDefined();
 
-    expect(ReactNoop.findInstance(classInstance)).toBe(hostSpan);
+    expect(findInstance(classInstance)).toBe(hostSpan);
 
     expect(ops).toEqual(['componentDidMount', hostSpan]);
 


### PR DESCRIPTION
# Motivation

The main motivation is that findDOMNode is breaking abstraction levels but allowing a parent to reason about what kind of children a component might render. It creates a refactoring hazard where you can't change the implementation details of a component because a parent might be reaching into its DOM node.

Attaching explicit refs is the alternative. The main thing that used to be difficult is creating a higher order component that seamlessly work with its children. This can now be achieved using forwardRefs.

Up until this point it was a loose recommendation that you don't use this functions but there are certain technical details that are twisting our hands to want to deprecate it.

- In the Fiber architecture it is not possible to cache the "current" node at a higher level since at any given point there are several possible future trees. This causes the findDOMNode algorithm to turn into a very complicated and possibly slow search algorithm in bad cases.
- In the compiler project, it becomes difficult to know if any given DOM node might need to be found. That forces us to replicate the tree structure just in case someone calls it. We'd rather not support this. Instead only explicit refs will be the ones that gets materialized.

We'll only deprecate this in StrictMode for the foreseeable future. It won't get deleted for a long time because lots of existing code depends on it. This is more about preventing new code being written using this outdated technique.

# PR

There are two scenarios. One is that we pass a component instance that is
already in strict mode or the node that we find is in strict mode if
an outer component renders into strict mode.

I use a separate method findHostInstanceWithWarning for this so that
a) I can pass the method name (findDOMNode/findNodeHandle).
b) Can ignore this warning in React Native mixins/NativeComponent that use this helper.

I don't want to expose the fiber to the renderers themselves.