### PR TITLE
[suspense] Avoid double commit by re-rendering immediately and reusing primary children

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -449,30 +449,8 @@ function commitLifeCycles(
       }
       return;
     }
-    case SuspenseComponent: {
-      let newState: SuspenseState | null = finishedWork.memoizedState;
-
-      let newDidTimeout;
-      let primaryChildParent = finishedWork;
-      if (newState === null) {
-        newDidTimeout = false;
-      } else {
-        newDidTimeout = true;
-        primaryChildParent = finishedWork.child;
-        if (newState.timedOutAt === NoWork) {
-          // If the children had not already timed out, record the time.
-          // This is used to compute the elapsed time during subsequent
-          // attempts to render the children.
-          newState.timedOutAt = requestCurrentTime();
-        }
-      }
-
-      if (primaryChildParent !== null) {
-        hideOrUnhideAllChildren(primaryChildParent, newDidTimeout);
-      }
-
-      return;
-    }
+    case SuspenseComponent:
+      break;
     case IncompleteClassComponent:
       break;
     default: {
@@ -1043,6 +1021,26 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       return;
     }
     case SuspenseComponent: {
+      let newState: SuspenseState | null = finishedWork.memoizedState;
+
+      let newDidTimeout;
+      let primaryChildParent = finishedWork;
+      if (newState === null) {
+        newDidTimeout = false;
+      } else {
+        newDidTimeout = true;
+        primaryChildParent = finishedWork.child;
+        if (newState.timedOutAt === NoWork) {
+          // If the children had not already timed out, record the time.
+          // This is used to compute the elapsed time during subsequent
+          // attempts to render the children.
+          newState.timedOutAt = requestCurrentTime();
+        }
+      }
+
+      if (primaryChildParent !== null) {
+        hideOrUnhideAllChildren(primaryChildParent, newDidTimeout);
+      }
       return;
     }
     case IncompleteClassComponent: {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -50,13 +50,12 @@ import {
   Placement,
   Snapshot,
   Update,
-  Callback,
 } from 'shared/ReactSideEffectTags';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 
-import {NoWork, Sync} from './ReactFiberExpirationTime';
+import {NoWork} from './ReactFiberExpirationTime';
 import {onCommitUnmount} from './ReactFiberDevToolsHook';
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
 import {getStackByFiberInDevAndProd} from './ReactCurrentFiber';
@@ -86,9 +85,7 @@ import {
 } from './ReactFiberHostConfig';
 import {
   captureCommitPhaseError,
-  flushPassiveEffects,
   requestCurrentTime,
-  scheduleWork,
 } from './ReactFiberScheduler';
 import {
   NoEffect as NoHookEffect,
@@ -453,47 +450,27 @@ function commitLifeCycles(
       return;
     }
     case SuspenseComponent: {
-      if (finishedWork.effectTag & Callback) {
-        // In non-strict mode, a suspense boundary times out by commiting
-        // twice: first, by committing the children in an inconsistent state,
-        // then hiding them and showing the fallback children in a subsequent
-        // commit.
-        const newState: SuspenseState = {
-          alreadyCaptured: true,
-          didTimeout: false,
-          timedOutAt: NoWork,
-        };
-        finishedWork.memoizedState = newState;
-        flushPassiveEffects();
-        scheduleWork(finishedWork, Sync);
-        return;
-      }
-      let oldState: SuspenseState | null =
-        current !== null ? current.memoizedState : null;
       let newState: SuspenseState | null = finishedWork.memoizedState;
-      let oldDidTimeout = oldState !== null ? oldState.didTimeout : false;
 
       let newDidTimeout;
       let primaryChildParent = finishedWork;
       if (newState === null) {
         newDidTimeout = false;
       } else {
-        newDidTimeout = newState.didTimeout;
-        if (newDidTimeout) {
-          primaryChildParent = finishedWork.child;
-          newState.alreadyCaptured = false;
-          if (newState.timedOutAt === NoWork) {
-            // If the children had not already timed out, record the time.
-            // This is used to compute the elapsed time during subsequent
-            // attempts to render the children.
-            newState.timedOutAt = requestCurrentTime();
-          }
+        newDidTimeout = true;
+        primaryChildParent = finishedWork.child;
+        if (newState.timedOutAt === NoWork) {
+          // If the children had not already timed out, record the time.
+          // This is used to compute the elapsed time during subsequent
+          // attempts to render the children.
+          newState.timedOutAt = requestCurrentTime();
         }
       }
 
-      if (newDidTimeout !== oldDidTimeout && primaryChildParent !== null) {
+      if (primaryChildParent !== null) {
         hideOrUnhideAllChildren(primaryChildParent, newDidTimeout);
       }
+
       return;
     }
     case IncompleteClassComponent:

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -981,6 +981,12 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
         ReactCurrentFiber.resetCurrentFiber();
       }
 
+      if (nextUnitOfWork !== null) {
+        // Completing this fiber spawned new work. Work on that next.
+        nextUnitOfWork.firstEffect = nextUnitOfWork.lastEffect = null;
+        return nextUnitOfWork;
+      }
+
       if (
         returnFiber !== null &&
         // Do not append effects to parents if a sibling failed to complete

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -11,17 +11,6 @@ import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
 export type SuspenseState = {|
-  // Whether a component in the child subtree already suspended. If true,
-  // subsequent suspends should bubble up to the next boundary.
-  alreadyCaptured: boolean,
-  // Whether the boundary renders the primary or fallback children. This is
-  // separate from `alreadyCaptured` because outside of strict mode, when a
-  // boundary times out, the first commit renders the primary children in an
-  // incomplete state, then performs a second commit to switch the fallback.
-  // In that first commit, `alreadyCaptured` is false and `didTimeout` is true.
-  didTimeout: boolean,
-  // The time at which the boundary timed out. This is separate from
-  // `didTimeout` because it's not set unless the boundary actually commits.
   timedOutAt: ExpirationTime,
 |};
 
@@ -36,5 +25,5 @@ export function shouldCaptureSuspense(
   // If it was the primary children that just suspended, capture and render the
   // fallback. Otherwise, don't capture and bubble to the next boundary.
   const nextState: SuspenseState | null = workInProgress.memoizedState;
-  return nextState === null || !nextState.didTimeout;
+  return nextState === null;
 }

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -690,5 +690,33 @@ describe('ReactSuspense', () => {
       );
       expect(mounts).toBe(1);
     });
+
+    it('does not get stuck with fallback in concurrent mode for a large delay', () => {
+      function App(props) {
+        return (
+          <Suspense maxDuration={10} fallback={<Text text="Loading..." />}>
+            <AsyncText ms={1000} text="Child 1" />
+            <AsyncText ms={7000} text="Child 2" />
+          </Suspense>
+        );
+      }
+
+      const root = ReactTestRenderer.create(<App />, {
+        unstable_isConcurrent: true,
+      });
+
+      expect(root).toFlushAndYield([
+        'Suspend! [Child 1]',
+        'Suspend! [Child 2]',
+        'Loading...',
+      ]);
+      jest.advanceTimersByTime(1000);
+      expect(ReactTestRenderer).toHaveYielded(['Promise resolved [Child 1]']);
+      expect(root).toFlushAndYield(['Child 1', 'Suspend! [Child 2]']);
+      jest.advanceTimersByTime(6000);
+      expect(ReactTestRenderer).toHaveYielded(['Promise resolved [Child 2]']);
+      expect(root).toFlushAndYield(['Child 1', 'Child 2']);
+      expect(root).toMatchRenderedOutput(['Child 1', 'Child 2'].join(''));
+    });
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -929,11 +929,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // Suspend during an async render.
       expect(ReactNoop.flushNextYield()).toEqual(['Suspend! [Step: 2]']);
       expect(ReactNoop.flush()).toEqual([
-        'Update did commit',
-        // Switch to the placeholder in a subsequent commit
         'Loading (1)',
         'Loading (2)',
         'Loading (3)',
+        'Update did commit',
       ]);
       expect(ReactNoop.getChildrenAsJSX()).toEqual(
         <React.Fragment>
@@ -1012,12 +1011,11 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           'Before',
           'Suspend! [Async: 1]',
           'After',
+          'Loading...',
           'Before',
           'Sync: 1',
           'After',
           'Did mount',
-          // The placeholder is rendered in a subsequent commit
-          'Loading...',
           'Promise resolved [Async: 1]',
           'Async: 1',
         ]);
@@ -1051,14 +1049,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         ]);
         expect(ReactNoop.flush()).toEqual([
           'After',
+          'Loading...',
           'Before',
           'Sync: 2',
           'After',
           'Update 1 did commit',
           'Update 2 did commit',
-
-          // Switch to the placeholder in a subsequent commit
-          'Loading...',
         ]);
         expect(ReactNoop.getChildrenAsJSX()).toEqual(
           <React.Fragment>
@@ -1149,12 +1145,11 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           'Before',
           'Suspend! [Async: 1]',
           'After',
+          'Loading...',
           'Before',
           'Sync: 1',
           'After',
           'Did mount',
-          // The placeholder is rendered in a subsequent commit
-          'Loading...',
           'Promise resolved [Async: 1]',
           'Async: 1',
         ]);
@@ -1188,14 +1183,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         ]);
         expect(ReactNoop.flush()).toEqual([
           'After',
+          'Loading...',
           'Before',
           'Sync: 2',
           'After',
           'Update 1 did commit',
           'Update 2 did commit',
-
-          // Switch to the placeholder in a subsequent commit
-          'Loading...',
         ]);
         expect(ReactNoop.getChildrenAsJSX()).toEqual(
           <React.Fragment>
@@ -1276,16 +1269,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         'Suspend! [B]',
         'C',
 
+        'Loading...',
         'Mount [A]',
         'Mount [B]',
         'Mount [C]',
-        'Commit root',
-
-        // In a subsequent commit, render a placeholder
-        'Loading...',
-        // Force delete all the existing children when switching to the
-        // placeholder. This should be a mount, not an update.
+        // This should be a mount, not an update.
         'Mount [Loading...]',
+        'Commit root',
       ]);
       expect(ReactNoop.getChildrenAsJSX()).toEqual(
         <React.Fragment>
@@ -1453,16 +1443,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'A',
       'Suspend! [B]',
       'C',
+      'Loading...',
 
       'Mount [A]',
       // B's lifecycle should not fire because it suspended
       // 'Mount [B]',
       'Mount [C]',
-      'Commit root',
-
-      // In a subsequent commit, render a placeholder
-      'Loading...',
       'Mount [Loading...]',
+      'Commit root',
     ]);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <React.Fragment>

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -2501,7 +2501,7 @@ describe('Profiler', () => {
         expect(renderer.toJSON()).toEqual(['loading', 'initial']);
 
         expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
-        expect(onRender).toHaveBeenCalledTimes(2); // Sync null commit, placeholder commit
+        expect(onRender).toHaveBeenCalledTimes(1);
         expect(onRender.mock.calls[0][6]).toMatchInteractions([
           initialRenderInteraction,
         ]);
@@ -2535,11 +2535,8 @@ describe('Profiler', () => {
         });
         expect(renderer.toJSON()).toEqual(['loading', 'updated']);
 
-        expect(onRender).toHaveBeenCalledTimes(2); // Sync null commit, placeholder commit
+        expect(onRender).toHaveBeenCalledTimes(1);
         expect(onRender.mock.calls[0][6]).toMatchInteractions([
-          highPriUpdateInteraction,
-        ]);
-        expect(onRender.mock.calls[1][6]).toMatchInteractions([
           highPriUpdateInteraction,
         ]);
         onRender.mockClear();


### PR DESCRIPTION
To support Suspense outside of concurrent mode, any component that starts rendering must commit synchronously without being interrupted. This means the normal path, where we unwind the stack and try again from the nearest Suspense boundary, won't work.

We used to have a special case where we commit the suspended tree in an incomplete state. Then, in a subsequent commit, we re-render using the fallback.

The first part — committing an incomplete tree — hasn't changed with this PR. But I've changed the second part — now we render the fallback children immediately, within the same commit.

Fixes https://github.com/facebook/react/issues/13999
Fixes https://github.com/facebook/react/issues/14013
Fixes https://github.com/facebook/react/issues/14073
Fixes https://github.com/facebook/react/pull/14078
Fixes https://github.com/facebook/react/pull/14079