### PR TITLE
Implement {,un}hideInstance on RN renderer

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -381,7 +381,16 @@ export function cloneHiddenInstance(
   props: Props,
   internalInstanceHandle: Object,
 ): Instance {
-  throw new Error('Not yet implemented.');
+  const viewConfig = instance.canonical.viewConfig;
+  const node = instance.node;
+  const updatePayload = ReactNativeAttributePayload.create(
+    {style: {display: 'none'}},
+    viewConfig.validAttributes,
+  );
+  return {
+    node: cloneNodeWithNewProps(node, updatePayload),
+    canonical: instance.canonical,
+  };
 }
 
 export function cloneUnhiddenInstance(
@@ -390,7 +399,17 @@ export function cloneUnhiddenInstance(
   props: Props,
   internalInstanceHandle: Object,
 ): Instance {
-  throw new Error('Not yet implemented.');
+  const viewConfig = instance.canonical.viewConfig;
+  const node = instance.node;
+  const updatePayload = ReactNativeAttributePayload.diff(
+    {...props, style: [props.style, {display: 'none'}]},
+    props,
+    viewConfig.validAttributes,
+  );
+  return {
+    node: cloneNodeWithNewProps(node, updatePayload),
+    canonical: instance.canonical,
+  };
 }
 
 export function createHiddenTextInstance(

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -454,7 +454,16 @@ export function resetTextContent(instance: Instance): void {
 }
 
 export function hideInstance(instance: Instance): void {
-  throw new Error('Not yet implemented.');
+  const viewConfig = instance.viewConfig;
+  const updatePayload = ReactNativeAttributePayload.create(
+    {style: {display: 'none'}},
+    viewConfig.validAttributes,
+  );
+  UIManager.updateView(
+    instance._nativeTag,
+    viewConfig.uiViewClassName,
+    updatePayload,
+  );
 }
 
 export function hideTextInstance(textInstance: TextInstance): void {
@@ -462,7 +471,17 @@ export function hideTextInstance(textInstance: TextInstance): void {
 }
 
 export function unhideInstance(instance: Instance, props: Props): void {
-  throw new Error('Not yet implemented.');
+  const viewConfig = instance.viewConfig;
+  const updatePayload = ReactNativeAttributePayload.diff(
+    {...props, style: [props.style, {display: 'none'}]},
+    props,
+    viewConfig.validAttributes,
+  );
+  UIManager.updateView(
+    instance._nativeTag,
+    viewConfig.uiViewClassName,
+    updatePayload,
+  );
 }
 
 export function unhideTextInstance(


### PR DESCRIPTION
This is required to use lazy.

Test Plan:
* Verified lazy works on a real world use case (shows spinner, shows real content).
* Verified that if I change the primary content's styles to have `display: 'none'` then it never appears (i.e., the code in `unhide` reads the styles successfully)