### PR TITLE
Tag MemoComponent with PerformedWork effectTag for DevTools Profiler

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -283,6 +283,8 @@ function updateMemoComponent(
       );
     }
   }
+  // React DevTools reads this flag.
+  workInProgress.effectTag |= PerformedWork;
   let newChild = createWorkInProgress(
     currentChild,
     nextProps,


### PR DESCRIPTION
It's hard for DevTools to detect when this component type renders or bails without this effect tag.

Related to facebook/react-devtools/pull/1222