### PR TITLE
Experimental event API: Swipe module with tests

### DIFF
--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -39,7 +39,7 @@ type EventData = {
   initial: Point,
   delta: Point,
   point: Point,
-  direction: SwipeDirection,
+  direction: null | SwipeDirection,
 };
 
 type SwipeEvent = {|
@@ -93,8 +93,7 @@ function dispatchSwipStartEvent(
     },
     initial: {x: state.startX, y: state.startY},
     point,
-    //TODO: fill pointerType
-    // pointerType: ... ,
+    pointerType: state.swipeTarget,
     direction: state.direction,
   };
   dispatchSwipeEvent(
@@ -120,8 +119,7 @@ function dispatchSwipeMoveEvent(
     },
     initial: {x: state.startX, y: state.startY},
     point,
-    //TODO: fill pointerType
-    // pointerType: ... ,
+    pointerType: state.swipeTarget,
     direction: state.direction,
   };
   dispatchSwipeEvent(

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -136,6 +136,7 @@ type SwipeState = {
   direction: null | SwipeDirection,
   isSwiping: boolean,
   lastDirection: null | SwipeDirection,
+  pointerType: null | PointerType,
   startX: number,
   startY: number,
   touchId: null | number,

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -27,19 +27,19 @@ type PointerType = 'mouse' | 'pen' | 'touch';
 
 type SwipeEventType = 'swipestart' | 'swipeend' | 'swipemove';
 
-type SwipeDirection = 'up' | 'left' | 'down' | 'right';
+type SwipeDirectionType = 'up' | 'left' | 'down' | 'right';
 
-type Point = {
+type PointType = {
   x: number,
   y: number,
 };
 
 type EventData = {
   pointerType: null | PointerType,
-  initial: Point,
-  delta: Point,
-  point: Point,
-  direction: null | SwipeDirection,
+  initial: PointType,
+  delta: PointType,
+  point: PointType,
+  direction: null | SwipeDirectionType,
 };
 
 type SwipeEvent = {|
@@ -47,14 +47,14 @@ type SwipeEvent = {|
   target: Element | Document,
   type: SwipeEventType,
   pointerType: null | PointerType,
-  initial: Point,
-  delta: Point,
-  point: Point,
-  direction: null | SwipeDirection,
+  initial: PointType,
+  delta: PointType,
+  point: PointType,
+  direction: null | SwipeDirectionType,
 |};
 
 //min distance traveled to be considered swipe
-const DEFAULT_TRESHOLD_SWIP = 10;
+const DEFAULT_TRESHOLD_SWIP = 1;
 
 function createSwipeEvent(
   type: SwipeEventType,
@@ -87,7 +87,7 @@ function dispatchSwipeStartEvent(
   context: ResponderContext,
   props: Object,
   state: SwipeState,
-  point: Point,
+  point: PointType,
 ) {
   const eventData = {
     delta: {
@@ -113,7 +113,7 @@ function dispatchSwipeMoveEvent(
   context: ResponderContext,
   props: Object,
   state: SwipeState,
-  point: Point,
+  point: PointType,
 ) {
   const eventData = {
     delta: {
@@ -136,9 +136,9 @@ function dispatchSwipeMoveEvent(
 }
 
 type SwipeState = {
-  direction: null | SwipeDirection,
+  direction: null | SwipeDirectionType,
   isSwiping: boolean,
-  lastDirection: null | SwipeDirection,
+  lastDirection: null | SwipeDirectionType,
   pointerType: null | PointerType,
   startX: number,
   startY: number,
@@ -197,7 +197,7 @@ const SwipeResponder = {
             state.x = x;
             state.y = y;
             state.swipeTarget = target;
-            state.pointerType = nativeEvent.pointerEvent;
+            state.pointerType = (nativeEvent: any).pointerType;
             if (props.onSwipeStart) {
               dispatchSwipeStartEvent(context, props, state, {x, y});
             }

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -23,6 +23,17 @@ if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
   });
 }
 
+type PointerType = 'mouse' | 'pointer' | 'touch';
+
+type SwipeEventType = 'swipestart' | 'swipeend' | 'swipemove';
+
+type SwipeDirection = 'up' | 'left' | 'down' | 'right';
+
+type Point = {
+  x: number,
+  y: number,
+};
+
 type EventData = {
   pointerType: PointerType,
   initial: Point,
@@ -30,16 +41,6 @@ type EventData = {
   point: Point,
   direction: SwipeDirection,
 };
-type PointerType = 'mouse' | 'pointer' | 'touch';
-
-type SwipeEventType = 'swipestart' | 'swipeend' | 'swipemove';
-
-type SwipeDirection = 'up' | 'left' | 'down' | 'right';
-
-type Point = {|
-  x: number,
-  y: number,
-|};
 
 type SwipeEvent = {|
   listener: SwipeEvent => void,
@@ -84,7 +85,7 @@ function dispatchSwipStartEvent(
   const eventData = {
     delta: {
       x: point.x - state.startX,
-      diffY: point.y - state.startY,
+      y: point.y - state.startY,
     },
     initial: {x: state.startX, y: state.startY},
     point,

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -25,10 +25,9 @@ if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
 
 type EventData = {
   pointerType: PointerType,
-  delta: {
-    x: number,
-    y: numer,
-  },
+  initial: Point,
+  delta: Point,
+  point: Point,
   direction: SwipeDirection,
 };
 type PointerType = 'mouse' | 'pointer' | 'touch';

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -23,7 +23,7 @@ if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
   });
 }
 
-// type PointerType = 'mouse' | 'pointer' | 'touch';
+type PointerType = 'mouse' | 'pointer' | 'touch';
 
 type SwipeEventType = 'swipestart' | 'swipeend' | 'swipemove';
 
@@ -35,7 +35,7 @@ type Point = {
 };
 
 type EventData = {
-  // pointerType: PointerType,
+  pointerType: null | PointerType,
   initial: Point,
   delta: Point,
   point: Point,
@@ -46,7 +46,7 @@ type SwipeEvent = {|
   listener: SwipeEvent => void,
   target: Element | Document,
   type: SwipeEventType,
-  // pointerType: PointerType,
+  pointerType: null | PointerType,
   initial: Point,
   delta: Point,
   point: Point,
@@ -93,7 +93,7 @@ function dispatchSwipStartEvent(
     },
     initial: {x: state.startX, y: state.startY},
     point,
-    // pointerType: state.swipeTarget,
+    pointerType: state.pointerType,
     direction: state.direction,
   };
   dispatchSwipeEvent(
@@ -119,7 +119,7 @@ function dispatchSwipeMoveEvent(
     },
     initial: {x: state.startX, y: state.startY},
     point,
-    // pointerType: state.swipeTarget,
+    pointerType: state.pointerType,
     direction: state.direction,
   };
   dispatchSwipeEvent(
@@ -151,6 +151,7 @@ const SwipeResponder = {
       direction: null,
       isSwiping: false,
       lastDirection: null,
+      pointerType: null,
       startX: 0,
       startY: 0,
       touchId: null,
@@ -192,6 +193,14 @@ const SwipeResponder = {
             state.x = x;
             state.y = y;
             state.swipeTarget = target;
+            //use if statement to prevent Fallthrough warning
+            if (type === 'touchstart') {
+              state.pointerType = 'touch';
+            } else if (type === 'mousedown') {
+              state.pointerType = 'mouse';
+            } else if (type === 'pointerdown') {
+              state.pointerType = 'pointer';
+            }
             if (props.onSwipeStart) {
               dispatchSwipStartEvent(context, props, state, {x, y});
             }

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -46,7 +46,11 @@ type SwipeEvent = {|
   listener: SwipeEvent => void,
   target: Element | Document,
   type: SwipeEventType,
+  pointerType: PointerType,
+  initial: Point,
   delta: Point,
+  point: Point,
+  direction: SwipeDirection,
 |};
 
 function createSwipeEvent(
@@ -112,7 +116,7 @@ function dispatchSwipeMoveEvent(
   const eventData = {
     delta: {
       x: point.x - state.startX,
-      diffY: point.y - state.startY,
+      y: point.y - state.startY,
     },
     initial: {x: state.startX, y: state.startY},
     point,

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -23,7 +23,7 @@ if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
   });
 }
 
-type PointerType = 'mouse' | 'pointer' | 'touch';
+// type PointerType = 'mouse' | 'pointer' | 'touch';
 
 type SwipeEventType = 'swipestart' | 'swipeend' | 'swipemove';
 
@@ -35,7 +35,7 @@ type Point = {
 };
 
 type EventData = {
-  pointerType: PointerType,
+  // pointerType: PointerType,
   initial: Point,
   delta: Point,
   point: Point,
@@ -46,11 +46,11 @@ type SwipeEvent = {|
   listener: SwipeEvent => void,
   target: Element | Document,
   type: SwipeEventType,
-  pointerType: PointerType,
+  // pointerType: PointerType,
   initial: Point,
   delta: Point,
   point: Point,
-  direction: SwipeDirection,
+  direction: null | SwipeDirection,
 |};
 
 function createSwipeEvent(
@@ -93,7 +93,7 @@ function dispatchSwipStartEvent(
     },
     initial: {x: state.startX, y: state.startY},
     point,
-    pointerType: state.swipeTarget,
+    // pointerType: state.swipeTarget,
     direction: state.direction,
   };
   dispatchSwipeEvent(
@@ -119,7 +119,7 @@ function dispatchSwipeMoveEvent(
     },
     initial: {x: state.startX, y: state.startY},
     point,
-    pointerType: state.swipeTarget,
+    // pointerType: state.swipeTarget,
     direction: state.direction,
   };
   dispatchSwipeEvent(

--- a/packages/react-events/src/__tests__/Swipe-test.internal.js
+++ b/packages/react-events/src/__tests__/Swipe-test.internal.js
@@ -281,6 +281,45 @@ describe('Swipe event responder', () => {
     });
   });
 
+  describe('PointerType', () => {
+    let onSwipeStart, ref, pointerType;
+
+    beforeEach(() => {
+      onSwipeStart = e => {
+        pointerType = e.pointerType;
+      };
+      ref = React.createRef();
+      const element = (
+        <Swipe onSwipeStart={onSwipeStart}>
+          <div ref={ref} />
+        </Swipe>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('sould be "mouse"', () => {
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      expect(pointerType).toEqual('mouse');
+    });
+
+    it('sould be "pointer"', () => {
+      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
+      expect(pointerType).toEqual('pointer');
+    });
+
+    it('sould be "touch"', () => {
+      ref.current.dispatchEvent(createTouchEvent('touchstart'));
+      expect(pointerType).toEqual('touch');
+    });
+
+    it('is called after "mouse"', () => {
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
+      ref.current.dispatchEvent(createTouchEvent('touchstart'));
+      expect(pointerType).toEqual('mouse');
+    });
+  });
+
   it('expect displayName to show up for event component', () => {
     expect(Swipe.displayName).toBe('Swipe');
   });

--- a/packages/react-events/src/__tests__/Swipe-test.internal.js
+++ b/packages/react-events/src/__tests__/Swipe-test.internal.js
@@ -20,6 +20,14 @@ const createMouseEvent = (type, x = 0, y = 0) => {
   return event;
 };
 
+const createPointerEvent = (type, x = 0, y = 0) => {
+  // const event = new PointerEvent(type, { bubbles: true, cancelable: false, screenX: x, screenY: y });
+  //TODO: check pointer event undefined error
+  const event = document.createEvent('MouseEvents');
+  event.initMouseEvent(type, true, true, window, 1, x, y, 0, 0);
+  return event;
+};
+
 const createTouchEvent = (type, x = 0, y = 0, identifiers = [1]) => {
   let touches = [];
   for (let i = 0; i < identifiers.length; i++) {
@@ -79,12 +87,12 @@ describe('Swipe event responder', () => {
     });
 
     it('is called after "pointerdown" event', () => {
-      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
       expect(onSwipeStart).toHaveBeenCalledTimes(1);
     });
 
     it('ignores emulated "mousedown" event', () => {
-      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
       ref.current.dispatchEvent(createMouseEvent('mousedown'));
       expect(onSwipeStart).toHaveBeenCalledTimes(1);
     });
@@ -116,9 +124,9 @@ describe('Swipe event responder', () => {
     });
 
     it('is called after "pointerup" event', () => {
-      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
       ref.current.dispatchEvent(createMouseEvent('pointermove', 50, 50));
-      ref.current.dispatchEvent(createMouseEvent('pointerup'));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
       expect(onSwipeEnd).toHaveBeenCalledTimes(1);
     });
 
@@ -161,7 +169,7 @@ describe('Swipe event responder', () => {
     });
 
     it('is called after "pointermove" event', () => {
-      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
       ref.current.dispatchEvent(createMouseEvent('pointermove', 50, 50));
       expect(onSwipe).toHaveBeenCalledTimes(1);
     });
@@ -176,7 +184,7 @@ describe('Swipe event responder', () => {
       ref.current.dispatchEvent(createTouchEvent('touchstart'));
       ref.current.dispatchEvent(createTouchEvent('touchend'));
       ref.current.dispatchEvent(createMouseEvent('mousemove', 50, 50));
-      ref.current.dispatchEvent(createMouseEvent('pointerup'));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
       expect(onSwipe).toHaveBeenCalledTimes(1);
     });
   });
@@ -200,45 +208,67 @@ describe('Swipe event responder', () => {
     });
 
     it('should be right', () => {
-      ref.current.dispatchEvent(createMouseEvent('mousedown'));
-      ref.current.dispatchEvent(createMouseEvent('mousemove', 50, 0));
-      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 50, 0));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
       expect(directions).toEqual(['right']);
     });
     it('should be left', () => {
-      ref.current.dispatchEvent(createMouseEvent('mousedown'));
-      ref.current.dispatchEvent(createMouseEvent('mousemove', -50, 0));
-      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', -50, 0));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
       expect(directions).toEqual(['left']);
     });
     it('should be up', () => {
-      ref.current.dispatchEvent(createMouseEvent('mousedown'));
-      ref.current.dispatchEvent(createMouseEvent('mousemove', 0, 50));
-      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 0, 50));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
       expect(directions).toEqual(['up']);
     });
     it('should be down', () => {
-      ref.current.dispatchEvent(createMouseEvent('mousedown'));
-      ref.current.dispatchEvent(createMouseEvent('mousemove', 0, -50));
-      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 0, -50));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
       expect(directions).toEqual(['down']);
     });
 
-    it('directions in events in the correct order vertical', () => {
-      ref.current.dispatchEvent(createMouseEvent('mousedown'));
-      ref.current.dispatchEvent(createMouseEvent('mousemove', -50, 0));
-      ref.current.dispatchEvent(createMouseEvent('mousemove', 50, 0));
-      ref.current.dispatchEvent(createMouseEvent('mousemove', 60, 0));
-      ref.current.dispatchEvent(createMouseEvent('mouseup'));
-      expect(directions).toEqual(['left', 'right', 'right']);
-    });
     it('directions in events in the correct order horizontal', () => {
-      ref.current.dispatchEvent(createMouseEvent('mousedown'));
-      ref.current.dispatchEvent(createMouseEvent('mousemove', 0, -50));
-      ref.current.dispatchEvent(createMouseEvent('mousemove', 0, 50));
-      ref.current.dispatchEvent(createMouseEvent('mousemove', 0, 60));
-      ref.current.dispatchEvent(createMouseEvent('mouseup'));
-      expect(directions).toEqual(['down', 'up', 'up']);
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', -50, 0));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 50, 0));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      expect(directions).toEqual(['left', 'right']);
+    });
+    it('directions in events in the correct order vertical', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 0, -50));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 0, 50));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      expect(directions).toEqual(['down', 'up']);
+    });
+    it('directions in events in the correct order horizontal and vertical', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 0, -50));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 50, 0));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 0, 50));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', -50, 0));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      expect(directions).toEqual(['down', 'right', 'up', 'left']);
+    });
+    it('directions in events in the correct order horizontal and vertical with leave pointer in each swipe', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 0, -50));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 50, 0));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 0, 50));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', -50, 0));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      expect(directions).toEqual(['down', 'right', 'up', 'left']);
     });
   });
 
@@ -278,45 +308,6 @@ describe('Swipe event responder', () => {
         'inner: onSwipeEnd',
         'outer: onSwipeEnd',
       ]);
-    });
-  });
-
-  describe('PointerType', () => {
-    let onSwipeStart, ref, pointerType;
-
-    beforeEach(() => {
-      onSwipeStart = e => {
-        pointerType = e.pointerType;
-      };
-      ref = React.createRef();
-      const element = (
-        <Swipe onSwipeStart={onSwipeStart}>
-          <div ref={ref} />
-        </Swipe>
-      );
-      ReactDOM.render(element, container);
-    });
-
-    it('sould be "mouse"', () => {
-      ref.current.dispatchEvent(createMouseEvent('mousedown'));
-      expect(pointerType).toEqual('mouse');
-    });
-
-    it('sould be "pointer"', () => {
-      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
-      expect(pointerType).toEqual('pointer');
-    });
-
-    it('sould be "touch"', () => {
-      ref.current.dispatchEvent(createTouchEvent('touchstart'));
-      expect(pointerType).toEqual('touch');
-    });
-
-    it('is called after "mouse"', () => {
-      ref.current.dispatchEvent(createMouseEvent('mousedown'));
-      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
-      ref.current.dispatchEvent(createTouchEvent('touchstart'));
-      expect(pointerType).toEqual('mouse');
     });
   });
 

--- a/packages/react-events/src/__tests__/Swipe-test.internal.js
+++ b/packages/react-events/src/__tests__/Swipe-test.internal.js
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactFeatureFlags;
+let ReactDOM;
+let Swipe;
+
+const createMouseEvent = (type, x = 0, y = 0) => {
+  const event = document.createEvent('MouseEvents');
+  event.initMouseEvent(type, true, true, window, 1, x, y, 0, 0);
+  return event;
+};
+
+const createTouchEvent = (type, x = 0, y = 0, identifiers = [1]) => {
+  let touches = [];
+  for (let i = 0; i < identifiers.length; i++) {
+    touches.push({
+      identifier: identifiers[i],
+      target: document,
+      clientX: 0,
+      clientY: 0,
+      screenX: x,
+      screenY: y,
+    });
+  }
+
+  const event = new TouchEvent(type, {
+    cancelable: true,
+    bubbles: true,
+    composed: true,
+    touches,
+    targetTouches: touches,
+    changedTouches: touches,
+  });
+  return event;
+};
+
+describe('Swipe event responder', () => {
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableEventAPI = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    Swipe = require('react-events/swipe');
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  describe('onSwipeStart', () => {
+    let onSwipeStart, ref;
+
+    beforeEach(() => {
+      onSwipeStart = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Swipe onSwipeStart={onSwipeStart}>
+          <div ref={ref} />
+        </Swipe>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('is called after "pointerdown" event', () => {
+      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
+      expect(onSwipeStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores emulated "mousedown" event', () => {
+      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      expect(onSwipeStart).toHaveBeenCalledTimes(1);
+    });
+
+    // No PointerEvent fallbacks
+    it('is called after "mousedown" event', () => {
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      expect(onSwipeStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called after "touchstart" event', () => {
+      ref.current.dispatchEvent(createTouchEvent('touchstart'));
+      expect(onSwipeStart).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onSwipeEnd', () => {
+    let onSwipeEnd, ref;
+
+    beforeEach(() => {
+      onSwipeEnd = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Swipe onSwipeEnd={onSwipeEnd}>
+          <div ref={ref} />
+        </Swipe>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('is called after "pointerup" event', () => {
+      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 50, 50));
+      ref.current.dispatchEvent(createMouseEvent('pointerup'));
+      expect(onSwipeEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores emulated "mouseup" event', () => {
+      ref.current.dispatchEvent(createTouchEvent('touchstart'));
+      ref.current.dispatchEvent(createTouchEvent('touchend'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 50, 50));
+      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      expect(onSwipeEnd).toHaveBeenCalledTimes(1);
+    });
+
+    // No PointerEvent fallbacks
+    it('is called after "mouseup" event', () => {
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', 50, 50));
+      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      expect(onSwipeEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called after "touchend" event', () => {
+      ref.current.dispatchEvent(createTouchEvent('touchstart'));
+      ref.current.dispatchEvent(createTouchEvent('touchmove', 50, 50));
+      ref.current.dispatchEvent(createTouchEvent('touchend'));
+      expect(onSwipeEnd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onSwipe', () => {
+    let onSwipe, ref;
+
+    beforeEach(() => {
+      onSwipe = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Swipe onSwipe={onSwipe}>
+          <div ref={ref} />
+        </Swipe>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('is called after "pointermove" event', () => {
+      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 50, 50));
+      expect(onSwipe).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called after "mousemove" event', () => {
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', 50, 50));
+      expect(onSwipe).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores emulated "mousemove" event', () => {
+      ref.current.dispatchEvent(createTouchEvent('touchstart'));
+      ref.current.dispatchEvent(createTouchEvent('touchend'));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', 50, 50));
+      ref.current.dispatchEvent(createMouseEvent('pointerup'));
+      expect(onSwipe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Directions', () => {
+    let ref, directions;
+
+    beforeEach(() => {
+      directions = [];
+      function onSwipe(e) {
+        directions.push(e.direction);
+      }
+
+      ref = React.createRef();
+      const element = (
+        <Swipe onSwipe={onSwipe}>
+          <div ref={ref} />
+        </Swipe>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('should be right', () => {
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', 50, 0));
+      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      expect(directions).toEqual(['right']);
+    });
+    it('should be left', () => {
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', -50, 0));
+      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      expect(directions).toEqual(['left']);
+    });
+    it('should be up', () => {
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', 0, 50));
+      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      expect(directions).toEqual(['up']);
+    });
+    it('should be down', () => {
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', 0, -50));
+      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      expect(directions).toEqual(['down']);
+    });
+
+    it('directions in events in the correct order vertical', () => {
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', -50, 0));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', 50, 0));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', 60, 0));
+      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      expect(directions).toEqual(['left', 'right', 'right']);
+    });
+    it('directions in events in the correct order horizontal', () => {
+      ref.current.dispatchEvent(createMouseEvent('mousedown'));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', 0, -50));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', 0, 50));
+      ref.current.dispatchEvent(createMouseEvent('mousemove', 0, 60));
+      ref.current.dispatchEvent(createMouseEvent('mouseup'));
+      expect(directions).toEqual(['down', 'up', 'up']);
+    });
+  });
+
+  describe('nested responders', () => {
+    //TODO: test for many touch identifier
+    it('dispatch events in the correct order', () => {
+      let events = [];
+      const ref = React.createRef();
+      const createEventHandler = msg => () => {
+        events.push(msg);
+      };
+
+      const element = (
+        <Swipe
+          onSwipe={createEventHandler('outer: onSwipe')}
+          onSwipeEnd={createEventHandler('outer: onSwipeEnd')}
+          onSwipeStart={createEventHandler('outer: onSwipeStart')}>
+          <Swipe
+            onSwipe={createEventHandler('inner: onSwipe')}
+            onSwipeEnd={createEventHandler('inner: onSwipeEnd')}
+            onSwipeStart={createEventHandler('inner: onSwipeStart')}>
+            <div ref={ref} />
+          </Swipe>
+        </Swipe>
+      );
+
+      ReactDOM.render(element, container);
+
+      ref.current.dispatchEvent(createMouseEvent('pointerdown'));
+      ref.current.dispatchEvent(createMouseEvent('pointermove', 50, 50));
+      ref.current.dispatchEvent(createMouseEvent('pointerup'));
+      expect(events).toEqual([
+        'inner: onSwipeStart',
+        'outer: onSwipeStart',
+        'inner: onSwipe',
+        'outer: onSwipe',
+        'inner: onSwipeEnd',
+        'outer: onSwipeEnd',
+      ]);
+    });
+  });
+
+  it('expect displayName to show up for event component', () => {
+    expect(Swipe.displayName).toBe('Swipe');
+  });
+});

--- a/packages/react-events/src/__tests__/Swipe-test.internal.js
+++ b/packages/react-events/src/__tests__/Swipe-test.internal.js
@@ -181,7 +181,7 @@ describe('Swipe event responder', () => {
     });
   });
 
-  describe('Directions', () => {
+  describe('Swipe Directions', () => {
     let ref, directions;
 
     beforeEach(() => {


### PR DESCRIPTION
Note: this is for an experimental event Swip API and writing tests.

  - Determine event object data 
```
    pointerType: 'mouse' | 'pointer' | 'touch'
    initial: { x: number, y: number },
    point: { x: number, y: number },
    delta:  { x: number, y: number }  
    direction: 'up' | 'left' | 'down' | 'right',
```
  - Combine onSwipe{Left,Right,Up,Down} into onSwipe
  - Write unit tests 
    - `onSwipeStart`
    - `onSwipeEnd`
    - `onSwipe`
    - `Directions`
    - `nested responders`
    - `PointerType`

And about `pointerType` I think we should set it by `context`.

Ref #15257