### PR TITLE
Use getComponentName() to reduce duplication

### DIFF
--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -185,21 +185,16 @@ function validateChildKeys(node, parentType) {
  */
 function validatePropTypes(element) {
   const type = element.type;
-  let name, propTypes;
+  const name = getComponentName(type);
+  let propTypes;
   if (typeof type === 'function') {
     // Class or function component
-    name = type.displayName || type.name;
     propTypes = type.propTypes;
   } else if (
     typeof type === 'object' &&
     type !== null &&
     type.$$typeof === REACT_FORWARD_REF_TYPE
   ) {
-    // ForwardRef
-    const functionName = type.render.displayName || type.render.name || '';
-    name =
-      type.displayName ||
-      (functionName !== '' ? `ForwardRef(${functionName})` : 'ForwardRef');
     propTypes = type.propTypes;
   } else {
     return;


### PR DESCRIPTION
We couldn't do it before because it used to take fiber and not type as argument. But it's been taking type as an argument for a while now so we can use it.

I don't actually care about duplication per se but it's easier to reuse this instead of having to remember to add this in both places. Note actually reading `propTypes` still diverges (https://github.com/facebook/react/issues/14159) and we'd need to decide on semantics before fixing it.
