### PR TITLE
Use |0 to coerce to number

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRendererContext.js
+++ b/packages/react-dom/src/server/ReactPartialRendererContext.js
@@ -56,12 +56,11 @@ export function validateContextBounds(
   context: ReactContext<any>,
   threadID: ThreadID,
 ) {
-  // If `react` package is < 16.6, _threadCount is undefined.
-  let initialThreadCount = context._threadCount || 0;
   // If we don't have enough slots in this context to store this threadID,
   // fill it in without leaving any holes to ensure that the VM optimizes
   // this as non-holey index properties.
-  for (let i = initialThreadCount; i <= threadID; i++) {
+  // (Note: If `react` package is < 16.6, _threadCount is undefined.)
+  for (let i = context._threadCount | 0; i <= threadID; i++) {
     // We assume that this is the same as the defaultValue which might not be
     // true if we're rendering inside a secondary renderer but they are
     // secondary because these use cases are very rare.


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/14291. Should be less work, right?

I don't think we can make this simpler without reverting the fix. The bug is very subtle and I think it would suck to keep shipping it.