### PR TITLE
[ESLint] Allow extraneous effect dependencies

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -330,8 +330,18 @@ export default {
             duplicateDependencies.add(key);
           }
         } else {
-          // Unnecessary dependency. Do nothing.
-          unnecessaryDependencies.add(key);
+          if (isEffect && !key.endsWith('.current')) {
+            // Effects may have extra "unnecessary" deps.
+            // Such as resetting scroll when ID changes.
+            // The exception is ref.current which is always wrong.
+            // Consider them legit.
+            if (suggestedDependencies.indexOf(key) === -1) {
+              suggestedDependencies.push(key);
+            }
+          } else {
+            // Unnecessary dependency. Remember to report it.
+            unnecessaryDependencies.add(key);
+          }
         }
       });
 


### PR DESCRIPTION
This makes cases like

```js
  useEffect(() => {
    window.scrollTo(0, 0);
  }, [activeTab]);
```

not warn.

However, it still warns for unused `useCallback`/`useMemo` deps.

Sebastian didn't disagree with this.

Resolves https://github.com/facebook/react/issues/14920#issuecomment-467212561.