### PR TITLE
Revert "[ShallowRenderer] Queue/rerender on dispatched action after render component with hooks"

### DIFF
--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -384,7 +384,7 @@ class ReactShallowRenderer {
         'an infinite loop.',
     );
 
-    if (componentIdentity === this._previousComponentIdentity) {
+    if (componentIdentity === this._currentlyRenderingComponent) {
       // This is a render phase update. Stash it in a lazily-created map of
       // queue -> linked list of updates. After this render pass, we'll restart
       // and apply the stashed updates on top of the work-in-progress hook.
@@ -408,13 +408,10 @@ class ReactShallowRenderer {
         }
         lastRenderPhaseUpdate.next = update;
       }
-
-      if (!this._rendering) {
-        this.render(this._element, this._context);
-      }
     } else {
       // This means an update has happened after the function component has
-      // returned from a different component.
+      // returned. On the server this is a no-op. In React Fiber, the update
+      // would be scheduled for a future render.
     }
   }
 

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
@@ -90,39 +90,6 @@ describe('ReactShallowRenderer with hooks', () => {
     );
   });
 
-  it('should work with updating a value from useState outside the render', () => {
-    function SomeComponent({defaultName}) {
-      const [name, updateName] = React.useState(defaultName);
-
-      return (
-        <div onClick={() => updateName('Dan')}>
-          <p>
-            Your name is: <span>{name}</span>
-          </p>
-        </div>
-      );
-    }
-
-    const shallowRenderer = createRenderer();
-    const element = <SomeComponent defaultName={'Dominic'} />;
-    const result = shallowRenderer.render(element);
-
-    expect(result.props.children).toEqual(
-      <p>
-        Your name is: <span>Dominic</span>
-      </p>,
-    );
-
-    result.props.onClick();
-    const updated = shallowRenderer.render(element);
-
-    expect(updated.props.children).toEqual(
-      <p>
-        Your name is: <span>Dan</span>
-      </p>,
-    );
-  });
-
   it('should work with useReducer', () => {
     function reducer(state, action) {
       switch (action.type) {


### PR DESCRIPTION
Reverts facebook/react#14802

This is not the right fix. This takes the code branch that was written for render phase updates, and reuses it for regular updates. Maybe it works, maybe it doesn't.

If we want to fix it, let's rename the variables and make sure the code actually works for general updates, and not just render phase updates. I have no confidence that it does because it was adapted 1:1 from the server renderer.