### PR TITLE
Proposal: use functional component as a first example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,8 @@ You can improve it by sending pull requests to [this repository](https://github.
 We have several examples [on the website](https://reactjs.org/). Here is the first one to get you started:
 
 ```jsx
-class HelloMessage extends React.Component {
-  render() {
-    return <div>Hello {this.props.name}</div>;
-  }
+function HelloMessage({ name }) {
+  return <div>Hello {name}</div>;
 }
 
 ReactDOM.render(


### PR DESCRIPTION
Given the fact that the hooks are released now and allow to do more using functional components, would it be a perfect moment to consider functional components as a default way to build react components? Starting with just README the very first example becomes clearer and no longer pulls classes' complexity.