### PR TITLE
Suspense component does not capture if `fallback` is not defined

### DIFF
--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -205,9 +205,9 @@ function throwException(
     workInProgress = returnFiber;
     do {
       if (workInProgress.tag === SuspenseComponent) {
-        const state = workInProgress.memoizedState;
-        const didTimeout = state !== null && state.didTimeout;
-        if (!didTimeout) {
+        const fallback = workInProgress.memoizedProps.fallback;
+        const didTimeout = workInProgress.memoizedState;
+        if (fallback !== undefined && !didTimeout) {
           // Found the nearest boundary.
 
           // If the boundary is not in concurrent mode, we should not suspend, and

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -207,7 +207,7 @@ function throwException(
       if (workInProgress.tag === SuspenseComponent) {
         const fallback = workInProgress.memoizedProps.fallback;
         const didTimeout = workInProgress.memoizedState;
-        if (fallback !== undefined && !didTimeout) {
+        if (!didTimeout && workInProgress.memoizedProps.fallback !== undefined) {
           // Found the nearest boundary.
 
           // If the boundary is not in concurrent mode, we should not suspend, and

--- a/packages/react-reconciler/src/__tests__/ReactPure-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactPure-test.internal.js
@@ -57,11 +57,11 @@ describe('pure', () => {
         Counter = pure(Counter);
 
         ReactNoop.render(
-          <Suspense>
+          <Suspense fallback={<Text text="Loading..." />}>
             <Counter count={0} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual([]);
+        expect(ReactNoop.flush()).toEqual(['Loading...']);
         await Promise.resolve();
         expect(ReactNoop.flush()).toEqual([0]);
         expect(ReactNoop.getChildren()).toEqual([span(0)]);
@@ -107,7 +107,7 @@ describe('pure', () => {
           state = {count: 0};
           render() {
             return (
-              <Suspense>
+              <Suspense fallback={<Text text="Loading..." />}>
                 <CountContext.Provider value={this.state.count}>
                   <Counter label="Count" />
                 </CountContext.Provider>
@@ -118,7 +118,7 @@ describe('pure', () => {
 
         const parent = React.createRef(null);
         ReactNoop.render(<Parent ref={parent} />);
-        expect(ReactNoop.flush()).toEqual([]);
+        expect(ReactNoop.flush()).toEqual(['Loading...']);
         await Promise.resolve();
         expect(ReactNoop.flush()).toEqual(['Count: 0']);
         expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -148,11 +148,11 @@ describe('pure', () => {
         });
 
         ReactNoop.render(
-          <Suspense>
+          <Suspense fallback={<Text text="Loading..." />}>
             <Counter count={0} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual([]);
+        expect(ReactNoop.flush()).toEqual(['Loading...']);
         await Promise.resolve();
         expect(ReactNoop.flush()).toEqual([0]);
         expect(ReactNoop.getChildren()).toEqual([span(0)]);
@@ -204,7 +204,7 @@ describe('pure', () => {
         const divRef = React.createRef();
 
         ReactNoop.render(
-          <Suspense>
+          <Suspense fallback={<Text text="Loading..." />}>
             <Transparent ref={divRef} />
           </Suspense>,
         );
@@ -224,11 +224,11 @@ describe('pure', () => {
         const divRef2 = React.createRef();
 
         ReactNoop.render(
-          <Suspense>
+          <Suspense fallback={<Text text="Loading..." />}>
             <Transparent ref={divRef} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual([]);
+        expect(ReactNoop.flush()).toEqual(['Loading...']);
         await Promise.resolve();
         expect(ReactNoop.flush()).toEqual(['Text']);
         expect(divRef.current.type).toBe('div');

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -106,7 +106,7 @@ describe('ReactSuspense', () => {
     function Foo() {
       ReactTestRenderer.unstable_yield('Foo');
       return (
-        <Suspense>
+        <Suspense fallback={<Text text="Loading..." />}>
           <Bar>
             <AsyncText text="A" ms={100} />
             <Text text="B" />
@@ -126,6 +126,7 @@ describe('ReactSuspense', () => {
       'Suspend! [A]',
       // But we keep rendering the siblings
       'B',
+      'Loading...',
     ]);
     expect(root).toMatchRenderedOutput(null);
 
@@ -270,5 +271,50 @@ describe('ReactSuspense', () => {
 
     expect(ReactTestRenderer).toHaveYielded(['Hi', 'Did mount: Hi']);
     expect(root).toMatchRenderedOutput('Hi');
+  });
+
+  it('only captures if `fallback` is defined', () => {
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <Suspense maxDuration={100}>
+          <AsyncText text="Hi" ms={5000} />
+        </Suspense>
+      </Suspense>,
+      {
+        unstable_isConcurrent: true,
+      },
+    );
+
+    expect(root).toFlushAndYield([
+      'Suspend! [Hi]',
+      // The outer fallback should be rendered, because the inner one does not
+      // have a `fallback` prop
+      'Loading...',
+    ]);
+    jest.advanceTimersByTime(1000);
+    expect(ReactTestRenderer).toHaveYielded([]);
+    expect(root).toFlushAndYield([]);
+    expect(root).toMatchRenderedOutput('Loading...');
+
+    jest.advanceTimersByTime(5000);
+    expect(ReactTestRenderer).toHaveYielded(['Promise resolved [Hi]']);
+    expect(root).toFlushAndYield(['Hi']);
+    expect(root).toMatchRenderedOutput('Hi');
+  });
+
+  it('throws if tree suspends and none of the Suspense ancestors have a fallback', () => {
+    const root = ReactTestRenderer.create(
+      <Suspense>
+        <AsyncText text="Hi" ms={1000} />
+      </Suspense>,
+      {
+        unstable_isConcurrent: true,
+      },
+    );
+
+    expect(root).toFlushAndThrow(
+      'An update was suspended, but no placeholder UI was provided.',
+    );
+    expect(ReactTestRenderer).toHaveYielded(['Suspend! [Hi]', 'Suspend! [Hi]']);
   });
 });


### PR DESCRIPTION
A missing fallback prop means the exception should propagate to the next
parent (like a rethrow). That way a Suspense component can specify other
props like maxDuration without needing to provide a fallback, too.

Closes #13864 

cc: @jaredpalmer