### PR TITLE
Add test for calling dispatch from useEffect cleanup

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -669,6 +669,37 @@ describe('ReactHooks', () => {
     }).toThrow('is not a function');
   });
 
+  it('calling dispatch from useEffect clean-up function calls the reducer', () => {
+    const {useEffect, useReducer} = React;
+
+    let count = 0;
+
+    function reducer(state, action) {
+      count += 1;
+      return state;
+    }
+
+    function App(props) {
+      const [state, dispatch] = useReducer(reducer, {});
+
+      useEffect(
+        () => {
+          return () => {
+            dispatch();
+          };
+        },
+        [state],
+      );
+
+      return null;
+    }
+
+    const root1 = ReactTestRenderer.create(null);
+    root1.update(<App />);
+    root1.update(null);
+    expect(count).toEqual(1);
+  });
+
   it('warns for bad useImperativeHandle first arg', () => {
     const {useImperativeHandle} = React;
     function App() {


### PR DESCRIPTION
Adds a test regarding #14285 . When dispatch is called from useEffect clean-up function, expect that the reducer is called. This was not the case in the past and was the source of #14285 