### PR TITLE
Add command to rollup to sync React Native renderer in OSS

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -61,6 +61,7 @@ const requestedBundleNames = (argv._[0] || '')
   .map(type => type.toLowerCase());
 const forcePrettyOutput = argv.pretty;
 const syncFBSourcePath = argv['sync-fbsource'];
+const syncOpenSourcePath = argv['sync-opensource'];
 const syncWWWPath = argv['sync-www'];
 const shouldExtractErrors = argv['extract-errors'];
 const errorCodeOpts = {
@@ -614,6 +615,8 @@ async function buildEverything() {
     await Sync.syncReactNative(syncFBSourcePath);
   } else if (syncWWWPath) {
     await Sync.syncReactDom('build/facebook-www', syncWWWPath);
+  } else if (syncOpenSourcePath) {
+    await Sync.syncReactNativeOSS(syncOpenSourcePath);
   }
 
   console.log(Stats.printResults());

--- a/scripts/rollup/sync.js
+++ b/scripts/rollup/sync.js
@@ -8,6 +8,7 @@ const DEFAULT_FB_SOURCE_PATH = '~/fbsource/';
 const DEFAULT_WWW_PATH = '~/www/';
 const RELATIVE_RN_OSS_PATH = 'xplat/js/react-native-github/Libraries/Renderer/';
 const RELATIVE_WWW_PATH = 'html/shared/react/';
+const RELATIVE_RN_PATH = 'Libraries/Renderer/';
 
 async function doSync(buildPath, destPath) {
   console.log(`${chalk.bgYellow.black(' SYNCING ')} React to ${destPath}`);
@@ -51,7 +52,16 @@ async function syncReactNative(fbSourcePath) {
   );
 }
 
+async function syncReactNativeOSS(openSourcePath) {
+  await syncReactNativeHelper(
+    'build/react-native',
+    openSourcePath,
+    RELATIVE_RN_PATH
+  );
+}
+
 module.exports = {
   syncReactDom,
   syncReactNative,
+  syncReactNativeOSS,
 };


### PR DESCRIPTION
This pull request adds a new `--sync-opensource` command to the rollup build script.

This differs from `--sync-fbsource`, because it tries to sync to this path:

    {PROVIDED PATH}/xplat/js/react-native-github/Libraries/Renderer/

While `--sync-opensource` will sync to:

    {PROVIDED PATH}/Libraries/Renderer/

This will make it easier for OSS users to update the React Native renderer to an alpha version of React for testing/tinkering. (Not recommended to send the RN repo bug reports as a result of doing this, however!)

Usage is like this:

```bash
> yarn build --sync-opensource=/path/to/react-native --type=RN_OSS
```