### PR TITLE
List ignored types instead of included types in the stack

### DIFF
--- a/packages/react-reconciler/src/ReactCurrentFiber.js
+++ b/packages/react-reconciler/src/ReactCurrentFiber.js
@@ -11,13 +11,12 @@ import type {Fiber} from './ReactFiber';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
-  IndeterminateComponent,
-  FunctionComponent,
-  ClassComponent,
-  HostComponent,
-  Mode,
-  LazyComponent,
-  SuspenseComponent,
+  HostRoot,
+  HostPortal,
+  HostText,
+  Fragment,
+  ContextProvider,
+  ContextConsumer,
 } from 'shared/ReactWorkTags';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import getComponentName from 'shared/getComponentName';
@@ -28,13 +27,14 @@ type LifeCyclePhase = 'render' | 'getChildContext';
 
 function describeFiber(fiber: Fiber): string {
   switch (fiber.tag) {
-    case IndeterminateComponent:
-    case LazyComponent:
-    case FunctionComponent:
-    case ClassComponent:
-    case HostComponent:
-    case Mode:
-    case SuspenseComponent:
+    case HostRoot:
+    case HostPortal:
+    case HostText:
+    case Fragment:
+    case ContextProvider:
+    case ContextConsumer:
+      return '';
+    default:
       const owner = fiber._debugOwner;
       const source = fiber._debugSource;
       const name = getComponentName(fiber.type);
@@ -43,8 +43,6 @@ function describeFiber(fiber: Fiber): string {
         ownerName = getComponentName(owner.type);
       }
       return describeComponentFrame(name, source, ownerName);
-    default:
-      return '';
   }
 }
 


### PR DESCRIPTION
The switch is getting pretty large and we constantly forget to add new types there. For example it is missing `Memo` which caught me off guard in another PR. `ForwardRef` too.

So I'm flipping this to list ignored types instead. Note that in any case, if `getComponentName()` doesn't return anything useful, we would skip over that line anyway.