### PR TITLE
Remove unstable_read() in favor of direct dispatcher call

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -20,6 +20,7 @@ import {
 import ReactStrictModeWarnings from './ReactStrictModeWarnings';
 import {isMounted} from 'react-reconciler/reflection';
 import * as ReactInstanceMap from 'shared/ReactInstanceMap';
+import ReactSharedInternals from 'shared/ReactSharedInternals';
 import shallowEqual from 'shared/shallowEqual';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
@@ -49,6 +50,13 @@ import {
   computeExpirationForFiber,
   scheduleWork,
 } from './ReactFiberScheduler';
+
+const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
+
+function readContext(contextType: any): any {
+  const dispatcher = ReactCurrentOwner.currentDispatcher;
+  return dispatcher.readContext(contextType);
+}
 
 const fakeInternalInstance = {};
 const isArray = Array.isArray;
@@ -508,7 +516,7 @@ function constructClassInstance(
   if (typeof contextType === 'object' && contextType !== null) {
     if (__DEV__) {
       if (
-        typeof contextType.unstable_read !== 'function' &&
+        contextType.Consumer === undefined &&
         !didWarnAboutInvalidateContextType.has(ctor)
       ) {
         didWarnAboutInvalidateContextType.add(ctor);
@@ -522,7 +530,7 @@ function constructClassInstance(
       }
     }
 
-    context = (contextType: any).unstable_read();
+    context = readContext((contextType: any));
   } else {
     unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
     const contextTypes = ctor.contextTypes;
@@ -725,7 +733,7 @@ function mountClassInstance(
 
   const contextType = ctor.contextType;
   if (typeof contextType === 'object' && contextType !== null) {
-    instance.context = (contextType: any).unstable_read();
+    instance.context = readContext(contextType);
   } else {
     const unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
     instance.context = getMaskedContext(workInProgress, unmaskedContext);
@@ -833,7 +841,7 @@ function resumeMountClassInstance(
   const contextType = ctor.contextType;
   let nextContext;
   if (typeof contextType === 'object' && contextType !== null) {
-    nextContext = (contextType: any).unstable_read();
+    nextContext = readContext(contextType);
   } else {
     const nextLegacyUnmaskedContext = getUnmaskedContext(
       workInProgress,
@@ -979,7 +987,7 @@ function updateClassInstance(
   const contextType = ctor.contextType;
   let nextContext;
   if (typeof contextType === 'object' && contextType !== null) {
-    nextContext = (contextType: any).unstable_read();
+    nextContext = readContext(contextType);
   } else {
     const nextUnmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
     nextContext = getMaskedContext(workInProgress, nextUnmaskedContext);

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -302,7 +302,7 @@ export function readContext<T>(
     if (lastContextDependency === null) {
       invariant(
         currentlyRenderingFiber !== null,
-        'Context.unstable_read(): Context can only be read while React is ' +
+        'Context can only be read while React is ' +
           'rendering, e.g. inside the render method or getDerivedStateFromProps.',
       );
       // This is the first dependency in the list

--- a/packages/react-reconciler/src/__tests__/ReactPure-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactPure-test.internal.js
@@ -90,8 +90,15 @@ describe('pure', () => {
 
         const CountContext = React.createContext(0);
 
+        function readContext(Context) {
+          const dispatcher =
+            React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+              .ReactCurrentOwner.currentDispatcher;
+          return dispatcher.readContext(Context);
+        }
+
         function Counter(props) {
-          const count = CountContext.unstable_read();
+          const count = readContext(CountContext);
           return <Text text={`${props.label}: ${count}`} />;
         }
         Counter = pure(Counter);

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -11,24 +11,8 @@ import {REACT_PROVIDER_TYPE, REACT_CONTEXT_TYPE} from 'shared/ReactSymbols';
 
 import type {ReactContext} from 'shared/ReactTypes';
 
-import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import warning from 'shared/warning';
-
-import ReactCurrentOwner from './ReactCurrentOwner';
-
-export function readContext<T>(
-  context: ReactContext<T>,
-  observedBits: void | number | boolean,
-): T {
-  const dispatcher = ReactCurrentOwner.currentDispatcher;
-  invariant(
-    dispatcher !== null,
-    'Context.unstable_read(): Context can only be read while React is ' +
-      'rendering, e.g. inside the render method or getDerivedStateFromProps.',
-  );
-  return dispatcher.readContext(context, observedBits);
-}
 
 export function createContext<T>(
   defaultValue: T,
@@ -61,7 +45,6 @@ export function createContext<T>(
     // These are circular
     Provider: (null: any),
     Consumer: (null: any),
-    unstable_read: (null: any),
   };
 
   context.Provider = {
@@ -69,10 +52,7 @@ export function createContext<T>(
     _context: context,
   };
 
-  context.unstable_read = readContext.bind(null, context);
-
   let hasWarnedAboutUsingNestedContextConsumers = false;
-  let hasWarnedAboutUsingConsumerUnstableRead = false;
   let hasWarnedAboutUsingConsumerProvider = false;
 
   if (__DEV__) {
@@ -83,17 +63,6 @@ export function createContext<T>(
       $$typeof: REACT_CONTEXT_TYPE,
       _context: context,
       _calculateChangedBits: context._calculateChangedBits,
-      unstable_read() {
-        if (!hasWarnedAboutUsingConsumerUnstableRead) {
-          hasWarnedAboutUsingConsumerUnstableRead = true;
-          warning(
-            false,
-            'Calling Context.Consumer.unstable_read() is not supported and will be removed in ' +
-              'a future major release. Did you mean to render Context.unstable_read() instead?',
-          );
-        }
-        return context.unstable_read();
-      },
     };
     // $FlowFixMe: Flow complains about not setting a value, which is intentional here
     Object.defineProperties(Consumer, {

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -556,7 +556,7 @@ describe('ReactContextValidator', () => {
     }
 
     expect(() => {
-      expect(() => ReactTestUtils.renderIntoDocument(<ComponentA />)).toThrow();
+      ReactTestUtils.renderIntoDocument(<ComponentA />);
     }).toWarnDev(
       'Warning: ComponentA defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
@@ -565,10 +565,10 @@ describe('ReactContextValidator', () => {
     );
 
     // Warnings should be deduped by component type
-    expect(() => ReactTestUtils.renderIntoDocument(<ComponentA />)).toThrow();
+    ReactTestUtils.renderIntoDocument(<ComponentA />);
 
     expect(() => {
-      expect(() => ReactTestUtils.renderIntoDocument(<ComponentB />)).toThrow();
+      ReactTestUtils.renderIntoDocument(<ComponentB />);
     }).toWarnDev(
       'Warning: ComponentB defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -54,7 +54,6 @@ export type ReactContext<T> = {
   $$typeof: Symbol | number,
   Consumer: ReactContext<T>,
   Provider: ReactProviderType<T>,
-  unstable_read: () => T,
 
   _calculateChangedBits: ((a: T, b: T) => number) | null,
 


### PR DESCRIPTION
It's an advanced feature that shouldn't be used by application code directly. For example classes are supposed to use `contextType` (https://github.com/reactjs/reactjs.org/pull/1265) instead.

So we want to hide it a bit deeper. This makes it only available via direct dispatcher read. Also removes an extra runtime check.