### PR TITLE
Fix Press module in experimental event API

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -38,8 +38,8 @@ type PressState = {
 
 function dispatchPressEvent(
   context: EventResponderContext,
-  name: string,
   state: PressState,
+  name: string,
   listener: (e: Object) => void,
 ): void {
   context.dispatchEvent(name, listener, state.pressTarget, true);
@@ -50,44 +50,50 @@ function dispatchPressInEvents(
   props: Object,
   state: PressState,
 ): void {
+  function dispatchPressChangeEvent(bool) {
+    const pressChangeEventListener = () => {
+      props.onPressChange(bool);
+    };
+    dispatchPressEvent(context, state, 'presschange', pressChangeEventListener);
+  }
+
   if (props.onPressIn) {
-    context.dispatchEvent('pressin', props.onPressIn, state.pressTarget, true);
+    dispatchPressEvent(context, state, 'pressin', props.onPressIn);
   }
   if (props.onPressChange) {
-    const pressChangeEventListener = () => {
-      props.onPressChange(true);
-    };
-    context.dispatchEvent(
-      'presschange',
-      pressChangeEventListener,
-      state.pressTarget,
-      true,
-    );
+    dispatchPressChangeEvent(true);
   }
-  if (!state.isLongPressed && (props.onLongPress || props.onLongPressChange)) {
+  if ((props.onLongPress || props.onLongPressChange) && !state.isLongPressed) {
     const longPressDelay = props.longPressDelay || 1000;
+
     state.longPressTimeout = setTimeout(() => {
       state.isLongPressed = true;
       state.longPressTimeout = null;
-      if (props.onLongPressChange) {
-        const longPressChangeEventListener = () => {
-          props.onLongPressChange(true);
-        };
-        context.dispatchEvent(
-          'longpresschange',
-          longPressChangeEventListener,
-          state.pressTarget,
-          true,
-        );
+
+      if (props.onPressChange && props.longPressCancelsPress) {
+        dispatchPressChangeEvent(false);
       }
-      if (props.onLongPress && !props.longPressCancelsPress) {
+
+      if (props.onLongPress) {
         const longPressEventListener = e => {
           props.onLongPress(e);
           if (e.nativeEvent.defaultPrevented) {
             state.defaultPrevented = true;
           }
         };
-        dispatchPressEvent(context, 'longpress', state, longPressEventListener);
+        dispatchPressEvent(context, state, 'longpress', longPressEventListener);
+      }
+
+      if (props.onLongPressChange) {
+        const longPressChangeEventListener = () => {
+          props.onLongPressChange(true);
+        };
+        dispatchPressEvent(
+          context,
+          state,
+          'longpresschange',
+          longPressChangeEventListener,
+        );
       }
     }, longPressDelay);
   }
@@ -103,33 +109,23 @@ function dispatchPressOutEvents(
     state.longPressTimeout = null;
   }
   if (props.onPressOut) {
-    context.dispatchEvent(
-      'pressout',
-      props.onPressOut,
-      state.pressTarget,
-      true,
-    );
+    dispatchPressEvent(context, state, 'pressout', props.onPressOut);
   }
-  if (props.onPressChange && !props.longPressCancelsPress) {
+  if (props.onPressChange) {
     const pressChangeEventListener = () => {
       props.onPressChange(false);
     };
-    context.dispatchEvent(
-      'presschange',
-      pressChangeEventListener,
-      state.pressTarget,
-      true,
-    );
+    dispatchPressEvent(context, state, 'presschange', pressChangeEventListener);
   }
-  if (state.isLongPressed && props.onLongPressChange) {
+  if (props.onLongPressChange && state.isLongPressed) {
     const longPressChangeEventListener = () => {
       props.onLongPressChange(false);
     };
-    context.dispatchEvent(
+    dispatchPressEvent(
+      context,
+      state,
       'longpresschange',
       longPressChangeEventListener,
-      state.pressTarget,
-      true,
     );
   }
 }
@@ -188,7 +184,7 @@ const PressResponder = {
             }
           };
         }
-        dispatchPressEvent(context, 'press', state, keyPressEventListener);
+        dispatchPressEvent(context, state, 'press', keyPressEventListener);
         break;
       }
       case 'touchstart':
@@ -233,7 +229,7 @@ const PressResponder = {
                 props.onPress &&
                 !(state.isLongPressed && props.longPressCancelsPress)
               ) {
-                dispatchPressEvent(context, 'press', state, props.onPress);
+                dispatchPressEvent(context, state, 'press', props.onPress);
               }
             }
           }
@@ -296,7 +292,7 @@ const PressResponder = {
                     state.defaultPrevented = true;
                   }
                 };
-                dispatchPressEvent(context, 'press', state, pressEventListener);
+                dispatchPressEvent(context, state, 'press', pressEventListener);
               }
             }
           }


### PR DESCRIPTION
Note: this is for an experimental event API that we're testing out internally at Facebook.

Fixes a regression in f4625f51823dd7faa02bba95ae731249ce07246c