### PR TITLE
Allow arbitrary types to be wrapped in pure

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -299,6 +299,14 @@ function shouldConstruct(Component: Function) {
   return !!(prototype && prototype.isReactComponent);
 }
 
+export function isSimpleFunctionComponent(type: any) {
+  return (
+    typeof type === 'function' &&
+    !shouldConstruct(type) &&
+    type.defaultProps === undefined
+  );
+}
+
 export function resolveLazyComponentTag(Component: Function): WorkTag {
   if (typeof Component === 'function') {
     return shouldConstruct(Component) ? ClassComponent : FunctionComponent;

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -299,10 +299,7 @@ function shouldConstruct(Component: Function) {
   return !!(prototype && prototype.isReactComponent);
 }
 
-export function resolveLazyComponentTag(
-  fiber: Fiber,
-  Component: Function,
-): WorkTag {
+export function resolveLazyComponentTag(Component: Function): WorkTag {
   if (typeof Component === 'function') {
     return shouldConstruct(Component) ? ClassComponent : FunctionComponent;
   } else if (Component !== undefined && Component !== null) {
@@ -406,20 +403,15 @@ export function createHostRootFiber(isConcurrent: boolean): Fiber {
   return createFiber(HostRoot, null, null, mode);
 }
 
-function createFiberFromElementWithoutDebugInfo(
-  element: ReactElement,
+export function createFiberFromTypeAndProps(
+  type: any, // React$ElementType
+  key: null | string,
+  pendingProps: any,
+  owner: null | Fiber,
   mode: TypeOfMode,
   expirationTime: ExpirationTime,
 ): Fiber {
-  let owner = null;
-  if (__DEV__) {
-    owner = element._owner;
-  }
-
   let fiber;
-  const type = element.type;
-  const key = element.key;
-  const pendingProps = element.props;
 
   let fiberTag = IndeterminateComponent;
   // The resolved type is set if we know what the final type will be. I.e. it's not lazy.
@@ -522,8 +514,18 @@ export function createFiberFromElement(
   mode: TypeOfMode,
   expirationTime: ExpirationTime,
 ): Fiber {
-  const fiber = createFiberFromElementWithoutDebugInfo(
-    element,
+  let owner = null;
+  if (__DEV__) {
+    owner = element._owner;
+  }
+  const type = element.type;
+  const key = element.key;
+  const pendingProps = element.props;
+  const fiber = createFiberFromTypeAndProps(
+    type,
+    key,
+    pendingProps,
+    owner,
     mode,
     expirationTime,
   );

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -35,6 +35,7 @@ import {
   Profiler,
   SuspenseComponent,
   PureComponent,
+  SimplePureComponent,
   LazyComponent,
 } from 'shared/ReactWorkTags';
 import {Placement, Ref, Update} from 'shared/ReactSideEffectTags';
@@ -539,6 +540,7 @@ function completeWork(
       break;
     case LazyComponent:
       break;
+    case SimplePureComponent:
     case FunctionComponent:
       break;
     case ClassComponent: {

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -415,8 +415,7 @@ exports[`ReactDebugFiberPerf supports pure 1`] = `
 
 ⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
-    ⚛ Pure(Foo) [mount]
-      ⚛ Foo [mount]
+    ⚛ Foo [mount]
 
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -416,6 +416,7 @@ exports[`ReactDebugFiberPerf supports pure 1`] = `
 ⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
     ⚛ Pure(Foo) [mount]
+      ⚛ Foo [mount]
 
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -28,6 +28,7 @@ import {
   ForwardRef,
   Profiler,
   PureComponent,
+  SimplePureComponent,
 } from 'shared/ReactWorkTags';
 import invariant from 'shared/invariant';
 import ReactVersion from 'shared/ReactVersion';
@@ -166,6 +167,7 @@ function toTree(node: ?Fiber) {
         rendered: childrenToTree(node.child),
       };
     case FunctionComponent:
+    case SimplePureComponent:
       return {
         nodeType: 'component',
         type: node.type,

--- a/packages/react/src/pure.js
+++ b/packages/react/src/pure.js
@@ -7,34 +7,26 @@
 
 import {REACT_PURE_TYPE} from 'shared/ReactSymbols';
 
+import isValidElementType from 'shared/isValidElementType';
 import warningWithoutStack from 'shared/warningWithoutStack';
 
 export default function pure<Props>(
-  render: (props: Props) => React$Node,
+  type: React$ElementType,
   compare?: (oldProps: Props, newProps: Props) => boolean,
 ) {
   if (__DEV__) {
-    if (typeof render !== 'function') {
+    if (!isValidElementType(type)) {
       warningWithoutStack(
         false,
-        'pure: The first argument must be a function component. Instead ' +
+        'pure: The first argument must be a component. Instead ' +
           'received: %s',
-        render === null ? 'null' : typeof render,
+        type === null ? 'null' : typeof type,
       );
-    } else {
-      const prototype = render.prototype;
-      if (prototype && prototype.isReactComponent) {
-        warningWithoutStack(
-          false,
-          'pure: The first argument must be a function component. Classes ' +
-            'are not supported. Use React.PureComponent instead.',
-        );
-      }
     }
   }
   return {
     $$typeof: REACT_PURE_TYPE,
-    render,
+    type,
     compare: compare === undefined ? null : compare,
   };
 }

--- a/packages/shared/ReactWorkTags.js
+++ b/packages/shared/ReactWorkTags.js
@@ -43,4 +43,5 @@ export const ForwardRef = 11;
 export const Profiler = 12;
 export const SuspenseComponent = 13;
 export const PureComponent = 14;
-export const LazyComponent = 15;
+export const SimplePureComponent = 15;
+export const LazyComponent = 16;

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -80,7 +80,7 @@ function getComponentName(type: mixed): string | null {
       case REACT_FORWARD_REF_TYPE:
         return getWrappedName(type, type.render, 'ForwardRef');
       case REACT_PURE_TYPE:
-        return getWrappedName(type, type.type, 'Pure');
+        return getComponentName(type.type);
       case REACT_LAZY_TYPE: {
         const thenable: LazyComponent<mixed> = (type: any);
         const resolvedThenable = refineResolvedLazyComponent(thenable);

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -80,7 +80,7 @@ function getComponentName(type: mixed): string | null {
       case REACT_FORWARD_REF_TYPE:
         return getWrappedName(type, type.render, 'ForwardRef');
       case REACT_PURE_TYPE:
-        return getWrappedName(type, type.render, 'Pure');
+        return getWrappedName(type, type.type, 'Pure');
       case REACT_LAZY_TYPE: {
         const thenable: LazyComponent<mixed> = (type: any);
         const resolvedThenable = refineResolvedLazyComponent(thenable);


### PR DESCRIPTION
First I made the PureComponent a slow path. This creates an outer fiber that container the pure check and an inner fiber that represents which ever type of component.

Then I added an optimized fast path for simple pure function components. This is special cased when there are no defaultProps and it's a simple function component instead of class. This doesn't require an extra fiber.

We could make it so that this also works with custom comparer but that means we have to go through one extra indirection to get to it. Maybe it's worth it, donno.
