### PR TITLE
include component stack in 'act(...)' warning

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -634,10 +634,9 @@ describe('ReactTestUtils', () => {
       button.dispatchEvent(new MouseEvent('click', {bubbles: true}));
     });
     expect(button.innerHTML).toBe('2');
-    expect(() => setValueRef(1)).toWarnDev(
-      ['An update to App inside a test was not wrapped in act(...).'],
-      {withoutStack: 1},
-    );
+    expect(() => setValueRef(1)).toWarnDev([
+      'An update to App inside a test was not wrapped in act(...).',
+    ]);
     document.body.removeChild(container);
   });
 

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1815,8 +1815,9 @@ export function warnIfNotCurrentlyBatchingInDev(fiber: Fiber): void {
           '});\n' +
           '/* assert on the output */\n\n' +
           "This ensures that you're testing the behavior the user would see in the browser." +
-          ' Learn more at https://fb.me/react-wrap-tests-with-act',
+          ' Learn more at https://fb.me/react-wrap-tests-with-act\n%s',
         getComponentName(fiber.type),
+        getStackByFiberInDevAndProd(fiber)
       );
     }
   }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1817,7 +1817,7 @@ export function warnIfNotCurrentlyBatchingInDev(fiber: Fiber): void {
           "This ensures that you're testing the behavior the user would see in the browser." +
           ' Learn more at https://fb.me/react-wrap-tests-with-act\n%s',
         getComponentName(fiber.type),
-        getStackByFiberInDevAndProd(fiber)
+        getStackByFiberInDevAndProd(fiber),
       );
     }
   }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -1815,7 +1815,8 @@ export function warnIfNotCurrentlyBatchingInDev(fiber: Fiber): void {
           '});\n' +
           '/* assert on the output */\n\n' +
           "This ensures that you're testing the behavior the user would see in the browser." +
-          ' Learn more at https://fb.me/react-wrap-tests-with-act\n%s',
+          ' Learn more at https://fb.me/react-wrap-tests-with-act' +
+          '%s',
         getComponentName(fiber.type),
         getStackByFiberInDevAndProd(fiber),
       );


### PR DESCRIPTION
Folks aren't seeing stack traces for their  calls in their jest setups, so this PR includes a component stack trace to make it easier to locate and wrap with `act(...)`. 