### PR TITLE
Update readme

### DIFF
--- a/fixtures/unstable-async/suspense/README.md
+++ b/fixtures/unstable-async/suspense/README.md
@@ -20,7 +20,7 @@ Follow these steps:
 # 1: Build react from source
 cd /path/to/react
 yarn
-yarn build dom-client,core,react-cache,scheduler --type=NODE
+yarn build react-dom/index,react/index,react-cache,scheduler --type=NODE
 
 # 2: Install fixture dependencies
 cd fixtures/unstable-async/suspense/

--- a/fixtures/unstable-async/time-slicing/README.md
+++ b/fixtures/unstable-async/time-slicing/README.md
@@ -18,7 +18,7 @@ There are also known bugs and inefficiencies in master so **don't use this fixtu
 # 1: Build react from source
 cd /path/to/react
 yarn
-yarn build dom-client,core,react-cache,scheduler --type=NODE
+yarn build react-dom/index,react/index,react-cache,scheduler --type=NODE
 
 # 2: Install fixture dependencies
 cd fixtures/unstable-async/time-slicing/

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -5,7 +5,7 @@
 In most cases, the only two commands you might want to use are:
 
 - `yarn start`
-- `yarn --cwd=../../ build core,dom-client --type=UMD_PROD && yarn start --skip-build`
+- `yarn --cwd=../../ build react/index,react-dom/index --type=UMD_PROD && yarn start --skip-build`
 
 The first command will run benchmarks with all the default settings. A local and remote build will occur on React and ReactDOM UMD bundles, both local and remote repos will be run against all benchmarks.
 

--- a/scripts/bench/build.js
+++ b/scripts/bench/build.js
@@ -104,7 +104,7 @@ async function buildBenchmarkBundlesFromGitRepo(
 async function buildReactBundles(reactPath = getDefaultReactPath(), skipBuild) {
   if (!skipBuild) {
     await executeCommand(
-      `cd ${reactPath} && yarn && yarn build core,dom-client --type=UMD_PROD`
+      `cd ${reactPath} && yarn && yarn build react/index,react-dom/index --type=UMD_PROD`
     );
   }
 }


### PR DESCRIPTION
https://github.com/facebook/react/issues/14175
After https://github.com/facebook/react/commit/051272f2012e1c2f75dc8ee9fe72a1d85cdac302 `yarn build core --type=UMD` and `yarn build dom-client --type=UMD` are useless now.
Also [reactjs.org how-to-contribute page](https://reactjs.org/docs/how-to-contribute.html#development-workflow) should be updated.