### PR TITLE
Warn about async infinite useEffect loop

### DIFF
--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -12,6 +12,7 @@
 let React;
 let ReactDOM;
 let ReactTestUtils;
+let Scheduler;
 
 describe('ReactUpdates', () => {
   beforeEach(() => {
@@ -19,6 +20,7 @@ describe('ReactUpdates', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactTestUtils = require('react-dom/test-utils');
+    Scheduler = require('scheduler');
   });
 
   it('should batch state when updating state twice', () => {
@@ -1524,4 +1526,99 @@ describe('ReactUpdates', () => {
       });
     });
   });
+
+  if (__DEV__) {
+    it('warns about a deferred infinite update loop with useEffect', async () => {
+      function NonTerminating() {
+        const [step, setStep] = React.useState(0);
+        React.useEffect(() => {
+          setStep(x => x + 1);
+          Scheduler.yieldValue(step);
+        });
+        return step;
+      }
+
+      function App() {
+        return <NonTerminating />;
+      }
+
+      let error = null;
+      let stack = null;
+      let originalConsoleError = console.error;
+      console.error = (e, s) => {
+        error = e;
+        stack = s;
+      };
+      try {
+        const container = document.createElement('div');
+        ReactDOM.render(<App />, container);
+        while (error === null) {
+          Scheduler.unstable_flushNumberOfYields(1);
+          await Promise.resolve();
+        }
+        expect(error).toContain('Warning: Maximum update depth exceeded.');
+        expect(stack).toContain('in NonTerminating');
+      } finally {
+        console.error = originalConsoleError;
+      }
+    });
+
+    it('can have nested updates if they do not cross the limit', async () => {
+      let _setStep;
+      const LIMIT = 50;
+
+      function Terminating() {
+        const [step, setStep] = React.useState(0);
+        _setStep = setStep;
+        React.useEffect(() => {
+          if (step < LIMIT) {
+            setStep(x => x + 1);
+            Scheduler.yieldValue(step);
+          }
+        });
+        return step;
+      }
+
+      const container = document.createElement('div');
+      ReactDOM.render(<Terminating />, container);
+
+      // Verify we can flush them asynchronously without warning
+      for (let i = 0; i < LIMIT * 2; i++) {
+        Scheduler.unstable_flushNumberOfYields(1);
+        await Promise.resolve();
+      }
+      expect(container.textContent).toBe('50');
+
+      // Verify restarting from 0 doesn't cross the limit
+      expect(() => {
+        _setStep(0);
+      }).toWarnDev(
+        'An update to Terminating inside a test was not wrapped in act',
+      );
+      expect(container.textContent).toBe('0');
+      for (let i = 0; i < LIMIT * 2; i++) {
+        Scheduler.unstable_flushNumberOfYields(1);
+        await Promise.resolve();
+      }
+      expect(container.textContent).toBe('50');
+    });
+
+    it('can have many updates inside useEffect without triggering a warning', () => {
+      function Terminating() {
+        const [step, setStep] = React.useState(0);
+        React.useEffect(() => {
+          for (let i = 0; i < 1000; i++) {
+            setStep(x => x + 1);
+          }
+          Scheduler.yieldValue('Done');
+        }, []);
+        return step;
+      }
+
+      const container = document.createElement('div');
+      ReactDOM.render(<Terminating />, container);
+      expect(Scheduler).toFlushAndYield(['Done']);
+      expect(container.textContent).toBe('1000');
+    });
+  }
 });

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1528,7 +1528,7 @@ describe('ReactUpdates', () => {
   });
 
   if (__DEV__) {
-    it('warns about a deferred infinite update loop with useEffect', async () => {
+    it('warns about a deferred infinite update loop with useEffect', () => {
       function NonTerminating() {
         const [step, setStep] = React.useState(0);
         React.useEffect(() => {
@@ -1554,7 +1554,6 @@ describe('ReactUpdates', () => {
         ReactDOM.render(<App />, container);
         while (error === null) {
           Scheduler.unstable_flushNumberOfYields(1);
-          await Promise.resolve();
         }
         expect(error).toContain('Warning: Maximum update depth exceeded.');
         expect(stack).toContain('in NonTerminating');
@@ -1563,7 +1562,7 @@ describe('ReactUpdates', () => {
       }
     });
 
-    it('can have nested updates if they do not cross the limit', async () => {
+    it('can have nested updates if they do not cross the limit', () => {
       let _setStep;
       const LIMIT = 50;
 
@@ -1585,7 +1584,6 @@ describe('ReactUpdates', () => {
       // Verify we can flush them asynchronously without warning
       for (let i = 0; i < LIMIT * 2; i++) {
         Scheduler.unstable_flushNumberOfYields(1);
-        await Promise.resolve();
       }
       expect(container.textContent).toBe('50');
 
@@ -1598,7 +1596,6 @@ describe('ReactUpdates', () => {
       expect(container.textContent).toBe('0');
       for (let i = 0; i < LIMIT * 2; i++) {
         Scheduler.unstable_flushNumberOfYields(1);
-        await Promise.resolve();
       }
       expect(container.textContent).toBe('50');
     });

--- a/packages/react-reconciler/src/ReactFiberScheduler.old.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.old.js
@@ -67,6 +67,7 @@ import {
 } from 'shared/ReactFeatureFlags';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
+import warning from 'shared/warning';
 import warningWithoutStack from 'shared/warningWithoutStack';
 
 import ReactFiberInstrumentation from './ReactFiberInstrumentation';
@@ -547,7 +548,9 @@ function commitPassiveEffects(root: FiberRoot, firstEffect: Fiber): void {
       let didError = false;
       let error;
       if (__DEV__) {
+        isInPassiveEffectDEV = true;
         invokeGuardedCallback(null, commitPassiveHookEffects, null, effect);
+        isInPassiveEffectDEV = false;
         if (hasCaughtError()) {
           didError = true;
           error = clearCaughtError();
@@ -580,6 +583,14 @@ function commitPassiveEffects(root: FiberRoot, firstEffect: Fiber): void {
   // Flush any sync work that was scheduled by effects
   if (!isBatchingUpdates && !isRendering) {
     performSyncWork();
+  }
+
+  if (__DEV__) {
+    if (rootWithPendingPassiveEffects === root) {
+      nestedPassiveEffectCountDEV++;
+    } else {
+      nestedPassiveEffectCountDEV = 0;
+    }
   }
 }
 
@@ -1897,6 +1908,21 @@ function scheduleWork(fiber: Fiber, expirationTime: ExpirationTime) {
         'the number of nested updates to prevent infinite loops.',
     );
   }
+  if (__DEV__) {
+    if (
+      isInPassiveEffectDEV &&
+      nestedPassiveEffectCountDEV > NESTED_PASSIVE_UPDATE_LIMIT
+    ) {
+      nestedPassiveEffectCountDEV = 0;
+      warning(
+        false,
+        'Maximum update depth exceeded. This can happen when a ' +
+          'component calls setState inside useEffect, but ' +
+          "useEffect either doesn't have a dependency array, or " +
+          'one of the dependencies changes on every render.',
+      );
+    }
+  }
 }
 
 function deferredUpdates<A>(fn: () => A): A {
@@ -1961,6 +1987,15 @@ let currentSchedulerTime: ExpirationTime = currentRendererTime;
 const NESTED_UPDATE_LIMIT = 50;
 let nestedUpdateCount: number = 0;
 let lastCommittedRootDuringThisBatch: FiberRoot | null = null;
+
+// Similar, but for useEffect infinite loops. These are DEV-only.
+const NESTED_PASSIVE_UPDATE_LIMIT = 50;
+let nestedPassiveEffectCountDEV;
+let isInPassiveEffectDEV;
+if (__DEV__) {
+  nestedPassiveEffectCountDEV = 0;
+  isInPassiveEffectDEV = false;
+}
 
 function recomputeCurrentRendererTime() {
   const currentTimeMs = now() - originalStartTimeMs;
@@ -2325,6 +2360,12 @@ function flushRoot(root: FiberRoot, expirationTime: ExpirationTime) {
 function finishRendering() {
   nestedUpdateCount = 0;
   lastCommittedRootDuringThisBatch = null;
+
+  if (__DEV__) {
+    if (rootWithPendingPassiveEffects === null) {
+      nestedPassiveEffectCountDEV = 0;
+    }
+  }
 
   if (completedBatches !== null) {
     const batches = completedBatches;


### PR DESCRIPTION
This surfaces problems like https://github.com/facebook/react/issues/14920#issuecomment-467785873 where the same root keeps scheduling updates inside useEffect, and never manages to "rest". It only catches the "synchronous" case (setState directly in useEffect).

<img width="1046" alt="Screen Shot 2019-03-21 at 4 54 45 PM" src="https://user-images.githubusercontent.com/810438/54769901-1784d800-4bfa-11e9-815d-839f1077f343.png">

I've made it DEV-only because a crash would be a breaking change. The heuristic might also not be perfect yet and I'd like to give it some time to see if there are edge false positives.