### PR TITLE
Detect React roots by checking the parent fiber

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -356,12 +356,14 @@ export function appendChild(parentInstance, child) {
   child.inject(parentInstance);
 }
 
-export function appendChildToContainer(parentInstance, child, containerIsRoot) {
+export function appendChildToContainer(parentInstance, child) {
   if (child.parentNode === parentInstance) {
     child.eject();
   }
   child.inject(parentInstance);
 }
+
+export const appendChildToPortalContainer = appendChildToContainer;
 
 export function insertBefore(parentInstance, child, beforeChild) {
   invariant(

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -356,7 +356,7 @@ export function appendChild(parentInstance, child) {
   child.inject(parentInstance);
 }
 
-export function appendChildToContainer(parentInstance, child) {
+export function appendChildToContainer(parentInstance, child, containerIsRoot) {
   if (child.parentNode === parentInstance) {
     child.eject();
   }

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -2683,6 +2683,23 @@ describe('ReactDOMComponent', () => {
           portalContainer,
         );
       }
+      const root = ReactDOM.unstable_createRoot(container);
+      root.render(<Component />);
+      jest.runAllTimers();
+
+      expect(typeof portalContainer.onclick).toBe('function');
+    });
+
+    it('adds onclick handler to a portal root mounted via a legacy React root', () => {
+      const container = document.createElement('div');
+      const portalContainer = document.createElement('div');
+
+      function Component() {
+        return ReactDOM.createPortal(
+          <div onClick={() => {}} />,
+          portalContainer,
+        );
+      }
 
       ReactDOM.render(<Component />, container);
       expect(typeof portalContainer.onclick).toBe('function');

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -2688,7 +2688,21 @@ describe('ReactDOMComponent', () => {
       expect(typeof portalContainer.onclick).toBe('function');
     });
 
-    it('does not add onclick handler to the React root', () => {
+    it('does not add onclick handler to a React root', () => {
+      const container = document.createElement('div');
+
+      function Component() {
+        return <div onClick={() => {}} />;
+      }
+
+      const root = ReactDOM.unstable_createRoot(container);
+      root.render(<Component />);
+      jest.runAllTimers();
+
+      expect(typeof container.onclick).not.toBe('function');
+    });
+
+    it('does not add onclick handler to a legacy React root', () => {
       const container = document.createElement('div');
 
       function Component() {

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -361,6 +361,7 @@ export function appendChild(
 export function appendChildToContainer(
   container: DOMContainer,
   child: Instance | TextInstance,
+  containerIsRoot: boolean,
 ): void {
   let parentNode;
   if (container.nodeType === COMMENT_NODE) {
@@ -378,11 +379,7 @@ export function appendChildToContainer(
   // This is why we ensure that non React root containers have inline onclick
   // defined.
   // https://github.com/facebook/react/issues/11918
-  const reactRootContainer = container._reactRootContainer;
-  if (
-    (reactRootContainer === null || reactRootContainer === undefined) &&
-    parentNode.onclick === null
-  ) {
+  if (!containerIsRoot && parentNode.onclick === null) {
     // TODO: This cast may not be sound for SVG, MathML or custom elements.
     trapClickOnNonInteractiveElement(((parentNode: any): HTMLElement));
   }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -375,27 +375,27 @@ export function appendChildToContainer(
 export function appendChildToPortalContainer(
   container: DOMContainer,
   child: Instance | TextInstance,
-  ): void {
-    let parentNode;
-    if (container.nodeType === COMMENT_NODE) {
-      parentNode = (container.parentNode: any);
-      parentNode.insertBefore(child, container);
-    } else {
-      parentNode = container;
-      parentNode.appendChild(child);
-    }
+): void {
+  let parentNode;
+  if (container.nodeType === COMMENT_NODE) {
+    parentNode = (container.parentNode: any);
+    parentNode.insertBefore(child, container);
+  } else {
+    parentNode = container;
+    parentNode.appendChild(child);
+  }
 
-    // If something inside a portal is clicked, that click should bubble
-    // through the React tree. However, on Mobile Safari the click would
-    // never bubble through the *DOM* tree unless an ancestor with onclick
-    // event exists. So we wouldn't see it and dispatch it.
-    // This is why we ensure that portal containers have inline onclick
-    // defined.
-    // https://github.com/facebook/react/issues/11918
-    if (parentNode.onclick === null) {
-      // TODO: This cast may not be sound for SVG, MathML or custom elements.
-      trapClickOnNonInteractiveElement(((parentNode: any): HTMLElement));
-    }
+  // If something inside a portal is clicked, that click should bubble
+  // through the React tree. However, on Mobile Safari the click would
+  // never bubble through the *DOM* tree unless an ancestor with onclick
+  // event exists. So we wouldn't see it and dispatch it.
+  // This is why we ensure that portal containers have inline onclick
+  // defined.
+  // https://github.com/facebook/react/issues/11918
+  if (parentNode.onclick === null) {
+    // TODO: This cast may not be sound for SVG, MathML or custom elements.
+    trapClickOnNonInteractiveElement(((parentNode: any): HTMLElement));
+  }
 }
 
 export function insertBefore(

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -361,7 +361,6 @@ export function appendChild(
 export function appendChildToContainer(
   container: DOMContainer,
   child: Instance | TextInstance,
-  containerIsRoot: boolean,
 ): void {
   let parentNode;
   if (container.nodeType === COMMENT_NODE) {
@@ -371,18 +370,32 @@ export function appendChildToContainer(
     parentNode = container;
     parentNode.appendChild(child);
   }
-  // This container might be used for a portal.
-  // If something inside a portal is clicked, that click should bubble
-  // through the React tree. However, on Mobile Safari the click would
-  // never bubble through the *DOM* tree unless an ancestor with onclick
-  // event exists. So we wouldn't see it and dispatch it.
-  // This is why we ensure that non React root containers have inline onclick
-  // defined.
-  // https://github.com/facebook/react/issues/11918
-  if (!containerIsRoot && parentNode.onclick === null) {
-    // TODO: This cast may not be sound for SVG, MathML or custom elements.
-    trapClickOnNonInteractiveElement(((parentNode: any): HTMLElement));
-  }
+}
+
+export function appendChildToPortalContainer(
+  container: DOMContainer,
+  child: Instance | TextInstance,
+  ): void {
+    let parentNode;
+    if (container.nodeType === COMMENT_NODE) {
+      parentNode = (container.parentNode: any);
+      parentNode.insertBefore(child, container);
+    } else {
+      parentNode = container;
+      parentNode.appendChild(child);
+    }
+
+    // If something inside a portal is clicked, that click should bubble
+    // through the React tree. However, on Mobile Safari the click would
+    // never bubble through the *DOM* tree unless an ancestor with onclick
+    // event exists. So we wouldn't see it and dispatch it.
+    // This is why we ensure that portal containers have inline onclick
+    // defined.
+    // https://github.com/facebook/react/issues/11918
+    if (parentNode.onclick === null) {
+      // TODO: This cast may not be sound for SVG, MathML or custom elements.
+      trapClickOnNonInteractiveElement(((parentNode: any): HTMLElement));
+    }
 }
 
 export function insertBefore(

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -301,7 +301,6 @@ export function appendChild(
 export function appendChildToContainer(
   parentInstance: Container,
   child: Instance | TextInstance,
-  containerIsRoot: boolean,
 ): void {
   const childTag = typeof child === 'number' ? child : child._nativeTag;
   UIManager.setChildren(
@@ -309,6 +308,8 @@ export function appendChildToContainer(
     [childTag], // reactTags
   );
 }
+
+export const appendChildToPortalContainer = appendChildToContainer;
 
 export function commitTextUpdate(
   textInstance: TextInstance,

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -301,6 +301,7 @@ export function appendChild(
 export function appendChildToContainer(
   parentInstance: Container,
   child: Instance | TextInstance,
+  containerIsRoot: boolean,
 ): void {
   const childTag = typeof child === 'number' ? child : child._nativeTag;
   UIManager.setChildren(

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -66,6 +66,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
   function appendChildToContainer(
     parentInstance: Container,
     child: Instance | TextInstance,
+    containerIsRoot: boolean,
   ): void {
     if (typeof parentInstance.rootID !== 'string') {
       // Some calls to this aren't typesafe.

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -66,7 +66,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
   function appendChildToContainer(
     parentInstance: Container,
     child: Instance | TextInstance,
-    containerIsRoot: boolean,
   ): void {
     if (typeof parentInstance.rootID !== 'string') {
       // Some calls to this aren't typesafe.
@@ -392,6 +391,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
         appendChild,
         appendChildToContainer,
+        appendChildToPortalContainer: appendChildToContainer,
         insertBefore,
         insertInContainerBefore,
         removeChild,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -951,7 +951,8 @@ function commitPlacement(finishedWork: Fiber): void {
         }
       } else {
         if (isContainer) {
-          appendChildToContainer(parent, node.stateNode);
+          const containerIsRoot = parentFiber.tag === HostRoot;
+          appendChildToContainer(parent, node.stateNode, containerIsRoot);
         } else {
           appendChild(parent, node.stateNode);
         }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -75,6 +75,7 @@ import {
   commitTextUpdate,
   appendChild,
   appendChildToContainer,
+  appendChildToPortalContainer,
   insertBefore,
   insertInContainerBefore,
   removeChild,
@@ -951,8 +952,11 @@ function commitPlacement(finishedWork: Fiber): void {
         }
       } else {
         if (isContainer) {
-          const containerIsRoot = parentFiber.tag === HostRoot;
-          appendChildToContainer(parent, node.stateNode, containerIsRoot);
+          if (parentFiber.tag === HostRoot) {
+            appendChildToContainer(parent, node.stateNode);
+          } else {
+            appendChildToPortalContainer(parent, node.stateNode);
+          }
         } else {
           appendChild(parent, node.stateNode);
         }

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.js
@@ -49,6 +49,9 @@ describe('ReactFiberHostContext', () => {
       appendChildToContainer: function() {
         return null;
       },
+      appendChildToPortalContainer: function() {
+        return null;
+      },
       supportsMutation: true,
     });
 
@@ -95,6 +98,9 @@ describe('ReactFiberHostContext', () => {
         return 0;
       },
       appendChildToContainer: function() {
+        return null;
+      },
+      appendChildToPortalContainer: function() {
         return null;
       },
       supportsMutation: true,

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -68,7 +68,8 @@ export const supportsHydration = $$$hostConfig.supportsHydration;
 // -------------------
 export const appendChild = $$$hostConfig.appendChild;
 export const appendChildToContainer = $$$hostConfig.appendChildToContainer;
-export const appendChildToPortalContainer = $$$hostConfig.appendChildToPortalContainer;
+export const appendChildToPortalContainer =
+  $$$hostConfig.appendChildToPortalContainer;
 export const commitTextUpdate = $$$hostConfig.commitTextUpdate;
 export const commitMount = $$$hostConfig.commitMount;
 export const commitUpdate = $$$hostConfig.commitUpdate;

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -68,6 +68,7 @@ export const supportsHydration = $$$hostConfig.supportsHydration;
 // -------------------
 export const appendChild = $$$hostConfig.appendChild;
 export const appendChildToContainer = $$$hostConfig.appendChildToContainer;
+export const appendChildToPortalContainer = $$$hostConfig.appendChildToPortalContainer;
 export const commitTextUpdate = $$$hostConfig.commitTextUpdate;
 export const commitMount = $$$hostConfig.commitMount;
 export const commitUpdate = $$$hostConfig.commitUpdate;

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -251,6 +251,7 @@ export function resetTextContent(testElement: Instance): void {
 }
 
 export const appendChildToContainer = appendChild;
+export const appendChildToPortalContainer = appendChild;
 export const insertInContainerBefore = insertBefore;
 export const removeChildFromContainer = removeChild;
 

--- a/packages/shared/HostConfigWithNoMutation.js
+++ b/packages/shared/HostConfigWithNoMutation.js
@@ -25,6 +25,7 @@ function shim(...args: any) {
 export const supportsMutation = false;
 export const appendChild = shim;
 export const appendChildToContainer = shim;
+export const appendChildToPortalContainer = shim;
 export const commitTextUpdate = shim;
 export const commitMount = shim;
 export const commitUpdate = shim;


### PR DESCRIPTION
Fixes #14535
Related to #13778
Alternative to #14682

As @gaearon already noted, we can not rely on a container node having a `_reactRootContainer` to detect a React Root since the `createRoot()` API will not set it.

Furthermore, the `createRoot()` API is currently only setting a property on the container in DEV mode.

We could:

 1. Set a property in prod as well. (#14682)
 2. Pass in more information into the `appendChildToContainer()` config.

This PR is an attempt to implement 2. to visualize the outcome. It feels bad to do this though since non of the other renderers need that property and I’m not sure how stable the reconciler API is (i.e if we can just add properties like this).
