### PR TITLE
Fix circular module imports causing file size increase

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -15,6 +15,7 @@ import {canUseDOM} from 'shared/ExecutionEnvironment';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import type {ReactEventResponderEventType} from 'shared/ReactTypes';
 import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
+import {setListenToResponderEvent} from '../events/DOMEventResponderSystem';
 
 import {
   getValueForAttribute,
@@ -1336,4 +1337,9 @@ export function listenToEventResponderEventTypes(
       }
     }
   }
+}
+
+// We can remove this once the event API is stable and out of a flag
+if (enableEventAPI) {
+  setListenToResponderEvent(listenToEventResponderEventTypes);
 }

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -15,7 +15,7 @@ import {canUseDOM} from 'shared/ExecutionEnvironment';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import type {ReactEventResponderEventType} from 'shared/ReactTypes';
 import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
-import {setListenToResponderEvent} from '../events/DOMEventResponderSystem';
+import {setListenToResponderEventTypes} from '../events/DOMEventResponderSystem';
 
 import {
   getValueForAttribute,
@@ -1341,5 +1341,5 @@ export function listenToEventResponderEventTypes(
 
 // We can remove this once the event API is stable and out of a flag
 if (enableEventAPI) {
-  setListenToResponderEvent(listenToEventResponderEventTypes);
+  setListenToResponderEventTypes(listenToEventResponderEventTypes);
 }

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -24,10 +24,17 @@ import {interactiveUpdates} from 'events/ReactGenericBatching';
 import {executeDispatch} from 'events/EventPluginUtils';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
-import {listenToEventResponderEventTypes} from '../client/ReactDOMComponent';
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
 
 import {enableEventAPI} from 'shared/ReactFeatureFlags';
+
+let listenToResponderEventImpl;
+
+export function setListenToResponderEvent(
+  _listenToResponderEventImpl: Function,
+) {
+  listenToResponderEventImpl = _listenToResponderEventImpl;
+}
 
 const rootEventTypesToEventComponents: Map<
   DOMTopLevelEventType | string,
@@ -156,7 +163,7 @@ DOMEventResponderContext.prototype.addRootEventTypes = function(
   rootEventTypes: Array<ReactEventResponderEventType>,
 ) {
   const element = this.eventTarget.ownerDocument;
-  listenToEventResponderEventTypes(rootEventTypes, element);
+  listenToResponderEventImpl(rootEventTypes, element);
   const eventComponent = this._fiber;
   for (let i = 0; i < rootEventTypes.length; i++) {
     const rootEventType = rootEventTypes[i];

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -28,12 +28,12 @@ import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
 
 import {enableEventAPI} from 'shared/ReactFeatureFlags';
 
-let listenToResponderEventImpl;
+let listenToResponderEventTypesImpl;
 
-export function setListenToResponderEvent(
-  _listenToResponderEventImpl: Function,
+export function setListenToResponderEventTypes(
+  _listenToResponderEventTypesImpl: Function,
 ) {
-  listenToResponderEventImpl = _listenToResponderEventImpl;
+  listenToResponderEventTypesImpl = _listenToResponderEventTypesImpl;
 }
 
 const rootEventTypesToEventComponents: Map<
@@ -163,7 +163,7 @@ DOMEventResponderContext.prototype.addRootEventTypes = function(
   rootEventTypes: Array<ReactEventResponderEventType>,
 ) {
   const element = this.eventTarget.ownerDocument;
-  listenToResponderEventImpl(rootEventTypes, element);
+  listenToResponderEventTypesImpl(rootEventTypes, element);
   const eventComponent = this._fiber;
   for (let i = 0; i < rootEventTypes.length; i++) {
     const rootEventType = rootEventTypes[i];


### PR DESCRIPTION
This PR is a follow up to https://github.com/facebook/react/pull/15228, where the PR increased the size of the bundle with flags due to a cyclic module reference that somehow caused Rollup/GCC to not optimize the output as well. This PR contains a work around that restores the bundle size to the original size.