### PR TITLE
Warn when creating multiple React roots on the same container

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -474,4 +474,23 @@ describe('ReactDOMRoot', () => {
       {withoutStack: true},
     );
   });
+
+  it('warns when calling createRoot() multiple times on the same container', () => {
+    const root = ReactDOM.unstable_createRoot(container);
+    root.render(<div>Hi</div>);
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('Hi');
+    expect(() => {
+      ReactDOM.unstable_createRoot(container);
+    }).toWarnDev(
+      [
+        'You are calling ReactDOM.unstable_createRoot() on a container where ' +
+          'ReactDOM.unstable_createRoot() was already called on. This is not ' +
+          'supported.',
+      ],
+      {withoutStack: true},
+    );
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('Hi');
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -508,4 +508,14 @@ describe('ReactDOMRoot', () => {
     jest.runAllTimers();
     expect(container.textContent).toEqual('Ho');
   });
+
+  it('allows calling createRoot() multiple times if the root is unmounted in sync', () => {
+    const root = ReactDOM.unstable_createRoot(container);
+    root.render(<div>Hi</div>);
+    root.unmount();
+    const root2 = ReactDOM.unstable_createRoot(container);
+    root2.render(<div>Ho</div>);
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('Ho');
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -493,4 +493,19 @@ describe('ReactDOMRoot', () => {
     jest.runAllTimers();
     expect(container.textContent).toEqual('Hi');
   });
+
+  it('allows calling createRoot() multiple times if the root is unmounted', () => {
+    const root = ReactDOM.unstable_createRoot(container);
+    root.render(<div>Hi</div>);
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('Hi');
+    root.unmount();
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('');
+
+    const root2 = ReactDOM.unstable_createRoot(container);
+    root2.render(<div>Ho</div>);
+    jest.runAllTimers();
+    expect(container.textContent).toEqual('Ho');
+  });
 });

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -392,6 +392,7 @@ ReactRoot.prototype.unmount = function(callback: ?() => mixed): Work {
   callback = callback === undefined ? null : callback;
   if (__DEV__) {
     warnOnInvalidCallback(callback, 'render');
+    root.containerInfo._reactHasBeenPassedToCreateRootDEV = null;
   }
   if (callback !== null) {
     work.then(callback);

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -846,6 +846,13 @@ function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
         'passed to ReactDOM.render(). This is not supported.',
       enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
     );
+    warningWithoutStack(
+      !container._reactHasBeenPassedToCreateRootDEV,
+      'You are calling ReactDOM.%s() on a container where ReactDOM.%s() was ' +
+        'already called on. This is not supported.',
+      enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
+      enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
+    );
     container._reactHasBeenPassedToCreateRootDEV = true;
   }
   const hydrate = options != null && options.hydrate === true;

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -851,6 +851,13 @@ function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
         'passed to ReactDOM.render(). This is not supported.',
       enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
     );
+    warningWithoutStack(
+      !container._reactHasBeenPassedToCreateRootDEV,
+      'You are calling ReactDOM.%s() on a container where ReactDOM.%s() was ' +
+        'already called on. This is not supported.',
+      enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
+      enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
+    );
     container._reactHasBeenPassedToCreateRootDEV = true;
   }
   const hydrate = options != null && options.hydrate === true;

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -397,6 +397,7 @@ ReactRoot.prototype.unmount = function(callback: ?() => mixed): Work {
   callback = callback === undefined ? null : callback;
   if (__DEV__) {
     warnOnInvalidCallback(callback, 'render');
+    root.containerInfo._reactHasBeenPassedToCreateRootDEV = null;
   }
   if (callback !== null) {
     work.then(callback);


### PR DESCRIPTION
We already warn when mixing `ReactDOM.render()` with `ReactDOM.createRoot()`. This seems like a good next step.