### PR TITLE
Run Placeholder tests in persistent mode, too

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -406,10 +406,17 @@ export function cloneUnhiddenInstance(
   };
 }
 
-export function createHiddenTextInstance(
+export function cloneHiddenTextInstance(
+  instance: Instance,
   text: string,
-  rootContainerInstance: Container,
-  hostContext: HostContext,
+  internalInstanceHandle: Object,
+): TextInstance {
+  throw new Error('Not yet implemented.');
+}
+
+export function cloneUnhiddenTextInstance(
+  instance: Instance,
+  text: string,
   internalInstanceHandle: Object,
 ): TextInstance {
   throw new Error('Not yet implemented.');

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -41,10 +41,18 @@ type Instance = {|
   text: string | null,
   prop: any,
   hidden: boolean,
+  context: HostContext,
 |};
-type TextInstance = {|text: string, id: number, hidden: boolean|};
+type TextInstance = {|
+  text: string,
+  id: number,
+  hidden: boolean,
+  context: HostContext,
+|};
+type HostContext = Object;
 
 const NO_CONTEXT = {};
+const UPPERCASE_CONTEXT = {};
 const UPDATE_SIGNAL = {};
 if (__DEV__) {
   Object.freeze(NO_CONTEXT);
@@ -190,10 +198,11 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       type: type,
       children: keepChildren ? instance.children : [],
       text: shouldSetTextContent(type, newProps)
-        ? (newProps.children: any) + ''
+        ? computeText((newProps.children: any) + '', instance.context)
         : null,
       prop: newProps.prop,
       hidden: newProps.hidden === true,
+      context: instance.context,
     };
     Object.defineProperty(clone, 'id', {
       value: clone.id,
@@ -201,6 +210,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     });
     Object.defineProperty(clone, 'text', {
       value: clone.text,
+      enumerable: false,
+    });
+    Object.defineProperty(clone, 'context', {
+      value: clone.context,
       enumerable: false,
     });
     hostCloneCounter++;
@@ -216,12 +229,23 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     );
   }
 
+  function computeText(rawText, hostContext) {
+    return hostContext === UPPERCASE_CONTEXT ? rawText.toUpperCase() : rawText;
+  }
+
   const sharedHostConfig = {
     getRootHostContext() {
       return NO_CONTEXT;
     },
 
-    getChildHostContext() {
+    getChildHostContext(
+      parentHostContext: HostContext,
+      type: string,
+      rootcontainerInstance: Container,
+    ) {
+      if (type === 'uppercase') {
+        return UPPERCASE_CONTEXT;
+      }
       return NO_CONTEXT;
     },
 
@@ -229,7 +253,12 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return instance;
     },
 
-    createInstance(type: string, props: Props): Instance {
+    createInstance(
+      type: string,
+      props: Props,
+      rootContainerInstance: Container,
+      hostContext: HostContext,
+    ): Instance {
       if (type === 'errorInCompletePhase') {
         throw new Error('Error in host config.');
       }
@@ -238,15 +267,20 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         type: type,
         children: [],
         text: shouldSetTextContent(type, props)
-          ? (props.children: any) + ''
+          ? computeText((props.children: any) + '', hostContext)
           : null,
         prop: props.prop,
         hidden: props.hidden === true,
+        context: hostContext,
       };
       // Hide from unit tests
       Object.defineProperty(inst, 'id', {value: inst.id, enumerable: false});
       Object.defineProperty(inst, 'text', {
         value: inst.text,
+        enumerable: false,
+      });
+      Object.defineProperty(inst, 'context', {
+        value: inst.context,
         enumerable: false,
       });
       return inst;
@@ -298,9 +332,21 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       hostContext: Object,
       internalInstanceHandle: Object,
     ): TextInstance {
-      const inst = {text: text, id: instanceCounter++, hidden: false};
+      if (hostContext === UPPERCASE_CONTEXT) {
+        text = text.toUpperCase();
+      }
+      const inst = {
+        text: text,
+        id: instanceCounter++,
+        hidden: false,
+        context: hostContext,
+      };
       // Hide from unit tests
       Object.defineProperty(inst, 'id', {value: inst.id, enumerable: false});
+      Object.defineProperty(inst, 'context', {
+        value: inst.context,
+        enumerable: false,
+      });
       return inst;
     },
 
@@ -343,7 +389,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           instance.prop = newProps.prop;
           instance.hidden = newProps.hidden === true;
           if (shouldSetTextContent(type, newProps)) {
-            instance.text = (newProps.children: any) + '';
+            instance.text = computeText(
+              (newProps.children: any) + '',
+              instance.context,
+            );
           }
         },
 
@@ -353,7 +402,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           newText: string,
         ): void {
           hostUpdateCounter++;
-          textInstance.text = newText;
+          textInstance.text = computeText(newText, textInstance.context);
         },
 
         appendChild,
@@ -463,10 +512,19 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           hostContext: Object,
           internalInstanceHandle: Object,
         ): TextInstance {
-          const inst = {text: text, id: instanceCounter++, hidden: true};
+          const inst = {
+            text: text,
+            id: instanceCounter++,
+            hidden: true,
+            context: hostContext,
+          };
           // Hide from unit tests
           Object.defineProperty(inst, 'id', {
             value: inst.id,
+            enumerable: false,
+          });
+          Object.defineProperty(inst, 'context', {
+            value: inst.context,
             enumerable: false,
           });
           return inst;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -502,32 +502,54 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
             true,
             null,
           );
-          clone.hidden = props.hidden;
+          clone.hidden = props.hidden === true;
           return clone;
         },
 
-        createHiddenTextInstance(
+        cloneHiddenTextInstance(
+          instance: TextInstance,
           text: string,
-          rootContainerInstance: Container,
-          hostContext: Object,
           internalInstanceHandle: Object,
         ): TextInstance {
-          const inst = {
-            text: text,
+          const clone = {
+            text: instance.text,
             id: instanceCounter++,
             hidden: true,
-            context: hostContext,
+            context: instance.context,
           };
           // Hide from unit tests
-          Object.defineProperty(inst, 'id', {
-            value: inst.id,
+          Object.defineProperty(clone, 'id', {
+            value: clone.id,
             enumerable: false,
           });
-          Object.defineProperty(inst, 'context', {
-            value: inst.context,
+          Object.defineProperty(clone, 'context', {
+            value: clone.context,
             enumerable: false,
           });
-          return inst;
+          return clone;
+        },
+
+        cloneUnhiddenTextInstance(
+          instance: TextInstance,
+          text: string,
+          internalInstanceHandle: Object,
+        ): TextInstance {
+          const clone = {
+            text: instance.text,
+            id: instanceCounter++,
+            hidden: false,
+            context: instance.context,
+          };
+          // Hide from unit tests
+          Object.defineProperty(clone, 'id', {
+            value: clone.id,
+            enumerable: false,
+          });
+          Object.defineProperty(clone, 'context', {
+            value: clone.context,
+            enumerable: false,
+          });
+          return clone;
         },
       };
 

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -17,7 +17,6 @@ import type {
   Container,
   ChildSet,
 } from './ReactFiberHostConfig';
-import type {SuspenseState} from './ReactFiberSuspenseComponent';
 
 import {
   IndeterminateComponent,
@@ -258,9 +257,11 @@ if (supportsMutation) {
           const newIsHidden = node.memoizedState !== null;
           if (newIsHidden) {
             const primaryChildParent = node.child;
-            appendAllChildren(parent, primaryChildParent, true, newIsHidden);
-            node = primaryChildParent.sibling;
-            continue;
+            if (primaryChildParent !== null) {
+              appendAllChildren(parent, primaryChildParent, true, newIsHidden);
+              node = primaryChildParent.sibling;
+              continue;
+            }
           } else {
             const primaryChildParent = node;
             appendAllChildren(parent, primaryChildParent, true, newIsHidden);
@@ -358,14 +359,16 @@ if (supportsMutation) {
           const newIsHidden = node.memoizedState !== null;
           if (newIsHidden) {
             const primaryChildParent = node.child;
-            appendAllChildrenToContainer(
-              containerChildSet,
-              primaryChildParent,
-              true,
-              newIsHidden,
-            );
-            node = primaryChildParent.sibling;
-            continue;
+            if (primaryChildParent !== null) {
+              appendAllChildrenToContainer(
+                containerChildSet,
+                primaryChildParent,
+                true,
+                newIsHidden,
+              );
+              node = primaryChildParent.sibling;
+              continue;
+            }
           } else {
             const primaryChildParent = node;
             appendAllChildrenToContainer(

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -8,12 +8,9 @@
  * @jest-environment node
  */
 
-// TODO: This does nothing since it was migrated from noop renderer to test
-// renderer! Switch back to noop renderer, or add persistent mode to test
-// renderer, or merge the two renderers into one somehow.
-// runPlaceholderTests('ReactSuspensePlaceholder (mutation)', () =>
-//   require('react-noop-renderer'),
-// );
+runPlaceholderTests('ReactSuspensePlaceholder (mutation)', () =>
+  require('react-noop-renderer'),
+);
 runPlaceholderTests('ReactSuspensePlaceholder (persistence)', () =>
   require('react-noop-renderer/persistent'),
 );
@@ -38,7 +35,7 @@ function runPlaceholderTests(suiteLabel, loadReactNoop) {
       ReactFeatureFlags.enableProfilerTimer = true;
       ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
       React = require('react');
-      ReactNoop = require('react-noop-renderer');
+      ReactNoop = loadReactNoop();
       Scheduler = require('scheduler');
       ReactCache = require('react-cache');
 

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -92,7 +92,9 @@ export const finalizeContainerChildren =
 export const replaceContainerChildren = $$$hostConfig.replaceContainerChildren;
 export const cloneHiddenInstance = $$$hostConfig.cloneHiddenInstance;
 export const cloneUnhiddenInstance = $$$hostConfig.cloneUnhiddenInstance;
-export const createHiddenTextInstance = $$$hostConfig.createHiddenTextInstance;
+export const cloneHiddenTextInstance = $$$hostConfig.cloneHiddenTextInstance;
+export const cloneUnhiddenTextInstance =
+  $$$hostConfig.cloneUnhiddenTextInstance;
 
 // -------------------
 //     Hydration

--- a/packages/shared/HostConfigWithNoPersistence.js
+++ b/packages/shared/HostConfigWithNoPersistence.js
@@ -30,4 +30,5 @@ export const finalizeContainerChildren = shim;
 export const replaceContainerChildren = shim;
 export const cloneHiddenInstance = shim;
 export const cloneUnhiddenInstance = shim;
-export const createHiddenTextInstance = shim;
+export const cloneHiddenTextInstance = shim;
+export const cloneUnhiddenTextInstance = shim;


### PR DESCRIPTION
I screwed up a few months ago when I converted the Suspense placeholder tests to use test renderer instead of noop renderer — I forgot that we were using noop renderer because it supports both mutation and persistent mode. This PR corrects that mistake by converting them back to the noop renderer. This exposed bugs in our persistent implementation. (We don't use Suspense in persistent mode anywhere yet, but it's what Fabric will use.)

This indicates we should stop using test renderer for our internal React tests, and that we should probably be running all our tests in both modes by default. (I also found a bug related to profiler in persistent mode.) But I'll leave that for a follow up.