### PR TITLE
Removed unnecessary null check

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -164,10 +164,7 @@ export function applyDerivedStateFromProps(
     warnOnUndefinedDerivedState(ctor, partialState);
   }
   // Merge the partial state and the previous state.
-  const memoizedState =
-    partialState === null || partialState === undefined
-      ? prevState
-      : Object.assign({}, prevState, partialState);
+  const memoizedState = Object.assign({}, prevState, partialState);
   workInProgress.memoizedState = memoizedState;
 
   // Once the update queue is empty, persist the derived state onto the


### PR DESCRIPTION
In my opinion this null check is not necessary. Object.assign handles null and undefined values.

Its not a big change but i think it makes the code a little bit more readable.