### PR TITLE
Add part of the event responder system for experimental event API

### DIFF
--- a/packages/events/EventBatching.js
+++ b/packages/events/EventBatching.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * @flow
+ */
+
+import invariant from 'shared/invariant';
+import {rethrowCaughtError} from 'shared/ReactErrorUtils';
+
+import type {ReactSyntheticEvent} from './ReactSyntheticEventType';
+import accumulateInto from './accumulateInto';
+import forEachAccumulated from './forEachAccumulated';
+import {executeDispatchesInOrder} from './EventPluginUtils';
+
+/**
+ * Internal queue of events that have accumulated their dispatches and are
+ * waiting to have their dispatches executed.
+ */
+let eventQueue: ?(Array<ReactSyntheticEvent> | ReactSyntheticEvent) = null;
+
+/**
+ * Dispatches an event and releases it back into the pool, unless persistent.
+ *
+ * @param {?object} event Synthetic event to be dispatched.
+ * @private
+ */
+const executeDispatchesAndRelease = function(event: ReactSyntheticEvent) {
+  if (event) {
+    executeDispatchesInOrder(event);
+
+    if (!event.isPersistent()) {
+      event.constructor.release(event);
+    }
+  }
+};
+const executeDispatchesAndReleaseTopLevel = function(e) {
+  return executeDispatchesAndRelease(e);
+};
+
+export function runEventsInBatch(
+  events: Array<ReactSyntheticEvent> | ReactSyntheticEvent | null,
+) {
+  if (events !== null) {
+    eventQueue = accumulateInto(eventQueue, events);
+  }
+
+  // Set `eventQueue` to null before processing it so that we can tell if more
+  // events get enqueued while processing.
+  const processingEventQueue = eventQueue;
+  eventQueue = null;
+
+  if (!processingEventQueue) {
+    return;
+  }
+
+  forEachAccumulated(processingEventQueue, executeDispatchesAndReleaseTopLevel);
+  invariant(
+    !eventQueue,
+    'processEventQueue(): Additional events were enqueued while processing ' +
+      'an event queue. Support for this has not yet been implemented.',
+  );
+  // This would be a good time to rethrow if any of the event handlers threw.
+  rethrowCaughtError();
+}

--- a/packages/events/__tests__/ResponderEventPlugin-test.internal.js
+++ b/packages/events/__tests__/ResponderEventPlugin-test.internal.js
@@ -11,7 +11,7 @@
 
 const {HostComponent} = require('shared/ReactWorkTags');
 
-let EventPluginHub;
+let EventBatching;
 let EventPluginUtils;
 let ResponderEventPlugin;
 
@@ -321,7 +321,7 @@ const run = function(config, hierarchyConfig, nativeEventConfig) {
   // At this point the negotiation events have been dispatched as part of the
   // extraction process, but not the side effectful events. Below, we dispatch
   // side effectful events.
-  EventPluginHub.runEventsInBatch(extractedEvents);
+  EventBatching.runEventsInBatch(extractedEvents);
 
   // Ensure that every event that declared an `order`, was actually dispatched.
   expect('number of events dispatched:' + runData.dispatchCount).toBe(
@@ -403,7 +403,7 @@ describe('ResponderEventPlugin', () => {
     jest.resetModules();
 
     const ReactDOMUnstableNativeDependencies = require('react-dom/unstable-native-dependencies');
-    EventPluginHub = require('events/EventPluginHub');
+    EventBatching = require('events/EventBatching');
     EventPluginUtils = require('events/EventPluginUtils');
     ResponderEventPlugin =
       ReactDOMUnstableNativeDependencies.ResponderEventPlugin;

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -44,10 +44,8 @@ import {
   enqueueStateRestore,
   restoreStateIfNeeded,
 } from 'events/ReactControlledComponent';
-import {
-  injection as EventPluginHubInjection,
-  runEventsInBatch,
-} from 'events/EventPluginHub';
+import {injection as EventPluginHubInjection} from 'events/EventPluginHub';
+import {runEventsInBatch} from 'events/EventBatching';
 import {eventNameDispatchConfigs} from 'events/EventPluginRegistry';
 import {
   accumulateTwoPhaseDispatches,

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -44,7 +44,6 @@ import {
 import dangerousStyleValue from '../shared/dangerousStyleValue';
 
 import type {DOMContainer} from './ReactDOM';
-import {currentEventComponentFibers} from '../events/DOMEventResponderSystem';
 import type {ReactEventResponder} from 'shared/ReactTypes';
 import {
   REACT_EVENT_COMPONENT_TYPE,
@@ -52,7 +51,6 @@ import {
   REACT_EVENT_TARGET_TOUCH_HIT,
 } from 'shared/ReactSymbols';
 import getElementFromTouchHitTarget from 'shared/getElementFromTouchHitTarget';
-import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
 export type Type = string;
 export type Props = {
@@ -865,16 +863,6 @@ export function handleEventComponent(
   internalInstanceHandle: Object,
 ): void {
   if (enableEventAPI) {
-    // We keep the event responder hub up-to-do with the state of
-    // event component fiber tree (it uses this to know what events to fire).
-    // To do this, we update the current event component fiber and remove
-    // the alternate fiber if it exists.
-    const eventComponetFiber = ((internalInstanceHandle: any): Fiber);
-    currentEventComponentFibers.add(eventComponetFiber);
-    const alternateFiber = eventComponetFiber.alternate;
-    if (alternateFiber !== null) {
-      currentEventComponentFibers.delete(alternateFiber);
-    }
     const rootElement = rootContainerInstance.ownerDocument;
     listenToEventResponderEvents(eventResponder, rootElement);
   }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -864,18 +864,20 @@ export function handleEventComponent(
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
 ): void {
-  // We keep the event responder hub up-to-do with the state of
-  // event component fiber tree (it uses this to know what events to fire).
-  // To do this, we update the current event component fiber and remove
-  // the alternate fiber if it exists.
-  const eventComponetFiber = ((internalInstanceHandle: any): Fiber);
-  currentEventComponentFibers.add(eventComponetFiber);
-  const alternateFiber = eventComponetFiber.alternate;
-  if (alternateFiber !== null) {
-    currentEventComponentFibers.delete(alternateFiber);
+  if (enableEventAPI) {
+    // We keep the event responder hub up-to-do with the state of
+    // event component fiber tree (it uses this to know what events to fire).
+    // To do this, we update the current event component fiber and remove
+    // the alternate fiber if it exists.
+    const eventComponetFiber = ((internalInstanceHandle: any): Fiber);
+    currentEventComponentFibers.add(eventComponetFiber);
+    const alternateFiber = eventComponetFiber.alternate;
+    if (alternateFiber !== null) {
+      currentEventComponentFibers.delete(alternateFiber);
+    }
+    const rootElement = rootContainerInstance.ownerDocument;
+    listenToEventResponderEvents(eventResponder, rootElement);
   }
-  const rootElement = rootContainerInstance.ownerDocument;
-  listenToEventResponderEvents(eventResponder, rootElement);
 }
 
 export function handleEventTarget(
@@ -883,20 +885,22 @@ export function handleEventTarget(
   props: Props,
   internalInstanceHandle: Object,
 ): void {
-  // Touch target hit slop handling
-  if (type === REACT_EVENT_TARGET_TOUCH_HIT) {
-    // Validates that there is a single element
-    const element = getElementFromTouchHitTarget(internalInstanceHandle);
-    if (element !== null) {
-      // We update the event target state node to be that of the element.
-      // We can then diff this entry to determine if we need to add the
-      // hit slop element, or change the dimensions of the hit slop.
-      const lastElement = internalInstanceHandle.stateNode;
-      if (lastElement !== element) {
-        internalInstanceHandle.stateNode = element;
-        // TODO: Create the hit slop element and attach it to the element
-      } else {
-        // TODO: Diff the left, top, right, bottom props
+  if (enableEventAPI) {
+    // Touch target hit slop handling
+    if (type === REACT_EVENT_TARGET_TOUCH_HIT) {
+      // Validates that there is a single element
+      const element = getElementFromTouchHitTarget(internalInstanceHandle);
+      if (element !== null) {
+        // We update the event target state node to be that of the element.
+        // We can then diff this entry to determine if we need to add the
+        // hit slop element, or change the dimensions of the hit slop.
+        const lastElement = internalInstanceHandle.stateNode;
+        if (lastElement !== element) {
+          internalInstanceHandle.stateNode = element;
+          // TODO: Create the hit slop element and attach it to the element
+        } else {
+          // TODO: Diff the left, top, right, bottom props
+        }
       }
     }
   }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -44,6 +44,7 @@ import {
 import dangerousStyleValue from '../shared/dangerousStyleValue';
 
 import type {DOMContainer} from './ReactDOM';
+import {currentEventComponentFibers} from '../events/DOMEventResponderSystem';
 import type {ReactEventResponder} from 'shared/ReactTypes';
 import {
   REACT_EVENT_COMPONENT_TYPE,
@@ -51,6 +52,7 @@ import {
   REACT_EVENT_TARGET_TOUCH_HIT,
 } from 'shared/ReactSymbols';
 import getElementFromTouchHitTarget from 'shared/getElementFromTouchHitTarget';
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
 export type Type = string;
 export type Props = {
@@ -862,6 +864,16 @@ export function handleEventComponent(
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
 ): void {
+  // We keep the event responder hub up-to-do with the state of
+  // event component fiber tree (it uses this to know what events to fire).
+  // To do this, we update the current event component fiber and remove
+  // the alternate fiber if it exists.
+  const eventComponetFiber = ((internalInstanceHandle: any): Fiber);
+  currentEventComponentFibers.add(eventComponetFiber);
+  const alternateFiber = eventComponetFiber.alternate;
+  if (alternateFiber !== null) {
+    currentEventComponentFibers.delete(alternateFiber);
+  }
   const rootElement = rootContainerInstance.ownerDocument;
   listenToEventResponderEvents(eventResponder, rootElement);
 }

--- a/packages/react-dom/src/events/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/ChangeEventPlugin.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {runEventsInBatch} from 'events/EventPluginHub';
+import {runEventsInBatch} from 'events/EventBatching';
 import {accumulateTwoPhaseDispatches} from 'events/EventPropagators';
 import {enqueueStateRestore} from 'events/ReactControlledComponent';
 import {batchedUpdates} from 'events/ReactGenericBatching';

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -19,7 +19,7 @@ import warning from 'shared/warning';
 import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
 import accumulateInto from 'events/accumulateInto';
 import SyntheticEvent from 'events/SyntheticEvent';
-import {runEventsInBatch} from 'events/ReactGenericBatching';
+import {runEventsInBatch} from 'events/EventBatching';
 import {interactiveUpdates} from 'events/ReactGenericBatching';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * @flow
+ */
+
+import {type EventSystemFlags} from 'events/EventSystemFlags';
+import type {AnyNativeEvent} from 'events/PluginModuleType';
+import {EventComponent} from 'shared/ReactWorkTags';
+import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
+import type {ReactEventResponder} from 'shared/ReactTypes';
+import warning from 'shared/warning';
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
+
+// We track the active component fibers so we can traverse through
+// the fiber tree and find the relative current fibers. We need to
+// do this because an update might have switched an event component
+// fiber to its alternate fiber.
+export const currentEventComponentFibers: Set<Fiber> = new Set();
+
+// Event responders provide us an array of target event types.
+// To ensure we fire the right responders for given events, we check
+// if the incoming event type is actually relevant for an event
+// responder. Instead of doing an O(n) lookup on the event responder
+// target event types array each time, we instead create a Set for
+// faster O(1) lookups.
+export const eventResponderValidEventTypes: Map<
+  ReactEventResponder,
+  Set<DOMTopLevelEventType>,
+> = new Map();
+
+function createValidEventTypeSet(targetEventTypes): Set<DOMTopLevelEventType> {
+  const eventTypeSet = new Set();
+  // Go through each target event type of the event responder
+  for (let i = 0, length = targetEventTypes.length; i < length; ++i) {
+    const targetEventType = targetEventTypes[i];
+
+    if (typeof targetEventType === 'string') {
+      eventTypeSet.add(((targetEventType: any): DOMTopLevelEventType));
+    } else {
+      if (__DEV__) {
+        warning(
+          typeof targetEventType === 'object' && targetEventType !== null,
+          'Event Responder: invalid entry in targetEventTypes array. ' +
+            'Entry must be string or an object. Instead, got %s.',
+          targetEventType,
+        );
+      }
+      const targetEventConfigObject = ((targetEventType: any): {
+        name: DOMTopLevelEventType,
+        passive?: boolean,
+        capture?: boolean,
+      });
+      eventTypeSet.add(targetEventConfigObject.name);
+    }
+  }
+  return eventTypeSet;
+}
+
+function handleTopLevelType(
+  topLevelType: DOMTopLevelEventType,
+  fiber: Fiber,
+  context: Object,
+): void {
+  const responder: ReactEventResponder = fiber.type.responder;
+  const props = fiber.memoizedProps;
+  const stateNode = fiber.stateNode;
+  let validEventTypesForResponder = eventResponderValidEventTypes.get(
+    responder,
+  );
+
+  if (validEventTypesForResponder === undefined) {
+    validEventTypesForResponder = createValidEventTypeSet(
+      responder.targetEventTypes,
+    );
+    eventResponderValidEventTypes.set(responder, validEventTypesForResponder);
+  }
+  if (!validEventTypesForResponder.has(topLevelType)) {
+    return;
+  }
+  let state = stateNode.get(responder);
+  if (state === undefined && responder.createInitialState !== undefined) {
+    state = responder.createInitialState(props);
+    stateNode.set(responder, state);
+  }
+  // TODO provide all the props for handleEvent
+  responder.handleEvent(context, props, state);
+}
+
+export function runResponderEventsInBatch(
+  topLevelType: DOMTopLevelEventType,
+  targetFiber: Fiber,
+  nativeEvent: AnyNativeEvent,
+  nativeEventTarget: EventTarget,
+  eventSystemFlags: EventSystemFlags,
+): void {
+  // TODO add proper event context
+  let context = ({}: any);
+  let node = targetFiber;
+  // Traverse up the fiber tree till we find event component fibers.
+  while (node !== null) {
+    if (node.tag === EventComponent) {
+      if (node.alternate !== null && !currentEventComponentFibers.has(node)) {
+        node = node.alternate;
+      }
+      // TODO create a responder context and pass it through
+      handleTopLevelType(topLevelType, node, context);
+    }
+    node = node.return;
+  }
+  // TODO dispatch extracted events from context (with batching)
+}

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -148,7 +148,7 @@ function handleTopLevelType(
   context: Object,
 ): void {
   const responder: ReactEventResponder = fiber.type.responder;
-  const {props, stateMap} = fiber.stateNode;
+  let {props, state} = fiber.stateNode;
   let validEventTypesForResponder = eventResponderValidEventTypes.get(
     responder,
   );
@@ -162,10 +162,8 @@ function handleTopLevelType(
   if (!validEventTypesForResponder.has(topLevelType)) {
     return;
   }
-  let state = stateMap.get(responder);
-  if (state === undefined && responder.createInitialState !== undefined) {
-    state = responder.createInitialState(props);
-    stateMap.set(responder, state);
+  if (state === null && responder.createInitialState !== undefined) {
+    state = fiber.stateNode.state = responder.createInitialState(props);
   }
   context._fiber = fiber;
   context._responder = responder;

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -188,9 +188,6 @@ export function trapEventForResponderEventSystem(
   passive: boolean,
 ): void {
   if (enableEventAPI) {
-    const dispatch = isInteractiveTopLevelEventType(topLevelType)
-      ? dispatchInteractiveEvent
-      : dispatchEvent;
     const rawEventName = getRawEventName(topLevelType);
     let eventFlags = RESPONDER_EVENT_SYSTEM;
 
@@ -210,7 +207,7 @@ export function trapEventForResponderEventSystem(
       eventFlags |= IS_ACTIVE;
     }
     // Check if interactive and wrap in interactiveUpdates
-    const listener = dispatch.bind(null, topLevelType, eventFlags);
+    const listener = dispatchEvent.bind(null, topLevelType, eventFlags);
     addEventListener(element, rawEventName, listener, {
       capture,
       passive,

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -12,7 +12,8 @@ import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
 
 import {batchedUpdates, interactiveUpdates} from 'events/ReactGenericBatching';
-import {runExtractedEventsInBatch} from 'events/EventPluginHub';
+import {runExtractedPluginEventsInBatch} from 'events/EventPluginHub';
+import {runResponderEventsInBatch} from '../events/DOMEventResponderSystem';
 import {isFiberMounted} from 'react-reconciler/reflection';
 import {HostRoot} from 'shared/ReactWorkTags';
 import {
@@ -130,16 +131,27 @@ function handleTopLevel(bookKeeping: BookKeepingInstance) {
 
   for (let i = 0; i < bookKeeping.ancestors.length; i++) {
     targetInst = bookKeeping.ancestors[i];
-    if (bookKeeping.eventSystemFlags === PLUGIN_EVENT_SYSTEM) {
-      runExtractedEventsInBatch(
-        ((bookKeeping.topLevelType: any): DOMTopLevelEventType),
+    const eventSystemFlags = bookKeeping.eventSystemFlags;
+    const eventTarget = getEventTarget(bookKeeping.nativeEvent);
+    const topLevelType = ((bookKeeping.topLevelType: any): DOMTopLevelEventType);
+    const nativeEvent = ((bookKeeping.nativeEvent: any): AnyNativeEvent);
+
+    if (eventSystemFlags === PLUGIN_EVENT_SYSTEM) {
+      runExtractedPluginEventsInBatch(
+        topLevelType,
         targetInst,
-        ((bookKeeping.nativeEvent: any): AnyNativeEvent),
-        getEventTarget(bookKeeping.nativeEvent),
+        nativeEvent,
+        eventTarget,
       );
-    } else {
-      // RESPONDER_EVENT_SYSTEM
-      // TODO: Add implementation
+    } else if (enableEventAPI && targetInst !== null) {
+      // Responder event system (experimental event API)
+      runResponderEventsInBatch(
+        topLevelType,
+        targetInst,
+        nativeEvent,
+        eventTarget,
+        eventSystemFlags,
+      );
     }
   }
 }

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -232,6 +232,7 @@ describe('DOMEventResponderSystem', () => {
             'magicclick',
             props.onMagicClick,
             context.eventTarget,
+            false,
           );
         }
       },

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactFeatureFlags;
+let ReactDOM;
+
+function createReactEventComponent(targetEventTypes, handleEvent) {
+  const testEventResponder = {
+    targetEventTypes,
+    handleEvent,
+  };
+
+  return {
+    $$typeof: Symbol.for('react.event_component'),
+    props: null,
+    responder: testEventResponder,
+  };
+}
+
+function dispatchClickEvent(element) {
+  const clickEvent = document.createEvent('Event');
+  clickEvent.initEvent('click', true, true);
+  element.dispatchEvent(clickEvent);
+}
+
+// This is a new feature in Fiber so I put it in its own test file. It could
+// probably move to one of the other test files once it is official.
+describe('DOMEventResponderSystem', () => {
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableEventAPI = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  it('the event responder handleEvent() function should fire on click event', () => {
+    let eventResponderFiredCount = 0;
+    const buttonRef = React.createRef();
+
+    const ClickEventComponent = createReactEventComponent(['click'], () => {
+      eventResponderFiredCount++;
+    });
+
+    const Test = () => (
+      <ClickEventComponent>
+        <button ref={buttonRef}>Click me!</button>
+      </ClickEventComponent>
+    );
+
+    ReactDOM.render(<Test />, container);
+    expect(container.innerHTML).toBe('<button>Click me!</button>');
+
+    // Clicking the button should trigger the event responder handleEvent()
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(eventResponderFiredCount).toBe(1);
+
+    // Unmounting the container and clicking should not increment anything
+    ReactDOM.render(null, container);
+    dispatchClickEvent(buttonElement);
+    expect(eventResponderFiredCount).toBe(1);
+
+    // Re-rendering the container and clicking should increase the counter again
+    ReactDOM.render(<Test />, container);
+    buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(eventResponderFiredCount).toBe(2);
+  });
+});

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -219,4 +219,40 @@ describe('DOMEventResponderSystem', () => {
 
     expect(eventLog).toEqual(['B', 'A']);
   });
+
+  it('custom event dispatching for click -> magicClick works', () => {
+    let eventLog = [];
+    const buttonRef = React.createRef();
+
+    const ClickEventComponent = createReactEventComponent(
+      ['click'],
+      (context, props) => {
+        if (props.onMagicClick) {
+          context.dispatchEvent(
+            'magicclick',
+            props.onMagicClick,
+            context.eventTarget,
+          );
+        }
+      },
+    );
+
+    function handleMagicEvent(e) {
+      eventLog.push('magic event fired', e.type);
+    }
+
+    const Test = () => (
+      <ClickEventComponent onMagicClick={handleMagicEvent}>
+        <button ref={buttonRef}>Click me!</button>
+      </ClickEventComponent>
+    );
+
+    ReactDOM.render(<Test />, container);
+
+    // Clicking the button should trigger the event responder handleEvent()
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+
+    expect(eventLog).toEqual(['magic event fired', 'magicclick']);
+  });
 });

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -49,10 +49,9 @@ import {
   enqueueStateRestore,
   restoreStateIfNeeded,
 } from 'events/ReactControlledComponent';
-import {
-  injection as EventPluginHubInjection,
-  runEventsInBatch,
-} from 'events/EventPluginHub';
+import {injection as EventPluginHubInjection} from 'events/EventPluginHub';
+
+import {runEventsInBatch} from 'events/EventBatching';
 import {eventNameDispatchConfigs} from 'events/EventPluginRegistry';
 import {
   accumulateTwoPhaseDispatches,

--- a/packages/react-native-renderer/src/ReactFabricEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactFabricEventEmitter.js
@@ -9,7 +9,10 @@
 
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
-import {getListener, runExtractedEventsInBatch} from 'events/EventPluginHub';
+import {
+  getListener,
+  runExtractedPluginEventsInBatch,
+} from 'events/EventPluginHub';
 import {registrationNameModules} from 'events/EventPluginRegistry';
 import {batchedUpdates} from 'events/ReactGenericBatching';
 
@@ -25,7 +28,7 @@ export function dispatchEvent(
 ) {
   const targetFiber = (target: null | Fiber);
   batchedUpdates(function() {
-    runExtractedEventsInBatch(
+    runExtractedPluginEventsInBatch(
       topLevelType,
       targetFiber,
       nativeEvent,

--- a/packages/react-native-renderer/src/ReactNativeEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactNativeEventEmitter.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
-import {getListener, runExtractedEventsInBatch} from 'events/EventPluginHub';
+import {
+  getListener,
+  runExtractedPluginEventsInBatch,
+} from 'events/EventPluginHub';
 import {registrationNameModules} from 'events/EventPluginRegistry';
 import {batchedUpdates} from 'events/ReactGenericBatching';
 import warningWithoutStack from 'shared/warningWithoutStack';
@@ -95,7 +98,7 @@ function _receiveRootNodeIDEvent(
   const nativeEvent = nativeEventParam || EMPTY_NATIVE_EVENT;
   const inst = getInstanceFromNode(rootNodeID);
   batchedUpdates(function() {
-    runExtractedEventsInBatch(
+    runExtractedPluginEventsInBatch(
       topLevelType,
       inst,
       nativeEvent,

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -625,7 +625,7 @@ export function createFiberFromEventComponent(
   fiber.type = eventComponent;
   fiber.stateNode = {
     props: pendingProps,
-    stateMap: new Map(),
+    state: null,
   };
   fiber.expirationTime = expirationTime;
   return fiber;

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -623,7 +623,10 @@ export function createFiberFromEventComponent(
   const fiber = createFiber(EventComponent, pendingProps, key, mode);
   fiber.elementType = eventComponent;
   fiber.type = eventComponent;
-  fiber.stateNode = new Map();
+  fiber.stateNode = {
+    props: pendingProps,
+    stateMap: new Map(),
+  };
   fiber.expirationTime = expirationTime;
   return fiber;
 }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -774,6 +774,8 @@ function completeWork(
         popHostContext(workInProgress);
         const rootContainerInstance = getRootHostContainer();
         const responder = workInProgress.type.responder;
+        // Update the props on the event component state node
+        workInProgress.stateNode.props = newProps;
         handleEventComponent(responder, rootContainerInstance, workInProgress);
       }
       break;

--- a/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
@@ -53,7 +53,7 @@ function initTestRenderer() {
 
 // This is a new feature in Fiber so I put it in its own test file. It could
 // probably move to one of the other test files once it is official.
-describe('ReactTopLevelText', () => {
+describe('ReactFiberEvents', () => {
   describe('NoopRenderer', () => {
     beforeEach(() => {
       initNoopRenderer();


### PR DESCRIPTION
Note: this is for an experimental event API that we're testing out internally at Facebook.

This PR adds logic to handle triggering event responders from events that are listened to at a top level. This follows on from previous PRs:

- https://github.com/facebook/react/pull/15036
- https://github.com/facebook/react/pull/15112
- https://github.com/facebook/react/pull/15150
- https://github.com/facebook/react/pull/15168

This PR also adds tests that validate the triggering of event responder `handleEvent` function.