### PR TITLE
Remove `import * as` pattern from the codebase

### DIFF
--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -7,7 +7,11 @@
 
 import React from 'react';
 import ReactVersion from 'shared/ReactVersion';
-import * as ARTRenderer from 'react-reconciler/inline.art';
+import {
+  createContainer,
+  updateContainer,
+  injectIntoDevTools,
+} from 'react-reconciler/inline.art';
 import Transform from 'art/core/transform';
 import Mode from 'art/modes/current';
 import FastNoSideEffects from 'art/modes/fast-noSideEffects';
@@ -61,8 +65,8 @@ class Surface extends React.Component {
 
     this._surface = Mode.Surface(+width, +height, this._tagRef);
 
-    this._mountNode = ARTRenderer.createContainer(this._surface);
-    ARTRenderer.updateContainer(this.props.children, this._mountNode, this);
+    this._mountNode = createContainer(this._surface);
+    updateContainer(this.props.children, this._mountNode, this);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -72,7 +76,7 @@ class Surface extends React.Component {
       this._surface.resize(+props.width, +props.height);
     }
 
-    ARTRenderer.updateContainer(this.props.children, this._mountNode, this);
+    updateContainer(this.props.children, this._mountNode, this);
 
     if (this._surface.render) {
       this._surface.render();
@@ -80,7 +84,7 @@ class Surface extends React.Component {
   }
 
   componentWillUnmount() {
-    ARTRenderer.updateContainer(null, this._mountNode, this);
+    updateContainer(null, this._mountNode, this);
   }
 
   render() {
@@ -132,7 +136,7 @@ class Text extends React.Component {
   }
 }
 
-ARTRenderer.injectIntoDevTools({
+injectIntoDevTools({
   findFiberByHostInstance: () => null,
   bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -19,15 +19,42 @@ import type {Container} from './ReactDOMHostConfig';
 import '../shared/checkReact';
 import './ReactDOMClientInjection';
 
-import * as DOMRenderer from 'react-reconciler/inline.dom';
-import * as ReactPortal from 'shared/ReactPortal';
+import {
+  computeUniqueAsyncExpiration,
+  findHostInstanceWithNoPortals,
+  updateContainerAtExpirationTime,
+  flushRoot,
+  createContainer,
+  updateContainer,
+  batchedUpdates,
+  unbatchedUpdates,
+  interactiveUpdates,
+  flushInteractiveUpdates,
+  flushSync,
+  flushControlled,
+  injectIntoDevTools,
+  getPublicRootInstance,
+  findHostInstance,
+  findHostInstanceWithWarning,
+} from 'react-reconciler/inline.dom';
+import {createPortal as createPortalImpl} from 'shared/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import * as ReactGenericBatching from 'events/ReactGenericBatching';
-import * as ReactControlledComponent from 'events/ReactControlledComponent';
-import * as EventPluginHub from 'events/EventPluginHub';
-import * as EventPluginRegistry from 'events/EventPluginRegistry';
-import * as EventPropagators from 'events/EventPropagators';
-import * as ReactInstanceMap from 'shared/ReactInstanceMap';
+import {setBatchingImplementation} from 'events/ReactGenericBatching';
+import {
+  setRestoreImplementation,
+  enqueueStateRestore,
+  restoreStateIfNeeded,
+} from 'events/ReactControlledComponent';
+import {
+  injection as EventPluginHubInjection,
+  runEventsInBatch,
+} from 'events/EventPluginHub';
+import {eventNameDispatchConfigs} from 'events/EventPluginRegistry';
+import {
+  accumulateTwoPhaseDispatches,
+  accumulateDirectDispatches,
+} from 'events/EventPropagators';
+import {has as hasInstance} from 'shared/ReactInstanceMap';
 import ReactVersion from 'shared/ReactVersion';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import getComponentName from 'shared/getComponentName';
@@ -36,9 +63,14 @@ import lowPriorityWarning from 'shared/lowPriorityWarning';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {enableStableConcurrentModeAPIs} from 'shared/ReactFeatureFlags';
 
-import * as ReactDOMComponentTree from './ReactDOMComponentTree';
+import {
+  getInstanceFromNode,
+  getNodeFromInstance,
+  getFiberCurrentPropsFromNode,
+  getClosestInstanceFromNode,
+} from './ReactDOMComponentTree';
 import {restoreControlledState} from './ReactDOMComponent';
-import * as ReactDOMEventListener from '../events/ReactDOMEventListener';
+import {dispatchEvent} from '../events/ReactDOMEventListener';
 import {
   ELEMENT_NODE,
   COMMENT_NODE,
@@ -74,7 +106,7 @@ if (__DEV__) {
 
   topLevelUpdateWarnings = (container: DOMContainer) => {
     if (container._reactRootContainer && container.nodeType !== COMMENT_NODE) {
-      const hostInstance = DOMRenderer.findHostInstanceWithNoPortals(
+      const hostInstance = findHostInstanceWithNoPortals(
         container._reactRootContainer._internalRoot.current,
       );
       if (hostInstance) {
@@ -90,9 +122,7 @@ if (__DEV__) {
 
     const isRootRenderedBySomeReact = !!container._reactRootContainer;
     const rootEl = getReactRootElementInContainer(container);
-    const hasNonRootReactChild = !!(
-      rootEl && ReactDOMComponentTree.getInstanceFromNode(rootEl)
-    );
+    const hasNonRootReactChild = !!(rootEl && getInstanceFromNode(rootEl));
 
     warningWithoutStack(
       !hasNonRootReactChild || isRootRenderedBySomeReact,
@@ -125,7 +155,7 @@ if (__DEV__) {
   };
 }
 
-ReactControlledComponent.setRestoreImplementation(restoreControlledState);
+setRestoreImplementation(restoreControlledState);
 
 export type DOMContainer =
   | (Element & {
@@ -165,7 +195,7 @@ type Root = {
 };
 
 function ReactBatch(root: ReactRoot) {
-  const expirationTime = DOMRenderer.computeUniqueAsyncExpiration();
+  const expirationTime = computeUniqueAsyncExpiration();
   this._expirationTime = expirationTime;
   this._root = root;
   this._next = null;
@@ -185,7 +215,7 @@ ReactBatch.prototype.render = function(children: ReactNodeList) {
   const internalRoot = this._root._internalRoot;
   const expirationTime = this._expirationTime;
   const work = new ReactWork();
-  DOMRenderer.updateContainerAtExpirationTime(
+  updateContainerAtExpirationTime(
     children,
     internalRoot,
     null,
@@ -256,7 +286,7 @@ ReactBatch.prototype.commit = function() {
 
   // Synchronously flush all the work up to this batch's expiration time.
   this._defer = false;
-  DOMRenderer.flushRoot(internalRoot, expirationTime);
+  flushRoot(internalRoot, expirationTime);
 
   // Pop the batch from the list.
   const next = this._next;
@@ -336,7 +366,7 @@ function ReactRoot(
   isConcurrent: boolean,
   hydrate: boolean,
 ) {
-  const root = DOMRenderer.createContainer(container, isConcurrent, hydrate);
+  const root = createContainer(container, isConcurrent, hydrate);
   this._internalRoot = root;
 }
 ReactRoot.prototype.render = function(
@@ -352,7 +382,7 @@ ReactRoot.prototype.render = function(
   if (callback !== null) {
     work.then(callback);
   }
-  DOMRenderer.updateContainer(children, root, null, work._onCommit);
+  updateContainer(children, root, null, work._onCommit);
   return work;
 };
 ReactRoot.prototype.unmount = function(callback: ?() => mixed): Work {
@@ -365,7 +395,7 @@ ReactRoot.prototype.unmount = function(callback: ?() => mixed): Work {
   if (callback !== null) {
     work.then(callback);
   }
-  DOMRenderer.updateContainer(null, root, null, work._onCommit);
+  updateContainer(null, root, null, work._onCommit);
   return work;
 };
 ReactRoot.prototype.legacy_renderSubtreeIntoContainer = function(
@@ -382,7 +412,7 @@ ReactRoot.prototype.legacy_renderSubtreeIntoContainer = function(
   if (callback !== null) {
     work.then(callback);
   }
-  DOMRenderer.updateContainer(children, root, parentComponent, work._onCommit);
+  updateContainer(children, root, parentComponent, work._onCommit);
   return work;
 };
 ReactRoot.prototype.createBatch = function(): Batch {
@@ -453,10 +483,10 @@ function shouldHydrateDueToLegacyHeuristic(container) {
   );
 }
 
-ReactGenericBatching.setBatchingImplementation(
-  DOMRenderer.batchedUpdates,
-  DOMRenderer.interactiveUpdates,
-  DOMRenderer.flushInteractiveUpdates,
+setBatchingImplementation(
+  batchedUpdates,
+  interactiveUpdates,
+  flushInteractiveUpdates,
 );
 
 let warnedAboutHydrateAPI = false;
@@ -535,12 +565,12 @@ function legacyRenderSubtreeIntoContainer(
     if (typeof callback === 'function') {
       const originalCallback = callback;
       callback = function() {
-        const instance = DOMRenderer.getPublicRootInstance(root._internalRoot);
+        const instance = getPublicRootInstance(root._internalRoot);
         originalCallback.call(instance);
       };
     }
     // Initial mount should not be batched.
-    DOMRenderer.unbatchedUpdates(() => {
+    unbatchedUpdates(() => {
       if (parentComponent != null) {
         root.legacy_renderSubtreeIntoContainer(
           parentComponent,
@@ -555,7 +585,7 @@ function legacyRenderSubtreeIntoContainer(
     if (typeof callback === 'function') {
       const originalCallback = callback;
       callback = function() {
-        const instance = DOMRenderer.getPublicRootInstance(root._internalRoot);
+        const instance = getPublicRootInstance(root._internalRoot);
         originalCallback.call(instance);
       };
     }
@@ -570,7 +600,7 @@ function legacyRenderSubtreeIntoContainer(
       root.render(children, callback);
     }
   }
-  return DOMRenderer.getPublicRootInstance(root._internalRoot);
+  return getPublicRootInstance(root._internalRoot);
 }
 
 function createPortal(
@@ -583,7 +613,7 @@ function createPortal(
     'Target container is not a DOM element.',
   );
   // TODO: pass ReactDOM portal implementation as third argument
-  return ReactPortal.createPortal(children, container, null, key);
+  return createPortalImpl(children, container, null, key);
 }
 
 const ReactDOM: Object = {
@@ -616,12 +646,9 @@ const ReactDOM: Object = {
       return (componentOrElement: any);
     }
     if (__DEV__) {
-      return DOMRenderer.findHostInstanceWithWarning(
-        componentOrElement,
-        'findDOMNode',
-      );
+      return findHostInstanceWithWarning(componentOrElement, 'findDOMNode');
     }
-    return DOMRenderer.findHostInstance(componentOrElement);
+    return findHostInstance(componentOrElement);
   },
 
   hydrate(element: React$Node, container: DOMContainer, callback: ?Function) {
@@ -656,7 +683,7 @@ const ReactDOM: Object = {
     callback: ?Function,
   ) {
     invariant(
-      parentComponent != null && ReactInstanceMap.has(parentComponent),
+      parentComponent != null && hasInstance(parentComponent),
       'parentComponent must be a valid React Component',
     );
     return legacyRenderSubtreeIntoContainer(
@@ -677,8 +704,7 @@ const ReactDOM: Object = {
     if (container._reactRootContainer) {
       if (__DEV__) {
         const rootEl = getReactRootElementInContainer(container);
-        const renderedByDifferentReact =
-          rootEl && !ReactDOMComponentTree.getInstanceFromNode(rootEl);
+        const renderedByDifferentReact = rootEl && !getInstanceFromNode(rootEl);
         warningWithoutStack(
           !renderedByDifferentReact,
           "unmountComponentAtNode(): The node you're attempting to unmount " +
@@ -687,7 +713,7 @@ const ReactDOM: Object = {
       }
 
       // Unmount should not be batched.
-      DOMRenderer.unbatchedUpdates(() => {
+      unbatchedUpdates(() => {
         legacyRenderSubtreeIntoContainer(null, null, container, false, () => {
           container._reactRootContainer = null;
         });
@@ -698,9 +724,7 @@ const ReactDOM: Object = {
     } else {
       if (__DEV__) {
         const rootEl = getReactRootElementInContainer(container);
-        const hasNonRootReactChild = !!(
-          rootEl && ReactDOMComponentTree.getInstanceFromNode(rootEl)
-        );
+        const hasNonRootReactChild = !!(rootEl && getInstanceFromNode(rootEl));
 
         // Check if the container itself is a React root node.
         const isContainerReactRoot =
@@ -740,29 +764,29 @@ const ReactDOM: Object = {
     return createPortal(...args);
   },
 
-  unstable_batchedUpdates: DOMRenderer.batchedUpdates,
+  unstable_batchedUpdates: batchedUpdates,
 
-  unstable_interactiveUpdates: DOMRenderer.interactiveUpdates,
+  unstable_interactiveUpdates: interactiveUpdates,
 
-  flushSync: DOMRenderer.flushSync,
+  flushSync: flushSync,
 
-  unstable_flushControlled: DOMRenderer.flushControlled,
+  unstable_flushControlled: flushControlled,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // Keep in sync with ReactDOMUnstableNativeDependencies.js
     // and ReactTestUtils.js. This is an array for better minification.
     Events: [
-      ReactDOMComponentTree.getInstanceFromNode,
-      ReactDOMComponentTree.getNodeFromInstance,
-      ReactDOMComponentTree.getFiberCurrentPropsFromNode,
-      EventPluginHub.injection.injectEventPluginsByName,
-      EventPluginRegistry.eventNameDispatchConfigs,
-      EventPropagators.accumulateTwoPhaseDispatches,
-      EventPropagators.accumulateDirectDispatches,
-      ReactControlledComponent.enqueueStateRestore,
-      ReactControlledComponent.restoreStateIfNeeded,
-      ReactDOMEventListener.dispatchEvent,
-      EventPluginHub.runEventsInBatch,
+      getInstanceFromNode,
+      getNodeFromInstance,
+      getFiberCurrentPropsFromNode,
+      EventPluginHubInjection.injectEventPluginsByName,
+      eventNameDispatchConfigs,
+      accumulateTwoPhaseDispatches,
+      accumulateDirectDispatches,
+      enqueueStateRestore,
+      restoreStateIfNeeded,
+      dispatchEvent,
+      runEventsInBatch,
     ],
   },
 };
@@ -790,8 +814,8 @@ if (enableStableConcurrentModeAPIs) {
   ReactDOM.unstable_createRoot = createRoot;
 }
 
-const foundDevTools = DOMRenderer.injectIntoDevTools({
-  findFiberByHostInstance: ReactDOMComponentTree.getClosestInstanceFromNode,
+const foundDevTools = injectIntoDevTools({
+  findFiberByHostInstance: getClosestInstanceFromNode,
   bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,
   rendererPackageName: 'react-dom',

--- a/packages/react-dom/src/client/ReactDOMClientInjection.js
+++ b/packages/react-dom/src/client/ReactDOMClientInjection.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as EventPluginHub from 'events/EventPluginHub';
-import * as EventPluginUtils from 'events/EventPluginUtils';
+import {injection as EventPluginHubInjection} from 'events/EventPluginHub';
+import {setComponentTree} from 'events/EventPluginUtils';
 
 import {
   getFiberCurrentPropsFromNode,
@@ -23,8 +23,8 @@ import SimpleEventPlugin from '../events/SimpleEventPlugin';
 /**
  * Inject modules for resolving DOM hierarchy and plugin ordering.
  */
-EventPluginHub.injection.injectEventPluginOrder(DOMEventPluginOrder);
-EventPluginUtils.setComponentTree(
+EventPluginHubInjection.injectEventPluginOrder(DOMEventPluginOrder);
+setComponentTree(
   getFiberCurrentPropsFromNode,
   getInstanceFromNode,
   getNodeFromInstance,
@@ -34,7 +34,7 @@ EventPluginUtils.setComponentTree(
  * Some important event plugins included by default (without having to require
  * them).
  */
-EventPluginHub.injection.injectEventPluginsByName({
+EventPluginHubInjection.injectEventPluginsByName({
   SimpleEventPlugin: SimpleEventPlugin,
   EnterLeaveEventPlugin: EnterLeaveEventPlugin,
   ChangeEventPlugin: ChangeEventPlugin,

--- a/packages/react-dom/src/client/ReactDOMFB.js
+++ b/packages/react-dom/src/client/ReactDOMFB.js
@@ -7,22 +7,30 @@
  * @flow
  */
 
-import * as ReactFiberTreeReflection from 'react-reconciler/reflection';
-import * as ReactInstanceMap from 'shared/ReactInstanceMap';
+import {findCurrentFiberUsingSlowPath} from 'react-reconciler/reflection';
+import {get as getInstance} from 'shared/ReactInstanceMap';
 import {addUserTimingListener} from 'shared/ReactFeatureFlags';
 
 import ReactDOM from './ReactDOM';
-import * as ReactBrowserEventEmitter from '../events/ReactBrowserEventEmitter';
-import * as ReactDOMComponentTree from './ReactDOMComponentTree';
+import {isEnabled} from '../events/ReactBrowserEventEmitter';
+import {getClosestInstanceFromNode} from './ReactDOMComponentTree';
 
 Object.assign(
   (ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: any),
   {
     // These are real internal dependencies that are trickier to remove:
-    ReactBrowserEventEmitter,
-    ReactFiberTreeReflection,
-    ReactDOMComponentTree,
-    ReactInstanceMap,
+    ReactBrowserEventEmitter: {
+      isEnabled,
+    },
+    ReactFiberTreeReflection: {
+      findCurrentFiberUsingSlowPath,
+    },
+    ReactDOMComponentTree: {
+      getClosestInstanceFromNode,
+    },
+    ReactInstanceMap: {
+      get: getInstance,
+    },
     // Perf experiment
     addUserTimingListener,
   },

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -23,10 +23,13 @@ import {
   warnForInsertedHydratedElement,
   warnForInsertedHydratedText,
 } from './ReactDOMComponent';
-import * as ReactInputSelection from './ReactInputSelection';
+import {getSelectionInformation, restoreSelection} from './ReactInputSelection';
 import setTextContent from './setTextContent';
 import {validateDOMNesting, updatedAncestorInfo} from './validateDOMNesting';
-import * as ReactBrowserEventEmitter from '../events/ReactBrowserEventEmitter';
+import {
+  isEnabled as ReactBrowserEventEmitterIsEnabled,
+  setEnabled as ReactBrowserEventEmitterSetEnabled,
+} from '../events/ReactBrowserEventEmitter';
 import {getChildNamespace} from '../shared/DOMNamespaces';
 import {
   ELEMENT_NODE,
@@ -152,15 +155,15 @@ export function getPublicInstance(instance: Instance): * {
 }
 
 export function prepareForCommit(containerInfo: Container): void {
-  eventsEnabled = ReactBrowserEventEmitter.isEnabled();
-  selectionInformation = ReactInputSelection.getSelectionInformation();
-  ReactBrowserEventEmitter.setEnabled(false);
+  eventsEnabled = ReactBrowserEventEmitterIsEnabled();
+  selectionInformation = getSelectionInformation();
+  ReactBrowserEventEmitterSetEnabled(false);
 }
 
 export function resetAfterCommit(containerInfo: Container): void {
-  ReactInputSelection.restoreSelection(selectionInformation);
+  restoreSelection(selectionInformation);
   selectionInformation = null;
-  ReactBrowserEventEmitter.setEnabled(eventsEnabled);
+  ReactBrowserEventEmitterSetEnabled(eventsEnabled);
   eventsEnabled = null;
 }
 

--- a/packages/react-dom/src/client/ReactDOMInput.js
+++ b/packages/react-dom/src/client/ReactDOMInput.js
@@ -12,11 +12,11 @@ import {getCurrentFiberOwnerNameInDevOrNull} from 'react-reconciler/src/ReactCur
 import invariant from 'shared/invariant';
 import warning from 'shared/warning';
 
-import * as DOMPropertyOperations from './DOMPropertyOperations';
+import {setValueForProperty} from './DOMPropertyOperations';
 import {getFiberCurrentPropsFromNode} from './ReactDOMComponentTree';
 import {getToStringValue, toString} from './ToStringValue';
 import ReactControlledValuePropTypes from '../shared/ReactControlledValuePropTypes';
-import * as inputValueTracking from './inputValueTracking';
+import {updateValueIfChanged} from './inputValueTracking';
 import {disableInputAttributeSyncing} from 'shared/ReactFeatureFlags';
 
 import type {ToStringValue} from './ToStringValue';
@@ -129,7 +129,7 @@ export function updateChecked(element: Element, props: Object) {
   const node = ((element: any): InputWithWrapperState);
   const checked = props.checked;
   if (checked != null) {
-    DOMPropertyOperations.setValueForProperty(node, 'checked', checked, false);
+    setValueForProperty(node, 'checked', checked, false);
   }
 }
 
@@ -389,7 +389,7 @@ function updateNamedCousins(rootNode, props) {
 
       // We need update the tracked value on the named cousin since the value
       // was changed but the input saw no event or value set
-      inputValueTracking.updateValueIfChanged(otherNode);
+      updateValueIfChanged(otherNode);
 
       // If this is a controlled radio button group, forcing the input that
       // was previously checked to update will cause it to be come re-checked

--- a/packages/react-dom/src/client/ReactInputSelection.js
+++ b/packages/react-dom/src/client/ReactInputSelection.js
@@ -7,7 +7,7 @@
 
 import getActiveElement from './getActiveElement';
 
-import * as ReactDOMSelection from './ReactDOMSelection';
+import {getOffsets, setOffsets} from './ReactDOMSelection';
 import {ELEMENT_NODE, TEXT_NODE} from '../shared/HTMLNodeType';
 
 function isTextNode(node) {
@@ -152,7 +152,7 @@ export function getSelection(input) {
     };
   } else {
     // Content editable or old IE textarea.
-    selection = ReactDOMSelection.getOffsets(input);
+    selection = getOffsets(input);
   }
 
   return selection || {start: 0, end: 0};
@@ -174,6 +174,6 @@ export function setSelection(input, offsets) {
     input.selectionStart = start;
     input.selectionEnd = Math.min(end, input.value.length);
   } else {
-    ReactDOMSelection.setOffsets(input, offsets);
+    setOffsets(input, offsets);
   }
 }

--- a/packages/react-dom/src/events/BeforeInputEventPlugin.js
+++ b/packages/react-dom/src/events/BeforeInputEventPlugin.js
@@ -22,7 +22,11 @@ import {
   TOP_TEXT_INPUT,
   TOP_PASTE,
 } from './DOMTopLevelEventTypes';
-import * as FallbackCompositionState from './FallbackCompositionState';
+import {
+  getData as FallbackCompositionStateGetData,
+  initialize as FallbackCompositionStateInitialize,
+  reset as FallbackCompositionStateReset,
+} from './FallbackCompositionState';
 import SyntheticCompositionEvent from './SyntheticCompositionEvent';
 import SyntheticInputEvent from './SyntheticInputEvent';
 
@@ -246,10 +250,10 @@ function extractCompositionEvent(
     // The current composition is stored statically and must not be
     // overwritten while composition continues.
     if (!isComposing && eventType === eventTypes.compositionStart) {
-      isComposing = FallbackCompositionState.initialize(nativeEventTarget);
+      isComposing = FallbackCompositionStateInitialize(nativeEventTarget);
     } else if (eventType === eventTypes.compositionEnd) {
       if (isComposing) {
-        fallbackData = FallbackCompositionState.getData();
+        fallbackData = FallbackCompositionStateGetData();
       }
     }
   }
@@ -346,8 +350,8 @@ function getFallbackBeforeInputChars(topLevelType: TopLevelType, nativeEvent) {
       (!canUseCompositionEvent &&
         isFallbackCompositionEnd(topLevelType, nativeEvent))
     ) {
-      const chars = FallbackCompositionState.getData();
-      FallbackCompositionState.reset();
+      const chars = FallbackCompositionStateGetData();
+      FallbackCompositionStateReset();
       isComposing = false;
       return chars;
     }

--- a/packages/react-dom/src/events/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/ChangeEventPlugin.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as EventPluginHub from 'events/EventPluginHub';
+import {runEventsInBatch} from 'events/EventPluginHub';
 import {accumulateTwoPhaseDispatches} from 'events/EventPropagators';
 import {enqueueStateRestore} from 'events/ReactControlledComponent';
 import {batchedUpdates} from 'events/ReactGenericBatching';
@@ -26,7 +26,7 @@ import {
 import getEventTarget from './getEventTarget';
 import isEventSupported from './isEventSupported';
 import {getNodeFromInstance} from '../client/ReactDOMComponentTree';
-import * as inputValueTracking from '../client/inputValueTracking';
+import {updateValueIfChanged} from '../client/inputValueTracking';
 import {setDefaultValue} from '../client/ReactDOMInput';
 import {disableInputAttributeSyncing} from 'shared/ReactFeatureFlags';
 
@@ -100,12 +100,12 @@ function manualDispatchChangeEvent(nativeEvent) {
 }
 
 function runEventInBatch(event) {
-  EventPluginHub.runEventsInBatch(event);
+  runEventsInBatch(event);
 }
 
 function getInstIfValueChanged(targetInst) {
   const targetNode = getNodeFromInstance(targetInst);
-  if (inputValueTracking.updateValueIfChanged(targetNode)) {
+  if (updateValueIfChanged(targetNode)) {
     return targetInst;
   }
 }

--- a/packages/react-dom/src/events/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/SelectEventPlugin.js
@@ -25,7 +25,7 @@ import {
 import {isListeningToAllDependencies} from './ReactBrowserEventEmitter';
 import getActiveElement from '../client/getActiveElement';
 import {getNodeFromInstance} from '../client/ReactDOMComponentTree';
-import * as ReactInputSelection from '../client/ReactInputSelection';
+import {hasSelectionCapabilities} from '../client/ReactInputSelection';
 import {DOCUMENT_NODE} from '../shared/HTMLNodeType';
 
 const skipSelectionChangeEvent =
@@ -66,10 +66,7 @@ let mouseDown = false;
  * @return {object}
  */
 function getSelection(node) {
-  if (
-    'selectionStart' in node &&
-    ReactInputSelection.hasSelectionCapabilities(node)
-  ) {
+  if ('selectionStart' in node && hasSelectionCapabilities(node)) {
     return {
       start: node.selectionStart,
       end: node.selectionEnd,

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {findCurrentFiberUsingSlowPath} from 'react-reconciler/reflection';
-import * as ReactInstanceMap from 'shared/ReactInstanceMap';
+import {get as getInstance} from 'shared/ReactInstanceMap';
 import {
   ClassComponent,
   FunctionComponent,
@@ -121,7 +121,7 @@ function validateClassInstance(inst, methodName) {
     // This is probably too relaxed but it's existing behavior.
     return;
   }
-  if (ReactInstanceMap.get(inst)) {
+  if (getInstance(inst)) {
     // This is a public instance indeed.
     return;
   }
@@ -198,7 +198,7 @@ const ReactTestUtils = {
     if (!ReactTestUtils.isCompositeComponent(inst)) {
       return false;
     }
-    const internalInstance = ReactInstanceMap.get(inst);
+    const internalInstance = getInstance(inst);
     const constructor = internalInstance.type;
     return constructor === type;
   },
@@ -208,7 +208,7 @@ const ReactTestUtils = {
     if (!inst) {
       return [];
     }
-    const internalInstance = ReactInstanceMap.get(inst);
+    const internalInstance = getInstance(inst);
     return findAllInRenderedFiberTreeInternal(internalInstance, test);
   },
 

--- a/packages/react-dom/src/unstable-native-dependencies/ReactDOMUnstableNativeDependencies.js
+++ b/packages/react-dom/src/unstable-native-dependencies/ReactDOMUnstableNativeDependencies.js
@@ -6,7 +6,7 @@
  */
 
 import ReactDOM from 'react-dom';
-import * as EventPluginUtils from 'events/EventPluginUtils';
+import {setComponentTree} from 'events/EventPluginUtils';
 import ResponderEventPlugin from 'events/ResponderEventPlugin';
 import ResponderTouchHistoryStore from 'events/ResponderTouchHistoryStore';
 
@@ -19,7 +19,7 @@ const [
   injectEventPluginsByName,
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
 
-EventPluginUtils.setComponentTree(
+setComponentTree(
   getFiberCurrentPropsFromNode,
   getInstanceFromNode,
   getNodeFromInstance,

--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -20,7 +20,7 @@ import invariant from 'shared/invariant';
 import TextInputState from 'TextInputState';
 import UIManager from 'UIManager';
 
-import * as ReactNativeAttributePayload from './ReactNativeAttributePayload';
+import {create} from './ReactNativeAttributePayload';
 import {
   mountSafeCallback_NOT_REALLY_SAFE,
   throwOnStylesProp,
@@ -149,10 +149,7 @@ export default function(
         warnForStyleProps(nativeProps, viewConfig.validAttributes);
       }
 
-      const updatePayload = ReactNativeAttributePayload.create(
-        nativeProps,
-        viewConfig.validAttributes,
-      );
+      const updatePayload = create(nativeProps, viewConfig.validAttributes);
 
       // Avoid the overhead of bridge calls if there's no update.
       // This is an expensive no-op for Android, and causes an unnecessary

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -19,9 +19,14 @@ import {
   mountSafeCallback_NOT_REALLY_SAFE,
   warnForStyleProps,
 } from './NativeMethodsMixinUtils';
-import * as ReactNativeAttributePayload from './ReactNativeAttributePayload';
-import * as ReactNativeFrameScheduling from './ReactNativeFrameScheduling';
-import * as ReactNativeViewConfigRegistry from 'ReactNativeViewConfigRegistry';
+import {create, diff} from './ReactNativeAttributePayload';
+import {
+  now as ReactNativeFrameSchedulingNow,
+  cancelDeferredCallback as ReactNativeFrameSchedulingCancelDeferredCallback,
+  scheduleDeferredCallback as ReactNativeFrameSchedulingScheduleDeferredCallback,
+  shouldYield as ReactNativeFrameSchedulingShouldYield,
+} from './ReactNativeFrameScheduling';
+import {get as getViewConfigForType} from 'ReactNativeViewConfigRegistry';
 
 import deepFreezeAndThrowOnMutationInDev from 'deepFreezeAndThrowOnMutationInDev';
 import invariant from 'shared/invariant';
@@ -138,10 +143,7 @@ class ReactFabricHostComponent {
       warnForStyleProps(nativeProps, this.viewConfig.validAttributes);
     }
 
-    const updatePayload = ReactNativeAttributePayload.create(
-      nativeProps,
-      this.viewConfig.validAttributes,
-    );
+    const updatePayload = create(nativeProps, this.viewConfig.validAttributes);
 
     // Avoid the overhead of bridge calls if there's no update.
     // This is an expensive no-op for Android, and causes an unnecessary
@@ -179,7 +181,7 @@ export function createInstance(
   const tag = nextReactTag;
   nextReactTag += 2;
 
-  const viewConfig = ReactNativeViewConfigRegistry.get(type);
+  const viewConfig = getViewConfigForType(type);
 
   if (__DEV__) {
     for (const key in viewConfig.validAttributes) {
@@ -194,10 +196,7 @@ export function createInstance(
     'Nesting of <View> within <Text> is not currently supported.',
   );
 
-  const updatePayload = ReactNativeAttributePayload.create(
-    props,
-    viewConfig.validAttributes,
-  );
+  const updatePayload = create(props, viewConfig.validAttributes);
 
   const node = createNode(
     tag, // reactTag
@@ -295,11 +294,7 @@ export function prepareUpdate(
   hostContext: HostContext,
 ): null | Object {
   const viewConfig = instance.canonical.viewConfig;
-  const updatePayload = ReactNativeAttributePayload.diff(
-    oldProps,
-    newProps,
-    viewConfig.validAttributes,
-  );
+  const updatePayload = diff(oldProps, newProps, viewConfig.validAttributes);
   // TODO: If the event handlers have changed, we need to update the current props
   // in the commit phase but there is no host config hook to do it yet.
   // So instead we hack it by updating it in the render phase.
@@ -327,12 +322,10 @@ export function shouldSetTextContent(type: string, props: Props): boolean {
 
 // The Fabric renderer is secondary to the existing React Native renderer.
 export const isPrimaryRenderer = false;
-export const now = ReactNativeFrameScheduling.now;
-export const scheduleDeferredCallback =
-  ReactNativeFrameScheduling.scheduleDeferredCallback;
-export const cancelDeferredCallback =
-  ReactNativeFrameScheduling.cancelDeferredCallback;
-export const shouldYield = ReactNativeFrameScheduling.shouldYield;
+export const now = ReactNativeFrameSchedulingNow;
+export const scheduleDeferredCallback = ReactNativeFrameSchedulingScheduleDeferredCallback;
+export const cancelDeferredCallback = ReactNativeFrameSchedulingCancelDeferredCallback;
+export const shouldYield = ReactNativeFrameSchedulingShouldYield;
 
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;
@@ -383,7 +376,7 @@ export function cloneHiddenInstance(
 ): Instance {
   const viewConfig = instance.canonical.viewConfig;
   const node = instance.node;
-  const updatePayload = ReactNativeAttributePayload.create(
+  const updatePayload = create(
     {style: {display: 'none'}},
     viewConfig.validAttributes,
   );
@@ -401,7 +394,7 @@ export function cloneUnhiddenInstance(
 ): Instance {
   const viewConfig = instance.canonical.viewConfig;
   const node = instance.node;
-  const updatePayload = ReactNativeAttributePayload.diff(
+  const updatePayload = diff(
     {...props, style: [props.style, {display: 'none'}]},
     props,
     viewConfig.validAttributes,

--- a/packages/react-native-renderer/src/ReactFabricInjection.js
+++ b/packages/react-native-renderer/src/ReactFabricInjection.js
@@ -9,15 +9,19 @@
 
 import './ReactNativeInjectionShared';
 
-import * as ReactFabricComponentTree from './ReactFabricComponentTree';
-import * as EventPluginUtils from 'events/EventPluginUtils';
+import {
+  getFiberCurrentPropsFromNode,
+  getInstanceFromNode,
+  getNodeFromInstance,
+} from './ReactFabricComponentTree';
+import {setComponentTree} from 'events/EventPluginUtils';
 import ReactFabricGlobalResponderHandler from './ReactFabricGlobalResponderHandler';
 import ResponderEventPlugin from 'events/ResponderEventPlugin';
 
-EventPluginUtils.setComponentTree(
-  ReactFabricComponentTree.getFiberCurrentPropsFromNode,
-  ReactFabricComponentTree.getInstanceFromNode,
-  ReactFabricComponentTree.getNodeFromInstance,
+setComponentTree(
+  getFiberCurrentPropsFromNode,
+  getInstanceFromNode,
+  getNodeFromInstance,
 );
 
 ResponderEventPlugin.injection.injectGlobalResponderHandler(

--- a/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
+++ b/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
@@ -13,15 +13,13 @@ import {
   accumulateDirectDispatches,
 } from 'events/EventPropagators';
 import type {TopLevelType} from 'events/TopLevelEventTypes';
-import * as ReactNativeViewConfigRegistry from 'ReactNativeViewConfigRegistry';
-import SyntheticEvent from 'events/SyntheticEvent';
-import invariant from 'shared/invariant';
-
-const {
+import {
   customBubblingEventTypes,
   customDirectEventTypes,
   eventTypes,
-} = ReactNativeViewConfigRegistry;
+} from 'ReactNativeViewConfigRegistry';
+import SyntheticEvent from 'events/SyntheticEvent';
+import invariant from 'shared/invariant';
 
 const ReactNativeBridgeEventPlugin = {
   eventTypes: eventTypes,

--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -21,7 +21,7 @@ import React from 'react';
 import TextInputState from 'TextInputState';
 import UIManager from 'UIManager';
 
-import * as ReactNativeAttributePayload from './ReactNativeAttributePayload';
+import {create} from './ReactNativeAttributePayload';
 import {mountSafeCallback_NOT_REALLY_SAFE} from './NativeMethodsMixinUtils';
 
 export default function(
@@ -156,10 +156,7 @@ export default function(
       const viewConfig: ReactNativeBaseComponentViewConfig<> =
         maybeInstance.viewConfig || maybeInstance.canonical.viewConfig;
 
-      const updatePayload = ReactNativeAttributePayload.create(
-        nativeProps,
-        viewConfig.validAttributes,
-      );
+      const updatePayload = create(nativeProps, viewConfig.validAttributes);
 
       // Avoid the overhead of bridge calls if there's no update.
       // This is an expensive no-op for Android, and causes an unnecessary

--- a/packages/react-native-renderer/src/ReactNativeEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactNativeEventEmitter.js
@@ -87,7 +87,7 @@ const removeTouchesAtIndices = function(
  * @param {TopLevelType} topLevelType Top level type of event.
  * @param {?object} nativeEventParam Object passed from native.
  */
-export function _receiveRootNodeIDEvent(
+function _receiveRootNodeIDEvent(
   rootNodeID: number,
   topLevelType: TopLevelType,
   nativeEventParam: ?AnyNativeEvent,

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -20,7 +20,7 @@ import type {Instance} from './ReactNativeHostConfig';
 import TextInputState from 'TextInputState';
 import UIManager from 'UIManager';
 
-import * as ReactNativeAttributePayload from './ReactNativeAttributePayload';
+import {create} from './ReactNativeAttributePayload';
 import {
   mountSafeCallback_NOT_REALLY_SAFE,
   warnForStyleProps,
@@ -84,10 +84,7 @@ class ReactNativeFiberHostComponent {
       warnForStyleProps(nativeProps, this.viewConfig.validAttributes);
     }
 
-    const updatePayload = ReactNativeAttributePayload.create(
-      nativeProps,
-      this.viewConfig.validAttributes,
-    );
+    const updatePayload = create(nativeProps, this.viewConfig.validAttributes);
 
     // Avoid the overhead of bridge calls if there's no update.
     // This is an expensive no-op for Android, and causes an unnecessary

--- a/packages/react-native-renderer/src/ReactNativeInjection.js
+++ b/packages/react-native-renderer/src/ReactNativeInjection.js
@@ -9,9 +9,13 @@
 
 import './ReactNativeInjectionShared';
 
-import * as ReactNativeComponentTree from './ReactNativeComponentTree';
-import * as EventPluginUtils from 'events/EventPluginUtils';
-import * as ReactNativeEventEmitter from './ReactNativeEventEmitter';
+import {
+  getFiberCurrentPropsFromNode,
+  getInstanceFromNode,
+  getNodeFromInstance,
+} from './ReactNativeComponentTree';
+import {setComponentTree} from 'events/EventPluginUtils';
+import {receiveEvent, receiveTouches} from './ReactNativeEventEmitter';
 import ReactNativeGlobalResponderHandler from './ReactNativeGlobalResponderHandler';
 import ResponderEventPlugin from 'events/ResponderEventPlugin';
 
@@ -21,12 +25,15 @@ import RCTEventEmitter from 'RCTEventEmitter';
 /**
  * Register the event emitter with the native bridge
  */
-RCTEventEmitter.register(ReactNativeEventEmitter);
+RCTEventEmitter.register({
+  receiveEvent,
+  receiveTouches,
+});
 
-EventPluginUtils.setComponentTree(
-  ReactNativeComponentTree.getFiberCurrentPropsFromNode,
-  ReactNativeComponentTree.getInstanceFromNode,
-  ReactNativeComponentTree.getNodeFromInstance,
+setComponentTree(
+  getFiberCurrentPropsFromNode,
+  getInstanceFromNode,
+  getNodeFromInstance,
 );
 
 ResponderEventPlugin.injection.injectGlobalResponderHandler(

--- a/packages/react-native-renderer/src/ReactNativeInjectionShared.js
+++ b/packages/react-native-renderer/src/ReactNativeInjectionShared.js
@@ -16,7 +16,7 @@
 // Module provided by RN:
 import 'InitializeCore';
 
-import * as EventPluginHub from 'events/EventPluginHub';
+import {injection as EventPluginHubInjection} from 'events/EventPluginHub';
 import ResponderEventPlugin from 'events/ResponderEventPlugin';
 
 import ReactNativeBridgeEventPlugin from './ReactNativeBridgeEventPlugin';
@@ -25,13 +25,13 @@ import ReactNativeEventPluginOrder from './ReactNativeEventPluginOrder';
 /**
  * Inject module for resolving DOM hierarchy and plugin ordering.
  */
-EventPluginHub.injection.injectEventPluginOrder(ReactNativeEventPluginOrder);
+EventPluginHubInjection.injectEventPluginOrder(ReactNativeEventPluginOrder);
 
 /**
  * Some important event plugins included by default (without having to require
  * them).
  */
-EventPluginHub.injection.injectEventPluginsByName({
+EventPluginHubInjection.injectEventPluginsByName({
   ResponderEventPlugin: ResponderEventPlugin,
   ReactNativeBridgeEventPlugin: ReactNativeBridgeEventPlugin,
 });

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -18,7 +18,7 @@ import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {UpdateQueue} from 'react-reconciler/src/ReactUpdateQueue';
 import type {ReactNodeList} from 'shared/ReactTypes';
 
-import * as ReactPortal from 'shared/ReactPortal';
+import {createPortal} from 'shared/ReactPortal';
 import expect from 'expect';
 import {REACT_FRAGMENT_TYPE, REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 
@@ -656,7 +656,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       container: Container,
       key: ?string = null,
     ) {
-      return ReactPortal.createPortal(children, container, null, key);
+      return createPortal(children, container, null, key);
     },
 
     // Shortcut for testing a single root

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -56,7 +56,11 @@ import getComponentName from 'shared/getComponentName';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings';
 import warning from 'shared/warning';
 import warningWithoutStack from 'shared/warningWithoutStack';
-import * as ReactCurrentFiber from './ReactCurrentFiber';
+import {
+  setCurrentPhase,
+  getCurrentFiberOwnerNameInDevOrNull,
+  getCurrentFiberStackInDev,
+} from './ReactCurrentFiber';
 import {startWorkTimer, cancelWorkTimer} from './ReactDebugFiberPerf';
 
 import {
@@ -215,9 +219,9 @@ function updateForwardRef(
   prepareToUseHooks(current, workInProgress, renderExpirationTime);
   if (__DEV__) {
     ReactCurrentOwner.current = workInProgress;
-    ReactCurrentFiber.setCurrentPhase('render');
+    setCurrentPhase('render');
     nextChildren = render(nextProps, ref);
-    ReactCurrentFiber.setCurrentPhase(null);
+    setCurrentPhase(null);
   } else {
     nextChildren = render(nextProps, ref);
   }
@@ -409,9 +413,9 @@ function updateFunctionComponent(
   prepareToUseHooks(current, workInProgress, renderExpirationTime);
   if (__DEV__) {
     ReactCurrentOwner.current = workInProgress;
-    ReactCurrentFiber.setCurrentPhase('render');
+    setCurrentPhase('render');
     nextChildren = Component(nextProps, context);
-    ReactCurrentFiber.setCurrentPhase(null);
+    setCurrentPhase(null);
   } else {
     nextChildren = Component(nextProps, context);
   }
@@ -548,7 +552,7 @@ function finishClassComponent(
     }
   } else {
     if (__DEV__) {
-      ReactCurrentFiber.setCurrentPhase('render');
+      setCurrentPhase('render');
       nextChildren = instance.render();
       if (
         debugRenderPhaseSideEffects ||
@@ -557,7 +561,7 @@ function finishClassComponent(
       ) {
         instance.render();
       }
-      ReactCurrentFiber.setCurrentPhase(null);
+      setCurrentPhase(null);
     } else {
       nextChildren = instance.render();
     }
@@ -1011,7 +1015,7 @@ function validateFunctionComponentInDev(workInProgress: Fiber, Component: any) {
   }
   if (workInProgress.ref !== null) {
     let info = '';
-    const ownerName = ReactCurrentFiber.getCurrentFiberOwnerNameInDevOrNull();
+    const ownerName = getCurrentFiberOwnerNameInDevOrNull();
     if (ownerName) {
       info += '\n\nCheck the render method of `' + ownerName + '`.';
     }
@@ -1378,7 +1382,7 @@ function updateContextProvider(
         newProps,
         'prop',
         'Context.Provider',
-        ReactCurrentFiber.getCurrentFiberStackInDev,
+        getCurrentFiberStackInDev,
       );
     }
   }
@@ -1469,9 +1473,9 @@ function updateContextConsumer(
   let newChildren;
   if (__DEV__) {
     ReactCurrentOwner.current = workInProgress;
-    ReactCurrentFiber.setCurrentPhase('render');
+    setCurrentPhase('render');
     newChildren = render(newValue);
-    ReactCurrentFiber.setCurrentPhase(null);
+    setCurrentPhase(null);
   } else {
     newChildren = render(newValue);
   }

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -19,7 +19,7 @@ import {
 } from 'shared/ReactFeatureFlags';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings';
 import {isMounted} from 'react-reconciler/reflection';
-import * as ReactInstanceMap from 'shared/ReactInstanceMap';
+import {get as getInstance, set as setInstance} from 'shared/ReactInstanceMap';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import shallowEqual from 'shared/shallowEqual';
 import getComponentName from 'shared/getComponentName';
@@ -188,7 +188,7 @@ export function applyDerivedStateFromProps(
 const classComponentUpdater = {
   isMounted,
   enqueueSetState(inst, payload, callback) {
-    const fiber = ReactInstanceMap.get(inst);
+    const fiber = getInstance(inst);
     const currentTime = requestCurrentTime();
     const expirationTime = computeExpirationForFiber(currentTime, fiber);
 
@@ -206,7 +206,7 @@ const classComponentUpdater = {
     scheduleWork(fiber, expirationTime);
   },
   enqueueReplaceState(inst, payload, callback) {
-    const fiber = ReactInstanceMap.get(inst);
+    const fiber = getInstance(inst);
     const currentTime = requestCurrentTime();
     const expirationTime = computeExpirationForFiber(currentTime, fiber);
 
@@ -226,7 +226,7 @@ const classComponentUpdater = {
     scheduleWork(fiber, expirationTime);
   },
   enqueueForceUpdate(inst, callback) {
-    const fiber = ReactInstanceMap.get(inst);
+    const fiber = getInstance(inst);
     const currentTime = requestCurrentTime();
     const expirationTime = computeExpirationForFiber(currentTime, fiber);
 
@@ -504,7 +504,7 @@ function adoptClassInstance(workInProgress: Fiber, instance: any): void {
   instance.updater = classComponentUpdater;
   workInProgress.stateNode = instance;
   // The instance needs access to the fiber so that it can schedule updates
-  ReactInstanceMap.set(instance, workInProgress);
+  setInstance(instance, workInProgress);
   if (__DEV__) {
     instance._reactInternalInstance = fakeInternalInstance;
   }

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -17,7 +17,7 @@ import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import checkPropTypes from 'prop-types/checkPropTypes';
 
-import * as ReactCurrentFiber from './ReactCurrentFiber';
+import {setCurrentPhase, getCurrentFiberStackInDev} from './ReactCurrentFiber';
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
 import {createCursor, push, pop} from './ReactFiberStack';
 
@@ -99,7 +99,7 @@ function getMaskedContext(
       context,
       'context',
       name,
-      ReactCurrentFiber.getCurrentFiberStackInDev,
+      getCurrentFiberStackInDev,
     );
   }
 
@@ -177,13 +177,13 @@ function processChildContext(
 
   let childContext;
   if (__DEV__) {
-    ReactCurrentFiber.setCurrentPhase('getChildContext');
+    setCurrentPhase('getChildContext');
   }
   startPhaseTimer(fiber, 'getChildContext');
   childContext = instance.getChildContext();
   stopPhaseTimer();
   if (__DEV__) {
-    ReactCurrentFiber.setCurrentPhase(null);
+    setCurrentPhase(null);
   }
   for (let contextKey in childContext) {
     invariant(
@@ -205,7 +205,7 @@ function processChildContext(
       // context from the parent component instance. The stack will be missing
       // because it's outside of the reconciliation, and so the pointer has not
       // been set. This is rare and doesn't matter. We'll also remove that API.
-      ReactCurrentFiber.getCurrentFiberStackInDev,
+      getCurrentFiberStackInDev,
     );
   }
 

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -68,7 +68,12 @@ import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 
 import ReactFiberInstrumentation from './ReactFiberInstrumentation';
-import * as ReactCurrentFiber from './ReactCurrentFiber';
+import {
+  getStackByFiberInDevAndProd,
+  phase as ReactCurrentFiberPhase,
+  resetCurrentFiber,
+  setCurrentFiber,
+} from './ReactCurrentFiber';
 import {
   now,
   scheduleDeferredCallback,
@@ -210,13 +215,13 @@ if (__DEV__) {
       isClass
         ? 'the componentWillUnmount method'
         : 'a useEffect cleanup function',
-      ReactCurrentFiber.getStackByFiberInDevAndProd(fiber),
+      getStackByFiberInDevAndProd(fiber),
     );
     didWarnStateUpdateForUnmountedComponent[componentName] = true;
   };
 
   warnAboutInvalidUpdates = function(instance: React$Component<any>) {
-    switch (ReactCurrentFiber.phase) {
+    switch (ReactCurrentFiberPhase) {
       case 'getChildContext':
         if (didWarnSetStateChildContext) {
           return;
@@ -392,7 +397,7 @@ function resetStack() {
 function commitAllHostEffects() {
   while (nextEffect !== null) {
     if (__DEV__) {
-      ReactCurrentFiber.setCurrentFiber(nextEffect);
+      setCurrentFiber(nextEffect);
     }
     recordEffect();
 
@@ -451,14 +456,14 @@ function commitAllHostEffects() {
   }
 
   if (__DEV__) {
-    ReactCurrentFiber.resetCurrentFiber();
+    resetCurrentFiber();
   }
 }
 
 function commitBeforeMutationLifecycles() {
   while (nextEffect !== null) {
     if (__DEV__) {
-      ReactCurrentFiber.setCurrentFiber(nextEffect);
+      setCurrentFiber(nextEffect);
     }
 
     const effectTag = nextEffect.effectTag;
@@ -472,7 +477,7 @@ function commitBeforeMutationLifecycles() {
   }
 
   if (__DEV__) {
-    ReactCurrentFiber.resetCurrentFiber();
+    resetCurrentFiber();
   }
 }
 
@@ -947,7 +952,7 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
     // progress.
     const current = workInProgress.alternate;
     if (__DEV__) {
-      ReactCurrentFiber.setCurrentFiber(workInProgress);
+      setCurrentFiber(workInProgress);
     }
 
     const returnFiber = workInProgress.return;
@@ -988,7 +993,7 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
       stopWorkTimer(workInProgress);
       resetChildExpirationTime(workInProgress, nextRenderExpirationTime);
       if (__DEV__) {
-        ReactCurrentFiber.resetCurrentFiber();
+        resetCurrentFiber();
       }
 
       if (nextUnitOfWork !== null) {
@@ -1076,7 +1081,7 @@ function completeUnitOfWork(workInProgress: Fiber): Fiber | null {
       }
 
       if (__DEV__) {
-        ReactCurrentFiber.resetCurrentFiber();
+        resetCurrentFiber();
       }
 
       if (next !== null) {
@@ -1132,7 +1137,7 @@ function performUnitOfWork(workInProgress: Fiber): Fiber | null {
   // See if beginning this work spawns more work.
   startWorkTimer(workInProgress);
   if (__DEV__) {
-    ReactCurrentFiber.setCurrentFiber(workInProgress);
+    setCurrentFiber(workInProgress);
   }
 
   if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
@@ -1161,7 +1166,7 @@ function performUnitOfWork(workInProgress: Fiber): Fiber | null {
   }
 
   if (__DEV__) {
-    ReactCurrentFiber.resetCurrentFiber();
+    resetCurrentFiber();
     if (isReplayingFailedUnitOfWork) {
       // Currently replaying a failed unit of work. This should be unreachable,
       // because the render phase is meant to be idempotent, and it should

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -12,7 +12,7 @@ import type {Fiber} from './ReactFiber';
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 
-import * as ReactInstanceMap from 'shared/ReactInstanceMap';
+import {get as getInstance} from 'shared/ReactInstanceMap';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import getComponentName from 'shared/getComponentName';
 import {
@@ -82,7 +82,7 @@ export function isMounted(component: React$Component<any, any>): boolean {
     }
   }
 
-  const fiber: ?Fiber = ReactInstanceMap.get(component);
+  const fiber: ?Fiber = getInstance(component);
   if (!fiber) {
     return false;
   }

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -8,7 +8,12 @@
  */
 
 import warning from 'shared/warning';
-import * as TestRendererScheduling from './ReactTestRendererScheduling';
+import {
+  nowImplementation as TestRendererSchedulingNowImplementation,
+  scheduleDeferredCallback as TestRendererSchedulingScheduleDeferredCallback,
+  cancelDeferredCallback as TestRendererSchedulingCancelDeferredCallback,
+  shouldYield as TestRendererSchedulingShouldYield,
+} from './ReactTestRendererScheduling';
 
 export type Type = string;
 export type Props = Object;
@@ -197,12 +202,10 @@ export function createTextInstance(
 export const isPrimaryRenderer = false;
 // This approach enables `now` to be mocked by tests,
 // Even after the reconciler has initialized and read host config values.
-export const now = () => TestRendererScheduling.nowImplementation();
-export const scheduleDeferredCallback =
-  TestRendererScheduling.scheduleDeferredCallback;
-export const cancelDeferredCallback =
-  TestRendererScheduling.cancelDeferredCallback;
-export const shouldYield = TestRendererScheduling.shouldYield;
+export const now = () => TestRendererSchedulingNowImplementation();
+export const scheduleDeferredCallback = TestRendererSchedulingScheduleDeferredCallback;
+export const cancelDeferredCallback = TestRendererSchedulingCancelDeferredCallback;
+export const shouldYield = TestRendererSchedulingShouldYield;
 
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;


### PR DESCRIPTION
Whenever we do this, Rollup needs to materialize this as an object. This causes it to also add the Babel compatibility property which is unnecessary bloat. However, since when we use these, we leak the object on the `this` binding which could deoptimize inlining/DCE. Most of the time this just works because GCC is smart enough to see that it doesn't leak but not always. By avoiding this pattern it's more predictable.

If we really need an object we should export default an object.

Currently there is an exception for DOMTopLevelEventTypes since listing out the imports is a PITA and it doesn't escape so it should get properly inlined. We should probably move to a different pattern to avoid this for consistency though.

Do we need to add this as a lint warning?