### PR TITLE
[scheduler] Post to MessageChannel instead of window

### DIFF
--- a/packages/scheduler/src/__tests__/SchedulerDOM-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerDOM-test.js
@@ -64,33 +64,26 @@ describe('SchedulerDOM', () => {
   let currentTime = 0;
 
   beforeEach(() => {
-    // TODO pull this into helper method, reduce repetition.
-    // mock the browser APIs which are used in schedule:
-    // - requestAnimationFrame should pass the DOMHighResTimeStamp argument
-    // - calling 'window.postMessage' should actually fire postmessage handlers
-    // - Date.now should return the correct thing
-    // - test with native performance.now()
     delete global.performance;
     global.requestAnimationFrame = function(cb) {
       return rAFCallbacks.push(() => {
         cb(startOfLatestFrame);
       });
     };
-    const originalAddEventListener = global.addEventListener;
-    postMessageCallback = null;
     postMessageEvents = [];
     postMessageErrors = [];
-    global.addEventListener = function(eventName, callback, useCapture) {
-      if (eventName === 'message') {
-        postMessageCallback = callback;
-      } else {
-        originalAddEventListener(eventName, callback, useCapture);
-      }
+    const port1 = {};
+    const port2 = {
+      postMessage(messageKey) {
+        const postMessageEvent = {source: port2, data: messageKey};
+        postMessageEvents.push(postMessageEvent);
+      },
     };
-    global.postMessage = function(messageKey, targetOrigin) {
-      const postMessageEvent = {source: window, data: messageKey};
-      postMessageEvents.push(postMessageEvent);
+    global.MessageChannel = function MessageChannel() {
+      this.port1 = port1;
+      this.port2 = port2;
     };
+    postMessageCallback = event => port1.onmessage(event);
     global.Date.now = function() {
       return currentTime;
     };


### PR DESCRIPTION
Scheduler needs to schedule a task that fires after paint. To do this, it currently posts a message event to `window`. This happens on every frame until the queue is empty. An unfortunate consequence is that every other message event handler also gets called on every frame; even if they exit immediately, this adds up to significant per-frame overhead.

Instead, we'll create a MessageChannel and post to that, with a fallback to the old behavior if MessageChannel does not exist.