### PR TITLE
Save CI-built node_modules as build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,4 +42,4 @@ jobs:
             - node_modules
 
       - store_artifacts:
-          path: ./build/node_modules.tar.gz
+          path: ./node_modules.tgz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,3 +40,6 @@ jobs:
           key: v1-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
+
+      - store_artifacts:
+          path: ./build/node_modules.tar.gz

--- a/scripts/circleci/pack_and_store_artifact.sh
+++ b/scripts/circleci/pack_and_store_artifact.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# NPM pack all modules to ensure we archive the correct set of files
+for dir in ./build/node_modules/* ; do
+  npm pack "$dir"
+done
+
+# Wrap everything in a single zip file for easy download by the publish script
+tar -zcvf ./node_modules.tgz ./*.tgz

--- a/scripts/circleci/test_entry_point.sh
+++ b/scripts/circleci/test_entry_point.sh
@@ -30,6 +30,7 @@ if [ $((2 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('yarn test-build-prod --maxWorkers=2')
   COMMANDS_TO_RUN+=('node ./scripts/tasks/danger')
   COMMANDS_TO_RUN+=('./scripts/circleci/upload_build.sh')
+  COMMANDS_TO_RUN+=('tar -zcvf ./build/node_modules.tar.gz ./build/node_modules')
 fi
 
 if [ $((3 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then

--- a/scripts/circleci/test_entry_point.sh
+++ b/scripts/circleci/test_entry_point.sh
@@ -30,7 +30,7 @@ if [ $((2 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
   COMMANDS_TO_RUN+=('yarn test-build-prod --maxWorkers=2')
   COMMANDS_TO_RUN+=('node ./scripts/tasks/danger')
   COMMANDS_TO_RUN+=('./scripts/circleci/upload_build.sh')
-  COMMANDS_TO_RUN+=('tar -zcvf ./build/node_modules.tar.gz ./build/node_modules')
+  COMMANDS_TO_RUN+=('./scripts/circleci/pack_and_store_artifact.sh')
 fi
 
 if [ $((3 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then


### PR DESCRIPTION
Let's save the `node_modules` created by the build script so that the script @acdlite is working on can publish them to NPM.

Example output [here](https://circleci.com/gh/facebook/react/12639#artifacts/containers/0):
![screen shot 2018-11-12 at 3 38 16 pm](https://user-images.githubusercontent.com/29597/48381517-13b3d880-e691-11e8-8813-87ce0eaf62b5.png)

Which extracts to:
<img width="882" alt="screen shot 2018-11-12 at 4 43 14 pm" src="https://user-images.githubusercontent.com/29597/48383324-1ff06380-e69a-11e8-9462-79b0ae5623c9.png">
