### PR TITLE
[Synchronous Suspense] Don't delete children of suspended component

### DIFF
--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -70,7 +70,6 @@ import {
   LOW_PRIORITY_EXPIRATION,
 } from './ReactFiberExpirationTime';
 import {findEarliestOutstandingPriorityLevel} from './ReactFiberPendingPriority';
-import {reconcileChildren} from './ReactFiberBeginWork';
 
 function createRootErrorUpdate(
   fiber: Fiber,
@@ -238,20 +237,10 @@ function throwException(
         if ((workInProgress.mode & ConcurrentMode) === NoEffect) {
           workInProgress.effectTag |= DidCapture;
 
-          // Unmount the source fiber's children
-          const nextChildren = null;
-          reconcileChildren(
-            sourceFiber.alternate,
-            sourceFiber,
-            nextChildren,
-            renderExpirationTime,
-          );
-          sourceFiber.effectTag &= ~Incomplete;
-
           // We're going to commit this fiber even though it didn't complete.
           // But we shouldn't call any lifecycle methods or callbacks. Remove
           // all lifecycle effect tags.
-          sourceFiber.effectTag &= ~LifecycleEffectMask;
+          sourceFiber.effectTag &= ~(LifecycleEffectMask | Incomplete);
 
           if (sourceFiber.tag === ClassComponent) {
             const current = sourceFiber.alternate;

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -937,6 +937,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ]);
       expect(ReactNoop.getChildrenAsJSX()).toEqual(
         <React.Fragment>
+          <span hidden={true} prop="Step: 1" />
           <span hidden={true} prop="Sibling" />
           <span prop="Loading (1)" />
           <span prop="Loading (2)" />
@@ -1060,6 +1061,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         expect(ReactNoop.getChildrenAsJSX()).toEqual(
           <React.Fragment>
             <span hidden={true} prop="Before" />
+            <span hidden={true} prop="Async: 1" />
             <span hidden={true} prop="After" />
             <span prop="Loading..." />
 
@@ -1194,6 +1196,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         expect(ReactNoop.getChildrenAsJSX()).toEqual(
           <React.Fragment>
             <span hidden={true} prop="Before" />
+            <span hidden={true} prop="Async: 1" />
             <span hidden={true} prop="After" />
             <span prop="Loading..." />
 


### PR DESCRIPTION
Vestigial behavior that should have been removed in #13823.

Found using the Suspense fuzz tester in #14147.