### PR TITLE
Add KeyboardEvent.code to synthetic event

### DIFF
--- a/packages/react-dom/src/events/SyntheticKeyboardEvent.js
+++ b/packages/react-dom/src/events/SyntheticKeyboardEvent.js
@@ -16,6 +16,7 @@ import getEventModifierState from './getEventModifierState';
  */
 const SyntheticKeyboardEvent = SyntheticUIEvent.extend({
   key: getEventKey,
+  code: null,
   location: null,
   ctrlKey: null,
   shiftKey: null,

--- a/packages/react-dom/src/events/SyntheticKeyboardEvent.js
+++ b/packages/react-dom/src/events/SyntheticKeyboardEvent.js
@@ -8,6 +8,7 @@
 import SyntheticUIEvent from './SyntheticUIEvent';
 import getEventCharCode from './getEventCharCode';
 import getEventKey from './getEventKey';
+import getEventCode from './getEventCode';
 import getEventModifierState from './getEventModifierState';
 
 /**
@@ -16,7 +17,7 @@ import getEventModifierState from './getEventModifierState';
  */
 const SyntheticKeyboardEvent = SyntheticUIEvent.extend({
   key: getEventKey,
-  code: null,
+  code: getEventCode,
   location: null,
   ctrlKey: null,
   shiftKey: null,

--- a/packages/react-dom/src/events/__tests__/SyntheticKeyboardEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticKeyboardEvent-test.js
@@ -451,6 +451,30 @@ describe('SyntheticKeyboardEvent', () => {
         });
       });
     });
+
+    describe('code', () => {
+      it('should throw (in dev) when KeyboardEvent.code is undefined', () => {
+        const node = ReactDOM.render(
+          <input
+            onKeyDown={e => {
+              return e.code;
+            }}
+          />,
+          container,
+        );
+        let evt = new KeyboardEvent('keydown', {
+          code: undefined,
+          bubbles: true,
+          cancelable: true,
+        });
+
+        if (__DEV__ && evt.code === undefined) {
+          expect(() => node.dispatchEvent(evt)).toThrowError();
+        } else {
+          node.dispatchEvent(evt);
+        }
+      });
+    });
   });
 
   describe('EventInterface', () => {

--- a/packages/react-dom/src/events/getEventCode.js
+++ b/packages/react-dom/src/events/getEventCode.js
@@ -1,0 +1,15 @@
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code#Code_values
+ * @param {object} nativeEvent
+ * @returns {string} Standardized keyboard code value if defined natively
+ */
+function getEventCode(nativeEvent: KeyboardEvent): string {
+  if (__DEV__ && nativeEvent.code === undefined) {
+    throw new ReferenceError(
+      'KeyboardEvent.code does not exist in this environment',
+    );
+  }
+  return nativeEvent.code;
+}
+
+export default getEventCode;


### PR DESCRIPTION
#14102 
Passing along `KeyboardEvent.code` from the native Keyboard Event. This is a very complex calculated value is not effected by keyboard layout unlike other KeyboardEvent values so there is no way to create a polyfill for browsers without support.