### PR TITLE
Fix memo and lazy element types being considered elements

### DIFF
--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -48,14 +48,14 @@ export function typeOf(object: any) {
             switch ($$typeofType) {
               case REACT_CONTEXT_TYPE:
               case REACT_FORWARD_REF_TYPE:
+              case REACT_LAZY_TYPE:
+              case REACT_MEMO_TYPE:
               case REACT_PROVIDER_TYPE:
                 return $$typeofType;
               default:
                 return $$typeof;
             }
         }
-      case REACT_LAZY_TYPE:
-      case REACT_MEMO_TYPE:
       case REACT_PORTAL_TYPE:
         return $$typeof;
     }

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -150,17 +150,17 @@ describe('ReactIs', () => {
 
   it('should identify memo', () => {
     const Component = () => React.createElement('div');
-    const memoized = React.memo(Component);
-    expect(ReactIs.typeOf(memoized)).toBe(ReactIs.Memo);
-    expect(ReactIs.isMemo(memoized)).toBe(true);
+    const Memoized = React.memo(Component);
+    expect(ReactIs.typeOf(<Memoized />)).toBe(ReactIs.Memo);
+    expect(ReactIs.isMemo(<Memoized />)).toBe(true);
     expect(ReactIs.isMemo(Component)).toBe(false);
   });
 
   it('should identify lazy', () => {
     const Component = () => React.createElement('div');
-    const lazyComponent = React.lazy(() => Component);
-    expect(ReactIs.typeOf(lazyComponent)).toBe(ReactIs.Lazy);
-    expect(ReactIs.isLazy(lazyComponent)).toBe(true);
+    const LazyComponent = React.lazy(() => Component);
+    expect(ReactIs.typeOf(<LazyComponent />)).toBe(ReactIs.Lazy);
+    expect(ReactIs.isLazy(<LazyComponent />)).toBe(true);
     expect(ReactIs.isLazy(Component)).toBe(false);
   });
 


### PR DESCRIPTION
`ReactIs.typeOf` is currently returning an element type for  `lazy` and `memo` even if the given value is not an element (i.e. return value of `React.createElement`) but and elementType. This is confusing since @sebmarkbage spoke against an `elementType` API in https://github.com/facebook/react/pull/12932#pullrequestreview-133808918. 

This means that it is currently possible to determine if a given elementType is a lazy or memo component. 

This PR changes the following behavior so that lazy and memo behave similar to e.g. forwardRef when passed to `is*` or `typeOf`.

```js
// current
const Forward = React.forwardRef(() => null);
const Memo = React.memo(() => null);

ReactIs.isValidElementType(Forward) === true;
ReactIs.isForward(Forward) === false;
ReactIs.isForward(<Forward />) === true;

ReactIs.isValidElementType(Memo) === true;
ReactIs.isMemo(Memo) === true;

// after
ReactIs.isMemo(Memo) === false;
ReactIs.isMemo(<Memo />) === true;
```

I just want to add that I would prefer if `ReactIs.typeOf(Memo)` *and* `ReactIs.typeOf(FowardRef)` would return the element type but as far as I understood @sebmarkbage both should return `undefined`.

Pinging @ljharb since it sounded like (https://github.com/facebook/react/pull/14313#pullrequestreview-178105229) that would be a breaking change for `enzyme`.

Related:
https://github.com/facebook/react/issues/12882#issuecomment-392267309
> `typeOf` checks the return value of `createElement`

or `ReactDOM.createPortal`. 

