### PR TITLE
Failing test for false positive "setState on unmounted component" warning

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1699,6 +1699,57 @@ describe('ReactHooks', () => {
     ).toThrow('Hello');
   });
 
+  it('does not fire a false positive warning when previous effect unmounts the component', () => {
+    let {useState, useEffect} = React;
+    let globalListener;
+
+    function A() {
+      const [show, setShow] = useState(true);
+      function hideMe() {
+        setShow(false);
+      }
+      return show ? <B hideMe={hideMe} /> : null;
+    }
+
+    function B(props) {
+      return <C {...props} />;
+    }
+
+    function C({hideMe}) {
+      const [, setState] = useState();
+
+      useEffect(() => {
+        let isStale = false;
+
+        globalListener = () => {
+          if (!isStale) {
+            setState('hello');
+          }
+        };
+
+        return () => {
+          isStale = true;
+          hideMe();
+        };
+      });
+      return null;
+    }
+
+    ReactTestRenderer.act(() => {
+      ReactTestRenderer.create(<A />);
+    });
+
+    expect(() => {
+      globalListener();
+      globalListener();
+    }).toWarnDev([
+      'An update to C inside a test was not wrapped in act',
+      'An update to C inside a test was not wrapped in act',
+      // Note: should *not* warn about updates on unmounted component.
+      // Because there's no way for component to know it got unmounted.
+    ]);
+  });
+
   // Regression test for https://github.com/facebook/react/issues/14790
   it('does not fire a false positive warning when suspending memo', async () => {
     const {Suspense, useState} = React;


### PR DESCRIPTION
Failing test for https://github.com/facebook/react/issues/15057.
Possibly relates to some cases of https://github.com/facebook/react/issues/14369.

The crux of the issue is that **even if we use a guard variable, sometimes an effect can't `setState` without triggering a warning**. In particular, this happens if:

* We set state in a component (e.g. from an event emitter call)
* We flush previous effect before we the state gets set
* Flushing previous effect caused a state change in a parent which resulted in component unmounting
* The scheduler thinks we *called* `setState` on an unmounted component, and warns

I'm not sure how to fix it. I imagine I'd expect that if `flushPassiveEffects` [here](https://github.com/facebook/react/blob/d0289c7e3a2dfc349dcce7f9eb3dee22464e97bd/packages/react-reconciler/src/ReactFiberHooks.js#L1109) led to unmounting of that component, we ideally shouldn't warn [here](https://github.com/facebook/react/blob/d0289c7e3a2dfc349dcce7f9eb3dee22464e97bd/packages/react-reconciler/src/ReactFiberScheduler.js#L1860).

I'm not sure if there are any bigger issues in cases where it's *not* unmounted though. Is this just a stray warning or is there a larger potential concern?