### PR TITLE
React v16.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@
   </summary>
 </details>
 
+## 16.8.5 (March 22, 2019)
+
+### React DOM
+
+* Don't set the first option as selected in select tag with `size` attribute. ([@kulek1](https://github.com/kulek1) in [#14242](https://github.com/facebook/react/pull/14242))
+* Improve the `useEffect(async () => ...)` warning message. ([@gaearon](https://github.com/gaearon) in [#15118](https://github.com/facebook/react/pull/15118))
+
+### React DOM Server
+
+* Improve the `useLayoutEffect` warning message when server rendering. ([@gaearon](https://github.com/gaearon) in [#15158](https://github.com/facebook/react/pull/15158))
+
+### React Shallow Renderer
+
+* Fix `setState` in shallow renderer to work with Hooks. ([@gaearon](https://github.com/gaearon) in [#15120](https://github.com/facebook/react/pull/15120))
+* Fix shallow renderer to support `React.memo`. ([@aweary](https://github.com/aweary) in [#14816](https://github.com/facebook/react/pull/14816))
+* Fix shallow renderer not allowing Hooks inside `forwardRef`. ([@eps1lon](https://github.com/eps1lon) in [#15100](https://github.com/facebook/react/pull/15100))
+
 ## 16.8.4 (March 5, 2019)
 
 ### React DOM and other renderers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 * Fix `setState` in shallow renderer to work with Hooks. ([@gaearon](https://github.com/gaearon) in [#15120](https://github.com/facebook/react/pull/15120))
 * Fix shallow renderer to support `React.memo`. ([@aweary](https://github.com/aweary) in [#14816](https://github.com/facebook/react/pull/14816))
-* Fix shallow renderer not allowing Hooks inside `forwardRef`. ([@eps1lon](https://github.com/eps1lon) in [#15100](https://github.com/facebook/react/pull/15100))
+* Fix shallow renderer to support Hooks inside `forwardRef`. ([@eps1lon](https://github.com/eps1lon) in [#15100](https://github.com/facebook/react/pull/15100))
 
 ## 16.8.4 (March 5, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Don't set the first option as selected in select tag with `size` attribute. ([@kulek1](https://github.com/kulek1) in [#14242](https://github.com/facebook/react/pull/14242))
 * Improve the `useEffect(async () => ...)` warning message. ([@gaearon](https://github.com/gaearon) in [#15118](https://github.com/facebook/react/pull/15118))
+* Improve the error message sometimes caused by duplicate React. ([@jaredpalmer](https://github.com/jaredpalmer) in [#15139](https://github.com/facebook/react/pull/15139))
 
 ### React DOM Server
 

--- a/fixtures/dom/src/components/fixtures/selects/index.js
+++ b/fixtures/dom/src/components/fixtures/selects/index.js
@@ -202,6 +202,34 @@ class SelectFixture extends React.Component {
             </select>
           </div>
         </TestCase>
+
+        <TestCase
+          title="A select with the size attribute should not set first option as selected"
+          relatedIssues="14239"
+          introducedIn="16.0.0">
+          <TestCase.ExpectedResult>
+            No options should be selected.
+          </TestCase.ExpectedResult>
+
+          <div className="test-fixture">
+            <select size="3">
+              <option>0</option>
+              <option>1</option>
+              <option>2</option>
+            </select>
+          </div>
+
+          <p className="footnote">
+            <b>Notes:</b> This happens if <code>size</code> is assigned after
+            options are selected. The select element picks the first item by
+            default, then it is expanded to show more options when{' '}
+            <code>size</code> is assigned, preserving the default selection.
+          </p>
+          <p className="footnote">
+            This was introduced in React 16.0.0 when options were added before
+            select attribute assignment.
+          </p>
+        </TestCase>
       </FixtureSet>
     );
   }

--- a/packages/create-subscription/package.json
+++ b/packages/create-subscription/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-subscription",
   "description": "utility for subscribing to external data sources inside React components",
-  "version": "16.8.4",
+  "version": "16.8.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",

--- a/packages/jest-react/package.json
+++ b/packages/jest-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-react",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Jest matchers and utilities for testing React components.",
   "main": "index.js",
   "repository": {

--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-art",
   "description": "React ART is a JavaScript library for drawing vector graphics using React. It provides declarative and reactive bindings to the ART library. Using the same declarative API you can render the output to either Canvas, SVG or VML (IE8).",
-  "version": "16.8.4",
+  "version": "16.8.5",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "scheduler": "^0.13.4"
+    "scheduler": "^0.13.5"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -239,7 +239,12 @@ describe('ReactHooksInspection', () => {
     expect(() => {
       ReactDebugTools.inspectHooks(Foo, {}, FakeDispatcherRef);
     }).toThrow(
-      'Hooks can only be called inside the body of a function component.',
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
 
     expect(getterCalls).toBe(1);

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -419,7 +419,12 @@ describe('ReactHooksInspectionIntegration', () => {
     expect(() => {
       ReactDebugTools.inspectHooksOfFiber(childFiber, FakeDispatcherRef);
     }).toThrow(
-      'Hooks can only be called inside the body of a function component.',
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
 
     expect(getterCalls).toBe(1);

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dom",
-  "version": "16.8.4",
+  "version": "16.8.5",
   "description": "React package for working with the DOM.",
   "main": "index.js",
   "repository": {
@@ -20,7 +20,7 @@
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "scheduler": "^0.13.4"
+    "scheduler": "^0.13.5"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -362,6 +362,32 @@ describe('ReactDOMSelect', () => {
     expect(node.options[2].selected).toBe(true); // gorilla
   });
 
+  it('does not select an item when size is initially set to greater than 1', () => {
+    const stub = (
+      <select size="2">
+        <option value="monkey">A monkey!</option>
+        <option value="giraffe">A giraffe!</option>
+        <option value="gorilla">A gorilla!</option>
+      </select>
+    );
+    const container = document.createElement('div');
+    const select = ReactDOM.render(stub, container);
+
+    expect(select.options[0].selected).toBe(false);
+    expect(select.options[1].selected).toBe(false);
+    expect(select.options[2].selected).toBe(false);
+
+    // Note: There is an inconsistency between JSDOM and Chrome where
+    // Chrome reports an empty string when no value is selected for a
+    // single-select with a size greater than 0. JSDOM reports the first
+    // value
+    //
+    // This assertion exists only for clarity of JSDOM behavior:
+    expect(select.value).toBe('monkey'); // "" in Chrome
+    // Despite this, the selection index is correct:
+    expect(select.selectedIndex).toBe(-1);
+  });
+
   it('should remember value when switching to uncontrolled', () => {
     let stub = (
       <select value={'giraffe'} onChange={noop}>

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
@@ -144,7 +144,12 @@ describe('ReactDOMServerHooks', () => {
 
         return render(<Counter />);
       },
-      'Hooks can only be called inside the body of a function component.',
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
 
     itRenders('multiple times when an updater is called', async render => {
@@ -626,7 +631,12 @@ describe('ReactDOMServerHooks', () => {
 
         return render(<Counter />);
       },
-      'Hooks can only be called inside the body of a function component.',
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
   });
 

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -419,14 +419,25 @@ export function createElement(
       // See discussion in https://github.com/facebook/react/pull/6896
       // and discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1276240
       domElement = ownerDocument.createElement(type);
-      // Normally attributes are assigned in `setInitialDOMProperties`, however the `multiple`
-      // attribute on `select`s needs to be added before `option`s are inserted. This prevents
-      // a bug where the `select` does not scroll to the correct option because singular
-      // `select` elements automatically pick the first item.
+      // Normally attributes are assigned in `setInitialDOMProperties`, however the `multiple` and `size`
+      // attributes on `select`s needs to be added before `option`s are inserted.
+      // This prevents:
+      // - a bug where the `select` does not scroll to the correct option because singular
+      //  `select` elements automatically pick the first item #13222
+      // - a bug where the `select` set the first item as selected despite the `size` attribute #14239
       // See https://github.com/facebook/react/issues/13222
-      if (type === 'select' && props.multiple) {
+      // and https://github.com/facebook/react/issues/14239
+      if (type === 'select') {
         const node = ((domElement: any): HTMLSelectElement);
-        node.multiple = true;
+        if (props.multiple) {
+          node.multiple = true;
+        } else if (props.size) {
+          // Setting a size greater than 1 causes a select to behave like `multiple=true`, where
+          // it is possible that no option is selected.
+          //
+          // This is only necessary when a select in "single selection mode".
+          node.size = props.size;
+        }
       }
     }
   } else {

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -57,8 +57,12 @@ let currentHookNameInDev: ?string;
 function resolveCurrentlyRenderingComponent(): Object {
   invariant(
     currentlyRenderingComponent !== null,
-    'Hooks can only be called inside the body of a function component. ' +
-      '(https://fb.me/react-invalid-hook-call)',
+    'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+      ' one of the following reasons:\n' +
+      '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+      '2. You might be breaking the Rules of Hooks\n' +
+      '3. You might have more than one copy of React in the same app\n' +
+      'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
   );
   if (__DEV__) {
     warning(

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -389,7 +389,8 @@ export function useLayoutEffect(
       "be encoded into the server renderer's output format. This will lead " +
       'to a mismatch between the initial, non-hydrated UI and the intended ' +
       'UI. To avoid this, useLayoutEffect should only be used in ' +
-      'components that render exclusively on the client.',
+      'components that render exclusively on the client. ' +
+      'See https://fb.me/react-uselayouteffect-ssr for common fixes.',
   );
 }
 

--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-is",
-  "version": "16.8.4",
+  "version": "16.8.5",
   "description": "Brand checking of React Elements.",
   "main": "index.js",
   "repository": {

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-reconciler",
   "description": "React package for creating custom renderers.",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "keywords": [
     "react"
   ],
@@ -33,7 +33,7 @@
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "scheduler": "^0.13.4"
+    "scheduler": "^0.13.5"
   },
   "browserify": {
     "transform": [

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -346,22 +346,23 @@ function commitHookEffectList(
             } else if (typeof destroy.then === 'function') {
               addendum =
                 '\n\nIt looks like you wrote useEffect(async () => ...) or returned a Promise. ' +
-                'Instead, you may write an async function separately ' +
-                'and then call it from inside the effect:\n\n' +
-                'async function fetchComment(commentId) {\n' +
-                '  // You can await here\n' +
-                '}\n\n' +
+                'Instead, write the async function inside your effect ' +
+                'and call it immediately:\n\n' +
                 'useEffect(() => {\n' +
-                '  fetchComment(commentId);\n' +
-                '}, [commentId]);\n\n' +
-                'In the future, React will provide a more idiomatic solution for data fetching ' +
-                "that doesn't involve writing effects manually.";
+                '  async function fetchData() {\n' +
+                '    // You can await here\n' +
+                '    const response = await MyAPI.getData(someId);\n' +
+                '    // ...\n' +
+                '  }\n' +
+                '  fetchData();\n' +
+                '}, [someId]);\n\n' +
+                'Learn more about data fetching with Hooks: https://fb.me/react-hooks-data-fetching';
             } else {
               addendum = ' You returned: ' + destroy;
             }
             warningWithoutStack(
               false,
-              'An Effect function must not return anything besides a function, ' +
+              'An effect function must not return anything besides a function, ' +
                 'which is used for clean-up.%s%s',
               addendum,
               getStackByFiberInDevAndProd(finishedWork),

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -355,7 +355,7 @@ function commitHookEffectList(
                 '    // ...\n' +
                 '  }\n' +
                 '  fetchData();\n' +
-                '}, [someId]);\n\n' +
+                `}, [someId]); // Or [] if effect doesn't need props or state\n\n` +
                 'Learn more about data fetching with Hooks: https://fb.me/react-hooks-data-fetching';
             } else {
               addendum = ' You returned: ' + destroy;

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -262,8 +262,12 @@ function warnOnHookMismatchInDev(currentHookName: HookType) {
 function throwInvalidHookError() {
   invariant(
     false,
-    'Hooks can only be called inside the body of a function component. ' +
-      '(https://fb.me/react-invalid-hook-call)',
+    'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+      ' one of the following reasons:\n' +
+      '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+      '2. You might be breaking the Rules of Hooks\n' +
+      '3. You might have more than one copy of React in the same app\n' +
+      'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
   );
 }
 

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -645,20 +645,20 @@ describe('ReactHooks', () => {
 
     const root1 = ReactTestRenderer.create(null);
     expect(() => root1.update(<App return={17} />)).toWarnDev([
-      'Warning: An Effect function must not return anything besides a ' +
+      'Warning: An effect function must not return anything besides a ' +
         'function, which is used for clean-up. You returned: 17',
     ]);
 
     const root2 = ReactTestRenderer.create(null);
     expect(() => root2.update(<App return={null} />)).toWarnDev([
-      'Warning: An Effect function must not return anything besides a ' +
+      'Warning: An effect function must not return anything besides a ' +
         'function, which is used for clean-up. You returned null. If your ' +
         'effect does not require clean up, return undefined (or nothing).',
     ]);
 
     const root3 = ReactTestRenderer.create(null);
     expect(() => root3.update(<App return={Promise.resolve()} />)).toWarnDev([
-      'Warning: An Effect function must not return anything besides a ' +
+      'Warning: An effect function must not return anything besides a ' +
         'function, which is used for clean-up.\n\n' +
         'It looks like you wrote useEffect(async () => ...) or returned a Promise.',
     ]);

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -44,7 +44,12 @@ describe('ReactHooks', () => {
       expect(() => {
         ReactTestRenderer.create(<Example />);
       }).toThrow(
-        'Hooks can only be called inside the body of a function component.',
+        'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen' +
+          ' for one of the following reasons:\n' +
+          '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+          '2. You might be breaking the Rules of Hooks\n' +
+          '3. You might have more than one copy of React in the same app\n' +
+          'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
       );
     });
   }
@@ -805,15 +810,30 @@ describe('ReactHooks', () => {
     const root = ReactTestRenderer.create(<MemoApp />);
     // trying to render again should trigger comparison and throw
     expect(() => root.update(<MemoApp />)).toThrow(
-      'Hooks can only be called inside the body of a function component',
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
     // the next round, it does a fresh mount, so should render
     expect(() => root.update(<MemoApp />)).not.toThrow(
-      'Hooks can only be called inside the body of a function component',
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
     // and then again, fail
     expect(() => root.update(<MemoApp />)).toThrow(
-      'Hooks can only be called inside the body of a function component',
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -108,7 +108,12 @@ describe('ReactHooksWithNoopRenderer', () => {
     ReactNoop.render(<BadCounter />);
 
     expect(() => ReactNoop.flush()).toThrow(
-      'Hooks can only be called inside the body of a function component.',
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
 
     // Confirm that a subsequent hook works properly.
@@ -131,7 +136,12 @@ describe('ReactHooksWithNoopRenderer', () => {
     }
     ReactNoop.render(<Counter />);
     expect(() => ReactNoop.flush()).toThrow(
-      'Hooks can only be called inside the body of a function component.',
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
 
     // Confirm that a subsequent hook works properly.
@@ -145,7 +155,12 @@ describe('ReactHooksWithNoopRenderer', () => {
 
   it('throws when called outside the render phase', () => {
     expect(() => useState(0)).toThrow(
-      'Hooks can only be called inside the body of a function component.',
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1514,7 +1514,12 @@ describe('ReactNewContext', () => {
       }
       ReactNoop.render(<Foo />);
       expect(ReactNoop.flush).toThrow(
-        'Hooks can only be called inside the body of a function component.',
+        'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen' +
+          ' for one of the following reasons:\n' +
+          '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+          '2. You might be breaking the Rules of Hooks\n' +
+          '3. You might have more than one copy of React in the same app\n' +
+          'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
       );
     });
 

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-test-renderer",
-  "version": "16.8.4",
+  "version": "16.8.5",
   "description": "React package for snapshot testing.",
   "main": "index.js",
   "repository": {
@@ -21,8 +21,8 @@
   "dependencies": {
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "react-is": "^16.8.4",
-    "scheduler": "^0.13.4"
+    "react-is": "^16.8.5",
+    "scheduler": "^0.13.5"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import {isForwardRef} from 'react-is';
+import {isForwardRef, isMemo, ForwardRef} from 'react-is';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import getComponentName from 'shared/getComponentName';
 import shallowEqual from 'shared/shallowEqual';
@@ -500,7 +500,8 @@ class ReactShallowRenderer {
       element.type,
     );
     invariant(
-      isForwardRef(element) || typeof element.type === 'function',
+      isForwardRef(element) ||
+        (typeof element.type === 'function' || isMemo(element.type)),
       'ReactShallowRenderer render(): Shallow rendering works only with custom ' +
         'components, but the provided element type was `%s`.',
       Array.isArray(element.type)
@@ -514,22 +515,36 @@ class ReactShallowRenderer {
       return;
     }
 
+    const elementType = isMemo(element.type) ? element.type.type : element.type;
+    const previousElement = this._element;
+
     this._rendering = true;
     this._element = element;
-    this._context = getMaskedContext(element.type.contextTypes, context);
+    this._context = getMaskedContext(elementType.contextTypes, context);
+
+    // Inner memo component props aren't currently validated in createElement.
+    if (isMemo(element.type) && elementType.propTypes) {
+      currentlyValidatingElement = element;
+      checkPropTypes(
+        elementType.propTypes,
+        element.props,
+        'prop',
+        getComponentName(elementType),
+        getStackAddendum,
+      );
+    }
 
     if (this._instance) {
-      this._updateClassComponent(element, this._context);
+      this._updateClassComponent(elementType, element, this._context);
     } else {
-      if (shouldConstruct(element.type)) {
-        this._instance = new element.type(
+      if (shouldConstruct(elementType)) {
+        this._instance = new elementType(
           element.props,
           this._context,
           this._updater,
         );
-
-        if (typeof element.type.getDerivedStateFromProps === 'function') {
-          const partialState = element.type.getDerivedStateFromProps.call(
+        if (typeof elementType.getDerivedStateFromProps === 'function') {
+          const partialState = elementType.getDerivedStateFromProps.call(
             null,
             element.props,
             this._instance.state,
@@ -543,39 +558,59 @@ class ReactShallowRenderer {
           }
         }
 
-        if (element.type.hasOwnProperty('contextTypes')) {
+        if (elementType.contextTypes) {
           currentlyValidatingElement = element;
-
           checkPropTypes(
-            element.type.contextTypes,
+            elementType.contextTypes,
             this._context,
             'context',
-            getName(element.type, this._instance),
+            getName(elementType, this._instance),
             getStackAddendum,
           );
 
           currentlyValidatingElement = null;
         }
 
-        this._mountClassComponent(element, this._context);
+        this._mountClassComponent(elementType, element, this._context);
       } else {
-        const prevDispatcher = ReactCurrentDispatcher.current;
-        ReactCurrentDispatcher.current = this._dispatcher;
-        this._prepareToUseHooks(element.type);
-        try {
-          if (isForwardRef(element)) {
-            this._rendered = element.type.render(element.props, element.ref);
-          } else {
-            this._rendered = element.type.call(
-              undefined,
-              element.props,
-              this._context,
-            );
+        let shouldRender = true;
+        if (
+          isMemo(element.type) &&
+          elementType === this._previousComponentIdentity &&
+          previousElement !== null
+        ) {
+          // This is a Memo component that is being re-rendered.
+          const compare = element.type.compare || shallowEqual;
+          if (compare(previousElement.props, element.props)) {
+            shouldRender = false;
           }
-        } finally {
-          ReactCurrentDispatcher.current = prevDispatcher;
         }
-        this._finishHooks(element, context);
+        if (shouldRender) {
+          const prevDispatcher = ReactCurrentDispatcher.current;
+          ReactCurrentDispatcher.current = this._dispatcher;
+          this._prepareToUseHooks(elementType);
+          try {
+            // elementType could still be a ForwardRef if it was
+            // nested inside Memo.
+            if (elementType.$$typeof === ForwardRef) {
+              invariant(
+                typeof elementType.render === 'function',
+                'forwardRef requires a render function but was given %s.',
+                typeof elementType.render,
+              );
+              this._rendered = elementType.render.call(
+                undefined,
+                element.props,
+                element.ref,
+              );
+            } else {
+              this._rendered = elementType(element.props, this._context);
+            }
+          } finally {
+            ReactCurrentDispatcher.current = prevDispatcher;
+          }
+          this._finishHooks(element, context);
+        }
       }
     }
 
@@ -601,7 +636,11 @@ class ReactShallowRenderer {
     this._instance = null;
   }
 
-  _mountClassComponent(element: ReactElement, context: null | Object) {
+  _mountClassComponent(
+    elementType: Function,
+    element: ReactElement,
+    context: null | Object,
+  ) {
     this._instance.context = context;
     this._instance.props = element.props;
     this._instance.state = this._instance.state || null;
@@ -616,7 +655,7 @@ class ReactShallowRenderer {
       // In order to support react-lifecycles-compat polyfilled components,
       // Unsafe lifecycles should not be invoked for components using the new APIs.
       if (
-        typeof element.type.getDerivedStateFromProps !== 'function' &&
+        typeof elementType.getDerivedStateFromProps !== 'function' &&
         typeof this._instance.getSnapshotBeforeUpdate !== 'function'
       ) {
         if (typeof this._instance.componentWillMount === 'function') {
@@ -638,8 +677,12 @@ class ReactShallowRenderer {
     // because DOM refs are not available.
   }
 
-  _updateClassComponent(element: ReactElement, context: null | Object) {
-    const {props, type} = element;
+  _updateClassComponent(
+    elementType: Function,
+    element: ReactElement,
+    context: null | Object,
+  ) {
+    const {props} = element;
 
     const oldState = this._instance.state || emptyObject;
     const oldProps = this._instance.props;
@@ -648,7 +691,7 @@ class ReactShallowRenderer {
       // In order to support react-lifecycles-compat polyfilled components,
       // Unsafe lifecycles should not be invoked for components using the new APIs.
       if (
-        typeof element.type.getDerivedStateFromProps !== 'function' &&
+        typeof elementType.getDerivedStateFromProps !== 'function' &&
         typeof this._instance.getSnapshotBeforeUpdate !== 'function'
       ) {
         if (typeof this._instance.componentWillReceiveProps === 'function') {
@@ -664,8 +707,8 @@ class ReactShallowRenderer {
 
     // Read state after cWRP in case it calls setState
     let state = this._newState || oldState;
-    if (typeof type.getDerivedStateFromProps === 'function') {
-      const partialState = type.getDerivedStateFromProps.call(
+    if (typeof elementType.getDerivedStateFromProps === 'function') {
+      const partialState = elementType.getDerivedStateFromProps.call(
         null,
         props,
         state,
@@ -685,7 +728,10 @@ class ReactShallowRenderer {
         state,
         context,
       );
-    } else if (type.prototype && type.prototype.isPureReactComponent) {
+    } else if (
+      elementType.prototype &&
+      elementType.prototype.isPureReactComponent
+    ) {
       shouldUpdate =
         !shallowEqual(oldProps, props) || !shallowEqual(oldState, state);
     }
@@ -694,7 +740,7 @@ class ReactShallowRenderer {
       // In order to support react-lifecycles-compat polyfilled components,
       // Unsafe lifecycles should not be invoked for components using the new APIs.
       if (
-        typeof element.type.getDerivedStateFromProps !== 'function' &&
+        typeof elementType.getDerivedStateFromProps !== 'function' &&
         typeof this._instance.getSnapshotBeforeUpdate !== 'function'
       ) {
         if (typeof this._instance.componentWillUpdate === 'function') {
@@ -729,7 +775,8 @@ function getDisplayName(element) {
   } else if (typeof element.type === 'string') {
     return element.type;
   } else {
-    return element.type.displayName || element.type.name || 'Unknown';
+    const elementType = isMemo(element.type) ? element.type.type : element.type;
+    return elementType.displayName || elementType.name || 'Unknown';
   }
 }
 

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -218,8 +218,12 @@ class ReactShallowRenderer {
   _validateCurrentlyRenderingComponent() {
     invariant(
       this._rendering && !this._instance,
-      'Hooks can only be called inside the body of a function component. ' +
-        '(https://fb.me/react-invalid-hook-call)',
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
   }
 

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -521,9 +521,7 @@ class ReactShallowRenderer {
     if (this._instance) {
       this._updateClassComponent(element, this._context);
     } else {
-      if (isForwardRef(element)) {
-        this._rendered = element.type.render(element.props, element.ref);
-      } else if (shouldConstruct(element.type)) {
+      if (shouldConstruct(element.type)) {
         this._instance = new element.type(
           element.props,
           this._context,
@@ -565,11 +563,15 @@ class ReactShallowRenderer {
         ReactCurrentDispatcher.current = this._dispatcher;
         this._prepareToUseHooks(element.type);
         try {
-          this._rendered = element.type.call(
-            undefined,
-            element.props,
-            this._context,
-          );
+          if (isForwardRef(element)) {
+            this._rendered = element.type.render(element.props, element.ref);
+          } else {
+            this._rendered = element.type.call(
+              undefined,
+              element.props,
+              this._context,
+            );
+          }
         } finally {
           ReactCurrentDispatcher.current = prevDispatcher;
         }

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -1565,4 +1565,46 @@ describe('ReactShallowRenderer', () => {
       'forwardRef requires a render function but was given object.',
     );
   });
+
+  it('should let you change type', () => {
+    function Foo({prop}) {
+      return <div>Foo {prop}</div>;
+    }
+    function Bar({prop}) {
+      return <div>Bar {prop}</div>;
+    }
+
+    const shallowRenderer = createRenderer();
+    shallowRenderer.render(<Foo prop="foo1" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Foo {'foo1'}</div>);
+    shallowRenderer.render(<Foo prop="foo2" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Foo {'foo2'}</div>);
+    shallowRenderer.render(<Bar prop="bar1" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Bar {'bar1'}</div>);
+    shallowRenderer.render(<Bar prop="bar2" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Bar {'bar2'}</div>);
+  });
+
+  it('should let you change class type', () => {
+    class Foo extends React.Component {
+      render() {
+        return <div>Foo {this.props.prop}</div>;
+      }
+    }
+    class Bar extends React.Component {
+      render() {
+        return <div>Bar {this.props.prop}</div>;
+      }
+    }
+
+    const shallowRenderer = createRenderer();
+    shallowRenderer.render(<Foo prop="foo1" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Foo {'foo1'}</div>);
+    shallowRenderer.render(<Foo prop="foo2" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Foo {'foo2'}</div>);
+    shallowRenderer.render(<Bar prop="bar1" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Bar {'bar1'}</div>);
+    shallowRenderer.render(<Bar prop="bar2" />);
+    expect(shallowRenderer.getRenderOutput()).toEqual(<div>Bar {'bar2'}</div>);
+  });
 });

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
@@ -304,4 +304,22 @@ describe('ReactShallowRenderer with hooks', () => {
       </div>,
     );
   });
+
+  it('should work with with forwardRef + any hook', () => {
+    const SomeComponent = React.forwardRef((props, ref) => {
+      const randomNumberRef = React.useRef({number: Math.random()});
+
+      return (
+        <div ref={ref}>
+          <p>The random number is: {randomNumberRef.current.number}</p>
+        </div>
+      );
+    });
+
+    const shallowRenderer = createRenderer();
+    let firstResult = shallowRenderer.render(<SomeComponent />);
+    let secondResult = shallowRenderer.render(<SomeComponent />);
+
+    expect(firstResult).toEqual(secondResult);
+  });
 });

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererMemo-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererMemo-test.js
@@ -14,7 +14,7 @@ let createRenderer;
 let PropTypes;
 let React;
 
-describe('ReactShallowRenderer', () => {
+describe('ReactShallowRendererMemo', () => {
   beforeEach(() => {
     jest.resetModules();
 
@@ -27,18 +27,20 @@ describe('ReactShallowRenderer', () => {
     const logs = [];
     const logger = message => () => logs.push(message) || true;
 
-    class SomeComponent extends React.Component {
-      UNSAFE_componentWillMount = logger('componentWillMount');
-      componentDidMount = logger('componentDidMount');
-      UNSAFE_componentWillReceiveProps = logger('componentWillReceiveProps');
-      shouldComponentUpdate = logger('shouldComponentUpdate');
-      UNSAFE_componentWillUpdate = logger('componentWillUpdate');
-      componentDidUpdate = logger('componentDidUpdate');
-      componentWillUnmount = logger('componentWillUnmount');
-      render() {
-        return <div />;
-      }
-    }
+    const SomeComponent = React.memo(
+      class SomeComponent extends React.Component {
+        UNSAFE_componentWillMount = logger('componentWillMount');
+        componentDidMount = logger('componentDidMount');
+        UNSAFE_componentWillReceiveProps = logger('componentWillReceiveProps');
+        shouldComponentUpdate = logger('shouldComponentUpdate');
+        UNSAFE_componentWillUpdate = logger('componentWillUpdate');
+        componentDidUpdate = logger('componentDidUpdate');
+        componentWillUnmount = logger('componentWillUnmount');
+        render() {
+          return <div />;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<SomeComponent foo={1} />);
@@ -70,17 +72,19 @@ describe('ReactShallowRenderer', () => {
     const logs = [];
     const logger = message => () => logs.push(message) || true;
 
-    class SomeComponent extends React.Component {
-      state = {};
-      static getDerivedStateFromProps = logger('getDerivedStateFromProps');
-      componentDidMount = logger('componentDidMount');
-      shouldComponentUpdate = logger('shouldComponentUpdate');
-      componentDidUpdate = logger('componentDidUpdate');
-      componentWillUnmount = logger('componentWillUnmount');
-      render() {
-        return <div />;
-      }
-    }
+    const SomeComponent = React.memo(
+      class SomeComponent extends React.Component {
+        state = {};
+        static getDerivedStateFromProps = logger('getDerivedStateFromProps');
+        componentDidMount = logger('componentDidMount');
+        shouldComponentUpdate = logger('shouldComponentUpdate');
+        componentDidUpdate = logger('componentDidUpdate');
+        componentWillUnmount = logger('componentWillUnmount');
+        render() {
+          return <div />;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<SomeComponent foo={1} />);
@@ -105,47 +109,51 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should not invoke deprecated lifecycles (cWM/cWRP/cWU) if new static gDSFP is present', () => {
-    class Component extends React.Component {
-      state = {};
-      static getDerivedStateFromProps() {
-        return null;
-      }
-      componentWillMount() {
-        throw Error('unexpected');
-      }
-      componentWillReceiveProps() {
-        throw Error('unexpected');
-      }
-      componentWillUpdate() {
-        throw Error('unexpected');
-      }
-      render() {
-        return null;
-      }
-    }
+    const Component = React.memo(
+      class Component extends React.Component {
+        state = {};
+        static getDerivedStateFromProps() {
+          return null;
+        }
+        componentWillMount() {
+          throw Error('unexpected');
+        }
+        componentWillReceiveProps() {
+          throw Error('unexpected');
+        }
+        componentWillUpdate() {
+          throw Error('unexpected');
+        }
+        render() {
+          return null;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<Component />);
   });
 
   it('should not invoke deprecated lifecycles (cWM/cWRP/cWU) if new getSnapshotBeforeUpdate is present', () => {
-    class Component extends React.Component {
-      getSnapshotBeforeUpdate() {
-        return null;
-      }
-      componentWillMount() {
-        throw Error('unexpected');
-      }
-      componentWillReceiveProps() {
-        throw Error('unexpected');
-      }
-      componentWillUpdate() {
-        throw Error('unexpected');
-      }
-      render() {
-        return null;
-      }
-    }
+    const Component = React.memo(
+      class Component extends React.Component {
+        getSnapshotBeforeUpdate() {
+          return null;
+        }
+        componentWillMount() {
+          throw Error('unexpected');
+        }
+        componentWillReceiveProps() {
+          throw Error('unexpected');
+        }
+        componentWillUpdate() {
+          throw Error('unexpected');
+        }
+        render() {
+          return null;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<Component value={1} />);
@@ -153,17 +161,19 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should not call getSnapshotBeforeUpdate or componentDidUpdate when updating since refs wont exist', () => {
-    class Component extends React.Component {
-      getSnapshotBeforeUpdate() {
-        throw Error('unexpected');
-      }
-      componentDidUpdate() {
-        throw Error('unexpected');
-      }
-      render() {
-        return null;
-      }
-    }
+    const Component = React.memo(
+      class Component extends React.Component {
+        getSnapshotBeforeUpdate() {
+          throw Error('unexpected');
+        }
+        componentDidUpdate() {
+          throw Error('unexpected');
+        }
+        render() {
+          return null;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<Component value={1} />);
@@ -171,13 +181,14 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should only render 1 level deep', () => {
-    function Parent() {
+    const Parent = React.memo(function Parent() {
       return (
         <div>
           <Child />
         </div>
       );
-    }
+    });
+
     function Child() {
       throw Error('This component should not render');
     }
@@ -187,16 +198,18 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should have shallow rendering', () => {
-    class SomeComponent extends React.Component {
-      render() {
-        return (
-          <div>
-            <span className="child1" />
-            <span className="child2" />
-          </div>
-        );
-      }
-    }
+    const SomeComponent = React.memo(
+      class SomeComponent extends React.Component {
+        render() {
+          return (
+            <div>
+              <span className="child1" />
+              <span className="child2" />
+            </div>
+          );
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SomeComponent />);
@@ -208,41 +221,21 @@ describe('ReactShallowRenderer', () => {
     ]);
   });
 
-  it('should handle ForwardRef', () => {
-    const testRef = React.createRef();
-    const SomeComponent = React.forwardRef((props, ref) => {
-      expect(ref).toEqual(testRef);
-      return (
-        <div>
-          <span className="child1" />
-          <span className="child2" />
-        </div>
-      );
-    });
-
-    const shallowRenderer = createRenderer();
-    const result = shallowRenderer.render(<SomeComponent ref={testRef} />);
-
-    expect(result.type).toBe('div');
-    expect(result.props.children).toEqual([
-      <span className="child1" />,
-      <span className="child2" />,
-    ]);
-  });
-
   it('should handle Profiler', () => {
-    class SomeComponent extends React.Component {
-      render() {
-        return (
-          <React.unstable_Profiler id="test" onRender={jest.fn()}>
-            <div>
-              <span className="child1" />
-              <span className="child2" />
-            </div>
-          </React.unstable_Profiler>
-        );
-      }
-    }
+    const SomeComponent = React.memo(
+      class SomeComponent extends React.Component {
+        render() {
+          return (
+            <React.unstable_Profiler id="test" onRender={jest.fn()}>
+              <div>
+                <span className="child1" />
+                <span className="child2" />
+              </div>
+            </React.unstable_Profiler>
+          );
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SomeComponent />);
@@ -258,16 +251,18 @@ describe('ReactShallowRenderer', () => {
 
   it('should enable shouldComponentUpdate to prevent a re-render', () => {
     let renderCounter = 0;
-    class SimpleComponent extends React.Component {
-      state = {update: false};
-      shouldComponentUpdate(nextProps, nextState) {
-        return this.state.update !== nextState.update;
-      }
-      render() {
-        renderCounter++;
-        return <div>{`${renderCounter}`}</div>;
-      }
-    }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {update: false};
+        shouldComponentUpdate(nextProps, nextState) {
+          return this.state.update !== nextState.update;
+        }
+        render() {
+          renderCounter++;
+          return <div>{`${renderCounter}`}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<SimpleComponent />);
@@ -283,13 +278,15 @@ describe('ReactShallowRenderer', () => {
 
   it('should enable PureComponent to prevent a re-render', () => {
     let renderCounter = 0;
-    class SimpleComponent extends React.PureComponent {
-      state = {update: false};
-      render() {
-        renderCounter++;
-        return <div>{`${renderCounter}`}</div>;
-      }
-    }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.PureComponent {
+        state = {update: false};
+        render() {
+          renderCounter++;
+          return <div>{`${renderCounter}`}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<SimpleComponent />);
@@ -305,16 +302,18 @@ describe('ReactShallowRenderer', () => {
 
   it('should not run shouldComponentUpdate during forced update', () => {
     let scuCounter = 0;
-    class SimpleComponent extends React.Component {
-      state = {count: 1};
-      shouldComponentUpdate() {
-        scuCounter++;
-        return false;
-      }
-      render() {
-        return <div>{`${this.state.count}`}</div>;
-      }
-    }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {count: 1};
+        shouldComponentUpdate() {
+          scuCounter++;
+          return false;
+        }
+        render() {
+          return <div>{`${this.state.count}`}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<SimpleComponent />);
@@ -343,12 +342,14 @@ describe('ReactShallowRenderer', () => {
 
   it('should rerender when calling forceUpdate', () => {
     let renderCounter = 0;
-    class SimpleComponent extends React.Component {
-      render() {
-        renderCounter += 1;
-        return <div />;
-      }
-    }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        render() {
+          renderCounter += 1;
+          return <div />;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<SimpleComponent />);
@@ -370,12 +371,14 @@ describe('ReactShallowRenderer', () => {
         </div>
       );
     }
+    const SomeMemoComponent = React.memo(SomeComponent);
+
     SomeComponent.contextTypes = {
       bar: PropTypes.string,
     };
 
     const shallowRenderer = createRenderer();
-    const result = shallowRenderer.render(<SomeComponent foo={'FOO'} />, {
+    const result = shallowRenderer.render(<SomeMemoComponent foo={'FOO'} />, {
       bar: 'BAR',
     });
 
@@ -389,7 +392,7 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should shallow render a component returning strings directly from render', () => {
-    const Text = ({value}) => value;
+    const Text = React.memo(({value}) => value);
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<Text value="foo" />);
@@ -397,7 +400,7 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should shallow render a component returning numbers directly from render', () => {
-    const Text = ({value}) => value;
+    const Text = React.memo(({value}) => value);
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<Text value={10} />);
@@ -563,15 +566,17 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('can access the mounted component instance', () => {
-    class SimpleComponent extends React.Component {
-      someMethod = () => {
-        return this.props.n;
-      };
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        someMethod = () => {
+          return this.props.n;
+        };
 
-      render() {
-        return <div>{this.props.n}</div>;
-      }
-    }
+        render() {
+          return <div>{this.props.n}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<SimpleComponent n={5} />);
@@ -579,15 +584,17 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('can shallowly render components with contextTypes', () => {
-    class SimpleComponent extends React.Component {
-      static contextTypes = {
-        name: PropTypes.string,
-      };
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        static contextTypes = {
+          name: PropTypes.string,
+        };
 
-      render() {
-        return <div />;
-      }
-    }
+        render() {
+          return <div />;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SimpleComponent />);
@@ -608,35 +615,37 @@ describe('ReactShallowRenderer', () => {
     const updatedProp = {prop: 'updated prop'};
     const updatedContext = {context: 'updated context'};
 
-    class SimpleComponent extends React.Component {
-      constructor(props, context) {
-        super(props, context);
-        this.state = initialState;
-      }
-      static contextTypes = {
-        context: PropTypes.string,
-      };
-      componentDidUpdate(...args) {
-        componentDidUpdateParams.push(...args);
-      }
-      UNSAFE_componentWillReceiveProps(...args) {
-        componentWillReceivePropsParams.push(...args);
-        this.setState((...innerArgs) => {
-          setStateParams.push(...innerArgs);
-          return updatedState;
-        });
-      }
-      UNSAFE_componentWillUpdate(...args) {
-        componentWillUpdateParams.push(...args);
-      }
-      shouldComponentUpdate(...args) {
-        shouldComponentUpdateParams.push(...args);
-        return true;
-      }
-      render() {
-        return null;
-      }
-    }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        constructor(props, context) {
+          super(props, context);
+          this.state = initialState;
+        }
+        static contextTypes = {
+          context: PropTypes.string,
+        };
+        componentDidUpdate(...args) {
+          componentDidUpdateParams.push(...args);
+        }
+        UNSAFE_componentWillReceiveProps(...args) {
+          componentWillReceivePropsParams.push(...args);
+          this.setState((...innerArgs) => {
+            setStateParams.push(...innerArgs);
+            return updatedState;
+          });
+        }
+        UNSAFE_componentWillUpdate(...args) {
+          componentWillUpdateParams.push(...args);
+        }
+        shouldComponentUpdate(...args) {
+          shouldComponentUpdateParams.push(...args);
+          return true;
+        }
+        render() {
+          return null;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(
@@ -683,29 +692,31 @@ describe('ReactShallowRenderer', () => {
     const updatedProp = {prop: 'updated prop'};
     const updatedContext = {context: 'updated context'};
 
-    class SimpleComponent extends React.Component {
-      constructor(props, context) {
-        super(props, context);
-        this.state = initialState;
-      }
-      static contextTypes = {
-        context: PropTypes.string,
-      };
-      componentDidUpdate(...args) {
-        componentDidUpdateParams.push(...args);
-      }
-      static getDerivedStateFromProps(...args) {
-        getDerivedStateFromPropsParams.push(args);
-        return null;
-      }
-      shouldComponentUpdate(...args) {
-        shouldComponentUpdateParams.push(...args);
-        return true;
-      }
-      render() {
-        return null;
-      }
-    }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        constructor(props, context) {
+          super(props, context);
+          this.state = initialState;
+        }
+        static contextTypes = {
+          context: PropTypes.string,
+        };
+        componentDidUpdate(...args) {
+          componentDidUpdateParams.push(...args);
+        }
+        static getDerivedStateFromProps(...args) {
+          getDerivedStateFromPropsParams.push(args);
+          return null;
+        }
+        shouldComponentUpdate(...args) {
+          shouldComponentUpdateParams.push(...args);
+          return true;
+        }
+        render() {
+          return null;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
 
@@ -739,23 +750,25 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('can shallowly render components with ref as function', () => {
-    class SimpleComponent extends React.Component {
-      state = {clicked: false};
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {clicked: false};
 
-      handleUserClick = () => {
-        this.setState({clicked: true});
-      };
+        handleUserClick = () => {
+          this.setState({clicked: true});
+        };
 
-      render() {
-        return (
-          <div
-            ref={() => {}}
-            onClick={this.handleUserClick}
-            className={this.state.clicked ? 'clicked' : ''}
-          />
-        );
-      }
-    }
+        render() {
+          return (
+            <div
+              ref={() => {}}
+              onClick={this.handleUserClick}
+              className={this.state.clicked ? 'clicked' : ''}
+            />
+          );
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<SimpleComponent />);
@@ -770,24 +783,26 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('can initialize state via static getDerivedStateFromProps', () => {
-    class SimpleComponent extends React.Component {
-      state = {
-        count: 1,
-      };
-
-      static getDerivedStateFromProps(props, prevState) {
-        return {
-          count: prevState.count + props.incrementBy,
-          other: 'foobar',
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {
+          count: 1,
         };
-      }
 
-      render() {
-        return (
-          <div>{`count:${this.state.count}, other:${this.state.other}`}</div>
-        );
-      }
-    }
+        static getDerivedStateFromProps(props, prevState) {
+          return {
+            count: prevState.count + props.incrementBy,
+            other: 'foobar',
+          };
+        }
+
+        render() {
+          return (
+            <div>{`count:${this.state.count}, other:${this.state.other}`}</div>
+          );
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SimpleComponent incrementBy={2} />);
@@ -795,15 +810,17 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('can setState in componentWillMount when shallow rendering', () => {
-    class SimpleComponent extends React.Component {
-      UNSAFE_componentWillMount() {
-        this.setState({groovy: 'doovy'});
-      }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        UNSAFE_componentWillMount() {
+          this.setState({groovy: 'doovy'});
+        }
 
-      render() {
-        return <div>{this.state.groovy}</div>;
-      }
-    }
+        render() {
+          return <div>{this.state.groovy}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SimpleComponent />);
@@ -811,22 +828,24 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('can setState in componentWillMount repeatedly when shallow rendering', () => {
-    class SimpleComponent extends React.Component {
-      state = {
-        separator: '-',
-      };
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {
+          separator: '-',
+        };
 
-      UNSAFE_componentWillMount() {
-        this.setState({groovy: 'doovy'});
-        this.setState({doovy: 'groovy'});
-      }
+        UNSAFE_componentWillMount() {
+          this.setState({groovy: 'doovy'});
+          this.setState({doovy: 'groovy'});
+        }
 
-      render() {
-        const {groovy, doovy, separator} = this.state;
+        render() {
+          const {groovy, doovy, separator} = this.state;
 
-        return <div>{`${groovy}${separator}${doovy}`}</div>;
-      }
-    }
+          return <div>{`${groovy}${separator}${doovy}`}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SimpleComponent />);
@@ -834,22 +853,24 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('can setState in componentWillMount with an updater function repeatedly when shallow rendering', () => {
-    class SimpleComponent extends React.Component {
-      state = {
-        separator: '-',
-      };
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {
+          separator: '-',
+        };
 
-      UNSAFE_componentWillMount() {
-        this.setState(state => ({groovy: 'doovy'}));
-        this.setState(state => ({doovy: state.groovy}));
-      }
+        UNSAFE_componentWillMount() {
+          this.setState(state => ({groovy: 'doovy'}));
+          this.setState(state => ({doovy: state.groovy}));
+        }
 
-      render() {
-        const {groovy, doovy, separator} = this.state;
+        render() {
+          const {groovy, doovy, separator} = this.state;
 
-        return <div>{`${groovy}${separator}${doovy}`}</div>;
-      }
-    }
+          return <div>{`${groovy}${separator}${doovy}`}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SimpleComponent />);
@@ -857,19 +878,21 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('can setState in componentWillReceiveProps when shallow rendering', () => {
-    class SimpleComponent extends React.Component {
-      state = {count: 0};
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {count: 0};
 
-      UNSAFE_componentWillReceiveProps(nextProps) {
-        if (nextProps.updateState) {
-          this.setState({count: 1});
+        UNSAFE_componentWillReceiveProps(nextProps) {
+          if (nextProps.updateState) {
+            this.setState({count: 1});
+          }
         }
-      }
 
-      render() {
-        return <div>{this.state.count}</div>;
-      }
-    }
+        render() {
+          return <div>{this.state.count}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     let result = shallowRenderer.render(
@@ -882,21 +905,23 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('can update state with static getDerivedStateFromProps when shallow rendering', () => {
-    class SimpleComponent extends React.Component {
-      state = {count: 1};
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {count: 1};
 
-      static getDerivedStateFromProps(nextProps, prevState) {
-        if (nextProps.updateState) {
-          return {count: nextProps.incrementBy + prevState.count};
+        static getDerivedStateFromProps(nextProps, prevState) {
+          if (nextProps.updateState) {
+            return {count: nextProps.incrementBy + prevState.count};
+          }
+
+          return null;
         }
 
-        return null;
-      }
-
-      render() {
-        return <div>{this.state.count}</div>;
-      }
-    }
+        render() {
+          return <div>{this.state.count}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     let result = shallowRenderer.render(
@@ -916,21 +941,23 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should not override state with stale values if prevState is spread within getDerivedStateFromProps', () => {
-    class SimpleComponent extends React.Component {
-      state = {value: 0};
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {value: 0};
 
-      static getDerivedStateFromProps(nextProps, prevState) {
-        return {...prevState};
-      }
+        static getDerivedStateFromProps(nextProps, prevState) {
+          return {...prevState};
+        }
 
-      updateState = () => {
-        this.setState(state => ({value: state.value + 1}));
-      };
+        updateState = () => {
+          this.setState(state => ({value: state.value + 1}));
+        };
 
-      render() {
-        return <div>{`value:${this.state.value}`}</div>;
-      }
-    }
+        render() {
+          return <div>{`value:${this.state.value}`}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     let result = shallowRenderer.render(<SimpleComponent />);
@@ -943,29 +970,31 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should pass previous state to shouldComponentUpdate even with getDerivedStateFromProps', () => {
-    class SimpleComponent extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {
-          value: props.value,
-        };
-      }
-
-      static getDerivedStateFromProps(nextProps, prevState) {
-        if (nextProps.value === prevState.value) {
-          return null;
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            value: props.value,
+          };
         }
-        return {value: nextProps.value};
-      }
 
-      shouldComponentUpdate(nextProps, nextState) {
-        return nextState.value !== this.state.value;
-      }
+        static getDerivedStateFromProps(nextProps, prevState) {
+          if (nextProps.value === prevState.value) {
+            return null;
+          }
+          return {value: nextProps.value};
+        }
 
-      render() {
-        return <div>{`value:${this.state.value}`}</div>;
-      }
-    }
+        shouldComponentUpdate(nextProps, nextState) {
+          return nextState.value !== this.state.value;
+        }
+
+        render() {
+          return <div>{`value:${this.state.value}`}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const initialResult = shallowRenderer.render(
@@ -981,20 +1010,22 @@ describe('ReactShallowRenderer', () => {
   it('can setState with an updater function', () => {
     let instance;
 
-    class SimpleComponent extends React.Component {
-      state = {
-        counter: 0,
-      };
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {
+          counter: 0,
+        };
 
-      render() {
-        instance = this;
-        return (
-          <button ref="button" onClick={this.onClick}>
-            {this.state.counter}
-          </button>
-        );
-      }
-    }
+        render() {
+          instance = this;
+          return (
+            <button ref="button" onClick={this.onClick}>
+              {this.state.counter}
+            </button>
+          );
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     let result = shallowRenderer.render(<SimpleComponent defaultCount={1} />);
@@ -1011,14 +1042,16 @@ describe('ReactShallowRenderer', () => {
   it('can access component instance from setState updater function', done => {
     let instance;
 
-    class SimpleComponent extends React.Component {
-      state = {};
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {};
 
-      render() {
-        instance = this;
-        return null;
-      }
-    }
+        render() {
+          instance = this;
+          return null;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<SimpleComponent />);
@@ -1032,15 +1065,17 @@ describe('ReactShallowRenderer', () => {
   it('can setState with a callback', () => {
     let instance;
 
-    class SimpleComponent extends React.Component {
-      state = {
-        counter: 0,
-      };
-      render() {
-        instance = this;
-        return <p>{this.state.counter}</p>;
-      }
-    }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {
+          counter: 0,
+        };
+        render() {
+          instance = this;
+          return <p>{this.state.counter}</p>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SimpleComponent />);
@@ -1060,15 +1095,17 @@ describe('ReactShallowRenderer', () => {
   it('can replaceState with a callback', () => {
     let instance;
 
-    class SimpleComponent extends React.Component {
-      state = {
-        counter: 0,
-      };
-      render() {
-        instance = this;
-        return <p>{this.state.counter}</p>;
-      }
-    }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {
+          counter: 0,
+        };
+        render() {
+          instance = this;
+          return <p>{this.state.counter}</p>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SimpleComponent />);
@@ -1094,15 +1131,17 @@ describe('ReactShallowRenderer', () => {
   it('can forceUpdate with a callback', () => {
     let instance;
 
-    class SimpleComponent extends React.Component {
-      state = {
-        counter: 0,
-      };
-      render() {
-        instance = this;
-        return <p>{this.state.counter}</p>;
-      }
-    }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        state = {
+          counter: 0,
+        };
+        render() {
+          instance = this;
+          return <p>{this.state.counter}</p>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SimpleComponent />);
@@ -1120,15 +1159,17 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('can pass context when shallowly rendering', () => {
-    class SimpleComponent extends React.Component {
-      static contextTypes = {
-        name: PropTypes.string,
-      };
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        static contextTypes = {
+          name: PropTypes.string,
+        };
 
-      render() {
-        return <div>{this.context.name}</div>;
-      }
-    }
+        render() {
+          return <div>{this.context.name}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const result = shallowRenderer.render(<SimpleComponent />, {
@@ -1138,19 +1179,21 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should track context across updates', () => {
-    class SimpleComponent extends React.Component {
-      static contextTypes = {
-        foo: PropTypes.string,
-      };
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        static contextTypes = {
+          foo: PropTypes.string,
+        };
 
-      state = {
-        bar: 'bar',
-      };
+        state = {
+          bar: 'bar',
+        };
 
-      render() {
-        return <div>{`${this.context.foo}:${this.state.bar}`}</div>;
-      }
-    }
+        render() {
+          return <div>{`${this.context.foo}:${this.state.bar}`}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     let result = shallowRenderer.render(<SimpleComponent />, {
@@ -1166,14 +1209,16 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should filter context by contextTypes', () => {
-    class SimpleComponent extends React.Component {
-      static contextTypes = {
-        foo: PropTypes.string,
-      };
-      render() {
-        return <div>{`${this.context.foo}:${this.context.bar}`}</div>;
-      }
-    }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        static contextTypes = {
+          foo: PropTypes.string,
+        };
+        render() {
+          return <div>{`${this.context.foo}:${this.context.bar}`}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     let result = shallowRenderer.render(<SimpleComponent />, {
@@ -1184,15 +1229,17 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('can fail context when shallowly rendering', () => {
-    class SimpleComponent extends React.Component {
-      static contextTypes = {
-        name: PropTypes.string.isRequired,
-      };
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        static contextTypes = {
+          name: PropTypes.string.isRequired,
+        };
 
-      render() {
-        return <div>{this.context.name}</div>;
-      }
-    }
+        render() {
+          return <div>{this.context.name}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     expect(() => shallowRenderer.render(<SimpleComponent />)).toWarnDev(
@@ -1203,15 +1250,17 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should warn about propTypes (but only once)', () => {
-    class SimpleComponent extends React.Component {
-      render() {
-        return React.createElement('div', null, this.props.name);
-      }
-    }
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        static propTypes = {
+          name: PropTypes.string.isRequired,
+        };
 
-    SimpleComponent.propTypes = {
-      name: PropTypes.string.isRequired,
-    };
+        render() {
+          return React.createElement('div', null, this.props.name);
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     expect(() =>
@@ -1224,19 +1273,21 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should enable rendering of cloned element', () => {
-    class SimpleComponent extends React.Component {
-      constructor(props) {
-        super(props);
+    const SimpleComponent = React.memo(
+      class SimpleComponent extends React.Component {
+        constructor(props) {
+          super(props);
 
-        this.state = {
-          bar: 'bar',
-        };
-      }
+          this.state = {
+            bar: 'bar',
+          };
+        }
 
-      render() {
-        return <div>{`${this.props.foo}:${this.state.bar}`}</div>;
-      }
-    }
+        render() {
+          return <div>{`${this.props.foo}:${this.state.bar}`}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     const el = <SimpleComponent foo="foo" />;
@@ -1251,25 +1302,27 @@ describe('ReactShallowRenderer', () => {
   it('this.state should be updated on setState callback inside componentWillMount', () => {
     let stateSuccessfullyUpdated = false;
 
-    class Component extends React.Component {
-      constructor(props, context) {
-        super(props, context);
-        this.state = {
-          hasUpdatedState: false,
-        };
-      }
+    const Component = React.memo(
+      class Component extends React.Component {
+        constructor(props, context) {
+          super(props, context);
+          this.state = {
+            hasUpdatedState: false,
+          };
+        }
 
-      UNSAFE_componentWillMount() {
-        this.setState(
-          {hasUpdatedState: true},
-          () => (stateSuccessfullyUpdated = this.state.hasUpdatedState),
-        );
-      }
+        UNSAFE_componentWillMount() {
+          this.setState(
+            {hasUpdatedState: true},
+            () => (stateSuccessfullyUpdated = this.state.hasUpdatedState),
+          );
+        }
 
-      render() {
-        return <div>{this.props.children}</div>;
-      }
-    }
+        render() {
+          return <div>{this.props.children}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<Component />);
@@ -1280,23 +1333,25 @@ describe('ReactShallowRenderer', () => {
     const mockFn = jest.fn();
     const shallowRenderer = createRenderer();
 
-    class Component extends React.Component {
-      constructor(props, context) {
-        super(props, context);
-        this.state = {
-          foo: 'foo',
-        };
-      }
+    const Component = React.memo(
+      class Component extends React.Component {
+        constructor(props, context) {
+          super(props, context);
+          this.state = {
+            foo: 'foo',
+          };
+        }
 
-      UNSAFE_componentWillMount() {
-        this.setState({foo: 'bar'}, () => mockFn());
-        this.setState({foo: 'foobar'}, () => mockFn());
-      }
+        UNSAFE_componentWillMount() {
+          this.setState({foo: 'bar'}, () => mockFn());
+          this.setState({foo: 'foobar'}, () => mockFn());
+        }
 
-      render() {
-        return <div>{this.state.foo}</div>;
-      }
-    }
+        render() {
+          return <div>{this.state.foo}</div>;
+        }
+      },
+    );
 
     shallowRenderer.render(<Component />);
 
@@ -1311,22 +1366,24 @@ describe('ReactShallowRenderer', () => {
   it('should call the setState callback even if shouldComponentUpdate = false', done => {
     const mockFn = jest.fn().mockReturnValue(false);
 
-    class Component extends React.Component {
-      constructor(props, context) {
-        super(props, context);
-        this.state = {
-          hasUpdatedState: false,
-        };
-      }
+    const Component = React.memo(
+      class Component extends React.Component {
+        constructor(props, context) {
+          super(props, context);
+          this.state = {
+            hasUpdatedState: false,
+          };
+        }
 
-      shouldComponentUpdate() {
-        return mockFn();
-      }
+        shouldComponentUpdate() {
+          return mockFn();
+        }
 
-      render() {
-        return <div>{this.state.hasUpdatedState}</div>;
-      }
-    }
+        render() {
+          return <div>{this.state.hasUpdatedState}</div>;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<Component />);
@@ -1362,11 +1419,13 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should have initial state of null if not defined', () => {
-    class SomeComponent extends React.Component {
-      render() {
-        return <span />;
-      }
-    }
+    const SomeComponent = React.memo(
+      class SomeComponent extends React.Component {
+        render() {
+          return <span />;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<SomeComponent />);
@@ -1377,29 +1436,31 @@ describe('ReactShallowRenderer', () => {
   it('should invoke both deprecated and new lifecycles if both are present', () => {
     const log = [];
 
-    class Component extends React.Component {
-      componentWillMount() {
-        log.push('componentWillMount');
-      }
-      componentWillReceiveProps() {
-        log.push('componentWillReceiveProps');
-      }
-      componentWillUpdate() {
-        log.push('componentWillUpdate');
-      }
-      UNSAFE_componentWillMount() {
-        log.push('UNSAFE_componentWillMount');
-      }
-      UNSAFE_componentWillReceiveProps() {
-        log.push('UNSAFE_componentWillReceiveProps');
-      }
-      UNSAFE_componentWillUpdate() {
-        log.push('UNSAFE_componentWillUpdate');
-      }
-      render() {
-        return null;
-      }
-    }
+    const Component = React.memo(
+      class Component extends React.Component {
+        componentWillMount() {
+          log.push('componentWillMount');
+        }
+        componentWillReceiveProps() {
+          log.push('componentWillReceiveProps');
+        }
+        componentWillUpdate() {
+          log.push('componentWillUpdate');
+        }
+        UNSAFE_componentWillMount() {
+          log.push('UNSAFE_componentWillMount');
+        }
+        UNSAFE_componentWillReceiveProps() {
+          log.push('UNSAFE_componentWillReceiveProps');
+        }
+        UNSAFE_componentWillUpdate() {
+          log.push('UNSAFE_componentWillUpdate');
+        }
+        render() {
+          return null;
+        }
+      },
+    );
 
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<Component foo="bar" />);
@@ -1419,19 +1480,21 @@ describe('ReactShallowRenderer', () => {
   it('should stop the update when setState returns null or undefined', () => {
     const log = [];
     let instance;
-    class Component extends React.Component {
-      constructor(props) {
-        super(props);
-        this.state = {
-          count: 0,
-        };
-      }
-      render() {
-        log.push('render');
-        instance = this;
-        return null;
-      }
-    }
+    const Component = React.memo(
+      class Component extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            count: 0,
+          };
+        }
+        render() {
+          log.push('render');
+          instance = this;
+          return null;
+        }
+      },
+    );
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<Component />);
     log.length = 0;
@@ -1446,123 +1509,12 @@ describe('ReactShallowRenderer', () => {
 
   it('should not get this in a function component', () => {
     const logs = [];
-    function Foo() {
+    const Foo = React.memo(function Foo() {
       logs.push(this);
       return <div>foo</div>;
-    }
+    });
     const shallowRenderer = createRenderer();
     shallowRenderer.render(<Foo foo="bar" />);
     expect(logs).toEqual([undefined]);
-  });
-
-  it('should handle memo', () => {
-    function Foo() {
-      return <div>foo</div>;
-    }
-    const MemoFoo = React.memo(Foo);
-    const shallowRenderer = createRenderer();
-    shallowRenderer.render(<MemoFoo />);
-  });
-
-  it('should enable React.memo to prevent a re-render', () => {
-    const logs = [];
-    const Foo = React.memo(({count}) => {
-      logs.push(`Foo: ${count}`);
-      return <div>{count}</div>;
-    });
-    const Bar = React.memo(({count}) => {
-      logs.push(`Bar: ${count}`);
-      return <div>{count}</div>;
-    });
-    const shallowRenderer = createRenderer();
-    shallowRenderer.render(<Foo count={1} />);
-    expect(logs).toEqual(['Foo: 1']);
-    logs.length = 0;
-    // Rendering the same element with the same props should be prevented
-    shallowRenderer.render(<Foo count={1} />);
-    expect(logs).toEqual([]);
-    // A different element with the same props should cause a re-render
-    shallowRenderer.render(<Bar count={1} />);
-    expect(logs).toEqual(['Bar: 1']);
-  });
-
-  it('should respect a custom comparison function with React.memo', () => {
-    let renderCount = 0;
-    function areEqual(props, nextProps) {
-      return props.foo === nextProps.foo;
-    }
-    const Foo = React.memo(({foo, bar}) => {
-      renderCount++;
-      return (
-        <div>
-          {foo} {bar}
-        </div>
-      );
-    }, areEqual);
-
-    const shallowRenderer = createRenderer();
-    shallowRenderer.render(<Foo foo={1} bar={1} />);
-    expect(renderCount).toBe(1);
-    // Change a prop that the comparison funciton ignores
-    shallowRenderer.render(<Foo foo={1} bar={2} />);
-    expect(renderCount).toBe(1);
-    shallowRenderer.render(<Foo foo={2} bar={2} />);
-    expect(renderCount).toBe(2);
-  });
-
-  it('should not call the comparison function with React.memo on the initial render', () => {
-    const areEqual = jest.fn(() => false);
-    const SomeComponent = React.memo(({foo}) => {
-      return <div>{foo}</div>;
-    }, areEqual);
-    const shallowRenderer = createRenderer();
-    shallowRenderer.render(<SomeComponent foo={1} />);
-    expect(areEqual).not.toHaveBeenCalled();
-    expect(shallowRenderer.getRenderOutput()).toEqual(<div>{1}</div>);
-  });
-
-  it('should handle memo(forwardRef())', () => {
-    const testRef = React.createRef();
-    const SomeComponent = React.forwardRef((props, ref) => {
-      expect(ref).toEqual(testRef);
-      return (
-        <div>
-          <span className="child1" />
-          <span className="child2" />
-        </div>
-      );
-    });
-
-    const SomeMemoComponent = React.memo(SomeComponent);
-
-    const shallowRenderer = createRenderer();
-    const result = shallowRenderer.render(<SomeMemoComponent ref={testRef} />);
-
-    expect(result.type).toBe('div');
-    expect(result.props.children).toEqual([
-      <span className="child1" />,
-      <span className="child2" />,
-    ]);
-  });
-
-  it('should warn for forwardRef(memo())', () => {
-    const testRef = React.createRef();
-    const SomeMemoComponent = React.memo(({foo}) => {
-      return <div>{foo}</div>;
-    });
-    const shallowRenderer = createRenderer();
-    expect(() => {
-      expect(() => {
-        const SomeComponent = React.forwardRef(SomeMemoComponent);
-        shallowRenderer.render(<SomeComponent ref={testRef} />);
-      }).toWarnDev(
-        'Warning: forwardRef requires a render function but received ' +
-          'a `memo` component. Instead of forwardRef(memo(...)), use ' +
-          'memo(forwardRef(...))',
-        {withoutStack: true},
-      );
-    }).toThrowError(
-      'forwardRef requires a render function but was given object.',
-    );
   });
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "react"
   ],
-  "version": "16.8.4",
+  "version": "16.8.5",
   "homepage": "https://reactjs.org/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",
@@ -29,7 +29,7 @@
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.6.2",
-    "scheduler": "^0.13.4"
+    "scheduler": "^0.13.5"
   },
   "browserify": {
     "transform": [

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -17,8 +17,12 @@ function resolveDispatcher() {
   const dispatcher = ReactCurrentDispatcher.current;
   invariant(
     dispatcher !== null,
-    'Hooks can only be called inside the body of a function component. ' +
-      '(https://fb.me/react-invalid-hook-call)',
+    'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+      ' one of the following reasons:\n' +
+      '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+      '2. You might be breaking the Rules of Hooks\n' +
+      '3. You might have more than one copy of React in the same app\n' +
+      'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
   );
   return dispatcher;
 }

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scheduler",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Cooperative scheduler for the browser environment.",
   "main": "index.js",
   "repository": {

--- a/packages/shared/ReactVersion.js
+++ b/packages/shared/ReactVersion.js
@@ -8,4 +8,4 @@
 'use strict';
 
 // TODO: this is special because it gets imported during build.
-module.exports = '16.8.4';
+module.exports = '16.8.5';

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -319,5 +319,7 @@
   "317": "Expected to have a hydrated suspense instance. This error is likely caused by a bug in React. Please file an issue.",
   "318": "A dehydrated suspense component was completed without a hydrated node. This is probably a bug in React.",
   "319": "A dehydrated suspense boundary must commit before trying to render. This is probably a bug in React.",
-  "320": "Expected ReactFiberErrorDialog.showErrorDialog to be a function."
+  "320": "Expected ReactFiberErrorDialog.showErrorDialog to be a function.",
+  "321": "Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You might be breaking the Rules of Hooks\n3. You might have more than one copy of React in the same app\nSee https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.",
+  "322": "forwardRef requires a render function but was given %s."
 }


### PR DESCRIPTION
This is based on 16.8.4 branch with the addition of:

* Improve async useEffect warning (#15104)
* Don't set the first option as selected in select tag with `size` attribute  (#14242)
* Fix shallow renderer not allowing hooks in forwardRef render functions (#15100)
* Use same example code for async effect warning (#15118)
* Support React.memo in ReactShallowRenderer (#14816)
* [Shallow] Implement setState for Hooks and remount on type change (#15120)
* Link to useLayoutEffect gist in a warning (#15158)
* Add more info to invalid hook call error message (#15139)

