### PR TITLE
Provide new jsx transform target for reactjs/rfcs#107

### DIFF
--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -22,6 +22,7 @@ import {
   createFactory,
   cloneElement,
   isValidElement,
+  jsx,
 } from './ReactElement';
 import {createContext} from './ReactContext';
 import {lazy} from './ReactLazy';
@@ -43,10 +44,16 @@ import {
   createElementWithValidation,
   createFactoryWithValidation,
   cloneElementWithValidation,
+  jsxWithValidation,
+  jsxWithValidationStatic,
+  jsxWithValidationDynamic,
 } from './ReactElementValidator';
 import ReactSharedInternals from './ReactSharedInternals';
 import {error, warn} from './withComponentStack';
-import {enableStableConcurrentModeAPIs} from 'shared/ReactFeatureFlags';
+import {
+  enableStableConcurrentModeAPIs,
+  enableJSXTransformAPI,
+} from 'shared/ReactFeatureFlags';
 
 const React = {
   Children: {
@@ -105,6 +112,19 @@ const React = {
 if (enableStableConcurrentModeAPIs) {
   React.ConcurrentMode = REACT_CONCURRENT_MODE_TYPE;
   React.unstable_ConcurrentMode = undefined;
+}
+
+if (enableJSXTransformAPI) {
+  if (__DEV__) {
+    React.jsxDEV = jsxWithValidation;
+    React.jsx = jsxWithValidationDynamic;
+    React.jsxs = jsxWithValidationStatic;
+  } else {
+    React.jsx = jsx;
+    // we may want to special case jsxs internally to take advantage of static children.
+    // for now we can ship identical prod functions
+    React.jsxs = jsx;
+  }
 }
 
 export default React;

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -108,7 +108,7 @@ function defineRefPropWarningGetter(props, displayName) {
  * indicating filename, line number, and/or other information.
  * @internal
  */
-const ReactElement = function(type, props, key, ref, owner, self, source) {
+const ReactElement = function(type, key, ref, self, source, owner, props) {
   const element = {
     // This tag allows us to uniquely identify this as a React Element
     $$typeof: REACT_ELEMENT_TYPE,
@@ -213,7 +213,15 @@ export function jsx(type, config, maybeKey) {
     }
   }
 
-  return ReactElement(type, props, key, ref, ReactCurrentOwner.current);
+  return ReactElement(
+    type,
+    key,
+    ref,
+    undefined,
+    undefined,
+    ReactCurrentOwner.current,
+    props,
+  );
 }
 
 /**
@@ -280,12 +288,12 @@ export function jsxDEV(type, config, maybeKey, source, self) {
 
   return ReactElement(
     type,
-    props,
     key,
     ref,
-    ReactCurrentOwner.current,
     self,
     source,
+    ReactCurrentOwner.current,
+    props,
   );
 }
 
@@ -368,12 +376,12 @@ export function createElement(type, config, children) {
   }
   return ReactElement(
     type,
-    props,
     key,
     ref,
-    ReactCurrentOwner.current,
     self,
     source,
+    ReactCurrentOwner.current,
+    props,
   );
 }
 
@@ -395,12 +403,12 @@ export function createFactory(type) {
 export function cloneAndReplaceKey(oldElement, newKey) {
   const newElement = ReactElement(
     oldElement.type,
-    oldElement.props,
     newKey,
     oldElement.ref,
-    oldElement._owner,
     oldElement._self,
     oldElement._source,
+    oldElement._owner,
+    oldElement.props,
   );
 
   return newElement;
@@ -478,7 +486,7 @@ export function cloneElement(element, config, children) {
     props.children = childArray;
   }
 
-  return ReactElement(element.type, props, key, ref, owner, self, source);
+  return ReactElement(element.type, key, ref, self, source, owner, props);
 }
 
 /**

--- a/packages/react/src/__tests__/ReactElementJSX-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementJSX-test.internal.js
@@ -1,0 +1,364 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let ReactFeatureFlags;
+let ReactTestUtils;
+
+// NOTE: We're explicitly not using JSX here. This is intended to test
+// a new React.jsx api which does not have a JSX transformer yet.
+// A lot of these tests are pulled from ReactElement-test because
+// this api is meant to be backwards compatible.
+describe('ReactElement.jsx', () => {
+  let originalSymbol;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    // Delete the native Symbol if we have one to ensure we test the
+    // unpolyfilled environment.
+    originalSymbol = global.Symbol;
+    global.Symbol = undefined;
+
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableJSXTransformAPI = true;
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactTestUtils = require('react-dom/test-utils');
+  });
+
+  afterEach(() => {
+    global.Symbol = originalSymbol;
+  });
+
+  it('allows static methods to be called using the type property', () => {
+    class StaticMethodComponentClass extends React.Component {
+      render() {
+        return React.jsx('div', {});
+      }
+    }
+    StaticMethodComponentClass.someStaticMethod = () => 'someReturnValue';
+
+    const element = React.jsx(StaticMethodComponentClass, {});
+    expect(element.type.someStaticMethod()).toBe('someReturnValue');
+  });
+
+  it('identifies valid elements', () => {
+    class Component extends React.Component {
+      render() {
+        return React.jsx('div', {});
+      }
+    }
+
+    expect(React.isValidElement(React.jsx('div', {}))).toEqual(true);
+    expect(React.isValidElement(React.jsx(Component, {}))).toEqual(true);
+
+    expect(React.isValidElement(null)).toEqual(false);
+    expect(React.isValidElement(true)).toEqual(false);
+    expect(React.isValidElement({})).toEqual(false);
+    expect(React.isValidElement('string')).toEqual(false);
+    expect(React.isValidElement(React.createFactory('div'))).toEqual(false);
+    expect(React.isValidElement(Component)).toEqual(false);
+    expect(React.isValidElement({type: 'div', props: {}})).toEqual(false);
+
+    const jsonElement = JSON.stringify(React.jsx('div', {}));
+    expect(React.isValidElement(JSON.parse(jsonElement))).toBe(true);
+  });
+
+  it('is indistinguishable from a plain object', () => {
+    const element = React.jsx('div', {className: 'foo'});
+    const object = {};
+    expect(element.constructor).toBe(object.constructor);
+  });
+
+  it('should use default prop value when removing a prop', () => {
+    class Component extends React.Component {
+      render() {
+        return React.jsx('span', {});
+      }
+    }
+    Component.defaultProps = {fruit: 'persimmon'};
+
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(
+      React.jsx(Component, {fruit: 'mango'}),
+      container,
+    );
+    expect(instance.props.fruit).toBe('mango');
+
+    ReactDOM.render(React.jsx(Component, {}), container);
+    expect(instance.props.fruit).toBe('persimmon');
+  });
+
+  it('should normalize props with default values', () => {
+    class Component extends React.Component {
+      render() {
+        return React.jsx('span', {children: this.props.prop});
+      }
+    }
+    Component.defaultProps = {prop: 'testKey'};
+
+    const instance = ReactTestUtils.renderIntoDocument(
+      React.jsx(Component, {}),
+    );
+    expect(instance.props.prop).toBe('testKey');
+
+    const inst2 = ReactTestUtils.renderIntoDocument(
+      React.jsx(Component, {prop: null}),
+    );
+    expect(inst2.props.prop).toBe(null);
+  });
+
+  it('throws when changing a prop (in dev) after element creation', () => {
+    class Outer extends React.Component {
+      render() {
+        const el = React.jsx('div', {className: 'moo'});
+
+        if (__DEV__) {
+          expect(function() {
+            el.props.className = 'quack';
+          }).toThrow();
+          expect(el.props.className).toBe('moo');
+        } else {
+          el.props.className = 'quack';
+          expect(el.props.className).toBe('quack');
+        }
+
+        return el;
+      }
+    }
+    const outer = ReactTestUtils.renderIntoDocument(
+      React.jsx(Outer, {color: 'orange'}),
+    );
+    if (__DEV__) {
+      expect(ReactDOM.findDOMNode(outer).className).toBe('moo');
+    } else {
+      expect(ReactDOM.findDOMNode(outer).className).toBe('quack');
+    }
+  });
+
+  it('throws when adding a prop (in dev) after element creation', () => {
+    const container = document.createElement('div');
+    class Outer extends React.Component {
+      render() {
+        const el = React.jsx('div', {children: this.props.sound});
+
+        if (__DEV__) {
+          expect(function() {
+            el.props.className = 'quack';
+          }).toThrow();
+          expect(el.props.className).toBe(undefined);
+        } else {
+          el.props.className = 'quack';
+          expect(el.props.className).toBe('quack');
+        }
+
+        return el;
+      }
+    }
+    Outer.defaultProps = {sound: 'meow'};
+    const outer = ReactDOM.render(React.jsx(Outer, {}), container);
+    expect(ReactDOM.findDOMNode(outer).textContent).toBe('meow');
+    if (__DEV__) {
+      expect(ReactDOM.findDOMNode(outer).className).toBe('');
+    } else {
+      expect(ReactDOM.findDOMNode(outer).className).toBe('quack');
+    }
+  });
+
+  it('does not warn for NaN props', () => {
+    class Test extends React.Component {
+      render() {
+        return React.jsx('div', {});
+      }
+    }
+    const test = ReactTestUtils.renderIntoDocument(
+      React.jsx(Test, {value: +undefined}),
+    );
+    expect(test.props.value).toBeNaN();
+  });
+
+  it('should warn when `key` is being accessed on composite element', () => {
+    const container = document.createElement('div');
+    class Child extends React.Component {
+      render() {
+        return React.jsx('div', {children: this.props.key});
+      }
+    }
+    class Parent extends React.Component {
+      render() {
+        return React.jsxs('div', {
+          children: [
+            React.jsx(Child, {}, '0'),
+            React.jsx(Child, {}, '1'),
+            React.jsx(Child, {}, '2'),
+          ],
+        });
+      }
+    }
+    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toWarnDev(
+      'Child: `key` is not a prop. Trying to access it will result ' +
+        'in `undefined` being returned. If you need to access the same ' +
+        'value within the child component, you should pass it as a different ' +
+        'prop. (https://fb.me/react-special-props)',
+      {withoutStack: true},
+    );
+  });
+
+  it('should warn when `key` is being accessed on a host element', () => {
+    const element = React.jsxs('div', {}, '3');
+    expect(() => void element.props.key).toWarnDev(
+      'div: `key` is not a prop. Trying to access it will result ' +
+        'in `undefined` being returned. If you need to access the same ' +
+        'value within the child component, you should pass it as a different ' +
+        'prop. (https://fb.me/react-special-props)',
+      {withoutStack: true},
+    );
+  });
+
+  it('should warn when `ref` is being accessed', () => {
+    const container = document.createElement('div');
+    class Child extends React.Component {
+      render() {
+        return React.jsx('div', {children: this.props.ref});
+      }
+    }
+    class Parent extends React.Component {
+      render() {
+        return React.jsx('div', {
+          children: React.jsx(Child, {ref: 'childElement'}),
+        });
+      }
+    }
+    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toWarnDev(
+      'Child: `ref` is not a prop. Trying to access it will result ' +
+        'in `undefined` being returned. If you need to access the same ' +
+        'value within the child component, you should pass it as a different ' +
+        'prop. (https://fb.me/react-special-props)',
+      {withoutStack: true},
+    );
+  });
+
+  it('identifies elements, but not JSON, if Symbols are supported', () => {
+    // Rudimentary polyfill
+    // Once all jest engines support Symbols natively we can swap this to test
+    // WITH native Symbols by default.
+    const REACT_ELEMENT_TYPE = function() {}; // fake Symbol
+    const OTHER_SYMBOL = function() {}; // another fake Symbol
+    global.Symbol = function(name) {
+      return OTHER_SYMBOL;
+    };
+    global.Symbol.for = function(key) {
+      if (key === 'react.element') {
+        return REACT_ELEMENT_TYPE;
+      }
+      return OTHER_SYMBOL;
+    };
+
+    jest.resetModules();
+
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableJSXTransformAPI = true;
+
+    React = require('react');
+
+    class Component extends React.Component {
+      render() {
+        return React.jsx('div');
+      }
+    }
+
+    expect(React.isValidElement(React.jsx('div', {}))).toEqual(true);
+    expect(React.isValidElement(React.jsx(Component, {}))).toEqual(true);
+
+    expect(React.isValidElement(null)).toEqual(false);
+    expect(React.isValidElement(true)).toEqual(false);
+    expect(React.isValidElement({})).toEqual(false);
+    expect(React.isValidElement('string')).toEqual(false);
+    expect(React.isValidElement(React.createFactory('div'))).toEqual(false);
+    expect(React.isValidElement(Component)).toEqual(false);
+    expect(React.isValidElement({type: 'div', props: {}})).toEqual(false);
+
+    const jsonElement = JSON.stringify(React.jsx('div', {}));
+    expect(React.isValidElement(JSON.parse(jsonElement))).toBe(false);
+  });
+
+  it('should warn when unkeyed children are passed to jsx', () => {
+    const container = document.createElement('div');
+    class Child extends React.Component {
+      render() {
+        return React.jsx('div', {});
+      }
+    }
+    class Parent extends React.Component {
+      render() {
+        return React.jsx('div', {
+          children: [
+            React.jsx(Child, {}),
+            React.jsx(Child, {}),
+            React.jsx(Child, {}),
+          ],
+        });
+      }
+    }
+    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toWarnDev(
+      'Warning: Each child in a list should have a unique "key" prop.\n\n' +
+        'Check the render method of `Parent`. See https://fb.me/react-warning-keys for more information.\n' +
+        '    in Child (created by Parent)\n' +
+        '    in Parent',
+    );
+  });
+
+  it('should warn when keys are passed as part of props', () => {
+    const container = document.createElement('div');
+    class Child extends React.Component {
+      render() {
+        return React.jsx('div', {});
+      }
+    }
+    class Parent extends React.Component {
+      render() {
+        return React.jsx('div', {
+          children: [React.jsx(Child, {key: '0'})],
+        });
+      }
+    }
+    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toWarnDev(
+      'Warning: React.jsx: Spreading a key to JSX is a deprecated pattern. ' +
+        'Explicitly pass a key after spreading props in your JSX call. ' +
+        'E.g. <ComponentName {...props} key={key} />',
+    );
+  });
+
+  it('should not warn when unkeyed children are passed to jsxs', () => {
+    const container = document.createElement('div');
+    class Child extends React.Component {
+      render() {
+        return React.jsx('div', {});
+      }
+    }
+    class Parent extends React.Component {
+      render() {
+        return React.jsxs('div', {
+          children: [
+            React.jsx(Child, {}),
+            React.jsx(Child, {}),
+            React.jsx(Child, {}),
+          ],
+        });
+      }
+    }
+    // TODO: an explicit expect for no warning?
+    ReactDOM.render(React.jsx(Parent, {}), container);
+  });
+});

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -68,3 +68,6 @@ export const enableEventAPI = false;
 // Enables rewritten version of ReactFiberScheduler. Added in case we need to
 // quickly revert it.
 export const enableNewScheduler = false;
+
+// New API for JSX transforms to target - https://github.com/reactjs/rfcs/pull/107
+export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -32,6 +32,7 @@ export const warnAboutDeprecatedLifecycles = true;
 export const warnAboutDeprecatedSetNativeProps = true;
 export const enableEventAPI = false;
 export const enableNewScheduler = false;
+export const enableJSXTransformAPI = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -29,6 +29,7 @@ export const enableSchedulerDebugging = false;
 export const warnAboutDeprecatedSetNativeProps = false;
 export const enableEventAPI = false;
 export const enableNewScheduler = false;
+export const enableJSXTransformAPI = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.new-scheduler.js
+++ b/packages/shared/forks/ReactFeatureFlags.new-scheduler.js
@@ -26,6 +26,6 @@ export const enableStableConcurrentModeAPIs = false;
 export const warnAboutShorthandPropertyCollision = false;
 export const warnAboutDeprecatedSetNativeProps = false;
 export const enableEventAPI = false;
+export const enableJSXTransformAPI = false;
 
 export const enableNewScheduler = true;
-export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.new-scheduler.js
+++ b/packages/shared/forks/ReactFeatureFlags.new-scheduler.js
@@ -28,3 +28,4 @@ export const warnAboutDeprecatedSetNativeProps = false;
 export const enableEventAPI = false;
 
 export const enableNewScheduler = true;
+export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -29,6 +29,7 @@ export const enableSchedulerDebugging = false;
 export const warnAboutDeprecatedSetNativeProps = false;
 export const enableEventAPI = false;
 export const enableNewScheduler = false;
+export const enableJSXTransformAPI = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -29,6 +29,7 @@ export const enableSchedulerDebugging = false;
 export const warnAboutDeprecatedSetNativeProps = false;
 export const enableEventAPI = false;
 export const enableNewScheduler = false;
+export const enableJSXTransformAPI = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -27,6 +27,7 @@ export const disableJavaScriptURLs = false;
 export const disableYielding = false;
 export const enableEventAPI = true;
 export const enableNewScheduler = false;
+export const enableJSXTransformAPI = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www-new-scheduler.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-new-scheduler.js
@@ -31,6 +31,7 @@ export {
 } from './ReactFeatureFlags.www';
 
 export const enableNewScheduler = true;
+export const enableJSXTransformAPI = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -74,6 +74,8 @@ function updateFlagOutsideOfReactCallStack() {
 
 export const enableEventAPI = true;
 
+export const enableJSXTransformAPI = true;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;


### PR DESCRIPTION
This exposes two new top-level functions on `React` - `jsx`, and `jsxs`. These are targets for JSX transformers which open up many simplifications to element creation described in https://github.com/reactjs/rfcs/pull/107.

The intent is to be backwards-compatible with the existing `createElement` call and to migrate transformers over so that most people are using this new transform. Once there are actual transforms written against this api, the more substantive changes can be tested.