### PR TITLE
Lazy components must use React.lazy

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -582,11 +582,6 @@ describe('ReactDOMServer', () => {
       );
       ReactDOMServer.renderToString(<LazyFoo />);
     }).toThrow('ReactDOMServer does not yet support lazy-loaded components.');
-
-    expect(() => {
-      const FooPromise = {then() {}};
-      ReactDOMServer.renderToString(<FooPromise />);
-    }).toThrow('ReactDOMServer does not yet support lazy-loaded components.');
   });
 
   it('should throw (in dev) when children are mutated during render', () => {

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -444,15 +444,18 @@ describe('ReactDOMServerHydration', () => {
   });
 
   it('should be able to use lazy components after hydrating', async () => {
-    const Lazy = new Promise(resolve => {
-      setTimeout(
-        () =>
-          resolve(function World() {
-            return 'world';
-          }),
-        1000,
-      );
-    });
+    const Lazy = React.lazy(
+      () =>
+        new Promise(resolve => {
+          setTimeout(
+            () =>
+              resolve(function World() {
+                return 'world';
+              }),
+            1000,
+          );
+        }),
+    );
     class HelloWorld extends React.Component {
       state = {isClient: false};
       componentDidMount() {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -38,6 +38,7 @@ import {
   REACT_PROFILER_TYPE,
   REACT_PROVIDER_TYPE,
   REACT_CONTEXT_TYPE,
+  REACT_LAZY_TYPE,
 } from 'shared/ReactSymbols';
 
 import {
@@ -1005,14 +1006,11 @@ class ReactDOMServerRenderer {
             this.stack.push(frame);
             return '';
           }
-          default:
-            if (typeof elementType.then === 'function') {
-              invariant(
-                false,
-                'ReactDOMServer does not yet support lazy-loaded components.',
-              );
-            }
-            break;
+          case REACT_LAZY_TYPE:
+            invariant(
+              false,
+              'ReactDOMServer does not yet support lazy-loaded components.',
+            );
         }
       }
 

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -60,6 +60,7 @@ import {
   REACT_CONCURRENT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
   REACT_PURE_TYPE,
+  REACT_LAZY_TYPE,
 } from 'shared/ReactSymbols';
 
 let hasBadMapPolyfill;
@@ -461,12 +462,9 @@ export function createFiberFromElement(
             case REACT_PURE_TYPE:
               fiberTag = PureComponent;
               break getTag;
-            default: {
-              if (typeof type.then === 'function') {
-                fiberTag = IndeterminateComponent;
-                break getTag;
-              }
-            }
+            case REACT_LAZY_TYPE:
+              fiberTag = IndeterminateComponent;
+              break getTag;
           }
         }
         let info = '';

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -104,12 +104,13 @@ import {
   updateClassInstance,
 } from './ReactFiberClassComponent';
 import {readLazyComponentType} from './ReactFiberLazyComponent';
-import {getResultFromResolvedThenable} from 'shared/ReactLazyComponent';
+import {getResultFromResolvedLazyComponent} from 'shared/ReactLazyComponent';
 import {
   resolveLazyComponentTag,
   createFiberFromFragment,
   createWorkInProgress,
 } from './ReactFiber';
+import {REACT_LAZY_TYPE} from 'shared/ReactSymbols';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
@@ -728,7 +729,7 @@ function mountIndeterminateComponent(
   if (
     typeof Component === 'object' &&
     Component !== null &&
-    typeof Component.then === 'function'
+    Component.$$typeof === REACT_LAZY_TYPE
   ) {
     // We can't start a User Timing measurement with correct label yet.
     // Cancel and resume right after we know the tag.
@@ -1422,7 +1423,7 @@ function beginWork(
         }
         case ClassComponentLazy: {
           const thenable = workInProgress.type;
-          const Component = getResultFromResolvedThenable(thenable);
+          const Component = getResultFromResolvedLazyComponent(thenable);
           if (isLegacyContextProvider(Component)) {
             pushLegacyContextProvider(workInProgress);
           }
@@ -1498,7 +1499,7 @@ function beginWork(
     }
     case FunctionComponentLazy: {
       const thenable = workInProgress.type;
-      const Component = getResultFromResolvedThenable(thenable);
+      const Component = getResultFromResolvedLazyComponent(thenable);
       const unresolvedProps = workInProgress.pendingProps;
       const child = updateFunctionComponent(
         current,
@@ -1523,7 +1524,7 @@ function beginWork(
     }
     case ClassComponentLazy: {
       const thenable = workInProgress.type;
-      const Component = getResultFromResolvedThenable(thenable);
+      const Component = getResultFromResolvedLazyComponent(thenable);
       const unresolvedProps = workInProgress.pendingProps;
       const child = updateClassComponent(
         current,
@@ -1565,7 +1566,7 @@ function beginWork(
     }
     case ForwardRefLazy: {
       const thenable = workInProgress.type;
-      const Component = getResultFromResolvedThenable(thenable);
+      const Component = getResultFromResolvedLazyComponent(thenable);
       const unresolvedProps = workInProgress.pendingProps;
       const child = updateForwardRef(
         current,
@@ -1608,7 +1609,7 @@ function beginWork(
     }
     case PureComponentLazy: {
       const thenable = workInProgress.type;
-      const Component = getResultFromResolvedThenable(thenable);
+      const Component = getResultFromResolvedLazyComponent(thenable);
       const unresolvedProps = workInProgress.pendingProps;
       const child = updatePureComponent(
         current,

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -42,7 +42,7 @@ import {
 } from 'shared/ReactWorkTags';
 import {Placement, Ref, Update} from 'shared/ReactSideEffectTags';
 import invariant from 'shared/invariant';
-import {getResultFromResolvedThenable} from 'shared/ReactLazyComponent';
+import {getResultFromResolvedLazyComponent} from 'shared/ReactLazyComponent';
 
 import {
   createInstance,
@@ -552,7 +552,7 @@ function completeWork(
       break;
     }
     case ClassComponentLazy: {
-      const Component = getResultFromResolvedThenable(workInProgress.type);
+      const Component = getResultFromResolvedLazyComponent(workInProgress.type);
       if (isLegacyContextProvider(Component)) {
         popLegacyContext(workInProgress);
       }

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -20,7 +20,7 @@ import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import checkPropTypes from 'prop-types/checkPropTypes';
-import {getResultFromResolvedThenable} from 'shared/ReactLazyComponent';
+import {getResultFromResolvedLazyComponent} from 'shared/ReactLazyComponent';
 
 import * as ReactCurrentFiber from './ReactCurrentFiber';
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
@@ -298,7 +298,7 @@ function findCurrentUnmaskedContext(fiber: Fiber): Object {
         break;
       }
       case ClassComponentLazy: {
-        const Component = getResultFromResolvedThenable(node.type);
+        const Component = getResultFromResolvedLazyComponent(node.type);
         if (isContextProvider(Component)) {
           return node.stateNode.__reactInternalMemoizedMergedChildContext;
         }

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -31,7 +31,7 @@ import {
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
-import {getResultFromResolvedThenable} from 'shared/ReactLazyComponent';
+import {getResultFromResolvedLazyComponent} from 'shared/ReactLazyComponent';
 
 import {getPublicInstance} from './ReactFiberHostConfig';
 import {
@@ -107,7 +107,7 @@ function getContextForSubtree(
       return processChildContext(fiber, Component, parentContext);
     }
   } else if (fiber.tag === ClassComponentLazy) {
-    const Component = getResultFromResolvedThenable(fiber.type);
+    const Component = getResultFromResolvedLazyComponent(fiber.type);
     if (isLegacyContextProvider(Component)) {
       return processChildContext(fiber, Component, parentContext);
     }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -53,7 +53,7 @@ import {
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
-import {getResultFromResolvedThenable} from 'shared/ReactLazyComponent';
+import {getResultFromResolvedLazyComponent} from 'shared/ReactLazyComponent';
 
 import {
   scheduleTimeout,
@@ -312,7 +312,9 @@ if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
         break;
       }
       case ClassComponentLazy: {
-        const Component = getResultFromResolvedThenable(failedUnitOfWork.type);
+        const Component = getResultFromResolvedLazyComponent(
+          failedUnitOfWork.type,
+        );
         if (isLegacyContextProvider(Component)) {
           popLegacyContext(failedUnitOfWork);
         }

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -1,0 +1,309 @@
+let React;
+let ReactTestRenderer;
+let ReactFeatureFlags;
+let Suspense;
+let lazy;
+
+describe('ReactLazy', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+    ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
+    React = require('react');
+    Suspense = React.unstable_Suspense;
+    lazy = React.lazy;
+    ReactTestRenderer = require('react-test-renderer');
+  });
+
+  function Text(props) {
+    ReactTestRenderer.unstable_yield(props.text);
+    return props.text;
+  }
+
+  it('suspends until module has loaded', async () => {
+    const LazyText = lazy(async () => Text);
+
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyText text="Hi" />
+      </Suspense>,
+      {
+        unstable_isConcurrent: true,
+      },
+    );
+
+    expect(root).toFlushAndYield(['Loading...']);
+    expect(root).toMatchRenderedOutput(null);
+
+    await LazyText;
+
+    expect(root).toFlushAndYield(['Hi']);
+    expect(root).toMatchRenderedOutput('Hi');
+
+    // Should not suspend on update
+    root.update(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyText text="Hi again" />
+      </Suspense>,
+    );
+    expect(root).toFlushAndYield(['Hi again']);
+    expect(root).toMatchRenderedOutput('Hi again');
+  });
+
+  it('uses `default` property, if it exists', async () => {
+    const LazyText = lazy(async () => ({default: Text}));
+
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyText text="Hi" />
+      </Suspense>,
+      {
+        unstable_isConcurrent: true,
+      },
+    );
+    expect(root).toFlushAndYield(['Loading...']);
+    expect(root).toMatchRenderedOutput(null);
+
+    await LazyText;
+
+    expect(root).toFlushAndYield(['Hi']);
+    expect(root).toMatchRenderedOutput('Hi');
+
+    // Should not suspend on update
+    root.update(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyText text="Hi again" />
+      </Suspense>,
+    );
+    expect(root).toFlushAndYield(['Hi again']);
+    expect(root).toMatchRenderedOutput('Hi again');
+  });
+
+  it('throws if promise rejects', async () => {
+    const LazyText = lazy(async () => {
+      throw new Error('Bad network');
+    });
+
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyText text="Hi" />
+      </Suspense>,
+      {
+        unstable_isConcurrent: true,
+      },
+    );
+
+    expect(root).toFlushAndYield(['Loading...']);
+    expect(root).toMatchRenderedOutput(null);
+
+    try {
+      await LazyText;
+    } catch (e) {}
+
+    expect(root).toFlushAndThrow('Bad network');
+  });
+
+  it('mount and reorder', async () => {
+    class Child extends React.Component {
+      componentDidMount() {
+        ReactTestRenderer.unstable_yield('Did mount: ' + this.props.label);
+      }
+      componentDidUpdate() {
+        ReactTestRenderer.unstable_yield('Did update: ' + this.props.label);
+      }
+      render() {
+        return <Text text={this.props.label} />;
+      }
+    }
+
+    const LazyChildA = lazy(async () => Child);
+    const LazyChildB = lazy(async () => Child);
+
+    function Parent({swap}) {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          {swap
+            ? [
+                <LazyChildB key="B" label="B" />,
+                <LazyChildA key="A" label="A" />,
+              ]
+            : [
+                <LazyChildA key="A" label="A" />,
+                <LazyChildB key="B" label="B" />,
+              ]}
+        </Suspense>
+      );
+    }
+
+    const root = ReactTestRenderer.create(<Parent swap={false} />, {
+      unstable_isConcurrent: true,
+    });
+
+    expect(root).toFlushAndYield(['Loading...']);
+    expect(root).toMatchRenderedOutput(null);
+
+    await LazyChildA;
+    await LazyChildB;
+
+    expect(root).toFlushAndYield(['A', 'B', 'Did mount: A', 'Did mount: B']);
+    expect(root).toMatchRenderedOutput('AB');
+
+    // Swap the position of A and B
+    root.update(<Parent swap={true} />);
+    expect(root).toFlushAndYield(['B', 'A', 'Did update: B', 'Did update: A']);
+    expect(root).toMatchRenderedOutput('BA');
+  });
+
+  it('resolves defaultProps, on mount and update', async () => {
+    function T(props) {
+      return <Text {...props} />;
+    }
+    T.defaultProps = {text: 'Hi'};
+    const LazyText = lazy(async () => T);
+
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyText />
+      </Suspense>,
+      {
+        unstable_isConcurrent: true,
+      },
+    );
+
+    expect(root).toFlushAndYield(['Loading...']);
+    expect(root).toMatchRenderedOutput(null);
+
+    await LazyText;
+
+    expect(root).toFlushAndYield(['Hi']);
+    expect(root).toMatchRenderedOutput('Hi');
+
+    T.defaultProps = {text: 'Hi again'};
+    root.update(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyText text="Hi again" />
+      </Suspense>,
+    );
+    expect(root).toFlushAndYield(['Hi again']);
+    expect(root).toMatchRenderedOutput('Hi again');
+  });
+
+  it('resolves defaultProps without breaking memoization', async () => {
+    function LazyImpl(props) {
+      ReactTestRenderer.unstable_yield('Lazy');
+      return (
+        <React.Fragment>
+          <Text text={props.siblingText} />
+          {props.children}
+        </React.Fragment>
+      );
+    }
+    LazyImpl.defaultProps = {siblingText: 'Sibling'};
+    const Lazy = lazy(async () => LazyImpl);
+
+    class Stateful extends React.Component {
+      state = {text: 'A'};
+      render() {
+        return <Text text={this.state.text} />;
+      }
+    }
+
+    const stateful = React.createRef(null);
+
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <Lazy>
+          <Stateful ref={stateful} />
+        </Lazy>
+      </Suspense>,
+      {
+        unstable_isConcurrent: true,
+      },
+    );
+    expect(root).toFlushAndYield(['Loading...']);
+    expect(root).toMatchRenderedOutput(null);
+
+    await Lazy;
+
+    expect(root).toFlushAndYield(['Lazy', 'Sibling', 'A']);
+    expect(root).toMatchRenderedOutput('SiblingA');
+
+    // Lazy should not re-render
+    stateful.current.setState({text: 'B'});
+    expect(root).toFlushAndYield(['B']);
+    expect(root).toMatchRenderedOutput('SiblingB');
+  });
+
+  it('includes lazy-loaded component in warning stack', async () => {
+    const LazyFoo = lazy(() => {
+      ReactTestRenderer.unstable_yield('Started loading');
+      const Foo = props => <div>{[<Text text="A" />, <Text text="B" />]}</div>;
+      return Promise.resolve(Foo);
+    });
+
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyFoo />
+      </Suspense>,
+      {
+        unstable_isConcurrent: true,
+      },
+    );
+
+    expect(root).toFlushAndYield(['Started loading', 'Loading...']);
+    expect(root).toMatchRenderedOutput(null);
+
+    await LazyFoo;
+
+    expect(() => {
+      expect(root).toFlushAndYield(['A', 'B']);
+    }).toWarnDev('    in Text (at **)\n' + '    in Foo (at **)');
+    expect(root).toMatchRenderedOutput(<div>AB</div>);
+  });
+
+  it('supports class and forwardRef components', async () => {
+    const LazyClass = lazy(async () => {
+      class Foo extends React.Component {
+        render() {
+          return <Text text="Foo" />;
+        }
+      }
+      return Foo;
+    });
+
+    const LazyForwardRef = lazy(async () => {
+      class Bar extends React.Component {
+        render() {
+          return <Text text="Bar" />;
+        }
+      }
+      return React.forwardRef((props, ref) => {
+        ReactTestRenderer.unstable_yield('forwardRef');
+        return <Bar ref={ref} />;
+      });
+    });
+
+    const ref = React.createRef();
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyClass />
+        <LazyForwardRef ref={ref} />
+      </Suspense>,
+      {
+        unstable_isConcurrent: true,
+      },
+    );
+
+    expect(root).toFlushAndYield(['Loading...']);
+    expect(root).toMatchRenderedOutput(null);
+    expect(ref.current).toBe(null);
+
+    await LazyClass;
+    await LazyForwardRef;
+
+    expect(root).toFlushAndYield(['Foo', 'forwardRef', 'Bar']);
+    expect(root).toMatchRenderedOutput('FooBar');
+    expect(ref.current).not.toBe(null);
+  });
+});

--- a/packages/react-reconciler/src/__tests__/ReactPure-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactPure-test.internal.js
@@ -42,9 +42,12 @@ describe('pure', () => {
     function Indirection(props) {
       return <Pure {...props} />;
     }
-    return Promise.resolve(Indirection);
+    return React.lazy(async () => Indirection);
   });
-  sharedTests('lazy', (...args) => Promise.resolve(React.pure(...args)));
+  sharedTests('lazy', (...args) => {
+    const Pure = React.pure(...args);
+    return React.lazy(async () => Pure);
+  });
 
   function sharedTests(label, pure) {
     describe(`${label}`, () => {

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -5,23 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-type Thenable<T, R> = {
-  then(resolve: (T) => mixed, reject: (mixed) => mixed): R,
-};
+import type {LazyComponent, Thenable} from 'shared/ReactLazyComponent';
 
-export function lazy<T, R>(ctor: () => Thenable<T, R>) {
-  let thenable = null;
+import {REACT_LAZY_TYPE} from 'shared/ReactSymbols';
+
+export function lazy<T, R>(ctor: () => Thenable<T, R>): LazyComponent<T> {
   return {
-    then(resolve, reject) {
-      if (thenable === null) {
-        // Lazily create thenable by wrapping in an extra thenable.
-        thenable = ctor();
-        ctor = null;
-      }
-      return thenable.then(resolve, reject);
-    },
+    $$typeof: REACT_LAZY_TYPE,
+    _ctor: ctor,
     // React uses these fields to store the result.
-    _reactStatus: -1,
-    _reactResult: null,
+    _status: -1,
+    _result: null,
   };
 }

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -7,30 +7,36 @@
  * @flow
  */
 
-export type Thenable<T> = {
-  then(resolve: (T) => mixed, reject: (mixed) => mixed): mixed,
-  _reactStatus?: 0 | 1 | 2,
-  _reactResult: any,
+export type Thenable<T, R> = {
+  then(resolve: (T) => mixed, reject: (mixed) => mixed): R,
 };
 
-type ResolvedThenable<T> = {
-  then(resolve: (T) => mixed, reject: (mixed) => mixed): mixed,
-  _reactStatus?: 1,
-  _reactResult: T,
+export type LazyComponent<T> = {
+  $$typeof: Symbol | number,
+  _ctor: () => Thenable<T, mixed>,
+  _status: 0 | 1 | 2,
+  _result: any,
+};
+
+type ResolvedLazyComponentThenable<T> = {
+  $$typeof: Symbol | number,
+  _ctor: () => Thenable<T, mixed>,
+  _status: 1,
+  _result: any,
 };
 
 export const Pending = 0;
 export const Resolved = 1;
 export const Rejected = 2;
 
-export function getResultFromResolvedThenable<T>(
-  thenable: ResolvedThenable<T>,
+export function getResultFromResolvedLazyComponent<T>(
+  lazyComponent: ResolvedLazyComponentThenable<T>,
 ): T {
-  return thenable._reactResult;
+  return lazyComponent._result;
 }
 
-export function refineResolvedThenable<T>(
-  thenable: Thenable<T>,
-): ResolvedThenable<T> | null {
-  return thenable._reactStatus === Resolved ? thenable._reactResult : null;
+export function refineResolvedLazyComponent<T>(
+  lazyComponent: LazyComponent<T>,
+): ResolvedLazyComponentThenable<T> | null {
+  return lazyComponent._status === Resolved ? lazyComponent._result : null;
 }

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -42,6 +42,7 @@ export const REACT_SUSPENSE_TYPE = hasSymbol
   ? Symbol.for('react.suspense')
   : 0xead1;
 export const REACT_PURE_TYPE = hasSymbol ? Symbol.for('react.pure') : 0xead3;
+export const REACT_LAZY_TYPE = hasSymbol ? Symbol.for('react.lazy') : 0xead4;
 
 const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Thenable} from 'shared/ReactLazyComponent';
+import type {LazyComponent} from 'shared/ReactLazyComponent';
 
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {
@@ -21,8 +21,9 @@ import {
   REACT_PROVIDER_TYPE,
   REACT_STRICT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
+  REACT_LAZY_TYPE,
 } from 'shared/ReactSymbols';
-import {refineResolvedThenable} from 'shared/ReactLazyComponent';
+import {refineResolvedLazyComponent} from 'shared/ReactLazyComponent';
 
 function getWrappedName(
   outerType: mixed,
@@ -80,12 +81,12 @@ function getComponentName(type: mixed): string | null {
         return getWrappedName(type, type.render, 'ForwardRef');
       case REACT_PURE_TYPE:
         return getWrappedName(type, type.render, 'Pure');
-    }
-    if (typeof type.then === 'function') {
-      const thenable: Thenable<mixed> = (type: any);
-      const resolvedThenable = refineResolvedThenable(thenable);
-      if (resolvedThenable) {
-        return getComponentName(resolvedThenable);
+      case REACT_LAZY_TYPE: {
+        const thenable: LazyComponent<mixed> = (type: any);
+        const resolvedThenable = refineResolvedLazyComponent(thenable);
+        if (resolvedThenable) {
+          return getComponentName(resolvedThenable);
+        }
       }
     }
   }

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -17,6 +17,7 @@ import {
   REACT_STRICT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
   REACT_PURE_TYPE,
+  REACT_LAZY_TYPE,
 } from 'shared/ReactSymbols';
 
 export default function isValidElementType(type: mixed) {
@@ -31,7 +32,7 @@ export default function isValidElementType(type: mixed) {
     type === REACT_SUSPENSE_TYPE ||
     (typeof type === 'object' &&
       type !== null &&
-      (typeof type.then === 'function' ||
+      (type.$$typeof === REACT_LAZY_TYPE ||
         type.$$typeof === REACT_PURE_TYPE ||
         type.$$typeof === REACT_PROVIDER_TYPE ||
         type.$$typeof === REACT_CONTEXT_TYPE ||


### PR DESCRIPTION
Removes support for using arbitrary promises as the type of a React element. Instead, promises must be wrapped in `React.lazy`. This gives us flexibility later if we need to change the protocol.

The reason is that promises do not provide a way to call their constructor multiple times. For example:

```js
const promiseForA = new Promise(resolve => {
  fetchA(a => resolve(a));
});
```

Given a reference to `promiseForA`, there's no way to call `fetchA` again. Calling `then` on the promise doesn't run the constructor again; it only attaches another listener.

In the future we will likely introduce an API like `React.eager` that is similar to `lazy` but eagerly calls the constructor. That gives us the ability to call the constructor multiple times. E.g. to increase the priority, or to retry if the first operation failed.