### PR TITLE
Updated release script's suggested next version

### DIFF
--- a/scripts/release/prepare-canary-commands/download-build-artifacts.js
+++ b/scripts/release/prepare-canary-commands/download-build-artifacts.js
@@ -4,7 +4,7 @@
 
 const http = require('request-promise-json');
 const {exec} = require('child-process-promise');
-const {readdirSync} = require('fs');
+const {existsSync, readdirSync} = require('fs');
 const {readJsonSync} = require('fs-extra');
 const {join} = require('path');
 const {logPromise} = require('../utils');
@@ -19,6 +19,10 @@ const run = async ({build, cwd}) => {
   const nodeModulesURL = metadata.find(
     entry => entry.path === 'home/circleci/project/node_modules.tgz'
   ).url;
+
+  if (!existsSync(join(cwd, 'build'))) {
+    await exec(`mkdir ./build`, {cwd});
+  }
 
   // Download and extract artifact
   await exec(`rm -rf ./build/node_modules*`, {cwd});

--- a/scripts/release/prepare-stable-commands/check-out-packages.js
+++ b/scripts/release/prepare-stable-commands/check-out-packages.js
@@ -18,6 +18,10 @@ const run = async ({cwd, local, packages, version}) => {
     return;
   }
 
+  if (!existsSync(join(cwd, 'build'))) {
+    await exec(`mkdir ./build`, {cwd});
+  }
+
   // Cleanup from previous builds
   await exec(`rm -rf ./build/node_modules*`, {cwd});
   await exec(`mkdir ./build/node_modules`, {cwd});

--- a/scripts/release/prepare-stable-commands/guess-stable-version-numbers.js
+++ b/scripts/release/prepare-stable-commands/guess-stable-version-numbers.js
@@ -6,6 +6,10 @@ const semver = require('semver');
 const {execRead, logPromise} = require('../utils');
 
 const run = async ({cwd, packages}, versionsMap) => {
+  const branch = await execRead('git branch | grep \\* | cut -d " " -f2', {
+    cwd,
+  });
+
   for (let i = 0; i < packages.length; i++) {
     const packageName = packages[i];
 
@@ -17,7 +21,13 @@ const run = async ({cwd, packages}, versionsMap) => {
 
       // Guess the next version by incrementing patch.
       // The script will confirm this later.
-      versionsMap.set(packageName, `${major}.${minor}.${patch + 1}`);
+      // By default, new releases from masters should increment the minor version number,
+      // and patch releases should be done from branches.
+      if (branch === 'master') {
+        versionsMap.set(packageName, `${major}.${minor + 1}.0`);
+      } else {
+        versionsMap.set(packageName, `${major}.${minor}.${patch + 1}`);
+      }
     } catch (error) {
       // If the package has not yet been published,
       // we'll require a version number to be entered later.


### PR DESCRIPTION
Based on team discussion during today's sync, the next version number will be:
* A minor bump if releasing from master
* A patch bump if releasing from a branch

The release script still enables user overrides for these values. This only affects the suggested next version.