### PR TITLE
Recover from errors with a boundary in completion phase

### DIFF
--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
@@ -2149,4 +2149,19 @@ describe('ReactErrorBoundaries', () => {
     expect(componentDidCatchError).toBe(thrownError);
     expect(getDerivedStateFromErrorError).toBe(thrownError);
   });
+
+  it('should catch errors from invariants in completion phase', () => {
+    const container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary>
+        <input>
+          <div />
+        </input>
+      </ErrorBoundary>,
+      container,
+    );
+    expect(container.textContent).toContain(
+      'Caught an error: input is a void element tag',
+    );
+  });
 });

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1299,9 +1299,9 @@ function renderRoot(root: FiberRoot, isYieldy: boolean): void {
           (resetCurrentlyProcessingQueue: any)();
         }
 
-        if (!wasCompleting) {
-          const failedUnitOfWork: Fiber = nextUnitOfWork;
-          if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
+        if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
+          if (!wasCompleting) {
+            const failedUnitOfWork: Fiber = nextUnitOfWork;
             replayUnitOfWork(failedUnitOfWork, thrownValue, isYieldy);
           }
         }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -947,6 +947,9 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
     const siblingFiber = workInProgress.sibling;
 
     if ((workInProgress.effectTag & Incomplete) === NoEffect) {
+      // Prepare this field so we can find an error boundary in case completing throws.
+      nextUnitOfWork = workInProgress;
+
       // This fiber completed.
       if (enableProfilerTimer) {
         if (workInProgress.mode & ProfileMode) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -954,12 +954,12 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
         mayReplayFailedUnitOfWork = false;
       }
       // This fiber completed.
+      // Remember we're completing this unit so we can find a boundary if it fails.
+      nextUnitOfWork = workInProgress;
       if (enableProfilerTimer) {
         if (workInProgress.mode & ProfileMode) {
           startProfilerTimer(workInProgress);
         }
-        // Remember we're completing this unit so we can find a boundary if it fails.
-        nextUnitOfWork = workInProgress;
         nextUnitOfWork = completeWork(
           current,
           workInProgress,
@@ -970,8 +970,6 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
           stopProfilerTimerIfRunningAndRecordDelta(workInProgress, false);
         }
       } else {
-        // Remember we're completing this unit so we can find a boundary if it fails.
-        nextUnitOfWork = workInProgress;
         nextUnitOfWork = completeWork(
           current,
           workInProgress,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1289,8 +1289,11 @@ function renderRoot(root: FiberRoot, isYieldy: boolean): void {
 
       // Reset in case completion throws.
       // This is only used in DEV and when replaying is on.
-      const mayReplay = mayReplayFailedUnitOfWork;
-      mayReplayFailedUnitOfWork = true;
+      let mayReplay;
+      if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
+        mayReplay = mayReplayFailedUnitOfWork;
+        mayReplayFailedUnitOfWork = true;
+      }
 
       if (nextUnitOfWork === null) {
         // This is a fatal error.


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/13820.

Dunno if this is an "idiomatic" fix. The issue is that we null out `nextUnitOfWork` as we traverse up during completion, but we also don't attempt to find an error boundary if `nextUnitOfWork` is null:

https://github.com/facebook/react/blob/b305c4e034bbb3b13df2028c0503a84f91e57455/packages/react-reconciler/src/ReactFiberScheduler.js#L1280-L1284

So errors in completion phase don't look for boundaries at all right now.