### PR TITLE
Experimental event API - wrap async dispatched events

### DIFF
--- a/packages/events/EventTypes.js
+++ b/packages/events/EventTypes.js
@@ -39,4 +39,5 @@ export type EventResponderContext = {
   ) => void,
   requestOwnership: (target: Element | Document | null) => boolean,
   releaseOwnership: (target: Element | Document | null) => boolean,
+  withAsyncDispatching: (func: () => void) => void,
 };

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -118,33 +118,42 @@ function dispatchPressStartEvents(
       DEFAULT_LONG_PRESS_DELAY_MS,
     );
 
-    state.longPressTimeout = setTimeout(() => {
-      state.isLongPressed = true;
-      state.longPressTimeout = null;
+    state.longPressTimeout = setTimeout(
+      () =>
+        context.withAsyncDispatching(() => {
+          state.isLongPressed = true;
+          state.longPressTimeout = null;
 
-      if (props.onLongPress) {
-        const longPressEventListener = e => {
-          props.onLongPress(e);
-          // TODO address this again at some point
-          // if (e.nativeEvent.defaultPrevented) {
-          //   state.defaultPrevented = true;
-          // }
-        };
-        dispatchPressEvent(context, state, 'longpress', longPressEventListener);
-      }
+          if (props.onLongPress) {
+            const longPressEventListener = e => {
+              props.onLongPress(e);
+              // TODO address this again at some point
+              // if (e.nativeEvent.defaultPrevented) {
+              //   state.defaultPrevented = true;
+              // }
+            };
+            dispatchPressEvent(
+              context,
+              state,
+              'longpress',
+              longPressEventListener,
+            );
+          }
 
-      if (props.onLongPressChange) {
-        const longPressChangeEventListener = () => {
-          props.onLongPressChange(true);
-        };
-        dispatchPressEvent(
-          context,
-          state,
-          'longpresschange',
-          longPressChangeEventListener,
-        );
-      }
-    }, delayLongPress);
+          if (props.onLongPressChange) {
+            const longPressChangeEventListener = () => {
+              props.onLongPressChange(true);
+            };
+            dispatchPressEvent(
+              context,
+              state,
+              'longpresschange',
+              longPressChangeEventListener,
+            );
+          }
+        }),
+      delayLongPress,
+    );
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue where async dispatched events from event modules were not properly handled. Previously, before the refactor PR, async events were never batched together.

To ensure they such events are batched together, the `context` creates a new event queue for async events and then restores the old event queue upon completion. To do this a new method on context is introduced, specifically `withAsyncDispatching`. This method ensures that all async events inside the callback are properly batched together without conflicting with previous event queues. This also simplifies event queues, where previously they had the notion of phases (which isn't necessary now).

@necolas to follow up with tests.