### PR TITLE
Fix to the memory leak issue with useEffect

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -316,7 +316,8 @@ function commitHookEffectList(
       }
       if ((effect.tag & mountTag) !== NoHookEffect) {
         // Mount
-        const create = effect.create;
+        const create = ((effect.create: any): () => mixed);
+        effect.create = null;
         let destroy = create();
         if (typeof destroy !== 'function') {
           if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -317,6 +317,8 @@ function commitHookEffectList(
       if ((effect.tag & mountTag) !== NoHookEffect) {
         // Mount
         const create = ((effect.create: any): () => mixed);
+        // Null out the `create` field, avoiding possible memory leaks
+        // due to retaining the function's closure context.
         effect.create = null;
         let destroy = create();
         if (typeof destroy !== 'function') {


### PR DESCRIPTION
This is a possible solution to the memory leak issues @localvoid alerted us to in this repro https://codesandbox.io/s/lz61v39r7.

I'm not 100% sure if the changes in this PR break something else, so it would be good to get @acdlite eye's on this. Specifically this PR makes the following changes:

- When processing an effect's `create` function, we `null` out the `create` field after. If we don't do this, the context of the `create` function closure causes memory retainment.
- Furthermore, if we don't pass the `create` function from `useEffect` to the dependencies array. Doing so, brings the memory retainment issue in the above point. Instead, we tag the `create` function with a field `__key` and assign a unique `symbol` to the function. We then use this symbol as the key in the dependencies.

I can confirm that in the cases of the repro the memory leak issues no longer exist with these two changes. Unfortunately, I don't know of any good way to make tests that can validate memory leaks. If anyone has ideas on how we might test these changes, please let me know.