### PR TITLE
Move EventComponent state creation to complete phase + tests

### DIFF
--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -13,9 +13,15 @@ let React;
 let ReactFeatureFlags;
 let ReactDOM;
 
-function createReactEventComponent(targetEventTypes, onEvent, onUnmount) {
+function createReactEventComponent(
+  targetEventTypes,
+  createInitialState,
+  onEvent,
+  onUnmount,
+) {
   const testEventResponder = {
     targetEventTypes,
+    createInitialState,
     onEvent,
     onUnmount,
   };
@@ -61,6 +67,7 @@ describe('DOMEventResponderSystem', () => {
 
     const ClickEventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       (event, context, props) => {
         eventResponderFiredCount++;
         eventLog.push({
@@ -114,6 +121,7 @@ describe('DOMEventResponderSystem', () => {
 
     const ClickEventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       (event, context, props) => {
         eventLog.push({
           name: event.type,
@@ -149,6 +157,7 @@ describe('DOMEventResponderSystem', () => {
 
     const ClickEventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       (event, context, props) => {
         eventResponderFiredCount++;
         eventLog.push({
@@ -193,6 +202,7 @@ describe('DOMEventResponderSystem', () => {
 
     const ClickEventComponentA = createReactEventComponent(
       ['click'],
+      undefined,
       (context, props) => {
         eventLog.push('A');
       },
@@ -200,6 +210,7 @@ describe('DOMEventResponderSystem', () => {
 
     const ClickEventComponentB = createReactEventComponent(
       ['click'],
+      undefined,
       (context, props) => {
         eventLog.push('B');
       },
@@ -228,6 +239,7 @@ describe('DOMEventResponderSystem', () => {
 
     const ClickEventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       (event, context, props) => {
         if (props.onMagicClick) {
           const syntheticEvent = {
@@ -265,6 +277,7 @@ describe('DOMEventResponderSystem', () => {
 
     const LongPressEventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       (event, context, props) => {
         const pressEvent = {
           listener: props.onPress,
@@ -323,7 +336,8 @@ describe('DOMEventResponderSystem', () => {
 
     const EventComponent = createReactEventComponent(
       [],
-      (event, context, props) => {},
+      undefined,
+      (event, context, props, state) => {},
       () => {
         onUnmountFired++;
       },
@@ -338,5 +352,30 @@ describe('DOMEventResponderSystem', () => {
     ReactDOM.render(<Test />, container);
     ReactDOM.render(null, container);
     expect(onUnmountFired).toEqual(1);
+  });
+
+  it('the event responder onUnmount() function should fire with state', () => {
+    let counter = 0;
+
+    const EventComponent = createReactEventComponent(
+      [],
+      () => ({
+        incrementAmount: 5,
+      }),
+      (event, context, props, state) => {},
+      (context, props, state) => {
+        counter += state.incrementAmount;
+      },
+    );
+
+    const Test = () => (
+      <EventComponent>
+        <button />
+      </EventComponent>
+    );
+
+    ReactDOM.render(<Test />, container);
+    ReactDOM.render(null, container);
+    expect(counter).toEqual(5);
   });
 });

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -774,10 +774,18 @@ function completeWork(
         popHostContext(workInProgress);
         const rootContainerInstance = getRootHostContainer();
         const responder = workInProgress.type.responder;
+        const stateNode = workInProgress.stateNode;
         // Update the props on the event component state node
-        workInProgress.stateNode.props = newProps;
+        stateNode.props = newProps;
         // Update the root container, so we can properly unmount events at some point
-        workInProgress.stateNode.rootInstance = rootContainerInstance;
+        stateNode.rootInstance = rootContainerInstance;
+        // Initialize event component state if createInitialState exists
+        if (
+          stateNode.state === null &&
+          responder.createInitialState !== undefined
+        ) {
+          stateNode.state = responder.createInitialState(newProps);
+        }
         handleEventComponent(responder, rootContainerInstance);
       }
       break;


### PR DESCRIPTION
Note: This is for the experimental event API.

This PR moves the creation of `EventComponent` state to always happen in the complete phase, rather than happen lazily upon the first event firing. This ensures that state is consistent, otherwise a component that hasn't had state created (because an event didn't fire), will likely break in the unmount phase because state is expected to exist. I added a test that validates this behaviour.

I also removed the `currentResponder` binding as it is no longer used anywhere and was just dead code.