### PR TITLE
Mark Profiler API as stable

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationSpecialTypes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationSpecialTypes-test.js
@@ -73,9 +73,9 @@ describe('ReactDOMServerIntegration', () => {
 
   itRenders('a Profiler component and its children', async render => {
     const element = await render(
-      <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
+      <React.Profiler id="profiler" onRender={jest.fn()}>
         <div>Test</div>
-      </React.unstable_Profiler>,
+      </React.Profiler>,
     );
     const parent = element.parentNode;
     const div = parent.childNodes[0];

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -391,9 +391,9 @@ describe('ReactDOMServerHydration', () => {
   it('should be able to render and hydrate Profiler components', () => {
     const callback = jest.fn();
     const markup = (
-      <React.unstable_Profiler id="profiler" onRender={callback}>
+      <React.Profiler id="profiler" onRender={callback}>
         <div>Hi</div>
-      </React.unstable_Profiler>
+      </React.Profiler>
     );
 
     const element = document.createElement('div');

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -182,14 +182,12 @@ describe('ReactIs', () => {
 
   it('should identify profile root', () => {
     expect(
-      ReactIs.typeOf(<React.unstable_Profiler id="foo" onRender={jest.fn()} />),
+      ReactIs.typeOf(<React.Profiler id="foo" onRender={jest.fn()} />),
     ).toBe(ReactIs.Profiler);
     expect(
-      ReactIs.isProfiler(
-        <React.unstable_Profiler id="foo" onRender={jest.fn()} />,
-      ),
+      ReactIs.isProfiler(<React.Profiler id="foo" onRender={jest.fn()} />),
     ).toBe(true);
-    expect(ReactIs.isProfiler({type: ReactIs.unstable_Profiler})).toBe(false);
+    expect(ReactIs.isProfiler({type: ReactIs.Profiler})).toBe(false);
     expect(ReactIs.isProfiler(<React.unstable_ConcurrentMode />)).toBe(false);
     expect(ReactIs.isProfiler(<div />)).toBe(false);
   });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -191,7 +191,7 @@ describe('ReactDebugFiberPerf', () => {
 
   it('does not include ConcurrentMode, StrictMode, or Profiler components in measurements', () => {
     ReactNoop.render(
-      <React.unstable_Profiler id="test" onRender={jest.fn()}>
+      <React.Profiler id="test" onRender={jest.fn()}>
         <React.StrictMode>
           <Parent>
             <React.unstable_ConcurrentMode>
@@ -199,7 +199,7 @@ describe('ReactDebugFiberPerf', () => {
             </React.unstable_ConcurrentMode>
           </Parent>
         </React.StrictMode>
-      </React.unstable_Profiler>,
+      </React.Profiler>,
     );
     addComment('Mount');
     expect(Scheduler).toFlushWithoutYielding();

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -31,7 +31,7 @@ describe('ReactSuspensePlaceholder', () => {
     Scheduler = require('scheduler');
     ReactCache = require('react-cache');
 
-    Profiler = React.unstable_Profiler;
+    Profiler = React.Profiler;
     Suspense = React.Suspense;
 
     TextResource = ReactCache.unstable_createResource(([text, ms = 0]) => {

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -234,12 +234,12 @@ describe('ReactShallowRenderer', () => {
     class SomeComponent extends React.Component {
       render() {
         return (
-          <React.unstable_Profiler id="test" onRender={jest.fn()}>
+          <React.Profiler id="test" onRender={jest.fn()}>
             <div>
               <span className="child1" />
               <span className="child2" />
             </div>
-          </React.unstable_Profiler>
+          </React.Profiler>
         );
       }
     }
@@ -247,7 +247,7 @@ describe('ReactShallowRenderer', () => {
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SomeComponent />);
 
-    expect(result.type).toBe(React.unstable_Profiler);
+    expect(result.type).toBe(React.Profiler);
     expect(result.props.children).toEqual(
       <div>
         <span className="child1" />

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererMemo-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererMemo-test.js
@@ -226,12 +226,12 @@ describe('ReactShallowRendererMemo', () => {
       class SomeComponent extends React.Component {
         render() {
           return (
-            <React.unstable_Profiler id="test" onRender={jest.fn()}>
+            <React.Profiler id="test" onRender={jest.fn()}>
               <div>
                 <span className="child1" />
                 <span className="child2" />
               </div>
-            </React.unstable_Profiler>
+            </React.Profiler>
           );
         }
       },
@@ -240,7 +240,7 @@ describe('ReactShallowRendererMemo', () => {
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SomeComponent />);
 
-    expect(result.type).toBe(React.unstable_Profiler);
+    expect(result.type).toBe(React.Profiler);
     expect(result.props.children).toEqual(
       <div>
         <span className="child1" />

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
@@ -39,9 +39,9 @@ describe('ReactTestRendererTraversal', () => {
               <View void="void" />
               <View void="void" />
             </ExampleNull>
-            <React.unstable_Profiler id="test" onRender={() => {}}>
+            <React.Profiler id="test" onRender={() => {}}>
               <ExampleForwardRef qux="qux" />
-            </React.unstable_Profiler>
+            </React.Profiler>
             <React.Fragment>
               <React.Fragment>
                 <Context.Provider value={null}>

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -77,6 +77,7 @@ const React = {
   useState,
 
   Fragment: REACT_FRAGMENT_TYPE,
+  Profiler: REACT_PROFILER_TYPE,
   StrictMode: REACT_STRICT_MODE_TYPE,
   Suspense: REACT_SUSPENSE_TYPE,
 
@@ -88,7 +89,6 @@ const React = {
   version: ReactVersion,
 
   unstable_ConcurrentMode: REACT_CONCURRENT_MODE_TYPE,
-  unstable_Profiler: REACT_PROFILER_TYPE,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: ReactSharedInternals,
 };
@@ -100,9 +100,7 @@ const React = {
 
 if (enableStableConcurrentModeAPIs) {
   React.ConcurrentMode = REACT_CONCURRENT_MODE_TYPE;
-  React.Profiler = REACT_PROFILER_TYPE;
   React.unstable_ConcurrentMode = undefined;
-  React.unstable_Profiler = undefined;
 }
 
 export default React;

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -127,7 +127,7 @@ describe('Profiler', () => {
             it('should warn if required params are missing', () => {
               expect(() => {
                 expect(() => {
-                  ReactTestRenderer.create(<React.unstable_Profiler />);
+                  ReactTestRenderer.create(<React.Profiler />);
                 }).toThrow('onRender is not a function');
               }).toWarnDev(
                 'Profiler must specify an "id" string and "onRender" function as props',
@@ -140,7 +140,7 @@ describe('Profiler', () => {
             // As root
             expect(
               ReactTestRenderer.create(
-                <React.unstable_Profiler id="label" onRender={jest.fn()} />,
+                <React.Profiler id="label" onRender={jest.fn()} />,
               ).toJSON(),
             ).toMatchSnapshot();
 
@@ -148,7 +148,7 @@ describe('Profiler', () => {
             expect(
               ReactTestRenderer.create(
                 <div>
-                  <React.unstable_Profiler id="label" onRender={jest.fn()} />
+                  <React.Profiler id="label" onRender={jest.fn()} />
                 </div>,
               ).toJSON(),
             ).toMatchSnapshot();
@@ -159,10 +159,10 @@ describe('Profiler', () => {
             const renderer = ReactTestRenderer.create(
               <div>
                 <span>outside span</span>
-                <React.unstable_Profiler id="label" onRender={jest.fn()}>
+                <React.Profiler id="label" onRender={jest.fn()}>
                   <span>inside span</span>
                   <FunctionComponent label="function component" />
-                </React.unstable_Profiler>
+                </React.Profiler>
               </div>,
             );
             expect(renderer.toJSON()).toMatchSnapshot();
@@ -176,13 +176,13 @@ describe('Profiler', () => {
               }
             }
             const renderer = ReactTestRenderer.create(
-              <React.unstable_Profiler id="outer" onRender={jest.fn()}>
+              <React.Profiler id="outer" onRender={jest.fn()}>
                 <FunctionComponent label="outer function component" />
-                <React.unstable_Profiler id="inner" onRender={jest.fn()}>
+                <React.Profiler id="inner" onRender={jest.fn()}>
                   <ClassComponent label="inner class component" />
                   <span>inner span</span>
-                </React.unstable_Profiler>
-              </React.unstable_Profiler>,
+                </React.Profiler>
+              </React.Profiler>,
             );
             expect(renderer.toJSON()).toMatchSnapshot();
           });
@@ -221,11 +221,11 @@ describe('Profiler', () => {
         expect(() =>
           ReactTestRenderer.create(
             <ClassComponent>
-              <React.unstable_Profiler id="do-not-throw" onRender={callback}>
-                <React.unstable_Profiler id="throw" onRender={callback}>
+              <React.Profiler id="do-not-throw" onRender={callback}>
+                <React.Profiler id="throw" onRender={callback}>
                   <div />
-                </React.unstable_Profiler>
-              </React.unstable_Profiler>
+                </React.Profiler>
+              </React.Profiler>
             </ClassComponent>,
           ),
         ).toThrow('expected');
@@ -242,10 +242,10 @@ describe('Profiler', () => {
         };
 
         ReactTestRenderer.create(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <Yield value="first" />
             <Yield value="last" />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
           {
             unstable_isConcurrent: true,
           },
@@ -312,9 +312,9 @@ describe('Profiler', () => {
         Scheduler.advanceTime(5); // 0 -> 5
 
         const renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <AdvanceTime />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -335,9 +335,9 @@ describe('Profiler', () => {
         Scheduler.advanceTime(20); // 15 -> 35
 
         renderer.update(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <AdvanceTime />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -358,9 +358,9 @@ describe('Profiler', () => {
         Scheduler.advanceTime(20); // 45 -> 65
 
         renderer.update(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <AdvanceTime byAmount={4} />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -384,13 +384,13 @@ describe('Profiler', () => {
 
         ReactTestRenderer.create(
           <React.Fragment>
-            <React.unstable_Profiler id="parent" onRender={callback}>
+            <React.Profiler id="parent" onRender={callback}>
               <AdvanceTime byAmount={10}>
-                <React.unstable_Profiler id="child" onRender={callback}>
+                <React.Profiler id="child" onRender={callback}>
                   <AdvanceTime byAmount={20} />
-                </React.unstable_Profiler>
+                </React.Profiler>
               </AdvanceTime>
-            </React.unstable_Profiler>
+            </React.Profiler>
           </React.Fragment>,
         );
 
@@ -419,12 +419,12 @@ describe('Profiler', () => {
 
         ReactTestRenderer.create(
           <React.Fragment>
-            <React.unstable_Profiler id="first" onRender={callback}>
+            <React.Profiler id="first" onRender={callback}>
               <AdvanceTime byAmount={20} />
-            </React.unstable_Profiler>
-            <React.unstable_Profiler id="second" onRender={callback}>
+            </React.Profiler>
+            <React.Profiler id="second" onRender={callback}>
               <AdvanceTime byAmount={5} />
-            </React.unstable_Profiler>
+            </React.Profiler>
           </React.Fragment>,
         );
 
@@ -453,9 +453,9 @@ describe('Profiler', () => {
         ReactTestRenderer.create(
           <React.Fragment>
             <AdvanceTime byAmount={20} />
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <AdvanceTime byAmount={5} />
-            </React.unstable_Profiler>
+            </React.Profiler>
             <AdvanceTime byAmount={20} />
           </React.Fragment>,
         );
@@ -489,17 +489,17 @@ describe('Profiler', () => {
         }
 
         const renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="outer" onRender={callback}>
+          <React.Profiler id="outer" onRender={callback}>
             <Updater>
-              <React.unstable_Profiler id="middle" onRender={callback}>
+              <React.Profiler id="middle" onRender={callback}>
                 <Pure>
-                  <React.unstable_Profiler id="inner" onRender={callback}>
+                  <React.Profiler id="inner" onRender={callback}>
                     <div />
-                  </React.unstable_Profiler>
+                  </React.Profiler>
                 </Pure>
-              </React.unstable_Profiler>
+              </React.Profiler>
             </Updater>
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         // All profile callbacks are called for initial render
@@ -526,11 +526,11 @@ describe('Profiler', () => {
         Scheduler.advanceTime(5); // 0 -> 5
 
         const renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <AdvanceTime byAmount={10}>
               <AdvanceTime byAmount={13} shouldComponentUpdate={false} />
             </AdvanceTime>
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -538,11 +538,11 @@ describe('Profiler', () => {
         Scheduler.advanceTime(30); // 28 -> 58
 
         renderer.update(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <AdvanceTime byAmount={4}>
               <AdvanceTime byAmount={7} shouldComponentUpdate={false} />
             </AdvanceTime>
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(2);
@@ -584,17 +584,17 @@ describe('Profiler', () => {
         Scheduler.advanceTime(5); // 0 -> 5
 
         const renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <WithLifecycles />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         Scheduler.advanceTime(15); // 13 -> 28
 
         renderer.update(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <WithLifecycles />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(2);
@@ -628,10 +628,10 @@ describe('Profiler', () => {
 
           // Render partially, but run out of time before completing.
           ReactTestRenderer.create(
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <Yield renderTime={2} />
               <Yield renderTime={3} />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
             {unstable_isConcurrent: true},
           );
           expect(Scheduler).toFlushAndYieldThrough(['Yield:2']);
@@ -663,13 +663,13 @@ describe('Profiler', () => {
           // Render partially, but don't finish.
           // This partial render should take 5ms of simulated time.
           ReactTestRenderer.create(
-            <React.unstable_Profiler id="outer" onRender={callback}>
+            <React.Profiler id="outer" onRender={callback}>
               <Yield renderTime={5} />
               <Yield renderTime={10} />
-              <React.unstable_Profiler id="inner" onRender={callback}>
+              <React.Profiler id="inner" onRender={callback}>
                 <Yield renderTime={17} />
-              </React.unstable_Profiler>
-            </React.unstable_Profiler>,
+              </React.Profiler>
+            </React.Profiler>,
             {unstable_isConcurrent: true},
           );
           expect(Scheduler).toFlushAndYieldThrough(['Yield:5']);
@@ -713,10 +713,10 @@ describe('Profiler', () => {
           // Render a partially update, but don't finish.
           // This partial render should take 10ms of simulated time.
           const renderer = ReactTestRenderer.create(
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <Yield renderTime={10} />
               <Yield renderTime={20} />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
             {unstable_isConcurrent: true},
           );
           expect(Scheduler).toFlushAndYieldThrough(['Yield:10']);
@@ -729,9 +729,9 @@ describe('Profiler', () => {
           // The interrupted work simulates an additional 5ms of time.
           renderer.unstable_flushSync(() => {
             renderer.update(
-              <React.unstable_Profiler id="test" onRender={callback}>
+              <React.Profiler id="test" onRender={callback}>
                 <Yield renderTime={5} />
-              </React.unstable_Profiler>,
+              </React.Profiler>,
             );
           });
           expect(Scheduler).toHaveYielded(['Yield:5']);
@@ -764,10 +764,10 @@ describe('Profiler', () => {
           Scheduler.advanceTime(5); // 0 -> 5
 
           const renderer = ReactTestRenderer.create(
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <Yield renderTime={6} />
               <Yield renderTime={15} />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
             {unstable_isConcurrent: true},
           );
 
@@ -788,11 +788,11 @@ describe('Profiler', () => {
           // Render a partially update, but don't finish.
           // This partial render should take 3ms of simulated time.
           renderer.update(
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <Yield renderTime={3} />
               <Yield renderTime={5} />
               <Yield renderTime={9} />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
           );
           expect(Scheduler).toFlushAndYieldThrough(['Yield:3']);
           expect(callback).toHaveBeenCalledTimes(0);
@@ -811,9 +811,9 @@ describe('Profiler', () => {
           // The interrupted work simulates an additional 11ms of time.
           renderer.unstable_flushSync(() => {
             renderer.update(
-              <React.unstable_Profiler id="test" onRender={callback}>
+              <React.Profiler id="test" onRender={callback}>
                 <Yield renderTime={11} />
-              </React.unstable_Profiler>,
+              </React.Profiler>,
             );
           });
           expect(Scheduler).toHaveYielded(['Yield:11']);
@@ -866,10 +866,10 @@ describe('Profiler', () => {
           Scheduler.advanceTime(5); // 0 -> 5
 
           const renderer = ReactTestRenderer.create(
-            <React.unstable_Profiler id="test" onRender={callback}>
+            <React.Profiler id="test" onRender={callback}>
               <FirstComponent />
               <SecondComponent />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
             {unstable_isConcurrent: true},
           );
 
@@ -979,12 +979,12 @@ describe('Profiler', () => {
                 Scheduler.advanceTime(5); // 0 -> 5
 
                 ReactTestRenderer.create(
-                  <React.unstable_Profiler id="test" onRender={callback}>
+                  <React.Profiler id="test" onRender={callback}>
                     <ErrorBoundary>
                       <AdvanceTime byAmount={9} />
                       <ThrowsError />
                     </ErrorBoundary>
-                  </React.unstable_Profiler>,
+                  </React.Profiler>,
                 );
 
                 expect(callback).toHaveBeenCalledTimes(2);
@@ -1058,12 +1058,12 @@ describe('Profiler', () => {
                 Scheduler.advanceTime(5); // 0 -> 5
 
                 ReactTestRenderer.create(
-                  <React.unstable_Profiler id="test" onRender={callback}>
+                  <React.Profiler id="test" onRender={callback}>
                     <ErrorBoundary>
                       <AdvanceTime byAmount={5} />
                       <ThrowsError />
                     </ErrorBoundary>
-                  </React.unstable_Profiler>,
+                  </React.Profiler>,
                 );
 
                 expect(callback).toHaveBeenCalledTimes(1);
@@ -1101,29 +1101,29 @@ describe('Profiler', () => {
                 // Simulate a renderer error during the "complete" phase.
                 // This mimics behavior like React Native's View/Text nesting validation.
                 ReactNoop.render(
-                  <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
+                  <React.Profiler id="profiler" onRender={jest.fn()}>
                     <errorInCompletePhase>hi</errorInCompletePhase>
-                  </React.unstable_Profiler>,
+                  </React.Profiler>,
                 );
                 expect(Scheduler).toFlushAndThrow('Error in host config.');
 
                 // A similar case we've seen caused by an invariant in ReactDOM.
                 // It didn't reproduce without a host component inside.
                 ReactNoop.render(
-                  <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
+                  <React.Profiler id="profiler" onRender={jest.fn()}>
                     <errorInCompletePhase>
                       <span>hi</span>
                     </errorInCompletePhase>
-                  </React.unstable_Profiler>,
+                  </React.Profiler>,
                 );
                 expect(Scheduler).toFlushAndThrow('Error in host config.');
 
                 // So long as the profiler timer's fiber stack is reset correctly,
                 // Subsequent renders should not error.
                 ReactNoop.render(
-                  <React.unstable_Profiler id="profiler" onRender={jest.fn()}>
+                  <React.Profiler id="profiler" onRender={jest.fn()}>
                     <span>hi</span>
-                  </React.unstable_Profiler>,
+                  </React.Profiler>,
                 );
                 expect(Scheduler).toFlushWithoutYielding();
               });
@@ -1138,9 +1138,9 @@ describe('Profiler', () => {
         Scheduler.advanceTime(5); // 0 -> 5
 
         const renderer = ReactTestRenderer.create(
-          <React.unstable_Profiler id="one" onRender={callback}>
+          <React.Profiler id="one" onRender={callback}>
             <AdvanceTime byAmount={2} />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -1148,9 +1148,9 @@ describe('Profiler', () => {
         Scheduler.advanceTime(20); // 7 -> 27
 
         renderer.update(
-          <React.unstable_Profiler id="two" onRender={callback}>
+          <React.Profiler id="two" onRender={callback}>
             <AdvanceTime byAmount={1} />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(2);
@@ -1193,9 +1193,9 @@ describe('Profiler', () => {
         }
 
         ReactTestRenderer.create(
-          <React.unstable_Profiler id="test" onRender={callback}>
+          <React.Profiler id="test" onRender={callback}>
             <ClassComponent />
-          </React.unstable_Profiler>,
+          </React.Profiler>,
         );
 
         expect(callback).toHaveBeenCalledTimes(1);
@@ -1545,9 +1545,9 @@ describe('Profiler', () => {
         Scheduler.unstable_now(),
         () => {
           renderer = ReactTestRenderer.create(
-            <React.unstable_Profiler id="test-profiler" onRender={onRender}>
+            <React.Profiler id="test-profiler" onRender={onRender}>
               <Example />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
             {
               unstable_isConcurrent: true,
             },
@@ -1717,9 +1717,9 @@ describe('Profiler', () => {
         Scheduler.unstable_now(),
         () => {
           renderer.update(
-            <React.unstable_Profiler id="test-profiler" onRender={onRender}>
+            <React.Profiler id="test-profiler" onRender={onRender}>
               <Example />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
           );
         },
       );
@@ -1794,10 +1794,10 @@ describe('Profiler', () => {
       Scheduler.advanceTime(5);
 
       const renderer = ReactTestRenderer.create(
-        <React.unstable_Profiler id="test" onRender={onRender}>
+        <React.Profiler id="test" onRender={onRender}>
           <FirstComponent />
           <SecondComponent />
-        </React.unstable_Profiler>,
+        </React.Profiler>,
         {unstable_isConcurrent: true},
       );
 
@@ -1975,9 +1975,9 @@ describe('Profiler', () => {
         Scheduler.unstable_now(),
         () => {
           ReactTestRenderer.create(
-            <React.unstable_Profiler id="test" onRender={onRender}>
+            <React.Profiler id="test" onRender={onRender}>
               <Example />
-            </React.unstable_Profiler>,
+            </React.Profiler>,
             {unstable_isConcurrent: true},
           );
         },
@@ -2182,9 +2182,9 @@ describe('Profiler', () => {
         render() {
           parentInstance = this;
           return (
-            <React.unstable_Profiler id="test-profiler" onRender={onRender}>
+            <React.Profiler id="test-profiler" onRender={onRender}>
               <Child count={this.state.count} />
-            </React.unstable_Profiler>
+            </React.Profiler>
           );
         }
       }
@@ -2274,13 +2274,13 @@ describe('Profiler', () => {
           Scheduler.unstable_now(),
           () => {
             ReactNoop.render(
-              <React.unstable_Profiler id="test-profiler" onRender={onRender}>
+              <React.Profiler id="test-profiler" onRender={onRender}>
                 <React.Suspense fallback={<Text text="Loading..." />}>
                   <AsyncText text="Async" ms={20000} />
                 </React.Suspense>
                 <Text text="Sync" />
                 <Monkey ref={monkey} />
-              </React.unstable_Profiler>,
+              </React.Profiler>,
             );
           },
         );
@@ -2361,13 +2361,13 @@ describe('Profiler', () => {
           interaction.timestamp,
           () => {
             ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={1000}
                   fallback={<Text text="loading" />}>
                   <AsyncText text="loaded" ms={2000} />
                 </React.Suspense>
-              </React.unstable_Profiler>,
+              </React.Profiler>,
             );
           },
         );
@@ -2415,13 +2415,13 @@ describe('Profiler', () => {
           interaction.timestamp,
           () => {
             ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={1000}
                   fallback={<Text text="loading" />}>
                   <AsyncComponentWithCascadingWork text="loaded" ms={2000} />
                 </React.Suspense>
-              </React.unstable_Profiler>,
+              </React.Profiler>,
             );
           },
         );
@@ -2454,13 +2454,13 @@ describe('Profiler', () => {
           interaction.timestamp,
           () => {
             ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={1000}
                   fallback={<Text text="loading" />}>
                   <AsyncText text="loaded" ms={2000} />
                 </React.Suspense>
-              </React.unstable_Profiler>,
+              </React.Profiler>,
               {
                 unstable_isConcurrent: true,
               },
@@ -2501,13 +2501,13 @@ describe('Profiler', () => {
           interaction.timestamp,
           () => {
             ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={2000}
                   fallback={<Text text="loading" />}>
                   <AsyncText text="loaded" ms={1000} />
                 </React.Suspense>
-              </React.unstable_Profiler>,
+              </React.Profiler>,
               {unstable_isConcurrent: true},
             );
           },
@@ -2544,14 +2544,14 @@ describe('Profiler', () => {
           initialRenderInteraction.timestamp,
           () => {
             renderer = ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={2000}
                   fallback={<Text text="loading" />}>
                   <AsyncText text="loaded" ms={1000} />
                 </React.Suspense>
                 <Text text="initial" />
-              </React.unstable_Profiler>,
+              </React.Profiler>,
             );
           },
         );
@@ -2578,14 +2578,14 @@ describe('Profiler', () => {
             highPriUpdateInteraction.timestamp,
             () => {
               renderer.update(
-                <React.unstable_Profiler id="app" onRender={onRender}>
+                <React.Profiler id="app" onRender={onRender}>
                   <React.Suspense
                     maxDuration={2000}
                     fallback={<Text text="loading" />}>
                     <AsyncText text="loaded" ms={1000} />
                   </React.Suspense>
                   <Text text="updated" />
-                </React.unstable_Profiler>,
+                </React.Profiler>,
               );
             },
           );
@@ -2630,14 +2630,14 @@ describe('Profiler', () => {
           initialRenderInteraction.timestamp,
           () => {
             renderer = ReactTestRenderer.create(
-              <React.unstable_Profiler id="app" onRender={onRender}>
+              <React.Profiler id="app" onRender={onRender}>
                 <React.Suspense
                   maxDuration={2000}
                   fallback={<Text text="loading" />}>
                   <AsyncText text="loaded" ms={1000} />
                 </React.Suspense>
                 <Text text="initial" />
-              </React.unstable_Profiler>,
+              </React.Profiler>,
               {unstable_isConcurrent: true},
             );
           },
@@ -2668,14 +2668,14 @@ describe('Profiler', () => {
             highPriUpdateInteraction.timestamp,
             () => {
               renderer.update(
-                <React.unstable_Profiler id="app" onRender={onRender}>
+                <React.Profiler id="app" onRender={onRender}>
                   <React.Suspense
                     maxDuration={2000}
                     fallback={<Text text="loading" />}>
                     <AsyncText text="loaded" ms={1000} />
                   </React.Suspense>
                   <Text text="updated" />
-                </React.unstable_Profiler>,
+                </React.Profiler>,
               );
             },
           );

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -57,13 +57,13 @@ describe('ReactProfiler DevTools integration', () => {
     const App = ({multiplier}) => {
       Scheduler.advanceTime(2);
       return (
-        <React.unstable_Profiler id="Profiler" onRender={onRender}>
+        <React.Profiler id="Profiler" onRender={onRender}>
           <AdvanceTime byAmount={3 * multiplier} shouldComponentUpdate={true} />
           <AdvanceTime
             byAmount={7 * multiplier}
             shouldComponentUpdate={false}
           />
-        </React.unstable_Profiler>
+        </React.Profiler>
       );
     };
 


### PR DESCRIPTION
The `Profiler` RFC (https://github.com/reactjs/rfcs/pull/51) is 10 months old and API hasn't changed in months. It seems like that we'll want to add a new API for `Suspense` metrics, but as a new prop that should not impact the existing `onRender` prop.

Maybe it's time to mark this API as stable? Opening for discussion purposes.

(If this lands, I will update and close out the RFC.)