### PR TITLE
Allow forwardRef to be composed with pure

### DIFF
--- a/packages/react/src/forwardRef.js
+++ b/packages/react/src/forwardRef.js
@@ -9,9 +9,15 @@ import {REACT_FORWARD_REF_TYPE} from 'shared/ReactSymbols';
 
 import warningWithoutStack from 'shared/warningWithoutStack';
 
+export type ForwardRef<Props> = {
+  $$typeof: Symbol,
+  render: (props: Props, ref: React$Ref<ElementType>) => React$Node,
+  compare: void | null | ((oldProps: Props, newProps: Props) => boolean),
+};
+
 export default function forwardRef<Props, ElementType: React$ElementType>(
   render: (props: Props, ref: React$Ref<ElementType>) => React$Node,
-) {
+): ForwardRef<Props> {
   if (__DEV__) {
     if (typeof render !== 'function') {
       warningWithoutStack(
@@ -42,5 +48,6 @@ export default function forwardRef<Props, ElementType: React$ElementType>(
   return {
     $$typeof: REACT_FORWARD_REF_TYPE,
     render,
+    compare: undefined,
   };
 }


### PR DESCRIPTION
This uses a different approach than the moddable approach because that approach also started getting quite complex and affects tags and symbols.

Instead, I just add a `compare` field to forwardRef's element type and use `undefined` to represent the lack of pure wrapper and null to represent the default.

This way we don't affect the perf of pure and when we drop forwardRef we can just drop this path.

This also handles the composition of multiple pure wrappers with custom comparisons.