### PR TITLE
Unify noop and test renderer assertion APIs

### DIFF
--- a/packages/react-art/src/__tests__/ReactART-test.js
+++ b/packages/react-art/src/__tests__/ReactART-test.js
@@ -385,7 +385,7 @@ describe('ReactART', () => {
       </CurrentRendererContext.Provider>,
     );
 
-    ReactNoop.flushThrough(['A']);
+    expect(ReactNoop).toFlushAndYieldThrough(['A']);
 
     ReactDOM.render(
       <Surface>
@@ -400,7 +400,7 @@ describe('ReactART', () => {
     expect(ops).toEqual([null, 'ART']);
 
     ops = [];
-    expect(ReactNoop.flush()).toEqual(['B', 'C']);
+    expect(ReactNoop).toFlushAndYield(['B', 'C']);
 
     expect(ops).toEqual(['Test']);
   });

--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
@@ -88,7 +88,7 @@ describe('ReactExpiration', () => {
     // haven't entered an idle callback, the scheduler must assume that we're
     // inside the same event.
     ReactNoop.advanceTime(2000);
-    expect(ReactNoop.clearYields()).toEqual(null);
+    expect(ReactNoop.clearYields()).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([span('B')]);
     // Schedule another update.
     ReactNoop.render(<Text text="B" />);
@@ -142,7 +142,7 @@ describe('ReactExpiration', () => {
       // haven't entered an idle callback, the scheduler must assume that we're
       // inside the same event.
       ReactNoop.advanceTime(2000);
-      expect(ReactNoop.clearYields()).toEqual(null);
+      expect(ReactNoop.clearYields()).toEqual([]);
       expect(ReactNoop.getChildren()).toEqual([span('B')]);
 
       // Perform some synchronous work. Again, the scheduler must assume we're

--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
@@ -73,7 +73,7 @@ describe('ReactExpiration', () => {
     ReactNoop.render(<Text text="B" />);
     // The updates should flush in separate batches, since sufficient time
     // passed in between them *and* they occurred in separate events.
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'A [render]',
       'A [commit]',
       'B [render]',
@@ -88,13 +88,13 @@ describe('ReactExpiration', () => {
     // haven't entered an idle callback, the scheduler must assume that we're
     // inside the same event.
     ReactNoop.advanceTime(2000);
-    expect(ReactNoop.clearYields()).toEqual([]);
+    expect(ReactNoop).toHaveYielded([]);
     expect(ReactNoop.getChildren()).toEqual([span('B')]);
     // Schedule another update.
     ReactNoop.render(<Text text="B" />);
     // The updates should flush in the same batch, since as far as the scheduler
     // knows, they may have occurred inside the same event.
-    expect(ReactNoop.flush()).toEqual(['B [render]', 'B [commit]']);
+    expect(ReactNoop).toFlushAndYield(['B [render]', 'B [commit]']);
   });
 
   it(
@@ -127,7 +127,7 @@ describe('ReactExpiration', () => {
       ReactNoop.render(<Text text="B" />);
       // The updates should flush in separate batches, since sufficient time
       // passed in between them *and* they occurred in separate events.
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         'A [render]',
         'A [commit]',
         'B [render]',
@@ -142,7 +142,7 @@ describe('ReactExpiration', () => {
       // haven't entered an idle callback, the scheduler must assume that we're
       // inside the same event.
       ReactNoop.advanceTime(2000);
-      expect(ReactNoop.clearYields()).toEqual([]);
+      expect(ReactNoop).toHaveYielded([]);
       expect(ReactNoop.getChildren()).toEqual([span('B')]);
 
       // Perform some synchronous work. Again, the scheduler must assume we're
@@ -156,7 +156,7 @@ describe('ReactExpiration', () => {
       ReactNoop.render(<Text text="B" />);
       // The updates should flush in the same batch, since as far as the scheduler
       // knows, they may have occurred inside the same event.
-      expect(ReactNoop.flush()).toEqual(['B [render]', 'B [commit]']);
+      expect(ReactNoop).toFlushAndYield(['B [render]', 'B [commit]']);
     },
   );
 
@@ -191,7 +191,7 @@ describe('ReactExpiration', () => {
 
     // Initial mount
     ReactNoop.render(<App />);
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'initial [A] [render]',
       'initial [B] [render]',
       'initial [C] [render]',
@@ -204,12 +204,18 @@ describe('ReactExpiration', () => {
 
     // Partial update
     subscribers.forEach(s => s.setState({text: '1'}));
-    ReactNoop.flushThrough(['1 [A] [render]', '1 [B] [render]']);
+    expect(ReactNoop).toFlushAndYieldThrough([
+      '1 [A] [render]',
+      '1 [B] [render]',
+    ]);
 
     // Before the update can finish, update again. Even though no time has
     // advanced, this update should be given a different expiration time than
     // the currently rendering one. So, C and D should render with 1, not 2.
     subscribers.forEach(s => s.setState({text: '2'}));
-    ReactNoop.flushThrough(['1 [C] [render]', '1 [D] [render]']);
+    expect(ReactNoop).toFlushAndYieldThrough([
+      '1 [C] [render]',
+      '1 [D] [render]',
+    ]);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -43,7 +43,7 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(element);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ReactNoop.getChildren()).toEqual([span()]);
   });
@@ -52,7 +52,7 @@ describe('ReactFragment', () => {
     const element = <React.Fragment />;
 
     ReactNoop.render(element);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ReactNoop.getChildren()).toEqual([]);
   });
@@ -65,7 +65,7 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(element);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ReactNoop.getChildren()).toEqual([text('hello '), span()]);
   });
@@ -78,7 +78,7 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(element);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ReactNoop.getChildren()).toEqual([span(), span()]);
   });
@@ -108,16 +108,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div(), div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -149,16 +149,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -199,16 +199,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div(), div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -242,16 +242,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -283,16 +283,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -325,16 +325,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div(), div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -364,16 +364,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -403,16 +403,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -444,16 +444,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -481,16 +481,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -522,16 +522,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -564,16 +564,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div(), span()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -605,16 +605,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div()]);
@@ -658,16 +658,16 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div(span(), div(div()), span())]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([div(span(), div(div()), span())]);
@@ -705,10 +705,10 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Each child in a list should have a unique "key" prop.',
     );
 
@@ -716,7 +716,7 @@ describe('ReactFragment', () => {
     expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
 
     ReactNoop.render(<Foo condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([div(div(), span())]);
@@ -752,12 +752,12 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Each child in a list should have a unique "key" prop.',
     );
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Each child in a list should have a unique "key" prop.',
     );
 
@@ -765,7 +765,7 @@ describe('ReactFragment', () => {
     expect(ReactNoop.getChildren()).toEqual([span(), div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Each child in a list should have a unique "key" prop.',
     );
 

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -74,7 +74,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     // Initial mount
     const counter = React.createRef(null);
     ReactNoop.render(<Counter label="Count" ref={counter} />);
-    expect(ReactNoop.flush()).toEqual(['Count: 0']);
+    expect(ReactNoop).toFlushAndYield(['Count: 0']);
     expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
     // Schedule some updates
@@ -84,17 +84,17 @@ describe('ReactHooksWithNoopRenderer', () => {
     });
 
     // Partially flush without committing
-    ReactNoop.flushThrough(['Count: 11']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Count: 11']);
     expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
     // Interrupt with a high priority update
     ReactNoop.flushSync(() => {
       ReactNoop.render(<Counter label="Total" />);
     });
-    expect(ReactNoop.clearYields()).toEqual(['Total: 0']);
+    expect(ReactNoop).toHaveYielded(['Total: 0']);
 
     // Resume rendering
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['Total: 11']);
     expect(ReactNoop.getChildren()).toEqual([span('Total: 11')]);
   });
 
@@ -107,7 +107,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     }
     ReactNoop.render(<BadCounter />);
 
-    expect(() => ReactNoop.flush()).toThrow(
+    expect(ReactNoop).toFlushAndThrow(
       'Hooks can only be called inside the body of a function component.',
     );
 
@@ -117,7 +117,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       return <Text text={count} />;
     }
     ReactNoop.render(<GoodCounter initialCount={10} />);
-    expect(ReactNoop.flush()).toEqual([10]);
+    expect(ReactNoop).toFlushAndYield([10]);
   });
 
   it('throws inside module-style components', () => {
@@ -130,7 +130,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       };
     }
     ReactNoop.render(<Counter />);
-    expect(() => ReactNoop.flush()).toThrow(
+    expect(ReactNoop).toFlushAndThrow(
       'Hooks can only be called inside the body of a function component.',
     );
 
@@ -140,7 +140,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       return <Text text={count} />;
     }
     ReactNoop.render(<GoodCounter initialCount={10} />);
-    expect(ReactNoop.flush()).toEqual([10]);
+    expect(ReactNoop).toFlushAndYield([10]);
   });
 
   it('throws when called outside the render phase', () => {
@@ -159,15 +159,15 @@ describe('ReactHooksWithNoopRenderer', () => {
       Counter = forwardRef(Counter);
       const counter = React.createRef(null);
       ReactNoop.render(<Counter ref={counter} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       act(() => counter.current.updateCount(1));
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
 
       act(() => counter.current.updateCount(count => count + 10));
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 11']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 11')]);
     });
 
@@ -183,11 +183,11 @@ describe('ReactHooksWithNoopRenderer', () => {
       Counter = forwardRef(Counter);
       const counter = React.createRef(null);
       ReactNoop.render(<Counter initialState={42} ref={counter} />);
-      expect(ReactNoop.flush()).toEqual(['getInitialState', 'Count: 42']);
+      expect(ReactNoop).toFlushAndYield(['getInitialState', 'Count: 42']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 42')]);
 
       act(() => counter.current.updateCount(7));
-      expect(ReactNoop.flush()).toEqual(['Count: 7']);
+      expect(ReactNoop).toFlushAndYield(['Count: 7']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 7')]);
     });
 
@@ -201,14 +201,14 @@ describe('ReactHooksWithNoopRenderer', () => {
       Counter = forwardRef(Counter);
       const counter = React.createRef(null);
       ReactNoop.render(<Counter ref={counter} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       act(() => counter.current.updateCount(7));
-      expect(ReactNoop.flush()).toEqual(['Count: 7']);
+      expect(ReactNoop).toFlushAndYield(['Count: 7']);
 
       act(() => counter.current.updateLabel('Total'));
-      expect(ReactNoop.flush()).toEqual(['Total: 7']);
+      expect(ReactNoop).toFlushAndYield(['Total: 7']);
     });
 
     it('returns the same updater function every time', () => {
@@ -219,15 +219,15 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + count} />;
       }
       ReactNoop.render(<Counter />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       act(() => updaters[0](1));
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
 
       act(() => updaters[0](count => count + 10));
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 11']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 11')]);
 
       expect(updaters).toEqual([updaters[0], updaters[0], updaters[0]]);
@@ -242,9 +242,9 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<Counter />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
       ReactNoop.render(null);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
       expect(() => act(() => _updateCount(1))).toWarnDev(
         "Warning: Can't perform a React state update on an unmounted " +
           'component. This is a no-op, but it indicates a memory leak in your ' +
@@ -264,15 +264,15 @@ describe('ReactHooksWithNoopRenderer', () => {
       Counter = memo(Counter);
 
       ReactNoop.render(<Counter />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       ReactNoop.render(<Counter />);
-      expect(ReactNoop.flush()).toEqual([]);
+      expect(ReactNoop).toFlushAndYield([]);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       act(() => _updateCount(1));
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
     });
   });
@@ -293,27 +293,27 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<ScrollView row={1} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Scrolling down: false']);
       expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: false')]);
 
       ReactNoop.render(<ScrollView row={5} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Scrolling down: true']);
       expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: true')]);
 
       ReactNoop.render(<ScrollView row={5} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Scrolling down: true']);
       expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: true')]);
 
       ReactNoop.render(<ScrollView row={10} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Scrolling down: true']);
       expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: true')]);
 
       ReactNoop.render(<ScrollView row={2} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Scrolling down: false']);
       expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: false')]);
 
       ReactNoop.render(<ScrollView row={2} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Scrolling down: false']);
       expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: false')]);
     });
 
@@ -328,7 +328,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<Counter />);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         'Render: 0',
         'Render: 1',
         'Render: 2',
@@ -351,7 +351,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<Counter />);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         // Should increase by three each time
         'Render: 0',
         'Render: 3',
@@ -371,7 +371,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={count} />;
       }
       ReactNoop.render(<Counter />);
-      expect(() => ReactNoop.flush()).toThrow(
+      expect(ReactNoop).toFlushAndThrow(
         'Too many re-renders. React limits the number of renders to prevent ' +
           'an infinite loop.',
       );
@@ -391,7 +391,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<Counter />);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         'Render: 0',
         'Render: 1',
         'Render: 2',
@@ -441,7 +441,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       Counter = forwardRef(Counter);
       const counter = React.createRef(null);
       ReactNoop.render(<Counter ref={counter} />);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         // The count should increase by alternating amounts of 10 and 1
         // until we reach 21.
         'Render: 0',
@@ -458,7 +458,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         counter.current.dispatch('reset');
       });
       ReactNoop.render(<Counter ref={counter} />);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         'Render: 0',
         'Render: 1',
         'Render: 11',
@@ -494,11 +494,11 @@ describe('ReactHooksWithNoopRenderer', () => {
       Counter = forwardRef(Counter);
       const counter = React.createRef(null);
       ReactNoop.render(<Counter ref={counter} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       act(() => counter.current.dispatch(INCREMENT));
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       act(() => {
         counter.current.dispatch(DECREMENT);
@@ -506,7 +506,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         counter.current.dispatch(DECREMENT);
       });
 
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: -2']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: -2')]);
     });
 
@@ -536,11 +536,11 @@ describe('ReactHooksWithNoopRenderer', () => {
       Counter = forwardRef(Counter);
       const counter = React.createRef(null);
       ReactNoop.render(<Counter initialCount={10} ref={counter} />);
-      expect(ReactNoop.flush()).toEqual(['Init', 'Count: 10']);
+      expect(ReactNoop).toFlushAndYield(['Init', 'Count: 10']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 10')]);
 
       act(() => counter.current.dispatch(INCREMENT));
-      expect(ReactNoop.flush()).toEqual(['Count: 11']);
+      expect(ReactNoop).toFlushAndYield(['Count: 11']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 11')]);
 
       act(() => {
@@ -549,7 +549,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         counter.current.dispatch(DECREMENT);
       });
 
-      expect(ReactNoop.flush()).toEqual(['Count: 8']);
+      expect(ReactNoop).toFlushAndYield(['Count: 8']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 8')]);
     });
 
@@ -571,7 +571,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       const counter = React.createRef(null);
       ReactNoop.render(<Counter ref={counter} />);
 
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       act(() => {
@@ -583,10 +583,10 @@ describe('ReactHooksWithNoopRenderer', () => {
       ReactNoop.flushSync(() => {
         counter.current.dispatch(INCREMENT);
       });
-      expect(ReactNoop.clearYields()).toEqual(['Count: 1']);
+      expect(ReactNoop).toHaveYielded(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
 
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 4']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 4')]);
     });
   });
@@ -600,17 +600,17 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Did commit [0]']);
+      expect(ReactNoop).toHaveYielded(['Did commit [0]']);
 
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       // Effects are deferred until after the commit
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Did commit [1]']);
+      expect(ReactNoop).toHaveYielded(['Did commit [1]']);
     });
 
     it('flushes passive effects even with sibling deletions', () => {
@@ -628,7 +628,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
       let passive = <PassiveEffect key="p" />;
       ReactNoop.render([<LayoutEffect key="l" />, passive]);
-      expect(ReactNoop.flush()).toEqual(['Layout', 'Passive', 'Layout effect']);
+      expect(ReactNoop).toFlushAndYield(['Layout', 'Passive', 'Layout effect']);
       expect(ReactNoop.getChildren()).toEqual([
         span('Layout'),
         span('Passive'),
@@ -637,13 +637,13 @@ describe('ReactHooksWithNoopRenderer', () => {
       // Destroying the first child shouldn't prevent the passive effect from
       // being executed
       ReactNoop.render([passive]);
-      expect(ReactNoop.clearYields()).toEqual(['Passive effect']);
-      expect(ReactNoop.flush()).toEqual([]);
+      expect(ReactNoop).toHaveYielded(['Passive effect']);
+      expect(ReactNoop).toFlushAndYield([]);
       expect(ReactNoop.getChildren()).toEqual([span('Passive')]);
 
       // (No effects are left to flush.)
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual([]);
+      expect(ReactNoop).toHaveYielded([]);
     });
 
     it('flushes passive effects even if siblings schedule an update', () => {
@@ -668,7 +668,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       ReactNoop.render([<PassiveEffect key="p" />, <LayoutEffect key="l" />]);
 
       act(() => {
-        expect(ReactNoop.flush()).toEqual([
+        expect(ReactNoop).toFlushAndYield([
           'Passive',
           'Layout',
           'Layout effect 0',
@@ -700,7 +700,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text="Layout" />;
       }
       ReactNoop.render([<PassiveEffect key="p" />, <LayoutEffect key="l" />]);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         'Passive',
         'Layout',
         'Layout effect',
@@ -734,20 +734,20 @@ describe('ReactHooksWithNoopRenderer', () => {
           return <Text text={props.count} />;
         }
         ReactNoop.render(<Counter count={0} />);
-        expect(ReactNoop.flush()).toEqual([0]);
+        expect(ReactNoop).toFlushAndYield([0]);
         expect(ReactNoop.getChildren()).toEqual([span(0)]);
 
         // Before the effects have a chance to flush, schedule another update
         ReactNoop.render(<Counter count={1} />);
-        expect(ReactNoop.clearYields()).toEqual([
+        expect(ReactNoop).toHaveYielded([
           // The previous effect flushes before the reconciliation
           'Committed state when effect was fired: 0',
         ]);
-        expect(ReactNoop.flush()).toEqual([1]);
+        expect(ReactNoop).toFlushAndYield([1]);
         expect(ReactNoop.getChildren()).toEqual([span(1)]);
 
         ReactNoop.flushPassiveEffects();
-        expect(ReactNoop.clearYields()).toEqual([
+        expect(ReactNoop).toHaveYielded([
           'Committed state when effect was fired: 1',
         ]);
       },
@@ -766,18 +766,18 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: (empty)']);
+      expect(ReactNoop).toFlushAndYield(['Count: (empty)']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Schedule update [0]']);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toHaveYielded(['Schedule update [0]']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
 
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Schedule update [1]']);
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toHaveYielded(['Schedule update [1]']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
     });
 
     it('updates have async priority even if effects are flushed early', () => {
@@ -793,24 +793,24 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: (empty)']);
+      expect(ReactNoop).toFlushAndYield(['Count: (empty)']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
 
       // Rendering again should flush the previous commit's effects
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.clearYields()).toEqual(['Schedule update [0]']);
-      ReactNoop.flushThrough(['Count: 0']);
+      expect(ReactNoop).toHaveYielded(['Schedule update [0]']);
+      expect(ReactNoop).toFlushAndYieldThrough(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
 
       ReactNoop.batchedUpdates(() => {
-        expect(ReactNoop.flush()).toEqual([]);
+        expect(ReactNoop).toFlushAndYield([]);
       });
 
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Schedule update [1]']);
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toHaveYielded(['Schedule update [1]']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
     });
 
@@ -827,14 +827,14 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       // Enqueuing this update forces the passive effect to be flushed --
       // updateCount(1) happens first, so 2 wins.
       act(() => _updateCount(2));
-      expect(ReactNoop.clearYields()).toEqual(['Will set count to 1']);
-      expect(ReactNoop.flush()).toEqual(['Count: 2']);
+      expect(ReactNoop).toHaveYielded(['Will set count to 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 2']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 2')]);
     });
 
@@ -872,7 +872,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           ReactNoop.render(<Counter count={0} />);
         },
       );
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(0);
@@ -880,8 +880,8 @@ describe('ReactHooksWithNoopRenderer', () => {
       // Enqueuing this update forces the passive effect to be flushed --
       // updateCount(1) happens first, so 2 wins.
       act(() => _updateCount(2));
-      expect(ReactNoop.clearYields()).toEqual(['Will set count to 1']);
-      expect(ReactNoop.flush()).toEqual(['Count: 2']);
+      expect(ReactNoop).toHaveYielded(['Will set count to 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 2']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 2')]);
 
       expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
@@ -911,13 +911,13 @@ describe('ReactHooksWithNoopRenderer', () => {
         }
         ReactNoop.renderLegacySyncRoot(<Counter count={0} />);
         // Even in sync mode, effects are deferred until after paint
-        expect(ReactNoop.clearYields()).toEqual(['Count: (empty)']);
+        expect(ReactNoop).toHaveYielded(['Count: (empty)']);
         expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
         // Now fire the effects
         ReactNoop.flushPassiveEffects();
         // There were multiple updates, but there should only be a
         // single render
-        expect(ReactNoop.clearYields()).toEqual(['Count: 0']);
+        expect(ReactNoop).toHaveYielded(['Count: 0']);
         expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       },
     );
@@ -937,7 +937,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: (empty)']);
+      expect(ReactNoop).toFlushAndYield(['Count: (empty)']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
 
       expect(() => {
@@ -956,19 +956,16 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Did create [0]']);
+      expect(ReactNoop).toHaveYielded(['Did create [0]']);
 
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual([
-        'Did destroy [0]',
-        'Did create [1]',
-      ]);
+      expect(ReactNoop).toHaveYielded(['Did destroy [0]', 'Did create [1]']);
     });
 
     it('unmounts on deletion', () => {
@@ -982,13 +979,13 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Did create [0]']);
+      expect(ReactNoop).toHaveYielded(['Did create [0]']);
 
       ReactNoop.render(null);
-      expect(ReactNoop.flush()).toEqual(['Did destroy [0]']);
+      expect(ReactNoop).toFlushAndYield(['Did destroy [0]']);
       expect(ReactNoop.getChildren()).toEqual([]);
     });
 
@@ -1003,19 +1000,19 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Did create [0]']);
+      expect(ReactNoop).toHaveYielded(['Did create [0]']);
 
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual([]);
+      expect(ReactNoop).toHaveYielded([]);
 
       ReactNoop.render(null);
-      expect(ReactNoop.flush()).toEqual(['Did destroy [0]']);
+      expect(ReactNoop).toFlushAndYield(['Did destroy [0]']);
       expect(ReactNoop.getChildren()).toEqual([]);
     });
 
@@ -1031,19 +1028,19 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Did create']);
+      expect(ReactNoop).toHaveYielded(['Did create']);
 
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Did destroy', 'Did create']);
+      expect(ReactNoop).toHaveYielded(['Did destroy', 'Did create']);
 
       ReactNoop.render(null);
-      expect(ReactNoop.flush()).toEqual(['Did destroy']);
+      expect(ReactNoop).toFlushAndYield(['Did destroy']);
       expect(ReactNoop.getChildren()).toEqual([]);
     });
 
@@ -1062,34 +1059,34 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={text} />;
       }
       ReactNoop.render(<Counter label="Count" count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Did create [Count: 0]']);
+      expect(ReactNoop).toHaveYielded(['Did create [Count: 0]']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       ReactNoop.render(<Counter label="Count" count={1} />);
       // Count changed
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Did destroy [Count: 0]',
         'Did create [Count: 1]',
       ]);
 
       ReactNoop.render(<Counter label="Count" count={1} />);
       // Nothing changed, so no effect should have fired
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual([]);
+      expect(ReactNoop).toHaveYielded([]);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
 
       ReactNoop.render(<Counter label="Total" count={1} />);
       // Label changed
-      expect(ReactNoop.flush()).toEqual(['Total: 1']);
+      expect(ReactNoop).toFlushAndYield(['Total: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Total: 1')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Did destroy [Count: 1]',
         'Did create [Total: 1]',
       ]);
@@ -1106,22 +1103,16 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual([
-        'Did commit 1 [0]',
-        'Did commit 2 [0]',
-      ]);
+      expect(ReactNoop).toHaveYielded(['Did commit 1 [0]', 'Did commit 2 [0]']);
 
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual([
-        'Did commit 1 [1]',
-        'Did commit 2 [1]',
-      ]);
+      expect(ReactNoop).toHaveYielded(['Did commit 1 [1]', 'Did commit 2 [1]']);
     });
 
     it('unmounts all previous effects before creating any new ones', () => {
@@ -1141,16 +1132,16 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Mount A [0]', 'Mount B [0]']);
+      expect(ReactNoop).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
 
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Unmount A [0]',
         'Unmount B [0]',
         'Mount A [1]',
@@ -1178,10 +1169,10 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       expect(() => ReactNoop.flushPassiveEffects()).toThrow('Oops');
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Mount A [0]',
         'Oops!',
         // Clean up effect A. There's no effect B to clean-up, because it
@@ -1212,17 +1203,17 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Mount A [0]', 'Mount B [0]']);
+      expect(ReactNoop).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
 
       // This update will trigger an errror
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       expect(() => ReactNoop.flushPassiveEffects()).toThrow('Oops');
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Unmount A [0]',
         'Unmount B [0]',
         'Mount A [1]',
@@ -1254,17 +1245,17 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Mount A [0]', 'Mount B [0]']);
+      expect(ReactNoop).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
 
       // This update will trigger an errror
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       expect(() => ReactNoop.flushPassiveEffects()).toThrow('Oops');
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Oops!',
         // B unmounts even though an error was thrown in the previous effect
         'Unmount B [0]',
@@ -1283,15 +1274,15 @@ describe('ReactHooksWithNoopRenderer', () => {
       Counter = memo(Counter);
 
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 0', 'Mount: 0']);
+      expect(ReactNoop).toFlushAndYield(['Count: 0', 'Mount: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.flush()).toEqual(['Count: 1', 'Unmount: 0', 'Mount: 1']);
+      expect(ReactNoop).toFlushAndYield(['Count: 1', 'Unmount: 0', 'Mount: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
 
       ReactNoop.render(null);
-      expect(ReactNoop.flush()).toEqual(['Unmount: 1']);
+      expect(ReactNoop).toFlushAndYield(['Unmount: 1']);
       expect(ReactNoop.getChildren()).toEqual([]);
     });
   });
@@ -1299,7 +1290,7 @@ describe('ReactHooksWithNoopRenderer', () => {
   describe('useLayoutEffect', () => {
     it('fires layout effects after the host has been mutated', () => {
       function getCommittedText() {
-        const yields = ReactNoop.clearYields();
+        const yields = ReactNoop.unstable_clearYields();
         const children = ReactNoop.getChildren();
         ReactNoop.yield(yields);
         if (children === null) {
@@ -1316,11 +1307,11 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual([[0], 'Current: 0']);
+      expect(ReactNoop).toFlushAndYield([[0], 'Current: 0']);
       expect(ReactNoop.getChildren()).toEqual([span(0)]);
 
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.flush()).toEqual([[1], 'Current: 1']);
+      expect(ReactNoop).toFlushAndYield([[1], 'Current: 1']);
       expect(ReactNoop.getChildren()).toEqual([span(1)]);
     });
 
@@ -1348,19 +1339,19 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<Counter count={0} />);
-      expect(ReactNoop.flush()).toEqual(['Mount layout [current: 0]']);
+      expect(ReactNoop).toFlushAndYield(['Mount layout [current: 0]']);
       expect(committedText).toEqual('0');
 
       ReactNoop.render(<Counter count={1} />);
-      expect(ReactNoop.clearYields()).toEqual(['Mount normal [current: 0]']);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toHaveYielded(['Mount normal [current: 0]']);
+      expect(ReactNoop).toFlushAndYield([
         'Unmount layout [current: 0]',
         'Mount layout [current: 1]',
       ]);
       expect(committedText).toEqual('1');
 
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Unmount normal [current: 1]',
         'Mount normal [current: 1]',
       ]);
@@ -1393,14 +1384,14 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       const button = React.createRef(null);
       ReactNoop.render(<Counter incrementBy={1} />);
-      expect(ReactNoop.flush()).toEqual(['Increment', 'Count: 0']);
+      expect(ReactNoop).toFlushAndYield(['Increment', 'Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([
         span('Increment'),
         span('Count: 0'),
       ]);
 
       act(button.current.increment);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         // Button should not re-render, because its props haven't changed
         // 'Increment',
         'Count: 1',
@@ -1412,7 +1403,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       // Increase the increment amount
       ReactNoop.render(<Counter incrementBy={10} />);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         // Inputs did change this time
         'Increment',
         'Count: 1',
@@ -1424,7 +1415,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       // Callback should have updated
       act(button.current.increment);
-      expect(ReactNoop.flush()).toEqual(['Count: 11']);
+      expect(ReactNoop).toFlushAndYield(['Count: 11']);
       expect(ReactNoop.getChildren()).toEqual([
         span('Increment'),
         span('Count: 11'),
@@ -1447,19 +1438,19 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<CapitalizedText text="hello" />);
-      expect(ReactNoop.flush()).toEqual(["Capitalize 'hello'", 'HELLO']);
+      expect(ReactNoop).toFlushAndYield(["Capitalize 'hello'", 'HELLO']);
       expect(ReactNoop.getChildren()).toEqual([span('HELLO')]);
 
       ReactNoop.render(<CapitalizedText text="hi" />);
-      expect(ReactNoop.flush()).toEqual(["Capitalize 'hi'", 'HI']);
+      expect(ReactNoop).toFlushAndYield(["Capitalize 'hi'", 'HI']);
       expect(ReactNoop.getChildren()).toEqual([span('HI')]);
 
       ReactNoop.render(<CapitalizedText text="hi" />);
-      expect(ReactNoop.flush()).toEqual(['HI']);
+      expect(ReactNoop).toFlushAndYield(['HI']);
       expect(ReactNoop.getChildren()).toEqual([span('HI')]);
 
       ReactNoop.render(<CapitalizedText text="goodbye" />);
-      expect(ReactNoop.flush()).toEqual(["Capitalize 'goodbye'", 'GOODBYE']);
+      expect(ReactNoop).toFlushAndYield(["Capitalize 'goodbye'", 'GOODBYE']);
       expect(ReactNoop.getChildren()).toEqual([span('GOODBYE')]);
     });
 
@@ -1480,16 +1471,16 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<LazyCompute compute={computeA} />);
-      expect(ReactNoop.flush()).toEqual(['compute A', 'A']);
+      expect(ReactNoop).toFlushAndYield(['compute A', 'A']);
 
       ReactNoop.render(<LazyCompute compute={computeA} />);
-      expect(ReactNoop.flush()).toEqual(['compute A', 'A']);
+      expect(ReactNoop).toFlushAndYield(['compute A', 'A']);
 
       ReactNoop.render(<LazyCompute compute={computeA} />);
-      expect(ReactNoop.flush()).toEqual(['compute A', 'A']);
+      expect(ReactNoop).toFlushAndYield(['compute A', 'A']);
 
       ReactNoop.render(<LazyCompute compute={computeB} />);
-      expect(ReactNoop.flush()).toEqual(['compute B', 'B']);
+      expect(ReactNoop).toFlushAndYield(['compute B', 'B']);
     });
 
     it('should not invoke memoized function during re-renders unless inputs change', () => {
@@ -1510,13 +1501,13 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<LazyCompute compute={compute} input="A" />);
-      expect(ReactNoop.flush()).toEqual(['compute A', 'A']);
+      expect(ReactNoop).toFlushAndYield(['compute A', 'A']);
 
       ReactNoop.render(<LazyCompute compute={compute} input="A" />);
-      expect(ReactNoop.flush()).toEqual(['A']);
+      expect(ReactNoop).toFlushAndYield(['A']);
 
       ReactNoop.render(<LazyCompute compute={compute} input="B" />);
-      expect(ReactNoop.flush()).toEqual(['compute B', 'B']);
+      expect(ReactNoop).toFlushAndYield(['compute B', 'B']);
     });
   });
 
@@ -1554,17 +1545,17 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<App />);
-      expect(ReactNoop.flush()).toEqual([]);
+      expect(ReactNoop).toFlushAndYield([]);
 
       ping(1);
       ping(2);
       ping(3);
 
-      expect(ReactNoop.clearYields()).toEqual([]);
+      expect(ReactNoop).toHaveYielded([]);
 
       jest.advanceTimersByTime(100);
 
-      expect(ReactNoop.clearYields()).toEqual(['ping: 3']);
+      expect(ReactNoop).toHaveYielded(['ping: 3']);
 
       ping(4);
       jest.advanceTimersByTime(20);
@@ -1572,10 +1563,10 @@ describe('ReactHooksWithNoopRenderer', () => {
       ping(6);
       jest.advanceTimersByTime(80);
 
-      expect(ReactNoop.clearYields()).toEqual([]);
+      expect(ReactNoop).toHaveYielded([]);
 
       jest.advanceTimersByTime(20);
-      expect(ReactNoop.clearYields()).toEqual(['ping: 6']);
+      expect(ReactNoop).toHaveYielded(['ping: 6']);
     });
 
     it('should return the same ref during re-renders', () => {
@@ -1596,10 +1587,10 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<Counter />);
-      expect(ReactNoop.flush()).toEqual(['val']);
+      expect(ReactNoop).toFlushAndYield(['val']);
 
       ReactNoop.render(<Counter />);
-      expect(ReactNoop.flush()).toEqual(['val']);
+      expect(ReactNoop).toFlushAndYield(['val']);
     });
   });
 
@@ -1620,14 +1611,14 @@ describe('ReactHooksWithNoopRenderer', () => {
       Counter = forwardRef(Counter);
       const counter = React.createRef(null);
       ReactNoop.render(<Counter ref={counter} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       expect(counter.current.count).toBe(0);
 
       act(() => {
         counter.current.dispatch(INCREMENT);
       });
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       // Intentionally not updated because of [] deps:
       expect(counter.current.count).toBe(0);
@@ -1650,14 +1641,14 @@ describe('ReactHooksWithNoopRenderer', () => {
       Counter = forwardRef(Counter);
       const counter = React.createRef(null);
       ReactNoop.render(<Counter ref={counter} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       expect(counter.current.count).toBe(0);
 
       act(() => {
         counter.current.dispatch(INCREMENT);
       });
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       expect(counter.current.count).toBe(1);
     });
@@ -1686,7 +1677,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       Counter = forwardRef(Counter);
       const counter = React.createRef(null);
       ReactNoop.render(<Counter ref={counter} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       expect(counter.current.count).toBe(0);
       expect(totalRefUpdates).toBe(1);
@@ -1694,14 +1685,14 @@ describe('ReactHooksWithNoopRenderer', () => {
       act(() => {
         counter.current.dispatch(INCREMENT);
       });
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       expect(counter.current.count).toBe(1);
       expect(totalRefUpdates).toBe(2);
 
       // Update that doesn't change the ref dependencies
       ReactNoop.render(<Counter ref={counter} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Count: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       expect(counter.current.count).toBe(1);
       expect(totalRefUpdates).toBe(2); // Should not increase since last time
@@ -1731,7 +1722,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<App loadC={false} />);
-      expect(ReactNoop.flush()).toEqual(['A: 0, B: 0, C: [not loaded]']);
+      expect(ReactNoop).toFlushAndYield(['A: 0, B: 0, C: [not loaded]']);
       expect(ReactNoop.getChildren()).toEqual([
         span('A: 0, B: 0, C: [not loaded]'),
       ]);
@@ -1741,21 +1732,21 @@ describe('ReactHooksWithNoopRenderer', () => {
         updateB(3);
       });
 
-      expect(ReactNoop.flush()).toEqual(['A: 2, B: 3, C: [not loaded]']);
+      expect(ReactNoop).toFlushAndYield(['A: 2, B: 3, C: [not loaded]']);
       expect(ReactNoop.getChildren()).toEqual([
         span('A: 2, B: 3, C: [not loaded]'),
       ]);
 
       ReactNoop.render(<App loadC={true} />);
       expect(() => {
-        expect(ReactNoop.flush()).toEqual(['A: 2, B: 3, C: 0']);
+        expect(ReactNoop).toFlushAndYield(['A: 2, B: 3, C: 0']);
       }).toThrow('Rendered more hooks than during the previous render');
 
       // Uncomment if/when we support this again
       // expect(ReactNoop.getChildren()).toEqual([span('A: 2, B: 3, C: 0')]);
 
       // updateC(4);
-      // expect(ReactNoop.flush()).toEqual(['A: 2, B: 3, C: 4']);
+      // expect(ReactNoop).toFlushAndYield(['A: 2, B: 3, C: 4']);
       // expect(ReactNoop.getChildren()).toEqual([span('A: 2, B: 3, C: 4')]);
     });
 
@@ -1783,17 +1774,17 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<App loadC={true} />);
-      expect(ReactNoop.flush()).toEqual(['A: 0, B: 0, C: 0']);
+      expect(ReactNoop).toFlushAndYield(['A: 0, B: 0, C: 0']);
       expect(ReactNoop.getChildren()).toEqual([span('A: 0, B: 0, C: 0')]);
       act(() => {
         updateA(2);
         updateB(3);
         updateC(4);
       });
-      expect(ReactNoop.flush()).toEqual(['A: 2, B: 3, C: 4']);
+      expect(ReactNoop).toFlushAndYield(['A: 2, B: 3, C: 4']);
       expect(ReactNoop.getChildren()).toEqual([span('A: 2, B: 3, C: 4')]);
       ReactNoop.render(<App loadC={false} />);
-      expect(() => ReactNoop.flush()).toThrow(
+      expect(ReactNoop).toFlushAndThrow(
         'Rendered fewer hooks than expected. This may be caused by an ' +
           'accidental early return statement.',
       );
@@ -1821,21 +1812,21 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<App showMore={false} />);
-      expect(ReactNoop.flush()).toEqual([]);
+      expect(ReactNoop).toFlushAndYield([]);
       ReactNoop.flushPassiveEffects();
-      expect(ReactNoop.clearYields()).toEqual(['Mount A']);
+      expect(ReactNoop).toHaveYielded(['Mount A']);
 
       ReactNoop.render(<App showMore={true} />);
       expect(() => {
-        expect(ReactNoop.flush()).toEqual([]);
+        expect(ReactNoop).toFlushAndYield([]);
       }).toThrow('Rendered more hooks than during the previous render');
 
       // Uncomment if/when we support this again
       // ReactNoop.flushPassiveEffects();
-      // expect(ReactNoop.clearYields()).toEqual(['Mount B']);
+      // expect(ReactNoop).toHaveYielded(['Mount B']);
 
       // ReactNoop.render(<App showMore={false} />);
-      // expect(() => ReactNoop.flush()).toThrow(
+      // expect(ReactNoop).toFlushAndThrow(
       //   'Rendered fewer hooks than expected. This may be caused by an ' +
       //     'accidental early return statement.',
       // );

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -35,7 +35,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
   });
 
   it('should render a simple component, in steps if needed', () => {
@@ -58,7 +58,7 @@ describe('ReactIncremental', () => {
     expect(ReactNoop.flushNextYield()).toEqual(['Foo']);
 
     // Do the rest of the work.
-    expect(ReactNoop.flush()).toEqual(['Bar', 'Bar', 'callback']);
+    expect(ReactNoop).toFlushAndYield(['Bar', 'Bar', 'callback']);
   });
 
   it('updates a previous render', () => {
@@ -96,7 +96,7 @@ describe('ReactIncremental', () => {
     ReactNoop.render(<Foo text="foo" />, () =>
       ops.push('renderCallbackCalled'),
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       'Foo',
@@ -114,7 +114,7 @@ describe('ReactIncremental', () => {
     ReactNoop.render(<Foo text="bar" />, () =>
       ops.push('secondRenderCallbackCalled'),
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     // TODO: Test bail out of host components. This is currently unobservable.
 
@@ -146,21 +146,21 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Foo text="foo" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['Foo', 'Bar', 'Bar']);
 
     ReactNoop.render(<Foo text="bar" />);
     // Flush part of the work
-    ReactNoop.flushThrough(['Foo', 'Bar']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo', 'Bar']);
 
     // This will abort the previous work and restart
     ReactNoop.flushSync(() => ReactNoop.render(null));
     ReactNoop.render(<Foo text="baz" />);
 
     // Flush part of the new work
-    ReactNoop.flushThrough(['Foo', 'Bar']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo', 'Bar']);
 
     // Flush the rest of the work which now includes the low priority
-    expect(ReactNoop.flush()).toEqual(['Bar']);
+    expect(ReactNoop).toFlushAndYield(['Bar']);
   });
 
   it('should call callbacks even if updates are aborted', () => {
@@ -186,7 +186,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     inst.setState(
       () => {
@@ -197,7 +197,7 @@ describe('ReactIncremental', () => {
     );
 
     // Flush part of the work
-    ReactNoop.flushThrough(['setState1']);
+    expect(ReactNoop).toFlushAndYieldThrough(['setState1']);
 
     // This will abort the previous work and restart
     ReactNoop.flushSync(() => ReactNoop.render(<Foo />));
@@ -210,7 +210,7 @@ describe('ReactIncremental', () => {
     );
 
     // Flush the rest of the work which now includes the low priority
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'setState1',
       'setState2',
       'callback1',
@@ -248,7 +248,7 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Foo text="foo" />);
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'Foo',
       'Bar',
       'Bar',
@@ -259,9 +259,9 @@ describe('ReactIncremental', () => {
     // Render part of the work. This should be enough to flush everything except
     // the middle which has lower priority.
     ReactNoop.render(<Foo text="bar" />);
-    ReactNoop.flushThrough(['Foo', 'Bar', 'Bar']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo', 'Bar', 'Bar']);
     // Flush only the remaining work
-    expect(ReactNoop.flush()).toEqual(['Middle', 'Middle']);
+    expect(ReactNoop).toFlushAndYield(['Middle', 'Middle']);
   });
 
   it('can deprioritize a tree from without dropping work', () => {
@@ -297,7 +297,7 @@ describe('ReactIncremental', () => {
     ReactNoop.flushSync(() => {
       ReactNoop.render(<Foo text="foo" />);
     });
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Foo', 'Bar', 'Bar', 'Middle', 'Middle']);
 
     ops = [];
@@ -312,7 +312,7 @@ describe('ReactIncremental', () => {
 
     // The hidden content was deprioritized from high to low priority. A low
     // priority callback should have been scheduled. Flush it now.
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Middle', 'Middle']);
   });
 
@@ -375,7 +375,7 @@ describe('ReactIncremental', () => {
     ops = [];
 
     // Flush the rest to make sure that the bailout didn't block this work.
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Middle']);
   });
 
@@ -455,7 +455,7 @@ describe('ReactIncremental', () => {
     // as a single batch. Therefore, it is correct that Middle should be in the
     // middle. If it occurs after the two "Bar" components then it was flushed
     // after them which is not correct.
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Bar', 'Middle', 'Bar']);
 
     ops = [];
@@ -473,7 +473,7 @@ describe('ReactIncremental', () => {
     // it. If the priority levels aren't down-prioritized correctly this may
     // abort rendering of the down-prioritized content.
     ReactNoop.render(<Foo text="bar" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Foo', 'Bar', 'Bar']);
   });
 
@@ -514,7 +514,7 @@ describe('ReactIncremental', () => {
     foo.setState({value: 'bar'});
 
     ops = [];
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Foo', 'Bar']);
   });
 
@@ -577,7 +577,7 @@ describe('ReactIncremental', () => {
     foo.setState({value: 'bar'});
 
     ops = [];
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(constructorCount).toEqual(1);
     expect(ops).toEqual([
       'componentWillMount: foo',
@@ -639,7 +639,7 @@ describe('ReactIncremental', () => {
     // Interrupt the rendering with a quick update. This should not touch the
     // middle content.
     ReactNoop.render(<Foo text="foo" text2="bar" step={0} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     // We've now rendered the entire tree but we didn't have to redo the work
     // done by the first Middle and Bar already.
@@ -674,7 +674,7 @@ describe('ReactIncremental', () => {
     // Since we did nothing to the middle subtree during the interruption,
     // we should be able to reuse the reconciliation work that we already did
     // without restarting.
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Middle']);
   });
 
@@ -727,7 +727,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Parent />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     ops = [];
 
     // Begin working on a low priority update to Child, but stop before
@@ -747,7 +747,7 @@ describe('ReactIncremental', () => {
     // Continue the low pri work. The work on Child and GrandChild was memoized
     // so they should not be worked on again.
     ops = [];
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual([
       // No Child
       // No Grandchild
@@ -803,7 +803,7 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Foo text="foo" step={0} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Foo', 'Bar', 'Content', 'Middle', 'Bar', 'Middle']);
 
@@ -836,7 +836,7 @@ describe('ReactIncremental', () => {
     // Since we did nothing to the middle subtree during the interruption,
     // we should be able to reuse the reconciliation work that we already did
     // without restarting.
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Middle']);
   });
 
@@ -857,16 +857,16 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Foo step={1} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ops = [];
     ReactNoop.render(<Foo step={2} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['shouldComponentUpdate: false']);
 
     ops = [];
     ReactNoop.render(<Foo step={3} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual([
       // If the memoized props were not updated during last bail out, sCU will
       // keep returning false.
@@ -897,10 +897,10 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(instance.state).toEqual({a: 'a'});
     instance.setState({b: 'b'});
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(instance.state).toEqual({a: 'a', b: 'b'});
   });
 
@@ -926,12 +926,12 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     // Call setState multiple times before flushing
     instance.setState({b: 'b'});
     instance.setState({c: 'c'});
     instance.setState({d: 'd'});
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(instance.state).toEqual({a: 'a', b: 'b', c: 'c', d: 'd'});
   });
 
@@ -961,15 +961,15 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Foo multiplier={2} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(instance.state.num).toEqual(1);
     instance.setState(updater);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(instance.state.num).toEqual(2);
 
     instance.setState(updater);
     ReactNoop.render(<Foo multiplier={3} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(instance.state.num).toEqual(6);
   });
 
@@ -1003,10 +1003,10 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Foo multiplier={2} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     instance.setState(updater);
     instance.setState(updater, callback);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(instance.state.num).toEqual(4);
     expect(instance.state.called).toEqual(true);
   });
@@ -1030,11 +1030,11 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     instance.setState({b: 'b'});
     instance.setState({c: 'c'});
     instance.updater.enqueueReplaceState(instance, {d: 'd'});
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(instance.state).toEqual({d: 'd'});
   });
 
@@ -1071,10 +1071,10 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Foo', 'Bar', 'Baz']);
     instance.forceUpdate();
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Foo', 'Bar', 'Baz', 'Bar', 'Baz']);
   });
 
@@ -1091,14 +1091,14 @@ describe('ReactIncremental', () => {
 
     const foo = React.createRef(null);
     ReactNoop.render(<Foo ref={foo} b={0} />);
-    expect(ReactNoop.flush()).toEqual(['A: 0, B: 0']);
+    expect(ReactNoop).toFlushAndYield(['A: 0, B: 0']);
 
     a = 1;
     foo.current.forceUpdate();
-    expect(ReactNoop.flush()).toEqual(['A: 1, B: 0']);
+    expect(ReactNoop).toFlushAndYield(['A: 1, B: 0']);
 
     ReactNoop.render(<Foo ref={foo} b={0} />);
-    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop).toFlushAndYield([]);
   });
 
   xit('can call sCU while resuming a partly mounted component', () => {
@@ -1193,7 +1193,7 @@ describe('ReactIncremental', () => {
         <Baz />
       </div>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ops = [];
 
@@ -1214,7 +1214,7 @@ describe('ReactIncremental', () => {
 
     ops = [];
 
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Bar:A-1', 'Baz']);
   });
 
@@ -1263,7 +1263,7 @@ describe('ReactIncremental', () => {
     ops = [];
 
     ReactNoop.render(<App x={1} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       'App',
@@ -1311,7 +1311,7 @@ describe('ReactIncremental', () => {
 
     ops = [];
     ReactNoop.render(<App x={1} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       'App',
@@ -1366,7 +1366,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<App x={0} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       'App',
@@ -1394,7 +1394,7 @@ describe('ReactIncremental', () => {
     ops = [];
 
     ReactNoop.render(<App x={2} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       'App',
@@ -1432,7 +1432,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<LifeCycle />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual(['getDerivedStateFromProps', 'render']);
     expect(instance.state).toEqual({foo: 'foo'});
@@ -1440,7 +1440,7 @@ describe('ReactIncremental', () => {
     ops = [];
 
     instance.changeState();
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       'getDerivedStateFromProps',
@@ -1472,7 +1472,7 @@ describe('ReactIncremental', () => {
 
     const child = React.createRef(null);
     ReactNoop.render(<Parent />);
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'getDerivedStateFromProps',
       'Parent',
       'Child',
@@ -1480,7 +1480,7 @@ describe('ReactIncremental', () => {
 
     // Schedule an update on the child. The parent should not re-render.
     child.current.setState({});
-    expect(ReactNoop.flush()).toEqual(['Child']);
+    expect(ReactNoop).toFlushAndYield(['Child']);
   });
 
   xit('does not call componentWillReceiveProps for state-only updates', () => {
@@ -1553,7 +1553,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<App y={0} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       'App',
@@ -1584,7 +1584,7 @@ describe('ReactIncremental', () => {
     // LifeCycle
     instances[1].tick();
 
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       // no componentWillReceiveProps
@@ -1617,7 +1617,7 @@ describe('ReactIncremental', () => {
     // Next we will update LifeCycle directly but not with new props.
     instances[1].tick();
 
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       // This should not trigger another componentWillReceiveProps because
@@ -1672,7 +1672,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<App x={0} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       'componentWillMount',
@@ -1685,7 +1685,7 @@ describe('ReactIncremental', () => {
 
     // Update to same props
     ReactNoop.render(<App x={0} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       'componentWillReceiveProps',
@@ -1715,7 +1715,7 @@ describe('ReactIncremental', () => {
 
     // ...but we'll interrupt it to rerender the same props.
     ReactNoop.render(<App x={1} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     // We can bail out this time, but we must call componentDidUpdate.
     expect(ops).toEqual([
@@ -1741,7 +1741,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     ops = [];
 
     ReactNoop.flushSync(() => {
@@ -1783,7 +1783,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     ops = [];
 
     function updater({n}) {
@@ -1798,7 +1798,7 @@ describe('ReactIncremental', () => {
     instance.setState(updater, () => ops.push('third callback'));
 
     expect(() => {
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('callback error');
 
     // The third callback isn't called because the second one throws
@@ -1897,7 +1897,7 @@ describe('ReactIncremental', () => {
       </Intl>,
     );
     expect(() =>
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         'Intl {}',
         'ShowLocale {"locale":"fr"}',
         'ShowBoth {"locale":"fr"}',
@@ -1916,7 +1916,7 @@ describe('ReactIncremental', () => {
         </div>
       </Intl>,
     );
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'Intl {}',
       'ShowLocale {"locale":"de"}',
       'ShowBoth {"locale":"de"}',
@@ -1930,7 +1930,7 @@ describe('ReactIncremental', () => {
         </div>
       </Intl>,
     );
-    ReactNoop.flushThrough(['Intl {}']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Intl {}']);
 
     ReactNoop.render(
       <Intl locale="en">
@@ -1942,7 +1942,7 @@ describe('ReactIncremental', () => {
       </Intl>,
     );
     expect(() =>
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         'ShowLocale {"locale":"sv"}',
         'ShowBoth {"locale":"sv"}',
         'Intl {}',
@@ -1986,7 +1986,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Recurse />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: Recurse',
       {withoutStack: true},
@@ -2023,7 +2023,7 @@ describe('ReactIncremental', () => {
     };
 
     ReactNoop.render(<Recurse />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: Recurse',
       {withoutStack: true},
@@ -2074,14 +2074,14 @@ describe('ReactIncremental', () => {
         <ShowLocale />
       </Intl>,
     );
-    ReactNoop.flushThrough([
+    expect(ReactNoop).toFlushAndYieldThrough([
       'Intl {}',
       'ShowLocale {"locale":"fr"}',
       'ShowLocale {"locale":"fr"}',
     ]);
 
     expect(() =>
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         'ShowLocale {"locale":"fr"}',
         'Intl {}',
         'ShowLocale {"locale":"ru"}',
@@ -2165,7 +2165,7 @@ describe('ReactIncremental', () => {
         </IndirectionFn>
       </Intl>,
     );
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: Intl, ShowLocaleClass, ShowLocaleFn',
       {withoutStack: true},
@@ -2181,7 +2181,7 @@ describe('ReactIncremental', () => {
 
     ops.length = 0;
     statefulInst.setState({x: 1});
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     // All work has been memoized because setState()
     // happened below the context and could not have affected it.
     expect(ops).toEqual([]);
@@ -2257,7 +2257,7 @@ describe('ReactIncremental', () => {
         </IndirectionFn>
       </Stateful>,
     );
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: Intl, ShowLocaleClass, ShowLocaleFn',
       {withoutStack: true},
@@ -2273,7 +2273,7 @@ describe('ReactIncremental', () => {
 
     ops.length = 0;
     statefulInst.setState({locale: 'gr'});
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual([
       // Intl is below setState() so it might have been
       // affected by it. Therefore we re-render and recompute
@@ -2326,7 +2326,7 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Root />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: Child',
       {withoutStack: true},
@@ -2334,7 +2334,7 @@ describe('ReactIncremental', () => {
 
     // Trigger an update in the middle of the tree
     instance.setState({});
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
   });
 
   it('maintains the correct context when unwinding due to an error in render', () => {
@@ -2376,7 +2376,7 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Root />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: ContextProvider',
       {withoutStack: true},
@@ -2387,7 +2387,7 @@ describe('ReactIncremental', () => {
     instance.setState({
       throwError: true,
     });
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Error boundaries should implement getDerivedStateFromError()',
       {withoutStack: true},
     );
@@ -2425,7 +2425,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<MyComponent />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       [
         'componentWillReceiveProps: Please update the following components ' +
           'to use static getDerivedStateFromProps instead: MyComponent',
@@ -2496,7 +2496,7 @@ describe('ReactIncremental', () => {
     // Initial render of the entire tree.
     // Renders: Root, Middle, FirstChild, SecondChild
     ReactNoop.render(<Root>A</Root>);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(renderCounter).toBe(1);
 
@@ -2518,7 +2518,7 @@ describe('ReactIncremental', () => {
     // The in-progress child content will bailout.
     // Renders: Root, Middle, FirstChild, SecondChild
     ReactNoop.render(<Root>B</Root>);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     // At this point the higher priority render has completed.
     // Since FirstChild props didn't change, sCU returned false.
@@ -2575,14 +2575,14 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: Child, TopContextProvider',
       {withoutStack: true},
     );
     expect(rendered).toEqual(['count:0']);
     instance.updateCount();
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(rendered).toEqual(['count:0', 'count:1']);
   });
 
@@ -2637,14 +2637,14 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: Child, MiddleContextProvider, TopContextProvider',
       {withoutStack: true},
     );
     expect(rendered).toEqual(['count:0']);
     instance.updateCount();
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(rendered).toEqual(['count:0', 'count:1']);
   });
 
@@ -2708,14 +2708,14 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: Child, MiddleContextProvider, TopContextProvider',
       {withoutStack: true},
     );
     expect(rendered).toEqual(['count:0']);
     instance.updateCount();
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(rendered).toEqual(['count:0']);
   });
 
@@ -2789,17 +2789,17 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: Child, MiddleContextProvider, TopContextProvider',
       {withoutStack: true},
     );
     expect(rendered).toEqual(['count:0, name:brian']);
     topInstance.updateCount();
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(rendered).toEqual(['count:0, name:brian']);
     middleInstance.updateName('not brian');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(rendered).toEqual([
       'count:0, name:brian',
       'count:1, name:not brian',
@@ -2818,12 +2818,12 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Parent step={1} />);
-    ReactNoop.flushThrough(['Parent: 1']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Parent: 1']);
 
     // Interrupt at same priority
     ReactNoop.render(<Parent step={2} />);
 
-    expect(ReactNoop.flush()).toEqual(['Child: 1', 'Parent: 2', 'Child: 2']);
+    expect(ReactNoop).toFlushAndYield(['Child: 1', 'Parent: 2', 'Child: 2']);
   });
 
   it('does not interrupt for update at lower priority', () => {
@@ -2838,13 +2838,13 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Parent step={1} />);
-    ReactNoop.flushThrough(['Parent: 1']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Parent: 1']);
 
     // Interrupt at lower priority
     ReactNoop.expire(2000);
     ReactNoop.render(<Parent step={2} />);
 
-    expect(ReactNoop.flush()).toEqual(['Child: 1', 'Parent: 2', 'Child: 2']);
+    expect(ReactNoop).toFlushAndYield(['Child: 1', 'Parent: 2', 'Child: 2']);
   });
 
   it('does interrupt for update at higher priority', () => {
@@ -2859,15 +2859,15 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Parent step={1} />);
-    ReactNoop.flushThrough(['Parent: 1']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Parent: 1']);
 
     // Interrupt at higher priority
     expect(
       ReactNoop.flushSync(() => ReactNoop.render(<Parent step={2} />)),
     ).toEqual(['Parent: 2', 'Child: 2']);
-    ReactNoop.clearYields();
+    expect(ReactNoop).toHaveYielded(['Parent: 2', 'Child: 2']);
 
-    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop).toFlushAndYield([]);
   });
 
   // We don't currently use fibers as keys. Re-enable this test if we
@@ -2889,7 +2889,7 @@ describe('ReactIncremental', () => {
         }
       }
       ReactNoop.render(<Boundary />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }
 
     // First, verify that this code path normally receives Fibers as keys,

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -615,6 +615,8 @@ describe('ReactIncrementalErrorHandling', () => {
       ReactNoop.flush();
     }).toThrow('Hello');
     expect(ReactNoop.clearYields()).toEqual([
+      'BrokenRender',
+
       // React retries one more time
       'RethrowErrorBoundary render',
       'BrokenRender',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -86,7 +86,7 @@ describe('ReactIncrementalErrorHandling', () => {
     );
 
     // Start rendering asynchronously
-    ReactNoop.flushThrough([
+    expect(ReactNoop).toFlushAndYieldThrough([
       'ErrorBoundary (try)',
       'Indirection',
       'Indirection',
@@ -96,9 +96,9 @@ describe('ReactIncrementalErrorHandling', () => {
     ]);
 
     // Still rendering async...
-    ReactNoop.flushThrough(['Indirection']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Indirection']);
 
-    ReactNoop.flushThrough([
+    expect(ReactNoop).toFlushAndYieldThrough([
       'Indirection',
 
       // Call getDerivedStateFromError and re-render the error boundary, this
@@ -179,7 +179,7 @@ describe('ReactIncrementalErrorHandling', () => {
     );
 
     // Start rendering asynchronously
-    ReactNoop.flushThrough([
+    expect(ReactNoop).toFlushAndYieldThrough([
       'ErrorBoundary (try)',
       'Indirection',
       'Indirection',
@@ -189,9 +189,9 @@ describe('ReactIncrementalErrorHandling', () => {
     ]);
 
     // Still rendering async...
-    ReactNoop.flushThrough(['Indirection']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Indirection']);
 
-    ReactNoop.flushThrough([
+    expect(ReactNoop).toFlushAndYieldThrough([
       'Indirection',
       // Now that the tree is complete, and there's no remaining work, React
       // reverts to sync mode to retry one more time before handling the error.
@@ -230,7 +230,7 @@ describe('ReactIncrementalErrorHandling', () => {
     ReactNoop.expire(2000);
     ReactNoop.render(<App isBroken={false} />, onCommit);
 
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       // The first render fails. But because there's a lower priority pending
       // update, it doesn't throw.
       'error',
@@ -270,7 +270,7 @@ describe('ReactIncrementalErrorHandling', () => {
     // Initial mount
     const parent = React.createRef(null);
     ReactNoop.render(<Parent ref={parent} childIsBroken={false} />);
-    expect(ReactNoop.flush()).toEqual(['Child']);
+    expect(ReactNoop).toFlushAndYield(['Child']);
     expect(ReactNoop.getChildren()).toEqual([span('Child')]);
 
     // Schedule a low priority update to hide the child
@@ -281,7 +281,7 @@ describe('ReactIncrementalErrorHandling', () => {
     ReactNoop.flushSync(() => {
       ReactNoop.render(<Parent ref={parent} childIsBroken={true} />);
     });
-    expect(ReactNoop.clearYields()).toEqual([
+    expect(ReactNoop).toHaveYielded([
       // First the sync update triggers an error
       'Error!',
       // Because there's a pending low priority update, we restart at the
@@ -321,10 +321,10 @@ describe('ReactIncrementalErrorHandling', () => {
     ReactNoop.render(<Parent />, () => ReactNoop.yield('commit'));
 
     // Render the bad component asynchronously
-    ReactNoop.flushThrough(['Parent', 'BadRender']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Parent', 'BadRender']);
 
     // Finish the rest of the async work
-    ReactNoop.flushThrough(['Sibling']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Sibling']);
 
     // React retries once, synchronously, before throwing.
     ops = [];
@@ -371,7 +371,7 @@ describe('ReactIncrementalErrorHandling', () => {
       </ErrorBoundary>,
     );
 
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'ErrorBoundary',
       'BadMount',
       'BadMount',
@@ -408,7 +408,7 @@ describe('ReactIncrementalErrorHandling', () => {
         <BrokenRender />
       </ErrorBoundary>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('Caught an error: Hello.')]);
   });
 
@@ -442,10 +442,10 @@ describe('ReactIncrementalErrorHandling', () => {
       </ErrorBoundary>,
     );
 
-    ReactNoop.flushThrough(['ErrorBoundary render success']);
+    expect(ReactNoop).toFlushAndYieldThrough(['ErrorBoundary render success']);
     expect(ReactNoop.getChildren()).toEqual([]);
 
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'BrokenRender',
       // React retries one more time
       'ErrorBoundary render success',
@@ -570,7 +570,7 @@ describe('ReactIncrementalErrorHandling', () => {
     );
 
     expect(() => {
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('Hello');
     expect(ops).toEqual([
       'RethrowErrorBoundary render',
@@ -609,12 +609,12 @@ describe('ReactIncrementalErrorHandling', () => {
       </RethrowErrorBoundary>,
     );
 
-    ReactNoop.flushThrough(['RethrowErrorBoundary render']);
+    expect(ReactNoop).toFlushAndYieldThrough(['RethrowErrorBoundary render']);
 
     expect(() => {
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('Hello');
-    expect(ReactNoop.clearYields()).toEqual([
+    expect(ReactNoop).toHaveYielded([
       'BrokenRender',
 
       // React retries one more time
@@ -711,7 +711,7 @@ describe('ReactIncrementalErrorHandling', () => {
         throw new Error('Hello');
       });
     }).toThrow('Hello');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('a:3')]);
   });
 
@@ -728,7 +728,7 @@ describe('ReactIncrementalErrorHandling', () => {
         });
       });
     }).toThrow('Hello');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('a:5')]);
   });
 
@@ -761,7 +761,7 @@ describe('ReactIncrementalErrorHandling', () => {
 
     ReactNoop.render(<BrokenRender />);
     expect(() => {
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('Hello');
     expect(ops).toEqual([
       'BrokenRender',
@@ -771,7 +771,7 @@ describe('ReactIncrementalErrorHandling', () => {
     ]);
     ops = [];
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Foo']);
   });
 
@@ -792,12 +792,12 @@ describe('ReactIncrementalErrorHandling', () => {
     }
 
     ReactNoop.render(<BrokenRender throw={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     ops = [];
 
     expect(() => {
       ReactNoop.render(<BrokenRender throw={true} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('Hello');
     expect(ops).toEqual([
       'BrokenRender',
@@ -808,7 +808,7 @@ describe('ReactIncrementalErrorHandling', () => {
 
     ops = [];
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Foo']);
   });
 
@@ -830,16 +830,16 @@ describe('ReactIncrementalErrorHandling', () => {
     }
 
     ReactNoop.render(<BrokenComponentWillUnmount />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(() => {
       ReactNoop.render(<div />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('Hello');
 
     ops = [];
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['Foo']);
   });
 
@@ -873,9 +873,9 @@ describe('ReactIncrementalErrorHandling', () => {
     }
 
     ReactNoop.render(<Parent />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     ReactNoop.render(null);
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       // Parent unmounts before the error is thrown.
       'Parent componentWillUnmount',
       'ThrowsOnUnmount componentWillUnmount',
@@ -912,7 +912,7 @@ describe('ReactIncrementalErrorHandling', () => {
     }
 
     ReactNoop.render(<Parent />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.flushSync(() => {
       ReactNoop.render(<Parent />);
@@ -946,7 +946,7 @@ describe('ReactIncrementalErrorHandling', () => {
       'a',
     );
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren('a')).toEqual([
       span('Caught an error: Hello.'),
     ]);
@@ -960,14 +960,14 @@ describe('ReactIncrementalErrorHandling', () => {
 
     ReactNoop.renderToRootWithID(<BrokenRender />, 'a');
     expect(() => {
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('Hello');
     expect(ReactNoop.getChildren('a')).toEqual([]);
 
     ReactNoop.renderToRootWithID(<BrokenRender />, 'a');
     ReactNoop.renderToRootWithID(<span prop="b:2" />, 'b');
     expect(() => {
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('Hello');
 
     expect(ReactNoop.getChildren('a')).toEqual([]);
@@ -976,7 +976,7 @@ describe('ReactIncrementalErrorHandling', () => {
     ReactNoop.renderToRootWithID(<span prop="a:3" />, 'a');
     ReactNoop.renderToRootWithID(<BrokenRender />, 'b');
     expect(() => {
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('Hello');
     expect(ReactNoop.getChildren('a')).toEqual([span('a:3')]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
@@ -985,7 +985,7 @@ describe('ReactIncrementalErrorHandling', () => {
     ReactNoop.renderToRootWithID(<BrokenRender />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:4" />, 'c');
     expect(() => {
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('Hello');
     expect(ReactNoop.getChildren('a')).toEqual([span('a:4')]);
     expect(ReactNoop.getChildren('b')).toEqual([]);
@@ -997,7 +997,7 @@ describe('ReactIncrementalErrorHandling', () => {
     ReactNoop.renderToRootWithID(<span prop="d:5" />, 'd');
     ReactNoop.renderToRootWithID(<BrokenRender />, 'e');
     expect(() => {
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('Hello');
     expect(ReactNoop.getChildren('a')).toEqual([span('a:5')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:5')]);
@@ -1012,7 +1012,7 @@ describe('ReactIncrementalErrorHandling', () => {
     ReactNoop.renderToRootWithID(<BrokenRender />, 'e');
     ReactNoop.renderToRootWithID(<span prop="f:6" />, 'f');
     expect(() => {
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrow('Hello');
     expect(ReactNoop.getChildren('a')).toEqual([]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:6')]);
@@ -1027,7 +1027,7 @@ describe('ReactIncrementalErrorHandling', () => {
     ReactNoop.unmountRootWithID('d');
     ReactNoop.unmountRootWithID('e');
     ReactNoop.unmountRootWithID('f');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren('a')).toEqual(null);
     expect(ReactNoop.getChildren('b')).toEqual(null);
     expect(ReactNoop.getChildren('c')).toEqual(null);
@@ -1088,7 +1088,7 @@ describe('ReactIncrementalErrorHandling', () => {
         <Connector />
       </Provider>,
     );
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: Connector, Provider',
       {withoutStack: true},
@@ -1121,7 +1121,7 @@ describe('ReactIncrementalErrorHandling', () => {
         <BrokenRender />
       </ErrorBoundary>,
     );
-    expect(ReactNoop.flush).toWarnDev([
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev([
       'Warning: React.createElement: type is invalid -- expected a string',
       // React retries once on error
       'Warning: React.createElement: type is invalid -- expected a string',
@@ -1163,14 +1163,14 @@ describe('ReactIncrementalErrorHandling', () => {
         <BrokenRender fail={false} />
       </ErrorBoundary>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(
       <ErrorBoundary>
         <BrokenRender fail={true} />
       </ErrorBoundary>,
     );
-    expect(ReactNoop.flush).toWarnDev([
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev([
       'Warning: React.createElement: type is invalid -- expected a string',
       // React retries once on error
       'Warning: React.createElement: type is invalid -- expected a string',
@@ -1194,7 +1194,7 @@ describe('ReactIncrementalErrorHandling', () => {
       'Warning: React.createElement: type is invalid -- expected a string',
       {withoutStack: true},
     );
-    expect(ReactNoop.flush).toThrowError(
+    expect(ReactNoop).toFlushAndThrow(
       'Element type is invalid: expected a string (for built-in components) or ' +
         'a class/function (for composite components) but got: undefined.' +
         (__DEV__
@@ -1204,7 +1204,7 @@ describe('ReactIncrementalErrorHandling', () => {
     );
 
     ReactNoop.render(<span prop="hi" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('hi')]);
   });
 
@@ -1243,11 +1243,11 @@ describe('ReactIncrementalErrorHandling', () => {
         </Parent>
       </Parent>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     inst.setState({fail: true});
     expect(() => {
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toThrowError('Hello.');
 
     expect(ops).toEqual([
@@ -1285,7 +1285,7 @@ describe('ReactIncrementalErrorHandling', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual(['barRef attach']);
     expect(ReactNoop.getChildren()).toEqual([div(span('Bar'))]);
 
@@ -1293,7 +1293,7 @@ describe('ReactIncrementalErrorHandling', () => {
 
     // Unmount
     ReactNoop.render(<Foo hide={true} />);
-    expect(() => ReactNoop.flush()).toThrow('Detach error');
+    expect(ReactNoop).toFlushAndThrow('Detach error');
     expect(ops).toEqual([
       'barRef detach',
       // Bar should unmount even though its ref threw an error while detaching
@@ -1305,14 +1305,14 @@ describe('ReactIncrementalErrorHandling', () => {
 
   it('handles error thrown by host config while working on failed root', () => {
     ReactNoop.render(<errorInBeginPhase />);
-    expect(() => ReactNoop.flush()).toThrow('Error in host config.');
+    expect(ReactNoop).toFlushAndThrow('Error in host config.');
   });
 
   it('handles error thrown by top-level callback', () => {
     ReactNoop.render(<div />, () => {
       throw new Error('Error!');
     });
-    expect(() => ReactNoop.flush()).toThrow('Error!');
+    expect(ReactNoop).toFlushAndThrow('Error!');
   });
 
   it('error boundaries capture non-errors', () => {
@@ -1359,7 +1359,7 @@ describe('ReactIncrementalErrorHandling', () => {
         </Indirection>
       </ErrorBoundary>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ops).toEqual([
       'ErrorBoundary (try)',
@@ -1430,7 +1430,7 @@ describe('ReactIncrementalErrorHandling', () => {
       </ErrorBoundary>,
     );
 
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'ErrorBoundary (try)',
       'throw',
       // Continue rendering siblings after BadRender throws
@@ -1480,7 +1480,7 @@ describe('ReactIncrementalErrorHandling', () => {
     }
 
     ReactNoop.render(<Parent step={1} />);
-    ReactNoop.flushThrough([
+    expect(ReactNoop).toFlushAndYieldThrough([
       'render',
       'throw',
       'render',
@@ -1522,7 +1522,7 @@ describe('ReactIncrementalErrorHandling', () => {
         <BrokenRender />
       </ErrorBoundary>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['render error message']);
     expect(ReactNoop.getChildren()).toEqual([
       span(
         'Caught an error:\n' +
@@ -1558,7 +1558,7 @@ describe('ReactIncrementalErrorHandling', () => {
         <BrokenRender />
       </ErrorBoundary>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('Caught an error: Hello')]);
   });
 
@@ -1582,7 +1582,7 @@ describe('ReactIncrementalErrorHandling', () => {
 
     ReactNoop.render(<Provider />);
     expect(() => {
-      expect(() => ReactNoop.flush()).toThrow('Oops!');
+      expect(ReactNoop).toFlushAndThrow('Oops!');
     }).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
         'Please update the following components: Provider',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
@@ -50,7 +50,7 @@ describe('ReactIncrementalErrorLogging', () => {
         </span>
       </div>,
     );
-    expect(() => ReactNoop.flush()).toThrowError('constructor error');
+    expect(ReactNoop).toFlushAndThrow('constructor error');
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
       __DEV__
@@ -86,7 +86,7 @@ describe('ReactIncrementalErrorLogging', () => {
         </span>
       </div>,
     );
-    expect(() => ReactNoop.flush()).toThrowError('componentDidMount error');
+    expect(ReactNoop).toFlushAndThrow('componentDidMount error');
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
       __DEV__
@@ -125,7 +125,7 @@ describe('ReactIncrementalErrorLogging', () => {
         </span>
       </div>,
     );
-    expect(() => ReactNoop.flush()).toThrow('render error');
+    expect(ReactNoop).toFlushAndThrow('render error');
     expect(logCapturedErrorCalls.length).toBe(1);
     expect(logCapturedErrorCalls[0]).toEqual(
       __DEV__
@@ -181,7 +181,7 @@ describe('ReactIncrementalErrorLogging', () => {
         <Foo />
       </ErrorBoundary>,
     );
-    expect(ReactNoop.flush()).toEqual(
+    expect(ReactNoop).toFlushAndYield(
       [
         'render: 0',
         __DEV__ && 'render: 0', // replay

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
@@ -22,7 +22,7 @@ describe('ReactIncrementalErrorReplay', () => {
 
   it('should fail gracefully on error in the host environment', () => {
     ReactNoop.render(<errorInBeginPhase />);
-    expect(() => ReactNoop.flush()).toThrow('Error in host config.');
+    expect(ReactNoop).toFlushAndThrow('Error in host config.');
   });
 
   it("should ignore error if it doesn't throw on retry", () => {
@@ -43,6 +43,6 @@ describe('ReactIncrementalErrorReplay', () => {
       }
     }
     ReactNoop.render(<App />);
-    expect(() => ReactNoop.flush()).not.toThrow();
+    expect(ReactNoop).toFlushWithoutYielding();
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -652,6 +652,7 @@ describe('ReactDebugFiberPerf', () => {
     ReactNoop.flushSync(() => {
       ReactNoop.render(<Foo />);
     });
+    expect(ReactNoop.clearYields()).toEqual(['Foo']);
     ReactNoop.flush();
     expect(getFlameChart()).toMatchSnapshot();
   });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -144,7 +144,7 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Mount');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(
       <Parent>
@@ -152,11 +152,11 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Update');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.render(null);
     addComment('Unmount');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(getFlameChart()).toMatchSnapshot();
   });
@@ -182,7 +182,7 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Mount');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(getFlameChart()).toMatchSnapshot();
   });
@@ -200,7 +200,7 @@ describe('ReactDebugFiberPerf', () => {
       </React.unstable_Profiler>,
     );
     addComment('Mount');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(getFlameChart()).toMatchSnapshot();
   });
@@ -216,7 +216,7 @@ describe('ReactDebugFiberPerf', () => {
       </Provider>,
     );
     addComment('Mount');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(getFlameChart()).toMatchSnapshot();
   });
@@ -248,13 +248,13 @@ describe('ReactDebugFiberPerf', () => {
         </Parent>
       </Parent>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     resetFlamechart();
 
     a.setState({});
     b.setState({});
     addComment('Should include just A and B, no Parents');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -274,7 +274,7 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Should print a warning');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -283,7 +283,7 @@ describe('ReactDebugFiberPerf', () => {
       componentDidMount() {
         ReactNoop.renderToRootWithID(<Child />, 'b');
         addComment('Scheduling another root from componentDidMount');
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
       }
       render() {
         return <div>{this.props.children}</div>;
@@ -292,7 +292,7 @@ describe('ReactDebugFiberPerf', () => {
 
     ReactNoop.renderToRootWithID(<Cascading />, 'a');
     addComment('Rendering the first root');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -315,7 +315,7 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Should not print a warning');
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       [
         'componentWillMount: Please update the following components ' +
           'to use componentDidMount instead: NotCascading' +
@@ -330,7 +330,7 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Should not print a warning');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -357,7 +357,7 @@ describe('ReactDebugFiberPerf', () => {
     }
     ReactNoop.render(<AllLifecycles />);
     addComment('Mount');
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       [
         'componentWillMount: Please update the following components ' +
           'to use componentDidMount instead: AllLifecycles' +
@@ -372,10 +372,10 @@ describe('ReactDebugFiberPerf', () => {
     );
     ReactNoop.render(<AllLifecycles />);
     addComment('Update');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     ReactNoop.render(null);
     addComment('Unmount');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -391,7 +391,7 @@ describe('ReactDebugFiberPerf', () => {
       );
     });
     addComment('Flush the child');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -431,9 +431,9 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Start rendering through B');
-    ReactNoop.flushThrough(['A', 'B']);
+    expect(ReactNoop).toFlushAndYieldThrough(['A', 'B']);
     addComment('Complete the rest');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['C']);
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -449,7 +449,7 @@ describe('ReactDebugFiberPerf', () => {
     );
     try {
       addComment('Will fatal');
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     } catch (err) {
       expect(err.message).toBe('Game over');
     }
@@ -459,7 +459,7 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Will reconcile from a clean state');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -495,7 +495,7 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Stop on Baddie and restart from Boundary');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -526,7 +526,7 @@ describe('ReactDebugFiberPerf', () => {
         <B />
       </Parent>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     resetFlamechart();
 
     ReactNoop.render(
@@ -538,7 +538,7 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('The commit phase should mention A and B just once');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     ReactNoop.render(
       <Parent>
         <A />
@@ -549,7 +549,7 @@ describe('ReactDebugFiberPerf', () => {
     );
     addComment("Because of deduplication, we don't know B was cascading,");
     addComment('but we should still see the warning for the commit phase.');
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -562,7 +562,7 @@ describe('ReactDebugFiberPerf', () => {
         {ReactNoop.createPortal(<Child />, portalContainer, null)}
       </Parent>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -575,7 +575,7 @@ describe('ReactDebugFiberPerf', () => {
         <MemoFoo />
       </Parent>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -603,7 +603,7 @@ describe('ReactDebugFiberPerf', () => {
         </React.Suspense>
       </Parent>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
 
     resolve(
@@ -621,7 +621,7 @@ describe('ReactDebugFiberPerf', () => {
         </React.Suspense>
       </Parent>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -652,8 +652,8 @@ describe('ReactDebugFiberPerf', () => {
     ReactNoop.flushSync(() => {
       ReactNoop.render(<Foo />);
     });
-    expect(ReactNoop.clearYields()).toEqual(['Foo']);
-    ReactNoop.flush();
+    expect(ReactNoop).toHaveYielded(['Foo']);
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 
@@ -664,7 +664,7 @@ describe('ReactDebugFiberPerf', () => {
 
     ReactNoop.render(<Foo />);
     ReactNoop.expire(6000);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(getFlameChart()).toMatchSnapshot();
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
@@ -31,8 +31,8 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.render(<span prop="1" />);
     expect(ReactNoop.getChildren()).toEqual([]);
 
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span('1')]);
+    expect(ReactNoop).toFlushWithoutYielding();
+    expect(ReactNoop).toMatchRenderedOutput(<span prop="1" />);
   });
 
   it('searches for work on other roots once the current root completes', () => {
@@ -40,7 +40,7 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.renderToRootWithID(<span prop="b:1" />, 'b');
     ReactNoop.renderToRootWithID(<span prop="c:1" />, 'c');
 
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     expect(ReactNoop.getChildren('a')).toEqual([span('a:1')]);
     expect(ReactNoop.getChildren('b')).toEqual([span('b:1')]);
@@ -50,8 +50,8 @@ describe('ReactIncrementalScheduling', () => {
   it('schedules top-level updates in order of priority', () => {
     // Initial render.
     ReactNoop.render(<span prop={1} />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span(1)]);
+    expect(ReactNoop).toFlushWithoutYielding();
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={1} />);
 
     ReactNoop.batchedUpdates(() => {
       ReactNoop.render(<span prop={5} />);
@@ -62,27 +62,27 @@ describe('ReactIncrementalScheduling', () => {
       });
     });
     // The sync updates flush first.
-    expect(ReactNoop.getChildren()).toEqual([span(4)]);
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={4} />);
 
     // The terminal value should be the last update that was scheduled,
     // regardless of priority. In this case, that's the last sync update.
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span(4)]);
+    expect(ReactNoop).toFlushWithoutYielding();
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={4} />);
   });
 
   it('schedules top-level updates with same priority in order of insertion', () => {
     // Initial render.
     ReactNoop.render(<span prop={1} />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span(1)]);
+    expect(ReactNoop).toFlushWithoutYielding();
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={1} />);
 
     ReactNoop.render(<span prop={2} />);
     ReactNoop.render(<span prop={3} />);
     ReactNoop.render(<span prop={4} />);
     ReactNoop.render(<span prop={5} />);
 
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span(5)]);
+    expect(ReactNoop).toFlushWithoutYielding();
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={5} />);
   });
 
   it('works on deferred roots in the order they were scheduled', () => {
@@ -102,7 +102,7 @@ describe('ReactIncrementalScheduling', () => {
       ReactNoop.renderToRootWithID(<Text text="b:1" />, 'b');
       ReactNoop.renderToRootWithID(<Text text="c:1" />, 'c');
     });
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['a:1', 'b:1', 'c:1']);
 
     expect(ReactNoop.getChildrenAsJSX('a')).toEqual('a:1');
     expect(ReactNoop.getChildrenAsJSX('b')).toEqual('b:1');
@@ -114,7 +114,7 @@ describe('ReactIncrementalScheduling', () => {
       ReactNoop.renderToRootWithID(<Text text="b:2" />, 'b');
     });
     // Ensure it starts in the order it was scheduled
-    ReactNoop.flushThrough(['c:2']);
+    expect(ReactNoop).toFlushAndYieldThrough(['c:2']);
 
     expect(ReactNoop.getChildrenAsJSX('a')).toEqual('a:1');
     expect(ReactNoop.getChildrenAsJSX('b')).toEqual('b:1');
@@ -124,12 +124,12 @@ describe('ReactIncrementalScheduling', () => {
       ReactNoop.renderToRootWithID(<Text text="a:2" />, 'a');
     });
     // Keep performing work in the order it was scheduled
-    ReactNoop.flushThrough(['b:2']);
+    expect(ReactNoop).toFlushAndYieldThrough(['b:2']);
     expect(ReactNoop.getChildrenAsJSX('a')).toEqual('a:1');
     expect(ReactNoop.getChildrenAsJSX('b')).toEqual('b:2');
     expect(ReactNoop.getChildrenAsJSX('c')).toEqual('c:2');
 
-    ReactNoop.flushThrough(['a:2']);
+    expect(ReactNoop).toFlushAndYieldThrough(['a:2']);
     expect(ReactNoop.getChildrenAsJSX('a')).toEqual('a:2');
     expect(ReactNoop.getChildrenAsJSX('b')).toEqual('b:2');
     expect(ReactNoop.getChildrenAsJSX('c')).toEqual('c:2');
@@ -175,7 +175,7 @@ describe('ReactIncrementalScheduling', () => {
 
     ReactNoop.render(<Foo />);
     // Render without committing
-    ReactNoop.flushThrough(['render: 0']);
+    expect(ReactNoop).toFlushAndYieldThrough(['render: 0']);
 
     // Do one more unit of work to commit
     expect(ReactNoop.flushNextYield()).toEqual([
@@ -188,7 +188,7 @@ describe('ReactIncrementalScheduling', () => {
     ]);
 
     instance.setState({tick: 2});
-    ReactNoop.flushThrough(['render: 2']);
+    expect(ReactNoop).toFlushAndYieldThrough(['render: 2']);
     expect(ReactNoop.flushNextYield()).toEqual([
       'componentDidUpdate: 2',
       'componentDidUpdate (before setState): 2',
@@ -243,31 +243,31 @@ describe('ReactIncrementalScheduling', () => {
       ReactNoop.render(<Foo />);
     });
     // The cDM update should not have flushed yet because it has async priority.
-    expect(ReactNoop.clearYields()).toEqual([
+    expect(ReactNoop).toHaveYielded([
       'render: 0',
       'componentDidMount (before setState): 0',
       'componentDidMount (after setState): 0',
     ]);
-    expect(ReactNoop.getChildren()).toEqual([span(0)]);
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={0} />);
 
     // Now flush the cDM update.
-    expect(ReactNoop.flush()).toEqual(['render: 1', 'componentDidUpdate: 1']);
-    expect(ReactNoop.getChildren()).toEqual([span(1)]);
+    expect(ReactNoop).toFlushAndYield(['render: 1', 'componentDidUpdate: 1']);
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={1} />);
 
     // Increment the tick to 2. This will trigger an update inside cDU. Flush
     // the first update without flushing the second one.
     instance.setState({tick: 2});
-    ReactNoop.flushThrough([
+    expect(ReactNoop).toFlushAndYieldThrough([
       'render: 2',
       'componentDidUpdate: 2',
       'componentDidUpdate (before setState): 2',
       'componentDidUpdate (after setState): 2',
     ]);
-    expect(ReactNoop.getChildren()).toEqual([span(2)]);
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={2} />);
 
     // Now flush the cDU update.
-    expect(ReactNoop.flush()).toEqual(['render: 3', 'componentDidUpdate: 3']);
-    expect(ReactNoop.getChildren()).toEqual([span(3)]);
+    expect(ReactNoop).toFlushAndYield(['render: 3', 'componentDidUpdate: 3']);
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={3} />);
   });
 
   it('performs Task work even after time runs out', () => {
@@ -290,13 +290,13 @@ describe('ReactIncrementalScheduling', () => {
     ReactNoop.render(<Foo />);
     // This should be just enough to complete all the work, but not enough to
     // commit it.
-    ReactNoop.flushThrough(['Foo']);
-    expect(ReactNoop.getChildren()).toEqual([]);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo']);
+    expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Do one more unit of work.
     ReactNoop.flushNextYield();
     // The updates should all be flushed with Task priority
-    expect(ReactNoop.getChildren()).toEqual([span(5)]);
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={5} />);
   });
 
   it('can opt-out of batching using unbatchedUpdates', () => {
@@ -309,16 +309,16 @@ describe('ReactIncrementalScheduling', () => {
       // updates are not batched
       ReactNoop.unbatchedUpdates(() => {
         ReactNoop.render(<span prop={1} />);
-        expect(ReactNoop.getChildren()).toEqual([span(1)]);
+        expect(ReactNoop).toMatchRenderedOutput(<span prop={1} />);
         ReactNoop.render(<span prop={2} />);
-        expect(ReactNoop.getChildren()).toEqual([span(2)]);
+        expect(ReactNoop).toMatchRenderedOutput(<span prop={2} />);
       });
 
       ReactNoop.render(<span prop={3} />);
-      expect(ReactNoop.getChildren()).toEqual([span(2)]);
+      expect(ReactNoop).toMatchRenderedOutput(<span prop={2} />);
     });
     // Remaining update is now flushed
-    expect(ReactNoop.getChildren()).toEqual([span(3)]);
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={3} />);
   });
 
   it('nested updates are always deferred, even inside unbatchedUpdates', () => {
@@ -335,7 +335,7 @@ describe('ReactIncrementalScheduling', () => {
             // in unbatchedUpdates.
             this.setState({step: 2});
           });
-          expect(ReactNoop.getChildren()).toEqual([span(1)]);
+          expect(ReactNoop).toMatchRenderedOutput(<span prop={1} />);
         }
       }
       render() {
@@ -345,13 +345,13 @@ describe('ReactIncrementalScheduling', () => {
       }
     }
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildren()).toEqual([span(0)]);
+    expect(ReactNoop).toFlushWithoutYielding();
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={0} />);
 
     ReactNoop.flushSync(() => {
       instance.setState({step: 1});
     });
-    expect(ReactNoop.getChildren()).toEqual([span(2)]);
+    expect(ReactNoop).toMatchRenderedOutput(<span prop={2} />);
 
     expect(ops).toEqual([
       'render: 0',
@@ -380,14 +380,16 @@ describe('ReactIncrementalScheduling', () => {
     }
 
     ReactNoop.render(<Foo step={1} />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => {
+      expect(ReactNoop).toFlushWithoutYielding();
+    }).toWarnDev(
       'componentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: Foo',
       {withoutStack: true},
     );
 
     ReactNoop.render(<Foo step={2} />);
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'has callback before setState: false',
       'has callback after setState: false',
     ]);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
@@ -243,10 +243,14 @@ describe('ReactIncrementalScheduling', () => {
       ReactNoop.render(<Foo />);
     });
     // The cDM update should not have flushed yet because it has async priority.
+    expect(ReactNoop.clearYields()).toEqual([
+      'render: 0',
+      'componentDidMount (before setState): 0',
+      'componentDidMount (after setState): 0',
+    ]);
     expect(ReactNoop.getChildren()).toEqual([span(0)]);
 
     // Now flush the cDM update.
-    ReactNoop.clearYields();
     expect(ReactNoop.flush()).toEqual(['render: 1', 'componentDidUpdate: 1']);
     expect(ReactNoop.getChildren()).toEqual([span(1)]);
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
@@ -53,11 +53,11 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo text="Hello" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div(span())]);
 
     ReactNoop.render(<Foo text="World" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div(span(), span())]);
   });
 
@@ -81,17 +81,17 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo text="Hello" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div(span(), span('test'))]);
 
     ReactNoop.render(<Foo text="World" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([
       div(span(), span(), div(), span('test')),
     ]);
 
     ReactNoop.render(<Foo text="Hi" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([
       div(span(), div(), span(), span('test')),
     ]);
@@ -114,11 +114,11 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo text="Hello" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div('Hello')]);
 
     ReactNoop.render(<Foo text="World" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div('World', 'World', '!')]);
   });
 
@@ -138,13 +138,13 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo show={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([
       div(div(), span('Hello'), 'World'),
     ]);
 
     ReactNoop.render(<Foo show={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div()]);
   });
 
@@ -180,23 +180,23 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo useClass={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div(span('Class'), 'Trail')]);
 
     expect(unmounted).toBe(false);
 
     ReactNoop.render(<Foo useFunction={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div(span('Function'), 'Trail')]);
 
     expect(unmounted).toBe(true);
 
     ReactNoop.render(<Foo useText={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div('Text', 'Trail')]);
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div('Trail')]);
   });
 
@@ -230,19 +230,19 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo useClass={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div(span('Class'), 'Trail')]);
 
     expect(unmounted).toBe(false);
 
     ReactNoop.render(<Foo useFunction={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div(span('Function'), 'Trail')]);
 
     expect(unmounted).toBe(true);
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div('Trail')]);
   });
 
@@ -267,7 +267,7 @@ describe('ReactIncrementalSideEffects', () => {
         <Foo show={true} />
       </div>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div()]);
     expect(ReactNoop.getChildren('portalContainer')).toEqual([
       div(),
@@ -280,7 +280,7 @@ describe('ReactIncrementalSideEffects', () => {
         <Foo show={false} />
       </div>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div()]);
     expect(ReactNoop.getChildren('portalContainer')).toEqual([]);
 
@@ -289,7 +289,7 @@ describe('ReactIncrementalSideEffects', () => {
         <Foo show={true} />
       </div>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div()]);
     expect(ReactNoop.getChildren('portalContainer')).toEqual([
       div(),
@@ -298,17 +298,17 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
 
     ReactNoop.render(null);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([]);
     expect(ReactNoop.getChildren('portalContainer')).toEqual([]);
 
     ReactNoop.render(<Foo show={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([]);
     expect(ReactNoop.getChildren('portalContainer')).toEqual([]);
 
     ReactNoop.render(<Foo show={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([]);
     expect(ReactNoop.getChildren('portalContainer')).toEqual([
       div(),
@@ -317,7 +317,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
 
     ReactNoop.render(null);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([]);
     expect(ReactNoop.getChildren('portalContainer')).toEqual([]);
   });
@@ -343,7 +343,7 @@ describe('ReactIncrementalSideEffects', () => {
         <Foo />
       </div>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([div()]);
     expect(ReactNoop.getChildren('portalContainer')).toEqual([
       div(),
@@ -352,12 +352,12 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
 
     ReactNoop.render(null);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([]);
     expect(ReactNoop.getChildren('portalContainer')).toEqual([]);
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([]);
     expect(ReactNoop.getChildren('portalContainer')).toEqual([
       div(),
@@ -366,7 +366,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
 
     ReactNoop.render(null);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([]);
     expect(ReactNoop.getChildren('portalContainer')).toEqual([]);
   });
@@ -391,7 +391,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo text="Hello" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['Foo', 'Bar', 'Bar', 'Bar']);
     expect(ReactNoop.getChildren()).toEqual([
       div(div(span('Hello'), span('Hello')), span('Yo')),
     ]);
@@ -399,7 +399,7 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop.render(<Foo text="World" />);
 
     // Flush some of the work without committing
-    ReactNoop.flushThrough(['Foo', 'Bar']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo', 'Bar']);
     expect(ReactNoop.getChildren()).toEqual([
       div(div(span('Hello'), span('Hello')), span('Yo')),
     ]);
@@ -423,7 +423,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo text="foo" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['Foo', 'Middle']);
 
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div>
@@ -434,7 +434,7 @@ describe('ReactIncrementalSideEffects', () => {
     );
 
     ReactNoop.render(<Foo text="bar" />, () => ReactNoop.yield('commit'));
-    ReactNoop.flushThrough(['Foo', 'commit']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo', 'commit']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div>
         <div hidden={true}>
@@ -443,7 +443,7 @@ describe('ReactIncrementalSideEffects', () => {
       </div>,
     );
 
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['Middle']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div>
         <div hidden={true}>
@@ -484,7 +484,7 @@ describe('ReactIncrementalSideEffects', () => {
 
     // Init
     ReactNoop.render(<Foo text="foo" step={0} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['Foo', 'Bar', 'Bar']);
 
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div hidden={true}>
@@ -500,7 +500,7 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop.render(<Foo text="bar" step={1} />, () =>
       ReactNoop.yield('commit'),
     );
-    ReactNoop.flushThrough(['Foo', 'commit', 'Bar']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo', 'commit', 'Bar']);
 
     // The tree remains unchanged.
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
@@ -516,7 +516,7 @@ describe('ReactIncrementalSideEffects', () => {
     // render some higher priority work. The middle content will bailout so
     // it remains untouched which means that it should reuse it next time.
     ReactNoop.render(<Foo text="foo" step={1} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['Foo', 'Bar', 'Bar']);
 
     // Since we did nothing to the middle subtree during the interruption,
     // we should be able to reuse the reconciliation work that we already did
@@ -569,7 +569,7 @@ describe('ReactIncrementalSideEffects', () => {
 
     // Init
     ReactNoop.render(<Foo text="foo" step={0} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['Foo', 'Content', 'Bar', 'Bar']);
 
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div hidden={true}>
@@ -583,7 +583,7 @@ describe('ReactIncrementalSideEffects', () => {
     // Make a quick update which will schedule low priority work to
     // update the middle content.
     ReactNoop.render(<Foo text="bar" step={1} />);
-    ReactNoop.flushThrough(['Foo', 'Content', 'Bar']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo', 'Content', 'Bar']);
 
     // The tree remains unchanged.
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
@@ -599,7 +599,7 @@ describe('ReactIncrementalSideEffects', () => {
     // render some higher priority work. The middle content will bailout so
     // it remains untouched which means that it should reuse it next time.
     ReactNoop.render(<Foo text="foo" step={1} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['Foo', 'Content', 'Bar', 'Bar']);
 
     // Since we did nothing to the middle subtree during the interruption,
     // we should be able to reuse the reconciliation work that we already did
@@ -622,7 +622,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
     ReactNoop.render(<Foo step={1} />);
     // This should be just enough to complete the tree without committing it
-    ReactNoop.flushThrough(['Foo']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(null);
     // To confirm, perform one more unit of work. The tree should now
     // be flushed.
@@ -631,7 +631,7 @@ describe('ReactIncrementalSideEffects', () => {
 
     ReactNoop.render(<Foo step={2} />);
     // This should be just enough to complete the tree without committing it
-    ReactNoop.flushThrough(['Foo']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(<span prop={1} />);
     // This time, before we commit the tree, we update the root component with
     // new props
@@ -643,7 +643,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildrenAsJSX()).toEqual(<span prop={2} />);
     // If we flush the rest of the work, we should get another commit that
     // renders 3. If it renders 2 again, that means an update was dropped.
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildrenAsJSX()).toEqual(<span prop={3} />);
   });
 
@@ -657,7 +657,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div hidden={true}>
         <span prop={1} />
@@ -723,7 +723,7 @@ describe('ReactIncrementalSideEffects', () => {
       ),
     ]);
     ReactNoop.render(<Foo tick={3} idx={1} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([
       div(
         span(3),
@@ -800,7 +800,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ops).toEqual(['Foo']);
     ops = [];
 
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([
       div(
         span(1),
@@ -867,7 +867,7 @@ describe('ReactIncrementalSideEffects', () => {
 
     // We should now be able to reuse some of the work we've already done
     // and replay those side-effects.
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([
       div(
         span(3),
@@ -917,7 +917,7 @@ describe('ReactIncrementalSideEffects', () => {
       );
     }
     ReactNoop.render(<Foo tick={0} idx={0} />);
-    expect(ReactNoop.flush()).toEqual(['Foo', 'Bar', 'Bar', 'Bar']);
+    expect(ReactNoop).toFlushAndYield(['Foo', 'Bar', 'Bar', 'Bar']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div>
         <span prop={0} />
@@ -930,7 +930,7 @@ describe('ReactIncrementalSideEffects', () => {
     );
 
     ReactNoop.render(<Foo tick={1} idx={1} />);
-    ReactNoop.flushThrough(['Foo', 'Bar', 'Bar']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo', 'Bar', 'Bar']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div>
         {/* Updated */}
@@ -948,7 +948,7 @@ describe('ReactIncrementalSideEffects', () => {
     // This should not be enough time to render the content of all the hidden
     // items. Including the set state since that is deprioritized.
     // ReactNoop.flushDeferredPri(35);
-    ReactNoop.flushThrough(['Bar']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Bar']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div>
         {/* Updated */}
@@ -964,7 +964,7 @@ describe('ReactIncrementalSideEffects', () => {
 
     // However, once we render fully, we will have enough time to finish it all
     // at once.
-    expect(ReactNoop.flush()).toEqual(['Bar', 'Bar', 'Bar']);
+    expect(ReactNoop).toFlushAndYield(['Bar', 'Bar', 'Bar']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div>
         <span prop={1} />
@@ -995,14 +995,14 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('foo')]);
     let called = false;
     instance.setState({text: 'bar'}, () => {
       expect(ReactNoop.getChildren()).toEqual([span('bar')]);
       called = true;
     });
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(called).toBe(true);
   });
 
@@ -1023,13 +1023,13 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('foo')]);
     let called = false;
     instance.setState({}, () => {
       called = true;
     });
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(called).toBe(true);
   });
 
@@ -1077,11 +1077,11 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo show={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual([]);
 
     ReactNoop.render(<Foo show={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual([
       'A',
       'Wrapper',
@@ -1140,7 +1140,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual([
       'mount:A',
       'mount:B',
@@ -1156,7 +1156,7 @@ describe('ReactIncrementalSideEffects', () => {
     ops = [];
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual([
       'update:A',
       'update:B',
@@ -1197,7 +1197,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo show={true} />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Warning: Function components cannot be given refs. ' +
         'Attempts to access this ref will fail. ' +
         'Did you mean to use React.forwardRef()?\n\n' +
@@ -1217,7 +1217,7 @@ describe('ReactIncrementalSideEffects', () => {
 
     // Refs that switch function instances get reinvoked
     ReactNoop.render(<Foo show={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual([
       // detach all refs that switched handlers first.
       null,
@@ -1230,7 +1230,7 @@ describe('ReactIncrementalSideEffects', () => {
     ops = [];
 
     ReactNoop.render(<Foo show={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual([
       // unmount
       null,
@@ -1261,7 +1261,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'Warning: A string ref, "bar", has been found within a strict mode tree.',
     );
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
@@ -306,7 +306,7 @@ describe('ReactIncrementalTriangle', () => {
       } else {
         ReactNoop.render(<App remainingDepth={MAX_DEPTH} key={keyCounter++} />);
       }
-      ReactNoop.flush();
+      ReactNoop.unstable_flushWithoutYielding();
       assertConsistentTree();
       return appInstance;
     }
@@ -388,7 +388,7 @@ describe('ReactIncrementalTriangle', () => {
               ReactNoop.unstable_flushNumberOfYields(action.unitsOfWork);
               break;
             case FLUSH_ALL:
-              ReactNoop.flush();
+              ReactNoop.unstable_flushWithoutYielding();
               break;
             case STEP:
               ReactNoop.deferredUpdates(() => {
@@ -430,7 +430,7 @@ describe('ReactIncrementalTriangle', () => {
         assertConsistentTree(activeLeafIndices);
       }
       // Flush remaining work
-      ReactNoop.flush();
+      ReactNoop.unstable_flushWithoutYielding();
       assertConsistentTree(activeLeafIndices, expectedCounterAtEnd);
     }
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -173,12 +173,12 @@ describe('ReactIncrementalUpdates', () => {
     instance.setState(createUpdate('g'));
 
     // The sync updates should have flushed, but not the async ones
+    expect(ReactNoop.clearYields()).toEqual(['e', 'f']);
     expect(ReactNoop.getChildren()).toEqual([span('ef')]);
 
     // Now flush the remaining work. Even though e and f were already processed,
     // they should be processed again, to ensure that the terminal state
     // is deterministic.
-    ReactNoop.clearYields();
     expect(ReactNoop.flush()).toEqual([
       'a',
       'b',
@@ -247,12 +247,12 @@ describe('ReactIncrementalUpdates', () => {
 
     // The sync updates should have flushed, but not the async ones. Update d
     // was dropped and replaced by e.
+    expect(ReactNoop.clearYields()).toEqual(['e', 'f']);
     expect(ReactNoop.getChildren()).toEqual([span('f')]);
 
     // Now flush the remaining work. Even though e and f were already processed,
     // they should be processed again, to ensure that the terminal state
     // is deterministic.
-    ReactNoop.clearYields();
     expect(ReactNoop.flush()).toEqual([
       'a',
       'b',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -48,9 +48,9 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flushThrough(['commit']);
+    expect(ReactNoop).toFlushAndYieldThrough(['commit']);
     expect(state).toEqual({a: 'a'});
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(state).toEqual({a: 'a', b: 'b', c: 'c'});
   });
 
@@ -71,7 +71,7 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(state).toEqual({a: 'a', b: 'b', c: 'c'});
   });
 
@@ -94,7 +94,7 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     ReactNoop.flushSync(() => {
       ReactNoop.deferredUpdates(() => {
@@ -121,7 +121,7 @@ describe('ReactIncrementalUpdates', () => {
 
     ops = [];
 
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     // Now the rest of the updates are flushed, including the replaceState.
     expect(instance.state).toEqual({c: 'c', d: 'd'});
     expect(ops).toEqual(['render', 'componentDidUpdate']);
@@ -144,7 +144,7 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     function createUpdate(letter) {
       return () => {
@@ -161,7 +161,7 @@ describe('ReactIncrementalUpdates', () => {
     instance.setState(createUpdate('c'));
 
     // Begin the updates but don't flush them yet
-    ReactNoop.flushThrough(['a', 'b', 'c']);
+    expect(ReactNoop).toFlushAndYieldThrough(['a', 'b', 'c']);
     expect(ReactNoop.getChildren()).toEqual([span('')]);
 
     // Schedule some more updates at different priorities
@@ -173,13 +173,13 @@ describe('ReactIncrementalUpdates', () => {
     instance.setState(createUpdate('g'));
 
     // The sync updates should have flushed, but not the async ones
-    expect(ReactNoop.clearYields()).toEqual(['e', 'f']);
+    expect(ReactNoop).toHaveYielded(['e', 'f']);
     expect(ReactNoop.getChildren()).toEqual([span('ef')]);
 
     // Now flush the remaining work. Even though e and f were already processed,
     // they should be processed again, to ensure that the terminal state
     // is deterministic.
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'a',
       'b',
       'c',
@@ -215,7 +215,7 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     function createUpdate(letter) {
       return () => {
@@ -232,7 +232,7 @@ describe('ReactIncrementalUpdates', () => {
     instance.setState(createUpdate('c'));
 
     // Begin the updates but don't flush them yet
-    ReactNoop.flushThrough(['a', 'b', 'c']);
+    expect(ReactNoop).toFlushAndYieldThrough(['a', 'b', 'c']);
     expect(ReactNoop.getChildren()).toEqual([span('')]);
 
     // Schedule some more updates at different priorities{
@@ -247,13 +247,13 @@ describe('ReactIncrementalUpdates', () => {
 
     // The sync updates should have flushed, but not the async ones. Update d
     // was dropped and replaced by e.
-    expect(ReactNoop.clearYields()).toEqual(['e', 'f']);
+    expect(ReactNoop).toHaveYielded(['e', 'f']);
     expect(ReactNoop.getChildren()).toEqual([span('f')]);
 
     // Now flush the remaining work. Even though e and f were already processed,
     // they should be processed again, to ensure that the terminal state
     // is deterministic.
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'a',
       'b',
       'c',
@@ -282,7 +282,7 @@ describe('ReactIncrementalUpdates', () => {
       }
     }
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     instance.setState({a: 'a'});
     instance.setState({b: 'b'});
@@ -291,7 +291,7 @@ describe('ReactIncrementalUpdates', () => {
     instance.updater.enqueueReplaceState(instance, previousState => ({
       previousState,
     }));
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(instance.state).toEqual({previousState: {a: 'a', b: 'b'}});
   });
 
@@ -315,7 +315,7 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ops).toEqual([
       'render',
       'did mount',
@@ -343,7 +343,7 @@ describe('ReactIncrementalUpdates', () => {
       }
     }
     ReactNoop.render(<Foo />);
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'componentWillReceiveProps: Please update the following components ' +
         'to use static getDerivedStateFromProps instead: Foo',
       {withoutStack: true},
@@ -374,7 +374,7 @@ describe('ReactIncrementalUpdates', () => {
     }
 
     ReactNoop.render(<Foo />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     instance.setState(function a() {
       ops.push('setState updater');
@@ -382,7 +382,7 @@ describe('ReactIncrementalUpdates', () => {
       return {a: 'a'};
     });
 
-    expect(ReactNoop.flush).toWarnDev(
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
       'An update (setState, replaceState, or forceUpdate) was scheduled ' +
         'from inside an update function. Update functions should be pure, ' +
         'with zero side-effects. Consider using componentDidUpdate or a ' +
@@ -404,7 +404,7 @@ describe('ReactIncrementalUpdates', () => {
       this.setState({a: 'a'});
       return {b: 'b'};
     });
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
   });
 
   it('getDerivedStateFromProps should update base state of updateQueue (based on product bug)', () => {
@@ -483,7 +483,7 @@ describe('ReactIncrementalUpdates', () => {
     ReactNoop.render(<Foo prop="hello" />);
 
     // There should be a separate render and commit for each update
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'Render: ',
       'Commit: ',
       'Render: he',
@@ -512,7 +512,7 @@ describe('ReactIncrementalUpdates', () => {
     jest.advanceTimersByTime(10000);
 
     // All the updates should render and commit in a single batch.
-    expect(ReactNoop.flush()).toEqual(['Render: goodbye', 'Commit: goodbye']);
+    expect(ReactNoop).toFlushAndYield(['Render: goodbye', 'Commit: goodbye']);
     expect(ReactNoop.getChildren()).toEqual([span('goodbye')]);
   });
 
@@ -552,7 +552,7 @@ describe('ReactIncrementalUpdates', () => {
     ReactNoop.renderToRootWithID(<Foo prop="hello" />, 'b');
 
     // There should be a separate render and commit for each update
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'Render: ',
       'Commit: ',
       'Render: ',
@@ -594,7 +594,7 @@ describe('ReactIncrementalUpdates', () => {
     jest.advanceTimersByTime(10000);
 
     // All the updates should render and commit in a single batch.
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'Render: goodbye',
       'Commit: goodbye',
       'Render: goodbye',

--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.internal.js
@@ -54,7 +54,7 @@ describe('memo', () => {
       return <App ref={() => {}} />;
     }
     ReactNoop.render(<Outer />);
-    expect(ReactNoop.flush).toWarnDev([
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev([
       'Warning: Function components cannot be given refs. Attempts to access ' +
         'this ref will fail.',
     ]);
@@ -72,7 +72,7 @@ describe('memo', () => {
       return <App ref={() => {}} />;
     }
     ReactNoop.render(<Outer />);
-    expect(ReactNoop.flush).toWarnDev([
+    expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev([
       'Warning: Function components cannot be given refs. Attempts to access ' +
         'this ref will fail.',
     ]);
@@ -106,9 +106,9 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual(['Loading...']);
+        expect(ReactNoop).toFlushAndYield(['Loading...']);
         await Promise.resolve();
-        expect(ReactNoop.flush()).toEqual([0]);
+        expect(ReactNoop).toFlushAndYield([0]);
         expect(ReactNoop.getChildren()).toEqual([span(0)]);
 
         // Should bail out because props have not changed
@@ -117,7 +117,7 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual([]);
+        expect(ReactNoop).toFlushAndYield([]);
         expect(ReactNoop.getChildren()).toEqual([span(0)]);
 
         // Should update because count prop changed
@@ -126,7 +126,7 @@ describe('memo', () => {
             <Counter count={1} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual([1]);
+        expect(ReactNoop).toFlushAndYield([1]);
         expect(ReactNoop.getChildren()).toEqual([span(1)]);
       });
 
@@ -161,19 +161,19 @@ describe('memo', () => {
 
         const parent = React.createRef(null);
         ReactNoop.render(<Parent ref={parent} />);
-        expect(ReactNoop.flush()).toEqual(['Loading...']);
+        expect(ReactNoop).toFlushAndYield(['Loading...']);
         await Promise.resolve();
-        expect(ReactNoop.flush()).toEqual(['Count: 0']);
+        expect(ReactNoop).toFlushAndYield(['Count: 0']);
         expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
         // Should bail out because props have not changed
         ReactNoop.render(<Parent ref={parent} />);
-        expect(ReactNoop.flush()).toEqual([]);
+        expect(ReactNoop).toFlushAndYield([]);
         expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
         // Should update because there was a context change
         parent.current.setState({count: 1});
-        expect(ReactNoop.flush()).toEqual(['Count: 1']);
+        expect(ReactNoop).toFlushAndYield(['Count: 1']);
         expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
       });
 
@@ -193,9 +193,9 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual(['Loading...']);
+        expect(ReactNoop).toFlushAndYield(['Loading...']);
         await Promise.resolve();
-        expect(ReactNoop.flush()).toEqual([0]);
+        expect(ReactNoop).toFlushAndYield([0]);
         expect(ReactNoop.getChildren()).toEqual([span(0)]);
 
         // Should bail out because props have not changed
@@ -204,7 +204,7 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual(['Old count: 0, New count: 0']);
+        expect(ReactNoop).toFlushAndYield(['Old count: 0, New count: 0']);
         expect(ReactNoop.getChildren()).toEqual([span(0)]);
 
         // Should update because count prop changed
@@ -213,7 +213,7 @@ describe('memo', () => {
             <Counter count={1} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual(['Old count: 0, New count: 1', 1]);
+        expect(ReactNoop).toFlushAndYield(['Old count: 0, New count: 1', 1]);
         expect(ReactNoop.getChildren()).toEqual([span(1)]);
       });
 
@@ -231,9 +231,9 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual(['Loading...']);
+        expect(ReactNoop).toFlushAndYield(['Loading...']);
         await Promise.resolve();
-        expect(ReactNoop.flush()).toEqual(['0!']);
+        expect(ReactNoop).toFlushAndYield(['0!']);
         expect(ReactNoop.getChildren()).toEqual([span('0!')]);
 
         // Should bail out because props have not changed
@@ -242,7 +242,7 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual([]);
+        expect(ReactNoop).toFlushAndYield([]);
         expect(ReactNoop.getChildren()).toEqual([span('0!')]);
 
         // Should update because count prop changed
@@ -251,7 +251,7 @@ describe('memo', () => {
             <Counter count={1} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual(['1!']);
+        expect(ReactNoop).toFlushAndYield(['1!']);
         expect(ReactNoop.getChildren()).toEqual([span('1!')]);
       });
 
@@ -284,9 +284,9 @@ describe('memo', () => {
             <Counter e={5} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual(['Loading...']);
+        expect(ReactNoop).toFlushAndYield(['Loading...']);
         await Promise.resolve();
-        expect(ReactNoop.flush()).toEqual([15]);
+        expect(ReactNoop).toFlushAndYield([15]);
         expect(ReactNoop.getChildren()).toEqual([span(15)]);
 
         // Should bail out because props have not changed
@@ -295,7 +295,7 @@ describe('memo', () => {
             <Counter e={5} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual([]);
+        expect(ReactNoop).toFlushAndYield([]);
         expect(ReactNoop.getChildren()).toEqual([span(15)]);
 
         // Should update because count prop changed
@@ -304,7 +304,7 @@ describe('memo', () => {
             <Counter e={10} />
           </Suspense>,
         );
-        expect(ReactNoop.flush()).toEqual([20]);
+        expect(ReactNoop).toFlushAndYield([20]);
         expect(ReactNoop.getChildren()).toEqual([span(20)]);
       });
 
@@ -334,7 +334,7 @@ describe('memo', () => {
         // Mount
         expect(() => {
           ReactNoop.render(<Fn inner="2" />);
-          ReactNoop.flush();
+          expect(ReactNoop).toFlushWithoutYielding();
         }).toWarnDev(
           'Invalid prop `inner` of type `string` supplied to `FnInner`, expected `number`.',
         );
@@ -342,7 +342,7 @@ describe('memo', () => {
         // Update
         expect(() => {
           ReactNoop.render(<Fn inner={false} />);
-          ReactNoop.flush();
+          expect(ReactNoop).toFlushWithoutYielding();
         }).toWarnDev(
           'Invalid prop `inner` of type `boolean` supplied to `FnInner`, expected `number`.',
         );
@@ -358,7 +358,7 @@ describe('memo', () => {
         // Mount
         expect(() => {
           ReactNoop.render(<Fn outer="3" />);
-          ReactNoop.flush();
+          expect(ReactNoop).toFlushWithoutYielding();
         }).toWarnDev(
           // Outer props are checked in createElement
           'Invalid prop `outer` of type `string` supplied to `FnInner`, expected `number`.',
@@ -367,7 +367,7 @@ describe('memo', () => {
         // Update
         expect(() => {
           ReactNoop.render(<Fn outer={false} />);
-          ReactNoop.flush();
+          expect(ReactNoop).toFlushWithoutYielding();
         }).toWarnDev(
           // Outer props are checked in createElement
           'Invalid prop `outer` of type `boolean` supplied to `FnInner`, expected `number`.',
@@ -389,12 +389,12 @@ describe('memo', () => {
 
         // No warning expected because defaultProps satisfy both.
         ReactNoop.render(<Outer />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
 
         // Mount
         expect(() => {
           ReactNoop.render(<Outer inner="2" middle="3" outer="4" />);
-          ReactNoop.flush();
+          expect(ReactNoop).toFlushWithoutYielding();
         }).toWarnDev([
           'Invalid prop `outer` of type `string` supplied to `Inner`, expected `number`.',
           'Invalid prop `middle` of type `string` supplied to `Inner`, expected `number`.',
@@ -406,7 +406,7 @@ describe('memo', () => {
           ReactNoop.render(
             <Outer inner={false} middle={false} outer={false} />,
           );
-          ReactNoop.flush();
+          expect(ReactNoop).toFlushWithoutYielding();
         }).toWarnDev([
           'Invalid prop `outer` of type `boolean` supplied to `Inner`, expected `number`.',
           'Invalid prop `middle` of type `boolean` supplied to `Inner`, expected `number`.',

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -144,12 +144,12 @@ describe('ReactNewContext', () => {
         }
 
         ReactNoop.render(<App value={2} />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
         expect(ReactNoop.getChildren()).toEqual([span('Result: 2')]);
 
         // Update
         ReactNoop.render(<App value={3} />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
         expect(ReactNoop.getChildren()).toEqual([span('Result: 3')]);
       });
 
@@ -202,7 +202,7 @@ describe('ReactNewContext', () => {
         }
 
         ReactNoop.render(<App value={2} />);
-        expect(ReactNoop.flush()).toEqual([
+        expect(ReactNoop).toFlushAndYield([
           'App',
           'Provider',
           'Indirection',
@@ -214,7 +214,7 @@ describe('ReactNewContext', () => {
 
         // Update
         ReactNoop.render(<App value={3} />);
-        expect(ReactNoop.flush()).toEqual([
+        expect(ReactNoop).toFlushAndYield([
           'App',
           'Provider',
           'Consumer render prop',
@@ -271,7 +271,7 @@ describe('ReactNewContext', () => {
         }
 
         ReactNoop.render(<App value={2} />);
-        expect(ReactNoop.flush()).toEqual([
+        expect(ReactNoop).toFlushAndYield([
           'App',
           'Provider',
           'Indirection',
@@ -283,7 +283,7 @@ describe('ReactNewContext', () => {
 
         // Update with the same context value
         ReactNoop.render(<App value={2} />);
-        expect(ReactNoop.flush()).toEqual([
+        expect(ReactNoop).toFlushAndYield([
           'App',
           'Provider',
           // Don't call render prop again
@@ -338,12 +338,12 @@ describe('ReactNewContext', () => {
         }
 
         ReactNoop.render(<App value={2} />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
         expect(ReactNoop.getChildren()).toEqual([span('Result: 8')]);
 
         // Update
         ReactNoop.render(<App value={3} />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
         expect(ReactNoop.getChildren()).toEqual([span('Result: 12')]);
       });
 
@@ -382,7 +382,7 @@ describe('ReactNewContext', () => {
             </BarConsumer>
           </React.Fragment>,
         );
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
       });
 
       it('multiple consumers in different branches', () => {
@@ -433,7 +433,7 @@ describe('ReactNewContext', () => {
         }
 
         ReactNoop.render(<App value={2} />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
         expect(ReactNoop.getChildren()).toEqual([
           span('Result: 4'),
           span('Result: 2'),
@@ -441,7 +441,7 @@ describe('ReactNewContext', () => {
 
         // Update
         ReactNoop.render(<App value={3} />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
         expect(ReactNoop.getChildren()).toEqual([
           span('Result: 6'),
           span('Result: 3'),
@@ -449,7 +449,7 @@ describe('ReactNewContext', () => {
 
         // Another update
         ReactNoop.render(<App value={4} />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
         expect(ReactNoop.getChildren()).toEqual([
           span('Result: 8'),
           span('Result: 4'),
@@ -505,7 +505,7 @@ describe('ReactNewContext', () => {
         }
 
         ReactNoop.render(<App value={NaN} />);
-        expect(ReactNoop.flush()).toEqual([
+        expect(ReactNoop).toFlushAndYield([
           'App',
           'Provider',
           'Indirection',
@@ -517,7 +517,7 @@ describe('ReactNewContext', () => {
 
         // Update
         ReactNoop.render(<App value={NaN} />);
-        expect(ReactNoop.flush()).toEqual([
+        expect(ReactNoop).toFlushAndYield([
           'App',
           'Provider',
           // Consumer should not re-render again
@@ -571,7 +571,7 @@ describe('ReactNewContext', () => {
         }
 
         ReactNoop.render(<App value="A" />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
         expect(ReactNoop.getChildren()).toEqual([
           // The second provider should use the default value.
           span('Result: Does not unwind'),
@@ -646,7 +646,7 @@ describe('ReactNewContext', () => {
         }
 
         ReactNoop.render(<App foo={1} bar={1} />);
-        expect(ReactNoop.flush()).toEqual(['Foo', 'Bar']);
+        expect(ReactNoop).toFlushAndYield(['Foo', 'Bar']);
         expect(ReactNoop.getChildren()).toEqual([
           span('Foo: 1'),
           span('Bar: 1'),
@@ -654,7 +654,7 @@ describe('ReactNewContext', () => {
 
         // Update only foo
         ReactNoop.render(<App foo={2} bar={1} />);
-        expect(ReactNoop.flush()).toEqual(['Foo']);
+        expect(ReactNoop).toFlushAndYield(['Foo']);
         expect(ReactNoop.getChildren()).toEqual([
           span('Foo: 2'),
           span('Bar: 1'),
@@ -662,7 +662,7 @@ describe('ReactNewContext', () => {
 
         // Update only bar
         ReactNoop.render(<App foo={2} bar={2} />);
-        expect(ReactNoop.flush()).toEqual(['Bar']);
+        expect(ReactNoop).toFlushAndYield(['Bar']);
         expect(ReactNoop.getChildren()).toEqual([
           span('Foo: 2'),
           span('Bar: 2'),
@@ -670,7 +670,7 @@ describe('ReactNewContext', () => {
 
         // Update both
         ReactNoop.render(<App foo={3} bar={3} />);
-        expect(ReactNoop.flush()).toEqual(['Foo', 'Bar']);
+        expect(ReactNoop).toFlushAndYield(['Foo', 'Bar']);
         expect(ReactNoop.getChildren()).toEqual([
           span('Foo: 3'),
           span('Bar: 3'),
@@ -763,7 +763,7 @@ describe('ReactNewContext', () => {
         }
 
         ReactNoop.render(<App foo={1} bar={1} />);
-        expect(ReactNoop.flush()).toEqual(['Foo', 'Bar', 'Foo']);
+        expect(ReactNoop).toFlushAndYield(['Foo', 'Bar', 'Foo']);
         expect(ReactNoop.getChildren()).toEqual([
           span('Foo: 1'),
           span('Bar: 1'),
@@ -772,7 +772,7 @@ describe('ReactNewContext', () => {
 
         // Update only foo
         ReactNoop.render(<App foo={2} bar={1} />);
-        expect(ReactNoop.flush()).toEqual(['Foo', 'Foo']);
+        expect(ReactNoop).toFlushAndYield(['Foo', 'Foo']);
         expect(ReactNoop.getChildren()).toEqual([
           span('Foo: 2'),
           span('Bar: 1'),
@@ -781,7 +781,7 @@ describe('ReactNewContext', () => {
 
         // Update only bar
         ReactNoop.render(<App foo={2} bar={2} />);
-        expect(ReactNoop.flush()).toEqual(['Bar']);
+        expect(ReactNoop).toFlushAndYield(['Bar']);
         expect(ReactNoop.getChildren()).toEqual([
           span('Foo: 2'),
           span('Bar: 2'),
@@ -790,7 +790,7 @@ describe('ReactNewContext', () => {
 
         // Update both
         ReactNoop.render(<App foo={3} bar={3} />);
-        expect(ReactNoop.flush()).toEqual(['Foo', 'Bar', 'Foo']);
+        expect(ReactNoop).toFlushAndYield(['Foo', 'Bar', 'Foo']);
         expect(ReactNoop.getChildren()).toEqual([
           span('Foo: 3'),
           span('Bar: 3'),
@@ -832,11 +832,11 @@ describe('ReactNewContext', () => {
 
         // Initial mount
         ReactNoop.render(<App value={1} />);
-        expect(ReactNoop.flush()).toEqual(['Consumer render prop', 'Child']);
+        expect(ReactNoop).toFlushAndYield(['Consumer render prop', 'Child']);
         expect(ReactNoop.getChildren()).toEqual([span('Context: 1, Step: 0')]);
 
         child.setState({step: 1});
-        expect(ReactNoop.flush()).toEqual(['Child']);
+        expect(ReactNoop).toFlushAndYield(['Child']);
         expect(ReactNoop.getChildren()).toEqual([span('Context: 1, Step: 1')]);
       });
 
@@ -885,7 +885,7 @@ describe('ReactNewContext', () => {
 
         // Initial mount
         ReactNoop.render(<App value={1} />);
-        expect(ReactNoop.flush()).toEqual([
+        expect(ReactNoop).toFlushAndYield([
           'App',
           'PureIndirection',
           'ChildWithInlineRenderCallback',
@@ -897,12 +897,12 @@ describe('ReactNewContext', () => {
 
         // Update (bailout)
         ReactNoop.render(<App value={1} />);
-        expect(ReactNoop.flush()).toEqual(['App']);
+        expect(ReactNoop).toFlushAndYield(['App']);
         expect(ReactNoop.getChildren()).toEqual([span(1), span(1)]);
 
         // Update (no bailout)
         ReactNoop.render(<App value={2} />);
-        expect(ReactNoop.flush()).toEqual(['App', 'Consumer', 'Consumer']);
+        expect(ReactNoop).toFlushAndYield(['App', 'Consumer', 'Consumer']);
         expect(ReactNoop.getChildren()).toEqual([span(2), span(2)]);
       });
 
@@ -921,7 +921,7 @@ describe('ReactNewContext', () => {
         }
 
         ReactNoop.render(<App theme="dark" />);
-        expect(ReactNoop.flush()).toEqual(['dark']);
+        expect(ReactNoop).toFlushAndYield(['dark']);
         expect(ReactNoop.getChildrenAsJSX()).toEqual(
           <div hidden={true}>
             <span prop="dark" />
@@ -929,7 +929,7 @@ describe('ReactNewContext', () => {
         );
 
         ReactNoop.render(<App theme="light" />);
-        expect(ReactNoop.flush()).toEqual(['light']);
+        expect(ReactNoop).toFlushAndYield(['light']);
         expect(ReactNoop.getChildrenAsJSX()).toEqual(
           <div hidden={true}>
             <span prop="light" />
@@ -968,11 +968,11 @@ describe('ReactNewContext', () => {
         }
 
         ReactNoop.render(<App reverse={false} />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
         ReactNoop.render(<App reverse={true} />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
         ReactNoop.render(<App reverse={false} />);
-        ReactNoop.flush();
+        expect(ReactNoop).toFlushWithoutYielding();
       });
 
       // This is a regression case for https://github.com/facebook/react/issues/12686
@@ -1025,14 +1025,14 @@ describe('ReactNewContext', () => {
         // Initial mount
         let inst;
         ReactNoop.render(<App ref={ref => (inst = ref)} />);
-        expect(ReactNoop.flush()).toEqual(['App']);
+        expect(ReactNoop).toFlushAndYield(['App']);
         expect(ReactNoop.getChildren()).toEqual([
           span('static 1'),
           span('static 2'),
         ]);
         // Update the first time
         inst.setState({step: 1});
-        expect(ReactNoop.flush()).toEqual(['App', 'Consumer']);
+        expect(ReactNoop).toFlushAndYield(['App', 'Consumer']);
         expect(ReactNoop.getChildren()).toEqual([
           span('static 1'),
           span('static 2'),
@@ -1040,7 +1040,7 @@ describe('ReactNewContext', () => {
         ]);
         // Update the second time
         inst.setState({step: 2});
-        expect(ReactNoop.flush()).toEqual(['App', 'Consumer']);
+        expect(ReactNoop).toFlushAndYield(['App', 'Consumer']);
         expect(ReactNoop.getChildren()).toEqual([
           span('static 1'),
           span('static 2'),
@@ -1062,11 +1062,11 @@ describe('ReactNewContext', () => {
       }
 
       ReactNoop.render(<App value={1} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
 
       // Update
       ReactNoop.render(<App value={2} />);
-      expect(ReactNoop.flush).toWarnDev(
+      expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
         'calculateChangedBits: Expected the return value to be a 31-bit ' +
           'integer. Instead received: 4294967295',
       );
@@ -1092,7 +1092,7 @@ describe('ReactNewContext', () => {
 
       ReactNoop.render(<App value={1} />);
       // Render past the Provider, but don't commit yet
-      ReactNoop.flushThrough(['Foo']);
+      expect(ReactNoop).toFlushAndYieldThrough(['Foo']);
 
       // Get a new copy of ReactNoop
       jest.resetModules();
@@ -1102,7 +1102,7 @@ describe('ReactNewContext', () => {
 
       // Render the provider again using a different renderer
       ReactNoop.render(<App value={1} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['Foo', 'Foo']);
 
       if (__DEV__) {
         expect(console.error.calls.argsFor(0)[0]).toContain(
@@ -1131,12 +1131,12 @@ describe('ReactNewContext', () => {
 
       // Initial mount
       ReactNoop.render(<App value={1} />);
-      expect(ReactNoop.flush()).toEqual(['App', 'Child']);
+      expect(ReactNoop).toFlushAndYield(['App', 'Child']);
       expect(ReactNoop.getChildren()).toEqual([span('Child')]);
 
       // Update
       ReactNoop.render(<App value={1} />);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         'App',
         // Child does not re-render
       ]);
@@ -1191,7 +1191,7 @@ describe('ReactNewContext', () => {
         </LegacyProvider>,
       );
       expect(() => {
-        expect(ReactNoop.flush()).toEqual(['LegacyProvider', 'App', 'Child']);
+        expect(ReactNoop).toFlushAndYield(['LegacyProvider', 'App', 'Child']);
       }).toWarnDev(
         'Legacy context API has been detected within a strict-mode tree: \n\n' +
           'Please update the following components: LegacyProvider',
@@ -1201,17 +1201,17 @@ describe('ReactNewContext', () => {
 
       // Update App with same value (should bail out)
       appRef.current.setState({value: 1});
-      expect(ReactNoop.flush()).toEqual(['App']);
+      expect(ReactNoop).toFlushAndYield(['App']);
       expect(ReactNoop.getChildren()).toEqual([span('Child')]);
 
       // Update LegacyProvider (should not bail out)
       legacyProviderRef.current.setState({value: 1});
-      expect(ReactNoop.flush()).toEqual(['LegacyProvider', 'App', 'Child']);
+      expect(ReactNoop).toFlushAndYield(['LegacyProvider', 'App', 'Child']);
       expect(ReactNoop.getChildren()).toEqual([span('Child')]);
 
       // Update App with same value (should bail out)
       appRef.current.setState({value: 1});
-      expect(ReactNoop.flush()).toEqual(['App']);
+      expect(ReactNoop).toFlushAndYield(['App']);
       expect(ReactNoop.getChildren()).toEqual([span('Child')]);
     });
   });
@@ -1221,7 +1221,7 @@ describe('ReactNewContext', () => {
       spyOnDev(console, 'error');
       const Context = React.createContext(0);
       ReactNoop.render(<Context.Consumer />);
-      expect(ReactNoop.flush).toThrow('render is not a function');
+      expect(ReactNoop).toFlushAndThrow('render is not a function');
       if (__DEV__) {
         expect(console.error.calls.argsFor(0)[0]).toContain(
           'A context consumer was rendered with multiple children, or a child ' +
@@ -1267,17 +1267,17 @@ describe('ReactNewContext', () => {
       }
 
       ReactNoop.render(<App foo={1} bar={1} />);
-      expect(ReactNoop.flush()).toEqual(['Foo: 1, Bar: 1']);
+      expect(ReactNoop).toFlushAndYield(['Foo: 1, Bar: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Foo: 1, Bar: 1')]);
 
       // Update foo
       ReactNoop.render(<App foo={2} bar={1} />);
-      expect(ReactNoop.flush()).toEqual(['Foo: 2, Bar: 1']);
+      expect(ReactNoop).toFlushAndYield(['Foo: 2, Bar: 1']);
       expect(ReactNoop.getChildren()).toEqual([span('Foo: 2, Bar: 1')]);
 
       // Update bar
       ReactNoop.render(<App foo={2} bar={2} />);
-      expect(ReactNoop.flush()).toEqual(['Foo: 2, Bar: 2']);
+      expect(ReactNoop).toFlushAndYield(['Foo: 2, Bar: 2']);
       expect(ReactNoop.getChildren()).toEqual([span('Foo: 2, Bar: 2')]);
     });
 
@@ -1313,12 +1313,12 @@ describe('ReactNewContext', () => {
       // Initial mount
       let inst;
       ReactNoop.render(<App value={1} ref={ref => (inst = ref)} />);
-      expect(ReactNoop.flush()).toEqual(['App', 'App#renderConsumer']);
+      expect(ReactNoop).toFlushAndYield(['App', 'App#renderConsumer']);
       expect(ReactNoop.getChildren()).toEqual([span('hello')]);
 
       // Update
       inst.setState({text: 'goodbye'});
-      expect(ReactNoop.flush()).toEqual(['App', 'App#renderConsumer']);
+      expect(ReactNoop).toFlushAndYield(['App', 'App#renderConsumer']);
       expect(ReactNoop.getChildren()).toEqual([span('goodbye')]);
     });
   });
@@ -1384,7 +1384,7 @@ describe('ReactNewContext', () => {
       }
 
       ReactNoop.render(<App foo={1} bar={1} baz={1} />);
-      expect(ReactNoop.flush()).toEqual(['Foo: 1, Bar: 1', 'Baz: 1']);
+      expect(ReactNoop).toFlushAndYield(['Foo: 1, Bar: 1', 'Baz: 1']);
       expect(ReactNoop.getChildren()).toEqual([
         span('Foo: 1, Bar: 1'),
         span('Baz: 1'),
@@ -1392,7 +1392,7 @@ describe('ReactNewContext', () => {
 
       // Update only foo
       ReactNoop.render(<App foo={2} bar={1} baz={1} />);
-      expect(ReactNoop.flush()).toEqual(['Foo: 2, Bar: 1']);
+      expect(ReactNoop).toFlushAndYield(['Foo: 2, Bar: 1']);
       expect(ReactNoop.getChildren()).toEqual([
         span('Foo: 2, Bar: 1'),
         span('Baz: 1'),
@@ -1400,7 +1400,7 @@ describe('ReactNewContext', () => {
 
       // Update only bar
       ReactNoop.render(<App foo={2} bar={2} baz={1} />);
-      expect(ReactNoop.flush()).toEqual(['Foo: 2, Bar: 2']);
+      expect(ReactNoop).toFlushAndYield(['Foo: 2, Bar: 2']);
       expect(ReactNoop.getChildren()).toEqual([
         span('Foo: 2, Bar: 2'),
         span('Baz: 1'),
@@ -1408,7 +1408,7 @@ describe('ReactNewContext', () => {
 
       // Update only baz
       ReactNoop.render(<App foo={2} bar={2} baz={2} />);
-      expect(ReactNoop.flush()).toEqual(['Baz: 2']);
+      expect(ReactNoop).toFlushAndYield(['Baz: 2']);
       expect(ReactNoop.getChildren()).toEqual([
         span('Foo: 2, Bar: 2'),
         span('Baz: 2'),
@@ -1453,12 +1453,12 @@ describe('ReactNewContext', () => {
       // Initial mount
       let inst;
       ReactNoop.render(<App value={1} ref={ref => (inst = ref)} />);
-      expect(ReactNoop.flush()).toEqual(['App', 'App#renderConsumer']);
+      expect(ReactNoop).toFlushAndYield(['App', 'App#renderConsumer']);
       expect(ReactNoop.getChildren()).toEqual([span('hello')]);
 
       // Update
       inst.setState({text: 'goodbye'});
-      expect(ReactNoop.flush()).toEqual(['App', 'App#renderConsumer']);
+      expect(ReactNoop).toFlushAndYield(['App', 'App#renderConsumer']);
       expect(ReactNoop.getChildren()).toEqual([span('goodbye')]);
     });
 
@@ -1476,7 +1476,7 @@ describe('ReactNewContext', () => {
       }
 
       ReactNoop.render(<Cls />);
-      expect(ReactNoop.flush).toWarnDev(
+      expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
         [
           'Context can only be read while React is rendering',
           'Cannot update during an existing state transition',
@@ -1495,7 +1495,7 @@ describe('ReactNewContext', () => {
         return [Context].map(useContext);
       }
       ReactNoop.render(<Foo />);
-      expect(ReactNoop.flush).toWarnDev(
+      expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
         'useContext() second argument is reserved for future ' +
           'use in React. Passing it is not supported. ' +
           'You passed: 0.\n\n' +
@@ -1513,7 +1513,7 @@ describe('ReactNewContext', () => {
         }
       }
       ReactNoop.render(<Foo />);
-      expect(ReactNoop.flush).toThrow(
+      expect(ReactNoop).toFlushAndThrow(
         'Hooks can only be called inside the body of a function component.',
       );
     });
@@ -1524,7 +1524,7 @@ describe('ReactNewContext', () => {
         return useContext(Context.Consumer);
       }
       ReactNoop.render(<Foo />);
-      expect(ReactNoop.flush).toWarnDev(
+      expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
         'Calling useContext(Context.Consumer) is not supported, may cause bugs, ' +
           'and will be removed in a future major release. ' +
           'Did you mean to call useContext(Context) instead?',
@@ -1538,7 +1538,7 @@ describe('ReactNewContext', () => {
         return null;
       }
       ReactNoop.render(<Foo />);
-      expect(ReactNoop.flush).toWarnDev(
+      expect(() => expect(ReactNoop).toFlushWithoutYielding()).toWarnDev(
         'Calling useContext(Context.Provider) is not supported. ' +
           'Did you mean to call useContext(Context) instead?',
       );
@@ -1580,12 +1580,12 @@ describe('ReactNewContext', () => {
       // Initial mount
       let inst;
       ReactNoop.render(<App value={1} ref={ref => (inst = ref)} />);
-      expect(ReactNoop.flush()).toEqual(['App', 'App#renderConsumer']);
+      expect(ReactNoop).toFlushAndYield(['App', 'App#renderConsumer']);
       expect(ReactNoop.getChildren()).toEqual([span('hello')]);
 
       // Update
       inst.setState({text: 'goodbye'});
-      expect(ReactNoop.flush()).toEqual(['App', 'App#renderConsumer']);
+      expect(ReactNoop).toFlushAndYield(['App', 'App#renderConsumer']);
       expect(ReactNoop.getChildren()).toEqual([span('goodbye')]);
     });
   });
@@ -1600,14 +1600,14 @@ describe('ReactNewContext', () => {
         <Context.Provider />
       </errorInCompletePhase>,
     );
-    expect(ReactNoop.flush).toThrow('Error in host config.');
+    expect(ReactNoop).toFlushAndThrow('Error in host config.');
 
     ReactNoop.render(
       <Context.Provider value={10}>
         <Context.Consumer>{value => <span prop={value} />}</Context.Consumer>
       </Context.Provider>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span(10)]);
   });
 
@@ -1769,7 +1769,7 @@ describe('ReactNewContext', () => {
         actions.forEach(action => {
           switch (action.type) {
             case FLUSH_ALL:
-              ReactNoop.flush();
+              ReactNoop.unstable_flushWithoutYielding();
               break;
             case FLUSH:
               ReactNoop.unstable_flushNumberOfYields(action.unitsOfWork);
@@ -1787,7 +1787,7 @@ describe('ReactNewContext', () => {
           assertConsistentTree();
         });
 
-        ReactNoop.flush();
+        ReactNoop.unstable_flushWithoutYielding();
         assertConsistentTree(finalExpectedValues);
       }
 
@@ -1839,7 +1839,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
 
     expect(() => {
       ReactNoop.render(<Component />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toWarnDev(
       'Rendering <Context> directly is not supported and will be removed in ' +
         'a future major release. Did you mean to render <Context.Consumer> instead?',
@@ -1865,7 +1865,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
     }
 
     ReactNoop.render(<Component />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
   });
 
   it('should warn with an error message when using nested context consumers in DEV', () => {
@@ -1886,7 +1886,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
 
     expect(() => {
       ReactNoop.render(<Component />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toWarnDev(
       'Rendering <Context.Consumer.Consumer> is not supported and will be removed in ' +
         'a future major release. Did you mean to render <Context.Consumer> instead?',
@@ -1910,7 +1910,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
 
     expect(() => {
       ReactNoop.render(<Component />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
     }).toWarnDev(
       'Rendering <Context.Consumer.Provider> is not supported and will be removed in ' +
         'a future major release. Did you mean to render <Context.Provider> instead?',

--- a/packages/react-reconciler/src/__tests__/ReactPersistent-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPersistent-test.js
@@ -66,12 +66,12 @@ describe('ReactPersistent', () => {
     }
 
     render(<Foo text="Hello" />);
-    ReactNoopPersistent.flush();
+    expect(ReactNoopPersistent).toFlushWithoutYielding();
     const originalChildren = getChildren();
     expect(originalChildren).toEqual([div(span())]);
 
     render(<Foo text="World" />);
-    ReactNoopPersistent.flush();
+    expect(ReactNoopPersistent).toFlushWithoutYielding();
     const newChildren = getChildren();
     expect(newChildren).toEqual([div(span(), span())]);
 
@@ -100,12 +100,12 @@ describe('ReactPersistent', () => {
     }
 
     render(<Foo text="Hello" />);
-    ReactNoopPersistent.flush();
+    expect(ReactNoopPersistent).toFlushWithoutYielding();
     const originalChildren = getChildren();
     expect(originalChildren).toEqual([div(span('Hello'))]);
 
     render(<Foo text="World" />);
-    ReactNoopPersistent.flush();
+    expect(ReactNoopPersistent).toFlushWithoutYielding();
     const newChildren = getChildren();
     expect(newChildren).toEqual([div(span('Hello'), span('World'))]);
 
@@ -126,12 +126,12 @@ describe('ReactPersistent', () => {
     }
 
     render(<Foo text="Hello" />);
-    ReactNoopPersistent.flush();
+    expect(ReactNoopPersistent).toFlushWithoutYielding();
     const originalChildren = getChildren();
     expect(originalChildren).toEqual([div('Hello', span())]);
 
     render(<Foo text="World" />);
-    ReactNoopPersistent.flush();
+    expect(ReactNoopPersistent).toFlushWithoutYielding();
     const newChildren = getChildren();
     expect(newChildren).toEqual([div('World', span())]);
 
@@ -167,7 +167,7 @@ describe('ReactPersistent', () => {
     const portalContainer = {rootID: 'persistent-portal-test', children: []};
     const emptyPortalChildSet = portalContainer.children;
     render(<Parent>{createPortal(<Child />, portalContainer, null)}</Parent>);
-    ReactNoopPersistent.flush();
+    expect(ReactNoopPersistent).toFlushWithoutYielding();
 
     expect(emptyPortalChildSet).toEqual([]);
 
@@ -181,7 +181,7 @@ describe('ReactPersistent', () => {
         {createPortal(<Child>Hello {'World'}</Child>, portalContainer, null)}
       </Parent>,
     );
-    ReactNoopPersistent.flush();
+    expect(ReactNoopPersistent).toFlushWithoutYielding();
 
     const newChildren = getChildren();
     expect(newChildren).toEqual([div()]);
@@ -198,7 +198,7 @@ describe('ReactPersistent', () => {
 
     // Deleting the Portal, should clear its children
     render(<Parent />);
-    ReactNoopPersistent.flush();
+    expect(ReactNoopPersistent).toFlushWithoutYielding();
 
     const clearedPortalChildren = portalContainer.children;
     expect(clearedPortalChildren).toEqual([]);

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -106,7 +106,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'Foo',
       'Bar',
       // A suspends
@@ -120,14 +120,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Flush some of the time
     await advanceTimers(50);
     // Still nothing...
-    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Flush the promise completely
     await advanceTimers(50);
     // Renders successfully
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [A]']);
-    expect(ReactNoop.flush()).toEqual(['Foo', 'Bar', 'A', 'B']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [A]']);
+    expect(ReactNoop).toFlushAndYield(['Foo', 'Bar', 'A', 'B']);
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
   });
 
@@ -143,7 +143,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Suspense>
       </Fragment>,
     );
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'Suspend! [A]',
       'Loading A...',
       'Suspend! [B]',
@@ -155,7 +155,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.expire(4000);
     await advanceTimers(4000);
 
-    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([
       span('Loading A...'),
       span('Loading B...'),
@@ -167,8 +167,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.expire(1000);
     await advanceTimers(1000);
 
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [A]']);
-    expect(ReactNoop.flush()).toEqual(['A']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [A]']);
+    expect(ReactNoop).toFlushAndYield(['A']);
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('Loading B...')]);
 
     // Advance time by enough that the second Suspense's promise resolves
@@ -176,8 +176,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.expire(1000);
     await advanceTimers(1000);
 
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [B]']);
-    expect(ReactNoop.flush()).toEqual(['B']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [B]']);
+    expect(ReactNoop).toFlushAndYield(['B']);
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
   });
 
@@ -191,7 +191,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </Suspense>,
     );
     // B suspends. Continue rendering the remaining siblings.
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'A',
       'Suspend! [B]',
       'C',
@@ -204,8 +204,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Wait for data to resolve
     await advanceTimers(100);
     // Renders successfully
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [B]']);
-    expect(ReactNoop.flush()).toEqual(['A', 'B', 'C', 'D']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [B]']);
+    expect(ReactNoop).toFlushAndYield(['A', 'B', 'C', 'D']);
     expect(ReactNoop.getChildren()).toEqual([
       span('A'),
       span('B'),
@@ -243,7 +243,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<App />);
-    expect(ReactNoop.flush()).toEqual(['Suspend! [Result]', 'Loading...']);
+    expect(ReactNoop).toFlushAndYield(['Suspend! [Result]', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     textResourceShouldFail = true;
@@ -251,9 +251,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await advanceTimers(1000);
     textResourceShouldFail = false;
 
-    expect(ReactNoop.clearYields()).toEqual(['Promise rejected [Result]']);
+    expect(ReactNoop).toHaveYielded(['Promise rejected [Result]']);
 
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'Error! [Result]',
 
       // React retries one more time
@@ -296,12 +296,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<App />);
-    expect(ReactNoop.flush()).toEqual(['Suspend! [Result]', 'Loading...']);
+    expect(ReactNoop).toFlushAndYield(['Suspend! [Result]', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     ReactNoop.expire(2000);
     await advanceTimers(2000);
-    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
 
     textResourceShouldFail = true;
@@ -309,8 +309,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await advanceTimers(1000);
     textResourceShouldFail = false;
 
-    expect(ReactNoop.clearYields()).toEqual(['Promise rejected [Result]']);
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toHaveYielded(['Promise rejected [Result]']);
+    expect(ReactNoop).toFlushAndYield([
       'Error! [Result]',
 
       // React retries one more time
@@ -337,15 +337,15 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Initial mount
     ReactNoop.render(<App highPri="A" lowPri="1" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushAndYield(['A', 'Suspend! [1]', 'Loading...']);
     await advanceTimers(0);
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [1]']);
-    ReactNoop.flush();
+    expect(ReactNoop).toHaveYielded(['Promise resolved [1]']);
+    expect(ReactNoop).toFlushAndYield(['A', '1']);
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('1')]);
 
     // Update the low-pri text
     ReactNoop.render(<App highPri="A" lowPri="2" />);
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'A',
       // Suspends
       'Suspend! [2]',
@@ -357,12 +357,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.flushSync(() => {
       ReactNoop.render(<App highPri="B" lowPri="1" />);
     });
-    expect(ReactNoop.clearYields()).toEqual(['B', '1']);
+    expect(ReactNoop).toHaveYielded(['B', '1']);
     expect(ReactNoop.getChildren()).toEqual([span('B'), span('1')]);
 
     // Unblock the low-pri text and finish
     await advanceTimers(0);
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [2]']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [2]']);
     expect(ReactNoop.getChildren()).toEqual([span('B'), span('1')]);
   });
 
@@ -377,18 +377,18 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<App showB={false} />);
-    expect(ReactNoop.flush()).toEqual(['Suspend! [A]', 'Loading...']);
+    expect(ReactNoop).toFlushAndYield(['Suspend! [A]', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Advance React's virtual time by enough to fall into a new async bucket.
     ReactNoop.expire(1200);
     ReactNoop.render(<App showB={true} />);
-    expect(ReactNoop.flush()).toEqual(['Suspend! [A]', 'B', 'Loading...']);
+    expect(ReactNoop).toFlushAndYield(['Suspend! [A]', 'B', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     await advanceTimers(0);
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [A]']);
-    expect(ReactNoop.flush()).toEqual(['A', 'B']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [A]']);
+    expect(ReactNoop).toFlushAndYield(['A', 'B']);
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
   });
 
@@ -413,7 +413,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Low pri
     ReactNoop.render(<App hide={true} />);
 
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       // The first update suspends
       'Suspend! [Async]',
       // but we have another pending update that we can work on
@@ -432,7 +432,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </Fragment>,
     );
 
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       // The async child suspends
       'Suspend! [Async]',
       // Render the placeholder
@@ -455,8 +455,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Once the promise resolves, we render the suspended view
     await advanceTimers(10000);
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Async]']);
-    expect(ReactNoop.flush()).toEqual(['Async']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [Async]']);
+    expect(ReactNoop).toFlushAndYield(['Async']);
     expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
   });
 
@@ -477,7 +477,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </Fragment>,
     );
 
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'Sync',
       // The async content suspends
       'Suspend! [Outer content]',
@@ -492,7 +492,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // We should see the outer loading placeholder.
     ReactNoop.expire(1500);
     await advanceTimers(1500);
-    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([
       span('Sync'),
       span('Loading outer...'),
@@ -505,10 +505,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // timed out at 1.5 seconds. So, 2 seconds have elapsed since the
     // placeholder timed out. That means we still haven't reached the 2.5 second
     // threshold of the inner placeholder.
-    expect(ReactNoop.clearYields()).toEqual([
-      'Promise resolved [Outer content]',
-    ]);
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toHaveYielded(['Promise resolved [Outer content]']);
+    expect(ReactNoop).toFlushAndYield([
       'Outer content',
       'Suspend! [Inner content]',
       'Loading inner...',
@@ -533,10 +531,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Finally, flush the inner promise. We should see the complete screen.
     ReactNoop.expire(1000);
     await advanceTimers(1000);
-    expect(ReactNoop.clearYields()).toEqual([
-      'Promise resolved [Inner content]',
-    ]);
-    expect(ReactNoop.flush()).toEqual(['Inner content']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [Inner content]']);
+    expect(ReactNoop).toFlushAndYield(['Inner content']);
     expect(ReactNoop.getChildren()).toEqual([
       span('Sync'),
       span('Outer content'),
@@ -556,7 +552,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Fragment>,
       ),
     );
-    expect(ReactNoop.clearYields()).toEqual([
+    expect(ReactNoop).toHaveYielded([
       // The async child suspends
       'Suspend! [Async]',
       // We immediately render the fallback UI
@@ -569,8 +565,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Once the promise resolves, we render the suspended view
     await advanceTimers(0);
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Async]']);
-    expect(ReactNoop.flush()).toEqual(['Async']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [Async]']);
+    expect(ReactNoop).toFlushAndYield(['Async']);
     expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
   });
 
@@ -587,7 +583,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Fragment>,
       ),
     );
-    expect(ReactNoop.clearYields()).toEqual([
+    expect(ReactNoop).toHaveYielded([
       'Suspend! [Async]',
       'Suspend! [Loading (inner)...]',
       'Sync',
@@ -607,7 +603,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </Fragment>,
     );
 
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       // The async child suspends
       'Suspend! [Async]',
       'Loading...',
@@ -622,13 +618,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // expiration time.
     ReactNoop.expire(2000);
     await advanceTimers(2000);
-    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('Loading...'), span('Sync')]);
 
     // Once the promise resolves, we render the suspended view
     await advanceTimers(1000);
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Async]']);
-    expect(ReactNoop.flush()).toEqual(['Async']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [Async]']);
+    expect(ReactNoop).toFlushAndYield(['Async']);
     expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
   });
 
@@ -643,8 +639,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     expect(ReactNoop.expire(1500)).toEqual([]);
     // Before we have a chance to flush, the promise resolves.
     await advanceTimers(2000);
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Async]']);
-    expect(ReactNoop.flush()).toEqual(['Async']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [Async]']);
+    expect(ReactNoop).toFlushAndYield(['Async']);
     expect(ReactNoop.getChildren()).toEqual([span('Async')]);
   });
 
@@ -672,11 +668,11 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     await advanceTimers(100);
 
-    expect(ReactNoop.clearYields()).toEqual([
+    expect(ReactNoop).toHaveYielded([
       'Promise resolved [A]',
       'Promise resolved [B]',
     ]);
-    expect(ReactNoop.flush()).toEqual(['A', 'B']);
+    expect(ReactNoop).toFlushAndYield(['A', 'B']);
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
   });
 
@@ -686,7 +682,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         <AsyncText text="Async" ms={100} />
       </Suspense>,
     );
-    expect(ReactNoop.flush()).toEqual(['Suspend! [Async]', 'Loading...']);
+    expect(ReactNoop).toFlushAndYield(['Suspend! [Async]', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Advance time by an amount slightly smaller than what's necessary to
@@ -694,14 +690,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await advanceTimers(99);
 
     // Nothing has rendered yet
-    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Resolve the promise
     await advanceTimers(1);
     // We can now resume rendering
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Async]']);
-    expect(ReactNoop.flush()).toEqual(['Async']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [Async]']);
+    expect(ReactNoop).toFlushAndYield(['Async']);
     expect(ReactNoop.getChildren()).toEqual([span('Async')]);
   });
 
@@ -721,20 +717,20 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Schedule an update
     ReactNoop.render(<App text="A" />);
     // The update should suspend.
-    expect(ReactNoop.flush()).toEqual(['Suspend! [A]', 'Loading...']);
+    expect(ReactNoop).toFlushAndYield(['Suspend! [A]', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Advance time until right before it expires. This number may need to
     // change if the default expiration for low priority updates is adjusted.
     await advanceTimers(4999);
     ReactNoop.expire(4999);
-    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Schedule another low priority update.
     ReactNoop.render(<App text="B" />);
     // This update should also suspend.
-    expect(ReactNoop.flush()).toEqual(['Suspend! [B]', 'Loading...']);
+    expect(ReactNoop).toFlushAndYield(['Suspend! [B]', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Schedule a high priority update. Its expiration time will fall between
@@ -742,17 +738,17 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.interactiveUpdates(() => {
       ReactNoop.render(<App text="C" />);
     });
-    expect(ReactNoop.flush()).toEqual(['C']);
+    expect(ReactNoop).toFlushAndYield(['C']);
     expect(ReactNoop.getChildren()).toEqual([span('C')]);
 
     await advanceTimers(10000);
     // Flush the remaining work.
-    expect(ReactNoop.clearYields()).toEqual([
+    expect(ReactNoop).toHaveYielded([
       'Promise resolved [A]',
       'Promise resolved [B]',
     ]);
     // Nothing else to render.
-    expect(ReactNoop.flush()).toEqual([]);
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('C')]);
   });
 
@@ -787,7 +783,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.advanceTime(10000);
     jest.advanceTimersByTime(10000);
 
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'Suspend! [goodbye]',
       'Loading...',
       'Commit: goodbye',
@@ -796,10 +792,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     ReactNoop.advanceTime(20000);
     await advanceTimers(20000);
-    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [goodbye]']);
+    expect(ReactNoop).toHaveYielded(['Promise resolved [goodbye]']);
     expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
 
-    expect(ReactNoop.flush()).toEqual(['goodbye']);
+    expect(ReactNoop).toFlushAndYield(['goodbye']);
     expect(ReactNoop.getChildren()).toEqual([span('goodbye')]);
   });
 
@@ -832,17 +828,17 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     it('works', async () => {
       ReactNoop.render(<DebouncedText text="A" ms={1000} />);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushAndYield(['A']);
       expect(ReactNoop.getChildren()).toEqual([]);
 
       await advanceTimers(800);
       ReactNoop.expire(800);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
       expect(ReactNoop.getChildren()).toEqual([]);
 
       await advanceTimers(1000);
       ReactNoop.expire(1000);
-      ReactNoop.flush();
+      expect(ReactNoop).toFlushWithoutYielding();
       expect(ReactNoop.getChildren()).toEqual([span('A')]);
     });
   });
@@ -859,18 +855,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Times out immediately, ignoring the specified threshold.
       ReactNoop.renderLegacySyncRoot(<App />);
-      expect(ReactNoop.clearYields()).toEqual([
-        'Suspend! [Result]',
-        'Loading...',
-      ]);
+      expect(ReactNoop).toHaveYielded(['Suspend! [Result]', 'Loading...']);
       expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
 
       ReactNoop.expire(100);
       await advanceTimers(100);
-      expect(ReactNoop.clearYields()).toEqual([
-        'Promise resolved [Result]',
-        'Result',
-      ]);
+      expect(ReactNoop).toHaveYielded(['Promise resolved [Result]', 'Result']);
 
       expect(ReactNoop.getChildren()).toEqual([span('Result')]);
     });
@@ -908,7 +898,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // Initial mount. This is synchronous, because the root is sync.
       ReactNoop.renderLegacySyncRoot(<App />);
       await advanceTimers(100);
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Suspend! [Step: 1]',
         'Sibling',
         'Loading (1)',
@@ -917,7 +907,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         'Promise resolved [Step: 1]',
         'Step: 1',
       ]);
-      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      expect(ReactNoop).toMatchRenderedOutput(
         <React.Fragment>
           <span prop="Step: 1" />
           <span prop="Sibling" />
@@ -931,13 +921,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Suspend during an async render.
       expect(ReactNoop.flushNextYield()).toEqual(['Suspend! [Step: 2]']);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop).toFlushAndYield([
         'Loading (1)',
         'Loading (2)',
         'Loading (3)',
         'Update did commit',
       ]);
-      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      expect(ReactNoop).toMatchRenderedOutput(
         <React.Fragment>
           <span hidden={true} prop="Step: 1" />
           <span hidden={true} prop="Sibling" />
@@ -948,11 +938,11 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
 
       await advanceTimers(100);
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Promise resolved [Step: 2]',
         'Step: 2',
       ]);
-      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      expect(ReactNoop).toMatchRenderedOutput(
         <React.Fragment>
           <span prop="Step: 2" />
           <span prop="Sibling" />
@@ -1011,7 +1001,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           ReactNoop.yield('Did mount'),
         );
         await advanceTimers(100);
-        expect(ReactNoop.clearYields()).toEqual([
+        expect(ReactNoop).toHaveYielded([
           'Before',
           'Suspend! [Async: 1]',
           'After',
@@ -1023,7 +1013,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           'Promise resolved [Async: 1]',
           'Async: 1',
         ]);
-        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        expect(ReactNoop).toMatchRenderedOutput(
           <React.Fragment>
             <span prop="Before" />
             <span prop="Async: 1" />
@@ -1044,14 +1034,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         );
 
         // Start rendering asynchronously
-        ReactNoop.flushThrough(['Before']);
+        expect(ReactNoop).toFlushAndYieldThrough(['Before']);
 
         // Now render the next child, which suspends
         expect(ReactNoop.flushNextYield()).toEqual([
           // This child suspends
           'Suspend! [Async: 2]',
         ]);
-        expect(ReactNoop.flush()).toEqual([
+        expect(ReactNoop).toFlushAndYield([
           'After',
           'Loading...',
           'Before',
@@ -1060,7 +1050,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           'Update 1 did commit',
           'Update 2 did commit',
         ]);
-        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        expect(ReactNoop).toMatchRenderedOutput(
           <React.Fragment>
             <span hidden={true} prop="Before" />
             <span hidden={true} prop="Async: 1" />
@@ -1076,12 +1066,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         // When the placeholder is pinged, the boundary must be re-rendered
         // synchronously.
         await advanceTimers(100);
-        expect(ReactNoop.clearYields()).toEqual([
+        expect(ReactNoop).toHaveYielded([
           'Promise resolved [Async: 2]',
           'Async: 2',
         ]);
 
-        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        expect(ReactNoop).toMatchRenderedOutput(
           <React.Fragment>
             <span prop="Before" />
             <span prop="Async: 2" />
@@ -1146,7 +1136,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           ReactNoop.yield('Did mount'),
         );
         await advanceTimers(100);
-        expect(ReactNoop.clearYields()).toEqual([
+        expect(ReactNoop).toHaveYielded([
           'Before',
           'Suspend! [Async: 1]',
           'After',
@@ -1158,7 +1148,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           'Promise resolved [Async: 1]',
           'Async: 1',
         ]);
-        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        expect(ReactNoop).toMatchRenderedOutput(
           <React.Fragment>
             <span prop="Before" />
             <span prop="Async: 1" />
@@ -1179,14 +1169,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         );
 
         // Start rendering asynchronously
-        ReactNoop.flushThrough(['Before']);
+        expect(ReactNoop).toFlushAndYieldThrough(['Before']);
 
         // Now render the next child, which suspends
         expect(ReactNoop.flushNextYield()).toEqual([
           // This child suspends
           'Suspend! [Async: 2]',
         ]);
-        expect(ReactNoop.flush()).toEqual([
+        expect(ReactNoop).toFlushAndYield([
           'After',
           'Loading...',
           'Before',
@@ -1195,7 +1185,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           'Update 1 did commit',
           'Update 2 did commit',
         ]);
-        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        expect(ReactNoop).toMatchRenderedOutput(
           <React.Fragment>
             <span hidden={true} prop="Before" />
             <span hidden={true} prop="Async: 1" />
@@ -1211,12 +1201,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         // When the placeholder is pinged, the boundary must be re-rendered
         // synchronously.
         await advanceTimers(100);
-        expect(ReactNoop.clearYields()).toEqual([
+        expect(ReactNoop).toHaveYielded([
           'Promise resolved [Async: 2]',
           'Async: 2',
         ]);
 
-        expect(ReactNoop.getChildrenAsJSX()).toEqual(
+        expect(ReactNoop).toMatchRenderedOutput(
           <React.Fragment>
             <span prop="Before" />
             <span prop="Async: 2" />
@@ -1270,7 +1260,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ReactNoop.renderLegacySyncRoot(<App />, () =>
         ReactNoop.yield('Commit root'),
       );
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'A',
         'Suspend! [B]',
         'C',
@@ -1283,7 +1273,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         'Mount [Loading...]',
         'Commit root',
       ]);
-      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      expect(ReactNoop).toMatchRenderedOutput(
         <React.Fragment>
           <span hidden={true} prop="A" />
           <span hidden={true} prop="C" />
@@ -1294,9 +1284,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(ReactNoop.clearYields()).toEqual(['Promise resolved [B]', 'B']);
+      expect(ReactNoop).toHaveYielded(['Promise resolved [B]', 'B']);
 
-      expect(ReactNoop.getChildrenAsJSX()).toEqual(
+      expect(ReactNoop).toMatchRenderedOutput(
         <React.Fragment>
           <span prop="A" />
           <span prop="B" />
@@ -1338,7 +1328,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Suspense>,
       );
 
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'constructor',
         'Suspend! [Hi]',
         'Loading...',
@@ -1346,7 +1336,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
 
       await advanceTimers(1000);
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Promise resolved [Hi]',
         'constructor',
         'Hi',
@@ -1382,7 +1372,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       ReactNoop.renderLegacySyncRoot(<Demo />);
 
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Suspend! [Hi]',
         'Loading...',
         // Re-render due to lifecycle update
@@ -1390,7 +1380,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ]);
       expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
       await advanceTimers(100);
-      expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Hi]', 'Hi']);
+      expect(ReactNoop).toHaveYielded(['Promise resolved [Hi]', 'Hi']);
       expect(ReactNoop.getChildren()).toEqual([span('Hi')]);
     });
 
@@ -1421,7 +1411,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       ReactNoop.renderLegacySyncRoot(<App middleText="B" />);
 
-      expect(ReactNoop.clearYields()).toEqual([
+      expect(ReactNoop).toHaveYielded([
         'Suspend! [Hi]',
         'Loading...',
         // The child should have already been hidden
@@ -1430,7 +1420,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       await advanceTimers(1000);
 
-      expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Hi]', 'Hi']);
+      expect(ReactNoop).toHaveYielded(['Promise resolved [Hi]', 'Hi']);
     });
   });
 
@@ -1493,7 +1483,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.renderLegacySyncRoot(<App />, () =>
       ReactNoop.yield('Commit root'),
     );
-    expect(ReactNoop.clearYields()).toEqual([
+    expect(ReactNoop).toHaveYielded([
       'A',
       'Suspend! [B]',
       'C',
@@ -1506,7 +1496,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'Mount [Loading...]',
       'Commit root',
     ]);
-    expect(ReactNoop.getChildrenAsJSX()).toEqual(
+    expect(ReactNoop).toMatchRenderedOutput(
       <React.Fragment>
         <span hidden={true} prop="A" />
         <span hidden={true} prop="C" />

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -126,13 +126,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Flush the promise completely
     await advanceTimers(50);
     // Renders successfully
-    expect(ReactNoop.flush()).toEqual([
-      'Promise resolved [A]',
-      'Foo',
-      'Bar',
-      'A',
-      'B',
-    ]);
+    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [A]']);
+    expect(ReactNoop.flush()).toEqual(['Foo', 'Bar', 'A', 'B']);
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
   });
 
@@ -172,7 +167,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.expire(1000);
     await advanceTimers(1000);
 
-    expect(ReactNoop.flush()).toEqual(['Promise resolved [A]', 'A']);
+    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [A]']);
+    expect(ReactNoop.flush()).toEqual(['A']);
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('Loading B...')]);
 
     // Advance time by enough that the second Suspense's promise resolves
@@ -180,7 +176,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.expire(1000);
     await advanceTimers(1000);
 
-    expect(ReactNoop.flush()).toEqual(['Promise resolved [B]', 'B']);
+    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [B]']);
+    expect(ReactNoop.flush()).toEqual(['B']);
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
   });
 
@@ -207,13 +204,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Wait for data to resolve
     await advanceTimers(100);
     // Renders successfully
-    expect(ReactNoop.flush()).toEqual([
-      'Promise resolved [B]',
-      'A',
-      'B',
-      'C',
-      'D',
-    ]);
+    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [B]']);
+    expect(ReactNoop.flush()).toEqual(['A', 'B', 'C', 'D']);
     expect(ReactNoop.getChildren()).toEqual([
       span('A'),
       span('B'),
@@ -259,8 +251,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await advanceTimers(1000);
     textResourceShouldFail = false;
 
+    expect(ReactNoop.clearYields()).toEqual(['Promise rejected [Result]']);
+
     expect(ReactNoop.flush()).toEqual([
-      'Promise rejected [Result]',
       'Error! [Result]',
 
       // React retries one more time
@@ -316,8 +309,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await advanceTimers(1000);
     textResourceShouldFail = false;
 
+    expect(ReactNoop.clearYields()).toEqual(['Promise rejected [Result]']);
     expect(ReactNoop.flush()).toEqual([
-      'Promise rejected [Result]',
       'Error! [Result]',
 
       // React retries one more time
@@ -346,6 +339,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.render(<App highPri="A" lowPri="1" />);
     ReactNoop.flush();
     await advanceTimers(0);
+    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [1]']);
     ReactNoop.flush();
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('1')]);
 
@@ -363,12 +357,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.flushSync(() => {
       ReactNoop.render(<App highPri="B" lowPri="1" />);
     });
-    expect(ReactNoop.flush()).toEqual(['B', '1']);
+    expect(ReactNoop.clearYields()).toEqual(['B', '1']);
     expect(ReactNoop.getChildren()).toEqual([span('B'), span('1')]);
 
     // Unblock the low-pri text and finish
     await advanceTimers(0);
-    expect(ReactNoop.flush()).toEqual(['Promise resolved [2]']);
+    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [2]']);
     expect(ReactNoop.getChildren()).toEqual([span('B'), span('1')]);
   });
 
@@ -393,7 +387,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     expect(ReactNoop.getChildren()).toEqual([]);
 
     await advanceTimers(0);
-    expect(ReactNoop.flush()).toEqual(['Promise resolved [A]', 'A', 'B']);
+    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [A]']);
+    expect(ReactNoop.flush()).toEqual(['A', 'B']);
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
   });
 
@@ -460,7 +455,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Once the promise resolves, we render the suspended view
     await advanceTimers(10000);
-    expect(ReactNoop.flush()).toEqual(['Promise resolved [Async]', 'Async']);
+    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Async]']);
+    expect(ReactNoop.flush()).toEqual(['Async']);
     expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
   });
 
@@ -509,8 +505,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // timed out at 1.5 seconds. So, 2 seconds have elapsed since the
     // placeholder timed out. That means we still haven't reached the 2.5 second
     // threshold of the inner placeholder.
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop.clearYields()).toEqual([
       'Promise resolved [Outer content]',
+    ]);
+    expect(ReactNoop.flush()).toEqual([
       'Outer content',
       'Suspend! [Inner content]',
       'Loading inner...',
@@ -535,10 +533,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Finally, flush the inner promise. We should see the complete screen.
     ReactNoop.expire(1000);
     await advanceTimers(1000);
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop.clearYields()).toEqual([
       'Promise resolved [Inner content]',
-      'Inner content',
     ]);
+    expect(ReactNoop.flush()).toEqual(['Inner content']);
     expect(ReactNoop.getChildren()).toEqual([
       span('Sync'),
       span('Outer content'),
@@ -571,7 +569,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Once the promise resolves, we render the suspended view
     await advanceTimers(0);
-    expect(ReactNoop.flush()).toEqual(['Promise resolved [Async]', 'Async']);
+    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Async]']);
+    expect(ReactNoop.flush()).toEqual(['Async']);
     expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
   });
 
@@ -628,7 +627,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Once the promise resolves, we render the suspended view
     await advanceTimers(1000);
-    expect(ReactNoop.flush()).toEqual(['Promise resolved [Async]', 'Async']);
+    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Async]']);
+    expect(ReactNoop.flush()).toEqual(['Async']);
     expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
   });
 
@@ -672,12 +672,11 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     await advanceTimers(100);
 
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop.clearYields()).toEqual([
       'Promise resolved [A]',
       'Promise resolved [B]',
-      'A',
-      'B',
     ]);
+    expect(ReactNoop.flush()).toEqual(['A', 'B']);
     expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
   });
 
@@ -701,7 +700,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Resolve the promise
     await advanceTimers(1);
     // We can now resume rendering
-    expect(ReactNoop.flush()).toEqual(['Promise resolved [Async]', 'Async']);
+    expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Async]']);
+    expect(ReactNoop.flush()).toEqual(['Async']);
     expect(ReactNoop.getChildren()).toEqual([span('Async')]);
   });
 
@@ -747,10 +747,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     await advanceTimers(10000);
     // Flush the remaining work.
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop.clearYields()).toEqual([
       'Promise resolved [A]',
       'Promise resolved [B]',
     ]);
+    // Nothing else to render.
+    expect(ReactNoop.flush()).toEqual([]);
     expect(ReactNoop.getChildren()).toEqual([span('C')]);
   });
 
@@ -863,8 +865,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ]);
       expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
 
+      ReactNoop.expire(100);
       await advanceTimers(100);
-      expect(ReactNoop.expire(100)).toEqual([
+      expect(ReactNoop.clearYields()).toEqual([
         'Promise resolved [Result]',
         'Result',
       ]);
@@ -945,7 +948,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
 
       await advanceTimers(100);
-      expect(ReactNoop.flush()).toEqual([
+      expect(ReactNoop.clearYields()).toEqual([
         'Promise resolved [Step: 2]',
         'Step: 2',
       ]);
@@ -1289,8 +1292,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </React.Fragment>,
       );
 
+      ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(ReactNoop.expire(1000)).toEqual(['Promise resolved [B]', 'B']);
+      expect(ReactNoop.clearYields()).toEqual(['Promise resolved [B]', 'B']);
 
       expect(ReactNoop.getChildrenAsJSX()).toEqual(
         <React.Fragment>
@@ -1377,8 +1381,16 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
 
       ReactNoop.renderLegacySyncRoot(<Demo />);
+
+      expect(ReactNoop.clearYields()).toEqual([
+        'Suspend! [Hi]',
+        'Loading...',
+        // Re-render due to lifecycle update
+        'Loading...',
+      ]);
       expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
       await advanceTimers(100);
+      expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Hi]', 'Hi']);
       expect(ReactNoop.getChildren()).toEqual([span('Hi')]);
     });
 

--- a/packages/react-reconciler/src/__tests__/ReactTopLevelFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTopLevelFragment-test.js
@@ -27,7 +27,7 @@ describe('ReactTopLevelFragment', function() {
       return [<div key="a">Hello</div>, <div key="b">World</div>];
     }
     ReactNoop.render(<Fragment />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
   });
 
   it('should preserve state when switching from a single child', function() {
@@ -48,14 +48,14 @@ describe('ReactTopLevelFragment', function() {
       );
     }
     ReactNoop.render(<Fragment />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     const instanceA = instance;
 
     expect(instanceA).not.toBe(null);
 
     ReactNoop.render(<Fragment condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     const instanceB = instance;
 
@@ -80,14 +80,14 @@ describe('ReactTopLevelFragment', function() {
       );
     }
     ReactNoop.render(<Fragment />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     const instanceA = instance;
 
     expect(instanceA).not.toBe(null);
 
     ReactNoop.render(<Fragment condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     const instanceB = instance;
 
@@ -110,21 +110,21 @@ describe('ReactTopLevelFragment', function() {
         : [<div key="b">Hello</div>, <Stateful key="a" />];
     }
     ReactNoop.render(<Fragment />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     const instanceA = instance;
 
     expect(instanceA).not.toBe(null);
 
     ReactNoop.render(<Fragment condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     const instanceB = instance;
 
     expect(instanceB).toBe(instanceA);
 
     ReactNoop.render(<Fragment condition={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     const instanceC = instance;
 
@@ -147,14 +147,14 @@ describe('ReactTopLevelFragment', function() {
         : [[<Stateful key="a" />, <div key="b">World</div>], <div key="c" />];
     }
     ReactNoop.render(<Fragment />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     const instanceA = instance;
 
     expect(instanceA).not.toBe(null);
 
     ReactNoop.render(<Fragment condition={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
 
     const instanceB = instance;
 

--- a/packages/react-reconciler/src/__tests__/ReactTopLevelText-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTopLevelText-test.js
@@ -25,14 +25,14 @@ describe('ReactTopLevelText', () => {
   it('should render a component returning strings directly from render', () => {
     const Text = ({value}) => value;
     ReactNoop.render(<Text value="foo" />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildrenAsJSX()).toEqual('foo');
+    expect(ReactNoop).toFlushWithoutYielding();
+    expect(ReactNoop).toMatchRenderedOutput('foo');
   });
 
   it('should render a component returning numbers directly from render', () => {
     const Text = ({value}) => value;
     ReactNoop.render(<Text value={10} />);
-    ReactNoop.flush();
-    expect(ReactNoop.getChildrenAsJSX()).toEqual('10');
+    expect(ReactNoop).toFlushWithoutYielding();
+    expect(ReactNoop).toMatchRenderedOutput('10');
   });
 });

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -215,28 +215,16 @@ exports[`ReactDebugFiberPerf measures deferred work in chunks 1`] = `
 ⚛ (React Tree Reconciliation: Yielded)
   ⚛ Parent [mount]
     ⚛ A [mount]
-
-⚛ (Waiting for async callback... will force flush in 5250 ms)
-
-⚛ (React Tree Reconciliation: Yielded)
-  ⚛ Parent [mount]
-    ⚛ A [mount]
       ⚛ Child [mount]
     ⚛ B [mount]
 
 ⚛ (Waiting for async callback... will force flush in 5250 ms)
 
 // Complete the rest
-⚛ (React Tree Reconciliation: Yielded)
+⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
     ⚛ B [mount]
       ⚛ Child [mount]
-    ⚛ C [mount]
-
-⚛ (Waiting for async callback... will force flush in 5250 ms)
-
-⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ Parent [mount]
     ⚛ C [mount]
       ⚛ Child [mount]
 

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -1018,7 +1018,7 @@ describe('ReactTestRenderer', () => {
       </Context.Provider>
     );
     ReactNoop.render(<App />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     ReactTestRenderer.create(<App />);
   });
 

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -1101,7 +1101,7 @@ describe('Profiler', () => {
                     <errorInCompletePhase>hi</errorInCompletePhase>
                   </React.unstable_Profiler>,
                 );
-                expect(ReactNoop.flush).toThrow('Error in host config.');
+                expect(ReactNoop).toFlushAndThrow('Error in host config.');
 
                 // A similar case we've seen caused by an invariant in ReactDOM.
                 // It didn't reproduce without a host component inside.
@@ -1112,7 +1112,7 @@ describe('Profiler', () => {
                     </errorInCompletePhase>
                   </React.unstable_Profiler>,
                 );
-                expect(ReactNoop.flush).toThrow('Error in host config.');
+                expect(ReactNoop).toFlushAndThrow('Error in host config.');
 
                 // So long as the profiler timer's fiber stack is reset correctly,
                 // Subsequent renders should not error.
@@ -1121,7 +1121,7 @@ describe('Profiler', () => {
                     <span>hi</span>
                   </React.unstable_Profiler>,
                 );
-                ReactNoop.flush();
+                expect(ReactNoop).toFlushWithoutYielding();
               });
             });
           },
@@ -1242,7 +1242,7 @@ describe('Profiler', () => {
 
     // Process some async work, but yield before committing it.
     ReactNoop.renderToRootWithID(<Parent duration={7} id="two" />, 'two');
-    ReactNoop.flushThrough(['Child:render:two']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Child:render:two']);
 
     ReactNoop.advanceTime(150);
 
@@ -1254,8 +1254,11 @@ describe('Profiler', () => {
 
     ReactNoop.advanceTime(200);
 
-    expect(ReactNoop.clearYields()).toEqual(['Parent:componentDidMount:one']);
-    ReactNoop.flush();
+    expect(ReactNoop).toHaveYielded(['Parent:componentDidMount:one']);
+    expect(ReactNoop).toFlushAndYield([
+      'Child:render:two',
+      'Parent:componentDidMount:two',
+    ]);
 
     expect(ReactNoop.getRoot('two').current.actualDuration).toBe(14);
   });
@@ -2237,7 +2240,7 @@ describe('Profiler', () => {
         expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
         expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
 
-        expect(ReactNoop.flush()).toEqual([
+        expect(ReactNoop).toFlushAndYield([
           'Suspend [Async]',
           'Text [Loading...]',
           'Text [Sync]',
@@ -2269,13 +2272,13 @@ describe('Profiler', () => {
 
         // An unrelated update in the middle shouldn't affect things...
         monkey.current.forceUpdate();
-        expect(ReactNoop.flush()).toEqual(['Monkey']);
+        expect(ReactNoop).toFlushAndYield(['Monkey']);
         expect(onRender).toHaveBeenCalledTimes(2);
 
         // Once the promise resolves, we render the suspended view
         await awaitableAdvanceTimers(10000);
-        expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Async]']);
-        expect(ReactNoop.flush()).toEqual(['AsyncText [Async]']);
+        expect(ReactNoop).toHaveYielded(['Promise resolved [Async]']);
+        expect(ReactNoop).toFlushAndYield(['AsyncText [Async]']);
         expect(ReactNoop.getChildrenAsJSX()).toEqual('AsyncSync');
         expect(onRender).toHaveBeenCalledTimes(3);
 

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -1254,6 +1254,7 @@ describe('Profiler', () => {
 
     ReactNoop.advanceTime(200);
 
+    expect(ReactNoop.clearYields()).toEqual(['Parent:componentDidMount:one']);
     ReactNoop.flush();
 
     expect(ReactNoop.getRoot('two').current.actualDuration).toBe(14);
@@ -2273,10 +2274,8 @@ describe('Profiler', () => {
 
         // Once the promise resolves, we render the suspended view
         await awaitableAdvanceTimers(10000);
-        expect(ReactNoop.flush()).toEqual([
-          'Promise resolved [Async]',
-          'AsyncText [Async]',
-        ]);
+        expect(ReactNoop.clearYields()).toEqual(['Promise resolved [Async]']);
+        expect(ReactNoop.flush()).toEqual(['AsyncText [Async]']);
         expect(ReactNoop.getChildrenAsJSX()).toEqual('AsyncSync');
         expect(onRender).toHaveBeenCalledTimes(3);
 

--- a/packages/react/src/__tests__/forwardRef-test.internal.js
+++ b/packages/react/src/__tests__/forwardRef-test.internal.js
@@ -40,7 +40,7 @@ describe('forwardRef', () => {
     ));
 
     ReactNoop.render(<RefForwardingComponent value={123} />);
-    expect(ReactNoop.flush()).toEqual([123]);
+    expect(ReactNoop).toFlushAndYield([123]);
   });
 
   it('should forward a ref for a single child', () => {
@@ -62,7 +62,7 @@ describe('forwardRef', () => {
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} value={123} />);
-    expect(ReactNoop.flush()).toEqual([123]);
+    expect(ReactNoop).toFlushAndYield([123]);
     expect(ref.current instanceof Child).toBe(true);
   });
 
@@ -91,7 +91,7 @@ describe('forwardRef', () => {
         <div />
       </div>,
     );
-    expect(ReactNoop.flush()).toEqual([123]);
+    expect(ReactNoop).toFlushAndYield([123]);
     expect(ref.current instanceof Child).toBe(true);
   });
 
@@ -123,11 +123,11 @@ describe('forwardRef', () => {
     };
 
     ReactNoop.render(<RefForwardingComponent ref={setRef} value={123} />);
-    expect(ReactNoop.flush()).toEqual([123]);
+    expect(ReactNoop).toFlushAndYield([123]);
     expect(ref instanceof Child).toBe(true);
     expect(setRefCount).toBe(1);
     ReactNoop.render(<RefForwardingComponent ref={setRef} value={456} />);
-    expect(ReactNoop.flush()).toEqual([456]);
+    expect(ReactNoop).toFlushAndYield([456]);
     expect(ref instanceof Child).toBe(true);
     expect(setRefCount).toBe(1);
   });
@@ -172,7 +172,7 @@ describe('forwardRef', () => {
         <RefForwardingComponent ref={ref} />
       </ErrorBoundary>,
     );
-    expect(ReactNoop.flush()).toEqual([
+    expect(ReactNoop).toFlushAndYield([
       'ErrorBoundary.render: try',
       'Wrapper',
       'BadRender throw',
@@ -216,9 +216,9 @@ describe('forwardRef', () => {
     }
 
     ReactNoop.render(<App />);
-    expect(ReactNoop.flush()).toEqual(['App', 'Forward', 'Middle', 'Inner']);
+    expect(ReactNoop).toFlushAndYield(['App', 'Forward', 'Middle', 'Inner']);
 
     inst.setState({});
-    expect(ReactNoop.flush()).toEqual(['Inner']);
+    expect(ReactNoop).toFlushAndYield(['Inner']);
   });
 });

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -38,11 +38,11 @@ describe('forwardRef', () => {
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} setRefOnDiv={true} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ref.current.type).toBe('div');
 
     ReactNoop.render(<RefForwardingComponent ref={ref} setRefOnDiv={false} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ref.current.type).toBe('span');
   });
 
@@ -52,7 +52,7 @@ describe('forwardRef', () => {
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ref.current).toBe(null);
   });
 
@@ -68,7 +68,7 @@ describe('forwardRef', () => {
         <div />
       </div>,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ref.current).toBe(null);
   });
 
@@ -101,14 +101,14 @@ describe('forwardRef', () => {
     ReactNoop.render(
       <RefForwardingComponent ref={ref} optional="foo" required="bar" />,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ref.current.children).toEqual([
       {text: 'foo', hidden: false},
       {text: 'bar', hidden: false},
     ]);
 
     ReactNoop.render(<RefForwardingComponent ref={ref} required="foo" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(ref.current.children).toEqual([
       {text: 'default', hidden: false},
       {text: 'foo', hidden: false},
@@ -240,11 +240,11 @@ describe('forwardRef', () => {
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(1);
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(2);
   });
 
@@ -263,13 +263,13 @@ describe('forwardRef', () => {
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(1);
 
     expect(ref.current.type).toBe('div');
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(1);
 
     const differentRef = React.createRef();
@@ -277,14 +277,14 @@ describe('forwardRef', () => {
     ReactNoop.render(
       <RefForwardingComponent ref={differentRef} optional="foo" />,
     );
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(2);
 
     expect(ref.current).toBe(null);
     expect(differentRef.current.type).toBe('div');
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="bar" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(3);
   });
 
@@ -304,19 +304,19 @@ describe('forwardRef', () => {
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="0" c="1" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(1);
 
     expect(ref.current.type).toBe('div');
 
     // Changing either a or b rerenders
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="1" c="1" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(2);
 
     // Changing c doesn't rerender
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="1" c="2" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(2);
 
     const ComposedMemo = React.memo(
@@ -325,29 +325,29 @@ describe('forwardRef', () => {
     );
 
     ReactNoop.render(<ComposedMemo ref={ref} a="0" b="0" c="0" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(3);
 
     // Changing just b no longer updates
     ReactNoop.render(<ComposedMemo ref={ref} a="0" b="1" c="0" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(3);
 
     // Changing just a and c updates
     ReactNoop.render(<ComposedMemo ref={ref} a="2" b="2" c="2" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(4);
 
     // Changing just c does not update
     ReactNoop.render(<ComposedMemo ref={ref} a="2" b="2" c="3" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(4);
 
     // Changing ref still rerenders
     const differentRef = React.createRef();
 
     ReactNoop.render(<ComposedMemo ref={differentRef} a="2" b="2" c="3" />);
-    ReactNoop.flush();
+    expect(ReactNoop).toFlushWithoutYielding();
     expect(renderCount).toBe(5);
 
     expect(ref.current).toBe(null);

--- a/scripts/jest/matchers/reactTestMatchers.js
+++ b/scripts/jest/matchers/reactTestMatchers.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const JestReact = require('jest-react');
+
+function captureAssertion(fn) {
+  // Trick to use a Jest matcher inside another Jest matcher. `fn` contains an
+  // assertion; if it throws, we capture the error and return it, so the stack
+  // trace presented to the user points to the original assertion in the
+  // test file.
+  try {
+    fn();
+  } catch (error) {
+    return {
+      pass: false,
+      message: () => error.message,
+    };
+  }
+  return {pass: true};
+}
+
+function isReactNoop(obj) {
+  return typeof obj.hasScheduledCallback === 'function';
+}
+
+function assertYieldsWereCleared(ReactNoop) {
+  const actualYields = ReactNoop.unstable_clearYields();
+  if (actualYields.length !== 0) {
+    throw new Error(
+      'Log of yielded values is not empty. ' +
+        'Call expect(ReactNoop).toHaveYielded(...) first.'
+    );
+  }
+}
+
+function toFlushAndYield(ReactNoop, expectedYields) {
+  if (!isReactNoop(ReactNoop)) {
+    return JestReact.unstable_toFlushAndYield(ReactNoop, expectedYields);
+  }
+  assertYieldsWereCleared(ReactNoop);
+  const actualYields = ReactNoop.unstable_flushWithoutYielding();
+  return captureAssertion(() => {
+    expect(actualYields).toEqual(expectedYields);
+  });
+}
+
+function toFlushAndYieldThrough(ReactNoop, expectedYields) {
+  if (!isReactNoop(ReactNoop)) {
+    return JestReact.unstable_toFlushAndYieldThrough(ReactNoop, expectedYields);
+  }
+  assertYieldsWereCleared(ReactNoop);
+  const actualYields = ReactNoop.unstable_flushNumberOfYields(
+    expectedYields.length
+  );
+  return captureAssertion(() => {
+    expect(actualYields).toEqual(expectedYields);
+  });
+}
+
+function toFlushWithoutYielding(ReactNoop) {
+  if (!isReactNoop(ReactNoop)) {
+    return JestReact.unstable_toFlushWithoutYielding(ReactNoop);
+  }
+  return toFlushAndYield(ReactNoop, []);
+}
+
+function toHaveYielded(ReactNoop, expectedYields) {
+  if (!isReactNoop(ReactNoop)) {
+    return JestReact.unstable_toHaveYielded(ReactNoop, expectedYields);
+  }
+  return captureAssertion(() => {
+    const actualYields = ReactNoop.unstable_clearYields();
+    expect(actualYields).toEqual(expectedYields);
+  });
+}
+
+function toFlushAndThrow(ReactNoop, ...rest) {
+  if (!isReactNoop(ReactNoop)) {
+    return JestReact.unstable_toFlushAndThrow(ReactNoop, ...rest);
+  }
+  assertYieldsWereCleared(ReactNoop);
+  return captureAssertion(() => {
+    expect(() => {
+      ReactNoop.unstable_flushWithoutYielding();
+    }).toThrow(...rest);
+  });
+}
+
+function toMatchRenderedOutput(ReactNoop, expectedJSX) {
+  if (!isReactNoop(ReactNoop)) {
+    return JestReact.unstable_toMatchRenderedOutput(ReactNoop, expectedJSX);
+  }
+  assertYieldsWereCleared(ReactNoop);
+  return captureAssertion(() => {
+    expect(ReactNoop.getChildrenAsJSX()).toEqual(expectedJSX);
+  });
+}
+
+module.exports = {
+  toFlushAndYield,
+  toFlushAndYieldThrough,
+  toFlushWithoutYielding,
+  toHaveYielded,
+  toFlushAndThrow,
+  toMatchRenderedOutput,
+};

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -43,17 +43,10 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
     global.spyOnDevAndProd = spyOn;
   }
 
-  const JestReact = require('jest-react');
   expect.extend({
     ...require('./matchers/interactionTracing'),
     ...require('./matchers/toWarnDev'),
-
-    toFlushWithoutYielding: JestReact.unstable_toFlushWithoutYielding,
-    toFlushAndYield: JestReact.unstable_toFlushAndYield,
-    toFlushAndYieldThrough: JestReact.unstable_toFlushAndYieldThrough,
-    toHaveYielded: JestReact.unstable_toHaveYielded,
-    toFlushAndThrow: JestReact.unstable_toFlushAndThrow,
-    toMatchRenderedOutput: JestReact.unstable_toMatchRenderedOutput,
+    ...require('./matchers/reactTestMatchers'),
   });
 
   require('jest-mock-scheduler');

--- a/scripts/jest/spec-equivalence-reporter/setupTests.js
+++ b/scripts/jest/spec-equivalence-reporter/setupTests.js
@@ -45,17 +45,10 @@ global.spyOnProd = function(...args) {
   }
 };
 
-const JestReact = require('jest-react');
 expect.extend({
   ...require('../matchers/interactionTracing'),
   ...require('../matchers/toWarnDev'),
-
-  toFlushWithoutYielding: JestReact.unstable_toFlushWithoutYielding,
-  toFlushAndYield: JestReact.unstable_toFlushAndYield,
-  toFlushAndYieldThrough: JestReact.unstable_toFlushAndYieldThrough,
-  toHaveYielded: JestReact.unstable_toHaveYielded,
-  toFlushAndThrow: JestReact.unstable_toFlushAndThrow,
-  toMatchRenderedOutput: JestReact.unstable_toMatchRenderedOutput,
+  ...require('../matchers/reactTestMatchers'),
 });
 
 beforeEach(() => (numExpectations = 0));


### PR DESCRIPTION
The matchers will fail if you flush work while the log is empty. Makes it harder to miss unexpected
behavior by forcing you to assert on every logged value. This is the pattern we already follow for test renderer. I've used the same APIs as test renderer, so it should be easy to switch between the two.

This is a large diff but it's mostly a big find-and-replace. The most important changes are in createReactNoop and reactTestMatchers.