### PR TITLE
Disable JS urls at build level for www

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -16,7 +16,6 @@ export const {
   debugRenderPhaseSideEffectsForStrictMode,
   replayFailedUnitOfWorkWithInvokeGuardedCallback,
   warnAboutDeprecatedLifecycles,
-  disableJavaScriptURLs,
   disableYielding,
   disableInputAttributeSyncing,
   warnAboutShorthandPropertyCollision,
@@ -38,6 +37,8 @@ export const enableSchedulerDebugging = true;
 export const enableStableConcurrentModeAPIs = false;
 
 export const enableSuspenseServerRenderer = true;
+
+export const disableJavaScriptURLs = true;
 
 // I've chosen to make this a static flag instead of a dynamic flag controlled
 // by a GK so that it doesn't increase bundle size. It should still be easy


### PR DESCRIPTION
This will be FB only for now but this will be on by default in open source for the next major.
