### PR TITLE
Invalid actualDuration+treeBaseDuration for hidden+suspended trees

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -66,7 +66,12 @@ import {
 } from './ReactChildFiber';
 import {processUpdateQueue} from './ReactUpdateQueue';
 import {NoWork, Never} from './ReactFiberExpirationTime';
-import {ConcurrentMode, StrictMode, NoContext} from './ReactTypeOfMode';
+import {
+  ConcurrentMode,
+  NoContext,
+  ProfileMode,
+  StrictMode,
+} from './ReactTypeOfMode';
 import {
   shouldSetTextContent,
   shouldDeprioritizeSubtree,
@@ -743,7 +748,7 @@ function mountLazyComponent(
 ) {
   if (_current !== null) {
     // An lazy component only mounts if it suspended inside a non-
-    // concurrent tree, in an inconsistent state. We want to tree it like
+    // concurrent tree, in an inconsistent state. We want to treat it like
     // a new mount, even though an empty version of it already committed.
     // Disconnect the alternate pointers.
     _current.alternate = null;
@@ -829,7 +834,7 @@ function mountIncompleteClassComponent(
 ) {
   if (_current !== null) {
     // An incomplete component only mounts if it suspended inside a non-
-    // concurrent tree, in an inconsistent state. We want to tree it like
+    // concurrent tree, in an inconsistent state. We want to treat it like
     // a new mount, even though an empty version of it already committed.
     // Disconnect the alternate pointers.
     _current.alternate = null;
@@ -886,7 +891,7 @@ function mountIndeterminateComponent(
 ) {
   if (_current !== null) {
     // An indeterminate component only mounts if it suspended inside a non-
-    // concurrent tree, in an inconsistent state. We want to tree it like
+    // concurrent tree, in an inconsistent state. We want to treat it like
     // a new mount, even though an empty version of it already committed.
     // Disconnect the alternate pointers.
     _current.alternate = null;
@@ -1239,6 +1244,15 @@ function updateSuspenseComponent(
           NoWork,
           null,
         );
+
+        if (enableProfilerTimer && workInProgress.mode & ProfileMode) {
+          // Fiber treeBaseDuration must be at least as large as the sum of children treeBaseDurations.
+          // Otherwise the profiler's onRender metrics will be off,
+          // and the DevTools Profiler flamegraph will visually break as well.
+          primaryChildFragment.treeBaseDuration =
+            currentPrimaryChild.treeBaseDuration;
+        }
+
         primaryChildFragment.effectTag |= Placement;
         primaryChildFragment.child = currentPrimaryChild;
         currentPrimaryChild.return = primaryChildFragment;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1246,11 +1246,14 @@ function updateSuspenseComponent(
         );
 
         if (enableProfilerTimer && workInProgress.mode & ProfileMode) {
-          // Fiber treeBaseDuration must be at least as large as the sum of children treeBaseDurations.
-          // Otherwise the profiler's onRender metrics will be off,
-          // and the DevTools Profiler flamegraph will visually break as well.
-          primaryChildFragment.treeBaseDuration =
-            currentPrimaryChild.treeBaseDuration;
+          // treeBaseDuration is the sum of all the child tree base durations.
+          let treeBaseDuration = 0;
+          let hiddenChild = currentPrimaryChild;
+          while (hiddenChild !== null) {
+            treeBaseDuration += hiddenChild.treeBaseDuration;
+            hiddenChild = hiddenChild.sibling;
+          }
+          primaryChildFragment.treeBaseDuration = treeBaseDuration;
         }
 
         primaryChildFragment.effectTag |= Placement;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1193,6 +1193,19 @@ function updateSuspenseComponent(
           }
         }
 
+        // Because primaryChildFragment is a new fiber that we're inserting as the
+        // parent of a new tree, we need to set its treeBaseDuration.
+        if (enableProfilerTimer && workInProgress.mode & ProfileMode) {
+          // treeBaseDuration is the sum of all the child tree base durations.
+          let treeBaseDuration = 0;
+          let hiddenChild = primaryChildFragment.child;
+          while (hiddenChild !== null) {
+            treeBaseDuration += hiddenChild.treeBaseDuration;
+            hiddenChild = hiddenChild.sibling;
+          }
+          primaryChildFragment.treeBaseDuration = treeBaseDuration;
+        }
+
         // Clone the fallback child fragment, too. These we'll continue
         // working on.
         const fallbackChildFragment = (primaryChildFragment.sibling = createWorkInProgress(
@@ -1245,17 +1258,6 @@ function updateSuspenseComponent(
           null,
         );
 
-        if (enableProfilerTimer && workInProgress.mode & ProfileMode) {
-          // treeBaseDuration is the sum of all the child tree base durations.
-          let treeBaseDuration = 0;
-          let hiddenChild = currentPrimaryChild;
-          while (hiddenChild !== null) {
-            treeBaseDuration += hiddenChild.treeBaseDuration;
-            hiddenChild = hiddenChild.sibling;
-          }
-          primaryChildFragment.treeBaseDuration = treeBaseDuration;
-        }
-
         primaryChildFragment.effectTag |= Placement;
         primaryChildFragment.child = currentPrimaryChild;
         currentPrimaryChild.return = primaryChildFragment;
@@ -1269,6 +1271,19 @@ function updateSuspenseComponent(
               ? (workInProgress.child: any).child
               : (workInProgress.child: any);
           primaryChildFragment.child = progressedPrimaryChild;
+        }
+
+        // Because primaryChildFragment is a new fiber that we're inserting as the
+        // parent of a new tree, we need to set its treeBaseDuration.
+        if (enableProfilerTimer && workInProgress.mode & ProfileMode) {
+          // treeBaseDuration is the sum of all the child tree base durations.
+          let treeBaseDuration = 0;
+          let hiddenChild = primaryChildFragment.child;
+          while (hiddenChild !== null) {
+            treeBaseDuration += hiddenChild.treeBaseDuration;
+            hiddenChild = hiddenChild.sibling;
+          }
+          primaryChildFragment.treeBaseDuration = treeBaseDuration;
         }
 
         // Create a fragment from the fallback children, too.

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1049,9 +1049,18 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
         return null;
       }
     } else {
-      if (workInProgress.mode & ProfileMode) {
+      if (enableProfilerTimer && workInProgress.mode & ProfileMode) {
         // Record the render duration for the fiber that errored.
         stopProfilerTimerIfRunningAndRecordDelta(workInProgress, false);
+
+        // Include the time spent working on failed children before continuing.
+        let actualDuration = workInProgress.actualDuration;
+        let child = workInProgress.child;
+        while (child !== null) {
+          actualDuration += child.actualDuration;
+          child = child.sibling;
+        }
+        workInProgress.actualDuration = actualDuration;
       }
 
       // This fiber did not complete because something threw. Pop values off
@@ -1074,19 +1083,6 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
         stopWorkTimer(workInProgress);
         if (__DEV__ && ReactFiberInstrumentation.debugTool) {
           ReactFiberInstrumentation.debugTool.onCompleteWork(workInProgress);
-        }
-
-        if (enableProfilerTimer) {
-          // Include the time spent working on failed children before continuing.
-          if (next.mode & ProfileMode) {
-            let actualDuration = next.actualDuration;
-            let child = next.child;
-            while (child !== null) {
-              actualDuration += child.actualDuration;
-              child = child.sibling;
-            }
-            next.actualDuration = actualDuration;
-          }
         }
 
         // If completing this work spawned new work, do that next. We'll come
@@ -1318,16 +1314,6 @@ function renderRoot(root: FiberRoot, isYieldy: boolean): void {
           // Record the time spent rendering before an error was thrown.
           // This avoids inaccurate Profiler durations in the case of a suspended render.
           stopProfilerTimerIfRunningAndRecordDelta(nextUnitOfWork, true);
-
-          // HACK Also propagate actualDuration for the time spent in the fiber that errored.
-          // This avoids inaccurate Profiler durations in the case of a suspended render.
-          // This happens automatically for sync renders, because of resetChildExpirationTime.
-          if (nextUnitOfWork.mode & ConcurrentMode) {
-            const returnFiber = nextUnitOfWork.return;
-            if (returnFiber !== null) {
-              returnFiber.actualDuration += nextUnitOfWork.actualDuration;
-            }
-          }
         }
 
         if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1314,6 +1314,12 @@ function renderRoot(root: FiberRoot, isYieldy: boolean): void {
         didFatal = true;
         onUncaughtError(thrownValue);
       } else {
+        if (enableProfilerTimer && nextUnitOfWork.mode & ProfileMode) {
+          // Record the time spent rendering before an error was thrown.
+          // This avoids inaccurate Profiler durations in the case of a suspended render.
+          stopProfilerTimerIfRunningAndRecordDelta(nextUnitOfWork, true);
+        }
+
         if (__DEV__) {
           // Reset global debug state
           // We assume this is defined in DEV

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1318,6 +1318,16 @@ function renderRoot(root: FiberRoot, isYieldy: boolean): void {
           // Record the time spent rendering before an error was thrown.
           // This avoids inaccurate Profiler durations in the case of a suspended render.
           stopProfilerTimerIfRunningAndRecordDelta(nextUnitOfWork, true);
+
+          // HACK Also propagate actualDuration for the time spent in the fiber that errored.
+          // This avoids inaccurate Profiler durations in the case of a suspended render.
+          // This happens automatically for sync renders, because of resetChildExpirationTime.
+          if (nextUnitOfWork.mode & ConcurrentMode) {
+            const returnFiber = nextUnitOfWork.return;
+            if (returnFiber !== null) {
+              returnFiber.actualDuration += nextUnitOfWork.actualDuration;
+            }
+          }
         }
 
         if (__DEV__) {

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -272,30 +272,24 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
       it('properly accounts for base durations when a suspended times out in a sync tree', () => {
         const root = ReactTestRenderer.create(<App />);
         expect(root.toJSON()).toEqual(['Loading...']);
-        expect(onRender).toHaveBeenCalledTimes(2);
+        expect(onRender).toHaveBeenCalledTimes(1);
 
-        // Initial mount should be 8ms–
-        // 2ms from Suspending, 1ms from the AsyncText it renders,
-        // And 5ms from NonSuspending.
-        expect(onRender.mock.calls[0][2]).toBe(8);
-        expect(onRender.mock.calls[0][3]).toBe(8);
-
-        // When the fallback UI is displayed, and the original UI is hidden,
-        // the baseDuration should only include the 10ms spent rendering Fallback,
-        // but the treeBaseDuration should include that and the 8ms spent in the hidden tree.
-        expect(onRender.mock.calls[1][2]).toBe(10);
-        expect(onRender.mock.calls[1][3]).toBe(18);
+        // Initial mount only shows the "Loading..." Fallback.
+        // The treeBaseDuration then should be 10ms spent rendering Fallback,
+        // but the actualDuration should also include the 8ms spent rendering the hidden tree.
+        expect(onRender.mock.calls[0][2]).toBe(18);
+        expect(onRender.mock.calls[0][3]).toBe(10);
 
         jest.advanceTimersByTime(1000);
 
         expect(root.toJSON()).toEqual(['Loaded', 'NonSuspending']);
-        expect(onRender).toHaveBeenCalledTimes(3);
+        expect(onRender).toHaveBeenCalledTimes(2);
 
         // When the suspending data is resolved and our final UI is rendered,
         // the baseDuration should only include the 1ms re-rendering AsyncText,
         // but the treeBaseDuration should include the full 8ms spent in the tree.
-        expect(onRender.mock.calls[2][2]).toBe(1);
-        expect(onRender.mock.calls[2][3]).toBe(8);
+        expect(onRender.mock.calls[1][2]).toBe(1);
+        expect(onRender.mock.calls[1][3]).toBe(8);
       });
 
       it('properly accounts for base durations when a suspended times out in a concurrent tree', () => {

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -232,24 +232,28 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
 
     describe('profiler durations', () => {
       let App;
-      let Fallback;
-      let Suspending;
       let onRender;
 
       beforeEach(() => {
         // Order of parameters: id, phase, actualDuration, treeBaseDuration
         onRender = jest.fn();
 
-        Fallback = () => {
+        const Fallback = () => {
           ReactTestRenderer.unstable_yield('Fallback');
-          advanceTimeBy(5);
+          advanceTimeBy(10);
           return 'Loading...';
         };
 
-        Suspending = () => {
+        const Suspending = () => {
           ReactTestRenderer.unstable_yield('Suspending');
           advanceTimeBy(2);
           return <AsyncText ms={1000} text="Loaded" fakeRenderDuration={1} />;
+        };
+
+        const NonSuspending = () => {
+          ReactTestRenderer.unstable_yield('NonSuspending');
+          advanceTimeBy(5);
+          return 'NonSuspending';
         };
 
         App = () => {
@@ -258,6 +262,7 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
             <Profiler id="root" onRender={onRender}>
               <Suspense maxDuration={500} fallback={<Fallback />}>
                 <Suspending />
+                <NonSuspending />
               </Suspense>
             </Profiler>
           );
@@ -266,30 +271,31 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
 
       it('properly accounts for base durations when a suspended times out in a sync tree', () => {
         const root = ReactTestRenderer.create(<App />);
-        expect(root.toJSON()).toEqual('Loading...');
+        expect(root.toJSON()).toEqual(['Loading...']);
         expect(onRender).toHaveBeenCalledTimes(2);
 
-        // Initial mount should be 3ms–
-        // 2ms from Suspending, and 1ms from the AsyncText it renders.
-        expect(onRender.mock.calls[0][2]).toBe(3);
-        expect(onRender.mock.calls[0][3]).toBe(3);
+        // Initial mount should be 8ms–
+        // 2ms from Suspending, 1ms from the AsyncText it renders,
+        // And 5ms from NonSuspending.
+        expect(onRender.mock.calls[0][2]).toBe(8);
+        expect(onRender.mock.calls[0][3]).toBe(8);
 
-        // When the fallback UI is displayed, and the origina UI hidden,
-        // the baseDuration should only include the 5ms spent rendering Fallback,
-        // but the treeBaseDuration should include that and the 3ms spent in Suspending.
-        expect(onRender.mock.calls[1][2]).toBe(5);
-        expect(onRender.mock.calls[1][3]).toBe(8);
+        // When the fallback UI is displayed, and the original UI is hidden,
+        // the baseDuration should only include the 10ms spent rendering Fallback,
+        // but the treeBaseDuration should include that and the 8ms spent in the hidden tree.
+        expect(onRender.mock.calls[1][2]).toBe(10);
+        expect(onRender.mock.calls[1][3]).toBe(18);
 
         jest.advanceTimersByTime(1000);
 
-        expect(root.toJSON()).toEqual('Loaded');
+        expect(root.toJSON()).toEqual(['Loaded', 'NonSuspending']);
         expect(onRender).toHaveBeenCalledTimes(3);
 
         // When the suspending data is resolved and our final UI is rendered,
         // the baseDuration should only include the 1ms re-rendering AsyncText,
-        // but the treeBaseDuration should include that and the 2ms spent rendering Suspending.
+        // but the treeBaseDuration should include the full 8ms spent in the tree.
         expect(onRender.mock.calls[2][2]).toBe(1);
-        expect(onRender.mock.calls[2][3]).toBe(3);
+        expect(onRender.mock.calls[2][3]).toBe(8);
       });
 
       it('properly accounts for base durations when a suspended times out in a concurrent tree', () => {
@@ -301,6 +307,7 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
           'App',
           'Suspending',
           'Suspend! [Loaded]',
+          'NonSuspending',
           'Fallback',
         ]);
         expect(root).toMatchRenderedOutput(null);
@@ -312,19 +319,19 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
         expect(onRender).toHaveBeenCalledTimes(1);
 
         // Initial mount only shows the "Loading..." Fallback.
-        // The treeBaseDuration then should be 5ms spent rendering Fallback,
-        // but the actualDuration should include that and the 3ms spent in Suspending.
-        expect(onRender.mock.calls[0][2]).toBe(8);
-        expect(onRender.mock.calls[0][3]).toBe(5);
+        // The treeBaseDuration then should be 10ms spent rendering Fallback,
+        // but the actualDuration should also include the 8ms spent rendering the hidden tree.
+        expect(onRender.mock.calls[0][2]).toBe(18);
+        expect(onRender.mock.calls[0][3]).toBe(10);
 
-        expect(root).toFlushAndYield(['Suspending', 'Loaded']);
-        expect(root).toMatchRenderedOutput('Loaded');
+        expect(root).toFlushAndYield(['Suspending', 'Loaded', 'NonSuspending']);
+        expect(root).toMatchRenderedOutput('LoadedNonSuspending');
         expect(onRender).toHaveBeenCalledTimes(2);
 
         // When the suspending data is resolved and our final UI is rendered,
-        // both times should include the 3ms re-rendering Suspending and AsyncText.
-        expect(onRender.mock.calls[1][2]).toBe(3);
-        expect(onRender.mock.calls[1][3]).toBe(3);
+        // both times should include the 8ms re-rendering Suspending and AsyncText.
+        expect(onRender.mock.calls[1][2]).toBe(8);
+        expect(onRender.mock.calls[1][3]).toBe(8);
       });
     });
   });

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -230,56 +230,102 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
       expect(root).toMatchRenderedOutput('AB2C');
     });
 
-    it('properly accounts for base durations when a suspended times out', () => {
-      // Order of parameters: id, phase, actualDuration, treeBaseDuration
-      const onRender = jest.fn();
+    describe('profiler durations', () => {
+      let App;
+      let Fallback;
+      let Suspending;
+      let onRender;
 
-      const Fallback = () => {
-        advanceTimeBy(5);
-        return 'Loading...';
-      };
+      beforeEach(() => {
+        // Order of parameters: id, phase, actualDuration, treeBaseDuration
+        onRender = jest.fn();
 
-      const Suspending = () => {
-        advanceTimeBy(2);
-        return <AsyncText ms={1000} text="Loaded" fakeRenderDuration={1} />;
-      };
+        Fallback = () => {
+          ReactTestRenderer.unstable_yield('Fallback');
+          advanceTimeBy(5);
+          return 'Loading...';
+        };
 
-      function App() {
-        return (
-          <Profiler id="root" onRender={onRender}>
-            <Suspense maxDuration={500} fallback={<Fallback />}>
-              <Suspending />
-            </Suspense>
-          </Profiler>
-        );
-      }
+        Suspending = () => {
+          ReactTestRenderer.unstable_yield('Suspending');
+          advanceTimeBy(2);
+          return <AsyncText ms={1000} text="Loaded" fakeRenderDuration={1} />;
+        };
 
-      // Initial mount
-      const root = ReactTestRenderer.create(<App />);
-      expect(root.toJSON()).toEqual('Loading...');
-      expect(onRender).toHaveBeenCalledTimes(2);
+        App = () => {
+          ReactTestRenderer.unstable_yield('App');
+          return (
+            <Profiler id="root" onRender={onRender}>
+              <Suspense maxDuration={500} fallback={<Fallback />}>
+                <Suspending />
+              </Suspense>
+            </Profiler>
+          );
+        };
+      });
 
-      // Initial mount should be 3ms–
-      // 2ms from Suspending, and 1ms from the AsyncText it renders.
-      expect(onRender.mock.calls[0][2]).toBe(3);
-      expect(onRender.mock.calls[0][3]).toBe(3);
+      it('properly accounts for base durations when a suspended times out in a sync tree', () => {
+        const root = ReactTestRenderer.create(<App />);
+        expect(root.toJSON()).toEqual('Loading...');
+        expect(onRender).toHaveBeenCalledTimes(2);
 
-      // When the fallback UI is displayed, and the origina UI hidden,
-      // the baseDuration should only include the 5ms spent rendering Fallback,
-      // but the treeBaseDuration should include that and the 3ms spent in Suspending.
-      expect(onRender.mock.calls[1][2]).toBe(5);
-      expect(onRender.mock.calls[1][3]).toBe(8);
+        // Initial mount should be 3ms–
+        // 2ms from Suspending, and 1ms from the AsyncText it renders.
+        expect(onRender.mock.calls[0][2]).toBe(3);
+        expect(onRender.mock.calls[0][3]).toBe(3);
 
-      jest.advanceTimersByTime(1000);
+        // When the fallback UI is displayed, and the origina UI hidden,
+        // the baseDuration should only include the 5ms spent rendering Fallback,
+        // but the treeBaseDuration should include that and the 3ms spent in Suspending.
+        expect(onRender.mock.calls[1][2]).toBe(5);
+        expect(onRender.mock.calls[1][3]).toBe(8);
 
-      expect(root.toJSON()).toEqual('Loaded');
-      expect(onRender).toHaveBeenCalledTimes(3);
+        jest.advanceTimersByTime(1000);
 
-      // When the suspending data is resolved and our final UI is rendered,
-      // the baseDuration should only include the 1ms re-rendering AsyncText,
-      // but the treeBaseDuration should include that and the 2ms spent rendering Suspending.
-      expect(onRender.mock.calls[2][2]).toBe(1);
-      expect(onRender.mock.calls[2][3]).toBe(3);
+        expect(root.toJSON()).toEqual('Loaded');
+        expect(onRender).toHaveBeenCalledTimes(3);
+
+        // When the suspending data is resolved and our final UI is rendered,
+        // the baseDuration should only include the 1ms re-rendering AsyncText,
+        // but the treeBaseDuration should include that and the 2ms spent rendering Suspending.
+        expect(onRender.mock.calls[2][2]).toBe(1);
+        expect(onRender.mock.calls[2][3]).toBe(3);
+      });
+
+      it('properly accounts for base durations when a suspended times out in a concurrent tree', () => {
+        const root = ReactTestRenderer.create(<App />, {
+          unstable_isConcurrent: true,
+        });
+
+        expect(root).toFlushAndYield([
+          'App',
+          'Suspending',
+          'Suspend! [Loaded]',
+          'Fallback',
+        ]);
+        expect(root).toMatchRenderedOutput(null);
+
+        jest.advanceTimersByTime(1000);
+
+        expect(ReactTestRenderer).toHaveYielded(['Promise resolved [Loaded]']);
+        expect(root).toMatchRenderedOutput('Loading...');
+        expect(onRender).toHaveBeenCalledTimes(1);
+
+        // Initial mount only shows the "Loading..." Fallback.
+        // The treeBaseDuration then should be 5ms spent rendering Fallback,
+        // but the actualDuration should include that and the 3ms spent in Suspending.
+        expect(onRender.mock.calls[0][2]).toBe(8);
+        expect(onRender.mock.calls[0][3]).toBe(5);
+
+        expect(root).toFlushAndYield(['Suspending', 'Loaded']);
+        expect(root).toMatchRenderedOutput('Loaded');
+        expect(onRender).toHaveBeenCalledTimes(2);
+
+        // When the suspending data is resolved and our final UI is rendered,
+        // both times should include the 3ms re-rendering Suspending and AsyncText.
+        expect(onRender.mock.calls[1][2]).toBe(3);
+        expect(onRender.mock.calls[1][3]).toBe(3);
+      });
     });
   });
 }

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -97,9 +97,10 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
       textResourceShouldFail = false;
     });
 
-    function Text(props) {
-      ReactTestRenderer.unstable_yield(props.text);
-      return props.text;
+    function Text({fakeRenderDuration = 0, text = 'Text'}) {
+      advanceTimeBy(fakeRenderDuration);
+      ReactTestRenderer.unstable_yield(text);
+      return text;
     }
 
     function AsyncText({fakeRenderDuration = 0, ms, text}) {
@@ -250,82 +251,207 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
           return <AsyncText ms={1000} text="Loaded" fakeRenderDuration={1} />;
         };
 
-        const NonSuspending = () => {
-          ReactTestRenderer.unstable_yield('NonSuspending');
-          advanceTimeBy(5);
-          return 'NonSuspending';
-        };
-
-        App = () => {
+        App = ({shouldSuspend, text = 'Text', textRenderDuration = 5}) => {
           ReactTestRenderer.unstable_yield('App');
           return (
             <Profiler id="root" onRender={onRender}>
               <Suspense maxDuration={500} fallback={<Fallback />}>
-                <Suspending />
-                <NonSuspending />
+                {shouldSuspend && <Suspending />}
+                <Text fakeRenderDuration={textRenderDuration} text={text} />
               </Suspense>
             </Profiler>
           );
         };
       });
 
-      it('properly accounts for base durations when a suspended times out in a sync tree', () => {
-        const root = ReactTestRenderer.create(<App />);
-        expect(root.toJSON()).toEqual(['Loading...']);
-        expect(onRender).toHaveBeenCalledTimes(1);
+      describe('when suspending during mount', () => {
+        it('properly accounts for base durations when a suspended times out in a sync tree', () => {
+          const root = ReactTestRenderer.create(<App shouldSuspend={true} />);
+          expect(root.toJSON()).toEqual(['Loading...']);
+          expect(onRender).toHaveBeenCalledTimes(1);
 
-        // Initial mount only shows the "Loading..." Fallback.
-        // The treeBaseDuration then should be 10ms spent rendering Fallback,
-        // but the actualDuration should also include the 8ms spent rendering the hidden tree.
-        expect(onRender.mock.calls[0][2]).toBe(18);
-        expect(onRender.mock.calls[0][3]).toBe(10);
+          // Initial mount only shows the "Loading..." Fallback.
+          // The treeBaseDuration then should be 10ms spent rendering Fallback,
+          // but the actualDuration should also include the 8ms spent rendering the hidden tree.
+          expect(onRender.mock.calls[0][2]).toBe(18);
+          expect(onRender.mock.calls[0][3]).toBe(10);
 
-        jest.advanceTimersByTime(1000);
+          jest.advanceTimersByTime(1000);
 
-        expect(root.toJSON()).toEqual(['Loaded', 'NonSuspending']);
-        expect(onRender).toHaveBeenCalledTimes(2);
+          expect(root.toJSON()).toEqual(['Loaded', 'Text']);
+          expect(onRender).toHaveBeenCalledTimes(2);
 
-        // When the suspending data is resolved and our final UI is rendered,
-        // the baseDuration should only include the 1ms re-rendering AsyncText,
-        // but the treeBaseDuration should include the full 8ms spent in the tree.
-        expect(onRender.mock.calls[1][2]).toBe(1);
-        expect(onRender.mock.calls[1][3]).toBe(8);
-      });
-
-      it('properly accounts for base durations when a suspended times out in a concurrent tree', () => {
-        const root = ReactTestRenderer.create(<App />, {
-          unstable_isConcurrent: true,
+          // When the suspending data is resolved and our final UI is rendered,
+          // the baseDuration should only include the 1ms re-rendering AsyncText,
+          // but the treeBaseDuration should include the full 8ms spent in the tree.
+          expect(onRender.mock.calls[1][2]).toBe(1);
+          expect(onRender.mock.calls[1][3]).toBe(8);
         });
 
-        expect(root).toFlushAndYield([
-          'App',
-          'Suspending',
-          'Suspend! [Loaded]',
-          'NonSuspending',
-          'Fallback',
-        ]);
-        expect(root).toMatchRenderedOutput(null);
+        it('properly accounts for base durations when a suspended times out in a concurrent tree', () => {
+          const root = ReactTestRenderer.create(<App shouldSuspend={true} />, {
+            unstable_isConcurrent: true,
+          });
 
-        jest.advanceTimersByTime(1000);
+          expect(root).toFlushAndYield([
+            'App',
+            'Suspending',
+            'Suspend! [Loaded]',
+            'Text',
+            'Fallback',
+          ]);
+          expect(root).toMatchRenderedOutput(null);
 
-        expect(ReactTestRenderer).toHaveYielded(['Promise resolved [Loaded]']);
-        expect(root).toMatchRenderedOutput('Loading...');
-        expect(onRender).toHaveBeenCalledTimes(1);
+          // Show the fallback UI.
+          jest.advanceTimersByTime(750);
+          expect(root).toMatchRenderedOutput('Loading...');
+          expect(onRender).toHaveBeenCalledTimes(1);
 
-        // Initial mount only shows the "Loading..." Fallback.
-        // The treeBaseDuration then should be 10ms spent rendering Fallback,
-        // but the actualDuration should also include the 8ms spent rendering the hidden tree.
-        expect(onRender.mock.calls[0][2]).toBe(18);
-        expect(onRender.mock.calls[0][3]).toBe(10);
+          // Initial mount only shows the "Loading..." Fallback.
+          // The treeBaseDuration then should be 10ms spent rendering Fallback,
+          // but the actualDuration should also include the 8ms spent rendering the hidden tree.
+          expect(onRender.mock.calls[0][2]).toBe(18);
+          expect(onRender.mock.calls[0][3]).toBe(10);
 
-        expect(root).toFlushAndYield(['Suspending', 'Loaded', 'NonSuspending']);
-        expect(root).toMatchRenderedOutput('LoadedNonSuspending');
-        expect(onRender).toHaveBeenCalledTimes(2);
+          // Resolve the pending promise.
+          jest.advanceTimersByTime(250);
+          expect(ReactTestRenderer).toHaveYielded([
+            'Promise resolved [Loaded]',
+          ]);
+          expect(root).toFlushAndYield(['Suspending', 'Loaded', 'Text']);
+          expect(root).toMatchRenderedOutput('LoadedText');
+          expect(onRender).toHaveBeenCalledTimes(2);
 
-        // When the suspending data is resolved and our final UI is rendered,
-        // both times should include the 8ms re-rendering Suspending and AsyncText.
-        expect(onRender.mock.calls[1][2]).toBe(8);
-        expect(onRender.mock.calls[1][3]).toBe(8);
+          // When the suspending data is resolved and our final UI is rendered,
+          // both times should include the 8ms re-rendering Suspending and AsyncText.
+          expect(onRender.mock.calls[1][2]).toBe(8);
+          expect(onRender.mock.calls[1][3]).toBe(8);
+        });
+      });
+
+      describe('when suspending during update', () => {
+        it('properly accounts for base durations when a suspended times out in a sync tree', () => {
+          const root = ReactTestRenderer.create(
+            <App shouldSuspend={false} textRenderDuration={5} />,
+          );
+          expect(root.toJSON()).toEqual('Text');
+          expect(onRender).toHaveBeenCalledTimes(1);
+
+          // Initial mount only shows the "Text" text.
+          // It should take 5ms to render.
+          expect(onRender.mock.calls[0][2]).toBe(5);
+          expect(onRender.mock.calls[0][3]).toBe(5);
+
+          root.update(<App shouldSuspend={true} textRenderDuration={5} />);
+          expect(root.toJSON()).toEqual(['Loading...']);
+          expect(onRender).toHaveBeenCalledTimes(2);
+
+          // The suspense update should only show the "Loading..." Fallback.
+          // Both durations should include 10ms spent rendering Fallback
+          // plus the 8ms rendering the (hidden) components.
+          expect(onRender.mock.calls[1][2]).toBe(18);
+          expect(onRender.mock.calls[1][3]).toBe(18);
+
+          root.update(
+            <App shouldSuspend={true} text="New" textRenderDuration={6} />,
+          );
+          expect(root.toJSON()).toEqual(['Loading...']);
+          expect(onRender).toHaveBeenCalledTimes(3);
+
+          // If we force another update while still timed out,
+          // but this time the Text component took 1ms longer to render.
+          // This should impact both actualDuration and treeBaseDuration.
+          expect(onRender.mock.calls[2][2]).toBe(19);
+          expect(onRender.mock.calls[2][3]).toBe(19);
+
+          jest.advanceTimersByTime(1000);
+
+          // TODO Change expected onRender count to 4.
+          // At the moment, every time we suspended while rendering will cause a commit.
+          // This will probably change in the future, but that's why there are two new ones.
+          expect(root.toJSON()).toEqual(['Loaded', 'New']);
+          expect(onRender).toHaveBeenCalledTimes(5);
+
+          // When the suspending data is resolved and our final UI is rendered,
+          // the baseDuration should only include the 1ms re-rendering AsyncText,
+          // but the treeBaseDuration should include the full 9ms spent in the tree.
+          expect(onRender.mock.calls[3][2]).toBe(1);
+          expect(onRender.mock.calls[3][3]).toBe(9);
+
+          // TODO Remove these assertions once this commit is gone.
+          // For now, there was no actual work done during this commit; see above comment.
+          expect(onRender.mock.calls[4][2]).toBe(0);
+          expect(onRender.mock.calls[4][3]).toBe(9);
+        });
+
+        it('properly accounts for base durations when a suspended times out in a concurrent tree', () => {
+          const root = ReactTestRenderer.create(
+            <App shouldSuspend={false} textRenderDuration={5} />,
+            {
+              unstable_isConcurrent: true,
+            },
+          );
+
+          expect(root).toFlushAndYield(['App', 'Text']);
+          expect(root).toMatchRenderedOutput('Text');
+          expect(onRender).toHaveBeenCalledTimes(1);
+
+          // Initial mount only shows the "Text" text.
+          // It should take 5ms to render.
+          expect(onRender.mock.calls[0][2]).toBe(5);
+          expect(onRender.mock.calls[0][3]).toBe(5);
+
+          root.update(<App shouldSuspend={true} textRenderDuration={5} />);
+          expect(root).toFlushAndYield([
+            'App',
+            'Suspending',
+            'Suspend! [Loaded]',
+            'Text',
+            'Fallback',
+          ]);
+          expect(root).toMatchRenderedOutput('Text');
+
+          // Show the fallback UI.
+          jest.advanceTimersByTime(750);
+          expect(root).toMatchRenderedOutput('Loading...');
+          expect(onRender).toHaveBeenCalledTimes(2);
+
+          // The suspense update should only show the "Loading..." Fallback.
+          // The actual duration should include 10ms spent rendering Fallback,
+          // plus the 8ms render all of the hidden, suspended subtree.
+          // But the tree base duration should only include 10ms spent rendering Fallback,
+          // plus the 5ms rendering the previously committed version of the hidden tree.
+          expect(onRender.mock.calls[1][2]).toBe(18);
+          expect(onRender.mock.calls[1][3]).toBe(15);
+
+          // Update again while timed out.
+          root.update(
+            <App shouldSuspend={true} text="New" textRenderDuration={6} />,
+          );
+          expect(root).toFlushAndYield([
+            'App',
+            'Suspending',
+            'Suspend! [Loaded]',
+            'New',
+            'Fallback',
+          ]);
+          expect(root).toMatchRenderedOutput('Loading...');
+          expect(onRender).toHaveBeenCalledTimes(2);
+
+          // Resolve the pending promise.
+          jest.advanceTimersByTime(250);
+          expect(ReactTestRenderer).toHaveYielded([
+            'Promise resolved [Loaded]',
+          ]);
+          expect(root).toFlushAndYield(['App', 'Suspending', 'Loaded', 'New']);
+          expect(onRender).toHaveBeenCalledTimes(3);
+
+          // When the suspending data is resolved and our final UI is rendered,
+          // both times should include the 6ms rendering Text,
+          // the 2ms rendering Suspending, and the 1ms rendering AsyncText.
+          expect(onRender.mock.calls[2][2]).toBe(9);
+          expect(onRender.mock.calls[2][3]).toBe(9);
+        });
       });
     });
   });


### PR DESCRIPTION
While testing some of our new APIs in DevTools, I noticed that the profiler (both the API and the DevTools visual profiler) reported invalid `actualDuration` and `treeBaseDuration` values when suspending.

The `treeBaseDuration` was incorrect for the fallback commit. It only included the fallback subtree duration, when it should also include the time spent rendering the hidden subtree.

The `actualDuration` value was incorrect for both the fallback commit _and_ the final, resolved commit. It didn't include time spent rendering the component that actually read from the cache (the one that threw).

- [x] Fixed `treeBaseDuration` by propagating its value from the suspended tree to the `Fragment` React temporarily wraps around it when showing the fallback UI.
- [x] Fixed `actualDuration` by recording elapsed profiler time in the event of an error.
- [x] Fixed `actualDuration` in concurrent mode by propagating the time spent rendering the suspending component to its parent.

Also updated `ReactSuspensePlaceholder-test.internal` to cover these new cases.