### PR TITLE
[ESLint] Warn against assignments from inside Hooks

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1617,6 +1617,7 @@ const tests = {
           useEffect(() => {
             value = 42;
             value2 = 100;
+            value = 43;
             console.log(value2);
             console.log(value3);
             setTimeout(() => {
@@ -1637,6 +1638,7 @@ const tests = {
           useEffect(() => {
             value = 42;
             value2 = 100;
+            value = 43;
             console.log(value2);
             console.log(value3);
             setTimeout(() => {
@@ -1647,19 +1649,19 @@ const tests = {
       `,
       errors: [
         // value
-        `Assigning a variable from inside a React useEffect Hook ` +
+        `Assignments to the 'value' variable from inside a React useEffect Hook ` +
           `will not persist between re-renders. ` +
           `If it's only needed by this Hook, move the variable inside it. ` +
           `Alternatively, declare a ref with the useRef Hook, ` +
           `and keep the mutable value in its 'current' property.`,
         // value2
-        `Assigning a variable from inside a React useEffect Hook ` +
+        `Assignments to the 'value2' variable from inside a React useEffect Hook ` +
           `will not persist between re-renders. ` +
           `If it's only needed by this Hook, move the variable inside it. ` +
           `Alternatively, declare a ref with the useRef Hook, ` +
           `and keep the mutable value in its 'current' property.`,
         // asyncValue
-        `Assigning a variable from inside a React useEffect Hook ` +
+        `Assignments to the 'asyncValue' variable from inside a React useEffect Hook ` +
           `will not persist between re-renders. ` +
           `If it's only needed by this Hook, move the variable inside it. ` +
           `Alternatively, declare a ref with the useRef Hook, ` +
@@ -1676,6 +1678,7 @@ const tests = {
           useEffect(() => {
             value = 42;
             value2 = 100;
+            value = 43;
             console.log(value2);
             console.log(value3);
             setTimeout(() => {
@@ -1696,6 +1699,7 @@ const tests = {
           useEffect(() => {
             value = 42;
             value2 = 100;
+            value = 43;
             console.log(value2);
             console.log(value3);
             setTimeout(() => {
@@ -1706,19 +1710,19 @@ const tests = {
       `,
       errors: [
         // value
-        `Assigning a variable from inside a React useEffect Hook ` +
+        `Assignments to the 'value' variable from inside a React useEffect Hook ` +
           `will not persist between re-renders. ` +
           `If it's only needed by this Hook, move the variable inside it. ` +
           `Alternatively, declare a ref with the useRef Hook, ` +
           `and keep the mutable value in its 'current' property.`,
         // value2
-        `Assigning a variable from inside a React useEffect Hook ` +
+        `Assignments to the 'value2' variable from inside a React useEffect Hook ` +
           `will not persist between re-renders. ` +
           `If it's only needed by this Hook, move the variable inside it. ` +
           `Alternatively, declare a ref with the useRef Hook, ` +
           `and keep the mutable value in its 'current' property.`,
         // asyncValue
-        `Assigning a variable from inside a React useEffect Hook ` +
+        `Assignments to the 'asyncValue' variable from inside a React useEffect Hook ` +
           `will not persist between re-renders. ` +
           `If it's only needed by this Hook, move the variable inside it. ` +
           `Alternatively, declare a ref with the useRef Hook, ` +

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -433,6 +433,19 @@ const tests = {
         });
       `,
     },
+    {
+      // This is not ideal but warning would likely create
+      // too many false positives. We do, however, prevent
+      // direct assignments.
+      code: `
+        function MyComponent(props) {
+          let obj = {};
+          useEffect(() => {
+            obj.foo = true;
+          }, [obj]);
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -891,7 +891,6 @@ const tests = {
       ],
     },
     {
-      // only: true,
       code: `
         function MyComponent(props) {
           useEffect(() => {
@@ -1606,6 +1605,124 @@ const tests = {
         // TODO: reporting props separately is superfluous. Fix to just props.onChange.
         "React Hook useEffect has missing dependencies: 'props' and 'props.onChange'. " +
           'Either include them or remove the dependency array.',
+      ],
+    },
+    {
+      code: `
+        function MyComponent(props) {
+          let value;
+          let value2;
+          let value3;
+          let asyncValue;
+          useEffect(() => {
+            value = 42;
+            value2 = 100;
+            console.log(value2);
+            console.log(value3);
+            setTimeout(() => {
+              asyncValue = 100;
+            });
+          }, []);
+        }
+      `,
+      // This is a separate warning unrelated to others.
+      // We could've made a separate rule for it but it's rare enough to name it.
+      // No autofix suggestion because the intent isn't clear.
+      output: `
+        function MyComponent(props) {
+          let value;
+          let value2;
+          let value3;
+          let asyncValue;
+          useEffect(() => {
+            value = 42;
+            value2 = 100;
+            console.log(value2);
+            console.log(value3);
+            setTimeout(() => {
+              asyncValue = 100;
+            });
+          }, []);
+        }
+      `,
+      errors: [
+        // value
+        `Assigning a variable from inside a React useEffect Hook ` +
+          `will not persist between re-renders. ` +
+          `If it's only needed by this Hook, move the variable inside it. ` +
+          `Alternatively, declare a ref with the useRef Hook, ` +
+          `and keep the mutable value in its 'current' property.`,
+        // value2
+        `Assigning a variable from inside a React useEffect Hook ` +
+          `will not persist between re-renders. ` +
+          `If it's only needed by this Hook, move the variable inside it. ` +
+          `Alternatively, declare a ref with the useRef Hook, ` +
+          `and keep the mutable value in its 'current' property.`,
+        // asyncValue
+        `Assigning a variable from inside a React useEffect Hook ` +
+          `will not persist between re-renders. ` +
+          `If it's only needed by this Hook, move the variable inside it. ` +
+          `Alternatively, declare a ref with the useRef Hook, ` +
+          `and keep the mutable value in its 'current' property.`,
+      ],
+    },
+    {
+      code: `
+        function MyComponent(props) {
+          let value;
+          let value2;
+          let value3;
+          let asyncValue;
+          useEffect(() => {
+            value = 42;
+            value2 = 100;
+            console.log(value2);
+            console.log(value3);
+            setTimeout(() => {
+              asyncValue = 100;
+            });
+          }, [value, value2, value3]);
+        }
+      `,
+      // This is a separate warning unrelated to others.
+      // We could've made a separate rule for it but it's rare enough to name it.
+      // No autofix suggestion because the intent isn't clear.
+      output: `
+        function MyComponent(props) {
+          let value;
+          let value2;
+          let value3;
+          let asyncValue;
+          useEffect(() => {
+            value = 42;
+            value2 = 100;
+            console.log(value2);
+            console.log(value3);
+            setTimeout(() => {
+              asyncValue = 100;
+            });
+          }, [value, value2, value3]);
+        }
+      `,
+      errors: [
+        // value
+        `Assigning a variable from inside a React useEffect Hook ` +
+          `will not persist between re-renders. ` +
+          `If it's only needed by this Hook, move the variable inside it. ` +
+          `Alternatively, declare a ref with the useRef Hook, ` +
+          `and keep the mutable value in its 'current' property.`,
+        // value2
+        `Assigning a variable from inside a React useEffect Hook ` +
+          `will not persist between re-renders. ` +
+          `If it's only needed by this Hook, move the variable inside it. ` +
+          `Alternatively, declare a ref with the useRef Hook, ` +
+          `and keep the mutable value in its 'current' property.`,
+        // asyncValue
+        `Assigning a variable from inside a React useEffect Hook ` +
+          `will not persist between re-renders. ` +
+          `If it's only needed by this Hook, move the variable inside it. ` +
+          `Alternatively, declare a ref with the useRef Hook, ` +
+          `and keep the mutable value in its 'current' property.`,
       ],
     },
   ],

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -186,7 +186,10 @@ export default {
           // again in our dependencies array. Remember whether it's static.
           if (!dependencies.has(dependency)) {
             const isStatic = isDefinitelyStaticDependency(reference);
-            dependencies.set(dependency, isStatic);
+            dependencies.set(dependency, {
+              isStatic,
+              reference,
+            });
           }
         }
         for (const childScope of currentScope.childScopes) {
@@ -258,6 +261,7 @@ export default {
       let unnecessaryDependencies = new Set();
       let missingDependencies = new Set();
       let actualDependencies = Array.from(dependencies.keys());
+      let foundStaleAssignments = false;
 
       function satisfies(actualDep, dep) {
         return actualDep === dep || actualDep.startsWith(dep + '.');
@@ -280,7 +284,22 @@ export default {
       });
 
       // Then fill in the missing ones.
-      dependencies.forEach((isStatic, key) => {
+      dependencies.forEach(({isStatic, reference}, key) => {
+        if (reference.writeExpr) {
+          foundStaleAssignments = true;
+          context.report({
+            node: reference.writeExpr,
+            message:
+              `Assigning a variable from inside a React ${context.getSource(
+                reactiveHook,
+              )} Hook ` +
+              `will not persist between re-renders. ` +
+              `If it's only needed by this Hook, move the variable inside it. ` +
+              `Alternatively, declare a ref with the useRef Hook, ` +
+              `and keep the mutable value in its 'current' property.`,
+          });
+        }
+
         if (
           !suggestedDependencies.some(suggestedDep =>
             satisfies(key, suggestedDep),
@@ -316,6 +335,11 @@ export default {
         unnecessaryDependencies.size;
 
       if (problemCount === 0) {
+        return;
+      }
+
+      if (foundStaleAssignments) {
+        // The intent isn't clear so we'll wait until you fix those first.
         return;
       }
 

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -290,7 +290,7 @@ export default {
           context.report({
             node: reference.writeExpr,
             message:
-              `Assigning a variable from inside a React ${context.getSource(
+              `Assignments to the '${key}' variable from inside a React ${context.getSource(
                 reactiveHook,
               )} Hook ` +
               `will not persist between re-renders. ` +


### PR DESCRIPTION
These are usually bugs and work by accident. You're supposed to use refs instead.

I thought about pulling this into its own rule. But then it's niche enough that it's hard to come up with a name that makes sense. And when it fires, the exhaustive deps warning becomes confusing. So I decided to make this mistake "cancel out" the exhaustive deps warning until you clarify the intent.

<img width="701" alt="screen shot 2019-02-21 at 5 16 52 pm" src="https://user-images.githubusercontent.com/810438/53188263-e4502880-35fc-11e9-9e27-123deb1ce677.png">


I plan to add a few more "niche" cases into this rule. Such as using `ref.current` in cleanup phase.