### PR TITLE
Fix findDOMNode incorrectly failing inside Suspense

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.internal.js
@@ -262,8 +262,8 @@ describe('ReactDOMSuspensePlaceholder', () => {
     }
 
     ReactDOM.render(<App />, container);
-    // expect(log).toEqual([]);
+    expect(log).toEqual(['cDM']);
     ReactDOM.render(<App />, container);
-    // expect(log).toEqual(['cDM']);
+    expect(log).toEqual(['cDM', 'cDU']);
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.internal.js
@@ -222,4 +222,48 @@ describe('ReactDOMSuspensePlaceholder', () => {
     await Lazy;
     expect(log).toEqual(['cDU first', 'cDU second']);
   });
+
+  // Regression test for https://github.com/facebook/react/issues/14188
+  it('can call findDOMNode() in a suspended component commit phase (#2)', () => {
+    let suspendOnce = Promise.resolve();
+    function Suspend() {
+      if (suspendOnce) {
+        let promise = suspendOnce;
+        suspendOnce = null;
+        throw promise;
+      }
+      return null;
+    }
+
+    const log = [];
+    class Child extends React.Component {
+      componentDidMount() {
+        log.push('cDM');
+        ReactDOM.findDOMNode(this);
+      }
+
+      componentDidUpdate() {
+        log.push('cDU');
+        ReactDOM.findDOMNode(this);
+      }
+
+      render() {
+        return null;
+      }
+    }
+
+    function App() {
+      return (
+        <Suspense fallback="Loading">
+          <Suspend />
+          <Child />
+        </Suspense>
+      );
+    }
+
+    ReactDOM.render(<App />, container);
+    // expect(log).toEqual([]);
+    ReactDOM.render(<App />, container);
+    // expect(log).toEqual(['cDM']);
+  });
 });

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -117,16 +117,17 @@ export function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
   let b = alternate;
   while (true) {
     let parentA = a.return;
-    let parentB = parentA ? parentA.alternate : null;
-    if (!parentA || !parentB) {
+    if (!parentA) {
       // We're at the root.
       break;
     }
 
-    // If both copies of the parent fiber point to the same child, we can
-    // assume that the child is current. This happens when we bailout on low
-    // priority: the bailed out fiber's child reuses the current child.
-    if (parentA.child === parentB.child) {
+    // If both copies of the parent fiber point to the same child (or if there
+    // is only a single parent fiber), we can assume that the child is current.
+    // This happens when we bailout on low priority: the bailed out fiber's
+    // child reuses the current child.
+    let parentB = parentA.alternate;
+    if (parentB === null || parentA.child === parentB.child) {
       let child = parentA.child;
       while (child) {
         if (child === a) {


### PR DESCRIPTION
Builds on https://github.com/facebook/react/pull/14197. Second test ~~is failing~~ is now fixed.

Based on the test in https://github.com/facebook/react/issues/14188#issuecomment-437705392 found by @arianon. Unlike the issue from https://github.com/facebook/react/pull/14197, this one seems like it existed even before the Suspense refactorings. So maybe it was always there.