### PR TITLE
Fix SSR missing data-reactroot attribute inside invisible React elements

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationFragment-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationFragment-test.js
@@ -102,5 +102,76 @@ describe('ReactDOMServerIntegration', () => {
     itRenders('an empty fragment', async render => {
       expect(await render(<React.Fragment />)).toBe(null);
     });
+
+    // Regression tests for https://github.com/facebook/react/issues/15012
+    describe('creates markup with data-reactroot="" attribute', () => {
+      it('within fragment', () => {
+        const App = () => (
+          <React.Fragment>
+            <div>
+              <div>Hello</div>
+            </div>
+          </React.Fragment>
+        );
+
+        expect(ReactDOMServer.renderToString(<App />)).toBe(
+          '<div data-reactroot=""><div>Hello</div></div>',
+        );
+      });
+
+      it('within nested fragments', () => {
+        const App = () => (
+          <React.Fragment>
+            <React.Fragment>
+              <div>
+                <div>Hello</div>
+              </div>
+            </React.Fragment>
+          </React.Fragment>
+        );
+
+        expect(ReactDOMServer.renderToString(<App />)).toBe(
+          '<div data-reactroot=""><div>Hello</div></div>',
+        );
+      });
+
+      it('with multiple DOM roots', () => {
+        const App = () => (
+          <React.Fragment>
+            <div>
+              <div>One</div>
+            </div>
+            <div>
+              <div>Two</div>
+            </div>
+          </React.Fragment>
+        );
+
+        expect(ReactDOMServer.renderToString(<App />)).toBe(
+          '<div data-reactroot=""><div>One</div></div><div data-reactroot=""><div>Two</div></div>',
+        );
+      });
+
+      it('with multiple DOM roots in multiple fragments', () => {
+        const App = () => (
+          <React.Fragment>
+            <React.Fragment>
+              <div>
+                <div>One</div>
+              </div>
+            </React.Fragment>
+            <React.Fragment>
+              <div>
+                <div>Two</div>
+              </div>
+            </React.Fragment>
+          </React.Fragment>
+        );
+
+        expect(ReactDOMServer.renderToString(<App />)).toBe(
+          '<div data-reactroot=""><div>One</div></div><div data-reactroot=""><div>Two</div></div>',
+        );
+      });
+    });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
@@ -421,8 +421,12 @@ describe('ReactDOMServerIntegration', () => {
       streamAmy._read(20);
       streamBob._read(20);
 
-      expect(streamAmy.read()).toBe('<header>Amy</header><footer>Amy</footer>');
-      expect(streamBob.read()).toBe('<header>Bob</header><footer>Bob</footer>');
+      expect(streamAmy.read()).toBe(
+        '<header data-reactroot="">Amy</header><footer data-reactroot="">Amy</footer>',
+      );
+      expect(streamBob.read()).toBe(
+        '<header data-reactroot="">Bob</header><footer data-reactroot="">Bob</footer>',
+      );
     });
 
     it('does not pollute parallel node streams when many are used', () => {
@@ -478,7 +482,11 @@ describe('ReactDOMServerIntegration', () => {
       // Assert that all stream rendered the expected output.
       for (let i = 0; i < streamCount; i++) {
         expect(streams[i].read()).toBe(
-          '<header>' + i + '</header><footer>' + i + '</footer>',
+          '<header data-reactroot="">' +
+            i +
+            '</header><footer data-reactroot="">' +
+            i +
+            '</footer>',
         );
       }
     });

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
@@ -583,5 +583,76 @@ describe('ReactDOMServerIntegration', () => {
         ),
       ).toBe('default');
     });
+
+    // Regression tests for https://github.com/facebook/react/issues/15012
+    describe('creates markup with data-reactroot="" attribute', () => {
+      it('within provider', () => {
+        const App = () => (
+          <Context.Provider value="foo">
+            <div>
+              <div>Hello</div>
+            </div>
+          </Context.Provider>
+        );
+
+        expect(ReactDOMServer.renderToString(<App />)).toBe(
+          '<div data-reactroot=""><div>Hello</div></div>',
+        );
+      });
+
+      it('within nested providers', () => {
+        const App = () => (
+          <Context.Provider value="foo">
+            <Context.Provider value="bar">
+              <div>
+                <div>Hello</div>
+              </div>
+            </Context.Provider>
+          </Context.Provider>
+        );
+
+        expect(ReactDOMServer.renderToString(<App />)).toBe(
+          '<div data-reactroot=""><div>Hello</div></div>',
+        );
+      });
+
+      it('with multiple DOM roots', () => {
+        const App = () => (
+          <Context.Provider value="foo">
+            <div>
+              <div>One</div>
+            </div>
+            <div>
+              <div>Two</div>
+            </div>
+          </Context.Provider>
+        );
+
+        expect(ReactDOMServer.renderToString(<App />)).toBe(
+          '<div data-reactroot=""><div>One</div></div><div data-reactroot=""><div>Two</div></div>',
+        );
+      });
+
+      it('with multiple DOM roots in multiple providers', () => {
+        const App = () => (
+          <Context.Provider value="foo">
+            <Context.Provider value="bar">
+              <div>
+                <div>One</div>
+              </div>
+            </Context.Provider>
+            <Context.Provider value="qux">
+              <div>
+                <div>Two</div>
+              </div>
+            </Context.Provider>
+          </Context.Provider>
+        );
+
+        expect(ReactDOMServer.renderToString(<App />)).toBe(
+          '<div data-reactroot=""><div>One</div></div><div data-reactroot=""><div>Two</div></div>',
+        );
+      });
+    });
   });
 });

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -673,6 +673,7 @@ class ReactDOMServerRenderer {
   previousWasTextNode: boolean;
   makeStaticMarkup: boolean;
   suspenseDepth: number;
+  domRootIndex: number;
 
   contextIndex: number;
   contextStack: Array<ReactContext<any>>;
@@ -702,6 +703,7 @@ class ReactDOMServerRenderer {
     this.previousWasTextNode = false;
     this.makeStaticMarkup = makeStaticMarkup;
     this.suspenseDepth = 0;
+    this.domRootIndex = 0;
 
     // Context (new API)
     this.contextIndex = -1;
@@ -811,6 +813,9 @@ class ReactDOMServerRenderer {
           const footer = frame.footer;
           if (footer !== '') {
             this.previousWasTextNode = false;
+          }
+          if (this.stack.length === this.domRootIndex) {
+            this.domRootIndex = 0;
           }
           this.stack.pop();
           if (frame.type === 'select') {
@@ -1419,7 +1424,7 @@ class ReactDOMServerRenderer {
       props,
       namespace,
       this.makeStaticMarkup,
-      this.stack.length === 1,
+      this.domRootIndex === 0,
     );
     let footer = '';
     if (omittedCloseTags.hasOwnProperty(tag)) {
@@ -1462,6 +1467,9 @@ class ReactDOMServerRenderer {
     }
     this.stack.push(frame);
     this.previousWasTextNode = false;
+    if (this.domRootIndex === 0) {
+      this.domRootIndex = this.stack.length;
+    }
     return out;
   }
 }


### PR DESCRIPTION
PR for #15012.

```js
const React = require('react'),
  {renderToString} = require('react-dom/server');

const Context = React.createContext();

const html = renderToString(
  <Context.Provider>
    <div>Hello!</div>
  </Context.Provider>
);
```

Before this PR, outputs:

```
'<div>Hello!</div>'
```

with this PR:

```
'<div data-reactroot="">Hello!</div>'
```

Implementation is through addition of a `.domRootFrame` property on `ReactDOMServerRenderer` instance.

* `domRootFrame` is `null` if no DOM element in stack above currently rendering element.
* When a entering a root DOM element, `domRootFrame` is set to the stack frame for that DOM element.
* When exiting root DOM element, `domRootFrame` is set back to `null` (the root element is identified by checking if the frame being popped from the stack is equal to `domRootFrame`)

I am not clear what desired behavior is when there are multiple DOM roots e.g.:

```
<React.Fragment>
  <div>One</div>
  <div>Two</div>
</React.Fragment>
```

I guess both `<div>`s should get `data-reactroot=""` markup, but not sure what the result on client side would be!

Any changes you want made, please shout.