### PR TITLE
Fix synchronous thenable rejection

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -47,7 +47,6 @@ export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
       lazyComponent._status = Pending;
       const ctor = lazyComponent._ctor;
       const thenable = ctor();
-      lazyComponent._result = thenable;
       thenable.then(
         moduleObject => {
           if (lazyComponent._status === Pending) {
@@ -74,10 +73,14 @@ export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
           }
         },
       );
-      // Check if it resolved synchronously
-      if (lazyComponent._status === Resolved) {
-        return lazyComponent._result;
+      // Handle synchronous thenables.
+      switch (lazyComponent._status) {
+        case Resolved:
+          return lazyComponent._result;
+        case Rejected:
+          throw lazyComponent._result;
       }
+      lazyComponent._result = thenable;
       throw thenable;
     }
   }

--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -47,6 +47,7 @@ export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
       lazyComponent._status = Pending;
       const ctor = lazyComponent._ctor;
       const thenable = ctor();
+      lazyComponent._result = thenable;
       thenable.then(
         moduleObject => {
           if (lazyComponent._status === Pending) {
@@ -77,7 +78,6 @@ export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
       if (lazyComponent._status === Resolved) {
         return lazyComponent._result;
       }
-      lazyComponent._result = thenable;
       throw thenable;
     }
   }

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -78,7 +78,7 @@ describe('ReactLazy', () => {
     expect(root).toMatchRenderedOutput('Hi');
   });
 
-  it('can handle synchronous thenable rejection', async () => {
+  it('can reject synchronously without suspending', async () => {
     const LazyText = lazy(() => ({
       then(resolve, reject) {
         reject(new Error('oh no'));
@@ -104,8 +104,7 @@ describe('ReactLazy', () => {
         </Suspense>
       </ErrorBoundary>,
     );
-    // TODO: ideally we could make it skip this commit.
-    expect(ReactTestRenderer).toHaveYielded(['Loading...']);
+    expect(ReactTestRenderer).toHaveYielded([]);
     expect(root).toMatchRenderedOutput('Error: oh no');
   });
 


### PR DESCRIPTION
This reverts https://github.com/facebook/react/pull/14632 (it has a bug), adds a regression test, and then changes behavior to a preferred one. See individual commits.