### PR TITLE
Add internal logic for listening to event responders

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -14,6 +14,7 @@ import warning from 'shared/warning';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import type {ReactEventResponder} from 'shared/ReactTypes';
+import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
 
 import {
   getValueForAttribute,
@@ -1281,7 +1282,7 @@ export function listenToEventResponderEvents(
   const {targetEventTypes} = eventResponder;
   // Get the listening set for this element. We use this to track
   // what events we're listening to.
-  const listeningSet = getListeningSetForElement(element, false);
+  const listeningSet = getListeningSetForElement(element);
 
   // Go through each target event type of the event responder
   for (let i = 0, length = targetEventTypes.length; i < length; ++i) {
@@ -1319,9 +1320,16 @@ export function listenToEventResponderEvents(
     // Create a unique name for this event, plus it's properties. We'll
     // use this to ensure we don't listen to the same event with the same
     // properties again.
-    const listeningName = `${name}_${passive}_${capture}`;
+    const listeningName = `${topLevelType}${passive ? '_passive' : ''}${
+      capture ? '_capture' : ''
+    }`;
     if (!listeningSet.has(listeningName)) {
-      trapEventForResponderEventSystem(element, topLevelType, capture, passive);
+      trapEventForResponderEventSystem(
+        element,
+        ((topLevelType: any): DOMTopLevelEventType),
+        capture,
+        passive,
+      );
       listeningSet.add(listeningName);
     }
   }

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -1323,9 +1323,9 @@ export function listenToEventResponderEvents(
       // Create a unique name for this event, plus it's properties. We'll
       // use this to ensure we don't listen to the same event with the same
       // properties again.
-      const listeningName = `${topLevelType}${passive ? '_passive' : ''}${
-        capture ? '_capture' : ''
-      }`;
+      const passiveKey = passive ? '_passive' : '';
+      const captureKey = capture ? '_capture' : '';
+      const listeningName = `${topLevelType}${passiveKey}${captureKey}`;
       if (!listeningSet.has(listeningName)) {
         trapEventForResponderEventSystem(
           element,

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -1283,7 +1283,7 @@ export function listenToEventResponderEvents(
 ): void {
   if (enableEventAPI) {
     const {targetEventTypes} = eventResponder;
-    // Get the listening set for this element. We use this to track
+    // Get the listening Set for this element. We use this to track
     // what events we're listening to.
     const listeningSet = getListeningSetForElement(element);
 
@@ -1294,7 +1294,7 @@ export function listenToEventResponderEvents(
       let capture = false;
       let passive = true;
 
-      // By default, if no event config object is provided (only a string),
+      // If no event config object is provided (i.e. - only a string),
       // we default to enabling passive and not capture.
       if (typeof targetEventType === 'string') {
         topLevelType = targetEventType;
@@ -1320,7 +1320,7 @@ export function listenToEventResponderEvents(
           capture = targetEventConfigObject.capture;
         }
       }
-      // Create a unique name for this event, plus it's properties. We'll
+      // Create a unique name for this event, plus its properties. We'll
       // use this to ensure we don't listen to the same event with the same
       // properties again.
       const passiveKey = passive ? '_passive' : '';

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -1280,7 +1280,7 @@ export function restoreControlledState(
 export function listenToEventResponderEvents(
   eventResponder: ReactEventResponder,
   element: Element | Document,
-) {
+): void {
   if (enableEventAPI) {
     const {targetEventTypes} = eventResponder;
     // Get the listening set for this element. We use this to track

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -24,6 +24,7 @@ import {
   warnForDeletedHydratableText,
   warnForInsertedHydratedElement,
   warnForInsertedHydratedText,
+  listenToEventResponderEvents,
 } from './ReactDOMComponent';
 import {getSelectionInformation, restoreSelection} from './ReactInputSelection';
 import setTextContent from './setTextContent';
@@ -861,7 +862,8 @@ export function handleEventComponent(
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
 ) {
-  // TODO: add handleEventComponent implementation
+  const rootElement = rootContainerInstance.ownerDocument;
+  listenToEventResponderEvents(eventResponder, rootElement);
 }
 
 export function handleEventTarget(

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -862,8 +862,10 @@ export function handleEventComponent(
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
 ) {
-  const rootElement = rootContainerInstance.ownerDocument;
-  listenToEventResponderEvents(eventResponder, rootElement);
+  if (enableEventAPI) {
+    const rootElement = rootContainerInstance.ownerDocument;
+    listenToEventResponderEvents(eventResponder, rootElement);
+  }
 }
 
 export function handleEventTarget(
@@ -871,20 +873,22 @@ export function handleEventTarget(
   props: Props,
   internalInstanceHandle: Object,
 ) {
-  // Touch target hit slop handling
-  if (type === REACT_EVENT_TARGET_TOUCH_HIT) {
-    // Validates that there is a single element
-    const element = getElementFromTouchHitTarget(internalInstanceHandle);
-    if (element !== null) {
-      // We update the event target state node to be that of the element.
-      // We can then diff this entry to determine if we need to add the
-      // hit slop element, or change the dimensions of the hit slop.
-      const lastElement = internalInstanceHandle.stateNode;
-      if (lastElement !== element) {
-        internalInstanceHandle.stateNode = element;
-        // TODO: Create the hit slop element and attach it to the element
-      } else {
-        // TODO: Diff the left, top, right, bottom props
+  if (enableEventAPI) {
+    // Touch target hit slop handling
+    if (type === REACT_EVENT_TARGET_TOUCH_HIT) {
+      // Validates that there is a single element
+      const element = getElementFromTouchHitTarget(internalInstanceHandle);
+      if (element !== null) {
+        // We update the event target state node to be that of the element.
+        // We can then diff this entry to determine if we need to add the
+        // hit slop element, or change the dimensions of the hit slop.
+        const lastElement = internalInstanceHandle.stateNode;
+        if (lastElement !== element) {
+          internalInstanceHandle.stateNode = element;
+          // TODO: Create the hit slop element and attach it to the element
+        } else {
+          // TODO: Diff the left, top, right, bottom props
+        }
       }
     }
   }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -862,10 +862,8 @@ export function handleEventComponent(
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
 ) {
-  if (enableEventAPI) {
-    const rootElement = rootContainerInstance.ownerDocument;
-    listenToEventResponderEvents(eventResponder, rootElement);
-  }
+  const rootElement = rootContainerInstance.ownerDocument;
+  listenToEventResponderEvents(eventResponder, rootElement);
 }
 
 export function handleEventTarget(
@@ -873,22 +871,20 @@ export function handleEventTarget(
   props: Props,
   internalInstanceHandle: Object,
 ) {
-  if (enableEventAPI) {
-    // Touch target hit slop handling
-    if (type === REACT_EVENT_TARGET_TOUCH_HIT) {
-      // Validates that there is a single element
-      const element = getElementFromTouchHitTarget(internalInstanceHandle);
-      if (element !== null) {
-        // We update the event target state node to be that of the element.
-        // We can then diff this entry to determine if we need to add the
-        // hit slop element, or change the dimensions of the hit slop.
-        const lastElement = internalInstanceHandle.stateNode;
-        if (lastElement !== element) {
-          internalInstanceHandle.stateNode = element;
-          // TODO: Create the hit slop element and attach it to the element
-        } else {
-          // TODO: Diff the left, top, right, bottom props
-        }
+  // Touch target hit slop handling
+  if (type === REACT_EVENT_TARGET_TOUCH_HIT) {
+    // Validates that there is a single element
+    const element = getElementFromTouchHitTarget(internalInstanceHandle);
+    if (element !== null) {
+      // We update the event target state node to be that of the element.
+      // We can then diff this entry to determine if we need to add the
+      // hit slop element, or change the dimensions of the hit slop.
+      const lastElement = internalInstanceHandle.stateNode;
+      if (lastElement !== element) {
+        internalInstanceHandle.stateNode = element;
+        // TODO: Create the hit slop element and attach it to the element
+      } else {
+        // TODO: Diff the left, top, right, bottom props
       }
     }
   }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -861,7 +861,7 @@ export function handleEventComponent(
   eventResponder: ReactEventResponder,
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
-) {
+): void {
   const rootElement = rootContainerInstance.ownerDocument;
   listenToEventResponderEvents(eventResponder, rootElement);
 }
@@ -870,7 +870,7 @@ export function handleEventTarget(
   type: Symbol | number,
   props: Props,
   internalInstanceHandle: Object,
-) {
+): void {
   // Touch target hit slop handling
   if (type === REACT_EVENT_TARGET_TOUCH_HIT) {
     // Validates that there is a single element

--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -90,12 +90,12 @@ const elementListeningSets:
   | WeakMap
   | Map<
       Document | Element | Node,
-      Set<DOMTopLevelEventType>,
+      Set<DOMTopLevelEventType | string>,
     > = new PossiblyWeakMap();
 
 export function getListeningSetForElement(
   element: Document | Element | Node,
-): Set<DOMTopLevelEventType> {
+): Set<DOMTopLevelEventType | string> {
   let listeningSet = elementListeningSets.get(element);
   if (listeningSet === undefined) {
     listeningSet = new Set();

--- a/packages/react-dom/src/events/ReactBrowserEventEmitter.js
+++ b/packages/react-dom/src/events/ReactBrowserEventEmitter.js
@@ -93,7 +93,7 @@ const elementListeningSets:
       Set<DOMTopLevelEventType>,
     > = new PossiblyWeakMap();
 
-function getListeningSetForElement(
+export function getListeningSetForElement(
   element: Document | Element | Node,
 ): Set<DOMTopLevelEventType> {
   let listeningSet = elementListeningSets.get(element);

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -60,15 +60,15 @@
       "filename": "react-dom.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 798048,
-      "gzip": 181482
+      "size": 813661,
+      "gzip": 184364
     },
     {
       "filename": "react-dom.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 107733,
-      "gzip": 34431
+      "size": 108035,
+      "gzip": 34515
     },
     {
       "filename": "ReactDOM-dev.js",
@@ -102,15 +102,15 @@
       "filename": "react-dom-test-utils.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 47988,
-      "gzip": 13245
+      "size": 48334,
+      "gzip": 13206
     },
     {
       "filename": "react-dom-test-utils.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 10288,
-      "gzip": 3812
+      "size": 9954,
+      "gzip": 3660
     },
     {
       "filename": "ReactTestUtils-dev.js",
@@ -137,15 +137,15 @@
       "filename": "react-dom-unstable-native-dependencies.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 61725,
-      "gzip": 16151
+      "size": 61643,
+      "gzip": 16033
     },
     {
       "filename": "react-dom-unstable-native-dependencies.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 11001,
-      "gzip": 3783
+      "size": 10669,
+      "gzip": 3640
     },
     {
       "filename": "ReactDOMUnstableNativeDependencies-dev.js",
@@ -179,15 +179,15 @@
       "filename": "react-dom-server.browser.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 129302,
-      "gzip": 34571
+      "size": 132758,
+      "gzip": 35195
     },
     {
       "filename": "react-dom-server.browser.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 19590,
-      "gzip": 7447
+      "size": 19756,
+      "gzip": 7540
     },
     {
       "filename": "ReactDOMServer-dev.js",
@@ -207,15 +207,15 @@
       "filename": "react-dom-server.node.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 131409,
-      "gzip": 35129
+      "size": 134747,
+      "gzip": 35752
     },
     {
       "filename": "react-dom-server.node.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 20483,
-      "gzip": 7757
+      "size": 20639,
+      "gzip": 7850
     },
     {
       "filename": "react-art.development.js",
@@ -718,8 +718,8 @@
       "filename": "react-dom.profiling.min.js",
       "bundleType": "NODE_PROFILING",
       "packageName": "react-dom",
-      "size": 110923,
-      "gzip": 35060
+      "size": 111211,
+      "gzip": 35133
     },
     {
       "filename": "ReactNativeRenderer-profiling.js",
@@ -1054,22 +1054,22 @@
       "filename": "react-dom-unstable-fire.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-dom",
-      "size": 798401,
-      "gzip": 181622
+      "size": 814014,
+      "gzip": 184503
     },
     {
       "filename": "react-dom-unstable-fire.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-dom",
-      "size": 107747,
-      "gzip": 34441
+      "size": 108049,
+      "gzip": 34524
     },
     {
       "filename": "react-dom-unstable-fire.profiling.min.js",
       "bundleType": "NODE_PROFILING",
       "packageName": "react-dom",
-      "size": 110937,
-      "gzip": 35069
+      "size": 111225,
+      "gzip": 35142
     },
     {
       "filename": "ReactFire-dev.js",


### PR DESCRIPTION
Note: this is for an experimental event API that we're testing out internally at Facebook.

This PR adds logic to listen to events defined in event responders, following on from previous PRs:

- https://github.com/facebook/react/pull/15036
- https://github.com/facebook/react/pull/15112
- https://github.com/facebook/react/pull/15150

This PR is quite difficult to test in isolation without creating unit tests that depend on internals (which I know we're moving away from as a team). In the next PR, I'll add further logic that connects the event firing to appropriate events that make for good public API tests. There isn't much to this PR to review other than a single function where most of the work happens, so hopefully it should be transparent as to what happens.l