### PR TITLE
Warn when mixing createRoot() and old APIs

### DIFF
--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -1,12 +1,17 @@
 <html>
   <body>
-    <script src="../../../build/node_modules/react/umd/react.development.js"></script>
-    <script src="../../../build/node_modules/react-dom/umd/react-dom.development.js"></script>
+    <script src="http://unpkg.com/react@next/umd/react.development.js"></script>
+    <script src="http://unpkg.com/react-dom@next/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <div id="container"></div>
     <script type="text/babel">
+      function Foo(props) {
+        const [foo, setFoo] = React.useState(42)
+          return <h1>Hello {props.name}!</h1>
+      }
+
       ReactDOM.render(
-        <h1>Hello World!</h1>,
+        <Foo name="Dan" />,
         document.getElementById('container')
       );
     </script>

--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -1,17 +1,12 @@
 <html>
   <body>
-    <script src="http://unpkg.com/react@next/umd/react.development.js"></script>
-    <script src="http://unpkg.com/react-dom@next/umd/react-dom.development.js"></script>
+    <script src="../../../build/node_modules/react/umd/react.development.js"></script>
+    <script src="../../../build/node_modules/react-dom/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <div id="container"></div>
     <script type="text/babel">
-      function Foo(props) {
-        const [foo, setFoo] = React.useState(42)
-          return <h1>Hello {props.name}!</h1>
-      }
-
       ReactDOM.render(
-        <Foo name="Dan" />,
+        <h1>Hello World!</h1>,
         document.getElementById('container')
       );
     </script>

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -386,7 +386,7 @@ describe('ReactDOMRoot', () => {
       [
         // We care about this warning:
         'You are calling ReactDOM.render() on a container that was previously ' +
-          'managed by ReactDOM.unstable_createRoot(). This is not supported. ' +
+          'passed to ReactDOM.unstable_createRoot(). This is not supported. ' +
           'Did you mean to call root.render(element)?',
         // This is more of a symptom but restructuring the code to avoid it isn't worth it:
         'Replacing React-rendered children with a new root component.',
@@ -409,7 +409,7 @@ describe('ReactDOMRoot', () => {
       [
         // We care about this warning:
         'You are calling ReactDOM.hydrate() on a container that was previously ' +
-          'managed by ReactDOM.unstable_createRoot(). This is not supported. ' +
+          'passed to ReactDOM.unstable_createRoot(). This is not supported. ' +
           'Did you mean to call root.render(element, {hydrate: true})?',
         // This is more of a symptom but restructuring the code to avoid it isn't worth it:
         'Replacing React-rendered children with a new root component.',
@@ -430,7 +430,7 @@ describe('ReactDOMRoot', () => {
       [
         // We care about this warning:
         'You are calling ReactDOM.unmountComponentAtNode() on a container that was previously ' +
-          'managed by ReactDOM.unstable_createRoot(). This is not supported. Did you mean to call root.unmount()?',
+          'passed to ReactDOM.unstable_createRoot(). This is not supported. Did you mean to call root.unmount()?',
         // This is more of a symptom but restructuring the code to avoid it isn't worth it:
         "The node you're attempting to unmount was rendered by React and is not a top-level container.",
       ],
@@ -470,7 +470,7 @@ describe('ReactDOMRoot', () => {
       ReactDOM.unstable_createRoot(container);
     }).toWarnDev(
       'You are calling ReactDOM.unstable_createRoot() on a container that was previously ' +
-        'managed by ReactDOM.render(). This is not supported.',
+        'passed to ReactDOM.render(). This is not supported.',
       {withoutStack: true},
     );
   });

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -374,4 +374,104 @@ describe('ReactDOMRoot', () => {
       'unstable_createRoot(...): Target container is not a DOM element.',
     );
   });
+
+  it('warns when rendering with legacy API into createRoot() container', () => {
+    const root = ReactDOM.unstable_createRoot(container);
+    root.render(<div>Hi</div>);
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('Hi');
+    expect(() => {
+      ReactDOM.render(<div>Bye</div>, container);
+    }).toWarnDev(
+      [
+        // We care about this warning:
+        'You are calling ReactDOM.render() on a container that was previously ' +
+          'managed by ReactDOM.unstable_createRoot(). This is not supported. ' +
+          'Did you mean to call root.render(element)?',
+        // This is more of a symptom but restructuring the code to avoid it isn't worth it:
+        'Replacing React-rendered children with a new root component.',
+      ],
+      {withoutStack: true},
+    );
+    jest.runAllTimers();
+    // This works now but we could disallow it:
+    expect(container.textContent).toEqual('Bye');
+  });
+
+  it('warns when hydrating with legacy API into createRoot() container', () => {
+    const root = ReactDOM.unstable_createRoot(container);
+    root.render(<div>Hi</div>);
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('Hi');
+    expect(() => {
+      ReactDOM.hydrate(<div>Hi</div>, container);
+    }).toWarnDev(
+      [
+        // We care about this warning:
+        'You are calling ReactDOM.hydrate() on a container that was previously ' +
+          'managed by ReactDOM.unstable_createRoot(). This is not supported. ' +
+          'Did you mean to call root.render(element, {hydrate: true})?',
+        // This is more of a symptom but restructuring the code to avoid it isn't worth it:
+        'Replacing React-rendered children with a new root component.',
+      ],
+      {withoutStack: true},
+    );
+  });
+
+  it('warns when unmounting with legacy API (no previous content)', () => {
+    const root = ReactDOM.unstable_createRoot(container);
+    root.render(<div>Hi</div>);
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('Hi');
+    let unmounted = false;
+    expect(() => {
+      unmounted = ReactDOM.unmountComponentAtNode(container);
+    }).toWarnDev(
+      [
+        // We care about this warning:
+        'You are calling ReactDOM.unmountComponentAtNode() on a container that was previously ' +
+          'managed by ReactDOM.unstable_createRoot(). This is not supported. Did you mean to call root.unmount()?',
+        // This is more of a symptom but restructuring the code to avoid it isn't worth it:
+        "The node you're attempting to unmount was rendered by React and is not a top-level container.",
+      ],
+      {withoutStack: true},
+    );
+    expect(unmounted).toBe(false);
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('Hi');
+    root.unmount();
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('');
+  });
+
+  it('warns when unmounting with legacy API (has previous content)', () => {
+    // Currently createRoot().render() doesn't clear this.
+    container.appendChild(document.createElement('div'));
+    // The rest is the same as test above.
+    const root = ReactDOM.unstable_createRoot(container);
+    root.render(<div>Hi</div>);
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('Hi');
+    let unmounted = false;
+    expect(() => {
+      unmounted = ReactDOM.unmountComponentAtNode(container);
+    }).toWarnDev('Did you mean to call root.unmount()?', {withoutStack: true});
+    expect(unmounted).toBe(false);
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('Hi');
+    root.unmount();
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('');
+  });
+
+  it('warns when passing legacy container to createRoot()', () => {
+    ReactDOM.render(<div>Hi</div>, container);
+    expect(() => {
+      ReactDOM.unstable_createRoot(container);
+    }).toWarnDev(
+      'You are calling ReactDOM.unstable_createRoot() on a container that was previously ' +
+        'managed by ReactDOM.render(). This is not supported.',
+      {withoutStack: true},
+    );
+  });
 });

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -159,11 +159,11 @@ setRestoreImplementation(restoreControlledState);
 export type DOMContainer =
   | (Element & {
       _reactRootContainer: ?Root,
-      _reactIsNewStyleRootDEV: ?boolean,
+      _reactHasBeenPassedToCreateRootDEV: ?boolean,
     })
   | (Document & {
       _reactRootContainer: ?Root,
-      _reactIsNewStyleRootDEV: ?boolean,
+      _reactHasBeenPassedToCreateRootDEV: ?boolean,
     });
 
 type Batch = FiberRootBatch & {
@@ -653,7 +653,7 @@ const ReactDOM: Object = {
     );
     if (__DEV__) {
       warningWithoutStack(
-        !container._reactIsNewStyleRootDEV,
+        !container._reactHasBeenPassedToCreateRootDEV,
         'You are calling ReactDOM.hydrate() on a container that was previously ' +
           'managed by ReactDOM.%s(). This is not supported. ' +
           'Did you mean to call root.render(element, {hydrate: true})?',
@@ -681,7 +681,7 @@ const ReactDOM: Object = {
     );
     if (__DEV__) {
       warningWithoutStack(
-        !container._reactIsNewStyleRootDEV,
+        !container._reactHasBeenPassedToCreateRootDEV,
         'You are calling ReactDOM.render() on a container that was previously ' +
           'managed by ReactDOM.%s(). This is not supported. ' +
           'Did you mean to call root.render(element)?',
@@ -728,7 +728,7 @@ const ReactDOM: Object = {
 
     if (__DEV__) {
       warningWithoutStack(
-        !container._reactIsNewStyleRootDEV,
+        !container._reactHasBeenPassedToCreateRootDEV,
         'You are calling ReactDOM.unmountComponentAtNode() on a container that was previously ' +
           'managed by ReactDOM.%s(). This is not supported. Did you mean to call root.unmount()?',
         enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
@@ -846,7 +846,7 @@ function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
         'managed by ReactDOM.render(). This is not supported.',
       enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
     );
-    container._reactIsNewStyleRootDEV = true;
+    container._reactHasBeenPassedToCreateRootDEV = true;
   }
   const hydrate = options != null && options.hydrate === true;
   return new ReactRoot(container, true, hydrate);

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -655,7 +655,7 @@ const ReactDOM: Object = {
       warningWithoutStack(
         !container._reactHasBeenPassedToCreateRootDEV,
         'You are calling ReactDOM.hydrate() on a container that was previously ' +
-          'managed by ReactDOM.%s(). This is not supported. ' +
+          'passed to ReactDOM.%s(). This is not supported. ' +
           'Did you mean to call root.render(element, {hydrate: true})?',
         enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
       );
@@ -683,7 +683,7 @@ const ReactDOM: Object = {
       warningWithoutStack(
         !container._reactHasBeenPassedToCreateRootDEV,
         'You are calling ReactDOM.render() on a container that was previously ' +
-          'managed by ReactDOM.%s(). This is not supported. ' +
+          'passed to ReactDOM.%s(). This is not supported. ' +
           'Did you mean to call root.render(element)?',
         enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
       );
@@ -730,7 +730,7 @@ const ReactDOM: Object = {
       warningWithoutStack(
         !container._reactHasBeenPassedToCreateRootDEV,
         'You are calling ReactDOM.unmountComponentAtNode() on a container that was previously ' +
-          'managed by ReactDOM.%s(). This is not supported. Did you mean to call root.unmount()?',
+          'passed to ReactDOM.%s(). This is not supported. Did you mean to call root.unmount()?',
         enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
       );
     }
@@ -843,7 +843,7 @@ function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
     warningWithoutStack(
       !container._reactRootContainer,
       'You are calling ReactDOM.%s() on a container that was previously ' +
-        'managed by ReactDOM.render(). This is not supported.',
+        'passed to ReactDOM.render(). This is not supported.',
       enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
     );
     container._reactHasBeenPassedToCreateRootDEV = true;

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -14,7 +14,6 @@ import type {
   FiberRoot,
   Batch as FiberRootBatch,
 } from 'react-reconciler/src/ReactFiberRoot';
-import type {Container} from './ReactDOMHostConfig';
 
 import '../shared/checkReact';
 import './ReactDOMClientInjection';

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -545,12 +545,6 @@ function legacyRenderSubtreeIntoContainer(
   forceHydrate: boolean,
   callback: ?Function,
 ) {
-  // TODO: Ensure all entry points contain this check
-  invariant(
-    isValidContainer(container),
-    'Target container is not a DOM element.',
-  );
-
   if (__DEV__) {
     topLevelUpdateWarnings(container);
   }
@@ -654,6 +648,10 @@ const ReactDOM: Object = {
   },
 
   hydrate(element: React$Node, container: DOMContainer, callback: ?Function) {
+    invariant(
+      isValidContainer(container),
+      'Target container is not a DOM element.',
+    );
     if (__DEV__) {
       warningWithoutStack(
         !container._reactIsNewStyleRootDEV,
@@ -663,7 +661,6 @@ const ReactDOM: Object = {
         enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
       );
     }
-
     // TODO: throw or warn if we couldn't hydrate?
     return legacyRenderSubtreeIntoContainer(
       null,
@@ -679,6 +676,10 @@ const ReactDOM: Object = {
     container: DOMContainer,
     callback: ?Function,
   ) {
+    invariant(
+      isValidContainer(container),
+      'Target container is not a DOM element.',
+    );
     if (__DEV__) {
       warningWithoutStack(
         !container._reactIsNewStyleRootDEV,
@@ -688,7 +689,6 @@ const ReactDOM: Object = {
         enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
       );
     }
-
     return legacyRenderSubtreeIntoContainer(
       null,
       element,
@@ -704,6 +704,10 @@ const ReactDOM: Object = {
     containerNode: DOMContainer,
     callback: ?Function,
   ) {
+    invariant(
+      isValidContainer(containerNode),
+      'Target container is not a DOM element.',
+    );
     invariant(
       parentComponent != null && hasInstance(parentComponent),
       'parentComponent must be a valid React Component',


### PR DESCRIPTION
It's confusing when you mix those — e.g. if you render with `createRoot().render()` but then call `unmountComponentAtNode()`. Sometimes it warns with misleading warnings, and sometimes (in particular, if there's existing content) it didn't warn at all. We don't have guarantees around how it works either (e.g. unmounting doesn't work).

I added an explicit DEV-only flag for whether something is a new-style root, and I warn whenever you try to mix the API one way or the other. The message suggests the right API to use. I didn't change the behavior.

I didn't clean up false positive further warnings because the code for them is all over the place and it's hard to untangle the assumptions. So warning at entry point seemed like the easiest thing to do. We want to keep these worlds separate anyway.