### PR TITLE
Add a low priority to the scheduler that still resolves

### DIFF
--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -12,7 +12,8 @@
 var ImmediatePriority = 1;
 var UserBlockingPriority = 2;
 var NormalPriority = 3;
-var IdlePriority = 4;
+var LowPriority = 4;
+var IdlePriority = 5;
 
 // Max 31 bit integer. The max integer size in V8 for 32-bit systems.
 // Math.pow(2, 30) - 1
@@ -24,6 +25,7 @@ var IMMEDIATE_PRIORITY_TIMEOUT = -1;
 // Eventually times out
 var USER_BLOCKING_PRIORITY = 250;
 var NORMAL_PRIORITY_TIMEOUT = 5000;
+var LOW_PRIORITY_TIMEOUT = 10000;
 // Never times out
 var IDLE_PRIORITY = maxSigned31BitInt;
 
@@ -220,6 +222,7 @@ function unstable_runWithPriority(priorityLevel, eventHandler) {
     case ImmediatePriority:
     case UserBlockingPriority:
     case NormalPriority:
+    case LowPriority:
     case IdlePriority:
       break;
     default:
@@ -283,6 +286,9 @@ function unstable_scheduleCallback(callback, deprecated_options) {
         break;
       case IdlePriority:
         expirationTime = startTime + IDLE_PRIORITY;
+        break;
+      case LowPriority:
+        expirationTime = startTime + LOW_PRIORITY_TIMEOUT;
         break;
       case NormalPriority:
       default:
@@ -655,6 +661,7 @@ export {
   UserBlockingPriority as unstable_UserBlockingPriority,
   NormalPriority as unstable_NormalPriority,
   IdlePriority as unstable_IdlePriority,
+  LowPriority as unstable_LowPriority,
   unstable_runWithPriority,
   unstable_scheduleCallback,
   unstable_cancelCallback,


### PR DESCRIPTION
Normal priority is for things that we still want the user to see and idle pri is for things that are more speculative and may never resolve. We do not currently have a priority for things (like logging or sending data back to servers) where we want to ensure that it resolves, but where we want other things to be able to happen first. This adds such a priority.

I was debating a bit between calling it 'low' priority or 'logging' priority. I went with calling it 'low' because you can use this for way more than logging, but opening to changing it.