### PR TITLE
expose flushEffects on TestUtils

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.internal.js
@@ -1,0 +1,38 @@
+let ReactFeatureFlags
+let React 
+let ReactDOM
+let ReactTestUtils
+
+describe("ReactTestUtils", () => {
+  beforeEach(() => {
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableHooks = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactTestUtils = require('react-dom/test-utils');
+  });
+
+
+  it('flushEffects should run any enqueued effects', () => {
+    let effected = false;
+    let layoutEffected = false;
+    function App() {
+      React.useEffect(() => {
+        effected = true;
+      });
+      React.useLayoutEffect(() => {
+        layoutEffected = true;
+      });
+      return null;
+    }
+    ReactTestUtils.renderIntoDocument(<App />);
+    // effects haven't fired yet
+    expect(effected).toBe(false);
+    // layout effects have, however
+    expect(layoutEffected).toBe(true);
+
+    ReactTestUtils.flushEffects();
+    // effects have now fired
+    expect(effected).toBe(true);
+  });
+})

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.internal.js
@@ -1,6 +1,5 @@
 let ReactFeatureFlags;
 let React;
-let ReactDOM;
 let ReactTestUtils;
 
 describe('ReactTestUtils', () => {

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.internal.js
@@ -1,17 +1,15 @@
-let ReactFeatureFlags
-let React 
-let ReactDOM
-let ReactTestUtils
+let ReactFeatureFlags;
+let React;
+let ReactDOM;
+let ReactTestUtils;
 
-describe("ReactTestUtils", () => {
+describe('ReactTestUtils', () => {
   beforeEach(() => {
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.enableHooks = true;
     React = require('react');
-    ReactDOM = require('react-dom');
     ReactTestUtils = require('react-dom/test-utils');
   });
-
 
   it('flushEffects should run any enqueued effects', () => {
     let effected = false;
@@ -35,4 +33,4 @@ describe("ReactTestUtils", () => {
     // effects have now fired
     expect(effected).toBe(true);
   });
-})
+});

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -14,6 +14,7 @@ let React;
 let ReactDOM;
 let ReactDOMServer;
 let ReactTestUtils;
+let ReactFeatureFlags;
 
 function getTestDocument(markup) {
   const doc = document.implementation.createHTMLDocument('');
@@ -28,6 +29,8 @@ function getTestDocument(markup) {
 
 describe('ReactTestUtils', () => {
   beforeEach(() => {
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableHooks = true;
     createRenderer = require('react-test-renderer/shallow').createRenderer;
     React = require('react');
     ReactDOM = require('react-dom');
@@ -514,5 +517,28 @@ describe('ReactTestUtils', () => {
 
     ReactTestUtils.renderIntoDocument(<Component />);
     expect(mockArgs.length).toEqual(0);
+  });
+
+  it('flushEffects should flush effects, duh', () => {
+    let effected = false;
+    let layoutEffected = false;
+    function App() {
+      React.useEffect(() => {
+        effected = true;
+      });
+      React.useLayoutEffect(() => {
+        layoutEffected = true;
+      });
+      return null;
+    }
+    ReactTestUtils.renderIntoDocument(<App />);
+    // effects haven't fired yet
+    expect(effected).toBe(false);
+    // layout effects have, however
+    expect(layoutEffected).toBe(true);
+
+    ReactTestUtils.flushEffects();
+    // effects have now fired
+    expect(effected).toBe(true);
   });
 });

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -14,7 +14,6 @@ let React;
 let ReactDOM;
 let ReactDOMServer;
 let ReactTestUtils;
-let ReactFeatureFlags;
 
 function getTestDocument(markup) {
   const doc = document.implementation.createHTMLDocument('');
@@ -29,8 +28,6 @@ function getTestDocument(markup) {
 
 describe('ReactTestUtils', () => {
   beforeEach(() => {
-    ReactFeatureFlags = require('shared/ReactFeatureFlags');
-    ReactFeatureFlags.enableHooks = true;
     createRenderer = require('react-test-renderer/shallow').createRenderer;
     React = require('react');
     ReactDOM = require('react-dom');
@@ -517,28 +514,5 @@ describe('ReactTestUtils', () => {
 
     ReactTestUtils.renderIntoDocument(<Component />);
     expect(mockArgs.length).toEqual(0);
-  });
-
-  it('flushEffects should run any enqueued effects', () => {
-    let effected = false;
-    let layoutEffected = false;
-    function App() {
-      React.useEffect(() => {
-        effected = true;
-      });
-      React.useLayoutEffect(() => {
-        layoutEffected = true;
-      });
-      return null;
-    }
-    ReactTestUtils.renderIntoDocument(<App />);
-    // effects haven't fired yet
-    expect(effected).toBe(false);
-    // layout effects have, however
-    expect(layoutEffected).toBe(true);
-
-    ReactTestUtils.flushEffects();
-    // effects have now fired
-    expect(effected).toBe(true);
   });
 });

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -519,7 +519,7 @@ describe('ReactTestUtils', () => {
     expect(mockArgs.length).toEqual(0);
   });
 
-  it('flushEffects should flush effects, duh', () => {
+  it('flushEffects should run any enqueued effects', () => {
     let effected = false;
     let layoutEffected = false;
     function App() {

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -811,7 +811,6 @@ const ReactDOM: Object = {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // Keep in sync with ReactDOMUnstableNativeDependencies.js
     // and ReactTestUtils.js. This is an array for better minification.
-    flushPassiveEffects,
     Events: [
       getInstanceFromNode,
       getNodeFromInstance,
@@ -824,6 +823,7 @@ const ReactDOM: Object = {
       restoreStateIfNeeded,
       dispatchEvent,
       runEventsInBatch,
+      flushPassiveEffects,
     ],
   },
 };

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -35,6 +35,7 @@ import {
   getPublicRootInstance,
   findHostInstance,
   findHostInstanceWithWarning,
+  flushPassiveEffects,
 } from 'react-reconciler/inline.dom';
 import {createPortal as createPortalImpl} from 'shared/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
@@ -810,6 +811,7 @@ const ReactDOM: Object = {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // Keep in sync with ReactDOMUnstableNativeDependencies.js
     // and ReactTestUtils.js. This is an array for better minification.
+    flushPassiveEffects,
     Events: [
       getInstanceFromNode,
       getNodeFromInstance,

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -40,6 +40,7 @@ import {
   getPublicRootInstance,
   findHostInstance,
   findHostInstanceWithWarning,
+  flushPassiveEffects,
 } from 'react-reconciler/inline.fire';
 import {createPortal as createPortalImpl} from 'shared/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
@@ -827,6 +828,7 @@ const ReactDOM: Object = {
       restoreStateIfNeeded,
       dispatchEvent,
       runEventsInBatch,
+      flushPassiveEffects,
     ],
   },
 };

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -22,10 +22,6 @@ import {ELEMENT_NODE} from '../shared/HTMLNodeType';
 import * as DOMTopLevelEventTypes from '../events/DOMTopLevelEventTypes';
 
 const {findDOMNode} = ReactDOM;
-const {
-  Events,
-  flushPassiveEffects,
-} = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 // Keep in sync with ReactDOMUnstableNativeDependencies.js
 // and ReactDOM.js:
 const [
@@ -42,7 +38,8 @@ const [
   restoreStateIfNeeded,
   dispatchEvent,
   runEventsInBatch,
-] = Events;
+  flushPassiveEffects,
+] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
 
 function Event(suffix) {}
 

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -22,6 +22,10 @@ import {ELEMENT_NODE} from '../shared/HTMLNodeType';
 import * as DOMTopLevelEventTypes from '../events/DOMTopLevelEventTypes';
 
 const {findDOMNode} = ReactDOM;
+const {
+  Events,
+  flushPassiveEffects,
+} = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 // Keep in sync with ReactDOMUnstableNativeDependencies.js
 // and ReactDOM.js:
 const [
@@ -38,7 +42,7 @@ const [
   restoreStateIfNeeded,
   dispatchEvent,
   runEventsInBatch,
-] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
+] = Events;
 
 function Event(suffix) {}
 
@@ -380,6 +384,8 @@ const ReactTestUtils = {
 
   Simulate: null,
   SimulateNative: {},
+
+  flushEffects: flushPassiveEffects,
 };
 
 /**

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -310,6 +310,7 @@ export {
   flushInteractiveUpdates,
   flushControlled,
   flushSync,
+  flushPassiveEffects,
 };
 
 export function getPublicRootInstance(


### PR DESCRIPTION
exposes flushEffects on TestUtils, letting testing libs to manually flush effects when testing their components. added a test. I'll update the docs/readmes if you folks think this a good approach. 
