### PR TITLE
 [ReactDOM] Add strict mode test for findDOMNode

### DIFF
--- a/packages/react-dom/src/__tests__/findDOMNode-test.js
+++ b/packages/react-dom/src/__tests__/findDOMNode-test.js
@@ -157,4 +157,34 @@ describe('findDOMNode', () => {
     ]);
     expect(match).toBe(child);
   });
+
+  it('findDOMNode should not warn if passed a host component inside StrictMode', () => {
+    let child = undefined;
+
+    class IsInStrictMode extends React.Component {
+      render() {
+        const {as: Component} = this.props;
+        return <Component ref={n => (child = n)} />;
+      }
+    }
+
+    ReactTestUtils.renderIntoDocument(
+      <StrictMode>
+        <IsInStrictMode as="span" />
+      </StrictMode>,
+    );
+
+    expect(() => ReactDOM.findDOMNode(child)).not.toWarnDev([
+      'Warning: findDOMNode is deprecated in StrictMode. ' +
+        'findDOMNode was passed an instance of span which is inside StrictMode. ' +
+        'Instead, add a ref directly to the element you want to reference.' +
+        '\n' +
+        '\n    in span (at **)' +
+        '\n    in IsInStrictMode (at **)' +
+        '\n    in StrictMode (at **)' +
+        '\n' +
+        '\nLearn more about using refs safely here:' +
+        '\nhttps://fb.me/react-strict-mode-find-node',
+    ]);
+  });
 });

--- a/packages/react-dom/src/__tests__/findDOMNode-test.js
+++ b/packages/react-dom/src/__tests__/findDOMNode-test.js
@@ -174,6 +174,9 @@ describe('findDOMNode', () => {
       </StrictMode>,
     );
 
-    expect(() => ReactDOM.findDOMNode(child)).not.toWarnDev(['**']);
+    // outside of dev toWarnDev would always pass which means negating it would always fail
+    if (__DEV__) {
+      expect(() => ReactDOM.findDOMNode(child)).not.toWarnDev(['**']);
+    }
   });
 });

--- a/packages/react-dom/src/__tests__/findDOMNode-test.js
+++ b/packages/react-dom/src/__tests__/findDOMNode-test.js
@@ -174,17 +174,6 @@ describe('findDOMNode', () => {
       </StrictMode>,
     );
 
-    expect(() => ReactDOM.findDOMNode(child)).not.toWarnDev([
-      'Warning: findDOMNode is deprecated in StrictMode. ' +
-        'findDOMNode was passed an instance of span which is inside StrictMode. ' +
-        'Instead, add a ref directly to the element you want to reference.' +
-        '\n' +
-        '\n    in span (at **)' +
-        '\n    in IsInStrictMode (at **)' +
-        '\n    in StrictMode (at **)' +
-        '\n' +
-        '\nLearn more about using refs safely here:' +
-        '\nhttps://fb.me/react-strict-mode-find-node',
-    ]);
+    expect(() => ReactDOM.findDOMNode(child)).not.toWarnDev(['**']);
   });
 });


### PR DESCRIPTION
#13841 deprecated presumably ["all usage"](https://github.com/facebook/react/pull/13841#issuecomment-429444800) of `findDOMNode`. This is not the case if passed a host component<sup>1</sup>. I wanted to verify if this is intended or not since we have a use case for not issuing a deprecation warning for host components:

We have a component library that lets the user pass a custom component that is rendered. It can be a different DOM node or an actual component:
```js
class LibraryComponent() {
  // this is incomplete. It's just one instance where we get it
  componentDidMount() {
    this.button = ReactDOM.findDOMNode(this);
    listenForFocusKeys(ownerWindow(this.button));

    if (this.props.action) {
      this.props.action({
        focusVisible: () => {
          this.setState({ focusVisible: true });
          this.button.focus();
        },
      });
    }
  }

  render() {
    const { as: Component } = this.props;
	return <Component />
  }
}
```
However we required the DOM node of the rendered component for focus handling (essentially adding a focus-visible polyfill). Before deprecation we used `findDOMNode(this)`. Now that `findDOMNode` is deprecated we want to move away from that usage while enabling some backwards compatibility:
```diff
class LibraryComponent() {
+ buttonRef = React.createRef();
  // this is incomplete. It's just one instance where we get it
  componentDidMount() {
-   this.button = ReactDOM.findDOMNode(this);
-   listenForFocusKeys(ownerWindow(this.button));
+   listenForFocusKeys(ownerWindow(this.getButtonNode()));

    if (this.props.action) {
      this.props.action({
        focusVisible: () => {
          this.setState({ focusVisible: true });
-         this.button.focus();
+         this.getButtonNode().focus();
        },
      });
    }
  }
  
+ getButtonNode() {
+   return ReactDOM.findDOMNode(this.buttonRef.current);
+ }

  render() {
    const { as: Component } = this.props;
-	return <Component />
+	return <Component ref={this.buttonRef} />
  }
}
```

This change:
1. is breaking usage with function components `<LibraryComponent as={SomeFunctionComponent} />`
2. strict mode compatible with `<LibraryComponent as="div" />` or any other host component or ref forwarding component
3. not strict mode ready but also not breaking for `<LibraryComponent as={SomeClassComponent} />`

The test added with this PR is basically ensuring the third behavior.

Followup on https://github.com/facebook/react/pull/13841#issuecomment-433416333

<sup>1</sup> Not sure if this is the correct term.