### PR TITLE
Use same example code for async effect warning

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -4446,19 +4446,15 @@ const tests = {
       errors: [
         `Effect callbacks are synchronous to prevent race conditions. ` +
           `Put the async function inside:\n\n` +
-          `useEffect(() => {\n` +
-          `  let ignore = false;\n` +
-          `  fetchSomething();\n` +
-          `\n` +
-          `  async function fetchSomething() {\n` +
-          `    const result = await ...\n` +
-          `    if (!ignore) setState(result);\n` +
-          `  }\n` +
-          `\n` +
-          `  return () => { ignore = true; };\n` +
-          `}, ...);\n` +
-          `\n` +
-          `This lets you handle multiple requests without bugs.`,
+          'useEffect(() => {\n' +
+          '  async function fetchData() {\n' +
+          '    // You can await here\n' +
+          '    const response = await MyAPI.getData(someId);\n' +
+          '    // ...\n' +
+          '  }\n' +
+          '  fetchData();\n' +
+          `}, [someId]); // Or [] if effect doesn't need props or state\n\n` +
+          'Learn more about data fetching with Hooks: https://fb.me/react-hooks-data-fetching',
       ],
     },
     {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -112,19 +112,15 @@ export default {
           message:
             `Effect callbacks are synchronous to prevent race conditions. ` +
             `Put the async function inside:\n\n` +
-            `useEffect(() => {\n` +
-            `  let ignore = false;\n` +
-            `  fetchSomething();\n` +
-            `\n` +
-            `  async function fetchSomething() {\n` +
-            `    const result = await ...\n` +
-            `    if (!ignore) setState(result);\n` +
-            `  }\n` +
-            `\n` +
-            `  return () => { ignore = true; };\n` +
-            `}, ...);\n` +
-            `\n` +
-            `This lets you handle multiple requests without bugs.`,
+            'useEffect(() => {\n' +
+            '  async function fetchData() {\n' +
+            '    // You can await here\n' +
+            '    const response = await MyAPI.getData(someId);\n' +
+            '    // ...\n' +
+            '  }\n' +
+            '  fetchData();\n' +
+            `}, [someId]); // Or [] if effect doesn't need props or state\n\n` +
+            'Learn more about data fetching with Hooks: https://fb.me/react-hooks-data-fetching',
         });
       }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -358,7 +358,7 @@ function commitHookEffectList(
                 '    // ...\n' +
                 '  }\n' +
                 '  fetchData();\n' +
-                '}, [someId]);\n\n' +
+                `}, [someId]); // Or [] if effect doesn't need props or state\n\n` +
                 'Learn more about data fetching with Hooks: https://fb.me/react-hooks-data-fetching';
             } else {
               addendum = ' You returned: ' + destroy;


### PR DESCRIPTION
I know y'all are tired of me tweaking this...

So I tried CRA 3.0 alpha (https://github.com/facebook/create-react-app/issues/6475) and realized it's confusing that both warnings show up with different snippets.

I also think the fully "correct" version is a bit too much for somebody writing this for the first time — and most class examples aren't correct either. So I opted instead to use the simpler first version, and the FAQ link shows you a better one.