### PR TITLE
Remove checked attribute when it becomes null

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -2036,4 +2036,25 @@ describe('ReactDOMInput', () => {
       expect(node.hasAttribute('value')).toBe(false);
     });
   });
+
+  it('removes the checked attribute when switching types on a controlled input', function() {
+    ReactDOM.render(
+      <input type="checkbox" checked={true} readOnly={true} />,
+      container,
+    );
+    ReactDOM.render(<input type="text" value="" readOnly={true} />, container);
+    const node = container.firstChild;
+
+    expect(node.hasAttribute('checked')).toBe(false);
+    expect(node.defaultChecked).toBe(false);
+  });
+
+  it('removes the checked attribute when switching types on an uncontrolled input', function() {
+    ReactDOM.render(<input type="checkbox" defaultChecked={true} />, container);
+    ReactDOM.render(<input type="text" />, container);
+    const node = container.firstChild;
+
+    expect(node.hasAttribute('checked')).toBe(false);
+    expect(node.defaultChecked).toBe(false);
+  });
 });

--- a/packages/react-dom/src/client/ReactDOMInput.js
+++ b/packages/react-dom/src/client/ReactDOMInput.js
@@ -227,8 +227,12 @@ export function updateWrapper(element: Element, props: Object) {
   } else {
     // When syncing the checked attribute, it only changes when it needs
     // to be removed, such as transitioning from a checkbox into a text input
-    if (props.checked == null && props.defaultChecked != null) {
-      node.defaultChecked = !!props.defaultChecked;
+    if (props.checked == null) {
+      if (props.defaultChecked == null) {
+        node.removeAttribute('checked');
+      } else {
+        node.defaultChecked = !!props.defaultChecked;
+      }
     }
   }
 }


### PR DESCRIPTION
This commit fixes an issue where removing input checked properties when switching input types did not remove the checked attribute.

This is the behavior for the React Fire fork of this behavior, however this case wasn't handled on the standard ReactDOM code paths.

I noticed this as a part of https://github.com/facebook/react/issues/13876, but it does not fix the original poster's issue.