### PR TITLE
Warn if ReactNoop.act is not awaited

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
@@ -67,7 +67,7 @@ describe('ReactExpiration', () => {
     // work signals to the renderer that the event has ended.
     ReactNoop.advanceTime(2000);
     // Don't advance time by enough to expire the first update.
-    expect(ReactNoop.flushExpired()).toEqual([]);
+    ReactNoop.flushExpired();
     expect(ReactNoop.getChildren()).toEqual([]);
     // Schedule another update.
     ReactNoop.render(<Text text="B" />);
@@ -121,7 +121,7 @@ describe('ReactExpiration', () => {
       // work signals to the renderer that the event has ended.
       ReactNoop.advanceTime(2000);
       // Don't advance time by enough to expire the first update.
-      expect(ReactNoop.flushExpired()).toEqual([]);
+      ReactNoop.flushExpired();
       expect(ReactNoop.getChildren()).toEqual([]);
       // Schedule another update.
       ReactNoop.render(<Text text="B" />);

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -55,7 +55,7 @@ describe('ReactIncremental', () => {
 
     ReactNoop.render(<Foo />, () => ReactNoop.yield('callback'));
     // Do one step of work.
-    expect(ReactNoop.flushNextYield()).toEqual(['Foo']);
+    expect(ReactNoop).toFlushAndYieldThrough(['Foo']);
 
     // Do the rest of the work.
     expect(ReactNoop).toFlushAndYield(['Bar', 'Bar', 'callback']);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -114,7 +114,8 @@ describe('ReactIncrementalErrorHandling', () => {
 
     // Instead, it will try rendering one more time, synchronously, in case that
     // happens to fix the error.
-    expect(ReactNoop.flushNextYield()).toEqual([
+    ReactNoop.flushNextYield();
+    expect(ReactNoop).toHaveYielded([
       'ErrorBoundary (try)',
       'Indirection',
       'Indirection',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
@@ -640,6 +640,7 @@ describe('ReactIncrementalSideEffects', () => {
     // Now let's commit. We already had a commit that was pending, which will
     // render 2.
     ReactNoop.flushNextYield();
+    expect(ReactNoop).toHaveYielded(['Foo']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(<span prop={2} />);
     // If we flush the rest of the work, we should get another commit that
     // renders 3. If it renders 2 again, that means an update was dropped.

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -449,7 +449,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await advanceTimers(10000);
     // No additional rendering work is required, since we already prepared
     // the placeholder.
-    expect(ReactNoop.flushExpired()).toEqual([]);
+    ReactNoop.flushExpired();
     // Should have committed the placeholder.
     expect(ReactNoop.getChildren()).toEqual([span('Loading...'), span('Sync')]);
 
@@ -634,9 +634,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         <AsyncText text="Async" ms={3000} />
       </Suspense>,
     );
-    expect(ReactNoop.flushNextYield()).toEqual(['Suspend! [Async]']);
+    ReactNoop.flushNextYield();
+    expect(ReactNoop).toHaveYielded(['Suspend! [Async]']);
     await advanceTimers(1500);
-    expect(ReactNoop.expire(1500)).toEqual([]);
+    ReactNoop.expire(1500);
     // Before we have a chance to flush, the promise resolves.
     await advanceTimers(2000);
     expect(ReactNoop).toHaveYielded(['Promise resolved [Async]']);
@@ -659,7 +660,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         <AsyncText text="B" ms={100} />
       </Suspense>,
     );
-    expect(ReactNoop.expire(10000)).toEqual([
+    ReactNoop.expire(10000);
+    expect(ReactNoop).toHaveYielded([
       'Suspend! [A]',
       'Suspend! [B]',
       'Loading...',
@@ -920,7 +922,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
 
       // Suspend during an async render.
-      expect(ReactNoop.flushNextYield()).toEqual(['Suspend! [Step: 2]']);
+      ReactNoop.flushNextYield();
+      expect(ReactNoop).toHaveYielded(['Suspend! [Step: 2]']);
       expect(ReactNoop).toFlushAndYield([
         'Loading (1)',
         'Loading (2)',
@@ -1037,7 +1040,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         expect(ReactNoop).toFlushAndYieldThrough(['Before']);
 
         // Now render the next child, which suspends
-        expect(ReactNoop.flushNextYield()).toEqual([
+        ReactNoop.flushNextYield();
+        expect(ReactNoop).toHaveYielded([
           // This child suspends
           'Suspend! [Async: 2]',
         ]);
@@ -1172,7 +1176,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         expect(ReactNoop).toFlushAndYieldThrough(['Before']);
 
         // Now render the next child, which suspends
-        expect(ReactNoop.flushNextYield()).toEqual([
+        ReactNoop.flushNextYield();
+        expect(ReactNoop).toHaveYielded([
           // This child suspends
           'Suspend! [Async: 2]',
         ]);

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -2256,7 +2256,7 @@ describe('Profiler', () => {
         await awaitableAdvanceTimers(10000);
         // No additional rendering work is required, since we already prepared
         // the placeholder.
-        expect(ReactNoop.flushExpired()).toEqual([]);
+        ReactNoop.flushExpired();
         // Should have committed the placeholder.
         expect(ReactNoop.getChildrenAsJSX()).toEqual('Loading...Sync');
         expect(onRender).toHaveBeenCalledTimes(1);

--- a/scripts/jest/matchers/reactTestMatchers.js
+++ b/scripts/jest/matchers/reactTestMatchers.js
@@ -37,7 +37,8 @@ function toFlushAndYield(ReactNoop, expectedYields) {
     return JestReact.unstable_toFlushAndYield(ReactNoop, expectedYields);
   }
   assertYieldsWereCleared(ReactNoop);
-  const actualYields = ReactNoop.unstable_flushWithoutYielding();
+  ReactNoop.unstable_flushWithoutYielding();
+  const actualYields = ReactNoop.unstable_clearYields();
   return captureAssertion(() => {
     expect(actualYields).toEqual(expectedYields);
   });
@@ -48,9 +49,8 @@ function toFlushAndYieldThrough(ReactNoop, expectedYields) {
     return JestReact.unstable_toFlushAndYieldThrough(ReactNoop, expectedYields);
   }
   assertYieldsWereCleared(ReactNoop);
-  const actualYields = ReactNoop.unstable_flushNumberOfYields(
-    expectedYields.length
-  );
+  ReactNoop.unstable_flushNumberOfYields(expectedYields.length);
+  const actualYields = ReactNoop.unstable_clearYields();
   return captureAssertion(() => {
     expect(actualYields).toEqual(expectedYields);
   });


### PR DESCRIPTION
Based on #14952

Updates the noop renderer tests to conform to the changes coming in #14853. It overlaps slightly with that PR but it doesn't implement the logic to warn when you nest async `act` calls; it only adds a warning if you call `act` without awaiting it.

I'm not sure if we should merge this PR now or if we should wait for #14853 to land first. It may make sense to merge this one and then rebase Sunil's forthcoming changes on top of that.

In other words, @threepointone, feel free to ignore this PR if you like — it only exists to potentially make your life easier.