### PR TITLE
[WIP] Refactor beginWork replay

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
@@ -186,7 +186,6 @@ describe('ReactIncrementalErrorLogging', () => {
         'render: 0',
         __DEV__ && 'render: 0', // replay
         'render: 1',
-        __DEV__ && 'render: 1', // replay
         'componentWillUnmount: 0',
       ].filter(Boolean),
     );


### PR DESCRIPTION
**WIP, doesn’t work**

I want to follow up on https://github.com/facebook/react/pull/14104#discussion_r231288310 and try to simplify this logic.

So far, I've tried to separate `beginWorkInDEV` that would call `beingWork` and fall back to `replay` in a `catch` block. A dozen tests are currently failing with a context mismatch or something like this, but I’m not sure why. I also realized that there might be a reason replaying calls `workLoop` rather than `beginWork` directly (which seems like it would be simpler?) — for example, `beginWork` might assume the profiler timer has already started. So we need to make sure that any initialization that happens prior to `beginWork` also happens on the replay code path, or revert to calling `workLoop`.