### PR TITLE
Suppress unmounted setState warning after flushing passive effects

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1702,6 +1702,7 @@ describe('ReactHooks', () => {
   it('does not fire a false positive warning when previous effect unmounts the component', () => {
     let {useState, useEffect} = React;
     let globalListener;
+    let _setState;
 
     function A() {
       const [show, setShow] = useState(true);
@@ -1721,7 +1722,14 @@ describe('ReactHooks', () => {
       useEffect(() => {
         let isStale = false;
 
+        _setState = setState;
         globalListener = () => {
+          if (!isStale) {
+            setState('hello');
+          }
+          if (!isStale) {
+            setState('goodbye');
+          }
           if (!isStale) {
             setState('hello');
           }
@@ -1747,6 +1755,15 @@ describe('ReactHooks', () => {
       'An update to C inside a test was not wrapped in act',
       // Note: should *not* warn about updates on unmounted component.
       // Because there's no way for component to know it got unmounted.
+    ]);
+
+    // Verify the warning isn't disabled permanently.
+    expect(() => {
+      ReactTestRenderer.act(() => {
+        _setState('bad');
+      });
+    }).toWarnDev([
+      "Can't perform a React state update on an unmounted component",
     ]);
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1699,6 +1699,57 @@ describe('ReactHooks', () => {
     ).toThrow('Hello');
   });
 
+  it('does not fire a false positive warning when previous effect unmounts the component', () => {
+    let {useState, useEffect} = React;
+    let globalListener;
+
+    function A() {
+      const [show, setShow] = useState(true);
+      function hideMe() {
+        setShow(false);
+      }
+      return show ? <B hideMe={hideMe} /> : null;
+    }
+
+    function B(props) {
+      return <C {...props} />;
+    }
+
+    function C({hideMe}) {
+      const [, setState] = useState();
+
+      useEffect(() => {
+        let isStale = false;
+
+        globalListener = () => {
+          if (!isStale) {
+            setState('hello');
+          }
+        };
+
+        return () => {
+          isStale = true;
+          hideMe();
+        };
+      });
+      return null;
+    }
+
+    ReactTestRenderer.act(() => {
+      ReactTestRenderer.create(<A />);
+    });
+
+    expect(() => {
+      globalListener();
+      globalListener();
+    }).toWarnDev([
+      'An update to C inside a test was not wrapped in act',
+      'An update to C inside a test was not wrapped in act',
+      // Note: should *not* warn about updates on unmounted component.
+      // Because there's no way for component to know it got unmounted.
+    ]);
+  });
+
   // Regression test for https://github.com/facebook/react/issues/14790
   it('does not fire a false positive warning when suspending memo', async () => {
     const {Suspense, useState} = React;


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/15057. (I verified sandbox doesn't warn anymore.)

If `setState(foo)` caused passive effects to flush, and those in turn caused the component to unmount, there is no way somebody could have foreseen that and guarded `setState` early. Therefore, flushing passive effects temporarily disables the warning until after the next time the work is scheduled.