### PR TITLE
Fix lazy() with defaultProps

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -103,7 +103,10 @@ import {
   resumeMountClassInstance,
   updateClassInstance,
 } from './ReactFiberClassComponent';
-import {readLazyComponentType} from './ReactFiberLazyComponent';
+import {
+  readLazyComponentType,
+  resolveDefaultProps,
+} from './ReactFiberLazyComponent';
 import {
   resolveLazyComponentTag,
   createFiberFromTypeAndProps,
@@ -727,21 +730,6 @@ function updateHostText(current, workInProgress) {
   // Nothing to do here. This is terminal. We'll do the completion step
   // immediately after.
   return null;
-}
-
-function resolveDefaultProps(Component, baseProps) {
-  if (Component && Component.defaultProps) {
-    // Resolve default props. Taken from ReactElement
-    const props = Object.assign({}, baseProps);
-    const defaultProps = Component.defaultProps;
-    for (let propName in defaultProps) {
-      if (props[propName] === undefined) {
-        props[propName] = defaultProps[propName];
-      }
-    }
-    return props;
-  }
-  return baseProps;
 }
 
 function mountLazyComponent(

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -771,10 +771,7 @@ function mountLazyComponent(
   workInProgress.type = Component;
   const resolvedTag = (workInProgress.tag = resolveLazyComponentTag(Component));
   startWorkTimer(workInProgress);
-  const resolvedProps = (workInProgress.pendingProps = resolveDefaultProps(
-    Component,
-    props,
-  ));
+  const resolvedProps = resolveDefaultProps(Component, props);
   let child;
   switch (resolvedTag) {
     case FunctionComponent: {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -771,7 +771,10 @@ function mountLazyComponent(
   workInProgress.type = Component;
   const resolvedTag = (workInProgress.tag = resolveLazyComponentTag(Component));
   startWorkTimer(workInProgress);
-  const resolvedProps = resolveDefaultProps(Component, props);
+  const resolvedProps = (workInProgress.pendingProps = resolveDefaultProps(
+    Component,
+    props,
+  ));
   let child;
   switch (resolvedTag) {
     case FunctionComponent: {

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -28,6 +28,7 @@ import warningWithoutStack from 'shared/warningWithoutStack';
 import {REACT_CONTEXT_TYPE} from 'shared/ReactSymbols';
 
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
+import {resolveDefaultProps} from './ReactFiberLazyComponent';
 import {StrictMode} from './ReactTypeOfMode';
 
 import {
@@ -987,7 +988,7 @@ function updateClassInstance(
   const instance = workInProgress.stateNode;
 
   const oldProps = workInProgress.memoizedProps;
-  instance.props = oldProps;
+  instance.props = resolveDefaultProps(workInProgress.type, oldProps);
 
   const oldContext = instance.context;
   const contextType = ctor.contextType;

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -988,7 +988,10 @@ function updateClassInstance(
   const instance = workInProgress.stateNode;
 
   const oldProps = workInProgress.memoizedProps;
-  instance.props = resolveDefaultProps(workInProgress.type, oldProps);
+  instance.props =
+    workInProgress.type === workInProgress.elementType
+      ? oldProps
+      : resolveDefaultProps(workInProgress.type, oldProps);
 
   const oldContext = instance.context;
   const contextType = ctor.contextType;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -229,13 +229,18 @@ function commitBeforeMutationLifeCycles(
           const prevState = current.memoizedState;
           startPhaseTimer(finishedWork, 'getSnapshotBeforeUpdate');
           const instance = finishedWork.stateNode;
-          instance.props = resolveDefaultProps(
-            finishedWork.type,
-            finishedWork.memoizedProps,
-          );
+          instance.props =
+            finishedWork.elementType === finishedWork.type
+              ? finishedWork.memoizedProps
+              : resolveDefaultProps(
+                  finishedWork.type,
+                  finishedWork.memoizedProps,
+                );
           instance.state = finishedWork.memoizedState;
           const snapshot = instance.getSnapshotBeforeUpdate(
-            resolveDefaultProps(finishedWork.type, prevProps),
+            finishedWork.elementType === finishedWork.type
+              ? prevProps
+              : resolveDefaultProps(finishedWork.type, prevProps),
             prevState,
           );
           if (__DEV__) {
@@ -349,24 +354,30 @@ function commitLifeCycles(
       if (finishedWork.effectTag & Update) {
         if (current === null) {
           startPhaseTimer(finishedWork, 'componentDidMount');
-          instance.props = resolveDefaultProps(
-            finishedWork.type,
-            finishedWork.memoizedProps,
-          );
+          instance.props =
+            finishedWork.elementType === finishedWork.type
+              ? finishedWork.memoizedProps
+              : resolveDefaultProps(
+                  finishedWork.type,
+                  finishedWork.memoizedProps,
+                );
           instance.state = finishedWork.memoizedState;
           instance.componentDidMount();
           stopPhaseTimer();
         } else {
-          const prevProps = resolveDefaultProps(
-            finishedWork.type,
-            current.memoizedProps,
-          );
+          const prevProps =
+            finishedWork.elementType === finishedWork.type
+              ? current.memoizedProps
+              : resolveDefaultProps(finishedWork.type, current.memoizedProps);
           const prevState = current.memoizedState;
           startPhaseTimer(finishedWork, 'componentDidUpdate');
-          instance.props = resolveDefaultProps(
-            finishedWork.type,
-            finishedWork.memoizedProps,
-          );
+          instance.props =
+            finishedWork.elementType === finishedWork.type
+              ? finishedWork.memoizedProps
+              : resolveDefaultProps(
+                  finishedWork.type,
+                  finishedWork.memoizedProps,
+                );
           instance.state = finishedWork.memoizedState;
           instance.componentDidUpdate(
             prevProps,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -143,8 +143,9 @@ export function logError(boundary: Fiber, errorInfo: CapturedValue<mixed>) {
 
 const callComponentWillUnmountWithTimer = function(current, instance) {
   startPhaseTimer(current, 'componentWillUnmount');
-  instance.props = current.memoizedProps;
-  instance.state = current.memoizedState;
+  // We could update instance props and state here,
+  // but instead we rely on them being set during last render.
+  // TODO: revisit this when we implement resuming.
   instance.componentWillUnmount();
   stopPhaseTimer();
 };
@@ -229,14 +230,9 @@ function commitBeforeMutationLifeCycles(
           const prevState = current.memoizedState;
           startPhaseTimer(finishedWork, 'getSnapshotBeforeUpdate');
           const instance = finishedWork.stateNode;
-          instance.props =
-            finishedWork.elementType === finishedWork.type
-              ? finishedWork.memoizedProps
-              : resolveDefaultProps(
-                  finishedWork.type,
-                  finishedWork.memoizedProps,
-                );
-          instance.state = finishedWork.memoizedState;
+          // We could update instance props and state here,
+          // but instead we rely on them being set during last render.
+          // TODO: revisit this when we implement resuming.
           const snapshot = instance.getSnapshotBeforeUpdate(
             finishedWork.elementType === finishedWork.type
               ? prevProps
@@ -354,14 +350,9 @@ function commitLifeCycles(
       if (finishedWork.effectTag & Update) {
         if (current === null) {
           startPhaseTimer(finishedWork, 'componentDidMount');
-          instance.props =
-            finishedWork.elementType === finishedWork.type
-              ? finishedWork.memoizedProps
-              : resolveDefaultProps(
-                  finishedWork.type,
-                  finishedWork.memoizedProps,
-                );
-          instance.state = finishedWork.memoizedState;
+          // We could update instance props and state here,
+          // but instead we rely on them being set during last render.
+          // TODO: revisit this when we implement resuming.
           instance.componentDidMount();
           stopPhaseTimer();
         } else {
@@ -371,14 +362,9 @@ function commitLifeCycles(
               : resolveDefaultProps(finishedWork.type, current.memoizedProps);
           const prevState = current.memoizedState;
           startPhaseTimer(finishedWork, 'componentDidUpdate');
-          instance.props =
-            finishedWork.elementType === finishedWork.type
-              ? finishedWork.memoizedProps
-              : resolveDefaultProps(
-                  finishedWork.type,
-                  finishedWork.memoizedProps,
-                );
-          instance.state = finishedWork.memoizedState;
+          // We could update instance props and state here,
+          // but instead we rely on them being set during last render.
+          // TODO: revisit this when we implement resuming.
           instance.componentDidUpdate(
             prevProps,
             prevState,
@@ -389,8 +375,9 @@ function commitLifeCycles(
       }
       const updateQueue = finishedWork.updateQueue;
       if (updateQueue !== null) {
-        instance.props = finishedWork.memoizedProps;
-        instance.state = finishedWork.memoizedState;
+        // We could update instance props and state here,
+        // but instead we rely on them being set during last render.
+        // TODO: revisit this when we implement resuming.
         commitUpdateQueue(
           finishedWork,
           updateQueue,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -143,9 +143,8 @@ export function logError(boundary: Fiber, errorInfo: CapturedValue<mixed>) {
 
 const callComponentWillUnmountWithTimer = function(current, instance) {
   startPhaseTimer(current, 'componentWillUnmount');
-  // We could update instance props and state here,
-  // but instead we rely on them being set during last render.
-  // TODO: revisit this when we implement resuming.
+  instance.props = current.memoizedProps;
+  instance.state = current.memoizedState;
   instance.componentWillUnmount();
   stopPhaseTimer();
 };

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -60,6 +60,7 @@ import {onCommitUnmount} from './ReactFiberDevToolsHook';
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
 import {getStackByFiberInDevAndProd} from './ReactCurrentFiber';
 import {logCapturedError} from './ReactFiberErrorLogger';
+import {resolveDefaultProps} from './ReactFiberLazyComponent';
 import {getCommitTime} from './ReactProfilerTimer';
 import {commitUpdateQueue} from './ReactUpdateQueue';
 import {
@@ -345,15 +346,24 @@ function commitLifeCycles(
       if (finishedWork.effectTag & Update) {
         if (current === null) {
           startPhaseTimer(finishedWork, 'componentDidMount');
-          instance.props = finishedWork.memoizedProps;
+          instance.props = resolveDefaultProps(
+            finishedWork.type,
+            finishedWork.memoizedProps,
+          );
           instance.state = finishedWork.memoizedState;
           instance.componentDidMount();
           stopPhaseTimer();
         } else {
-          const prevProps = current.memoizedProps;
+          const prevProps = resolveDefaultProps(
+            finishedWork.type,
+            current.memoizedProps,
+          );
           const prevState = current.memoizedState;
           startPhaseTimer(finishedWork, 'componentDidUpdate');
-          instance.props = finishedWork.memoizedProps;
+          instance.props = resolveDefaultProps(
+            finishedWork.type,
+            finishedWork.memoizedProps,
+          );
           instance.state = finishedWork.memoizedState;
           instance.componentDidUpdate(
             prevProps,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -229,10 +229,13 @@ function commitBeforeMutationLifeCycles(
           const prevState = current.memoizedState;
           startPhaseTimer(finishedWork, 'getSnapshotBeforeUpdate');
           const instance = finishedWork.stateNode;
-          instance.props = finishedWork.memoizedProps;
+          instance.props = resolveDefaultProps(
+            finishedWork.type,
+            finishedWork.memoizedProps,
+          );
           instance.state = finishedWork.memoizedState;
           const snapshot = instance.getSnapshotBeforeUpdate(
-            prevProps,
+            resolveDefaultProps(finishedWork.type, prevProps),
             prevState,
           );
           if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -12,7 +12,7 @@ import type {LazyComponent, Thenable} from 'shared/ReactLazyComponent';
 import {Resolved, Rejected, Pending} from 'shared/ReactLazyComponent';
 import warning from 'shared/warning';
 
-export function resolveDefaultProps(Component, baseProps) {
+export function resolveDefaultProps(Component: any, baseProps: Object): Object {
   if (Component && Component.defaultProps) {
     // Resolve default props. Taken from ReactElement
     const props = Object.assign({}, baseProps);

--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -12,6 +12,21 @@ import type {LazyComponent, Thenable} from 'shared/ReactLazyComponent';
 import {Resolved, Rejected, Pending} from 'shared/ReactLazyComponent';
 import warning from 'shared/warning';
 
+export function resolveDefaultProps(Component, baseProps) {
+  if (Component && Component.defaultProps) {
+    // Resolve default props. Taken from ReactElement
+    const props = Object.assign({}, baseProps);
+    const defaultProps = Component.defaultProps;
+    for (let propName in defaultProps) {
+      if (props[propName] === undefined) {
+        props[propName] = defaultProps[propName];
+      }
+    }
+    return props;
+  }
+  return baseProps;
+}
+
 export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
   const status = lazyComponent._status;
   const result = lazyComponent._result;

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -379,7 +379,7 @@ describe('ReactLazy', () => {
       'shouldComponentUpdate (this.props): A',
       'shouldComponentUpdate (nextProps): A',
       'A2', // render
-      'getSnapshotBeforeUpdate (this.props): undefined',
+      'getSnapshotBeforeUpdate (this.props): A',
       'getSnapshotBeforeUpdate (prevProps): A',
       'componentDidUpdate: A',
     ]);

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -283,7 +283,6 @@ describe('ReactLazy', () => {
   });
 
   it('sets defaultProps for modern lifecycles', async () => {
-    const log = [];
     class C extends React.Component {
       static defaultProps = {text: 'A'};
       state = {};
@@ -326,7 +325,6 @@ describe('ReactLazy', () => {
       }
 
       getSnapshotBeforeUpdate(prevProps) {
-        console.log(this.props);
         ReactTestRenderer.unstable_yield(
           `getSnapshotBeforeUpdate: ${prevProps.text} -> ${this.props.text}`,
         );
@@ -378,7 +376,6 @@ describe('ReactLazy', () => {
   });
 
   it('sets defaultProps for legacy lifecycles', async () => {
-    const log = [];
     class C extends React.Component {
       static defaultProps = {text: 'A'};
       state = {};

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -282,11 +282,10 @@ describe('ReactLazy', () => {
     expect(root).toMatchRenderedOutput('SiblingB');
   });
 
-  it('sets defaultProps for all lifecycles', async () => {
+  it('sets defaultProps for modern lifecycles', async () => {
     const log = [];
     class C extends React.Component {
       static defaultProps = {text: 'A'};
-      // Added to allow gDSFP
       state = {};
 
       static getDerivedStateFromProps(props) {
@@ -307,9 +306,9 @@ describe('ReactLazy', () => {
         );
       }
 
-      componentDidUpdate() {
+      componentDidUpdate(prevProps) {
         ReactTestRenderer.unstable_yield(
-          `componentDidUpdate: ${this.props.text}`,
+          `componentDidUpdate: ${prevProps.text} -> ${this.props.text}`,
         );
       }
 
@@ -321,10 +320,7 @@ describe('ReactLazy', () => {
 
       shouldComponentUpdate(nextProps) {
         ReactTestRenderer.unstable_yield(
-          `shouldComponentUpdate (this.props): ${this.props.text}`,
-        );
-        ReactTestRenderer.unstable_yield(
-          `shouldComponentUpdate (nextProps): ${nextProps.text}`,
+          `shouldComponentUpdate: ${this.props.text} -> ${nextProps.text}`,
         );
         return true;
       }
@@ -332,10 +328,7 @@ describe('ReactLazy', () => {
       getSnapshotBeforeUpdate(prevProps) {
         console.log(this.props);
         ReactTestRenderer.unstable_yield(
-          `getSnapshotBeforeUpdate (this.props): ${this.props.text}`,
-        );
-        ReactTestRenderer.unstable_yield(
-          `getSnapshotBeforeUpdate (prevProps): ${prevProps.text}`,
+          `getSnapshotBeforeUpdate: ${prevProps.text} -> ${this.props.text}`,
         );
         return null;
       }
@@ -364,7 +357,7 @@ describe('ReactLazy', () => {
     expect(root).toFlushAndYield([
       'constructor: A',
       'getDerivedStateFromProps: A',
-      'A1', // render
+      'A1',
       'componentDidMount: A',
     ]);
 
@@ -376,12 +369,10 @@ describe('ReactLazy', () => {
 
     expect(root).toFlushAndYield([
       'getDerivedStateFromProps: A',
-      'shouldComponentUpdate (this.props): A',
-      'shouldComponentUpdate (nextProps): A',
-      'A2', // render
-      'getSnapshotBeforeUpdate (this.props): A',
-      'getSnapshotBeforeUpdate (prevProps): A',
-      'componentDidUpdate: A',
+      'shouldComponentUpdate: A -> A',
+      'A2',
+      'getSnapshotBeforeUpdate: A -> A',
+      'componentDidUpdate: A -> A',
     ]);
     expect(root).toMatchRenderedOutput('A2');
   });

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -364,7 +364,6 @@ describe('ReactLazy', () => {
         <LazyClass num={2} />
       </Suspense>,
     );
-
     expect(root).toFlushAndYield([
       'getDerivedStateFromProps: A',
       'shouldComponentUpdate: A -> A',
@@ -373,6 +372,20 @@ describe('ReactLazy', () => {
       'componentDidUpdate: A -> A',
     ]);
     expect(root).toMatchRenderedOutput('A2');
+
+    root.update(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyClass num={3} />
+      </Suspense>,
+    );
+    expect(root).toFlushAndYield([
+      'getDerivedStateFromProps: A',
+      'shouldComponentUpdate: A -> A',
+      'A3',
+      'getSnapshotBeforeUpdate: A -> A',
+      'componentDidUpdate: A -> A',
+    ]);
+    expect(root).toMatchRenderedOutput('A3');
   });
 
   it('sets defaultProps for legacy lifecycles', async () => {
@@ -424,7 +437,6 @@ describe('ReactLazy', () => {
         <LazyClass num={2} />
       </Suspense>,
     );
-
     expect(ReactTestRenderer).toHaveYielded([
       'UNSAFE_componentWillMount: A',
       'A1',
@@ -434,6 +446,19 @@ describe('ReactLazy', () => {
     ]);
     expect(root).toFlushAndYield([]);
     expect(root).toMatchRenderedOutput('A2');
+
+    root.update(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyClass num={3} />
+      </Suspense>,
+    );
+    expect(ReactTestRenderer).toHaveYielded([
+      'UNSAFE_componentWillReceiveProps: A -> A',
+      'UNSAFE_componentWillUpdate: A -> A',
+      'A3',
+    ]);
+    expect(root).toFlushAndYield([]);
+    expect(root).toMatchRenderedOutput('A3');
   });
 
   it('includes lazy-loaded component in warning stack', async () => {


### PR DESCRIPTION
Builds on failing tests from https://github.com/facebook/react/pull/14108.
Fixes https://github.com/facebook/react/issues/13960.

I might have missed something. Just pushing it before going home. I haven't thought about the perf impact of this. Maybe we need to change the strategy and store them?