### PR TITLE
add Rollup build fail information for the developer

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -30,7 +30,9 @@ let loggedErrors = new Set();
 process.on('unhandledRejection', err => {
   if (loggedErrors.has(err)) {
     // No need to print it twice.
-    console.error('React build has been explicitly stopped due to errors in promises');
+    console.error(
+      'React build has been explicitly stopped due to errors in promises'
+    );
     process.exit(1);
   }
   throw err;
@@ -567,7 +569,9 @@ function handleRollupWarning(warning) {
     console.error();
     console.error(warning.message || warning);
     console.error();
-    console.error('React build has been explicitly stopped due to Rollup warnings');
+    console.error(
+      'React build has been explicitly stopped due to Rollup warnings'
+    );
     process.exit(1);
   } else {
     // The warning is from one of the plugins.

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -30,6 +30,7 @@ let loggedErrors = new Set();
 process.on('unhandledRejection', err => {
   if (loggedErrors.has(err)) {
     // No need to print it twice.
+    console.error('React build has been explicitly stopped due to errors in promises');
     process.exit(1);
   }
   throw err;
@@ -566,6 +567,7 @@ function handleRollupWarning(warning) {
     console.error();
     console.error(warning.message || warning);
     console.error();
+    console.error('React build has been explicitly stopped due to Rollup warnings');
     process.exit(1);
   } else {
     // The warning is from one of the plugins.


### PR DESCRIPTION
Purpose:

As a developer, I would be really nice to easily identify whether a build failed due to external or internal reasons.

Internal reasons are where we deliberately fail a build. 
As I experimented with updating the Rollup version I experienced failures due to Rollup warnings.

In newer versions of Rollup they introduced "CIRCULAR_DEPENDENCY" warning which will fail the react-dom build.

If I knew the build fail was due to the build.js file explicitly invoking process.exit(1), then I would have spend less time debugging the reason of the build failure.
