### PR TITLE
Add progress bars to longer running async release tasks

### DIFF
--- a/scripts/release/.gitignore
+++ b/scripts/release/.gitignore
@@ -1,0 +1,1 @@
+.progress-estimator

--- a/scripts/release/create-canary-commands/build-artifacts.js
+++ b/scripts/release/create-canary-commands/build-artifacts.js
@@ -21,5 +21,5 @@ const run = async ({cwd, dry, tempDirectory}) => {
 };
 
 module.exports = async params => {
-  return logPromise(run(params), 'Building artifacts', true);
+  return logPromise(run(params), 'Building artifacts', 420000);
 };

--- a/scripts/release/package.json
+++ b/scripts/release/package.json
@@ -15,6 +15,7 @@
     "folder-hash": "^2.1.2",
     "fs-extra": "^4.0.2",
     "log-update": "^2.1.0",
+    "progress-estimator": "^0.1.1",
     "prompt-promise": "^1.0.3",
     "request-promise-json": "^1.0.4",
     "semver": "^5.4.1"

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const {dots} = require('cli-spinners');
 const {exec} = require('child-process-promise');
 const {createPatch} = require('diff');
 const {hashElement} = require('folder-hash');
@@ -8,8 +7,14 @@ const {readdirSync, readFileSync, statSync, writeFileSync} = require('fs');
 const {readJson, writeJson} = require('fs-extra');
 const logUpdate = require('log-update');
 const {join} = require('path');
+const {logProgress, configure} = require('progress-estimator');
 const prompt = require('prompt-promise');
 const theme = require('./theme');
+
+// https://www.npmjs.com/package/progress-estimator#configuration
+configure({
+  storagePath: join(__dirname, '.progress-estimator'),
+});
 
 const confirm = async message => {
   const confirmation = await prompt(theme`\n{caution ${message}} (y/N) `);
@@ -86,39 +91,8 @@ const handleError = error => {
   process.exit(1);
 };
 
-const logPromise = async (promise, text, isLongRunningTask = false) => {
-  const {frames, interval} = dots;
-
-  let index = 0;
-
-  const inProgressMessage = `- this may take a few ${
-    isLongRunningTask ? 'minutes' : 'seconds'
-  }`;
-
-  const id = setInterval(() => {
-    index = ++index % frames.length;
-    logUpdate(
-      theme`{spinnerInProgress ${
-        frames[index]
-      }} ${text} {dimmed ${inProgressMessage}}`
-    );
-  }, interval);
-
-  try {
-    const returnValue = await promise;
-
-    clearInterval(id);
-
-    logUpdate(theme`{spinnerSuccess ✓} ${text}`);
-    logUpdate.done();
-
-    return returnValue;
-  } catch (error) {
-    logUpdate.clear();
-
-    throw error;
-  }
-};
+const logPromise = async (promise, text, estimatedDuration) =>
+  logProgress(promise, text, estimatedDuration);
 
 const printDiff = (path, beforeContents, afterContents) => {
   const patch = createPatch(path, beforeContents, afterContents);

--- a/scripts/release/yarn.lock
+++ b/scripts/release/yarn.lock
@@ -21,6 +21,11 @@ ansi-escapes@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
 
+ansi-escapes@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
+  integrity sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==
+
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
@@ -28,6 +33,13 @@ ansi-regex@^3.0.0:
 ansi-styles@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
 
@@ -106,6 +118,15 @@ chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 child-process-promise@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/child-process-promise/-/child-process-promise-2.2.1.tgz#4730a11ef610fad450b8f223c79d31d7bdad8074"
@@ -128,6 +149,11 @@ cli-cursor@^2.0.0:
 cli-spinners@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.1.0.tgz#f1847b168844d917a671eb9d147e3df497c90d06"
+
+cli-spinners@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
+  integrity sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==
 
 co@^4.6.0:
   version "4.6.0"
@@ -302,6 +328,11 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
 hawk@~6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
@@ -322,6 +353,11 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+humanize-duration@^3.15.3:
+  version "3.15.3"
+  resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.15.3.tgz#600a939bd9d9a16b696e907b3fc08d1a4f15e8c9"
+  integrity sha512-BMz6w8p3NVa6QP9wDtqUkXfwgBqDaZ5z/np0EYdoWrLqL849Onp6JWMXMhbHtuvO9jUThLN5H1ThRQ8dUWnYkA==
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
@@ -396,6 +432,15 @@ log-update@^2.1.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
+log-update@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
+  integrity sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+  dependencies:
+    ansi-escapes "^3.0.0"
+    cli-cursor "^2.0.0"
+    wrap-ansi "^3.0.1"
+
 lru-cache@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
@@ -456,6 +501,16 @@ onetime@^2.0.0:
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+
+progress-estimator@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/progress-estimator/-/progress-estimator-0.1.1.tgz#7be93392953f4ebf00ab1d217d50aff6a8ff5c22"
+  integrity sha512-OIUUGnzDbhAjxP1NXo6EhLbWyJEFtkJiexxRQSY68CYMCzO9mEi2JDnTt896xMmin8H8HB2W0dIf/SMRTj+02A==
+  dependencies:
+    chalk "^2.4.1"
+    cli-spinners "^1.3.1"
+    humanize-duration "^3.15.3"
+    log-update "^2.3.0"
 
 promise-polyfill@^6.0.1:
   version "6.0.2"
@@ -583,6 +638,13 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
     has-flag "^2.0.0"
+
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
 
 table-layout@^0.4.1:
   version "0.4.2"


### PR DESCRIPTION
Use the new [`progress-estimator`](https://npmjs.com/package/progress-estimator) package to add progress bars to our release script tasks.

For example:
![update-with-progress-bars](https://user-images.githubusercontent.com/29597/48973196-c9b2e700-efee-11e8-8556-f95d766414d7.gif)
