### PR TITLE
Make all readContext() and Hook-in-a-Hook checks DEV-only

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
@@ -419,50 +419,47 @@ describe('ReactDOMServerHooks', () => {
       },
     );
 
-    itThrowsWhenRendering(
-      'a hook inside useMemo',
-      async render => {
-        function App() {
-          useMemo(() => {
-            useState();
-            return 0;
-          });
-          return null;
-        }
-        return render(<App />);
-      },
-      'Hooks can only be called inside the body of a function component.',
-    );
+    itRenders('with a warning for useState inside useMemo', async render => {
+      function App() {
+        useMemo(() => {
+          useState();
+          return 0;
+        });
+        return 'hi';
+      }
 
-    itThrowsWhenRendering(
-      'a hook inside useReducer',
-      async render => {
-        function App() {
-          const [value, dispatch] = useReducer((state, action) => {
-            useRef(0);
-            return state;
-          }, 0);
-          dispatch('foo');
-          return value;
-        }
-        return render(<App />);
-      },
-      'Hooks can only be called inside the body of a function component.',
-    );
+      const domNode = await render(<App />, 1);
+      expect(domNode.textContent).toEqual('hi');
+    });
 
-    itThrowsWhenRendering(
-      'a hook inside useState',
-      async render => {
-        function App() {
-          useState(() => {
-            useRef(0);
-            return 0;
-          });
+    itRenders('with a warning for useRef inside useReducer', async render => {
+      function App() {
+        const [value, dispatch] = useReducer((state, action) => {
+          useRef(0);
+          return state + 1;
+        }, 0);
+        if (value === 0) {
+          dispatch();
         }
-        return render(<App />);
-      },
-      'Hooks can only be called inside the body of a function component.',
-    );
+        return value;
+      }
+
+      const domNode = await render(<App />, 1);
+      expect(domNode.textContent).toEqual('1');
+    });
+
+    itRenders('with a warning for useRef inside useState', async render => {
+      function App() {
+        const [value] = useState(() => {
+          useRef(0);
+          return 0;
+        });
+        return value;
+      }
+
+      const domNode = await render(<App />, 1);
+      expect(domNode.textContent).toEqual('0');
+    });
   });
 
   describe('useRef', () => {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
@@ -716,4 +716,36 @@ describe('ReactDOMServerHooks', () => {
       expect(domNode.textContent).toEqual('undefined');
     });
   });
+
+  describe('readContext', () => {
+    function readContext(Context, observedBits) {
+      const dispatcher =
+        React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+          .ReactCurrentDispatcher.current;
+      return dispatcher.readContext(Context, observedBits);
+    }
+
+    itRenders('with a warning inside useMemo and useReducer', async render => {
+      const Context = React.createContext(42);
+
+      function ReadInMemo(props) {
+        let count = React.useMemo(() => readContext(Context), []);
+        return <Text text={count} />;
+      }
+
+      function ReadInReducer(props) {
+        let [count, dispatch] = React.useReducer(() => readContext(Context));
+        if (count !== 42) {
+          dispatch();
+        }
+        return <Text text={count} />;
+      }
+
+      const domNode1 = await render(<ReadInMemo />, 1);
+      expect(domNode1.textContent).toEqual('42');
+
+      const domNode2 = await render(<ReadInReducer />, 1);
+      expect(domNode2.textContent).toEqual('42');
+    });
+  });
 });

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -15,8 +15,8 @@ import type {HookEffectTag} from './ReactHookEffectTags';
 import {NoWork} from './ReactFiberExpirationTime';
 import {
   readContext,
-  stashContextDependencies,
-  unstashContextDependencies,
+  stashContextDependenciesInDEV,
+  unstashContextDependenciesInDEV,
 } from './ReactFiberNewContext';
 import {
   Update as UpdateEffect,
@@ -599,10 +599,14 @@ export function useReducer<S, A>(
             const action = update.action;
             // Temporarily clear to forbid calling Hooks in a reducer.
             currentlyRenderingFiber = null;
-            stashContextDependencies();
+            if (__DEV__) {
+              stashContextDependenciesInDEV();
+            }
             newState = reducer(newState, action);
             currentlyRenderingFiber = fiber;
-            unstashContextDependencies();
+            if (__DEV__) {
+              unstashContextDependenciesInDEV();
+            }
             update = update.next;
           } while (update !== null);
 
@@ -673,10 +677,14 @@ export function useReducer<S, A>(
             const action = update.action;
             // Temporarily clear to forbid calling Hooks in a reducer.
             currentlyRenderingFiber = null;
-            stashContextDependencies();
+            if (__DEV__) {
+              stashContextDependenciesInDEV();
+            }
             newState = reducer(newState, action);
             currentlyRenderingFiber = fiber;
-            unstashContextDependencies();
+            if (__DEV__) {
+              unstashContextDependenciesInDEV();
+            }
           }
         }
         prevUpdate = update;
@@ -707,7 +715,9 @@ export function useReducer<S, A>(
   }
   // Temporarily clear to forbid calling Hooks in a reducer.
   currentlyRenderingFiber = null;
-  stashContextDependencies();
+  if (__DEV__) {
+    stashContextDependenciesInDEV();
+  }
   // There's no existing queue, so this is the initial render.
   if (reducer === basicStateReducer) {
     // Special case for `useState`.
@@ -718,7 +728,9 @@ export function useReducer<S, A>(
     initialState = reducer(initialState, initialAction);
   }
   currentlyRenderingFiber = fiber;
-  unstashContextDependencies();
+  if (__DEV__) {
+    unstashContextDependenciesInDEV();
+  }
   workInProgressHook.memoizedState = workInProgressHook.baseState = initialState;
   queue = workInProgressHook.queue = {
     last: null,
@@ -962,10 +974,14 @@ export function useMemo<T>(
 
   // Temporarily clear to forbid calling Hooks.
   currentlyRenderingFiber = null;
-  stashContextDependencies();
+  if (__DEV__) {
+    stashContextDependenciesInDEV();
+  }
   const nextValue = nextCreate();
   currentlyRenderingFiber = fiber;
-  unstashContextDependencies();
+  if (__DEV__) {
+    unstashContextDependenciesInDEV();
+  }
   workInProgressHook.memoizedState = [nextValue, nextDeps];
   if (__DEV__) {
     currentHookNameInDev = null;
@@ -1066,10 +1082,14 @@ function dispatchAction<S, A>(
           // Temporarily clear to forbid calling Hooks in a reducer.
           let maybeFiber = currentlyRenderingFiber; // Note: likely null now unlike `fiber`
           currentlyRenderingFiber = null;
-          stashContextDependencies();
+          if (__DEV__) {
+            stashContextDependenciesInDEV();
+          }
           const eagerState = eagerReducer(currentState, action);
           currentlyRenderingFiber = maybeFiber;
-          unstashContextDependencies();
+          if (__DEV__) {
+            unstashContextDependenciesInDEV();
+          }
           // Stash the eagerly computed state, and the reducer used to compute
           // it, on the update object. If the reducer hasn't changed by the
           // time we enter the render phase, then the eager state can be used

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -311,6 +311,11 @@ export function renderWithHooks(
   currentlyRenderingFiber = workInProgress;
   firstCurrentHook = current !== null ? current.memoizedState : null;
 
+  if (__DEV__) {
+    exitDisallowedContextReadInDEV();
+    isInHookUserCodeInDev = false;
+  }
+
   // The following should have already been reset
   // currentHook = null;
   // workInProgressHook = null;
@@ -407,6 +412,8 @@ export function bailoutHooks(
 export function resetHooks(): void {
   if (__DEV__) {
     flushHookMismatchWarnings();
+    exitDisallowedContextReadInDEV();
+    isInHookUserCodeInDev = false;
   }
 
   // This is used to reset the state of this module when a component throws.
@@ -1113,6 +1120,7 @@ function dispatchAction<S, A>(
           // Suppress the error. It will throw again in the render phase.
         } finally {
           if (__DEV__) {
+            exitDisallowedContextReadInDEV();
             isInHookUserCodeInDev = false;
           }
         }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -15,8 +15,8 @@ import type {HookEffectTag} from './ReactHookEffectTags';
 import {NoWork} from './ReactFiberExpirationTime';
 import {
   readContext,
-  stashContextDependenciesInDEV,
-  unstashContextDependenciesInDEV,
+  enterDisallowedContextReadInDEV,
+  exitDisallowedContextReadInDEV,
 } from './ReactFiberNewContext';
 import {
   Update as UpdateEffect,
@@ -610,12 +610,12 @@ export function useReducer<S, A>(
             // render's.
             const action = update.action;
             if (__DEV__) {
-              stashContextDependenciesInDEV();
+              enterDisallowedContextReadInDEV();
               isInHookUserCodeInDev = true;
             }
             newState = reducer(newState, action);
             if (__DEV__) {
-              unstashContextDependenciesInDEV();
+              exitDisallowedContextReadInDEV();
               isInHookUserCodeInDev = false;
             }
             update = update.next;
@@ -687,12 +687,12 @@ export function useReducer<S, A>(
           } else {
             const action = update.action;
             if (__DEV__) {
-              stashContextDependenciesInDEV();
+              enterDisallowedContextReadInDEV();
               isInHookUserCodeInDev = true;
             }
             newState = reducer(newState, action);
             if (__DEV__) {
-              unstashContextDependenciesInDEV();
+              exitDisallowedContextReadInDEV();
               isInHookUserCodeInDev = false;
             }
           }
@@ -724,7 +724,7 @@ export function useReducer<S, A>(
     return [workInProgressHook.memoizedState, dispatch];
   }
   if (__DEV__) {
-    stashContextDependenciesInDEV();
+    enterDisallowedContextReadInDEV();
     isInHookUserCodeInDev = true;
   }
   // There's no existing queue, so this is the initial render.
@@ -737,7 +737,7 @@ export function useReducer<S, A>(
     initialState = reducer(initialState, initialAction);
   }
   if (__DEV__) {
-    unstashContextDependenciesInDEV();
+    exitDisallowedContextReadInDEV();
     isInHookUserCodeInDev = false;
   }
   workInProgressHook.memoizedState = workInProgressHook.baseState = initialState;
@@ -982,12 +982,12 @@ export function useMemo<T>(
   }
 
   if (__DEV__) {
-    stashContextDependenciesInDEV();
+    enterDisallowedContextReadInDEV();
     isInHookUserCodeInDev = true;
   }
   const nextValue = nextCreate();
   if (__DEV__) {
-    unstashContextDependenciesInDEV();
+    exitDisallowedContextReadInDEV();
     isInHookUserCodeInDev = false;
   }
   workInProgressHook.memoizedState = [nextValue, nextDeps];
@@ -1088,12 +1088,12 @@ function dispatchAction<S, A>(
         try {
           const currentState: S = (queue.eagerState: any);
           if (__DEV__) {
-            stashContextDependenciesInDEV();
+            enterDisallowedContextReadInDEV();
             isInHookUserCodeInDev = true;
           }
           const eagerState = eagerReducer(currentState, action);
           if (__DEV__) {
-            unstashContextDependenciesInDEV();
+            exitDisallowedContextReadInDEV();
             isInHookUserCodeInDev = false;
           }
           // Stash the eagerly computed state, and the reducer used to compute

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -72,6 +72,7 @@ type HookType =
 // the first instance of a hook mismatch in a component,
 // represented by a portion of it's stacktrace
 let currentHookMismatchInDev = null;
+let isInHookUserCodeInDev = false;
 
 let didWarnAboutMismatchedHooksForComponent;
 if (__DEV__) {
@@ -153,6 +154,17 @@ function resolveCurrentlyRenderingFiber(): Fiber {
     currentlyRenderingFiber !== null,
     'Hooks can only be called inside the body of a function component.',
   );
+  if (__DEV__) {
+    // Check if we're inside Hooks like useMemo(). DEV-only for perf.
+    // TODO: we can make a better warning message with currentHookNameInDev
+    // if we also make sure it's consistently assigned in the right order.
+    warning(
+      !isInHookUserCodeInDev,
+      'Hooks can only be called inside the body of a function component. ' +
+        'Do not call Hooks inside other Hooks. For more information, see ' +
+        'https://fb.me/rules-of-hooks',
+    );
+  }
   return currentlyRenderingFiber;
 }
 
@@ -573,7 +585,7 @@ export function useReducer<S, A>(
       currentHookNameInDev = 'useReducer';
     }
   }
-  let fiber = (currentlyRenderingFiber = resolveCurrentlyRenderingFiber());
+  currentlyRenderingFiber = resolveCurrentlyRenderingFiber();
   workInProgressHook = createWorkInProgressHook();
   if (__DEV__) {
     currentHookNameInDev = null;
@@ -597,15 +609,14 @@ export function useReducer<S, A>(
             // priority because it will always be the same as the current
             // render's.
             const action = update.action;
-            // Temporarily clear to forbid calling Hooks in a reducer.
-            currentlyRenderingFiber = null;
             if (__DEV__) {
               stashContextDependenciesInDEV();
+              isInHookUserCodeInDev = true;
             }
             newState = reducer(newState, action);
-            currentlyRenderingFiber = fiber;
             if (__DEV__) {
               unstashContextDependenciesInDEV();
+              isInHookUserCodeInDev = false;
             }
             update = update.next;
           } while (update !== null);
@@ -675,15 +686,14 @@ export function useReducer<S, A>(
             newState = ((update.eagerState: any): S);
           } else {
             const action = update.action;
-            // Temporarily clear to forbid calling Hooks in a reducer.
-            currentlyRenderingFiber = null;
             if (__DEV__) {
               stashContextDependenciesInDEV();
+              isInHookUserCodeInDev = true;
             }
             newState = reducer(newState, action);
-            currentlyRenderingFiber = fiber;
             if (__DEV__) {
               unstashContextDependenciesInDEV();
+              isInHookUserCodeInDev = false;
             }
           }
         }
@@ -713,10 +723,9 @@ export function useReducer<S, A>(
     const dispatch: Dispatch<A> = (queue.dispatch: any);
     return [workInProgressHook.memoizedState, dispatch];
   }
-  // Temporarily clear to forbid calling Hooks in a reducer.
-  currentlyRenderingFiber = null;
   if (__DEV__) {
     stashContextDependenciesInDEV();
+    isInHookUserCodeInDev = true;
   }
   // There's no existing queue, so this is the initial render.
   if (reducer === basicStateReducer) {
@@ -727,9 +736,9 @@ export function useReducer<S, A>(
   } else if (initialAction !== undefined && initialAction !== null) {
     initialState = reducer(initialState, initialAction);
   }
-  currentlyRenderingFiber = fiber;
   if (__DEV__) {
     unstashContextDependenciesInDEV();
+    isInHookUserCodeInDev = false;
   }
   workInProgressHook.memoizedState = workInProgressHook.baseState = initialState;
   queue = workInProgressHook.queue = {
@@ -953,7 +962,7 @@ export function useMemo<T>(
   if (__DEV__) {
     currentHookNameInDev = 'useMemo';
   }
-  let fiber = (currentlyRenderingFiber = resolveCurrentlyRenderingFiber());
+  currentlyRenderingFiber = resolveCurrentlyRenderingFiber();
   workInProgressHook = createWorkInProgressHook();
 
   const nextDeps = deps === undefined ? null : deps;
@@ -972,15 +981,14 @@ export function useMemo<T>(
     }
   }
 
-  // Temporarily clear to forbid calling Hooks.
-  currentlyRenderingFiber = null;
   if (__DEV__) {
     stashContextDependenciesInDEV();
+    isInHookUserCodeInDev = true;
   }
   const nextValue = nextCreate();
-  currentlyRenderingFiber = fiber;
   if (__DEV__) {
     unstashContextDependenciesInDEV();
+    isInHookUserCodeInDev = false;
   }
   workInProgressHook.memoizedState = [nextValue, nextDeps];
   if (__DEV__) {
@@ -1079,16 +1087,14 @@ function dispatchAction<S, A>(
       if (eagerReducer !== null) {
         try {
           const currentState: S = (queue.eagerState: any);
-          // Temporarily clear to forbid calling Hooks in a reducer.
-          let maybeFiber = currentlyRenderingFiber; // Note: likely null now unlike `fiber`
-          currentlyRenderingFiber = null;
           if (__DEV__) {
             stashContextDependenciesInDEV();
+            isInHookUserCodeInDev = true;
           }
           const eagerState = eagerReducer(currentState, action);
-          currentlyRenderingFiber = maybeFiber;
           if (__DEV__) {
             unstashContextDependenciesInDEV();
+            isInHookUserCodeInDev = false;
           }
           // Stash the eagerly computed state, and the reducer used to compute
           // it, on the update object. If the reducer hasn't changed by the
@@ -1105,6 +1111,10 @@ function dispatchAction<S, A>(
           }
         } catch (error) {
           // Suppress the error. It will throw again in the render phase.
+        } finally {
+          if (__DEV__) {
+            isInHookUserCodeInDev = false;
+          }
         }
       }
     }

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -52,10 +52,8 @@ let currentlyRenderingFiber: Fiber | null = null;
 let lastContextDependency: ContextDependency<mixed> | null = null;
 let lastContextWithAllBitsObserved: ReactContext<any> | null = null;
 
-// We stash the variables above before entering user code in Hooks.
-let stashedCurrentlyRenderingFiber: Fiber | null = null;
-let stashedLastContextDependency: ContextDependency<mixed> | null = null;
-let stashedLastContextWithAllBitsObserved: ReactContext<any> | null = null;
+// Used in DEV to track whether reading context should warn.
+let areContextDependenciesStashedInDEV: boolean = false;
 
 export function resetContextDependences(): void {
   // This is called right before React yields execution, to ensure `readContext`
@@ -63,26 +61,21 @@ export function resetContextDependences(): void {
   currentlyRenderingFiber = null;
   lastContextDependency = null;
   lastContextWithAllBitsObserved = null;
-
-  stashedCurrentlyRenderingFiber = null;
-  stashedLastContextDependency = null;
-  stashedLastContextWithAllBitsObserved = null;
+  if (__DEV__) {
+    areContextDependenciesStashedInDEV = false;
+  }
 }
 
-export function stashContextDependencies(): void {
-  stashedCurrentlyRenderingFiber = currentlyRenderingFiber;
-  stashedLastContextDependency = lastContextDependency;
-  stashedLastContextWithAllBitsObserved = lastContextWithAllBitsObserved;
-
-  currentlyRenderingFiber = null;
-  lastContextDependency = null;
-  lastContextWithAllBitsObserved = null;
+export function stashContextDependenciesInDEV(): void {
+  if (__DEV__) {
+    areContextDependenciesStashedInDEV = true;
+  }
 }
 
-export function unstashContextDependencies(): void {
-  currentlyRenderingFiber = stashedCurrentlyRenderingFiber;
-  lastContextDependency = stashedLastContextDependency;
-  lastContextWithAllBitsObserved = stashedLastContextWithAllBitsObserved;
+export function unstashContextDependenciesInDEV(): void {
+  if (__DEV__) {
+    areContextDependenciesStashedInDEV = false;
+  }
 }
 
 export function pushProvider<T>(providerFiber: Fiber, nextValue: T): void {
@@ -304,6 +297,18 @@ export function readContext<T>(
   context: ReactContext<T>,
   observedBits: void | number | boolean,
 ): T {
+  if (__DEV__) {
+    // This warning would fire if you read context inside a Hook like useMemo.
+    // Unlike the class check below, it's not enforced in production for perf.
+    warning(
+      !areContextDependenciesStashedInDEV,
+      'Context can only be read while React is rendering. ' +
+        'In classes, you can read it in the render method or getDerivedStateFromProps. ' +
+        'In function components, you can read it directly in the function body, but not ' +
+        'inside Hooks like useReducer() or useMemo().',
+    );
+  }
+
   if (lastContextWithAllBitsObserved === context) {
     // Nothing to do. We already observe everything in this context.
   } else if (observedBits === false || observedBits === 0) {

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -52,8 +52,7 @@ let currentlyRenderingFiber: Fiber | null = null;
 let lastContextDependency: ContextDependency<mixed> | null = null;
 let lastContextWithAllBitsObserved: ReactContext<any> | null = null;
 
-// Used in DEV to track whether reading context should warn.
-let areContextDependenciesStashedInDEV: boolean = false;
+let isDisallowedContextReadInDEV: boolean = false;
 
 export function resetContextDependences(): void {
   // This is called right before React yields execution, to ensure `readContext`
@@ -62,19 +61,19 @@ export function resetContextDependences(): void {
   lastContextDependency = null;
   lastContextWithAllBitsObserved = null;
   if (__DEV__) {
-    areContextDependenciesStashedInDEV = false;
+    isDisallowedContextReadInDEV = false;
   }
 }
 
-export function stashContextDependenciesInDEV(): void {
+export function enterDisallowedContextReadInDEV(): void {
   if (__DEV__) {
-    areContextDependenciesStashedInDEV = true;
+    isDisallowedContextReadInDEV = true;
   }
 }
 
-export function unstashContextDependenciesInDEV(): void {
+export function exitDisallowedContextReadInDEV(): void {
   if (__DEV__) {
-    areContextDependenciesStashedInDEV = false;
+    isDisallowedContextReadInDEV = false;
   }
 }
 
@@ -301,7 +300,7 @@ export function readContext<T>(
     // This warning would fire if you read context inside a Hook like useMemo.
     // Unlike the class check below, it's not enforced in production for perf.
     warning(
-      !areContextDependenciesStashedInDEV,
+      !isDisallowedContextReadInDEV,
       'Context can only be read while React is rendering. ' +
         'In classes, you can read it in the render method or getDerivedStateFromProps. ' +
         'In function components, you can read it directly in the function body, but not ' +

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -88,6 +88,10 @@ import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
 import {NoWork} from './ReactFiberExpirationTime';
+import {
+  stashContextDependenciesInDEV,
+  unstashContextDependenciesInDEV,
+} from './ReactFiberNewContext';
 import {Callback, ShouldCapture, DidCapture} from 'shared/ReactSideEffectTags';
 import {ClassComponent} from 'shared/ReactWorkTags';
 
@@ -348,6 +352,7 @@ function getStateFromUpdate<State>(
       if (typeof payload === 'function') {
         // Updater function
         if (__DEV__) {
+          stashContextDependenciesInDEV();
           if (
             debugRenderPhaseSideEffects ||
             (debugRenderPhaseSideEffectsForStrictMode &&
@@ -356,7 +361,11 @@ function getStateFromUpdate<State>(
             payload.call(instance, prevState, nextProps);
           }
         }
-        return payload.call(instance, prevState, nextProps);
+        const nextState = payload.call(instance, prevState, nextProps);
+        if (__DEV__) {
+          unstashContextDependenciesInDEV();
+        }
+        return nextState;
       }
       // State object
       return payload;
@@ -372,6 +381,7 @@ function getStateFromUpdate<State>(
       if (typeof payload === 'function') {
         // Updater function
         if (__DEV__) {
+          stashContextDependenciesInDEV();
           if (
             debugRenderPhaseSideEffects ||
             (debugRenderPhaseSideEffectsForStrictMode &&
@@ -381,6 +391,9 @@ function getStateFromUpdate<State>(
           }
         }
         partialState = payload.call(instance, prevState, nextProps);
+        if (__DEV__) {
+          unstashContextDependenciesInDEV();
+        }
       } else {
         // Partial state object
         partialState = payload;

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -89,8 +89,8 @@ import type {ExpirationTime} from './ReactFiberExpirationTime';
 
 import {NoWork} from './ReactFiberExpirationTime';
 import {
-  stashContextDependenciesInDEV,
-  unstashContextDependenciesInDEV,
+  enterDisallowedContextReadInDEV,
+  exitDisallowedContextReadInDEV,
 } from './ReactFiberNewContext';
 import {Callback, ShouldCapture, DidCapture} from 'shared/ReactSideEffectTags';
 import {ClassComponent} from 'shared/ReactWorkTags';
@@ -352,7 +352,7 @@ function getStateFromUpdate<State>(
       if (typeof payload === 'function') {
         // Updater function
         if (__DEV__) {
-          stashContextDependenciesInDEV();
+          enterDisallowedContextReadInDEV();
           if (
             debugRenderPhaseSideEffects ||
             (debugRenderPhaseSideEffectsForStrictMode &&
@@ -363,7 +363,7 @@ function getStateFromUpdate<State>(
         }
         const nextState = payload.call(instance, prevState, nextProps);
         if (__DEV__) {
-          unstashContextDependenciesInDEV();
+          exitDisallowedContextReadInDEV();
         }
         return nextState;
       }
@@ -381,7 +381,7 @@ function getStateFromUpdate<State>(
       if (typeof payload === 'function') {
         // Updater function
         if (__DEV__) {
-          stashContextDependenciesInDEV();
+          enterDisallowedContextReadInDEV();
           if (
             debugRenderPhaseSideEffects ||
             (debugRenderPhaseSideEffectsForStrictMode &&
@@ -392,7 +392,7 @@ function getStateFromUpdate<State>(
         }
         partialState = payload.call(instance, prevState, nextProps);
         if (__DEV__) {
-          unstashContextDependenciesInDEV();
+          exitDisallowedContextReadInDEV();
         }
       } else {
         // Partial state object

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -671,7 +671,7 @@ describe('ReactHooks', () => {
     expect(root.toJSON()).toEqual('123');
   });
 
-  it('throws when reading context inside useMemo', () => {
+  it('warns when reading context inside useMemo', () => {
     const {useMemo, createContext} = React;
     const ReactCurrentDispatcher =
       React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
@@ -684,12 +684,12 @@ describe('ReactHooks', () => {
       }, []);
     }
 
-    expect(() => ReactTestRenderer.create(<App />)).toThrow(
+    expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
       'Context can only be read while React is rendering',
     );
   });
 
-  it('throws when reading context inside useMemo after reading outside it', () => {
+  it('warns when reading context inside useMemo after reading outside it', () => {
     const {useMemo, createContext} = React;
     const ReactCurrentDispatcher =
       React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
@@ -706,13 +706,14 @@ describe('ReactHooks', () => {
       }, []);
     }
 
-    expect(() => ReactTestRenderer.create(<App />)).toThrow(
+    expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
       'Context can only be read while React is rendering',
     );
     expect(firstRead).toBe('light');
     expect(secondRead).toBe('light');
   });
 
+  // Throws because there's no runtime cost for being strict here.
   it('throws when reading context inside useEffect', () => {
     const {useEffect, createContext} = React;
     const ReactCurrentDispatcher =
@@ -734,6 +735,7 @@ describe('ReactHooks', () => {
     );
   });
 
+  // Throws because there's no runtime cost for being strict here.
   it('throws when reading context inside useLayoutEffect', () => {
     const {useLayoutEffect, createContext} = React;
     const ReactCurrentDispatcher =
@@ -754,7 +756,7 @@ describe('ReactHooks', () => {
     );
   });
 
-  it('throws when reading context inside useReducer', () => {
+  it('warns when reading context inside useReducer', () => {
     const {useReducer, createContext} = React;
     const ReactCurrentDispatcher =
       React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
@@ -772,13 +774,13 @@ describe('ReactHooks', () => {
       return null;
     }
 
-    expect(() => ReactTestRenderer.create(<App />)).toThrow(
+    expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
       'Context can only be read while React is rendering',
     );
   });
 
   // Edge case.
-  it('throws when reading context inside eager useReducer', () => {
+  it('warns when reading context inside eager useReducer', () => {
     const {useState, createContext} = React;
     const ThemeContext = createContext('light');
 
@@ -809,7 +811,7 @@ describe('ReactHooks', () => {
           <Cls />
         </React.Fragment>,
       ),
-    ).toThrow('Context can only be read while React is rendering');
+    ).toWarnDev('Context can only be read while React is rendering');
   });
 
   it('throws when calling hooks inside useReducer', () => {

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -646,29 +646,17 @@ describe('ReactHooks', () => {
     );
   });
 
-  it('throws when calling hooks inside useMemo', () => {
+  it('warns when calling hooks inside useMemo', () => {
     const {useMemo, useState} = React;
     function App() {
       useMemo(() => {
         useState(0);
-        return 1;
       });
       return null;
     }
-
-    function Simple() {
-      const [value] = useState(123);
-      return value;
-    }
-    let root = ReactTestRenderer.create(null);
-    expect(() => root.update(<App />)).toThrow(
+    expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
       'Hooks can only be called inside the body of a function component',
     );
-
-    // we want to assure that no hook machinery has broken
-    // so we render a fresh component with a hook just to be sure
-    root.update(<Simple />);
-    expect(root.toJSON()).toEqual('123');
   });
 
   it('warns when reading context inside useMemo', () => {
@@ -814,17 +802,19 @@ describe('ReactHooks', () => {
     ).toWarnDev('Context can only be read while React is rendering');
   });
 
-  it('throws when calling hooks inside useReducer', () => {
+  it('warns when calling hooks inside useReducer', () => {
     const {useReducer, useRef} = React;
     function App() {
       const [value, dispatch] = useReducer((state, action) => {
         useRef(0);
-        return state;
+        return state + 1;
       }, 0);
-      dispatch('foo');
+      if (value === 0) {
+        dispatch('foo');
+      }
       return value;
     }
-    expect(() => ReactTestRenderer.create(<App />)).toThrow(
+    expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
       'Hooks can only be called inside the body of a function component',
     );
   });
@@ -836,8 +826,9 @@ describe('ReactHooks', () => {
         useRef(0);
         return 0;
       });
+      return null;
     }
-    expect(() => ReactTestRenderer.create(<App />)).toThrow(
+    expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
       'Hooks can only be called inside the body of a function component',
     );
   });
@@ -1125,6 +1116,38 @@ describe('ReactHooks', () => {
         '   -------------------------------\n' +
         '1. useReducer         useState\n' +
         '   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^',
+    ]);
+  });
+
+  // Regression test for #14674
+  it('does not swallow original error when updating another component in render phase', () => {
+    let {useState} = React;
+
+    let _setState;
+    function A() {
+      const [, setState] = useState(0);
+      _setState = setState;
+      return null;
+    }
+
+    function B() {
+      _setState(() => {
+        throw new Error('Hello');
+      });
+      return null;
+    }
+
+    expect(() =>
+      expect(() =>
+        ReactTestRenderer.create(
+          <React.Fragment>
+            <A />
+            <B />
+          </React.Fragment>,
+        ),
+      ).toThrow('Hello'),
+    ).toWarnDev([
+      'Hooks can only be called inside the body of a function component',
     ]);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1346,6 +1346,31 @@ describe('ReactNewContext', () => {
       expect(ReactNoop.flush()).toEqual(['App', 'App#renderConsumer']);
       expect(ReactNoop.getChildren()).toEqual([span('goodbye')]);
     });
+
+    it('warns when reading context inside render phase class setState updater', () => {
+      const ThemeContext = React.createContext('light');
+
+      class Cls extends React.Component {
+        state = {};
+        render() {
+          this.setState(() => {
+            readContext(ThemeContext);
+          });
+          return null;
+        }
+      }
+
+      ReactNoop.render(<Cls />);
+      expect(ReactNoop.flush).toWarnDev(
+        [
+          'Context can only be read while React is rendering',
+          'Cannot update during an existing state transition',
+        ],
+        {
+          withoutStack: 1,
+        },
+      );
+    });
   });
 
   describe('useContext', () => {


### PR DESCRIPTION
* Changes it to be DEV-only
* Implements it for SSR
* Adds a similar DEV-only check for render phase class updates
* Changes all Hooks-in-Hooks warnings to similarly be DEV-only, removing the flaky current variable reassignment that led to bugs (includes a regression test)