### PR TITLE
Always bail out timed out children even if they receive an update

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1093,6 +1093,7 @@ function updateSuspenseComponent(
         ));
         fallbackChildFragment.effectTag |= Placement;
         child = primaryChildFragment;
+        primaryChildFragment.expirationTime = primaryChildFragment.childExpirationTime = NoWork;
         // Skip the primary children, and continue working on the
         // fallback children.
         next = fallbackChildFragment;
@@ -1147,6 +1148,7 @@ function updateSuspenseComponent(
         ));
         fallbackChildFragment.effectTag |= Placement;
         child = primaryChildFragment;
+        primaryChildFragment.expirationTime = primaryChildFragment.childExpirationTime = NoWork;
         // Skip the primary children, and continue working on the
         // fallback children.
         next = fallbackChildFragment;
@@ -1464,6 +1466,7 @@ function beginWork(
             const nextState = workInProgress.memoizedState;
             const nextDidTimeout = nextState !== null && nextState.didTimeout;
             if (nextDidTimeout) {
+              child.expirationTime = child.childExpirationTime = NoWork;
               return child.sibling;
             } else {
               return child;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1093,7 +1093,7 @@ function updateSuspenseComponent(
         ));
         fallbackChildFragment.effectTag |= Placement;
         child = primaryChildFragment;
-        primaryChildFragment.expirationTime = primaryChildFragment.childExpirationTime = NoWork;
+        primaryChildFragment.childExpirationTime = NoWork;
         // Skip the primary children, and continue working on the
         // fallback children.
         next = fallbackChildFragment;
@@ -1148,7 +1148,7 @@ function updateSuspenseComponent(
         ));
         fallbackChildFragment.effectTag |= Placement;
         child = primaryChildFragment;
-        primaryChildFragment.expirationTime = primaryChildFragment.childExpirationTime = NoWork;
+        primaryChildFragment.childExpirationTime = NoWork;
         // Skip the primary children, and continue working on the
         // fallback children.
         next = fallbackChildFragment;
@@ -1466,7 +1466,7 @@ function beginWork(
             const nextState = workInProgress.memoizedState;
             const nextDidTimeout = nextState !== null && nextState.didTimeout;
             if (nextDidTimeout) {
-              child.expirationTime = child.childExpirationTime = NoWork;
+              child.childExpirationTime = NoWork;
               return child.sibling;
             } else {
               return child;


### PR DESCRIPTION
I moved resetChildExpirationTime to ReactFiberCompleteWork so we can insert an additional reset only for SuspenseComponent.