### PR TITLE
[new] [react-is] add `typeOfElementType`, extracted from `typeOf`

### DIFF
--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -27,33 +27,35 @@ import {
 import isValidElementType from 'shared/isValidElementType';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 
+export function typeOfElementType(type: any) {
+  switch (type) {
+    case REACT_ASYNC_MODE_TYPE:
+    case REACT_CONCURRENT_MODE_TYPE:
+    case REACT_FRAGMENT_TYPE:
+    case REACT_PROFILER_TYPE:
+    case REACT_STRICT_MODE_TYPE:
+    case REACT_SUSPENSE_TYPE:
+      return type;
+    default:
+      const $$typeofType = type && type.$$typeof;
+
+      switch ($$typeofType) {
+        case REACT_CONTEXT_TYPE:
+        case REACT_FORWARD_REF_TYPE:
+        case REACT_PROVIDER_TYPE:
+          return $$typeofType;
+        default:
+          return REACT_ELEMENT_TYPE;
+      }
+  }
+}
+
 export function typeOf(object: any) {
   if (typeof object === 'object' && object !== null) {
     const $$typeof = object.$$typeof;
     switch ($$typeof) {
       case REACT_ELEMENT_TYPE:
-        const type = object.type;
-
-        switch (type) {
-          case REACT_ASYNC_MODE_TYPE:
-          case REACT_CONCURRENT_MODE_TYPE:
-          case REACT_FRAGMENT_TYPE:
-          case REACT_PROFILER_TYPE:
-          case REACT_STRICT_MODE_TYPE:
-          case REACT_SUSPENSE_TYPE:
-            return type;
-          default:
-            const $$typeofType = type && type.$$typeof;
-
-            switch ($$typeofType) {
-              case REACT_CONTEXT_TYPE:
-              case REACT_FORWARD_REF_TYPE:
-              case REACT_PROVIDER_TYPE:
-                return $$typeofType;
-              default:
-                return $$typeof;
-            }
-        }
+        return typeOfElementType(object.type);
       case REACT_LAZY_TYPE:
       case REACT_MEMO_TYPE:
       case REACT_PORTAL_TYPE:

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -69,23 +69,6 @@ describe('ReactIs', () => {
     expect(ReactIs.isValidElementType({type: 'div', props: {}})).toEqual(false);
   });
 
-  it('should identify concurrent mode', () => {
-    expect(ReactIs.typeOf(<React.unstable_ConcurrentMode />)).toBe(
-      ReactIs.ConcurrentMode,
-    );
-    expect(ReactIs.typeOfElementType(React.unstable_ConcurrentMode)).toBe(
-      ReactIs.ConcurrentMode,
-    );
-    expect(ReactIs.isConcurrentMode(<React.unstable_ConcurrentMode />)).toBe(
-      true,
-    );
-    expect(ReactIs.isConcurrentMode({type: ReactIs.ConcurrentMode})).toBe(
-      false,
-    );
-    expect(ReactIs.isConcurrentMode(<React.StrictMode />)).toBe(false);
-    expect(ReactIs.isConcurrentMode(<div />)).toBe(false);
-  });
-
   it('should identify context consumers', () => {
     const Context = React.createContext(false);
     expect(ReactIs.typeOf(<Context.Consumer />)).toBe(ReactIs.ContextConsumer);

--- a/packages/react-is/src/__tests__/ReactIs-test.js
+++ b/packages/react-is/src/__tests__/ReactIs-test.js
@@ -69,9 +69,29 @@ describe('ReactIs', () => {
     expect(ReactIs.isValidElementType({type: 'div', props: {}})).toEqual(false);
   });
 
+  it('should identify concurrent mode', () => {
+    expect(ReactIs.typeOf(<React.unstable_ConcurrentMode />)).toBe(
+      ReactIs.ConcurrentMode,
+    );
+    expect(ReactIs.typeOfElementType(React.unstable_ConcurrentMode)).toBe(
+      ReactIs.ConcurrentMode,
+    );
+    expect(ReactIs.isConcurrentMode(<React.unstable_ConcurrentMode />)).toBe(
+      true,
+    );
+    expect(ReactIs.isConcurrentMode({type: ReactIs.ConcurrentMode})).toBe(
+      false,
+    );
+    expect(ReactIs.isConcurrentMode(<React.StrictMode />)).toBe(false);
+    expect(ReactIs.isConcurrentMode(<div />)).toBe(false);
+  });
+
   it('should identify context consumers', () => {
     const Context = React.createContext(false);
     expect(ReactIs.typeOf(<Context.Consumer />)).toBe(ReactIs.ContextConsumer);
+    expect(ReactIs.typeOfElementType(Context.Consumer)).toBe(
+      ReactIs.ContextConsumer,
+    );
     expect(ReactIs.isContextConsumer(<Context.Consumer />)).toBe(true);
     expect(ReactIs.isContextConsumer(<Context.Provider />)).toBe(false);
     expect(ReactIs.isContextConsumer(<div />)).toBe(false);
@@ -80,6 +100,9 @@ describe('ReactIs', () => {
   it('should identify context providers', () => {
     const Context = React.createContext(false);
     expect(ReactIs.typeOf(<Context.Provider />)).toBe(ReactIs.ContextProvider);
+    expect(ReactIs.typeOfElementType(Context.Provider)).toBe(
+      ReactIs.ContextProvider,
+    );
     expect(ReactIs.isContextProvider(<Context.Provider />)).toBe(true);
     expect(ReactIs.isContextProvider(<Context.Consumer />)).toBe(false);
     expect(ReactIs.isContextProvider(<div />)).toBe(false);
@@ -87,6 +110,7 @@ describe('ReactIs', () => {
 
   it('should identify elements', () => {
     expect(ReactIs.typeOf(<div />)).toBe(ReactIs.Element);
+    expect(ReactIs.typeOfElementType('div')).toBe(ReactIs.Element);
     expect(ReactIs.isElement(<div />)).toBe(true);
     expect(ReactIs.isElement('div')).toBe(false);
     expect(ReactIs.isElement(true)).toBe(false);
@@ -107,6 +131,9 @@ describe('ReactIs', () => {
   it('should identify ref forwarding component', () => {
     const RefForwardingComponent = React.forwardRef((props, ref) => null);
     expect(ReactIs.typeOf(<RefForwardingComponent />)).toBe(ReactIs.ForwardRef);
+    expect(ReactIs.typeOfElementType(RefForwardingComponent)).toBe(
+      ReactIs.ForwardRef,
+    );
     expect(ReactIs.isForwardRef(<RefForwardingComponent />)).toBe(true);
     expect(ReactIs.isForwardRef({type: ReactIs.StrictMode})).toBe(false);
     expect(ReactIs.isForwardRef(<div />)).toBe(false);
@@ -114,6 +141,7 @@ describe('ReactIs', () => {
 
   it('should identify fragments', () => {
     expect(ReactIs.typeOf(<React.Fragment />)).toBe(ReactIs.Fragment);
+    expect(ReactIs.typeOfElementType(React.Fragment)).toBe(ReactIs.Fragment);
     expect(ReactIs.isFragment(<React.Fragment />)).toBe(true);
     expect(ReactIs.isFragment({type: ReactIs.Fragment})).toBe(false);
     expect(ReactIs.isFragment('React.Fragment')).toBe(false);
@@ -147,6 +175,9 @@ describe('ReactIs', () => {
 
   it('should identify strict mode', () => {
     expect(ReactIs.typeOf(<React.StrictMode />)).toBe(ReactIs.StrictMode);
+    expect(ReactIs.typeOfElementType(React.StrictMode)).toBe(
+      ReactIs.StrictMode,
+    );
     expect(ReactIs.isStrictMode(<React.StrictMode />)).toBe(true);
     expect(ReactIs.isStrictMode({type: ReactIs.StrictMode})).toBe(false);
     expect(ReactIs.isStrictMode(<div />)).toBe(false);
@@ -154,6 +185,7 @@ describe('ReactIs', () => {
 
   it('should identify suspense', () => {
     expect(ReactIs.typeOf(<React.Suspense />)).toBe(ReactIs.Suspense);
+    expect(ReactIs.typeOfElementType(React.Suspense)).toBe(ReactIs.Suspense);
     expect(ReactIs.isSuspense(<React.Suspense />)).toBe(true);
     expect(ReactIs.isSuspense({type: ReactIs.Suspense})).toBe(false);
     expect(ReactIs.isSuspense('React.Suspense')).toBe(false);
@@ -164,6 +196,7 @@ describe('ReactIs', () => {
     expect(
       ReactIs.typeOf(<React.Profiler id="foo" onRender={jest.fn()} />),
     ).toBe(ReactIs.Profiler);
+    expect(ReactIs.typeOfElementType(React.Profiler)).toBe(ReactIs.Profiler);
     expect(
       ReactIs.isProfiler(<React.Profiler id="foo" onRender={jest.fn()} />),
     ).toBe(true);


### PR DESCRIPTION
By extracting this functionality, I'll be able to simplify the logic in enzyme [here](https://github.com/airbnb/enzyme/blob/master/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js#L320-L322) by comparing directly to the type rather than needing to make a fake element.