### PR TITLE
Remove false positive warning and add TODOs about `current` being non-null

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -220,6 +220,10 @@ function updateForwardRef(
   nextProps: any,
   renderExpirationTime: ExpirationTime,
 ) {
+  // TODO: current can be non-null here even if the component
+  // hasn't yet mounted. This happens after the first render suspends.
+  // We'll need to figure out if this is fine or can cause issues.
+
   if (__DEV__) {
     if (workInProgress.type !== workInProgress.elementType) {
       // Lazy component props can't be validated in createElement
@@ -415,6 +419,10 @@ function updateSimpleMemoComponent(
   updateExpirationTime,
   renderExpirationTime: ExpirationTime,
 ): null | Fiber {
+  // TODO: current can be non-null here even if the component
+  // hasn't yet mounted. This happens when the inner render suspends.
+  // We'll need to figure out if this is fine or can cause issues.
+
   if (__DEV__) {
     if (workInProgress.type !== workInProgress.elementType) {
       // Lazy component props can't be validated in createElement

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -449,17 +449,6 @@ function mountWorkInProgressHook(): Hook {
 
   if (__DEV__) {
     (hook: any)._debugType = (currentHookNameInDev: any);
-    if (
-      currentlyRenderingFiber !== null &&
-      currentlyRenderingFiber.alternate !== null
-    ) {
-      warning(
-        false,
-        '%s: Rendered more hooks than during the previous render. This is ' +
-          'not currently supported and may lead to unexpected behavior.',
-        getComponentName(currentlyRenderingFiber.type),
-      );
-    }
   }
   if (workInProgressHook === null) {
     // This is the first hook in the list

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1368,7 +1368,7 @@ describe('ReactHooks', () => {
   });
 
   // Regression test for https://github.com/facebook/react/issues/14790
-  it('does not fire a false positive warning when suspending', async () => {
+  it('does not fire a false positive warning when suspending memo', async () => {
     const {Suspense, useState, useRef} = React;
 
     let wasSuspended = false;
@@ -1388,6 +1388,68 @@ describe('ReactHooks', () => {
     }
 
     const Wrapper = React.memo(Child);
+    const root = ReactTestRenderer.create(
+      <Suspense fallback="loading">
+        <Wrapper />
+      </Suspense>,
+    );
+    expect(root).toMatchRenderedOutput('loading');
+    await Promise.resolve();
+    expect(root).toMatchRenderedOutput('hello');
+  });
+
+  // Regression test for https://github.com/facebook/react/issues/14790
+  it('does not fire a false positive warning when suspending forwardRef', async () => {
+    const {Suspense, useState, useRef} = React;
+
+    let wasSuspended = false;
+    function trySuspend() {
+      if (!wasSuspended) {
+        throw new Promise(resolve => {
+          wasSuspended = true;
+          resolve();
+        });
+      }
+    }
+
+    function render(props, ref) {
+      React.useState();
+      trySuspend();
+      return 'hello';
+    }
+
+    const Wrapper = React.forwardRef(render);
+    const root = ReactTestRenderer.create(
+      <Suspense fallback="loading">
+        <Wrapper />
+      </Suspense>,
+    );
+    expect(root).toMatchRenderedOutput('loading');
+    await Promise.resolve();
+    expect(root).toMatchRenderedOutput('hello');
+  });
+
+  // Regression test for https://github.com/facebook/react/issues/14790
+  it('does not fire a false positive warning when suspending memo(forwardRef)', async () => {
+    const {Suspense, useState, useRef} = React;
+
+    let wasSuspended = false;
+    function trySuspend() {
+      if (!wasSuspended) {
+        throw new Promise(resolve => {
+          wasSuspended = true;
+          resolve();
+        });
+      }
+    }
+
+    function render(props, ref) {
+      React.useState();
+      trySuspend();
+      return 'hello';
+    }
+
+    const Wrapper = React.memo(React.forwardRef(render));
     const root = ReactTestRenderer.create(
       <Suspense fallback="loading">
         <Wrapper />

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1369,7 +1369,7 @@ describe('ReactHooks', () => {
 
   // Regression test for https://github.com/facebook/react/issues/14790
   it('does not fire a false positive warning when suspending memo', async () => {
-    const {Suspense, useState, useRef} = React;
+    const {Suspense, useState} = React;
 
     let wasSuspended = false;
     function trySuspend() {
@@ -1382,7 +1382,7 @@ describe('ReactHooks', () => {
     }
 
     function Child() {
-      React.useState();
+      useState();
       trySuspend();
       return 'hello';
     }
@@ -1400,7 +1400,7 @@ describe('ReactHooks', () => {
 
   // Regression test for https://github.com/facebook/react/issues/14790
   it('does not fire a false positive warning when suspending forwardRef', async () => {
-    const {Suspense, useState, useRef} = React;
+    const {Suspense, useState} = React;
 
     let wasSuspended = false;
     function trySuspend() {
@@ -1413,7 +1413,7 @@ describe('ReactHooks', () => {
     }
 
     function render(props, ref) {
-      React.useState();
+      useState();
       trySuspend();
       return 'hello';
     }
@@ -1431,7 +1431,7 @@ describe('ReactHooks', () => {
 
   // Regression test for https://github.com/facebook/react/issues/14790
   it('does not fire a false positive warning when suspending memo(forwardRef)', async () => {
-    const {Suspense, useState, useRef} = React;
+    const {Suspense, useState} = React;
 
     let wasSuspended = false;
     function trySuspend() {
@@ -1444,7 +1444,7 @@ describe('ReactHooks', () => {
     }
 
     function render(props, ref) {
-      React.useState();
+      useState();
       trySuspend();
       return 'hello';
     }


### PR DESCRIPTION
Failing test for https://github.com/facebook/react/issues/14790.

Seems like we expect that alternate is always empty for Hook "mounts" but that's not the cause if a memo'd component has previously suspended.

Not sure what idiomatic fix is.