### PR TITLE
[scheduler] Add method for forcing a lower framerate

### DIFF
--- a/fixtures/scheduler/index.html
+++ b/fixtures/scheduler/index.html
@@ -105,6 +105,20 @@
         <div><b>Actual:</b></div>
         <div id="test-8"></div>
     </li>
+    <li>
+      <p>Can force a specific framerate</p>
+      <p><b>IMPORTANT:</b> This test may be flaky if other tests have been run in this js instance. To get a clean test refresh the page before running test 9</p>
+      <button onClick="runTestNine()">Run Test 9</button>
+      <div><b>Expected:</b></div>
+      <div id="test-9-expected">
+      </div>
+      <div> -------------------------------------------------</div>
+      <div> If you see the same above and below it's correct.
+        <div> -------------------------------------------------</div>
+        <div><b>Actual:</b></div>
+        <div id="test-9"></div>
+      </div>
+    </li>
   </ol>
   <script src="../../build/node_modules/react/umd/react.development.js"></script>
   <script src="../../build/node_modules/scheduler/umd/scheduler.development.js"></script>
@@ -117,6 +131,8 @@ const {
   unstable_getFirstCallbackNode: getFirstCallbackNode,
   unstable_pauseExecution: pauseExecution,
   unstable_continueExecution: continueExecution,
+  unstable_forceFrameRate: forceFrameRate,
+  unstable_shouldYield: shouldYield,
 } = Scheduler;
 function displayTestResult(testNumber) {
   const expectationNode = document.getElementById('test-' + testNumber + '-expected');
@@ -242,6 +258,13 @@ const expectedResults = [
     'Queue size: 2.',
     'Finishing...',
     'Done!',
+  ],
+  // test 9
+  [
+    'Forcing new frame times...',
+    'Using new frame time!',
+    'Using new frame time!',
+    'Finished!',
   ],
 ];
 function runTestOne() {
@@ -567,6 +590,50 @@ function runTestEight() {
 
 function continueTestEight() {
   continueExecution();
+}
+
+function runTestNine() {
+  clearTestResult(9);
+  // We have this to make sure that the thing that goes right after it can get a full frame
+  var forceFrameFinish = () => {
+    while (!shouldYield()) {
+      waitForTimeToPass(1);
+    }
+    waitForTimeToPass(100);
+  }
+  scheduleCallback(forceFrameFinish);
+  scheduleCallback(() => {
+    var startTime = now();
+    while (!shouldYield()) {}
+    var initialFrameTime = now() - startTime;
+    var newFrameTime = (initialFrameTime * 2) > 60 ? (initialFrameTime * 2) : 60;
+    var newFrameRate = Math.floor(1000/newFrameTime);
+    updateTestResult(9, `Forcing new frame times...`);
+    displayTestResult(9);
+    forceFrameRate(newFrameRate);
+    var toSchedule = (again) => {
+      var startTime = now();
+      while (!shouldYield()) {}
+      var frameTime = now() - startTime;
+      if (frameTime >= (newFrameTime-8)) {
+        updateTestResult(9, `Using new frame time!`);
+      } else {
+        updateTestResult(9, `Failed to use new frame time. (off by ${newFrameTime - frameTime}ms)`);
+      }
+      displayTestResult(9);
+      if (again) {
+        scheduleCallback(forceFrameFinish);
+        scheduleCallback(() => {toSchedule(false);});
+      } else {
+        updateTestResult(9, `Finished!`);
+        forceFrameRate(0);
+        displayTestResult(9);
+        checkTestResult(9);
+      }
+    }
+    scheduleCallback(forceFrameFinish);
+    scheduleCallback(() => {toSchedule(true);});
+  });
 }
 
     </script type="text/babel">

--- a/packages/react/src/ReactSharedInternals.js
+++ b/packages/react/src/ReactSharedInternals.js
@@ -18,6 +18,7 @@ import {
   unstable_continueExecution,
   unstable_wrapCallback,
   unstable_getCurrentPriorityLevel,
+  unstable_forceFrameRate,
 } from 'scheduler';
 import {
   __interactionsRef,
@@ -60,6 +61,7 @@ if (__UMD__) {
       unstable_pauseExecution,
       unstable_continueExecution,
       unstable_getCurrentPriorityLevel,
+      unstable_forceFrameRate,
     },
     SchedulerTracing: {
       __interactionsRef,

--- a/packages/scheduler/npm/umd/scheduler.development.js
+++ b/packages/scheduler/npm/umd/scheduler.development.js
@@ -96,6 +96,13 @@
     );
   }
 
+  function unstable_forceFrameRate() {
+    return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler.unstable_forceFrameRate.apply(
+      this,
+      arguments
+    );
+  }
+
   return Object.freeze({
     unstable_now: unstable_now,
     unstable_scheduleCallback: unstable_scheduleCallback,
@@ -108,5 +115,6 @@
     unstable_continueExecution: unstable_continueExecution,
     unstable_pauseExecution: unstable_pauseExecution,
     unstable_getFirstCallbackNode: unstable_getFirstCallbackNode,
+    unstable_forceFrameRate: unstable_forceFrameRate,
   });
 });

--- a/packages/scheduler/npm/umd/scheduler.production.min.js
+++ b/packages/scheduler/npm/umd/scheduler.production.min.js
@@ -90,6 +90,13 @@
     return undefined;
   }
 
+  function unstable_forceFrameRate() {
+    return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler.unstable_forceFrameRate.apply(
+      this,
+      arguments
+    );
+  }
+
   return Object.freeze({
     unstable_now: unstable_now,
     unstable_scheduleCallback: unstable_scheduleCallback,
@@ -102,5 +109,6 @@
     unstable_continueExecution: unstable_continueExecution,
     unstable_pauseExecution: unstable_pauseExecution,
     unstable_getFirstCallbackNode: unstable_getFirstCallbackNode,
+    unstable_forceFrameRate: unstable_forceFrameRate,
   });
 });

--- a/packages/scheduler/npm/umd/scheduler.profiling.min.js
+++ b/packages/scheduler/npm/umd/scheduler.profiling.min.js
@@ -90,6 +90,13 @@
     return undefined;
   }
 
+  function unstable_forceFrameRate() {
+    return global.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler.unstable_forceFrameRate.apply(
+      this,
+      arguments
+    );
+  }
+
   return Object.freeze({
     unstable_now: unstable_now,
     unstable_scheduleCallback: unstable_scheduleCallback,
@@ -102,5 +109,6 @@
     unstable_continueExecution: unstable_continueExecution,
     unstable_pauseExecution: unstable_pauseExecution,
     unstable_getFirstCallbackNode: unstable_getFirstCallbackNode,
+    unstable_forceFrameRate: unstable_forceFrameRate,
   });
 });

--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -511,6 +511,7 @@ if (hasNativePerformanceNow) {
 var requestHostCallback;
 var cancelHostCallback;
 var shouldYieldToHost;
+var forceFrameRate;
 
 var globalValue = null;
 if (typeof window !== 'undefined') {
@@ -526,6 +527,7 @@ if (globalValue && globalValue._schedMock) {
   cancelHostCallback = globalImpl[1];
   shouldYieldToHost = globalImpl[2];
   getCurrentTime = globalImpl[3];
+  forceFrameRate = globalImpl[4];
 } else if (
   // If Scheduler runs in a non-DOM environment, it falls back to a naive
   // implementation using setTimeout.
@@ -560,6 +562,7 @@ if (globalValue && globalValue._schedMock) {
   shouldYieldToHost = function() {
     return false;
   };
+  forceFrameRate = function() {};
 } else {
   if (typeof console !== 'undefined') {
     // TODO: Remove fb.me link
@@ -593,9 +596,28 @@ if (globalValue && globalValue._schedMock) {
   // frames.
   var previousFrameTime = 33;
   var activeFrameTime = 33;
+  var fpsLocked = false;
 
   shouldYieldToHost = function() {
     return frameDeadline <= getCurrentTime();
+  };
+
+  forceFrameRate = function(fps) {
+    if (fps < 0 || fps > 125) {
+      console.error(
+        'forceFrameRate takes a positive int between 0 and 125, ' +
+          'forcing framerates higher than 125 fps is not unsupported',
+      );
+      return;
+    }
+    if (fps > 0) {
+      activeFrameTime = Math.floor(1000 / fps);
+      fpsLocked = true;
+    } else {
+      // reset the framerate
+      activeFrameTime = 33;
+      fpsLocked = false;
+    }
   };
 
   // We use the postMessage trick to defer idle work until after the repaint.
@@ -662,6 +684,7 @@ if (globalValue && globalValue._schedMock) {
 
     var nextFrameTime = rafTime - frameDeadline + activeFrameTime;
     if (
+      !fpsLocked &&
       nextFrameTime < activeFrameTime &&
       previousFrameTime < activeFrameTime
     ) {
@@ -729,4 +752,5 @@ export {
   unstable_pauseExecution,
   unstable_getFirstCallbackNode,
   getCurrentTime as unstable_now,
+  forceFrameRate as unstable_forceFrameRate,
 };

--- a/packages/shared/forks/Scheduler.umd.js
+++ b/packages/shared/forks/Scheduler.umd.js
@@ -27,6 +27,7 @@ const {
   unstable_NormalPriority,
   unstable_LowPriority,
   unstable_IdlePriority,
+  unstable_forceFrameRate,
 } = ReactInternals.Scheduler;
 
 export {
@@ -45,4 +46,5 @@ export {
   unstable_NormalPriority,
   unstable_LowPriority,
   unstable_IdlePriority,
+  unstable_forceFrameRate,
 };

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -4,29 +4,29 @@
       "filename": "react.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react",
-      "size": 97676,
-      "gzip": 25688
+      "size": 102592,
+      "gzip": 26606
     },
     {
       "filename": "react.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react",
-      "size": 11771,
-      "gzip": 4678
+      "size": 12812,
+      "gzip": 4973
     },
     {
       "filename": "react.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react",
-      "size": 60944,
-      "gzip": 16507
+      "size": 63522,
+      "gzip": 17094
     },
     {
       "filename": "react.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react",
-      "size": 6223,
-      "gzip": 2655
+      "size": 6831,
+      "gzip": 2816
     },
     {
       "filename": "React-dev.js",
@@ -46,29 +46,29 @@
       "filename": "react-dom.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 725813,
-      "gzip": 167799
+      "size": 769973,
+      "gzip": 175975
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 99920,
-      "gzip": 32521
+      "size": 107779,
+      "gzip": 34786
     },
     {
       "filename": "react-dom.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 721011,
-      "gzip": 166399
+      "size": 764363,
+      "gzip": 174415
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 99914,
-      "gzip": 32052
+      "size": 107953,
+      "gzip": 34218
     },
     {
       "filename": "ReactDOM-dev.js",
@@ -88,29 +88,29 @@
       "filename": "react-dom-test-utils.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 45937,
-      "gzip": 12585
+      "size": 48184,
+      "gzip": 13291
     },
     {
       "filename": "react-dom-test-utils.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 10199,
-      "gzip": 3787
+      "size": 10504,
+      "gzip": 3882
     },
     {
       "filename": "react-dom-test-utils.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 45651,
-      "gzip": 12521
+      "size": 47898,
+      "gzip": 13220
     },
     {
       "filename": "react-dom-test-utils.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 9969,
-      "gzip": 3726
+      "size": 10281,
+      "gzip": 3814
     },
     {
       "filename": "ReactTestUtils-dev.js",
@@ -123,7 +123,7 @@
       "filename": "react-dom-unstable-native-dependencies.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 62059,
+      "size": 62058,
       "gzip": 16289
     },
     {
@@ -137,7 +137,7 @@
       "filename": "react-dom-unstable-native-dependencies.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 61723,
+      "size": 61722,
       "gzip": 16156
     },
     {
@@ -165,29 +165,29 @@
       "filename": "react-dom-server.browser.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-dom",
-      "size": 122056,
-      "gzip": 32469
+      "size": 129015,
+      "gzip": 34487
     },
     {
       "filename": "react-dom-server.browser.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-dom",
-      "size": 16402,
-      "gzip": 6237
+      "size": 19078,
+      "gzip": 7340
     },
     {
       "filename": "react-dom-server.browser.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 118094,
-      "gzip": 31495
+      "size": 125053,
+      "gzip": 33529
     },
     {
       "filename": "react-dom-server.browser.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 16301,
-      "gzip": 6233
+      "size": 18998,
+      "gzip": 7325
     },
     {
       "filename": "ReactDOMServer-dev.js",
@@ -207,43 +207,43 @@
       "filename": "react-dom-server.node.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 120062,
-      "gzip": 32036
+      "size": 127160,
+      "gzip": 34084
     },
     {
       "filename": "react-dom-server.node.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 17126,
-      "gzip": 6544
+      "size": 19891,
+      "gzip": 7641
     },
     {
       "filename": "react-art.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-art",
-      "size": 507846,
-      "gzip": 112120
+      "size": 543911,
+      "gzip": 118349
     },
     {
       "filename": "react-art.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-art",
-      "size": 91897,
-      "gzip": 28219
+      "size": 99648,
+      "gzip": 30583
     },
     {
       "filename": "react-art.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-art",
-      "size": 437983,
-      "gzip": 94680
+      "size": 473191,
+      "gzip": 100715
     },
     {
       "filename": "react-art.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-art",
-      "size": 56044,
-      "gzip": 17298
+      "size": 63856,
+      "gzip": 19515
     },
     {
       "filename": "ReactART-dev.js",
@@ -291,29 +291,29 @@
       "filename": "react-test-renderer.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-test-renderer",
-      "size": 450951,
-      "gzip": 97435
+      "size": 485642,
+      "gzip": 103166
     },
     {
       "filename": "react-test-renderer.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-test-renderer",
-      "size": 57293,
-      "gzip": 17617
+      "size": 65240,
+      "gzip": 19977
     },
     {
       "filename": "react-test-renderer.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-test-renderer",
-      "size": 446052,
-      "gzip": 96263
+      "size": 479861,
+      "gzip": 101802
     },
     {
       "filename": "react-test-renderer.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-test-renderer",
-      "size": 56955,
-      "gzip": 17453
+      "size": 64908,
+      "gzip": 19675
     },
     {
       "filename": "ReactTestRenderer-dev.js",
@@ -326,29 +326,29 @@
       "filename": "react-test-renderer-shallow.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-test-renderer",
-      "size": 26400,
-      "gzip": 7200
+      "size": 38084,
+      "gzip": 9724
     },
     {
       "filename": "react-test-renderer-shallow.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-test-renderer",
-      "size": 7442,
-      "gzip": 2425
+      "size": 11382,
+      "gzip": 3422
     },
     {
       "filename": "react-test-renderer-shallow.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-test-renderer",
-      "size": 20656,
-      "gzip": 5736
+      "size": 32246,
+      "gzip": 8323
     },
     {
       "filename": "react-test-renderer-shallow.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-test-renderer",
-      "size": 8141,
-      "gzip": 2697
+      "size": 12043,
+      "gzip": 3734
     },
     {
       "filename": "ReactShallowRenderer-dev.js",
@@ -361,57 +361,57 @@
       "filename": "react-noop-renderer.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-noop-renderer",
-      "size": 28829,
-      "gzip": 6286
+      "size": 32858,
+      "gzip": 7514
     },
     {
       "filename": "react-noop-renderer.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-noop-renderer",
-      "size": 10889,
-      "gzip": 3632
+      "size": 11486,
+      "gzip": 3766
     },
     {
       "filename": "react-reconciler.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-reconciler",
-      "size": 435777,
-      "gzip": 93120
+      "size": 470158,
+      "gzip": 99031
     },
     {
       "filename": "react-reconciler.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-reconciler",
-      "size": 57202,
-      "gzip": 17158
+      "size": 65107,
+      "gzip": 19316
     },
     {
       "filename": "react-reconciler-persistent.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-reconciler",
-      "size": 434187,
-      "gzip": 92481
+      "size": 468496,
+      "gzip": 98371
     },
     {
       "filename": "react-reconciler-persistent.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-reconciler",
-      "size": 57213,
-      "gzip": 17164
+      "size": 65118,
+      "gzip": 19322
     },
     {
       "filename": "react-reconciler-reflection.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-reconciler",
-      "size": 15764,
-      "gzip": 4943
+      "size": 16132,
+      "gzip": 5091
     },
     {
       "filename": "react-reconciler-reflection.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-reconciler",
-      "size": 2614,
-      "gzip": 1153
+      "size": 2757,
+      "gzip": 1247
     },
     {
       "filename": "react-call-return.development.js",
@@ -431,29 +431,29 @@
       "filename": "react-is.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-is",
-      "size": 7691,
-      "gzip": 2393
+      "size": 8255,
+      "gzip": 2495
     },
     {
       "filename": "react-is.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-is",
-      "size": 2171,
-      "gzip": 854
+      "size": 2342,
+      "gzip": 898
     },
     {
       "filename": "react-is.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-is",
-      "size": 7502,
-      "gzip": 2344
+      "size": 8066,
+      "gzip": 2445
     },
     {
       "filename": "react-is.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-is",
-      "size": 2132,
-      "gzip": 793
+      "size": 2339,
+      "gzip": 838
     },
     {
       "filename": "ReactIs-dev.js",
@@ -501,36 +501,36 @@
       "filename": "React-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react",
-      "size": 58338,
-      "gzip": 15703
+      "size": 60774,
+      "gzip": 16145
     },
     {
       "filename": "React-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react",
-      "size": 15346,
-      "gzip": 4131
+      "size": 15734,
+      "gzip": 4187
     },
     {
       "filename": "ReactDOM-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-dom",
-      "size": 742241,
-      "gzip": 167544
+      "size": 787573,
+      "gzip": 175673
     },
     {
       "filename": "ReactDOM-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-dom",
-      "size": 317018,
-      "gzip": 58396
+      "size": 322477,
+      "gzip": 59021
     },
     {
       "filename": "ReactTestUtils-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-dom",
-      "size": 42313,
-      "gzip": 11425
+      "size": 44798,
+      "gzip": 12159
     },
     {
       "filename": "ReactDOMUnstableNativeDependencies-dev.js",
@@ -550,113 +550,113 @@
       "filename": "ReactDOMServer-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-dom",
-      "size": 119227,
-      "gzip": 31112
+      "size": 126064,
+      "gzip": 33024
     },
     {
       "filename": "ReactDOMServer-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-dom",
-      "size": 41626,
-      "gzip": 9808
+      "size": 45841,
+      "gzip": 10591
     },
     {
       "filename": "ReactART-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-art",
-      "size": 445295,
-      "gzip": 93558
+      "size": 482449,
+      "gzip": 100037
     },
     {
       "filename": "ReactART-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-art",
-      "size": 187912,
-      "gzip": 32090
+      "size": 194706,
+      "gzip": 33110
     },
     {
       "filename": "ReactNativeRenderer-dev.js",
       "bundleType": "RN_FB_DEV",
       "packageName": "react-native-renderer",
-      "size": 573493,
-      "gzip": 124971
+      "size": 610009,
+      "gzip": 131067
     },
     {
       "filename": "ReactNativeRenderer-prod.js",
       "bundleType": "RN_FB_PROD",
       "packageName": "react-native-renderer",
-      "size": 244566,
-      "gzip": 43021
+      "size": 251999,
+      "gzip": 43951
     },
     {
       "filename": "ReactNativeRenderer-dev.js",
       "bundleType": "RN_OSS_DEV",
       "packageName": "react-native-renderer",
-      "size": 573182,
-      "gzip": 124874
+      "size": 609920,
+      "gzip": 131031
     },
     {
       "filename": "ReactNativeRenderer-prod.js",
       "bundleType": "RN_OSS_PROD",
       "packageName": "react-native-renderer",
-      "size": 229659,
-      "gzip": 39880
+      "size": 252013,
+      "gzip": 43947
     },
     {
       "filename": "ReactFabric-dev.js",
       "bundleType": "RN_FB_DEV",
       "packageName": "react-native-renderer",
-      "size": 563576,
-      "gzip": 122418
+      "size": 600643,
+      "gzip": 128741
     },
     {
       "filename": "ReactFabric-prod.js",
       "bundleType": "RN_FB_PROD",
       "packageName": "react-native-renderer",
-      "size": 223730,
-      "gzip": 38540
+      "size": 244188,
+      "gzip": 42473
     },
     {
       "filename": "ReactFabric-dev.js",
       "bundleType": "RN_OSS_DEV",
       "packageName": "react-native-renderer",
-      "size": 563611,
-      "gzip": 122433
+      "size": 600546,
+      "gzip": 128704
     },
     {
       "filename": "ReactFabric-prod.js",
       "bundleType": "RN_OSS_PROD",
       "packageName": "react-native-renderer",
-      "size": 223766,
-      "gzip": 38555
+      "size": 244194,
+      "gzip": 42463
     },
     {
       "filename": "ReactTestRenderer-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-test-renderer",
-      "size": 453557,
-      "gzip": 95443
+      "size": 489809,
+      "gzip": 101460
     },
     {
       "filename": "ReactShallowRenderer-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-test-renderer",
-      "size": 18564,
-      "gzip": 4859
+      "size": 30628,
+      "gzip": 7749
     },
     {
       "filename": "ReactIs-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-is",
-      "size": 5873,
-      "gzip": 1621
+      "size": 6437,
+      "gzip": 1724
     },
     {
       "filename": "ReactIs-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-is",
-      "size": 4382,
-      "gzip": 1135
+      "size": 4838,
+      "gzip": 1202
     },
     {
       "filename": "scheduler.development.js",
@@ -676,15 +676,15 @@
       "filename": "scheduler.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "scheduler",
-      "size": 22073,
-      "gzip": 5976
+      "size": 24456,
+      "gzip": 6331
     },
     {
       "filename": "scheduler.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "scheduler",
-      "size": 4755,
-      "gzip": 1865
+      "size": 5321,
+      "gzip": 2015
     },
     {
       "filename": "SimpleCacheProvider-dev.js",
@@ -704,50 +704,50 @@
       "filename": "react-noop-renderer-persistent.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-noop-renderer",
-      "size": 28948,
-      "gzip": 6299
+      "size": 32977,
+      "gzip": 7525
     },
     {
       "filename": "react-noop-renderer-persistent.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-noop-renderer",
-      "size": 10911,
-      "gzip": 3639
+      "size": 11508,
+      "gzip": 3772
     },
     {
       "filename": "react-dom.profiling.min.js",
       "bundleType": "NODE_PROFILING",
       "packageName": "react-dom",
-      "size": 102985,
-      "gzip": 32673
+      "size": 111100,
+      "gzip": 35065
     },
     {
       "filename": "ReactNativeRenderer-profiling.js",
       "bundleType": "RN_OSS_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 235342,
-      "gzip": 41248
+      "size": 258454,
+      "gzip": 45509
     },
     {
       "filename": "ReactFabric-profiling.js",
       "bundleType": "RN_OSS_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 228530,
-      "gzip": 39962
+      "size": 250512,
+      "gzip": 44015
     },
     {
       "filename": "Scheduler-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "scheduler",
-      "size": 22314,
-      "gzip": 6027
+      "size": 24739,
+      "gzip": 6379
     },
     {
       "filename": "Scheduler-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "scheduler",
-      "size": 13375,
-      "gzip": 2927
+      "size": 14857,
+      "gzip": 3124
     },
     {
       "filename": "react.profiling.min.js",
@@ -760,50 +760,50 @@
       "filename": "React-profiling.js",
       "bundleType": "FB_WWW_PROFILING",
       "packageName": "react",
-      "size": 15346,
-      "gzip": 4131
+      "size": 15734,
+      "gzip": 4187
     },
     {
       "filename": "ReactDOM-profiling.js",
       "bundleType": "FB_WWW_PROFILING",
       "packageName": "react-dom",
-      "size": 323954,
-      "gzip": 59824
+      "size": 328970,
+      "gzip": 60443
     },
     {
       "filename": "ReactNativeRenderer-profiling.js",
       "bundleType": "RN_FB_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 250505,
-      "gzip": 44397
+      "size": 258435,
+      "gzip": 45515
     },
     {
       "filename": "ReactFabric-profiling.js",
       "bundleType": "RN_FB_PROFILING",
       "packageName": "react-native-renderer",
-      "size": 228489,
-      "gzip": 39945
+      "size": 250501,
+      "gzip": 44019
     },
     {
       "filename": "react.profiling.min.js",
       "bundleType": "UMD_PROFILING",
       "packageName": "react",
-      "size": 13977,
-      "gzip": 5211
+      "size": 15063,
+      "gzip": 5520
     },
     {
       "filename": "react-dom.profiling.min.js",
       "bundleType": "UMD_PROFILING",
       "packageName": "react-dom",
-      "size": 102894,
-      "gzip": 33243
+      "size": 110774,
+      "gzip": 35660
     },
     {
       "filename": "scheduler-tracing.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "scheduler",
-      "size": 10480,
-      "gzip": 2403
+      "size": 10554,
+      "gzip": 2432
     },
     {
       "filename": "scheduler-tracing.production.min.js",
@@ -823,8 +823,8 @@
       "filename": "SchedulerTracing-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "scheduler",
-      "size": 10467,
-      "gzip": 2295
+      "size": 10195,
+      "gzip": 2139
     },
     {
       "filename": "SchedulerTracing-prod.js",
@@ -844,43 +844,43 @@
       "filename": "react-cache.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-cache",
-      "size": 9015,
-      "gzip": 3022
+      "size": 9030,
+      "gzip": 3016
     },
     {
       "filename": "react-cache.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-cache",
-      "size": 2204,
-      "gzip": 1128
+      "size": 2199,
+      "gzip": 1125
     },
     {
       "filename": "ReactCache-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-cache",
-      "size": 7409,
-      "gzip": 2374
+      "size": 7429,
+      "gzip": 2370
     },
     {
       "filename": "ReactCache-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-cache",
-      "size": 5180,
-      "gzip": 1645
+      "size": 5200,
+      "gzip": 1641
     },
     {
       "filename": "react-cache.development.js",
       "bundleType": "UMD_DEV",
       "packageName": "react-cache",
-      "size": 9246,
-      "gzip": 3094
+      "size": 9261,
+      "gzip": 3090
     },
     {
       "filename": "react-cache.production.min.js",
       "bundleType": "UMD_PROD",
       "packageName": "react-cache",
-      "size": 2403,
-      "gzip": 1219
+      "size": 2398,
+      "gzip": 1215
     },
     {
       "filename": "jest-react.development.js",
@@ -914,22 +914,22 @@
       "filename": "react-debug-tools.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-debug-tools",
-      "size": 16717,
-      "gzip": 4965
+      "size": 19024,
+      "gzip": 5638
     },
     {
       "filename": "react-debug-tools.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-debug-tools",
-      "size": 5402,
-      "gzip": 2187
+      "size": 5800,
+      "gzip": 2343
     },
     {
       "filename": "eslint-plugin-react-hooks.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "eslint-plugin-react-hooks",
-      "size": 26113,
-      "gzip": 6008
+      "size": 26115,
+      "gzip": 6005
     },
     {
       "filename": "eslint-plugin-react-hooks.production.min.js",
@@ -1023,11 +1023,102 @@
       "gzip": 659
     },
     {
+      "filename": "react-dom-unstable-fire.development.js",
+      "bundleType": "UMD_DEV",
+      "packageName": "react-dom",
+      "size": 770327,
+      "gzip": 176122
+    },
+    {
+      "filename": "react-dom-unstable-fire.production.min.js",
+      "bundleType": "UMD_PROD",
+      "packageName": "react-dom",
+      "size": 107794,
+      "gzip": 34795
+    },
+    {
+      "filename": "react-dom-unstable-fire.profiling.min.js",
+      "bundleType": "UMD_PROFILING",
+      "packageName": "react-dom",
+      "size": 110789,
+      "gzip": 35669
+    },
+    {
+      "filename": "react-dom-unstable-fire.development.js",
+      "bundleType": "NODE_DEV",
+      "packageName": "react-dom",
+      "size": 764716,
+      "gzip": 174561
+    },
+    {
+      "filename": "react-dom-unstable-fire.production.min.js",
+      "bundleType": "NODE_PROD",
+      "packageName": "react-dom",
+      "size": 107967,
+      "gzip": 34227
+    },
+    {
+      "filename": "react-dom-unstable-fire.profiling.min.js",
+      "bundleType": "NODE_PROFILING",
+      "packageName": "react-dom",
+      "size": 111114,
+      "gzip": 35074
+    },
+    {
+      "filename": "ReactFire-dev.js",
+      "bundleType": "FB_WWW_DEV",
+      "packageName": "react-dom",
+      "size": 786764,
+      "gzip": 175592
+    },
+    {
+      "filename": "ReactFire-prod.js",
+      "bundleType": "FB_WWW_PROD",
+      "packageName": "react-dom",
+      "size": 310682,
+      "gzip": 56661
+    },
+    {
+      "filename": "ReactFire-profiling.js",
+      "bundleType": "FB_WWW_PROFILING",
+      "packageName": "react-dom",
+      "size": 317212,
+      "gzip": 58089
+    },
+    {
+      "filename": "jest-mock-scheduler.development.js",
+      "bundleType": "NODE_DEV",
+      "packageName": "jest-mock-scheduler",
+      "size": 1533,
+      "gzip": 724
+    },
+    {
+      "filename": "jest-mock-scheduler.production.min.js",
+      "bundleType": "NODE_PROD",
+      "packageName": "jest-mock-scheduler",
+      "size": 671,
+      "gzip": 437
+    },
+    {
+      "filename": "JestMockScheduler-dev.js",
+      "bundleType": "FB_WWW_DEV",
+      "packageName": "jest-mock-scheduler",
+      "size": 1511,
+      "gzip": 711
+    },
+    {
+      "filename": "JestMockScheduler-prod.js",
+      "bundleType": "FB_WWW_PROD",
+      "packageName": "jest-mock-scheduler",
+      "size": 1085,
+      "gzip": 532
+    },
+    {
       "filename": "ESLintPluginReactHooks-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "eslint-plugin-react-hooks",
-      "size": 27786,
-      "gzip": 6149
+      "size": 27788,
+      "gzip": 6145
     }
   ]
 }


### PR DESCRIPTION
This is a follow up to https://github.com/facebook/react/pull/14746. On very low end devices we may want to force scheduler to run at a lower framerate than 30fps even if the browser/device supports something faster. Lower spec devices may not be able to run enough tasks within 33ms to make meaningful progress, so this adds a function that lets developers force a specific frame rate.