### PR TITLE
Fixed an issue with simple memo components being updated with new props during context change

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -592,8 +592,9 @@ function updateSimpleMemoComponent(
   }
   if (current !== null) {
     const prevProps = current.memoizedProps;
+    nextProps = shallowEqual(prevProps, nextProps) ? prevProps : nextProps;
     if (
-      shallowEqual(prevProps, nextProps) &&
+      prevProps === nextProps &&
       current.ref === workInProgress.ref &&
       // Prevent bailout if the implementation changed due to hot reload.
       (__DEV__ ? workInProgress.type === current.type : true)

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -592,7 +592,11 @@ function updateSimpleMemoComponent(
   }
   if (current !== null) {
     const prevProps = current.memoizedProps;
-    nextProps = shallowEqual(prevProps, nextProps) ? prevProps : nextProps;
+    // potentially recycle `prevProps` if they are the same
+    // this allows hooks depending on the `props` to be reused
+    workInProgress.pendingProps = nextProps = shallowEqual(prevProps, nextProps)
+      ? prevProps
+      : nextProps;
     if (
       prevProps === nextProps &&
       current.ref === workInProgress.ref &&

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -592,8 +592,9 @@ function updateSimpleMemoComponent(
   }
   if (current !== null) {
     const prevProps = current.memoizedProps;
+    nextProps = shallowEqual(prevProps, nextProps) ? prevProps : nextProps;
     if (
-      shallowEqual(prevProps, nextProps) &&
+      prevProps === nextProps &&
       current.ref === workInProgress.ref &&
       // Prevent bailout if the implementation changed due to hot reload.
       (__DEV__ ? workInProgress.type === current.type : true)

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -592,7 +592,11 @@ function updateSimpleMemoComponent(
   }
   if (current !== null) {
     const prevProps = current.memoizedProps;
-    nextProps = shallowEqual(prevProps, nextProps) ? prevProps : nextProps;
+    // potentially recycle `prevProps` if they are the same
+    // this allows hooks depending on the `props` to be reused
+    workInProgress.pendingProps = nextProps = shallowEqual(prevProps, nextProps)
+      ? prevProps
+      : nextProps;
     if (
       prevProps === nextProps &&
       current.ref === workInProgress.ref &&

--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.js
@@ -222,6 +222,12 @@ describe('memo', () => {
         expect(ReactNoop.getChildren()).toEqual([
           span('Inner render count: 1'),
         ]);
+
+        ReactNoop.render(<Parent value={ctxValue++} />);
+        expect(Scheduler).toFlushAndYield([]);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Inner render count: 1'),
+        ]);
       });
 
       it('accepts custom comparison function', async () => {


### PR DESCRIPTION
This is **not ready to be merged yet** because it only provides a failing test, I'd like to work on fixing this issue - but I would really appreciate some guidance with this. I've tried to understand what exactly is happening (wanted to send a PR with a fix already in it 😉 ), but failed to do so - need to dig deeper.

My current conclusion is that this fails because of the "simple memo" optimization - `workLoop` doesnt see this memo element at all, it "jumps" from working on Outer directly to Inner which has fresh `pendingProps` which are used as argument for working on Inner as it correctly has to rerender itself because it reads changed context. So it doesnt bail out on finished work (correctly) and commits used new props as memoized ones later.

**Why this matters?**
Because it's inconsistent with "regular" memo component. Conceptually from the user's perspective `React.memo(Component)` & `React.memo(Component, shallowEqual)` should behave exactly the same (but they dont)

I've prepared a demo to showcase the problem - https://codesandbox.io/s/jp21pwzrv9