### PR TITLE
Warn for javascript: URLs in DOM sinks

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+/* eslint-disable no-script-url */
+
+'use strict';
+
+const ReactDOMServerIntegrationUtils = require('./utils/ReactDOMServerIntegrationTestUtils');
+
+let React;
+let ReactDOM;
+let ReactDOMServer;
+
+function initModules() {
+  jest.resetModuleRegistry();
+  const ReactFeatureFlags = require('shared/ReactFeatureFlags');
+  ReactFeatureFlags.disableJavaScriptURLs = true;
+
+  React = require('react');
+  ReactDOM = require('react-dom');
+  ReactDOMServer = require('react-dom/server');
+
+  // Make them available to the helpers.
+  return {
+    ReactDOM,
+    ReactDOMServer,
+  };
+}
+
+const {
+  resetModules,
+  itRenders,
+  itThrowsWhenRendering,
+} = ReactDOMServerIntegrationUtils(initModules);
+
+describe('ReactDOMServerIntegration', () => {
+  beforeEach(() => {
+    resetModules();
+  });
+
+  itRenders('a http link with the word javascript in it', async render => {
+    const e = await render(
+      <a href="http://javascript:0/thisisfine">Click me</a>,
+    );
+    expect(e.tagName).toBe('A');
+    expect(e.href).toBe('http://javascript:0/thisisfine');
+  });
+
+  itThrowsWhenRendering(
+    'a javascript protocol href',
+    render => render(<a href="javascript:notfine">p0wned</a>, 1),
+    'XSS',
+  );
+
+  itThrowsWhenRendering(
+    'a javascript protocol area href',
+    render =>
+      render(
+        <map>
+          <area href="javascript:notfine" />
+        </map>,
+        1,
+      ),
+    'XSS',
+  );
+
+  itThrowsWhenRendering(
+    'a javascript protocol form action',
+    render => render(<form action="javascript:notfine">p0wned</form>, 1),
+    'XSS',
+  );
+
+  itThrowsWhenRendering(
+    'a javascript protocol button formAction',
+    render => render(<input formAction="javascript:notfine" />, 1),
+    'XSS',
+  );
+
+  itThrowsWhenRendering(
+    'a javascript protocol input formAction',
+    render =>
+      render(<button formAction="javascript:notfine">p0wned</button>, 1),
+    'XSS',
+  );
+
+  itThrowsWhenRendering(
+    'a javascript protocol iframe src',
+    render => render(<iframe src="javascript:notfine" />, 1),
+    'XSS',
+  );
+
+  itThrowsWhenRendering(
+    'a javascript protocol frame src',
+    render =>
+      render(
+        <frameset>
+          <frame src="javascript:notfine" />
+        </frameset>,
+        1,
+      ),
+    'XSS',
+  );
+
+  itThrowsWhenRendering(
+    'a javascript protocol in an SVG link',
+    render =>
+      render(
+        <svg>
+          <a href="javascript:notfine" />
+        </svg>,
+        1,
+      ),
+    'XSS',
+  );
+
+  itThrowsWhenRendering(
+    'a javascript protocol in an SVG link with a namespace',
+    render =>
+      render(
+        <svg>
+          <a xlinkHref="javascript:notfine" />
+        </svg>,
+        1,
+      ),
+    'XSS',
+  );
+});

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
@@ -17,33 +17,7 @@ let React;
 let ReactDOM;
 let ReactDOMServer;
 
-function initModules() {
-  jest.resetModuleRegistry();
-  const ReactFeatureFlags = require('shared/ReactFeatureFlags');
-  ReactFeatureFlags.disableJavaScriptURLs = true;
-
-  React = require('react');
-  ReactDOM = require('react-dom');
-  ReactDOMServer = require('react-dom/server');
-
-  // Make them available to the helpers.
-  return {
-    ReactDOM,
-    ReactDOMServer,
-  };
-}
-
-const {
-  resetModules,
-  itRenders,
-  itThrowsWhenRendering,
-} = ReactDOMServerIntegrationUtils(initModules);
-
-describe('ReactDOMServerIntegration', () => {
-  beforeEach(() => {
-    resetModules();
-  });
-
+function runTests(itRenders, itRejects) {
   itRenders('a http link with the word javascript in it', async render => {
     const e = await render(
       <a href="http://javascript:0/thisisfine">Click me</a>,
@@ -52,82 +26,134 @@ describe('ReactDOMServerIntegration', () => {
     expect(e.href).toBe('http://javascript:0/thisisfine');
   });
 
-  itThrowsWhenRendering(
-    'a javascript protocol href',
-    render => render(<a href="javascript:notfine">p0wned</a>, 1),
-    'XSS',
-  );
+  itRejects('a javascript protocol href', async render => {
+    const e = await render(<a href="javascript:notfine">p0wned</a>, 1);
+    expect(e.href).toBe('javascript:notfine');
+  });
 
-  itThrowsWhenRendering(
-    'a javascript protocol area href',
-    render =>
-      render(
-        <map>
-          <area href="javascript:notfine" />
-        </map>,
-        1,
-      ),
-    'XSS',
-  );
+  itRejects('a javascript protocol area href', async render => {
+    const e = await render(
+      <map>
+        <area href="javascript:notfine" />
+      </map>,
+      1,
+    );
+    expect(e.firstChild.href).toBe('javascript:notfine');
+  });
 
-  itThrowsWhenRendering(
-    'a javascript protocol form action',
-    render => render(<form action="javascript:notfine">p0wned</form>, 1),
-    'XSS',
-  );
+  itRejects('a javascript protocol form action', async render => {
+    const e = await render(<form action="javascript:notfine">p0wned</form>, 1);
+    expect(e.action).toBe('javascript:notfine');
+  });
 
-  itThrowsWhenRendering(
-    'a javascript protocol button formAction',
-    render => render(<input formAction="javascript:notfine" />, 1),
-    'XSS',
-  );
+  itRejects('a javascript protocol button formAction', async render => {
+    const e = await render(<input formAction="javascript:notfine" />, 1);
+    expect(e.getAttribute('formAction')).toBe('javascript:notfine');
+  });
 
-  itThrowsWhenRendering(
-    'a javascript protocol input formAction',
-    render =>
-      render(<button formAction="javascript:notfine">p0wned</button>, 1),
-    'XSS',
-  );
+  itRejects('a javascript protocol input formAction', async render => {
+    const e = await render(
+      <button formAction="javascript:notfine">p0wned</button>,
+      1,
+    );
+    expect(e.getAttribute('formAction')).toBe('javascript:notfine');
+  });
 
-  itThrowsWhenRendering(
-    'a javascript protocol iframe src',
-    render => render(<iframe src="javascript:notfine" />, 1),
-    'XSS',
-  );
+  itRejects('a javascript protocol iframe src', async render => {
+    const e = await render(<iframe src="javascript:notfine" />, 1);
+    expect(e.src).toBe('javascript:notfine');
+  });
 
-  itThrowsWhenRendering(
-    'a javascript protocol frame src',
-    render =>
-      render(
+  itRejects('a javascript protocol frame src', async render => {
+    const e = await render(
+      <html>
+        <head />
         <frameset>
           <frame src="javascript:notfine" />
-        </frameset>,
-        1,
-      ),
-    'XSS',
-  );
+        </frameset>
+      </html>,
+      1,
+    );
+    expect(e.lastChild.firstChild.src).toBe('javascript:notfine');
+  });
 
-  itThrowsWhenRendering(
-    'a javascript protocol in an SVG link',
-    render =>
-      render(
-        <svg>
-          <a href="javascript:notfine" />
-        </svg>,
-        1,
-      ),
-    'XSS',
-  );
+  itRejects('a javascript protocol in an SVG link', async render => {
+    const e = await render(
+      <svg>
+        <a href="javascript:notfine" />
+      </svg>,
+      1,
+    );
+    expect(e.firstChild.getAttribute('href')).toBe('javascript:notfine');
+  });
 
-  itThrowsWhenRendering(
+  itRejects(
     'a javascript protocol in an SVG link with a namespace',
-    render =>
-      render(
+    async render => {
+      const e = await render(
         <svg>
           <a xlinkHref="javascript:notfine" />
         </svg>,
         1,
-      ),
-    'XSS',
+      );
+      expect(
+        e.firstChild.getAttributeNS('http://www.w3.org/1999/xlink', 'href'),
+      ).toBe('javascript:notfine');
+    },
+  );
+}
+
+describe('ReactDOMServerIntegration - Untrusted URLs', () => {
+  function initModules() {
+    jest.resetModuleRegistry();
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMServer = require('react-dom/server');
+
+    // Make them available to the helpers.
+    return {
+      ReactDOM,
+      ReactDOMServer,
+    };
+  }
+
+  const {resetModules, itRenders} = ReactDOMServerIntegrationUtils(initModules);
+
+  beforeEach(() => {
+    resetModules();
+  });
+
+  runTests(itRenders, itRenders);
+});
+
+describe('ReactDOMServerIntegration - Untrusted URLs - disableJavaScriptURLs', () => {
+  function initModules() {
+    jest.resetModuleRegistry();
+    const ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.disableJavaScriptURLs = true;
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMServer = require('react-dom/server');
+
+    // Make them available to the helpers.
+    return {
+      ReactDOM,
+      ReactDOMServer,
+    };
+  }
+
+  const {
+    resetModules,
+    itRenders,
+    itThrowsWhenRendering,
+  } = ReactDOMServerIntegrationUtils(initModules);
+
+  beforeEach(() => {
+    resetModules();
+  });
+
+  runTests(itRenders, (message, test) =>
+    itThrowsWhenRendering(message, test, 'blocked a javascript: URL'),
   );
 });

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
@@ -27,8 +27,16 @@ function runTests(itRenders, itRejectsRendering, expectToReject) {
   });
 
   itRejectsRendering('a javascript protocol href', async render => {
-    const e = await render(<a href="javascript:notfine">p0wned</a>, 1);
-    expect(e.href).toBe('javascript:notfine');
+    // Only the first one warns. The second warning is deduped.
+    const e = await render(
+      <div>
+        <a href="javascript:notfine">p0wned</a>
+        <a href="javascript:notfineagain">p0wned again</a>
+      </div>,
+      1,
+    );
+    expect(e.firstChild.href).toBe('javascript:notfine');
+    expect(e.lastChild.href).toBe('javascript:notfineagain');
   });
 
   itRejectsRendering(
@@ -162,7 +170,7 @@ describe('ReactDOMServerIntegration - Untrusted URLs', () => {
     expect(fn).toWarnDev(
       'Warning: A future version of React will block javascript: URLs as a security precaution. ' +
         'Use event handlers instead if you can. If you need to generate unsafe HTML try using ' +
-        'dangerouslySetInnerHTML instead.\n' +
+        'dangerouslySetInnerHTML instead. React was passed "javascript:notfine".\n' +
         '    in a (at **)',
     ),
   );

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
@@ -226,13 +226,18 @@ describe('ReactDOMServerIntegration - Untrusted URLs - disableJavaScriptURLs', (
 
   itRenders('only the first invocation of toString', async render => {
     let expectedToStringCalls = 1;
-    if (
-      render === clientRenderOnBadMarkup ||
-      render === clientRenderOnServerString
-    ) {
-      // The hydration calls it one extra time.
+    if (render === clientRenderOnBadMarkup) {
+      // It gets called once on the server and once on the client
+      // which happens to share the same object in our test runner.
       expectedToStringCalls = 2;
     }
+    if (render === clientRenderOnServerString && __DEV__) {
+      // The hydration validation calls it one extra time.
+      // TODO: It would be good if we only called toString once for
+      // consistency but the code structure makes that hard right now.
+      expectedToStringCalls = 2;
+    }
+
     let toStringCalls = 0;
     let firstIsSafe = {
       toString() {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
@@ -17,7 +17,7 @@ let React;
 let ReactDOM;
 let ReactDOMServer;
 
-function runTests(itRenders, itRejects, expectToReject) {
+function runTests(itRenders, itRejectsRendering, expectToReject) {
   itRenders('a http link with the word javascript in it', async render => {
     const e = await render(
       <a href="http://javascript:0/thisisfine">Click me</a>,
@@ -26,22 +26,25 @@ function runTests(itRenders, itRejects, expectToReject) {
     expect(e.href).toBe('http://javascript:0/thisisfine');
   });
 
-  itRejects('a javascript protocol href', async render => {
+  itRejectsRendering('a javascript protocol href', async render => {
     const e = await render(<a href="javascript:notfine">p0wned</a>, 1);
     expect(e.href).toBe('javascript:notfine');
   });
 
-  itRejects('a javascript protocol with leading spaces', async render => {
-    const e = await render(
-      <a href={'  \t \u0000\u001F\u0003javascript\n: notfine'}>p0wned</a>,
-      1,
-    );
-    // We use an approximate comparison here because JSDOM might not parse
-    // \u0000 in HTML properly.
-    expect(e.href).toContain('notfine');
-  });
+  itRejectsRendering(
+    'a javascript protocol with leading spaces',
+    async render => {
+      const e = await render(
+        <a href={'  \t \u0000\u001F\u0003javascript\n: notfine'}>p0wned</a>,
+        1,
+      );
+      // We use an approximate comparison here because JSDOM might not parse
+      // \u0000 in HTML properly.
+      expect(e.href).toContain('notfine');
+    },
+  );
 
-  itRejects(
+  itRejectsRendering(
     'a javascript protocol with intermediate new lines and mixed casing',
     async render => {
       const e = await render(
@@ -52,7 +55,7 @@ function runTests(itRenders, itRejects, expectToReject) {
     },
   );
 
-  itRejects('a javascript protocol area href', async render => {
+  itRejectsRendering('a javascript protocol area href', async render => {
     const e = await render(
       <map>
         <area href="javascript:notfine" />
@@ -62,17 +65,20 @@ function runTests(itRenders, itRejects, expectToReject) {
     expect(e.firstChild.href).toBe('javascript:notfine');
   });
 
-  itRejects('a javascript protocol form action', async render => {
+  itRejectsRendering('a javascript protocol form action', async render => {
     const e = await render(<form action="javascript:notfine">p0wned</form>, 1);
     expect(e.action).toBe('javascript:notfine');
   });
 
-  itRejects('a javascript protocol button formAction', async render => {
-    const e = await render(<input formAction="javascript:notfine" />, 1);
-    expect(e.getAttribute('formAction')).toBe('javascript:notfine');
-  });
+  itRejectsRendering(
+    'a javascript protocol button formAction',
+    async render => {
+      const e = await render(<input formAction="javascript:notfine" />, 1);
+      expect(e.getAttribute('formAction')).toBe('javascript:notfine');
+    },
+  );
 
-  itRejects('a javascript protocol input formAction', async render => {
+  itRejectsRendering('a javascript protocol input formAction', async render => {
     const e = await render(
       <button formAction="javascript:notfine">p0wned</button>,
       1,
@@ -80,12 +86,12 @@ function runTests(itRenders, itRejects, expectToReject) {
     expect(e.getAttribute('formAction')).toBe('javascript:notfine');
   });
 
-  itRejects('a javascript protocol iframe src', async render => {
+  itRejectsRendering('a javascript protocol iframe src', async render => {
     const e = await render(<iframe src="javascript:notfine" />, 1);
     expect(e.src).toBe('javascript:notfine');
   });
 
-  itRejects('a javascript protocol frame src', async render => {
+  itRejectsRendering('a javascript protocol frame src', async render => {
     const e = await render(
       <html>
         <head />
@@ -98,7 +104,7 @@ function runTests(itRenders, itRejects, expectToReject) {
     expect(e.lastChild.firstChild.src).toBe('javascript:notfine');
   });
 
-  itRejects('a javascript protocol in an SVG link', async render => {
+  itRejectsRendering('a javascript protocol in an SVG link', async render => {
     const e = await render(
       <svg>
         <a href="javascript:notfine" />
@@ -108,7 +114,7 @@ function runTests(itRenders, itRejects, expectToReject) {
     expect(e.firstChild.getAttribute('href')).toBe('javascript:notfine');
   });
 
-  itRejects(
+  itRejectsRendering(
     'a javascript protocol in an SVG link with a namespace',
     async render => {
       const e = await render(

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
@@ -31,6 +31,27 @@ function runTests(itRenders, itRejects) {
     expect(e.href).toBe('javascript:notfine');
   });
 
+  itRejects('a javascript protocol with leading spaces', async render => {
+    const e = await render(
+      <a href={'  \t \u0000\u001F\u0003javascript\n: notfine'}>p0wned</a>,
+      1,
+    );
+    // We use an approximate comparison here because JSDOM might not parse
+    // \u0000 in HTML properly.
+    expect(e.href).toContain('notfine');
+  });
+
+  itRejects(
+    'a javascript protocol with intermediate new lines and mixed casing',
+    async render => {
+      const e = await render(
+        <a href={'\t\r\n Jav\rasCr\r\niP\t\n\rt\n:notfine'}>p0wned</a>,
+        1,
+      );
+      expect(e.href).toBe('javascript:notfine');
+    },
+  );
+
   itRejects('a javascript protocol area href', async render => {
     const e = await render(
       <map>

--- a/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
+++ b/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
@@ -357,6 +357,7 @@ module.exports = function(initModules) {
     asyncReactDOMRender,
     serverRender,
     clientCleanRender,
+    clientRenderOnBadMarkup,
     clientRenderOnServerString,
     renderIntoDom,
     streamRender,

--- a/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
+++ b/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
@@ -19,6 +19,28 @@ module.exports = function(initModules) {
     ({ReactDOM, ReactDOMServer} = initModules());
   }
 
+  function shouldUseDocument(reactElement) {
+    // Used for whole document tests.
+    return reactElement && reactElement.type === 'html';
+  }
+
+  function getContainerFromMarkup(reactElement, markup) {
+    if (shouldUseDocument(reactElement)) {
+      const doc = document.implementation.createHTMLDocument('');
+      doc.open();
+      doc.write(
+        markup ||
+          '<!doctype html><html><meta charset=utf-8><title>test doc</title>',
+      );
+      doc.close();
+      return doc;
+    } else {
+      const container = document.createElement('div');
+      container.innerHTML = markup;
+      return container;
+    }
+  }
+
   // Helper functions for rendering tests
   // ====================================
 
@@ -97,9 +119,7 @@ module.exports = function(initModules) {
   // Does not render on client or perform client-side revival.
   async function serverRender(reactElement, errorCount = 0) {
     const markup = await renderIntoString(reactElement, errorCount);
-    const domElement = document.createElement('div');
-    domElement.innerHTML = markup;
-    return domElement.firstChild;
+    return getContainerFromMarkup(reactElement, markup).firstChild;
   }
 
   // this just drains a readable piped into it to a string, which can be accessed
@@ -133,27 +153,28 @@ module.exports = function(initModules) {
   // Does not render on client or perform client-side revival.
   async function streamRender(reactElement, errorCount = 0) {
     const markup = await renderIntoStream(reactElement, errorCount);
-    const domElement = document.createElement('div');
-    domElement.innerHTML = markup;
-    return domElement.firstChild;
+    return getContainerFromMarkup(reactElement, markup).firstChild;
   }
 
   const clientCleanRender = (element, errorCount = 0) => {
-    const div = document.createElement('div');
-    return renderIntoDom(element, div, false, errorCount);
+    if (shouldUseDocument(element)) {
+      // Documents can't be rendered from scratch.
+      return clientRenderOnServerString(element, errorCount);
+    }
+    const container = document.createElement('div');
+    return renderIntoDom(element, container, false, errorCount);
   };
 
   const clientRenderOnServerString = async (element, errorCount = 0) => {
     const markup = await renderIntoString(element, errorCount);
     resetModules();
 
-    const domElement = document.createElement('div');
-    domElement.innerHTML = markup;
-    let serverNode = domElement.firstChild;
+    let container = getContainerFromMarkup(element, markup);
+    let serverNode = container.firstChild;
 
     const firstClientNode = await renderIntoDom(
       element,
-      domElement,
+      container,
       true,
       errorCount,
     );
@@ -178,19 +199,35 @@ module.exports = function(initModules) {
 
   const clientRenderOnBadMarkup = async (element, errorCount = 0) => {
     // First we render the top of bad mark up.
-    const domElement = document.createElement('div');
-    domElement.innerHTML =
-      '<div id="badIdWhichWillCauseMismatch" data-reactroot="" data-reactid="1"></div>';
-    await renderIntoDom(element, domElement, true, errorCount + 1);
+
+    let container = getContainerFromMarkup(
+      element,
+      shouldUseDocument(element)
+        ? '<html><body><div id="badIdWhichWillCauseMismatch" /></body></html>'
+        : '<div id="badIdWhichWillCauseMismatch" data-reactroot="" data-reactid="1"></div>',
+    );
+
+    await renderIntoDom(element, container, true, errorCount + 1);
 
     // This gives us the resulting text content.
-    const hydratedTextContent = domElement.textContent;
+    const hydratedTextContent =
+      container.lastChild && container.lastChild.textContent;
 
     // Next we render the element into a clean DOM node client side.
-    const cleanDomElement = document.createElement('div');
-    await asyncReactDOMRender(element, cleanDomElement, true);
+    let cleanContainer;
+    if (shouldUseDocument(element)) {
+      // We can't render into a document during a clean render,
+      // so instead, we'll render the children into the document element.
+      cleanContainer = getContainerFromMarkup(element, '<html></html>')
+        .documentElement;
+      element = element.props.children;
+    } else {
+      cleanContainer = document.createElement('div');
+    }
+    await asyncReactDOMRender(element, cleanContainer, true);
     // This gives us the expected text content.
-    const cleanTextContent = cleanDomElement.textContent;
+    const cleanTextContent =
+      cleanContainer.lastChild && cleanContainer.lastChild.textContent;
 
     // The only guarantee is that text content has been patched up if needed.
     expect(hydratedTextContent).toBe(cleanTextContent);

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -40,7 +40,7 @@ export function getValueForProperty(
         // If we haven't fully disabled javascript: URLs, and if
         // the hydration is successful of a javascript: URL, we
         // still want to warn on the client.
-        sanitizeURL(expected);
+        sanitizeURL('' + (expected: any));
       }
 
       const attributeName = propertyInfo.attributeName;

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -15,6 +15,7 @@ import {
   BOOLEAN,
   OVERLOADED_BOOLEAN,
 } from '../shared/DOMProperty';
+import sanitizeURL from '../shared/sanitizeURL';
 
 import type {PropertyInfo} from '../shared/DOMProperty';
 
@@ -164,6 +165,9 @@ export function setValueForProperty(
       // `setAttribute` with objects becomes only `[object]` in IE8/9,
       // ('' + value) makes it output the correct toString()-value.
       attributeValue = '' + (value: any);
+      if (propertyInfo.sanitizeURL) {
+        sanitizeURL(attributeValue);
+      }
     }
     if (attributeNamespace) {
       node.setAttributeNS(attributeNamespace, attributeName, attributeValue);

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -16,6 +16,7 @@ import {
   OVERLOADED_BOOLEAN,
 } from '../shared/DOMProperty';
 import sanitizeURL from '../shared/sanitizeURL';
+import {disableJavaScriptURLs} from 'shared/ReactFeatureFlags';
 
 import type {PropertyInfo} from '../shared/DOMProperty';
 
@@ -35,6 +36,13 @@ export function getValueForProperty(
       const {propertyName} = propertyInfo;
       return (node: any)[propertyName];
     } else {
+      if (!disableJavaScriptURLs && propertyInfo.sanitizeURL) {
+        // If we haven't fully disabled javascript: URLs, and if
+        // the hydration is successful of a javascript: URL, we
+        // still want to warn on the client.
+        sanitizeURL(expected);
+      }
+
       const attributeName = propertyInfo.attributeName;
 
       let stringValue = null;

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -282,7 +282,9 @@ if (__DEV__) {
         );
       // https://html.spec.whatwg.org/multipage/semantics.html#the-html-element
       case 'html':
-        return tag === 'head' || tag === 'body';
+        return tag === 'head' || tag === 'body' || tag === 'frameset';
+      case 'frameset':
+        return tag === 'frame';
       case '#document':
         return tag === 'html';
     }
@@ -314,6 +316,7 @@ if (__DEV__) {
       case 'caption':
       case 'col':
       case 'colgroup':
+      case 'frameset':
       case 'frame':
       case 'head':
       case 'html':

--- a/packages/react-dom/src/server/DOMMarkupOperations.js
+++ b/packages/react-dom/src/server/DOMMarkupOperations.js
@@ -17,6 +17,7 @@ import {
   shouldIgnoreAttribute,
   shouldRemoveAttribute,
 } from '../shared/DOMProperty';
+import sanitizeURL from '../shared/sanitizeURL';
 import quoteAttributeValueForBrowser from './quoteAttributeValueForBrowser';
 
 /**
@@ -58,6 +59,10 @@ export function createMarkupForProperty(name: string, value: mixed): string {
     if (type === BOOLEAN || (type === OVERLOADED_BOOLEAN && value === true)) {
       return attributeName + '=""';
     } else {
+      if (propertyInfo.sanitizeURL) {
+        value = '' + (value: any);
+        sanitizeURL(value);
+      }
       return attributeName + '=' + quoteAttributeValueForBrowser(value);
     }
   } else if (isAttributeNameSafe(name)) {

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -51,6 +51,7 @@ export type PropertyInfo = {|
   +mustUseProperty: boolean,
   +propertyName: string,
   +type: PropertyType,
+  +sanitizeURL: boolean,
 |};
 
 /* eslint-disable max-len */
@@ -186,6 +187,7 @@ function PropertyInfoRecord(
   mustUseProperty: boolean,
   attributeName: string,
   attributeNamespace: string | null,
+  sanitizeURL: boolean,
 ) {
   this.acceptsBooleans =
     type === BOOLEANISH_STRING ||
@@ -196,6 +198,7 @@ function PropertyInfoRecord(
   this.mustUseProperty = mustUseProperty;
   this.propertyName = name;
   this.type = type;
+  this.sanitizeURL = sanitizeURL;
 }
 
 // When adding attributes to this list, be sure to also add them to
@@ -223,6 +226,7 @@ const properties = {};
     false, // mustUseProperty
     name, // attributeName
     null, // attributeNamespace
+    false, // sanitizeURL
   );
 });
 
@@ -240,6 +244,7 @@ const properties = {};
     false, // mustUseProperty
     attributeName, // attributeName
     null, // attributeNamespace
+    false, // sanitizeURL
   );
 });
 
@@ -253,6 +258,7 @@ const properties = {};
     false, // mustUseProperty
     name.toLowerCase(), // attributeName
     null, // attributeNamespace
+    false, // sanitizeURL
   );
 });
 
@@ -272,6 +278,7 @@ const properties = {};
     false, // mustUseProperty
     name, // attributeName
     null, // attributeNamespace
+    false, // sanitizeURL
   );
 });
 
@@ -308,6 +315,7 @@ const properties = {};
     false, // mustUseProperty
     name.toLowerCase(), // attributeName
     null, // attributeNamespace
+    false, // sanitizeURL
   );
 });
 
@@ -331,6 +339,7 @@ const properties = {};
     true, // mustUseProperty
     name, // attributeName
     null, // attributeNamespace
+    false, // sanitizeURL
   );
 });
 
@@ -350,6 +359,7 @@ const properties = {};
     false, // mustUseProperty
     name, // attributeName
     null, // attributeNamespace
+    false, // sanitizeURL
   );
 });
 
@@ -370,6 +380,7 @@ const properties = {};
     false, // mustUseProperty
     name, // attributeName
     null, // attributeNamespace
+    false, // sanitizeURL
   );
 });
 
@@ -381,6 +392,7 @@ const properties = {};
     false, // mustUseProperty
     name.toLowerCase(), // attributeName
     null, // attributeNamespace
+    false, // sanitizeURL
   );
 });
 
@@ -478,6 +490,7 @@ const capitalize = token => token[1].toUpperCase();
     false, // mustUseProperty
     attributeName,
     null, // attributeNamespace
+    false, // sanitizeURL
   );
 });
 
@@ -485,7 +498,6 @@ const capitalize = token => token[1].toUpperCase();
 [
   'xlink:actuate',
   'xlink:arcrole',
-  'xlink:href',
   'xlink:role',
   'xlink:show',
   'xlink:title',
@@ -502,6 +514,7 @@ const capitalize = token => token[1].toUpperCase();
     false, // mustUseProperty
     attributeName,
     'http://www.w3.org/1999/xlink',
+    false, // sanitizeURL
   );
 });
 
@@ -522,6 +535,7 @@ const capitalize = token => token[1].toUpperCase();
     false, // mustUseProperty
     attributeName,
     'http://www.w3.org/XML/1998/namespace',
+    false, // sanitizeURL
   );
 });
 
@@ -535,5 +549,29 @@ const capitalize = token => token[1].toUpperCase();
     false, // mustUseProperty
     attributeName.toLowerCase(), // attributeName
     null, // attributeNamespace
+    false, // sanitizeURL
+  );
+});
+
+// These attributes accept URLs. These must not allow javascript: URLS.
+// These will also need to accept Trusted Types object in the future.
+const xlinkHref = 'xlinkHref';
+properties[xlinkHref] = new PropertyInfoRecord(
+  'xlinkHref',
+  STRING,
+  false, // mustUseProperty
+  'xlink:href',
+  'http://www.w3.org/1999/xlink',
+  true, // sanitizeURL
+);
+
+['src', 'href', 'action', 'formAction'].forEach(attributeName => {
+  properties[attributeName] = new PropertyInfoRecord(
+    attributeName,
+    STRING,
+    false, // mustUseProperty
+    attributeName.toLowerCase(), // attributeName
+    null, // attributeNamespace
+    true, // sanitizeURL
   );
 });

--- a/packages/react-dom/src/shared/sanitizeURL.js
+++ b/packages/react-dom/src/shared/sanitizeURL.js
@@ -29,6 +29,8 @@ if (__DEV__) {
 /* eslint-disable max-len */
 const isJavaScriptProtocol = /^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*\:/i;
 
+let didWarn = false;
+
 function sanitizeURL(url: string) {
   if (disableJavaScriptURLs) {
     invariant(
@@ -36,12 +38,14 @@ function sanitizeURL(url: string) {
       'React has blocked a javascript: URL as a security precaution.%s',
       __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '',
     );
-  } else if (__DEV__) {
+  } else if (__DEV__ && !didWarn && isJavaScriptProtocol.test(url)) {
+    didWarn = true;
     warning(
-      !isJavaScriptProtocol.test(url),
+      false,
       'A future version of React will block javascript: URLs as a security precaution. ' +
         'Use event handlers instead if you can. If you need to generate unsafe HTML try ' +
-        'using dangerouslySetInnerHTML instead.',
+        'using dangerouslySetInnerHTML instead. React was passed %s.',
+      JSON.stringify(url),
     );
   }
 }

--- a/packages/react-dom/src/shared/sanitizeURL.js
+++ b/packages/react-dom/src/shared/sanitizeURL.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import invariant from 'shared/invariant';
+import warning from 'shared/warning';
+import ReactSharedInternals from 'shared/ReactSharedInternals';
+
+let ReactDebugCurrentFrame = null;
+if (__DEV__) {
+  ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+}
+
+// TODO: This is not sufficient. Will include more.
+let isJavaScriptProtocol = /^\s*javascript\:/i;
+
+function sanitizeURL(url: string) {
+  invariant(
+    !isJavaScriptProtocol.test(url),
+    'XSS.%s',
+    __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '',
+  );
+}
+
+export default sanitizeURL;

--- a/packages/react-dom/src/shared/sanitizeURL.js
+++ b/packages/react-dom/src/shared/sanitizeURL.js
@@ -8,6 +8,7 @@
 import invariant from 'shared/invariant';
 import warning from 'shared/warning';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
+import {disableJavaScriptURLs} from 'shared/ReactFeatureFlags';
 
 let ReactDebugCurrentFrame = null;
 if (__DEV__) {
@@ -18,11 +19,20 @@ if (__DEV__) {
 let isJavaScriptProtocol = /^\s*javascript\:/i;
 
 function sanitizeURL(url: string) {
-  invariant(
-    !isJavaScriptProtocol.test(url),
-    'XSS.%s',
-    __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '',
-  );
+  if (disableJavaScriptURLs) {
+    invariant(
+      !isJavaScriptProtocol.test(url),
+      'React has blocked a javascript: URL as a security precaution.%s',
+      __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '',
+    );
+  } else if (__DEV__) {
+    warning(
+      !isJavaScriptProtocol.test(url),
+      'A future version of React will block javascript: URLs as a security precaution. ' +
+        'Use event handlers instead if you can. If you need to generate unsafe HTML try ' +
+        'using dangerouslySetInnerHTML instead.',
+    );
+  }
 }
 
 export default sanitizeURL;

--- a/packages/react-dom/src/shared/sanitizeURL.js
+++ b/packages/react-dom/src/shared/sanitizeURL.js
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import invariant from 'shared/invariant';
@@ -10,7 +12,7 @@ import warning from 'shared/warning';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {disableJavaScriptURLs} from 'shared/ReactFeatureFlags';
 
-let ReactDebugCurrentFrame = null;
+let ReactDebugCurrentFrame = ((null: any): {getStackAddendum(): string});
 if (__DEV__) {
   ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
 }

--- a/packages/react-dom/src/shared/sanitizeURL.js
+++ b/packages/react-dom/src/shared/sanitizeURL.js
@@ -15,8 +15,17 @@ if (__DEV__) {
   ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
 }
 
-// TODO: This is not sufficient. Will include more.
-let isJavaScriptProtocol = /^\s*javascript\:/i;
+// A javascript: URL can contain leading C0 control or \u0020 SPACE,
+// and any newline or tab are filtered out as if they're not part of the URL.
+// https://url.spec.whatwg.org/#url-parsing
+// Tab or newline are defined as \r\n\t:
+// https://infra.spec.whatwg.org/#ascii-tab-or-newline
+// A C0 control is a code point in the range \u0000 NULL to \u001F
+// INFORMATION SEPARATOR ONE, inclusive:
+// https://infra.spec.whatwg.org/#c0-control-or-space
+
+/* eslint-disable max-len */
+const isJavaScriptProtocol = /^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*\:/i;
 
 function sanitizeURL(url: string) {
   if (disableJavaScriptURLs) {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -42,6 +42,9 @@ export function addUserTimingListener() {
   throw new Error('Not implemented.');
 }
 
+// Disable javascript: URL strings in href for XSS protection.
+export const disableJavaScriptURLs = false;
+
 // React Fire: prevent the value and checked attributes from syncing
 // with their related DOM properties
 export const disableInputAttributeSyncing = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -24,6 +24,7 @@ export const enableStableConcurrentModeAPIs = false;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 export const debugRenderPhaseSideEffectsForStrictMode = true;
+export const disableJavaScriptURLs = false;
 export const disableInputAttributeSyncing = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -20,6 +20,7 @@ export const warnAboutDeprecatedLifecycles = false;
 export const enableProfilerTimer = __PROFILE__;
 export const enableSchedulerTracing = __PROFILE__;
 export const enableSuspenseServerRenderer = false;
+export const disableJavaScriptURLs = false;
 export const disableInputAttributeSyncing = false;
 export const enableStableConcurrentModeAPIs = false;
 export const warnAboutShorthandPropertyCollision = false;

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -20,6 +20,7 @@ export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const enableProfilerTimer = __PROFILE__;
 export const enableSchedulerTracing = __PROFILE__;
 export const enableSuspenseServerRenderer = false;
+export const disableJavaScriptURLs = false;
 export const disableInputAttributeSyncing = false;
 export const enableStableConcurrentModeAPIs = false;
 export const warnAboutShorthandPropertyCollision = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -20,6 +20,7 @@ export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = false;
 export const enableSchedulerTracing = false;
 export const enableSuspenseServerRenderer = false;
+export const disableJavaScriptURLs = false;
 export const disableInputAttributeSyncing = false;
 export const enableStableConcurrentModeAPIs = false;
 export const warnAboutShorthandPropertyCollision = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -23,6 +23,7 @@ export const enableSuspenseServerRenderer = false;
 export const enableStableConcurrentModeAPIs = false;
 export const enableSchedulerDebugging = false;
 export const warnAboutDeprecatedSetNativeProps = false;
+export const disableJavaScriptURLs = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -16,6 +16,7 @@ export const {
   debugRenderPhaseSideEffectsForStrictMode,
   replayFailedUnitOfWorkWithInvokeGuardedCallback,
   warnAboutDeprecatedLifecycles,
+  disableJavaScriptURLs,
   disableInputAttributeSyncing,
   warnAboutShorthandPropertyCollision,
   warnAboutDeprecatedSetNativeProps,


### PR DESCRIPTION
## Motivation

URLs is a common attack surface. If an attack can get a user provided URL into one of the DOM sinks it is essentially game over. Even partials of URLs can be bad.

`javascript:` links execute arbitrary code in the context of the page. URLs in image srcs can be used to track or even exfiltrate some data. URLs in script tags can execute arbitrary URLs. Links to mobile apps can cause problems.

There is no way we can cover all cases because there are many intentional use cases that overlap with unintentional ones. We intend to support [Trusted Types](https://github.com/WICG/trusted-types) objects passed to sinks like `<a href=...>` etc. which allows safe URLs to be distinguished from unsafe ones. The right approach here is a whitelist instead of a blacklist. However, opting in to Trusted Types is kind of non-trivial so we'd expect it to take a while for most sites.

In the meantime there is one XSS hole that is particularly common to forget about. This could be a `javascript:` URL.

```js
<a href={url}>...</a>
```

JavaScript URLs are particularly bad because it gains full control over the page where as other vulnerabilities relies on other things going wrong (such as native apps) or has limited access.

JavaScript URLs is also not really a legit use case once you're on the client in React since you can just attach event listeners and preventDefault instead.

Once you upgrade to [Trusted Types](https://github.com/WICG/trusted-types) or [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), the first thing you'll do is probably add a filter that blocks JavaScript URLs anyway.

One thing React can do to help with this problem in the meantime is to forbid `javascript:` URLs when rendered by React - by default.

## Breaking Change

Unfortunately, this would be a breaking change. This PR introduces a DEV mode deprecation warning which will last for the remainder of React 16.x. This doesn't actually provide any safety but it lets people clean up all their existing use cases.

Behind a flag, we also enable actually enforcing this block in production mode at runtime, which we'll turn on for a future React major.

## Coverage

This PR adds a flag to the property info for a few property names. We only block javascript URLs in native DOM, not in Custom Elements. We block this on the property name basis but the intention is to cover these cases which are confirmed to execute JavaScript URLs:

HTML

```js
<a href />
<form action />
<iframe src />
<area href />
<button formaction />
<input formaction />
<frame src />
```

SVG
```js
<a xlinkHref />
<a href />
```

The `<script src />` case is inherently broken since it executes script anyway.

We don't validate `<script text />`, `ref.innerHTML` and `<iframe srcdoc />` but they're more known to be dangerous. The future solution for those is to let pass-through Trusted Types to these values and use the policy to control them.

My understanding is that we don't need to cover these because they already don't execute `javascript:` URLs:

```js
<base href />
<link href />
<img src />
<input type="image" src />
<source src />
<track src />
<media src />
<embed src />
<img srcset />
<object data />
<object codebase />
<meta http-equiv="refresh" content="0;URL='...'" />
```

They can be other vulnerabilities though so in the future we'll also allow them to accept Trusted Types.

## PR

For code reviewers: The first two commits just enables us to write tests against `frameset`.




