### PR TITLE
Ignore update when React and number input isNaN()

### DIFF
--- a/fixtures/dom/src/components/fixtures/number-inputs/NumericParsedInput.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/NumericParsedInput.js
@@ -1,0 +1,30 @@
+import Fixture from '../../Fixture';
+
+const React = window.React;
+
+export default class NumbericParsedInput extends React.Component {
+  state = {
+    value: 0,
+  };
+
+  onChange = event => {
+    this.setState({
+      value: event.target.valueAsNumber,
+    });
+  };
+
+  render() {
+    const {value} = this.state;
+
+    return (
+      <Fixture>
+        <div>{this.props.children}</div>
+
+        <div className="control-box">
+          <input type="number" value={value} onChange={this.onChange} />
+          <pre>Value: {value}</pre>
+        </div>
+      </Fixture>
+    );
+  }
+}

--- a/fixtures/dom/src/components/fixtures/number-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/number-inputs/index.js
@@ -3,6 +3,7 @@ import TestCase from '../../TestCase';
 import NumberTestCase from './NumberTestCase';
 import NumberInputDecimal from './NumberInputDecimal';
 import NumberInputExtraZeroes from './NumberInputExtraZeroes';
+import NumericParsedInput from './NumericParsedInput.js';
 
 const React = window.React;
 
@@ -185,6 +186,21 @@ function NumberInputs() {
           </a>{' '}
           that we can not control for.
         </p>
+      </TestCase>
+
+      <TestCase title="Assigning NaN to an invalid number input">
+        <TestCase.Steps>
+          <li>
+            Enter an invalid number, like <code>3.2...</code>
+          </li>
+        </TestCase.Steps>
+
+        <TestCase.ExpectedResult>
+          The input should not clear the value as soon as the number becomes
+          invalid.
+        </TestCase.ExpectedResult>
+
+        <NumericParsedInput />
       </TestCase>
     </FixtureSet>
   );

--- a/packages/react-dom/src/client/ReactDOMInput.js
+++ b/packages/react-dom/src/client/ReactDOMInput.js
@@ -177,13 +177,22 @@ export function updateWrapper(element: Element, props: Object) {
 
   if (value != null) {
     if (type === 'number') {
-      if (
-        (value === 0 && node.value === '') ||
-        // We explicitly want to coerce to number here if possible.
-        // eslint-disable-next-line
-        node.value != (value: any)
-      ) {
-        node.value = toString(value);
+      let nodeValue = node.value;
+
+      // If the React prop value is NaN and current input value is invalid,
+      // it means both React and the DOM have invalid states (reported as
+      // empty). In this case, do not assign the value property, which would
+      // clear user input. The resulting state remains the same while still
+      // maintaining user expectations.
+      if (!(isNaN(value) && nodeValue === '')) {
+        if (
+          (value === 0 && nodeValue === '') ||
+          // We explicitly want to coerce to number here if possible.
+          // eslint-disable-next-line
+          nodeValue != (value: any)
+        ) {
+          node.value = toString(value);
+        }
       }
     } else if (node.value !== toString(value)) {
       node.value = toString(value);


### PR DESCRIPTION
This commit prevents an issue where assigning NaN to an invalid input causes a text wipe that disrupts text entry:

![nan-input](https://user-images.githubusercontent.com/590904/54960968-2b8f4900-4f1c-11e9-9155-c4da1b9caa3c.gif)

This happens if referencing `input.valueAsNumber` directly, or by calling `Number(input.value)` in the onChange callback of an input. This results in a comparison of `NaN` to `""`, which always returns `true`, assigning a blank string to the input and clearing the input's text.

It's also worth mentioning that assigning NaN to an input raises this warning:

![image](https://user-images.githubusercontent.com/590904/54960587-7e680100-4f1a-11e9-9f00-bfb0e202f530.png)

However we still allow the value to fall through and get assigned to the input.

This code is pretty gnarly, and I don't love adding more knots, but I believe this addresses https://github.com/facebook/react/issues/11877 and avoids some bad user experience.

## Test Plan

Take a look at the number input fixtures and the new fixture at the bottom here:
https://react-dom-fixtures-nan-inputs.surge.sh/number-inputs
