### PR TITLE
Avoid new Set([iterable]) for thenables

### DIFF
--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -214,7 +214,8 @@ function throwException(
         // attach another listener to flip the boundary back to its normal state.
         const thenables: Set<Thenable> = (workInProgress.updateQueue: any);
         if (thenables === null) {
-          workInProgress.updateQueue = (new Set([thenable]): any);
+          workInProgress.updateQueue = (new Set(): any);
+          workInProgress.updateQueue.add(thenable);
         } else {
           thenables.add(thenable);
         }


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/14583

I wrote and [deployed](http://miniature-song.surge.sh/) [a small test app](https://gist.github.com/aweary/e5d0e9c354ab3ee34bc67440d899702f) and verified that this fixes the issue outlined in #14583 in IE11 on Windows 8. 