### PR TITLE
react-debug-tools accepts currentDispatcher ref as param

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -406,10 +406,16 @@ function buildTree(rootStack, readHookLog): HooksTree {
 }
 
 export function inspectHooks<Props>(
-  currentDispatcher: CurrentDispatcherRef,
   renderFunction: Props => React$Node,
   props: Props,
+  currentDispatcher: ?CurrentDispatcherRef,
 ): HooksTree {
+  // DevTools will pass the current renderer's injected dispatcher.
+  // Other apps might compile debug hooks as part of their app though.
+  if (currentDispatcher == null) {
+    currentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
+  }
+
   let previousDispatcher = currentDispatcher.current;
   let readHookLog;
   currentDispatcher.current = Dispatcher;
@@ -448,10 +454,10 @@ function restoreContexts(contextMap: Map<ReactContext<any>, any>) {
 }
 
 function inspectHooksOfForwardRef<Props, Ref>(
-  currentDispatcher: CurrentDispatcherRef,
   renderFunction: (Props, Ref) => React$Node,
   props: Props,
   ref: Ref,
+  currentDispatcher: CurrentDispatcherRef,
 ): HooksTree {
   let previousDispatcher = currentDispatcher.current;
   let readHookLog;
@@ -485,9 +491,15 @@ function resolveDefaultProps(Component, baseProps) {
 }
 
 export function inspectHooksOfFiber(
-  currentDispatcher: CurrentDispatcherRef,
   fiber: Fiber,
+  currentDispatcher: ?CurrentDispatcherRef,
 ) {
+  // DevTools will pass the current renderer's injected dispatcher.
+  // Other apps might compile debug hooks as part of their app though.
+  if (currentDispatcher == null) {
+    currentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
+  }
+
   if (
     fiber.tag !== FunctionComponent &&
     fiber.tag !== SimpleMemoComponent &&
@@ -512,13 +524,13 @@ export function inspectHooksOfFiber(
     setupContexts(contextMap, fiber);
     if (fiber.tag === ForwardRef) {
       return inspectHooksOfForwardRef(
-        currentDispatcher,
         type.render,
         props,
         fiber.ref,
+        currentDispatcher,
       );
     }
-    return inspectHooks(currentDispatcher, type, props);
+    return inspectHooks(type, props, currentDispatcher);
   } finally {
     currentHook = null;
     restoreContexts(contextMap);

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.internal.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.internal.js
@@ -12,6 +12,7 @@
 
 let React;
 let ReactDebugTools;
+let currentDispatcher;
 
 describe('ReactHooksInspection', () => {
   beforeEach(() => {
@@ -21,6 +22,10 @@ describe('ReactHooksInspection', () => {
     ReactFeatureFlags.enableHooks = true;
     React = require('react');
     ReactDebugTools = require('react-debug-tools');
+
+    currentDispatcher =
+      React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+        .ReactCurrentDispatcher;
   });
 
   it('should inspect a simple useState hook', () => {
@@ -28,7 +33,7 @@ describe('ReactHooksInspection', () => {
       let [state] = React.useState('hello world');
       return <div>{state}</div>;
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    let tree = ReactDebugTools.inspectHooks(currentDispatcher, Foo, {});
     expect(tree).toEqual([
       {
         name: 'State',
@@ -47,7 +52,7 @@ describe('ReactHooksInspection', () => {
       let value = useCustom('hello world');
       return <div>{value}</div>;
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    let tree = ReactDebugTools.inspectHooks(currentDispatcher, Foo, {});
     expect(tree).toEqual([
       {
         name: 'Custom',
@@ -79,7 +84,7 @@ describe('ReactHooksInspection', () => {
         </div>
       );
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    let tree = ReactDebugTools.inspectHooks(currentDispatcher, Foo, {});
     expect(tree).toEqual([
       {
         name: 'Custom',
@@ -142,7 +147,7 @@ describe('ReactHooksInspection', () => {
         </div>
       );
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    let tree = ReactDebugTools.inspectHooks(currentDispatcher, Foo, {});
     expect(tree).toEqual([
       {
         name: 'Bar',
@@ -207,7 +212,7 @@ describe('ReactHooksInspection', () => {
       let value = React.useContext(MyContext);
       return <div>{value}</div>;
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    let tree = ReactDebugTools.inspectHooks(currentDispatcher, Foo, {});
     expect(tree).toEqual([
       {
         name: 'Context',

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.internal.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.internal.js
@@ -13,6 +13,7 @@
 let React;
 let ReactTestRenderer;
 let ReactDebugTools;
+let currentDispatcher;
 
 describe('ReactHooksInspectionIntergration', () => {
   beforeEach(() => {
@@ -23,6 +24,10 @@ describe('ReactHooksInspectionIntergration', () => {
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
     ReactDebugTools = require('react-debug-tools');
+
+    currentDispatcher =
+      React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+        .ReactCurrentDispatcher;
   });
 
   it('should inspect the current state of useState hooks', () => {
@@ -39,7 +44,10 @@ describe('ReactHooksInspectionIntergration', () => {
     let renderer = ReactTestRenderer.create(<Foo prop="prop" />);
 
     let childFiber = renderer.root.findByType(Foo)._currentFiber();
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    let tree = ReactDebugTools.inspectHooksOfFiber(
+      currentDispatcher,
+      childFiber,
+    );
     expect(tree).toEqual([
       {name: 'State', value: 'hello', subHooks: []},
       {name: 'State', value: 'world', subHooks: []},
@@ -53,7 +61,7 @@ describe('ReactHooksInspectionIntergration', () => {
     setStateA('Hi');
 
     childFiber = renderer.root.findByType(Foo)._currentFiber();
-    tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    tree = ReactDebugTools.inspectHooksOfFiber(currentDispatcher, childFiber);
 
     expect(tree).toEqual([
       {name: 'State', value: 'Hi', subHooks: []},
@@ -63,7 +71,7 @@ describe('ReactHooksInspectionIntergration', () => {
     setStateB('world!');
 
     childFiber = renderer.root.findByType(Foo)._currentFiber();
-    tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    tree = ReactDebugTools.inspectHooksOfFiber(currentDispatcher, childFiber);
 
     expect(tree).toEqual([
       {name: 'State', value: 'Hi', subHooks: []},
@@ -111,7 +119,10 @@ describe('ReactHooksInspectionIntergration', () => {
 
     let {onClick: updateStates} = renderer.root.findByType('div').props;
 
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    let tree = ReactDebugTools.inspectHooksOfFiber(
+      currentDispatcher,
+      childFiber,
+    );
     expect(tree).toEqual([
       {name: 'State', value: 'a', subHooks: []},
       {name: 'Reducer', value: 'b', subHooks: []},
@@ -126,7 +137,7 @@ describe('ReactHooksInspectionIntergration', () => {
     updateStates();
 
     childFiber = renderer.root.findByType(Foo)._currentFiber();
-    tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    tree = ReactDebugTools.inspectHooksOfFiber(currentDispatcher, childFiber);
 
     expect(tree).toEqual([
       {name: 'State', value: 'A', subHooks: []},
@@ -152,7 +163,10 @@ describe('ReactHooksInspectionIntergration', () => {
       </MyContext.Provider>,
     );
     let childFiber = renderer.root.findByType(Foo)._currentFiber();
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    let tree = ReactDebugTools.inspectHooksOfFiber(
+      currentDispatcher,
+      childFiber,
+    );
     expect(tree).toEqual([
       {
         name: 'Context',
@@ -172,7 +186,10 @@ describe('ReactHooksInspectionIntergration', () => {
     let renderer = ReactTestRenderer.create(<Foo ref={ref} />);
 
     let childFiber = renderer.root.findByType(Foo)._currentFiber();
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    let tree = ReactDebugTools.inspectHooksOfFiber(
+      currentDispatcher,
+      childFiber,
+    );
     expect(tree).toEqual([
       {name: 'ImperativeHandle', value: obj, subHooks: []},
     ]);
@@ -187,7 +204,10 @@ describe('ReactHooksInspectionIntergration', () => {
     let renderer = ReactTestRenderer.create(<Foo />);
     // TODO: Test renderer findByType is broken for memo. Have to search for the inner.
     let childFiber = renderer.root.findByType(InnerFoo)._currentFiber();
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    let tree = ReactDebugTools.inspectHooksOfFiber(
+      currentDispatcher,
+      childFiber,
+    );
     expect(tree).toEqual([{name: 'State', value: 'hello', subHooks: []}]);
   });
 
@@ -202,7 +222,10 @@ describe('ReactHooksInspectionIntergration', () => {
     }
     let renderer = ReactTestRenderer.create(<Foo />);
     let childFiber = renderer.root.findByType(Foo)._currentFiber();
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    let tree = ReactDebugTools.inspectHooksOfFiber(
+      currentDispatcher,
+      childFiber,
+    );
     expect(tree).toEqual([
       {
         name: 'Custom',
@@ -238,7 +261,10 @@ describe('ReactHooksInspectionIntergration', () => {
     await LazyFoo;
 
     let childFiber = renderer.root._currentFiber();
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    let tree = ReactDebugTools.inspectHooksOfFiber(
+      currentDispatcher,
+      childFiber,
+    );
     expect(tree).toEqual([{name: 'State', value: 'def', subHooks: []}]);
   });
 });


### PR DESCRIPTION
In support of https://github.com/facebook/react-devtools/pull/1272.

The `react-debug-tools` package can't import shared internals because it isn't bundled along with the application. Instead it needs to accept those internals from DevTools, which gets them from the renderer (#14550).