### PR TITLE
[ESLint] Validate useEffect without deps too

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -2971,6 +2971,36 @@ const tests = {
     },
     {
       code: `
+        function MyComponent() {
+          const myRef = useRef();
+          useEffect(() => {
+            const handleMove = () => {};
+            myRef.current.addEventListener('mousemove', handleMove);
+            return () => myRef.current.removeEventListener('mousemove', handleMove);
+          });
+          return <div ref={myRef} />;
+        }
+      `,
+      output: `
+        function MyComponent() {
+          const myRef = useRef();
+          useEffect(() => {
+            const handleMove = () => {};
+            myRef.current.addEventListener('mousemove', handleMove);
+            return () => myRef.current.removeEventListener('mousemove', handleMove);
+          });
+          return <div ref={myRef} />;
+        }
+      `,
+      errors: [
+        `The ref value 'myRef.current' will likely have changed by the time ` +
+          `this effect cleanup function runs. If this ref points to a node ` +
+          `rendered by React, copy 'myRef.current' to a variable inside the effect, ` +
+          `and use that variable in the cleanup function.`,
+      ],
+    },
+    {
+      code: `
         function useMyThing(myRef) {
           useEffect(() => {
             const handleMove = () => {};
@@ -4441,6 +4471,31 @@ const tests = {
       output: `
         function Thing() {
           useEffect(async () => {}, []);
+        }
+      `,
+      errors: [
+        `Effect callbacks are synchronous to prevent race conditions. ` +
+          `Put the async function inside:\n\n` +
+          'useEffect(() => {\n' +
+          '  async function fetchData() {\n' +
+          '    // You can await here\n' +
+          '    const response = await MyAPI.getData(someId);\n' +
+          '    // ...\n' +
+          '  }\n' +
+          '  fetchData();\n' +
+          `}, [someId]); // Or [] if effect doesn't need props or state\n\n` +
+          'Learn more about data fetching with Hooks: https://fb.me/react-hooks-data-fetching',
+      ],
+    },
+    {
+      code: `
+        function Thing() {
+          useEffect(async () => {});
+        }
+      `,
+      output: `
+        function Thing() {
+          useEffect(async () => {});
         }
       `,
       errors: [

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -88,7 +88,7 @@ export default {
       // So no need to check for dependency inclusion.
       const depsIndex = callbackIndex + 1;
       const declaredDependenciesNode = node.parent.arguments[depsIndex];
-      if (!declaredDependenciesNode) {
+      if (!declaredDependenciesNode && !isEffect) {
         // These are only used for optimization.
         if (
           reactiveHookName === 'useMemo' ||
@@ -468,6 +468,9 @@ export default {
         },
       );
 
+      if (!declaredDependenciesNode) {
+        return;
+      }
       const declaredDependencies = [];
       const externalDependencies = new Set();
       if (declaredDependenciesNode.type !== 'ArrayExpression') {


### PR DESCRIPTION
There's a few checks that are still useful whether you specified deps or not. We used to exit too early, but not we exit until we actually need declared deps. This will catch more mistakes.