### PR TITLE
React.lazy constructor must return result of a dynamic import

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -571,14 +571,19 @@ describe('ReactDOMServer', () => {
       ReactDOMServer.renderToString(<React.unstable_Suspense />);
     }).toThrow('ReactDOMServer does not yet support Suspense.');
 
+    async function fakeImport(result) {
+      return {default: result};
+    }
+
     expect(() => {
-      const LazyFoo = React.lazy(
-        () =>
+      const LazyFoo = React.lazy(() =>
+        fakeImport(
           new Promise(resolve =>
             resolve(function Foo() {
               return <div />;
             }),
           ),
+        ),
       );
       ReactDOMServer.renderToString(<LazyFoo />);
     }).toThrow('ReactDOMServer does not yet support lazy-loaded components.');

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -444,14 +444,20 @@ describe('ReactDOMServerHydration', () => {
   });
 
   it('should be able to use lazy components after hydrating', async () => {
+    async function fakeImport(result) {
+      return {default: result};
+    }
+
     const Lazy = React.lazy(
       () =>
         new Promise(resolve => {
           setTimeout(
             () =>
-              resolve(function World() {
-                return 'world';
-              }),
+              resolve(
+                fakeImport(function World() {
+                  return 'world';
+                }),
+              ),
             1000,
           );
         }),

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -573,6 +573,10 @@ describe('ReactDebugFiberPerf', () => {
       return <span />;
     }
 
+    async function fakeImport(result) {
+      return {default: result};
+    }
+
     let resolve;
     const LazyFoo = React.lazy(
       () =>
@@ -591,9 +595,11 @@ describe('ReactDebugFiberPerf', () => {
     ReactNoop.flush();
     expect(getFlameChart()).toMatchSnapshot();
 
-    resolve(function Foo() {
-      return <div />;
-    });
+    resolve(
+      fakeImport(function Foo() {
+        return <div />;
+      }),
+    );
     await LazyFoo;
 
     ReactNoop.render(

--- a/packages/react-reconciler/src/__tests__/ReactPure-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactPure-test.internal.js
@@ -34,6 +34,10 @@ describe('pure', () => {
     return <span prop={props.text} />;
   }
 
+  async function fakeImport(result) {
+    return {default: result};
+  }
+
   // Tests should run against both the lazy and non-lazy versions of `pure`.
   // To make the tests work for both versions, we wrap the non-lazy version in
   // a lazy function component.
@@ -42,11 +46,11 @@ describe('pure', () => {
     function Indirection(props) {
       return <Pure {...props} />;
     }
-    return React.lazy(async () => Indirection);
+    return React.lazy(() => fakeImport(Indirection));
   });
   sharedTests('lazy', (...args) => {
     const Pure = React.pure(...args);
-    return React.lazy(async () => Pure);
+    return React.lazy(() => fakeImport(Pure));
   });
 
   function sharedTests(label, pure) {

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -256,7 +256,11 @@ describe('ReactSuspense', () => {
       }
     }
 
-    const LazyClass = React.lazy(() => Promise.resolve(Class));
+    async function fakeImport(result) {
+      return {default: result};
+    }
+
+    const LazyClass = React.lazy(() => fakeImport(Class));
 
     const root = ReactTestRenderer.create(
       <Suspense fallback={<Text text="Loading..." />}>

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -13,14 +13,14 @@ export type Thenable<T, R> = {
 
 export type LazyComponent<T> = {
   $$typeof: Symbol | number,
-  _ctor: () => Thenable<T, mixed>,
+  _ctor: () => Thenable<{default: T}, mixed>,
   _status: 0 | 1 | 2,
   _result: any,
 };
 
-type ResolvedLazyComponentThenable<T> = {
+type ResolvedLazyComponent<T> = {
   $$typeof: Symbol | number,
-  _ctor: () => Thenable<T, mixed>,
+  _ctor: () => Thenable<{default: T}, mixed>,
   _status: 1,
   _result: any,
 };
@@ -30,13 +30,13 @@ export const Resolved = 1;
 export const Rejected = 2;
 
 export function getResultFromResolvedLazyComponent<T>(
-  lazyComponent: ResolvedLazyComponentThenable<T>,
+  lazyComponent: ResolvedLazyComponent<T>,
 ): T {
   return lazyComponent._result;
 }
 
 export function refineResolvedLazyComponent<T>(
   lazyComponent: LazyComponent<T>,
-): ResolvedLazyComponentThenable<T> | null {
+): ResolvedLazyComponent<T> | null {
   return lazyComponent._status === Resolved ? lazyComponent._result : null;
 }


### PR DESCRIPTION
## Based on #13885

We may want to change the protocol later, so until then we'll be restrictive. Heuristic is to check for existence of `default`.

See #13885 for more details.