### PR TITLE
[ESLint] Enforce deps array in useMemo and useCallback

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -179,6 +179,16 @@ const tests = {
       `,
     },
     {
+      // Valid because they have meaning without deps.
+      code: `
+        function MyComponent(props) {
+          useEffect(() => {});
+          useLayoutEffect(() => {});
+          useImperativeHandle(props.innerRef, () => {});
+        }
+      `,
+    },
+    {
       code: `
         function MyComponent(props) {
           useEffect(() => {
@@ -922,6 +932,26 @@ const tests = {
       errors: [
         "React Hook useEffect has a missing dependency: 'local'. " +
           'Either include it or remove the dependency array.',
+      ],
+    },
+    {
+      // Invalid because they don't have a meaning without deps.
+      code: `
+        function MyComponent(props) {
+          const value = useMemo(() => { return 2*2; });
+          const fn = useCallback(() => { alert('foo'); });
+        }
+      `,
+      // We don't know what you meant.
+      output: `
+        function MyComponent(props) {
+          const value = useMemo(() => { return 2*2; });
+          const fn = useCallback(() => { alert('foo'); });
+        }
+      `,
+      errors: [
+        "React Hook useMemo doesn't serve any purpose without a dependency array as a second argument.",
+        "React Hook useCallback doesn't serve any purpose without a dependency array as a second argument.",
       ],
     },
     {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -87,6 +87,18 @@ export default {
       const depsIndex = callbackIndex + 1;
       const declaredDependenciesNode = node.parent.arguments[depsIndex];
       if (!declaredDependenciesNode) {
+        // These are only used for optimization.
+        if (
+          reactiveHookName === 'useMemo' ||
+          reactiveHookName === 'useCallback'
+        ) {
+          context.report({
+            node: node,
+            message:
+              `React Hook ${reactiveHookName} doesn't serve any purpose ` +
+              `without a dependency array as a second argument.`,
+          });
+        }
         return;
       }
 


### PR DESCRIPTION
They serve no purpose without a deps array. We have a similar rule on internally and it caught mistakes.

```js
function MyComponent(props) {
  const value = useMemo(() => { return 2*2; }); // Warning
  const fn = useCallback(() => { alert('foo'); }); // Warning
}
```

We still allow it from type perspective. In the future we might have a smart compiler that fills them in. But if you use this rule, you're doing it manually so you should be aware when your optimization doesn't work.

This is also a missing piece for the `useCallback` enforcement thing I'm working on separately. I'll send another PR for that.