### PR TITLE
[scheduler] Rename priority levels

### DIFF
--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -10,9 +10,9 @@
 
 // TODO: Use symbols?
 var ImmediatePriority = 1;
-var InteractivePriority = 2;
+var UserBlockingPriority = 2;
 var NormalPriority = 3;
-var WheneverPriority = 4;
+var IdlePriority = 4;
 
 // Max 31 bit integer. The max integer size in V8 for 32-bit systems.
 // Math.pow(2, 30) - 1
@@ -22,10 +22,10 @@ var maxSigned31BitInt = 1073741823;
 // Times out immediately
 var IMMEDIATE_PRIORITY_TIMEOUT = -1;
 // Eventually times out
-var INTERACTIVE_PRIORITY_TIMEOUT = 250;
+var USER_BLOCKING_PRIORITY = 250;
 var NORMAL_PRIORITY_TIMEOUT = 5000;
 // Never times out
-var WHENEVER_PRIORITY_TIMEOUT = maxSigned31BitInt;
+var IDLE_PRIORITY = maxSigned31BitInt;
 
 // Callbacks are stored as a circular, doubly linked list.
 var firstCallbackNode = null;
@@ -254,9 +254,9 @@ function flushWork(didTimeout) {
 function unstable_runWithPriority(priorityLevel, eventHandler) {
   switch (priorityLevel) {
     case ImmediatePriority:
-    case InteractivePriority:
+    case UserBlockingPriority:
     case NormalPriority:
-    case WheneverPriority:
+    case IdlePriority:
       break;
     default:
       priorityLevel = NormalPriority;
@@ -314,11 +314,11 @@ function unstable_scheduleCallback(callback, deprecated_options) {
       case ImmediatePriority:
         expirationTime = startTime + IMMEDIATE_PRIORITY_TIMEOUT;
         break;
-      case InteractivePriority:
-        expirationTime = startTime + INTERACTIVE_PRIORITY_TIMEOUT;
+      case UserBlockingPriority:
+        expirationTime = startTime + USER_BLOCKING_PRIORITY;
         break;
-      case WheneverPriority:
-        expirationTime = startTime + WHENEVER_PRIORITY_TIMEOUT;
+      case IdlePriority:
+        expirationTime = startTime + IDLE_PRIORITY;
         break;
       case NormalPriority:
       default:
@@ -679,9 +679,9 @@ if (typeof window !== 'undefined' && window._schedMock) {
 
 export {
   ImmediatePriority as unstable_ImmediatePriority,
-  InteractivePriority as unstable_InteractivePriority,
+  UserBlockingPriority as unstable_UserBlockingPriority,
   NormalPriority as unstable_NormalPriority,
-  WheneverPriority as unstable_WheneverPriority,
+  IdlePriority as unstable_IdlePriority,
   unstable_runWithPriority,
   unstable_scheduleCallback,
   unstable_cancelCallback,

--- a/packages/scheduler/src/__tests__/SchedulerNoDOM-test.internal.js
+++ b/packages/scheduler/src/__tests__/SchedulerNoDOM-test.internal.js
@@ -12,7 +12,7 @@
 let scheduleCallback;
 let runWithPriority;
 let ImmediatePriority;
-let InteractivePriority;
+let UserBlockingPriority;
 
 describe('SchedulerNoDOM', () => {
   // If Scheduler runs in a non-DOM environment, it falls back to a naive
@@ -27,7 +27,7 @@ describe('SchedulerNoDOM', () => {
     scheduleCallback = Scheduler.unstable_scheduleCallback;
     runWithPriority = Scheduler.unstable_runWithPriority;
     ImmediatePriority = Scheduler.unstable_ImmediatePriority;
-    InteractivePriority = Scheduler.unstable_InteractivePriority;
+    UserBlockingPriority = Scheduler.unstable_UserBlockingPriority;
   });
 
   it('runAllTimers flushes all scheduled callbacks', () => {
@@ -55,7 +55,7 @@ describe('SchedulerNoDOM', () => {
     scheduleCallback(() => {
       log.push('B');
     });
-    runWithPriority(InteractivePriority, () => {
+    runWithPriority(UserBlockingPriority, () => {
       scheduleCallback(() => {
         log.push('C');
       });
@@ -78,7 +78,7 @@ describe('SchedulerNoDOM', () => {
     scheduleCallback(() => {
       log.push('B');
     });
-    runWithPriority(InteractivePriority, () => {
+    runWithPriority(UserBlockingPriority, () => {
       scheduleCallback(() => {
         log.push('C');
       });


### PR DESCRIPTION
- "Interactive" -> "User-blocking"
- "Whenever" -> "Idle"

These are the terms used by @spanicker in their main-thread scheduling proposal: https://github.com/spanicker/main-thread-scheduling#api-sketch

That proposal also uses "microtask" instead of "immediate" and "default" instead of "normal." Not sure about "microtask" because I don't think most people know what that is. And our implementation isn't a proper microtask, though you could use it to implement microtasks if you made sure to wrap every entry point. I don't really have a preference between "default" and "normal."

These aren't necessarily the final names. Still prefixed by `unstable_`.