### PR TITLE
Add Press event prop types and fix a check in Safari

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -10,6 +10,11 @@
 import type {EventResponderContext} from 'events/EventTypes';
 import {REACT_EVENT_COMPONENT_TYPE} from 'shared/ReactSymbols';
 
+const DEFAULT_PRESS_DELAY_MS = 0;
+const DEFAULT_PRESS_END_DELAY_MS = 0;
+const DEFAULT_PRESS_START_DELAY_MS = 0;
+const DEFAULT_LONG_PRESS_DELAY_MS = 1000;
+
 const targetEventTypes = [
   {name: 'click', passive: false},
   {name: 'keydown', passive: false},
@@ -81,7 +86,7 @@ function dispatchPressStartEvents(
     dispatchPressChangeEvent(true);
   }
   if ((props.onLongPress || props.onLongPressChange) && !state.isLongPressed) {
-    const delayLongPress = calculateDelayMS(props.delayLongPress, 0, 1000);
+    const delayLongPress = calculateDelayMS(props.delayLongPress, 0, DEFAULT_LONG_PRESS_DELAY_MS);
 
     state.longPressTimeout = setTimeout(() => {
       state.isLongPressed = true;

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -164,6 +164,11 @@ function isAnchorTagElement(eventTarget: EventTarget): boolean {
   return (eventTarget: any).nodeName === 'A';
 }
 
+function isValidKeyPress(key: string): boolean {
+  // Accessibility for keyboards. Space and Enter only.
+  return key === ' ' || key === 'Enter';
+}
+
 function calculateDelayMS(delay: ?number, min = 0, fallback = 0) {
   const maybeNumber = delay == null ? null : delay;
   return Math.max(min, maybeNumber != null ? maybeNumber : fallback);
@@ -191,15 +196,11 @@ const PressResponder = {
 
     switch (eventType) {
       case 'keydown': {
-        if (!props.onPress || context.isTargetOwned(eventTarget)) {
-          return;
-        }
-        const isValidKeyPress =
-          (event: any).which === 13 ||
-          (event: any).which === 32 ||
-          (event: any).keyCode === 13;
-
-        if (!isValidKeyPress) {
+        if (
+          !props.onPress ||
+          context.isTargetOwned(eventTarget) ||
+          !isValidKeyPress((event: any).key)
+        ) {
           return;
         }
         let keyPressEventListener = props.onPress;

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -26,6 +26,23 @@ if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
   rootEventTypes.push({name: 'mouseup', passive: false});
 }
 
+type PressProps = {
+  disabled: boolean,
+  delayLongPress: number,
+  delayPress: number,
+  delayPressEnd: number,
+  delayPressStart: number,
+  hitSlop: Object,
+  onLongPress: (e: Object) => void,
+  onLongPressChange: (boolean) => void,
+  onLongPressShouldCancelPress: () => boolean,
+  onPress: (e: Object) => void,
+  onPressChange: (boolean) => void,
+  onPressEnd: (e: Object) => void,
+  onPressStart: (e: Object) => void,
+  pressRententionOffset: Object,
+};
+
 type PressState = {
   defaultPrevented: boolean,
   isAnchorTouched: boolean,
@@ -47,7 +64,7 @@ function dispatchPressEvent(
 
 function dispatchPressStartEvents(
   context: EventResponderContext,
-  props: Object,
+  props: PressProps,
   state: PressState,
 ): void {
   function dispatchPressChangeEvent(bool) {
@@ -105,7 +122,7 @@ function dispatchPressStartEvents(
 
 function dispatchPressEndEvents(
   context: EventResponderContext,
-  props: Object,
+  props: PressProps,
   state: PressState,
 ): void {
   if (state.longPressTimeout !== null) {
@@ -158,7 +175,7 @@ const PressResponder = {
   },
   handleEvent(
     context: EventResponderContext,
-    props: Object,
+    props: PressProps,
     state: PressState,
   ): void {
     const {eventTarget, eventType, event} = context;

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -218,8 +218,12 @@ const PressResponder = {
         dispatchPressEvent(context, state, 'press', keyPressEventListener);
         break;
       }
+
+      /**
+       * Touch event implementations are only needed for Safari, which lacks
+       * support for pointer events.
+       */
       case 'touchstart':
-        // Touch events are for Safari, which lack pointer event support.
         if (!state.isPressed && !context.isTargetOwned(eventTarget)) {
           // We bail out of polyfilling anchor tags, given the same heuristics
           // explained above in regards to needing to use click events.
@@ -235,7 +239,6 @@ const PressResponder = {
 
         break;
       case 'touchend': {
-        // Touch events are for Safari, which lack pointer event support
         if (state.isAnchorTouched) {
           return;
         }
@@ -275,6 +278,10 @@ const PressResponder = {
         }
         break;
       }
+
+      /**
+       * Respond to pointer events and fall back to mouse.
+       */
       case 'pointerdown':
       case 'mousedown': {
         if (
@@ -282,7 +289,7 @@ const PressResponder = {
           !context.isTargetOwned(eventTarget) &&
           !state.shouldSkipMouseAfterTouch
         ) {
-          if ((event: any).pointerType === 'mouse') {
+          if ((event: any).pointerType === 'mouse' || eventType === 'mousedown') {
             // Ignore if we are pressing on hit slop area with mouse
             if (
               context.isPositionWithinTouchHitTarget(
@@ -304,8 +311,8 @@ const PressResponder = {
         }
         break;
       }
-      case 'mouseup':
-      case 'pointerup': {
+      case 'pointerup':
+      case 'mouseup': {
         if (state.isPressed) {
           if (state.shouldSkipMouseAfterTouch) {
             state.shouldSkipMouseAfterTouch = false;
@@ -342,6 +349,7 @@ const PressResponder = {
         state.isAnchorTouched = false;
         break;
       }
+
       case 'scroll':
       case 'touchcancel':
       case 'contextmenu':

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -34,10 +34,8 @@ if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
 type PressProps = {
   disabled: boolean,
   delayLongPress: number,
-  delayPress: number,
   delayPressEnd: number,
   delayPressStart: number,
-  hitSlop: Object,
   onLongPress: (e: Object) => void,
   onLongPressChange: boolean => void,
   onLongPressShouldCancelPress: () => boolean,

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -10,9 +10,9 @@
 import type {EventResponderContext} from 'events/EventTypes';
 import {REACT_EVENT_COMPONENT_TYPE} from 'shared/ReactSymbols';
 
-const DEFAULT_PRESS_DELAY_MS = 0;
-const DEFAULT_PRESS_END_DELAY_MS = 0;
-const DEFAULT_PRESS_START_DELAY_MS = 0;
+// const DEFAULT_PRESS_DELAY_MS = 0;
+// const DEFAULT_PRESS_END_DELAY_MS = 0;
+// const DEFAULT_PRESS_START_DELAY_MS = 0;
 const DEFAULT_LONG_PRESS_DELAY_MS = 1000;
 
 const targetEventTypes = [
@@ -39,10 +39,10 @@ type PressProps = {
   delayPressStart: number,
   hitSlop: Object,
   onLongPress: (e: Object) => void,
-  onLongPressChange: (boolean) => void,
+  onLongPressChange: boolean => void,
   onLongPressShouldCancelPress: () => boolean,
   onPress: (e: Object) => void,
-  onPressChange: (boolean) => void,
+  onPressChange: boolean => void,
   onPressEnd: (e: Object) => void,
   onPressStart: (e: Object) => void,
   pressRententionOffset: Object,
@@ -86,7 +86,11 @@ function dispatchPressStartEvents(
     dispatchPressChangeEvent(true);
   }
   if ((props.onLongPress || props.onLongPressChange) && !state.isLongPressed) {
-    const delayLongPress = calculateDelayMS(props.delayLongPress, 0, DEFAULT_LONG_PRESS_DELAY_MS);
+    const delayLongPress = calculateDelayMS(
+      props.delayLongPress,
+      0,
+      DEFAULT_LONG_PRESS_DELAY_MS,
+    );
 
     state.longPressTimeout = setTimeout(() => {
       state.isLongPressed = true;
@@ -289,7 +293,10 @@ const PressResponder = {
           !context.isTargetOwned(eventTarget) &&
           !state.shouldSkipMouseAfterTouch
         ) {
-          if ((event: any).pointerType === 'mouse' || eventType === 'mousedown') {
+          if (
+            (event: any).pointerType === 'mouse' ||
+            eventType === 'mousedown'
+          ) {
             // Ignore if we are pressing on hit slop area with mouse
             if (
               context.isPositionWithinTouchHitTarget(

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -83,8 +83,7 @@ describe('Press event responder', () => {
 
     events = [];
     const keyDownEvent = new KeyboardEvent('keydown', {
-      which: 13,
-      keyCode: 13,
+      key: 'Enter',
       bubbles: true,
       cancelable: true,
     });


### PR DESCRIPTION
* Adds Press prop types
* Creates constants for default delay ms
* Fixes a mouse pointer check for Safari (no pointer events)