### PR TITLE
Add full TouchHitTarget hit slop (experimental event API) to ReactDOM

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -447,11 +447,13 @@ export function handleEventComponent(
   // TODO: add handleEventComponent implementation
 }
 
-export function handleEventTarget(
-  type: Symbol | number,
-  props: Props,
+export function createTouchHitTargetInstance(
   parentInstance: Container,
+  props: Props,
+  rootContainerInstance: Container,
+  hostContext: HostContext,
   internalInstanceHandle: Object,
 ) {
-  // TODO: add handleEventTarget implementation
+  // TODO: add createTouchHitTargetInstance implementation
+  return (null: any);
 }

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -443,17 +443,19 @@ export function handleEventComponent(
   eventResponder: ReactEventResponder,
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
-) {
-  // TODO: add handleEventComponent implementation
+): void {
+  throw new Error('Not yet implemented.');
 }
 
 export function createTouchHitTargetInstance(
+  bottom: number,
+  left: number,
+  right: number,
+  top: number,
   parentInstance: Container,
-  props: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
   internalInstanceHandle: Object,
-) {
-  // TODO: add createTouchHitTargetInstance implementation
-  return (null: any);
+): Instance {
+  throw new Error('Not yet implemented.');
 }

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -447,27 +447,27 @@ export function handleEventComponent(
   throw new Error('Not yet implemented.');
 }
 
-export function createTouchHitTargetInstance(
-  bottom: number,
-  left: number,
-  right: number,
-  top: number,
-  rootContainerInstance: Container,
-  hostContext: HostContext,
-  internalInstanceHandle: Object,
-): Instance {
+export function getEventTargetChildElement(
+  type: Symbol | number,
+  props: Props,
+): null {
   throw new Error('Not yet implemented.');
 }
 
-export function commitTouchHitTargetUpdate(
-  bottom: number,
-  left: number,
-  right: number,
-  top: number,
-  parentInstance: Container,
+export function handleEventTarget(
+  type: Symbol | number,
+  props: Props,
   rootContainerInstance: Container,
-  hostContext: HostContext,
   internalInstanceHandle: Object,
+): boolean {
+  throw new Error('Not yet implemented.');
+}
+
+export function commitEventTarget(
+  type: Symbol | number,
+  props: Props,
+  instance: Instance,
+  parentInstance: Instance,
 ): void {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -452,10 +452,22 @@ export function createTouchHitTargetInstance(
   left: number,
   right: number,
   top: number,
-  parentInstance: Container,
   rootContainerInstance: Container,
   hostContext: HostContext,
   internalInstanceHandle: Object,
 ): Instance {
+  throw new Error('Not yet implemented.');
+}
+
+export function commitTouchHitTargetUpdate(
+  bottom: number,
+  left: number,
+  right: number,
+  top: number,
+  parentInstance: Container,
+  rootContainerInstance: Container,
+  hostContext: HostContext,
+  internalInstanceHandle: Object,
+): void {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -1341,10 +1341,10 @@ export function listenToEventResponderEventTypes(
 }
 
 export function createTouchHitTargetElement(
-  bottom: number | void | null,
-  left: number | void | null,
-  right: number | void | null,
-  top: number | void | null,
+  bottom: number,
+  left: number,
+  right: number,
+  top: number,
   rootContainerInstance: Element | Document,
   parentNamespace: string,
 ): HTMLElement {
@@ -1357,20 +1357,48 @@ export function createTouchHitTargetElement(
   const touchHitTargetElementStyle = touchHitTargetElement.style;
 
   touchHitTargetElementStyle.position = 'absolute';
-  if (top != null) {
+  if (top !== 0) {
     touchHitTargetElementStyle.top = `-${top}px`;
   }
-  if (left != null) {
+  if (left !== 0) {
     touchHitTargetElementStyle.left = `-${left}px`;
   }
-  if (right != null) {
+  if (right !== 0) {
     touchHitTargetElementStyle.right = `-${right}px`;
   }
-  if (bottom != null) {
+  if (bottom !== 0) {
     touchHitTargetElementStyle.bottom = `-${bottom}px`;
   }
 
   return touchHitTargetElement;
+}
+
+export function updateTouchHitTargetElement(
+  oldBottom: number,
+  oldLeft: number,
+  oldRight: number,
+  oldTop: number,
+  newBottom: number,
+  newLeft: number,
+  newRight: number,
+  newTop: number,
+  touchHitTargetElement: Element,
+) {
+  const touchHitTargetElementStyle = ((touchHitTargetElement: any): HTMLElement)
+    .style;
+
+  if (oldTop !== newTop) {
+    touchHitTargetElementStyle.top = `-${newTop}px`;
+  }
+  if (oldLeft !== newLeft) {
+    touchHitTargetElementStyle.left = `-${newLeft}px`;
+  }
+  if (oldRight !== newRight) {
+    touchHitTargetElementStyle.right = `-${newRight}px`;
+  }
+  if (oldBottom !== newBottom) {
+    touchHitTargetElementStyle.bottom = `-${newBottom}px`;
+  }
 }
 
 // We can remove this once the event API is stable and out of a flag

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -98,6 +98,7 @@ const AUTOFOCUS = 'autoFocus';
 const CHILDREN = 'children';
 const STYLE = 'style';
 const HTML = '__html';
+const EMPTY_OBJECT = {};
 
 const {html: HTML_NAMESPACE} = Namespaces;
 
@@ -1337,6 +1338,39 @@ export function listenToEventResponderEventTypes(
       }
     }
   }
+}
+
+export function createTouchHitTargetElement(
+  bottom: number | void | null,
+  left: number | void | null,
+  right: number | void | null,
+  top: number | void | null,
+  rootContainerInstance: Element | Document,
+  parentNamespace: string,
+): HTMLElement {
+  const touchHitTargetElement = ((createElement(
+    'div',
+    EMPTY_OBJECT,
+    rootContainerInstance,
+    parentNamespace,
+  ): any): HTMLElement);
+  const touchHitTargetElementStyle = touchHitTargetElement.style;
+
+  touchHitTargetElementStyle.position = 'absolute';
+  if (top != null) {
+    touchHitTargetElementStyle.top = `-${top}px`;
+  }
+  if (left != null) {
+    touchHitTargetElementStyle.left = `-${left}px`;
+  }
+  if (right != null) {
+    touchHitTargetElementStyle.right = `-${right}px`;
+  }
+  if (bottom != null) {
+    touchHitTargetElementStyle.bottom = `-${bottom}px`;
+  }
+
+  return touchHitTargetElement;
 }
 
 // We can remove this once the event API is stable and out of a flag

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -98,7 +98,6 @@ const AUTOFOCUS = 'autoFocus';
 const CHILDREN = 'children';
 const STYLE = 'style';
 const HTML = '__html';
-const EMPTY_OBJECT = {};
 
 const {html: HTML_NAMESPACE} = Namespaces;
 
@@ -1337,67 +1336,6 @@ export function listenToEventResponderEventTypes(
         listeningSet.add(listeningName);
       }
     }
-  }
-}
-
-export function createTouchHitTargetElement(
-  bottom: number,
-  left: number,
-  right: number,
-  top: number,
-  rootContainerInstance: Element | Document,
-  parentNamespace: string,
-): HTMLElement {
-  const touchHitTargetElement = ((createElement(
-    'div',
-    EMPTY_OBJECT,
-    rootContainerInstance,
-    parentNamespace,
-  ): any): HTMLElement);
-  const touchHitTargetElementStyle = touchHitTargetElement.style;
-
-  touchHitTargetElementStyle.position = 'absolute';
-  if (top !== 0) {
-    touchHitTargetElementStyle.top = `-${top}px`;
-  }
-  if (left !== 0) {
-    touchHitTargetElementStyle.left = `-${left}px`;
-  }
-  if (right !== 0) {
-    touchHitTargetElementStyle.right = `-${right}px`;
-  }
-  if (bottom !== 0) {
-    touchHitTargetElementStyle.bottom = `-${bottom}px`;
-  }
-
-  return touchHitTargetElement;
-}
-
-export function updateTouchHitTargetElement(
-  oldBottom: number,
-  oldLeft: number,
-  oldRight: number,
-  oldTop: number,
-  newBottom: number,
-  newLeft: number,
-  newRight: number,
-  newTop: number,
-  touchHitTargetElement: Element,
-) {
-  const touchHitTargetElementStyle = ((touchHitTargetElement: any): HTMLElement)
-    .style;
-
-  if (oldTop !== newTop) {
-    touchHitTargetElementStyle.top = `-${newTop}px`;
-  }
-  if (oldLeft !== newLeft) {
-    touchHitTargetElementStyle.left = `-${newLeft}px`;
-  }
-  if (oldRight !== newRight) {
-    touchHitTargetElementStyle.right = `-${newRight}px`;
-  }
-  if (oldBottom !== newBottom) {
-    touchHitTargetElementStyle.bottom = `-${newBottom}px`;
   }
 }
 

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -5,10 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {HostComponent, HostText, EventTarget} from 'shared/ReactWorkTags';
+import {HostComponent, HostText} from 'shared/ReactWorkTags';
 import invariant from 'shared/invariant';
-
-import {enableEventAPI} from 'shared/ReactFeatureFlags';
 
 const randomKey = Math.random()
   .toString(36)
@@ -40,11 +38,7 @@ export function getClosestInstanceFromNode(node) {
   }
 
   let inst = node[internalInstanceKey];
-  if (
-    inst.tag === HostComponent ||
-    inst.tag === HostText ||
-    (enableEventAPI && inst.tag === EventTarget)
-  ) {
+  if (inst.tag === HostComponent || inst.tag === HostText) {
     // In Fiber, this will always be the deepest root.
     return inst;
   }
@@ -59,11 +53,7 @@ export function getClosestInstanceFromNode(node) {
 export function getInstanceFromNode(node) {
   const inst = node[internalInstanceKey];
   if (inst) {
-    if (
-      inst.tag === HostComponent ||
-      inst.tag === HostText ||
-      (enableEventAPI && inst.tag === EventTarget)
-    ) {
+    if (inst.tag === HostComponent || inst.tag === HostText) {
       return inst;
     } else {
       return null;
@@ -77,11 +67,7 @@ export function getInstanceFromNode(node) {
  * DOM node.
  */
 export function getNodeFromInstance(inst) {
-  if (
-    inst.tag === HostComponent ||
-    inst.tag === HostText ||
-    (enableEventAPI && inst.tag === EventTarget)
-  ) {
+  if (inst.tag === HostComponent || inst.tag === HostText) {
     // In Fiber this, is just the state node right now. We assume it will be
     // a host component or host text.
     return inst.stateNode;

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {HostComponent, HostText} from 'shared/ReactWorkTags';
+import {HostComponent, HostText, EventTarget} from 'shared/ReactWorkTags';
 import invariant from 'shared/invariant';
 
 const randomKey = Math.random()
@@ -38,7 +38,11 @@ export function getClosestInstanceFromNode(node) {
   }
 
   let inst = node[internalInstanceKey];
-  if (inst.tag === HostComponent || inst.tag === HostText) {
+  if (
+    inst.tag === HostComponent ||
+    inst.tag === HostText ||
+    inst.tag === EventTarget
+  ) {
     // In Fiber, this will always be the deepest root.
     return inst;
   }
@@ -53,7 +57,11 @@ export function getClosestInstanceFromNode(node) {
 export function getInstanceFromNode(node) {
   const inst = node[internalInstanceKey];
   if (inst) {
-    if (inst.tag === HostComponent || inst.tag === HostText) {
+    if (
+      inst.tag === HostComponent ||
+      inst.tag === HostText ||
+      inst.tag === EventTarget
+    ) {
       return inst;
     } else {
       return null;
@@ -67,7 +75,11 @@ export function getInstanceFromNode(node) {
  * DOM node.
  */
 export function getNodeFromInstance(inst) {
-  if (inst.tag === HostComponent || inst.tag === HostText) {
+  if (
+    inst.tag === HostComponent ||
+    inst.tag === HostText ||
+    inst.tag === EventTarget
+  ) {
     // In Fiber this, is just the state node right now. We assume it will be
     // a host component or host text.
     return inst.stateNode;

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -8,6 +8,8 @@
 import {HostComponent, HostText, EventTarget} from 'shared/ReactWorkTags';
 import invariant from 'shared/invariant';
 
+import {enableEventAPI} from 'shared/ReactFeatureFlags';
+
 const randomKey = Math.random()
   .toString(36)
   .slice(2);
@@ -41,7 +43,7 @@ export function getClosestInstanceFromNode(node) {
   if (
     inst.tag === HostComponent ||
     inst.tag === HostText ||
-    inst.tag === EventTarget
+    (enableEventAPI && inst.tag === EventTarget)
   ) {
     // In Fiber, this will always be the deepest root.
     return inst;
@@ -60,7 +62,7 @@ export function getInstanceFromNode(node) {
     if (
       inst.tag === HostComponent ||
       inst.tag === HostText ||
-      inst.tag === EventTarget
+      (enableEventAPI && inst.tag === EventTarget)
     ) {
       return inst;
     } else {
@@ -78,7 +80,7 @@ export function getNodeFromInstance(inst) {
   if (
     inst.tag === HostComponent ||
     inst.tag === HostText ||
-    inst.tag === EventTarget
+    (enableEventAPI && inst.tag === EventTarget)
   ) {
     // In Fiber this, is just the state node right now. We assume it will be
     // a host component or host text.

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -68,6 +68,7 @@ export type EventTargetChildElement = {
   props: null | {
     style?: {
       position?: string,
+      zIndex?: number,
       bottom?: string,
       left?: string,
       right?: string,
@@ -916,6 +917,7 @@ export function getEventTargetChildElement(
         props: {
           style: {
             position: 'absolute',
+            zIndex: -1,
             bottom: bottom ? `-${bottom}px` : '0px',
             left: left ? `-${left}px` : '0px',
             right: right ? `-${right}px` : '0px',
@@ -950,12 +952,21 @@ export function commitEventTarget(
         // typically force a style recalculation and force a layout,
         // reflow -– both of which are sync are expensive.
         const computedStyles = window.getComputedStyle(parentInstance);
+        const position = computedStyles.getPropertyValue('position');
         warning(
-          computedStyles.getPropertyValue('position') !== 'static',
+          position !== '' && position !== 'static',
           '<TouchHitTarget> inserts an empty absolutely positioned <div>. ' +
             'This requires its parent DOM node to be positioned too, but the ' +
             'parent DOM node was found to have the style "position" set to ' +
-            'value "static". Try using a "position" value of "relative".',
+            'either no value, or a value of "static". Try using a "position" ' +
+            'value of "relative".',
+        );
+        warning(
+          computedStyles.getPropertyValue('zIndex') !== '',
+          '<TouchHitTarget> inserts an empty <div> with "z-index" of "-1". ' +
+            'This requires its parent DOM node to have a "z-index" great than "-1",' +
+            'but the parent DOM node was found to no "z-index" value set.' +
+            ' Try using a "z-index" value of "0" or greater.',
         );
       }
     }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -26,6 +26,7 @@ import {
   warnForInsertedHydratedText,
   listenToEventResponderEventTypes,
   createTouchHitTargetElement,
+  updateTouchHitTargetElement,
 } from './ReactDOMComponent';
 import {getSelectionInformation, restoreSelection} from './ReactInputSelection';
 import setTextContent from './setTextContent';
@@ -58,10 +59,6 @@ export type Props = {
   style?: {
     display?: string,
   },
-  bottom?: null | number,
-  left?: null | number,
-  right?: null | number,
-  top?: null | number,
 };
 export type Container = Element | Document;
 export type Instance = Element;
@@ -907,21 +904,25 @@ export function handleEventComponent(
 }
 
 export function createTouchHitTargetInstance(
+  bottom: number,
+  left: number,
+  right: number,
+  top: number,
   parentInstance: Container,
-  props: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
   internalInstanceHandle: Object,
 ): Instance {
-  const {bottom, left, right, top} = props;
   let parentNamespace: string;
   if (__DEV__) {
     const hostContextDev = ((hostContext: any): HostContextDev);
     parentNamespace = hostContextDev.namespace;
-    throw new Error(
-      '<TouchHitTarget> was used in an unsupported DOM namespace. ' +
-        'Ensure the <TouchHitTarget> is used in an HTML namespace.',
-    );
+    if (parentNamespace !== HTML_NAMESPACE) {
+      throw new Error(
+        '<TouchHitTarget> was used in an unsupported DOM namespace. ' +
+          'Ensure the <TouchHitTarget> is used in an HTML namespace.',
+      );
+    }
   } else {
     parentNamespace = ((hostContext: any): HostContextProd);
   }
@@ -935,4 +936,28 @@ export function createTouchHitTargetInstance(
   );
   precacheFiberNode(internalInstanceHandle, touchHitTargetInstance);
   return touchHitTargetInstance;
+}
+
+export function commitTouchHitTargetUpdate(
+  oldBottom: number,
+  oldLeft: number,
+  oldRight: number,
+  oldTop: number,
+  newBottom: number,
+  newLeft: number,
+  newRight: number,
+  newTop: number,
+  touchHitTargetInstance: Instance,
+): void {
+  updateTouchHitTargetElement(
+    oldBottom,
+    oldLeft,
+    oldRight,
+    oldTop,
+    newBottom,
+    newLeft,
+    newRight,
+    newTop,
+    touchHitTargetInstance,
+  );
 }

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -294,7 +294,8 @@ DOMEventResponderContext.prototype.isPositionWithinTouchHitTarget = function(
   if (childFiber === null) {
     return false;
   }
-  if (childFiber.tag === EventTargetWorkTag) {
+  const parentFiber = childFiber.return;
+  if (parentFiber !== null && parentFiber.tag === EventTargetWorkTag) {
     // TODO find another way to do this without using the
     // expensive getBoundingClientRect.
     const {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1182,12 +1182,15 @@ class ReactDOMServerRenderer {
                 if (bottom === 0 && left === 0 && right === 0 && top === 0) {
                   return '';
                 }
-                let topString = top ? `-${top}px;` : '';
-                let leftString = left ? `-${left}px;` : '';
-                let rightString = right ? `-${right}px;` : '';
-                let bottomString = bottom ? `-${bottom}px;` : '';
+                let topString = top ? `-${top}px` : '0px';
+                let leftString = left ? `-${left}px` : '0px';
+                let rightString = right ? `-${right}px` : '0x';
+                let bottomString = bottom ? `-${bottom}px` : '0px';
 
-                return `<div style="position:absolute;${topString}${leftString}${rightString}${bottomString}"></div>`;
+                return (
+                  `<div style="position:absolute;bottom:` +
+                  `${bottomString};left:${leftString};right:${rightString};top:${topString}"></div>`
+                );
               }
               const nextChildren = toArray(
                 ((nextChild: any): ReactElement).props.children,

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1188,7 +1188,7 @@ class ReactDOMServerRenderer {
                 let bottomString = bottom ? `-${bottom}px` : '0px';
 
                 return (
-                  `<div style="position:absolute;bottom:` +
+                  `<div style="position:absolute;z-index:-1;bottom:` +
                   `${bottomString};left:${leftString};right:${rightString};top:${topString}"></div>`
                 );
               }

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -39,6 +39,7 @@ import {
   REACT_MEMO_TYPE,
   REACT_EVENT_COMPONENT_TYPE,
   REACT_EVENT_TARGET_TYPE,
+  REACT_EVENT_TARGET_TOUCH_HIT,
 } from 'shared/ReactSymbols';
 
 import {
@@ -1168,6 +1169,26 @@ class ReactDOMServerRenderer {
           case REACT_EVENT_COMPONENT_TYPE:
           case REACT_EVENT_TARGET_TYPE: {
             if (enableEventAPI) {
+              if (
+                elementType.$$typeof === REACT_EVENT_TARGET_TYPE &&
+                elementType.type === REACT_EVENT_TARGET_TOUCH_HIT
+              ) {
+                const props = nextElement.props;
+                const bottom = props.bottom || 0;
+                const left = props.left || 0;
+                const right = props.right || 0;
+                const top = props.top || 0;
+
+                if (bottom === 0 && left === 0 && right === 0 && top === 0) {
+                  return '';
+                }
+                let topString = top ? `-${top}px;` : '';
+                let leftString = left ? `-${left}px;` : '';
+                let rightString = right ? `-${right}px;` : '';
+                let bottomString = bottom ? `-${bottom}px;` : '';
+
+                return `<div style="position:absolute;${topString}${leftString}${rightString}${bottomString}"></div>`;
+              }
               const nextChildren = toArray(
                 ((nextChild: any): ReactElement).props.children,
               );

--- a/packages/react-events/src/__tests__/TouchHitTarget-test.internal.js
+++ b/packages/react-events/src/__tests__/TouchHitTarget-test.internal.js
@@ -16,6 +16,7 @@ let ReactFeatureFlags;
 let EventComponent;
 let ReactTestRenderer;
 let ReactDOM;
+let ReactDOMServer;
 let ReactSymbols;
 let ReactEvents;
 let TouchHitTarget;
@@ -56,6 +57,11 @@ function initTestRenderer() {
 function initReactDOM() {
   init();
   ReactDOM = require('react-dom');
+}
+
+function initReactDOMServer() {
+  init();
+  ReactDOMServer = require('react-dom/server');
 }
 
 describe('TouchHitTarget', () => {
@@ -316,6 +322,316 @@ describe('TouchHitTarget', () => {
       }).toWarnDev(
         'Warning: validateDOMNesting: <TouchHitTarget> cannot not be a direct child of an event component. ' +
           'Ensure <TouchHitTarget> is a direct child of a DOM element.',
+      );
+    });
+
+    it('should render a conditional TouchHitTarget correctly (false -> true)', () => {
+      let cond = false;
+
+      const Test = () => (
+        <EventComponent>
+          <div>
+            {cond ? null : (
+              <TouchHitTarget top={10} left={10} right={10} bottom={10} />
+            )}
+          </div>
+        </EventComponent>
+      );
+
+      const container = document.createElement('div');
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe(
+        '<div><div style="position: absolute; top: -10px; ' +
+          'left: -10px; right: -10px; bottom: -10px;"></div></div>',
+      );
+
+      cond = true;
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe('<div></div>');
+    });
+
+    it('should render a conditional TouchHitTarget correctly (true -> false)', () => {
+      let cond = true;
+
+      const Test = () => (
+        <EventComponent>
+          <div>
+            {cond ? null : (
+              <TouchHitTarget top={10} left={10} right={10} bottom={10} />
+            )}
+          </div>
+        </EventComponent>
+      );
+
+      const container = document.createElement('div');
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe('<div></div>');
+
+      cond = false;
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe(
+        '<div><div style="position: absolute; top: -10px; ' +
+          'left: -10px; right: -10px; bottom: -10px;"></div></div>',
+      );
+    });
+
+    it('should render a conditional TouchHitTarget hit slop correctly (false -> true)', () => {
+      let cond = false;
+
+      const Test = () => (
+        <EventComponent>
+          <div>
+            {cond ? (
+              <TouchHitTarget />
+            ) : (
+              <TouchHitTarget top={10} left={10} right={10} bottom={10} />
+            )}
+          </div>
+        </EventComponent>
+      );
+
+      const container = document.createElement('div');
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe(
+        '<div><div style="position: absolute; top: -10px; ' +
+          'left: -10px; right: -10px; bottom: -10px;"></div></div>',
+      );
+
+      cond = true;
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe(
+        '<div><div style="position: absolute; top: -0px; ' +
+          'left: -0px; right: -0px; bottom: -0px;"></div></div>',
+      );
+    });
+
+    it('should render a conditional TouchHitTarget hit slop correctly (true -> false)', () => {
+      let cond = true;
+
+      const Test = () => (
+        <EventComponent>
+          <div>
+            <span>Random span 1</span>
+            {cond ? (
+              <TouchHitTarget />
+            ) : (
+              <TouchHitTarget top={10} left={10} right={10} bottom={10} />
+            )}
+            <span>Random span 2</span>
+          </div>
+        </EventComponent>
+      );
+
+      const container = document.createElement('div');
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe(
+        '<div><span>Random span 1</span><span>Random span 2</span></div>',
+      );
+
+      cond = false;
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe(
+        '<div><span>Random span 1</span><div style="position: absolute; top: -10px; ' +
+          'left: -10px; right: -10px; bottom: -10px;"></div><span>Random span 2</span></div>',
+      );
+    });
+
+    it('should update TouchHitTarget hit slop values correctly (false -> true)', () => {
+      let cond = false;
+
+      const Test = () => (
+        <EventComponent>
+          <div>
+            <span>Random span 1</span>
+            {cond ? (
+              <TouchHitTarget top={10} left={null} right={10} bottom={10} />
+            ) : (
+              <TouchHitTarget
+                top={undefined}
+                left={20}
+                right={null}
+                bottom={0}
+              />
+            )}
+            <span>Random span 2</span>
+          </div>
+        </EventComponent>
+      );
+
+      const container = document.createElement('div');
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe(
+        '<div><span>Random span 1</span><div style="position: absolute; ' +
+          'left: -20px;"></div><span>Random span 2</span></div>',
+      );
+
+      cond = true;
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe(
+        '<div><span>Random span 1</span><div style="position: absolute; left: -0px; ' +
+          'top: -10px; right: -10px; bottom: -10px;"></div><span>Random span 2</span></div>',
+      );
+    });
+
+    it('should update TouchHitTarget hit slop values correctly (true -> false)', () => {
+      let cond = true;
+
+      const Test = () => (
+        <EventComponent>
+          <div>
+            <span>Random span 1</span>
+            {cond ? (
+              <TouchHitTarget top={10} left={null} right={10} bottom={10} />
+            ) : (
+              <TouchHitTarget
+                top={undefined}
+                left={20}
+                right={null}
+                bottom={0}
+              />
+            )}
+            <span>Random span 2</span>
+          </div>
+        </EventComponent>
+      );
+
+      const container = document.createElement('div');
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe(
+        '<div><span>Random span 1</span><div style="position: absolute; ' +
+          'top: -10px; right: -10px; bottom: -10px;"></div><span>Random span 2</span></div>',
+      );
+
+      cond = false;
+      ReactDOM.render(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe(
+        '<div><span>Random span 1</span><div style="position: absolute; top: -0px; ' +
+          'right: -0px; bottom: -0px; left: -20px;"></div><span>Random span 2</span></div>',
+      );
+    });
+
+    it('should hydrate TouchHitTarget hit slop elements correcty', () => {
+      const Test = () => (
+        <EventComponent>
+          <div>
+            <TouchHitTarget />
+          </div>
+        </EventComponent>
+      );
+
+      const container = document.createElement('div');
+      container.innerHTML = '<div></div>';
+      ReactDOM.hydrate(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe('<div></div>');
+
+      const Test2 = () => (
+        <EventComponent>
+          <div>
+            <TouchHitTarget top={10} left={10} right={10} bottom={10} />
+          </div>
+        </EventComponent>
+      );
+
+      const container2 = document.createElement('div');
+      container2.innerHTML =
+        '<div><div style="position:absolute;-10px;-10px;-10px;-10px;"></div></div>';
+      ReactDOM.hydrate(<Test2 />, container2);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container2.innerHTML).toBe(
+        '<div><div style="position:absolute;-10px;-10px;-10px;-10px;"></div></div>',
+      );
+    });
+
+    it('should hydrate TouchHitTarget hit slop elements correcty and patch them', () => {
+      const Test = () => (
+        <EventComponent>
+          <div>
+            <TouchHitTarget top={10} left={10} right={10} bottom={10} />
+          </div>
+        </EventComponent>
+      );
+
+      const container = document.createElement('div');
+      container.innerHTML = '<div></div>';
+      ReactDOM.hydrate(<Test />, container);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(container.innerHTML).toBe(
+        '<div><div style="position: absolute; top: -10px; left: -10px; right: -10px; bottom: -10px;"></div></div>',
+      );
+    });
+  });
+
+  describe('ReactDOMServer', () => {
+    beforeEach(() => {
+      initReactDOMServer();
+      EventComponent = createReactEventComponent();
+      TouchHitTarget = ReactEvents.TouchHitTarget;
+    });
+
+    it('should not warn when a TouchHitTarget is used correctly', () => {
+      const Test = () => (
+        <EventComponent>
+          <div>
+            <TouchHitTarget />
+          </div>
+        </EventComponent>
+      );
+
+      const output = ReactDOMServer.renderToString(<Test />);
+      expect(output).toBe('<div></div>');
+    });
+
+    it('should render a TouchHitTarget with hit slop values', () => {
+      const Test = () => (
+        <EventComponent>
+          <div>
+            <TouchHitTarget top={10} left={10} right={10} bottom={10} />
+          </div>
+        </EventComponent>
+      );
+
+      let output = ReactDOMServer.renderToString(<Test />);
+      expect(output).toBe(
+        '<div><div style="position:absolute;-10px;-10px;-10px;-10px;"></div></div>',
+      );
+
+      const Test2 = () => (
+        <EventComponent>
+          <div>
+            <TouchHitTarget top={null} left={undefined} right={0} bottom={10} />
+          </div>
+        </EventComponent>
+      );
+
+      output = ReactDOMServer.renderToString(<Test2 />);
+      expect(output).toBe(
+        '<div><div style="position:absolute;-10px;"></div></div>',
+      );
+
+      const Test3 = () => (
+        <EventComponent>
+          <div>
+            <TouchHitTarget top={1} left={2} right={3} bottom={4} />
+          </div>
+        </EventComponent>
+      );
+
+      output = ReactDOMServer.renderToString(<Test3 />);
+      expect(output).toBe(
+        '<div><div style="position:absolute;-1px;-2px;-3px;-4px;"></div></div>',
       );
     });
   });

--- a/packages/react-events/src/__tests__/TouchHitTarget-test.internal.js
+++ b/packages/react-events/src/__tests__/TouchHitTarget-test.internal.js
@@ -100,9 +100,7 @@ describe('TouchHitTarget', () => {
       expect(() => {
         ReactNoop.render(<Test />);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: <TouchHitTarget> must not have any children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
 
       const Test2 = () => (
         <EventComponent>
@@ -115,9 +113,7 @@ describe('TouchHitTarget', () => {
       expect(() => {
         ReactNoop.render(<Test2 />);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: <TouchHitTarget> must not have any children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
 
       // Should render without warnings
       const Test3 = () => (
@@ -187,9 +183,7 @@ describe('TouchHitTarget', () => {
       expect(() => {
         root.update(<Test />);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: <TouchHitTarget> must not have any children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
 
       const Test2 = () => (
         <EventComponent>
@@ -202,9 +196,7 @@ describe('TouchHitTarget', () => {
       expect(() => {
         root.update(<Test2 />);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: <TouchHitTarget> must not have any children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
 
       // Should render without warnings
       const Test3 = () => (
@@ -275,9 +267,7 @@ describe('TouchHitTarget', () => {
       expect(() => {
         ReactDOM.render(<Test />, container);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: <TouchHitTarget> must not have any children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
 
       const Test2 = () => (
         <EventComponent>
@@ -290,9 +280,7 @@ describe('TouchHitTarget', () => {
       expect(() => {
         ReactDOM.render(<Test2 />, container);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: <TouchHitTarget> must not have any children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
 
       // Should render without warnings
       const Test3 = () => (
@@ -342,8 +330,8 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; top: -10px; ' +
-          'left: -10px; right: -10px; bottom: -10px;"></div></div>',
+        '<div><div style="position: absolute; bottom: -10px; ' +
+          'left: -10px; right: -10px; top: -10px;"></div></div>',
       );
 
       cond = true;
@@ -374,8 +362,8 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; top: -10px; ' +
-          'left: -10px; right: -10px; bottom: -10px;"></div></div>',
+        '<div><div style="position: absolute; bottom: -10px; ' +
+          'left: -10px; right: -10px; top: -10px;"></div></div>',
       );
     });
 
@@ -398,17 +386,14 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; top: -10px; ' +
-          'left: -10px; right: -10px; bottom: -10px;"></div></div>',
+        '<div><div style="position: absolute; bottom: -10px; ' +
+          'left: -10px; right: -10px; top: -10px;"></div></div>',
       );
 
       cond = true;
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
-      expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; top: -0px; ' +
-          'left: -0px; right: -0px; bottom: -0px;"></div></div>',
-      );
+      expect(container.innerHTML).toBe('<div></div>');
     });
 
     it('should render a conditional TouchHitTarget hit slop correctly (true -> false)', () => {
@@ -439,8 +424,8 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; top: -10px; ' +
-          'left: -10px; right: -10px; bottom: -10px;"></div><span>Random span 2</span></div>',
+        '<div><span>Random span 1</span><div style="position: absolute; bottom: -10px; ' +
+          'left: -10px; right: -10px; top: -10px;"></div><span>Random span 2</span></div>',
       );
     });
 
@@ -470,16 +455,16 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; ' +
-          'left: -20px;"></div><span>Random span 2</span></div>',
+        '<div><span>Random span 1</span><div style="position: absolute; bottom: 0px; ' +
+          'left: -20px; right: 0px; top: 0px;"></div><span>Random span 2</span></div>',
       );
 
       cond = true;
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; left: -0px; ' +
-          'top: -10px; right: -10px; bottom: -10px;"></div><span>Random span 2</span></div>',
+        '<div><span>Random span 1</span><div style="position: absolute; bottom: 0px; ' +
+          'left: -20px; right: 0px; top: 0px;"></div><span>Random span 2</span></div>',
       );
     });
 
@@ -509,16 +494,16 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; ' +
-          'top: -10px; right: -10px; bottom: -10px;"></div><span>Random span 2</span></div>',
+        '<div><span>Random span 1</span><div style="position: absolute; bottom: -10px; ' +
+          'left: 0px; right: -10px; top: -10px;"></div><span>Random span 2</span></div>',
       );
 
       cond = false;
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; top: -0px; ' +
-          'right: -0px; bottom: -0px; left: -20px;"></div><span>Random span 2</span></div>',
+        '<div><span>Random span 1</span><div style="position: absolute; bottom: -10px; ' +
+          'left: 0px; right: -10px; top: -10px;"></div><span>Random span 2</span></div>',
       );
     });
 
@@ -547,11 +532,11 @@ describe('TouchHitTarget', () => {
 
       const container2 = document.createElement('div');
       container2.innerHTML =
-        '<div><div style="position:absolute;-10px;-10px;-10px;-10px;"></div></div>';
+        '<div><div style="position:absolute;bottom:-10px;left:-10px;right:-10px;top:-10px"></div></div>';
       ReactDOM.hydrate(<Test2 />, container2);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container2.innerHTML).toBe(
-        '<div><div style="position:absolute;-10px;-10px;-10px;-10px;"></div></div>',
+        '<div><div style="position:absolute;bottom:-10px;left:-10px;right:-10px;top:-10px"></div></div>',
       );
     });
 
@@ -566,10 +551,16 @@ describe('TouchHitTarget', () => {
 
       const container = document.createElement('div');
       container.innerHTML = '<div></div>';
-      ReactDOM.hydrate(<Test />, container);
+      expect(() => {
+        ReactDOM.hydrate(<Test />, container);
+        expect(Scheduler).toFlushWithoutYielding();
+      }).toWarnDev(
+        'Warning: Expected server HTML to contain a matching <div> in <div>.',
+        {withoutStack: true},
+      );
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; top: -10px; left: -10px; right: -10px; bottom: -10px;"></div></div>',
+        '<div><div style="position: absolute; bottom: -10px; left: -10px; right: -10px; top: -10px;"></div></div>',
       );
     });
   });
@@ -605,7 +596,7 @@ describe('TouchHitTarget', () => {
 
       let output = ReactDOMServer.renderToString(<Test />);
       expect(output).toBe(
-        '<div><div style="position:absolute;-10px;-10px;-10px;-10px;"></div></div>',
+        '<div><div style="position:absolute;bottom:-10px;left:-10px;right:-10px;top:-10px"></div></div>',
       );
 
       const Test2 = () => (
@@ -618,7 +609,7 @@ describe('TouchHitTarget', () => {
 
       output = ReactDOMServer.renderToString(<Test2 />);
       expect(output).toBe(
-        '<div><div style="position:absolute;-10px;"></div></div>',
+        '<div><div style="position:absolute;bottom:-10px;left:0px;right:0x;top:0px"></div></div>',
       );
 
       const Test3 = () => (
@@ -631,7 +622,7 @@ describe('TouchHitTarget', () => {
 
       output = ReactDOMServer.renderToString(<Test3 />);
       expect(output).toBe(
-        '<div><div style="position:absolute;-1px;-2px;-3px;-4px;"></div></div>',
+        '<div><div style="position:absolute;bottom:-4px;left:-2px;right:-3px;top:-1px"></div></div>',
       );
     });
   });

--- a/packages/react-events/src/__tests__/TouchHitTarget-test.internal.js
+++ b/packages/react-events/src/__tests__/TouchHitTarget-test.internal.js
@@ -330,7 +330,7 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; bottom: -10px; ' +
+        '<div><div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: -10px; right: -10px; top: -10px;"></div></div>',
       );
 
@@ -362,7 +362,7 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; bottom: -10px; ' +
+        '<div><div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: -10px; right: -10px; top: -10px;"></div></div>',
       );
     });
@@ -386,7 +386,7 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; bottom: -10px; ' +
+        '<div><div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: -10px; right: -10px; top: -10px;"></div></div>',
       );
 
@@ -424,7 +424,7 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; bottom: -10px; ' +
+        '<div><span>Random span 1</span><div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: -10px; right: -10px; top: -10px;"></div><span>Random span 2</span></div>',
       );
     });
@@ -455,7 +455,7 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; bottom: 0px; ' +
+        '<div><span>Random span 1</span><div style="position: absolute; z-index: -1; bottom: 0px; ' +
           'left: -20px; right: 0px; top: 0px;"></div><span>Random span 2</span></div>',
       );
 
@@ -463,7 +463,7 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; bottom: 0px; ' +
+        '<div><span>Random span 1</span><div style="position: absolute; z-index: -1; bottom: 0px; ' +
           'left: -20px; right: 0px; top: 0px;"></div><span>Random span 2</span></div>',
       );
     });
@@ -494,7 +494,7 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; bottom: -10px; ' +
+        '<div><span>Random span 1</span><div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: 0px; right: -10px; top: -10px;"></div><span>Random span 2</span></div>',
       );
 
@@ -502,7 +502,7 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; bottom: -10px; ' +
+        '<div><span>Random span 1</span><div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: 0px; right: -10px; top: -10px;"></div><span>Random span 2</span></div>',
       );
     });
@@ -532,11 +532,11 @@ describe('TouchHitTarget', () => {
 
       const container2 = document.createElement('div');
       container2.innerHTML =
-        '<div><div style="position:absolute;bottom:-10px;left:-10px;right:-10px;top:-10px"></div></div>';
+        '<div><div style="position:absolute;z-index:-1;bottom:-10px;left:-10px;right:-10px;top:-10px"></div></div>';
       ReactDOM.hydrate(<Test2 />, container2);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container2.innerHTML).toBe(
-        '<div><div style="position:absolute;bottom:-10px;left:-10px;right:-10px;top:-10px"></div></div>',
+        '<div><div style="position:absolute;z-index:-1;bottom:-10px;left:-10px;right:-10px;top:-10px"></div></div>',
       );
     });
 
@@ -560,7 +560,8 @@ describe('TouchHitTarget', () => {
       );
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; bottom: -10px; left: -10px; right: -10px; top: -10px;"></div></div>',
+        '<div><div style="position: absolute; z-index: -1; bottom: -10px; ' +
+          'left: -10px; right: -10px; top: -10px;"></div></div>',
       );
     });
   });
@@ -596,7 +597,7 @@ describe('TouchHitTarget', () => {
 
       let output = ReactDOMServer.renderToString(<Test />);
       expect(output).toBe(
-        '<div><div style="position:absolute;bottom:-10px;left:-10px;right:-10px;top:-10px"></div></div>',
+        '<div><div style="position:absolute;z-index:-1;bottom:-10px;left:-10px;right:-10px;top:-10px"></div></div>',
       );
 
       const Test2 = () => (
@@ -609,7 +610,7 @@ describe('TouchHitTarget', () => {
 
       output = ReactDOMServer.renderToString(<Test2 />);
       expect(output).toBe(
-        '<div><div style="position:absolute;bottom:-10px;left:0px;right:0x;top:0px"></div></div>',
+        '<div><div style="position:absolute;z-index:-1;bottom:-10px;left:0px;right:0x;top:0px"></div></div>',
       );
 
       const Test3 = () => (
@@ -622,7 +623,7 @@ describe('TouchHitTarget', () => {
 
       output = ReactDOMServer.renderToString(<Test3 />);
       expect(output).toBe(
-        '<div><div style="position:absolute;bottom:-4px;left:-2px;right:-3px;top:-1px"></div></div>',
+        '<div><div style="position:absolute;z-index:-1;bottom:-4px;left:-2px;right:-3px;top:-1px"></div></div>',
       );
     });
   });

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -411,17 +411,6 @@ export function cloneHiddenTextInstance(
   throw new Error('Not yet implemented.');
 }
 
-export function cloneHiddenTouchHitTargetInstance(
-  instance: Instance,
-  bottom: number,
-  left: number,
-  right: number,
-  top: number,
-  internalInstanceHandle: Object,
-) {
-  throw new Error('Not yet implemented.');
-}
-
 export function createContainerChildSet(container: Container): ChildSet {
   return createChildNodeSet(container);
 }

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -453,29 +453,27 @@ export function handleEventComponent(
   throw new Error('Not yet implemented.');
 }
 
-export function createTouchHitTargetInstance(
-  bottom: number,
-  left: number,
-  right: number,
-  top: number,
-  rootContainerInstance: Container,
-  hostContext: HostContext,
-  internalInstanceHandle: Object,
-): Instance {
+export function getEventTargetChildElement(
+  type: Symbol | number,
+  props: Props,
+): null {
   throw new Error('Not yet implemented.');
 }
 
-export function commitTouchHitTargetUpdate(
-  oldBottom: number,
-  oldLeft: number,
-  oldRight: number,
-  oldTop: number,
-  newBottom: number,
-  newLeft: number,
-  newRight: number,
-  newTop: number,
-  touchHitTargetInstance: Instance,
-  parentInstance: null | Container,
+export function handleEventTarget(
+  type: Symbol | number,
+  props: Props,
+  rootContainerInstance: Container,
+  internalInstanceHandle: Object,
+): boolean {
+  throw new Error('Not yet implemented.');
+}
+
+export function commitEventTarget(
+  type: Symbol | number,
+  props: Props,
+  instance: Instance,
+  parentInstance: Instance,
 ): void {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -458,7 +458,6 @@ export function createTouchHitTargetInstance(
   left: number,
   right: number,
   top: number,
-  parentInstance: Container,
   rootContainerInstance: Container,
   hostContext: HostContext,
   internalInstanceHandle: Object,
@@ -476,6 +475,7 @@ export function commitTouchHitTargetUpdate(
   newRight: number,
   newTop: number,
   touchHitTargetInstance: Instance,
+  parentInstance: null | Container,
 ): void {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -442,11 +442,13 @@ export function handleEventComponent(
   // TODO: add handleEventComponent implementation
 }
 
-export function handleEventTarget(
-  type: Symbol | number,
-  props: Props,
+export function createTouchHitTargetInstance(
   parentInstance: Container,
+  props: Props,
+  rootContainerInstance: Container,
+  hostContext: HostContext,
   internalInstanceHandle: Object,
 ) {
-  // TODO: add handleEventTarget implementation
+  // TODO: add createTouchHitTargetInstance implementation
+  return (null: any);
 }

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -411,6 +411,17 @@ export function cloneHiddenTextInstance(
   throw new Error('Not yet implemented.');
 }
 
+export function cloneHiddenTouchHitTargetInstance(
+  instance: Instance,
+  bottom: number,
+  left: number,
+  right: number,
+  top: number,
+  internalInstanceHandle: Object,
+) {
+  throw new Error('Not yet implemented.');
+}
+
 export function createContainerChildSet(container: Container): ChildSet {
   return createChildNodeSet(container);
 }
@@ -438,17 +449,33 @@ export function handleEventComponent(
   eventResponder: ReactEventResponder,
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
-) {
-  // TODO: add handleEventComponent implementation
+): void {
+  throw new Error('Not yet implemented.');
 }
 
 export function createTouchHitTargetInstance(
+  bottom: number,
+  left: number,
+  right: number,
+  top: number,
   parentInstance: Container,
-  props: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
   internalInstanceHandle: Object,
-) {
-  // TODO: add createTouchHitTargetInstance implementation
-  return (null: any);
+): Instance {
+  throw new Error('Not yet implemented.');
+}
+
+export function commitTouchHitTargetUpdate(
+  oldBottom: number,
+  oldLeft: number,
+  oldRight: number,
+  oldTop: number,
+  newBottom: number,
+  newLeft: number,
+  newRight: number,
+  newTop: number,
+  touchHitTargetInstance: Instance,
+): void {
+  throw new Error('Not yet implemented.');
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -502,12 +502,28 @@ export function handleEventComponent(
 }
 
 export function createTouchHitTargetInstance(
+  bottom: number,
+  left: number,
+  right: number,
+  top: number,
   parentInstance: Container,
-  props: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
   internalInstanceHandle: Object,
-) {
-  // TODO: add createTouchHitTargetInstance implementation
-  return (null: any);
+): Instance {
+  throw new Error('Not yet implemented.');
+}
+
+export function commitTouchHitTargetUpdate(
+  oldBottom: number,
+  oldLeft: number,
+  oldRight: number,
+  oldTop: number,
+  newBottom: number,
+  newLeft: number,
+  newRight: number,
+  newTop: number,
+  touchHitTargetInstance: Instance,
+): void {
+  throw new Error('Not yet implemented.');
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -498,32 +498,30 @@ export function handleEventComponent(
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
 ) {
-  // TODO: add handleEventComponent implementation
-}
-
-export function createTouchHitTargetInstance(
-  bottom: number,
-  left: number,
-  right: number,
-  top: number,
-  rootContainerInstance: Container,
-  hostContext: HostContext,
-  internalInstanceHandle: Object,
-): Instance {
   throw new Error('Not yet implemented.');
 }
 
-export function commitTouchHitTargetUpdate(
-  oldBottom: number,
-  oldLeft: number,
-  oldRight: number,
-  oldTop: number,
-  newBottom: number,
-  newLeft: number,
-  newRight: number,
-  newTop: number,
-  touchHitTargetInstance: Instance,
-  parentInstance: null | Container,
+export function getEventTargetChildElement(
+  type: Symbol | number,
+  props: Props,
+): null {
+  throw new Error('Not yet implemented.');
+}
+
+export function handleEventTarget(
+  type: Symbol | number,
+  props: Props,
+  rootContainerInstance: Container,
+  internalInstanceHandle: Object,
+): boolean {
+  throw new Error('Not yet implemented.');
+}
+
+export function commitEventTarget(
+  type: Symbol | number,
+  props: Props,
+  instance: Instance,
+  parentInstance: Instance,
 ): void {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -501,11 +501,13 @@ export function handleEventComponent(
   // TODO: add handleEventComponent implementation
 }
 
-export function handleEventTarget(
-  type: Symbol | number,
-  props: Props,
+export function createTouchHitTargetInstance(
   parentInstance: Container,
+  props: Props,
+  rootContainerInstance: Container,
+  hostContext: HostContext,
   internalInstanceHandle: Object,
 ) {
-  // TODO: add handleEventTarget implementation
+  // TODO: add createTouchHitTargetInstance implementation
+  return (null: any);
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -506,7 +506,6 @@ export function createTouchHitTargetInstance(
   left: number,
   right: number,
   top: number,
-  parentInstance: Container,
   rootContainerInstance: Container,
   hostContext: HostContext,
   internalInstanceHandle: Object,
@@ -524,6 +523,7 @@ export function commitTouchHitTargetUpdate(
   newRight: number,
   newTop: number,
   touchHitTargetInstance: Instance,
+  parentInstance: null | Container,
 ): void {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -628,17 +628,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           });
           return clone;
         },
-
-        cloneHiddenTouchHitTargetInstance(
-          instance: Instance,
-          bottom: number,
-          left: number,
-          right: number,
-          top: number,
-          internalInstanceHandle: Object,
-        ) {
-          throw new Error('Not yet implemented.');
-        },
       };
 
   const NoopRenderer = reconciler(hostConfig);

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -432,15 +432,14 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       // NO-OP
     },
 
-    handleEventTarget(
-      type: Symbol | number,
-      props: Props,
+    createTouchHitTargetInstance(
       parentInstance: Container,
+      props: Props,
+      rootContainerInstance: Container,
+      hostContext: HostContext,
       internalInstanceHandle: Object,
     ) {
-      if (type === REACT_EVENT_TARGET_TOUCH_HIT) {
-        // TODO
-      }
+      // TODO: add createTouchHitTargetInstance implementation
     },
   };
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -431,17 +431,8 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       // NO-OP
     },
 
-    createTouchHitTargetInstance(
-      bottom: number,
-      left: number,
-      right: number,
-      top: number,
-      parentInstance: Container,
-      rootContainerInstance: Container,
-      hostContext: HostContext,
-      internalInstanceHandle: Object,
-    ): Instance {
-      throw new Error('Not yet implemented.');
+    createTouchHitTargetInstance() {
+      // NO-OP
     },
   };
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -432,13 +432,16 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     },
 
     createTouchHitTargetInstance(
+      bottom: number,
+      left: number,
+      right: number,
+      top: number,
       parentInstance: Container,
-      props: Props,
       rootContainerInstance: Container,
       hostContext: HostContext,
       internalInstanceHandle: Object,
-    ) {
-      // TODO: add createTouchHitTargetInstance implementation
+    ): Instance {
+      throw new Error('Not yet implemented.');
     },
   };
 
@@ -587,6 +590,17 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
             enumerable: false,
           });
           return clone;
+        },
+
+        cloneHiddenTouchHitTargetInstance(
+          instance: Instance,
+          bottom: number,
+          left: number,
+          right: number,
+          top: number,
+          internalInstanceHandle: Object,
+        ) {
+          throw new Error('Not yet implemented.');
         },
       };
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -451,6 +451,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
             props: {
               style: {
                 position: 'absolute',
+                zIndex: -1,
                 bottom: bottom ? `-${bottom}px` : '0px',
                 left: left ? `-${left}px` : '0px',
                 right: right ? `-${right}px` : '0px',

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -33,12 +33,32 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {enableEventAPI} from 'shared/ReactFeatureFlags';
 
+type EventTargetChildElement = {
+  type: string,
+  props: null | {
+    style?: {
+      position?: string,
+      bottom?: string,
+      left?: string,
+      right?: string,
+      top?: string,
+    },
+  },
+};
 type Container = {
   rootID: string,
   children: Array<Instance | TextInstance>,
   pendingChildren: Array<Instance | TextInstance>,
 };
-type Props = {prop: any, hidden: boolean, children?: mixed};
+type Props = {
+  prop: any,
+  hidden: boolean,
+  children?: mixed,
+  bottom?: null | number,
+  left?: null | number,
+  right?: null | number,
+  top?: null | number,
+};
 type Instance = {|
   type: string,
   id: number,
@@ -299,12 +319,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       rootContainerInstance: Container,
       hostContext: HostContext,
     ): Instance {
-      if (__DEV__ && enableEventAPI) {
-        warning(
-          hostContext !== EVENT_TOUCH_HIT_TARGET_CONTEXT,
-          'validateDOMNesting: <TouchHitTarget> must not have any children.',
-        );
-      }
       if (type === 'errorInCompletePhase') {
         throw new Error('Error in host config.');
       }
@@ -380,18 +394,8 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     ): TextInstance {
       if (__DEV__ && enableEventAPI) {
         warning(
-          hostContext !== EVENT_TOUCH_HIT_TARGET_CONTEXT,
-          'validateDOMNesting: <TouchHitTarget> must not have any children.',
-        );
-        warning(
           hostContext !== EVENT_COMPONENT_CONTEXT,
           'validateDOMNesting: React event components cannot have text DOM nodes as children. ' +
-            'Wrap the child text "%s" in an element.',
-          text,
-        );
-        warning(
-          hostContext !== EVENT_TARGET_CONTEXT,
-          'validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
             'Wrap the child text "%s" in an element.',
           text,
         );
@@ -431,7 +435,49 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       // NO-OP
     },
 
-    createTouchHitTargetInstance() {
+    getEventTargetChildElement(
+      type: Symbol | number,
+      props: Props,
+    ): null | EventTargetChildElement {
+      if (enableEventAPI) {
+        if (type === REACT_EVENT_TARGET_TOUCH_HIT) {
+          const {bottom, left, right, top} = props;
+
+          if (!bottom && !left && !right && !top) {
+            return null;
+          }
+          return {
+            type: 'div',
+            props: {
+              style: {
+                position: 'absolute',
+                bottom: bottom ? `-${bottom}px` : '0px',
+                left: left ? `-${left}px` : '0px',
+                right: right ? `-${right}px` : '0px',
+                top: top ? `-${top}px` : '0px',
+              },
+            },
+          };
+        }
+      }
+      return null;
+    },
+
+    handleEventTarget(
+      type: Symbol | number,
+      props: Props,
+      rootContainerInstance: Container,
+      internalInstanceHandle: Object,
+    ): boolean {
+      return false;
+    },
+
+    commitEventTarget(
+      type: Symbol | number,
+      props: Props,
+      instance: Instance,
+      parentInstance: Instance,
+    ): void {
       // NO-OP
     },
   };

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -61,7 +61,10 @@ import shallowEqual from 'shared/shallowEqual';
 import getComponentName from 'shared/getComponentName';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings';
 import {refineResolvedLazyComponent} from 'shared/ReactLazyComponent';
-import {REACT_LAZY_TYPE} from 'shared/ReactSymbols';
+import {
+  REACT_LAZY_TYPE,
+  REACT_EVENT_TARGET_TOUCH_HIT,
+} from 'shared/ReactSymbols';
 import warning from 'shared/warning';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {
@@ -1981,8 +1984,13 @@ function updateEventComponent(current, workInProgress, renderExpirationTime) {
 }
 
 function updateEventTarget(current, workInProgress, renderExpirationTime) {
+  const type = workInProgress.type.type;
   const nextProps = workInProgress.pendingProps;
   let nextChildren = nextProps.children;
+
+  if (type === REACT_EVENT_TARGET_TOUCH_HIT && current === null) {
+    tryToClaimNextHydratableInstance(workInProgress);
+  }
 
   reconcileChildren(
     current,

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -119,10 +119,7 @@ if (supportsMutation) {
     let node = workInProgress.child;
     while (node !== null) {
       if (node.tag === HostComponent || node.tag === HostText) {
-        const instance = node.stateNode;
-        if (instance !== null) {
-          appendInitialChild(parent, instance);
-        }
+        appendInitialChild(parent, node.stateNode);
       } else if (node.tag === HostPortal) {
         // If we have a portal child, then we don't want to traverse
         // down its children. Instead, we'll get insertions from each child in

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -23,7 +23,6 @@ import {
   HostRoot,
   SuspenseComponent,
   DehydratedSuspenseComponent,
-  EventTarget,
 } from 'shared/ReactWorkTags';
 import {Deletion, Placement} from 'shared/ReactSideEffectTags';
 import invariant from 'shared/invariant';
@@ -50,14 +49,8 @@ import {
   didNotFindHydratableInstance,
   didNotFindHydratableTextInstance,
   didNotFindHydratableSuspenseInstance,
-  hydrateTouchHitTargetInstance,
-  canHydrateTouchHitTargetInstance,
 } from './ReactFiberHostConfig';
-import {
-  enableSuspenseServerRenderer,
-  enableEventAPI,
-} from 'shared/ReactFeatureFlags';
-import {REACT_EVENT_TARGET_TOUCH_HIT} from 'shared/ReactSymbols';
+import {enableSuspenseServerRenderer} from 'shared/ReactFeatureFlags';
 
 // The deepest Fiber on the stack involved in a hydration context.
 // This may have been an insertion or a hydration.
@@ -228,21 +221,6 @@ function tryHydrate(fiber, nextInstance) {
       }
       return false;
     }
-    case EventTarget: {
-      if (enableEventAPI) {
-        const type = fiber.type.type;
-        if (type === REACT_EVENT_TARGET_TOUCH_HIT) {
-          const touchHitTargetInstance = canHydrateTouchHitTargetInstance(
-            nextInstance,
-          );
-          if (touchHitTargetInstance !== null) {
-            fiber.stateNode = (touchHitTargetInstance: Instance);
-            return true;
-          }
-        }
-      }
-      return false;
-    }
     default:
       return false;
   }
@@ -366,24 +344,6 @@ function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
   return shouldUpdate;
 }
 
-function prepareToHydrateTouchHitTargetInstance(
-  bottom: number,
-  left: number,
-  right: number,
-  top: number,
-  fiber: Fiber,
-): boolean {
-  if (!supportsHydration) {
-    invariant(
-      false,
-      'Expected prepareToHydrateTouchHitTargetInstance() to never be called. ' +
-        'This error is likely caused by a bug in React. Please file an issue.',
-    );
-  }
-  const instance: Instance = fiber.stateNode;
-  return hydrateTouchHitTargetInstance(bottom, left, right, top, instance);
-}
-
 function skipPastDehydratedSuspenseInstance(fiber: Fiber): void {
   if (!supportsHydration) {
     invariant(
@@ -480,5 +440,4 @@ export {
   prepareToHydrateHostTextInstance,
   skipPastDehydratedSuspenseInstance,
   popHydrationState,
-  prepareToHydrateTouchHitTargetInstance,
 };

--- a/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
@@ -127,9 +127,9 @@ describe('ReactFiberEvents', () => {
     it('should render a simple event component with a single event target', () => {
       const Test = () => (
         <EventComponent>
-          <EventTarget>
-            <div>Hello world</div>
-          </EventTarget>
+          <div>
+            Hello world<EventTarget />
+          </div>
         </EventComponent>
       );
 
@@ -148,10 +148,7 @@ describe('ReactFiberEvents', () => {
       expect(() => {
         ReactNoop.render(<Test />);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
-          'Wrap the child text "Hello world" in an element.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should warn when an event target has a direct text child #2', () => {
@@ -167,19 +164,15 @@ describe('ReactFiberEvents', () => {
       expect(() => {
         ReactNoop.render(<Test />);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
-          'Wrap the child text "Hello world" in an element.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should not warn if an event target is not a direct child of an event component', () => {
       const Test = () => (
         <EventComponent>
           <div>
-            <EventTarget>
-              <span>Child 1</span>
-            </EventTarget>
+            <EventTarget />
+            <span>Child 1</span>
           </div>
         </EventComponent>
       );
@@ -207,9 +200,7 @@ describe('ReactFiberEvents', () => {
       expect(() => {
         ReactNoop.render(<Test />);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets must not have event components as children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should handle event components correctly with error boundaries', () => {
@@ -219,11 +210,9 @@ describe('ReactFiberEvents', () => {
 
       const Test = () => (
         <EventComponent>
-          <EventTarget>
-            <span>
-              <ErrorComponent />
-            </span>
-          </EventTarget>
+          <span>
+            <ErrorComponent />
+          </span>
         </EventComponent>
       );
 
@@ -268,11 +257,9 @@ describe('ReactFiberEvents', () => {
 
       const Parent = () => (
         <EventComponent>
-          <EventTarget>
-            <div>
-              <Child />
-            </div>
-          </EventTarget>
+          <div>
+            <Child />
+          </div>
         </EventComponent>
       );
 
@@ -321,9 +308,7 @@ describe('ReactFiberEvents', () => {
 
       const Parent = () => (
         <EventComponent>
-          <EventTarget>
-            <Child />
-          </EventTarget>
+          <Child />
         </EventComponent>
       );
 
@@ -341,7 +326,7 @@ describe('ReactFiberEvents', () => {
         });
         expect(Scheduler).toFlushWithoutYielding();
       }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
+        'Warning: validateDOMNesting: React event components cannot have text DOM nodes as children. ' +
           'Wrap the child text "Text!" in an element.',
       );
     });
@@ -355,11 +340,7 @@ describe('ReactFiberEvents', () => {
         _updateCounter = updateCounter;
 
         if (counter === 1) {
-          return (
-            <EventComponent>
-              <div>Child</div>
-            </EventComponent>
-          );
+          return <EventTarget>123</EventTarget>;
         }
 
         return (
@@ -370,18 +351,20 @@ describe('ReactFiberEvents', () => {
       }
 
       const Parent = () => (
-        <EventComponent>
-          <EventTarget>
+        <div>
+          <EventComponent>
             <Child />
-          </EventTarget>
-        </EventComponent>
+          </EventComponent>
+        </div>
       );
 
       ReactNoop.render(<Parent />);
       expect(Scheduler).toFlushWithoutYielding();
       expect(ReactNoop).toMatchRenderedOutput(
         <div>
-          <span>Child - 0</span>
+          <div>
+            <span>Child - 0</span>
+          </div>
         </div>,
       );
 
@@ -390,9 +373,7 @@ describe('ReactFiberEvents', () => {
           _updateCounter(counter => counter + 1);
         });
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets must not have event components as children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should error with a component stack contains the names of the event components and event targets', () => {
@@ -404,11 +385,9 @@ describe('ReactFiberEvents', () => {
 
       const Test = () => (
         <EventComponent>
-          <EventTarget>
-            <span>
-              <ErrorComponent />
-            </span>
-          </EventTarget>
+          <span>
+            <ErrorComponent />
+          </span>
         </EventComponent>
       );
 
@@ -437,7 +416,6 @@ describe('ReactFiberEvents', () => {
 
       expect(componentStackMessage.includes('ErrorComponent')).toBe(true);
       expect(componentStackMessage.includes('span')).toBe(true);
-      expect(componentStackMessage.includes('TestEventTarget')).toBe(true);
       expect(componentStackMessage.includes('TestEventComponent')).toBe(true);
       expect(componentStackMessage.includes('Test')).toBe(true);
       expect(componentStackMessage.includes('Wrapper')).toBe(true);
@@ -498,9 +476,9 @@ describe('ReactFiberEvents', () => {
     it('should render a simple event component with a single event target', () => {
       const Test = () => (
         <EventComponent>
-          <EventTarget>
-            <div>Hello world</div>
-          </EventTarget>
+          <div>
+            Hello world<EventTarget />
+          </div>
         </EventComponent>
       );
 
@@ -511,9 +489,8 @@ describe('ReactFiberEvents', () => {
 
       const Test2 = () => (
         <EventComponent>
-          <EventTarget>
-            <span>I am now a span</span>
-          </EventTarget>
+          <EventTarget />
+          <span>I am now a span</span>
         </EventComponent>
       );
 
@@ -533,10 +510,7 @@ describe('ReactFiberEvents', () => {
       expect(() => {
         root.update(<Test />);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
-          'Wrap the child text "Hello world" in an element.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should warn when an event target has a direct text child #2', () => {
@@ -553,19 +527,15 @@ describe('ReactFiberEvents', () => {
       expect(() => {
         root.update(<Test />);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
-          'Wrap the child text "Hello world" in an element.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should not warn if an event target is not a direct child of an event component', () => {
       const Test = () => (
         <EventComponent>
           <div>
-            <EventTarget>
-              <span>Child 1</span>
-            </EventTarget>
+            <EventTarget />
+            <span>Child 1</span>
           </div>
         </EventComponent>
       );
@@ -595,9 +565,7 @@ describe('ReactFiberEvents', () => {
       expect(() => {
         root.update(<Test />);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets must not have event components as children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should handle event components correctly with error boundaries', () => {
@@ -607,11 +575,9 @@ describe('ReactFiberEvents', () => {
 
       const Test = () => (
         <EventComponent>
-          <EventTarget>
-            <span>
-              <ErrorComponent />
-            </span>
-          </EventTarget>
+          <span>
+            <ErrorComponent />
+          </span>
         </EventComponent>
       );
 
@@ -620,7 +586,7 @@ describe('ReactFiberEvents', () => {
           error: null,
         };
 
-        componentDidCatch(error, errStack) {
+        componentDidCatch(error) {
           this.setState({
             error,
           });
@@ -657,11 +623,9 @@ describe('ReactFiberEvents', () => {
 
       const Parent = () => (
         <EventComponent>
-          <EventTarget>
-            <div>
-              <Child />
-            </div>
-          </EventTarget>
+          <div>
+            <Child />
+          </div>
         </EventComponent>
       );
 
@@ -710,9 +674,7 @@ describe('ReactFiberEvents', () => {
 
       const Parent = () => (
         <EventComponent>
-          <EventTarget>
-            <Child />
-          </EventTarget>
+          <Child />
         </EventComponent>
       );
 
@@ -730,7 +692,7 @@ describe('ReactFiberEvents', () => {
           _updateCounter(counter => counter + 1);
         });
       }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
+        'Warning: validateDOMNesting: React event components cannot have text DOM nodes as children. ' +
           'Wrap the child text "Text!" in an element.',
       );
     });
@@ -744,11 +706,7 @@ describe('ReactFiberEvents', () => {
         _updateCounter = updateCounter;
 
         if (counter === 1) {
-          return (
-            <EventComponent>
-              <div>Child</div>
-            </EventComponent>
-          );
+          return <EventTarget>123</EventTarget>;
         }
 
         return (
@@ -759,11 +717,11 @@ describe('ReactFiberEvents', () => {
       }
 
       const Parent = () => (
-        <EventComponent>
-          <EventTarget>
+        <div>
+          <EventComponent>
             <Child />
-          </EventTarget>
-        </EventComponent>
+          </EventComponent>
+        </div>
       );
 
       const root = ReactTestRenderer.create(null);
@@ -771,7 +729,9 @@ describe('ReactFiberEvents', () => {
       expect(Scheduler).toFlushWithoutYielding();
       expect(root).toMatchRenderedOutput(
         <div>
-          <span>Child - 0</span>
+          <div>
+            <span>Child - 0</span>
+          </div>
         </div>,
       );
 
@@ -780,9 +740,7 @@ describe('ReactFiberEvents', () => {
           _updateCounter(counter => counter + 1);
         });
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets must not have event components as children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should error with a component stack contains the names of the event components and event targets', () => {
@@ -794,11 +752,9 @@ describe('ReactFiberEvents', () => {
 
       const Test = () => (
         <EventComponent>
-          <EventTarget>
-            <span>
-              <ErrorComponent />
-            </span>
-          </EventTarget>
+          <span>
+            <ErrorComponent />
+          </span>
         </EventComponent>
       );
 
@@ -828,7 +784,6 @@ describe('ReactFiberEvents', () => {
 
       expect(componentStackMessage.includes('ErrorComponent')).toBe(true);
       expect(componentStackMessage.includes('span')).toBe(true);
-      expect(componentStackMessage.includes('TestEventTarget')).toBe(true);
       expect(componentStackMessage.includes('TestEventComponent')).toBe(true);
       expect(componentStackMessage.includes('Test')).toBe(true);
       expect(componentStackMessage.includes('Wrapper')).toBe(true);
@@ -888,9 +843,9 @@ describe('ReactFiberEvents', () => {
     it('should render a simple event component with a single event target', () => {
       const Test = () => (
         <EventComponent>
-          <EventTarget>
-            <div>Hello world</div>
-          </EventTarget>
+          <div>
+            Hello world<EventTarget />
+          </div>
         </EventComponent>
       );
 
@@ -901,9 +856,8 @@ describe('ReactFiberEvents', () => {
 
       const Test2 = () => (
         <EventComponent>
-          <EventTarget>
-            <span>I am now a span</span>
-          </EventTarget>
+          <EventTarget />
+          <span>I am now a span</span>
         </EventComponent>
       );
 
@@ -923,10 +877,7 @@ describe('ReactFiberEvents', () => {
         const container = document.createElement('div');
         ReactDOM.render(<Test />, container);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
-          'Wrap the child text "Hello world" in an element.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should warn when an event target has a direct text child #2', () => {
@@ -943,19 +894,15 @@ describe('ReactFiberEvents', () => {
         const container = document.createElement('div');
         ReactDOM.render(<Test />, container);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
-          'Wrap the child text "Hello world" in an element.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should not warn if an event target is not a direct child of an event component', () => {
       const Test = () => (
         <EventComponent>
           <div>
-            <EventTarget>
-              <span>Child 1</span>
-            </EventTarget>
+            <EventTarget />
+            <span>Child 1</span>
           </div>
         </EventComponent>
       );
@@ -981,9 +928,7 @@ describe('ReactFiberEvents', () => {
         const container = document.createElement('div');
         ReactDOM.render(<Test />, container);
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets must not have event components as children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should handle event components correctly with error boundaries', () => {
@@ -993,11 +938,9 @@ describe('ReactFiberEvents', () => {
 
       const Test = () => (
         <EventComponent>
-          <EventTarget>
-            <span>
-              <ErrorComponent />
-            </span>
-          </EventTarget>
+          <span>
+            <ErrorComponent />
+          </span>
         </EventComponent>
       );
 
@@ -1043,11 +986,9 @@ describe('ReactFiberEvents', () => {
 
       const Parent = () => (
         <EventComponent>
-          <EventTarget>
-            <div>
-              <Child />
-            </div>
-          </EventTarget>
+          <div>
+            <Child />
+          </div>
         </EventComponent>
       );
 
@@ -1087,9 +1028,7 @@ describe('ReactFiberEvents', () => {
 
       const Parent = () => (
         <EventComponent>
-          <EventTarget>
-            <Child />
-          </EventTarget>
+          <Child />
         </EventComponent>
       );
 
@@ -1103,7 +1042,7 @@ describe('ReactFiberEvents', () => {
         });
         expect(Scheduler).toFlushWithoutYielding();
       }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets cannot have text DOM nodes as children. ' +
+        'Warning: validateDOMNesting: React event components cannot have text DOM nodes as children. ' +
           'Wrap the child text "Text!" in an element.',
       );
     });
@@ -1117,11 +1056,7 @@ describe('ReactFiberEvents', () => {
         _updateCounter = updateCounter;
 
         if (counter === 1) {
-          return (
-            <EventComponent>
-              <div>Child</div>
-            </EventComponent>
-          );
+          return <EventTarget>123</EventTarget>;
         }
 
         return (
@@ -1132,25 +1067,25 @@ describe('ReactFiberEvents', () => {
       }
 
       const Parent = () => (
-        <EventComponent>
-          <EventTarget>
+        <div>
+          <EventComponent>
             <Child />
-          </EventTarget>
-        </EventComponent>
+          </EventComponent>
+        </div>
       );
 
       const container = document.createElement('div');
       ReactDOM.render(<Parent />, container);
-      expect(container.innerHTML).toBe('<div><span>Child - 0</span></div>');
+      expect(container.innerHTML).toBe(
+        '<div><div><span>Child - 0</span></div></div>',
+      );
 
       expect(() => {
         ReactTestUtils.act(() => {
           _updateCounter(counter => counter + 1);
         });
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
-        'Warning: validateDOMNesting: React event targets must not have event components as children.',
-      );
+      }).toWarnDev('Warning: Event targets should not have children.');
     });
 
     it('should error with a component stack contains the names of the event components and event targets', () => {
@@ -1162,11 +1097,9 @@ describe('ReactFiberEvents', () => {
 
       const Test = () => (
         <EventComponent>
-          <EventTarget>
-            <span>
-              <ErrorComponent />
-            </span>
-          </EventTarget>
+          <span>
+            <ErrorComponent />
+          </span>
         </EventComponent>
       );
 
@@ -1195,7 +1128,6 @@ describe('ReactFiberEvents', () => {
 
       expect(componentStackMessage.includes('ErrorComponent')).toBe(true);
       expect(componentStackMessage.includes('span')).toBe(true);
-      expect(componentStackMessage.includes('TestEventTarget')).toBe(true);
       expect(componentStackMessage.includes('TestEventComponent')).toBe(true);
       expect(componentStackMessage.includes('Test')).toBe(true);
       expect(componentStackMessage.includes('Wrapper')).toBe(true);
@@ -1222,9 +1154,9 @@ describe('ReactFiberEvents', () => {
     it('should render a simple event component with a single event target', () => {
       const Test = () => (
         <EventComponent>
-          <EventTarget>
-            <div>Hello world</div>
-          </EventTarget>
+          <div>
+            Hello world<EventTarget />
+          </div>
         </EventComponent>
       );
 

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -85,6 +85,8 @@ export const hideInstance = $$$hostConfig.hideInstance;
 export const hideTextInstance = $$$hostConfig.hideTextInstance;
 export const unhideInstance = $$$hostConfig.unhideInstance;
 export const unhideTextInstance = $$$hostConfig.unhideTextInstance;
+export const commitTouchHitTargetUpdate =
+  $$$hostConfig.commitTouchHitTargetUpdate;
 
 // -------------------
 //     Persistence
@@ -99,6 +101,8 @@ export const finalizeContainerChildren =
 export const replaceContainerChildren = $$$hostConfig.replaceContainerChildren;
 export const cloneHiddenInstance = $$$hostConfig.cloneHiddenInstance;
 export const cloneHiddenTextInstance = $$$hostConfig.cloneHiddenTextInstance;
+export const cloneHiddenTouchHitTargetInstance =
+  $$$hostConfig.cloneHiddenTouchHitTargetInstance;
 
 // -------------------
 //     Hydration

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -103,8 +103,6 @@ export const finalizeContainerChildren =
 export const replaceContainerChildren = $$$hostConfig.replaceContainerChildren;
 export const cloneHiddenInstance = $$$hostConfig.cloneHiddenInstance;
 export const cloneHiddenTextInstance = $$$hostConfig.cloneHiddenTextInstance;
-export const cloneHiddenTouchHitTargetInstance =
-  $$$hostConfig.cloneHiddenTouchHitTargetInstance;
 
 // -------------------
 //     Hydration

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -146,3 +146,7 @@ export const didNotFindHydratableTextInstance =
   $$$hostConfig.didNotFindHydratableTextInstance;
 export const didNotFindHydratableSuspenseInstance =
   $$$hostConfig.didNotFindHydratableSuspenseInstance;
+export const hydrateTouchHitTargetInstance =
+  $$$hostConfig.hydrateTouchHitTargetInstance;
+export const canHydrateTouchHitTargetInstance =
+  $$$hostConfig.canHydrateTouchHitTargetInstance;

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -64,8 +64,9 @@ export const supportsMutation = $$$hostConfig.supportsMutation;
 export const supportsPersistence = $$$hostConfig.supportsPersistence;
 export const supportsHydration = $$$hostConfig.supportsHydration;
 export const handleEventComponent = $$$hostConfig.handleEventComponent;
-export const createTouchHitTargetInstance =
-  $$$hostConfig.createTouchHitTargetInstance;
+export const handleEventTarget = $$$hostConfig.handleEventTarget;
+export const getEventTargetChildElement =
+  $$$hostConfig.getEventTargetChildElement;
 
 // -------------------
 //      Mutation
@@ -87,6 +88,7 @@ export const unhideInstance = $$$hostConfig.unhideInstance;
 export const unhideTextInstance = $$$hostConfig.unhideTextInstance;
 export const commitTouchHitTargetUpdate =
   $$$hostConfig.commitTouchHitTargetUpdate;
+export const commitEventTarget = $$$hostConfig.commitEventTarget;
 
 // -------------------
 //     Persistence
@@ -146,7 +148,3 @@ export const didNotFindHydratableTextInstance =
   $$$hostConfig.didNotFindHydratableTextInstance;
 export const didNotFindHydratableSuspenseInstance =
   $$$hostConfig.didNotFindHydratableSuspenseInstance;
-export const hydrateTouchHitTargetInstance =
-  $$$hostConfig.hydrateTouchHitTargetInstance;
-export const canHydrateTouchHitTargetInstance =
-  $$$hostConfig.canHydrateTouchHitTargetInstance;

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -64,7 +64,8 @@ export const supportsMutation = $$$hostConfig.supportsMutation;
 export const supportsPersistence = $$$hostConfig.supportsPersistence;
 export const supportsHydration = $$$hostConfig.supportsHydration;
 export const handleEventComponent = $$$hostConfig.handleEventComponent;
-export const handleEventTarget = $$$hostConfig.handleEventTarget;
+export const createTouchHitTargetInstance =
+  $$$hostConfig.createTouchHitTargetInstance;
 
 // -------------------
 //      Mutation

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -329,17 +329,33 @@ export function handleEventComponent(
   eventResponder: ReactEventResponder,
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
-) {
-  // TODO: add handleEventComponent implementation
+): void {
+  throw new Error('Not yet implemented.');
 }
 
 export function createTouchHitTargetInstance(
+  bottom: number,
+  left: number,
+  right: number,
+  top: number,
   parentInstance: Container,
-  props: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
   internalInstanceHandle: Object,
 ): Instance {
-  // TODO: add createTouchHitTargetInstance implementation
-  return (null: any);
+  throw new Error('Not yet implemented.');
+}
+
+export function commitTouchHitTargetUpdate(
+  oldBottom: number,
+  oldLeft: number,
+  oldRight: number,
+  oldTop: number,
+  newBottom: number,
+  newLeft: number,
+  newRight: number,
+  newTop: number,
+  touchHitTargetInstance: Instance,
+): void {
+  throw new Error('Not yet implemented.');
 }

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -330,7 +330,7 @@ export function handleEventComponent(
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
 ): void {
-  throw new Error('Not yet implemented.');
+  // noop
 }
 
 export function createTouchHitTargetInstance(
@@ -338,12 +338,44 @@ export function createTouchHitTargetInstance(
   left: number,
   right: number,
   top: number,
-  parentInstance: Container,
   rootContainerInstance: Container,
   hostContext: HostContext,
   internalInstanceHandle: Object,
 ): Instance {
-  throw new Error('Not yet implemented.');
+  let topStyle = '';
+  let leftStyle = '';
+  let rightStyle = '';
+  let bottomStyle = '';
+
+  if (top !== 0) {
+    topStyle = `-${top}px`;
+  }
+  if (left !== 0) {
+    leftStyle = `-${left}px`;
+  }
+  if (right !== 0) {
+    rightStyle = `-${right}px`;
+  }
+  if (bottom !== 0) {
+    bottomStyle = `-${bottom}px`;
+  }
+
+  return {
+    type: 'div',
+    props: {
+      style: {
+        position: 'absolute',
+        top: topStyle,
+        left: leftStyle,
+        right: rightStyle,
+        bottom: bottomStyle,
+      },
+    },
+    isHidden: false,
+    children: [],
+    rootContainerInstance,
+    tag: 'INSTANCE',
+  };
 }
 
 export function commitTouchHitTargetUpdate(
@@ -356,6 +388,20 @@ export function commitTouchHitTargetUpdate(
   newRight: number,
   newTop: number,
   touchHitTargetInstance: Instance,
+  parentInstance: null | Container,
 ): void {
-  throw new Error('Not yet implemented.');
+  const style = touchHitTargetInstance.props.style;
+
+  if (oldTop !== newTop) {
+    style.top = `-${newTop}px`;
+  }
+  if (oldLeft !== newLeft) {
+    style.left = `-${newLeft}px`;
+  }
+  if (oldRight !== newRight) {
+    style.right = `-${newRight}px`;
+  }
+  if (oldBottom !== newBottom) {
+    style.bottom = `-${newBottom}px`;
+  }
 }

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -333,13 +333,13 @@ export function handleEventComponent(
   // TODO: add handleEventComponent implementation
 }
 
-export function handleEventTarget(
-  type: Symbol | number,
-  props: Props,
+export function createTouchHitTargetInstance(
   parentInstance: Container,
+  props: Props,
+  rootContainerInstance: Container,
+  hostContext: HostContext,
   internalInstanceHandle: Object,
-) {
-  if (type === REACT_EVENT_TARGET_TOUCH_HIT) {
-    // TODO
-  }
+): Instance {
+  // TODO: add createTouchHitTargetInstance implementation
+  return (null: any);
 }

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -351,6 +351,7 @@ export function getEventTargetChildElement(
         props: {
           style: {
             position: 'absolute',
+            zIndex: -1,
             bottom: bottom ? `-${bottom}px` : '0px',
             left: left ? `-${left}px` : '0px',
             right: right ? `-${right}px` : '0px',

--- a/packages/shared/HostConfigWithNoHydration.js
+++ b/packages/shared/HostConfigWithNoHydration.js
@@ -47,3 +47,5 @@ export const didNotFindHydratableContainerSuspenseInstance = shim;
 export const didNotFindHydratableInstance = shim;
 export const didNotFindHydratableTextInstance = shim;
 export const didNotFindHydratableSuspenseInstance = shim;
+export const canHydrateTouchHitTargetInstance = shim;
+export const hydrateTouchHitTargetInstance = shim;

--- a/packages/shared/HostConfigWithNoPersistence.js
+++ b/packages/shared/HostConfigWithNoPersistence.js
@@ -30,3 +30,4 @@ export const finalizeContainerChildren = shim;
 export const replaceContainerChildren = shim;
 export const cloneHiddenInstance = shim;
 export const cloneHiddenTextInstance = shim;
+export const cloneHiddenTouchHitTargetInstance = shim;


### PR DESCRIPTION
This PR is a complete replacement for the work suggested and originally started in https://github.com/facebook/react/pull/15261.

This PR aims add doing the following:

- Support ReactDOM rendering `<TouchHitTarget>` elements. These elements can have optional numerical and nullable `top`, `left`, `right` and `bottom` props.
- Support server-side rendering of these the hit targets along with their hit slop properties.
- Support hydration from server-side rendered content for these hit targets.
- Host configs now get additional methods: `getEventTargetChildElement` and `commitEventTarget`.
- Tests mainly covering ReactDOM/ReactDOMServer support.

Furthermore, I found that we can't actually test the hit slop logic in JSDOM because it doesn't support a bunch of the DOM APIs that `<TouchHitTarget>` and respective event responders use. We'll need to come up with a different strategy for that, maybe @necolas has some ideas.

Ref #15257