### PR TITLE
Do not keep bailouted actions which might lead to reducer computing wrong value on update later

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1123,21 +1123,6 @@ function dispatchAction<S, A>(
       next: null,
     };
 
-    // Append the update to the end of the list.
-    const last = queue.last;
-    if (last === null) {
-      // This is the first update. Create a circular list.
-      update.next = update;
-    } else {
-      const first = last.next;
-      if (first !== null) {
-        // Still circular.
-        update.next = first;
-      }
-      last.next = update;
-    }
-    queue.last = update;
-
     if (
       fiber.expirationTime === NoWork &&
       (alternate === null || alternate.expirationTime === NoWork)
@@ -1182,6 +1167,22 @@ function dispatchAction<S, A>(
         warnIfNotCurrentlyBatchingInDev(fiber);
       }
     }
+
+    // Append the update to the end of the list.
+    const last = queue.last;
+    if (last === null) {
+      // This is the first update. Create a circular list.
+      update.next = update;
+    } else {
+      const first = last.next;
+      if (first !== null) {
+        // Still circular.
+        update.next = first;
+      }
+      last.next = update;
+    }
+    queue.last = update;
+
     scheduleWork(fiber, expirationTime);
   }
 }


### PR DESCRIPTION
This is a fix for what I think is a bug which I've reported in https://github.com/facebook/react/issues/15088

The issue might be observed here https://codesandbox.io/s/n97q1o6nq4 . Just increment the counter -> disable the whole thing -> increment few times (those are going to bail out) -> enable the counter -> observe a counter incrementing by the amount of actions which have bailouted previously.
