### PR TITLE
Log User Timing API entries for Profiler nodes in the production+prof…

### DIFF
--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -96,7 +96,7 @@ exports[`ReactDebugFiberPerf does not include ConcurrentMode, StrictMode, or Pro
 
 // Mount
 ⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ Profiler [mount]
+  ⚛ Profiler(test) [mount]
     ⚛ Parent [mount]
       ⚛ Child [mount]
 


### PR DESCRIPTION
Resolves issue #15255 cc @bgirard 

React uses the [User Timing API](https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API) to mark and measure time spent working on various things for development builds. This can be a useful source of information when it comes to cross-referencing browser performance traces. We avoid doing this in production mode though, due to the performance overhead of using the API.

I believe that we could make an exception for our [profiling bundles](https://fb.me/react-profiling) and log measurements for `Profiler` nodes only. This should be a lot less heavyweight than the full development measurements, while still providing a potentially useful signal in the trace logs.

Here's an initial pass at this. This change has a minimal impact on the development bundle behavior- (including the `Profiler` id as part of the display name)- which seemed safe enough. I also verified that none of the timer related code leaks into the production bundle.

### Development bundle

![Screen Shot 2019-03-29 at 1 25 51 PM](https://user-images.githubusercontent.com/29597/55260818-9d220c80-5226-11e9-94fd-fa739eddf838.png)

### Profiling bundle

![Screen Shot 2019-03-29 at 1 30 42 PM](https://user-images.githubusercontent.com/29597/55260924-deb2b780-5226-11e9-82fd-94780a139e91.png)
