### PR TITLE
Special case crossOrigin for SVG image elements

### DIFF
--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -525,13 +525,15 @@ const capitalize = token => token[1].toUpperCase();
   );
 });
 
-// Special case: this attribute exists both in HTML and SVG.
-// Its "tabindex" attribute name is case-sensitive in SVG so we can't just use
-// its React `tabIndex` name, like we do for attributes that exist only in HTML.
-properties.tabIndex = new PropertyInfoRecord(
-  'tabIndex',
-  STRING,
-  false, // mustUseProperty
-  'tabindex', // attributeName
-  null, // attributeNamespace
-);
+// These attribute exists both in HTML and SVG.
+// The attribute name is case-sensitive in SVG so we can't just use
+// the React name like we do for attributes that exist only in HTML.
+['tabIndex', 'crossOrigin'].forEach(attributeName => {
+  properties[attributeName] = new PropertyInfoRecord(
+    attributeName,
+    STRING,
+    false, // mustUseProperty
+    attributeName.toLowerCase(), // attributeName
+    null, // attributeNamespace
+  );
+});


### PR DESCRIPTION
Resolves #14829

According to the [SVG2 spec](https://www.w3.org/TR/SVG2/embedded.html#ImageElementCrossoriginAttribute) `crossOrigin` is allowed on certain SVG elements. We already had a special case for `tabIndex` which also exists in both the HTML and SVG specs, so this extends that to `crossOrigin`