### PR TITLE
Add tests for Press responder event module

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -86,21 +86,13 @@ function dispatchPressStartEvents(
   if ((props.onLongPress || props.onLongPressChange) && !state.isLongPressed) {
     const delayLongPress = calculateDelayMS(
       props.delayLongPress,
-      0,
+      10,
       DEFAULT_LONG_PRESS_DELAY_MS,
     );
 
     state.longPressTimeout = setTimeout(() => {
       state.isLongPressed = true;
       state.longPressTimeout = null;
-
-      if (
-        props.onPressChange &&
-        props.onLongPressShouldCancelPress &&
-        props.onLongPressShouldCancelPress()
-      ) {
-        dispatchPressChangeEvent(false);
-      }
 
       if (props.onLongPress) {
         const longPressEventListener = e => {


### PR DESCRIPTION
Add tests for every implemented prop and feature of the Press responder event module.

Patches the Press module to fix two failing tests: default `delayLongPress` cannot be shorter than 10ms; `onPressChange` timing should not change if `onPress` is cancelled by `onLongPressShouldCancelPress`.

NOTE: The default longPress delay should be `500` to match Android and React Native - https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/ViewConfiguration.java#66. This will be fixed once https://github.com/facebook/react/pull/15288 is merged