### PR TITLE
Adding isMemo check to react-is package

### DIFF
--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -16,6 +16,7 @@ import {
   REACT_ELEMENT_TYPE,
   REACT_FORWARD_REF_TYPE,
   REACT_FRAGMENT_TYPE,
+  REACT_MEMO_TYPE,
   REACT_PORTAL_TYPE,
   REACT_PROFILER_TYPE,
   REACT_PROVIDER_TYPE,
@@ -27,7 +28,6 @@ import lowPriorityWarning from 'shared/lowPriorityWarning';
 export function typeOf(object: any) {
   if (typeof object === 'object' && object !== null) {
     const $$typeof = object.$$typeof;
-
     switch ($$typeof) {
       case REACT_ELEMENT_TYPE:
         const type = object.type;
@@ -51,6 +51,7 @@ export function typeOf(object: any) {
                 return $$typeof;
             }
         }
+      case REACT_MEMO_TYPE:
       case REACT_PORTAL_TYPE:
         return $$typeof;
     }
@@ -69,6 +70,7 @@ export const ForwardRef = REACT_FORWARD_REF_TYPE;
 export const Fragment = REACT_FRAGMENT_TYPE;
 export const Profiler = REACT_PROFILER_TYPE;
 export const Portal = REACT_PORTAL_TYPE;
+export const Memo = REACT_MEMO_TYPE;
 export const StrictMode = REACT_STRICT_MODE_TYPE;
 
 export {isValidElementType};
@@ -114,6 +116,9 @@ export function isFragment(object: any) {
 }
 export function isProfiler(object: any) {
   return typeOf(object) === REACT_PROFILER_TYPE;
+}
+export function isMemo(object: any) {
+  return typeOf(object) === REACT_MEMO_TYPE;
 }
 export function isPortal(object: any) {
   return typeOf(object) === REACT_PORTAL_TYPE;

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -144,6 +144,14 @@ describe('ReactIs', () => {
     expect(ReactIs.isPortal(div)).toBe(false);
   });
 
+  it('should identify memo', () => {
+    const Component = () => React.createElement('div');
+    const memoized = React.memo(Component);
+    expect(ReactIs.typeOf(memoized)).toBe(ReactIs.Memo);
+    expect(ReactIs.isMemo(memoized)).toBe(true);
+    expect(ReactIs.isMemo(Component)).toBe(false);
+  });
+
   it('should identify strict mode', () => {
     expect(ReactIs.typeOf(<React.StrictMode />)).toBe(ReactIs.StrictMode);
     expect(ReactIs.isStrictMode(<React.StrictMode />)).toBe(true);


### PR DESCRIPTION
This pull request is related to #14278 

What does it do?

Adds isMemo check to the react-is package.

Why?

Adding isMemo check will help to write a clean code for packages which are doing custom rendering, like Enzyme.

Please see the issue and PR raised on Enzyme

airbnb/enzyme#1875
airbnb/enzyme#1914

