### PR TITLE
ReactNoop.yield -> Scheduler.yieldValue

### DIFF
--- a/packages/create-subscription/src/__tests__/createSubscription-test.internal.js
+++ b/packages/create-subscription/src/__tests__/createSubscription-test.internal.js
@@ -60,7 +60,7 @@ describe('createSubscription', () => {
     ReactNoop.render(
       <Subscription source={observable}>
         {(value = 'default') => {
-          ReactNoop.yield(value);
+          Scheduler.yieldValue(value);
           return null;
         }}
       </Subscription>,
@@ -97,7 +97,7 @@ describe('createSubscription', () => {
     });
 
     function render(value = 'default') {
-      ReactNoop.yield(value);
+      Scheduler.yieldValue(value);
       return null;
     }
 
@@ -126,9 +126,9 @@ describe('createSubscription', () => {
 
       function render(hasLoaded) {
         if (hasLoaded === undefined) {
-          ReactNoop.yield('loading');
+          Scheduler.yieldValue('loading');
         } else {
-          ReactNoop.yield(hasLoaded ? 'finished' : 'failed');
+          Scheduler.yieldValue(hasLoaded ? 'finished' : 'failed');
         }
         return null;
       }
@@ -169,7 +169,7 @@ describe('createSubscription', () => {
       });
 
       function render(value = 'default') {
-        ReactNoop.yield(value);
+        Scheduler.yieldValue(value);
         return null;
       }
 
@@ -203,7 +203,7 @@ describe('createSubscription', () => {
       });
 
       function render(hasLoaded) {
-        ReactNoop.yield('rendered');
+        Scheduler.yieldValue('rendered');
         return null;
       }
 
@@ -235,7 +235,7 @@ describe('createSubscription', () => {
     });
 
     function render(value = 'default') {
-      ReactNoop.yield(value);
+      Scheduler.yieldValue(value);
       return null;
     }
 
@@ -268,7 +268,7 @@ describe('createSubscription', () => {
     const log = [];
 
     function Child({value}) {
-      ReactNoop.yield('Child: ' + value);
+      Scheduler.yieldValue('Child: ' + value);
       return null;
     }
 
@@ -305,7 +305,7 @@ describe('createSubscription', () => {
         return (
           <Subscription source={this.state.observed}>
             {(value = 'default') => {
-              ReactNoop.yield('Subscriber: ' + value);
+              Scheduler.yieldValue('Subscriber: ' + value);
               return <Child value={value} />;
             }}
           </Subscription>
@@ -355,7 +355,7 @@ describe('createSubscription', () => {
     const log = [];
 
     function Child({value}) {
-      ReactNoop.yield('Child: ' + value);
+      Scheduler.yieldValue('Child: ' + value);
       return null;
     }
 
@@ -392,7 +392,7 @@ describe('createSubscription', () => {
         return (
           <Subscription source={this.state.observed}>
             {(value = 'default') => {
-              ReactNoop.yield('Subscriber: ' + value);
+              Scheduler.yieldValue('Subscriber: ' + value);
               return <Child value={value} />;
             }}
           </Subscription>

--- a/packages/react-art/src/__tests__/ReactART-test.js
+++ b/packages/react-art/src/__tests__/ReactART-test.js
@@ -359,7 +359,7 @@ describe('ReactART', () => {
     const CurrentRendererContext = React.createContext(null);
 
     function Yield(props) {
-      ReactNoop.yield(props.value);
+      Scheduler.yieldValue(props.value);
       return null;
     }
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -696,8 +696,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return Scheduler.unstable_flushExpired();
     },
 
-    yield: Scheduler.yieldValue,
-
     batchedUpdates: NoopRenderer.batchedUpdates,
 
     deferredUpdates: NoopRenderer.deferredUpdates,

--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
@@ -51,13 +51,13 @@ describe('ReactExpiration', () => {
   it('two updates of like priority in the same event always flush within the same batch', () => {
     class Text extends React.Component {
       componentDidMount() {
-        ReactNoop.yield(`${this.props.text} [commit]`);
+        Scheduler.yieldValue(`${this.props.text} [commit]`);
       }
       componentDidUpdate() {
-        ReactNoop.yield(`${this.props.text} [commit]`);
+        Scheduler.yieldValue(`${this.props.text} [commit]`);
       }
       render() {
-        ReactNoop.yield(`${this.props.text} [render]`);
+        Scheduler.yieldValue(`${this.props.text} [render]`);
         return <span prop={this.props.text} />;
       }
     }
@@ -116,13 +116,13 @@ describe('ReactExpiration', () => {
     () => {
       class Text extends React.Component {
         componentDidMount() {
-          ReactNoop.yield(`${this.props.text} [commit]`);
+          Scheduler.yieldValue(`${this.props.text} [commit]`);
         }
         componentDidUpdate() {
-          ReactNoop.yield(`${this.props.text} [commit]`);
+          Scheduler.yieldValue(`${this.props.text} [commit]`);
         }
         render() {
-          ReactNoop.yield(`${this.props.text} [render]`);
+          Scheduler.yieldValue(`${this.props.text} [render]`);
           return <span prop={this.props.text} />;
         }
       }
@@ -188,13 +188,13 @@ describe('ReactExpiration', () => {
       state = {text: store.text};
       componentDidMount() {
         subscribers.push(this);
-        ReactNoop.yield(`${this.state.text} [${this.props.label}] [commit]`);
+        Scheduler.yieldValue(`${this.state.text} [${this.props.label}] [commit]`);
       }
       componentDidUpdate() {
-        ReactNoop.yield(`${this.state.text} [${this.props.label}] [commit]`);
+        Scheduler.yieldValue(`${this.state.text} [${this.props.label}] [commit]`);
       }
       render() {
-        ReactNoop.yield(`${this.state.text} [${this.props.label}] [render]`);
+        Scheduler.yieldValue(`${this.state.text} [${this.props.label}] [render]`);
         return <span prop={this.state.text} />;
       }
     }

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -61,7 +61,7 @@ describe('ReactHooksWithNoopRenderer', () => {
   }
 
   function Text(props) {
-    ReactNoop.yield(props.text);
+    Scheduler.yieldValue(props.text);
     return <span prop={props.text} />;
   }
 
@@ -176,7 +176,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('lazy state initializer', () => {
       function Counter(props, ref) {
         const [count, updateCount] = useState(() => {
-          ReactNoop.yield('getInitialState');
+          Scheduler.yieldValue('getInitialState');
           return props.initialState;
         });
         useImperativeHandle(ref, () => ({updateCount}));
@@ -325,7 +325,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         if (count < 3) {
           setCount(count + 1);
         }
-        ReactNoop.yield('Render: ' + count);
+        Scheduler.yieldValue('Render: ' + count);
         return <Text text={count} />;
       }
 
@@ -348,7 +348,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           setCount(c => c + 1);
           setCount(c => c + 1);
         }
-        ReactNoop.yield('Render: ' + count);
+        Scheduler.yieldValue('Render: ' + count);
         return <Text text={count} />;
       }
 
@@ -369,7 +369,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       function Counter({row: newRow}) {
         let [count, setCount] = useState(0);
         setCount(count + 1);
-        ReactNoop.yield('Render: ' + count);
+        Scheduler.yieldValue('Render: ' + count);
         return <Text text={count} />;
       }
       ReactNoop.render(<Counter />);
@@ -388,7 +388,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         if (count < 3) {
           dispatch('increment');
         }
-        ReactNoop.yield('Render: ' + count);
+        Scheduler.yieldValue('Render: ' + count);
         return <Text text={count} />;
       }
 
@@ -437,7 +437,7 @@ describe('ReactHooksWithNoopRenderer', () => {
             setReducer(() => reducerA);
           }
         }
-        ReactNoop.yield('Render: ' + count);
+        Scheduler.yieldValue('Render: ' + count);
         return <Text text={count} />;
       }
       Counter = forwardRef(Counter);
@@ -529,7 +529,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       function Counter(props, ref) {
         const [count, dispatch] = useReducer(reducer, props, p => {
-          ReactNoop.yield('Init');
+          Scheduler.yieldValue('Init');
           return p.initialCount;
         });
         useImperativeHandle(ref, () => ({dispatch}));
@@ -597,12 +597,12 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('simple mount and update', () => {
       function Counter(props) {
         useEffect(() => {
-          ReactNoop.yield(`Passive effect [${props.count}]`);
+          Scheduler.yieldValue(`Passive effect [${props.count}]`);
         });
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -610,7 +610,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(Scheduler).toFlushAndYield(['Passive effect [0]']);
 
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
@@ -621,13 +621,13 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('flushes passive effects even with sibling deletions', () => {
       function LayoutEffect(props) {
         useLayoutEffect(() => {
-          ReactNoop.yield(`Layout effect`);
+          Scheduler.yieldValue(`Layout effect`);
         });
         return <Text text="Layout" />;
       }
       function PassiveEffect(props) {
         useEffect(() => {
-          ReactNoop.yield(`Passive effect`);
+          Scheduler.yieldValue(`Passive effect`);
         }, []);
         return <Text text="Passive" />;
       }
@@ -658,7 +658,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('flushes passive effects even if siblings schedule an update', () => {
       function PassiveEffect(props) {
         useEffect(() => {
-          ReactNoop.yield('Passive effect');
+          Scheduler.yieldValue('Passive effect');
         });
         return <Text text="Passive" />;
       }
@@ -669,7 +669,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           if (count === 0) {
             setCount(1);
           }
-          ReactNoop.yield('Layout effect ' + count);
+          Scheduler.yieldValue('Layout effect ' + count);
         });
         return <Text text="Layout" />;
       }
@@ -696,13 +696,13 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('flushes passive effects even if siblings schedule a new root', () => {
       function PassiveEffect(props) {
         useEffect(() => {
-          ReactNoop.yield('Passive effect');
+          Scheduler.yieldValue('Passive effect');
         }, []);
         return <Text text="Passive" />;
       }
       function LayoutEffect(props) {
         useLayoutEffect(() => {
-          ReactNoop.yield('Layout effect');
+          Scheduler.yieldValue('Layout effect');
           // Scheduling work shouldn't interfere with the queued passive effect
           ReactNoop.renderToRootWithID(<Text text="New Root" />, 'root2');
         });
@@ -736,21 +736,21 @@ describe('ReactHooksWithNoopRenderer', () => {
 
         function Counter(props) {
           useEffect(() => {
-            ReactNoop.yield(
+            Scheduler.yieldValue(
               `Committed state when effect was fired: ${getCommittedText()}`,
             );
           });
           return <Text text={props.count} />;
         }
         ReactNoop.render(<Counter count={0} />, () =>
-          ReactNoop.yield('Sync effect'),
+          Scheduler.yieldValue('Sync effect'),
         );
         expect(Scheduler).toFlushAndYieldThrough([0, 'Sync effect']);
         expect(ReactNoop.getChildren()).toEqual([span(0)]);
 
         // Before the effects have a chance to flush, schedule another update
         ReactNoop.render(<Counter count={1} />, () =>
-          ReactNoop.yield('Sync effect'),
+          Scheduler.yieldValue('Sync effect'),
         );
         expect(Scheduler).toHaveYielded([
           // The previous effect flushes before the reconciliation
@@ -771,7 +771,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         const [count, updateCount] = useState('(empty)');
         useEffect(
           () => {
-            ReactNoop.yield(`Schedule update [${props.count}]`);
+            Scheduler.yieldValue(`Schedule update [${props.count}]`);
             updateCount(props.count);
           },
           [props.count],
@@ -779,7 +779,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough([
         'Count: (empty)',
@@ -791,7 +791,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(Scheduler).toFlushAndYield(['Count: 0']);
 
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -805,7 +805,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         const [count, updateCount] = useState('(empty)');
         useEffect(
           () => {
-            ReactNoop.yield(`Schedule update [${props.count}]`);
+            Scheduler.yieldValue(`Schedule update [${props.count}]`);
             updateCount(props.count);
           },
           [props.count],
@@ -813,7 +813,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough([
         'Count: (empty)',
@@ -823,7 +823,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       // Rendering again should flush the previous commit's effects
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toHaveYielded(['Schedule update [0]']);
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0']);
@@ -844,14 +844,14 @@ describe('ReactHooksWithNoopRenderer', () => {
         const [count, updateCount] = useState(0);
         _updateCount = updateCount;
         useEffect(() => {
-          ReactNoop.yield(`Will set count to 1`);
+          Scheduler.yieldValue(`Will set count to 1`);
           updateCount(1);
         }, []);
         return <Text text={'Count: ' + count} />;
       }
 
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -884,7 +884,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           expect(SchedulerTracing.unstable_getCurrent()).toMatchInteractions([
             tracingEvent,
           ]);
-          ReactNoop.yield(`Will set count to 1`);
+          Scheduler.yieldValue(`Will set count to 1`);
           updateCount(1);
         }, []);
         return <Text text={'Count: ' + count} />;
@@ -896,7 +896,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         tracingEvent.timestamp,
         () => {
           ReactNoop.render(<Counter count={0} />, () =>
-            ReactNoop.yield('Sync effect'),
+            Scheduler.yieldValue('Sync effect'),
           );
         },
       );
@@ -955,7 +955,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         const [count, updateCount] = useState('(empty)');
         useEffect(
           () => {
-            ReactNoop.yield(`Schedule update [${props.count}]`);
+            Scheduler.yieldValue(`Schedule update [${props.count}]`);
             ReactNoop.flushSync(() => {
               updateCount(props.count);
             });
@@ -965,7 +965,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough([
         'Count: (empty)',
@@ -981,15 +981,15 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('unmounts previous effect', () => {
       function Counter(props) {
         useEffect(() => {
-          ReactNoop.yield(`Did create [${props.count}]`);
+          Scheduler.yieldValue(`Did create [${props.count}]`);
           return () => {
-            ReactNoop.yield(`Did destroy [${props.count}]`);
+            Scheduler.yieldValue(`Did destroy [${props.count}]`);
           };
         });
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -997,7 +997,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(Scheduler).toHaveYielded(['Did create [0]']);
 
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
@@ -1008,15 +1008,15 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('unmounts on deletion', () => {
       function Counter(props) {
         useEffect(() => {
-          ReactNoop.yield(`Did create [${props.count}]`);
+          Scheduler.yieldValue(`Did create [${props.count}]`);
           return () => {
-            ReactNoop.yield(`Did destroy [${props.count}]`);
+            Scheduler.yieldValue(`Did destroy [${props.count}]`);
           };
         });
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -1031,15 +1031,15 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('unmounts on deletion after skipped effect', () => {
       function Counter(props) {
         useEffect(() => {
-          ReactNoop.yield(`Did create [${props.count}]`);
+          Scheduler.yieldValue(`Did create [${props.count}]`);
           return () => {
-            ReactNoop.yield(`Did destroy [${props.count}]`);
+            Scheduler.yieldValue(`Did destroy [${props.count}]`);
           };
         }, []);
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -1047,7 +1047,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(Scheduler).toHaveYielded(['Did create [0]']);
 
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
@@ -1061,9 +1061,9 @@ describe('ReactHooksWithNoopRenderer', () => {
 
     it('always fires effects if no dependencies are provided', () => {
       function effect() {
-        ReactNoop.yield(`Did create`);
+        Scheduler.yieldValue(`Did create`);
         return () => {
-          ReactNoop.yield(`Did destroy`);
+          Scheduler.yieldValue(`Did destroy`);
         };
       }
       function Counter(props) {
@@ -1071,7 +1071,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -1079,7 +1079,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(Scheduler).toHaveYielded(['Did create']);
 
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
@@ -1096,9 +1096,9 @@ describe('ReactHooksWithNoopRenderer', () => {
         const text = `${props.label}: ${props.count}`;
         useEffect(
           () => {
-            ReactNoop.yield(`Did create [${text}]`);
+            Scheduler.yieldValue(`Did create [${text}]`);
             return () => {
-              ReactNoop.yield(`Did destroy [${text}]`);
+              Scheduler.yieldValue(`Did destroy [${text}]`);
             };
           },
           [props.label, props.count],
@@ -1106,7 +1106,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={text} />;
       }
       ReactNoop.render(<Counter label="Count" count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       ReactNoop.flushPassiveEffects();
@@ -1114,7 +1114,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       ReactNoop.render(<Counter label="Count" count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       // Count changed
       expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
@@ -1126,7 +1126,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       ]);
 
       ReactNoop.render(<Counter label="Count" count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       // Nothing changed, so no effect should have fired
       expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
@@ -1135,7 +1135,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
 
       ReactNoop.render(<Counter label="Total" count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       // Label changed
       expect(Scheduler).toFlushAndYieldThrough(['Total: 1', 'Sync effect']);
@@ -1150,15 +1150,15 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('multiple effects', () => {
       function Counter(props) {
         useEffect(() => {
-          ReactNoop.yield(`Did commit 1 [${props.count}]`);
+          Scheduler.yieldValue(`Did commit 1 [${props.count}]`);
         });
         useEffect(() => {
-          ReactNoop.yield(`Did commit 2 [${props.count}]`);
+          Scheduler.yieldValue(`Did commit 2 [${props.count}]`);
         });
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -1166,7 +1166,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(Scheduler).toHaveYielded(['Did commit 1 [0]', 'Did commit 2 [0]']);
 
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
@@ -1177,21 +1177,21 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('unmounts all previous effects before creating any new ones', () => {
       function Counter(props) {
         useEffect(() => {
-          ReactNoop.yield(`Mount A [${props.count}]`);
+          Scheduler.yieldValue(`Mount A [${props.count}]`);
           return () => {
-            ReactNoop.yield(`Unmount A [${props.count}]`);
+            Scheduler.yieldValue(`Unmount A [${props.count}]`);
           };
         });
         useEffect(() => {
-          ReactNoop.yield(`Mount B [${props.count}]`);
+          Scheduler.yieldValue(`Mount B [${props.count}]`);
           return () => {
-            ReactNoop.yield(`Unmount B [${props.count}]`);
+            Scheduler.yieldValue(`Unmount B [${props.count}]`);
           };
         });
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -1199,7 +1199,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(Scheduler).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
 
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
@@ -1215,24 +1215,24 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('handles errors on mount', () => {
       function Counter(props) {
         useEffect(() => {
-          ReactNoop.yield(`Mount A [${props.count}]`);
+          Scheduler.yieldValue(`Mount A [${props.count}]`);
           return () => {
-            ReactNoop.yield(`Unmount A [${props.count}]`);
+            Scheduler.yieldValue(`Unmount A [${props.count}]`);
           };
         });
         useEffect(() => {
-          ReactNoop.yield('Oops!');
+          Scheduler.yieldValue('Oops!');
           throw new Error('Oops!');
           // eslint-disable-next-line no-unreachable
-          ReactNoop.yield(`Mount B [${props.count}]`);
+          Scheduler.yieldValue(`Mount B [${props.count}]`);
           return () => {
-            ReactNoop.yield(`Unmount B [${props.count}]`);
+            Scheduler.yieldValue(`Unmount B [${props.count}]`);
           };
         });
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -1250,25 +1250,25 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('handles errors on update', () => {
       function Counter(props) {
         useEffect(() => {
-          ReactNoop.yield(`Mount A [${props.count}]`);
+          Scheduler.yieldValue(`Mount A [${props.count}]`);
           return () => {
-            ReactNoop.yield(`Unmount A [${props.count}]`);
+            Scheduler.yieldValue(`Unmount A [${props.count}]`);
           };
         });
         useEffect(() => {
           if (props.count === 1) {
-            ReactNoop.yield('Oops!');
+            Scheduler.yieldValue('Oops!');
             throw new Error('Oops!');
           }
-          ReactNoop.yield(`Mount B [${props.count}]`);
+          Scheduler.yieldValue(`Mount B [${props.count}]`);
           return () => {
-            ReactNoop.yield(`Unmount B [${props.count}]`);
+            Scheduler.yieldValue(`Unmount B [${props.count}]`);
           };
         });
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -1277,7 +1277,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       // This update will trigger an errror
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
@@ -1297,24 +1297,24 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('handles errors on unmount', () => {
       function Counter(props) {
         useEffect(() => {
-          ReactNoop.yield(`Mount A [${props.count}]`);
+          Scheduler.yieldValue(`Mount A [${props.count}]`);
           return () => {
-            ReactNoop.yield('Oops!');
+            Scheduler.yieldValue('Oops!');
             throw new Error('Oops!');
             // eslint-disable-next-line no-unreachable
-            ReactNoop.yield(`Unmount A [${props.count}]`);
+            Scheduler.yieldValue(`Unmount A [${props.count}]`);
           };
         });
         useEffect(() => {
-          ReactNoop.yield(`Mount B [${props.count}]`);
+          Scheduler.yieldValue(`Mount B [${props.count}]`);
           return () => {
-            ReactNoop.yield(`Unmount B [${props.count}]`);
+            Scheduler.yieldValue(`Unmount B [${props.count}]`);
           };
         });
         return <Text text={'Count: ' + props.count} />;
       }
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
@@ -1323,7 +1323,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       // This update will trigger an errror
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
       expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
@@ -1339,15 +1339,15 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('works with memo', () => {
       function Counter({count}) {
         useLayoutEffect(() => {
-          ReactNoop.yield('Mount: ' + count);
-          return () => ReactNoop.yield('Unmount: ' + count);
+          Scheduler.yieldValue('Mount: ' + count);
+          return () => Scheduler.yieldValue('Unmount: ' + count);
         });
         return <Text text={'Count: ' + count} />;
       }
       Counter = memo(Counter);
 
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough([
         'Count: 0',
@@ -1357,7 +1357,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
 
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough([
         'Count: 1',
@@ -1378,7 +1378,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       function getCommittedText() {
         const yields = Scheduler.unstable_clearYields();
         const children = ReactNoop.getChildren();
-        ReactNoop.yield(yields);
+        Scheduler.yieldValue(yields);
         if (children === null) {
           return null;
         }
@@ -1387,13 +1387,13 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       function Counter(props) {
         useLayoutEffect(() => {
-          ReactNoop.yield(`Current: ${getCommittedText()}`);
+          Scheduler.yieldValue(`Current: ${getCommittedText()}`);
         });
         return <Text text={props.count} />;
       }
 
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough([
         [0],
@@ -1403,7 +1403,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(ReactNoop.getChildren()).toEqual([span(0)]);
 
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough([
         [1],
@@ -1422,22 +1422,22 @@ describe('ReactHooksWithNoopRenderer', () => {
           // intentionally omits a mutation effect.
           committedText = props.count + '';
 
-          ReactNoop.yield(`Mount layout [current: ${committedText}]`);
+          Scheduler.yieldValue(`Mount layout [current: ${committedText}]`);
           return () => {
-            ReactNoop.yield(`Unmount layout [current: ${committedText}]`);
+            Scheduler.yieldValue(`Unmount layout [current: ${committedText}]`);
           };
         });
         useEffect(() => {
-          ReactNoop.yield(`Mount normal [current: ${committedText}]`);
+          Scheduler.yieldValue(`Mount normal [current: ${committedText}]`);
           return () => {
-            ReactNoop.yield(`Unmount normal [current: ${committedText}]`);
+            Scheduler.yieldValue(`Unmount normal [current: ${committedText}]`);
           };
         });
         return null;
       }
 
       ReactNoop.render(<Counter count={0} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough([
         'Mount layout [current: 0]',
@@ -1446,7 +1446,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(committedText).toEqual('0');
 
       ReactNoop.render(<Counter count={1} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toHaveYielded(['Mount normal [current: 0]']);
       expect(Scheduler).toFlushAndYieldThrough([
@@ -1535,7 +1535,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         const text = props.text;
         const capitalizedText = useMemo(
           () => {
-            ReactNoop.yield(`Capitalize '${text}'`);
+            Scheduler.yieldValue(`Capitalize '${text}'`);
             return text.toUpperCase();
           },
           [text],
@@ -1567,12 +1567,12 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       function computeA() {
-        ReactNoop.yield('compute A');
+        Scheduler.yieldValue('compute A');
         return 'A';
       }
 
       function computeB() {
-        ReactNoop.yield('compute B');
+        Scheduler.yieldValue('compute B');
         return 'B';
       }
 
@@ -1602,7 +1602,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       function compute(val) {
-        ReactNoop.yield('compute ' + val);
+        Scheduler.yieldValue('compute ' + val);
         return val;
       }
 
@@ -1642,7 +1642,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       function App() {
         ping = useDebouncedCallback(
           value => {
-            ReactNoop.yield('ping: ' + value);
+            Scheduler.yieldValue('ping: ' + value);
           },
           100,
           [],
@@ -1911,17 +1911,17 @@ describe('ReactHooksWithNoopRenderer', () => {
     it('unmount effects', () => {
       function App(props) {
         useEffect(() => {
-          ReactNoop.yield('Mount A');
+          Scheduler.yieldValue('Mount A');
           return () => {
-            ReactNoop.yield('Unmount A');
+            Scheduler.yieldValue('Unmount A');
           };
         }, []);
 
         if (props.showMore) {
           useEffect(() => {
-            ReactNoop.yield('Mount B');
+            Scheduler.yieldValue('Mount B');
             return () => {
-              ReactNoop.yield('Unmount B');
+              Scheduler.yieldValue('Unmount B');
             };
           }, []);
         }
@@ -1930,7 +1930,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<App showMore={false} />, () =>
-        ReactNoop.yield('Sync effect'),
+        Scheduler.yieldValue('Sync effect'),
       );
       expect(Scheduler).toFlushAndYieldThrough(['Sync effect']);
       ReactNoop.flushPassiveEffects();

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -42,7 +42,7 @@ describe('ReactIncremental', () => {
 
   it('should render a simple component, in steps if needed', () => {
     function Bar() {
-      ReactNoop.yield('Bar');
+      Scheduler.yieldValue('Bar');
       return (
         <span>
           <div>Hello World</div>
@@ -51,11 +51,11 @@ describe('ReactIncremental', () => {
     }
 
     function Foo() {
-      ReactNoop.yield('Foo');
+      Scheduler.yieldValue('Foo');
       return [<Bar key="a" isBar={true} />, <Bar key="b" isBar={true} />];
     }
 
-    ReactNoop.render(<Foo />, () => ReactNoop.yield('callback'));
+    ReactNoop.render(<Foo />, () => Scheduler.yieldValue('callback'));
     // Do one step of work.
     expect(ReactNoop.flushNextYield()).toEqual(['Foo']);
 
@@ -132,12 +132,12 @@ describe('ReactIncremental', () => {
 
   it('can cancel partially rendered work and restart', () => {
     function Bar(props) {
-      ReactNoop.yield('Bar');
+      Scheduler.yieldValue('Bar');
       return <div>{props.children}</div>;
     }
 
     function Foo(props) {
-      ReactNoop.yield('Foo');
+      Scheduler.yieldValue('Foo');
       return (
         <div>
           <Bar>{props.text}</Bar>
@@ -192,10 +192,10 @@ describe('ReactIncremental', () => {
 
     inst.setState(
       () => {
-        ReactNoop.yield('setState1');
+        Scheduler.yieldValue('setState1');
         return {text: 'bar'};
       },
-      () => ReactNoop.yield('callback1'),
+      () => Scheduler.yieldValue('callback1'),
     );
 
     // Flush part of the work
@@ -205,10 +205,10 @@ describe('ReactIncremental', () => {
     ReactNoop.flushSync(() => ReactNoop.render(<Foo />));
     inst.setState(
       () => {
-        ReactNoop.yield('setState2');
+        Scheduler.yieldValue('setState2');
         return {text2: 'baz'};
       },
-      () => ReactNoop.yield('callback2'),
+      () => Scheduler.yieldValue('callback2'),
     );
 
     // Flush the rest of the work which now includes the low priority
@@ -223,17 +223,17 @@ describe('ReactIncremental', () => {
 
   it('can deprioritize unfinished work and resume it later', () => {
     function Bar(props) {
-      ReactNoop.yield('Bar');
+      Scheduler.yieldValue('Bar');
       return <div>{props.children}</div>;
     }
 
     function Middle(props) {
-      ReactNoop.yield('Middle');
+      Scheduler.yieldValue('Middle');
       return <span>{props.children}</span>;
     }
 
     function Foo(props) {
-      ReactNoop.yield('Foo');
+      Scheduler.yieldValue('Foo');
       return (
         <div>
           <Bar>{props.text}</Bar>
@@ -1086,7 +1086,7 @@ describe('ReactIncremental', () => {
     class Foo extends React.PureComponent {
       render() {
         const msg = `A: ${a}, B: ${this.props.b}`;
-        ReactNoop.yield(msg);
+        Scheduler.yieldValue(msg);
         return msg;
       }
     }
@@ -1456,18 +1456,18 @@ describe('ReactIncremental', () => {
     class Parent extends React.Component {
       state = {parentRenders: 0};
       static getDerivedStateFromProps(props, prevState) {
-        ReactNoop.yield('getDerivedStateFromProps');
+        Scheduler.yieldValue('getDerivedStateFromProps');
         return prevState.parentRenders + 1;
       }
       render() {
-        ReactNoop.yield('Parent');
+        Scheduler.yieldValue('Parent');
         return <Child parentRenders={this.state.parentRenders} ref={child} />;
       }
     }
 
     class Child extends React.Component {
       render() {
-        ReactNoop.yield('Child');
+        Scheduler.yieldValue('Child');
         return this.props.parentRenders;
       }
     }
@@ -1819,7 +1819,7 @@ describe('ReactIncremental', () => {
         };
       }
       render() {
-        ReactNoop.yield('Intl ' + JSON.stringify(this.context));
+        Scheduler.yieldValue('Intl ' + JSON.stringify(this.context));
         return this.props.children;
       }
     }
@@ -1834,7 +1834,7 @@ describe('ReactIncremental', () => {
         };
       }
       render() {
-        ReactNoop.yield('Router ' + JSON.stringify(this.context));
+        Scheduler.yieldValue('Router ' + JSON.stringify(this.context));
         return this.props.children;
       }
     }
@@ -1844,7 +1844,7 @@ describe('ReactIncremental', () => {
         locale: PropTypes.string,
       };
       render() {
-        ReactNoop.yield('ShowLocale ' + JSON.stringify(this.context));
+        Scheduler.yieldValue('ShowLocale ' + JSON.stringify(this.context));
         return this.context.locale;
       }
     }
@@ -1854,13 +1854,13 @@ describe('ReactIncremental', () => {
         route: PropTypes.string,
       };
       render() {
-        ReactNoop.yield('ShowRoute ' + JSON.stringify(this.context));
+        Scheduler.yieldValue('ShowRoute ' + JSON.stringify(this.context));
         return this.context.route;
       }
     }
 
     function ShowBoth(props, context) {
-      ReactNoop.yield('ShowBoth ' + JSON.stringify(context));
+      Scheduler.yieldValue('ShowBoth ' + JSON.stringify(context));
       return `${context.route} in ${context.locale}`;
     }
     ShowBoth.contextTypes = {
@@ -1870,14 +1870,14 @@ describe('ReactIncremental', () => {
 
     class ShowNeither extends React.Component {
       render() {
-        ReactNoop.yield('ShowNeither ' + JSON.stringify(this.context));
+        Scheduler.yieldValue('ShowNeither ' + JSON.stringify(this.context));
         return null;
       }
     }
 
     class Indirection extends React.Component {
       render() {
-        ReactNoop.yield('Indirection ' + JSON.stringify(this.context));
+        Scheduler.yieldValue('Indirection ' + JSON.stringify(this.context));
         return [
           <ShowLocale key="a" />,
           <ShowRoute key="b" />,
@@ -2049,7 +2049,7 @@ describe('ReactIncremental', () => {
         };
       }
       render() {
-        ReactNoop.yield('Intl ' + JSON.stringify(this.context));
+        Scheduler.yieldValue('Intl ' + JSON.stringify(this.context));
         return this.props.children;
       }
     }
@@ -2059,7 +2059,7 @@ describe('ReactIncremental', () => {
         locale: PropTypes.string,
       };
       render() {
-        ReactNoop.yield('ShowLocale ' + JSON.stringify(this.context));
+        Scheduler.yieldValue('ShowLocale ' + JSON.stringify(this.context));
         return this.context.locale;
       }
     }
@@ -2810,12 +2810,12 @@ describe('ReactIncremental', () => {
 
   it('does not interrupt for update at same priority', () => {
     function Parent(props) {
-      ReactNoop.yield('Parent: ' + props.step);
+      Scheduler.yieldValue('Parent: ' + props.step);
       return <Child step={props.step} />;
     }
 
     function Child(props) {
-      ReactNoop.yield('Child: ' + props.step);
+      Scheduler.yieldValue('Child: ' + props.step);
       return null;
     }
 
@@ -2830,12 +2830,12 @@ describe('ReactIncremental', () => {
 
   it('does not interrupt for update at lower priority', () => {
     function Parent(props) {
-      ReactNoop.yield('Parent: ' + props.step);
+      Scheduler.yieldValue('Parent: ' + props.step);
       return <Child step={props.step} />;
     }
 
     function Child(props) {
-      ReactNoop.yield('Child: ' + props.step);
+      Scheduler.yieldValue('Child: ' + props.step);
       return null;
     }
 
@@ -2851,12 +2851,12 @@ describe('ReactIncremental', () => {
 
   it('does interrupt for update at higher priority', () => {
     function Parent(props) {
-      ReactNoop.yield('Parent: ' + props.step);
+      Scheduler.yieldValue('Parent: ' + props.step);
       return <Child step={props.step} />;
     }
 
     function Child(props) {
-      ReactNoop.yield('Child: ' + props.step);
+      Scheduler.yieldValue('Child: ' + props.step);
       return null;
     }
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -45,31 +45,31 @@ describe('ReactIncrementalErrorHandling', () => {
     class ErrorBoundary extends React.Component {
       state = {error: null};
       static getDerivedStateFromError(error) {
-        ReactNoop.yield('getDerivedStateFromError');
+        Scheduler.yieldValue('getDerivedStateFromError');
         return {error};
       }
       render() {
         if (this.state.error) {
-          ReactNoop.yield('ErrorBoundary (catch)');
+          Scheduler.yieldValue('ErrorBoundary (catch)');
           return <ErrorMessage error={this.state.error} />;
         }
-        ReactNoop.yield('ErrorBoundary (try)');
+        Scheduler.yieldValue('ErrorBoundary (try)');
         return this.props.children;
       }
     }
 
     function ErrorMessage(props) {
-      ReactNoop.yield('ErrorMessage');
+      Scheduler.yieldValue('ErrorMessage');
       return <span prop={`Caught an error: ${props.error.message}`} />;
     }
 
     function Indirection(props) {
-      ReactNoop.yield('Indirection');
+      Scheduler.yieldValue('Indirection');
       return props.children || null;
     }
 
     function BadRender() {
-      ReactNoop.yield('throw');
+      Scheduler.yieldValue('throw');
       throw new Error('oops!');
     }
 
@@ -138,31 +138,31 @@ describe('ReactIncrementalErrorHandling', () => {
     class ErrorBoundary extends React.Component {
       state = {error: null};
       componentDidCatch(error) {
-        ReactNoop.yield('componentDidCatch');
+        Scheduler.yieldValue('componentDidCatch');
         this.setState({error});
       }
       render() {
         if (this.state.error) {
-          ReactNoop.yield('ErrorBoundary (catch)');
+          Scheduler.yieldValue('ErrorBoundary (catch)');
           return <ErrorMessage error={this.state.error} />;
         }
-        ReactNoop.yield('ErrorBoundary (try)');
+        Scheduler.yieldValue('ErrorBoundary (try)');
         return this.props.children;
       }
     }
 
     function ErrorMessage(props) {
-      ReactNoop.yield('ErrorMessage');
+      Scheduler.yieldValue('ErrorMessage');
       return <span prop={`Caught an error: ${props.error.message}`} />;
     }
 
     function Indirection(props) {
-      ReactNoop.yield('Indirection');
+      Scheduler.yieldValue('Indirection');
       return props.children || null;
     }
 
     function BadRender() {
-      ReactNoop.yield('throw');
+      Scheduler.yieldValue('throw');
       throw new Error('oops!');
     }
 
@@ -217,15 +217,15 @@ describe('ReactIncrementalErrorHandling', () => {
   it("retries at a lower priority if there's additional pending work", () => {
     function App(props) {
       if (props.isBroken) {
-        ReactNoop.yield('error');
+        Scheduler.yieldValue('error');
         throw new Error('Oops!');
       }
-      ReactNoop.yield('success');
+      Scheduler.yieldValue('success');
       return <span prop="Everything is fine." />;
     }
 
     function onCommit() {
-      ReactNoop.yield('commit');
+      Scheduler.yieldValue('commit');
     }
 
     function interrupt() {
@@ -259,11 +259,11 @@ describe('ReactIncrementalErrorHandling', () => {
     class Parent extends React.Component {
       state = {hideChild: false};
       componentDidUpdate() {
-        ReactNoop.yield('commit: ' + this.state.hideChild);
+        Scheduler.yieldValue('commit: ' + this.state.hideChild);
       }
       render() {
         if (this.state.hideChild) {
-          ReactNoop.yield('(empty)');
+          Scheduler.yieldValue('(empty)');
           return <span prop="(empty)" />;
         }
         return <Child isBroken={this.props.childIsBroken} />;
@@ -272,10 +272,10 @@ describe('ReactIncrementalErrorHandling', () => {
 
     function Child(props) {
       if (props.isBroken) {
-        ReactNoop.yield('Error!');
+        Scheduler.yieldValue('Error!');
         throw new Error('Error!');
       }
-      ReactNoop.yield('Child');
+      Scheduler.yieldValue('Child');
       return <span prop="Child" />;
     }
 
@@ -309,19 +309,19 @@ describe('ReactIncrementalErrorHandling', () => {
     let ops = [];
     function BadRender() {
       ops.push('BadRender');
-      ReactNoop.yield('BadRender');
+      Scheduler.yieldValue('BadRender');
       throw new Error('oops');
     }
 
     function Sibling() {
       ops.push('Sibling');
-      ReactNoop.yield('Sibling');
+      Scheduler.yieldValue('Sibling');
       return <span prop="Sibling" />;
     }
 
     function Parent() {
       ops.push('Parent');
-      ReactNoop.yield('Parent');
+      Scheduler.yieldValue('Parent');
       return (
         <React.Fragment>
           <BadRender />
@@ -330,7 +330,7 @@ describe('ReactIncrementalErrorHandling', () => {
       );
     }
 
-    ReactNoop.render(<Parent />, () => ReactNoop.yield('commit'));
+    ReactNoop.render(<Parent />, () => Scheduler.yieldValue('commit'));
 
     // Render the bad component asynchronously
     expect(Scheduler).toFlushAndYieldThrough(['Parent', 'BadRender']);
@@ -355,7 +355,7 @@ describe('ReactIncrementalErrorHandling', () => {
         throw new Error(`Error ${++id}`);
       }
       render() {
-        ReactNoop.yield('BadMount');
+        Scheduler.yieldValue('BadMount');
         return null;
       }
     }
@@ -363,14 +363,14 @@ describe('ReactIncrementalErrorHandling', () => {
     class ErrorBoundary extends React.Component {
       state = {errorCount: 0};
       componentDidCatch(error) {
-        ReactNoop.yield(`componentDidCatch: ${error.message}`);
+        Scheduler.yieldValue(`componentDidCatch: ${error.message}`);
         this.setState(state => ({errorCount: state.errorCount + 1}));
       }
       render() {
         if (this.state.errorCount > 0) {
           return <span prop={`Number of errors: ${this.state.errorCount}`} />;
         }
-        ReactNoop.yield('ErrorBoundary');
+        Scheduler.yieldValue('ErrorBoundary');
         return this.props.children;
       }
     }
@@ -428,23 +428,23 @@ describe('ReactIncrementalErrorHandling', () => {
     class ErrorBoundary extends React.Component {
       state = {error: null};
       componentDidCatch(error) {
-        ReactNoop.yield('ErrorBoundary componentDidCatch');
+        Scheduler.yieldValue('ErrorBoundary componentDidCatch');
         this.setState({error});
       }
       render() {
         if (this.state.error) {
-          ReactNoop.yield('ErrorBoundary render error');
+          Scheduler.yieldValue('ErrorBoundary render error');
           return (
             <span prop={`Caught an error: ${this.state.error.message}.`} />
           );
         }
-        ReactNoop.yield('ErrorBoundary render success');
+        Scheduler.yieldValue('ErrorBoundary render success');
         return this.props.children;
       }
     }
 
     function BrokenRender(props) {
-      ReactNoop.yield('BrokenRender');
+      Scheduler.yieldValue('BrokenRender');
       throw new Error('Hello');
     }
 
@@ -601,17 +601,17 @@ describe('ReactIncrementalErrorHandling', () => {
   it('propagates an error from a noop error boundary during partial deferred mounting', () => {
     class RethrowErrorBoundary extends React.Component {
       componentDidCatch(error) {
-        ReactNoop.yield('RethrowErrorBoundary componentDidCatch');
+        Scheduler.yieldValue('RethrowErrorBoundary componentDidCatch');
         throw error;
       }
       render() {
-        ReactNoop.yield('RethrowErrorBoundary render');
+        Scheduler.yieldValue('RethrowErrorBoundary render');
         return this.props.children;
       }
     }
 
     function BrokenRender() {
-      ReactNoop.yield('BrokenRender');
+      Scheduler.yieldValue('BrokenRender');
       throw new Error('Hello');
     }
 
@@ -858,7 +858,7 @@ describe('ReactIncrementalErrorHandling', () => {
   it('should not attempt to recover an unmounting error boundary', () => {
     class Parent extends React.Component {
       componentWillUnmount() {
-        ReactNoop.yield('Parent componentWillUnmount');
+        Scheduler.yieldValue('Parent componentWillUnmount');
       }
       render() {
         return <Boundary />;
@@ -867,7 +867,7 @@ describe('ReactIncrementalErrorHandling', () => {
 
     class Boundary extends React.Component {
       componentDidCatch(e) {
-        ReactNoop.yield(`Caught error: ${e.message}`);
+        Scheduler.yieldValue(`Caught error: ${e.message}`);
       }
       render() {
         return <ThrowsOnUnmount />;
@@ -876,7 +876,7 @@ describe('ReactIncrementalErrorHandling', () => {
 
     class ThrowsOnUnmount extends React.Component {
       componentWillUnmount() {
-        ReactNoop.yield('ThrowsOnUnmount componentWillUnmount');
+        Scheduler.yieldValue('ThrowsOnUnmount componentWillUnmount');
         throw new Error('unmount error');
       }
       render() {
@@ -1406,31 +1406,31 @@ describe('ReactIncrementalErrorHandling', () => {
     class ErrorBoundary extends React.Component {
       state = {error: null};
       componentDidCatch(error) {
-        ReactNoop.yield('componentDidCatch');
+        Scheduler.yieldValue('componentDidCatch');
         this.setState({error});
       }
       render() {
         if (this.state.error) {
-          ReactNoop.yield('ErrorBoundary (catch)');
+          Scheduler.yieldValue('ErrorBoundary (catch)');
           return <ErrorMessage error={this.state.error} />;
         }
-        ReactNoop.yield('ErrorBoundary (try)');
+        Scheduler.yieldValue('ErrorBoundary (try)');
         return this.props.children;
       }
     }
 
     function ErrorMessage(props) {
-      ReactNoop.yield('ErrorMessage');
+      Scheduler.yieldValue('ErrorMessage');
       return <span prop={`Caught an error: ${props.error.message}`} />;
     }
 
     function BadRenderSibling(props) {
-      ReactNoop.yield('BadRenderSibling');
+      Scheduler.yieldValue('BadRenderSibling');
       return null;
     }
 
     function BadRender() {
-      ReactNoop.yield('throw');
+      Scheduler.yieldValue('throw');
       throw new Error('oops!');
     }
 
@@ -1468,25 +1468,25 @@ describe('ReactIncrementalErrorHandling', () => {
     // where we checked for the existence of didUpdate instead of didMount, and
     // didMount was not defined.
     function BadRender() {
-      ReactNoop.yield('throw');
+      Scheduler.yieldValue('throw');
       throw new Error('oops!');
     }
 
     class Parent extends React.Component {
       state = {error: null, other: false};
       componentDidCatch(error) {
-        ReactNoop.yield('did catch');
+        Scheduler.yieldValue('did catch');
         this.setState({error});
       }
       componentDidUpdate() {
-        ReactNoop.yield('did update');
+        Scheduler.yieldValue('did update');
       }
       render() {
         if (this.state.error) {
-          ReactNoop.yield('render error message');
+          Scheduler.yieldValue('render error message');
           return <span prop={`Caught an error: ${this.state.error.message}`} />;
         }
-        ReactNoop.yield('render');
+        Scheduler.yieldValue('render');
         return <BadRender />;
       }
     }
@@ -1512,7 +1512,7 @@ describe('ReactIncrementalErrorHandling', () => {
       }
       render() {
         if (this.state.errorInfo) {
-          ReactNoop.yield('render error message');
+          Scheduler.yieldValue('render error message');
           return (
             <span
               prop={`Caught an error:${normalizeCodeLocInfo(

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
@@ -167,10 +167,10 @@ describe('ReactIncrementalErrorLogging', () => {
         this.setState({step: 1});
       }
       componentWillUnmount() {
-        ReactNoop.yield('componentWillUnmount: ' + this.state.step);
+        Scheduler.yieldValue('componentWillUnmount: ' + this.state.step);
       }
       render() {
-        ReactNoop.yield('render: ' + this.state.step);
+        Scheduler.yieldValue('render: ' + this.state.step);
         if (this.state.step > 0) {
           throw new Error('oops');
         }

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -399,21 +399,21 @@ describe('ReactDebugFiberPerf', () => {
   it('measures deferred work in chunks', () => {
     class A extends React.Component {
       render() {
-        ReactNoop.yield('A');
+        Scheduler.yieldValue('A');
         return <div>{this.props.children}</div>;
       }
     }
 
     class B extends React.Component {
       render() {
-        ReactNoop.yield('B');
+        Scheduler.yieldValue('B');
         return <div>{this.props.children}</div>;
       }
     }
 
     class C extends React.Component {
       render() {
-        ReactNoop.yield('C');
+        Scheduler.yieldValue('C');
         return <div>{this.props.children}</div>;
       }
     }
@@ -644,7 +644,7 @@ describe('ReactDebugFiberPerf', () => {
 
   it('warns if an in-progress update is interrupted', () => {
     function Foo() {
-      ReactNoop.yield('Foo');
+      Scheduler.yieldValue('Foo');
       return <span />;
     }
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
@@ -47,10 +47,10 @@ describe('ReactIncrementalReflection', () => {
       }
       UNSAFE_componentWillMount() {
         instances.push(this);
-        ReactNoop.yield('componentWillMount: ' + this._isMounted());
+        Scheduler.yieldValue('componentWillMount: ' + this._isMounted());
       }
       componentDidMount() {
-        ReactNoop.yield('componentDidMount: ' + this._isMounted());
+        Scheduler.yieldValue('componentDidMount: ' + this._isMounted());
       }
       render() {
         return <span />;
@@ -91,16 +91,16 @@ describe('ReactIncrementalReflection', () => {
         instances.push(this);
       }
       componentWillUnmount() {
-        ReactNoop.yield('componentWillUnmount: ' + this._isMounted());
+        Scheduler.yieldValue('componentWillUnmount: ' + this._isMounted());
       }
       render() {
-        ReactNoop.yield('Component');
+        Scheduler.yieldValue('Component');
         return <span />;
       }
     }
 
     function Other() {
-      ReactNoop.yield('Other');
+      Scheduler.yieldValue('Other');
       return <span />;
     }
 
@@ -149,22 +149,22 @@ describe('ReactIncrementalReflection', () => {
     class Component extends React.Component {
       UNSAFE_componentWillMount() {
         classInstance = this;
-        ReactNoop.yield(['componentWillMount', findInstance(this)]);
+        Scheduler.yieldValue(['componentWillMount', findInstance(this)]);
       }
       componentDidMount() {
-        ReactNoop.yield(['componentDidMount', findInstance(this)]);
+        Scheduler.yieldValue(['componentDidMount', findInstance(this)]);
       }
       UNSAFE_componentWillUpdate() {
-        ReactNoop.yield(['componentWillUpdate', findInstance(this)]);
+        Scheduler.yieldValue(['componentWillUpdate', findInstance(this)]);
       }
       componentDidUpdate() {
-        ReactNoop.yield(['componentDidUpdate', findInstance(this)]);
+        Scheduler.yieldValue(['componentDidUpdate', findInstance(this)]);
       }
       componentWillUnmount() {
-        ReactNoop.yield(['componentWillUnmount', findInstance(this)]);
+        Scheduler.yieldValue(['componentWillUnmount', findInstance(this)]);
       }
       render() {
-        ReactNoop.yield('render');
+        Scheduler.yieldValue('render');
         return this.props.step < 2 ? (
           <span ref={ref => (this.span = ref)} />
         ) : this.props.step === 2 ? (
@@ -177,7 +177,7 @@ describe('ReactIncrementalReflection', () => {
 
     function Sibling() {
       // Sibling is used to assert that we've rendered past the first component.
-      ReactNoop.yield('render sibling');
+      Scheduler.yieldValue('render sibling');
       return <span />;
     }
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
@@ -92,7 +92,7 @@ describe('ReactIncrementalScheduling', () => {
     function Text({text}) {
       useEffect(
         () => {
-          ReactNoop.yield(text);
+          Scheduler.yieldValue(text);
         },
         [text],
       );
@@ -144,24 +144,24 @@ describe('ReactIncrementalScheduling', () => {
       state = {tick: 0};
 
       componentDidMount() {
-        ReactNoop.yield(
+        Scheduler.yieldValue(
           'componentDidMount (before setState): ' + this.state.tick,
         );
         this.setState({tick: 1});
         // We're in a batch. Update hasn't flushed yet.
-        ReactNoop.yield(
+        Scheduler.yieldValue(
           'componentDidMount (after setState): ' + this.state.tick,
         );
       }
 
       componentDidUpdate() {
-        ReactNoop.yield('componentDidUpdate: ' + this.state.tick);
+        Scheduler.yieldValue('componentDidUpdate: ' + this.state.tick);
         if (this.state.tick === 2) {
-          ReactNoop.yield(
+          Scheduler.yieldValue(
             'componentDidUpdate (before setState): ' + this.state.tick,
           );
           this.setState({tick: 3});
-          ReactNoop.yield(
+          Scheduler.yieldValue(
             'componentDidUpdate (after setState): ' + this.state.tick,
           );
           // We're in a batch. Update hasn't flushed yet.
@@ -169,7 +169,7 @@ describe('ReactIncrementalScheduling', () => {
       }
 
       render() {
-        ReactNoop.yield('render: ' + this.state.tick);
+        Scheduler.yieldValue('render: ' + this.state.tick);
         instance = this;
         return <span prop={this.state.tick} />;
       }
@@ -209,11 +209,11 @@ describe('ReactIncrementalScheduling', () => {
 
       componentDidMount() {
         ReactNoop.deferredUpdates(() => {
-          ReactNoop.yield(
+          Scheduler.yieldValue(
             'componentDidMount (before setState): ' + this.state.tick,
           );
           this.setState({tick: 1});
-          ReactNoop.yield(
+          Scheduler.yieldValue(
             'componentDidMount (after setState): ' + this.state.tick,
           );
         });
@@ -221,13 +221,13 @@ describe('ReactIncrementalScheduling', () => {
 
       componentDidUpdate() {
         ReactNoop.deferredUpdates(() => {
-          ReactNoop.yield('componentDidUpdate: ' + this.state.tick);
+          Scheduler.yieldValue('componentDidUpdate: ' + this.state.tick);
           if (this.state.tick === 2) {
-            ReactNoop.yield(
+            Scheduler.yieldValue(
               'componentDidUpdate (before setState): ' + this.state.tick,
             );
             this.setState({tick: 3});
-            ReactNoop.yield(
+            Scheduler.yieldValue(
               'componentDidUpdate (after setState): ' + this.state.tick,
             );
           }
@@ -235,7 +235,7 @@ describe('ReactIncrementalScheduling', () => {
       }
 
       render() {
-        ReactNoop.yield('render: ' + this.state.tick);
+        Scheduler.yieldValue('render: ' + this.state.tick);
         instance = this;
         return <span prop={this.state.tick} />;
       }
@@ -285,7 +285,7 @@ describe('ReactIncrementalScheduling', () => {
         });
       }
       render() {
-        ReactNoop.yield('Foo');
+        Scheduler.yieldValue('Foo');
         return <span prop={this.state.step} />;
       }
     }

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
@@ -375,12 +375,12 @@ describe('ReactIncrementalSideEffects', () => {
 
   it('does not update child nodes if a flush is aborted', () => {
     function Bar(props) {
-      ReactNoop.yield('Bar');
+      Scheduler.yieldValue('Bar');
       return <span prop={props.text} />;
     }
 
     function Foo(props) {
-      ReactNoop.yield('Foo');
+      Scheduler.yieldValue('Foo');
       return (
         <div>
           <div>
@@ -409,12 +409,12 @@ describe('ReactIncrementalSideEffects', () => {
 
   it('preserves a previously rendered node when deprioritized', () => {
     function Middle(props) {
-      ReactNoop.yield('Middle');
+      Scheduler.yieldValue('Middle');
       return <span prop={props.children} />;
     }
 
     function Foo(props) {
-      ReactNoop.yield('Foo');
+      Scheduler.yieldValue('Foo');
       return (
         <div>
           <div hidden={true}>
@@ -435,7 +435,7 @@ describe('ReactIncrementalSideEffects', () => {
       </div>,
     );
 
-    ReactNoop.render(<Foo text="bar" />, () => ReactNoop.yield('commit'));
+    ReactNoop.render(<Foo text="bar" />, () => Scheduler.yieldValue('commit'));
     expect(Scheduler).toFlushAndYieldThrough(['Foo', 'commit']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div>
@@ -457,7 +457,7 @@ describe('ReactIncrementalSideEffects', () => {
 
   it('can reuse side-effects after being preempted', () => {
     function Bar(props) {
-      ReactNoop.yield('Bar');
+      Scheduler.yieldValue('Bar');
       return <span prop={props.children} />;
     }
 
@@ -469,7 +469,7 @@ describe('ReactIncrementalSideEffects', () => {
     );
 
     function Foo(props) {
-      ReactNoop.yield('Foo');
+      Scheduler.yieldValue('Foo');
       return (
         <div hidden={true}>
           {props.step === 0 ? (
@@ -500,7 +500,7 @@ describe('ReactIncrementalSideEffects', () => {
     // Make a quick update which will schedule low priority work to
     // update the middle content.
     ReactNoop.render(<Foo text="bar" step={1} />, () =>
-      ReactNoop.yield('commit'),
+      Scheduler.yieldValue('commit'),
     );
     expect(Scheduler).toFlushAndYieldThrough(['Foo', 'commit', 'Bar']);
 
@@ -540,7 +540,7 @@ describe('ReactIncrementalSideEffects', () => {
         return this.props.children !== nextProps.children;
       }
       render() {
-        ReactNoop.yield('Bar');
+        Scheduler.yieldValue('Bar');
         return <span prop={this.props.children} />;
       }
     }
@@ -550,7 +550,7 @@ describe('ReactIncrementalSideEffects', () => {
         return this.props.step !== nextProps.step;
       }
       render() {
-        ReactNoop.yield('Content');
+        Scheduler.yieldValue('Content');
         return (
           <div>
             <Bar>{this.props.step === 0 ? 'Hi' : 'Hello'}</Bar>
@@ -561,7 +561,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     function Foo(props) {
-      ReactNoop.yield('Foo');
+      Scheduler.yieldValue('Foo');
       return (
         <div hidden={true}>
           <Content step={props.step} text={props.text} />
@@ -619,7 +619,7 @@ describe('ReactIncrementalSideEffects', () => {
 
   it('can update a completed tree before it has a chance to commit', () => {
     function Foo(props) {
-      ReactNoop.yield('Foo');
+      Scheduler.yieldValue('Foo');
       return <span prop={props.step} />;
     }
     ReactNoop.render(<Foo step={1} />);
@@ -901,12 +901,12 @@ describe('ReactIncrementalSideEffects', () => {
         this.setState({active: true});
       }
       render() {
-        ReactNoop.yield('Bar');
+        Scheduler.yieldValue('Bar');
         return <span prop={this.state.active ? 'X' : this.props.idx} />;
       }
     }
     function Foo(props) {
-      ReactNoop.yield('Foo');
+      Scheduler.yieldValue('Foo');
       return (
         <div>
           <span prop={props.tick} />

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
@@ -216,7 +216,7 @@ describe('ReactIncrementalTriangle', () => {
       }
       render() {
         if (yieldAfterEachRender) {
-          ReactNoop.yield(this);
+          Scheduler.yieldValue(this);
         }
         const {counter, remainingDepth} = this.props;
         return (

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -34,7 +34,7 @@ describe('ReactIncrementalUpdates', () => {
     class Foo extends React.Component {
       state = {};
       componentDidMount() {
-        ReactNoop.yield('commit');
+        Scheduler.yieldValue('commit');
         ReactNoop.deferredUpdates(() => {
           // Has low priority
           this.setState({b: 'b'});
@@ -150,7 +150,7 @@ describe('ReactIncrementalUpdates', () => {
 
     function createUpdate(letter) {
       return () => {
-        ReactNoop.yield(letter);
+        Scheduler.yieldValue(letter);
         return {
           [letter]: letter,
         };
@@ -221,7 +221,7 @@ describe('ReactIncrementalUpdates', () => {
 
     function createUpdate(letter) {
       return () => {
-        ReactNoop.yield(letter);
+        Scheduler.yieldValue(letter);
         return {
           [letter]: letter,
         };
@@ -461,9 +461,9 @@ describe('ReactIncrementalUpdates', () => {
     const {useEffect} = React;
 
     function App({label}) {
-      ReactNoop.yield('Render: ' + label);
+      Scheduler.yieldValue('Render: ' + label);
       useEffect(() => {
-        ReactNoop.yield('Commit: ' + label);
+        Scheduler.yieldValue('Commit: ' + label);
       });
       return label;
     }
@@ -547,9 +547,9 @@ describe('ReactIncrementalUpdates', () => {
     const {useEffect} = React;
 
     function App({label}) {
-      ReactNoop.yield('Render: ' + label);
+      Scheduler.yieldValue('Render: ' + label);
       useEffect(() => {
-        ReactNoop.yield('Commit: ' + label);
+        Scheduler.yieldValue('Commit: ' + label);
       });
       return label;
     }

--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.internal.js
@@ -36,7 +36,7 @@ describe('memo', () => {
   }
 
   function Text(props) {
-    ReactNoop.yield(props.text);
+    Scheduler.yieldValue(props.text);
     return <span prop={props.text} />;
   }
 
@@ -184,7 +184,7 @@ describe('memo', () => {
           return <Text text={count} />;
         }
         Counter = memo(Counter, (oldProps, newProps) => {
-          ReactNoop.yield(
+          Scheduler.yieldValue(
             `Old count: ${oldProps.count}, New count: ${newProps.count}`,
           );
           return oldProps.count === newProps.count;

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -30,7 +30,7 @@ describe('ReactNewContext', () => {
   });
 
   function Text(props) {
-    ReactNoop.yield(props.text);
+    Scheduler.yieldValue(props.text);
     return <span prop={props.text} />;
   }
 
@@ -160,7 +160,7 @@ describe('ReactNewContext', () => {
         const ContextConsumer = getConsumer(Context);
 
         function Provider(props) {
-          ReactNoop.yield('Provider');
+          Scheduler.yieldValue('Provider');
           return (
             <Context.Provider value={props.value}>
               {props.children}
@@ -169,11 +169,11 @@ describe('ReactNewContext', () => {
         }
 
         function Consumer(props) {
-          ReactNoop.yield('Consumer');
+          Scheduler.yieldValue('Consumer');
           return (
             <ContextConsumer>
               {value => {
-                ReactNoop.yield('Consumer render prop');
+                Scheduler.yieldValue('Consumer render prop');
                 return <span prop={'Result: ' + value} />;
               }}
             </ContextConsumer>
@@ -185,13 +185,13 @@ describe('ReactNewContext', () => {
             return false;
           }
           render() {
-            ReactNoop.yield('Indirection');
+            Scheduler.yieldValue('Indirection');
             return this.props.children;
           }
         }
 
         function App(props) {
-          ReactNoop.yield('App');
+          Scheduler.yieldValue('App');
           return (
             <Provider value={props.value}>
               <Indirection>
@@ -229,7 +229,7 @@ describe('ReactNewContext', () => {
         const ContextConsumer = getConsumer(Context);
 
         function Provider(props) {
-          ReactNoop.yield('Provider');
+          Scheduler.yieldValue('Provider');
           return (
             <Context.Provider value={props.value}>
               {props.children}
@@ -238,11 +238,11 @@ describe('ReactNewContext', () => {
         }
 
         function Consumer(props) {
-          ReactNoop.yield('Consumer');
+          Scheduler.yieldValue('Consumer');
           return (
             <ContextConsumer>
               {value => {
-                ReactNoop.yield('Consumer render prop');
+                Scheduler.yieldValue('Consumer render prop');
                 return <span prop={'Result: ' + value} />;
               }}
             </ContextConsumer>
@@ -254,13 +254,13 @@ describe('ReactNewContext', () => {
             return false;
           }
           render() {
-            ReactNoop.yield('Indirection');
+            Scheduler.yieldValue('Indirection');
             return this.props.children;
           }
         }
 
         function App(props) {
-          ReactNoop.yield('App');
+          Scheduler.yieldValue('App');
           return (
             <Provider value={props.value}>
               <Indirection>
@@ -463,7 +463,7 @@ describe('ReactNewContext', () => {
         const ContextConsumer = getConsumer(Context);
 
         function Provider(props) {
-          ReactNoop.yield('Provider');
+          Scheduler.yieldValue('Provider');
           return (
             <Context.Provider value={props.value}>
               {props.children}
@@ -472,11 +472,11 @@ describe('ReactNewContext', () => {
         }
 
         function Consumer(props) {
-          ReactNoop.yield('Consumer');
+          Scheduler.yieldValue('Consumer');
           return (
             <ContextConsumer>
               {value => {
-                ReactNoop.yield('Consumer render prop');
+                Scheduler.yieldValue('Consumer render prop');
                 return <span prop={'Result: ' + value} />;
               }}
             </ContextConsumer>
@@ -488,13 +488,13 @@ describe('ReactNewContext', () => {
             return false;
           }
           render() {
-            ReactNoop.yield('Indirection');
+            Scheduler.yieldValue('Indirection');
             return this.props.children;
           }
         }
 
         function App(props) {
-          ReactNoop.yield('App');
+          Scheduler.yieldValue('App');
           return (
             <Provider value={props.value}>
               <Indirection>
@@ -605,7 +605,7 @@ describe('ReactNewContext', () => {
           return (
             <Consumer unstable_observedBits={0b01}>
               {value => {
-                ReactNoop.yield('Foo');
+                Scheduler.yieldValue('Foo');
                 return <span prop={'Foo: ' + value.foo} />;
               }}
             </Consumer>
@@ -616,7 +616,7 @@ describe('ReactNewContext', () => {
           return (
             <Consumer unstable_observedBits={0b10}>
               {value => {
-                ReactNoop.yield('Bar');
+                Scheduler.yieldValue('Bar');
                 return <span prop={'Bar: ' + value.bar} />;
               }}
             </Consumer>
@@ -704,7 +704,7 @@ describe('ReactNewContext', () => {
           return (
             <Consumer unstable_observedBits={0b01}>
               {value => {
-                ReactNoop.yield('Foo');
+                Scheduler.yieldValue('Foo');
                 return (
                   <React.Fragment>
                     <span prop={'Foo: ' + value.foo} />
@@ -720,7 +720,7 @@ describe('ReactNewContext', () => {
           return (
             <Consumer unstable_observedBits={0b10}>
               {value => {
-                ReactNoop.yield('Bar');
+                Scheduler.yieldValue('Bar');
                 return (
                   <React.Fragment>
                     <span prop={'Bar: ' + value.bar} />
@@ -808,7 +808,7 @@ describe('ReactNewContext', () => {
         class Child extends React.Component {
           state = {step: 0};
           render() {
-            ReactNoop.yield('Child');
+            Scheduler.yieldValue('Child');
             return (
               <span
                 prop={`Context: ${this.props.context}, Step: ${
@@ -824,7 +824,7 @@ describe('ReactNewContext', () => {
             <Context.Provider value={props.value}>
               <Consumer>
                 {value => {
-                  ReactNoop.yield('Consumer render prop');
+                  Scheduler.yieldValue('Consumer render prop');
                   return <Child ref={inst => (child = inst)} context={value} />;
                 }}
               </Consumer>
@@ -847,24 +847,24 @@ describe('ReactNewContext', () => {
         const Consumer = getConsumer(Context);
 
         function renderChildValue(value) {
-          ReactNoop.yield('Consumer');
+          Scheduler.yieldValue('Consumer');
           return <span prop={value} />;
         }
 
         function ChildWithInlineRenderCallback() {
-          ReactNoop.yield('ChildWithInlineRenderCallback');
+          Scheduler.yieldValue('ChildWithInlineRenderCallback');
           // Note: we are intentionally passing an inline arrow. Don't refactor.
           return <Consumer>{value => renderChildValue(value)}</Consumer>;
         }
 
         function ChildWithCachedRenderCallback() {
-          ReactNoop.yield('ChildWithCachedRenderCallback');
+          Scheduler.yieldValue('ChildWithCachedRenderCallback');
           return <Consumer>{renderChildValue}</Consumer>;
         }
 
         class PureIndirection extends React.PureComponent {
           render() {
-            ReactNoop.yield('PureIndirection');
+            Scheduler.yieldValue('PureIndirection');
             return (
               <React.Fragment>
                 <ChildWithInlineRenderCallback />
@@ -876,7 +876,7 @@ describe('ReactNewContext', () => {
 
         class App extends React.Component {
           render() {
-            ReactNoop.yield('App');
+            Scheduler.yieldValue('App');
             return (
               <Context.Provider value={this.props.value}>
                 <PureIndirection />
@@ -988,7 +988,7 @@ describe('ReactNewContext', () => {
           };
 
           render() {
-            ReactNoop.yield('App');
+            Scheduler.yieldValue('App');
             return (
               <Context.Provider value={this.state.step}>
                 <StaticContent />
@@ -1016,7 +1016,7 @@ describe('ReactNewContext', () => {
             return (
               <ContextConsumer>
                 {value => {
-                  ReactNoop.yield('Consumer');
+                  Scheduler.yieldValue('Consumer');
                   return <span prop={value} />;
                 }}
               </ContextConsumer>
@@ -1079,7 +1079,7 @@ describe('ReactNewContext', () => {
       const Context = React.createContext(0);
 
       function Foo(props) {
-        ReactNoop.yield('Foo');
+        Scheduler.yieldValue('Foo');
         return null;
       }
 
@@ -1119,14 +1119,14 @@ describe('ReactNewContext', () => {
       const Context = React.createContext(0);
 
       function Child() {
-        ReactNoop.yield('Child');
+        Scheduler.yieldValue('Child');
         return <span prop="Child" />;
       }
 
       const children = <Child />;
 
       function App(props) {
-        ReactNoop.yield('App');
+        Scheduler.yieldValue('App');
         return (
           <Context.Provider value={props.value}>{children}</Context.Provider>
         );
@@ -1150,7 +1150,7 @@ describe('ReactNewContext', () => {
       const Context = React.createContext(0);
 
       function Child() {
-        ReactNoop.yield('Child');
+        Scheduler.yieldValue('Child');
         return <span prop="Child" />;
       }
 
@@ -1165,7 +1165,7 @@ describe('ReactNewContext', () => {
           return {legacyValue: this.state.legacyValue};
         }
         render() {
-          ReactNoop.yield('LegacyProvider');
+          Scheduler.yieldValue('LegacyProvider');
           return this.props.children;
         }
       }
@@ -1173,7 +1173,7 @@ describe('ReactNewContext', () => {
       class App extends React.Component {
         state = {value: 1};
         render() {
-          ReactNoop.yield('App');
+          Scheduler.yieldValue('App');
           return (
             <Context.Provider value={this.state.value}>
               {this.props.children}
@@ -1299,12 +1299,12 @@ describe('ReactNewContext', () => {
         };
 
         renderConsumer = context => {
-          ReactNoop.yield('App#renderConsumer');
+          Scheduler.yieldValue('App#renderConsumer');
           return <span prop={this.state.text} />;
         };
 
         render() {
-          ReactNoop.yield('App');
+          Scheduler.yieldValue('App');
           return (
             <Context.Provider value={this.props.value}>
               <Consumer>{this.renderConsumer}</Consumer>
@@ -1439,12 +1439,12 @@ describe('ReactNewContext', () => {
         };
 
         renderConsumer = context => {
-          ReactNoop.yield('App#renderConsumer');
+          Scheduler.yieldValue('App#renderConsumer');
           return <span prop={this.state.text} />;
         };
 
         render() {
-          ReactNoop.yield('App');
+          Scheduler.yieldValue('App');
           return (
             <Context.Provider value={this.props.value}>
               <Consumer>{this.renderConsumer}</Consumer>
@@ -1566,12 +1566,12 @@ describe('ReactNewContext', () => {
         };
 
         renderConsumer = context => {
-          ReactNoop.yield('App#renderConsumer');
+          Scheduler.yieldValue('App#renderConsumer');
           return <span prop={this.state.text} />;
         };
 
         render() {
-          ReactNoop.yield('App');
+          Scheduler.yieldValue('App');
           return (
             <Context.Provider value={this.props.value}>
               <Consumer>{this.renderConsumer}</Consumer>
@@ -1694,7 +1694,7 @@ describe('ReactNewContext', () => {
           return false;
         }
         render() {
-          ReactNoop.yield();
+          Scheduler.yieldValue();
           if (this.props.depth >= this.props.maxDepth) {
             return null;
           }

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -33,10 +33,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       return new Promise((resolve, reject) =>
         setTimeout(() => {
           if (textResourceShouldFail) {
-            ReactNoop.yield(`Promise rejected [${text}]`);
+            Scheduler.yieldValue(`Promise rejected [${text}]`);
             reject(new Error('Failed to load: ' + text));
           } else {
-            ReactNoop.yield(`Promise resolved [${text}]`);
+            Scheduler.yieldValue(`Promise resolved [${text}]`);
             resolve(text);
           }
         }, ms),
@@ -69,7 +69,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   }
 
   function Text(props) {
-    ReactNoop.yield(props.text);
+    Scheduler.yieldValue(props.text);
     return <span prop={props.text} ref={props.hostRef} />;
   }
 
@@ -77,13 +77,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     const text = props.text;
     try {
       TextResource.read([props.text, props.ms]);
-      ReactNoop.yield(text);
+      Scheduler.yieldValue(text);
       return <span prop={text} />;
     } catch (promise) {
       if (typeof promise.then === 'function') {
-        ReactNoop.yield(`Suspend! [${text}]`);
+        Scheduler.yieldValue(`Suspend! [${text}]`);
       } else {
-        ReactNoop.yield(`Error! [${text}]`);
+        Scheduler.yieldValue(`Error! [${text}]`);
       }
       throw promise;
     }
@@ -91,12 +91,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
   it('suspends rendering and continues later', async () => {
     function Bar(props) {
-      ReactNoop.yield('Bar');
+      Scheduler.yieldValue('Bar');
       return props.children;
     }
 
     function Foo() {
-      ReactNoop.yield('Foo');
+      Scheduler.yieldValue('Foo');
       return (
         <Suspense fallback={<Text text="Loading..." />}>
           <Bar>
@@ -758,10 +758,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   it('flushes all expired updates in a single batch', async () => {
     class Foo extends React.Component {
       componentDidUpdate() {
-        ReactNoop.yield('Commit: ' + this.props.text);
+        Scheduler.yieldValue('Commit: ' + this.props.text);
       }
       componentDidMount() {
-        ReactNoop.yield('Commit: ' + this.props.text);
+        Scheduler.yieldValue('Commit: ' + this.props.text);
       }
       render() {
         return (
@@ -919,7 +919,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Update. This starts out asynchronously.
       text.current.setState({step: 2}, () =>
-        ReactNoop.yield('Update did commit'),
+        Scheduler.yieldValue('Update did commit'),
       );
 
       // Suspend during an async render.
@@ -1001,7 +1001,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
         // Initial mount
         ReactNoop.renderLegacySyncRoot(<App />, () =>
-          ReactNoop.yield('Did mount'),
+          Scheduler.yieldValue('Did mount'),
         );
         await advanceTimers(100);
         expect(Scheduler).toHaveYielded([
@@ -1030,10 +1030,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
         // Update. This starts out asynchronously.
         text1.current.setState({text: 'Async: 2'}, () =>
-          ReactNoop.yield('Update 1 did commit'),
+          Scheduler.yieldValue('Update 1 did commit'),
         );
         text2.current.setState({text: 'Sync: 2'}, () =>
-          ReactNoop.yield('Update 2 did commit'),
+          Scheduler.yieldValue('Update 2 did commit'),
         );
 
         // Start rendering asynchronously
@@ -1136,7 +1136,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
         // Initial mount
         ReactNoop.renderLegacySyncRoot(<App />, () =>
-          ReactNoop.yield('Did mount'),
+          Scheduler.yieldValue('Did mount'),
         );
         await advanceTimers(100);
         expect(Scheduler).toHaveYielded([
@@ -1165,10 +1165,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
         // Update. This starts out asynchronously.
         text1.current.setState({text: 'Async: 2'}, () =>
-          ReactNoop.yield('Update 1 did commit'),
+          Scheduler.yieldValue('Update 1 did commit'),
         );
         text2.current.setState({text: 'Sync: 2'}, () =>
-          ReactNoop.yield('Update 2 did commit'),
+          Scheduler.yieldValue('Update 2 did commit'),
         );
 
         // Start rendering asynchronously
@@ -1226,10 +1226,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     it('does not re-render siblings in loose mode', async () => {
       class TextWithLifecycle extends React.Component {
         componentDidMount() {
-          ReactNoop.yield(`Mount [${this.props.text}]`);
+          Scheduler.yieldValue(`Mount [${this.props.text}]`);
         }
         componentDidUpdate() {
-          ReactNoop.yield(`Update [${this.props.text}]`);
+          Scheduler.yieldValue(`Update [${this.props.text}]`);
         }
         render() {
           return <Text {...this.props} />;
@@ -1238,10 +1238,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       class AsyncTextWithLifecycle extends React.Component {
         componentDidMount() {
-          ReactNoop.yield(`Mount [${this.props.text}]`);
+          Scheduler.yieldValue(`Mount [${this.props.text}]`);
         }
         componentDidUpdate() {
-          ReactNoop.yield(`Update [${this.props.text}]`);
+          Scheduler.yieldValue(`Update [${this.props.text}]`);
         }
         render() {
           return <AsyncText {...this.props} />;
@@ -1261,7 +1261,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
 
       ReactNoop.renderLegacySyncRoot(<App />, () =>
-        ReactNoop.yield('Commit root'),
+        Scheduler.yieldValue('Commit root'),
       );
       expect(Scheduler).toHaveYielded([
         'A',
@@ -1303,24 +1303,24 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         constructor(props) {
           super(props);
           const text = props.text;
-          ReactNoop.yield('constructor');
+          Scheduler.yieldValue('constructor');
           try {
             TextResource.read([props.text, props.ms]);
             this.state = {text};
           } catch (promise) {
             if (typeof promise.then === 'function') {
-              ReactNoop.yield(`Suspend! [${text}]`);
+              Scheduler.yieldValue(`Suspend! [${text}]`);
             } else {
-              ReactNoop.yield(`Error! [${text}]`);
+              Scheduler.yieldValue(`Error! [${text}]`);
             }
             throw promise;
           }
         }
         componentDidMount() {
-          ReactNoop.yield('componentDidMount');
+          Scheduler.yieldValue('componentDidMount');
         }
         render() {
-          ReactNoop.yield(this.state.text);
+          Scheduler.yieldValue(this.state.text);
           return <span prop={this.state.text} />;
         }
       }
@@ -1394,7 +1394,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         const child = useRef(null);
 
         useLayoutEffect(() => {
-          ReactNoop.yield('Child is hidden: ' + child.current.hidden);
+          Scheduler.yieldValue('Child is hidden: ' + child.current.hidden);
         });
 
         return (
@@ -1430,13 +1430,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   it('does not call lifecycles of a suspended component', async () => {
     class TextWithLifecycle extends React.Component {
       componentDidMount() {
-        ReactNoop.yield(`Mount [${this.props.text}]`);
+        Scheduler.yieldValue(`Mount [${this.props.text}]`);
       }
       componentDidUpdate() {
-        ReactNoop.yield(`Update [${this.props.text}]`);
+        Scheduler.yieldValue(`Update [${this.props.text}]`);
       }
       componentWillUnmount() {
-        ReactNoop.yield(`Unmount [${this.props.text}]`);
+        Scheduler.yieldValue(`Unmount [${this.props.text}]`);
       }
       render() {
         return <Text {...this.props} />;
@@ -1445,26 +1445,26 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     class AsyncTextWithLifecycle extends React.Component {
       componentDidMount() {
-        ReactNoop.yield(`Mount [${this.props.text}]`);
+        Scheduler.yieldValue(`Mount [${this.props.text}]`);
       }
       componentDidUpdate() {
-        ReactNoop.yield(`Update [${this.props.text}]`);
+        Scheduler.yieldValue(`Update [${this.props.text}]`);
       }
       componentWillUnmount() {
-        ReactNoop.yield(`Unmount [${this.props.text}]`);
+        Scheduler.yieldValue(`Unmount [${this.props.text}]`);
       }
       render() {
         const text = this.props.text;
         const ms = this.props.ms;
         try {
           TextResource.read([text, ms]);
-          ReactNoop.yield(text);
+          Scheduler.yieldValue(text);
           return <span prop={text} />;
         } catch (promise) {
           if (typeof promise.then === 'function') {
-            ReactNoop.yield(`Suspend! [${text}]`);
+            Scheduler.yieldValue(`Suspend! [${text}]`);
           } else {
-            ReactNoop.yield(`Error! [${text}]`);
+            Scheduler.yieldValue(`Error! [${text}]`);
           }
           throw promise;
         }
@@ -1484,7 +1484,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.renderLegacySyncRoot(<App />, () =>
-      ReactNoop.yield('Commit root'),
+      Scheduler.yieldValue('Commit root'),
     );
     expect(Scheduler).toHaveYielded([
       'A',

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -1208,13 +1208,13 @@ describe('Profiler', () => {
 
     const Child = ({duration, id}) => {
       Scheduler.advanceTime(duration);
-      ReactNoop.yield(`Child:render:${id}`);
+      Scheduler.yieldValue(`Child:render:${id}`);
       return null;
     };
 
     class Parent extends React.Component {
       componentDidMount() {
-        ReactNoop.yield(`Parent:componentDidMount:${this.props.id}`);
+        Scheduler.yieldValue(`Parent:componentDidMount:${this.props.id}`);
       }
       render() {
         const {duration, id} = this.props;
@@ -2261,7 +2261,7 @@ describe('Profiler', () => {
         const monkey = React.createRef();
         class Monkey extends React.Component {
           render() {
-            ReactNoop.yield('Monkey');
+            Scheduler.yieldValue('Monkey');
             return null;
           }
         }

--- a/packages/react/src/__tests__/forwardRef-test.internal.js
+++ b/packages/react/src/__tests__/forwardRef-test.internal.js
@@ -28,7 +28,7 @@ describe('forwardRef', () => {
   it('should work without a ref to be forwarded', () => {
     class Child extends React.Component {
       render() {
-        ReactNoop.yield(this.props.value);
+        Scheduler.yieldValue(this.props.value);
         return null;
       }
     }
@@ -48,7 +48,7 @@ describe('forwardRef', () => {
   it('should forward a ref for a single child', () => {
     class Child extends React.Component {
       render() {
-        ReactNoop.yield(this.props.value);
+        Scheduler.yieldValue(this.props.value);
         return null;
       }
     }
@@ -71,7 +71,7 @@ describe('forwardRef', () => {
   it('should forward a ref for multiple children', () => {
     class Child extends React.Component {
       render() {
-        ReactNoop.yield(this.props.value);
+        Scheduler.yieldValue(this.props.value);
         return null;
       }
     }
@@ -103,7 +103,7 @@ describe('forwardRef', () => {
         super(props);
       }
       render() {
-        ReactNoop.yield(this.props.value);
+        Scheduler.yieldValue(this.props.value);
         return null;
       }
     }
@@ -138,28 +138,28 @@ describe('forwardRef', () => {
     class ErrorBoundary extends React.Component {
       state = {error: null};
       componentDidCatch(error) {
-        ReactNoop.yield('ErrorBoundary.componentDidCatch');
+        Scheduler.yieldValue('ErrorBoundary.componentDidCatch');
         this.setState({error});
       }
       render() {
         if (this.state.error) {
-          ReactNoop.yield('ErrorBoundary.render: catch');
+          Scheduler.yieldValue('ErrorBoundary.render: catch');
           return null;
         }
-        ReactNoop.yield('ErrorBoundary.render: try');
+        Scheduler.yieldValue('ErrorBoundary.render: try');
         return this.props.children;
       }
     }
 
     class BadRender extends React.Component {
       render() {
-        ReactNoop.yield('BadRender throw');
+        Scheduler.yieldValue('BadRender throw');
         throw new Error('oops!');
       }
     }
 
     function Wrapper(props) {
-      ReactNoop.yield('Wrapper');
+      Scheduler.yieldValue('Wrapper');
       return <BadRender {...props} ref={props.forwardedRef} />;
     }
 
@@ -196,24 +196,24 @@ describe('forwardRef', () => {
 
     class Inner extends React.Component {
       render() {
-        ReactNoop.yield('Inner');
+        Scheduler.yieldValue('Inner');
         inst = this;
         return <div ref={this.props.forwardedRef} />;
       }
     }
 
     function Middle(props) {
-      ReactNoop.yield('Middle');
+      Scheduler.yieldValue('Middle');
       return <Inner {...props} />;
     }
 
     const Forward = React.forwardRef((props, ref) => {
-      ReactNoop.yield('Forward');
+      Scheduler.yieldValue('Forward');
       return <Middle {...props} forwardedRef={ref} />;
     });
 
     function App() {
-      ReactNoop.yield('App');
+      Scheduler.yieldValue('App');
       return <Forward />;
     }
 


### PR DESCRIPTION
These used to be different things, but now ReactNoop.yield merely re-exports Scheduler.yieldValue, so let's get rid of it.