### PR TITLE
Warn when using createRef() in function components

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1182,20 +1182,37 @@ function dispatchAction<S, A>(
   }
 }
 
-export const ContextOnlyDispatcher: Dispatcher = {
-  readContext,
+export const ContextOnlyDispatcher: Dispatcher = __DEV__
+  ? {
+      readContext,
 
-  useCallback: throwInvalidHookError,
-  useContext: throwInvalidHookError,
-  useEffect: throwInvalidHookError,
-  useImperativeHandle: throwInvalidHookError,
-  useLayoutEffect: throwInvalidHookError,
-  useMemo: throwInvalidHookError,
-  useReducer: throwInvalidHookError,
-  useRef: throwInvalidHookError,
-  useState: throwInvalidHookError,
-  useDebugValue: throwInvalidHookError,
-};
+      useCallback: throwInvalidHookError,
+      useContext: throwInvalidHookError,
+      useEffect: throwInvalidHookError,
+      useImperativeHandle: throwInvalidHookError,
+      useLayoutEffect: throwInvalidHookError,
+      useMemo: throwInvalidHookError,
+      useReducer: throwInvalidHookError,
+      useRef: throwInvalidHookError,
+      useState: throwInvalidHookError,
+      useDebugValue: throwInvalidHookError,
+
+      _isContextOnlyDispatcherDEV: true,
+    }
+  : {
+      readContext,
+
+      useCallback: throwInvalidHookError,
+      useContext: throwInvalidHookError,
+      useEffect: throwInvalidHookError,
+      useImperativeHandle: throwInvalidHookError,
+      useLayoutEffect: throwInvalidHookError,
+      useMemo: throwInvalidHookError,
+      useReducer: throwInvalidHookError,
+      useRef: throwInvalidHookError,
+      useState: throwInvalidHookError,
+      useDebugValue: throwInvalidHookError,
+    };
 
 const HooksDispatcherOnMount: Dispatcher = {
   readContext,

--- a/packages/react/src/ReactCreateRef.js
+++ b/packages/react/src/ReactCreateRef.js
@@ -8,12 +8,26 @@
 
 import type {RefObject} from 'shared/ReactTypes';
 
+import getComponentName from 'shared/getComponentName';
+import ReactSharedInternals from 'shared/ReactSharedInternals';
+import warning from 'shared/warning';
+
 // an immutable object with a single mutable value
 export function createRef(): RefObject {
   const refObject = {
     current: null,
   };
   if (__DEV__) {
+    const dispatcher = ReactSharedInternals.ReactCurrentDispatcher.current;
+    const owner = ReactSharedInternals.ReactCurrentOwner.current;
+    warning(
+      dispatcher === null || dispatcher._isContextOnlyDispatcherDEV === true,
+      '%s is a function component but called React.createRef(). This will ' +
+        'create a new ref on every render instead of reusing it. Did you ' +
+        'mean to use React.useRef() instead?',
+      getComponentName(owner.type) || 'A component',
+    );
+
     Object.seal(refObject);
   }
   return refObject;

--- a/packages/react/src/__tests__/ReactCreateRef-test.js
+++ b/packages/react/src/__tests__/ReactCreateRef-test.js
@@ -57,4 +57,53 @@ describe('ReactCreateRef', () => {
         '    in Wrapper (at **)',
     );
   });
+
+  it('allows createRef in component constructors', () => {
+    class Component extends React.Component {
+      ref = React.createRef();
+      render() {
+        return <div>Oh yes!</div>;
+      }
+    }
+
+    const renderer = ReactTestRenderer.create(<Component />);
+
+    expect(renderer.toJSON()).toEqual({
+      type: 'div',
+      props: {},
+      children: ['Oh yes!'],
+    });
+  });
+
+  it('should warn in dev if used within a function component', () => {
+    function Component() {
+      React.createRef();
+      return <div>Oh no!</div>;
+    }
+
+    function Wrapper(props) {
+      return props.children;
+    }
+
+    let renderer;
+    expect(() => {
+      renderer = ReactTestRenderer.create(
+        <Wrapper>
+          <Component />
+        </Wrapper>,
+      );
+    }).toWarnDev(
+      'Warning: Component is a function component but called ' +
+        'React.createRef(). This will create a new ref on every render ' +
+        'instead of reusing it. Did you mean to use React.useRef() instead?\n' +
+        '    in Component (at **)\n' +
+        '    in Wrapper (at **)',
+    );
+
+    expect(renderer.toJSON()).toEqual({
+      type: 'div',
+      props: {},
+      children: ['Oh no!'],
+    });
+  });
 });


### PR DESCRIPTION
When enabling `react-hooks/exhaustive-deps` I noticed a strange issue that took me quite some time to figure out. A ref was used inside an effect hook but the linting rule still wanted me to declare it as a dependency. I remembered that I saw code that could detect wether `React.useRef()` is used and it took me a few minutes until I realized that the component in question was using `React.createRef()` instead.

I remember that I did a similar mistake in the beginning when I first played with hooks as the concept was not clear to me yet so I figured a warning would be helpful for others.

The implementation is not so nice unfortunately since we can't just assert for a missing dispatcher because the dispatcher is set to the context-only-dispatcher when class constructors are run (which is when we want `React.createRef()` to be used). I added a DEV only extension to the dispatcher but I'm open for other ideas. Maybe we need to split the `CurrentDispatcher` into the `CurrentHookDispatcher` and the `CurrentContextDispatcher` so we handle that differently?