### PR TITLE
Tweak context invariant message

### DIFF
--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -330,8 +330,10 @@ export function readContext<T>(
     if (lastContextDependency === null) {
       invariant(
         currentlyRenderingFiber !== null,
-        'Context can only be read while React is ' +
-          'rendering, e.g. inside the render method or getDerivedStateFromProps.',
+        'Context can only be read while React is rendering. ' +
+          'In classes, you can read it in the render method or getDerivedStateFromProps. ' +
+          'In function components, you can read it directly in the function body, but not ' +
+          'inside Hooks like useReducer() or useMemo().',
       );
 
       // This is the first dependency for this component. Create a new list.


### PR DESCRIPTION
It was too class-focused, making it confusing for Hook misuse problems.