### PR TITLE
[ESLint] Fix ESLint rule crash in an edge case

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -838,6 +838,17 @@ const tests = {
         }
       `,
     },
+    {
+      // Regression test for a crash
+      code: `
+        function Podcasts() {
+          useEffect(() => {
+            setPodcasts([]);
+          }, []);
+          let [podcasts, setPodcasts] = useState(null);
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -3810,6 +3821,32 @@ const tests = {
       errors: [
         "React Hook useEffect has a missing dependency: 'tick'. " +
           'Either include it or remove the dependency array.',
+      ],
+    },
+    {
+      // Regression test for a crash
+      code: `
+        function Podcasts() {
+          useEffect(() => {
+            alert(podcasts);
+          }, []);
+          let [podcasts, setPodcasts] = useState(null);
+        }
+      `,
+      // Note: this autofix is shady because
+      // the variable is used before declaration.
+      // TODO: Maybe we can catch those fixes and not autofix.
+      output: `
+        function Podcasts() {
+          useEffect(() => {
+            alert(podcasts);
+          }, [podcasts]);
+          let [podcasts, setPodcasts] = useState(null);
+        }
+      `,
+      errors: [
+        `React Hook useEffect has a missing dependency: 'podcasts'. ` +
+          `Either include it or remove the dependency array.`,
       ],
     },
   ],

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -164,7 +164,17 @@ export default {
         }
         // Detect primitive constants
         // const foo = 42
-        const declaration = def.node.parent;
+        let declaration = def.node.parent;
+        if (declaration == null) {
+          // This might happen if variable is declared after the callback.
+          // In that case ESLint won't set up .parent refs.
+          // So we'll set them up manually.
+          fastFindReferenceWithParent(componentScope.block, def.node.id);
+          declaration = def.node.parent;
+          if (declaration == null) {
+            return false;
+          }
+        }
         if (
           declaration.kind === 'const' &&
           init.type === 'Literal' &&


### PR DESCRIPTION
The fix itself is a bit shady but we already rely on this hack in a few places. I'd like to find a way to avoid it in the future but at least this fixes the crash. (This could also be an ESLint bug, I'm not sure.)