### PR TITLE
chore(tests): don't rely on jest fake timers scheduling real timers

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.internal.js
@@ -43,9 +43,8 @@ describe('ReactDOMSuspensePlaceholder', () => {
     }
     jest.advanceTimersByTime(ms);
     // Wait until the end of the current tick
-    return new Promise(resolve => {
-      setImmediate(resolve);
-    });
+    // We cannot use a timer since we're faking them
+    return Promise.resolve().then(() => {});
   }
 
   function Text(props) {

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -62,9 +62,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
     jest.advanceTimersByTime(ms);
     // Wait until the end of the current tick
-    return new Promise(resolve => {
-      setImmediate(resolve);
-    });
+    // We cannot use a timer since we're faking them
+    return Promise.resolve().then(() => {});
   }
 
   function Text(props) {

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -2194,9 +2194,8 @@ describe('Profiler', () => {
       function awaitableAdvanceTimers(ms) {
         jest.advanceTimersByTime(ms);
         // Wait until the end of the current tick
-        return new Promise(resolve => {
-          setImmediate(resolve);
-        });
+        // We cannot use a timer since we're faking them
+        return Promise.resolve().then(() => {});
       }
 
       it('traces both the temporary placeholder and the finished render for an interaction', async () => {

--- a/packages/react/src/__tests__/ReactProfilerDOM-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDOM-test.internal.js
@@ -18,15 +18,6 @@ let ReactCache;
 function initEnvForAsyncTesting() {
   // Boilerplate copied from ReactDOMRoot-test
   // TODO pull this into helper method, reduce repetition.
-  const originalDateNow = Date.now;
-  global.Date.now = function() {
-    return originalDateNow();
-  };
-  global.requestAnimationFrame = function(cb) {
-    return setTimeout(() => {
-      cb(Date.now());
-    });
-  };
   const originalAddEventListener = global.addEventListener;
   let postMessageCallback;
   global.addEventListener = function(eventName, callback, useCapture) {
@@ -140,7 +131,7 @@ describe('ProfilerDOM', () => {
 
               // Evaluate in an unwrapped callback,
               // Because trace/wrap won't decrement the count within the wrapped callback.
-              setImmediate(() => {
+              Promise.resolve().then(() => {
                 expect(onInteractionTraced).toHaveBeenCalledTimes(1);
                 expect(
                   onInteractionScheduledWorkCompleted,

--- a/packages/react/src/__tests__/ReactProfilerDOM-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDOM-test.internal.js
@@ -18,6 +18,12 @@ let ReactCache;
 function initEnvForAsyncTesting() {
   // Boilerplate copied from ReactDOMRoot-test
   // TODO pull this into helper method, reduce repetition.
+  // TODO remove `requestAnimationFrame` when upgrading to Jest 24 with Lolex
+  global.requestAnimationFrame = function(cb) {
+    return setTimeout(() => {
+      cb(Date.now());
+    });
+  };
   const originalAddEventListener = global.addEventListener;
   let postMessageCallback;
   global.addEventListener = function(eventName, callback, useCapture) {


### PR DESCRIPTION
I'm currently working on replacing Jest's custom fake timers implementation with Lolex (https://github.com/facebook/jest/pull/5171). As part of that, I wanted to test that React's tests still work. They didn't...

A quirk of Jest's current implementation is that we schedule `process.nextTick` and `setImmediate` on the real timers, even though they're faked. Then we just make sure to do nothing if Jest invoked the function when advancing time, or vice versa if Node triggered it before us. That behavior is intentionally _not_ re-implemented in the new version.

This PR changes from using `setImmediate` to `Promise.resolve().then()` to "wait 1 tick" which behaves the same.