### PR TITLE
Fix SSR useCallback in render phase

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
@@ -516,6 +516,19 @@ describe('ReactDOMServerHooks', () => {
       expect(domNode.tagName).toEqual('SPAN');
       expect(domNode.textContent).toEqual('Count: 0');
     });
+
+    itRenders('should support render time callbacks', async render => {
+      function Counter(props) {
+        const renderCount = useCallback(increment => {
+          return 'Count: ' + (props.count + increment);
+        });
+        return <Text text={renderCount(3)} />;
+      }
+      const domNode = await render(<Counter count={2} />);
+      expect(clearYields()).toEqual(['Count: 5']);
+      expect(domNode.tagName).toEqual('SPAN');
+      expect(domNode.textContent).toEqual('Count: 5');
+    });
   });
 
   describe('useImperativeMethods', () => {

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -341,6 +341,9 @@ function dispatchAction<A>(
 }
 
 function noop(): void {}
+function identity(fn: Function): Function {
+  return fn;
+}
 
 export let currentThreadID: ThreadID = 0;
 
@@ -357,10 +360,10 @@ export const Dispatcher = {
   useState,
   useMutationEffect,
   useLayoutEffect,
+  // Callbacks are passed as they are in the server environment.
+  useCallback: identity,
   // useImperativeMethods is not run in the server environment
   useImperativeMethods: noop,
-  // Callbacks are not run in the server environment.
-  useCallback: noop,
   // Effects are not run in the server environment.
   useEffect: noop,
 };


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/14241.

`useCallback` in SSR should be an identity function, not a noop.