### PR TITLE
--save is no longer needed

### DIFF
--- a/packages/create-subscription/README.md
+++ b/packages/create-subscription/README.md
@@ -36,7 +36,7 @@ This abstraction can handle a variety of subscription types, including:
 yarn add create-subscription
 
 # NPM
-npm install create-subscription --save
+npm install create-subscription
 ```
 
 # Usage


### PR DESCRIPTION
`--save` is on by default as of npm 5. `npm install create-subscription` is equivalent to `npm install --save create-subscription` now
