### PR TITLE
Adds react-events package for internal testing

### DIFF
--- a/packages/react-events/README.md
+++ b/packages/react-events/README.md
@@ -1,0 +1,3 @@
+# `react-events`
+
+This is package is intended for use with the experimental React events API.

--- a/packages/react-events/index.js
+++ b/packages/react-events/index.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const ReactEvents = require('./src/ReactEvents');
+
+// TODO: decide on the top-level export form.
+// This is hacky but makes it work with both Rollup and Jest.
+module.exports = ReactEvents.default || ReactEvents;

--- a/packages/react-events/npm/index.js
+++ b/packages/react-events/npm/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-events.production.min.js');
+} else {
+  module.exports = require('./cjs/react-events.development.js');
+}

--- a/packages/react-events/package.json
+++ b/packages/react-events/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "react"
   ],
-  "version": "16.8.4",
+  "version": "0.1.0",
   "homepage": "https://reactjs.org/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",

--- a/packages/react-events/package.json
+++ b/packages/react-events/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "react-events",
+  "description": "React is a JavaScript library for building user interfaces.",
+  "keywords": [
+    "react"
+  ],
+  "version": "16.8.4",
+  "homepage": "https://reactjs.org/",
+  "bugs": "https://github.com/facebook/react/issues",
+  "license": "MIT",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "build-info.json",
+    "cjs/",
+    "umd/"
+  ],
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/react.git",
+    "directory": "packages/react"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "loose-envify": "^1.1.0"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
+  }
+}

--- a/packages/react-events/src/ReactEvents.js
+++ b/packages/react-events/src/ReactEvents.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {REACT_EVENT_TARGET_TYPE} from 'shared/ReactSymbols';
+import type {ReactEventTarget} from 'shared/ReactTypes';
+
+const TouchHitTarget: ReactEventTarget = {
+  $$typeof: REACT_EVENT_TARGET_TYPE,
+  type: 'touch-hit',
+};
+
+const ReactEvents = {
+  TouchHitTarget,
+};
+
+export default ReactEvents;

--- a/packages/react-events/src/ReactEvents.js
+++ b/packages/react-events/src/ReactEvents.js
@@ -7,12 +7,15 @@
  * @flow
  */
 
-import {REACT_EVENT_TARGET_TYPE} from 'shared/ReactSymbols';
+import {
+  REACT_EVENT_TARGET_TYPE,
+  REACT_EVENT_TARGET_TOUCH_HIT,
+} from 'shared/ReactSymbols';
 import type {ReactEventTarget} from 'shared/ReactTypes';
 
 const TouchHitTarget: ReactEventTarget = {
   $$typeof: REACT_EVENT_TARGET_TYPE,
-  type: 'touch-hit',
+  type: REACT_EVENT_TARGET_TOUCH_HIT,
 };
 
 const ReactEvents = {

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -53,6 +53,11 @@ export const REACT_EVENT_TARGET_TYPE = hasSymbol
   ? Symbol.for('react.event_target')
   : 0xead6;
 
+// React event targets
+export const REACT_EVENT_TARGET_TOUCH_HIT = hasSymbol
+  ? Symbol.for('react.event_target.touch_hit')
+  : 0xead7;
+
 const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';
 

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -95,5 +95,5 @@ export type ReactEvent = {|
 
 export type ReactEventTarget = {|
   $$typeof: Symbol | number,
-  type: string,
+  type: Symbol | number,
 |};

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -461,6 +461,15 @@ const bundles = [
     global: 'SchedulerTracing',
     externals: [],
   },
+
+  /******* React Events (experimental) *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD, FB_WWW_DEV, FB_WWW_PROD],
+    moduleType: ISOMORPHIC,
+    entry: 'react-events',
+    global: 'ReactEvents',
+    externals: [],
+  },
 ];
 
 // Based on deep-freeze by substack (public domain)

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -1147,6 +1147,34 @@
       "packageName": "scheduler",
       "size": 12088,
       "gzip": 2473
+    },
+    {
+      "filename": "react-events.development.js",
+      "bundleType": "NODE_DEV",
+      "packageName": "react-events",
+      "size": 1135,
+      "gzip": 623
+    },
+    {
+      "filename": "react-events.production.min.js",
+      "bundleType": "NODE_PROD",
+      "packageName": "react-events",
+      "size": 448,
+      "gzip": 328
+    },
+    {
+      "filename": "ReactEvents-dev.js",
+      "bundleType": "FB_WWW_DEV",
+      "packageName": "react-events",
+      "size": 1106,
+      "gzip": 613
+    },
+    {
+      "filename": "ReactEvents-prod.js",
+      "bundleType": "FB_WWW_PROD",
+      "packageName": "react-events",
+      "size": 643,
+      "gzip": 377
     }
   ]
 }


### PR DESCRIPTION
This PR adds a `react-events` package that will act as the home for the user-facing APIs for the experimental event API. This package is only intended for internal testing right now. This also adds a bundle to the build script so we can build the `react-events` package to consume internally.

This PR will be a dependency for https://github.com/facebook/react/pull/15112.