### PR TITLE
react-events package follow up

### DIFF
--- a/packages/react-events/index.js
+++ b/packages/react-events/index.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactEvents = require('./src/ReactEvents');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactEvents.default || ReactEvents;
+export * from './src/ReactEvents';

--- a/packages/react-events/src/ReactEvents.js
+++ b/packages/react-events/src/ReactEvents.js
@@ -13,13 +13,7 @@ import {
 } from 'shared/ReactSymbols';
 import type {ReactEventTarget} from 'shared/ReactTypes';
 
-const TouchHitTarget: ReactEventTarget = {
+export const TouchHitTarget: ReactEventTarget = {
   $$typeof: REACT_EVENT_TARGET_TYPE,
   type: REACT_EVENT_TARGET_TOUCH_HIT,
 };
-
-const ReactEvents = {
-  TouchHitTarget,
-};
-
-export default ReactEvents;


### PR DESCRIPTION
Follow up to https://github.com/facebook/react/pull/15150. Changed the module export syntax to reflect that of newer modules, rather than the older modules (I originally used the ReactDOM package as the base template).