### PR TITLE
Fix false positive getDefaultProps warning when mixing development and production versions

### DIFF
--- a/addons/create-react-class/factory.js
+++ b/addons/create-react-class/factory.js
@@ -807,6 +807,9 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
     Constructor.prototype = new ReactClassComponent();
     Constructor.prototype.constructor = Constructor;
     Constructor.prototype.__reactAutoBindPairs = [];
+    if (process.env.NODE_ENV !== 'production') {
+      Constructor.prototype.isInDEVMode = true;
+    }
 
     injectedMixins.forEach(mixSpecIntoComponent.bind(null, Constructor));
 

--- a/src/isomorphic/classic/element/ReactElementValidator.js
+++ b/src/isomorphic/classic/element/ReactElementValidator.js
@@ -187,7 +187,8 @@ function validatePropTypes(element) {
   }
   if (typeof componentClass.getDefaultProps === 'function') {
     warning(
-      componentClass.getDefaultProps.isReactClassApproved,
+      componentClass.getDefaultProps.isReactClassApproved ||
+        Object.getPrototypeOf(componentClass.prototype).isInDEVMode !== true,
       'getDefaultProps is only used on classic React.createClass ' +
         'definitions. Use a static property named `defaultProps` instead.',
     );

--- a/src/isomorphic/modern/class/ReactBaseClasses.js
+++ b/src/isomorphic/modern/class/ReactBaseClasses.js
@@ -30,6 +30,10 @@ function ReactComponent(props, context, updater) {
 
 ReactComponent.prototype.isReactComponent = {};
 
+if (__DEV__) {
+  ReactComponent.prototype.isInDEVMode = true;
+}
+
 /**
  * Sets a subset of the state. Always use this to mutate
  * state. You should treat `this.state` as immutable.


### PR DESCRIPTION
Regarding #9999 
Add isInDevMode to classic create-react-class and ReactBaseClasses
So when checking getDefaultProps, it can skip it if create-react-class
is in prod build
