### PR TITLE
Only call destroy when destroy is a function

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -321,7 +321,7 @@ function commitHookEffectList(
         // Unmount
         const destroy = effect.destroy;
         effect.destroy = undefined;
-        if (destroy !== undefined) {
+        if (typeof destroy === 'function') {
           destroy();
         }
       }
@@ -824,8 +824,7 @@ function commitContainer(finishedWork: Fiber) {
       const portalOrRoot: {
         containerInfo: Container,
         pendingChildren: ChildSet,
-      } =
-        finishedWork.stateNode;
+      } = finishedWork.stateNode;
       const {containerInfo, pendingChildren} = portalOrRoot;
       replaceContainerChildren(containerInfo, pendingChildren);
       return;


### PR DESCRIPTION
Currently experiencing an issue when returning null from useEffect, when a component unmounts react throws an error. 
