### PR TITLE
Typo in comment

### DIFF
--- a/packages/create-subscription/src/__tests__/createSubscription-test.internal.js
+++ b/packages/create-subscription/src/__tests__/createSubscription-test.internal.js
@@ -431,7 +431,7 @@ describe('createSubscription', () => {
       'Parent.componentDidUpdate',
     ]);
 
-    // Updates from the new subsribable should be ignored.
+    // Updates from the new subscribable should be ignored.
     observableB.next('b-1');
     expect(ReactNoop.flush()).toEqual([]);
     expect(log).toEqual([


### PR DESCRIPTION
"synchronously" instead of "syncrhonously".