### PR TITLE
Fix React.lazy infinite loop on passing undefined

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -50,9 +50,9 @@ export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
       thenable.then(
         moduleObject => {
           if (lazyComponent._status === Pending) {
-            const defaultExport = moduleObject.default;
+            const _result = moduleObject ? moduleObject.default : moduleObject;
             if (__DEV__) {
-              if (defaultExport === undefined) {
+              if (result === undefined) {
                 warning(
                   false,
                   'lazy: Expected the result of a dynamic import() call. ' +
@@ -63,7 +63,7 @@ export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
               }
             }
             lazyComponent._status = Resolved;
-            lazyComponent._result = defaultExport;
+            lazyComponent._result = _result;
           }
         },
         error => {

--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -52,7 +52,7 @@ export function readLazyComponentType<T>(lazyComponent: LazyComponent<T>): T {
           if (lazyComponent._status === Pending) {
             const _result = moduleObject ? moduleObject.default : moduleObject;
             if (__DEV__) {
-              if (result === undefined) {
+              if (_result === undefined) {
                 warning(
                   false,
                   'lazy: Expected the result of a dynamic import() call. ' +


### PR DESCRIPTION
Related to #15019 

The following code no longer produces a loop.

```
const Component = React.lazy(() => Promise.resolve(undefined));
      ReactDOM.render(
        <div>
          <h1>Hello World!</h1>
          <React.Suspense fallback="..">
            <Component />
          </React.Suspense>
        </div>,
        document.getElementById('container')
      );
```

Instead, an error is shown: (tried on dev.html standalone fixture)

```
Uncaught Invariant Violation: Element type is invalid. Received a promise that resolves to: undefined. Lazy element type must resolve to a class or function.
```