### PR TITLE
Centralize props memoization

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -230,7 +230,6 @@ function updateForwardRef(
     nextChildren,
     renderExpirationTime,
   );
-  memoizeProps(workInProgress, nextProps);
   return workInProgress.child;
 }
 
@@ -282,7 +281,6 @@ function updatePureComponent(
     nextChildren,
     renderExpirationTime,
   );
-  memoizeProps(workInProgress, nextProps);
   return workInProgress.child;
 }
 
@@ -298,7 +296,6 @@ function updateFragment(
     nextChildren,
     renderExpirationTime,
   );
-  memoizeProps(workInProgress, nextChildren);
   return workInProgress.child;
 }
 
@@ -314,7 +311,6 @@ function updateMode(
     nextChildren,
     renderExpirationTime,
   );
-  memoizeProps(workInProgress, nextChildren);
   return workInProgress.child;
 }
 
@@ -334,7 +330,6 @@ function updateProfiler(
     nextChildren,
     renderExpirationTime,
   );
-  memoizeProps(workInProgress, nextProps);
   return workInProgress.child;
 }
 
@@ -378,7 +373,6 @@ function updateFunctionComponent(
     nextChildren,
     renderExpirationTime,
   );
-  memoizeProps(workInProgress, nextProps);
   return workInProgress.child;
 }
 
@@ -530,10 +524,9 @@ function finishClassComponent(
     );
   }
 
-  // Memoize props and state using the values we just used to render.
+  // Memoize state using the values we just used to render.
   // TODO: Restructure so we never read values from the instance.
   memoizeState(workInProgress, instance.state);
-  memoizeProps(workInProgress, instance.props);
 
   // The context might have changed so we need to recalculate it.
   if (hasContext) {
@@ -667,7 +660,6 @@ function updateHostComponent(current, workInProgress, renderExpirationTime) {
   ) {
     // Schedule this fiber to re-render at offscreen priority. Then bailout.
     workInProgress.expirationTime = Never;
-    workInProgress.memoizedProps = nextProps;
     return null;
   }
 
@@ -677,7 +669,6 @@ function updateHostComponent(current, workInProgress, renderExpirationTime) {
     nextChildren,
     renderExpirationTime,
   );
-  memoizeProps(workInProgress, nextProps);
   return workInProgress.child;
 }
 
@@ -685,8 +676,6 @@ function updateHostText(current, workInProgress) {
   if (current === null) {
     tryToClaimNextHydratableInstance(workInProgress);
   }
-  const nextProps = workInProgress.pendingProps;
-  memoizeProps(workInProgress, nextProps);
   // Nothing to do here. This is terminal. We'll do the completion step
   // immediately after.
   return null;
@@ -796,7 +785,6 @@ function mountIndeterminateComponent(
         );
       }
     }
-    workInProgress.memoizedProps = props;
     return child;
   }
 
@@ -945,7 +933,6 @@ function mountIndeterminateComponent(
       }
     }
     reconcileChildren(null, workInProgress, value, renderExpirationTime);
-    memoizeProps(workInProgress, props);
     return workInProgress.child;
   }
 }
@@ -1156,7 +1143,6 @@ function updateSuspenseComponent(
     }
   }
 
-  workInProgress.memoizedProps = nextProps;
   workInProgress.memoizedState = nextState;
   workInProgress.child = child;
   return next;
@@ -1181,7 +1167,6 @@ function updatePortalComponent(
       nextChildren,
       renderExpirationTime,
     );
-    memoizeProps(workInProgress, nextChildren);
   } else {
     reconcileChildren(
       current,
@@ -1189,7 +1174,6 @@ function updatePortalComponent(
       nextChildren,
       renderExpirationTime,
     );
-    memoizeProps(workInProgress, nextChildren);
   }
   return workInProgress.child;
 }
@@ -1206,7 +1190,6 @@ function updateContextProvider(
   const oldProps = workInProgress.memoizedProps;
 
   const newValue = newProps.value;
-  workInProgress.memoizedProps = newProps;
 
   if (__DEV__) {
     const providerPropTypes = workInProgress.type.propTypes;
@@ -1318,7 +1301,6 @@ function updateContextConsumer(
   // React DevTools reads this flag.
   workInProgress.effectTag |= PerformedWork;
   reconcileChildren(current, workInProgress, newChildren, renderExpirationTime);
-  workInProgress.memoizedProps = newProps;
   return workInProgress.child;
 }
 
@@ -1376,11 +1358,7 @@ function bailoutOnAlreadyFinishedWork(
   }
 }
 
-// TODO: Delete memoizeProps/State and move to reconcile/bailout instead
-function memoizeProps(workInProgress: Fiber, nextProps: any) {
-  workInProgress.memoizedProps = nextProps;
-}
-
+// TODO: Delete memoizeState and move to reconcile/bailout instead
 function memoizeState(workInProgress: Fiber, nextState: any) {
   workInProgress.memoizedState = nextState;
   // Don't reset the updateQueue, in case there are pending updates. Resetting
@@ -1508,7 +1486,6 @@ function beginWork(
         resolveDefaultProps(Component, unresolvedProps),
         renderExpirationTime,
       );
-      workInProgress.memoizedProps = unresolvedProps;
       return child;
     }
     case ClassComponent: {
@@ -1533,7 +1510,6 @@ function beginWork(
         resolveDefaultProps(Component, unresolvedProps),
         renderExpirationTime,
       );
-      workInProgress.memoizedProps = unresolvedProps;
       return child;
     }
     case HostRoot:
@@ -1575,7 +1551,6 @@ function beginWork(
         resolveDefaultProps(Component, unresolvedProps),
         renderExpirationTime,
       );
-      workInProgress.memoizedProps = unresolvedProps;
       return child;
     }
     case Fragment:
@@ -1619,7 +1594,6 @@ function beginWork(
         updateExpirationTime,
         renderExpirationTime,
       );
-      workInProgress.memoizedProps = unresolvedProps;
       return child;
     }
     default:

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -526,7 +526,7 @@ function finishClassComponent(
 
   // Memoize state using the values we just used to render.
   // TODO: Restructure so we never read values from the instance.
-  memoizeState(workInProgress, instance.state);
+  workInProgress.memoizedState = instance.state;
 
   // The context might have changed so we need to recalculate it.
   if (hasContext) {
@@ -1356,13 +1356,6 @@ function bailoutOnAlreadyFinishedWork(
     cloneChildFibers(current, workInProgress);
     return workInProgress.child;
   }
-}
-
-// TODO: Delete memoizeState and move to reconcile/bailout instead
-function memoizeState(workInProgress: Fiber, nextState: any) {
-  workInProgress.memoizedState = nextState;
-  // Don't reset the updateQueue, in case there are pending updates. Resetting
-  // is handled by processUpdateQueue.
 }
 
 function beginWork(

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1086,6 +1086,7 @@ function performUnitOfWork(workInProgress: Fiber): Fiber | null {
     }
 
     next = beginWork(current, workInProgress, nextRenderExpirationTime);
+    workInProgress.memoizedProps = workInProgress.pendingProps;
 
     if (workInProgress.mode & ProfileMode) {
       // Record the render duration assuming we didn't bailout (or error).
@@ -1093,6 +1094,7 @@ function performUnitOfWork(workInProgress: Fiber): Fiber | null {
     }
   } else {
     next = beginWork(current, workInProgress, nextRenderExpirationTime);
+    workInProgress.memoizedProps = workInProgress.pendingProps;
   }
 
   if (__DEV__) {


### PR DESCRIPTION
We compare pendingProps against memoizedProps in beginWork so we already have strong assumptions that can't vary by branch. So we can simplify this which lets us get rid of the special case in lazy.