### PR TITLE
[Synchronous Suspense] Suspending a class outside concurrent mode

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -33,7 +33,7 @@ import {
   MemoComponent,
   SimpleMemoComponent,
   LazyComponent,
-  IncompleteComponent,
+  IncompleteClassComponent,
 } from 'shared/ReactWorkTags';
 import {
   NoEffect,
@@ -841,9 +841,11 @@ function mountLazyComponent(
   return child;
 }
 
-function mountIncompleteComponent(
+function mountIncompleteClassComponent(
   _current,
   workInProgress,
+  Component,
+  nextProps,
   renderExpirationTime,
 ) {
   if (_current !== null) {
@@ -859,12 +861,6 @@ function mountIncompleteComponent(
 
   // Promote the fiber to a class and try rendering again.
   workInProgress.tag = ClassComponent;
-  const Component = workInProgress.type;
-  const unresolvedProps = workInProgress.pendingProps;
-  const resolvedProps =
-    workInProgress.elementType === Component
-      ? unresolvedProps
-      : resolveDefaultProps(Component, unresolvedProps);
 
   // The rest of this function is a fork of `updateClassComponent`
 
@@ -883,13 +879,13 @@ function mountIncompleteComponent(
   constructClassInstance(
     workInProgress,
     Component,
-    resolvedProps,
+    nextProps,
     renderExpirationTime,
   );
   mountClassInstance(
     workInProgress,
     Component,
-    resolvedProps,
+    nextProps,
     renderExpirationTime,
   );
 
@@ -1717,10 +1713,18 @@ function beginWork(
         renderExpirationTime,
       );
     }
-    case IncompleteComponent: {
-      return mountIncompleteComponent(
+    case IncompleteClassComponent: {
+      const Component = workInProgress.type;
+      const unresolvedProps = workInProgress.pendingProps;
+      const resolvedProps =
+        workInProgress.elementType === Component
+          ? unresolvedProps
+          : resolveDefaultProps(Component, unresolvedProps);
+      return mountIncompleteClassComponent(
         current,
         workInProgress,
+        Component,
+        resolvedProps,
         renderExpirationTime,
       );
     }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -33,6 +33,7 @@ import {
   MemoComponent,
   SimpleMemoComponent,
   LazyComponent,
+  IncompleteComponent,
 } from 'shared/ReactWorkTags';
 import {
   NoEffect,
@@ -762,7 +763,7 @@ function mountLazyComponent(
   renderExpirationTime,
 ) {
   if (_current !== null) {
-    // An indeterminate component only mounts if it suspended inside a non-
+    // An lazy component only mounts if it suspended inside a non-
     // concurrent tree, in an inconsistent state. We want to tree it like
     // a new mount, even though an empty version of it already committed.
     // Disconnect the alternate pointers.
@@ -838,6 +839,68 @@ function mountLazyComponent(
     }
   }
   return child;
+}
+
+function mountIncompleteComponent(
+  _current,
+  workInProgress,
+  renderExpirationTime,
+) {
+  if (_current !== null) {
+    // An incomplete component only mounts if it suspended inside a non-
+    // concurrent tree, in an inconsistent state. We want to tree it like
+    // a new mount, even though an empty version of it already committed.
+    // Disconnect the alternate pointers.
+    _current.alternate = null;
+    workInProgress.alternate = null;
+    // Since this is conceptually a new fiber, schedule a Placement effect
+    workInProgress.effectTag |= Placement;
+  }
+
+  // Promote the fiber to a class and try rendering again.
+  workInProgress.tag = ClassComponent;
+  const Component = workInProgress.type;
+  const unresolvedProps = workInProgress.pendingProps;
+  const resolvedProps =
+    workInProgress.elementType === Component
+      ? unresolvedProps
+      : resolveDefaultProps(Component, unresolvedProps);
+
+  // The rest of this function is a fork of `updateClassComponent`
+
+  // Push context providers early to prevent context stack mismatches.
+  // During mounting we don't know the child context yet as the instance doesn't exist.
+  // We will invalidate the child context in finishClassComponent() right after rendering.
+  let hasContext;
+  if (isLegacyContextProvider(Component)) {
+    hasContext = true;
+    pushLegacyContextProvider(workInProgress);
+  } else {
+    hasContext = false;
+  }
+  prepareToReadContext(workInProgress, renderExpirationTime);
+
+  constructClassInstance(
+    workInProgress,
+    Component,
+    resolvedProps,
+    renderExpirationTime,
+  );
+  mountClassInstance(
+    workInProgress,
+    Component,
+    resolvedProps,
+    renderExpirationTime,
+  );
+
+  return finishClassComponent(
+    null,
+    workInProgress,
+    Component,
+    true,
+    hasContext,
+    renderExpirationTime,
+  );
 }
 
 function mountIndeterminateComponent(
@@ -1651,6 +1714,13 @@ function beginWork(
         workInProgress.type,
         workInProgress.pendingProps,
         updateExpirationTime,
+        renderExpirationTime,
+      );
+    }
+    case IncompleteComponent: {
+      return mountIncompleteComponent(
+        current,
+        workInProgress,
         renderExpirationTime,
       );
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -32,6 +32,7 @@ import {
   HostPortal,
   Profiler,
   SuspenseComponent,
+  IncompleteComponent,
 } from 'shared/ReactWorkTags';
 import {
   invokeGuardedCallback,
@@ -221,6 +222,7 @@ function commitBeforeMutationLifeCycles(
     case HostComponent:
     case HostText:
     case HostPortal:
+    case IncompleteComponent:
       // Nothing to do for these component types
       return;
     default: {
@@ -392,6 +394,8 @@ function commitLifeCycles(
       }
       return;
     }
+    case IncompleteComponent:
+      break;
     default: {
       invariant(
         false,
@@ -495,7 +499,13 @@ function commitUnmount(current: Fiber): void {
     case ClassComponent: {
       safelyDetachRef(current);
       const instance = current.stateNode;
-      if (typeof instance.componentWillUnmount === 'function') {
+      if (
+        // Typically, a component that mounted will have an instance. However,
+        // outside of concurrent mode, a suspended component may commit without
+        // an instance, so we need to check whether it exists.
+        instance !== null &&
+        typeof instance.componentWillUnmount === 'function'
+      ) {
         safelyCallComponentWillUnmount(current, instance);
       }
       return;
@@ -922,6 +932,9 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       return;
     }
     case SuspenseComponent: {
+      return;
+    }
+    case IncompleteComponent: {
       return;
     }
     default: {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -32,7 +32,7 @@ import {
   HostPortal,
   Profiler,
   SuspenseComponent,
-  IncompleteComponent,
+  IncompleteClassComponent,
 } from 'shared/ReactWorkTags';
 import {
   invokeGuardedCallback,
@@ -222,7 +222,7 @@ function commitBeforeMutationLifeCycles(
     case HostComponent:
     case HostText:
     case HostPortal:
-    case IncompleteComponent:
+    case IncompleteClassComponent:
       // Nothing to do for these component types
       return;
     default: {
@@ -394,7 +394,7 @@ function commitLifeCycles(
       }
       return;
     }
-    case IncompleteComponent:
+    case IncompleteClassComponent:
       break;
     default: {
       invariant(
@@ -934,7 +934,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
     case SuspenseComponent: {
       return;
     }
-    case IncompleteComponent: {
+    case IncompleteClassComponent: {
       return;
     }
     default: {

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -37,7 +37,7 @@ import {
   MemoComponent,
   SimpleMemoComponent,
   LazyComponent,
-  IncompleteComponent,
+  IncompleteClassComponent,
 } from 'shared/ReactWorkTags';
 import {Placement, Ref, Update} from 'shared/ReactSideEffectTags';
 import invariant from 'shared/invariant';
@@ -718,7 +718,7 @@ function completeWork(
       break;
     case MemoComponent:
       break;
-    case IncompleteComponent: {
+    case IncompleteClassComponent: {
       // Same as class component case. I put it down here so that the tags are
       // sequential to ensure this switch is compiled to a jump table.
       const Component = workInProgress.type;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -37,6 +37,7 @@ import {
   MemoComponent,
   SimpleMemoComponent,
   LazyComponent,
+  IncompleteComponent,
 } from 'shared/ReactWorkTags';
 import {Placement, Ref, Update} from 'shared/ReactSideEffectTags';
 import invariant from 'shared/invariant';
@@ -717,6 +718,15 @@ function completeWork(
       break;
     case MemoComponent:
       break;
+    case IncompleteComponent: {
+      // Same as class component case. I put it down here so that the tags are
+      // sequential to ensure this switch is compiled to a jump table.
+      const Component = workInProgress.type;
+      if (isLegacyContextProvider(Component)) {
+        popLegacyContext(workInProgress);
+      }
+      break;
+    }
     default:
       invariant(
         false,

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -25,7 +25,7 @@ import {
   HostPortal,
   ContextProvider,
   SuspenseComponent,
-  IncompleteComponent,
+  IncompleteClassComponent,
 } from 'shared/ReactWorkTags';
 import {
   DidCapture,
@@ -258,7 +258,7 @@ function throwException(
               // This is a new mount. Change the tag so it's not mistaken for a
               // completed component. For example, we should not call
               // componentWillUnmount if it is deleted.
-              sourceFiber.tag = IncompleteComponent;
+              sourceFiber.tag = IncompleteClassComponent;
             }
           }
 

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -25,6 +25,7 @@ import {
   HostPortal,
   ContextProvider,
   SuspenseComponent,
+  IncompleteComponent,
 } from 'shared/ReactWorkTags';
 import {
   DidCapture,
@@ -252,10 +253,12 @@ function throwException(
             // But we shouldn't call any lifecycle methods or callbacks. Remove
             // all lifecycle effect tags.
             sourceFiber.effectTag &= ~LifecycleEffectMask;
-            if (sourceFiber.alternate === null) {
-              // Set the instance back to null. We use this as a heuristic to
-              // detect that the fiber mounted in an inconsistent state.
-              sourceFiber.stateNode = null;
+            const current = sourceFiber.alternate;
+            if (current === null) {
+              // This is a new mount. Change the tag so it's not mistaken for a
+              // completed component. For example, we should not call
+              // componentWillUnmount if it is deleted.
+              sourceFiber.tag = IncompleteComponent;
             }
           }
 

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -29,6 +29,7 @@ import {
   Profiler,
   MemoComponent,
   SimpleMemoComponent,
+  IncompleteComponent,
 } from 'shared/ReactWorkTags';
 import invariant from 'shared/invariant';
 import ReactVersion from 'shared/ReactVersion';
@@ -193,6 +194,7 @@ function toTree(node: ?Fiber) {
     case Profiler:
     case ForwardRef:
     case MemoComponent:
+    case IncompleteComponent:
       return childrenToTree(node.child);
     default:
       invariant(

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -29,7 +29,7 @@ import {
   Profiler,
   MemoComponent,
   SimpleMemoComponent,
-  IncompleteComponent,
+  IncompleteClassComponent,
 } from 'shared/ReactWorkTags';
 import invariant from 'shared/invariant';
 import ReactVersion from 'shared/ReactVersion';
@@ -194,7 +194,7 @@ function toTree(node: ?Fiber) {
     case Profiler:
     case ForwardRef:
     case MemoComponent:
-    case IncompleteComponent:
+    case IncompleteClassComponent:
       return childrenToTree(node.child);
     default:
       invariant(

--- a/packages/shared/ReactWorkTags.js
+++ b/packages/shared/ReactWorkTags.js
@@ -45,4 +45,4 @@ export const SuspenseComponent = 13;
 export const MemoComponent = 14;
 export const SimpleMemoComponent = 15;
 export const LazyComponent = 16;
-export const IncompleteComponent = 17;
+export const IncompleteClassComponent = 17;

--- a/packages/shared/ReactWorkTags.js
+++ b/packages/shared/ReactWorkTags.js
@@ -45,3 +45,4 @@ export const SuspenseComponent = 13;
 export const MemoComponent = 14;
 export const SimpleMemoComponent = 15;
 export const LazyComponent = 16;
+export const IncompleteComponent = 17;


### PR DESCRIPTION
When a class component suspends during mount outside concurrent mode, change the tag so it's not mistaken for a completed component. For example, we should not call componentWillUnmount if it is deleted.