### PR TITLE
Make useEffect(async) warning more verbose

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -337,7 +337,7 @@ function commitHookEffectList(
                   'nothing.%s%s',
                 typeof destroy.then === 'function'
                   ? '\n\nIt looks like you wrote useEffect(async () => ...) or returned a Promise. ' +
-                    'Instead, you may write an async function separately, ' +
+                    'Instead, you may write an async function separately ' +
                     'and then call it from inside the effect:\n\n' +
                     'async function fetchComment(commentId) {\n' +
                     '  // You can await here\n' +

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -336,9 +336,17 @@ function commitHookEffectList(
                 'useEffect function must return a cleanup function or ' +
                   'nothing.%s%s',
                 typeof destroy.then === 'function'
-                  ? ' Promises and useEffect(async () => ...) are not ' +
-                    'supported, but you can call an async function inside an ' +
-                    'effect.'
+                  ? '\n\nIt looks like you wrote useEffect(async () => ...) or returned a Promise. ' +
+                    'Instead, you may write an async function separately, ' +
+                    'and then call it from inside the effect:\n\n' +
+                    'async function fetchComment(commentId) {\n' +
+                    '  // You can await here\n' +
+                    '}\n\n' +
+                    'useEffect(() => {\n' +
+                    '  fetchComment(commentId);\n' +
+                    '}, [commentId]);\n\n' +
+                    'In the future, React will provide a more idiomatic solution for data fetching ' +
+                    "that doesn't involve writing effects manually."
                   : '',
                 getStackByFiberInDevAndProd(finishedWork),
               );

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -75,10 +75,8 @@ describe('ReactHooks', () => {
     expect(() => {
       root.update(<App return={Promise.resolve()} />);
     }).toWarnDev([
-      'Warning: useEffect function must return a cleanup function or ' +
-        'nothing. Promises and useEffect(async () => ...) are not supported, ' +
-        'but you can call an async function inside an effect.\n' +
-        '    in App (at **)',
+      'Warning: useEffect function must return a cleanup function or nothing.\n\n' +
+        'It looks like you wrote useEffect(async () => ...) or returned a Promise.',
     ]);
   });
 


### PR DESCRIPTION
Adds a more detailed message. People still get tripped over this:

* https://github.com/facebook/react/issues/14326
* https://mobile.twitter.com/bardiarastin/status/1064144863388680192

New message:

<img width="671" alt="screen shot 2018-11-26 at 3 53 12 pm" src="https://user-images.githubusercontent.com/810438/49025407-7ded7280-f193-11e8-953e-635152d81f83.png">
