### PR TITLE
Ensure React object shape is monomorphic

### DIFF
--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -48,7 +48,9 @@ import {
 import ReactSharedInternals from './ReactSharedInternals';
 import {enableStableConcurrentModeAPIs} from 'shared/ReactFeatureFlags';
 
-const React = {
+// Please make sure that no properties are added to this object after its
+// creation. This ensures the object keeps the same shape for performance reasons.
+export default {
   Children: {
     map,
     forEach,
@@ -78,27 +80,27 @@ const React = {
   version: ReactVersion,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: ReactSharedInternals,
+
+  ConcurrentMode: enableStableConcurrentModeAPIs
+    ? REACT_CONCURRENT_MODE_TYPE
+    : null,
+  Profiler: enableStableConcurrentModeAPIs ? REACT_PROFILER_TYPE : null,
+
+  unstable_ConcurrentMode: !enableStableConcurrentModeAPIs
+    ? REACT_CONCURRENT_MODE_TYPE
+    : null,
+  unstable_Profiler: !enableStableConcurrentModeAPIs
+    ? REACT_PROFILER_TYPE
+    : null,
+
+  useCallback: enableHooks ? useCallback : null,
+  useContext: enableHooks ? useContext : null,
+  useEffect: enableHooks ? useEffect : null,
+  useImperativeMethods: enableHooks ? useImperativeMethods : null,
+  useLayoutEffect: enableHooks ? useLayoutEffect : null,
+  useMemo: enableHooks ? useMemo : null,
+  useMutationEffect: enableHooks ? useMutationEffect : null,
+  useReducer: enableHooks ? useReducer : null,
+  useRef: enableHooks ? useRef : null,
+  useState: enableHooks ? useState : null,
 };
-
-if (enableStableConcurrentModeAPIs) {
-  React.ConcurrentMode = REACT_CONCURRENT_MODE_TYPE;
-  React.Profiler = REACT_PROFILER_TYPE;
-} else {
-  React.unstable_ConcurrentMode = REACT_CONCURRENT_MODE_TYPE;
-  React.unstable_Profiler = REACT_PROFILER_TYPE;
-}
-
-if (enableHooks) {
-  React.useCallback = useCallback;
-  React.useContext = useContext;
-  React.useEffect = useEffect;
-  React.useImperativeMethods = useImperativeMethods;
-  React.useLayoutEffect = useLayoutEffect;
-  React.useMemo = useMemo;
-  React.useMutationEffect = useMutationEffect;
-  React.useReducer = useReducer;
-  React.useRef = useRef;
-  React.useState = useState;
-}
-
-export default React;

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -50,57 +50,107 @@ import {enableStableConcurrentModeAPIs} from 'shared/ReactFeatureFlags';
 
 // Please make sure that no properties are added to this object after its
 // creation. This ensures the object keeps the same shape for performance reasons.
-export default {
-  Children: {
-    map,
-    forEach,
-    count,
-    toArray,
-    only,
-  },
+let React;
+// We should remove the need for two objects if hooks are enabled by default.
+if (enableHooks) {
+  React = {
+    Children: {
+      map,
+      forEach,
+      count,
+      toArray,
+      only,
+    },
 
-  createRef,
-  Component,
-  PureComponent,
+    createRef,
+    Component,
+    PureComponent,
 
-  createContext,
-  forwardRef,
-  lazy,
-  memo,
+    createContext,
+    forwardRef,
+    lazy,
+    memo,
 
-  Fragment: REACT_FRAGMENT_TYPE,
-  StrictMode: REACT_STRICT_MODE_TYPE,
-  Suspense: REACT_SUSPENSE_TYPE,
+    Fragment: REACT_FRAGMENT_TYPE,
+    StrictMode: REACT_STRICT_MODE_TYPE,
+    Suspense: REACT_SUSPENSE_TYPE,
 
-  createElement: __DEV__ ? createElementWithValidation : createElement,
-  cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,
-  createFactory: __DEV__ ? createFactoryWithValidation : createFactory,
-  isValidElement: isValidElement,
+    createElement: __DEV__ ? createElementWithValidation : createElement,
+    cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,
+    createFactory: __DEV__ ? createFactoryWithValidation : createFactory,
+    isValidElement: isValidElement,
 
-  version: ReactVersion,
+    version: ReactVersion,
 
-  __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: ReactSharedInternals,
+    __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: ReactSharedInternals,
 
-  ConcurrentMode: enableStableConcurrentModeAPIs
-    ? REACT_CONCURRENT_MODE_TYPE
-    : null,
-  Profiler: enableStableConcurrentModeAPIs ? REACT_PROFILER_TYPE : null,
+    ConcurrentMode: enableStableConcurrentModeAPIs
+      ? REACT_CONCURRENT_MODE_TYPE
+      : null,
+    Profiler: enableStableConcurrentModeAPIs ? REACT_PROFILER_TYPE : null,
 
-  unstable_ConcurrentMode: !enableStableConcurrentModeAPIs
-    ? REACT_CONCURRENT_MODE_TYPE
-    : null,
-  unstable_Profiler: !enableStableConcurrentModeAPIs
-    ? REACT_PROFILER_TYPE
-    : null,
+    unstable_ConcurrentMode: !enableStableConcurrentModeAPIs
+      ? REACT_CONCURRENT_MODE_TYPE
+      : null,
+    unstable_Profiler: !enableStableConcurrentModeAPIs
+      ? REACT_PROFILER_TYPE
+      : null,
 
-  useCallback: enableHooks ? useCallback : null,
-  useContext: enableHooks ? useContext : null,
-  useEffect: enableHooks ? useEffect : null,
-  useImperativeMethods: enableHooks ? useImperativeMethods : null,
-  useLayoutEffect: enableHooks ? useLayoutEffect : null,
-  useMemo: enableHooks ? useMemo : null,
-  useMutationEffect: enableHooks ? useMutationEffect : null,
-  useReducer: enableHooks ? useReducer : null,
-  useRef: enableHooks ? useRef : null,
-  useState: enableHooks ? useState : null,
-};
+    useCallback,
+    useContext,
+    useEffect,
+    useImperativeMethods,
+    useLayoutEffect,
+    useMemo,
+    useMutationEffect,
+    useReducer,
+    useRef,
+    useState,
+  };
+} else {
+  React = {
+    Children: {
+      map,
+      forEach,
+      count,
+      toArray,
+      only,
+    },
+
+    createRef,
+    Component,
+    PureComponent,
+
+    createContext,
+    forwardRef,
+    lazy,
+    memo,
+
+    Fragment: REACT_FRAGMENT_TYPE,
+    StrictMode: REACT_STRICT_MODE_TYPE,
+    Suspense: REACT_SUSPENSE_TYPE,
+
+    createElement: __DEV__ ? createElementWithValidation : createElement,
+    cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,
+    createFactory: __DEV__ ? createFactoryWithValidation : createFactory,
+    isValidElement: isValidElement,
+
+    version: ReactVersion,
+
+    __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: ReactSharedInternals,
+
+    ConcurrentMode: enableStableConcurrentModeAPIs
+      ? REACT_CONCURRENT_MODE_TYPE
+      : null,
+    Profiler: enableStableConcurrentModeAPIs ? REACT_PROFILER_TYPE : null,
+
+    unstable_ConcurrentMode: !enableStableConcurrentModeAPIs
+      ? REACT_CONCURRENT_MODE_TYPE
+      : null,
+    unstable_Profiler: !enableStableConcurrentModeAPIs
+      ? REACT_PROFILER_TYPE
+      : null,
+  };
+}
+
+export default React;

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -4,29 +4,29 @@
       "filename": "react.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react",
-      "size": 97676,
-      "gzip": 25688
+      "size": 98230,
+      "gzip": 25813
     },
     {
       "filename": "react.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react",
-      "size": 11771,
-      "gzip": 4678
+      "size": 11814,
+      "gzip": 4693
     },
     {
       "filename": "react.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react",
-      "size": 60944,
-      "gzip": 16507
+      "size": 61323,
+      "gzip": 16601
     },
     {
       "filename": "react.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react",
-      "size": 6223,
-      "gzip": 2655
+      "size": 6238,
+      "gzip": 2661
     },
     {
       "filename": "React-dev.js",
@@ -46,29 +46,29 @@
       "filename": "react-dom.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 725515,
-      "gzip": 167737
+      "size": 733293,
+      "gzip": 169730
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 100307,
-      "gzip": 32617
+      "size": 100002,
+      "gzip": 32559
     },
     {
       "filename": "react-dom.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 720713,
-      "gzip": 166331
+      "size": 728491,
+      "gzip": 168322
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 100301,
-      "gzip": 32146
+      "size": 99997,
+      "gzip": 32064
     },
     {
       "filename": "ReactDOM-dev.js",
@@ -165,29 +165,29 @@
       "filename": "react-dom-server.browser.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 120524,
-      "gzip": 32011
+      "size": 127086,
+      "gzip": 33820
     },
     {
       "filename": "react-dom-server.browser.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 16402,
-      "gzip": 6237
+      "size": 17702,
+      "gzip": 6843
     },
     {
       "filename": "react-dom-server.browser.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 116562,
-      "gzip": 31037
+      "size": 123124,
+      "gzip": 32862
     },
     {
       "filename": "react-dom-server.browser.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 16301,
-      "gzip": 6233
+      "size": 17611,
+      "gzip": 6847
     },
     {
       "filename": "ReactDOMServer-dev.js",
@@ -207,43 +207,43 @@
       "filename": "react-dom-server.node.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 118530,
-      "gzip": 31584
+      "size": 125199,
+      "gzip": 33412
     },
     {
       "filename": "react-dom-server.node.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 17126,
-      "gzip": 6544
+      "size": 18495,
+      "gzip": 7153
     },
     {
       "filename": "react-art.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-art",
-      "size": 507548,
-      "gzip": 112066
+      "size": 508552,
+      "gzip": 112237
     },
     {
       "filename": "react-art.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-art",
-      "size": 92284,
-      "gzip": 28330
+      "size": 92099,
+      "gzip": 28349
     },
     {
       "filename": "react-art.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-art",
-      "size": 437685,
-      "gzip": 94610
+      "size": 438689,
+      "gzip": 94783
     },
     {
       "filename": "react-art.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-art",
-      "size": 56431,
-      "gzip": 17393
+      "size": 56305,
+      "gzip": 17413
     },
     {
       "filename": "ReactART-dev.js",
@@ -291,29 +291,29 @@
       "filename": "react-test-renderer.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-test-renderer",
-      "size": 450653,
-      "gzip": 97378
+      "size": 451657,
+      "gzip": 97549
     },
     {
       "filename": "react-test-renderer.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-test-renderer",
-      "size": 57674,
-      "gzip": 17698
+      "size": 57493,
+      "gzip": 17664
     },
     {
       "filename": "react-test-renderer.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-test-renderer",
-      "size": 445754,
-      "gzip": 96206
+      "size": 446758,
+      "gzip": 96371
     },
     {
       "filename": "react-test-renderer.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-test-renderer",
-      "size": 57342,
-      "gzip": 17539
+      "size": 57214,
+      "gzip": 17541
     },
     {
       "filename": "ReactTestRenderer-dev.js",
@@ -375,29 +375,29 @@
       "filename": "react-reconciler.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-reconciler",
-      "size": 435479,
-      "gzip": 93068
+      "size": 436482,
+      "gzip": 93254
     },
     {
       "filename": "react-reconciler.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-reconciler",
-      "size": 57593,
-      "gzip": 17242
+      "size": 57284,
+      "gzip": 17177
     },
     {
       "filename": "react-reconciler-persistent.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-reconciler",
-      "size": 433889,
-      "gzip": 92426
+      "size": 434892,
+      "gzip": 92607
     },
     {
       "filename": "react-reconciler-persistent.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-reconciler",
-      "size": 57604,
-      "gzip": 17248
+      "size": 57295,
+      "gzip": 17183
     },
     {
       "filename": "react-reconciler-reflection.development.js",
@@ -501,29 +501,29 @@
       "filename": "React-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react",
-      "size": 58338,
-      "gzip": 15703
+      "size": 58715,
+      "gzip": 15799
     },
     {
       "filename": "React-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react",
-      "size": 15346,
-      "gzip": 4131
+      "size": 15369,
+      "gzip": 4141
     },
     {
       "filename": "ReactDOM-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-dom",
-      "size": 742105,
-      "gzip": 167549
+      "size": 750149,
+      "gzip": 169487
     },
     {
       "filename": "ReactDOM-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-dom",
-      "size": 318358,
-      "gzip": 58562
+      "size": 317066,
+      "gzip": 58428
     },
     {
       "filename": "ReactTestUtils-dev.js",
@@ -550,92 +550,92 @@
       "filename": "ReactDOMServer-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-dom",
-      "size": 117649,
-      "gzip": 30639
+      "size": 124339,
+      "gzip": 32487
     },
     {
       "filename": "ReactDOMServer-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-dom",
-      "size": 41626,
-      "gzip": 9808
+      "size": 46012,
+      "gzip": 10760
     },
     {
       "filename": "ReactART-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-art",
-      "size": 445159,
-      "gzip": 93560
+      "size": 445805,
+      "gzip": 93649
     },
     {
       "filename": "ReactART-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-art",
-      "size": 189135,
-      "gzip": 32266
+      "size": 188165,
+      "gzip": 32199
     },
     {
       "filename": "ReactNativeRenderer-dev.js",
       "bundleType": "RN_FB_DEV",
       "packageName": "react-native-renderer",
-      "size": 573357,
-      "gzip": 124963
+      "size": 574003,
+      "gzip": 125110
     },
     {
       "filename": "ReactNativeRenderer-prod.js",
       "bundleType": "RN_FB_PROD",
       "packageName": "react-native-renderer",
-      "size": 245987,
-      "gzip": 43227
+      "size": 244571,
+      "gzip": 43048
     },
     {
       "filename": "ReactNativeRenderer-dev.js",
       "bundleType": "RN_OSS_DEV",
       "packageName": "react-native-renderer",
-      "size": 573046,
-      "gzip": 124866
+      "size": 573692,
+      "gzip": 125015
     },
     {
       "filename": "ReactNativeRenderer-prod.js",
       "bundleType": "RN_OSS_PROD",
       "packageName": "react-native-renderer",
-      "size": 231080,
-      "gzip": 40077
+      "size": 229664,
+      "gzip": 39899
     },
     {
       "filename": "ReactFabric-dev.js",
       "bundleType": "RN_FB_DEV",
       "packageName": "react-native-renderer",
-      "size": 563440,
-      "gzip": 122415
+      "size": 564086,
+      "gzip": 122567
     },
     {
       "filename": "ReactFabric-prod.js",
       "bundleType": "RN_FB_PROD",
       "packageName": "react-native-renderer",
-      "size": 225188,
-      "gzip": 38730
+      "size": 223510,
+      "gzip": 38530
     },
     {
       "filename": "ReactFabric-dev.js",
       "bundleType": "RN_OSS_DEV",
       "packageName": "react-native-renderer",
-      "size": 563475,
-      "gzip": 122429
+      "size": 564121,
+      "gzip": 122581
     },
     {
       "filename": "ReactFabric-prod.js",
       "bundleType": "RN_OSS_PROD",
       "packageName": "react-native-renderer",
-      "size": 225224,
-      "gzip": 38745
+      "size": 223546,
+      "gzip": 38545
     },
     {
       "filename": "ReactTestRenderer-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-test-renderer",
-      "size": 453421,
-      "gzip": 95442
+      "size": 454067,
+      "gzip": 95534
     },
     {
       "filename": "ReactShallowRenderer-dev.js",
@@ -676,15 +676,15 @@
       "filename": "scheduler.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "scheduler",
-      "size": 22073,
-      "gzip": 5976
+      "size": 22292,
+      "gzip": 6016
     },
     {
       "filename": "scheduler.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "scheduler",
-      "size": 4755,
-      "gzip": 1865
+      "size": 4814,
+      "gzip": 1885
     },
     {
       "filename": "SimpleCacheProvider-dev.js",
@@ -718,36 +718,36 @@
       "filename": "react-dom.profiling.min.js",
       "bundleType": "NODE_PROFILING",
       "packageName": "react-dom",
-      "size": 103137,
-      "gzip": 32687
+      "size": 103365,
+      "gzip": 32871
     },
     {
       "filename": "ReactNativeRenderer-profiling.js",
       "bundleType": "RN_OSS_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 236392,
-      "gzip": 41298
+      "size": 235519,
+      "gzip": 41280
     },
     {
       "filename": "ReactFabric-profiling.js",
       "bundleType": "RN_OSS_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 229595,
-      "gzip": 40005
+      "size": 228440,
+      "gzip": 39992
     },
     {
       "filename": "Scheduler-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "scheduler",
-      "size": 22314,
-      "gzip": 6027
+      "size": 22533,
+      "gzip": 6066
     },
     {
       "filename": "Scheduler-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "scheduler",
-      "size": 13375,
-      "gzip": 2927
+      "size": 13496,
+      "gzip": 2945
     },
     {
       "filename": "react.profiling.min.js",
@@ -760,43 +760,43 @@
       "filename": "React-profiling.js",
       "bundleType": "FB_WWW_PROFILING",
       "packageName": "react",
-      "size": 15346,
-      "gzip": 4131
+      "size": 15369,
+      "gzip": 4141
     },
     {
       "filename": "ReactDOM-profiling.js",
       "bundleType": "FB_WWW_PROFILING",
       "packageName": "react-dom",
-      "size": 324711,
-      "gzip": 59847
+      "size": 324433,
+      "gzip": 60053
     },
     {
       "filename": "ReactNativeRenderer-profiling.js",
       "bundleType": "RN_FB_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 251555,
-      "gzip": 44455
+      "size": 250682,
+      "gzip": 44434
     },
     {
       "filename": "ReactFabric-profiling.js",
       "bundleType": "RN_FB_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 229554,
-      "gzip": 39988
+      "size": 228399,
+      "gzip": 39975
     },
     {
       "filename": "react.profiling.min.js",
       "bundleType": "UMD_PROFILING",
       "packageName": "react",
-      "size": 13977,
-      "gzip": 5211
+      "size": 14020,
+      "gzip": 5228
     },
     {
       "filename": "react-dom.profiling.min.js",
       "bundleType": "UMD_PROFILING",
       "packageName": "react-dom",
-      "size": 103046,
-      "gzip": 33256
+      "size": 103271,
+      "gzip": 33429
     },
     {
       "filename": "scheduler-tracing.development.js",
@@ -937,6 +937,13 @@
       "packageName": "eslint-plugin-react-hooks",
       "size": 4943,
       "gzip": 1815
+    },
+    {
+      "filename": "ESLintPluginReactHooks-dev.js",
+      "bundleType": "FB_WWW_DEV",
+      "packageName": "eslint-plugin-react-hooks",
+      "size": 27469,
+      "gzip": 6036
     }
   ]
 }

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -4,29 +4,29 @@
       "filename": "react.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react",
-      "size": 98230,
-      "gzip": 25813
+      "size": 97676,
+      "gzip": 25688
     },
     {
       "filename": "react.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react",
-      "size": 11814,
-      "gzip": 4693
+      "size": 11771,
+      "gzip": 4678
     },
     {
       "filename": "react.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react",
-      "size": 61323,
-      "gzip": 16601
+      "size": 60944,
+      "gzip": 16507
     },
     {
       "filename": "react.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react",
-      "size": 6238,
-      "gzip": 2661
+      "size": 6223,
+      "gzip": 2655
     },
     {
       "filename": "React-dev.js",
@@ -46,29 +46,29 @@
       "filename": "react-dom.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 733293,
-      "gzip": 169730
+      "size": 725515,
+      "gzip": 167737
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 100002,
-      "gzip": 32559
+      "size": 100307,
+      "gzip": 32617
     },
     {
       "filename": "react-dom.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 728491,
-      "gzip": 168322
+      "size": 720713,
+      "gzip": 166331
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 99997,
-      "gzip": 32064
+      "size": 100301,
+      "gzip": 32146
     },
     {
       "filename": "ReactDOM-dev.js",
@@ -165,29 +165,29 @@
       "filename": "react-dom-server.browser.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 127086,
-      "gzip": 33820
+      "size": 120524,
+      "gzip": 32011
     },
     {
       "filename": "react-dom-server.browser.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 17702,
-      "gzip": 6843
+      "size": 16402,
+      "gzip": 6237
     },
     {
       "filename": "react-dom-server.browser.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 123124,
-      "gzip": 32862
+      "size": 116562,
+      "gzip": 31037
     },
     {
       "filename": "react-dom-server.browser.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 17611,
-      "gzip": 6847
+      "size": 16301,
+      "gzip": 6233
     },
     {
       "filename": "ReactDOMServer-dev.js",
@@ -207,43 +207,43 @@
       "filename": "react-dom-server.node.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 125199,
-      "gzip": 33412
+      "size": 118530,
+      "gzip": 31584
     },
     {
       "filename": "react-dom-server.node.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 18495,
-      "gzip": 7153
+      "size": 17126,
+      "gzip": 6544
     },
     {
       "filename": "react-art.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-art",
-      "size": 508552,
-      "gzip": 112237
+      "size": 507548,
+      "gzip": 112066
     },
     {
       "filename": "react-art.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-art",
-      "size": 92099,
-      "gzip": 28349
+      "size": 92284,
+      "gzip": 28330
     },
     {
       "filename": "react-art.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-art",
-      "size": 438689,
-      "gzip": 94783
+      "size": 437685,
+      "gzip": 94610
     },
     {
       "filename": "react-art.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-art",
-      "size": 56305,
-      "gzip": 17413
+      "size": 56431,
+      "gzip": 17393
     },
     {
       "filename": "ReactART-dev.js",
@@ -291,29 +291,29 @@
       "filename": "react-test-renderer.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-test-renderer",
-      "size": 451657,
-      "gzip": 97549
+      "size": 450653,
+      "gzip": 97378
     },
     {
       "filename": "react-test-renderer.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-test-renderer",
-      "size": 57493,
-      "gzip": 17664
+      "size": 57674,
+      "gzip": 17698
     },
     {
       "filename": "react-test-renderer.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-test-renderer",
-      "size": 446758,
-      "gzip": 96371
+      "size": 445754,
+      "gzip": 96206
     },
     {
       "filename": "react-test-renderer.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-test-renderer",
-      "size": 57214,
-      "gzip": 17541
+      "size": 57342,
+      "gzip": 17539
     },
     {
       "filename": "ReactTestRenderer-dev.js",
@@ -375,29 +375,29 @@
       "filename": "react-reconciler.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-reconciler",
-      "size": 436482,
-      "gzip": 93254
+      "size": 435479,
+      "gzip": 93068
     },
     {
       "filename": "react-reconciler.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-reconciler",
-      "size": 57284,
-      "gzip": 17177
+      "size": 57593,
+      "gzip": 17242
     },
     {
       "filename": "react-reconciler-persistent.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-reconciler",
-      "size": 434892,
-      "gzip": 92607
+      "size": 433889,
+      "gzip": 92426
     },
     {
       "filename": "react-reconciler-persistent.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-reconciler",
-      "size": 57295,
-      "gzip": 17183
+      "size": 57604,
+      "gzip": 17248
     },
     {
       "filename": "react-reconciler-reflection.development.js",
@@ -501,29 +501,29 @@
       "filename": "React-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react",
-      "size": 58715,
-      "gzip": 15799
+      "size": 58338,
+      "gzip": 15703
     },
     {
       "filename": "React-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react",
-      "size": 15369,
-      "gzip": 4141
+      "size": 15346,
+      "gzip": 4131
     },
     {
       "filename": "ReactDOM-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-dom",
-      "size": 750149,
-      "gzip": 169487
+      "size": 742105,
+      "gzip": 167549
     },
     {
       "filename": "ReactDOM-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-dom",
-      "size": 317066,
-      "gzip": 58428
+      "size": 318358,
+      "gzip": 58562
     },
     {
       "filename": "ReactTestUtils-dev.js",
@@ -550,92 +550,92 @@
       "filename": "ReactDOMServer-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-dom",
-      "size": 124339,
-      "gzip": 32487
+      "size": 117649,
+      "gzip": 30639
     },
     {
       "filename": "ReactDOMServer-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-dom",
-      "size": 46012,
-      "gzip": 10760
+      "size": 41626,
+      "gzip": 9808
     },
     {
       "filename": "ReactART-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-art",
-      "size": 445805,
-      "gzip": 93649
+      "size": 445159,
+      "gzip": 93560
     },
     {
       "filename": "ReactART-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-art",
-      "size": 188165,
-      "gzip": 32199
+      "size": 189135,
+      "gzip": 32266
     },
     {
       "filename": "ReactNativeRenderer-dev.js",
       "bundleType": "RN_FB_DEV",
       "packageName": "react-native-renderer",
-      "size": 574003,
-      "gzip": 125110
+      "size": 573357,
+      "gzip": 124963
     },
     {
       "filename": "ReactNativeRenderer-prod.js",
       "bundleType": "RN_FB_PROD",
       "packageName": "react-native-renderer",
-      "size": 244571,
-      "gzip": 43048
+      "size": 245987,
+      "gzip": 43227
     },
     {
       "filename": "ReactNativeRenderer-dev.js",
       "bundleType": "RN_OSS_DEV",
       "packageName": "react-native-renderer",
-      "size": 573692,
-      "gzip": 125015
+      "size": 573046,
+      "gzip": 124866
     },
     {
       "filename": "ReactNativeRenderer-prod.js",
       "bundleType": "RN_OSS_PROD",
       "packageName": "react-native-renderer",
-      "size": 229664,
-      "gzip": 39899
+      "size": 231080,
+      "gzip": 40077
     },
     {
       "filename": "ReactFabric-dev.js",
       "bundleType": "RN_FB_DEV",
       "packageName": "react-native-renderer",
-      "size": 564086,
-      "gzip": 122567
+      "size": 563440,
+      "gzip": 122415
     },
     {
       "filename": "ReactFabric-prod.js",
       "bundleType": "RN_FB_PROD",
       "packageName": "react-native-renderer",
-      "size": 223510,
-      "gzip": 38530
+      "size": 225188,
+      "gzip": 38730
     },
     {
       "filename": "ReactFabric-dev.js",
       "bundleType": "RN_OSS_DEV",
       "packageName": "react-native-renderer",
-      "size": 564121,
-      "gzip": 122581
+      "size": 563475,
+      "gzip": 122429
     },
     {
       "filename": "ReactFabric-prod.js",
       "bundleType": "RN_OSS_PROD",
       "packageName": "react-native-renderer",
-      "size": 223546,
-      "gzip": 38545
+      "size": 225224,
+      "gzip": 38745
     },
     {
       "filename": "ReactTestRenderer-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-test-renderer",
-      "size": 454067,
-      "gzip": 95534
+      "size": 453421,
+      "gzip": 95442
     },
     {
       "filename": "ReactShallowRenderer-dev.js",
@@ -676,15 +676,15 @@
       "filename": "scheduler.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "scheduler",
-      "size": 22292,
-      "gzip": 6016
+      "size": 22073,
+      "gzip": 5976
     },
     {
       "filename": "scheduler.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "scheduler",
-      "size": 4814,
-      "gzip": 1885
+      "size": 4755,
+      "gzip": 1865
     },
     {
       "filename": "SimpleCacheProvider-dev.js",
@@ -718,36 +718,36 @@
       "filename": "react-dom.profiling.min.js",
       "bundleType": "NODE_PROFILING",
       "packageName": "react-dom",
-      "size": 103365,
-      "gzip": 32871
+      "size": 103137,
+      "gzip": 32687
     },
     {
       "filename": "ReactNativeRenderer-profiling.js",
       "bundleType": "RN_OSS_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 235519,
-      "gzip": 41280
+      "size": 236392,
+      "gzip": 41298
     },
     {
       "filename": "ReactFabric-profiling.js",
       "bundleType": "RN_OSS_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 228440,
-      "gzip": 39992
+      "size": 229595,
+      "gzip": 40005
     },
     {
       "filename": "Scheduler-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "scheduler",
-      "size": 22533,
-      "gzip": 6066
+      "size": 22314,
+      "gzip": 6027
     },
     {
       "filename": "Scheduler-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "scheduler",
-      "size": 13496,
-      "gzip": 2945
+      "size": 13375,
+      "gzip": 2927
     },
     {
       "filename": "react.profiling.min.js",
@@ -760,43 +760,43 @@
       "filename": "React-profiling.js",
       "bundleType": "FB_WWW_PROFILING",
       "packageName": "react",
-      "size": 15369,
-      "gzip": 4141
+      "size": 15346,
+      "gzip": 4131
     },
     {
       "filename": "ReactDOM-profiling.js",
       "bundleType": "FB_WWW_PROFILING",
       "packageName": "react-dom",
-      "size": 324433,
-      "gzip": 60053
+      "size": 324711,
+      "gzip": 59847
     },
     {
       "filename": "ReactNativeRenderer-profiling.js",
       "bundleType": "RN_FB_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 250682,
-      "gzip": 44434
+      "size": 251555,
+      "gzip": 44455
     },
     {
       "filename": "ReactFabric-profiling.js",
       "bundleType": "RN_FB_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 228399,
-      "gzip": 39975
+      "size": 229554,
+      "gzip": 39988
     },
     {
       "filename": "react.profiling.min.js",
       "bundleType": "UMD_PROFILING",
       "packageName": "react",
-      "size": 14020,
-      "gzip": 5228
+      "size": 13977,
+      "gzip": 5211
     },
     {
       "filename": "react-dom.profiling.min.js",
       "bundleType": "UMD_PROFILING",
       "packageName": "react-dom",
-      "size": 103271,
-      "gzip": 33429
+      "size": 103046,
+      "gzip": 33256
     },
     {
       "filename": "scheduler-tracing.development.js",
@@ -937,13 +937,6 @@
       "packageName": "eslint-plugin-react-hooks",
       "size": 4943,
       "gzip": 1815
-    },
-    {
-      "filename": "ESLintPluginReactHooks-dev.js",
-      "bundleType": "FB_WWW_DEV",
-      "packageName": "eslint-plugin-react-hooks",
-      "size": 27469,
-      "gzip": 6036
     }
   ]
 }


### PR DESCRIPTION
The main `React` object's property call-sites suffer from deoptimizing because we assign properties to the object after its creation, thus changing the object's shape (hidden class). This moves all properties back into the object literal.