### PR TITLE
Fix react-cache UMD build

### DIFF
--- a/packages/react-cache/package.json
+++ b/packages/react-cache/package.json
@@ -8,7 +8,8 @@
     "LICENSE",
     "README.md",
     "index.js",
-    "cjs/"
+    "cjs/",
+    "umd/"
   ],
   "peerDependencies": {
     "react": "^16.3.0-alpha.1"


### PR DESCRIPTION
I plan to publish `react-cache@2.0.0-alpha.1` once this lands.