### PR TITLE
Track Event Time as the Start Time for Suspense

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
@@ -251,7 +251,10 @@ describe('React hooks DevTools integration', () => {
       </div>,
       {unstable_isConcurrent: true},
     );
+
     expect(Scheduler).toFlushAndYield([]);
+    // Ensure we timeout any suspense time.
+    jest.advanceTimersByTime(1000);
     const fiber = renderer.root._currentFiber().child;
     if (__DEV__) {
       // First render was locked

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1413,7 +1413,8 @@ function updateSuspenseComponent(
     // Something in this boundary's subtree already suspended. Switch to
     // rendering the fallback children.
     nextState = {
-      timedOutAt: nextState !== null ? nextState.timedOutAt : NoWork,
+      fallbackExpirationTime:
+        nextState !== null ? nextState.fallbackExpirationTime : NoWork,
     };
     nextDidTimeout = true;
     workInProgress.effectTag &= ~DidCapture;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1275,13 +1275,13 @@ function commitSuspenseComponent(finishedWork: Fiber) {
   } else {
     newDidTimeout = true;
     primaryChildParent = finishedWork.child;
-    if (newState.timedOutAt === NoWork) {
+    if (newState.fallbackExpirationTime === NoWork) {
       // If the children had not already timed out, record the time.
       // This is used to compute the elapsed time during subsequent
       // attempts to render the children.
       // We model this as a normal pri expiration time since that's
       // how we infer start time for updates.
-      newState.timedOutAt = computeAsyncExpirationNoBucket(
+      newState.fallbackExpirationTime = computeAsyncExpirationNoBucket(
         requestCurrentTime(),
       );
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -63,7 +63,10 @@ import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import warning from 'shared/warning';
 
-import {NoWork} from './ReactFiberExpirationTime';
+import {
+  NoWork,
+  computeAsyncExpirationNoBucket,
+} from './ReactFiberExpirationTime';
 import {onCommitUnmount} from './ReactFiberDevToolsHook';
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
 import {getStackByFiberInDevAndProd} from './ReactCurrentFiber';
@@ -1276,7 +1279,11 @@ function commitSuspenseComponent(finishedWork: Fiber) {
       // If the children had not already timed out, record the time.
       // This is used to compute the elapsed time during subsequent
       // attempts to render the children.
-      newState.timedOutAt = requestCurrentTime();
+      // We model this as a normal pri expiration time since that's
+      // how we infer start time for updates.
+      newState.timedOutAt = computeAsyncExpirationNoBucket(
+        requestCurrentTime(),
+      );
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -692,8 +692,9 @@ function completeWork(
           // Mark the event time of the switching from fallback to normal children,
           // based on the start of when we first showed the fallback. This time
           // was given a normal pri expiration time at the time it was shown.
-          const timedOutAt: ExpirationTime = prevState.timedOutAt;
-          markRenderEventTime(timedOutAt);
+          const fallbackExpirationTimeExpTime: ExpirationTime =
+            prevState.fallbackExpirationTime;
+          markRenderEventTime(fallbackExpirationTimeExpTime);
 
           // Delete the fallback.
           // TODO: Would it be better to store the fallback fragment on

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -18,6 +18,7 @@ import type {
   ChildSet,
 } from './ReactFiberHostConfig';
 import type {ReactEventComponentInstance} from 'shared/ReactTypes';
+import type {SuspenseState} from './ReactFiberSuspenseComponent';
 
 import {
   IndeterminateComponent,
@@ -92,6 +93,7 @@ import {
   enableSuspenseServerRenderer,
   enableEventAPI,
 } from 'shared/ReactFeatureFlags';
+import {markRenderEventTime} from './ReactFiberScheduler';
 
 function markUpdate(workInProgress: Fiber) {
   // Tag the fiber with an update effect. This turns a Placement into
@@ -665,7 +667,7 @@ function completeWork(
     case ForwardRef:
       break;
     case SuspenseComponent: {
-      const nextState = workInProgress.memoizedState;
+      const nextState: null | SuspenseState = workInProgress.memoizedState;
       if ((workInProgress.effectTag & DidCapture) !== NoEffect) {
         // Something suspended. Re-render with the fallback children.
         workInProgress.expirationTime = renderExpirationTime;
@@ -674,34 +676,46 @@ function completeWork(
       }
 
       const nextDidTimeout = nextState !== null;
-      const prevDidTimeout = current !== null && current.memoizedState !== null;
-
+      let prevDidTimeout = false;
       if (current === null) {
         // In cases where we didn't find a suitable hydration boundary we never
         // downgraded this to a DehydratedSuspenseComponent, but we still need to
         // pop the hydration state since we might be inside the insertion tree.
         popHydrationState(workInProgress);
-      } else if (!nextDidTimeout && prevDidTimeout) {
-        // We just switched from the fallback to the normal children. Delete
-        // the fallback.
-        // TODO: Would it be better to store the fallback fragment on
-        // the stateNode during the begin phase?
-        const currentFallbackChild: Fiber | null = (current.child: any).sibling;
-        if (currentFallbackChild !== null) {
-          // Deletions go at the beginning of the return fiber's effect list
-          const first = workInProgress.firstEffect;
-          if (first !== null) {
-            workInProgress.firstEffect = currentFallbackChild;
-            currentFallbackChild.nextEffect = first;
-          } else {
-            workInProgress.firstEffect = workInProgress.lastEffect = currentFallbackChild;
-            currentFallbackChild.nextEffect = null;
+      } else {
+        const prevState: null | SuspenseState = current.memoizedState;
+        prevDidTimeout = prevState !== null;
+        if (!nextDidTimeout && prevState !== null) {
+          // We just switched from the fallback to the normal children.
+
+          // Mark the event time of the switching from fallback to normal children,
+          // based on the start of when we first showed the fallback. This time
+          // was given a normal pri expiration time at the time it was shown.
+          const timedOutAt: ExpirationTime = prevState.timedOutAt;
+          markRenderEventTime(timedOutAt);
+
+          // Delete the fallback.
+          // TODO: Would it be better to store the fallback fragment on
+          // the stateNode during the begin phase?
+          const currentFallbackChild: Fiber | null = (current.child: any)
+            .sibling;
+          if (currentFallbackChild !== null) {
+            // Deletions go at the beginning of the return fiber's effect list
+            const first = workInProgress.firstEffect;
+            if (first !== null) {
+              workInProgress.firstEffect = currentFallbackChild;
+              currentFallbackChild.nextEffect = first;
+            } else {
+              workInProgress.firstEffect = workInProgress.lastEffect = currentFallbackChild;
+              currentFallbackChild.nextEffect = null;
+            }
+            currentFallbackChild.effectTag = Deletion;
           }
-          currentFallbackChild.effectTag = Deletion;
         }
       }
 
       if (supportsPersistence) {
+        // TODO: Only schedule updates if not prevDidTimeout.
         if (nextDidTimeout) {
           // If this boundary just timed out, schedule an effect to attach a
           // retry listener to the proimse. This flag is also used to hide the
@@ -710,6 +724,7 @@ function completeWork(
         }
       }
       if (supportsMutation) {
+        // TODO: Only schedule updates if these values are non equal, i.e. it changed.
         if (nextDidTimeout || prevDidTimeout) {
           // If this boundary just timed out, schedule an effect to attach a
           // retry listener to the proimse. This flag is also used to hide the

--- a/packages/react-reconciler/src/ReactFiberExpirationTime.js
+++ b/packages/react-reconciler/src/ReactFiberExpirationTime.js
@@ -70,6 +70,14 @@ export function computeAsyncExpiration(
   );
 }
 
+// Same as computeAsyncExpiration but without the bucketing logic. This is
+// used to compute timestamps instead of actual expiration times.
+export function computeAsyncExpirationNoBucket(
+  currentTime: ExpirationTime,
+): ExpirationTime {
+  return currentTime - LOW_PRIORITY_EXPIRATION / UNIT_SIZE;
+}
+
 // We intentionally set a higher expiration time for interactive updates in
 // dev than in production.
 //

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -34,6 +34,7 @@ import {
   flushPassiveEffects,
   requestCurrentTime,
   warnIfNotCurrentlyActingUpdatesInDev,
+  markRenderEventTime,
 } from './ReactFiberScheduler';
 
 import invariant from 'shared/invariant';
@@ -718,6 +719,16 @@ function updateReducer<S, I, A>(
           remainingExpirationTime = updateExpirationTime;
         }
       } else {
+        // This update does have sufficient priority.
+
+        // Mark the event time of this update as relevant to this render pass.
+        // TODO: This should ideally use the true event time of this update rather than
+        // its priority which is a derived and not reverseable value.
+        // TODO: We should skip this update if it was already committed but currently
+        // we have no way of detecting the difference between a committed and suspended
+        // update here.
+        markRenderEventTime(updateExpirationTime);
+
         // Process this update.
         if (update.eagerReducer === reducer) {
           // If this update was processed eagerly, and its reducer matches the

--- a/packages/react-reconciler/src/ReactFiberPendingPriority.js
+++ b/packages/react-reconciler/src/ReactFiberPendingPriority.js
@@ -219,23 +219,6 @@ function clearPing(root, completedTime) {
   }
 }
 
-export function findEarliestOutstandingPriorityLevel(
-  root: FiberRoot,
-  renderExpirationTime: ExpirationTime,
-): ExpirationTime {
-  let earliestExpirationTime = renderExpirationTime;
-
-  const earliestPendingTime = root.earliestPendingTime;
-  const earliestSuspendedTime = root.earliestSuspendedTime;
-  if (earliestPendingTime > earliestExpirationTime) {
-    earliestExpirationTime = earliestPendingTime;
-  }
-  if (earliestSuspendedTime > earliestExpirationTime) {
-    earliestExpirationTime = earliestSuspendedTime;
-  }
-  return earliestExpirationTime;
-}
-
 export function didExpireAtExpirationTime(
   root: FiberRoot,
   currentTime: ExpirationTime,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -14,6 +14,7 @@ import {
   computeExpirationForFiber as computeExpirationForFiber_old,
   captureCommitPhaseError as captureCommitPhaseError_old,
   onUncaughtError as onUncaughtError_old,
+  markRenderEventTime as markRenderEventTime_old,
   renderDidSuspend as renderDidSuspend_old,
   renderDidError as renderDidError_old,
   pingSuspendedRoot as pingSuspendedRoot_old,
@@ -34,7 +35,6 @@ import {
   computeUniqueAsyncExpiration as computeUniqueAsyncExpiration_old,
   flushPassiveEffects as flushPassiveEffects_old,
   warnIfNotCurrentlyActingUpdatesInDev as warnIfNotCurrentlyActingUpdatesInDev_old,
-  inferStartTimeFromExpirationTime as inferStartTimeFromExpirationTime_old,
 } from './ReactFiberScheduler.old';
 
 import {
@@ -42,6 +42,7 @@ import {
   computeExpirationForFiber as computeExpirationForFiber_new,
   captureCommitPhaseError as captureCommitPhaseError_new,
   onUncaughtError as onUncaughtError_new,
+  markRenderEventTime as markRenderEventTime_new,
   renderDidSuspend as renderDidSuspend_new,
   renderDidError as renderDidError_new,
   pingSuspendedRoot as pingSuspendedRoot_new,
@@ -62,7 +63,6 @@ import {
   computeUniqueAsyncExpiration as computeUniqueAsyncExpiration_new,
   flushPassiveEffects as flushPassiveEffects_new,
   warnIfNotCurrentlyActingUpdatesInDev as warnIfNotCurrentlyActingUpdatesInDev_new,
-  inferStartTimeFromExpirationTime as inferStartTimeFromExpirationTime_new,
 } from './ReactFiberScheduler.new';
 
 export const requestCurrentTime = enableNewScheduler
@@ -77,6 +77,9 @@ export const captureCommitPhaseError = enableNewScheduler
 export const onUncaughtError = enableNewScheduler
   ? onUncaughtError_new
   : onUncaughtError_old;
+export const markRenderEventTime = enableNewScheduler
+  ? markRenderEventTime_new
+  : markRenderEventTime_old;
 export const renderDidSuspend = enableNewScheduler
   ? renderDidSuspend_new
   : renderDidSuspend_old;
@@ -133,9 +136,6 @@ export const flushPassiveEffects = enableNewScheduler
 export const warnIfNotCurrentlyActingUpdatesInDev = enableNewScheduler
   ? warnIfNotCurrentlyActingUpdatesInDev_new
   : warnIfNotCurrentlyActingUpdatesInDev_old;
-export const inferStartTimeFromExpirationTime = enableNewScheduler
-  ? inferStartTimeFromExpirationTime_new
-  : inferStartTimeFromExpirationTime_old;
 
 export type Thenable = {
   then(resolve: () => mixed, reject?: () => mixed): void | Thenable,

--- a/packages/react-reconciler/src/ReactFiberScheduler.new.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.new.js
@@ -194,7 +194,11 @@ let workInProgress: Fiber | null = null;
 let renderExpirationTime: ExpirationTime = NoWork;
 // Whether to root completed, errored, suspended, etc.
 let workInProgressRootExitStatus: RootExitStatus = RootIncomplete;
-let workInProgressRootAbsoluteTimeoutMs: number = -1;
+// Most recent event time among processed updates during this render.
+// This is conceptually a time stamp but expressed in terms of an ExpirationTime
+// because we deal mostly with expiration times in the hot path, so this avoids
+// the conversion happening in the hot path.
+let workInProgressRootMostRecentEventTime: ExpirationTime = Sync;
 
 let nextEffect: Fiber | null = null;
 let hasUncaughtError = false;
@@ -678,7 +682,7 @@ function prepareFreshStack(root, expirationTime) {
   workInProgress = createWorkInProgress(root.current, null, expirationTime);
   renderExpirationTime = expirationTime;
   workInProgressRootExitStatus = RootIncomplete;
-  workInProgressRootAbsoluteTimeoutMs = -1;
+  workInProgressRootMostRecentEventTime = Sync;
 
   if (__DEV__) {
     ReactStrictModeWarnings.discardPendingWarnings();
@@ -884,10 +888,12 @@ function renderRoot(
         // at that level.
         return renderRoot.bind(null, root, lastPendingTime);
       }
-      if (!isSync) {
+      // If workInProgressRootMostRecentEventTime is Sync, that means we didn't
+      // track any event times. That can happen if we retried but nothing switched
+      // from fallback to content. There's no reason to delay doing no work.
+      if (!isSync && workInProgressRootMostRecentEventTime !== Sync) {
         const msUntilTimeout = computeMsUntilTimeout(
-          root,
-          workInProgressRootAbsoluteTimeoutMs,
+          workInProgressRootMostRecentEventTime,
         );
         if (msUntilTimeout > 0) {
           // The render is suspended, it hasn't timed out, and there's no lower
@@ -913,20 +919,15 @@ function renderRoot(
   }
 }
 
-export function renderDidSuspend(
-  root: FiberRoot,
-  absoluteTimeoutMs: number,
-  // TODO: Don't need this argument anymore
-  suspendedTime: ExpirationTime,
-) {
-  if (
-    absoluteTimeoutMs >= 0 &&
-    workInProgressRootAbsoluteTimeoutMs < absoluteTimeoutMs
-  ) {
-    workInProgressRootAbsoluteTimeoutMs = absoluteTimeoutMs;
-    if (workInProgressRootExitStatus === RootIncomplete) {
-      workInProgressRootExitStatus = RootSuspended;
-    }
+export function markRenderEventTime(expirationTime: ExpirationTime): void {
+  if (expirationTime < workInProgressRootMostRecentEventTime) {
+    workInProgressRootMostRecentEventTime = expirationTime;
+  }
+}
+
+export function renderDidSuspend(): void {
+  if (workInProgressRootExitStatus === RootIncomplete) {
+    workInProgressRootExitStatus = RootSuspended;
   }
 }
 
@@ -937,6 +938,13 @@ export function renderDidError() {
   ) {
     workInProgressRootExitStatus = RootErrored;
   }
+}
+
+function inferTimeFromExpirationTime(expirationTime: ExpirationTime): number {
+  // We don't know exactly when the update was scheduled, but we can infer an
+  // approximate start time from the expiration time.
+  const earliestExpirationTimeMs = expirationTimeToMs(expirationTime);
+  return earliestExpirationTimeMs - LOW_PRIORITY_EXPIRATION + initialTimeMs;
 }
 
 function workLoopSync() {
@@ -1805,37 +1813,20 @@ export function resolveRetryThenable(boundaryFiber: Fiber, thenable: Thenable) {
   retryTimedOutBoundary(boundaryFiber);
 }
 
-export function inferStartTimeFromExpirationTime(
-  root: FiberRoot,
-  expirationTime: ExpirationTime,
-) {
-  // We don't know exactly when the update was scheduled, but we can infer an
-  // approximate start time from the expiration time.
-  const earliestExpirationTimeMs = expirationTimeToMs(root.firstPendingTime);
-  // TODO: Track this on the root instead. It's more accurate, doesn't rely on
-  // assumptions about priority, and isn't coupled to Scheduler details.
-  return earliestExpirationTimeMs - LOW_PRIORITY_EXPIRATION;
-}
-
-function computeMsUntilTimeout(root, absoluteTimeoutMs) {
+function computeMsUntilTimeout(mostRecentEventTime: ExpirationTime) {
   if (disableYielding) {
     // Timeout immediately when yielding is disabled.
     return 0;
   }
 
-  // Find the earliest uncommitted expiration time in the tree, including
-  // work that is suspended. The timeout threshold cannot be longer than
-  // the overall expiration.
-  const earliestExpirationTimeMs = expirationTimeToMs(root.firstPendingTime);
-  if (earliestExpirationTimeMs < absoluteTimeoutMs) {
-    absoluteTimeoutMs = earliestExpirationTimeMs;
-  }
+  const eventTimeMs: number = inferTimeFromExpirationTime(mostRecentEventTime);
+  const currentTimeMs: number = now();
+  const timeElapsed = currentTimeMs - eventTimeMs;
 
-  // Subtract the current time from the absolute timeout to get the number
-  // of milliseconds until the timeout. In other words, convert an absolute
-  // timestamp to a relative time. This is the value that is passed
-  // to `setTimeout`.
-  let msUntilTimeout = absoluteTimeoutMs - now();
+  // TODO: Account for the Just Noticeable Difference
+  const timeoutMs = 150;
+  const msUntilTimeout = timeoutMs - timeElapsed;
+  // This is the value that is passed to `setTimeout`.
   return msUntilTimeout < 0 ? 0 : msUntilTimeout;
 }
 

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -11,7 +11,7 @@ import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
 export type SuspenseState = {|
-  timedOutAt: ExpirationTime,
+  fallbackExpirationTime: ExpirationTime,
 |};
 
 export function shouldCaptureSuspense(workInProgress: Fiber): boolean {

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -13,7 +13,6 @@ import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {CapturedValue} from './ReactCapturedValue';
 import type {Update} from './ReactUpdateQueue';
 import type {Thenable} from './ReactFiberScheduler';
-import type {SuspenseState} from './ReactFiberSuspenseComponent';
 
 import {unstable_wrap as Schedule_tracing_wrap} from 'scheduler/tracing';
 import getComponentName from 'shared/getComponentName';
@@ -42,7 +41,7 @@ import {
   enableSuspenseServerRenderer,
   enableEventAPI,
 } from 'shared/ReactFeatureFlags';
-import {ConcurrentMode} from './ReactTypeOfMode';
+import {ConcurrentMode, NoContext} from './ReactTypeOfMode';
 import {shouldCaptureSuspense} from './ReactFiberSuspenseComponent';
 
 import {createCapturedValue} from './ReactCapturedValue';
@@ -70,12 +69,11 @@ import {
   isAlreadyFailedLegacyErrorBoundary,
   pingSuspendedRoot,
   resolveRetryThenable,
-  inferStartTimeFromExpirationTime,
 } from './ReactFiberScheduler';
 
 import invariant from 'shared/invariant';
-import maxSigned31BitInt from './maxSigned31BitInt';
-import {Sync, expirationTimeToMs} from './ReactFiberExpirationTime';
+
+import {Sync} from './ReactFiberExpirationTime';
 
 const PossiblyWeakSet = typeof WeakSet === 'function' ? WeakSet : Set;
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
@@ -206,44 +204,8 @@ function throwException(
     // This is a thenable.
     const thenable: Thenable = (value: any);
 
-    // Find the earliest timeout threshold of all the placeholders in the
-    // ancestor path. We could avoid this traversal by storing the thresholds on
-    // the stack, but we choose not to because we only hit this path if we're
-    // IO-bound (i.e. if something suspends). Whereas the stack is used even in
-    // the non-IO- bound case.
-    let workInProgress = returnFiber;
-    let earliestTimeoutMs = -1;
-    let startTimeMs = -1;
-    do {
-      if (workInProgress.tag === SuspenseComponent) {
-        const current = workInProgress.alternate;
-        if (current !== null) {
-          const currentState: SuspenseState | null = current.memoizedState;
-          if (currentState !== null) {
-            // Reached a boundary that already timed out. Do not search
-            // any further.
-            const timedOutAt = currentState.timedOutAt;
-            startTimeMs = expirationTimeToMs(timedOutAt);
-            // Do not search any further.
-            break;
-          }
-        }
-        const defaultSuspenseTimeout = 150;
-        if (
-          earliestTimeoutMs === -1 ||
-          defaultSuspenseTimeout < earliestTimeoutMs
-        ) {
-          earliestTimeoutMs = defaultSuspenseTimeout;
-        }
-      }
-      // If there is a DehydratedSuspenseComponent we don't have to do anything because
-      // if something suspends inside it, we will simply leave that as dehydrated. It
-      // will never timeout.
-      workInProgress = workInProgress.return;
-    } while (workInProgress !== null);
-
     // Schedule the nearest Suspense to re-render the timed out view.
-    workInProgress = returnFiber;
+    let workInProgress = returnFiber;
     do {
       if (
         workInProgress.tag === SuspenseComponent &&
@@ -270,7 +232,7 @@ function throwException(
         // Note: It doesn't matter whether the component that suspended was
         // inside a concurrent mode tree. If the Suspense is outside of it, we
         // should *not* suspend the commit.
-        if ((workInProgress.mode & ConcurrentMode) === NoEffect) {
+        if ((workInProgress.mode & ConcurrentMode) === NoContext) {
           workInProgress.effectTag |= DidCapture;
 
           // We're going to commit this fiber even though it didn't complete.
@@ -308,31 +270,7 @@ function throwException(
 
         attachPingListener(root, renderExpirationTime, thenable);
 
-        let absoluteTimeoutMs;
-        if (earliestTimeoutMs === -1) {
-          // If no explicit threshold is given, default to an arbitrarily large
-          // value. The actual size doesn't matter because the threshold for the
-          // whole tree will be clamped to the expiration time.
-          absoluteTimeoutMs = maxSigned31BitInt;
-        } else {
-          if (startTimeMs === -1) {
-            // This suspend happened outside of any already timed-out
-            // placeholders. We don't know exactly when the update was
-            // scheduled, but we can infer an approximate start time based on
-            // the expiration time and the priority.
-            startTimeMs = inferStartTimeFromExpirationTime(
-              root,
-              renderExpirationTime,
-            );
-          }
-          absoluteTimeoutMs = startTimeMs + earliestTimeoutMs;
-        }
-
-        // Mark the earliest timeout in the suspended fiber's ancestor path.
-        // After completing the root, we'll take the largest of all the
-        // suspended fiber's timeouts and use it to compute a timeout for the
-        // whole tree.
-        renderDidSuspend(root, absoluteTimeoutMs, renderExpirationTime);
+        renderDidSuspend();
 
         workInProgress.effectTag |= ShouldCapture;
         workInProgress.expirationTime = renderExpirationTime;

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -62,7 +62,6 @@ import {
 } from './ReactFiberContext';
 import {popProvider} from './ReactFiberNewContext';
 import {
-  renderDidSuspend,
   renderDidError,
   onUncaughtError,
   markLegacyErrorBoundaryAsFailed,
@@ -269,8 +268,6 @@ function throwException(
         // with the normal suspend path.
 
         attachPingListener(root, renderExpirationTime, thenable);
-
-        renderDidSuspend();
 
         workInProgress.effectTag |= ShouldCapture;
         workInProgress.expirationTime = renderExpirationTime;

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -101,6 +101,7 @@ import {
 } from 'shared/ReactFeatureFlags';
 
 import {StrictMode} from './ReactTypeOfMode';
+import {markRenderEventTime} from './ReactFiberScheduler';
 
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
@@ -454,8 +455,17 @@ export function processUpdateQueue<State>(
         newExpirationTime = updateExpirationTime;
       }
     } else {
-      // This update does have sufficient priority. Process it and compute
-      // a new result.
+      // This update does have sufficient priority.
+
+      // Mark the event time of this update as relevant to this render pass.
+      // TODO: This should ideally use the true event time of this update rather than
+      // its priority which is a derived and not reverseable value.
+      // TODO: We should skip this update if it was already committed but currently
+      // we have no way of detecting the difference between a committed and suspended
+      // update here.
+      markRenderEventTime(updateExpirationTime);
+
+      // Process it and compute a new result.
       resultState = getStateFromUpdate(
         workInProgress,
         queue,


### PR DESCRIPTION
The new suspense model is based on the last "event time" that influenced the suspended render.

The "event time" is the time of the "update" (root render, setState, dispatch) - which we infer from its expiration time.

If this is a "retry", then there is no "update" and the event time is the time we committed the fallback. This event time is only accounted for if we actually switch from fallback to content, i.e. make progress. If we retry and don't make further progress, then this event time isn't accounted for.

To make the math simple and fast, I model the committed time as an "normal pri expiration time" at the time it committed.

Since there can be multiple updates and retries in the same batch, we use the most recent time for our heuristic. That ensures that we at least never wait longer than we otherwise would've.

Since we can't tell the difference between committed and suspended updates, this PR will error on the side of including committed updates.

For now, I still use the hard coded 150ms suspense time starting from the event time. In a follow up, I'll add the Just Noticeable Difference heuristic instead.