### PR TITLE
Add directory details to the package.json of all packages

### DIFF
--- a/packages/create-subscription/package.json
+++ b/packages/create-subscription/package.json
@@ -2,7 +2,11 @@
   "name": "create-subscription",
   "description": "utility for subscribing to external data sources inside React components",
   "version": "16.7.0",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/create-subscription"
+  },
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -3,7 +3,11 @@
   "name": "eslint-plugin-react-hooks",
   "description": "ESLint rules for React Hooks",
   "version": "0.0.0",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/eslint-plugin-react-hooks"
+  },
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/jest-mock-scheduler/package.json
+++ b/packages/jest-mock-scheduler/package.json
@@ -4,7 +4,11 @@
   "version": "0.1.0",
   "description": "Jest matchers and utilities for testing the scheduler package.",
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/jest-mock-scheduler"
+  },
   "keywords": [
     "jest",
     "scheduler"

--- a/packages/jest-react/package.json
+++ b/packages/jest-react/package.json
@@ -3,7 +3,11 @@
   "version": "0.5.0",
   "description": "Jest matchers and utilities for testing React components.",
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/jest-react"
+  },
   "keywords": [
     "react",
     "jest",

--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -3,7 +3,11 @@
   "description": "React ART is a JavaScript library for drawing vector graphics using React. It provides declarative and reactive bindings to the ART library. Using the same declarative API you can render the output to either Canvas, SVG or VML (IE8).",
   "version": "16.7.0",
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-art"
+  },
   "keywords": [
     "react",
     "art",

--- a/packages/react-cache/package.json
+++ b/packages/react-cache/package.json
@@ -3,7 +3,11 @@
   "name": "react-cache",
   "description": "A basic cache for React applications",
   "version": "2.0.0-alpha.0",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-cache"
+  },
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/react-debug-tools/package.json
+++ b/packages/react-debug-tools/package.json
@@ -17,7 +17,11 @@
     "cjs/"
   ],
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-debug-tools"
+  },
   "engines": {
     "node": ">=0.10.0"
   },

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -3,7 +3,11 @@
   "version": "16.7.0",
   "description": "React package for working with the DOM.",
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-dom"
+  },
   "keywords": [
     "react"
   ],

--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -3,7 +3,11 @@
   "version": "16.7.0",
   "description": "Brand checking of React Elements.",
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-is"
+  },
   "keywords": [
     "react"
   ],

--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -2,7 +2,11 @@
   "name": "react-native-renderer",
   "version": "16.0.0",
   "private": true,
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-native-renderer"
+  },
   "dependencies": {
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",

--- a/packages/react-noop-renderer/package.json
+++ b/packages/react-noop-renderer/package.json
@@ -4,7 +4,11 @@
   "private": true,
   "description": "React package for testing the Fiber reconciler.",
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-noop-renderer"
+  },
   "license": "MIT",
   "dependencies": {
     "object-assign": "^4.1.1",

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -18,7 +18,11 @@
     "cjs/"
   ],
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-reconciler"
+  },
   "engines": {
     "node": ">=0.10.0"
   },

--- a/packages/react-stream/package.json
+++ b/packages/react-stream/package.json
@@ -16,7 +16,11 @@
     "cjs/"
   ],
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-stream"
+  },
   "engines": {
     "node": ">=0.10.0"
   },

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -3,7 +3,11 @@
   "version": "16.7.0",
   "description": "React package for snapshot testing.",
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-test-renderer"
+  },
   "keywords": [
     "react",
     "react-native",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,7 +17,11 @@
     "umd/"
   ],
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react"
+  },
   "engines": {
     "node": ">=0.10.0"
   },

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -3,7 +3,11 @@
   "version": "0.12.0",
   "description": "Cooperative scheduler for the browser environment.",
   "main": "index.js",
-  "repository": "facebook/react",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/scheduler"
+  },
   "license": "MIT",
   "keywords": [
     "react"


### PR DESCRIPTION
Specifying the directory as part of the `repository` field in a `package.json` allows third party tools to provide better support when working with monorepos. For example, it allows them to correctly construct a commit diff for a specific package.

This format was accepted by npm in https://github.com/npm/rfcs/pull/19.