### PR TITLE
[scheduler] Deadline object -> shouldYield

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -8,6 +8,7 @@
 export {
   unstable_now as now,
   unstable_scheduleCallback as scheduleDeferredCallback,
+  unstable_shouldYield as shouldYield,
   unstable_cancelCallback as cancelDeferredCallback,
 } from 'scheduler';
 import Transform from 'art/core/transform';

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -65,6 +65,7 @@ export type NoTimeout = -1;
 export {
   unstable_now as now,
   unstable_scheduleCallback as scheduleDeferredCallback,
+  unstable_shouldYield as shouldYield,
   unstable_cancelCallback as cancelDeferredCallback,
 } from 'scheduler';
 

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -332,6 +332,7 @@ export const scheduleDeferredCallback =
   ReactNativeFrameScheduling.scheduleDeferredCallback;
 export const cancelDeferredCallback =
   ReactNativeFrameScheduling.cancelDeferredCallback;
+export const shouldYield = ReactNativeFrameScheduling.shouldYield;
 
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -238,6 +238,7 @@ export const scheduleDeferredCallback =
   ReactNativeFrameScheduling.scheduleDeferredCallback;
 export const cancelDeferredCallback =
   ReactNativeFrameScheduling.cancelDeferredCallback;
+export const shouldYield = ReactNativeFrameScheduling.shouldYield;
 
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -271,7 +271,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           scheduledCallbackTimeout === -1 ||
           scheduledCallbackTimeout > newTimeout
         ) {
-          scheduledCallbackTimeout = newTimeout;
+          scheduledCallbackTimeout = elapsedTimeInMs + newTimeout;
         }
       }
       return 0;
@@ -284,6 +284,8 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       scheduledCallback = null;
       scheduledCallbackTimeout = -1;
     },
+
+    shouldYield,
 
     scheduleTimeout: setTimeout,
     cancelTimeout: clearTimeout,
@@ -407,35 +409,44 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
   let yieldedValues = null;
 
+  let didYield;
   let unitsRemaining;
 
-  function* flushUnitsOfWork(n: number): Generator<Array<mixed>, void, void> {
-    let didStop = false;
-    while (!didStop && scheduledCallback !== null) {
-      let cb = scheduledCallback;
-      scheduledCallback = null;
-      unitsRemaining = n;
-      cb({
-        timeRemaining() {
-          if (yieldedValues !== null) {
-            return 0;
-          }
-          if (unitsRemaining-- > 0) {
-            return 999;
-          }
-          didStop = true;
-          return 0;
-        },
-        didTimeout:
-          scheduledCallbackTimeout !== -1 &&
-          elapsedTimeInMs > scheduledCallbackTimeout,
-      });
-
-      if (yieldedValues !== null) {
-        const values = yieldedValues;
-        yieldedValues = null;
-        yield values;
+  function shouldYield() {
+    if (
+      scheduledCallbackTimeout === -1 ||
+      elapsedTimeInMs > scheduledCallbackTimeout
+    ) {
+      return false;
+    } else {
+      if (didYield || yieldedValues !== null) {
+        return true;
       }
+      if (unitsRemaining-- > 0) {
+        return false;
+      }
+      didYield = true;
+      return true;
+    }
+  }
+
+  function* flushUnitsOfWork(n: number): Generator<Array<mixed>, void, void> {
+    unitsRemaining = n + 1;
+    didYield = false;
+    try {
+      while (!didYield && scheduledCallback !== null) {
+        let cb = scheduledCallback;
+        scheduledCallback = null;
+        cb();
+        if (yieldedValues !== null) {
+          const values = yieldedValues;
+          yieldedValues = null;
+          yield values;
+        }
+      }
+    } finally {
+      unitsRemaining = -1;
+      didYield = false;
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -2125,12 +2125,12 @@ function performWork(minExpirationTime: ExpirationTime, isYieldy: boolean) {
       nextFlushedExpirationTime !== NoWork &&
       (minExpirationTime === NoWork ||
         minExpirationTime >= nextFlushedExpirationTime) &&
-      (!didYield || currentRendererTime >= nextFlushedExpirationTime)
+      !(didYield && currentRendererTime < nextFlushedExpirationTime)
     ) {
       performWorkOnRoot(
         nextFlushedRoot,
         nextFlushedExpirationTime,
-        !(currentRendererTime >= nextFlushedExpirationTime),
+        currentRendererTime < nextFlushedExpirationTime,
       );
       findHighestPriorityRoot();
       recomputeCurrentRendererTime();

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -52,6 +52,7 @@ export const shouldDeprioritizeSubtree =
 export const createTextInstance = $$$hostConfig.createTextInstance;
 export const scheduleDeferredCallback = $$$hostConfig.scheduleDeferredCallback;
 export const cancelDeferredCallback = $$$hostConfig.cancelDeferredCallback;
+export const shouldYield = $$$hostConfig.shouldYield;
 export const scheduleTimeout = $$$hostConfig.setTimeout;
 export const cancelTimeout = $$$hostConfig.clearTimeout;
 export const noTimeout = $$$hostConfig.noTimeout;

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -198,6 +198,7 @@ export const scheduleDeferredCallback =
   TestRendererScheduling.scheduleDeferredCallback;
 export const cancelDeferredCallback =
   TestRendererScheduling.cancelDeferredCallback;
+export const shouldYield = TestRendererScheduling.shouldYield;
 
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;

--- a/packages/react-test-renderer/src/ReactTestRendererScheduling.js
+++ b/packages/react-test-renderer/src/ReactTestRendererScheduling.js
@@ -7,15 +7,16 @@
  * @flow
  */
 
-import type {Deadline} from 'react-reconciler/src/ReactFiberScheduler';
-
 // Current virtual time
 export let nowImplementation = () => 0;
-export let scheduledCallback: ((deadline: Deadline) => mixed) | null = null;
+export let scheduledCallback: (() => mixed) | null = null;
 export let yieldedValues: Array<mixed> = [];
 
+let didStop: boolean = false;
+let expectedNumberOfYields: number = -1;
+
 export function scheduleDeferredCallback(
-  callback: (deadline: Deadline) => mixed,
+  callback: () => mixed,
   options?: {timeout: number},
 ): number {
   scheduledCallback = callback;
@@ -31,21 +32,25 @@ export function setNowImplementation(implementation: () => number): void {
   nowImplementation = implementation;
 }
 
+export function shouldYield() {
+  if (
+    expectedNumberOfYields !== -1 &&
+    yieldedValues.length >= expectedNumberOfYields
+  ) {
+    // We at least as many values as expected. Stop rendering.
+    didStop = true;
+    return true;
+  }
+  // Keep rendering.
+  return false;
+}
+
 export function flushAll(): Array<mixed> {
   yieldedValues = [];
   while (scheduledCallback !== null) {
     const cb = scheduledCallback;
     scheduledCallback = null;
-    cb({
-      timeRemaining() {
-        // Keep rendering until there's no more work
-        return 999;
-      },
-      // React's scheduler has its own way of keeping track of expired
-      // work and doesn't read this, so don't bother setting it to the
-      // correct value.
-      didTimeout: false,
-    });
+    cb();
   }
   const values = yieldedValues;
   yieldedValues = [];
@@ -53,30 +58,21 @@ export function flushAll(): Array<mixed> {
 }
 
 export function flushNumberOfYields(count: number): Array<mixed> {
-  let didStop = false;
+  expectedNumberOfYields = count;
+  didStop = false;
   yieldedValues = [];
-  while (scheduledCallback !== null && !didStop) {
-    const cb = scheduledCallback;
-    scheduledCallback = null;
-    cb({
-      timeRemaining() {
-        if (yieldedValues.length >= count) {
-          // We at least as many values as expected. Stop rendering.
-          didStop = true;
-          return 0;
-        }
-        // Keep rendering.
-        return 999;
-      },
-      // React's scheduler has its own way of keeping track of expired
-      // work and doesn't read this, so don't bother setting it to the
-      // correct value.
-      didTimeout: false,
-    });
+  try {
+    while (scheduledCallback !== null && !didStop) {
+      const cb = scheduledCallback;
+      scheduledCallback = null;
+      cb();
+    }
+    return yieldedValues;
+  } finally {
+    expectedNumberOfYields = -1;
+    didStop = false;
+    yieldedValues = [];
   }
-  const values = yieldedValues;
-  yieldedValues = [];
-  return values;
 }
 
 export function yieldValue(value: mixed): void {

--- a/packages/react-test-renderer/src/ReactTestRendererScheduling.js
+++ b/packages/react-test-renderer/src/ReactTestRendererScheduling.js
@@ -37,7 +37,7 @@ export function shouldYield() {
     expectedNumberOfYields !== -1 &&
     yieldedValues.length >= expectedNumberOfYields
   ) {
-    // We at least as many values as expected. Stop rendering.
+    // We yielded at least as many values as expected. Stop rendering.
     didStop = true;
     return true;
   }

--- a/packages/react/src/ReactSharedInternals.js
+++ b/packages/react/src/ReactSharedInternals.js
@@ -8,6 +8,7 @@
 import assign from 'object-assign';
 import {
   unstable_cancelCallback,
+  unstable_shouldYield,
   unstable_now,
   unstable_scheduleCallback,
   unstable_runWithPriority,
@@ -43,6 +44,7 @@ if (__UMD__) {
   Object.assign(ReactSharedInternals, {
     Scheduler: {
       unstable_cancelCallback,
+      unstable_shouldYield,
       unstable_now,
       unstable_scheduleCallback,
       unstable_runWithPriority,

--- a/packages/scheduler/npm/umd/scheduler.development.js
+++ b/packages/scheduler/npm/umd/scheduler.development.js
@@ -39,6 +39,13 @@
     );
   }
 
+  function unstable_shouldYield() {
+    return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler.unstable_shouldYield.apply(
+      this,
+      arguments
+    );
+  }
+
   function unstable_runWithPriority() {
     return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler.unstable_runWithPriority.apply(
       this,
@@ -64,6 +71,7 @@
     unstable_now: unstable_now,
     unstable_scheduleCallback: unstable_scheduleCallback,
     unstable_cancelCallback: unstable_cancelCallback,
+    unstable_shouldYield: unstable_shouldYield,
     unstable_runWithPriority: unstable_runWithPriority,
     unstable_wrapCallback: unstable_wrapCallback,
     unstable_getCurrentPriorityLevel: unstable_getCurrentPriorityLevel,

--- a/packages/scheduler/npm/umd/scheduler.production.min.js
+++ b/packages/scheduler/npm/umd/scheduler.production.min.js
@@ -39,6 +39,13 @@
     );
   }
 
+  function unstable_shouldYield() {
+    return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler.unstable_shouldYield.apply(
+      this,
+      arguments
+    );
+  }
+
   function unstable_runWithPriority() {
     return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler.unstable_runWithPriority.apply(
       this,
@@ -64,6 +71,7 @@
     unstable_now: unstable_now,
     unstable_scheduleCallback: unstable_scheduleCallback,
     unstable_cancelCallback: unstable_cancelCallback,
+    unstable_shouldYield: unstable_shouldYield,
     unstable_runWithPriority: unstable_runWithPriority,
     unstable_wrapCallback: unstable_wrapCallback,
     unstable_getCurrentPriorityLevel: unstable_getCurrentPriorityLevel,

--- a/packages/scheduler/npm/umd/scheduler.profiling.min.js
+++ b/packages/scheduler/npm/umd/scheduler.profiling.min.js
@@ -39,6 +39,13 @@
     );
   }
 
+  function unstable_shouldYield() {
+    return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler.unstable_shouldYield.apply(
+      this,
+      arguments
+    );
+  }
+
   function unstable_runWithPriority() {
     return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler.unstable_runWithPriority.apply(
       this,
@@ -64,6 +71,7 @@
     unstable_now: unstable_now,
     unstable_scheduleCallback: unstable_scheduleCallback,
     unstable_cancelCallback: unstable_cancelCallback,
+    unstable_shouldYield: unstable_shouldYield,
     unstable_runWithPriority: unstable_runWithPriority,
     unstable_wrapCallback: unstable_wrapCallback,
     unstable_getCurrentPriorityLevel: unstable_getCurrentPriorityLevel,

--- a/packages/scheduler/src/__tests__/SchedulerDOM-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerDOM-test.js
@@ -105,9 +105,6 @@ describe('SchedulerDOM', () => {
       scheduleCallback(cb);
       advanceOneFrame({timeLeftInFrame: 15});
       expect(cb).toHaveBeenCalledTimes(1);
-      // should not have timed out and should include a timeRemaining method
-      expect(cb.mock.calls[0][0].didTimeout).toBe(false);
-      expect(typeof cb.mock.calls[0][0].timeRemaining()).toBe('number');
     });
 
     it('inserts its rAF callback as early into the queue as possible', () => {
@@ -144,16 +141,6 @@ describe('SchedulerDOM', () => {
         // after a delay, calls as many callbacks as it has time for
         advanceOneFrame({timeLeftInFrame: 15});
         expect(callbackLog).toEqual(['A', 'B']);
-        // callbackA should not have timed out and should include a timeRemaining method
-        expect(callbackA.mock.calls[0][0].didTimeout).toBe(false);
-        expect(typeof callbackA.mock.calls[0][0].timeRemaining()).toBe(
-          'number',
-        );
-        // callbackA should not have timed out and should include a timeRemaining method
-        expect(callbackB.mock.calls[0][0].didTimeout).toBe(false);
-        expect(typeof callbackB.mock.calls[0][0].timeRemaining()).toBe(
-          'number',
-        );
       });
 
       it("accepts callbacks betweeen animationFrame and postMessage and doesn't stall", () => {

--- a/packages/shared/forks/Scheduler.umd.js
+++ b/packages/shared/forks/Scheduler.umd.js
@@ -15,6 +15,12 @@ const {
   unstable_cancelCallback,
   unstable_now,
   unstable_scheduleCallback,
+  unstable_shouldYield,
 } = ReactInternals.Scheduler;
 
-export {unstable_cancelCallback, unstable_now, unstable_scheduleCallback};
+export {
+  unstable_cancelCallback,
+  unstable_now,
+  unstable_scheduleCallback,
+  unstable_shouldYield,
+};


### PR DESCRIPTION
Instead of using a requestIdleCallback-style deadline object, expose a method Scheduler.shouldYield that returns true if there's a higher priority event in the queue.