### PR TITLE
give  `canUseDOM` with a possibility to be a constant

### DIFF
--- a/packages/shared/ExecutionEnvironment.js
+++ b/packages/shared/ExecutionEnvironment.js
@@ -9,6 +9,6 @@
 
 export const canUseDOM: boolean = !!(
   typeof window !== 'undefined' &&
-  window.document &&
-  window.document.createElement
+  typeof window.document !== 'undefined' &&
+  typeof window.document.createElement !== 'undefined'
 );


### PR DESCRIPTION
https://webpack.js.org/plugins/define-plugin/

Webpack's DefinePlugin has the ability to replace `typeof expr` to a constant in compile-time, which should lead to better dead-code-elimination.
