### PR TITLE
Fix react-dom/server context leaks when render stream destroyed early

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
@@ -483,6 +483,46 @@ describe('ReactDOMServerIntegration', () => {
       }
     });
 
+    it('does not pollute later renders when stream destroyed', () => {
+      const LoggedInUser = React.createContext('default');
+
+      const AppWithUser = user => (
+        <LoggedInUser.Provider value={user}>
+          <header>
+            <LoggedInUser.Consumer>{whoAmI => whoAmI}</LoggedInUser.Consumer>
+          </header>
+        </LoggedInUser.Provider>
+      );
+
+      const stream = ReactDOMServer.renderToNodeStream(
+        AppWithUser('Amy'),
+      ).setEncoding('utf8');
+
+      const {threadID} = stream.partialRenderer;
+
+      // Read enough to render Provider but not enough for it to be exited
+      stream._read(10);
+      expect(LoggedInUser[threadID]).toBe('Amy');
+
+      stream.destroy();
+
+      const AppWithUserNoProvider = () => (
+        <LoggedInUser.Consumer>{whoAmI => whoAmI}</LoggedInUser.Consumer>
+      );
+
+      const stream2 = ReactDOMServer.renderToNodeStream(
+        AppWithUserNoProvider(),
+      ).setEncoding('utf8');
+
+      // Sanity check to ensure 2nd render has same threadID as 1st render,
+      // otherwise this test is not testing what it's meant to
+      expect(stream2.partialRenderer.threadID).toBe(threadID);
+
+      const markup = stream2.read(Infinity);
+
+      expect(markup).toBe('default');
+    });
+
     it('frees context value reference when stream destroyed', () => {
       const LoggedInUser = React.createContext('default');
 

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -715,6 +715,7 @@ class ReactDOMServerRenderer {
   destroy() {
     if (!this.exhausted) {
       this.exhausted = true;
+      this.clearProviders();
       freeThreadID(this.threadID);
     }
   }
@@ -748,7 +749,7 @@ class ReactDOMServerRenderer {
     context[threadID] = provider.props.value;
   }
 
-  popProvider<T>(provider: ReactProvider<T>): void {
+  popProvider<T>(provider?: ReactProvider<T>): void {
     const index = this.contextIndex;
     if (__DEV__) {
       warningWithoutStack(
@@ -774,6 +775,16 @@ class ReactDOMServerRenderer {
     // We've already verified that this context has been expanded to accommodate
     // this thread id, so we don't need to do it again.
     context[this.threadID] = previousValue;
+  }
+
+  clearProviders(): void {
+    while (this.contextIndex > -1) {
+      if (__DEV__) {
+        this.popProvider((this.contextProviderStack: any)[this.contextIndex]);
+      } else {
+        this.popProvider();
+      }
+    }
   }
 
   read(bytes: number): string | null {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -749,7 +749,7 @@ class ReactDOMServerRenderer {
     context[threadID] = provider.props.value;
   }
 
-  popProvider<T>(provider?: ReactProvider<T>): void {
+  popProvider<T>(provider: ReactProvider<T>): void {
     const index = this.contextIndex;
     if (__DEV__) {
       warningWithoutStack(
@@ -778,12 +778,11 @@ class ReactDOMServerRenderer {
   }
 
   clearProviders(): void {
-    while (this.contextIndex > -1) {
-      if (__DEV__) {
-        this.popProvider((this.contextProviderStack: any)[this.contextIndex]);
-      } else {
-        this.popProvider();
-      }
+    // Restore any remaining providers on the stack to previous values
+    for (let index = this.contextIndex; index >= 0; index--) {
+      const context: ReactContext<any> = this.contextStack[index];
+      const previousValue = this.contextValueStack[index];
+      context[this.threadID] = previousValue;
     }
   }
 


### PR DESCRIPTION
Fix and test case for #14705.

Note: This makes `.popProvider`'s `provider` argument optional. It's only used in dev mode anyway, but I'm not sure if this is the wrong thing to do. Please excuse me - I've never used Flow before.