### PR TITLE
Don't lint against Hooks after conditional throw

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -261,6 +261,15 @@ eslintTester.run('react-hooks', ReactHooksESLintRule, {
         useState();
       }
     `,
+    `
+      // Valid because exceptions abort rendering
+      function RegressionTest() {
+        if (page == null) {
+          throw new Error('oh no!');
+        }
+        useState();
+      }
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -139,7 +139,9 @@ export default {
 
           // Compute `paths` and cache it. Guarding against cycles.
           cache.set(segment.id, null);
-          if (segment.prevSegments.length === 0) {
+          if (codePath.thrownSegments.includes(segment)) {
+            paths = 0;
+          } else if (segment.prevSegments.length === 0) {
             paths = 1;
           } else {
             paths = 0;
@@ -199,7 +201,9 @@ export default {
 
           // Compute `paths` and cache it. Guarding against cycles.
           cache.set(segment.id, null);
-          if (segment.nextSegments.length === 0) {
+          if (codePath.thrownSegments.includes(segment)) {
+            paths = 0;
+          } else if (segment.nextSegments.length === 0) {
             paths = 1;
           } else {
             paths = 0;


### PR DESCRIPTION
Seems like this should be OK. Fixes #14038.

Now when tracking paths, we completely ignore segments that end in a throw.
