### PR TITLE
Release script auto-determine the latest Canary build if none specified

### DIFF
--- a/scripts/release/prepare-canary-commands/get-latest-master-build-number.js
+++ b/scripts/release/prepare-canary-commands/get-latest-master-build-number.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const http = require('request-promise-json');
+const {logPromise} = require('../utils');
+
+const run = async () => {
+  // https://circleci.com/docs/api/#recent-builds-for-a-project-branch
+  const metadataURL = `https://circleci.com/api/v1.1/project/github/facebook/react/tree/master`;
+  const metadata = await http.get(metadataURL, true);
+  const build = metadata.find(entry => entry.branch === 'master').build_num;
+
+  return build;
+};
+
+module.exports = async params => {
+  return logPromise(
+    run(params),
+    'Determining latest Circle CI for the master branch'
+  );
+};

--- a/scripts/release/prepare-canary-commands/get-latest-master-build-number.js
+++ b/scripts/release/prepare-canary-commands/get-latest-master-build-number.js
@@ -9,7 +9,9 @@ const run = async () => {
   // https://circleci.com/docs/api/#recent-builds-for-a-project-branch
   const metadataURL = `https://circleci.com/api/v1.1/project/github/facebook/react/tree/master`;
   const metadata = await http.get(metadataURL, true);
-  const build = metadata.find(entry => entry.branch === 'master').build_num;
+  const build = metadata.find(
+    entry => entry.branch === 'master' && entry.status === 'success'
+  ).build_num;
 
   return build;
 };

--- a/scripts/release/prepare-canary-commands/parse-params.js
+++ b/scripts/release/prepare-canary-commands/parse-params.js
@@ -3,7 +3,6 @@
 'use strict';
 
 const commandLineArgs = require('command-line-args');
-const commandLineUsage = require('command-line-usage');
 
 const paramDefinitions = [
   {
@@ -16,30 +15,6 @@ const paramDefinitions = [
 
 module.exports = () => {
   const params = commandLineArgs(paramDefinitions);
-
-  if (!params.build) {
-    const usage = commandLineUsage([
-      {
-        content:
-          'Prepare a Circle CI build to be published to NPM as a canary.',
-      },
-      {
-        header: 'Options',
-        optionList: paramDefinitions,
-      },
-      {
-        header: 'Examples',
-        content: [
-          {
-            desc: 'Example:',
-            example: '$ ./prepare-canary.js [bold]{--build=}[underline]{12639}',
-          },
-        ],
-      },
-    ]);
-    console.log(usage);
-    process.exit(1);
-  }
 
   return params;
 };

--- a/scripts/release/prepare-canary.js
+++ b/scripts/release/prepare-canary.js
@@ -7,6 +7,7 @@ const {getPublicPackages, handleError} = require('./utils');
 
 const checkEnvironmentVariables = require('./prepare-canary-commands/check-environment-variables');
 const downloadBuildArtifacts = require('./prepare-canary-commands/download-build-artifacts');
+const getLatestMasterBuildNumber = require('./prepare-canary-commands/get-latest-master-build-number');
 const parseParams = require('./prepare-canary-commands/parse-params');
 const printPrereleaseSummary = require('./shared-commands/print-prerelease-summary');
 
@@ -15,6 +16,10 @@ const run = async () => {
     const params = parseParams();
     params.cwd = join(__dirname, '..', '..');
     params.packages = await getPublicPackages();
+
+    if (!params.build) {
+      params.build = await getLatestMasterBuildNumber();
+    }
 
     await checkEnvironmentVariables(params);
     await downloadBuildArtifacts(params);


### PR DESCRIPTION
Seems like this would be useful if we want to integrate with the FB sync script. Also it's just convenient.

Now you can prepare a specified build:
```sh
./scripts/release/prepare-canary.js --build=12774
```

Or just prepare the most recent one from `master`:
```
./scripts/release/prepare-canary.js
```

### Demo
![kapture 2018-11-27 at 15 07 40](https://user-images.githubusercontent.com/29597/49117638-3ed42580-f256-11e8-8956-f966dacf6f72.gif)
