### PR TITLE
[Shallow] Implement setState for Hooks and remount on type change

### DIFF
--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -178,6 +178,10 @@ class ReactShallowRenderer {
   };
 
   constructor() {
+    this._reset();
+  }
+
+  _reset() {
     this._context = null;
     this._element = null;
     this._instance = null;
@@ -513,6 +517,9 @@ class ReactShallowRenderer {
 
     if (this._rendering) {
       return;
+    }
+    if (this._element != null && this._element.type !== element.type) {
+      this._reset();
     }
 
     const elementType = isMemo(element.type) ? element.type.type : element.type;

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -624,13 +624,7 @@ class ReactShallowRenderer {
         this._instance.componentWillUnmount();
       }
     }
-
-    this._firstWorkInProgressHook = null;
-    this._context = null;
-    this._element = null;
-    this._newState = null;
-    this._rendered = null;
-    this._instance = null;
+    this._reset();
   }
 
   _mountClassComponent(

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -574,7 +574,6 @@ class ReactShallowRenderer {
         let shouldRender = true;
         if (
           isMemo(element.type) &&
-          elementType === this._previousComponentIdentity &&
           previousElement !== null
         ) {
           // This is a Memo component that is being re-rendered.
@@ -586,7 +585,8 @@ class ReactShallowRenderer {
         if (shouldRender) {
           const prevDispatcher = ReactCurrentDispatcher.current;
           ReactCurrentDispatcher.current = this._dispatcher;
-          this._prepareToUseHooks(elementType);
+          const componentIdentity = {};
+          this._prepareToUseHooks(componentIdentity);
           try {
             // elementType could still be a ForwardRef if it was
             // nested inside Memo.

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -31,7 +31,7 @@ type Update<A> = {
 };
 
 type UpdateQueue<A> = {
-  last: Update<A> | null,
+  first: Update<A> | null,
   dispatch: any,
 };
 
@@ -196,7 +196,6 @@ class ReactShallowRenderer {
     this._isReRender = false;
     this._didScheduleRenderPhaseUpdate = false;
     this._renderPhaseUpdates = null;
-    this._currentlyRenderingComponent = null;
     this._numberOfReRenders = 0;
   }
 
@@ -211,7 +210,6 @@ class ReactShallowRenderer {
   _dispatcher: DispatcherType;
   _workInProgressHook: null | Hook;
   _firstWorkInProgressHook: null | Hook;
-  _currentlyRenderingComponent: null | Object;
   _renderPhaseUpdates: Map<UpdateQueue<any>, Update<any>> | null;
   _isReRender: boolean;
   _didScheduleRenderPhaseUpdate: boolean;
@@ -219,7 +217,7 @@ class ReactShallowRenderer {
 
   _validateCurrentlyRenderingComponent() {
     invariant(
-      this._currentlyRenderingComponent !== null,
+      this._rendering && !this._instance,
       'Hooks can only be called inside the body of a function component. ' +
         '(https://fb.me/react-invalid-hook-call)',
     );
@@ -234,33 +232,44 @@ class ReactShallowRenderer {
       this._validateCurrentlyRenderingComponent();
       this._createWorkInProgressHook();
       const workInProgressHook: Hook = (this._workInProgressHook: any);
+
       if (this._isReRender) {
-        // This is a re-render. Apply the new render phase updates to the previous
-        // current hook.
+        // This is a re-render.
         const queue: UpdateQueue<A> = (workInProgressHook.queue: any);
         const dispatch: Dispatch<A> = (queue.dispatch: any);
-        if (this._renderPhaseUpdates !== null) {
-          // Render phase updates are stored in a map of queue -> linked list
-          const firstRenderPhaseUpdate = this._renderPhaseUpdates.get(queue);
-          if (firstRenderPhaseUpdate !== undefined) {
-            (this._renderPhaseUpdates: any).delete(queue);
-            let newState = workInProgressHook.memoizedState;
-            let update = firstRenderPhaseUpdate;
-            do {
-              // Process this render phase update. We don't have to check the
-              // priority because it will always be the same as the current
-              // render's.
-              const action = update.action;
-              newState = reducer(newState, action);
-              update = update.next;
-            } while (update !== null);
-
-            workInProgressHook.memoizedState = newState;
-
-            return [newState, dispatch];
+        if (this._numberOfReRenders > 0) {
+          // Apply the new render phase updates to the previous current hook.
+          if (this._renderPhaseUpdates !== null) {
+            // Render phase updates are stored in a map of queue -> linked list
+            const firstRenderPhaseUpdate = this._renderPhaseUpdates.get(queue);
+            if (firstRenderPhaseUpdate !== undefined) {
+              (this._renderPhaseUpdates: any).delete(queue);
+              let newState = workInProgressHook.memoizedState;
+              let update = firstRenderPhaseUpdate;
+              do {
+                const action = update.action;
+                newState = reducer(newState, action);
+                update = update.next;
+              } while (update !== null);
+              workInProgressHook.memoizedState = newState;
+              return [newState, dispatch];
+            }
           }
+          return [workInProgressHook.memoizedState, dispatch];
         }
-        return [workInProgressHook.memoizedState, dispatch];
+        // Process updates outside of render
+        let newState = workInProgressHook.memoizedState;
+        let update = queue.first;
+        if (update !== null) {
+          do {
+            const action = update.action;
+            newState = reducer(newState, action);
+            update = update.next;
+          } while (update !== null);
+          queue.first = null;
+          workInProgressHook.memoizedState = newState;
+        }
+        return [newState, dispatch];
       } else {
         let initialState;
         if (reducer === basicStateReducer) {
@@ -275,16 +284,12 @@ class ReactShallowRenderer {
         }
         workInProgressHook.memoizedState = initialState;
         const queue: UpdateQueue<A> = (workInProgressHook.queue = {
-          last: null,
+          first: null,
           dispatch: null,
         });
         const dispatch: Dispatch<
           A,
-        > = (queue.dispatch = (this._dispatchAction.bind(
-          this,
-          (this._currentlyRenderingComponent: any),
-          queue,
-        ): any));
+        > = (queue.dispatch = (this._dispatchAction.bind(this, queue): any));
         return [workInProgressHook.memoizedState, dispatch];
       }
     };
@@ -375,18 +380,14 @@ class ReactShallowRenderer {
     };
   }
 
-  _dispatchAction<A>(
-    componentIdentity: Object,
-    queue: UpdateQueue<A>,
-    action: A,
-  ) {
+  _dispatchAction<A>(queue: UpdateQueue<A>, action: A) {
     invariant(
       this._numberOfReRenders < RE_RENDER_LIMIT,
       'Too many re-renders. React limits the number of renders to prevent ' +
         'an infinite loop.',
     );
 
-    if (componentIdentity === this._currentlyRenderingComponent) {
+    if (this._rendering) {
       // This is a render phase update. Stash it in a lazily-created map of
       // queue -> linked list of updates. After this render pass, we'll restart
       // and apply the stashed updates on top of the work-in-progress hook.
@@ -411,9 +412,24 @@ class ReactShallowRenderer {
         lastRenderPhaseUpdate.next = update;
       }
     } else {
-      // This means an update has happened after the function component has
-      // returned. On the server this is a no-op. In React Fiber, the update
-      // would be scheduled for a future render.
+      const update: Update<A> = {
+        action,
+        next: null,
+      };
+
+      // Append the update to the end of the list.
+      let last = queue.first;
+      if (last === null) {
+        queue.first = update;
+      } else {
+        while (last.next !== null) {
+          last = last.next;
+        }
+        last.next = update;
+      }
+
+      // Re-render now.
+      this.render(this._element, this._context);
     }
   }
 
@@ -443,10 +459,6 @@ class ReactShallowRenderer {
     return this._workInProgressHook;
   }
 
-  _prepareToUseHooks(componentIdentity: Object): void {
-    this._currentlyRenderingComponent = componentIdentity;
-  }
-
   _finishHooks(element: ReactElement, context: null | Object) {
     if (this._didScheduleRenderPhaseUpdate) {
       // Updates were scheduled during the render phase. They are stored in
@@ -461,7 +473,6 @@ class ReactShallowRenderer {
       this._rendering = false;
       this.render(element, context);
     } else {
-      this._currentlyRenderingComponent = null;
       this._workInProgressHook = null;
       this._renderPhaseUpdates = null;
       this._numberOfReRenders = 0;
@@ -572,10 +583,7 @@ class ReactShallowRenderer {
         this._mountClassComponent(elementType, element, this._context);
       } else {
         let shouldRender = true;
-        if (
-          isMemo(element.type) &&
-          previousElement !== null
-        ) {
+        if (isMemo(element.type) && previousElement !== null) {
           // This is a Memo component that is being re-rendered.
           const compare = element.type.compare || shallowEqual;
           if (compare(previousElement.props, element.props)) {
@@ -585,8 +593,6 @@ class ReactShallowRenderer {
         if (shouldRender) {
           const prevDispatcher = ReactCurrentDispatcher.current;
           ReactCurrentDispatcher.current = this._dispatcher;
-          const componentIdentity = {};
-          this._prepareToUseHooks(componentIdentity);
           try {
             // elementType could still be a ForwardRef if it was
             // nested inside Memo.

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -198,7 +198,6 @@ class ReactShallowRenderer {
     this._renderPhaseUpdates = null;
     this._currentlyRenderingComponent = null;
     this._numberOfReRenders = 0;
-    this._previousComponentIdentity = null;
   }
 
   _context: null | Object;
@@ -213,7 +212,6 @@ class ReactShallowRenderer {
   _workInProgressHook: null | Hook;
   _firstWorkInProgressHook: null | Hook;
   _currentlyRenderingComponent: null | Object;
-  _previousComponentIdentity: null | Object;
   _renderPhaseUpdates: Map<UpdateQueue<any>, Update<any>> | null;
   _isReRender: boolean;
   _didScheduleRenderPhaseUpdate: boolean;
@@ -446,14 +444,7 @@ class ReactShallowRenderer {
   }
 
   _prepareToUseHooks(componentIdentity: Object): void {
-    if (
-      this._previousComponentIdentity !== null &&
-      this._previousComponentIdentity !== componentIdentity
-    ) {
-      this._firstWorkInProgressHook = null;
-    }
     this._currentlyRenderingComponent = componentIdentity;
-    this._previousComponentIdentity = componentIdentity;
   }
 
   _finishHooks(element: ReactElement, context: null | Object) {
@@ -635,7 +626,6 @@ class ReactShallowRenderer {
     }
 
     this._firstWorkInProgressHook = null;
-    this._previousComponentIdentity = null;
     this._context = null;
     this._element = null;
     this._newState = null;

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -1565,4 +1565,46 @@ describe('ReactShallowRenderer', () => {
       'forwardRef requires a render function but was given object.',
     );
   });
+
+  it('should let you change type', () => {
+    function Foo({prop}) {
+      return <div>Foo {prop}</div>;
+    }
+    function Bar({prop}) {
+      return <div>Bar {prop}</div>;
+    }
+
+    const shallowRenderer = createRenderer();
+    shallowRenderer.render(<Foo prop="foo1" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Foo {'foo1'}</div>);
+    shallowRenderer.render(<Foo prop="foo2" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Foo {'foo2'}</div>);
+    shallowRenderer.render(<Bar prop="bar1" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Bar {'bar1'}</div>);
+    shallowRenderer.render(<Bar prop="bar2" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Bar {'bar2'}</div>);
+  });
+
+  it('should let you change class type', () => {
+    class Foo extends React.Component {
+      render() {
+        return <div>Foo {this.props.prop}</div>;
+      }
+    }
+    class Bar extends React.Component {
+      render() {
+        return <div>Bar {this.props.prop}</div>;
+      }
+    }
+
+    const shallowRenderer = createRenderer();
+    shallowRenderer.render(<Foo prop="foo1" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Foo {'foo1'}</div>);
+    shallowRenderer.render(<Foo prop="foo2" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Foo {'foo2'}</div>);
+    shallowRenderer.render(<Bar prop="bar1" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Bar {'bar1'}</div>);
+    shallowRenderer.render(<Bar prop="bar2" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Bar {'bar2'}</div>);
+  });
 });


### PR DESCRIPTION
Fixes #14840.

Alternative to https://github.com/facebook/react/pull/14841. While reviewing it, I realized some of the complexity in how we implemented it is relates to an existing bug in the shallow renderer. In particularly, rendering twice with different element type kept reusing the old class instance. I fixed this in 50f22627ef91772456b36f52786c7cf2f1774db5. (Now it behaves consistently on unmount/mount and on rendering a different element type.) While this has been broken for a long while, the old behavior of ignoring the type change plainly doesn't make sense — so if it breaks any tests, it means those tests were testing the wrong thing.

This allowed me to remove a bunch of fields and simplify the logic to match shallow renderer assumptions. In the last commit (4972adbc71bfc6c8bbe05c3b6da1a09fda4043b5), I'm adding support for state updates to shallow renderer. I think it's a bit simpler than what we tried in #14841.

I checked these changes don't break Enzyme test suite.