### PR TITLE
Remove ReactNoop.flushDeferredPri and flushUnitsOfWork

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
@@ -50,7 +50,7 @@ describe('ReactIncrementalErrorLogging', () => {
         </span>
       </div>,
     );
-    expect(ReactNoop.flushDeferredPri).toThrowError('constructor error');
+    expect(() => ReactNoop.flush()).toThrowError('constructor error');
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
       __DEV__
@@ -86,7 +86,7 @@ describe('ReactIncrementalErrorLogging', () => {
         </span>
       </div>,
     );
-    expect(ReactNoop.flushDeferredPri).toThrowError('componentDidMount error');
+    expect(() => ReactNoop.flush()).toThrowError('componentDidMount error');
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
       __DEV__
@@ -125,7 +125,7 @@ describe('ReactIncrementalErrorLogging', () => {
         </span>
       </div>,
     );
-    expect(ReactNoop.flushDeferredPri).toThrow('render error');
+    expect(() => ReactNoop.flush()).toThrow('render error');
     expect(logCapturedErrorCalls.length).toBe(1);
     expect(logCapturedErrorCalls[0]).toEqual(
       __DEV__

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
@@ -385,7 +385,7 @@ describe('ReactIncrementalTriangle', () => {
         ReactNoop.flushSync(() => {
           switch (action.type) {
             case FLUSH:
-              ReactNoop.flushUnitsOfWork(action.unitsOfWork);
+              ReactNoop.unstable_flushNumberOfYields(action.unitsOfWork);
               break;
             case FLUSH_ALL:
               ReactNoop.flush();

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -32,6 +32,7 @@ describe('ReactIncrementalUpdates', () => {
     class Foo extends React.Component {
       state = {};
       componentDidMount() {
+        ReactNoop.yield('commit');
         ReactNoop.deferredUpdates(() => {
           // Has low priority
           this.setState({b: 'b'});
@@ -47,7 +48,7 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flushDeferredPri(25);
+    ReactNoop.flushThrough(['commit']);
     expect(state).toEqual({a: 'a'});
     ReactNoop.flush();
     expect(state).toEqual({a: 'a', b: 'b', c: 'c'});

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1691,6 +1691,7 @@ describe('ReactNewContext', () => {
           return false;
         }
         render() {
+          ReactNoop.yield();
           if (this.props.depth >= this.props.maxDepth) {
             return null;
           }
@@ -1771,7 +1772,7 @@ describe('ReactNewContext', () => {
               ReactNoop.flush();
               break;
             case FLUSH:
-              ReactNoop.flushUnitsOfWork(action.unitsOfWork);
+              ReactNoop.unstable_flushNumberOfYields(action.unitsOfWork);
               break;
             case UPDATE:
               finalExpectedValues = {

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -211,25 +211,33 @@ exports[`ReactDebugFiberPerf measures a simple reconciliation 1`] = `
 exports[`ReactDebugFiberPerf measures deferred work in chunks 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5250 ms)
 
-// Start mounting Parent and A
+// Start rendering through B
+⚛ (React Tree Reconciliation: Yielded)
+  ⚛ Parent [mount]
+    ⚛ A [mount]
+
+⚛ (Waiting for async callback... will force flush in 5250 ms)
+
 ⚛ (React Tree Reconciliation: Yielded)
   ⚛ Parent [mount]
     ⚛ A [mount]
       ⚛ Child [mount]
+    ⚛ B [mount]
 
 ⚛ (Waiting for async callback... will force flush in 5250 ms)
 
-// Mount B just a little (but not enough to memoize)
+// Complete the rest
 ⚛ (React Tree Reconciliation: Yielded)
   ⚛ Parent [mount]
     ⚛ B [mount]
+      ⚛ Child [mount]
+    ⚛ C [mount]
 
 ⚛ (Waiting for async callback... will force flush in 5250 ms)
 
-// Complete B and Parent
 ⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
-    ⚛ B [mount]
+    ⚛ C [mount]
       ⚛ Child [mount]
 
 ⚛ (Committing Changes)
@@ -396,20 +404,6 @@ exports[`ReactDebugFiberPerf supports Suspense and lazy 2`] = `
 "
 `;
 
-exports[`ReactDebugFiberPerf supports portals 1`] = `
-"⚛ (Waiting for async callback... will force flush in 5250 ms)
-
-⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ Parent [mount]
-    ⚛ Child [mount]
-
-⚛ (Committing Changes)
-  ⚛ (Committing Snapshot Effects: 0 Total)
-  ⚛ (Committing Host Effects: 2 Total)
-  ⚛ (Calling Lifecycle Methods: 0 Total)
-"
-`;
-
 exports[`ReactDebugFiberPerf supports memo 1`] = `
 "⚛ (Waiting for async callback... will force flush in 5250 ms)
 
@@ -420,6 +414,20 @@ exports[`ReactDebugFiberPerf supports memo 1`] = `
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)
   ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
+"
+`;
+
+exports[`ReactDebugFiberPerf supports portals 1`] = `
+"⚛ (Waiting for async callback... will force flush in 5250 ms)
+
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [mount]
+    ⚛ Child [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 2 Total)
   ⚛ (Calling Lifecycle Methods: 0 Total)
 "
 `;


### PR DESCRIPTION
Some of our older tests worked by counting how many times React checked whether it should yield to the main thread, instead of something publicly observable like how many times a component is rendered.

Our newer tests have converged on a style where we push into a log and make assertions on the log. This pattern is less coupled to the implementation while still being sufficient to test performance optimizations, like resuming (whenever we add that back).

This PR removes `flushDeferredPri` and `flushUnitsOfWork` and upgrades the affected tests.

## Follow-ups

- Unify noop and test renderer APIs
  - Replace the generator implementation by having `ReactNoop.yield` push into a global array.
  - Use custom jest matchers to flush and assert on yielded values.
  - Warn if a test attempts to flush work while the log is non-empty.