### PR TITLE
Flip event passive logic on passiveBrowserEventsSupported

### DIFF
--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -188,11 +188,11 @@ export function trapEventForResponderEventSystem(
     // and can provide polyfills if needed.
     if (passive) {
       if (passiveBrowserEventsSupported) {
+        eventFlags |= IS_PASSIVE;
+      } else {
         eventFlags |= IS_ACTIVE;
         eventFlags |= PASSIVE_NOT_SUPPORTED;
         passive = false;
-      } else {
-        eventFlags |= IS_PASSIVE;
       }
     } else {
       eventFlags |= IS_ACTIVE;


### PR DESCRIPTION
A quick fix for a conditional that was the inverse of what it should be, as pointed out in https://github.com/facebook/react/pull/15036/files/8b34efad7e476d5c7d5cc8ca4919372f924d7737#diff-ef5dd95abc83612d6596f035b629d5a4. I'll make sure to add a regression test for this in an upcoming PR.