### PR TITLE
Fix host context issues around EventComponents and EventTargets

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2112,8 +2112,15 @@ function beginWork(
             // been unsuspended it has committed as a regular Suspense component.
             // If it needs to be retried, it should have work scheduled on it.
             workInProgress.effectTag |= DidCapture;
-            break;
           }
+          break;
+        }
+        case EventComponent:
+        case EventTarget: {
+          if (enableEventAPI) {
+            pushHostContextForEvent(workInProgress);
+          }
+          break;
         }
       }
       return bailoutOnAlreadyFinishedWork(

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -27,6 +27,8 @@ import {
   SuspenseComponent,
   DehydratedSuspenseComponent,
   IncompleteClassComponent,
+  EventComponent,
+  EventTarget,
 } from 'shared/ReactWorkTags';
 import {
   DidCapture,
@@ -38,6 +40,7 @@ import {
 import {
   enableSchedulerTracing,
   enableSuspenseServerRenderer,
+  enableEventAPI,
 } from 'shared/ReactFeatureFlags';
 import {ConcurrentMode} from './ReactTypeOfMode';
 import {shouldCaptureSuspense} from './ReactFiberSuspenseComponent';
@@ -509,6 +512,12 @@ function unwindWork(
       return null;
     case ContextProvider:
       popProvider(workInProgress);
+      return null;
+    case EventComponent:
+    case EventTarget:
+      if (enableEventAPI) {
+        popHostContext(workInProgress);
+      }
       return null;
     default:
       return null;

--- a/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
@@ -310,7 +310,7 @@ describe('ReactFiberEvents', () => {
       );
     });
 
-    it('should handle errors in re-renders where there is a bail-out in a parent', () => {
+    it('should handle re-renders where there is a bail-out in a parent and an error occurs', () => {
       let _updateCounter;
 
       function Child() {
@@ -352,6 +352,55 @@ describe('ReactFiberEvents', () => {
         expect(Scheduler).toFlushWithoutYielding();
       }).toWarnDev(
         'Warning: <TouchHitTarget> must have a single DOM element as a child. Found no children.',
+      );
+    });
+
+    it('should handle re-renders where there is a bail-out in a parent and an error occurs #2', () => {
+      let _updateCounter;
+
+      function Child() {
+        const [counter, updateCounter] = React.useState(0);
+
+        _updateCounter = updateCounter;
+
+        if (counter === 1) {
+          return (
+            <EventComponent>
+              <div>Child</div>
+            </EventComponent>
+          );
+        }
+
+        return (
+          <div>
+            <span>Child - {counter}</span>
+          </div>
+        );
+      }
+
+      const Parent = () => (
+        <EventComponent>
+          <EventTarget>
+            <Child />
+          </EventTarget>
+        </EventComponent>
+      );
+
+      ReactNoop.render(<Parent />);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(ReactNoop).toMatchRenderedOutput(
+        <div>
+          <span>Child - 0</span>
+        </div>,
+      );
+
+      expect(() => {
+        ReactNoop.act(() => {
+          _updateCounter(counter => counter + 1);
+        });
+        expect(Scheduler).toFlushWithoutYielding();
+      }).toWarnDev(
+        'Warning: validateDOMNesting: React event targets must not have event components as children.',
       );
     });
   });
@@ -632,7 +681,7 @@ describe('ReactFiberEvents', () => {
       );
     });
 
-    it('should handle errors in re-renders where there is a bail-out in a parent', () => {
+    it('should handle re-renders where there is a bail-out in a parent and an error occurs', () => {
       let _updateCounter;
 
       function Child() {
@@ -674,6 +723,56 @@ describe('ReactFiberEvents', () => {
         });
       }).toWarnDev(
         'Warning: <TouchHitTarget> must have a single DOM element as a child. Found no children.',
+      );
+    });
+
+    it('should handle re-renders where there is a bail-out in a parent and an error occurs #2', () => {
+      let _updateCounter;
+
+      function Child() {
+        const [counter, updateCounter] = React.useState(0);
+
+        _updateCounter = updateCounter;
+
+        if (counter === 1) {
+          return (
+            <EventComponent>
+              <div>Child</div>
+            </EventComponent>
+          );
+        }
+
+        return (
+          <div>
+            <span>Child - {counter}</span>
+          </div>
+        );
+      }
+
+      const Parent = () => (
+        <EventComponent>
+          <EventTarget>
+            <Child />
+          </EventTarget>
+        </EventComponent>
+      );
+
+      const root = ReactTestRenderer.create(null);
+      root.update(<Parent />);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput(
+        <div>
+          <span>Child - 0</span>
+        </div>,
+      );
+
+      expect(() => {
+        ReactTestRenderer.act(() => {
+          _updateCounter(counter => counter + 1);
+        });
+        expect(Scheduler).toFlushWithoutYielding();
+      }).toWarnDev(
+        'Warning: validateDOMNesting: React event targets must not have event components as children.',
       );
     });
   });
@@ -944,7 +1043,7 @@ describe('ReactFiberEvents', () => {
       );
     });
 
-    it('should handle errors in re-renders where there is a bail-out in a parent', () => {
+    it('should handle re-renders where there is a bail-out in a parent and an error occurs', () => {
       let _updateCounter;
 
       function Child() {
@@ -982,6 +1081,51 @@ describe('ReactFiberEvents', () => {
         expect(Scheduler).toFlushWithoutYielding();
       }).toWarnDev(
         'Warning: <TouchHitTarget> must have a single DOM element as a child. Found no children.',
+      );
+    });
+
+    it('should handle re-renders where there is a bail-out in a parent and an error occurs #2', () => {
+      let _updateCounter;
+
+      function Child() {
+        const [counter, updateCounter] = React.useState(0);
+
+        _updateCounter = updateCounter;
+
+        if (counter === 1) {
+          return (
+            <EventComponent>
+              <div>Child</div>
+            </EventComponent>
+          );
+        }
+
+        return (
+          <div>
+            <span>Child - {counter}</span>
+          </div>
+        );
+      }
+
+      const Parent = () => (
+        <EventComponent>
+          <EventTarget>
+            <Child />
+          </EventTarget>
+        </EventComponent>
+      );
+
+      const container = document.createElement('div');
+      ReactDOM.render(<Parent />, container);
+      expect(container.innerHTML).toBe('<div><span>Child - 0</span></div>');
+
+      expect(() => {
+        ReactTestUtils.act(() => {
+          _updateCounter(counter => counter + 1);
+        });
+        expect(Scheduler).toFlushWithoutYielding();
+      }).toWarnDev(
+        'Warning: validateDOMNesting: React event targets must not have event components as children.',
       );
     });
   });

--- a/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
@@ -200,6 +200,45 @@ describe('ReactFiberEvents', () => {
         'Warning: validateDOMNesting: React event targets must be direct children of event components.',
       );
     });
+
+    it('event components should correctly work with error boundaries', () => {
+      function ErrorComponent() {
+        throw new Error('Failed!');
+      }
+
+      const Test = () => (
+        <EventComponent>
+          <EventTarget>
+            <span>
+              <ErrorComponent />
+            </span>
+          </EventTarget>
+        </EventComponent>
+      );
+
+      class Wrapper extends React.Component {
+        state = {
+          error: null,
+        };
+
+        componentDidCatch(error) {
+          this.setState({
+            error,
+          });
+        }
+
+        render() {
+          if (this.state.error) {
+            return 'Worked!';
+          }
+          return <Test />;
+        }
+      }
+
+      ReactNoop.render(<Wrapper />);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(ReactNoop).toMatchRenderedOutput('Worked!');
+    });
   });
 
   describe('TestRenderer', () => {
@@ -368,6 +407,46 @@ describe('ReactFiberEvents', () => {
         'Warning: validateDOMNesting: React event targets must be direct children of event components.',
       );
     });
+
+    it('event components should correctly work with error boundaries', () => {
+      function ErrorComponent() {
+        throw new Error('Failed!');
+      }
+
+      const Test = () => (
+        <EventComponent>
+          <EventTarget>
+            <span>
+              <ErrorComponent />
+            </span>
+          </EventTarget>
+        </EventComponent>
+      );
+
+      class Wrapper extends React.Component {
+        state = {
+          error: null,
+        };
+
+        componentDidCatch(error) {
+          this.setState({
+            error,
+          });
+        }
+
+        render() {
+          if (this.state.error) {
+            return 'Worked!';
+          }
+          return <Test />;
+        }
+      }
+
+      const root = ReactTestRenderer.create(null);
+      root.update(<Wrapper />);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput('Worked!');
+    });
   });
 
   describe('ReactDOM', () => {
@@ -534,6 +613,46 @@ describe('ReactFiberEvents', () => {
       }).toWarnDev(
         'Warning: validateDOMNesting: React event targets must be direct children of event components.',
       );
+    });
+
+    it('event components should correctly work with error boundaries', () => {
+      function ErrorComponent() {
+        throw new Error('Failed!');
+      }
+
+      const Test = () => (
+        <EventComponent>
+          <EventTarget>
+            <span>
+              <ErrorComponent />
+            </span>
+          </EventTarget>
+        </EventComponent>
+      );
+
+      class Wrapper extends React.Component {
+        state = {
+          error: null,
+        };
+
+        componentDidCatch(error) {
+          this.setState({
+            error,
+          });
+        }
+
+        render() {
+          if (this.state.error) {
+            return 'Worked!';
+          }
+          return <Test />;
+        }
+      }
+
+      const container = document.createElement('div');
+      ReactDOM.render(<Wrapper />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe('Worked!');
     });
   });
 


### PR DESCRIPTION
This PR adds more support for host context with EventComponent and EventTarget fiber work types along with tests that validate this works during the unwind phase (for example, when an error occurs). This also adds support for pushing event host context in begin phase.