### PR TITLE
Support sync thenables for lazy()

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -47,6 +47,7 @@ export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
       lazyComponent._status = Pending;
       const ctor = lazyComponent._ctor;
       const thenable = ctor();
+      lazyComponent._result = thenable;
       thenable.then(
         moduleObject => {
           if (lazyComponent._status === Pending) {
@@ -73,9 +74,9 @@ export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
           }
         },
       );
-      // Don't race with a sync thenable
-      if (lazyComponent._status === Pending) {
-        lazyComponent._result = thenable;
+      // Check if it resolved synchronously
+      if (lazyComponent._status === Resolved) {
+        return lazyComponent._result;
       }
       throw thenable;
     }

--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -73,7 +73,10 @@ export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
           }
         },
       );
-      lazyComponent._result = thenable;
+      // Don't race with a sync thenable
+      if (lazyComponent._status === Pending) {
+        lazyComponent._result = thenable;
+      }
       throw thenable;
     }
   }

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -74,7 +74,7 @@ describe('ReactLazy', () => {
       </Suspense>,
     );
 
-    expect(ReactTestRenderer).toHaveYielded(['Loading...', 'Hi']);
+    expect(ReactTestRenderer).toHaveYielded(['Hi']);
     expect(root).toMatchRenderedOutput('Hi');
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -61,6 +61,23 @@ describe('ReactLazy', () => {
     expect(root).toMatchRenderedOutput('Hi again');
   });
 
+  it('can resolve synchronously without suspending', async () => {
+    const LazyText = lazy(() => ({
+      then(cb) {
+        cb({default: Text});
+      },
+    }));
+
+    const root = ReactTestRenderer.create(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <LazyText text="Hi" />
+      </Suspense>,
+    );
+
+    expect(ReactTestRenderer).toHaveYielded(['Loading...', 'Hi']);
+    expect(root).toMatchRenderedOutput('Hi');
+  });
+
   it('multiple lazy components', async () => {
     function Foo() {
       return <Text text="Foo" />;


### PR DESCRIPTION
Why don't we? Currently they fail with a confusing error because of a race condition (status gets set to resolved but then the result gets overwritten by the next line). This should fix it.

I figured this might be useful for testing. See https://github.com/airbnb/enzyme/issues/1917#issuecomment-454208642. It's awkward that people look for workarounds like `waitForLazyLoaded` in a synchronous environment. Supporting sync thenables could be a nice solution to that.