### PR TITLE
Use Function.prototype.apply in warningWithoutStack

### DIFF
--- a/packages/shared/warningWithoutStack.js
+++ b/packages/shared/warningWithoutStack.js
@@ -32,44 +32,12 @@ if (__DEV__) {
       return;
     }
     if (typeof console !== 'undefined') {
-      const [a, b, c, d, e, f, g, h] = args.map(item => '' + item);
-      const message = 'Warning: ' + format;
+      const argsWithFormat = args.map(item => '' + item);
+      argsWithFormat.unshift('Warning: ' + format);
 
-      // We intentionally don't use spread (or .apply) because it breaks IE9:
-      // https://github.com/facebook/react/issues/13610
-      switch (args.length) {
-        case 0:
-          console.error(message);
-          break;
-        case 1:
-          console.error(message, a);
-          break;
-        case 2:
-          console.error(message, a, b);
-          break;
-        case 3:
-          console.error(message, a, b, c);
-          break;
-        case 4:
-          console.error(message, a, b, c, d);
-          break;
-        case 5:
-          console.error(message, a, b, c, d, e);
-          break;
-        case 6:
-          console.error(message, a, b, c, d, e, f);
-          break;
-        case 7:
-          console.error(message, a, b, c, d, e, f, g);
-          break;
-        case 8:
-          console.error(message, a, b, c, d, e, f, g, h);
-          break;
-        default:
-          throw new Error(
-            'warningWithoutStack() currently supports at most 8 arguments.',
-          );
-      }
+      // We intentionally don't use spread (or .apply) directly because it
+      // breaks IE9: https://github.com/facebook/react/issues/13610
+      Function.prototype.apply.call(console.error, console, argsWithFormat);
     }
     try {
       // --- Welcome to debugging React ---


### PR DESCRIPTION
console.error.apply() fails in IE9, but I verified this works (and it works everywhere else too). :)

Ref #13610.