### PR TITLE
Fix the error message to reflect the method name

### DIFF
--- a/packages/jest-react/src/JestReact.js
+++ b/packages/jest-react/src/JestReact.js
@@ -30,7 +30,7 @@ function assertYieldsWereCleared(root) {
   invariant(
     actualYields.length === 0,
     'Log of yielded values is not empty. ' +
-      'Call expect(ReactTestRenderer).unstable_toHaveYielded(...) first.',
+      'Call expect(ReactTestRenderer).toHaveYielded(...) first.',
   );
 }
 


### PR DESCRIPTION
The method suggested in this error message doesn't exist. It tripped me more than once.

Does it get renamed somewhere? We should either fix the error message or fix the name.