### PR TITLE
Allow node 11 as devEngine

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mattiasbuelens/web-streams-polyfill": "0.1.0"
   },
   "devEngines": {
-    "node": "8.x || 9.x || 10.x"
+    "node": "8.x || 9.x || 10.x || 11.x"
   },
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"


### PR DESCRIPTION
Using node 11 throws incompatibility error. This fixes it. Only test I performed was to run `yarn build -- --type=RN_OSS` everything seemed ok.

Usual `yarn test` also passes.
