### PR TITLE
Fix debug tools crashing on inspecting a component using useContext

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -93,6 +93,7 @@ function useContext<T>(
   context: ReactContext<T>,
   observedBits: void | number | boolean,
 ): T {
+  nextHook();
   hookLog.push({
     primitive: 'Context',
     stackError: new Error(),


### PR DESCRIPTION
This pull request should fix a bug with the `useContext` function breaking the devtools because the useContext function is  not calling the `nextHook()` function.

Example Sandbox:
https://codesandbox.io/s/z2qok540m

Related issue:
https://github.com/facebookincubator/redux-react-hook/issues/34