### PR TITLE
Deprecate ref.setNativeProps in favor of ReactNative.setNativeProps

### DIFF
--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -29,6 +29,8 @@ import {
 
 import warningWithoutStack from 'shared/warningWithoutStack';
 
+import {warnAboutDeprecatedSetNativeProps} from 'shared/ReactFeatureFlags';
+
 export default function(
   findNodeHandle: any => ?number,
   findHostInstance: any => any,
@@ -124,13 +126,15 @@ export default function(
      */
     setNativeProps: function(nativeProps: Object) {
       if (__DEV__) {
-        warningWithoutStack(
-          false,
-          'Warning: Calling ref.setNativeProps(nativeProps) ' +
-            'is deprecated and will be removed in a future release. ' +
-            'Use the setNativeProps export from the react-native package instead.' +
-            "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
-        );
+        if (warnAboutDeprecatedSetNativeProps) {
+          warningWithoutStack(
+            false,
+            'Warning: Calling ref.setNativeProps(nativeProps) ' +
+              'is deprecated and will be removed in a future release. ' +
+              'Use the setNativeProps export from the react-native package instead.' +
+              "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
+          );
+        }
       }
       // Class components don't have viewConfig -> validateAttributes.
       // Nor does it make sense to set native props on a non-native component.

--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -27,6 +27,8 @@ import {
   warnForStyleProps,
 } from './NativeMethodsMixinUtils';
 
+import warningWithoutStack from 'shared/warningWithoutStack';
+
 export default function(
   findNodeHandle: any => ?number,
   findHostInstance: any => any,
@@ -121,6 +123,15 @@ export default function(
      * Manipulation](docs/direct-manipulation.html)).
      */
     setNativeProps: function(nativeProps: Object) {
+      if (__DEV__) {
+        warningWithoutStack(
+          false,
+          'Warning: Calling ref.setNativeProps(nativeProps) ' +
+            'is deprecated and will be removed in a future release. ' +
+            'Use the setNativeProps export from the react-native package instead.' +
+            "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
+        );
+      }
       // Class components don't have viewConfig -> validateAttributes.
       // Nor does it make sense to set native props on a non-native component.
       // Instead, find the nearest host component and set props on it.

--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -28,7 +28,6 @@ import {
 } from './NativeMethodsMixinUtils';
 
 import warningWithoutStack from 'shared/warningWithoutStack';
-
 import {warnAboutDeprecatedSetNativeProps} from 'shared/ReactFeatureFlags';
 
 export default function(

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -30,6 +30,7 @@ import {get as getViewConfigForType} from 'ReactNativeViewConfigRegistry';
 
 import deepFreezeAndThrowOnMutationInDev from 'deepFreezeAndThrowOnMutationInDev';
 import invariant from 'shared/invariant';
+import warningWithoutStack from 'shared/warningWithoutStack';
 
 import {dispatchEvent} from './ReactFabricEventEmitter';
 
@@ -140,6 +141,13 @@ class ReactFabricHostComponent {
 
   setNativeProps(nativeProps: Object) {
     if (__DEV__) {
+      warningWithoutStack(
+        false,
+        'Warning: Calling ref.setNativeProps(nativeProps) ' +
+          'is deprecated and will be removed in a future release. ' +
+          'Use the setNativeProps export from the react-native package instead.' +
+          "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
+      );
       warnForStyleProps(nativeProps, this.viewConfig.validAttributes);
     }
 

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -31,6 +31,7 @@ import {get as getViewConfigForType} from 'ReactNativeViewConfigRegistry';
 import deepFreezeAndThrowOnMutationInDev from 'deepFreezeAndThrowOnMutationInDev';
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
+import {warnAboutDeprecatedSetNativeProps} from 'shared/ReactFeatureFlags';
 
 import {dispatchEvent} from './ReactFabricEventEmitter';
 
@@ -141,13 +142,15 @@ class ReactFabricHostComponent {
 
   setNativeProps(nativeProps: Object) {
     if (__DEV__) {
-      warningWithoutStack(
-        false,
-        'Warning: Calling ref.setNativeProps(nativeProps) ' +
-          'is deprecated and will be removed in a future release. ' +
-          'Use the setNativeProps export from the react-native package instead.' +
-          "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
-      );
+      if (warnAboutDeprecatedSetNativeProps) {
+        warningWithoutStack(
+          false,
+          'Warning: Calling ref.setNativeProps(nativeProps) ' +
+            'is deprecated and will be removed in a future release. ' +
+            'Use the setNativeProps export from the react-native package instead.' +
+            "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
+        );
+      }
       warnForStyleProps(nativeProps, this.viewConfig.validAttributes);
     }
 

--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -25,6 +25,7 @@ import {create} from './ReactNativeAttributePayload';
 import {mountSafeCallback_NOT_REALLY_SAFE} from './NativeMethodsMixinUtils';
 
 import warningWithoutStack from 'shared/warningWithoutStack';
+import {warnAboutDeprecatedSetNativeProps} from 'shared/ReactFeatureFlags';
 
 export default function(
   findNodeHandle: any => ?number,
@@ -135,13 +136,15 @@ export default function(
      */
     setNativeProps(nativeProps: Object): void {
       if (__DEV__) {
-        warningWithoutStack(
-          false,
-          'Warning: Calling ref.setNativeProps(nativeProps) ' +
-            'is deprecated and will be removed in a future release. ' +
-            'Use the setNativeProps export from the react-native package instead.' +
-            "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
-        );
+        if (warnAboutDeprecatedSetNativeProps) {
+          warningWithoutStack(
+            false,
+            'Warning: Calling ref.setNativeProps(nativeProps) ' +
+              'is deprecated and will be removed in a future release. ' +
+              'Use the setNativeProps export from the react-native package instead.' +
+              "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
+          );
+        }
       }
 
       // Class components don't have viewConfig -> validateAttributes.

--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -24,6 +24,8 @@ import UIManager from 'UIManager';
 import {create} from './ReactNativeAttributePayload';
 import {mountSafeCallback_NOT_REALLY_SAFE} from './NativeMethodsMixinUtils';
 
+import warningWithoutStack from 'shared/warningWithoutStack';
+
 export default function(
   findNodeHandle: any => ?number,
   findHostInstance: any => any,
@@ -132,6 +134,16 @@ export default function(
      * Manipulation](docs/direct-manipulation.html)).
      */
     setNativeProps(nativeProps: Object): void {
+      if (__DEV__) {
+        warningWithoutStack(
+          false,
+          'Warning: Calling ref.setNativeProps(nativeProps) ' +
+            'is deprecated and will be removed in a future release. ' +
+            'Use the setNativeProps export from the react-native package instead.' +
+            "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
+        );
+      }
+
       // Class components don't have viewConfig -> validateAttributes.
       // Nor does it make sense to set native props on a non-native component.
       // Instead, find the nearest host component and set props on it.

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -28,6 +28,8 @@ import {
 
 import warningWithoutStack from 'shared/warningWithoutStack';
 
+import {warnAboutDeprecatedSetNativeProps} from 'shared/ReactFeatureFlags';
+
 /**
  * This component defines the same methods as NativeMethodsMixin but without the
  * findNodeHandle wrapper. This wrapper is unnecessary for HostComponent views
@@ -83,13 +85,15 @@ class ReactNativeFiberHostComponent {
 
   setNativeProps(nativeProps: Object) {
     if (__DEV__) {
-      warningWithoutStack(
-        false,
-        'Warning: Calling ref.setNativeProps(nativeProps) ' +
-          'is deprecated and will be removed in a future release. ' +
-          'Use the setNativeProps export from the react-native package instead.' +
-          "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
-      );
+      if (warnAboutDeprecatedSetNativeProps) {
+        warningWithoutStack(
+          false,
+          'Warning: Calling ref.setNativeProps(nativeProps) ' +
+            'is deprecated and will be removed in a future release. ' +
+            'Use the setNativeProps export from the react-native package instead.' +
+            "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
+        );
+      }
       warnForStyleProps(nativeProps, this.viewConfig.validAttributes);
     }
 

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -27,7 +27,6 @@ import {
 } from './NativeMethodsMixinUtils';
 
 import warningWithoutStack from 'shared/warningWithoutStack';
-
 import {warnAboutDeprecatedSetNativeProps} from 'shared/ReactFeatureFlags';
 
 /**

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -26,6 +26,8 @@ import {
   warnForStyleProps,
 } from './NativeMethodsMixinUtils';
 
+import warningWithoutStack from 'shared/warningWithoutStack';
+
 /**
  * This component defines the same methods as NativeMethodsMixin but without the
  * findNodeHandle wrapper. This wrapper is unnecessary for HostComponent views
@@ -81,6 +83,13 @@ class ReactNativeFiberHostComponent {
 
   setNativeProps(nativeProps: Object) {
     if (__DEV__) {
+      warningWithoutStack(
+        false,
+        'Warning: Calling ref.setNativeProps(nativeProps) ' +
+          'is deprecated and will be removed in a future release. ' +
+          'Use the setNativeProps export from the react-native package instead.' +
+          "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n",
+      );
       warnForStyleProps(nativeProps, this.viewConfig.validAttributes);
     }
 

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -12,6 +12,7 @@
 
 let React;
 let ReactFabric;
+let ReactFeatureFlags;
 let createReactClass;
 let createReactNativeComponentClass;
 let UIManager;
@@ -35,6 +36,8 @@ describe('ReactFabric', () => {
 
     React = require('react');
     StrictMode = React.StrictMode;
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.warnAboutDeprecatedSetNativeProps = true;
     ReactFabric = require('react-native-renderer/fabric');
     FabricUIManager = require('FabricUIManager');
     UIManager = require('UIManager');

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -19,6 +19,12 @@ let FabricUIManager;
 let StrictMode;
 let NativeMethodsMixin;
 
+const SET_NATIVE_PROPS_DEPRECATION_MESSAGE =
+  'Warning: Calling ref.setNativeProps(nativeProps) ' +
+  'is deprecated and will be removed in a future release. ' +
+  'Use the setNativeProps export from the react-native package instead.' +
+  "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n";
+
 jest.mock('shared/ReactFeatureFlags', () =>
   require('shared/forks/ReactFeatureFlags.native-oss'),
 );
@@ -201,10 +207,19 @@ describe('ReactFabric', () => {
       );
       expect(UIManager.updateView).not.toBeCalled();
 
-      viewRef.setNativeProps({});
+      expect(() => {
+        viewRef.setNativeProps({});
+      }).toWarnDev([SET_NATIVE_PROPS_DEPRECATION_MESSAGE], {
+        withoutStack: true,
+      });
+
       expect(UIManager.updateView).not.toBeCalled();
 
-      viewRef.setNativeProps({foo: 'baz'});
+      expect(() => {
+        viewRef.setNativeProps({foo: 'baz'});
+      }).toWarnDev([SET_NATIVE_PROPS_DEPRECATION_MESSAGE], {
+        withoutStack: true,
+      });
       expect(UIManager.updateView).toHaveBeenCalledTimes(1);
       expect(UIManager.updateView).toHaveBeenCalledWith(
         expect.any(Number),

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -11,6 +11,7 @@
 'use strict';
 
 let React;
+let ReactFeatureFlags;
 let StrictMode;
 let ReactNative;
 let createReactClass;
@@ -30,6 +31,8 @@ describe('ReactNative', () => {
 
     React = require('react');
     StrictMode = React.StrictMode;
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.warnAboutDeprecatedSetNativeProps = true;
     ReactNative = require('react-native-renderer');
     UIManager = require('UIManager');
     createReactClass = require('create-react-class/factory')(

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -18,6 +18,12 @@ let createReactNativeComponentClass;
 let UIManager;
 let NativeMethodsMixin;
 
+const SET_NATIVE_PROPS_DEPRECATION_MESSAGE =
+  'Warning: Calling ref.setNativeProps(nativeProps) ' +
+  'is deprecated and will be removed in a future release. ' +
+  'Use the setNativeProps export from the react-native package instead.' +
+  "\n\timport {setNativeProps} from 'react-native';\n\tsetNativeProps(ref, nativeProps);\n";
+
 describe('ReactNative', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -98,7 +104,7 @@ describe('ReactNative', () => {
     expect(UIManager.updateView).toHaveBeenCalledTimes(4);
   });
 
-  it('should not call UIManager.updateView from setNativeProps for properties that have not changed', () => {
+  it('should not call UIManager.updateView from ref.setNativeProps for properties that have not changed', () => {
     const View = createReactNativeComponentClass('RCTView', () => ({
       validAttributes: {foo: true},
       uiViewClassName: 'RCTView',
@@ -132,10 +138,19 @@ describe('ReactNative', () => {
       );
       expect(UIManager.updateView).not.toBeCalled();
 
-      viewRef.setNativeProps({});
+      expect(() => {
+        viewRef.setNativeProps({});
+      }).toWarnDev([SET_NATIVE_PROPS_DEPRECATION_MESSAGE], {
+        withoutStack: true,
+      });
       expect(UIManager.updateView).not.toBeCalled();
 
-      viewRef.setNativeProps({foo: 'baz'});
+      expect(() => {
+        viewRef.setNativeProps({foo: 'baz'});
+      }).toWarnDev([SET_NATIVE_PROPS_DEPRECATION_MESSAGE], {
+        withoutStack: true,
+      });
+
       expect(UIManager.updateView).toHaveBeenCalledTimes(1);
       expect(UIManager.updateView).toHaveBeenCalledWith(
         expect.any(Number),
@@ -164,7 +179,9 @@ describe('ReactNative', () => {
       11,
     );
 
+    ReactNative.setNativeProps(viewRef, {});
     expect(UIManager.updateView).not.toBeCalled();
+
     ReactNative.setNativeProps(viewRef, {foo: 'baz'});
     expect(UIManager.updateView).toHaveBeenCalledTimes(1);
     expect(UIManager.updateView).toHaveBeenCalledWith(

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -51,3 +51,7 @@ export const disableInputAttributeSyncing = false;
 export const enableStableConcurrentModeAPIs = false;
 
 export const warnAboutShorthandPropertyCollision = false;
+
+// See https://github.com/react-native-community/discussions-and-proposals/issues/72 for more information
+// This is a flag so we can fix warnings in RN core before turning it on
+export const warnAboutDeprecatedSetNativeProps = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -13,9 +13,7 @@ import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as FeatureFlagsShimType from './ReactFeatureFlags.native-fb';
 
 // Re-export dynamic flags from the fbsource version.
-export const {
-  debugRenderPhaseSideEffects,
-} = require('ReactFeatureFlags');
+export const {debugRenderPhaseSideEffects} = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.
 export const enableUserTimingAPI = __DEV__;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -13,7 +13,9 @@ import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as FeatureFlagsShimType from './ReactFeatureFlags.native-fb';
 
 // Re-export dynamic flags from the fbsource version.
-export const {debugRenderPhaseSideEffects} = require('ReactFeatureFlags');
+export const {
+  debugRenderPhaseSideEffects,
+} = require('ReactFeatureFlags');
 
 // The rest of the flags are static for better dead code elimination.
 export const enableUserTimingAPI = __DEV__;
@@ -27,7 +29,7 @@ export const debugRenderPhaseSideEffectsForStrictMode = true;
 export const disableInputAttributeSyncing = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = true;
-export const warnAboutDeprecatedSetNativeProps = false;
+export const warnAboutDeprecatedSetNativeProps = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -27,6 +27,7 @@ export const debugRenderPhaseSideEffectsForStrictMode = true;
 export const disableInputAttributeSyncing = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = true;
+export const warnAboutDeprecatedSetNativeProps = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -24,6 +24,7 @@ export const disableInputAttributeSyncing = false;
 export const enableStableConcurrentModeAPIs = false;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
+export const warnAboutDeprecatedSetNativeProps = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -24,6 +24,7 @@ export const disableInputAttributeSyncing = false;
 export const enableStableConcurrentModeAPIs = false;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
+export const warnAboutDeprecatedSetNativeProps = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -24,6 +24,7 @@ export const disableInputAttributeSyncing = false;
 export const enableStableConcurrentModeAPIs = false;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
+export const warnAboutDeprecatedSetNativeProps = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -22,6 +22,7 @@ export const enableSchedulerTracing = false;
 export const enableSuspenseServerRenderer = false;
 export const enableStableConcurrentModeAPIs = false;
 export const enableSchedulerDebugging = false;
+export const warnAboutDeprecatedSetNativeProps = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -18,6 +18,7 @@ export const {
   warnAboutDeprecatedLifecycles,
   disableInputAttributeSyncing,
   warnAboutShorthandPropertyCollision,
+  warnAboutDeprecatedSetNativeProps,
 } = require('ReactFeatureFlags');
 
 // In www, we have experimental support for gathering data


### PR DESCRIPTION
Related to: react-native-community/discussions-and-proposals#72

We want people to call the new top level API for setNativeProps that was added in https://github.com/facebook/react/pull/14907. This PR adds deprecation warnings for the current methods. 

I need to think about how I want to handle the migration of core and internal and could use some insight. I could:

- hold off on landing this and instead update core to the new API before any warnings land
- land this and add a yellow box ignore internally as we are converting core. If this change goes out with 0.60 then we have time. We might want to land this in 0.59 to have the warnings out as soon as possible although that would also mean we'd need to cherry pick the fixes for these warnings in core into 0.59