### PR TITLE
Add back early return in setOffsets which was removed in 16.5.0

### DIFF
--- a/packages/react-dom/src/client/ReactDOMSelection.js
+++ b/packages/react-dom/src/client/ReactDOMSelection.js
@@ -153,6 +153,14 @@ export function getModernOffsetsFromPoints(
 export function setOffsets(node, offsets) {
   const doc = node.ownerDocument || document;
   const win = (doc && doc.defaultView) || window;
+
+  // Edge fails with "Object expected" in some scenarios.
+  // (For instance: TinyMCE editor used in a list component that supports pasting to add more,
+  // fails when pasting 100+ items)
+  if (!win.getSelection) {
+    return;
+  }
+
   const selection = win.getSelection();
   const length = node.textContent.length;
   let start = Math.min(offsets.start, length);


### PR DESCRIPTION
The scenario is that we have a TinyMCE editor (which uses an iframe, which the relevant code changes in #13650 made changes related to), and this editor is shown in every row in a list component.
The editor supports pasting to add more rows, and when pasting a lot of items (100+), we get "Object expected", due to getSelection not being present on the Window object. Seems strange obviously, but there could be some security issue with Edge or something? Not sure.

Not sure how to test this so didn't add any unit tests for it. The early return existed pre 16.5.0, this PR adds it back.