### PR TITLE
Add a null type test for memo

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.internal.js
@@ -306,10 +306,18 @@ describe('memo', () => {
         expect(ReactNoop.getChildren()).toEqual([span(20)]);
       });
 
-      it('warns if first argument is undefined', () => {
+      it('warns if the first argument is undefined', () => {
         expect(() => memo()).toWarnDev(
           'memo: The first argument must be a component. Instead ' +
             'received: undefined',
+          {withoutStack: true},
+        );
+      });
+
+      it('warns if the first argument is null', () => {
+        expect(() => memo(null)).toWarnDev(
+          'memo: The first argument must be a component. Instead ' +
+            'received: null',
           {withoutStack: true},
         );
       });

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -130,7 +130,7 @@ const createMatcherFor = consoleMethod =>
       };
 
       // TODO Decide whether we need to support nested toWarn* expectations.
-      // If we don't need id, add a check here to see if this is already our spy,
+      // If we don't need it, add a check here to see if this is already our spy,
       // And throw an error.
       const originalMethod = console[consoleMethod];
 


### PR DESCRIPTION
Add a unit test case for memo to check type `null`, and fix a typo in the related jest matcher `toWarnDev`.

The code coverage of `memo` increases from:
```bash
--------------------------------------------|----------|----------|----------|----------|-------------------|
File                                        |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------------------------------|----------|----------|----------|----------|-------------------|
  memo.js                                   |      100 |    68.75 |      100 |      100 |       13,17,19,23 |
```
to:

```bash
--------------------------------------------|----------|----------|----------|----------|-------------------|
File                                        |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------------------------------|----------|----------|----------|----------|-------------------|
  memo.js                                   |      100 |       75 |      100 |      100 |          13,17,19 |
```
