### PR TITLE
Memoize promise listeners to prevent exponential growth

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1474,6 +1474,7 @@ function updateSuspenseComponent(
         );
       }
     }
+    workInProgress.stateNode = current.stateNode;
   }
 
   workInProgress.memoizedState = nextState;

--- a/packages/react-reconciler/src/ReactFiberPendingPriority.js
+++ b/packages/react-reconciler/src/ReactFiberPendingPriority.js
@@ -62,6 +62,10 @@ export function markCommittedPriorityLevels(
     return;
   }
 
+  if (earliestRemainingTime < root.latestPingedTime) {
+    root.latestPingedTime = NoWork;
+  }
+
   // Let's see if the previous latest known pending level was just flushed.
   const latestPendingTime = root.latestPendingTime;
   if (latestPendingTime !== NoWork) {
@@ -209,10 +213,8 @@ export function markPingedPriorityLevel(
 }
 
 function clearPing(root, completedTime) {
-  // TODO: Track whether the root was pinged during the render phase. If so,
-  // we need to make sure we don't lose track of it.
   const latestPingedTime = root.latestPingedTime;
-  if (latestPingedTime !== NoWork && latestPingedTime >= completedTime) {
+  if (latestPingedTime >= completedTime) {
     root.latestPingedTime = NoWork;
   }
 }

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -10,6 +10,7 @@
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {TimeoutHandle, NoTimeout} from './ReactFiberHostConfig';
+import type {Thenable} from './ReactFiberScheduler';
 import type {Interaction} from 'scheduler/src/Tracing';
 
 import {noTimeout} from './ReactFiberHostConfig';
@@ -50,6 +51,11 @@ type BaseFiberRootProperties = {|
   // The latest priority level that was pinged by a resolved promise and can
   // be retried.
   latestPingedTime: ExpirationTime,
+
+  pingCache:
+    | WeakMap<Thenable, Set<ExpirationTime>>
+    | Map<Thenable, Set<ExpirationTime>>
+    | null,
 
   // If an error is thrown, and there are no more updates in the queue, we try
   // rendering from the root one more time, synchronously, before handling
@@ -121,6 +127,8 @@ export function createFiberRoot(
       latestSuspendedTime: NoWork,
       latestPingedTime: NoWork,
 
+      pingCache: null,
+
       didError: false,
 
       pendingCommitExpirationTime: NoWork,
@@ -143,6 +151,8 @@ export function createFiberRoot(
       current: uninitializedFiber,
       containerInfo: containerInfo,
       pendingChildren: null,
+
+      pingCache: null,
 
       earliestPendingTime: NoWork,
       latestPendingTime: NoWork,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -125,13 +125,8 @@ import {
   computeAsyncExpiration,
   computeInteractiveExpiration,
 } from './ReactFiberExpirationTime';
-import {ConcurrentMode, ProfileMode, NoContext} from './ReactTypeOfMode';
-import {
-  enqueueUpdate,
-  resetCurrentlyProcessingQueue,
-  ForceUpdate,
-  createUpdate,
-} from './ReactUpdateQueue';
+import {ConcurrentMode, ProfileMode} from './ReactTypeOfMode';
+import {enqueueUpdate, resetCurrentlyProcessingQueue} from './ReactUpdateQueue';
 import {createCapturedValue} from './ReactCapturedValue';
 import {
   isContextProvider as isLegacyContextProvider,
@@ -174,6 +169,8 @@ import {Dispatcher, DispatcherWithoutHooks} from './ReactFiberDispatcher';
 
 export type Thenable = {
   then(resolve: () => mixed, reject?: () => mixed): mixed,
+  _reactPingCache: Map<FiberRoot, Set<ExpirationTime>> | void,
+  _reactRetryCache: Set<Fiber> | void,
 };
 
 const {ReactCurrentOwner} = ReactSharedInternals;
@@ -1646,61 +1643,40 @@ function renderDidError() {
   nextRenderDidError = true;
 }
 
-function retrySuspendedRoot(
-  root: FiberRoot,
-  boundaryFiber: Fiber,
-  sourceFiber: Fiber,
-  suspendedTime: ExpirationTime,
-) {
-  let retryTime;
-
-  if (isPriorityLevelSuspended(root, suspendedTime)) {
-    // Ping at the original level
-    retryTime = suspendedTime;
-
-    markPingedPriorityLevel(root, retryTime);
+function pingSuspendedRoot(root: FiberRoot, pingTime: ExpirationTime) {
+  // A promise that previously suspended React from committing has resolved.
+  // If React is still suspended, try again at the previous level (pingTime).
+  if (nextRoot !== null && nextRenderExpirationTime === pingTime) {
+    // Received a ping at the same priority level at which we're currently
+    // rendering. Restart from the root.
+    nextRoot = null;
   } else {
-    // Suspense already timed out. Compute a new expiration time
-    const currentTime = requestCurrentTime();
-    retryTime = computeExpirationForFiber(currentTime, boundaryFiber);
+    // Confirm that the root is still suspended at this level. Otherwise exit.
+    if (isPriorityLevelSuspended(root, pingTime)) {
+      // Ping at the original level
+      markPingedPriorityLevel(root, pingTime);
+      const rootExpirationTime = root.expirationTime;
+      if (rootExpirationTime !== NoWork) {
+        requestWork(root, rootExpirationTime);
+      }
+    }
+  }
+}
+
+function retryTimedOutBoundary(boundaryFiber: Fiber) {
+  // The boundary fiber (a Suspense component) previously timed out and was
+  // rendered in its fallback state. One of the promises that suspended it has
+  // resolved, which means at least part of the tree was likely unblocked. Try
+  // rendering again, at a new expiration time.
+  const currentTime = requestCurrentTime();
+  const retryTime = computeExpirationForFiber(currentTime, boundaryFiber);
+  const root = scheduleWorkToRoot(boundaryFiber, retryTime);
+  if (root !== null) {
     markPendingPriorityLevel(root, retryTime);
-  }
-
-  // TODO: If the suspense fiber has already rendered the primary children
-  // without suspending (that is, all of the promises have already resolved),
-  // we should not trigger another update here. One case this happens is when
-  // we are in sync mode and a single promise is thrown both on initial render
-  // and on update; we attach two .then(retrySuspendedRoot) callbacks and each
-  // one performs Sync work, rerendering the Suspense.
-
-  if ((boundaryFiber.mode & ConcurrentMode) !== NoContext) {
-    if (root === nextRoot && nextRenderExpirationTime === suspendedTime) {
-      // Received a ping at the same priority level at which we're currently
-      // rendering. Restart from the root.
-      nextRoot = null;
+    const rootExpirationTime = root.expirationTime;
+    if (rootExpirationTime !== NoWork) {
+      requestWork(root, rootExpirationTime);
     }
-  }
-
-  scheduleWorkToRoot(boundaryFiber, retryTime);
-  if ((boundaryFiber.mode & ConcurrentMode) === NoContext) {
-    // Outside of concurrent mode, we must schedule an update on the source
-    // fiber, too, since it already committed in an inconsistent state and
-    // therefore does not have any pending work.
-    scheduleWorkToRoot(sourceFiber, retryTime);
-    const sourceTag = sourceFiber.tag;
-    if (sourceTag === ClassComponent && sourceFiber.stateNode !== null) {
-      // When we try rendering again, we should not reuse the current fiber,
-      // since it's known to be in an inconsistent state. Use a force updte to
-      // prevent a bail out.
-      const update = createUpdate(retryTime);
-      update.tag = ForceUpdate;
-      enqueueUpdate(sourceFiber, update);
-    }
-  }
-
-  const rootExpirationTime = root.expirationTime;
-  if (rootExpirationTime !== NoWork) {
-    requestWork(root, rootExpirationTime);
   }
 }
 
@@ -2550,7 +2526,8 @@ export {
   onUncaughtError,
   renderDidSuspend,
   renderDidError,
-  retrySuspendedRoot,
+  pingSuspendedRoot,
+  retryTimedOutBoundary,
   markLegacyErrorBoundaryAsFailed,
   isAlreadyFailedLegacyErrorBoundary,
   scheduleWork,

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -14,10 +14,7 @@ export type SuspenseState = {|
   timedOutAt: ExpirationTime,
 |};
 
-export function shouldCaptureSuspense(
-  current: Fiber | null,
-  workInProgress: Fiber,
-): boolean {
+export function shouldCaptureSuspense(workInProgress: Fiber): boolean {
   // In order to capture, the Suspense component must have a fallback prop.
   if (workInProgress.memoizedProps.fallback === undefined) {
     return false;

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -43,6 +43,8 @@ import {
   enqueueCapturedUpdate,
   createUpdate,
   CaptureUpdate,
+  ForceUpdate,
+  enqueueUpdate,
 } from './ReactUpdateQueue';
 import {logError} from './ReactFiberCommitWork';
 import {getStackByFiberInDevAndProd} from './ReactCurrentFiber';
@@ -59,7 +61,7 @@ import {
   onUncaughtError,
   markLegacyErrorBoundaryAsFailed,
   isAlreadyFailedLegacyErrorBoundary,
-  retrySuspendedRoot,
+  pingSuspendedRoot,
 } from './ReactFiberScheduler';
 
 import invariant from 'shared/invariant';
@@ -202,29 +204,18 @@ function throwException(
     do {
       if (
         workInProgress.tag === SuspenseComponent &&
-        shouldCaptureSuspense(workInProgress.alternate, workInProgress)
+        shouldCaptureSuspense(workInProgress)
       ) {
         // Found the nearest boundary.
 
-        // If the boundary is not in concurrent mode, we should not suspend, and
-        // likewise, when the promise resolves, we should ping synchronously.
-        const pingTime =
-          (workInProgress.mode & ConcurrentMode) === NoEffect
-            ? Sync
-            : renderExpirationTime;
-
-        // Attach a listener to the promise to "ping" the root and retry.
-        let onResolveOrReject = retrySuspendedRoot.bind(
-          null,
-          root,
-          workInProgress,
-          sourceFiber,
-          pingTime,
-        );
-        if (enableSchedulerTracing) {
-          onResolveOrReject = Schedule_tracing_wrap(onResolveOrReject);
+        // Stash the promise on the boundary fiber. If the boundary times out, we'll
+        // attach another listener to flip the boundary back to its normal state.
+        const thenables: Set<Thenable> = (workInProgress.updateQueue: any);
+        if (thenables === null) {
+          workInProgress.updateQueue = (new Set([thenable]): any);
+        } else {
+          thenables.add(thenable);
         }
-        thenable.then(onResolveOrReject, onResolveOrReject);
 
         // If the boundary is outside of concurrent mode, we should *not*
         // suspend the commit. Pretend as if the suspended component rendered
@@ -243,18 +234,25 @@ function throwException(
           sourceFiber.effectTag &= ~(LifecycleEffectMask | Incomplete);
 
           if (sourceFiber.tag === ClassComponent) {
-            const current = sourceFiber.alternate;
-            if (current === null) {
+            const currentSourceFiber = sourceFiber.alternate;
+            if (currentSourceFiber === null) {
               // This is a new mount. Change the tag so it's not mistaken for a
               // completed class component. For example, we should not call
               // componentWillUnmount if it is deleted.
               sourceFiber.tag = IncompleteClassComponent;
+            } else {
+              // When we try rendering again, we should not reuse the current fiber,
+              // since it's known to be in an inconsistent state. Use a force updte to
+              // prevent a bail out.
+              const update = createUpdate(Sync);
+              update.tag = ForceUpdate;
+              enqueueUpdate(sourceFiber, update);
             }
           }
 
-          // The source fiber did not complete. Mark it with the current
-          // render priority to indicate that it still has pending work.
-          sourceFiber.expirationTime = renderExpirationTime;
+          // The source fiber did not complete. Mark it with Sync priority to
+          // indicate that it still has pending work.
+          sourceFiber.expirationTime = Sync;
 
           // Exit without suspending.
           return;
@@ -262,6 +260,33 @@ function throwException(
 
         // Confirmed that the boundary is in a concurrent mode tree. Continue
         // with the normal suspend path.
+
+        // Attach a listener to the promise to "ping" the root and retry. But
+        // only if one does not already exist for the current render expiration
+        // time (which acts like a "thread ID" here).
+        let pingCache: Map<FiberRoot, Set<ExpirationTime>> | void =
+          thenable._reactPingCache;
+        let threadIDs;
+        if (pingCache === undefined) {
+          pingCache = thenable._reactPingCache = new Map();
+          threadIDs = new Set();
+          pingCache.set(root, threadIDs);
+        } else {
+          threadIDs = pingCache.get(root);
+          if (threadIDs === undefined) {
+            threadIDs = new Set();
+            pingCache.set(root, threadIDs);
+          }
+        }
+        if (!threadIDs.has(renderExpirationTime)) {
+          // Memoize using the thread ID to prevent redundant listeners.
+          threadIDs.add(renderExpirationTime);
+          let ping = pingSuspendedRoot.bind(null, root, renderExpirationTime);
+          if (enableSchedulerTracing) {
+            ping = Schedule_tracing_wrap(ping);
+          }
+          thenable.then(ping, ping);
+        }
 
         let absoluteTimeoutMs;
         if (earliestTimeoutMs === -1) {

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -8,6 +8,9 @@
  * @jest-environment node
  */
 
+// TODO: This does nothing since it was migrated from noop renderer to test
+// renderer! Switch back to noop renderer, or add persistent mode to test
+// renderer, or merge the two renderers into one somehow.
 // runPlaceholderTests('ReactSuspensePlaceholder (mutation)', () =>
 //   require('react-noop-renderer'),
 // );

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -8,9 +8,9 @@
  * @jest-environment node
  */
 
-runPlaceholderTests('ReactSuspensePlaceholder (mutation)', () =>
-  require('react-noop-renderer'),
-);
+// runPlaceholderTests('ReactSuspensePlaceholder (mutation)', () =>
+//   require('react-noop-renderer'),
+// );
 runPlaceholderTests('ReactSuspensePlaceholder (persistence)', () =>
   require('react-noop-renderer/persistent'),
 );

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -366,22 +366,14 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
 
           jest.advanceTimersByTime(1000);
 
-          // TODO Change expected onRender count to 4.
-          // At the moment, every time we suspended while rendering will cause a commit.
-          // This will probably change in the future, but that's why there are two new ones.
           expect(root.toJSON()).toEqual(['Loaded', 'New']);
-          expect(onRender).toHaveBeenCalledTimes(5);
+          expect(onRender).toHaveBeenCalledTimes(4);
 
           // When the suspending data is resolved and our final UI is rendered,
           // the baseDuration should only include the 1ms re-rendering AsyncText,
           // but the treeBaseDuration should include the full 9ms spent in the tree.
           expect(onRender.mock.calls[3][2]).toBe(1);
           expect(onRender.mock.calls[3][3]).toBe(9);
-
-          // TODO Remove these assertions once this commit is gone.
-          // For now, there was no actual work done during this commit; see above comment.
-          expect(onRender.mock.calls[4][2]).toBe(0);
-          expect(onRender.mock.calls[4][3]).toBe(9);
         });
 
         it('properly accounts for base durations when a suspended times out in a concurrent tree', () => {

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -2548,22 +2548,15 @@ describe('Profiler', () => {
         await originalPromise;
         expect(renderer.toJSON()).toEqual(['loaded', 'updated']);
 
-        // TODO: Bug. This *should* just be one render tied to both interactions.
-        expect(onRender).toHaveBeenCalledTimes(2);
+        expect(onRender).toHaveBeenCalledTimes(1);
         expect(onRender.mock.calls[0][6]).toMatchInteractions([
           initialRenderInteraction,
         ]);
-        expect(onRender.mock.calls[1][6]).toMatchInteractions([
-          highPriUpdateInteraction,
-        ]);
 
-        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
         expect(
           onInteractionScheduledWorkCompleted.mock.calls[0][0],
         ).toMatchInteraction(initialRenderInteraction);
-        expect(
-          onInteractionScheduledWorkCompleted.mock.calls[1][0],
-        ).toMatchInteraction(highPriUpdateInteraction);
       });
 
       it('handles high-pri renderers between suspended and resolved (async) trees', async () => {

--- a/scripts/rollup/validate/eslintrc.cjs.js
+++ b/scripts/rollup/validate/eslintrc.cjs.js
@@ -12,6 +12,7 @@ module.exports = {
     Proxy: true,
     Symbol: true,
     WeakMap: true,
+    WeakSet: true,
     Uint16Array: true,
     // Vendor specific
     MSApp: true,

--- a/scripts/rollup/validate/eslintrc.fb.js
+++ b/scripts/rollup/validate/eslintrc.fb.js
@@ -12,6 +12,7 @@ module.exports = {
     Symbol: true,
     Proxy: true,
     WeakMap: true,
+    WeakSet: true,
     Uint16Array: true,
     // Vendor specific
     MSApp: true,

--- a/scripts/rollup/validate/eslintrc.rn.js
+++ b/scripts/rollup/validate/eslintrc.rn.js
@@ -12,6 +12,7 @@ module.exports = {
     Symbol: true,
     Proxy: true,
     WeakMap: true,
+    WeakSet: true,
     // Vendor specific
     MSApp: true,
     __REACT_DEVTOOLS_GLOBAL_HOOK__: true,

--- a/scripts/rollup/validate/eslintrc.umd.js
+++ b/scripts/rollup/validate/eslintrc.umd.js
@@ -11,6 +11,7 @@ module.exports = {
     Symbol: true,
     Proxy: true,
     WeakMap: true,
+    WeakSet: true,
     Uint16Array: true,
     // Vendor specific
     MSApp: true,


### PR DESCRIPTION
Previously, React would attach a new listener every time a promise is thrown, regardless of whether the same listener was already attached during a previous render. Because React attempts to render every time a promise resolves, the number of listeners grows quickly.

This was especially bad in synchronous mode because the renders that happen when the promise pings are not batched together. So if a single promise has multiple listeners for the same root, there will be multiple renders, which in turn results in more listeners being added to the remaining unresolved promises. This results in exponential growth in the number of listeners with respect to the number of IO-bound components in a single render.

Fixes #14220