### PR TITLE
Backwards compat fix for ReactCurrentDispatcher on older react versions

### DIFF
--- a/packages/shared/ReactSharedInternals.js
+++ b/packages/shared/ReactSharedInternals.js
@@ -10,4 +10,19 @@ import React from 'react';
 const ReactSharedInternals =
   React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 
+// Add fallback for newer renderers running with older react package versions.
+// Current owner and dispatcher used to share the same ref,
+// but PR #14548 split them out to better support the react-debug-tools package.
+if (!ReactSharedInternals.hasOwnProperty('ReactCurrentDispatcher')) {
+  const {ReactCurrentOwner} = ReactSharedInternals;
+  ReactSharedInternals.ReactCurrentDispatcher = {
+    get current() {
+      return ReactCurrentOwner.currentDispatcher;
+    },
+    set current(value) {
+      ReactCurrentOwner.currentDispatcher = value;
+    },
+  };
+}
+
 export default ReactSharedInternals;

--- a/packages/shared/ReactSharedInternals.js
+++ b/packages/shared/ReactSharedInternals.js
@@ -10,18 +10,12 @@ import React from 'react';
 const ReactSharedInternals =
   React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 
-// Add fallback for newer renderers running with older react package versions.
+// Prevent newer renderers from RTE when used with older react package versions.
 // Current owner and dispatcher used to share the same ref,
 // but PR #14548 split them out to better support the react-debug-tools package.
 if (!ReactSharedInternals.hasOwnProperty('ReactCurrentDispatcher')) {
-  const {ReactCurrentOwner} = ReactSharedInternals;
   ReactSharedInternals.ReactCurrentDispatcher = {
-    get current() {
-      return ReactCurrentOwner.currentDispatcher;
-    },
-    set current(value) {
-      ReactCurrentOwner.currentDispatcher = value;
-    },
+    current: null,
   };
 }
 


### PR DESCRIPTION
Potential fix for #14763.

Current owner and dispatcher used to share the same ref, but PR #14548 split them out to better support the `react-debug-tools` package. This had the unintended side effect of newer renderers incompatible with versions of the `react` package that predate this change.

This PR adds a fallback property.