### PR TITLE
expose htmlattribute -> htmlAttribute mapping in react-dom

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -39,6 +39,7 @@ import {enableStableConcurrentModeAPIs} from 'shared/ReactFeatureFlags';
 import * as ReactDOMComponentTree from './ReactDOMComponentTree';
 import {restoreControlledState} from './ReactDOMComponent';
 import * as ReactDOMEventListener from '../events/ReactDOMEventListener';
+import possibleStandardNames from '../shared/possibleStandardNames';
 import {
   ELEMENT_NODE,
   COMMENT_NODE,
@@ -747,6 +748,8 @@ const ReactDOM: Object = {
   flushSync: DOMRenderer.flushSync,
 
   unstable_flushControlled: DOMRenderer.flushControlled,
+
+  attributeMapping: possibleStandardNames,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // Keep in sync with ReactDOMUnstableNativeDependencies.js


### PR DESCRIPTION
There are a ton of libraries that reimplement this functionality, leading to unnecessary bundle weight. We can make things easier on the community by simply exporting what react-dom itself uses.