### PR TITLE
Support Suspense in shallow renderer

### DIFF
--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import {isForwardRef} from 'react-is';
+import {isForwardRef, isSuspense} from 'react-is';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import getComponentName from 'shared/getComponentName';
 import shallowEqual from 'shared/shallowEqual';
@@ -499,7 +499,9 @@ class ReactShallowRenderer {
       element.type,
     );
     invariant(
-      isForwardRef(element) || typeof element.type === 'function',
+      isSuspense(element) ||
+        isForwardRef(element) ||
+        typeof element.type === 'function',
       'ReactShallowRenderer render(): Shallow rendering works only with custom ' +
         'components, but the provided element type was `%s`.',
       Array.isArray(element.type)
@@ -520,7 +522,9 @@ class ReactShallowRenderer {
     if (this._instance) {
       this._updateClassComponent(element, this._context);
     } else {
-      if (isForwardRef(element)) {
+      if (isSuspense(element)) {
+        this._rendered = element.props.children;
+      } else if (isForwardRef(element)) {
         this._rendered = element.type.render(element.props, element.ref);
       } else if (shouldConstruct(element.type)) {
         this._instance = new element.type(

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -13,6 +13,7 @@
 let createRenderer;
 let PropTypes;
 let React;
+let ReactIs;
 
 describe('ReactShallowRenderer', () => {
   beforeEach(() => {
@@ -21,6 +22,7 @@ describe('ReactShallowRenderer', () => {
     createRenderer = require('react-test-renderer/shallow').createRenderer;
     PropTypes = require('prop-types');
     React = require('react');
+    ReactIs = require('react-is');
   });
 
   it('should call all of the legacy lifecycle hooks', () => {
@@ -254,6 +256,31 @@ describe('ReactShallowRenderer', () => {
         <span className="child2" />
       </div>,
     );
+  });
+
+  it('should handle Suspense', () => {
+    const fallback = <div>fallback</div>;
+    const shallowRenderer = createRenderer();
+    const targetText = 'test';
+    const result = shallowRenderer.render(
+      <React.Suspense fallback={fallback}>
+        <div>{targetText}</div>
+      </React.Suspense>,
+    );
+    expect(result.type).toBe('div');
+    expect(result.props.children).toBe(targetText);
+  });
+
+  it('should shallow render lazy component in children and not to handle fallback', () => {
+    const fallback = <div>fallback</div>;
+    const LazyComponent = React.lazy(() => Promise.resolve({default: null}));
+    const shallowRenderer = createRenderer();
+    const result = shallowRenderer.render(
+      <React.Suspense fallback={fallback}>
+        <LazyComponent />
+      </React.Suspense>,
+    );
+    expect(ReactIs.isLazy(result.type)).toBe(true);
   });
 
   it('should enable shouldComponentUpdate to prevent a re-render', () => {


### PR DESCRIPTION
Try to support `Suspense` in shallow renderer, which may partially solve #14170 . Also in airbnb/enzyme#1975 I'm trying to add support of Suspense and Lazy but stuck with that shallow renderer not support it.

I know this is arguable - or even not make sense - to shallow render Suspense. But, in some of use cases people would be like to know what's rendering in one layer down of `Suspense` (like [wrapper.dive](https://airbnb.io/enzyme/docs/api/ShallowWrapper/dive.html)), so I think it's still valuable.

Currently in the PR I haven't handled the `fallback` and `lazy`, just plainly return children under Suspense. I'm not sure if it's good to handle fallback - find all the lazy component under Suspense and render it and wait for thenable resolve to update, which is complicated in fiber implementaion - in shallow rendering. I think it would be great for testing to have a simpler implementation, but not sure if there is other consideration here.