### PR TITLE
[scheduler] Pass didTimeout argument to callbacks

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -2219,9 +2219,9 @@ function shouldYieldToRenderer() {
   return false;
 }
 
-function performAsyncWork() {
+function performAsyncWork(didTimeout) {
   try {
-    if (!shouldYieldToRenderer()) {
+    if (didTimeout) {
       // The callback timed out. That means at least one update has expired.
       // Iterate through the root schedule. If they contain expired work, set
       // the next render expiration time to the current time. This has the effect

--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -94,7 +94,7 @@ function flushFirstCallback() {
   currentExpirationTime = expirationTime;
   var continuationCallback;
   try {
-    continuationCallback = callback();
+    continuationCallback = callback(currentDidTimeout);
   } finally {
     currentPriorityLevel = previousPriorityLevel;
     currentExpirationTime = previousExpirationTime;


### PR DESCRIPTION
As I prepare to refactor the Fiber scheduler, I've noticed some quirks in our implementation. This PR addresses one of them.

---

There's no reason for a timed out Scheduler callback to check `shouldYield`, because the value will always be false until the work has completed. The `didTimeout` argument provides this information to the callback so it can avoid the redundant checks.

React's existing check for whether a callback has timed out didn't make any sense, but happened to work anyway. I don't think the wrongness of the old implementation is observable via React APIs but it's incoherent regardless.