### PR TITLE
Prune NPM metadata fields from packages before re-publishing

### DIFF
--- a/scripts/release/prepare-stable-commands/prune-package-registry-metadata.js
+++ b/scripts/release/prepare-stable-commands/prune-package-registry-metadata.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const {logPromise} = require('../utils');
+const {readJson, writeJson} = require('fs-extra');
+const {join} = require('path');
+
+const run = async ({cwd, packages}) => {
+  const nodeModulesPath = join(cwd, 'build/node_modules');
+
+  for (let i = 0; i < packages.length; i++) {
+    const packageName = packages[i];
+    const packageJSONPath = join(nodeModulesPath, packageName, 'package.json');
+    const packageJSON = await readJson(packageJSONPath);
+
+    // NPM adds a lot of metadata fields on checkout.
+    // It's nice to strip these before re-publishing the package.
+    for (let key in packageJSON) {
+      if (key.startsWith('_')) {
+        delete packageJSON[key];
+      }
+    }
+
+    await writeJson(packageJSONPath, packageJSON, {spaces: 2});
+  }
+};
+
+module.exports = async params => {
+  return logPromise(run(params), 'Pruning package registry metadata');
+};

--- a/scripts/release/prepare-stable.js
+++ b/scripts/release/prepare-stable.js
@@ -10,6 +10,7 @@ const confirmStableVersionNumbers = require('./prepare-stable-commands/confirm-s
 const guessStableVersionNumbers = require('./prepare-stable-commands/guess-stable-version-numbers');
 const parseParams = require('./prepare-stable-commands/parse-params');
 const printPrereleaseSummary = require('./shared-commands/print-prerelease-summary');
+const prunePackageRegistryMetadata = require('./prepare-stable-commands/prune-package-registry-metadata');
 const testPackagingFixture = require('./shared-commands/test-packaging-fixture');
 const testTracingFixture = require('./shared-commands/test-tracing-fixture');
 const updateStableVersionNumbers = require('./prepare-stable-commands/update-stable-version-numbers');
@@ -28,6 +29,7 @@ const run = async () => {
     await checkOutPackages(params);
     await guessStableVersionNumbers(params, versionsMap);
     await confirmStableVersionNumbers(params, versionsMap);
+    await prunePackageRegistryMetadata(params);
     await updateStableVersionNumbers(params, versionsMap);
 
     if (!params.skipTests) {


### PR DESCRIPTION
The latest React release [has some weird fields in the package JSON](https://unpkg.com/react@16.7.0/package.json) that [weren't there in the canary](https://unpkg.com/react@canary/package.json). These fields (all beginning with "_") contain package registry meta data.

It's not ideal that we publish package with these fields still around. Technically, they aren't even valid since [NPM rules](https://docs.npmjs.com/files/package.json) and the [packages JSON spec](http://wiki.commonjs.org/wiki/Packages/1.1) say that field names beginning with underscores are reserved.

So this PR adds a step that prunes these fields as part of preparing a stable release.

### JSON diff before
```diff
1a2,25
>   "_from": "react@0.0.0-3e15b1c69",
>   "_id": "react@0.0.0-3e15b1c69",
>   "_inBundle": false,
>   "_integrity": "sha512-jGp8MiBrV1FuT0kLcUlb7zjZiaWAcaQ001qCbUen7SHHtnE3Apdl7d7fHshrEOytgoPWSm2pc7vdz1nICqmIDw==",
>   "_location": "/react",
>   "_phantomChildren": {},
>   "_requested": {
>     "type": "version",
>     "registry": true,
>     "raw": "react@0.0.0-3e15b1c69",
>     "name": "react",
>     "escapedName": "react",
>     "rawSpec": "0.0.0-3e15b1c69",
>     "saveSpec": null,
>     "fetchSpec": "0.0.0-3e15b1c69"
>   },
>   "_requiredBy": [
>     "#USER",
>     "/"
>   ],
>   "_resolved": "https://registry.npmjs.org/react/-/react-0.0.0-3e15b1c69.tgz",
>   "_shasum": "a10d5c3fd611046fd5ab65503e6df0b37db99fc0",
>   "_spec": "react@0.0.0-3e15b1c69",
>   "_where": "/Users/bvaughn/Documents/git/react/build/node_modules",
7c31,34
<   "bugs": "https://github.com/facebook/react/issues",
---
>   "bugs": {
>     "url": "https://github.com/facebook/react/issues"
>   },
>   "bundleDependencies": false,
12,13c39,42
<     "scheduler": "0.0.0-3e15b1c69"
<   },  "description": "React is a JavaScript library for building user interfaces.",
---
>     "scheduler": "^0.13.0"
>   },
>   "deprecated": false,
>   "description": "React is a JavaScript library for building user interfaces.",
32,34c61,66
<   "repository": "facebook/react",
<   "version": "0.0.0-3e15b1c69"
< }
\ No newline at end of file
---
>   "repository": {
>     "type": "git",
>     "url": "git+https://github.com/facebook/react.git"
>   },
>   "version": "16.8.0"
> }
```
### JSON diff after
```diff
7c7,10
<   "bugs": "https://github.com/facebook/react/issues",
---
>   "bugs": {
>     "url": "https://github.com/facebook/react/issues"
>   },
>   "bundleDependencies": false,
12,13c15,18
<     "scheduler": "0.0.0-3e15b1c69"
<   },  "description": "React is a JavaScript library for building user interfaces.",
---
>     "scheduler": "^0.13.0"
>   },
>   "deprecated": false,
>   "description": "React is a JavaScript library for building user interfaces.",
32,34c37,42
<   "repository": "facebook/react",
<   "version": "0.0.0-3e15b1c69"
< }
\ No newline at end of file
---
>   "repository": {
>     "type": "git",
>     "url": "git+https://github.com/facebook/react.git"
>   },
>   "version": "16.8.0"
> }
```