### PR TITLE
Store entire build directory as CI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           path: ./node_modules.tgz
 
       - store_artifacts:
-          path: ./build/facebook-www
+          path: ./build
 
       - store_artifacts:
           path: ./scripts/error-codes/codes.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,4 +44,7 @@ jobs:
           path: ./node_modules.tgz
 
       - store_artifacts:
+          path: ./build/facebook-www
+
+      - store_artifacts:
           path: ./scripts/error-codes/codes.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           path: ./node_modules.tgz
 
       - store_artifacts:
-          path: ./build
+          path: ./build.tgz
 
       - store_artifacts:
           path: ./scripts/error-codes/codes.json

--- a/scripts/circleci/pack_and_store_artifact.sh
+++ b/scripts/circleci/pack_and_store_artifact.sh
@@ -2,10 +2,14 @@
 
 set -e
 
+# Compress build directory into a single tarball for easy download
+tar -zcvf ./build.tgz ./build
+
 # NPM pack all modules to ensure we archive the correct set of files
-for dir in ./build/node_modules/* ; do
+cd ./build/node_modules
+for dir in ./* ; do
   npm pack "$dir"
 done
 
-# Wrap everything in a single zip file for easy download by the publish script
-tar -zcvf ./node_modules.tgz ./*.tgz
+# Compress packed modules into a single tarball for easy download by the publish script
+tar -zcvf ../../node_modules.tgz ./*.tgz


### PR DESCRIPTION
Updates the Circle CI config to store Facebook bundles as build artifacts. We already do this for our npm packages.

**Update:** Might as well store entire `build/` directory