### PR TITLE
Replace noop's fake Scheduler implementation with mock Scheduler build

### DIFF
--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -18,6 +18,7 @@ import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {UpdateQueue} from 'react-reconciler/src/ReactUpdateQueue';
 import type {ReactNodeList} from 'shared/ReactTypes';
 
+import * as Scheduler from 'scheduler';
 import {createPortal} from 'shared/ReactPortal';
 import expect from 'expect';
 import {REACT_FRAGMENT_TYPE, REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
@@ -51,9 +52,6 @@ if (__DEV__) {
 }
 
 function createReactNoop(reconciler: Function, useMutation: boolean) {
-  let scheduledCallback = null;
-  let scheduledCallbackTimeout = -1;
-  let scheduledPassiveCallback = null;
   let instanceCounter = 0;
   let hostDiffCounter = 0;
   let hostUpdateCounter = 0;
@@ -218,8 +216,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     );
   }
 
-  let elapsedTimeInMs = 0;
-
   const sharedHostConfig = {
     getRootHostContext() {
       return NO_CONTEXT;
@@ -308,66 +304,23 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return inst;
     },
 
-    scheduleDeferredCallback(callback, options) {
-      if (scheduledCallback) {
-        throw new Error(
-          'Scheduling a callback twice is excessive. Instead, keep track of ' +
-            'whether the callback has already been scheduled.',
-        );
-      }
-      scheduledCallback = callback;
-      if (
-        typeof options === 'object' &&
-        options !== null &&
-        typeof options.timeout === 'number'
-      ) {
-        const newTimeout = options.timeout;
-        if (
-          scheduledCallbackTimeout === -1 ||
-          scheduledCallbackTimeout > newTimeout
-        ) {
-          scheduledCallbackTimeout = elapsedTimeInMs + newTimeout;
-        }
-      }
-      return 0;
-    },
+    scheduleDeferredCallback: Scheduler.unstable_scheduleCallback,
+    cancelDeferredCallback: Scheduler.unstable_cancelCallback,
 
-    cancelDeferredCallback() {
-      if (scheduledCallback === null) {
-        throw new Error('No callback is scheduled.');
-      }
-      scheduledCallback = null;
-      scheduledCallbackTimeout = -1;
-    },
-
-    shouldYield,
+    shouldYield: Scheduler.unstable_shouldYield,
 
     scheduleTimeout: setTimeout,
     cancelTimeout: clearTimeout,
     noTimeout: -1,
-    schedulePassiveEffects(callback) {
-      if (scheduledCallback) {
-        throw new Error(
-          'Scheduling a callback twice is excessive. Instead, keep track of ' +
-            'whether the callback has already been scheduled.',
-        );
-      }
-      scheduledPassiveCallback = callback;
-    },
-    cancelPassiveEffects() {
-      if (scheduledPassiveCallback === null) {
-        throw new Error('No passive effects callback is scheduled.');
-      }
-      scheduledPassiveCallback = null;
-    },
+
+    schedulePassiveEffects: Scheduler.unstable_scheduleCallback,
+    cancelPassiveEffects: Scheduler.unstable_cancelCallback,
 
     prepareForCommit(): void {},
 
     resetAfterCommit(): void {},
 
-    now(): number {
-      return elapsedTimeInMs;
-    },
+    now: Scheduler.unstable_now,
 
     isPrimaryRenderer: true,
     supportsHydration: false,
@@ -534,71 +487,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
   const roots = new Map();
   const DEFAULT_ROOT_ID = '<default>';
 
-  let yieldedValues: Array<mixed> = [];
-  let didStop: boolean = false;
-  let expectedNumberOfYields: number = -1;
-
-  function shouldYield() {
-    if (
-      expectedNumberOfYields !== -1 &&
-      yieldedValues.length >= expectedNumberOfYields &&
-      (scheduledCallbackTimeout === -1 ||
-        elapsedTimeInMs < scheduledCallbackTimeout)
-    ) {
-      // We yielded at least as many values as expected. Stop rendering.
-      didStop = true;
-      return true;
-    }
-    // Keep rendering.
-    return false;
-  }
-
-  function flushAll(): Array<mixed> {
-    yieldedValues = [];
-    while (scheduledCallback !== null) {
-      const cb = scheduledCallback;
-      scheduledCallback = null;
-      const didTimeout =
-        scheduledCallbackTimeout !== -1 &&
-        scheduledCallbackTimeout < elapsedTimeInMs;
-      cb(didTimeout);
-    }
-    const values = yieldedValues;
-    yieldedValues = [];
-    return values;
-  }
-
-  function flushNumberOfYields(count: number): Array<mixed> {
-    expectedNumberOfYields = count;
-    didStop = false;
-    yieldedValues = [];
-    try {
-      while (scheduledCallback !== null && !didStop) {
-        const cb = scheduledCallback;
-        scheduledCallback = null;
-        const didTimeout =
-          scheduledCallbackTimeout !== -1 &&
-          scheduledCallbackTimeout < elapsedTimeInMs;
-        cb(didTimeout);
-      }
-      return yieldedValues;
-    } finally {
-      expectedNumberOfYields = -1;
-      didStop = false;
-      yieldedValues = [];
-    }
-  }
-
-  function yieldValue(value: mixed): void {
-    yieldedValues.push(value);
-  }
-
-  function clearYields(): Array<mixed> {
-    const values = yieldedValues;
-    yieldedValues = [];
-    return values;
-  }
-
   function childToJSX(child, text) {
     if (text !== null) {
       return text;
@@ -653,6 +541,8 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
   }
 
   const ReactNoop = {
+    _Scheduler: Scheduler,
+
     getChildren(rootID: string = DEFAULT_ROOT_ID) {
       const container = rootContainers.get(rootID);
       if (container) {
@@ -763,14 +653,9 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return NoopRenderer.findHostInstance(component);
     },
 
-    // TODO: Should only be used via a Jest plugin (like we do with the
-    // test renderer).
-    unstable_flushWithoutYielding: flushAll,
-    unstable_flushNumberOfYields: flushNumberOfYields,
-    unstable_clearYields: clearYields,
-
     flushNextYield(): Array<mixed> {
-      return flushNumberOfYields(1);
+      Scheduler.unstable_flushNumberOfYields(1);
+      return Scheduler.unstable_clearYields();
     },
 
     flushWithHostCounters(
@@ -788,7 +673,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       hostUpdateCounter = 0;
       hostCloneCounter = 0;
       try {
-        flushAll();
+        Scheduler.flushAll();
         return useMutation
           ? {
               hostDiffCounter,
@@ -805,24 +690,13 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       }
     },
 
-    expire(ms: number): Array<mixed> {
-      ReactNoop.advanceTime(ms);
-      return ReactNoop.flushExpired();
-    },
-
-    advanceTime(ms: number): void {
-      elapsedTimeInMs += ms;
-    },
+    expire: Scheduler.advanceTime,
 
     flushExpired(): Array<mixed> {
-      return flushNumberOfYields(0);
+      return Scheduler.unstable_flushExpired();
     },
 
-    yield: yieldValue,
-
-    hasScheduledCallback() {
-      return !!scheduledCallback;
-    },
+    yield: Scheduler.yieldValue,
 
     batchedUpdates: NoopRenderer.batchedUpdates,
 
@@ -870,9 +744,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     },
 
     flushSync(fn: () => mixed) {
-      yieldedValues = [];
       NoopRenderer.flushSync(fn);
-      return yieldedValues;
     },
 
     flushPassiveEffects() {
@@ -997,12 +869,13 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         _next: null,
       };
       root.firstBatch = batch;
-      const actual = flushAll();
+      Scheduler.unstable_flushWithoutYielding();
+      const actual = Scheduler.unstable_clearYields();
       expect(actual).toEqual(expectedFlush);
       return (expectedCommit: Array<mixed>) => {
         batch._defer = false;
         NoopRenderer.flushRoot(root, expiration);
-        expect(yieldedValues).toEqual(expectedCommit);
+        expect(Scheduler.unstable_clearYields()).toEqual(expectedCommit);
       };
     },
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -18,7 +18,7 @@ import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {UpdateQueue} from 'react-reconciler/src/ReactUpdateQueue';
 import type {ReactNodeList} from 'shared/ReactTypes';
 
-import * as Scheduler from 'scheduler';
+import * as Scheduler from 'scheduler/unstable_mock';
 import {createPortal} from 'shared/ReactPortal';
 import expect from 'expect';
 import {REACT_FRAGMENT_TYPE, REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -2862,9 +2862,7 @@ describe('ReactIncremental', () => {
     expect(ReactNoop).toFlushAndYieldThrough(['Parent: 1']);
 
     // Interrupt at higher priority
-    expect(
-      ReactNoop.flushSync(() => ReactNoop.render(<Parent step={2} />)),
-    ).toEqual(['Parent: 2', 'Child: 2']);
+    ReactNoop.flushSync(() => ReactNoop.render(<Parent step={2} />));
     expect(ReactNoop).toHaveYielded(['Parent: 2', 'Child: 2']);
 
     expect(ReactNoop).toFlushAndYield([]);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -283,7 +283,6 @@ describe('ReactDebugFiberPerf', () => {
       componentDidMount() {
         ReactNoop.renderToRootWithID(<Child />, 'b');
         addComment('Scheduling another root from componentDidMount');
-        expect(ReactNoop).toFlushWithoutYielding();
       }
       render() {
         return <div>{this.props.children}</div>;

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
@@ -361,37 +361,4 @@ describe('ReactIncrementalScheduling', () => {
       'componentDidUpdate: 2',
     ]);
   });
-
-  it('updates do not schedule a new callback if already inside a callback', () => {
-    class Foo extends React.Component {
-      state = {foo: 'foo'};
-      UNSAFE_componentWillReceiveProps() {
-        ReactNoop.yield(
-          'has callback before setState: ' + ReactNoop.hasScheduledCallback(),
-        );
-        this.setState({foo: 'baz'});
-        ReactNoop.yield(
-          'has callback after setState: ' + ReactNoop.hasScheduledCallback(),
-        );
-      }
-      render() {
-        return null;
-      }
-    }
-
-    ReactNoop.render(<Foo step={1} />);
-    expect(() => {
-      expect(ReactNoop).toFlushWithoutYielding();
-    }).toWarnDev(
-      'componentWillReceiveProps: Please update the following components ' +
-        'to use static getDerivedStateFromProps instead: Foo',
-      {withoutStack: true},
-    );
-
-    ReactNoop.render(<Foo step={2} />);
-    expect(ReactNoop).toFlushAndYield([
-      'has callback before setState: false',
-      'has callback after setState: false',
-    ]);
-  });
 });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
@@ -13,6 +13,7 @@
 let React;
 let ReactFeatureFlags;
 let ReactNoop;
+let Scheduler;
 
 describe('ReactIncrementalTriangle', () => {
   beforeEach(() => {
@@ -21,6 +22,7 @@ describe('ReactIncrementalTriangle', () => {
     ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
     React = require('react');
     ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
   });
 
   function span(prop) {
@@ -306,7 +308,7 @@ describe('ReactIncrementalTriangle', () => {
       } else {
         ReactNoop.render(<App remainingDepth={MAX_DEPTH} key={keyCounter++} />);
       }
-      ReactNoop.unstable_flushWithoutYielding();
+      Scheduler.unstable_flushWithoutYielding();
       assertConsistentTree();
       return appInstance;
     }
@@ -385,10 +387,10 @@ describe('ReactIncrementalTriangle', () => {
         ReactNoop.flushSync(() => {
           switch (action.type) {
             case FLUSH:
-              ReactNoop.unstable_flushNumberOfYields(action.unitsOfWork);
+              Scheduler.unstable_flushNumberOfYields(action.unitsOfWork);
               break;
             case FLUSH_ALL:
-              ReactNoop.unstable_flushWithoutYielding();
+              Scheduler.unstable_flushWithoutYielding();
               break;
             case STEP:
               ReactNoop.deferredUpdates(() => {
@@ -430,7 +432,7 @@ describe('ReactIncrementalTriangle', () => {
         assertConsistentTree(activeLeafIndices);
       }
       // Flush remaining work
-      ReactNoop.unstable_flushWithoutYielding();
+      Scheduler.unstable_flushWithoutYielding();
       assertConsistentTree(activeLeafIndices, expectedCounterAtEnd);
     }
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -13,6 +13,7 @@
 let React;
 let ReactFeatureFlags;
 let ReactNoop;
+let Scheduler;
 
 describe('ReactIncrementalUpdates', () => {
   beforeEach(() => {
@@ -21,6 +22,7 @@ describe('ReactIncrementalUpdates', () => {
     ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
     React = require('react');
     ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
   });
 
   function span(prop) {
@@ -456,33 +458,50 @@ describe('ReactIncrementalUpdates', () => {
   });
 
   it('flushes all expired updates in a single batch', () => {
-    class Foo extends React.Component {
-      componentDidUpdate() {
-        ReactNoop.yield('Commit: ' + this.props.prop);
-      }
-      componentDidMount() {
-        ReactNoop.yield('Commit: ' + this.props.prop);
-      }
-      render() {
-        ReactNoop.yield('Render: ' + this.props.prop);
-        return <span prop={this.props.prop} />;
-      }
+    const {useEffect} = React;
+
+    function App({label}) {
+      ReactNoop.yield('Render: ' + label);
+      useEffect(() => {
+        ReactNoop.yield('Commit: ' + label);
+      });
+      return label;
+    }
+
+    function interrupt() {
+      ReactNoop.flushSync(() => {
+        ReactNoop.renderToRootWithID(null, 'other-root');
+      });
     }
 
     // First, as a sanity check, assert what happens when four low pri
     // updates in separate batches are all flushed in the same callback
-    ReactNoop.render(<Foo prop="" />);
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.render(<Foo prop="he" />);
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.render(<Foo prop="hell" />);
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.render(<Foo prop="hello" />);
+    ReactNoop.render(<App label="" />);
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
 
-    // There should be a separate render and commit for each update
+    ReactNoop.render(<App label="he" />);
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
+
+    ReactNoop.render(<App label="hell" />);
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
+
+    ReactNoop.render(<App label="hello" />);
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
+
+    // Each update flushes in a separate commit.
+    // Note: This isn't necessarily the ideal behavior. It might be better to
+    // batch all of these updates together. The fact that they don't is an
+    // implementation detail. The important part of this unit test is what
+    // happens when they expire, in which case they really should be batched to
+    // avoid blocking the main thread for a long time.
     expect(ReactNoop).toFlushAndYield([
       'Render: ',
       'Commit: ',
@@ -493,65 +512,86 @@ describe('ReactIncrementalUpdates', () => {
       'Render: hello',
       'Commit: hello',
     ]);
-    expect(ReactNoop.getChildren()).toEqual([span('hello')]);
 
-    // Now do the same thing, except this time expire all the updates
-    // before flushing them.
-    ReactNoop.render(<Foo prop="" />);
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.render(<Foo prop="go" />);
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.render(<Foo prop="good" />);
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.render(<Foo prop="goodbye" />);
+    // Now do the same thing over again, but this time, expire all the updates
+    // instead of flushing them normally.
+    ReactNoop.render(<App label="" />);
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
 
-    ReactNoop.advanceTime(10000);
-    jest.advanceTimersByTime(10000);
+    ReactNoop.render(<App label="go" />);
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
+
+    ReactNoop.render(<App label="good" />);
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
+
+    ReactNoop.render(<App label="goodbye" />);
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
 
     // All the updates should render and commit in a single batch.
-    expect(ReactNoop).toFlushAndYield(['Render: goodbye', 'Commit: goodbye']);
-    expect(ReactNoop.getChildren()).toEqual([span('goodbye')]);
+    Scheduler.advanceTime(10000);
+    expect(ReactNoop).toHaveYielded(['Render: goodbye']);
+    // Passive effect
+    expect(ReactNoop).toFlushAndYield(['Commit: goodbye']);
   });
 
   it('flushes all expired updates in a single batch across multiple roots', () => {
     // Same as previous test, but with two roots.
-    class Foo extends React.Component {
-      componentDidUpdate() {
-        ReactNoop.yield('Commit: ' + this.props.prop);
-      }
-      componentDidMount() {
-        ReactNoop.yield('Commit: ' + this.props.prop);
-      }
-      render() {
-        ReactNoop.yield('Render: ' + this.props.prop);
-        return <span prop={this.props.prop} />;
-      }
+    const {useEffect} = React;
+
+    function App({label}) {
+      ReactNoop.yield('Render: ' + label);
+      useEffect(() => {
+        ReactNoop.yield('Commit: ' + label);
+      });
+      return label;
+    }
+
+    function interrupt() {
+      ReactNoop.flushSync(() => {
+        ReactNoop.renderToRootWithID(null, 'other-root');
+      });
     }
 
     // First, as a sanity check, assert what happens when four low pri
     // updates in separate batches are all flushed in the same callback
-    ReactNoop.renderToRootWithID(<Foo prop="" />, 'a');
-    ReactNoop.renderToRootWithID(<Foo prop="" />, 'b');
+    ReactNoop.renderToRootWithID(<App label="" />, 'a');
+    ReactNoop.renderToRootWithID(<App label="" />, 'b');
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
 
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.renderToRootWithID(<Foo prop="he" />, 'a');
-    ReactNoop.renderToRootWithID(<Foo prop="he" />, 'b');
+    ReactNoop.renderToRootWithID(<App label="he" />, 'a');
+    ReactNoop.renderToRootWithID(<App label="he" />, 'b');
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
 
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.renderToRootWithID(<Foo prop="hell" />, 'a');
-    ReactNoop.renderToRootWithID(<Foo prop="hell" />, 'b');
+    ReactNoop.renderToRootWithID(<App label="hell" />, 'a');
+    ReactNoop.renderToRootWithID(<App label="hell" />, 'b');
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
 
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.renderToRootWithID(<Foo prop="hello" />, 'a');
-    ReactNoop.renderToRootWithID(<Foo prop="hello" />, 'b');
+    ReactNoop.renderToRootWithID(<App label="hello" />, 'a');
+    ReactNoop.renderToRootWithID(<App label="hello" />, 'b');
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
 
-    // There should be a separate render and commit for each update
+    // Each update flushes in a separate commit.
+    // Note: This isn't necessarily the ideal behavior. It might be better to
+    // batch all of these updates together. The fact that they don't is an
+    // implementation detail. The important part of this unit test is what
+    // happens when they expire, in which case they really should be batched to
+    // avoid blocking the main thread for a long time.
     expect(ReactNoop).toFlushAndYield([
       'Render: ',
       'Commit: ',
@@ -570,37 +610,41 @@ describe('ReactIncrementalUpdates', () => {
       'Render: hello',
       'Commit: hello',
     ]);
-    expect(ReactNoop.getChildren('a')).toEqual([span('hello')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('hello')]);
 
-    // Now do the same thing, except this time expire all the updates
-    // before flushing them.
-    ReactNoop.renderToRootWithID(<Foo prop="" />, 'a');
-    ReactNoop.renderToRootWithID(<Foo prop="" />, 'b');
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.renderToRootWithID(<Foo prop="go" />, 'a');
-    ReactNoop.renderToRootWithID(<Foo prop="go" />, 'b');
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.renderToRootWithID(<Foo prop="good" />, 'a');
-    ReactNoop.renderToRootWithID(<Foo prop="good" />, 'b');
-    ReactNoop.expire(1000);
-    jest.advanceTimersByTime(1000);
-    ReactNoop.renderToRootWithID(<Foo prop="goodbye" />, 'a');
-    ReactNoop.renderToRootWithID(<Foo prop="goodbye" />, 'b');
+    // Now do the same thing over again, but this time, expire all the updates
+    // instead of flushing them normally.
+    ReactNoop.renderToRootWithID(<App label="" />, 'a');
+    ReactNoop.renderToRootWithID(<App label="" />, 'b');
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
 
-    ReactNoop.advanceTime(10000);
-    jest.advanceTimersByTime(10000);
+    ReactNoop.renderToRootWithID(<App label="go" />, 'a');
+    ReactNoop.renderToRootWithID(<App label="go" />, 'b');
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
+
+    ReactNoop.renderToRootWithID(<App label="good" />, 'a');
+    ReactNoop.renderToRootWithID(<App label="good" />, 'b');
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
+
+    ReactNoop.renderToRootWithID(<App label="goodbye" />, 'a');
+    ReactNoop.renderToRootWithID(<App label="goodbye" />, 'b');
+    Scheduler.advanceTime(1000);
+    expect(ReactNoop).toFlushAndYieldThrough(['Render: ']);
+    interrupt();
 
     // All the updates should render and commit in a single batch.
-    expect(ReactNoop).toFlushAndYield([
+    Scheduler.advanceTime(10000);
+    expect(ReactNoop).toHaveYielded([
       'Render: goodbye',
       'Commit: goodbye',
       'Render: goodbye',
-      'Commit: goodbye',
     ]);
-    expect(ReactNoop.getChildren('a')).toEqual([span('goodbye')]);
-    expect(ReactNoop.getChildren('b')).toEqual([span('goodbye')]);
+    // Passive effect
+    expect(ReactNoop).toFlushAndYield(['Commit: goodbye']);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -14,6 +14,7 @@ let ReactFeatureFlags = require('shared/ReactFeatureFlags');
 let React = require('react');
 let useContext;
 let ReactNoop;
+let Scheduler;
 let gen;
 
 describe('ReactNewContext', () => {
@@ -24,6 +25,7 @@ describe('ReactNewContext', () => {
     React = require('react');
     useContext = React.useContext;
     ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
     gen = require('random-seed');
   });
 
@@ -1769,10 +1771,10 @@ describe('ReactNewContext', () => {
         actions.forEach(action => {
           switch (action.type) {
             case FLUSH_ALL:
-              ReactNoop.unstable_flushWithoutYielding();
+              Scheduler.unstable_flushWithoutYielding();
               break;
             case FLUSH:
-              ReactNoop.unstable_flushNumberOfYields(action.unitsOfWork);
+              Scheduler.unstable_flushNumberOfYields(action.unitsOfWork);
               break;
             case UPDATE:
               finalExpectedValues = {
@@ -1787,7 +1789,7 @@ describe('ReactNewContext', () => {
           assertConsistentTree();
         });
 
-        ReactNoop.unstable_flushWithoutYielding();
+        Scheduler.unstable_flushWithoutYielding();
         assertConsistentTree(finalExpectedValues);
       }
 

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -169,7 +169,11 @@ const forks = Object.freeze({
   },
 
   'scheduler/src/SchedulerHostConfig': (bundleType, entry, dependencies) => {
-    if (entry === 'scheduler/unstable_mock') {
+    if (
+      entry === 'scheduler/unstable_mock' ||
+      entry === 'react-noop-renderer' ||
+      entry === 'react-noop-renderer/persistent'
+    ) {
       return 'scheduler/src/forks/SchedulerHostConfig.mock';
     }
     return 'scheduler/src/forks/SchedulerHostConfig.default';


### PR DESCRIPTION
The noop renderer has its own mock implementation of the Scheduler interface, with the ability to partially render work in tests. Now that this functionality has been lifted into a proper mock Scheduler build, we can use that instead.

Most of the existing noop tests were unaffected, but I did have to make some changes. The biggest one involved passive effects: previously, they were scheduled on a separate queue from the queue that handles rendering. After this change, both rendering and effects are scheduled in the Scheduler queue. I think this is a better approach because tests no longer have to worry about the difference; if you call `flushAll`, all the work is flushed, both rendering and effects. But for those few tests that do care to flush the rendering without the effects, that's still possible using the `yieldValue` API.

Follow-up: Do the same for test renderer.