### PR TITLE
Warn about reassigning this.props

### DIFF
--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -1758,7 +1758,8 @@ describe('ReactCompositeComponent', () => {
       ReactDOM.render(<Bad />, container);
     }).toWarnDev(
       [
-        'Reassigning `this.props` is not supported and will lead to bugs.',
+        'It looks like Bad is reassigning its own `this.props` while rendering. ' +
+          'This is not supported and can lead to confusing bugs.',
         'Expected Bad props to match memoized props before componentDidMount. ' +
           'This might either be because of a bug in React, or because a component ' +
           'reassigns its own `this.props`. Please file an issue.',

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -1743,6 +1743,32 @@ describe('ReactCompositeComponent', () => {
     );
   });
 
+  it('should warn about reassigning this.props while rendering', () => {
+    class Bad extends React.Component {
+      componentDidMount() {}
+      componentDidUpdate() {}
+      render() {
+        this.props = {...this.props};
+        return null;
+      }
+    }
+
+    const container = document.createElement('div');
+    expect(() => {
+      ReactDOM.render(<Bad />, container);
+    }).toWarnDev(
+      [
+        'Reassigning `this.props` is not supported and will lead to bugs.',
+        'Expected Bad props to match memoized props before componentDidMount. ' +
+          'This might either be because of a bug in React, or because a component ' +
+          'reassigns its own `this.props`. Please file an issue.',
+      ],
+      {
+        withoutStack: 1,
+      },
+    );
+  });
+
   it('should return error if render is not defined', () => {
     class RenderTestUndefinedRender extends React.Component {}
 

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -1757,16 +1757,8 @@ describe('ReactCompositeComponent', () => {
     expect(() => {
       ReactDOM.render(<Bad />, container);
     }).toWarnDev(
-      [
-        'It looks like Bad is reassigning its own `this.props` while rendering. ' +
-          'This is not supported and can lead to confusing bugs.',
-        'Expected Bad props to match memoized props before componentDidMount. ' +
-          'This might either be because of a bug in React, or because a component ' +
-          'reassigns its own `this.props`. Please file an issue.',
-      ],
-      {
-        withoutStack: 1,
-      },
+      'It looks like Bad is reassigning its own `this.props` while rendering. ' +
+        'This is not supported and can lead to confusing bugs.',
     );
   });
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -126,7 +126,7 @@ let didWarnAboutBadClass;
 let didWarnAboutContextTypeOnFunctionComponent;
 let didWarnAboutGetDerivedStateOnFunctionComponent;
 let didWarnAboutFunctionRefs;
-let didWarnAboutReassigningProps;
+export let didWarnAboutReassigningProps;
 
 if (__DEV__) {
   didWarnAboutBadClass = {};

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -126,12 +126,14 @@ let didWarnAboutBadClass;
 let didWarnAboutContextTypeOnFunctionComponent;
 let didWarnAboutGetDerivedStateOnFunctionComponent;
 let didWarnAboutFunctionRefs;
+let didWarnAboutReassigningProps;
 
 if (__DEV__) {
   didWarnAboutBadClass = {};
   didWarnAboutContextTypeOnFunctionComponent = {};
   didWarnAboutGetDerivedStateOnFunctionComponent = {};
   didWarnAboutFunctionRefs = {};
+  didWarnAboutReassigningProps = false;
 }
 
 export function reconcileChildren(
@@ -491,7 +493,7 @@ function updateClassComponent(
       renderExpirationTime,
     );
   }
-  return finishClassComponent(
+  const nextUnitOfWork = finishClassComponent(
     current,
     workInProgress,
     Component,
@@ -499,6 +501,17 @@ function updateClassComponent(
     hasContext,
     renderExpirationTime,
   );
+  if (__DEV__) {
+    let inst = workInProgress.stateNode;
+    if (inst.props !== nextProps) {
+      warning(
+        didWarnAboutReassigningProps,
+        'Reassigning `this.props` is not supported and will lead to bugs.',
+      );
+      didWarnAboutReassigningProps = true;
+    }
+  }
+  return nextUnitOfWork;
 }
 
 function finishClassComponent(

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -506,7 +506,9 @@ function updateClassComponent(
     if (inst.props !== nextProps) {
       warning(
         didWarnAboutReassigningProps,
-        'Reassigning `this.props` is not supported and will lead to bugs.',
+        'It looks like %s is reassigning its own `this.props` while rendering. ' +
+          'This is not supported and can lead to confusing bugs.',
+        getComponentName(workInProgress.type) || 'a component',
       );
       didWarnAboutReassigningProps = true;
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -99,6 +99,7 @@ import {
   UnmountPassive,
   MountPassive,
 } from './ReactHookEffectTags';
+import {didWarnAboutReassigningProps} from './ReactFiberBeginWork';
 
 let didWarnAboutUndefinedSnapshotBeforeUpdate: Set<mixed> | null = null;
 if (__DEV__) {
@@ -234,7 +235,10 @@ function commitBeforeMutationLifeCycles(
           // but instead we rely on them being set during last render.
           // TODO: revisit this when we implement resuming.
           if (__DEV__) {
-            if (finishedWork.type === finishedWork.elementType) {
+            if (
+              finishedWork.type === finishedWork.elementType &&
+              !didWarnAboutReassigningProps
+            ) {
               warning(
                 instance.props === finishedWork.memoizedProps,
                 'Expected %s props to match memoized props before ' +
@@ -376,7 +380,10 @@ function commitLifeCycles(
           // but instead we rely on them being set during last render.
           // TODO: revisit this when we implement resuming.
           if (__DEV__) {
-            if (finishedWork.type === finishedWork.elementType) {
+            if (
+              finishedWork.type === finishedWork.elementType &&
+              !didWarnAboutReassigningProps
+            ) {
               warning(
                 instance.props === finishedWork.memoizedProps,
                 'Expected %s props to match memoized props before ' +
@@ -410,7 +417,10 @@ function commitLifeCycles(
           // but instead we rely on them being set during last render.
           // TODO: revisit this when we implement resuming.
           if (__DEV__) {
-            if (finishedWork.type === finishedWork.elementType) {
+            if (
+              finishedWork.type === finishedWork.elementType &&
+              !didWarnAboutReassigningProps
+            ) {
               warning(
                 instance.props === finishedWork.memoizedProps,
                 'Expected %s props to match memoized props before ' +
@@ -442,7 +452,10 @@ function commitLifeCycles(
       const updateQueue = finishedWork.updateQueue;
       if (updateQueue !== null) {
         if (__DEV__) {
-          if (finishedWork.type === finishedWork.elementType) {
+          if (
+            finishedWork.type === finishedWork.elementType &&
+            !didWarnAboutReassigningProps
+          ) {
             warning(
               instance.props === finishedWork.memoizedProps,
               'Expected %s props to match memoized props before ' +

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -237,15 +237,21 @@ function commitBeforeMutationLifeCycles(
             if (finishedWork.type === finishedWork.elementType) {
               warning(
                 instance.props === finishedWork.memoizedProps,
-                'Expected instance props to match memoized props before ' +
-                  'getSnapshotBeforeUpdate. This is likely due to a bug in React. ' +
+                'Expected %s props to match memoized props before ' +
+                  'getSnapshotBeforeUpdate. ' +
+                  'This might either be because of a bug in React, or because ' +
+                  'a component reassigns its own `this.props`. ' +
                   'Please file an issue.',
+                getComponentName(finishedWork.type) || 'instance',
               );
               warning(
                 instance.state === finishedWork.memoizedState,
-                'Expected instance state to match memoized state before ' +
-                  'getSnapshotBeforeUpdate. This is likely due to a bug in React. ' +
+                'Expected %s state to match memoized state before ' +
+                  'getSnapshotBeforeUpdate. ' +
+                  'This might either be because of a bug in React, or because ' +
+                  'a component reassigns its own `this.props`. ' +
                   'Please file an issue.',
+                getComponentName(finishedWork.type) || 'instance',
               );
             }
           }
@@ -373,15 +379,21 @@ function commitLifeCycles(
             if (finishedWork.type === finishedWork.elementType) {
               warning(
                 instance.props === finishedWork.memoizedProps,
-                'Expected instance props to match memoized props before ' +
-                  'componentDidMount. This is likely due to a bug in React. ' +
+                'Expected %s props to match memoized props before ' +
+                  'componentDidMount. ' +
+                  'This might either be because of a bug in React, or because ' +
+                  'a component reassigns its own `this.props`. ' +
                   'Please file an issue.',
+                getComponentName(finishedWork.type) || 'instance',
               );
               warning(
                 instance.state === finishedWork.memoizedState,
-                'Expected instance state to match memoized state before ' +
-                  'componentDidMount. This is likely due to a bug in React. ' +
+                'Expected %s state to match memoized state before ' +
+                  'componentDidMount. ' +
+                  'This might either be because of a bug in React, or because ' +
+                  'a component reassigns its own `this.props`. ' +
                   'Please file an issue.',
+                getComponentName(finishedWork.type) || 'instance',
               );
             }
           }
@@ -401,15 +413,21 @@ function commitLifeCycles(
             if (finishedWork.type === finishedWork.elementType) {
               warning(
                 instance.props === finishedWork.memoizedProps,
-                'Expected instance props to match memoized props before ' +
-                  'componentDidUpdate. This is likely due to a bug in React. ' +
+                'Expected %s props to match memoized props before ' +
+                  'componentDidUpdate. ' +
+                  'This might either be because of a bug in React, or because ' +
+                  'a component reassigns its own `this.props`. ' +
                   'Please file an issue.',
+                getComponentName(finishedWork.type) || 'instance',
               );
               warning(
                 instance.state === finishedWork.memoizedState,
-                'Expected instance state to match memoized state before ' +
-                  'componentDidUpdate. This is likely due to a bug in React. ' +
+                'Expected %s state to match memoized state before ' +
+                  'componentDidUpdate. ' +
+                  'This might either be because of a bug in React, or because ' +
+                  'a component reassigns its own `this.props`. ' +
                   'Please file an issue.',
+                getComponentName(finishedWork.type) || 'instance',
               );
             }
           }
@@ -427,15 +445,21 @@ function commitLifeCycles(
           if (finishedWork.type === finishedWork.elementType) {
             warning(
               instance.props === finishedWork.memoizedProps,
-              'Expected instance props to match memoized props before ' +
-                'processing the update queue. This is likely due to a bug in React. ' +
+              'Expected %s props to match memoized props before ' +
+                'processing the update queue. ' +
+                'This might either be because of a bug in React, or because ' +
+                'a component reassigns its own `this.props`. ' +
                 'Please file an issue.',
+              getComponentName(finishedWork.type) || 'instance',
             );
             warning(
               instance.state === finishedWork.memoizedState,
-              'Expected instance state to match memoized state before ' +
-                'processing the update queue. This is likely due to a bug in React. ' +
+              'Expected %s state to match memoized state before ' +
+                'processing the update queue. ' +
+                'This might either be because of a bug in React, or because ' +
+                'a component reassigns its own `this.props`. ' +
                 'Please file an issue.',
+              getComponentName(finishedWork.type) || 'instance',
             );
           }
         }


### PR DESCRIPTION
Related to https://github.com/facebook/react/issues/14224.

This adds a new warning when you reassign `this.props` during rendering. This has never been supported but apparently some libraries (like deprecated `react-css-modules`) do that.

Since this causes confusing warnings in the commit phase (where we aren't sure if it's our bug or not), I'm adding an earlier warning that fires in the render phase and has a component stack.

As a bonus, I reworded and added component name to the commit phase warning so that it's less difficult to figure out which component causes it.