### PR TITLE
Show deprecated context object warnings usage in ReactDOM server

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -91,6 +91,7 @@ let validatePropertiesInDevelopment = (type, props) => {};
 let pushCurrentDebugStack = (stack: Array<Frame>) => {};
 let pushElementToDebugStack = (element: ReactElement) => {};
 let popCurrentDebugStack = () => {};
+let hasWarnedAboutUsingContextAsConsumer = false;
 
 if (__DEV__) {
   ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
@@ -1054,9 +1055,35 @@ class ReactDOMServerRenderer {
             return '';
           }
           case REACT_CONTEXT_TYPE: {
-            const consumer: ReactConsumer<any> = (nextChild: any);
-            const nextProps: any = consumer.props;
-            const nextValue = consumer.type._currentValue;
+            let reactContext: ReactContext<any> = nextChild.type;
+            // The logic below for Context differs depending on PROD or DEV mode. In
+            // DEV mode, we create a separate object for Context.Consumer that acts
+            // like a proxy to Context. This proxy object adds unnecessary code in PROD
+            // so we use the old behaviour (Context.Consumer references Context) to
+            // reduce size and overhead. The separate object references context via
+            // a property called "_context", which also gives us the ability to check
+            // in DEV mode if this property exists or not and warn if it does not.
+            if (__DEV__) {
+              if ((reactContext: any)._context === undefined) {
+                // This may be because it's a Context (rather than a Consumer).
+                // Or it may be because it's older React where they're the same thing.
+                // We only want to warn if we're sure it's a new React.
+                if (reactContext !== reactContext.Consumer) {
+                  if (!hasWarnedAboutUsingContextAsConsumer) {
+                    hasWarnedAboutUsingContextAsConsumer = true;
+                    warning(
+                      false,
+                      'Rendering <Context> directly is not supported and will be removed in ' +
+                        'a future major release. Did you mean to render <Context.Consumer> instead?',
+                    );
+                  }
+                }
+              } else {
+                reactContext = (reactContext: any)._context;
+              }
+            }
+            const nextProps: any = nextChild.props;
+            const nextValue = reactContext._currentValue;
 
             const nextChildren = toArray(nextProps.children(nextValue));
             const frame: Frame = {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1051,7 +1051,7 @@ class ReactDOMServerRenderer {
             return '';
           }
           case REACT_CONTEXT_TYPE: {
-            let reactContext: ReactContext<any> = (nextChild: any).type;
+            let reactContext = (nextChild: any).type;
             // The logic below for Context differs depending on PROD or DEV mode. In
             // DEV mode, we create a separate object for Context.Consumer that acts
             // like a proxy to Context. This proxy object adds unnecessary code in PROD

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1055,7 +1055,7 @@ class ReactDOMServerRenderer {
             return '';
           }
           case REACT_CONTEXT_TYPE: {
-            let reactContext: ReactContext<any> = nextChild.type;
+            let reactContext: ReactContext<any> = (nextChild: any).type;
             // The logic below for Context differs depending on PROD or DEV mode. In
             // DEV mode, we create a separate object for Context.Consumer that acts
             // like a proxy to Context. This proxy object adds unnecessary code in PROD
@@ -1082,7 +1082,7 @@ class ReactDOMServerRenderer {
                 reactContext = (reactContext: any)._context;
               }
             }
-            const nextProps: any = nextChild.props;
+            const nextProps: any = (nextChild: any).props;
             const nextValue = reactContext._currentValue;
 
             const nextChildren = toArray(nextProps.children(nextValue));

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -10,7 +10,6 @@
 import type {ReactElement} from 'shared/ReactElementType';
 import type {
   ReactProvider,
-  ReactConsumer,
   ReactContext,
 } from 'shared/ReactTypes';
 

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -8,10 +8,7 @@
  */
 
 import type {ReactElement} from 'shared/ReactElementType';
-import type {
-  ReactProvider,
-  ReactContext,
-} from 'shared/ReactTypes';
+import type {ReactProvider, ReactContext} from 'shared/ReactTypes';
 
 import React from 'react';
 import invariant from 'shared/invariant';


### PR DESCRIPTION
This is a follow up to https://github.com/facebook/react/pull/13829.

This PR adds deprecated context object usage warnings that mirror the same warnings as in  https://github.com/facebook/react/pull/13829. Specifically:

## dev when using consumer: 

- Before: When using `Context.Consumer`, it's the same as `Context` so nothing special is handled.

- After: When `Context.Consumer` is used the at the beginning of reconciliation, the fiber is given the `_context` field from the `Consumer`, that references to `Context`.

## dev when using context:

- Before: When using `Context`, it's the same as the previous case (but the wrong behaviour).

- After: When `Context` we check if `_context` field exists on it (which we added to the new proxy object) and because it won't (only Context.Consumer does) we trigger a new warning.

## prod when using consumer:

- Before & After: When using `Context.Consumer`, it's the same as `Context` so nothing special is handled.

## prod when using context:

- Before & After: When using `Context`, it's the same as the previous case so nothing special is handled.

This behaviour is backwards compatible with previous versions of React.
