### PR TITLE
Refactor createElement to use slice instead of for loop

### DIFF
--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -206,10 +206,7 @@ export function createElement(type, config, children) {
   if (childrenLength === 1) {
     props.children = children;
   } else if (childrenLength > 1) {
-    const childArray = Array(childrenLength);
-    for (let i = 0; i < childrenLength; i++) {
-      childArray[i] = arguments[i + 2];
-    }
+    const childArray = arguments.slice(2);
     if (__DEV__) {
       if (Object.freeze) {
         Object.freeze(childArray);
@@ -346,10 +343,7 @@ export function cloneElement(element, config, children) {
   if (childrenLength === 1) {
     props.children = children;
   } else if (childrenLength > 1) {
-    const childArray = Array(childrenLength);
-    for (let i = 0; i < childrenLength; i++) {
-      childArray[i] = arguments[i + 2];
-    }
+    const childArray = arguments.slice(2);
     props.children = childArray;
   }
 


### PR DESCRIPTION
Refactor createElement function to use slice due to being more performant over for loop as benchmarked here: https://jsperf.com/duplicate-array-using-slice-vs-for