### PR TITLE
Enable hooks in www build

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -21,7 +21,7 @@ export const {
 } = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.
-export const enableHooks = false;
+export const enableHooks = true;
 
 // In www, we have experimental support for gathering data
 // from User Timing API calls in production. By default, we


### PR DESCRIPTION
The `enableHooks` feature flag used to only control whether the API was exposed on the React package. But since #14111 landed, it also determines if the dispatcher and implementation are included in the bundle.

We're using hooks in www, so I've switched the feature flag to `true` in the www build.

(Alternatively, we could have two feature flags: one for the implementation and dispatcher, and one for exposing the API on the React package.)