### PR TITLE
Check correct commit phase props in fuzz tester

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
@@ -189,6 +189,7 @@ describe('ReactIncrementalTriangle', () => {
           leafTriangles.push(this);
         }
         this.state = {isActive: false};
+        this.child = React.createRef(null);
       }
       activate() {
         this.setState({isActive: true});
@@ -202,6 +203,14 @@ describe('ReactIncrementalTriangle', () => {
           this.props.activeDepth !== nextProps.activeDepth ||
           this.state.isActive !== nextState.isActive
         );
+      }
+      componentDidUpdate() {
+        if (this.child.current !== null) {
+          const {prop: currentCounter} = JSON.parse(this.child.current.prop);
+          if (this.props.counter !== currentCounter) {
+            throw new Error('Incorrect props in lifecycle');
+          }
+        }
       }
       render() {
         if (yieldAfterEachRender) {
@@ -228,7 +237,7 @@ describe('ReactIncrementalTriangle', () => {
                       activeDepthProp,
                       activeDepthContext,
                     });
-                    return <span prop={output} />;
+                    return <span ref={this.child} prop={output} />;
                   }
 
                   return (


### PR DESCRIPTION
Adds a check to the existing fuzz tester to confirm that the props are set to the latest values in the commit phase. Only checks componentDidUpdate; we already have unit tests for the other lifecycles, so I think this is good enough. This is only a redundancy.