### PR TITLE
Renamed outdated schedule/tracing references

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -180,11 +180,11 @@ let warnAboutInvalidUpdates;
 
 if (enableSchedulerTracing) {
   // Provide explicit error message when production+profiling bundle of e.g. react-dom
-  // is used with production (non-profiling) bundle of schedule/tracing
+  // is used with production (non-profiling) bundle of scheduler/tracing
   invariant(
     __interactionsRef != null && __interactionsRef.current != null,
     'It is not supported to run the profiling version of a renderer (for example, `react-dom/profiling`) ' +
-      'without also replacing the `schedule/tracing` module with `schedule/tracing-profiling`. ' +
+      'without also replacing the `scheduler/tracing` module with `scheduler/tracing-profiling`. ' +
       'Your bundler might have a setting for aliasing both modules. ' +
       'Learn more at http://fb.me/react-profiling',
   );

--- a/packages/react-reconciler/src/__tests__/ReactTracing-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactTracing-test.internal.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('ReactTracing', () => {
-  it('should error if profiling renderer and non-profiling schedule/tracing bundles are combined', () => {
+  it('should error if profiling renderer and non-profiling scheduler/tracing bundles are combined', () => {
     jest.resetModules();
 
     const ReactFeatureFlags = require('shared/ReactFeatureFlags');


### PR DESCRIPTION
Looks like we missed these somehow.