### PR TITLE
Double-render function components in DEV in StrictMode

### DIFF
--- a/packages/react-art/src/__tests__/ReactART-test.js
+++ b/packages/react-art/src/__tests__/ReactART-test.js
@@ -385,7 +385,7 @@ describe('ReactART', () => {
       </CurrentRendererContext.Provider>,
     );
 
-    ReactNoop.flushThrough(['A']);
+    ReactNoop.flushThrough(__DEV__ ? ['A', 'A'] : ['A']);
 
     ReactDOM.render(
       <Surface>
@@ -400,7 +400,9 @@ describe('ReactART', () => {
     expect(ops).toEqual([null, 'ART']);
 
     ops = [];
-    expect(ReactNoop.flush()).toEqual(['B', 'C']);
+    expect(ReactNoop.flush()).toEqual(
+      __DEV__ ? ['B', 'B', 'C', 'C'] : ['B', 'C'],
+    );
 
     expect(ops).toEqual(['Test']);
   });

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -232,7 +232,7 @@ describe('ReactDOMRoot', () => {
     // Flush all async work.
     jest.runAllTimers();
     // Root should complete without committing.
-    expect(ops).toEqual(['Foo']);
+    expect(ops).toEqual(__DEV__ ? ['Foo', 'Foo'] : ['Foo']);
     expect(container.textContent).toEqual('');
 
     ops = [];

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1173,7 +1173,20 @@ function mountIndeterminateComponent(
       context,
       renderExpirationTime,
     );
-    // TODO: double-render here in strict mode.
+    if (
+      debugRenderPhaseSideEffects ||
+      (debugRenderPhaseSideEffectsForStrictMode &&
+        workInProgress.mode & StrictMode)
+    ) {
+      renderWithHooks(
+        null,
+        workInProgress,
+        Component,
+        props,
+        context,
+        renderExpirationTime,
+      );
+    }
   } else {
     value = renderWithHooks(
       null,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -250,6 +250,20 @@ function updateForwardRef(
       ref,
       renderExpirationTime,
     );
+    if (
+      debugRenderPhaseSideEffects ||
+      (debugRenderPhaseSideEffectsForStrictMode &&
+        workInProgress.mode & StrictMode)
+    ) {
+      renderWithHooks(
+        current,
+        workInProgress,
+        render,
+        nextProps,
+        ref,
+        renderExpirationTime,
+      );
+    }
     setCurrentPhase(null);
   } else {
     nextChildren = renderWithHooks(
@@ -543,6 +557,20 @@ function updateFunctionComponent(
       context,
       renderExpirationTime,
     );
+    if (
+      debugRenderPhaseSideEffects ||
+      (debugRenderPhaseSideEffectsForStrictMode &&
+        workInProgress.mode & StrictMode)
+    ) {
+      renderWithHooks(
+        current,
+        workInProgress,
+        Component,
+        nextProps,
+        context,
+        renderExpirationTime,
+      );
+    }
     setCurrentPhase(null);
   } else {
     nextChildren = renderWithHooks(
@@ -1145,6 +1173,7 @@ function mountIndeterminateComponent(
       context,
       renderExpirationTime,
     );
+    // TODO: double-render here in strict mode.
   } else {
     value = renderWithHooks(
       null,

--- a/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
@@ -70,7 +70,11 @@ describe('ErrorBoundaryReconciliation', () => {
         if (isConcurrent) {
           renderer.unstable_flushAll();
         }
-      }).toWarnDev(isConcurrent ? ['invalid', 'invalid', 'invalid', 'invalid'] : ['invalid']);
+      }).toWarnDev(
+        isConcurrent
+          ? ['invalid', 'invalid', 'invalid', 'invalid']
+          : ['invalid'],
+      );
       const Fallback = fallbackTagName;
       expect(renderer).toMatchRenderedOutput(<Fallback prop="ErrorBoundary" />);
     }

--- a/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
@@ -70,7 +70,7 @@ describe('ErrorBoundaryReconciliation', () => {
         if (isConcurrent) {
           renderer.unstable_flushAll();
         }
-      }).toWarnDev(isConcurrent ? ['invalid', 'invalid'] : ['invalid']);
+      }).toWarnDev(isConcurrent ? ['invalid', 'invalid', 'invalid', 'invalid'] : ['invalid']);
       const Fallback = fallbackTagName;
       expect(renderer).toMatchRenderedOutput(<Fallback prop="ErrorBoundary" />);
     }

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.internal.js
@@ -11,11 +11,14 @@
 'use strict';
 
 let React;
+let ReactFeatureFlags;
 let ReactTestRenderer;
 
 describe('ReactTestRendererAsync', () => {
   beforeEach(() => {
     jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
   });
@@ -62,19 +65,11 @@ describe('ReactTestRendererAsync', () => {
       unstable_isConcurrent: true,
     });
 
-    expect(renderer).toFlushAndYield(
-      __DEV__
-        ? ['A:1', 'A:1', 'B:1', 'B:1', 'C:1', 'C:1']
-        : ['A:1', 'B:1', 'C:1'],
-    );
+    expect(renderer).toFlushAndYield(['A:1', 'B:1', 'C:1']);
     expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
 
     renderer.update(<Parent step={2} />);
-    expect(renderer).toFlushAndYield(
-      __DEV__
-        ? ['A:2', 'A:2', 'B:2', 'B:2', 'C:2', 'C:2']
-        : ['A:2', 'B:2', 'C:2'],
-    );
+    expect(renderer).toFlushAndYield(['A:2', 'B:2', 'C:2']);
     expect(renderer.toJSON()).toEqual(['A:2', 'B:2', 'C:2']);
   });
 
@@ -97,14 +92,12 @@ describe('ReactTestRendererAsync', () => {
     });
 
     // Flush the first two siblings
-    expect(renderer).toFlushAndYieldThrough(
-      __DEV__ ? ['A:1', 'A:1', 'B:1', 'B:1'] : ['A:1', 'B:1'],
-    );
+    expect(renderer).toFlushAndYieldThrough(['A:1', 'B:1']);
     // Did not commit yet.
     expect(renderer.toJSON()).toEqual(null);
 
     // Flush the remaining work
-    expect(renderer).toFlushAndYield(__DEV__ ? ['C:1', 'C:1'] : ['C:1']);
+    expect(renderer).toFlushAndYield(['C:1']);
     expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
   });
 
@@ -136,7 +129,7 @@ describe('ReactTestRendererAsync', () => {
     });
 
     // Flush the some of the changes, but don't commit
-    expect(renderer).toFlushAndYieldThrough(__DEV__ ? ['A:1', 'A:1'] : ['A:1']);
+    expect(renderer).toFlushAndYieldThrough(['A:1']);
     expect(renderer.toJSON()).toEqual(null);
 
     // Interrupt with higher priority properties
@@ -232,54 +225,30 @@ describe('ReactTestRendererAsync', () => {
       });
 
       expect(renderer).toFlushAndThrow('Oh no!');
-      expect(ReactTestRenderer).toHaveYielded(
-        __DEV__
-          ? [
-              'A',
-              'A',
-              'B',
-              'B',
-              'C',
-              'C',
-              'D',
-              'D',
-              'A',
-              'A',
-              'B',
-              'B',
-              'C',
-              'C',
-              'D',
-              'D',
-            ]
-          : ['A', 'B', 'C', 'D', 'A', 'B', 'C', 'D'],
-      );
+      expect(ReactTestRenderer).toHaveYielded([
+        'A',
+        'B',
+        'C',
+        'D',
+        'A',
+        'B',
+        'C',
+        'D',
+      ]);
 
       renderer.update(<App />);
 
       expect(renderer).toFlushAndThrow('Oh no!');
-      expect(ReactTestRenderer).toHaveYielded(
-        __DEV__
-          ? [
-              'A',
-              'A',
-              'B',
-              'B',
-              'C',
-              'C',
-              'D',
-              'D',
-              'A',
-              'A',
-              'B',
-              'B',
-              'C',
-              'C',
-              'D',
-              'D',
-            ]
-          : ['A', 'B', 'C', 'D', 'A', 'B', 'C', 'D'],
-      );
+      expect(ReactTestRenderer).toHaveYielded([
+        'A',
+        'B',
+        'C',
+        'D',
+        'A',
+        'B',
+        'C',
+        'D',
+      ]);
 
       renderer.update(<App />);
       expect(renderer).toFlushAndThrow('Oh no!');

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
@@ -66,7 +66,14 @@ describe('ReactTestRendererAsync', () => {
     expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
 
     renderer.update(<Parent step={2} />);
-    expect(renderer).toFlushAndYield(['A:2', 'B:2', 'C:2']);
+    expect(renderer).toFlushAndYield(__DEV__ ? [
+      'A:2',
+      'A:2',
+      'B:2',
+      'B:2',
+      'C:2',
+      'C:2'
+    ] : ['A:2', 'B:2', 'C:2']);
     expect(renderer.toJSON()).toEqual(['A:2', 'B:2', 'C:2']);
   });
 

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
@@ -62,18 +62,19 @@ describe('ReactTestRendererAsync', () => {
       unstable_isConcurrent: true,
     });
 
-    expect(renderer).toFlushAndYield(['A:1', 'B:1', 'C:1']);
+    expect(renderer).toFlushAndYield(
+      __DEV__
+        ? ['A:1', 'A:1', 'B:1', 'B:1', 'C:1', 'C:1']
+        : ['A:1', 'B:1', 'C:1'],
+    );
     expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
 
     renderer.update(<Parent step={2} />);
-    expect(renderer).toFlushAndYield(__DEV__ ? [
-      'A:2',
-      'A:2',
-      'B:2',
-      'B:2',
-      'C:2',
-      'C:2'
-    ] : ['A:2', 'B:2', 'C:2']);
+    expect(renderer).toFlushAndYield(
+      __DEV__
+        ? ['A:2', 'A:2', 'B:2', 'B:2', 'C:2', 'C:2']
+        : ['A:2', 'B:2', 'C:2'],
+    );
     expect(renderer.toJSON()).toEqual(['A:2', 'B:2', 'C:2']);
   });
 
@@ -96,12 +97,14 @@ describe('ReactTestRendererAsync', () => {
     });
 
     // Flush the first two siblings
-    expect(renderer).toFlushAndYieldThrough(['A:1', 'B:1']);
+    expect(renderer).toFlushAndYieldThrough(
+      __DEV__ ? ['A:1', 'A:1', 'B:1', 'B:1'] : ['A:1', 'B:1'],
+    );
     // Did not commit yet.
     expect(renderer.toJSON()).toEqual(null);
 
     // Flush the remaining work
-    expect(renderer).toFlushAndYield(['C:1']);
+    expect(renderer).toFlushAndYield(__DEV__ ? ['C:1', 'C:1'] : ['C:1']);
     expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
   });
 
@@ -133,7 +136,7 @@ describe('ReactTestRendererAsync', () => {
     });
 
     // Flush the some of the changes, but don't commit
-    expect(renderer).toFlushAndYieldThrough(['A:1']);
+    expect(renderer).toFlushAndYieldThrough(__DEV__ ? ['A:1', 'A:1'] : ['A:1']);
     expect(renderer.toJSON()).toEqual(null);
 
     // Interrupt with higher priority properties
@@ -229,30 +232,54 @@ describe('ReactTestRendererAsync', () => {
       });
 
       expect(renderer).toFlushAndThrow('Oh no!');
-      expect(ReactTestRenderer).toHaveYielded([
-        'A',
-        'B',
-        'C',
-        'D',
-        'A',
-        'B',
-        'C',
-        'D',
-      ]);
+      expect(ReactTestRenderer).toHaveYielded(
+        __DEV__
+          ? [
+              'A',
+              'A',
+              'B',
+              'B',
+              'C',
+              'C',
+              'D',
+              'D',
+              'A',
+              'A',
+              'B',
+              'B',
+              'C',
+              'C',
+              'D',
+              'D',
+            ]
+          : ['A', 'B', 'C', 'D', 'A', 'B', 'C', 'D'],
+      );
 
       renderer.update(<App />);
 
       expect(renderer).toFlushAndThrow('Oh no!');
-      expect(ReactTestRenderer).toHaveYielded([
-        'A',
-        'B',
-        'C',
-        'D',
-        'A',
-        'B',
-        'C',
-        'D',
-      ]);
+      expect(ReactTestRenderer).toHaveYielded(
+        __DEV__
+          ? [
+              'A',
+              'A',
+              'B',
+              'B',
+              'C',
+              'C',
+              'D',
+              'D',
+              'A',
+              'A',
+              'B',
+              'B',
+              'C',
+              'C',
+              'D',
+              'D',
+            ]
+          : ['A', 'B', 'C', 'D', 'A', 'B', 'C', 'D'],
+      );
 
       renderer.update(<App />);
       expect(renderer).toFlushAndThrow('Oh no!');

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -241,11 +241,11 @@ describe('forwardRef', () => {
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(1);
+    expect(renderCount).toBe(__DEV__ ? 2 : 1);
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(2);
+    expect(renderCount).toBe(__DEV__ ? 4 : 2);
   });
 
   it('should bailout if forwardRef is wrapped in memo', () => {
@@ -264,13 +264,13 @@ describe('forwardRef', () => {
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(1);
+    expect(renderCount).toBe(__DEV__ ? 2 : 1);
 
     expect(ref.current.type).toBe('div');
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(1);
+    expect(renderCount).toBe(__DEV__ ? 2 : 1);
 
     const differentRef = React.createRef();
 
@@ -278,14 +278,14 @@ describe('forwardRef', () => {
       <RefForwardingComponent ref={differentRef} optional="foo" />,
     );
     ReactNoop.flush();
-    expect(renderCount).toBe(2);
+    expect(renderCount).toBe(__DEV__ ? 4 : 2);
 
     expect(ref.current).toBe(null);
     expect(differentRef.current.type).toBe('div');
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="bar" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(3);
+    expect(renderCount).toBe(__DEV__ ? 6 : 3);
   });
 
   it('should custom memo comparisons to compose', () => {
@@ -305,19 +305,19 @@ describe('forwardRef', () => {
 
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="0" c="1" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(1);
+    expect(renderCount).toBe(__DEV__ ? 2 : 1);
 
     expect(ref.current.type).toBe('div');
 
     // Changing either a or b rerenders
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="1" c="1" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(2);
+    expect(renderCount).toBe(__DEV__ ? 4 : 2);
 
     // Changing c doesn't rerender
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="1" c="2" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(2);
+    expect(renderCount).toBe(__DEV__ ? 4 : 2);
 
     const ComposedMemo = React.memo(
       RefForwardingComponent,
@@ -326,29 +326,29 @@ describe('forwardRef', () => {
 
     ReactNoop.render(<ComposedMemo ref={ref} a="0" b="0" c="0" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(3);
+    expect(renderCount).toBe(__DEV__ ? 6 : 3);
 
     // Changing just b no longer updates
     ReactNoop.render(<ComposedMemo ref={ref} a="0" b="1" c="0" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(3);
+    expect(renderCount).toBe(__DEV__ ? 6 : 3);
 
     // Changing just a and c updates
     ReactNoop.render(<ComposedMemo ref={ref} a="2" b="2" c="2" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(4);
+    expect(renderCount).toBe(__DEV__ ? 8 : 4);
 
     // Changing just c does not update
     ReactNoop.render(<ComposedMemo ref={ref} a="2" b="2" c="3" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(4);
+    expect(renderCount).toBe(__DEV__ ? 8 : 4);
 
     // Changing ref still rerenders
     const differentRef = React.createRef();
 
     ReactNoop.render(<ComposedMemo ref={differentRef} a="2" b="2" c="3" />);
     ReactNoop.flush();
-    expect(renderCount).toBe(5);
+    expect(renderCount).toBe(__DEV__ ? 10 : 5);
 
     expect(ref.current).toBe(null);
     expect(differentRef.current.type).toBe('div');


### PR DESCRIPTION
@acdlite noticed we're not doing this, but we should. It's DEV-only. Function components already need to not have observable side effects — so I think this is perfectly reasonable to do in a minor.

The test changes are a bit wonky. Maybe we could abstract this away but I felt it's only a few files for now and not too bad.