### PR TITLE
[ESLint] Treat functions that don't capture anything as static

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -34,6 +34,22 @@ export default {
         : undefined;
     const options = {additionalHooks};
 
+    // Should be shared between visitors.
+    let staticKnownValueCache = new WeakMap();
+    let functionWithoutCapturedValueCache = new WeakMap();
+    function memoizeWithWeakMap(fn, map) {
+      return function(arg) {
+        if (map.has(arg)) {
+          // to verify cache hits:
+          // console.log(arg.name)
+          return map.get(arg);
+        }
+        const result = fn(arg);
+        map.set(arg, result);
+        return result;
+      };
+    }
+
     return {
       FunctionExpression: visitFunctionExpression,
       ArrowFunctionExpression: visitFunctionExpression,
@@ -105,6 +121,151 @@ export default {
         componentScope = currentScope;
       }
 
+      // Next we'll define a few helpers that helps us
+      // tell if some values don't have to be declared as deps.
+
+      // Some are known to be static based on Hook calls.
+      // const [state, setState] = useState() / React.useState()
+      //               ^^^ true for this reference
+      // const [state, dispatch] = useReducer() / React.useReducer()
+      //               ^^^ true for this reference
+      // const ref = useRef()
+      //       ^^^ true for this reference
+      // False for everything else.
+      function isStaticKnownHookValue(resolved) {
+        if (!Array.isArray(resolved.defs)) {
+          return false;
+        }
+        const def = resolved.defs[0];
+        if (def == null) {
+          return false;
+        }
+        // Look for `let stuff = ...`
+        if (def.node.type !== 'VariableDeclarator') {
+          return false;
+        }
+        const init = def.node.init;
+        if (init == null) {
+          return false;
+        }
+        // Detect primitive constants
+        // const foo = 42
+        const declaration = def.node.parent;
+        if (
+          declaration.kind === 'const' &&
+          init.type === 'Literal' &&
+          (typeof init.value === 'string' ||
+            typeof init.value === 'number' ||
+            init.value === null)
+        ) {
+          // Definitely static
+          return true;
+        }
+        // Detect known Hook calls
+        // const [_, setState] = useState()
+        if (init.type !== 'CallExpression') {
+          return false;
+        }
+        let callee = init.callee;
+        // Step into `= React.something` initializer.
+        if (
+          callee.type === 'MemberExpression' &&
+          callee.object.name === 'React' &&
+          callee.property != null &&
+          !callee.computed
+        ) {
+          callee = callee.property;
+        }
+        if (callee.type !== 'Identifier') {
+          return false;
+        }
+        const id = def.node.id;
+        if (callee.name === 'useRef' && id.type === 'Identifier') {
+          // useRef() return value is static.
+          return true;
+        } else if (callee.name === 'useState' || callee.name === 'useReducer') {
+          // Only consider second value in initializing tuple static.
+          if (
+            id.type === 'ArrayPattern' &&
+            id.elements.length === 2 &&
+            Array.isArray(resolved.identifiers) &&
+            // Is second tuple value the same reference we're checking?
+            id.elements[1] === resolved.identifiers[0]
+          ) {
+            return true;
+          }
+        }
+        // By default assume it's dynamic.
+        return false;
+      }
+
+      // Some are just functions that don't reference anything dynamic.
+      function isFunctionWithoutCapturedValues(resolved) {
+        if (!Array.isArray(resolved.defs)) {
+          return false;
+        }
+        const def = resolved.defs[0];
+        if (def == null) {
+          return false;
+        }
+        if (def.node == null || def.node.id == null) {
+          return false;
+        }
+        // Search the direct component subscopes for
+        // top-level function definitions matching this reference.
+        const fnNode = def.node;
+        let childScopes = componentScope.childScopes;
+        let fnScope = null;
+        let i;
+        for (i = 0; i < childScopes.length; i++) {
+          let childScope = childScopes[i];
+          let childScopeBlock = childScope.block;
+          if (
+            // function handleChange() {}
+            (fnNode.type === 'FunctionDeclaration' &&
+              childScopeBlock === fnNode) ||
+            // const handleChange = () => {}
+            // const handleChange = function() {}
+            (fnNode.type === 'VariableDeclarator' &&
+              childScopeBlock.parent === fnNode)
+          ) {
+            // Found it!
+            fnScope = childScope;
+            break;
+          }
+        }
+        if (fnScope == null) {
+          return false;
+        }
+        // Does this function capture any values
+        // that are either in pure scopes (aka render)?
+        for (i = 0; i < fnScope.through.length; i++) {
+          const ref = fnScope.through[i];
+          if (ref.resolved == null) {
+            continue;
+          }
+          if (
+            pureScopes.has(ref.resolved.scope) &&
+            // Static values are fine though,
+            // although we won't check functions deeper.
+            !memoizedIsStaticKnownHookValue(ref.resolved)
+          ) {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      // Remember such values. Avoid re-running extra checks on them.
+      const memoizedIsStaticKnownHookValue = memoizeWithWeakMap(
+        isStaticKnownHookValue,
+        staticKnownValueCache,
+      );
+      const memoizedIsFunctionWithoutCapturedValues = memoizeWithWeakMap(
+        isFunctionWithoutCapturedValues,
+        functionWithoutCapturedValueCache,
+      );
+
       // These are usually mistaken. Collect them.
       const currentRefsInEffectCleanup = new Map();
 
@@ -172,7 +333,10 @@ export default {
           // Add the dependency to a map so we can make sure it is referenced
           // again in our dependencies array. Remember whether it's static.
           if (!dependencies.has(dependency)) {
-            const isStatic = isDefinitelyStaticDependency(reference);
+            const resolved = reference.resolved;
+            const isStatic =
+              memoizedIsStaticKnownHookValue(resolved) ||
+              memoizedIsFunctionWithoutCapturedValues(resolved);
             dependencies.set(dependency, {
               isStatic,
               reference,
@@ -776,83 +940,6 @@ function getReactiveHookCallbackIndex(calleeNode, options) {
         return -1;
       }
   }
-}
-
-// const [state, setState] = useState() / React.useState()
-//               ^^^ true for this reference
-// const [state, dispatch] = useReducer() / React.useReducer()
-//               ^^^ true for this reference
-// const ref = useRef()
-//       ^^^ true for this reference
-// False for everything else.
-function isDefinitelyStaticDependency(reference) {
-  // This function is written defensively because I'm not sure about corner cases.
-  // TODO: we can strengthen this if we're sure about the types.
-  const resolved = reference.resolved;
-  if (resolved == null || !Array.isArray(resolved.defs)) {
-    return false;
-  }
-  const def = resolved.defs[0];
-  if (def == null) {
-    return false;
-  }
-  // Look for `let stuff = ...`
-  if (def.node.type !== 'VariableDeclarator') {
-    return false;
-  }
-  const init = def.node.init;
-  if (init == null) {
-    return false;
-  }
-  // Detect primitive constants
-  // const foo = 42
-  const declaration = def.node.parent;
-  if (
-    declaration.kind === 'const' &&
-    init.type === 'Literal' &&
-    (typeof init.value === 'string' ||
-      typeof init.value === 'number' ||
-      init.value === null)
-  ) {
-    // Definitely static
-    return true;
-  }
-  // Detect known Hook calls
-  // const [_, setState] = useState()
-  if (init.type !== 'CallExpression') {
-    return false;
-  }
-  let callee = init.callee;
-  // Step into `= React.something` initializer.
-  if (
-    callee.type === 'MemberExpression' &&
-    callee.object.name === 'React' &&
-    callee.property != null &&
-    !callee.computed
-  ) {
-    callee = callee.property;
-  }
-  if (callee.type !== 'Identifier') {
-    return false;
-  }
-  const id = def.node.id;
-  if (callee.name === 'useRef' && id.type === 'Identifier') {
-    // useRef() return value is static.
-    return true;
-  } else if (callee.name === 'useState' || callee.name === 'useReducer') {
-    // Only consider second value in initializing tuple static.
-    if (
-      id.type === 'ArrayPattern' &&
-      id.elements.length === 2 &&
-      Array.isArray(reference.resolved.identifiers) &&
-      // Is second tuple value the same reference we're checking?
-      id.elements[1] === reference.resolved.identifiers[0]
-    ) {
-      return true;
-    }
-  }
-  // By default assume it's dynamic.
-  return false;
 }
 
 /**

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -238,7 +238,7 @@ export default {
           return false;
         }
         // Does this function capture any values
-        // that are either in pure scopes (aka render)?
+        // that are in pure scopes (aka render)?
         for (i = 0; i < fnScope.through.length; i++) {
           const ref = fnScope.through[i];
           if (ref.resolved == null) {
@@ -253,6 +253,8 @@ export default {
             return false;
           }
         }
+        // If we got here, this function doesn't capture anything
+        // from render--or everything it captures is known static.
         return true;
       }
 


### PR DESCRIPTION
The exact heuristics will take me some time to figure out. This is just the first minimal draft.

It lifts the restriction on specifying functions as deps where it's safe. In particular, a function like

```js
  function tick() {
    setCount(c => c + 1);
  }
```

would be considered safe because it doesn't capture any render-phase values except knowingly static ones (we only do this if `setCount` comes from `useState` Hook).

So we could omit it:

```js
  useEffect(() => {
    let id = setInterval(() => {
      tick();
    }, 1000);
    return () => clearInterval(id);
  }, []); // No warning
```

But if we change `tick` to be

```js
  function tick() {
    setCount(count + 1);
  }
```

it would warn, asking you to add `tick` to dependencies.

We only do this check one level deep. So it helps for helper functions that only set state or dispatch, but you might end up in a situation where you can't add a prop to one of them without triggering warnings for all effects using it. Ideally we might want to push you to `useReducer` a bit sooner but I haven't figured out what a good flow is.

**This PR makes the rule strictly more relaxed. It doesn't add any new behaviors, it just fires the warnings less often in cases where it's safe.**

In follow-ups, we'll need to tweak the behavior and warnings to be more useful for functions. Such as we might want to detect the above special case and *suggest the updater form* if it would fix the warning. Similarly, we could detect always-new deps (like `tick`) and in that case suggest wrapping in `useCallback`.