### PR TITLE
Fix issue with multiple code branches in hooks linter

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -270,6 +270,17 @@ eslintTester.run('react-hooks', ReactHooksESLintRule, {
         useState();
       }
     `,
+    `
+      // Valid because the loop doesn't change the order of hooks calls.
+      function RegressionTest() {
+        const res = [];
+        const additionalCond = true;
+        for (let i = 0; i !== 10 && additionalCond; ++i ) {
+          res.push(i);
+        }
+        React.useLayoutEffect(() => {});
+      }
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -281,6 +281,64 @@ eslintTester.run('react-hooks', ReactHooksESLintRule, {
         React.useLayoutEffect(() => {});
       }
     `,
+    `
+      // Is valid but hard to compute by brute-forcing
+      function MyComponent() {
+        // 40 conditions
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+        if (c) {} else {}
+
+        // 10 hooks
+        useHook();
+        useHook();
+        useHook();
+        useHook();
+        useHook();
+        useHook();
+        useHook();
+        useHook();
+        useHook();
+        useHook();
+      }
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -110,47 +110,29 @@ export default {
          * Segments 1 and 2 have one path to the beginning of `MyComponent` and
          * segment 3 has two paths to the beginning of `MyComponent` since we
          * could have either taken the path of segment 1 or segment 2.
-         *
-         * Populates `cyclic` with cyclic segments.
          */
 
-        function countPathsFromStart(segment) {
-          const {cache} = countPathsFromStart;
-          let paths = cache.get(segment.id);
-
-          // If `paths` is null then we've found a cycle! Add it to `cyclic` and
-          // any other segments which are a part of this cycle.
-          if (paths === null) {
-            if (cyclic.has(segment.id)) {
-              return 0;
-            } else {
-              cyclic.add(segment.id);
-              for (const prevSegment of segment.prevSegments) {
-                countPathsFromStart(prevSegment);
-              }
-              return 0;
-            }
-          }
-
-          // We have a cached `paths`. Return it.
-          if (paths !== undefined) {
-            return paths;
-          }
-
-          // Compute `paths` and cache it. Guarding against cycles.
-          cache.set(segment.id, null);
+        function countPathsFromStart(segment, visited = new Set()) {
           if (codePath.thrownSegments.includes(segment)) {
-            paths = 0;
-          } else if (segment.prevSegments.length === 0) {
-            paths = 1;
-          } else {
-            paths = 0;
-            for (const prevSegment of segment.prevSegments) {
-              paths += countPathsFromStart(prevSegment);
+            return 0;
+          }
+
+          // We reached the destination
+          if (segment.prevSegments.length === 0) {
+            return 1;
+          }
+
+          let paths = 0;
+          visited.add(segment.id);
+
+          for (const prevSegment of segment.prevSegments) {
+            // Check if we already visited the segment so we don't fall into a cycle.
+            if (!visited.has(prevSegment.id)) {
+              paths += countPathsFromStart(prevSegment, visited);
             }
           }
-          cache.set(segment.id, paths);
 
+          visited.delete(segment.id);
           return paths;
         }
 
@@ -271,7 +253,6 @@ export default {
           return length;
         }
 
-        countPathsFromStart.cache = new Map();
         countPathsToEnd.cache = new Map();
         shortestPathLengthToStart.cache = new Map();
 

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -396,20 +396,6 @@ exports[`ReactDebugFiberPerf supports Suspense and lazy 2`] = `
 "
 `;
 
-exports[`ReactDebugFiberPerf supports memo 1`] = `
-"⚛ (Waiting for async callback... will force flush in 5250 ms)
-
-⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ Parent [mount]
-    ⚛ Foo [mount]
-
-⚛ (Committing Changes)
-  ⚛ (Committing Snapshot Effects: 0 Total)
-  ⚛ (Committing Host Effects: 1 Total)
-  ⚛ (Calling Lifecycle Methods: 0 Total)
-"
-`;
-
 exports[`ReactDebugFiberPerf supports portals 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5250 ms)
 
@@ -420,6 +406,20 @@ exports[`ReactDebugFiberPerf supports portals 1`] = `
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)
   ⚛ (Committing Host Effects: 2 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
+"
+`;
+
+exports[`ReactDebugFiberPerf supports memo 1`] = `
+"⚛ (Waiting for async callback... will force flush in 5250 ms)
+
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [mount]
+    ⚛ Foo [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 1 Total)
   ⚛ (Calling Lifecycle Methods: 0 Total)
 "
 `;

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -396,20 +396,6 @@ exports[`ReactDebugFiberPerf supports Suspense and lazy 2`] = `
 "
 `;
 
-exports[`ReactDebugFiberPerf supports portals 1`] = `
-"⚛ (Waiting for async callback... will force flush in 5250 ms)
-
-⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ Parent [mount]
-    ⚛ Child [mount]
-
-⚛ (Committing Changes)
-  ⚛ (Committing Snapshot Effects: 0 Total)
-  ⚛ (Committing Host Effects: 2 Total)
-  ⚛ (Calling Lifecycle Methods: 0 Total)
-"
-`;
-
 exports[`ReactDebugFiberPerf supports memo 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5250 ms)
 
@@ -420,6 +406,20 @@ exports[`ReactDebugFiberPerf supports memo 1`] = `
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)
   ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
+"
+`;
+
+exports[`ReactDebugFiberPerf supports portals 1`] = `
+"⚛ (Waiting for async callback... will force flush in 5250 ms)
+
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [mount]
+    ⚛ Child [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 2 Total)
   ⚛ (Calling Lifecycle Methods: 0 Total)
 "
 `;


### PR DESCRIPTION
I changed the algorithm to a simple DFS so we can find the correct number of possible paths from the hook to the start of the function.

I'm not sure I should change the other (similar) functions as I couldn't think of a breaking example for them.

Fixes #14362 