### PR TITLE
Rename inputsAreEqual to areHookInputsEqual & move it to shared

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -7,6 +7,7 @@
  * @flow
  */
 import type {ReactContext} from 'shared/ReactTypes';
+import areHookInputsEqual from 'shared/areHookInputsEqual';
 
 import invariant from 'shared/invariant';
 import warning from 'shared/warning';
@@ -236,7 +237,7 @@ function useMemo<T>(
   ) {
     const prevState = workInProgressHook.memoizedState;
     const prevInputs = prevState[1];
-    if (inputsAreEqual(nextInputs, prevInputs)) {
+    if (areHookInputsEqual(nextInputs, prevInputs)) {
       return prevState[0];
     }
   }
@@ -329,25 +330,6 @@ function dispatchAction<A>(
     // returned. On the server this is a no-op. In React Fiber, the update
     // would be scheduled for a future render.
   }
-}
-
-function inputsAreEqual(arr1, arr2) {
-  // Don't bother comparing lengths because these arrays are always
-  // passed inline.
-  for (let i = 0; i < arr1.length; i++) {
-    // Inlined Object.is polyfill.
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
-    const val1 = arr1[i];
-    const val2 = arr2[i];
-    if (
-      (val1 === val2 && (val1 !== 0 || 1 / val1 === 1 / (val2: any))) ||
-      (val1 !== val1 && val2 !== val2) // eslint-disable-line no-self-compare
-    ) {
-      continue;
-    }
-    return false;
-  }
-  return true;
 }
 
 function noop(): void {}

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -36,7 +36,7 @@ import {
 } from './ReactFiberScheduler';
 
 import invariant from 'shared/invariant';
-import warning from 'shared/warning';
+import areHookInputsEqual from 'shared/areHookInputsEqual';
 
 type Update<A> = {
   expirationTime: ExpirationTime,
@@ -548,7 +548,7 @@ function useEffectImpl(fiberEffectTag, hookEffectTag, create, inputs): void {
   if (currentHook !== null) {
     const prevEffect = currentHook.memoizedState;
     destroy = prevEffect.destroy;
-    if (inputsAreEqual(nextInputs, prevEffect.inputs)) {
+    if (areHookInputsEqual(nextInputs, prevEffect.inputs)) {
       pushEffect(NoHookEffect, create, destroy, nextInputs);
       return;
     }
@@ -612,7 +612,7 @@ export function useCallback<T>(
   const prevState = workInProgressHook.memoizedState;
   if (prevState !== null) {
     const prevInputs = prevState[1];
-    if (inputsAreEqual(nextInputs, prevInputs)) {
+    if (areHookInputsEqual(nextInputs, prevInputs)) {
       return prevState[0];
     }
   }
@@ -633,7 +633,7 @@ export function useMemo<T>(
   const prevState = workInProgressHook.memoizedState;
   if (prevState !== null) {
     const prevInputs = prevState[1];
-    if (inputsAreEqual(nextInputs, prevInputs)) {
+    if (areHookInputsEqual(nextInputs, prevInputs)) {
       return prevState[0];
     }
   }
@@ -703,34 +703,4 @@ function dispatchAction<A>(fiber: Fiber, queue: UpdateQueue<A>, action: A) {
     queue.last = update;
     scheduleWork(fiber, expirationTime);
   }
-}
-
-function inputsAreEqual(arr1, arr2) {
-  // Don't bother comparing lengths in prod because these arrays should be
-  // passed inline.
-  if (__DEV__) {
-    warning(
-      arr1.length === arr2.length,
-      'Detected a variable number of hook dependencies. The length of the ' +
-        'dependencies array should be constant between renders.\n\n' +
-        'Previous: %s\n' +
-        'Incoming: %s',
-      arr1.join(', '),
-      arr2.join(', '),
-    );
-  }
-  for (let i = 0; i < arr1.length; i++) {
-    // Inlined Object.is polyfill.
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
-    const val1 = arr1[i];
-    const val2 = arr2[i];
-    if (
-      (val1 === val2 && (val1 !== 0 || 1 / val1 === 1 / (val2: any))) ||
-      (val1 !== val1 && val2 !== val2) // eslint-disable-line no-self-compare
-    ) {
-      continue;
-    }
-    return false;
-  }
-  return true;
 }

--- a/packages/shared/areHookInputsEqual.js
+++ b/packages/shared/areHookInputsEqual.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import warning from 'shared/warning';
+
+export default function areHookInputsEqual(arr1: any[], arr2: any[]) {
+  // Don't bother comparing lengths in prod because these arrays should be
+  // passed inline.
+  if (__DEV__) {
+    warning(
+      arr1.length === arr2.length,
+      'Detected a variable number of hook dependencies. The length of the ' +
+        'dependencies array should be constant between renders.\n\n' +
+        'Previous: %s\n' +
+        'Incoming: %s',
+      arr1.join(', '),
+      arr2.join(', '),
+    );
+  }
+  for (let i = 0; i < arr1.length; i++) {
+    // Inlined Object.is polyfill.
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+    const val1 = arr1[i];
+    const val2 = arr2[i];
+    if (
+      (val1 === val2 && (val1 !== 0 || 1 / val1 === 1 / (val2: any))) ||
+      (val1 !== val1 && val2 !== val2) // eslint-disable-line no-self-compare
+    ) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
I know its bikeshedding but the name of this function triggered my OCD a little bit because it sounds (to me) like a name for a boolean variable. Most commonly other functions with similar purpose are named in the codebase with verb as first work, i.e. `isValidElementType`.

While renaming it I've also noticed that this code was duplicated and already out of sync (one having a dev warning, one not having it) so I thought it would be also a good thing to move it to shared directory to keep a single source of truth.
