### PR TITLE
Update escaping of attribute and text HTML characters in SSR

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1599,9 +1599,7 @@ describe('ReactDOMComponent', () => {
           ),
         ),
       ).toBe(
-        '<div title="&#x27;&quot;&lt;&gt;&amp;" style="text-align:&#x27;&quot;&lt;&gt;&amp;">' +
-          '&#x27;&quot;&lt;&gt;&amp;' +
-          '</div>',
+        `<div title=\"'&quot;<>&amp;\" style=\"text-align:'&quot;<>&amp;\">'\"&lt;&gt;&amp;</div>`,
       );
     });
   });

--- a/packages/react-dom/src/__tests__/escapeTextForBrowser-test.js
+++ b/packages/react-dom/src/__tests__/escapeTextForBrowser-test.js
@@ -24,14 +24,14 @@ describe('escapeTextForBrowser', () => {
     expect(response).toMatch('<span data-reactroot="">&amp;</span>');
   });
 
-  it('double quote is escaped when passed as text content', () => {
+  it('double quote is not escaped when passed as text content', () => {
     const response = ReactDOMServer.renderToString(<span>{'"'}</span>);
-    expect(response).toMatch('<span data-reactroot="">&quot;</span>');
+    expect(response).toMatch('<span data-reactroot="">"</span>');
   });
 
-  it('single quote is escaped when passed as text content', () => {
+  it('single quote is not escaped when passed as text content', () => {
     const response = ReactDOMServer.renderToString(<span>{"'"}</span>);
-    expect(response).toMatch('<span data-reactroot="">&#x27;</span>');
+    expect(response).toMatch(`<span data-reactroot="">'</span>`);
   });
 
   it('greater than entity is escaped when passed as text content', () => {
@@ -59,8 +59,7 @@ describe('escapeTextForBrowser', () => {
       <span>{'<script type=\'\' src=""></script>'}</span>,
     );
     expect(response).toMatch(
-      '<span data-reactroot="">&lt;script type=&#x27;&#x27; ' +
-        'src=&quot;&quot;&gt;&lt;/script&gt;</span>',
+      `<span data-reactroot=\"\">&lt;script type='' src=\"\"&gt;&lt;/script&gt;</span>`,
     );
   });
 });

--- a/packages/react-dom/src/__tests__/quoteAttributeValueForBrowser-test.js
+++ b/packages/react-dom/src/__tests__/quoteAttributeValueForBrowser-test.js
@@ -29,19 +29,19 @@ describe('quoteAttributeValueForBrowser', () => {
     expect(response).toMatch('<img data-attr="&quot;" data-reactroot=""/>');
   });
 
-  it('single quote is escaped inside attributes', () => {
+  it('single quote is not escaped inside attributes', () => {
     const response = ReactDOMServer.renderToString(<img data-attr="'" />);
-    expect(response).toMatch('<img data-attr="&#x27;" data-reactroot=""/>');
+    expect(response).toMatch(`<img data-attr="'" data-reactroot=""/>`);
   });
 
-  it('greater than entity is escaped inside attributes', () => {
+  it('greater than entity is not escaped inside attributes', () => {
     const response = ReactDOMServer.renderToString(<img data-attr=">" />);
-    expect(response).toMatch('<img data-attr="&gt;" data-reactroot=""/>');
+    expect(response).toMatch('<img data-attr=">" data-reactroot=""/>');
   });
 
-  it('lower than entity is escaped inside attributes', () => {
+  it('lower than entity is not escaped inside attributes', () => {
     const response = ReactDOMServer.renderToString(<img data-attr="<" />);
-    expect(response).toMatch('<img data-attr="&lt;" data-reactroot=""/>');
+    expect(response).toMatch('<img data-attr="<" data-reactroot=""/>');
   });
 
   it('number is escaped to string inside attributes', () => {
@@ -67,9 +67,7 @@ describe('quoteAttributeValueForBrowser', () => {
       <img data-attr={'<script type=\'\' src=""></script>'} />,
     );
     expect(response).toMatch(
-      '<img data-attr="&lt;script type=&#x27;&#x27; ' +
-        'src=&quot;&quot;&gt;&lt;/script&gt;" ' +
-        'data-reactroot=""/>',
+      `<img data-attr=\"<script type='' src=&quot;&quot;></script>\" data-reactroot=\"\"/>`,
     );
   });
 });

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -50,7 +50,7 @@ import {
   createMarkupForProperty,
   createMarkupForRoot,
 } from './DOMMarkupOperations';
-import escapeTextForBrowser from './escapeTextForBrowser';
+import {escapeText} from './escapeTextForBrowser';
 import {
   prepareToUseHooks,
   finishHooks,
@@ -280,7 +280,7 @@ function getNonChildrenInnerMarkup(props) {
   } else {
     const content = props.children;
     if (typeof content === 'string' || typeof content === 'number') {
-      return escapeTextForBrowser(content);
+      return escapeText(content);
     }
   }
   return null;
@@ -886,13 +886,13 @@ class ReactDOMServerRenderer {
         return '';
       }
       if (this.makeStaticMarkup) {
-        return escapeTextForBrowser(text);
+        return escapeText(text);
       }
       if (this.previousWasTextNode) {
-        return '<!-- -->' + escapeTextForBrowser(text);
+        return '<!-- -->' + escapeText(text);
       }
       this.previousWasTextNode = true;
-      return escapeTextForBrowser(text);
+      return escapeText(text);
     } else {
       let nextChild;
       ({child: nextChild, context} = resolve(child, context, this.threadID));

--- a/packages/react-dom/src/server/quoteAttributeValueForBrowser.js
+++ b/packages/react-dom/src/server/quoteAttributeValueForBrowser.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import escapeTextForBrowser from './escapeTextForBrowser';
+import {escapeAttributeValue} from './escapeTextForBrowser';
 
 /**
  * Escapes attribute value to prevent scripting attacks.
@@ -14,7 +14,7 @@ import escapeTextForBrowser from './escapeTextForBrowser';
  * @return {string} An escaped string.
  */
 function quoteAttributeValueForBrowser(value) {
-  return '"' + escapeTextForBrowser(value) + '"';
+  return '"' + escapeAttributeValue(value) + '"';
 }
 
 export default quoteAttributeValueForBrowser;


### PR DESCRIPTION
I noticed when profiling parts of ReactDOM, I noticed that the escaping of HTML characters in SSR was particularly slow. Looking into it more, I changed the implementation to a much faster one that uses `String.prototype.indexOf` rather than RegEx (`indexOf` was faster in Chrome/Firefox and Safari) and also opted to use a similar implementation to other libraries when it comes to the escaping of characters. I then noticed something interesting: we are escaping characters that no longer need to be escaped.

For DOM node attributes, we don't need to escape single quotes or left/right angle brackets. You can try this out yourself in all the different browsers (I never tested IE8). For text nodes, you don't need to escape single or double quotes, again this can be validated in all browsers using the DOM API. You can see for yourself below:

```js
var x = document.createElement('div');
x.textContent = `'"><&`;
console.log(x.outerHTML);

var y = document.createElement('div');
y.setAttribute("foo", `'"><&`);
console.log(y.outerHTML);
```

Not only does this improve SSR render performance it also improves hydration when checking if the text nodes have changed, as before we'd mismatch in far more cases where there was a difference in the diffing due to escaped characters of a text node value not matching that of what React derives.

The difference in SSR rendering before (this is using the `hacker-news` benchmark in `scripts`):

```
// Before:
hacker-news 17.2ms
// After:
hacker-news 14.4ms
```

Using the `color-picker` benchmark from Marko:

```
// Before:
react x 6,857 ops/sec ±0.73% (94 runs sampled)
// After:
react x 7,485 ops/sec ±0.44% (93 runs sampled)
```