### PR TITLE
Simplify CSS shorthand property warning

### DIFF
--- a/packages/react-dom/src/shared/CSSShorthandProperty.js
+++ b/packages/react-dom/src/shared/CSSShorthandProperty.js
@@ -7,249 +7,186 @@
 
 // List derived from Gecko source code:
 // https://github.com/mozilla/gecko-dev/blob/4e638efc71/layout/style/test/property_database.js
-export const shorthandToLonghandInDev = __DEV__
-  ? {
-      animation: [
-        'animationDelay',
-        'animationDirection',
-        'animationDuration',
-        'animationFillMode',
-        'animationIterationCount',
-        'animationName',
-        'animationPlayState',
-        'animationTimingFunction',
-      ],
-      background: [
-        'backgroundAttachment',
-        'backgroundClip',
-        'backgroundColor',
-        'backgroundImage',
-        'backgroundOrigin',
-        'backgroundPositionX',
-        'backgroundPositionY',
-        'backgroundRepeat',
-        'backgroundSize',
-      ],
-      backgroundPosition: ['backgroundPositionX', 'backgroundPositionY'],
-      border: [
-        'borderBottomColor',
-        'borderBottomStyle',
-        'borderBottomWidth',
-        'borderImageOutset',
-        'borderImageRepeat',
-        'borderImageSlice',
-        'borderImageSource',
-        'borderImageWidth',
-        'borderLeftColor',
-        'borderLeftStyle',
-        'borderLeftWidth',
-        'borderRightColor',
-        'borderRightStyle',
-        'borderRightWidth',
-        'borderTopColor',
-        'borderTopStyle',
-        'borderTopWidth',
-      ],
-      borderBlockEnd: [
-        'borderBlockEndColor',
-        'borderBlockEndStyle',
-        'borderBlockEndWidth',
-      ],
-      borderBlockStart: [
-        'borderBlockStartColor',
-        'borderBlockStartStyle',
-        'borderBlockStartWidth',
-      ],
-      borderBottom: [
-        'borderBottomColor',
-        'borderBottomStyle',
-        'borderBottomWidth',
-      ],
-      borderColor: [
-        'borderBottomColor',
-        'borderLeftColor',
-        'borderRightColor',
-        'borderTopColor',
-      ],
-      borderImage: [
-        'borderImageOutset',
-        'borderImageRepeat',
-        'borderImageSlice',
-        'borderImageSource',
-        'borderImageWidth',
-      ],
-      borderInlineEnd: [
-        'borderInlineEndColor',
-        'borderInlineEndStyle',
-        'borderInlineEndWidth',
-      ],
-      borderInlineStart: [
-        'borderInlineStartColor',
-        'borderInlineStartStyle',
-        'borderInlineStartWidth',
-      ],
-      borderLeft: ['borderLeftColor', 'borderLeftStyle', 'borderLeftWidth'],
-      borderRadius: [
-        'borderBottomLeftRadius',
-        'borderBottomRightRadius',
-        'borderTopLeftRadius',
-        'borderTopRightRadius',
-      ],
-      borderRight: ['borderRightColor', 'borderRightStyle', 'borderRightWidth'],
-      borderStyle: [
-        'borderBottomStyle',
-        'borderLeftStyle',
-        'borderRightStyle',
-        'borderTopStyle',
-      ],
-      borderTop: ['borderTopColor', 'borderTopStyle', 'borderTopWidth'],
-      borderWidth: [
-        'borderBottomWidth',
-        'borderLeftWidth',
-        'borderRightWidth',
-        'borderTopWidth',
-      ],
-      columnRule: ['columnRuleColor', 'columnRuleStyle', 'columnRuleWidth'],
-      columns: ['columnCount', 'columnWidth'],
-      flex: ['flexBasis', 'flexGrow', 'flexShrink'],
-      flexFlow: ['flexDirection', 'flexWrap'],
-      font: [
-        'fontFamily',
-        'fontFeatureSettings',
-        'fontKerning',
-        'fontLanguageOverride',
-        'fontSize',
-        'fontSizeAdjust',
-        'fontStretch',
-        'fontStyle',
-        'fontVariant',
-        'fontVariantAlternates',
-        'fontVariantCaps',
-        'fontVariantEastAsian',
-        'fontVariantLigatures',
-        'fontVariantNumeric',
-        'fontVariantPosition',
-        'fontWeight',
-        'lineHeight',
-      ],
-      fontVariant: [
-        'fontVariantAlternates',
-        'fontVariantCaps',
-        'fontVariantEastAsian',
-        'fontVariantLigatures',
-        'fontVariantNumeric',
-        'fontVariantPosition',
-      ],
-      gap: ['columnGap', 'rowGap'],
-      grid: [
-        'gridAutoColumns',
-        'gridAutoFlow',
-        'gridAutoRows',
-        'gridTemplateAreas',
-        'gridTemplateColumns',
-        'gridTemplateRows',
-      ],
-      gridArea: [
-        'gridColumnEnd',
-        'gridColumnStart',
-        'gridRowEnd',
-        'gridRowStart',
-      ],
-      gridColumn: ['gridColumnEnd', 'gridColumnStart'],
-      gridColumnGap: ['columnGap'],
-      gridGap: ['columnGap', 'rowGap'],
-      gridRow: ['gridRowEnd', 'gridRowStart'],
-      gridRowGap: ['rowGap'],
-      gridTemplate: [
-        'gridTemplateAreas',
-        'gridTemplateColumns',
-        'gridTemplateRows',
-      ],
-      listStyle: ['listStyleImage', 'listStylePosition', 'listStyleType'],
-      margin: ['marginBottom', 'marginLeft', 'marginRight', 'marginTop'],
-      marker: ['markerEnd', 'markerMid', 'markerStart'],
-      mask: [
-        'maskClip',
-        'maskComposite',
-        'maskImage',
-        'maskMode',
-        'maskOrigin',
-        'maskPositionX',
-        'maskPositionY',
-        'maskRepeat',
-        'maskSize',
-      ],
-      maskPosition: ['maskPositionX', 'maskPositionY'],
-      outline: ['outlineColor', 'outlineStyle', 'outlineWidth'],
-      overflow: ['overflowX', 'overflowY'],
-      padding: ['paddingBottom', 'paddingLeft', 'paddingRight', 'paddingTop'],
-      placeContent: ['alignContent', 'justifyContent'],
-      placeItems: ['alignItems', 'justifyItems'],
-      placeSelf: ['alignSelf', 'justifySelf'],
-      textDecoration: [
-        'textDecorationColor',
-        'textDecorationLine',
-        'textDecorationStyle',
-      ],
-      textEmphasis: ['textEmphasisColor', 'textEmphasisStyle'],
-      transition: [
-        'transitionDelay',
-        'transitionDuration',
-        'transitionProperty',
-        'transitionTimingFunction',
-      ],
-      wordWrap: ['overflowWrap'],
-    }
-  : {};
-
-export const longhandToShorthandInDev = {};
-
-export const overlappingShorthandsInDev = {};
-
-/**
- * obj[key].push(val), handling new keys.
- */
-function pushToValueArray(obj, key, val) {
-  let arr = obj[key];
-  if (!arr) {
-    obj[key] = arr = [];
-  }
-  arr.push(val);
-}
-
-if (__DEV__) {
-  // eslint-disable-next-line no-var
-  var shorthand;
-
-  // We want to treat properties like 'backgroundPosition' as one of the
-  // properties that 'background' expands to, even though that's technically
-  // incorrect.
-  for (shorthand in shorthandToLonghandInDev) {
-    const longhands = shorthandToLonghandInDev[shorthand];
-    for (const shorthand2 in shorthandToLonghandInDev) {
-      // eslint-disable-next-line no-var
-      var longhands2 = shorthandToLonghandInDev[shorthand2];
-      if (shorthand <= shorthand2) {
-        continue;
-      }
-      if (longhands.every(l => l === shorthand || longhands2.includes(l))) {
-        // ex: shorthand = 'backgroundPosition', shorthand2 = 'background'
-        longhands2.push(shorthand);
-      } else if (
-        longhands.some(l => l !== shorthand && longhands2.includes(l))
-      ) {
-        // ex: shorthand = 'borderLeft', shorthand2 = 'borderStyle'
-        pushToValueArray(overlappingShorthandsInDev, shorthand, shorthand2);
-        pushToValueArray(overlappingShorthandsInDev, shorthand2, shorthand);
-      }
-    }
-  }
-
-  // Flip into {maskPositionX: ['mask', 'maskPosition']} for reverse lookups
-  for (shorthand in shorthandToLonghandInDev) {
-    const longhands = shorthandToLonghandInDev[shorthand];
-    longhands.forEach(longhand => {
-      pushToValueArray(longhandToShorthandInDev, longhand, shorthand);
-    });
-  }
-}
+export const shorthandToLonghand = {
+  animation: [
+    'animationDelay',
+    'animationDirection',
+    'animationDuration',
+    'animationFillMode',
+    'animationIterationCount',
+    'animationName',
+    'animationPlayState',
+    'animationTimingFunction',
+  ],
+  background: [
+    'backgroundAttachment',
+    'backgroundClip',
+    'backgroundColor',
+    'backgroundImage',
+    'backgroundOrigin',
+    'backgroundPositionX',
+    'backgroundPositionY',
+    'backgroundRepeat',
+    'backgroundSize',
+  ],
+  backgroundPosition: ['backgroundPositionX', 'backgroundPositionY'],
+  border: [
+    'borderBottomColor',
+    'borderBottomStyle',
+    'borderBottomWidth',
+    'borderImageOutset',
+    'borderImageRepeat',
+    'borderImageSlice',
+    'borderImageSource',
+    'borderImageWidth',
+    'borderLeftColor',
+    'borderLeftStyle',
+    'borderLeftWidth',
+    'borderRightColor',
+    'borderRightStyle',
+    'borderRightWidth',
+    'borderTopColor',
+    'borderTopStyle',
+    'borderTopWidth',
+  ],
+  borderBlockEnd: [
+    'borderBlockEndColor',
+    'borderBlockEndStyle',
+    'borderBlockEndWidth',
+  ],
+  borderBlockStart: [
+    'borderBlockStartColor',
+    'borderBlockStartStyle',
+    'borderBlockStartWidth',
+  ],
+  borderBottom: ['borderBottomColor', 'borderBottomStyle', 'borderBottomWidth'],
+  borderColor: [
+    'borderBottomColor',
+    'borderLeftColor',
+    'borderRightColor',
+    'borderTopColor',
+  ],
+  borderImage: [
+    'borderImageOutset',
+    'borderImageRepeat',
+    'borderImageSlice',
+    'borderImageSource',
+    'borderImageWidth',
+  ],
+  borderInlineEnd: [
+    'borderInlineEndColor',
+    'borderInlineEndStyle',
+    'borderInlineEndWidth',
+  ],
+  borderInlineStart: [
+    'borderInlineStartColor',
+    'borderInlineStartStyle',
+    'borderInlineStartWidth',
+  ],
+  borderLeft: ['borderLeftColor', 'borderLeftStyle', 'borderLeftWidth'],
+  borderRadius: [
+    'borderBottomLeftRadius',
+    'borderBottomRightRadius',
+    'borderTopLeftRadius',
+    'borderTopRightRadius',
+  ],
+  borderRight: ['borderRightColor', 'borderRightStyle', 'borderRightWidth'],
+  borderStyle: [
+    'borderBottomStyle',
+    'borderLeftStyle',
+    'borderRightStyle',
+    'borderTopStyle',
+  ],
+  borderTop: ['borderTopColor', 'borderTopStyle', 'borderTopWidth'],
+  borderWidth: [
+    'borderBottomWidth',
+    'borderLeftWidth',
+    'borderRightWidth',
+    'borderTopWidth',
+  ],
+  columnRule: ['columnRuleColor', 'columnRuleStyle', 'columnRuleWidth'],
+  columns: ['columnCount', 'columnWidth'],
+  flex: ['flexBasis', 'flexGrow', 'flexShrink'],
+  flexFlow: ['flexDirection', 'flexWrap'],
+  font: [
+    'fontFamily',
+    'fontFeatureSettings',
+    'fontKerning',
+    'fontLanguageOverride',
+    'fontSize',
+    'fontSizeAdjust',
+    'fontStretch',
+    'fontStyle',
+    'fontVariant',
+    'fontVariantAlternates',
+    'fontVariantCaps',
+    'fontVariantEastAsian',
+    'fontVariantLigatures',
+    'fontVariantNumeric',
+    'fontVariantPosition',
+    'fontWeight',
+    'lineHeight',
+  ],
+  fontVariant: [
+    'fontVariantAlternates',
+    'fontVariantCaps',
+    'fontVariantEastAsian',
+    'fontVariantLigatures',
+    'fontVariantNumeric',
+    'fontVariantPosition',
+  ],
+  gap: ['columnGap', 'rowGap'],
+  grid: [
+    'gridAutoColumns',
+    'gridAutoFlow',
+    'gridAutoRows',
+    'gridTemplateAreas',
+    'gridTemplateColumns',
+    'gridTemplateRows',
+  ],
+  gridArea: ['gridColumnEnd', 'gridColumnStart', 'gridRowEnd', 'gridRowStart'],
+  gridColumn: ['gridColumnEnd', 'gridColumnStart'],
+  gridColumnGap: ['columnGap'],
+  gridGap: ['columnGap', 'rowGap'],
+  gridRow: ['gridRowEnd', 'gridRowStart'],
+  gridRowGap: ['rowGap'],
+  gridTemplate: [
+    'gridTemplateAreas',
+    'gridTemplateColumns',
+    'gridTemplateRows',
+  ],
+  listStyle: ['listStyleImage', 'listStylePosition', 'listStyleType'],
+  margin: ['marginBottom', 'marginLeft', 'marginRight', 'marginTop'],
+  marker: ['markerEnd', 'markerMid', 'markerStart'],
+  mask: [
+    'maskClip',
+    'maskComposite',
+    'maskImage',
+    'maskMode',
+    'maskOrigin',
+    'maskPositionX',
+    'maskPositionY',
+    'maskRepeat',
+    'maskSize',
+  ],
+  maskPosition: ['maskPositionX', 'maskPositionY'],
+  outline: ['outlineColor', 'outlineStyle', 'outlineWidth'],
+  overflow: ['overflowX', 'overflowY'],
+  padding: ['paddingBottom', 'paddingLeft', 'paddingRight', 'paddingTop'],
+  placeContent: ['alignContent', 'justifyContent'],
+  placeItems: ['alignItems', 'justifyItems'],
+  placeSelf: ['alignSelf', 'justifySelf'],
+  textDecoration: [
+    'textDecorationColor',
+    'textDecorationLine',
+    'textDecorationStyle',
+  ],
+  textEmphasis: ['textEmphasisColor', 'textEmphasisStyle'],
+  transition: [
+    'transitionDelay',
+    'transitionDuration',
+    'transitionProperty',
+    'transitionTimingFunction',
+  ],
+  wordWrap: ['overflowWrap'],
+};


### PR DESCRIPTION
I figured out a simpler way to do #14181. It does allocate some but I think that's OK. Time complexity might even be better since we avoid the nested loops the old one had.
