### PR TITLE
Reuse logic between createElement and cloneElement

### DIFF
--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -337,6 +337,11 @@ export function cloneElement(element, config, children) {
     for (let i = 0; i < childrenLength; i++) {
       childArray[i] = arguments[i + 2];
     }
+    if (__DEV__) {
+      if (Object.freeze) {
+        Object.freeze(childArray);
+      }
+    }
     props.children = childArray;
   }
 


### PR DESCRIPTION
I have been going through the codebase to better understand how React works under the hood, when I noticed that `createElement` and `cloneElement` appeared to handle setting props differently, which didn't make sense to me based on what I know about React. After looking closer, I realized that they both actually do the same thing, but the difference in logic threw me off a bit at first glance.

This PR adds a minor refactor to reuse the shared logic between `createElement` and `cloneElement` so that it is more explicit that the props are set in the same way.