### PR TITLE
Fix an internal crash when a reducer throws during render of another component

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -922,6 +922,7 @@ describe('ReactHooks', () => {
       _setState(() => {
         throw new Error('Hello');
       });
+      return null;
     }
 
     expect(() =>

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -906,4 +906,31 @@ describe('ReactHooks', () => {
         '   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^',
     ]);
   });
+
+  // Regression test for #14674
+  it('does not swallow original error when updating another component in render phase', () => {
+    let {useState} = React;
+
+    let _setState;
+    function A() {
+      const [, setState] = useState(0);
+      _setState = setState;
+      return null;
+    }
+
+    function B() {
+      _setState(() => {
+        throw new Error('Hello');
+      });
+    }
+
+    expect(() =>
+      ReactTestRenderer.create(
+        <React.Fragment>
+          <A />
+          <B />
+        </React.Fragment>,
+      ),
+    ).toThrow('Hello');
+  });
 });


### PR DESCRIPTION
Seems like a bug that the original message gets lost.

<img width="639" alt="screen shot 2019-01-23 at 5 09 40 pm" src="https://user-images.githubusercontent.com/810438/51624022-eb1e4980-1f31-11e9-972a-95d81e5b3bc8.png">
