### PR TITLE
Suggestion, Hook: Avoid rerender if useReducer's dispatch is called before the hook

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -487,6 +487,29 @@ describe('ReactHooksWithNoopRenderer', () => {
       ]);
       expect(ReactNoop.getChildren()).toEqual([span(22)]);
     });
+
+    it("doesn't rerender is dispatch is called before hook", () => {
+      let rendersCount = 0;
+
+      function Counter() {
+        const setCountRef = useRef(null);
+        if (setCountRef.current) {
+          setCountRef.current(value => value + 1);
+        }
+        const [count, setCount] = useState(1);
+        setCountRef.current = setCount;
+        rendersCount += 1;
+        return <Text text={`${count} ${rendersCount}`} />;
+      }
+
+      ReactNoop.render(<Counter />);
+      ReactNoop.flush();
+      expect(ReactNoop.getChildren()).toEqual([span('1 1')]);
+
+      ReactNoop.render(<Counter />);
+      ReactNoop.flush();
+      expect(ReactNoop.getChildren()).toEqual([span('2 2')]);
+    });
   });
 
   describe('useReducer', () => {


### PR DESCRIPTION
**Current behaviour**
When rendering a component, if I call the `dispatch` (setState) function of `useReducer` before I actually call `useReducer`, it will trigger the component to be rerendered.
This behaviour is demonstrated [here](https://codesandbox.io/s/p75yo957w7), the custom hook's code is copied bellow.

**Suggested behaviour**
In the current implementation, dispatched actions (and mostly the ones triggered during the render phase) are handled inside `useReducer`. If the `dispatch` function is called before `useReducer`, we don't have to wait to rerender to handle this action.
This new behaviour is demonstrated in the current Pull Request.
I'm not expecting a negative effect because hooks are currently meant to be called always in same order and not conditionally.

**Motivation**
I came to this change trying to implement a custom hook `useDerivedState`:
```
const useDerivedState = (computeDerivedState, inputs, initialState = null) => {
  const setStateRef = useRef(null);
  useMemo(() => {
    if (setStateRef.current) {
      const setState = setStateRef.current;
      setState(prevState => {
        const newState = computeDerivedState(prevState);
        return newState !== undefined ? newState : prevState;
      });
    }
  }, inputs);
  const stateStuff = useState(() => {
    let state = initialState;
    if (typeof state === "function") {
      state = state();
    }
    return computeDerivedState(state);
  });
  [, setStateRef.current] = stateStuff;
  return stateStuff;
};
```