### PR TITLE
fix(eslint-plugin-react-hooks): node version upgraded to 7 for object.entries 

### DIFF
--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/facebook/react/issues"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=7"
   },
   "homepage": "https://reactjs.org/",
   "peerDependencies": {


### PR DESCRIPTION
Fixes #14949 

`Object.entries` is used here 
https://github.com/facebook/react/blame/master/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js#L535
which is not supported by `node 6`
Ref: https://node.green/#ES2017-features-Object-static-methods-Object-entries

Solution:
Upgraded node engine to 7