### PR TITLE
Remove Flow types from Scheduler and Tracing

### DIFF
--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -11,7 +11,7 @@ import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {TimeoutHandle, NoTimeout} from './ReactFiberHostConfig';
 import type {Thenable} from './ReactFiberScheduler';
-import type {Interaction} from 'scheduler/src/Tracing';
+import type {Interaction} from 'scheduler/tracing';
 
 import {noTimeout} from './ReactFiberHostConfig';
 import {createHostRootFiber} from './ReactFiber';

--- a/packages/react-reconciler/src/ReactFiberScheduler.old.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.old.js
@@ -10,7 +10,7 @@
 import type {Fiber} from './ReactFiber';
 import type {Batch, FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
-import type {Interaction} from 'scheduler/src/Tracing';
+import type {Interaction} from 'scheduler/tracing';
 
 // Intentionally not named imports because Rollup would use dynamic dispatch for
 // CommonJS interop named imports.

--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -106,7 +106,7 @@ function flushFirstCallback() {
   // A callback may return a continuation. The continuation should be scheduled
   // with the same priority and expiration as the just-finished callback.
   if (typeof continuationCallback === 'function') {
-    var continuationNode: CallbackNode = {
+    var continuationNode = {
       callback: continuationCallback,
       priorityLevel,
       expirationTime,

--- a/packages/scheduler/src/SchedulerHostConfig.js
+++ b/packages/scheduler/src/SchedulerHostConfig.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  */
 
 throw new Error('This module must be shimmed by a specific build.');

--- a/packages/scheduler/src/Tracing.js
+++ b/packages/scheduler/src/Tracing.js
@@ -4,71 +4,24 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  */
 
 import {enableSchedulerTracing} from 'shared/ReactFeatureFlags';
 
-export type Interaction = {|
-  __count: number,
-  id: number,
-  name: string,
-  timestamp: number,
-|};
-
-export type Subscriber = {
-  // A new interaction has been created via the trace() method.
-  onInteractionTraced: (interaction: Interaction) => void,
-
-  // All scheduled async work for an interaction has finished.
-  onInteractionScheduledWorkCompleted: (interaction: Interaction) => void,
-
-  // New async work has been scheduled for a set of interactions.
-  // When this work is later run, onWorkStarted/onWorkStopped will be called.
-  // A batch of async/yieldy work may be scheduled multiple times before completing.
-  // In that case, onWorkScheduled may be called more than once before onWorkStopped.
-  // Work is scheduled by a "thread" which is identified by a unique ID.
-  onWorkScheduled: (interactions: Set<Interaction>, threadID: number) => void,
-
-  // A batch of scheduled work has been canceled.
-  // Work is done by a "thread" which is identified by a unique ID.
-  onWorkCanceled: (interactions: Set<Interaction>, threadID: number) => void,
-
-  // A batch of work has started for a set of interactions.
-  // When this work is complete, onWorkStopped will be called.
-  // Work is not always completed synchronously; yielding may occur in between.
-  // A batch of async/yieldy work may also be re-started before completing.
-  // In that case, onWorkStarted may be called more than once before onWorkStopped.
-  // Work is done by a "thread" which is identified by a unique ID.
-  onWorkStarted: (interactions: Set<Interaction>, threadID: number) => void,
-
-  // A batch of work has completed for a set of interactions.
-  // Work is done by a "thread" which is identified by a unique ID.
-  onWorkStopped: (interactions: Set<Interaction>, threadID: number) => void,
-};
-
-export type InteractionsRef = {
-  current: Set<Interaction>,
-};
-
-export type SubscriberRef = {
-  current: Subscriber | null,
-};
-
 const DEFAULT_THREAD_ID = 0;
 
 // Counters used to generate unique IDs.
-let interactionIDCounter: number = 0;
-let threadIDCounter: number = 0;
+let interactionIDCounter = 0;
+let threadIDCounter = 0;
 
 // Set of currently traced interactions.
 // Interactions "stack"–
 // Meaning that newly traced interactions are appended to the previously active set.
 // When an interaction goes out of scope, the previous set (if any) is restored.
-let interactionsRef: InteractionsRef = (null: any);
+let interactionsRef = null;
 
 // Listener(s) to notify when interactions begin and end.
-let subscriberRef: SubscriberRef = (null: any);
+let subscriberRef = null;
 
 if (enableSchedulerTracing) {
   interactionsRef = {
@@ -80,8 +33,7 @@ if (enableSchedulerTracing) {
 }
 
 export {interactionsRef as __interactionsRef, subscriberRef as __subscriberRef};
-
-export function unstable_clear(callback: Function): any {
+export function unstable_clear(callback) {
   if (!enableSchedulerTracing) {
     return callback();
   }
@@ -95,30 +47,27 @@ export function unstable_clear(callback: Function): any {
     interactionsRef.current = prevInteractions;
   }
 }
-
-export function unstable_getCurrent(): Set<Interaction> | null {
+export function unstable_getCurrent() {
   if (!enableSchedulerTracing) {
     return null;
   } else {
     return interactionsRef.current;
   }
 }
-
-export function unstable_getThreadID(): number {
+export function unstable_getThreadID() {
   return ++threadIDCounter;
 }
-
 export function unstable_trace(
-  name: string,
-  timestamp: number,
-  callback: Function,
-  threadID: number = DEFAULT_THREAD_ID,
-): any {
+  name,
+  timestamp,
+  callback,
+  threadID = DEFAULT_THREAD_ID,
+) {
   if (!enableSchedulerTracing) {
     return callback();
   }
 
-  const interaction: Interaction = {
+  const interaction = {
     __count: 1,
     id: interactionIDCounter++,
     name,
@@ -172,10 +121,7 @@ export function unstable_trace(
   return returnValue;
 }
 
-export function unstable_wrap(
-  callback: Function,
-  threadID: number = DEFAULT_THREAD_ID,
-): Function {
+export function unstable_wrap(callback, threadID = DEFAULT_THREAD_ID) {
   if (!enableSchedulerTracing) {
     return callback;
   }

--- a/packages/scheduler/src/TracingSubscriptions.js
+++ b/packages/scheduler/src/TracingSubscriptions.js
@@ -4,20 +4,18 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  */
 
-import type {Interaction, Subscriber} from './Tracing';
-
 import {enableSchedulerTracing} from 'shared/ReactFeatureFlags';
+
 import {__subscriberRef} from './Tracing';
 
-let subscribers: Set<Subscriber> = (null: any);
+let subscribers = null;
 if (enableSchedulerTracing) {
   subscribers = new Set();
 }
 
-export function unstable_subscribe(subscriber: Subscriber): void {
+export function unstable_subscribe(subscriber) {
   if (enableSchedulerTracing) {
     subscribers.add(subscriber);
 
@@ -33,8 +31,7 @@ export function unstable_subscribe(subscriber: Subscriber): void {
     }
   }
 }
-
-export function unstable_unsubscribe(subscriber: Subscriber): void {
+export function unstable_unsubscribe(subscriber) {
   if (enableSchedulerTracing) {
     subscribers.delete(subscriber);
 
@@ -44,7 +41,7 @@ export function unstable_unsubscribe(subscriber: Subscriber): void {
   }
 }
 
-function onInteractionTraced(interaction: Interaction): void {
+function onInteractionTraced(interaction) {
   let didCatchError = false;
   let caughtError = null;
 
@@ -64,10 +61,9 @@ function onInteractionTraced(interaction: Interaction): void {
   }
 }
 
-function onInteractionScheduledWorkCompleted(interaction: Interaction): void {
+function onInteractionScheduledWorkCompleted(interaction) {
   let didCatchError = false;
   let caughtError = null;
-
   subscribers.forEach(subscriber => {
     try {
       subscriber.onInteractionScheduledWorkCompleted(interaction);
@@ -84,13 +80,9 @@ function onInteractionScheduledWorkCompleted(interaction: Interaction): void {
   }
 }
 
-function onWorkScheduled(
-  interactions: Set<Interaction>,
-  threadID: number,
-): void {
+function onWorkScheduled(interactions, threadID) {
   let didCatchError = false;
   let caughtError = null;
-
   subscribers.forEach(subscriber => {
     try {
       subscriber.onWorkScheduled(interactions, threadID);
@@ -107,10 +99,9 @@ function onWorkScheduled(
   }
 }
 
-function onWorkStarted(interactions: Set<Interaction>, threadID: number): void {
+function onWorkStarted(interactions, threadID) {
   let didCatchError = false;
   let caughtError = null;
-
   subscribers.forEach(subscriber => {
     try {
       subscriber.onWorkStarted(interactions, threadID);
@@ -127,10 +118,9 @@ function onWorkStarted(interactions: Set<Interaction>, threadID: number): void {
   }
 }
 
-function onWorkStopped(interactions: Set<Interaction>, threadID: number): void {
+function onWorkStopped(interactions, threadID) {
   let didCatchError = false;
   let caughtError = null;
-
   subscribers.forEach(subscriber => {
     try {
       subscriber.onWorkStopped(interactions, threadID);
@@ -147,13 +137,9 @@ function onWorkStopped(interactions: Set<Interaction>, threadID: number): void {
   }
 }
 
-function onWorkCanceled(
-  interactions: Set<Interaction>,
-  threadID: number,
-): void {
+function onWorkCanceled(interactions, threadID) {
   let didCatchError = false;
   let caughtError = null;
-
   subscribers.forEach(subscriber => {
     try {
       subscriber.onWorkCanceled(interactions, threadID);

--- a/packages/scheduler/src/forks/SchedulerHostConfig.mock.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.mock.js
@@ -3,32 +3,27 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
-let currentTime: number = 0;
-let scheduledCallback: (boolean => void) | null = null;
-let scheduledCallbackExpiration: number = -1;
-let yieldedValues: Array<mixed> | null = null;
-let expectedNumberOfYields: number = -1;
-let didStop: boolean = false;
-let isFlushing: boolean = false;
+let currentTime = 0;
+let scheduledCallback = null;
+let scheduledCallbackExpiration = -1;
+let yieldedValues = null;
+let expectedNumberOfYields = -1;
+let didStop = false;
+let isFlushing = false;
 
-export function requestHostCallback(
-  callback: boolean => void,
-  expiration: number,
-) {
+export function requestHostCallback(callback, expiration) {
   scheduledCallback = callback;
   scheduledCallbackExpiration = expiration;
 }
 
-export function cancelHostCallback(): void {
+export function cancelHostCallback() {
   scheduledCallback = null;
   scheduledCallbackExpiration = -1;
 }
 
-export function shouldYieldToHost(): boolean {
+export function shouldYieldToHost() {
   if (
     (expectedNumberOfYields !== -1 &&
       yieldedValues !== null &&
@@ -43,7 +38,7 @@ export function shouldYieldToHost(): boolean {
   return false;
 }
 
-export function getCurrentTime(): number {
+export function getCurrentTime() {
   return currentTime;
 }
 
@@ -61,7 +56,7 @@ export function reset() {
 }
 
 // Should only be used via an assertion helper that inspects the yielded values.
-export function unstable_flushNumberOfYields(count: number): void {
+export function unstable_flushNumberOfYields(count) {
   if (isFlushing) {
     throw new Error('Already flushing work.');
   }
@@ -99,7 +94,7 @@ export function unstable_flushExpired() {
   }
 }
 
-export function unstable_flushWithoutYielding(): void {
+export function unstable_flushWithoutYielding() {
   if (isFlushing) {
     throw new Error('Already flushing work.');
   }
@@ -120,7 +115,7 @@ export function unstable_flushWithoutYielding(): void {
   }
 }
 
-export function unstable_clearYields(): Array<mixed> {
+export function unstable_clearYields() {
   if (yieldedValues === null) {
     return [];
   }
@@ -129,7 +124,7 @@ export function unstable_clearYields(): Array<mixed> {
   return values;
 }
 
-export function flushAll(): void {
+export function flushAll() {
   if (yieldedValues !== null) {
     throw new Error(
       'Log is not empty. Assert on the log of yielded values before ' +
@@ -146,7 +141,7 @@ export function flushAll(): void {
   }
 }
 
-export function yieldValue(value: mixed): void {
+export function yieldValue(value) {
   if (yieldedValues === null) {
     yieldedValues = [value];
   } else {
@@ -154,7 +149,7 @@ export function yieldValue(value: mixed): void {
   }
 }
 
-export function advanceTime(ms: number) {
+export function advanceTime(ms) {
   currentTime += ms;
   // If the host callback timed out, flush the expired work.
   if (

--- a/packages/scheduler/tracing.js
+++ b/packages/scheduler/tracing.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 'use strict';

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -41,3 +41,78 @@ declare module 'EventListener' {
     capture: (target: Element, type: string, callback: Function) => mixed,
   };
 }
+
+// Libdefs for Scheduler
+
+declare module 'scheduler/tracing' {
+  declare type Interaction = {|
+    __count: number,
+    id: number,
+    name: string,
+    timestamp: number,
+  |};
+
+  declare type Subscriber = {
+    // A new interaction has been created via the trace() method.
+    onInteractionTraced: (interaction: Interaction) => void,
+
+    // All scheduled async work for an interaction has finished.
+    onInteractionScheduledWorkCompleted: (interaction: Interaction) => void,
+
+    // New async work has been scheduled for a set of interactions.
+    // When this work is later run, onWorkStarted/onWorkStopped will be called.
+    // A batch of async/yieldy work may be scheduled multiple times before completing.
+    // In that case, onWorkScheduled may be called more than once before onWorkStopped.
+    // Work is scheduled by a "thread" which is identified by a unique ID.
+    onWorkScheduled: (interactions: Set<Interaction>, threadID: number) => void,
+
+    // A batch of scheduled work has been canceled.
+    // Work is done by a "thread" which is identified by a unique ID.
+    onWorkCanceled: (interactions: Set<Interaction>, threadID: number) => void,
+
+    // A batch of work has started for a set of interactions.
+    // When this work is complete, onWorkStopped will be called.
+    // Work is not always completed synchronously; yielding may occur in between.
+    // A batch of async/yieldy work may also be re-started before completing.
+    // In that case, onWorkStarted may be called more than once before onWorkStopped.
+    // Work is done by a "thread" which is identified by a unique ID.
+    onWorkStarted: (interactions: Set<Interaction>, threadID: number) => void,
+
+    // A batch of work has completed for a set of interactions.
+    // Work is done by a "thread" which is identified by a unique ID.
+    onWorkStopped: (interactions: Set<Interaction>, threadID: number) => void,
+  };
+
+  declare type InteractionsRef = {
+    current: Set<Interaction>,
+  };
+
+  declare type SubscriberRef = {
+    current: Subscriber | null,
+  };
+
+  declare var __interactionsRef: InteractionsRef;
+  declare var __subscriberRef: SubscriberRef;
+
+  declare function unstable_clear(callback: Function): any;
+
+  declare function unstable_getCurrent(): Set<Interaction> | null;
+
+  declare function unstable_getThreadID(): number;
+
+  declare function unstable_trace(
+    name: string,
+    timestamp: number,
+    callback: Function,
+    threadID: number,
+  ): any;
+
+  declare function unstable_wrap(
+    callback: Function,
+    threadID?: number,
+  ): Function;
+
+  declare function unstable_subscribe(subscriber: Subscriber): void;
+
+  declare function unstable_unsubscribe(subscriber: Subscriber): void;
+}


### PR DESCRIPTION
The idea is to make the scheduler as unopinionated and uncontroversial as possible.

Currently it's a bit of a mix and match and also use our build tooling. This keeps spreading.

Let's make a decision here either way and stick to it.

