### PR TITLE
Allow for null targetFiber for root event handling

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -259,7 +259,7 @@ function handleTopLevelType(
 
 export function runResponderEventsInBatch(
   topLevelType: DOMTopLevelEventType,
-  targetFiber: Fiber,
+  targetFiber: null | Fiber,
   nativeEvent: AnyNativeEvent,
   nativeEventTarget: EventTarget,
   eventSystemFlags: EventSystemFlags,

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -143,7 +143,7 @@ function handleTopLevel(bookKeeping: BookKeepingInstance) {
         nativeEvent,
         eventTarget,
       );
-    } else if (enableEventAPI && targetInst !== null) {
+    } else if (enableEventAPI) {
       // Responder event system (experimental event API)
       runResponderEventsInBatch(
         topLevelType,


### PR DESCRIPTION
When dealing with the experimental event API, the target fiber might be null when the event is triggered on the document. This code path is a valid one and get's handled by the root events that are attached on demand from an event responder.