### PR TITLE
Rename release script fixture test scheduler->tracing

### DIFF
--- a/scripts/release/prepare-canary.js
+++ b/scripts/release/prepare-canary.js
@@ -11,7 +11,7 @@ const getLatestMasterBuildNumber = require('./prepare-canary-commands/get-latest
 const parseParams = require('./prepare-canary-commands/parse-params');
 const printPrereleaseSummary = require('./shared-commands/print-prerelease-summary');
 const testPackagingFixture = require('./shared-commands/test-packaging-fixture');
-const testSchedulerFixture = require('./shared-commands/test-scheduler-fixture');
+const testTracingFixture = require('./shared-commands/test-tracing-fixture');
 
 const run = async () => {
   try {
@@ -28,7 +28,7 @@ const run = async () => {
 
     if (!params.skipTests) {
       await testPackagingFixture(params);
-      await testSchedulerFixture(params);
+      await testTracingFixture(params);
     }
 
     await printPrereleaseSummary(params);

--- a/scripts/release/prepare-stable.js
+++ b/scripts/release/prepare-stable.js
@@ -11,7 +11,7 @@ const guessStableVersionNumbers = require('./prepare-stable-commands/guess-stabl
 const parseParams = require('./prepare-stable-commands/parse-params');
 const printPrereleaseSummary = require('./shared-commands/print-prerelease-summary');
 const testPackagingFixture = require('./shared-commands/test-packaging-fixture');
-const testSchedulerFixture = require('./shared-commands/test-scheduler-fixture');
+const testTracingFixture = require('./shared-commands/test-tracing-fixture');
 const updateStableVersionNumbers = require('./prepare-stable-commands/update-stable-version-numbers');
 
 const run = async () => {
@@ -32,7 +32,7 @@ const run = async () => {
 
     if (!params.skipTests) {
       await testPackagingFixture(params);
-      await testSchedulerFixture(params);
+      await testTracingFixture(params);
     }
 
     await printPrereleaseSummary(params);

--- a/scripts/release/shared-commands/test-tracing-fixture.js
+++ b/scripts/release/shared-commands/test-tracing-fixture.js
@@ -43,7 +43,7 @@ const validate = async ({cwd}) => {
 const run = async ({cwd}) => {
   const errorMessage = await logPromise(
     validate({cwd}),
-    'Verifying "scheduler" fixture'
+    'Verifying "scheduler/tracing" fixture'
   );
   if (errorMessage) {
     console.error(theme.error(errorMessage));


### PR DESCRIPTION
The test is testing [the "tracing" fixture](https://github.com/facebook/react/tree/master/fixtures/tracing), not [the "scheduler" fixture](https://github.com/facebook/react/tree/master/fixtures/scheduler), so the previous name was confusing.

Once the scheduler fixture is fixed (#14557) I would be happy to add an automated test for it as well.