### PR TITLE
Support nonRenderPhase updates in ShallowRenderer

### DIFF
--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -459,6 +459,8 @@ class ReactShallowRenderer {
         }
         lastUpdate.next = update;
       }
+      // Finally, invoke a new render
+      this._renderer.render(this._renderer._element, this._renderer._context);
     }
   }
 

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -460,7 +460,8 @@ class ReactShallowRenderer {
         lastUpdate.next = update;
       }
       // Finally, invoke a new render
-      this._renderer.render(this._renderer._element, this._renderer._context);
+      const renderer = this._updater._renderer;
+      renderer.render(renderer._element, renderer._context);
     }
   }
 

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -1454,4 +1454,37 @@ describe('ReactShallowRenderer', () => {
     shallowRenderer.render(<Foo foo="bar" />);
     expect(logs).toEqual([undefined]);
   });
+
+  it('should work with updating a value from useState outside the render', () => {
+    function SomeComponent({defaultName}) {
+      const [name, updateName] = React.useState(defaultName);
+
+      return (
+        <div onClick={() => updateName('Dan')}>
+          <p>
+            Your name is: <span>{name}</span>
+          </p>
+        </div>
+      );
+    }
+
+    const shallowRenderer = createRenderer();
+    const element = <SomeComponent defaultName={'Dominic'} />;
+    const result = shallowRenderer.render(element);
+
+    expect(result.props.children).toEqual(
+      <p>
+        Your name is: <span>Dominic</span>
+      </p>,
+    );
+
+    result.props.onClick();
+    const updated = shallowRenderer.render(element);
+
+    expect(updated.props.children).toEqual(
+      <p>
+        Your name is: <span>Dan</span>
+      </p>,
+    );
+  });
 });


### PR DESCRIPTION
Addresses the issue with https://github.com/facebook/react/issues/14840.

Following up from the fix in https://github.com/facebook/react/pull/14802 – which although somewhat correct, it didn't make sense when aligned with the comments. I've addressed the comments and approach so it should fix the original issue whilst keeping non-render phase updates and render-phase updates separate. 