### PR TITLE
Clear memoizedState on unmount of fiber to avoid memory leak

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -728,9 +728,11 @@ function detachFiber(current: Fiber) {
   // itself will be GC:ed when the parent updates the next time.
   current.return = null;
   current.child = null;
+  current.memoizedState = null;
   if (current.alternate) {
     current.alternate.child = null;
     current.alternate.return = null;
+    current.alternate.memoizedState = null;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -729,10 +729,18 @@ function detachFiber(current: Fiber) {
   current.return = null;
   current.child = null;
   current.memoizedState = null;
+  current.updateQueue = null;
+  current.firstEffect = null;
+  current.lastEffect = null;
+  current.nextEffect = null;
   if (current.alternate) {
-    current.alternate.child = null;
     current.alternate.return = null;
+    current.alternate.child = null;
     current.alternate.memoizedState = null;
+    current.alternate.updateQueue = null;
+    current.alternate.firstEffect = null;
+    current.alternate.lastEffect = null;
+    current.alternate.nextEffect = null;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -726,13 +726,13 @@ function detachFiber(current: Fiber) {
   // get GC:ed but we don't know which for sure which parent is the current
   // one so we'll settle for GC:ing the subtree of this child. This child
   // itself will be GC:ed when the parent updates the next time.
+  // We do not null out the 'nextEffect' field as it causes tests to fail.
   current.return = null;
   current.child = null;
   current.memoizedState = null;
   current.updateQueue = null;
   current.firstEffect = null;
   current.lastEffect = null;
-  current.nextEffect = null;
   if (current.alternate) {
     current.alternate.return = null;
     current.alternate.child = null;
@@ -740,7 +740,6 @@ function detachFiber(current: Fiber) {
     current.alternate.updateQueue = null;
     current.alternate.firstEffect = null;
     current.alternate.lastEffect = null;
-    current.alternate.nextEffect = null;
   }
 }
 


### PR DESCRIPTION
This is an alternative approach to https://github.com/facebook/react/pull/14153. This PR aims at clearing the memory leak when the associated fibers containing the references to the closures (stored in `memoizedState`) still exist after being unmounted. The fix is to simply `null` out the `memoizedState` field which seems to clear up the retained functions.