### PR TITLE
[react-is] add back proper AsyncMode symbol, for back compat

### DIFF
--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -10,6 +10,7 @@
 'use strict';
 
 import {
+  REACT_ASYNC_MODE_TYPE,
   REACT_CONCURRENT_MODE_TYPE,
   REACT_CONTEXT_TYPE,
   REACT_ELEMENT_TYPE,
@@ -32,6 +33,7 @@ export function typeOf(object: any) {
         const type = object.type;
 
         switch (type) {
+          case REACT_ASYNC_MODE_TYPE:
           case REACT_CONCURRENT_MODE_TYPE:
           case REACT_FRAGMENT_TYPE:
           case REACT_PROFILER_TYPE:
@@ -57,8 +59,8 @@ export function typeOf(object: any) {
   return undefined;
 }
 
-// AsyncMode alias is deprecated along with isAsyncMode
-export const AsyncMode = REACT_CONCURRENT_MODE_TYPE;
+// AsyncMode is deprecated along with isAsyncMode
+export const AsyncMode = REACT_ASYNC_MODE_TYPE;
 export const ConcurrentMode = REACT_CONCURRENT_MODE_TYPE;
 export const ContextConsumer = REACT_CONTEXT_TYPE;
 export const ContextProvider = REACT_PROVIDER_TYPE;
@@ -86,7 +88,7 @@ export function isAsyncMode(object: any) {
       );
     }
   }
-  return isConcurrentMode(object);
+  return isConcurrentMode(object) || typeOf(object) === REACT_ASYNC_MODE_TYPE;
 }
 export function isConcurrentMode(object: any) {
   return typeOf(object) === REACT_CONCURRENT_MODE_TYPE;

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -69,7 +69,7 @@ describe('ReactIs', () => {
     expect(ReactIs.isValidElementType({type: 'div', props: {}})).toEqual(false);
   });
 
-  it('should identify async mode', () => {
+  it('should identify concurrent mode', () => {
     expect(ReactIs.typeOf(<React.unstable_ConcurrentMode />)).toBe(
       ReactIs.ConcurrentMode,
     );

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -32,6 +32,9 @@ export const REACT_PROVIDER_TYPE = hasSymbol
 export const REACT_CONTEXT_TYPE = hasSymbol
   ? Symbol.for('react.context')
   : 0xeace;
+export const REACT_ASYNC_MODE_TYPE = hasSymbol
+  ? Symbol.for('react.async_mode')
+  : 0xeacf;
 export const REACT_CONCURRENT_MODE_TYPE = hasSymbol
   ? Symbol.for('react.concurrent_mode')
   : 0xeacf;

--- a/packages/shared/__tests__/ReactSymbols-test.internal.js
+++ b/packages/shared/__tests__/ReactSymbols-test.internal.js
@@ -31,7 +31,12 @@ describe('ReactSymbols', () => {
     const originalSymbolFor = global.Symbol.for;
     global.Symbol.for = null;
     try {
-      expectToBeUnique(Object.entries(require('shared/ReactSymbols')));
+      const entries = Object.entries(require('shared/ReactSymbols')).filter(
+        // REACT_ASYNC_MODE_TYPE and REACT_CONCURRENT_MODE_TYPE have the same numeric value
+        // for legacy backwards compatibility
+        ([key]) => key !== 'REACT_ASYNC_MODE_TYPE',
+      );
+      expectToBeUnique(entries);
     } finally {
       global.Symbol.for = originalSymbolFor;
     }


### PR DESCRIPTION
 - Partial revert of #13732
 - Fixes #13958.

I didn't add tests for `isAsyncMode` because #13732 didn't preserve any - happy to add them if needed.