### PR TITLE
Remove outdated comment

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1327,8 +1327,7 @@ describe('ReactDOMComponent', () => {
           'The tag <foo> is unrecognized in this browser',
         );
         ReactTestUtils.renderIntoDocument(<foo />);
-        
-        ReactTestUtils.renderIntoDocument(<time />);
+
         // Corner case. Make sure out deduplication logic doesn't break with weird tag.
         expect(() =>
           ReactTestUtils.renderIntoDocument(<hasOwnProperty />),

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1327,11 +1327,7 @@ describe('ReactDOMComponent', () => {
           'The tag <foo> is unrecognized in this browser',
         );
         ReactTestUtils.renderIntoDocument(<foo />);
-        // This is a funny case.
-        // Chrome is the only major browser not shipping <time>. But as of July
-        // 2017 it intends to ship it due to widespread usage. We intentionally
-        // *don't* warn for <time> even if it's unrecognized by Chrome because
-        // it soon will be, and many apps have been using it anyway.
+        
         ReactTestUtils.renderIntoDocument(<time />);
         // Corner case. Make sure out deduplication logic doesn't break with weird tag.
         expect(() =>

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -75,7 +75,6 @@ let normalizeHTML;
 
 if (__DEV__) {
   warnedUnknownTags = {
-    time: true,
     // There are working polyfills for <dialog>. Let people use it.
     dialog: true,
     // Electron ships a custom <webview> tag to display external web content in

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -75,10 +75,6 @@ let normalizeHTML;
 
 if (__DEV__) {
   warnedUnknownTags = {
-    // Chrome is the only major browser not shipping <time>. But as of July
-    // 2017 it intends to ship it due to widespread usage. We intentionally
-    // *don't* warn for <time> even if it's unrecognized by Chrome because
-    // it soon will be, and many apps have been using it anyway.
     time: true,
     // There are working polyfills for <dialog>. Let people use it.
     dialog: true,


### PR DESCRIPTION
Since chrome has already supported `time` tag,i think this comment is outdated.

Here's some related links:
[Time Tag Browser Compatibility On MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)
[Time Tag Browser Compatibility On 'Can i use'](https://caniuse.com/#search=HTML5%20semantic%20elements)

And i do not think we still need to specially ignore <time/> and test it.