### PR TITLE
Fix areHookInputsEqual method  warning params order

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -315,8 +315,8 @@ function areHookInputsEqual(
           'Previous: %s\n' +
           'Incoming: %s',
         currentHookNameInDev,
-        `[${nextDeps.join(', ')}]`,
         `[${prevDeps.join(', ')}]`,
+        `[${nextDeps.join(', ')}]`,
       );
     }
   }

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -608,8 +608,8 @@ describe('ReactHooks', () => {
       'Warning: The final argument passed to useLayoutEffect changed size ' +
         'between renders. The order and size of this array must remain ' +
         'constant.\n\n' +
-        'Previous: [A, B]\n' +
-        'Incoming: [A]\n',
+        'Previous: [A]\n' +
+        'Incoming: [A, B]\n',
     ]);
   });
 


### PR DESCRIPTION
Fix hooks areHookInputsEqual method  warning params order