### PR TITLE
fix(auto-version-update): update root package version while publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "version": "16.6.1",
   "workspaces": [
     "packages/*"
   ],

--- a/scripts/release/publish-commands/update-stable-version-numbers.js
+++ b/scripts/release/publish-commands/update-stable-version-numbers.js
@@ -36,14 +36,21 @@ const run = async ({cwd, packages, tags}) => {
 
   // Update the shared React version source file.
   const sourceReactVersionPath = join(cwd, 'packages/shared/ReactVersion.js');
-  const {version} = await readJson(
+  const {version: reactVersion} = await readJson(
     join(nodeModulesPath, 'react', 'package.json')
   );
   const sourceReactVersion = readFileSync(
     sourceReactVersionPath,
     'utf8'
-  ).replace(/module\.exports = '[^']+';/, `module.exports = '${version}';`);
+  ).replace(/module\.exports = '[^']+';/, `module.exports = '${reactVersion}';`);
   writeFileSync(sourceReactVersionPath, sourceReactVersion);
+
+  // Update root package version same as React version.
+  const rootPackageJSONPath = join(cwd, 'package.json');
+  const rootPackageJSON = await readJson(rootPackageJSONPath);
+  rootPackageJSON.version = reactVersion;
+
+  await writeJson(rootPackageJSONPath, rootPackageJSON, {spaces: 2});
 };
 
 module.exports = run;

--- a/scripts/release/publish-commands/update-stable-version-numbers.js
+++ b/scripts/release/publish-commands/update-stable-version-numbers.js
@@ -36,21 +36,14 @@ const run = async ({cwd, packages, tags}) => {
 
   // Update the shared React version source file.
   const sourceReactVersionPath = join(cwd, 'packages/shared/ReactVersion.js');
-  const {version: reactVersion} = await readJson(
+  const {version} = await readJson(
     join(nodeModulesPath, 'react', 'package.json')
   );
   const sourceReactVersion = readFileSync(
     sourceReactVersionPath,
     'utf8'
-  ).replace(/module\.exports = '[^']+';/, `module.exports = '${reactVersion}';`);
+  ).replace(/module\.exports = '[^']+';/, `module.exports = '${version}';`);
   writeFileSync(sourceReactVersionPath, sourceReactVersion);
-
-  // Update root package version same as React version.
-  const rootPackageJSONPath = join(cwd, 'package.json');
-  const rootPackageJSON = await readJson(rootPackageJSONPath);
-  rootPackageJSON.version = reactVersion;
-
-  await writeJson(rootPackageJSONPath, rootPackageJSON, {spaces: 2});
 };
 
 module.exports = run;


### PR DESCRIPTION
Fixes #14985 

Root Cause: #14201 

In `scripts/release/publish-commands` scripts we only updated the packages versions and the version in `ReactVersion.js`. But not the root package version.

**Possible Solutions**

- [ ] Updating the root package version number as per react version.
- [x] Remove version from root package json.