### PR TITLE
Refactor event object creation for the experimental event API

### DIFF
--- a/packages/events/EventTypes.js
+++ b/packages/events/EventTypes.js
@@ -10,12 +10,6 @@
 import type {AnyNativeEvent} from 'events/PluginModuleType';
 import type {ReactEventResponderEventType} from 'shared/ReactTypes';
 
-type ParitalEventObject = {
-  listener: ($Shape<ParitalEventObject>) => void,
-  target: Element | Document,
-  type: string,
-};
-
 export type EventResponderContext = {
   event: AnyNativeEvent,
   eventTarget: Element | Document,

--- a/packages/events/EventTypes.js
+++ b/packages/events/EventTypes.js
@@ -24,8 +24,11 @@ export type EventResponderContext = {
   isPassiveSupported: () => boolean,
   dispatchEvent: <E>(
     eventObject: E,
-    discrete: boolean,
-    capture: boolean,
+    {
+      capture?: boolean,
+      discrete?: boolean,
+      stopPropagation?: boolean,
+    },
   ) => void,
   isTargetWithinElement: (
     childTarget: Element | Document,

--- a/packages/events/EventTypes.js
+++ b/packages/events/EventTypes.js
@@ -7,29 +7,32 @@
  * @flow
  */
 
-import SyntheticEvent from 'events/SyntheticEvent';
 import type {AnyNativeEvent} from 'events/PluginModuleType';
 import type {ReactEventResponderEventType} from 'shared/ReactTypes';
 
+type ParitalEventObject = {
+  listener: ($Shape<ParitalEventObject>) => void,
+  target: Element | Document,
+  type: string,
+};
+
 export type EventResponderContext = {
   event: AnyNativeEvent,
-  eventTarget: EventTarget,
+  eventTarget: Element | Document,
   eventType: string,
   isPassive: () => boolean,
   isPassiveSupported: () => boolean,
-  dispatchEvent: (
-    name: string,
-    listener: (e: SyntheticEvent) => void | null,
-    pressTarget: EventTarget | null,
+  dispatchEvent: <E>(
+    eventObject: E,
     discrete: boolean,
-    extraProperties?: Object,
+    capture: boolean,
   ) => void,
   isTargetWithinElement: (
-    childTarget: EventTarget,
-    parentTarget: EventTarget,
+    childTarget: Element | Document,
+    parentTarget: Element | Document,
   ) => boolean,
-  isTargetOwned: EventTarget => boolean,
-  isTargetWithinEventComponent: EventTarget => boolean,
+  isTargetOwned: (Element | Document) => boolean,
+  isTargetWithinEventComponent: (Element | Document) => boolean,
   isPositionWithinTouchHitTarget: (x: number, y: number) => boolean,
   addRootEventTypes: (
     rootEventTypes: Array<ReactEventResponderEventType>,
@@ -37,6 +40,6 @@ export type EventResponderContext = {
   removeRootEventTypes: (
     rootEventTypes: Array<ReactEventResponderEventType>,
   ) => void,
-  requestOwnership: (target: EventTarget | null) => boolean,
-  releaseOwnership: (target: EventTarget | null) => boolean,
+  requestOwnership: (target: Element | Document | null) => boolean,
+  releaseOwnership: (target: Element | Document | null) => boolean,
 };

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -47,16 +47,16 @@ const targetEventTypeCached: Map<
 const targetOwnership: Map<EventTarget, Fiber> = new Map();
 const eventsWithStopPropagation:
   | WeakSet
-  | Set<$Shape<ParitalEventObject>> = new PossiblyWeakSet();
+  | Set<$Shape<PartialEventObject>> = new PossiblyWeakSet();
 
-type ParitalEventObject = {
-  listener: ($Shape<ParitalEventObject>) => void,
+type PartialEventObject = {
+  listener: ($Shape<PartialEventObject>) => void,
   target: Element | Document,
   type: string,
 };
 type EventQueue = {
-  bubble: null | Array<$Shape<ParitalEventObject>>,
-  capture: null | Array<$Shape<ParitalEventObject>>,
+  bubble: null | Array<$Shape<PartialEventObject>>,
+  capture: null | Array<$Shape<PartialEventObject>>,
   discrete: boolean,
   phase: EventQueuePhase,
 };
@@ -74,15 +74,15 @@ function createEventQueue(phase: EventQueuePhase): EventQueue {
   };
 }
 
-function processEvent(event: $Shape<ParitalEventObject>): void {
+function processEvent(event: $Shape<PartialEventObject>): void {
   const type = event.type;
   const listener = event.listener;
   invokeGuardedCallbackAndCatchFirstError(type, listener, undefined, event);
 }
 
 function processEvents(
-  bubble: null | Array<$Shape<ParitalEventObject>>,
-  capture: null | Array<$Shape<ParitalEventObject>>,
+  bubble: null | Array<$Shape<PartialEventObject>>,
+  capture: null | Array<$Shape<PartialEventObject>>,
 ): void {
   let i, length;
 
@@ -181,7 +181,7 @@ DOMEventResponderContext.prototype.dispatchEvent = function(
       );
     };
   }
-  const eventObject = ((possibleEventObject: any): $Shape<ParitalEventObject>);
+  const eventObject = ((possibleEventObject: any): $Shape<PartialEventObject>);
   let events;
 
   if (capture) {

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -228,12 +228,12 @@ describe('DOMEventResponderSystem', () => {
       ['click'],
       (context, props) => {
         if (props.onMagicClick) {
-          context.dispatchEvent(
-            'magicclick',
-            props.onMagicClick,
-            context.eventTarget,
-            false,
-          );
+          const event = {
+            listener: props.onMagicClick,
+            target: context.eventTarget,
+            type: 'magicclick',
+          };
+          context.dispatchEvent(event, true, false);
         }
       },
     );

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -233,7 +233,7 @@ describe('DOMEventResponderSystem', () => {
             target: context.eventTarget,
             type: 'magicclick',
           };
-          context.dispatchEvent(event, true, false);
+          context.dispatchEvent(event, {discrete: true});
         }
       },
     );

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -14,7 +14,7 @@ const targetEventTypes = ['pointerdown', 'pointercancel'];
 const rootEventTypes = ['pointerup', {name: 'pointermove', passive: false}];
 
 type DragState = {
-  dragTarget: null | EventTarget,
+  dragTarget: null | Element | Document,
   isPointerDown: boolean,
   isDragging: boolean,
   startX: number,
@@ -33,18 +33,45 @@ if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
   });
 }
 
+type EventData = {
+  diffX: number,
+  diffY: number,
+};
+type DragEventType = 'dragend' | 'dragchange' | 'dragmove';
+
+type DragEvent = {|
+  listener: DragEvent => void,
+  target: Element | Document,
+  type: DragEventType,
+  diffX?: number,
+  diffY?: number,
+|};
+
+function createDragEvent(
+  type: DragEventType,
+  target: Element | Document,
+  listener: DragEvent => void,
+  eventData?: EventData,
+): DragEvent {
+  return {
+    listener,
+    target,
+    type,
+    ...eventData,
+  };
+}
+
 function dispatchDragEvent(
   context: EventResponderContext,
-  name: string,
-  listener: (e: Object) => void,
+  name: DragEventType,
+  listener: DragEvent => void,
   state: DragState,
   discrete: boolean,
-  eventData?: {
-    diffX: number,
-    diffY: number,
-  },
+  eventData?: EventData,
 ): void {
-  context.dispatchEvent(name, listener, state.dragTarget, discrete, eventData);
+  const target = ((state.dragTarget: any): Element | Document);
+  const syntheticEvent = createDragEvent(name, target, listener, eventData);
+  context.dispatchEvent(syntheticEvent, discrete, false);
 }
 
 const DragResponder = {
@@ -112,10 +139,11 @@ const DragResponder = {
                 const dragChangeEventListener = () => {
                   props.onDragChange(true);
                 };
-                context.dispatchEvent(
+                dispatchDragEvent(
+                  context,
                   'dragchange',
                   dragChangeEventListener,
-                  state.dragTarget,
+                  state,
                   true,
                 );
               }
@@ -160,10 +188,11 @@ const DragResponder = {
             const dragChangeEventListener = () => {
               props.onDragChange(false);
             };
-            context.dispatchEvent(
+            dispatchDragEvent(
+              context,
               'dragchange',
               dragChangeEventListener,
-              state.dragTarget,
+              state,
               true,
             );
           }

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -71,7 +71,7 @@ function dispatchDragEvent(
 ): void {
   const target = ((state.dragTarget: any): Element | Document);
   const syntheticEvent = createDragEvent(name, target, listener, eventData);
-  context.dispatchEvent(syntheticEvent, discrete, false);
+  context.dispatchEvent(syntheticEvent, {discrete});
 }
 
 const DragResponder = {

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -50,7 +50,7 @@ function dispatchFocusInEvents(context: EventResponderContext, props: Object) {
       eventTarget,
       props.onFocus,
     );
-    context.dispatchEvent(syntheticEvent, true, false);
+    context.dispatchEvent(syntheticEvent, {discrete: true});
   }
   if (props.onFocusChange) {
     const focusChangeEventListener = () => {
@@ -61,7 +61,7 @@ function dispatchFocusInEvents(context: EventResponderContext, props: Object) {
       eventTarget,
       focusChangeEventListener,
     );
-    context.dispatchEvent(syntheticEvent, true, false);
+    context.dispatchEvent(syntheticEvent, {discrete: true});
   }
 }
 
@@ -72,7 +72,7 @@ function dispatchFocusOutEvents(context: EventResponderContext, props: Object) {
   }
   if (props.onBlur) {
     const syntheticEvent = createFocusEvent('blur', eventTarget, props.onBlur);
-    context.dispatchEvent(syntheticEvent, true, false);
+    context.dispatchEvent(syntheticEvent, {discrete: true});
   }
   if (props.onFocusChange) {
     const focusChangeEventListener = () => {
@@ -83,7 +83,7 @@ function dispatchFocusOutEvents(context: EventResponderContext, props: Object) {
       eventTarget,
       focusChangeEventListener,
     );
-    context.dispatchEvent(syntheticEvent, true, false);
+    context.dispatchEvent(syntheticEvent, {discrete: true});
   }
 }
 

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -19,24 +19,49 @@ type FocusState = {
   isFocused: boolean,
 };
 
+type FocusEventType = 'focus' | 'blur' | 'focuschange';
+
+type FocusEvent = {|
+  listener: FocusEvent => void,
+  target: Element | Document,
+  type: FocusEventType,
+|};
+
+function createFocusEvent(
+  type: FocusEventType,
+  target: Element | Document,
+  listener: FocusEvent => void,
+): FocusEvent {
+  return {
+    listener,
+    target,
+    type,
+  };
+}
+
 function dispatchFocusInEvents(context: EventResponderContext, props: Object) {
   const {event, eventTarget} = context;
   if (context.isTargetWithinEventComponent((event: any).relatedTarget)) {
     return;
   }
   if (props.onFocus) {
-    context.dispatchEvent('focus', props.onFocus, eventTarget, true);
+    const syntheticEvent = createFocusEvent(
+      'focus',
+      eventTarget,
+      props.onFocus,
+    );
+    context.dispatchEvent(syntheticEvent, true, false);
   }
   if (props.onFocusChange) {
     const focusChangeEventListener = () => {
       props.onFocusChange(true);
     };
-    context.dispatchEvent(
+    const syntheticEvent = createFocusEvent(
       'focuschange',
-      focusChangeEventListener,
       eventTarget,
-      true,
+      focusChangeEventListener,
     );
+    context.dispatchEvent(syntheticEvent, true, false);
   }
 }
 
@@ -46,18 +71,19 @@ function dispatchFocusOutEvents(context: EventResponderContext, props: Object) {
     return;
   }
   if (props.onBlur) {
-    context.dispatchEvent('blur', props.onBlur, eventTarget, true);
+    const syntheticEvent = createFocusEvent('blur', eventTarget, props.onBlur);
+    context.dispatchEvent(syntheticEvent, true, false);
   }
   if (props.onFocusChange) {
     const focusChangeEventListener = () => {
       props.onFocusChange(false);
     };
-    context.dispatchEvent(
+    const syntheticEvent = createFocusEvent(
       'focuschange',
-      focusChangeEventListener,
       eventTarget,
-      true,
+      focusChangeEventListener,
     );
+    context.dispatchEvent(syntheticEvent, true, false);
   }
 }
 

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -23,7 +23,7 @@ type HoverState = {
   isTouched: boolean,
 };
 
-type HoverEventType = 'hover' | 'hoverstart' | 'hoverend' | 'hoverchange';
+type HoverEventType = 'hoverstart' | 'hoverend' | 'hoverchange';
 
 type HoverEvent = {|
   listener: HoverEvent => void,

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -23,6 +23,26 @@ type HoverState = {
   isTouched: boolean,
 };
 
+type HoverEventType = 'hover' | 'hoverstart' | 'hoverend' | 'hoverchange';
+
+type HoverEvent = {|
+  listener: HoverEvent => void,
+  target: Element | Document,
+  type: HoverEventType,
+|};
+
+function createHoverEvent(
+  type: HoverEventType,
+  target: Element | Document,
+  listener: HoverEvent => void,
+): HoverEvent {
+  return {
+    listener,
+    target,
+    type,
+  };
+}
+
 // In the case we don't have PointerEvents (Safari), we listen to touch events
 // too
 if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
@@ -39,18 +59,23 @@ function dispatchHoverStartEvents(
     return;
   }
   if (props.onHoverStart) {
-    context.dispatchEvent('hoverstart', props.onHoverStart, eventTarget, true);
+    const syntheticEvent = createHoverEvent(
+      'hoverstart',
+      eventTarget,
+      props.onHoverStart,
+    );
+    context.dispatchEvent(syntheticEvent, true, false);
   }
   if (props.onHoverChange) {
     const hoverChangeEventListener = () => {
       props.onHoverChange(true);
     };
-    context.dispatchEvent(
+    const syntheticEvent = createHoverEvent(
       'hoverchange',
-      hoverChangeEventListener,
       eventTarget,
-      true,
+      hoverChangeEventListener,
     );
+    context.dispatchEvent(syntheticEvent, true, false);
   }
 }
 
@@ -60,18 +85,23 @@ function dispatchHoverEndEvents(context: EventResponderContext, props: Object) {
     return;
   }
   if (props.onHoverEnd) {
-    context.dispatchEvent('hoverend', props.onHoverEnd, eventTarget, true);
+    const syntheticEvent = createHoverEvent(
+      'hoverend',
+      eventTarget,
+      props.onHoverEnd,
+    );
+    context.dispatchEvent(syntheticEvent, true, false);
   }
   if (props.onHoverChange) {
     const hoverChangeEventListener = () => {
       props.onHoverChange(false);
     };
-    context.dispatchEvent(
+    const syntheticEvent = createHoverEvent(
       'hoverchange',
-      hoverChangeEventListener,
       eventTarget,
-      true,
+      hoverChangeEventListener,
     );
+    context.dispatchEvent(syntheticEvent, true, false);
   }
 }
 

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -64,7 +64,7 @@ function dispatchHoverStartEvents(
       eventTarget,
       props.onHoverStart,
     );
-    context.dispatchEvent(syntheticEvent, true, false);
+    context.dispatchEvent(syntheticEvent, {discrete: true});
   }
   if (props.onHoverChange) {
     const hoverChangeEventListener = () => {
@@ -75,7 +75,7 @@ function dispatchHoverStartEvents(
       eventTarget,
       hoverChangeEventListener,
     );
-    context.dispatchEvent(syntheticEvent, true, false);
+    context.dispatchEvent(syntheticEvent, {discrete: true});
   }
 }
 
@@ -90,7 +90,7 @@ function dispatchHoverEndEvents(context: EventResponderContext, props: Object) {
       eventTarget,
       props.onHoverEnd,
     );
-    context.dispatchEvent(syntheticEvent, true, false);
+    context.dispatchEvent(syntheticEvent, {discrete: true});
   }
   if (props.onHoverChange) {
     const hoverChangeEventListener = () => {
@@ -101,7 +101,7 @@ function dispatchHoverEndEvents(context: EventResponderContext, props: Object) {
       eventTarget,
       hoverChangeEventListener,
     );
-    context.dispatchEvent(syntheticEvent, true, false);
+    context.dispatchEvent(syntheticEvent, {discrete: true});
   }
 }
 

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -36,13 +36,13 @@ type PressProps = {
   delayLongPress: number,
   delayPressEnd: number,
   delayPressStart: number,
-  onLongPress: (e: Object) => void,
+  onLongPress: (e: PressEvent) => void,
   onLongPressChange: boolean => void,
   onLongPressShouldCancelPress: () => boolean,
-  onPress: (e: Object) => void,
+  onPress: (e: PressEvent) => void,
   onPressChange: boolean => void,
-  onPressEnd: (e: Object) => void,
-  onPressStart: (e: Object) => void,
+  onPressEnd: (e: PressEvent) => void,
+  onPressStart: (e: PressEvent) => void,
   pressRententionOffset: Object,
 };
 
@@ -52,17 +52,45 @@ type PressState = {
   isLongPressed: boolean,
   isPressed: boolean,
   longPressTimeout: null | TimeoutID,
-  pressTarget: null | EventTarget,
+  pressTarget: null | Element | Document,
   shouldSkipMouseAfterTouch: boolean,
 };
+
+type PressEventType =
+  | 'press'
+  | 'pressstart'
+  | 'pressend'
+  | 'presschange'
+  | 'longpress'
+  | 'longpresschange';
+
+type PressEvent = {|
+  listener: PressEvent => void,
+  target: Element | Document,
+  type: PressEventType,
+|};
+
+function createPressEvent(
+  type: PressEventType,
+  target: Element | Document,
+  listener: PressEvent => void,
+): PressEvent {
+  return {
+    listener,
+    target,
+    type,
+  };
+}
 
 function dispatchPressEvent(
   context: EventResponderContext,
   state: PressState,
-  name: string,
+  name: PressEventType,
   listener: (e: Object) => void,
 ): void {
-  context.dispatchEvent(name, listener, state.pressTarget, true);
+  const target = ((state.pressTarget: any): Element | Document);
+  const syntheticEvent = createPressEvent(name, target, listener);
+  context.dispatchEvent(syntheticEvent, true, false);
 }
 
 function dispatchPressStartEvents(
@@ -105,9 +133,10 @@ function dispatchPressStartEvents(
       if (props.onLongPress) {
         const longPressEventListener = e => {
           props.onLongPress(e);
-          if (e.nativeEvent.defaultPrevented) {
-            state.defaultPrevented = true;
-          }
+          // TODO address this again at some point
+          // if (e.nativeEvent.defaultPrevented) {
+          //   state.defaultPrevented = true;
+          // }
         };
         dispatchPressEvent(context, state, 'longpress', longPressEventListener);
       }
@@ -201,24 +230,7 @@ const PressResponder = {
         ) {
           return;
         }
-        let keyPressEventListener = props.onPress;
-
-        // Wrap listener with prevent default behaviour, unless
-        // we are dealing with an anchor. Anchor tags are special beacuse
-        // we need to use the "click" event, to properly allow browser
-        // heuristics for cancelling link clicks. Furthermore, iOS and
-        // Android can show previous of anchor tags that requires working
-        // with click rather than touch events (and mouse down/up).
-        if (!isAnchorTagElement(eventTarget)) {
-          keyPressEventListener = e => {
-            if (!e.isDefaultPrevented() && !e.nativeEvent.defaultPrevented) {
-              e.preventDefault();
-              state.defaultPrevented = true;
-              props.onPress(e);
-            }
-          };
-        }
-        dispatchPressEvent(context, state, 'press', keyPressEventListener);
+        dispatchPressEvent(context, state, 'press', props.onPress);
         break;
       }
 
@@ -340,9 +352,10 @@ const PressResponder = {
               ) {
                 const pressEventListener = e => {
                   props.onPress(e);
-                  if (e.nativeEvent.defaultPrevented) {
-                    state.defaultPrevented = true;
-                  }
+                  // TODO address this again at some point
+                  // if (e.nativeEvent.defaultPrevented) {
+                  //   state.defaultPrevented = true;
+                  // }
                 };
                 dispatchPressEvent(context, state, 'press', pressEventListener);
               }

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -90,7 +90,7 @@ function dispatchPressEvent(
 ): void {
   const target = ((state.pressTarget: any): Element | Document);
   const syntheticEvent = createPressEvent(name, target, listener);
-  context.dispatchEvent(syntheticEvent, true, false);
+  context.dispatchEvent(syntheticEvent, {discrete: true});
 }
 
 function dispatchPressStartEvents(

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -23,18 +23,45 @@ if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
   });
 }
 
+type EventData = {
+  diffX: number,
+  diffY: number,
+};
+type SwipeEventType = 'swipeleft' | 'swiperight' | 'swipeend' | 'swipemove';
+
+type SwipeEvent = {|
+  listener: SwipeEvent => void,
+  target: Element | Document,
+  type: SwipeEventType,
+  diffX?: number,
+  diffY?: number,
+|};
+
+function createSwipeEvent(
+  type: SwipeEventType,
+  target: Element | Document,
+  listener: SwipeEvent => void,
+  eventData?: EventData,
+): SwipeEvent {
+  return {
+    listener,
+    target,
+    type,
+    ...eventData,
+  };
+}
+
 function dispatchSwipeEvent(
   context: EventResponderContext,
-  name: string,
-  listener: (e: Object) => void,
+  name: SwipeEventType,
+  listener: SwipeEvent => void,
   state: SwipeState,
   discrete: boolean,
-  eventData?: {
-    diffX: number,
-    diffY: number,
-  },
+  eventData?: EventData,
 ) {
-  context.dispatchEvent(name, listener, state.swipeTarget, discrete, eventData);
+  const target = ((state.swipeTarget: any): Element | Document);
+  const syntheticEvent = createSwipeEvent(name, target, listener, eventData);
+  context.dispatchEvent(syntheticEvent, discrete, false);
 }
 
 type SwipeState = {
@@ -44,7 +71,7 @@ type SwipeState = {
   startX: number,
   startY: number,
   touchId: null | number,
-  swipeTarget: null | EventTarget,
+  swipeTarget: null | Element | Document,
   x: number,
   y: number,
 };

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -61,7 +61,7 @@ function dispatchSwipeEvent(
 ) {
   const target = ((state.swipeTarget: any): Element | Document);
   const syntheticEvent = createSwipeEvent(name, target, listener, eventData);
-  context.dispatchEvent(syntheticEvent, discrete, false);
+  context.dispatchEvent(syntheticEvent, {discrete});
 }
 
 type SwipeState = {

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -89,8 +89,10 @@ describe('Press event responder', () => {
     });
     buttonRef.current.dispatchEvent(keyDownEvent);
 
-    // press 1 should not occur as press 2 will preventDefault
-    expect(events).toEqual(['keydown', 'press 2']);
+    // TODO update this test once we have a form of stopPropagation in
+    // the responder system again. This test had to be updated because
+    // we have removed stopPropagation() from synthetic events.
+    expect(events).toEqual(['keydown', 'press 2', 'press 1']);
   });
 
   it('should support onPressStart and onPressEnd', () => {


### PR DESCRIPTION
This PR refactors the experimental event API to use event objects at the point of the responder module, rather than via indirection through the responder context `dispatchEvent`. This allows responder events to be strongly typed and it also means we can avoid using the plugin event system to dispatch the event and instead handle the event directly within the responder system itself.

Furthermore, this removes `stopPropagation` and `preventDefault` from event objects. The short term expectation is that their functionality will exist again but, instead of imperative method calls, the behaviour will live inside the React component tree. This will happen in follow up PRs.