### PR TITLE
Disallow reading context during useMemo etc

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -20,7 +20,6 @@ import {
 import ReactStrictModeWarnings from './ReactStrictModeWarnings';
 import {isMounted} from 'react-reconciler/reflection';
 import {get as getInstance, set as setInstance} from 'shared/ReactInstanceMap';
-import ReactSharedInternals from 'shared/ReactSharedInternals';
 import shallowEqual from 'shared/shallowEqual';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
@@ -48,19 +47,13 @@ import {
   hasContextChanged,
   emptyContextObject,
 } from './ReactFiberContext';
+import {readContext} from './ReactFiberNewContext';
 import {
   requestCurrentTime,
   computeExpirationForFiber,
   scheduleWork,
   flushPassiveEffects,
 } from './ReactFiberScheduler';
-
-const ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
-
-function readContext(contextType: any): any {
-  const dispatcher = ReactCurrentDispatcher.current;
-  return dispatcher.readContext(contextType);
-}
 
 const fakeInternalInstance = {};
 const isArray = Array.isArray;

--- a/packages/react-reconciler/src/ReactFiberDispatcher.js
+++ b/packages/react-reconciler/src/ReactFiberDispatcher.js
@@ -7,8 +7,8 @@
  * @flow
  */
 
-import {readContext} from './ReactFiberNewContext';
 import {
+  readContext,
   useCallback,
   useContext,
   useEffect,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -14,7 +14,7 @@ import type {HookEffectTag} from './ReactHookEffectTags';
 
 import {NoWork} from './ReactFiberExpirationTime';
 import {enableHooks} from 'shared/ReactFeatureFlags';
-import {readContext} from './ReactFiberNewContext';
+import {readContext as readContextWithoutCheck} from './ReactFiberNewContext';
 import {
   Update as UpdateEffect,
   Passive as PassiveEffect,
@@ -394,7 +394,7 @@ export function useContext<T>(
   // Ensure we're in a function component (class components support only the
   // .unstable_read() form)
   resolveCurrentlyRenderingFiber();
-  return readContext(context, observedBits);
+  return readContextWithoutCheck(context, observedBits);
 }
 
 export function useState<S>(
@@ -769,6 +769,19 @@ export function useMemo<T>(
   currentlyRenderingFiber = fiber;
   workInProgressHook.memoizedState = [nextValue, nextDeps];
   return nextValue;
+}
+
+export function readContext<T>(
+  context: ReactContext<T>,
+  observedBits: void | number | boolean,
+): T {
+  invariant(
+    currentlyRenderingFiber !== null,
+    'Context can only be read inside the body of a function component. ' +
+      'If you read context inside a Hook like useMemo or useReducer, ' +
+      'move the call directly into the component body.',
+  );
+  return readContextWithoutCheck(context, observedBits);
 }
 
 function dispatchAction<S, A>(

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -647,7 +647,7 @@ describe('ReactHooks', () => {
     }
 
     expect(() => ReactTestRenderer.create(<App />)).toThrow(
-      'Context can only be read inside the body of a function component',
+      'Context can only be read inside the body of a component',
     );
   });
 
@@ -711,7 +711,7 @@ describe('ReactHooks', () => {
     }
 
     expect(() => ReactTestRenderer.create(<App />)).toThrow(
-      'Context can only be read inside the body of a function component.',
+      'Context can only be read inside the body of a component.',
     );
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -633,6 +633,88 @@ describe('ReactHooks', () => {
     expect(root.toJSON()).toEqual('123');
   });
 
+  it('throws when reading context inside useMemo', () => {
+    const {useMemo, createContext} = React;
+    const ReactCurrentDispatcher =
+      React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+        .ReactCurrentDispatcher;
+
+    const ThemeContext = createContext('light');
+    function App() {
+      return useMemo(() => {
+        return ReactCurrentDispatcher.current.readContext(ThemeContext);
+      }, []);
+    }
+
+    expect(() => ReactTestRenderer.create(<App />)).toThrow(
+      'Context can only be read inside the body of a function component',
+    );
+  });
+
+  it('throws when reading context inside useEffect', () => {
+    const {useEffect, createContext} = React;
+    const ReactCurrentDispatcher =
+      React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+        .ReactCurrentDispatcher;
+
+    const ThemeContext = createContext('light');
+    function App() {
+      useEffect(() => {
+        ReactCurrentDispatcher.current.readContext(ThemeContext);
+      });
+      return null;
+    }
+
+    const root = ReactTestRenderer.create(<App />);
+    expect(() => root.update(<App />)).toThrow(
+      // The exact message doesn't matter, just make sure we don't allow this
+      "Cannot read property 'readContext' of null",
+    );
+  });
+
+  it('throws when reading context inside useLayoutEffect', () => {
+    const {useLayoutEffect, createContext} = React;
+    const ReactCurrentDispatcher =
+      React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+        .ReactCurrentDispatcher;
+
+    const ThemeContext = createContext('light');
+    function App() {
+      useLayoutEffect(() => {
+        ReactCurrentDispatcher.current.readContext(ThemeContext);
+      });
+      return null;
+    }
+
+    expect(() => ReactTestRenderer.create(<App />)).toThrow(
+      // The exact message doesn't matter, just make sure we don't allow this
+      "Cannot read property 'readContext' of null",
+    );
+  });
+
+  it('throws when reading context inside useReducer', () => {
+    const {useReducer, createContext} = React;
+    const ReactCurrentDispatcher =
+      React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+        .ReactCurrentDispatcher;
+
+    const ThemeContext = createContext('light');
+    function App() {
+      useReducer(
+        () => {
+          ReactCurrentDispatcher.current.readContext(ThemeContext);
+        },
+        null,
+        {},
+      );
+      return null;
+    }
+
+    expect(() => ReactTestRenderer.create(<App />)).toThrow(
+      'Context can only be read inside the body of a function component.',
+    );
+  });
+
   it('throws when calling hooks inside useReducer', () => {
     const {useReducer, useRef} = React;
     function App() {


### PR DESCRIPTION
This extends https://github.com/facebook/react/pull/14608 to direct `readContext` calls and adds tests. It turned out it's not super easy.

I started by directing Dispatcher's `readContext` to `FiberHooks` implementation so that we can check `currentlyRenderingFiber` (which https://github.com/facebook/react/pull/14608 temporarily resets before calling user code from Hooks). But then I realized `currentlyRenderingFiber` is also `null` for classes and context consumers from which it's legit to `readContext()`.

I struggled a bit but then noticed we already rely on `renderExpirationTime` (per comment) to tell whether we're in a Hook-capable component or not. So I used that too, and only throw if `renderExpirationTime !== NoWork` (we’re using Hooks) and `currentlyRenderingFiber === null` (we’ve stepped into the user code).

While I was there, I also removed unnecessary `FiberBeginWork -> CurrentDispatcher -> readContext` indirection in favor of a direct call, as  `FiberBeginWork` itself is our own code.

This PR is client-side only. I started looking into SSR but I think there might be more warts there and I want to do it separately.