### PR TITLE
[WIP] Replay load/error events that happen earlier than commit

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMEarlyEvent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEarlyEvent-test.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let ConcurrentMode;
+
+beforeEach(() => {
+  React = require('react');
+  ConcurrentMode = React.unstable_ConcurrentMode;
+  ReactDOM = require('react-dom');
+});
+
+describe('ReactDOMImg', () => {
+  let container;
+
+  beforeEach(() => {
+    // TODO pull this into helper method, reduce repetition.
+    // mock the browser APIs which are used in schedule:
+    // - requestAnimationFrame should pass the DOMHighResTimeStamp argument
+    // - calling 'window.postMessage' should actually fire postmessage handlers
+    global.requestAnimationFrame = function(cb) {
+      return setTimeout(() => {
+        cb(Date.now());
+      });
+    };
+    const originalAddEventListener = global.addEventListener;
+    let postMessageCallback;
+    global.addEventListener = function(eventName, callback, useCapture) {
+      if (eventName === 'message') {
+        postMessageCallback = callback;
+      } else {
+        originalAddEventListener(eventName, callback, useCapture);
+      }
+    };
+    global.postMessage = function(messageKey, targetOrigin) {
+      const postMessageEvent = {source: window, data: messageKey};
+      if (postMessageCallback) {
+        postMessageCallback(postMessageEvent);
+      }
+    };
+    jest.resetModules();
+    container = document.createElement('div');
+    ReactDOM = require('react-dom');
+
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('should trigger load events even if they fire early', () => {
+    const onLoadSpy = jest.fn();
+
+    const loadEvent = document.createEvent('Event');
+    loadEvent.initEvent('load', false, false);
+
+    // TODO: Write test
+
+    ReactDOM.render(
+      <ConcurrentMode>
+        <img onLoad={onLoadSpy} />
+      </ConcurrentMode>,
+    );
+
+    // someHowGetAnImage.dispatchEvent(loadEvent);
+
+    // expect(onLoadSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -491,8 +491,8 @@ export function setInitialProperties(
     case 'img':
     case 'image':
     case 'link':
-      trapBubbledEvent(TOP_ERROR, domElement);
-      trapBubbledEvent(TOP_LOAD, domElement);
+      trapBubbledEvent(TOP_ERROR, domElement, true);
+      trapBubbledEvent(TOP_LOAD, domElement, true);
       props = rawProps;
       break;
     case 'form':

--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -25,6 +25,7 @@ import {
   isEnabled,
   trapBubbledEvent,
   trapCapturedEvent,
+  replayEarlyEvent,
 } from './ReactDOMEventListener';
 import isEventSupported from './isEventSupported';
 
@@ -187,4 +188,10 @@ export function isListeningToAllDependencies(
   return true;
 }
 
-export {setEnabled, isEnabled, trapBubbledEvent, trapCapturedEvent};
+export {
+  setEnabled,
+  isEnabled,
+  trapBubbledEvent,
+  replayEarlyEvent,
+  trapCapturedEvent,
+};


### PR DESCRIPTION
If we create an img/image/link those might fire their load event before we commit. If that happens, we need to store the event so that we can replay it during the commit phase.

I had an idea to fix it but this is still WIP because I actually need to test if this approach works.

- [x] Write code
- [ ] Write unit tests
- [ ] Write fixtures
