### PR TITLE
Prevent bundling of Node polyfills when importing TestUtils/TestRenderer

### DIFF
--- a/packages/shared/enqueueTask.js
+++ b/packages/shared/enqueueTask.js
@@ -12,10 +12,13 @@ import warningWithoutStack from './warningWithoutStack';
 let didWarnAboutMessageChannel = false;
 let enqueueTask;
 try {
+  // read require off the module object to get around the bundlers.
+  // we don't want them to detect a require and bundle a Node polyfill.
+  let requireString = ('require' + Math.random()).slice(0, 7);
+  let nodeRequire = module && module[requireString];
   // assuming we're in node, let's try to get node's
-  // version of setImmediate, bypassing fake timers if any
-  let r = require; // trick packagers not to bundle this stuff.
-  enqueueTask = r('timers').setImmediate;
+  // version of setImmediate, bypassing fake timers if any.
+  enqueueTask = nodeRequire('timers').setImmediate;
 } catch (_err) {
   // we're in a browser
   // we can't use regular timers because they may still be faked


### PR DESCRIPTION
I think this fixes https://github.com/facebook/react/pull/14853#discussion_r271517721.

In particular, there are two cases we'd like to avoid:

* We don't want Webpack to emit a warning about `require` expression being dynamic.
* We don't want Webpack to include its Node polyfills (for example, for `timers` or for `global`) because we access them. *(This is happening on master.)*

Effectively, we want to obscure the `require` call from webpack. There are a few webpack-specific ways to do it but they seem brittle. Additionally, naïve ways to obscure it (like the current code) are inlined by GCC at our build step for the prod bundle.

Instead, I'm reading `module.require` — which doesn't even exist in webpack runtime but exists in Node. Webpack doesn't analyze it. To further strengthen it, I make the `require` string itself dynamic. Seems like this is sufficient. I only tested webpack and Node. It might be worth testing that browserify or Rollup work as expected — but they also not known for noisy warnings so I assume it should be fine.

This wouldn't work if TestRender or TestUtils were a Node ESM because there would be no `require` in it. But that's status quo anyway because our current `require` call wouldn't work either.