### PR TITLE
Flush passive effects before interactive updates

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -2541,14 +2541,8 @@ function interactiveUpdates<A, B, C, R>(
   // This needs to happen before we read any handlers, because the effect of
   // the previous event may influence which handlers are called during
   // this event.
-  if (
-    !isBatchingUpdates &&
-    !isRendering &&
-    lowestPriorityPendingInteractiveExpirationTime !== NoWork
-  ) {
-    // Synchronously flush pending interactive updates.
-    performWork(lowestPriorityPendingInteractiveExpirationTime, false);
-    lowestPriorityPendingInteractiveExpirationTime = NoWork;
+  if (!isBatchingUpdates) {
+    flushInteractiveUpdates();
   }
   const previousIsBatchingInteractiveUpdates = isBatchingInteractiveUpdates;
   const previousIsBatchingUpdates = isBatchingUpdates;
@@ -2571,6 +2565,7 @@ function flushInteractiveUpdates() {
     lowestPriorityPendingInteractiveExpirationTime !== NoWork
   ) {
     // Synchronously flush pending interactive updates.
+    flushPassiveEffects();
     performWork(lowestPriorityPendingInteractiveExpirationTime, false);
     lowestPriorityPendingInteractiveExpirationTime = NoWork;
   }


### PR DESCRIPTION
Related to https://github.com/facebook/react/pull/15122#issuecomment-473591116. This ensures that if passive effect cleanup leads to removing an event handler, it gets removed early enough.

This doesn't solve the false positive case in https://github.com/facebook/react/issues/15057 (which wasn't caused by an interactive update). However, I realized wrapping it into `ReactDOM.unstable_interactiveUpdates` does so maybe that's the solution for it?