### PR TITLE
make a fork for ReactCurrentDispatcher

### DIFF
--- a/packages/react/src/forks/ReactCurrentDispatcher.www.js
+++ b/packages/react/src/forks/ReactCurrentDispatcher.www.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default require('ReactCurrentDispatcher');

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -218,6 +218,19 @@ const forks = Object.freeze({
     }
   },
 
+  // Similarly, we preserve an inline require to ReactCurrentDispatcher.
+  // See the explanation in FB version of ReactCurrentDispatcher in www:
+  'react/src/ReactCurrentDispatcher': (bundleType, entry) => {
+    switch (bundleType) {
+      case FB_WWW_DEV:
+      case FB_WWW_PROD:
+      case FB_WWW_PROFILING:
+        return 'react/src/forks/ReactCurrentDispatcher.www.js';
+      default:
+        return null;
+    }
+  },
+
   // Different wrapping/reporting for caught errors.
   'shared/invokeGuardedCallbackImpl': (bundleType, entry) => {
     switch (bundleType) {


### PR DESCRIPTION
we need to 'fork' ReactCurrentDispatcher just like we did for ReactCurrentOwner. I'm testing this right now, putting the PR out there to make sure I copy-pasted right. 