### PR TITLE
Fix bug in cloneHook

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -253,7 +253,7 @@ function cloneHook(hook: Hook): Hook {
   return {
     memoizedState: hook.memoizedState,
 
-    baseState: hook.memoizedState,
+    baseState: hook.baseState,
     queue: hook.queue,
     baseUpdate: hook.baseUpdate,
 

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -566,6 +566,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(ReactNoop.getChildren()).toEqual([span('Count: 8')]);
     });
 
+    // Regression test for https://github.com/facebook/react/issues/14360
     it('handles dispatches with mixed priorities', () => {
       const INCREMENT = 'INCREMENT';
 
@@ -583,22 +584,17 @@ describe('ReactHooksWithNoopRenderer', () => {
       const counter = React.createRef(null);
       ReactNoop.render(<Counter ref={counter} />);
 
-      // initial Render should be 'Count: 0'
       ReactNoop.flush();
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
-      // dispatch some low prio increments
       counter.current.dispatch(INCREMENT);
       counter.current.dispatch(INCREMENT);
       counter.current.dispatch(INCREMENT);
-
-      // dispatch and apply a high prio increment
       ReactNoop.flushSync(() => {
         counter.current.dispatch(INCREMENT);
       });
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
 
-      // apply all increments
       ReactNoop.flush();
       expect(ReactNoop.getChildren()).toEqual([span('Count: 4')]);
     });


### PR DESCRIPTION
Fixes #14360 and adds a test for mixed priority dispatches.

It was broken because `cloneHook` assigned `memoizedState` instead of
`baseState` from the original hook to `baseState` of the clone.
