### PR TITLE
Don't run danger on bad build

### DIFF
--- a/scripts/circleci/build.sh
+++ b/scripts/circleci/build.sh
@@ -8,6 +8,9 @@ set -e
 # the merge base by Dangerfile instead. See https://github.com/facebook/react/pull/12606.
 if [ -z "$CI_PULL_REQUEST" ]; then
   curl -o scripts/rollup/results.json http://react.zpao.com/builds/master/latest/results.json
+else
+  # If build fails, cause danger to fail/abort too
+  rm scripts/rollup/results.json
 fi
 
 yarn build --extract-errors

--- a/scripts/rollup/stats.js
+++ b/scripts/rollup/stats.js
@@ -5,7 +5,9 @@ const filesize = require('filesize');
 const chalk = require('chalk');
 const join = require('path').join;
 const fs = require('fs');
-const prevBuildResults = require('./results.json');
+const prevBuildResults = fs.existsSync(__dirname + '/results.json')
+  ? require('./results.json')
+  : {bundleSizes: []};
 
 const currentBuildResults = {
   // Mutated inside build.js during a build run.


### PR DESCRIPTION
sizebot comments can be confusing when not based on reality.

If results.json doesn't exist, danger will fail. This is what we want.
