### PR TITLE
Link to useLayoutEffect gist in a warning

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -393,7 +393,8 @@ export function useLayoutEffect(
       "be encoded into the server renderer's output format. This will lead " +
       'to a mismatch between the initial, non-hydrated UI and the intended ' +
       'UI. To avoid this, useLayoutEffect should only be used in ' +
-      'components that render exclusively on the client.',
+      'components that render exclusively on the client. ' +
+      'See https://fb.me/react-uselayouteffect-ssr for common fixes.',
   );
 }
 


### PR DESCRIPTION
I wrote up a small gist since it's a confusing issue and I don't think you can really fit it into the warning text. I have a paragraph on this in the docs but I figured a dedicated gist is more isolated and can explain this nuance better.