### PR TITLE
[TestUtils.act] warn when using TestUtils.act in node

### DIFF
--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -392,16 +392,17 @@ const ReactTestUtils = {
 
   act(callback: () => void): Thenable {
     if (actContainerElement === null) {
-      // first, test whether we can actually create the stub element
-      invariant(
-        typeof document !== 'undefined' &&
-          document !== null &&
-          typeof document.createElement === 'function',
-        'It looks like you called TestUtils.act() in a non-browser-like environment' +
-          "(like node.js). This is not supported. If you're using" +
-          'TestRenderer for your tests, you should call ' +
-          'TestRenderer.act(...) instead of TestUtils.act(...).',
-      );
+      // warn if we can't actually create the stub element
+      if (__DEV__) {
+        warningWithoutStack(
+          typeof document !== 'undefined' &&
+            document !== null &&
+            typeof document.createElement === 'function',
+          'It looks like you called TestUtils.act() in a non-browser environment. ' +
+            "If you're using TestRenderer for your tests, you should call " +
+            'TestRenderer.act(...) instead of TestUtils.act(...).',
+        );
+      }
       // then make it
       actContainerElement = document.createElement('div');
     }

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -398,7 +398,7 @@ const ReactTestUtils = {
           typeof document !== 'undefined' &&
             document !== null &&
             typeof document.createElement === 'function',
-          'It looks like you called TestUtils.act() in a non-browser environment. ' +
+          'It looks like you called TestUtils.act(...) in a non-browser environment. ' +
             "If you're using TestRenderer for your tests, you should call " +
             'TestRenderer.act(...) instead of TestUtils.act(...).',
         );

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -1043,7 +1043,7 @@ describe('ReactTestRenderer', () => {
 
       expect(called).toBe(true);
     });
-    it('warns if you use TestUtils.act instead of TestRenderer.act in node', () => {
+    it('throws if you use TestUtils.act instead of TestRenderer.act in node', () => {
       jest.resetModules();
       const {act} = require('react-dom/test-utils');
       expect(() => act(() => {})).toThrow(

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -1043,11 +1043,18 @@ describe('ReactTestRenderer', () => {
 
       expect(called).toBe(true);
     });
-    it('throws if you use TestUtils.act instead of TestRenderer.act in node', () => {
+    it('warns and throws if you use TestUtils.act instead of TestRenderer.act in node', () => {
+      // we warn when you try to load 2 renderers in the same 'scope'
+      // so as suggested, we call resetModules() to carry on with the test
       jest.resetModules();
       const {act} = require('react-dom/test-utils');
-      expect(() => act(() => {})).toThrow(
-        'It looks like you called TestUtils.act() in a non-browser-like environment(like node.js)',
+      expect(() => {
+        expect(() => act(() => {})).toThrow('document is not defined');
+      }).toWarnDev(
+        [
+          'It looks like you called TestUtils.act() in a non-browser environment',
+        ],
+        {withoutStack: 1},
       );
     });
   });

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -1052,7 +1052,7 @@ describe('ReactTestRenderer', () => {
         expect(() => act(() => {})).toThrow('document is not defined');
       }).toWarnDev(
         [
-          'It looks like you called TestUtils.act() in a non-browser environment',
+          'It looks like you called TestUtils.act(...) in a non-browser environment',
         ],
         {withoutStack: 1},
       );

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -1023,7 +1023,7 @@ describe('ReactTestRenderer', () => {
   });
 
   describe('act', () => {
-    it('works', () => {
+    it('can use .act() to batch updates and effects', () => {
       function App(props) {
         React.useEffect(() => {
           props.callback();
@@ -1042,6 +1042,13 @@ describe('ReactTestRenderer', () => {
       });
 
       expect(called).toBe(true);
+    });
+    it('warns if you use TestUtils.act instead of TestRenderer.act in node', () => {
+      jest.resetModules();
+      const {act} = require('react-dom/test-utils');
+      expect(() => act(() => {})).toThrow(
+        'It looks like you called TestUtils.act() in a non-browser-like environment(like node.js)',
+      );
     });
   });
 });


### PR DESCRIPTION
- lazily initializes the stub element we use when flushing effects 
- adds a warning for when you try to run in in node (rather, non-document envs)
- fixes #14764 