### PR TITLE
[refactor][client/ReactDOM] convert force Boolean casting to Flow Ano…

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -452,8 +452,8 @@ ReactRoot.prototype.createBatch = function(): Batch {
  * @return {boolean} True if the DOM is a valid DOM node.
  * @internal
  */
-function isValidContainer(node) {
-  return !!(
+function isValidContainer(node): boolean {
+  return (
     node &&
     (node.nodeType === ELEMENT_NODE ||
       node.nodeType === DOCUMENT_NODE ||


### PR DESCRIPTION
Change as title.

### why
I think this is safer than before.

For example, add deliberately value change as a invalid for Logical Expression.

```diff
-    node &&
+  NaN &&
    (node.nodeType === ELEMENT_NODE ||
      node.nodeType === DOCUMENT_NODE ||
```

After that run ` yarn flow dom` command.  
As a result Flow can find illegal values by static analysis before runtime.  
In addition if assigned illegal values into the expression,
result value is forcibly cast to boolean, making debugging difficult.

- console output
```diff
ryota.murakami@ryotas-MacBook-Pro ~/f/react> yarn flow dom
yarn run v1.12.3
$ node ./scripts/tasks/flow.js dom
Running Flow on the dom renderer...
Launching Flow server for /Users/ryota.murakami/fork/react/scripts/flow/dom
Spawned flow server (pid=2118)
Logs will go to /private/tmp/flow/zSUserszSryota.murakamizSforkzSreactzSscriptszSflowzSdom.log
Monitor logs will go to /private/tmp/flow/zSUserszSryota.murakamizSforkzSreactzSscriptszSflowzSdom.monitor_log
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ ../../../packages/react-dom/src/client/ReactDOM.js:457:5

+ Cannot return
+ NaN && ((node.nodeType === ELEMENT_NODE) || (node.nodeType === DOCUMENT_NODE) || (node.nodeType === DOCUMENT_FRAGMENT_NO
+ DE) || ((node.nodeType === COMMENT_NODE) && (node.nodeValue === ' react-mou...'))) because number [1] is incompatible
+ with boolean [2].

     ../../../packages/react-dom/src/client/ReactDOM.js
     454│  */
 [2] 455│ function isValidContainer(node): boolean {
     456│   return (
     457│     NaN &&
     458│     (node.nodeType === ELEMENT_NODE ||
     459│       node.nodeType === DOCUMENT_NODE ||
     460│       node.nodeType === DOCUMENT_FRAGMENT_NODE ||
     461│       (node.nodeType === COMMENT_NODE &&
     462│         node.nodeValue === ' react-mount-point-unstable '))
     463│   );
     464│ }
     465│

     /private/tmp/flow/flowlib_bb4a3db/core.js
 [1]  11│ declare var NaN: number;



Found 1 error
Flow failed for the dom renderer
```

Thank you so much😀