### PR TITLE
feat(eslint-plugin-react-hooks): autofix inject deps on useMemo or useCallback

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1087,7 +1087,7 @@ const tests = {
       ],
     },
     {
-      // Infer deps onto hooks that need them
+      // Does nothing to deps on useMemo/useCallback if no options specified
       code: `
         function MyComponent(props) {
           let foo = 42;
@@ -1107,6 +1107,65 @@ const tests = {
           const value = useMemo(() => {
             console.log(foo);
           });
+          const fn = useCallback(() => {
+             alert(bar);
+          });
+        }
+      `,
+      errors: [
+        'React Hook useMemo does nothing when called with only one argument. ' +
+          'Did you forget to pass an array of dependencies?',
+        "React Hook useMemo has a missing dependency: 'foo'. " +
+          'Did you mean to include it?',
+        'React Hook useCallback does nothing when called with only one argument. ' +
+          'Did you forget to pass an array of dependencies?',
+        "React Hook useCallback has a missing dependency: 'bar'. " +
+          'Did you mean to include it?',
+      ],
+    },
+    {
+      // Does nothing to deps on useMemo if no deps required
+      code: `
+        function MyComponent(props) {
+          const value = useMemo(() => { return 2*2; });
+          const fn = useCallback(() => { alert('foo'); });
+        }
+      `,
+      output: `
+        function MyComponent(props) {
+          const value = useMemo(() => { return 2*2; });
+          const fn = useCallback(() => { alert('foo'); });
+        }
+      `,
+      errors: [
+        'React Hook useMemo does nothing when called with only one argument. ' +
+          'Did you forget to pass an array of dependencies?',
+        'React Hook useCallback does nothing when called with only one argument. ' +
+          'Did you forget to pass an array of dependencies?',
+      ],
+      options: [{missingDependencies: 'inject'}],
+    },
+    {
+      // Inject deps onto hooks that need them
+      code: `
+        function MyComponent(props) {
+          let foo = 42;
+          let bar = 43;
+          const value = useMemo(() => {
+            console.log(foo);
+          });
+          const fn = useCallback(() => {
+             alert(bar);
+          });
+        }
+      `,
+      output: `
+        function MyComponent(props) {
+          let foo = 42;
+          let bar = 43;
+          const value = useMemo(() => {
+            console.log(foo);
+          }, [foo]);
           const fn = useCallback(() => {
              alert(bar);
           }, [bar]);
@@ -1122,32 +1181,7 @@ const tests = {
         "React Hook useCallback has a missing dependency: 'bar'. " +
           'Did you mean to include it?',
       ],
-    },
-    {
-      code: `
-        function MyComponent(props) {
-          const local = {};
-          useCallback(() => {
-            console.log(props.foo);
-            console.log(props.bar);
-          });
-        }
-      `,
-      output: `
-        function MyComponent(props) {
-          const local = {};
-          useCallback(() => {
-            console.log(props.foo);
-            console.log(props.bar);
-          }, [props.bar, props.foo]);
-        }
-      `,
-      errors: [
-        'React Hook useCallback does nothing when called with only one argument. ' +
-          'Did you forget to pass an array of dependencies?',
-        "React Hook useCallback has missing dependencies: 'props.bar' and 'props.foo'. " +
-          'Did you mean to include them?',
-      ],
+      options: [{missingDependencies: 'inject'}],
     },
     {
       // Regression test

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1087,7 +1087,7 @@ const tests = {
       ],
     },
     {
-      // Does nothing to deps on useMemo/useCallback if no options specified
+      // Infer deps onto hooks that need them
       code: `
         function MyComponent(props) {
           let foo = 42;
@@ -1107,65 +1107,6 @@ const tests = {
           const value = useMemo(() => {
             console.log(foo);
           });
-          const fn = useCallback(() => {
-             alert(bar);
-          });
-        }
-      `,
-      errors: [
-        'React Hook useMemo does nothing when called with only one argument. ' +
-          'Did you forget to pass an array of dependencies?',
-        "React Hook useMemo has a missing dependency: 'foo'. " +
-          'Did you mean to include it?',
-        'React Hook useCallback does nothing when called with only one argument. ' +
-          'Did you forget to pass an array of dependencies?',
-        "React Hook useCallback has a missing dependency: 'bar'. " +
-          'Did you mean to include it?',
-      ],
-    },
-    {
-      // Does nothing to deps on useMemo if no deps required
-      code: `
-        function MyComponent(props) {
-          const value = useMemo(() => { return 2*2; });
-          const fn = useCallback(() => { alert('foo'); });
-        }
-      `,
-      output: `
-        function MyComponent(props) {
-          const value = useMemo(() => { return 2*2; });
-          const fn = useCallback(() => { alert('foo'); });
-        }
-      `,
-      errors: [
-        'React Hook useMemo does nothing when called with only one argument. ' +
-          'Did you forget to pass an array of dependencies?',
-        'React Hook useCallback does nothing when called with only one argument. ' +
-          'Did you forget to pass an array of dependencies?',
-      ],
-      options: [{missingDependencies: 'inject'}],
-    },
-    {
-      // Inject deps onto hooks that need them
-      code: `
-        function MyComponent(props) {
-          let foo = 42;
-          let bar = 43;
-          const value = useMemo(() => {
-            console.log(foo);
-          });
-          const fn = useCallback(() => {
-             alert(bar);
-          });
-        }
-      `,
-      output: `
-        function MyComponent(props) {
-          let foo = 42;
-          let bar = 43;
-          const value = useMemo(() => {
-            console.log(foo);
-          }, [foo]);
           const fn = useCallback(() => {
              alert(bar);
           }, [bar]);
@@ -1181,7 +1122,32 @@ const tests = {
         "React Hook useCallback has a missing dependency: 'bar'. " +
           'Did you mean to include it?',
       ],
-      options: [{missingDependencies: 'inject'}],
+    },
+    {
+      code: `
+        function MyComponent(props) {
+          const local = {};
+          useCallback(() => {
+            console.log(props.foo);
+            console.log(props.bar);
+          });
+        }
+      `,
+      output: `
+        function MyComponent(props) {
+          const local = {};
+          useCallback(() => {
+            console.log(props.foo);
+            console.log(props.bar);
+          }, [props.bar, props.foo]);
+        }
+      `,
+      errors: [
+        'React Hook useCallback does nothing when called with only one argument. ' +
+          'Did you forget to pass an array of dependencies?',
+        "React Hook useCallback has missing dependencies: 'props.bar' and 'props.foo'. " +
+          'Did you mean to include them?',
+      ],
     },
     {
       // Regression test

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1087,6 +1087,103 @@ const tests = {
       ],
     },
     {
+      // Does nothing to deps on useMemo/useCallback if no options specified
+      code: `
+        function MyComponent(props) {
+          let foo = 42;
+          let bar = 43;
+          const value = useMemo(() => {
+            console.log(foo);
+          });
+          const fn = useCallback(() => {
+             alert(bar);
+          });
+        }
+      `,
+      output: `
+        function MyComponent(props) {
+          let foo = 42;
+          let bar = 43;
+          const value = useMemo(() => {
+            console.log(foo);
+          });
+          const fn = useCallback(() => {
+             alert(bar);
+          });
+        }
+      `,
+      errors: [
+        'React Hook useMemo does nothing when called with only one argument. ' +
+          'Did you forget to pass an array of dependencies?',
+        "React Hook useMemo has a missing dependency: 'foo'. " +
+          'Did you mean to include it?',
+        'React Hook useCallback does nothing when called with only one argument. ' +
+          'Did you forget to pass an array of dependencies?',
+        "React Hook useCallback has a missing dependency: 'bar'. " +
+          'Did you mean to include it?',
+      ],
+    },
+    {
+      // Does nothing to deps on useMemo if no deps required
+      code: `
+        function MyComponent(props) {
+          const value = useMemo(() => { return 2*2; });
+          const fn = useCallback(() => { alert('foo'); });
+        }
+      `,
+      output: `
+        function MyComponent(props) {
+          const value = useMemo(() => { return 2*2; });
+          const fn = useCallback(() => { alert('foo'); });
+        }
+      `,
+      errors: [
+        'React Hook useMemo does nothing when called with only one argument. ' +
+          'Did you forget to pass an array of dependencies?',
+        'React Hook useCallback does nothing when called with only one argument. ' +
+          'Did you forget to pass an array of dependencies?',
+      ],
+      options: [{missingDependencies: 'inject'}],
+    },
+    {
+      // Inject deps onto hooks that need them
+      code: `
+        function MyComponent(props) {
+          let foo = 42;
+          let bar = 43;
+          const value = useMemo(() => {
+            console.log(foo);
+          });
+          const fn = useCallback(() => {
+             alert(bar);
+          });
+        }
+      `,
+      output: `
+        function MyComponent(props) {
+          let foo = 42;
+          let bar = 43;
+          const value = useMemo(() => {
+            console.log(foo);
+          }, [foo]);
+          const fn = useCallback(() => {
+             alert(bar);
+          }, [bar]);
+        }
+      `,
+      errors: [
+        'React Hook useMemo does nothing when called with only one argument. ' +
+          'Did you forget to pass an array of dependencies?',
+        "React Hook useMemo has a missing dependency: 'foo'. " +
+          'Did you mean to include it?',
+        'React Hook useCallback does nothing when called with only one argument. ' +
+          'Did you forget to pass an array of dependencies?',
+        "React Hook useCallback has a missing dependency: 'bar'. " +
+          'Did you mean to include it?',
+      ],
+      options: [{missingDependencies: 'inject'}],
+    },
+    {
       // Regression test
       code: `
         function MyComponent() {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -20,10 +20,6 @@ export default {
           additionalHooks: {
             type: 'string',
           },
-          missingDependencies: {
-            // TODO: Can this have an enum option for just removing the hook
-            enum: ['inject'],
-          },
         },
       },
     ],
@@ -37,17 +33,8 @@ export default {
         ? new RegExp(context.options[0].additionalHooks)
         : undefined;
 
-    // Currently only supports "useMemo" & "useCallback"
-    const ifMissingDependencies =
-      context.options &&
-      context.options[0] &&
-      context.options[0].missingDependencies
-        ? context.options[0].missingDependencies
-        : undefined;
-
     const options = {
       additionalHooks,
-      missingDependencies: ifMissingDependencies,
     };
 
     // Should be shared between visitors.
@@ -972,7 +959,6 @@ export default {
         !declaredDependenciesNode &&
         (reactiveHookName === 'useMemo' || reactiveHookName === 'useCallback')
       ) {
-        // TODO: Can this have an autofix to remove hook if suggestedDependencies is empty
         if (suggestedDependencies.length > 0) {
           context.report({
             node: node.parent.callee,
@@ -980,14 +966,13 @@ export default {
               `React Hook ${context.getSource(reactiveHook)} has ` +
               getWarningMessage(missingDependencies, 'a', 'missing', 'include'),
             fix(fixer) {
-              // TODO: consider preserving the comments or formatting?
-              if (options.missingDependencies === 'inject') {
+              if (reactiveHookName === 'useCallback') {
                 return fixer.insertTextAfter(
                   callbackNode,
                   `, [${suggestedDependencies.join(', ')}]`,
                 );
               }
-              return null;
+              return;
             },
           });
         }


### PR DESCRIPTION
This feat injects dependencies onto useMemo/useCallback if the second argument is not provided and it has a dependency.
I was thinking not to break code that already uses useMemo without the second argument, that the fix shouldn't be applied unless the developer explicitly wants that change, but I'm open to better ideas.
Ideally there would also be a fix option where it just removes the useMemo/useCallback hook if there are no deps required