### PR TITLE
Strict mode and default mode should have same Suspense semantics

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -110,12 +110,7 @@ import {
   computeAsyncExpiration,
   computeInteractiveExpiration,
 } from './ReactFiberExpirationTime';
-import {
-  ConcurrentMode,
-  ProfileMode,
-  NoContext,
-  StrictMode,
-} from './ReactTypeOfMode';
+import {ConcurrentMode, ProfileMode, NoContext} from './ReactTypeOfMode';
 import {enqueueUpdate, resetCurrentlyProcessingQueue} from './ReactUpdateQueue';
 import {createCapturedValue} from './ReactCapturedValue';
 import {
@@ -1602,10 +1597,10 @@ function retrySuspendedRoot(
   }
 
   scheduleWorkToRoot(boundaryFiber, retryTime);
-  if ((boundaryFiber.mode & StrictMode) === NoContext) {
-    // Outside of strict mode, we must schedule an update on the source fiber,
-    // too, since it already committed in an inconsistent state and therefore
-    // does not have any pending work.
+  if ((boundaryFiber.mode & ConcurrentMode) === NoContext) {
+    // Outside of concurrent mode, we must schedule an update on the source
+    // fiber, too, since it already committed in an inconsistent state and
+    // therefore does not have any pending work.
     scheduleWorkToRoot(sourceFiber, retryTime);
   }
 

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -36,7 +36,7 @@ import {
   LifecycleEffectMask,
 } from 'shared/ReactSideEffectTags';
 import {enableSchedulerTracing} from 'shared/ReactFeatureFlags';
-import {StrictMode, ConcurrentMode} from './ReactTypeOfMode';
+import {ConcurrentMode} from './ReactTypeOfMode';
 
 import {createCapturedValue} from './ReactCapturedValue';
 import {
@@ -230,15 +230,15 @@ function throwException(
           }
           thenable.then(onResolveOrReject, onResolveOrReject);
 
-          // If the boundary is outside of strict mode, we should *not* suspend
-          // the commit. Pretend as if the suspended component rendered null and
-          // keep rendering. In the commit phase, we'll schedule a subsequent
-          // synchronous update to re-render the Suspense.
+          // If the boundary is outside of concurrent mode, we should *not*
+          // suspend the commit. Pretend as if the suspended component rendered
+          // null and keep rendering. In the commit phase, we'll schedule a
+          // subsequent synchronous update to re-render the Suspense.
           //
           // Note: It doesn't matter whether the component that suspended was
-          // inside a strict mode tree. If the Suspense is outside of it, we
+          // inside a concurrent mode tree. If the Suspense is outside of it, we
           // should *not* suspend the commit.
-          if ((workInProgress.mode & StrictMode) === NoEffect) {
+          if ((workInProgress.mode & ConcurrentMode) === NoEffect) {
             workInProgress.effectTag |= CallbackEffect;
 
             // Unmount the source fiber's children
@@ -274,8 +274,8 @@ function throwException(
             return;
           }
 
-          // Confirmed that the boundary is in a strict mode tree. Continue with
-          // the normal suspend path.
+          // Confirmed that the boundary is in a concurrent mode tree. Continue
+          // with the normal suspend path.
 
           let absoluteTimeoutMs;
           if (earliestTimeoutMs === -1) {


### PR DESCRIPTION
In the default mode, Suspense has special semantics where, in addition to timing out immediately, we don't unwind the stack before rendering the fallback. Instead, we commit the tree in an inconsistent state, then synchronous render *again* to switch to the fallback. This is slower but is less likely to cause issues with older components that perform side effects in the render phase (e.g. componentWillMount, componentWillUpdate, and componentWillReceiveProps).

We should do this in strict mode, too, so that there are no semantic differences (in prod, at least) between default mode and strict mode. The rationale is that it makes it easier to wrap a tree in strict mode and start migrating components incrementally without worrying about new bugs in production.