### PR TITLE
React events: keyboard press, types, tests

### DIFF
--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -10,10 +10,12 @@
 import type {EventResponderContext} from 'events/EventTypes';
 import {REACT_EVENT_COMPONENT_TYPE} from 'shared/ReactSymbols';
 
-const targetEventTypes = [
-  {name: 'focus', passive: true, capture: true},
-  {name: 'blur', passive: true, capture: true},
-];
+type FocusProps = {
+  disabled: boolean,
+  onBlur: (e: FocusEvent) => void,
+  onFocus: (e: FocusEvent) => void,
+  onFocusChange: boolean => void,
+};
 
 type FocusState = {
   isFocused: boolean,
@@ -27,6 +29,11 @@ type FocusEvent = {|
   type: FocusEventType,
 |};
 
+const targetEventTypes = [
+  {name: 'focus', passive: true, capture: true},
+  {name: 'blur', passive: true, capture: true},
+];
+
 function createFocusEvent(
   type: FocusEventType,
   target: Element | Document,
@@ -39,7 +46,10 @@ function createFocusEvent(
   };
 }
 
-function dispatchFocusInEvents(context: EventResponderContext, props: Object) {
+function dispatchFocusInEvents(
+  context: EventResponderContext,
+  props: FocusProps,
+) {
   const {event, eventTarget} = context;
   if (context.isTargetWithinEventComponent((event: any).relatedTarget)) {
     return;
@@ -53,19 +63,22 @@ function dispatchFocusInEvents(context: EventResponderContext, props: Object) {
     context.dispatchEvent(syntheticEvent, {discrete: true});
   }
   if (props.onFocusChange) {
-    const focusChangeEventListener = () => {
+    const listener = () => {
       props.onFocusChange(true);
     };
     const syntheticEvent = createFocusEvent(
       'focuschange',
       eventTarget,
-      focusChangeEventListener,
+      listener,
     );
     context.dispatchEvent(syntheticEvent, {discrete: true});
   }
 }
 
-function dispatchFocusOutEvents(context: EventResponderContext, props: Object) {
+function dispatchFocusOutEvents(
+  context: EventResponderContext,
+  props: FocusProps,
+) {
   const {event, eventTarget} = context;
   if (context.isTargetWithinEventComponent((event: any).relatedTarget)) {
     return;
@@ -75,13 +88,13 @@ function dispatchFocusOutEvents(context: EventResponderContext, props: Object) {
     context.dispatchEvent(syntheticEvent, {discrete: true});
   }
   if (props.onFocusChange) {
-    const focusChangeEventListener = () => {
+    const listener = () => {
       props.onFocusChange(false);
     };
     const syntheticEvent = createFocusEvent(
       'focuschange',
       eventTarget,
-      focusChangeEventListener,
+      listener,
     );
     context.dispatchEvent(syntheticEvent, {discrete: true});
   }

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -52,7 +52,7 @@ type PressEvent = {|
 // const DEFAULT_PRESS_DELAY_MS = 0;
 // const DEFAULT_PRESS_END_DELAY_MS = 0;
 // const DEFAULT_PRESS_START_DELAY_MS = 0;
-const DEFAULT_LONG_PRESS_DELAY_MS = 1000;
+const DEFAULT_LONG_PRESS_DELAY_MS = 500;
 
 const targetEventTypes = [
   {name: 'click', passive: false},

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -81,7 +81,7 @@ function createPressEvent(
   };
 }
 
-function dispatchPressEvent(
+function dispatchEvent(
   context: EventResponderContext,
   state: PressState,
   name: PressEventType,
@@ -101,11 +101,11 @@ function dispatchPressStartEvents(
     const pressChangeEventListener = () => {
       props.onPressChange(bool);
     };
-    dispatchPressEvent(context, state, 'presschange', pressChangeEventListener);
+    dispatchEvent(context, state, 'presschange', pressChangeEventListener);
   }
 
   if (props.onPressStart) {
-    dispatchPressEvent(context, state, 'pressstart', props.onPressStart);
+    dispatchEvent(context, state, 'pressstart', props.onPressStart);
   }
   if (props.onPressChange) {
     dispatchPressChangeEvent(true);
@@ -131,7 +131,7 @@ function dispatchPressStartEvents(
               //   state.defaultPrevented = true;
               // }
             };
-            dispatchPressEvent(
+            dispatchEvent(
               context,
               state,
               'longpress',
@@ -143,7 +143,7 @@ function dispatchPressStartEvents(
             const longPressChangeEventListener = () => {
               props.onLongPressChange(true);
             };
-            dispatchPressEvent(
+            dispatchEvent(
               context,
               state,
               'longpresschange',
@@ -166,19 +166,19 @@ function dispatchPressEndEvents(
     state.longPressTimeout = null;
   }
   if (props.onPressEnd) {
-    dispatchPressEvent(context, state, 'pressend', props.onPressEnd);
+    dispatchEvent(context, state, 'pressend', props.onPressEnd);
   }
   if (props.onPressChange) {
     const pressChangeEventListener = () => {
       props.onPressChange(false);
     };
-    dispatchPressEvent(context, state, 'presschange', pressChangeEventListener);
+    dispatchEvent(context, state, 'presschange', pressChangeEventListener);
   }
   if (props.onLongPressChange && state.isLongPressed) {
     const longPressChangeEventListener = () => {
       props.onLongPressChange(false);
     };
-    dispatchPressEvent(
+    dispatchEvent(
       context,
       state,
       'longpresschange',
@@ -230,7 +230,7 @@ const PressResponder = {
         ) {
           return;
         }
-        dispatchPressEvent(context, state, 'press', props.onPress);
+        dispatchEvent(context, state, 'press', props.onPress);
         break;
       }
 
@@ -282,7 +282,7 @@ const PressResponder = {
                   props.onLongPressShouldCancelPress()
                 )
               ) {
-                dispatchPressEvent(context, state, 'press', props.onPress);
+                dispatchEvent(context, state, 'press', props.onPress);
               }
             }
           }
@@ -357,7 +357,7 @@ const PressResponder = {
                   //   state.defaultPrevented = true;
                   // }
                 };
-                dispatchPressEvent(context, state, 'press', pressEventListener);
+                dispatchEvent(context, state, 'press', pressEventListener);
               }
             }
           }

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -10,27 +10,6 @@
 import type {EventResponderContext} from 'events/EventTypes';
 import {REACT_EVENT_COMPONENT_TYPE} from 'shared/ReactSymbols';
 
-// const DEFAULT_PRESS_DELAY_MS = 0;
-// const DEFAULT_PRESS_END_DELAY_MS = 0;
-// const DEFAULT_PRESS_START_DELAY_MS = 0;
-const DEFAULT_LONG_PRESS_DELAY_MS = 1000;
-
-const targetEventTypes = [
-  {name: 'click', passive: false},
-  {name: 'keydown', passive: false},
-  'pointerdown',
-  'pointercancel',
-  'contextmenu',
-];
-const rootEventTypes = [{name: 'pointerup', passive: false}, 'scroll'];
-
-// In the case we don't have PointerEvents (Safari), we listen to touch events
-// too
-if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
-  targetEventTypes.push('touchstart', 'touchend', 'mousedown', 'touchcancel');
-  rootEventTypes.push({name: 'mouseup', passive: false});
-}
-
 type PressProps = {
   disabled: boolean,
   delayLongPress: number,
@@ -69,6 +48,26 @@ type PressEvent = {|
   target: Element | Document,
   type: PressEventType,
 |};
+
+// const DEFAULT_PRESS_DELAY_MS = 0;
+// const DEFAULT_PRESS_END_DELAY_MS = 0;
+// const DEFAULT_PRESS_START_DELAY_MS = 0;
+const DEFAULT_LONG_PRESS_DELAY_MS = 1000;
+
+const targetEventTypes = [
+  {name: 'click', passive: false},
+  {name: 'keydown', passive: false},
+  'pointerdown',
+  'pointercancel',
+  'contextmenu',
+];
+const rootEventTypes = [{name: 'pointerup', passive: false}, 'scroll'];
+
+// If PointerEvents is not supported (e.g., Safari), also listen to touch and mouse events.
+if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
+  targetEventTypes.push('touchstart', 'touchend', 'mousedown', 'touchcancel');
+  rootEventTypes.push({name: 'mouseup', passive: false});
+}
 
 function createPressEvent(
   type: PressEventType,

--- a/packages/react-events/src/__tests__/Focus-test.internal.js
+++ b/packages/react-events/src/__tests__/Focus-test.internal.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactFeatureFlags;
+let ReactDOM;
+let Focus;
+
+const createFocusEvent = type => {
+  const event = document.createEvent('Event');
+  event.initEvent(type, true, true);
+  return event;
+};
+
+describe('Focus event responder', () => {
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableEventAPI = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    Focus = require('react-events/focus');
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  describe('onBlur', () => {
+    let onBlur, ref;
+
+    beforeEach(() => {
+      onBlur = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Focus onBlur={onBlur}>
+          <div ref={ref} />
+        </Focus>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('is called after "blur" event', () => {
+      ref.current.dispatchEvent(createFocusEvent('focus'));
+      ref.current.dispatchEvent(createFocusEvent('blur'));
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onFocus', () => {
+    let onFocus, ref;
+
+    beforeEach(() => {
+      onFocus = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Focus onFocus={onFocus}>
+          <div ref={ref} />
+        </Focus>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('is called after "focus" event', () => {
+      ref.current.dispatchEvent(createFocusEvent('focus'));
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onFocusChange', () => {
+    let onFocusChange, ref;
+
+    beforeEach(() => {
+      onFocusChange = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Focus onFocusChange={onFocusChange}>
+          <div ref={ref} />
+        </Focus>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('is called after "blur" and "focus" events', () => {
+      ref.current.dispatchEvent(createFocusEvent('focus'));
+      expect(onFocusChange).toHaveBeenCalledTimes(1);
+      expect(onFocusChange).toHaveBeenCalledWith(true);
+      ref.current.dispatchEvent(createFocusEvent('blur'));
+      expect(onFocusChange).toHaveBeenCalledTimes(2);
+      expect(onFocusChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('expect displayName to show up for event component', () => {
+    expect(Focus.displayName).toBe('Focus');
+  });
+});

--- a/packages/react-events/src/__tests__/Hover-test.internal.js
+++ b/packages/react-events/src/__tests__/Hover-test.internal.js
@@ -186,4 +186,8 @@ describe('Hover event responder', () => {
     // TODO: complete delayHoverStart tests
     // describe('delayHoverEnd', () => {});
   });
+
+  it('expect displayName to show up for event component', () => {
+    expect(Hover.displayName).toBe('Hover');
+  });
 });

--- a/packages/react-events/src/__tests__/Hover-test.internal.js
+++ b/packages/react-events/src/__tests__/Hover-test.internal.js
@@ -14,6 +14,12 @@ let ReactFeatureFlags;
 let ReactDOM;
 let Hover;
 
+const createPointerEvent = type => {
+  const event = document.createEvent('Event');
+  event.initEvent(type, true, true);
+  return event;
+};
+
 describe('Hover event responder', () => {
   let container;
 
@@ -34,69 +40,150 @@ describe('Hover event responder', () => {
     container = null;
   });
 
-  it('should support onHover', () => {
-    let divRef = React.createRef();
-    let events = [];
+  describe('onHoverStart', () => {
+    let onHoverStart, ref;
 
-    function handleOnHover(e) {
-      if (e) {
-        events.push('hover in');
-      } else {
-        events.push('hover out');
-      }
-    }
-
-    function Component() {
-      return (
-        <Hover onHoverChange={handleOnHover}>
-          <div ref={divRef}>Hover me!</div>
+    beforeEach(() => {
+      onHoverStart = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Hover onHoverStart={onHoverStart}>
+          <div ref={ref} />
         </Hover>
       );
-    }
+      ReactDOM.render(element, container);
+    });
 
-    ReactDOM.render(<Component />, container);
+    it('is called after "pointerover" event', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerover'));
+      expect(onHoverStart).toHaveBeenCalledTimes(1);
+    });
 
-    const mouseOverEvent = document.createEvent('Event');
-    mouseOverEvent.initEvent('mouseover', true, true);
-    divRef.current.dispatchEvent(mouseOverEvent);
+    it('is not called if "pointerover" pointerType is touch', () => {
+      const event = createPointerEvent('pointerover');
+      event.pointerType = 'touch';
+      ref.current.dispatchEvent(event);
+      expect(onHoverStart).not.toBeCalled();
+    });
 
-    const mouseOutEvent = document.createEvent('Event');
-    mouseOutEvent.initEvent('mouseout', true, true);
-    divRef.current.dispatchEvent(mouseOutEvent);
+    it('ignores browser emulated "mouseover" event', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerover'));
+      ref.current.dispatchEvent(createPointerEvent('mouseover'));
+      expect(onHoverStart).toHaveBeenCalledTimes(1);
+    });
 
-    expect(events).toEqual(['hover in', 'hover out']);
+    // No PointerEvent fallbacks
+    it('is called after "mouseover" event', () => {
+      ref.current.dispatchEvent(createPointerEvent('mouseover'));
+      expect(onHoverStart).toHaveBeenCalledTimes(1);
+    });
+    it('is not called after "touchstart"', () => {
+      ref.current.dispatchEvent(createPointerEvent('touchstart'));
+      ref.current.dispatchEvent(createPointerEvent('touchend'));
+      ref.current.dispatchEvent(createPointerEvent('mouseover'));
+      expect(onHoverStart).not.toBeCalled();
+    });
+
+    // TODO: complete delayHoverStart tests
+    // describe('delayHoverStart', () => {});
   });
 
-  it('should support onHoverStart and onHoverEnd', () => {
-    let divRef = React.createRef();
-    let events = [];
+  describe('onHoverChange', () => {
+    let onHoverChange, ref;
 
-    function handleOnHoverStart() {
-      events.push('onHoverStart');
-    }
-
-    function handleOnHoverEnd() {
-      events.push('onHoverEnd');
-    }
-
-    function Component() {
-      return (
-        <Hover onHoverStart={handleOnHoverStart} onHoverEnd={handleOnHoverEnd}>
-          <div ref={divRef}>Hover me!</div>
+    beforeEach(() => {
+      onHoverChange = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Hover onHoverChange={onHoverChange}>
+          <div ref={ref} />
         </Hover>
       );
-    }
+      ReactDOM.render(element, container);
+    });
 
-    ReactDOM.render(<Component />, container);
+    it('is called after "pointerover" and "pointerout" events', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerover'));
+      expect(onHoverChange).toHaveBeenCalledTimes(1);
+      expect(onHoverChange).toHaveBeenCalledWith(true);
+      ref.current.dispatchEvent(createPointerEvent('pointerout'));
+      expect(onHoverChange).toHaveBeenCalledTimes(2);
+      expect(onHoverChange).toHaveBeenCalledWith(false);
+    });
 
-    const mouseOverEvent = document.createEvent('Event');
-    mouseOverEvent.initEvent('mouseover', true, true);
-    divRef.current.dispatchEvent(mouseOverEvent);
+    // No PointerEvent fallbacks
+    it('is called after "mouseover" and "mouseout" events', () => {
+      ref.current.dispatchEvent(createPointerEvent('mouseover'));
+      expect(onHoverChange).toHaveBeenCalledTimes(1);
+      expect(onHoverChange).toHaveBeenCalledWith(true);
+      ref.current.dispatchEvent(createPointerEvent('mouseout'));
+      expect(onHoverChange).toHaveBeenCalledTimes(2);
+      expect(onHoverChange).toHaveBeenCalledWith(false);
+    });
+  });
 
-    const mouseOutEvent = document.createEvent('Event');
-    mouseOutEvent.initEvent('mouseout', true, true);
-    divRef.current.dispatchEvent(mouseOutEvent);
+  describe('onHoverEnd', () => {
+    let onHoverEnd, ref;
 
-    expect(events).toEqual(['onHoverStart', 'onHoverEnd']);
+    beforeEach(() => {
+      onHoverEnd = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Hover onHoverEnd={onHoverEnd}>
+          <div ref={ref} />
+        </Hover>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('is called after "pointerout" event', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerover'));
+      ref.current.dispatchEvent(createPointerEvent('pointerout'));
+      expect(onHoverEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not called if "pointerover" pointerType is touch', () => {
+      const event = createPointerEvent('pointerover');
+      event.pointerType = 'touch';
+      ref.current.dispatchEvent(event);
+      ref.current.dispatchEvent(createPointerEvent('pointerout'));
+      expect(onHoverEnd).not.toBeCalled();
+    });
+
+    it('ignores browser emulated "mouseout" event', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerover'));
+      ref.current.dispatchEvent(createPointerEvent('pointerout'));
+      ref.current.dispatchEvent(createPointerEvent('mouseout'));
+      expect(onHoverEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called after "pointercancel" event', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerover'));
+      ref.current.dispatchEvent(createPointerEvent('pointercancel'));
+      expect(onHoverEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not called again after "pointercancel" event if it follows "pointerout"', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerover'));
+      ref.current.dispatchEvent(createPointerEvent('pointerout'));
+      ref.current.dispatchEvent(createPointerEvent('pointercancel'));
+      expect(onHoverEnd).toHaveBeenCalledTimes(1);
+    });
+
+    // No PointerEvent fallbacks
+    it('is called after "mouseout" event', () => {
+      ref.current.dispatchEvent(createPointerEvent('mouseover'));
+      ref.current.dispatchEvent(createPointerEvent('mouseout'));
+      expect(onHoverEnd).toHaveBeenCalledTimes(1);
+    });
+    it('is not called after "touchend"', () => {
+      ref.current.dispatchEvent(createPointerEvent('touchstart'));
+      ref.current.dispatchEvent(createPointerEvent('touchend'));
+      ref.current.dispatchEvent(createPointerEvent('mouseout'));
+      expect(onHoverEnd).not.toBeCalled();
+    });
+
+    // TODO: complete delayHoverStart tests
+    // describe('delayHoverEnd', () => {});
   });
 });

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -14,7 +14,7 @@ let ReactFeatureFlags;
 let ReactDOM;
 let Press;
 
-const DEFAULT_LONG_PRESS_DELAY = 1000;
+const DEFAULT_LONG_PRESS_DELAY = 500;
 
 const createPointerEvent = type => {
   const event = document.createEvent('Event');

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -69,7 +69,7 @@ describe('Event responder: Press', () => {
       expect(onPressStart).toHaveBeenCalledTimes(1);
     });
 
-    it('ignores emulated "mousedown" event', () => {
+    it('ignores browser emulated "mousedown" event', () => {
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
       ref.current.dispatchEvent(createPointerEvent('mousedown'));
       expect(onPressStart).toHaveBeenCalledTimes(1);
@@ -109,7 +109,7 @@ describe('Event responder: Press', () => {
       expect(onPressEnd).toHaveBeenCalledTimes(1);
     });
 
-    it('ignores emulated "mouseup" event', () => {
+    it('ignores browser emulated "mouseup" event', () => {
       ref.current.dispatchEvent(createPointerEvent('touchstart'));
       ref.current.dispatchEvent(createPointerEvent('touchend'));
       ref.current.dispatchEvent(createPointerEvent('mouseup'));
@@ -122,7 +122,6 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(createPointerEvent('mouseup'));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
     });
-
     it('is called after "touchend" event', () => {
       ref.current.dispatchEvent(createPointerEvent('touchstart'));
       ref.current.dispatchEvent(createPointerEvent('touchend'));
@@ -152,6 +151,24 @@ describe('Event responder: Press', () => {
       expect(onPressChange).toHaveBeenCalledTimes(1);
       expect(onPressChange).toHaveBeenCalledWith(true);
       ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      expect(onPressChange).toHaveBeenCalledTimes(2);
+      expect(onPressChange).toHaveBeenCalledWith(false);
+    });
+
+    // No PointerEvent fallbacks
+    it('is called after "mousedown" and "mouseup" events', () => {
+      ref.current.dispatchEvent(createPointerEvent('mousedown'));
+      expect(onPressChange).toHaveBeenCalledTimes(1);
+      expect(onPressChange).toHaveBeenCalledWith(true);
+      ref.current.dispatchEvent(createPointerEvent('mouseup'));
+      expect(onPressChange).toHaveBeenCalledTimes(2);
+      expect(onPressChange).toHaveBeenCalledWith(false);
+    });
+    it('is called after "touchstart" and "touchend" events', () => {
+      ref.current.dispatchEvent(createPointerEvent('touchstart'));
+      expect(onPressChange).toHaveBeenCalledTimes(1);
+      expect(onPressChange).toHaveBeenCalledWith(true);
+      ref.current.dispatchEvent(createPointerEvent('touchend'));
       expect(onPressChange).toHaveBeenCalledTimes(2);
       expect(onPressChange).toHaveBeenCalledWith(false);
     });

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -75,6 +75,25 @@ describe('Event responder: Press', () => {
       expect(onPressStart).toHaveBeenCalledTimes(1);
     });
 
+    it('is called once after "keydown" events for Enter', () => {
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
+      expect(onPressStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called once after "keydown" events for Spacebar', () => {
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: ' '}));
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: ' '}));
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: ' '}));
+      expect(onPressStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not called after "keydown" for other keys', () => {
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'a'}));
+      expect(onPressStart).not.toBeCalled();
+    });
+
     // No PointerEvent fallbacks
     it('is called after "mousedown" event', () => {
       ref.current.dispatchEvent(createPointerEvent('mousedown'));
@@ -116,6 +135,24 @@ describe('Event responder: Press', () => {
       expect(onPressEnd).toHaveBeenCalledTimes(1);
     });
 
+    it('is called after "keyup" event for Enter', () => {
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
+      ref.current.dispatchEvent(createKeyboardEvent('keyup', {key: 'Enter'}));
+      expect(onPressEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called after "keyup" event for Spacebar', () => {
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: ' '}));
+      ref.current.dispatchEvent(createKeyboardEvent('keyup', {key: ' '}));
+      expect(onPressEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not called after "keyup" event for other keys', () => {
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
+      ref.current.dispatchEvent(createKeyboardEvent('keyup', {key: 'a'}));
+      expect(onPressEnd).not.toBeCalled();
+    });
+
     // No PointerEvent fallbacks
     it('is called after "mouseup" event', () => {
       ref.current.dispatchEvent(createPointerEvent('mousedown'));
@@ -151,6 +188,15 @@ describe('Event responder: Press', () => {
       expect(onPressChange).toHaveBeenCalledTimes(1);
       expect(onPressChange).toHaveBeenCalledWith(true);
       ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      expect(onPressChange).toHaveBeenCalledTimes(2);
+      expect(onPressChange).toHaveBeenCalledWith(false);
+    });
+
+    it('is called after valid "keydown" and "keyup" events', () => {
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
+      expect(onPressChange).toHaveBeenCalledTimes(1);
+      expect(onPressChange).toHaveBeenCalledWith(true);
+      ref.current.dispatchEvent(createKeyboardEvent('keyup', {key: 'Enter'}));
       expect(onPressChange).toHaveBeenCalledTimes(2);
       expect(onPressChange).toHaveBeenCalledWith(false);
     });
@@ -193,6 +239,20 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(createPointerEvent('pointerup'));
       expect(onPress).toHaveBeenCalledTimes(1);
     });
+
+    it('is called after valid "keyup" event', () => {
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
+      ref.current.dispatchEvent(createKeyboardEvent('keyup', {key: 'Enter'}));
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    // No PointerEvent fallbacks
+    // TODO: jsdom missing APIs
+    //it('is called after "touchend" event', () => {
+    //ref.current.dispatchEvent(createPointerEvent('touchstart'));
+    //ref.current.dispatchEvent(createPointerEvent('touchend'));
+    //expect(onPress).toHaveBeenCalledTimes(1);
+    //});
   });
 
   describe('onLongPress', () => {
@@ -209,7 +269,7 @@ describe('Event responder: Press', () => {
       ReactDOM.render(element, container);
     });
 
-    it('is called if press lasts default delay', () => {
+    it('is called if "pointerdown" lasts default delay', () => {
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
       jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DELAY - 1);
       expect(onLongPress).not.toBeCalled();
@@ -217,10 +277,26 @@ describe('Event responder: Press', () => {
       expect(onLongPress).toHaveBeenCalledTimes(1);
     });
 
-    it('is not called if press is released before delay', () => {
+    it('is not called if "pointerup" is dispatched before delay', () => {
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
       jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DELAY - 1);
       ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      jest.advanceTimersByTime(1);
+      expect(onLongPress).not.toBeCalled();
+    });
+
+    it('is called if valid "keydown" lasts default delay', () => {
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
+      jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DELAY - 1);
+      expect(onLongPress).not.toBeCalled();
+      jest.advanceTimersByTime(1);
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not called if valid "keyup" is dispatched before delay', () => {
+      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
+      jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DELAY - 1);
+      ref.current.dispatchEvent(createKeyboardEvent('keyup', {key: 'Enter'}));
       jest.advanceTimersByTime(1);
       expect(onLongPress).not.toBeCalled();
     });
@@ -356,7 +432,7 @@ describe('Event responder: Press', () => {
 
   describe('nested responders', () => {
     it('dispatch events in the correct order', () => {
-      let events = [];
+      const events = [];
       const ref = React.createRef();
       const createEventHandler = msg => () => {
         events.push(msg);
@@ -402,13 +478,6 @@ describe('Event responder: Press', () => {
         'outer: onPressChange',
         'outer: onPress',
       ]);
-
-      events = [];
-      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
-      // TODO update this test once we have a form of stopPropagation in
-      // the responder system again. This test had to be updated because
-      // we have removed stopPropagation() from synthetic events.
-      expect(events).toEqual(['keydown', 'inner: onPress', 'outer: onPress']);
     });
   });
 


### PR DESCRIPTION
I suggest reviewing this by stepping through the individual commits. This patch addresses the following tasks:

* Adding flow types for Hover and Focus props.
* Improved Hover and Press test coverage.
* Reducing the default length of `delayLongPress`.
* Adds keyboard support for all the press events.