### PR TITLE
Fix crash during server render in React 16.6.0

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -284,8 +284,13 @@ export function createTextInstance(
 }
 
 export const isPrimaryRenderer = true;
-export const scheduleTimeout = setTimeout;
-export const cancelTimeout = clearTimeout;
+// This initialization code may run even on server environments
+// if a component just imports ReactDOM (e.g. for findDOMNode).
+// Some environments might not have setTimeout or clearTimeout.
+export const scheduleTimeout =
+  typeof setTimeout === 'function' ? setTimeout : (undefined: any);
+export const cancelTimeout =
+  typeof clearTimeout === 'function' ? clearTimeout : (undefined: any);
 export const noTimeout = -1;
 
 // -------------------


### PR DESCRIPTION
This fixes a bug introduced in React 16.6.0, which was not present in 16.5.2.

Runtimes without `setTimeout` and `clearTimeout` (e.g. ClearScript for .NET) are now crashing just by importing `react-dom`.

This replicates the fix for `scheduler` introduced in #13088 for `react-dom`, by checking for existence of `setTimeout` and `clearTimeout` in the runtime before using them.
