### PR TITLE
Remove usage of `fbjs/lib/invariant` in ReactNativeViewConfigRegistry.

### DIFF
--- a/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
+++ b/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
@@ -15,7 +15,7 @@ import type {
   ViewConfigGetter,
 } from './ReactNativeTypes';
 
-const invariant = require('fbjs/lib/invariant');
+const invariant = require('invariant');
 
 // Event configs
 const customBubblingEventTypes = {};


### PR DESCRIPTION
I'm trying to remove fbjs from react-native. This is the corresponding change necessary in the React repo.

I am unsure how to test this so I'm assuming that CI will tell me if something is wrong here. Also please tell me if the `invariant` entry in `package.json` shall go somewhere else. I'm assuming since this is synced to react-native for product uses that `invariant` as a dev dependency on the root is good enough for testing.