### PR TITLE
Avoid dynamic dispatch for scheduler calls

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -5,21 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  unstable_scheduleCallback as scheduleDeferredCallback,
-  unstable_cancelCallback as cancelDeferredCallback,
-} from 'scheduler';
-export {
-  unstable_now as now,
-  unstable_scheduleCallback as scheduleDeferredCallback,
-  unstable_shouldYield as shouldYield,
-  unstable_cancelCallback as cancelDeferredCallback,
-} from 'scheduler';
 import Transform from 'art/core/transform';
 import Mode from 'art/modes/current';
+import * as Scheduler from 'scheduler';
 import invariant from 'shared/invariant';
 
 import {TYPES, EVENT_TYPES, childrenAsString} from './ReactARTInternals';
+
+// Intentionally not named imports because Rollup would
+// use dynamic dispatch for CommonJS interop named imports.
+const {
+  unstable_now: now,
+  unstable_scheduleCallback: scheduleDeferredCallback,
+  unstable_shouldYield: shouldYield,
+  unstable_cancelCallback: cancelDeferredCallback,
+} = Scheduler;
+
+export {now, scheduleDeferredCallback, shouldYield, cancelDeferredCallback};
 
 const pooledTransform = new Transform();
 

--- a/packages/react-cache/src/LRU.js
+++ b/packages/react-cache/src/LRU.js
@@ -7,7 +7,11 @@
  * @flow
  */
 
-import {unstable_scheduleCallback as scheduleCallback} from 'scheduler';
+import * as Scheduler from 'scheduler';
+
+// Intentionally not named imports because Rollup would
+// use dynamic dispatch for CommonJS interop named imports.
+const {unstable_scheduleCallback: scheduleCallback} = Scheduler;
 
 type Entry<T> = {|
   value: T,

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import * as Scheduler from 'scheduler';
+
 import {precacheFiberNode, updateFiberProps} from './ReactDOMComponentTree';
 import {
   createElement,
@@ -70,17 +72,18 @@ export type ChildSet = void; // Unused
 export type TimeoutHandle = TimeoutID;
 export type NoTimeout = -1;
 
-import {
-  unstable_scheduleCallback as scheduleDeferredCallback,
-  unstable_cancelCallback as cancelDeferredCallback,
-} from 'scheduler';
 import {enableSuspenseServerRenderer} from 'shared/ReactFeatureFlags';
-export {
-  unstable_now as now,
-  unstable_scheduleCallback as scheduleDeferredCallback,
-  unstable_shouldYield as shouldYield,
-  unstable_cancelCallback as cancelDeferredCallback,
-} from 'scheduler';
+
+// Intentionally not named imports because Rollup would
+// use dynamic dispatch for CommonJS interop named imports.
+const {
+  unstable_now: now,
+  unstable_scheduleCallback: scheduleDeferredCallback,
+  unstable_shouldYield: shouldYield,
+  unstable_cancelCallback: cancelDeferredCallback,
+} = Scheduler;
+
+export {now, scheduleDeferredCallback, shouldYield, cancelDeferredCallback};
 
 let SUPPRESS_HYDRATION_WARNING;
 if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -17,16 +17,7 @@ import {
   __subscriberRef,
   unstable_wrap as Scheduler_tracing_wrap,
 } from 'scheduler/tracing';
-import {
-  unstable_next as Scheduler_next,
-  unstable_getCurrentPriorityLevel as getCurrentPriorityLevel,
-  unstable_runWithPriority as runWithPriority,
-  unstable_ImmediatePriority as ImmediatePriority,
-  unstable_UserBlockingPriority as UserBlockingPriority,
-  unstable_NormalPriority as NormalPriority,
-  unstable_LowPriority as LowPriority,
-  unstable_IdlePriority as IdlePriority,
-} from 'scheduler';
+import * as Scheduler from 'scheduler';
 import {
   invokeGuardedCallback,
   hasCaughtError,
@@ -180,6 +171,19 @@ import {ContextOnlyDispatcher} from './ReactFiberHooks';
 export type Thenable = {
   then(resolve: () => mixed, reject?: () => mixed): mixed,
 };
+
+// Intentionally not named imports because Rollup would
+// use dynamic dispatch for CommonJS interop named imports.
+const {
+  unstable_next: Scheduler_next,
+  unstable_getCurrentPriorityLevel: getCurrentPriorityLevel,
+  unstable_runWithPriority: runWithPriority,
+  unstable_ImmediatePriority: ImmediatePriority,
+  unstable_UserBlockingPriority: UserBlockingPriority,
+  unstable_NormalPriority: NormalPriority,
+  unstable_LowPriority: LowPriority,
+  unstable_IdlePriority: IdlePriority,
+} = Scheduler;
 
 const {ReactCurrentDispatcher, ReactCurrentOwner} = ReactSharedInternals;
 

--- a/packages/react/src/ReactSharedInternals.js
+++ b/packages/react/src/ReactSharedInternals.js
@@ -6,35 +6,8 @@
  */
 
 import assign from 'object-assign';
-import {
-  unstable_cancelCallback,
-  unstable_shouldYield,
-  unstable_now,
-  unstable_scheduleCallback,
-  unstable_runWithPriority,
-  unstable_next,
-  unstable_getFirstCallbackNode,
-  unstable_pauseExecution,
-  unstable_continueExecution,
-  unstable_wrapCallback,
-  unstable_getCurrentPriorityLevel,
-  unstable_IdlePriority,
-  unstable_ImmediatePriority,
-  unstable_LowPriority,
-  unstable_NormalPriority,
-  unstable_UserBlockingPriority,
-} from 'scheduler';
-import {
-  __interactionsRef,
-  __subscriberRef,
-  unstable_clear,
-  unstable_getCurrent,
-  unstable_getThreadID,
-  unstable_subscribe,
-  unstable_trace,
-  unstable_unsubscribe,
-  unstable_wrap,
-} from 'scheduler/tracing';
+import * as Scheduler from 'scheduler';
+import * as SchedulerTracing from 'scheduler/tracing';
 import ReactCurrentDispatcher from './ReactCurrentDispatcher';
 import ReactCurrentOwner from './ReactCurrentOwner';
 import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
@@ -53,35 +26,8 @@ if (__UMD__) {
   // This re-export is only required for UMD bundles;
   // CJS bundles use the shared NPM package.
   Object.assign(ReactSharedInternals, {
-    Scheduler: {
-      unstable_cancelCallback,
-      unstable_shouldYield,
-      unstable_now,
-      unstable_scheduleCallback,
-      unstable_runWithPriority,
-      unstable_next,
-      unstable_wrapCallback,
-      unstable_getFirstCallbackNode,
-      unstable_pauseExecution,
-      unstable_continueExecution,
-      unstable_getCurrentPriorityLevel,
-      unstable_IdlePriority,
-      unstable_ImmediatePriority,
-      unstable_LowPriority,
-      unstable_NormalPriority,
-      unstable_UserBlockingPriority,
-    },
-    SchedulerTracing: {
-      __interactionsRef,
-      __subscriberRef,
-      unstable_clear,
-      unstable_getCurrent,
-      unstable_getThreadID,
-      unstable_subscribe,
-      unstable_trace,
-      unstable_unsubscribe,
-      unstable_wrap,
-    },
+    Scheduler,
+    SchedulerTracing,
   });
 }
 


### PR DESCRIPTION
I noticed our prod bundles have code like:

<img width="813" alt="screen shot 2019-02-27 at 4 00 48 pm" src="https://user-images.githubusercontent.com/810438/53503894-df7def80-3aa8-11e9-9059-b702616cfd88.png">

This is because `scheduler` is a CommonJS external module. Rollup calls named exports on these with dot notation. This seems very non-ideal in hot paths.

I'm not sure if there's an easy way to fix it on the build level. But scheduler is the only external module we use and it's easy to fix at callsites. So I just did that. Star imports for everything else stay an anti-pattern.

This also removes some re-export junk in the UMD bundle.

Fixed version:

<img width="617" alt="screen shot 2019-02-27 at 4 02 16 pm" src="https://user-images.githubusercontent.com/810438/53504026-16540580-3aa9-11e9-9129-d621ec3f6f2f.png">
