### PR TITLE
Expose extra internals in FB build of react-dom/unstable-new-scheduler

### DIFF
--- a/packages/react-dom/unstable-new-scheduler.fb.js
+++ b/packages/react-dom/unstable-new-scheduler.fb.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const ReactDOMFB = require('./src/client/ReactDOMFB');
+
+// TODO: decide on the top-level export form.
+// This is hacky but makes it work with both Rollup and Jest.
+module.exports = ReactDOMFB.default || ReactDOMFB;


### PR DESCRIPTION
The Facebook build of React DOM uses a forked entry point that exposes additional secret internals. I didn't account for this when I added the react-dom/unstable-new-scheduler build, so the extra internals are currently missing. This commit adds them.