### PR TITLE
Separate current owner and dispatcher

### DIFF
--- a/packages/react-cache/src/ReactCache.js
+++ b/packages/react-cache/src/ReactCache.js
@@ -46,11 +46,12 @@ const Pending = 0;
 const Resolved = 1;
 const Rejected = 2;
 
-const currentOwner =
-  React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner;
+const ReactCurrentDispatcher =
+  React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+    .ReactCurrentDispatcher;
 
 function readContext(Context, observedBits) {
-  const dispatcher = currentOwner.currentDispatcher;
+  const dispatcher = ReactCurrentDispatcher.current;
   if (dispatcher === null) {
     throw new Error(
       'react-cache: read and preload may only be called from within a ' +

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -20,7 +20,7 @@ import {
   ForwardRef,
 } from 'shared/ReactWorkTags';
 
-const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
+const ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
 
 // Used to track hooks called during a render
 
@@ -409,9 +409,9 @@ export function inspectHooks<Props>(
   renderFunction: Props => React$Node,
   props: Props,
 ): HooksTree {
-  let previousDispatcher = ReactCurrentOwner.currentDispatcher;
+  let previousDispatcher = ReactCurrentDispatcher.current;
   let readHookLog;
-  ReactCurrentOwner.currentDispatcher = Dispatcher;
+  ReactCurrentDispatcher.current = Dispatcher;
   let ancestorStackError;
   try {
     ancestorStackError = new Error();
@@ -419,7 +419,7 @@ export function inspectHooks<Props>(
   } finally {
     readHookLog = hookLog;
     hookLog = [];
-    ReactCurrentOwner.currentDispatcher = previousDispatcher;
+    ReactCurrentDispatcher.current = previousDispatcher;
   }
   let rootStack = ErrorStackParser.parse(ancestorStackError);
   return buildTree(rootStack, readHookLog);
@@ -451,9 +451,9 @@ function inspectHooksOfForwardRef<Props, Ref>(
   props: Props,
   ref: Ref,
 ): HooksTree {
-  let previousDispatcher = ReactCurrentOwner.currentDispatcher;
+  let previousDispatcher = ReactCurrentDispatcher.current;
   let readHookLog;
-  ReactCurrentOwner.currentDispatcher = Dispatcher;
+  ReactCurrentDispatcher.current = Dispatcher;
   let ancestorStackError;
   try {
     ancestorStackError = new Error();
@@ -461,7 +461,7 @@ function inspectHooksOfForwardRef<Props, Ref>(
   } finally {
     readHookLog = hookLog;
     hookLog = [];
-    ReactCurrentOwner.currentDispatcher = previousDispatcher;
+    ReactCurrentDispatcher.current = previousDispatcher;
   }
   let rootStack = ErrorStackParser.parse(ancestorStackError);
   return buildTree(rootStack, readHookLog);

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -13,7 +13,7 @@
 let React;
 let ReactDOMServer;
 let PropTypes;
-let ReactCurrentOwner;
+let ReactCurrentDispatcher;
 
 function normalizeCodeLocInfo(str) {
   return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
@@ -25,9 +25,9 @@ describe('ReactDOMServer', () => {
     React = require('react');
     PropTypes = require('prop-types');
     ReactDOMServer = require('react-dom/server');
-    ReactCurrentOwner =
+    ReactCurrentDispatcher =
       React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
-        .ReactCurrentOwner;
+        .ReactCurrentDispatcher;
   });
 
   describe('renderToString', () => {
@@ -439,7 +439,7 @@ describe('ReactDOMServer', () => {
       const Context = React.createContext(0);
 
       function readContext(context) {
-        return ReactCurrentOwner.currentDispatcher.readContext(context);
+        return ReactCurrentDispatcher.current.readContext(context);
       }
 
       function Consumer(props) {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -87,7 +87,7 @@ const toArray = ((React.Children.toArray: any): toArrayType);
 // Each stack is an array of frames which may contain nested stacks of elements.
 let currentDebugStacks = [];
 
-let ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
+let ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
 let ReactDebugCurrentFrame;
 let prevGetCurrentStackImpl = null;
 let getCurrentServerStackImpl = () => '';
@@ -785,11 +785,11 @@ class ReactDOMServerRenderer {
 
     const prevThreadID = currentThreadID;
     setCurrentThreadID(this.threadID);
-    const prevDispatcher = ReactCurrentOwner.currentDispatcher;
+    const prevDispatcher = ReactCurrentDispatcher.current;
     if (enableHooks) {
-      ReactCurrentOwner.currentDispatcher = Dispatcher;
+      ReactCurrentDispatcher.current = Dispatcher;
     } else {
-      ReactCurrentOwner.currentDispatcher = DispatcherWithoutHooks;
+      ReactCurrentDispatcher.current = DispatcherWithoutHooks;
     }
     try {
       // Markup generated within <Suspense> ends up buffered until we know
@@ -870,7 +870,7 @@ class ReactDOMServerRenderer {
       }
       return out[0];
     } finally {
-      ReactCurrentOwner.currentDispatcher = prevDispatcher;
+      ReactCurrentDispatcher.current = prevDispatcher;
       setCurrentThreadID(prevThreadID);
     }
   }

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -55,10 +55,10 @@ import {
   flushPassiveEffects,
 } from './ReactFiberScheduler';
 
-const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
+const ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
 
 function readContext(contextType: any): any {
-  const dispatcher = ReactCurrentOwner.currentDispatcher;
+  const dispatcher = ReactCurrentDispatcher.current;
   return dispatcher.readContext(contextType);
 }
 

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -171,7 +171,7 @@ export type Thenable = {
   then(resolve: () => mixed, reject?: () => mixed): mixed,
 };
 
-const {ReactCurrentOwner} = ReactSharedInternals;
+const {ReactCurrentDispatcher, ReactCurrentOwner} = ReactSharedInternals;
 
 let didWarnAboutStateTransition;
 let didWarnSetStateChildContext;
@@ -1209,9 +1209,9 @@ function renderRoot(root: FiberRoot, isYieldy: boolean): void {
 
   isWorking = true;
   if (enableHooks) {
-    ReactCurrentOwner.currentDispatcher = Dispatcher;
+    ReactCurrentDispatcher.current = Dispatcher;
   } else {
-    ReactCurrentOwner.currentDispatcher = DispatcherWithoutHooks;
+    ReactCurrentDispatcher.current = DispatcherWithoutHooks;
   }
 
   const expirationTime = root.nextExpirationTimeToWorkOn;
@@ -1373,7 +1373,7 @@ function renderRoot(root: FiberRoot, isYieldy: boolean): void {
 
   // We're done performing work. Time to clean up.
   isWorking = false;
-  ReactCurrentOwner.currentDispatcher = null;
+  ReactCurrentDispatcher.current = null;
   resetContextDependences();
   resetHooks();
 

--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.internal.js
@@ -136,7 +136,7 @@ describe('memo', () => {
         function readContext(Context) {
           const dispatcher =
             React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
-              .ReactCurrentOwner.currentDispatcher;
+              .ReactCurrentDispatcher.current;
           return dispatcher.readContext(Context);
         }
 

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -39,8 +39,8 @@ describe('ReactNewContext', () => {
 
   function readContext(Context, observedBits) {
     const dispatcher =
-      React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner
-        .currentDispatcher;
+      React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+        .ReactCurrentDispatcher.current;
     return dispatcher.readContext(Context, observedBits);
   }
 

--- a/packages/react/src/ReactCurrentDispatcher.js
+++ b/packages/react/src/ReactCurrentDispatcher.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import typeof {Dispatcher} from 'react-reconciler/src/ReactFiberDispatcher';
+
+/**
+ * Keeps track of the current dispatcher.
+ */
+const ReactCurrentDispatcher = {
+  /**
+   * @internal
+   * @type {ReactComponent}
+   */
+  current: (null: null | Dispatcher),
+};
+
+export default ReactCurrentDispatcher;

--- a/packages/react/src/ReactCurrentOwner.js
+++ b/packages/react/src/ReactCurrentOwner.js
@@ -8,7 +8,6 @@
  */
 
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
-import typeof {Dispatcher} from 'react-reconciler/src/ReactFiberDispatcher';
 
 /**
  * Keeps track of the current owner.
@@ -22,7 +21,6 @@ const ReactCurrentOwner = {
    * @type {ReactComponent}
    */
   current: (null: null | Fiber),
-  currentDispatcher: (null: null | Dispatcher),
 };
 
 export default ReactCurrentOwner;

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -11,10 +11,10 @@ import type {ReactContext} from 'shared/ReactTypes';
 import invariant from 'shared/invariant';
 import warning from 'shared/warning';
 
-import ReactCurrentOwner from './ReactCurrentOwner';
+import ReactCurrentDispatcher from './ReactCurrentDispatcher';
 
 function resolveDispatcher() {
-  const dispatcher = ReactCurrentOwner.currentDispatcher;
+  const dispatcher = ReactCurrentDispatcher.current;
   invariant(
     dispatcher !== null,
     'Hooks can only be called inside the body of a function component.',

--- a/packages/react/src/ReactSharedInternals.js
+++ b/packages/react/src/ReactSharedInternals.js
@@ -29,10 +29,12 @@ import {
   unstable_unsubscribe,
   unstable_wrap,
 } from 'scheduler/tracing';
+import ReactCurrentDispatcher from './ReactCurrentDispatcher';
 import ReactCurrentOwner from './ReactCurrentOwner';
 import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
 
 const ReactSharedInternals = {
+  ReactCurrentDispatcher,
   ReactCurrentOwner,
   // Used by renderers to avoid bundling object-assign twice in UMD bundles:
   assign,


### PR DESCRIPTION
This is part tech-debt cleanup, since the dispatcher didn't really belong in the owner ref to begin with.

Also this will be used by the DevTools to support hooks. DevTools need a way to modify the current dispatcher, so renderers will need to inject this ref at runtime.

Note that external libraries depending on React internals may be impacted by this, but [there are migration strategies involving feature detection](https://github.com/facebook/react/pull/14548#issuecomment-452448465) and in general, we don't really support accessing the internals data structure.