### PR TITLE
Upgrade rollup from 0.5.2 to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "random-seed": "^0.3.0",
     "react-lifecycles-compat": "^3.0.2",
     "rimraf": "^2.6.1",
-    "rollup": "^0.52.1",
+    "rollup": "^1.7.0",
     "rollup-plugin-babel": "^3.0.1",
     "rollup-plugin-commonjs": "^8.2.6",
     "rollup-plugin-node-resolve": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,6 +101,16 @@
   dependencies:
     "@types/whatwg-streams" "^0.0.6"
 
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://npm.hubteam.com/npm-nexus/repository/npm-all/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/node@^11.9.5":
+  version "11.11.4"
+  resolved "https://npm.hubteam.com/npm-nexus/repository/npm-all/@types/node/-/node-11.11.4.tgz#8808bd5a82bbf6f5d412eff1c228d178e7c24bb3"
+  integrity sha512-02tIL+QIi/RW4E5xILdoAMjeJ9kYq5t5S2vciUdFPXv/ikFTb0zK8q9vXkg4+WAJuYXGiVT1H28AkD2C+IkXVw==
+
 "@types/whatwg-streams@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@types/whatwg-streams/-/whatwg-streams-0.0.6.tgz#5062c67efb695c886fe3dbb9618df35aac418503"
@@ -137,6 +147,11 @@ acorn@^5.0.0, acorn@^5.3.0:
 acorn@^5.2.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+
+acorn@^6.1.1:
+  version "6.1.1"
+  resolved "https://npm.hubteam.com/npm-nexus/repository/npm-all/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
 agent-base@^4.1.0:
   version "4.1.2"
@@ -4430,9 +4445,14 @@ rollup-pluginutils@^1.5.0:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
 
-rollup@^0.52.1:
-  version "0.52.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.52.1.tgz#610e8e1be432f18fcfbfa865408a1cd7618cd707"
+rollup@^1.7.0:
+  version "1.7.0"
+  resolved "https://npm.hubteam.com/npm-nexus/repository/npm-all/rollup/-/rollup-1.7.0.tgz#2f5063c0f344f2225d1077655dc54d105a512bb2"
+  integrity sha512-hjuWSCgoQsFSTsmsNP4AH1l1kfkFqW82gW00V9nL81Zr3JtnKn3rvxh18jUAAEMb7qNoHj21PR5SqbK2mhBgMg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "^11.9.5"
+    acorn "^6.1.1"
 
 rsvp@^3.3.3:
   version "3.6.2"


### PR DESCRIPTION
After coming across https://github.com/facebook/react/issues/14635, I thought I would follow @gaearon's suggestion there to submit a pull request to upgrade Rollup to v1.x. 

There are a few breaking changes in this upgrade path, as described in [Rollup's changelog.](https://github.com/rollup/rollup/blob/master/CHANGELOG.md). I've included them below, but I don't have a lot of context for what any of them mean.

<details>


- Revert class id preservation from #2025 (#2048)
- Refactor missing export plugin hook (#1987)
- Deprecate the legacy option and thus IE8 support (#2141)
optimizeChunks is renamed to experimentalOptimizeChunks to reflect this feature is not production-ready yet (#2575)
- Several (mostly deprecated) options have been removed or renamed (#2293, #2409):
    ```
    banner -> output.banner
    dest -> output.file
    entry -> input
    experimentalCodeSplitting -> now always active
    experimentalDynamicImport -> now always active
    experimentalPreserveModules -> preserveModules
    exports -> output.exports
    extend -> output.extend
    footer -> output.footer
    format -> output.format
    freeze -> output.freeze
    globals -> output.globals
    indent -> output.indent
    interop -> output.interop
    intro -> output.intro
    load -> use plugin API
    moduleName -> output.name
    name -> output.name
    noConflict -> output.noConflict
    output.moduleId -> output.amd.id
    outro -> output.outro
    paths -> output.paths
    preferConst -> output.preferConst
    pureExternalModules -> treeshake.pureExternalModules
    resolveExternal -> use plugin API
    resolveId -> use plugin API
    sourcemap -> output.sourcemap
    sourceMap -> output.sourcemap
    sourceMapFile -> output.sourcemapFile
    strict -> output.strict
    targets -> use output as an array
    transform -> use plugin API
    useStrict -> output.strict
    ```
- In general, output options can no longer be used as input options (#2409)
bundle.generate and bundle.write now return a new format (#2293)
Several plugin hooks have become deprecated and will display warnings when used (#2409):
    ```
    transformBundle
    transformChunk
    ongenerate
    onwrite
    ```
- Plugin transform dependencies are deprecated in favour of using the this.addWatchFile plugin context function (#2409)
- Accessing this.watcher in plugin hooks is deprecated in favour of the watchChange plugin hook and the this.addWatchFile plugin context function (#2409)
- Using dynamic import statements will by default create a new chunk unless inlineDynamicImports is used (#2293)
- Rollup now uses acorn@6 which means that acorn plugins must be compatible with this version; acorn is now external for non-browser builds to make plugins work (#2293)
</details>
