### PR TITLE
Add a warning to useRef/useState/useReducer invoked with a missing argument instead of undefined

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
@@ -422,7 +422,7 @@ describe('ReactDOMServerHooks', () => {
     itRenders('with a warning for useState inside useMemo', async render => {
       function App() {
         useMemo(() => {
-          useState();
+          useState(0);
           return 0;
         });
         return 'hi';
@@ -804,7 +804,10 @@ describe('ReactDOMServerHooks', () => {
       }
 
       function ReadInReducer(props) {
-        let [count, dispatch] = React.useReducer(() => readContext(Context));
+        let [count, dispatch] = React.useReducer(
+          () => readContext(Context),
+          undefined,
+        );
         if (count !== 42) {
           dispatch();
         }

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1529,4 +1529,61 @@ describe('ReactHooks', () => {
     await Promise.resolve();
     expect(root).toMatchRenderedOutput('hello');
   });
+
+  it('warns about incorrect number of arguments to useState', () => {
+    const {useState} = React;
+
+    function Counter() {
+      useState();
+      useState(undefined);
+      useState('too', 'many');
+      return null;
+    }
+
+    expect(() => {
+      ReactTestRenderer.create(<Counter />);
+    }).toWarnDev([
+      'Expected exactly one argument to React.useState(initialState), instead received 0.',
+      'Expected exactly one argument to React.useState(initialState), instead received 2.',
+    ]);
+  });
+
+  it('warns about incorrect number of arguments to useRef', () => {
+    const {useRef} = React;
+
+    function Counter() {
+      useRef();
+      useRef(undefined);
+      useRef('too', 'many');
+      return null;
+    }
+
+    expect(() => {
+      ReactTestRenderer.create(<Counter />);
+    }).toWarnDev([
+      'Expected exactly one argument to React.useRef(initialValue), instead received 0.',
+      'Expected exactly one argument to React.useRef(initialValue), instead received 2.',
+    ]);
+  });
+
+  it('warns about incorrect number of arguments to useReducer', () => {
+    const {useReducer} = React;
+
+    function Counter() {
+      useReducer();
+      useReducer(() => 'too few');
+      useReducer(() => 0, 0);
+      useReducer(() => 0, 0, () => 0);
+      useReducer(() => 0, 0, () => 0, 'too many');
+      return null;
+    }
+
+    expect(() => {
+      ReactTestRenderer.create(<Counter />);
+    }).toWarnDev([
+      'Expected between 2 and 3 arguments to React.useReducer(reducer, value), instead received 0.',
+      'Expected between 2 and 3 arguments to React.useReducer(reducer, value), instead received 1.',
+      'Expected between 2 and 3 arguments to React.useReducer(reducer, value), instead received 4.',
+    ]);
+  });
 });

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1533,7 +1533,7 @@ describe('ReactHooks', () => {
   it('warns about incorrect number of arguments to useState', () => {
     const {useState} = React;
 
-    function Counter() {
+    function Test() {
       useState();
       useState(undefined);
       useState('too', 'many');
@@ -1541,7 +1541,7 @@ describe('ReactHooks', () => {
     }
 
     expect(() => {
-      ReactTestRenderer.create(<Counter />);
+      ReactTestRenderer.create(<Test />);
     }).toWarnDev([
       'Expected exactly one argument to React.useState(initialState), instead received 0.',
       'Expected exactly one argument to React.useState(initialState), instead received 2.',
@@ -1551,7 +1551,7 @@ describe('ReactHooks', () => {
   it('warns about incorrect number of arguments to useRef', () => {
     const {useRef} = React;
 
-    function Counter() {
+    function Test() {
       useRef();
       useRef(undefined);
       useRef('too', 'many');
@@ -1559,7 +1559,7 @@ describe('ReactHooks', () => {
     }
 
     expect(() => {
-      ReactTestRenderer.create(<Counter />);
+      ReactTestRenderer.create(<Test />);
     }).toWarnDev([
       'Expected exactly one argument to React.useRef(initialValue), instead received 0.',
       'Expected exactly one argument to React.useRef(initialValue), instead received 2.',
@@ -1569,7 +1569,7 @@ describe('ReactHooks', () => {
   it('warns about incorrect number of arguments to useReducer', () => {
     const {useReducer} = React;
 
-    function Counter() {
+    function Test() {
       useReducer();
       useReducer(() => 'too few');
       useReducer(() => 0, 0);
@@ -1579,7 +1579,7 @@ describe('ReactHooks', () => {
     }
 
     expect(() => {
-      ReactTestRenderer.create(<Counter />);
+      ReactTestRenderer.create(<Test />);
     }).toWarnDev([
       'Expected between 2 and 3 arguments to React.useReducer(reducer, value), instead received 0.',
       'Expected between 2 and 3 arguments to React.useReducer(reducer, value), instead received 1.',

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -994,7 +994,7 @@ describe('ReactHooks', () => {
       if (value === 0) {
         dispatch('foo');
       }
-      useState();
+      useState(undefined);
       return value;
     }
     expect(() => {
@@ -1033,7 +1033,7 @@ describe('ReactHooks', () => {
       React.useMemo(() => {
         // Trigger warnings
         ReactCurrentDispatcher.current.readContext(ThemeContext);
-        React.useRef();
+        React.useRef(0);
         // Interrupt exit from a Hook
         throw new Error('No.');
       }, []);
@@ -1067,13 +1067,13 @@ describe('ReactHooks', () => {
     ]);
 
     function Valid() {
-      React.useState();
+      React.useState(undefined);
       React.useMemo(() => {});
-      React.useReducer(() => {});
+      React.useReducer(() => {}, undefined);
       React.useEffect(() => {});
       React.useLayoutEffect(() => {});
       React.useCallback(() => {});
-      React.useRef();
+      React.useRef(undefined);
       React.useImperativeHandle(() => {}, () => {});
       if (__DEV__) {
         React.useDebugValue();
@@ -1452,7 +1452,7 @@ describe('ReactHooks', () => {
     }
 
     function Child() {
-      useState();
+      useState(undefined);
       trySuspend();
       return 'hello';
     }
@@ -1483,7 +1483,7 @@ describe('ReactHooks', () => {
     }
 
     function render(props, ref) {
-      useState();
+      useState(undefined);
       trySuspend();
       return 'hello';
     }
@@ -1514,7 +1514,7 @@ describe('ReactHooks', () => {
     }
 
     function render(props, ref) {
-      useState();
+      useState(undefined);
       trySuspend();
       return 'hello';
     }

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -80,6 +80,7 @@ export function useReducer<S, I, A>(
 }
 
 export function useRef<T>(initialValue: T): {current: T} {
+  const dispatcher = resolveDispatcher();
   if (__DEV__) {
     // this is the only place where, if the user gives no arguments,
     // the argument will actually be missing instead of just being undefined.
@@ -89,7 +90,6 @@ export function useRef<T>(initialValue: T): {current: T} {
       arguments.length,
     );
   }
-  const dispatcher = resolveDispatcher();
   return dispatcher.useRef(initialValue);
 }
 

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -67,6 +67,15 @@ export function useContext<T>(
 
 export function useState<S>(initialState: (() => S) | S) {
   const dispatcher = resolveDispatcher();
+  if (__DEV__) {
+    // this is the only place where, if the user gives no arguments,
+    // the argument will actually be missing instead of just being undefined.
+    warning(
+      arguments.length === 1,
+      'Expected exactly one argument to React.useState(initialState), instead received %s.',
+      arguments.length,
+    );
+  }
   return dispatcher.useState(initialState);
 }
 

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -80,6 +80,15 @@ export function useReducer<S, I, A>(
 }
 
 export function useRef<T>(initialValue: T): {current: T} {
+  if (__DEV__) {
+    // this is the only place where, if the user gives no arguments,
+    // the argument will actually be missing instead of just being undefined.
+    warning(
+      arguments.length === 1,
+      'Expected exactly one argument to React.useRef(initialValue), instead received %s.',
+      arguments.length,
+    );
+  }
   const dispatcher = resolveDispatcher();
   return dispatcher.useRef(initialValue);
 }

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -85,6 +85,15 @@ export function useReducer<S, I, A>(
   init?: I => S,
 ) {
   const dispatcher = resolveDispatcher();
+  if (__DEV__) {
+    // this is the only place where, if the user gives no arguments,
+    // the argument will actually be missing instead of just being undefined.
+    warning(
+      arguments.length >= 2 && arguments.length <= 3,
+      'Expected between 2 and 3 arguments to React.useReducer(reducer, value), instead received %s.',
+      arguments.length,
+    );
+  }
   return dispatcher.useReducer(reducer, initialArg, init);
 }
 


### PR DESCRIPTION
As per the discussion on https://twitter.com/dan_abramov/status/1097844767956918274