### PR TITLE
Fix scheduler setTimeout() re-entrancy check

### DIFF
--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -473,9 +473,11 @@ if (globalValue && globalValue._schedMock) {
   var _callback = null;
   var _flushCallback = function(didTimeout) {
     if (_callback !== null) {
-      var cb = _callback;
-      _callback = null;
-      cb(didTimeout);
+      try {
+        _callback(didTimeout);
+      } finally {
+        _callback = null;
+      }
     }
   };
   requestHostCallback = function(cb, ms) {


### PR DESCRIPTION
While looking at publishing a patch for the `scheduler@0.12.0-alpha` I noticed that I'd broken the re-entrancy check for the `setTimeout` branch.

I'm not sure this actually matters, since this check looks to be redundant. (There's also a `isExecutingCallback` check that prevents `requestHostCallback` from being called while another callback is being executed.)