### PR TITLE
Prepare 16.8 alpha

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
@@ -14,7 +14,7 @@ let ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 let ReactDOM;
 
-const ConcurrentMode = React.unstable_ConcurrentMode;
+const ConcurrentMode = React.ConcurrentMode;
 
 const setUntrackedInputValue = Object.getOwnPropertyDescriptor(
   HTMLInputElement.prototype,
@@ -163,7 +163,7 @@ describe('ReactDOMFiberAsync', () => {
     });
 
     it('createRoot makes the entire tree async', () => {
-      const root = ReactDOM.unstable_createRoot(container);
+      const root = ReactDOM.createRoot(container);
       root.render(<div>Hi</div>);
       expect(container.textContent).toEqual('');
       jest.runAllTimers();
@@ -185,7 +185,7 @@ describe('ReactDOMFiberAsync', () => {
         }
       }
 
-      const root = ReactDOM.unstable_createRoot(container);
+      const root = ReactDOM.createRoot(container);
       root.render(<Component />);
       expect(container.textContent).toEqual('');
       jest.runAllTimers();

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -12,7 +12,7 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 let ReactDOMServer = require('react-dom/server');
-let ConcurrentMode = React.unstable_ConcurrentMode;
+let ConcurrentMode = React.ConcurrentMode;
 
 describe('ReactDOMRoot', () => {
   let container;
@@ -63,18 +63,18 @@ describe('ReactDOMRoot', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
-    ConcurrentMode = React.unstable_ConcurrentMode;
+    ConcurrentMode = React.ConcurrentMode;
   });
 
   it('renders children', () => {
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     root.render(<div>Hi</div>);
     jest.runAllTimers();
     expect(container.textContent).toEqual('Hi');
   });
 
   it('unmounts children', () => {
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     root.render(<div>Hi</div>);
     jest.runAllTimers();
     expect(container.textContent).toEqual('Hi');
@@ -84,7 +84,7 @@ describe('ReactDOMRoot', () => {
   });
 
   it('`root.render` returns a thenable work object', () => {
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     const work = root.render(<ConcurrentMode>Hi</ConcurrentMode>);
     let ops = [];
     work.then(() => {
@@ -102,7 +102,7 @@ describe('ReactDOMRoot', () => {
   });
 
   it('resolves `work.then` callback synchronously if the work already committed', () => {
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     const work = root.render(<ConcurrentMode>Hi</ConcurrentMode>);
     jest.runAllTimers();
     let ops = [];
@@ -126,7 +126,7 @@ describe('ReactDOMRoot', () => {
     // Does not hydrate by default
     const container1 = document.createElement('div');
     container1.innerHTML = markup;
-    const root1 = ReactDOM.unstable_createRoot(container1);
+    const root1 = ReactDOM.createRoot(container1);
     root1.render(
       <div>
         <span />
@@ -137,7 +137,7 @@ describe('ReactDOMRoot', () => {
     // Accepts `hydrate` option
     const container2 = document.createElement('div');
     container2.innerHTML = markup;
-    const root2 = ReactDOM.unstable_createRoot(container2, {hydrate: true});
+    const root2 = ReactDOM.createRoot(container2, {hydrate: true});
     root2.render(
       <div>
         <span />
@@ -150,7 +150,7 @@ describe('ReactDOMRoot', () => {
 
   it('does not clear existing children', async () => {
     container.innerHTML = '<div>a</div><div>b</div>';
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     root.render(
       <div>
         <span>c</span>
@@ -170,7 +170,7 @@ describe('ReactDOMRoot', () => {
   });
 
   it('can defer a commit by batching it', () => {
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     const batch = root.createBatch();
     batch.render(<div>Hi</div>);
     // Hasn't committed yet
@@ -193,7 +193,7 @@ describe('ReactDOMRoot', () => {
       }
     }
 
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     const batch = root.createBatch();
     batch.render(
       <ConcurrentMode>
@@ -226,7 +226,7 @@ describe('ReactDOMRoot', () => {
       ops.push('Foo');
       return props.children;
     }
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     const batch = root.createBatch();
     batch.render(<Foo>Hi</Foo>);
     // Flush all async work.
@@ -244,7 +244,7 @@ describe('ReactDOMRoot', () => {
   });
 
   it('can wait for a batch to finish', () => {
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     const batch = root.createBatch();
     batch.render(<ConcurrentMode>Foo</ConcurrentMode>);
 
@@ -266,7 +266,7 @@ describe('ReactDOMRoot', () => {
   });
 
   it('`batch.render` returns a thenable work object', () => {
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     const batch = root.createBatch();
     const work = batch.render('Hi');
     let ops = [];
@@ -285,7 +285,7 @@ describe('ReactDOMRoot', () => {
   });
 
   it('can commit an empty batch', () => {
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     root.render(<ConcurrentMode>1</ConcurrentMode>);
 
     advanceCurrentTime(2000);
@@ -302,7 +302,7 @@ describe('ReactDOMRoot', () => {
 
   it('two batches created simultaneously are committed separately', () => {
     // (In other words, they have distinct expiration times)
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     const batch1 = root.createBatch();
     batch1.render(1);
     const batch2 = root.createBatch();
@@ -318,7 +318,7 @@ describe('ReactDOMRoot', () => {
   });
 
   it('commits an earlier batch without committing a later batch', () => {
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     const batch1 = root.createBatch();
     batch1.render(1);
 
@@ -337,7 +337,7 @@ describe('ReactDOMRoot', () => {
   });
 
   it('commits a later batch without committing an earlier batch', () => {
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     const batch1 = root.createBatch();
     batch1.render(1);
 
@@ -357,7 +357,7 @@ describe('ReactDOMRoot', () => {
   });
 
   it('handles fatal errors triggered by batch.commit()', () => {
-    const root = ReactDOM.unstable_createRoot(container);
+    const root = ReactDOM.createRoot(container);
     const batch = root.createBatch();
     const InvalidType = undefined;
     expect(() => batch.render(<InvalidType />)).toWarnDev(
@@ -369,9 +369,7 @@ describe('ReactDOMRoot', () => {
 
   it('throws a good message on invalid containers', () => {
     expect(() => {
-      ReactDOM.unstable_createRoot(<div>Hi</div>);
-    }).toThrow(
-      'unstable_createRoot(...): Target container is not a DOM element.',
-    );
+      ReactDOM.createRoot(<div>Hi</div>);
+    }).toThrow('createRoot(...): Target container is not a DOM element.');
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationModes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationModes-test.js
@@ -104,12 +104,12 @@ describe('ReactDOMServerIntegration', () => {
     });
   });
 
-  describe('React.unstable_ConcurrentMode', () => {
+  describe('React.ConcurrentMode', () => {
     itRenders('an concurrent mode with one child', async render => {
       let e = await render(
-        <React.unstable_ConcurrentMode>
+        <React.ConcurrentMode>
           <div>text1</div>
-        </React.unstable_ConcurrentMode>,
+        </React.ConcurrentMode>,
       );
       let parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
@@ -121,19 +121,19 @@ describe('ReactDOMServerIntegration', () => {
       };
       let Footer = props => {
         return (
-          <React.unstable_ConcurrentMode>
+          <React.ConcurrentMode>
             <h2>footer</h2>
             <h3>about</h3>
-          </React.unstable_ConcurrentMode>
+          </React.ConcurrentMode>
         );
       };
       let e = await render(
-        <React.unstable_ConcurrentMode>
+        <React.ConcurrentMode>
           <div>text1</div>
           <span>text2</span>
           <Header />
           <Footer />
-        </React.unstable_ConcurrentMode>,
+        </React.ConcurrentMode>,
       );
       let parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
@@ -145,21 +145,21 @@ describe('ReactDOMServerIntegration', () => {
 
     itRenders('a nested concurrent mode', async render => {
       let e = await render(
-        <React.unstable_ConcurrentMode>
-          <React.unstable_ConcurrentMode>
+        <React.ConcurrentMode>
+          <React.ConcurrentMode>
             <div>text1</div>
-          </React.unstable_ConcurrentMode>
+          </React.ConcurrentMode>
           <span>text2</span>
-          <React.unstable_ConcurrentMode>
-            <React.unstable_ConcurrentMode>
-              <React.unstable_ConcurrentMode>
+          <React.ConcurrentMode>
+            <React.ConcurrentMode>
+              <React.ConcurrentMode>
                 {null}
                 <p />
-              </React.unstable_ConcurrentMode>
+              </React.ConcurrentMode>
               {false}
-            </React.unstable_ConcurrentMode>
-          </React.unstable_ConcurrentMode>
-        </React.unstable_ConcurrentMode>,
+            </React.ConcurrentMode>
+          </React.ConcurrentMode>
+        </React.ConcurrentMode>,
       );
       let parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
@@ -168,7 +168,7 @@ describe('ReactDOMServerIntegration', () => {
     });
 
     itRenders('an empty concurrent mode', async render => {
-      expect(await render(<React.unstable_ConcurrentMode />)).toBe(null);
+      expect(await render(<React.ConcurrentMode />)).toBe(null);
     });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationSpecialTypes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationSpecialTypes-test.js
@@ -73,9 +73,9 @@ describe('ReactDOMServerIntegration', () => {
 
   itRenders('a Profiler component and its children', async render => {
     const element = await render(
-      <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
+      <React.Profiler id="profiler" onRender={jest.fn()}>
         <div>Test</div>
-      </React.unstable_Profiler>,
+      </React.Profiler>,
     );
     const parent = element.parentNode;
     const div = parent.childNodes[0];

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -391,9 +391,9 @@ describe('ReactDOMServerHydration', () => {
   it('should be able to render and hydrate Profiler components', () => {
     const callback = jest.fn();
     const markup = (
-      <React.unstable_Profiler id="profiler" onRender={callback}>
+      <React.Profiler id="profiler" onRender={callback}>
         <div>Hi</div>
-      </React.unstable_Profiler>
+      </React.Profiler>
     );
 
     const element = document.createElement('div');

--- a/packages/react-dom/src/events/__tests__/ChangeEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/ChangeEventPlugin-test.internal.js
@@ -486,7 +486,7 @@ describe('ChangeEventPlugin', () => {
       ReactDOM = require('react-dom');
     });
     it('text input', () => {
-      const root = ReactDOM.unstable_createRoot(container);
+      const root = ReactDOM.createRoot(container);
       let input;
 
       let ops = [];
@@ -533,7 +533,7 @@ describe('ChangeEventPlugin', () => {
     });
 
     it('checkbox input', () => {
-      const root = ReactDOM.unstable_createRoot(container);
+      const root = ReactDOM.createRoot(container);
       let input;
 
       let ops = [];
@@ -595,7 +595,7 @@ describe('ChangeEventPlugin', () => {
     });
 
     it('textarea', () => {
-      const root = ReactDOM.unstable_createRoot(container);
+      const root = ReactDOM.createRoot(container);
       let textarea;
 
       let ops = [];
@@ -642,7 +642,7 @@ describe('ChangeEventPlugin', () => {
     });
 
     it('parent of input', () => {
-      const root = ReactDOM.unstable_createRoot(container);
+      const root = ReactDOM.createRoot(container);
       let input;
 
       let ops = [];
@@ -693,7 +693,7 @@ describe('ChangeEventPlugin', () => {
     });
 
     it('is async for non-input events', () => {
-      const root = ReactDOM.unstable_createRoot(container);
+      const root = ReactDOM.createRoot(container);
       let input;
 
       let ops = [];

--- a/packages/react-dom/src/events/__tests__/SimpleEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/SimpleEventPlugin-test.internal.js
@@ -262,7 +262,7 @@ describe('SimpleEventPlugin', function() {
 
     it('flushes pending interactive work before extracting event handler', () => {
       container = document.createElement('div');
-      const root = ReactDOM.unstable_createRoot(container);
+      const root = ReactDOM.createRoot(container);
       document.body.appendChild(container);
 
       let ops = [];
@@ -342,7 +342,7 @@ describe('SimpleEventPlugin', function() {
 
     it('end result of many interactive updates is deterministic', () => {
       container = document.createElement('div');
-      const root = ReactDOM.unstable_createRoot(container);
+      const root = ReactDOM.createRoot(container);
       document.body.appendChild(container);
 
       let button;
@@ -426,9 +426,9 @@ describe('SimpleEventPlugin', function() {
                 // Intentionally not using the updater form here
                 () => this.setState({highPriCount: this.state.highPriCount + 1})
               }>
-              <React.unstable_ConcurrentMode>
+              <React.ConcurrentMode>
                 <Button highPriCount={this.state.highPriCount} />
-              </React.unstable_ConcurrentMode>
+              </React.ConcurrentMode>
             </div>
           );
         }

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -58,9 +58,7 @@ describe('ReactIs', () => {
       true,
     );
     expect(ReactIs.isValidElementType(React.Fragment)).toEqual(true);
-    expect(ReactIs.isValidElementType(React.unstable_ConcurrentMode)).toEqual(
-      true,
-    );
+    expect(ReactIs.isValidElementType(React.ConcurrentMode)).toEqual(true);
     expect(ReactIs.isValidElementType(React.StrictMode)).toEqual(true);
     expect(ReactIs.isValidElementType(React.Suspense)).toEqual(true);
 
@@ -73,12 +71,10 @@ describe('ReactIs', () => {
   });
 
   it('should identify concurrent mode', () => {
-    expect(ReactIs.typeOf(<React.unstable_ConcurrentMode />)).toBe(
+    expect(ReactIs.typeOf(<React.ConcurrentMode />)).toBe(
       ReactIs.ConcurrentMode,
     );
-    expect(ReactIs.isConcurrentMode(<React.unstable_ConcurrentMode />)).toBe(
-      true,
-    );
+    expect(ReactIs.isConcurrentMode(<React.ConcurrentMode />)).toBe(true);
     expect(ReactIs.isConcurrentMode({type: ReactIs.ConcurrentMode})).toBe(
       false,
     );
@@ -117,7 +113,7 @@ describe('ReactIs', () => {
     expect(ReactIs.isElement(<Context.Provider />)).toBe(true);
     expect(ReactIs.isElement(<Context.Consumer />)).toBe(true);
     expect(ReactIs.isElement(<React.Fragment />)).toBe(true);
-    expect(ReactIs.isElement(<React.unstable_ConcurrentMode />)).toBe(true);
+    expect(ReactIs.isElement(<React.ConcurrentMode />)).toBe(true);
     expect(ReactIs.isElement(<React.StrictMode />)).toBe(true);
     expect(ReactIs.isElement(<React.Suspense />)).toBe(true);
   });
@@ -127,7 +123,7 @@ describe('ReactIs', () => {
     expect(ReactIs.typeOf(<RefForwardingComponent />)).toBe(ReactIs.ForwardRef);
     expect(ReactIs.isForwardRef(<RefForwardingComponent />)).toBe(true);
     expect(ReactIs.isForwardRef({type: ReactIs.StrictMode})).toBe(false);
-    expect(ReactIs.isForwardRef(<React.unstable_ConcurrentMode />)).toBe(false);
+    expect(ReactIs.isForwardRef(<React.ConcurrentMode />)).toBe(false);
     expect(ReactIs.isForwardRef(<div />)).toBe(false);
   });
 
@@ -168,7 +164,7 @@ describe('ReactIs', () => {
     expect(ReactIs.typeOf(<React.StrictMode />)).toBe(ReactIs.StrictMode);
     expect(ReactIs.isStrictMode(<React.StrictMode />)).toBe(true);
     expect(ReactIs.isStrictMode({type: ReactIs.StrictMode})).toBe(false);
-    expect(ReactIs.isStrictMode(<React.unstable_ConcurrentMode />)).toBe(false);
+    expect(ReactIs.isStrictMode(<React.ConcurrentMode />)).toBe(false);
     expect(ReactIs.isStrictMode(<div />)).toBe(false);
   });
 
@@ -182,15 +178,13 @@ describe('ReactIs', () => {
 
   it('should identify profile root', () => {
     expect(
-      ReactIs.typeOf(<React.unstable_Profiler id="foo" onRender={jest.fn()} />),
+      ReactIs.typeOf(<React.Profiler id="foo" onRender={jest.fn()} />),
     ).toBe(ReactIs.Profiler);
     expect(
-      ReactIs.isProfiler(
-        <React.unstable_Profiler id="foo" onRender={jest.fn()} />,
-      ),
+      ReactIs.isProfiler(<React.Profiler id="foo" onRender={jest.fn()} />),
     ).toBe(true);
-    expect(ReactIs.isProfiler({type: ReactIs.unstable_Profiler})).toBe(false);
-    expect(ReactIs.isProfiler(<React.unstable_ConcurrentMode />)).toBe(false);
+    expect(ReactIs.isProfiler({type: ReactIs.Profiler})).toBe(false);
+    expect(ReactIs.isProfiler(<React.ConcurrentMode />)).toBe(false);
     expect(ReactIs.isProfiler(<div />)).toBe(false);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -188,15 +188,15 @@ describe('ReactDebugFiberPerf', () => {
 
   it('does not include ConcurrentMode, StrictMode, or Profiler components in measurements', () => {
     ReactNoop.render(
-      <React.unstable_Profiler id="test" onRender={jest.fn()}>
+      <React.Profiler id="test" onRender={jest.fn()}>
         <React.StrictMode>
           <Parent>
-            <React.unstable_ConcurrentMode>
+            <React.ConcurrentMode>
               <Child />
-            </React.unstable_ConcurrentMode>
+            </React.ConcurrentMode>
           </Parent>
         </React.StrictMode>
-      </React.unstable_Profiler>,
+      </React.Profiler>,
     );
     addComment('Mount');
     ReactNoop.flush();

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -50,7 +50,7 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
       ReactTestRenderer.unstable_setNowImplementation(mockNow);
       ReactCache = require('react-cache');
 
-      Profiler = React.unstable_Profiler;
+      Profiler = React.Profiler;
       Suspense = React.Suspense;
 
       TextResource = ReactCache.unstable_createResource(([text, ms = 0]) => {

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -26,7 +26,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactCache = require('react-cache');
     Suspense = React.Suspense;
     StrictMode = React.StrictMode;
-    ConcurrentMode = React.unstable_ConcurrentMode;
+    ConcurrentMode = React.ConcurrentMode;
 
     TextResource = ReactCache.unstable_createResource(([text, ms = 0]) => {
       return new Promise((resolve, reject) =>

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -234,12 +234,12 @@ describe('ReactShallowRenderer', () => {
     class SomeComponent extends React.Component {
       render() {
         return (
-          <React.unstable_Profiler id="test" onRender={jest.fn()}>
+          <React.Profiler id="test" onRender={jest.fn()}>
             <div>
               <span className="child1" />
               <span className="child2" />
             </div>
-          </React.unstable_Profiler>
+          </React.Profiler>
         );
       }
     }
@@ -247,7 +247,7 @@ describe('ReactShallowRenderer', () => {
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SomeComponent />);
 
-    expect(result.type).toBe(React.unstable_Profiler);
+    expect(result.type).toBe(React.Profiler);
     expect(result.props.children).toEqual(
       <div>
         <span className="child1" />

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
@@ -39,9 +39,9 @@ describe('ReactTestRendererTraversal', () => {
               <View void="void" />
               <View void="void" />
             </ExampleNull>
-            <React.unstable_Profiler id="test" onRender={() => {}}>
+            <React.Profiler id="test" onRender={() => {}}>
               <ExampleForwardRef qux="qux" />
-            </React.unstable_Profiler>
+            </React.Profiler>
             <React.Fragment>
               <React.Fragment>
                 <Context.Provider value={null}>

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -146,7 +146,7 @@ describe('Profiler', () => {
             it('should warn if required params are missing', () => {
               expect(() => {
                 expect(() => {
-                  ReactTestRenderer.create(<React.unstable_Profiler />);
+                  ReactTestRenderer.create(<React.Profiler />);
                 }).toThrow('onRender is not a function');
               }).toWarnDev(
                 'Profiler must specify an "id" string and "onRender" function as props',
@@ -159,7 +159,7 @@ describe('Profiler', () => {
             // As root
             expect(
               ReactTestRenderer.create(
-                <React.unstable_Profiler id="label" onRender={jest.fn()} />,
+                <React.Profiler id="label" onRender={jest.fn()} />,
               ).toJSON(),
             ).toMatchSnapshot();
 
@@ -167,7 +167,7 @@ describe('Profiler', () => {
             expect(
               ReactTestRenderer.create(
                 <div>
-                  <React.unstable_Profiler id="label" onRender={jest.fn()} />
+                  <React.Profiler id="label" onRender={jest.fn()} />
                 </div>,
               ).toJSON(),
             ).toMatchSnapshot();
@@ -178,10 +178,10 @@ describe('Profiler', () => {
             const renderer = ReactTestRenderer.create(
               <div>
                 <span>outside span</span>
-                <React.unstable_Profiler id="label" onRender={jest.fn()}>
+                <React.Profiler id="label" onRender={jest.fn()}>
                   <span>inside span</span>
                   <FunctionComponent label="function component" />
-                </React.unstable_Profiler>
+                </React.Profiler>
               </div>,
             );
             expect(renderer.toJSON()).toMatchSnapshot();
@@ -195,13 +195,13 @@ describe('Profiler', () => {
               }
             }
             const renderer = ReactTestRenderer.create(
-              <React.unstable_Profiler id="outer" onRender={jest.fn()}>
+              <React.Profiler id="outer" onRender={jest.fn()}>
                 <FunctionComponent label="outer function component" />
-                <React.unstable_Profiler id="inner" onRender={jest.fn()}>
+                <React.Profiler id="inner" onRender={jest.fn()}>
                   <ClassComponent label="inner class component" />
                   <span>inner span</span>
-                </React.unstable_Profiler>
-              </React.unstable_Profiler>,
+                </React.Profiler>
+              </React.Profiler>,
             );
             expect(renderer.toJSON()).toMatchSnapshot();
           });
@@ -240,11 +240,11 @@ describe('Profiler', () => {
         expect(() =>
           ReactTestRenderer.create(
             <ClassComponent>
-              <React.unstable_Profiler id="do-not-throw" onRender={callback}>
-                <React.unstable_Profiler id="throw" onRender={callback}>
+              <React.Profiler id="do-not-throw" onRender={callback}>
+                <React.Profiler id="throw" onRender={callback}>
                   <div />
-                </React.unstable_Profiler>
-              </React.unstable_Profiler>
+                </React.Profiler>
+              </React.Profiler>
             </ClassComponent>,
           ),
         ).toThrow('expected');
@@ -261,10 +261,10 @@ describe('Profiler', () => {
         };
 
         const renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <Yield value="first" />
             <Yield value="last" />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
           {
             unstable_isConcurrent: true,
           },
@@ -301,9 +301,9 @@ describe('Profiler', () => {
         advanceTimeBy(5); // 0 -> 5
 
         const renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <AdvanceTime />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -324,9 +324,9 @@ describe('Profiler', () => {
         advanceTimeBy(20); // 15 -> 35
 
         renderer.update(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <AdvanceTime />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -347,9 +347,9 @@ describe('Profiler', () => {
         advanceTimeBy(20); // 45 -> 65
 
         renderer.update(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <AdvanceTime byAmount={4} />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -373,13 +373,13 @@ describe('Profiler', () => {
 
         ReactTestRenderer.create(
           <React.Fragment>
-            <React.unstable_Profiler id="parent" onRender={callback}>
+            <React.Profiler id="parent" onRender={callback}>
               <AdvanceTime byAmount={10}>
-                <React.unstable_Profiler id="child" onRender={callback}>
+                <React.Profiler id="child" onRender={callback}>
                   <AdvanceTime byAmount={20} />
-                </React.unstable_Profiler>
+                </React.Profiler>
               </AdvanceTime>
-            </React.unstable_Profiler>
+            </React.Profiler>
           </React.Fragment>,
         );
 
@@ -408,12 +408,12 @@ describe('Profiler', () => {
 
         ReactTestRenderer.create(
           <React.Fragment>
-            <React.unstable_Profiler id="first" onRender={callback}>
+            <React.Profiler id="first" onRender={callback}>
               <AdvanceTime byAmount={20} />
-            </React.unstable_Profiler>
-            <React.unstable_Profiler id="second" onRender={callback}>
+            </React.Profiler>
+            <React.Profiler id="second" onRender={callback}>
               <AdvanceTime byAmount={5} />
-            </React.unstable_Profiler>
+            </React.Profiler>
           </React.Fragment>,
         );
 
@@ -442,9 +442,9 @@ describe('Profiler', () => {
         ReactTestRenderer.create(
           <React.Fragment>
             <AdvanceTime byAmount={20} />
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <AdvanceTime byAmount={5} />
-            </React.unstable_Profiler>
+            </React.Profiler>
             <AdvanceTime byAmount={20} />
           </React.Fragment>,
         );
@@ -478,17 +478,17 @@ describe('Profiler', () => {
         }
 
         const renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="outer" onRender={callback}>
+          <React.Profiler id="outer" onRender={callback}>
             <Updater>
-              <React.unstable_Profiler id="middle" onRender={callback}>
+              <React.Profiler id="middle" onRender={callback}>
                 <Pure>
-                  <React.unstable_Profiler id="inner" onRender={callback}>
+                  <React.Profiler id="inner" onRender={callback}>
                     <div />
-                  </React.unstable_Profiler>
+                  </React.Profiler>
                 </Pure>
-              </React.unstable_Profiler>
+              </React.Profiler>
             </Updater>
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         // All profile callbacks are called for initial render
@@ -515,11 +515,11 @@ describe('Profiler', () => {
         advanceTimeBy(5); // 0 -> 5
 
         const renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <AdvanceTime byAmount={10}>
               <AdvanceTime byAmount={13} shouldComponentUpdate={false} />
             </AdvanceTime>
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -527,11 +527,11 @@ describe('Profiler', () => {
         advanceTimeBy(30); // 28 -> 58
 
         renderer.update(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <AdvanceTime byAmount={4}>
               <AdvanceTime byAmount={7} shouldComponentUpdate={false} />
             </AdvanceTime>
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(2);
@@ -573,17 +573,17 @@ describe('Profiler', () => {
         advanceTimeBy(5); // 0 -> 5
 
         const renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <WithLifecycles />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         advanceTimeBy(15); // 13 -> 28
 
         renderer.update(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <WithLifecycles />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(2);
@@ -617,10 +617,10 @@ describe('Profiler', () => {
 
           // Render partially, but run out of time before completing.
           const renderer = ReactTestRenderer.create(
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <Yield renderTime={2} />
               <Yield renderTime={3} />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
             {unstable_isConcurrent: true},
           );
           expect(renderer).toFlushAndYieldThrough(['Yield:2']);
@@ -652,13 +652,13 @@ describe('Profiler', () => {
           // Render partially, but don't finish.
           // This partial render should take 5ms of simulated time.
           const renderer = ReactTestRenderer.create(
-            <React.unstable_Profiler id="outer" onRender={callback}>
+            <React.Profiler id="outer" onRender={callback}>
               <Yield renderTime={5} />
               <Yield renderTime={10} />
-              <React.unstable_Profiler id="inner" onRender={callback}>
+              <React.Profiler id="inner" onRender={callback}>
                 <Yield renderTime={17} />
-              </React.unstable_Profiler>
-            </React.unstable_Profiler>,
+              </React.Profiler>
+            </React.Profiler>,
             {unstable_isConcurrent: true},
           );
           expect(renderer).toFlushAndYieldThrough(['Yield:5']);
@@ -702,10 +702,10 @@ describe('Profiler', () => {
           // Render a partially update, but don't finish.
           // This partial render should take 10ms of simulated time.
           const renderer = ReactTestRenderer.create(
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <Yield renderTime={10} />
               <Yield renderTime={20} />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
             {unstable_isConcurrent: true},
           );
           expect(renderer).toFlushAndYieldThrough(['Yield:10']);
@@ -718,9 +718,9 @@ describe('Profiler', () => {
           // The interrupted work simulates an additional 5ms of time.
           renderer.unstable_flushSync(() => {
             renderer.update(
-              <React.unstable_Profiler id="test" onRender={callback}>
+              <React.Profiler id="test" onRender={callback}>
                 <Yield renderTime={5} />
-              </React.unstable_Profiler>,
+              </React.Profiler>,
             );
           });
           expect(ReactTestRenderer).toHaveYielded(['Yield:5']);
@@ -753,10 +753,10 @@ describe('Profiler', () => {
           advanceTimeBy(5); // 0 -> 5
 
           const renderer = ReactTestRenderer.create(
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <Yield renderTime={6} />
               <Yield renderTime={15} />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
             {unstable_isConcurrent: true},
           );
 
@@ -777,11 +777,11 @@ describe('Profiler', () => {
           // Render a partially update, but don't finish.
           // This partial render should take 3ms of simulated time.
           renderer.update(
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <Yield renderTime={3} />
               <Yield renderTime={5} />
               <Yield renderTime={9} />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
           );
           expect(renderer).toFlushAndYieldThrough(['Yield:3']);
           expect(callback).toHaveBeenCalledTimes(0);
@@ -800,9 +800,9 @@ describe('Profiler', () => {
           // The interrupted work simulates an additional 11ms of time.
           renderer.unstable_flushSync(() => {
             renderer.update(
-              <React.unstable_Profiler id="test" onRender={callback}>
+              <React.Profiler id="test" onRender={callback}>
                 <Yield renderTime={11} />
-              </React.unstable_Profiler>,
+              </React.Profiler>,
             );
           });
           expect(ReactTestRenderer).toHaveYielded(['Yield:11']);
@@ -859,10 +859,10 @@ describe('Profiler', () => {
           advanceTimeBy(5); // 0 -> 5
 
           const renderer = ReactTestRenderer.create(
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <FirstComponent />
               <SecondComponent />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
             {unstable_isConcurrent: true},
           );
 
@@ -975,12 +975,12 @@ describe('Profiler', () => {
                 advanceTimeBy(5); // 0 -> 5
 
                 ReactTestRenderer.create(
-                  <React.unstable_Profiler id="test" onRender={callback}>
+                  <React.Profiler id="test" onRender={callback}>
                     <ErrorBoundary>
                       <AdvanceTime byAmount={9} />
                       <ThrowsError />
                     </ErrorBoundary>
-                  </React.unstable_Profiler>,
+                  </React.Profiler>,
                 );
 
                 expect(callback).toHaveBeenCalledTimes(2);
@@ -1054,12 +1054,12 @@ describe('Profiler', () => {
                 advanceTimeBy(5); // 0 -> 5
 
                 ReactTestRenderer.create(
-                  <React.unstable_Profiler id="test" onRender={callback}>
+                  <React.Profiler id="test" onRender={callback}>
                     <ErrorBoundary>
                       <AdvanceTime byAmount={5} />
                       <ThrowsError />
                     </ErrorBoundary>
-                  </React.unstable_Profiler>,
+                  </React.Profiler>,
                 );
 
                 expect(callback).toHaveBeenCalledTimes(1);
@@ -1097,29 +1097,29 @@ describe('Profiler', () => {
                 // Simulate a renderer error during the "complete" phase.
                 // This mimics behavior like React Native's View/Text nesting validation.
                 ReactNoop.render(
-                  <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
+                  <React.Profiler id="profiler" onRender={jest.fn()}>
                     <errorInCompletePhase>hi</errorInCompletePhase>
-                  </React.unstable_Profiler>,
+                  </React.Profiler>,
                 );
                 expect(ReactNoop.flush).toThrow('Error in host config.');
 
                 // A similar case we've seen caused by an invariant in ReactDOM.
                 // It didn't reproduce without a host component inside.
                 ReactNoop.render(
-                  <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
+                  <React.Profiler id="profiler" onRender={jest.fn()}>
                     <errorInCompletePhase>
                       <span>hi</span>
                     </errorInCompletePhase>
-                  </React.unstable_Profiler>,
+                  </React.Profiler>,
                 );
                 expect(ReactNoop.flush).toThrow('Error in host config.');
 
                 // So long as the profiler timer's fiber stack is reset correctly,
                 // Subsequent renders should not error.
                 ReactNoop.render(
-                  <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
+                  <React.Profiler id="profiler" onRender={jest.fn()}>
                     <span>hi</span>
-                  </React.unstable_Profiler>,
+                  </React.Profiler>,
                 );
                 ReactNoop.flush();
               });
@@ -1134,9 +1134,9 @@ describe('Profiler', () => {
         advanceTimeBy(5); // 0 -> 5
 
         const renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="one" onRender={callback}>
+          <React.Profiler id="one" onRender={callback}>
             <AdvanceTime byAmount={2} />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -1144,9 +1144,9 @@ describe('Profiler', () => {
         advanceTimeBy(20); // 7 -> 27
 
         renderer.update(
-          <React.unstable_Profiler id="two" onRender={callback}>
+          <React.Profiler id="two" onRender={callback}>
             <AdvanceTime byAmount={1} />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(2);
@@ -1189,9 +1189,9 @@ describe('Profiler', () => {
         }
 
         ReactTestRenderer.create(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <ClassComponent />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -1519,9 +1519,9 @@ describe('Profiler', () => {
         mockNow(),
         () => {
           renderer = ReactTestRenderer.create(
-            <React.unstable_Profiler id="test-profiler" onRender={onRender}>
+            <React.Profiler id="test-profiler" onRender={onRender}>
               <Example />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
             {
               unstable_isConcurrent: true,
             },
@@ -1684,9 +1684,9 @@ describe('Profiler', () => {
       };
       SchedulerTracing.unstable_trace(interactionTwo.name, mockNow(), () => {
         renderer.update(
-          <React.unstable_Profiler id="test-profiler" onRender={onRender}>
+          <React.Profiler id="test-profiler" onRender={onRender}>
             <Example />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
       });
 
@@ -1760,10 +1760,10 @@ describe('Profiler', () => {
       advanceTimeBy(5);
 
       const renderer = ReactTestRenderer.create(
-        <React.unstable_Profiler id="test" onRender={onRender}>
+        <React.Profiler id="test" onRender={onRender}>
           <FirstComponent />
           <SecondComponent />
-        </React.unstable_Profiler>,
+        </React.Profiler>,
         {unstable_isConcurrent: true},
       );
 
@@ -1935,9 +1935,9 @@ describe('Profiler', () => {
       let renderer;
       SchedulerTracing.unstable_trace(interactionOne.name, mockNow(), () => {
         renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="test" onRender={onRender}>
+          <React.Profiler id="test" onRender={onRender}>
             <Example />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
           {unstable_isConcurrent: true},
         );
       });
@@ -2133,9 +2133,9 @@ describe('Profiler', () => {
         render() {
           parentInstance = this;
           return (
-            <React.unstable_Profiler id="test-profiler" onRender={onRender}>
+            <React.Profiler id="test-profiler" onRender={onRender}>
               <Child count={this.state.count} />
-            </React.unstable_Profiler>
+            </React.Profiler>
           );
         }
       }
@@ -2218,13 +2218,13 @@ describe('Profiler', () => {
         const onRender = jest.fn();
         SchedulerTracing.unstable_trace(interaction.name, mockNow(), () => {
           ReactNoop.render(
-            <React.unstable_Profiler id="test-profiler" onRender={onRender}>
+            <React.Profiler id="test-profiler" onRender={onRender}>
               <React.Suspense fallback={<Text text="Loading..." />}>
                 <AsyncText text="Async" ms={20000} />
               </React.Suspense>
               <Text text="Sync" />
               <Monkey ref={monkey} />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
           );
         });
 
@@ -2306,13 +2306,13 @@ describe('Profiler', () => {
           interaction.timestamp,
           () => {
             ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={1000}
                   fallback={<Text text="loading" />}>
                   <AsyncText text="loaded" ms={2000} />
                 </React.Suspense>
-              </React.unstable_Profiler>,
+              </React.Profiler>,
             );
           },
         );
@@ -2360,13 +2360,13 @@ describe('Profiler', () => {
           interaction.timestamp,
           () => {
             ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={1000}
                   fallback={<Text text="loading" />}>
                   <AsyncComponentWithCascadingWork text="loaded" ms={2000} />
                 </React.Suspense>
-              </React.unstable_Profiler>,
+              </React.Profiler>,
             );
           },
         );
@@ -2400,13 +2400,13 @@ describe('Profiler', () => {
           interaction.timestamp,
           () => {
             renderer = ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={1000}
                   fallback={<Text text="loading" />}>
                   <AsyncText text="loaded" ms={2000} />
                 </React.Suspense>
-              </React.unstable_Profiler>,
+              </React.Profiler>,
               {
                 unstable_isConcurrent: true,
               },
@@ -2448,13 +2448,13 @@ describe('Profiler', () => {
           interaction.timestamp,
           () => {
             renderer = ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={2000}
                   fallback={<Text text="loading" />}>
                   <AsyncText text="loaded" ms={1000} />
                 </React.Suspense>
-              </React.unstable_Profiler>,
+              </React.Profiler>,
               {unstable_isConcurrent: true},
             );
           },
@@ -2487,14 +2487,14 @@ describe('Profiler', () => {
           initialRenderInteraction.timestamp,
           () => {
             renderer = ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={2000}
                   fallback={<Text text="loading" />}>
                   <AsyncText text="loaded" ms={1000} />
                 </React.Suspense>
                 <Text text="initial" />
-              </React.unstable_Profiler>,
+              </React.Profiler>,
             );
           },
         );
@@ -2521,14 +2521,14 @@ describe('Profiler', () => {
             highPriUpdateInteraction.timestamp,
             () => {
               renderer.update(
-                <React.unstable_Profiler id="app" onRender={onRender}>
+                <React.Profiler id="app" onRender={onRender}>
                   <React.Suspense
                     maxDuration={2000}
                     fallback={<Text text="loading" />}>
                     <AsyncText text="loaded" ms={1000} />
                   </React.Suspense>
                   <Text text="updated" />
-                </React.unstable_Profiler>,
+                </React.Profiler>,
               );
             },
           );
@@ -2573,14 +2573,14 @@ describe('Profiler', () => {
           initialRenderInteraction.timestamp,
           () => {
             renderer = ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={2000}
                   fallback={<Text text="loading" />}>
                   <AsyncText text="loaded" ms={1000} />
                 </React.Suspense>
                 <Text text="initial" />
-              </React.unstable_Profiler>,
+              </React.Profiler>,
               {unstable_isConcurrent: true},
             );
           },
@@ -2611,14 +2611,14 @@ describe('Profiler', () => {
             highPriUpdateInteraction.timestamp,
             () => {
               renderer.update(
-                <React.unstable_Profiler id="app" onRender={onRender}>
+                <React.Profiler id="app" onRender={onRender}>
                   <React.Suspense
                     maxDuration={2000}
                     fallback={<Text text="loading" />}>
                     <AsyncText text="loaded" ms={1000} />
                   </React.Suspense>
                   <Text text="updated" />
-                </React.unstable_Profiler>,
+                </React.Profiler>,
               );
             },
           );

--- a/packages/react/src/__tests__/ReactProfilerDOM-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDOM-test.internal.js
@@ -110,7 +110,7 @@ describe('ProfilerDOM', () => {
       interaction = Array.from(interactions)[0];
 
       element = document.createElement('div');
-      const root = ReactDOM.unstable_createRoot(element);
+      const root = ReactDOM.createRoot(element);
       batch = root.createBatch();
       batch.render(
         <React.Suspense maxDuration={100} fallback={<Text text="Loading..." />}>

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -68,13 +68,13 @@ describe('ReactProfiler DevTools integration', () => {
     const App = ({multiplier}) => {
       advanceTimeBy(2);
       return (
-        <React.unstable_Profiler id="Profiler" onRender={onRender}>
+        <React.Profiler id="Profiler" onRender={onRender}>
           <AdvanceTime byAmount={3 * multiplier} shouldComponentUpdate={true} />
           <AdvanceTime
             byAmount={7 * multiplier}
             shouldComponentUpdate={false}
           />
-        </React.unstable_Profiler>
+        </React.Profiler>
       );
     };
 

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -313,9 +313,9 @@ describe('ReactStrictMode', () => {
         UNSAFE_componentWillReceiveProps() {}
         render() {
           return (
-            <React.unstable_ConcurrentMode>
+            <React.ConcurrentMode>
               <AsyncRoot />
-            </React.unstable_ConcurrentMode>
+            </React.ConcurrentMode>
           );
         }
       }
@@ -381,9 +381,9 @@ describe('ReactStrictMode', () => {
         UNSAFE_componentWillReceiveProps() {}
         render() {
           return (
-            <React.unstable_ConcurrentMode>
+            <React.ConcurrentMode>
               <AsyncRoot />
-            </React.unstable_ConcurrentMode>
+            </React.ConcurrentMode>
           );
         }
       }
@@ -449,22 +449,22 @@ describe('ReactStrictMode', () => {
       class AsyncRootOne extends React.Component {
         render() {
           return (
-            <React.unstable_ConcurrentMode>
+            <React.ConcurrentMode>
               <Foo>
                 <Bar />
               </Foo>
-            </React.unstable_ConcurrentMode>
+            </React.ConcurrentMode>
           );
         }
       }
       class AsyncRootTwo extends React.Component {
         render() {
           return (
-            <React.unstable_ConcurrentMode>
+            <React.ConcurrentMode>
               <Foo>
                 <Baz />
               </Foo>
-            </React.unstable_ConcurrentMode>
+            </React.ConcurrentMode>
           );
         }
       }
@@ -517,9 +517,9 @@ describe('ReactStrictMode', () => {
       class AsyncRoot extends React.Component {
         render() {
           return (
-            <React.unstable_ConcurrentMode>
+            <React.ConcurrentMode>
               {this.props.foo ? <Foo /> : <Bar />}
-            </React.unstable_ConcurrentMode>
+            </React.ConcurrentMode>
           );
         }
       }

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -9,7 +9,7 @@
 
 export const enableUserTimingAPI = __DEV__;
 
-export const enableHooks = false;
+export const enableHooks = true;
 // Helps identify side effects in begin-phase lifecycle hooks and setState reducers:
 export const debugRenderPhaseSideEffects = false;
 
@@ -49,6 +49,6 @@ export const disableInputAttributeSyncing = false;
 
 // These APIs will no longer be "unstable" in the upcoming 16.7 release,
 // Control this behavior with a flag to support 16.6 minor releases in the meanwhile.
-export const enableStableConcurrentModeAPIs = false;
+export const enableStableConcurrentModeAPIs = true;
 
 export const warnAboutShorthandPropertyCollision = false;

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -15,14 +15,14 @@ import typeof * as PersistentFeatureFlagsType from './ReactFeatureFlags.persiste
 export const debugRenderPhaseSideEffects = false;
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableUserTimingAPI = __DEV__;
-export const enableHooks = false;
+export const enableHooks = true;
 export const warnAboutDeprecatedLifecycles = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const enableProfilerTimer = __PROFILE__;
 export const enableSchedulerTracing = __PROFILE__;
 export const enableSuspenseServerRenderer = false;
 export const disableInputAttributeSyncing = false;
-export const enableStableConcurrentModeAPIs = false;
+export const enableStableConcurrentModeAPIs = true;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -15,14 +15,14 @@ import typeof * as PersistentFeatureFlagsType from './ReactFeatureFlags.persiste
 export const debugRenderPhaseSideEffects = false;
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableUserTimingAPI = __DEV__;
-export const enableHooks = false;
+export const enableHooks = true;
 export const warnAboutDeprecatedLifecycles = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = false;
 export const enableSchedulerTracing = false;
 export const enableSuspenseServerRenderer = false;
 export const disableInputAttributeSyncing = false;
-export const enableStableConcurrentModeAPIs = false;
+export const enableStableConcurrentModeAPIs = true;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 


### PR DESCRIPTION
To fix https://github.com/facebook/react/issues/14481.

This matches the feature set enabled in 16.7 alpha — even though we won't actually ship ConcurrentMode in the next minor. We'll need to have another discussion about what `next` tag means and whether it should be more like RCs (with `future` tag pointing to all-included builds). But I think this discussion can wait until we ship Hooks in a stable.

This release is mostly motivated by fixing https://github.com/facebook/react/issues/14481#issuecomment-451700486.