### PR TITLE
Use Entry in `yarn build ...` Instead of Label

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -410,6 +410,12 @@ function getPlugins(
   ].filter(Boolean);
 }
 
+const isIndexName = /\/index(.js)?$/;
+
+function endsWith(str, suffix) {
+  return str.substr(str.length - suffix.length) === suffix;
+}
+
 function shouldSkipBundle(bundle, bundleType) {
   const shouldSkipBundleType = bundle.bundleTypes.indexOf(bundleType) === -1;
   if (shouldSkipBundleType) {
@@ -425,7 +431,14 @@ function shouldSkipBundle(bundle, bundleType) {
   }
   if (requestedBundleNames.length > 0) {
     const isAskingForDifferentNames = requestedBundleNames.every(
-      requestedName => bundle.label.indexOf(requestedName) === -1
+      // If the name ends with `something/index` we only match if the
+      // entry ends in something. Such as `react-dom/index` only matches
+      // `react-dom` but not `react-dom/server`. Everything else is fuzzy
+      // search.
+      requestedName =>
+        isIndexName.test(requestedName)
+          ? !endsWith(bundle.entry, requestedName.replace(isIndexName, ''))
+          : bundle.entry.indexOf(requestedName) === -1
     );
     if (isAskingForDifferentNames) {
       return true;

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -410,12 +410,6 @@ function getPlugins(
   ].filter(Boolean);
 }
 
-const isIndexName = /\/index(.js)?$/;
-
-function endsWith(str, suffix) {
-  return str.substr(str.length - suffix.length) === suffix;
-}
-
 function shouldSkipBundle(bundle, bundleType) {
   const shouldSkipBundleType = bundle.bundleTypes.indexOf(bundleType) === -1;
   if (shouldSkipBundleType) {
@@ -436,9 +430,7 @@ function shouldSkipBundle(bundle, bundleType) {
       // `react-dom` but not `react-dom/server`. Everything else is fuzzy
       // search.
       requestedName =>
-        isIndexName.test(requestedName)
-          ? !endsWith(bundle.entry, requestedName.replace(isIndexName, ''))
-          : bundle.entry.indexOf(requestedName) === -1
+        (bundle.entry + '/index.js').indexOf(requestedName) === -1
     );
     if (isAskingForDifferentNames) {
       return true;

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -53,12 +53,30 @@ const {
   RN_FB_PROFILING,
 } = Bundles.bundleTypes;
 
-const requestedBundleTypes = (argv.type || '')
-  .split(',')
-  .map(type => type.toUpperCase());
-const requestedBundleNames = (argv._[0] || '')
-  .split(',')
-  .map(type => type.toLowerCase());
+function parseRequestedNames(names, toCase) {
+  let result = [];
+  for (let i = 0; i < names.length; i++) {
+    let splitNames = names[i].split(',');
+    for (let j = 0; j < splitNames.length; j++) {
+      let name = splitNames[j].trim();
+      if (!name) {
+        continue;
+      }
+      if (toCase === 'uppercase') {
+        name = name.toUpperCase();
+      } else if (toCase === 'lowercase') {
+        name = name.toLowerCase();
+      }
+      result.push(name);
+    }
+  }
+  return result;
+}
+
+const requestedBundleTypes = argv.type
+  ? parseRequestedNames([argv.type], 'uppercase')
+  : [];
+const requestedBundleNames = parseRequestedNames(argv._, 'lowercase');
 const forcePrettyOutput = argv.pretty;
 const syncFBSourcePath = argv['sync-fbsource'];
 const syncWWWPath = argv['sync-www'];

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -56,7 +56,6 @@ const NON_FIBER_RENDERER = moduleTypes.NON_FIBER_RENDERER;
 const bundles = [
   /******* Isomorphic *******/
   {
-    label: 'core',
     bundleTypes: [
       UMD_DEV,
       UMD_PROD,
@@ -75,7 +74,6 @@ const bundles = [
 
   /******* React DOM *******/
   {
-    label: 'dom-client',
     bundleTypes: [
       UMD_DEV,
       UMD_PROD,
@@ -95,7 +93,6 @@ const bundles = [
 
   //******* Test Utils *******/
   {
-    label: 'dom-test-utils',
     moduleType: RENDERER_UTILS,
     bundleTypes: [FB_WWW_DEV, NODE_DEV, NODE_PROD, UMD_DEV, UMD_PROD],
     entry: 'react-dom/test-utils',
@@ -105,7 +102,6 @@ const bundles = [
 
   /* React DOM internals required for react-native-web (e.g., to shim native events from react-dom) */
   {
-    label: 'dom-unstable-native-dependencies',
     bundleTypes: [
       UMD_DEV,
       UMD_PROD,
@@ -122,7 +118,6 @@ const bundles = [
 
   /******* React DOM Server *******/
   {
-    label: 'dom-server-browser',
     bundleTypes: [
       UMD_DEV,
       UMD_PROD,
@@ -138,7 +133,6 @@ const bundles = [
   },
 
   {
-    label: 'dom-server-node',
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: NON_FIBER_RENDERER,
     entry: 'react-dom/server.node',
@@ -147,7 +141,6 @@ const bundles = [
 
   /******* React ART *******/
   {
-    label: 'art',
     bundleTypes: [
       UMD_DEV,
       UMD_PROD,
@@ -169,7 +162,6 @@ const bundles = [
 
   /******* React Native *******/
   {
-    label: 'native-fb',
     bundleTypes: [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer',
@@ -189,7 +181,6 @@ const bundles = [
   },
 
   {
-    label: 'native',
     bundleTypes: [RN_OSS_DEV, RN_OSS_PROD, RN_OSS_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer',
@@ -210,7 +201,6 @@ const bundles = [
 
   /******* React Native Fabric *******/
   {
-    label: 'native-fabric-fb',
     bundleTypes: [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer/fabric',
@@ -231,7 +221,6 @@ const bundles = [
   },
 
   {
-    label: 'native-fabric',
     bundleTypes: [RN_OSS_DEV, RN_OSS_PROD, RN_OSS_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer/fabric',
@@ -253,7 +242,6 @@ const bundles = [
 
   /******* React Test Renderer *******/
   {
-    label: 'test',
     bundleTypes: [FB_WWW_DEV, NODE_DEV, NODE_PROD, UMD_DEV, UMD_PROD],
     moduleType: RENDERER,
     entry: 'react-test-renderer',
@@ -262,7 +250,6 @@ const bundles = [
   },
 
   {
-    label: 'test-shallow',
     bundleTypes: [FB_WWW_DEV, NODE_DEV, NODE_PROD, UMD_DEV, UMD_PROD],
     moduleType: NON_FIBER_RENDERER,
     entry: 'react-test-renderer/shallow',
@@ -272,7 +259,6 @@ const bundles = [
 
   /******* React Noop Renderer (used for tests) *******/
   {
-    label: 'noop',
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-noop-renderer',
@@ -295,7 +281,6 @@ const bundles = [
 
   /******* React Noop Persistent Renderer (used for tests) *******/
   {
-    label: 'noop-persistent',
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-noop-renderer/persistent',
@@ -318,7 +303,6 @@ const bundles = [
 
   /******* React Reconciler *******/
   {
-    label: 'react-reconciler',
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RECONCILER,
     entry: 'react-reconciler',
@@ -328,7 +312,6 @@ const bundles = [
 
   /******* React Persistent Reconciler *******/
   {
-    label: 'react-reconciler-persistent',
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RECONCILER,
     entry: 'react-reconciler/persistent',
@@ -338,7 +321,6 @@ const bundles = [
 
   /******* Reflection *******/
   {
-    label: 'reconciler-reflection',
     moduleType: RENDERER_UTILS,
     bundleTypes: [NODE_DEV, NODE_PROD],
     entry: 'react-reconciler/reflection',
@@ -348,7 +330,6 @@ const bundles = [
 
   /******* React Is *******/
   {
-    label: 'react-is',
     bundleTypes: [
       NODE_DEV,
       NODE_PROD,
@@ -365,7 +346,6 @@ const bundles = [
 
   /******* React Debug Tools *******/
   {
-    label: 'react-debug-tools',
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react-debug-tools',
@@ -375,7 +355,6 @@ const bundles = [
 
   /******* React Cache (experimental) *******/
   {
-    label: 'react-cache',
     bundleTypes: [
       FB_WWW_DEV,
       FB_WWW_PROD,
@@ -392,7 +371,6 @@ const bundles = [
 
   /******* createComponentWithSubscriptions (experimental) *******/
   {
-    label: 'create-subscription',
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'create-subscription',
@@ -402,7 +380,6 @@ const bundles = [
 
   /******* React Scheduler (experimental) *******/
   {
-    label: 'scheduler',
     bundleTypes: [NODE_DEV, NODE_PROD, FB_WWW_DEV, FB_WWW_PROD],
     moduleType: ISOMORPHIC,
     entry: 'scheduler',
@@ -412,7 +389,6 @@ const bundles = [
 
   /******* Jest React (experimental) *******/
   {
-    label: 'jest-react',
     bundleTypes: [NODE_DEV, NODE_PROD, FB_WWW_DEV, FB_WWW_PROD],
     moduleType: ISOMORPHIC,
     entry: 'jest-react',
@@ -422,7 +398,6 @@ const bundles = [
 
   /******* ESLint Plugin for Hooks (proposal) *******/
   {
-    label: 'eslint-plugin-react-hooks',
     // TODO: it's awkward to create a bundle for this
     // but if we don't, the package won't get copied.
     // We also can't create just DEV bundle because
@@ -436,7 +411,6 @@ const bundles = [
   },
 
   {
-    label: 'scheduler-tracing',
     bundleTypes: [
       FB_WWW_DEV,
       FB_WWW_PROD,


### PR DESCRIPTION
`yarn build core,dom` -> `yarn build react/index react-dom`

or

`yarn build core,dom-client` -> `yarn build react/,dom/index`

I've been frustrated that I can never guess what arguments `yarn build` expects so always end up building everything.

First, I improved the argument parsing a bit so that you don't have to separate the bundle names by commas. But commas still work. This ensures that `yarn build core dom` includes DOM.

It also ensures that spaces like `yarn build core, dom` doesn't build EVERYTHING by becoming an empty entry which matches everything.

I also got rid of label in bundles config. These follow a fairly arbitrary naming convention so I can never guess.

Instead I just use the name from npm entry name using fuzzy search.

There are some cases where this is weird. E.g. `yarn build react` builds everything since everything is called something with `react` in it.

There is one special case. The entry gets appended with `/index.js` at the end.

That allows to build things like `yarn build react/` to only build isomorphic. Or `yarn build react-dom/index` to exclude the server renderers where as `yarn build react-dom` includes server renderers.
