### PR TITLE
Don't prompt to git tag a canary release

### DIFF
--- a/scripts/release/publish-commands/confirm-version-and-tags.js
+++ b/scripts/release/publish-commands/confirm-version-and-tags.js
@@ -39,6 +39,8 @@ const run = async ({cwd, packages, tags}) => {
   }
 
   await confirm('Do you want to proceed?');
+
+  clear();
 };
 
 // Run this directly because it's fast,

--- a/scripts/release/publish-commands/print-follow-up-instructions.js
+++ b/scripts/release/publish-commands/print-follow-up-instructions.js
@@ -20,65 +20,69 @@ const run = async ({cwd, packages, tags}) => {
 
   clear();
 
-  console.log(
-    theme.caution`The release has been published but you're not done yet!`
-  );
-
-  if (tags.includes('latest')) {
-    console.log();
+  if (tags.length === 1 && tags[0] === 'canary') {
+    console.log(theme.header`A canary release has been pulbished!`);
+  } else {
     console.log(
-      theme.header`Please review and commit all local, staged changes.`
+      theme.caution`The release has been published but you're not done yet!`
     );
 
-    console.log();
-    console.log('Version numbers have been updated in the following files:');
-    for (let i = 0; i < packages.length; i++) {
-      const packageName = packages[i];
-      console.log(theme.path`• packages/%s/package.json`, packageName);
-    }
-    console.log(theme.path`• packages/shared/ReactVersion.js`);
-
-    console.log();
-    if (environment === 'ci') {
-      console.log('Auto-generated error codes have been updated as well:');
-      console.log(theme.path`• scripts/error-codes/codes.json`);
-    } else {
+    if (tags.includes('latest')) {
+      console.log();
       console.log(
-        theme`{caution The release that was just published was created locally.} ` +
-          theme`Because of this, you will need to update the generated ` +
-          theme`{path scripts/error-codes/codes.json} file manually:`
+        theme.header`Please review and commit all local, staged changes.`
       );
-      console.log(theme`  {command git checkout} {version ${commit}}`);
-      console.log(theme`  {command yarn build -- --extract-errors}`);
+
+      console.log();
+      console.log('Version numbers have been updated in the following files:');
+      for (let i = 0; i < packages.length; i++) {
+        const packageName = packages[i];
+        console.log(theme.path`• packages/%s/package.json`, packageName);
+      }
+      console.log(theme.path`• packages/shared/ReactVersion.js`);
+
+      console.log();
+      if (environment === 'ci') {
+        console.log('Auto-generated error codes have been updated as well:');
+        console.log(theme.path`• scripts/error-codes/codes.json`);
+      } else {
+        console.log(
+          theme`{caution The release that was just published was created locally.} ` +
+            theme`Because of this, you will need to update the generated ` +
+            theme`{path scripts/error-codes/codes.json} file manually:`
+        );
+        console.log(theme`  {command git checkout} {version ${commit}}`);
+        console.log(theme`  {command yarn build -- --extract-errors}`);
+      }
     }
+
+    console.log();
+    console.log(
+      theme`{header Don't forget to update and commit the }{path CHANGELOG}`
+    );
+
+    // Prompt the release engineer to tag the commit and update the CHANGELOG.
+    // (The script could automatically do this, but this seems safer.)
+    console.log();
+    console.log(
+      theme.header`Tag the source for this release in Git with the following command:`
+    );
+    console.log(
+      theme`  {command git tag -a v}{version %s} {command -m "v%s"} {version %s}`,
+      version,
+      version,
+      commit
+    );
+    console.log(theme.command`  git push origin --tags`);
+
+    console.log();
+    console.log(theme.header`Lastly, please fill in the release on GitHub:`);
+    console.log(
+      theme.link`https://github.com/facebook/react/releases/tag/v%s`,
+      version
+    );
+    console.log();
   }
-
-  console.log();
-  console.log(
-    theme`{header Don't forget to update and commit the }{path CHANGELOG}`
-  );
-
-  // Prompt the release engineer to tag the commit and update the CHANGELOG.
-  // (The script could automatically do this, but this seems safer.)
-  console.log();
-  console.log(
-    theme.header`Tag the source for this release in Git with the following command:`
-  );
-  console.log(
-    theme`  {command git tag -a v}{version %s} {command -m "v%s"} {version %s}`,
-    version,
-    version,
-    commit
-  );
-  console.log(theme.command`  git push origin --tags`);
-
-  console.log();
-  console.log(theme.header`Lastly, please fill in the release on GitHub:`);
-  console.log(
-    theme.link`https://github.com/facebook/react/releases/tag/v%s`,
-    version
-  );
-  console.log();
 };
 
 module.exports = run;

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -3,12 +3,15 @@
 'use strict';
 
 const {exec} = require('child-process-promise');
+const clear = require('clear');
 const {readJsonSync} = require('fs-extra');
 const {join} = require('path');
 const {confirm, execRead} = require('../utils');
 const theme = require('../theme');
 
 const run = async ({cwd, dry, packages, tags}, otp) => {
+  clear();
+
   for (let i = 0; i < packages.length; i++) {
     const packageName = packages[i];
     const packagePath = join(cwd, 'build/node_modules', packageName);


### PR DESCRIPTION
After publishing a canary release:
<img width="377" alt="screen shot 2018-12-02 at 11 34 11 am" src="https://user-images.githubusercontent.com/29597/49343989-592b4c00-f626-11e8-9e12-ba065e2b255b.png">

After publishing a stable release:
<img width="410" alt="screen shot 2018-12-02 at 11 34 27 am" src="https://user-images.githubusercontent.com/29597/49343990-59c3e280-f626-11e8-9d84-ffa4122417e9.png">

(Note that I didn't _actually_ publish either release above, just ran the script with a `--dry` flag.)