### PR TITLE
throw an error on useContext(Consumer) / useContext(Provider)

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1423,27 +1423,26 @@ describe('ReactNewContext', () => {
       );
     });
 
-    it('warns when passed a consumer', () => {
+    it('throws when passed a consumer', () => {
       const Context = React.createContext(0);
       function Foo() {
         return useContext(Context.Consumer);
       }
       ReactNoop.render(<Foo />);
-      expect(ReactNoop.flush).toWarnDev(
-        'Calling useContext(Context.Consumer) is not supported, may cause bugs, ' +
-          'and will be removed in a future major release. ' +
+      expect(ReactNoop.flush).toThrow(
+        'Calling useContext(Context.Consumer) is not supported. ' +
           'Did you mean to call useContext(Context) instead?',
       );
     });
 
-    it('warns when passed a provider', () => {
+    it('throws when passed a provider', () => {
       const Context = React.createContext(0);
       function Foo() {
         useContext(Context.Provider);
         return null;
       }
       ReactNoop.render(<Foo />);
-      expect(ReactNoop.flush).toWarnDev(
+      expect(ReactNoop.flush).toThrow(
         'Calling useContext(Context.Provider) is not supported. ' +
           'Did you mean to call useContext(Context) instead?',
       );

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -22,7 +22,6 @@ function resolveDispatcher() {
   return dispatcher;
 }
 
-
 export function useContext<T>(
   Context: ReactContext<T>,
   observedBits: number | boolean | void,
@@ -49,7 +48,6 @@ export function useContext<T>(
   }
   return dispatcher.useContext(Context, observedBits);
 }
-
 
 export function useState<S>(initialState: (() => S) | S) {
   const dispatcher = resolveDispatcher();

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -22,6 +22,7 @@ function resolveDispatcher() {
   return dispatcher;
 }
 
+
 export function useContext<T>(
   Context: ReactContext<T>,
   observedBits: number | boolean | void,
@@ -33,23 +34,22 @@ export function useContext<T>(
       const realContext = (Context: any)._context;
       // Don't deduplicate because this legitimately causes bugs
       // and nobody should be using this in existing code.
-      if (realContext.Consumer === Context) {
-        warning(
-          false,
-          'Calling useContext(Context.Consumer) is not supported, may cause bugs, and will be ' +
-            'removed in a future major release. Did you mean to call useContext(Context) instead?',
-        );
-      } else if (realContext.Provider === Context) {
-        warning(
-          false,
-          'Calling useContext(Context.Provider) is not supported. ' +
-            'Did you mean to call useContext(Context) instead?',
-        );
-      }
+      invariant(
+        realContext.Consumer !== Context,
+        'Calling useContext(Context.Consumer) is not supported. ' +
+          'Did you mean to call useContext(Context) instead?',
+      );
+
+      invariant(
+        realContext.Provider !== Context,
+        'Calling useContext(Context.Provider) is not supported. ' +
+          'Did you mean to call useContext(Context) instead?',
+      );
     }
   }
   return dispatcher.useContext(Context, observedBits);
 }
+
 
 export function useState<S>(initialState: (() => S) | S) {
   const dispatcher = resolveDispatcher();


### PR DESCRIPTION
this is an odd one, because the way we've implemented it. this PR introduces an invariant in dev mode (which won't throw in prod!) but we feel that's the best call given that this is already a hot path. 