### PR TITLE
[Synchronous Suspense] Unmounting a suspended class component

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -496,6 +496,9 @@ function commitUnmount(current: Fiber): void {
       safelyDetachRef(current);
       const instance = current.stateNode;
       if (
+        // Typically, a component that mounted will have an instance. However,
+        // outside of concurrent mode, a suspended component may commit without
+        // an instance, so we need to check whether it exists.
         instance !== null &&
         typeof instance.componentWillUnmount === 'function'
       ) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -495,7 +495,10 @@ function commitUnmount(current: Fiber): void {
     case ClassComponent: {
       safelyDetachRef(current);
       const instance = current.stateNode;
-      if (typeof instance.componentWillUnmount === 'function') {
+      if (
+        instance !== null &&
+        typeof instance.componentWillUnmount === 'function'
+      ) {
         safelyCallComponentWillUnmount(current, instance);
       }
       return;


### PR DESCRIPTION
Previously we assumed any mounted class component would have an instance, but that's not the case for classes that suspend outside of Concurrent mode.