### PR TITLE
Clear fields on unmount of fiber to avoid memory leak

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -732,8 +732,8 @@ function detachFiber(current: Fiber) {
   current.updateQueue = null;
   const alternate = current.alternate;
   if (alternate !== null) {
-    alternate.child = null;
     alternate.return = null;
+    alternate.child = null;
     alternate.memoizedState = null;
     alternate.updateQueue = null;
   }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -728,9 +728,14 @@ function detachFiber(current: Fiber) {
   // itself will be GC:ed when the parent updates the next time.
   current.return = null;
   current.child = null;
-  if (current.alternate) {
-    current.alternate.child = null;
-    current.alternate.return = null;
+  current.memoizedState = null;
+  current.updateQueue = null;
+  const alternate = current.alternate;
+  if (alternate !== null) {
+    alternate.child = null;
+    alternate.return = null;
+    alternate.memoizedState = null;
+    alternate.updateQueue = null;
   }
 }
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/facebook/react/pull/14218. In that PR, fields that we were unsure about were `null`ed out. This changes the `null`ing out of fields to the two that we know are safe to `null` out – specifically, `memoizedState` and `updateQueue`. This stops the memory leak we encounter when the associated fibers containing the references to the closures (stored in memoizedState) still exist after being unmounted