### PR TITLE
Adds React event component and React event target support to SSR renderer

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -22,6 +22,7 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
   warnAboutDeprecatedLifecycles,
   enableSuspenseServerRenderer,
+  enableEventAPI,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -36,6 +37,8 @@ import {
   REACT_CONTEXT_TYPE,
   REACT_LAZY_TYPE,
   REACT_MEMO_TYPE,
+  REACT_EVENT_COMPONENT_TYPE,
+  REACT_EVENT_TARGET_TYPE,
 } from 'shared/ReactSymbols';
 
 import {
@@ -1160,6 +1163,27 @@ class ReactDOMServerRenderer {
               ((frame: any): FrameDev).debugElementStack = [];
             }
             this.stack.push(frame);
+            return '';
+          }
+          case REACT_EVENT_COMPONENT_TYPE:
+          case REACT_EVENT_TARGET_TYPE: {
+            if (enableEventAPI) {
+              const nextChildren = toArray(
+                ((nextChild: any): ReactElement).props.children,
+              );
+              const frame: Frame = {
+                type: null,
+                domNamespace: parentNamespace,
+                children: nextChildren,
+                childIndex: 0,
+                context: context,
+                footer: '',
+              };
+              if (__DEV__) {
+                ((frame: any): FrameDev).debugElementStack = [];
+              }
+              this.stack.push(frame);
+            }
             return '';
           }
           case REACT_LAZY_TYPE:

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1183,9 +1183,14 @@ class ReactDOMServerRenderer {
                 ((frame: any): FrameDev).debugElementStack = [];
               }
               this.stack.push(frame);
+              return '';
             }
-            return '';
+            invariant(
+              false,
+              'ReactDOMServer does not yet support the event API.',
+            );
           }
+          // eslint-disable-next-line-no-fallthrough
           case REACT_LAZY_TYPE:
             invariant(
               false,

--- a/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
- * @jest-environment node
  */
 
 'use strict';
@@ -16,6 +15,8 @@ let Scheduler;
 let ReactFeatureFlags;
 let EventComponent;
 let ReactTestRenderer;
+let ReactDOM;
+let ReactDOMServer;
 let EventTarget;
 let ReactEvents;
 
@@ -49,6 +50,16 @@ function initNoopRenderer() {
 function initTestRenderer() {
   init();
   ReactTestRenderer = require('react-test-renderer');
+}
+
+function initReactDOM() {
+  init();
+  ReactDOM = require('react-dom');
+}
+
+function initReactDOMServer() {
+  init();
+  ReactDOMServer = require('react-dom/server');
 }
 
 // This is a new feature in Fiber so I put it in its own test file. It could
@@ -356,6 +367,215 @@ describe('ReactFiberEvents', () => {
       }).toWarnDev(
         'Warning: validateDOMNesting: React event targets must be direct children of event components.',
       );
+    });
+  });
+
+  describe('ReactDOM', () => {
+    beforeEach(() => {
+      initReactDOM();
+      EventComponent = createReactEventComponent();
+      EventTarget = ReactEvents.TouchHitTarget;
+    });
+
+    it('should render a simple event component with a single child', () => {
+      const Test = () => (
+        <EventComponent>
+          <div>Hello world</div>
+        </EventComponent>
+      );
+      const container = document.createElement('div');
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe('<div>Hello world</div>');
+    });
+
+    it('should warn when an event component has a direct text child', () => {
+      const Test = () => <EventComponent>Hello world</EventComponent>;
+
+      expect(() => {
+        const container = document.createElement('div');
+        ReactDOM.render(<Test />, container);
+        expect(Scheduler).toFlushWithoutYielding();
+      }).toWarnDev(
+        'Warning: validateDOMNesting: React event components cannot have text DOM nodes as children. ' +
+          'Wrap the child text "Hello world" in an element.',
+      );
+    });
+
+    it('should warn when an event component has a direct text child #2', () => {
+      const ChildWrapper = () => 'Hello world';
+      const Test = () => (
+        <EventComponent>
+          <ChildWrapper />
+        </EventComponent>
+      );
+
+      expect(() => {
+        const container = document.createElement('div');
+        ReactDOM.render(<Test />, container);
+        expect(Scheduler).toFlushWithoutYielding();
+      }).toWarnDev(
+        'Warning: validateDOMNesting: React event components cannot have text DOM nodes as children. ' +
+          'Wrap the child text "Hello world" in an element.',
+      );
+    });
+
+    it('should render a simple event component with a single event target', () => {
+      const Test = () => (
+        <EventComponent>
+          <EventTarget>
+            <div>Hello world</div>
+          </EventTarget>
+        </EventComponent>
+      );
+
+      const container = document.createElement('div');
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe('<div>Hello world</div>');
+
+      const Test2 = () => (
+        <EventComponent>
+          <EventTarget>
+            <span>I am now a span</span>
+          </EventTarget>
+        </EventComponent>
+      );
+
+      ReactDOM.render(<Test2 />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe('<span>I am now a span</span>');
+    });
+
+    it('should warn when an event target has a direct text child', () => {
+      const Test = () => (
+        <EventComponent>
+          <EventTarget>Hello world</EventTarget>
+        </EventComponent>
+      );
+
+      expect(() => {
+        const container = document.createElement('div');
+        ReactDOM.render(<Test />, container);
+        expect(Scheduler).toFlushWithoutYielding();
+      }).toWarnDev([
+        'Warning: validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
+          'Wrap the child text "Hello world" in an element.',
+        'Warning: <TouchHitTarget> must have a single DOM element as a child. Found no children.',
+      ]);
+    });
+
+    it('should warn when an event target has a direct text child #2', () => {
+      const ChildWrapper = () => 'Hello world';
+      const Test = () => (
+        <EventComponent>
+          <EventTarget>
+            <ChildWrapper />
+          </EventTarget>
+        </EventComponent>
+      );
+
+      expect(() => {
+        const container = document.createElement('div');
+        ReactDOM.render(<Test />, container);
+        expect(Scheduler).toFlushWithoutYielding();
+      }).toWarnDev([
+        'Warning: validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
+          'Wrap the child text "Hello world" in an element.',
+        'Warning: <TouchHitTarget> must have a single DOM element as a child. Found no children.',
+      ]);
+    });
+
+    it('should warn when an event target has more than one child', () => {
+      const Test = () => (
+        <EventComponent>
+          <EventTarget>
+            <span>Child 1</span>
+            <span>Child 2</span>
+          </EventTarget>
+        </EventComponent>
+      );
+
+      const container = document.createElement('div');
+      expect(() => {
+        ReactDOM.render(<Test />, container);
+        expect(Scheduler).toFlushWithoutYielding();
+      }).toWarnDev(
+        'Warning: <TouchHitTarget> must only have a single DOM element as a child. Found many children.',
+      );
+      // This should not fire a warning, as this is now valid.
+      const Test2 = () => (
+        <EventComponent>
+          <EventTarget>
+            <span>Child 1</span>
+          </EventTarget>
+        </EventComponent>
+      );
+      ReactDOM.render(<Test2 />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe('<span>Child 1</span>');
+    });
+
+    it('should warn if an event target is not a direct child of an event component', () => {
+      const Test = () => (
+        <EventComponent>
+          <div>
+            <EventTarget>
+              <span>Child 1</span>
+            </EventTarget>
+          </div>
+        </EventComponent>
+      );
+
+      expect(() => {
+        const container = document.createElement('div');
+        ReactDOM.render(<Test />, container);
+        expect(Scheduler).toFlushWithoutYielding();
+      }).toWarnDev(
+        'Warning: validateDOMNesting: React event targets must be direct children of event components.',
+      );
+    });
+  });
+
+  describe('ReactDOMServer', () => {
+    beforeEach(() => {
+      initReactDOMServer();
+      EventComponent = createReactEventComponent();
+      EventTarget = ReactEvents.TouchHitTarget;
+    });
+
+    it('should render a simple event component with a single child', () => {
+      const Test = () => (
+        <EventComponent>
+          <div>Hello world</div>
+        </EventComponent>
+      );
+      const output = ReactDOMServer.renderToString(<Test />);
+      expect(output).toBe('<div>Hello world</div>');
+    });
+
+    it('should render a simple event component with a single event target', () => {
+      const Test = () => (
+        <EventComponent>
+          <EventTarget>
+            <div>Hello world</div>
+          </EventTarget>
+        </EventComponent>
+      );
+
+      let output = ReactDOMServer.renderToString(<Test />);
+      expect(output).toBe('<div>Hello world</div>');
+
+      const Test2 = () => (
+        <EventComponent>
+          <EventTarget>
+            <span>I am now a span</span>
+          </EventTarget>
+        </EventComponent>
+      );
+
+      output = ReactDOMServer.renderToString(<Test2 />);
+      expect(output).toBe('<span>I am now a span</span>');
     });
   });
 });

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -1152,127 +1152,29 @@
       "filename": "react-events.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-events",
-      "size": 990,
-      "gzip": 545
+      "size": 1135,
+      "gzip": 623
     },
     {
       "filename": "react-events.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-events",
-      "size": 506,
-      "gzip": 343
+      "size": 448,
+      "gzip": 328
     },
     {
       "filename": "ReactEvents-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-events",
-      "size": 956,
-      "gzip": 536
+      "size": 1106,
+      "gzip": 613
     },
     {
       "filename": "ReactEvents-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-events",
-      "size": 687,
-      "gzip": 410
-    },
-    {
-      "filename": "react-events.development.js",
-      "bundleType": "UMD_DEV",
-      "packageName": "react-events",
-      "size": 1183,
-      "gzip": 605
-    },
-    {
-      "filename": "react-events.production.min.js",
-      "bundleType": "UMD_PROD",
-      "packageName": "react-events",
-      "size": 676,
-      "gzip": 420
-    },
-    {
-      "filename": "react-events-press.development.js",
-      "bundleType": "UMD_DEV",
-      "packageName": "react-events",
-      "size": 10147,
-      "gzip": 2467
-    },
-    {
-      "filename": "react-events-press.production.min.js",
-      "bundleType": "UMD_PROD",
-      "packageName": "react-events",
-      "size": 4169,
-      "gzip": 1426
-    },
-    {
-      "filename": "react-events-press.development.js",
-      "bundleType": "NODE_DEV",
-      "packageName": "react-events",
-      "size": 9973,
-      "gzip": 2424
-    },
-    {
-      "filename": "react-events-press.production.min.js",
-      "bundleType": "NODE_PROD",
-      "packageName": "react-events",
-      "size": 4002,
-      "gzip": 1370
-    },
-    {
-      "filename": "ReactEventsPress-dev.js",
-      "bundleType": "FB_WWW_DEV",
-      "packageName": "react-events",
-      "size": 10209,
-      "gzip": 2469
-    },
-    {
-      "filename": "ReactEventsPress-prod.js",
-      "bundleType": "FB_WWW_PROD",
-      "packageName": "react-events",
-      "size": 8373,
-      "gzip": 1778
-    },
-    {
-      "filename": "react-events-hover.development.js",
-      "bundleType": "UMD_DEV",
-      "packageName": "react-events",
-      "size": 4837,
-      "gzip": 1343
-    },
-    {
-      "filename": "react-events-hover.production.min.js",
-      "bundleType": "UMD_PROD",
-      "packageName": "react-events",
-      "size": 2162,
-      "gzip": 891
-    },
-    {
-      "filename": "react-events-hover.development.js",
-      "bundleType": "NODE_DEV",
-      "packageName": "react-events",
-      "size": 4663,
-      "gzip": 1301
-    },
-    {
-      "filename": "react-events-hover.production.min.js",
-      "bundleType": "NODE_PROD",
-      "packageName": "react-events",
-      "size": 1993,
-      "gzip": 834
-    },
-    {
-      "filename": "ReactEventsHover-dev.js",
-      "bundleType": "FB_WWW_DEV",
-      "packageName": "react-events",
-      "size": 4643,
-      "gzip": 1323
-    },
-    {
-      "filename": "ReactEventsHover-prod.js",
-      "bundleType": "FB_WWW_PROD",
-      "packageName": "react-events",
-      "size": 3852,
-      "gzip": 1076
+      "size": 643,
+      "gzip": 377
     }
   ]
 }

--- a/scripts/rollup/results.json
+++ b/scripts/rollup/results.json
@@ -1152,29 +1152,127 @@
       "filename": "react-events.development.js",
       "bundleType": "NODE_DEV",
       "packageName": "react-events",
-      "size": 1135,
-      "gzip": 623
+      "size": 990,
+      "gzip": 545
     },
     {
       "filename": "react-events.production.min.js",
       "bundleType": "NODE_PROD",
       "packageName": "react-events",
-      "size": 448,
-      "gzip": 328
+      "size": 506,
+      "gzip": 343
     },
     {
       "filename": "ReactEvents-dev.js",
       "bundleType": "FB_WWW_DEV",
       "packageName": "react-events",
-      "size": 1106,
-      "gzip": 613
+      "size": 956,
+      "gzip": 536
     },
     {
       "filename": "ReactEvents-prod.js",
       "bundleType": "FB_WWW_PROD",
       "packageName": "react-events",
-      "size": 643,
-      "gzip": 377
+      "size": 687,
+      "gzip": 410
+    },
+    {
+      "filename": "react-events.development.js",
+      "bundleType": "UMD_DEV",
+      "packageName": "react-events",
+      "size": 1183,
+      "gzip": 605
+    },
+    {
+      "filename": "react-events.production.min.js",
+      "bundleType": "UMD_PROD",
+      "packageName": "react-events",
+      "size": 676,
+      "gzip": 420
+    },
+    {
+      "filename": "react-events-press.development.js",
+      "bundleType": "UMD_DEV",
+      "packageName": "react-events",
+      "size": 10147,
+      "gzip": 2467
+    },
+    {
+      "filename": "react-events-press.production.min.js",
+      "bundleType": "UMD_PROD",
+      "packageName": "react-events",
+      "size": 4169,
+      "gzip": 1426
+    },
+    {
+      "filename": "react-events-press.development.js",
+      "bundleType": "NODE_DEV",
+      "packageName": "react-events",
+      "size": 9973,
+      "gzip": 2424
+    },
+    {
+      "filename": "react-events-press.production.min.js",
+      "bundleType": "NODE_PROD",
+      "packageName": "react-events",
+      "size": 4002,
+      "gzip": 1370
+    },
+    {
+      "filename": "ReactEventsPress-dev.js",
+      "bundleType": "FB_WWW_DEV",
+      "packageName": "react-events",
+      "size": 10209,
+      "gzip": 2469
+    },
+    {
+      "filename": "ReactEventsPress-prod.js",
+      "bundleType": "FB_WWW_PROD",
+      "packageName": "react-events",
+      "size": 8373,
+      "gzip": 1778
+    },
+    {
+      "filename": "react-events-hover.development.js",
+      "bundleType": "UMD_DEV",
+      "packageName": "react-events",
+      "size": 4837,
+      "gzip": 1343
+    },
+    {
+      "filename": "react-events-hover.production.min.js",
+      "bundleType": "UMD_PROD",
+      "packageName": "react-events",
+      "size": 2162,
+      "gzip": 891
+    },
+    {
+      "filename": "react-events-hover.development.js",
+      "bundleType": "NODE_DEV",
+      "packageName": "react-events",
+      "size": 4663,
+      "gzip": 1301
+    },
+    {
+      "filename": "react-events-hover.production.min.js",
+      "bundleType": "NODE_PROD",
+      "packageName": "react-events",
+      "size": 1993,
+      "gzip": 834
+    },
+    {
+      "filename": "ReactEventsHover-dev.js",
+      "bundleType": "FB_WWW_DEV",
+      "packageName": "react-events",
+      "size": 4643,
+      "gzip": 1323
+    },
+    {
+      "filename": "ReactEventsHover-prod.js",
+      "bundleType": "FB_WWW_PROD",
+      "packageName": "react-events",
+      "size": 3852,
+      "gzip": 1076
     }
   ]
 }


### PR DESCRIPTION
Note: this is for an experimental event API that we're testing out internally at Facebook.

This PR adds support for server side rendering for the experimental event API along with tests. I also added some ReactDOM renderer tests to the same test file to be consistent and give more coverage.

#15036
#15112
#15150
#15168
#15179 
#15228