### PR TITLE
Experimental Event API: Add targets and responder utility method for finding targets

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -31,10 +31,7 @@ import warning from 'shared/warning';
 import {enableEventAPI} from 'shared/ReactFeatureFlags';
 import {invokeGuardedCallbackAndCatchFirstError} from 'shared/ReactErrorUtils';
 
-import {
-  getClosestInstanceFromNode,
-  getFiberCurrentPropsFromNode,
-} from '../client/ReactDOMComponentTree';
+import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
 
 export let listenToResponderEventTypesImpl;
 

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -445,9 +445,9 @@ describe('DOMEventResponderSystem', () => {
     const Test = () => (
       <EventComponent>
         <div ref={divRef}>
-          <EventTarget />
+          <EventTarget foo={1} />
           <button ref={buttonRef}>
-            <EventTarget />
+            <EventTarget foo={2} />
             Press me!
           </button>
         </div>
@@ -461,7 +461,20 @@ describe('DOMEventResponderSystem', () => {
     dispatchClickEvent(buttonElement);
     jest.runAllTimers();
 
-    expect(queryResult).toEqual([buttonElement, divElement]);
+    expect(queryResult).toEqual([
+      {
+        node: buttonElement,
+        props: {
+          foo: 2,
+        },
+      },
+      {
+        node: divElement,
+        props: {
+          foo: 1,
+        },
+      },
+    ]);
   });
 
   it('should be possible to query event targets for their elements by type', () => {
@@ -478,8 +491,9 @@ describe('DOMEventResponderSystem', () => {
       ['click'],
       undefined,
       (event, context, props, state) => {
-        queryResult = Array.from(
-          context.getEventTargetsFromTarget(event.target, eventTargetType2),
+        queryResult = context.getEventTargetsFromTarget(
+          event.target,
+          eventTargetType2,
         );
       },
     );
@@ -487,9 +501,9 @@ describe('DOMEventResponderSystem', () => {
     const Test = () => (
       <EventComponent>
         <div ref={divRef}>
-          <EventTarget2 />
+          <EventTarget2 foo={1} />
           <button ref={buttonRef}>
-            <EventTarget />
+            <EventTarget foo={2} />
             Press me!
           </button>
         </div>
@@ -503,7 +517,14 @@ describe('DOMEventResponderSystem', () => {
     dispatchClickEvent(buttonElement);
     jest.runAllTimers();
 
-    expect(queryResult).toEqual([divElement]);
+    expect(queryResult).toEqual([
+      {
+        node: divElement,
+        props: {
+          foo: 1,
+        },
+      },
+    ]);
   });
 
   it('should be possible to query event targets for their elements by key', () => {
@@ -517,8 +538,10 @@ describe('DOMEventResponderSystem', () => {
       ['click'],
       undefined,
       (event, context, props, state) => {
-        queryResult = Array.from(
-          context.getEventTargetsFromTarget(event.target, undefined, 'a'),
+        queryResult = context.getEventTargetsFromTarget(
+          event.target,
+          undefined,
+          'a',
         );
       },
     );
@@ -526,9 +549,9 @@ describe('DOMEventResponderSystem', () => {
     const Test = () => (
       <EventComponent>
         <div ref={divRef}>
-          <EventTarget />
+          <EventTarget foo={1} />
           <button ref={buttonRef}>
-            <EventTarget key="a" />
+            <EventTarget key="a" foo={2} />
             Press me!
           </button>
         </div>
@@ -541,7 +564,14 @@ describe('DOMEventResponderSystem', () => {
     dispatchClickEvent(buttonElement);
     jest.runAllTimers();
 
-    expect(queryResult).toEqual([buttonElement]);
+    expect(queryResult).toEqual([
+      {
+        node: buttonElement,
+        props: {
+          foo: 2,
+        },
+      },
+    ]);
   });
 
   it('should be possible to query event targets for their elements by type and key', () => {
@@ -560,19 +590,23 @@ describe('DOMEventResponderSystem', () => {
       ['click'],
       undefined,
       (event, context, props, state) => {
-        queryResult = Array.from(
-          context.getEventTargetsFromTarget(
-            event.target,
-            eventTargetType2,
-            'a',
-          ),
+        queryResult = context.getEventTargetsFromTarget(
+          event.target,
+          eventTargetType2,
+          'a',
         );
-        queryResult2 = Array.from(
-          context.getEventTargetsFromTarget(event.target, eventTargetType, 'c'),
+
+        queryResult2 = context.getEventTargetsFromTarget(
+          event.target,
+          eventTargetType,
+          'c',
         );
+
         // Should return an empty array as this doesn't exist
-        queryResult3 = Array.from(
-          context.getEventTargetsFromTarget(event.target, eventTargetType, 'd'),
+        queryResult3 = context.getEventTargetsFromTarget(
+          event.target,
+          eventTargetType,
+          'd',
         );
       },
     );
@@ -580,10 +614,10 @@ describe('DOMEventResponderSystem', () => {
     const Test = () => (
       <EventComponent>
         <div ref={divRef}>
-          <EventTarget2 key="a" />
-          <EventTarget2 key="b" />
+          <EventTarget2 key="a" foo={1} />
+          <EventTarget2 key="b" foo={2} />
           <button ref={buttonRef}>
-            <EventTarget key="c" />
+            <EventTarget key="c" foo={3} />
             Press me!
           </button>
         </div>
@@ -597,8 +631,22 @@ describe('DOMEventResponderSystem', () => {
     dispatchClickEvent(buttonElement);
     jest.runAllTimers();
 
-    expect(queryResult).toEqual([divElement]);
-    expect(queryResult2).toEqual([buttonElement]);
+    expect(queryResult).toEqual([
+      {
+        node: divElement,
+        props: {
+          foo: 1,
+        },
+      },
+    ]);
+    expect(queryResult2).toEqual([
+      {
+        node: buttonElement,
+        props: {
+          foo: 3,
+        },
+      },
+    ]);
     expect(queryResult3).toEqual([]);
   });
 });

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -425,7 +425,7 @@ describe('DOMEventResponderSystem', () => {
     expect(onOwnershipChangeFired).toEqual(1);
   });
 
-  it('should be possible to query event targets for their elements', () => {
+  it('should be possible to get event targets', () => {
     let queryResult = null;
     const buttonRef = React.createRef();
     const divRef = React.createRef();
@@ -477,7 +477,7 @@ describe('DOMEventResponderSystem', () => {
     ]);
   });
 
-  it('should be possible to query event targets for their elements by type', () => {
+  it('should be possible to query event targets by type', () => {
     let queryResult = null;
     const buttonRef = React.createRef();
     const divRef = React.createRef();
@@ -527,7 +527,7 @@ describe('DOMEventResponderSystem', () => {
     ]);
   });
 
-  it('should be possible to query event targets for their elements by key', () => {
+  it('should be possible to query event targets by key', () => {
     let queryResult = null;
     const buttonRef = React.createRef();
     const divRef = React.createRef();
@@ -574,7 +574,7 @@ describe('DOMEventResponderSystem', () => {
     ]);
   });
 
-  it('should be possible to query event targets for their elements by type and key', () => {
+  it('should be possible to query event targets by type and key', () => {
     let queryResult = null;
     let queryResult2 = null;
     let queryResult3 = null;

--- a/packages/react-events/src/ReactEvents.js
+++ b/packages/react-events/src/ReactEvents.js
@@ -10,10 +10,22 @@
 import {
   REACT_EVENT_TARGET_TYPE,
   REACT_EVENT_TARGET_TOUCH_HIT,
+  REACT_EVENT_FOCUS_TARGET,
+  REACT_EVENT_PRESS_TARGET,
 } from 'shared/ReactSymbols';
 import type {ReactEventTarget} from 'shared/ReactTypes';
 
 export const TouchHitTarget: ReactEventTarget = {
   $$typeof: REACT_EVENT_TARGET_TYPE,
   type: REACT_EVENT_TARGET_TOUCH_HIT,
+};
+
+export const FocusTarget: ReactEventTarget = {
+  $$typeof: REACT_EVENT_TARGET_TYPE,
+  type: REACT_EVENT_FOCUS_TARGET,
+};
+
+export const PressTarget: ReactEventTarget = {
+  $$typeof: REACT_EVENT_TARGET_TYPE,
+  type: REACT_EVENT_PRESS_TARGET,
 };

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -638,6 +638,10 @@ export function createFiberFromEventTarget(
   fiber.elementType = eventTarget;
   fiber.type = eventTarget;
   fiber.expirationTime = expirationTime;
+  // Store latest props
+  fiber.stateNode = {
+    props: pendingProps,
+  };
   return fiber;
 }
 

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -841,6 +841,9 @@ function completeWork(
           rootContainerInstance,
           workInProgress,
         );
+        // Update the latest props on the stateNode. This is used
+        // during the event phase to find the most current props.
+        workInProgress.stateNode.props = newProps;
         if (shouldUpdate) {
           markUpdate(workInProgress);
         }

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -57,6 +57,12 @@ export const REACT_EVENT_TARGET_TYPE = hasSymbol
 export const REACT_EVENT_TARGET_TOUCH_HIT = hasSymbol
   ? Symbol.for('react.event_target.touch_hit')
   : 0xead7;
+export const REACT_EVENT_FOCUS_TARGET = hasSymbol
+  ? Symbol.for('react.event_target.focus')
+  : 0xead8;
+export const REACT_EVENT_PRESS_TARGET = hasSymbol
+  ? Symbol.for('react.event_target.press')
+  : 0xead9;
 
 const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -169,4 +169,9 @@ export type ReactResponderContext = {
   requestOwnership: () => boolean,
   releaseOwnership: () => boolean,
   setTimeout: (func: () => void, timeout: number) => TimeoutID,
+  getEventTargetsFromTarget: (
+    target: Element | Document,
+    queryType?: Symbol | number,
+    queryKey?: string,
+  ) => Set<Element>,
 };

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -173,5 +173,8 @@ export type ReactResponderContext = {
     target: Element | Document,
     queryType?: Symbol | number,
     queryKey?: string,
-  ) => Set<Element>,
+  ) => Array<{
+    node: Element,
+    props: null | Object,
+  }>,
 };

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -31,6 +31,8 @@ import {
 import {refineResolvedLazyComponent} from 'shared/ReactLazyComponent';
 import type {ReactEventComponent, ReactEventTarget} from 'shared/ReactTypes';
 
+import {enableEventAPI} from './ReactFeatureFlags';
+
 function getWrappedName(
   outerType: mixed,
   innerType: any,
@@ -96,25 +98,29 @@ function getComponentName(type: mixed): string | null {
         break;
       }
       case REACT_EVENT_COMPONENT_TYPE: {
-        const eventComponent = ((type: any): ReactEventComponent);
-        const displayName = eventComponent.displayName;
-        if (displayName !== undefined) {
-          return displayName;
+        if (enableEventAPI) {
+          const eventComponent = ((type: any): ReactEventComponent);
+          const displayName = eventComponent.displayName;
+          if (displayName !== undefined) {
+            return displayName;
+          }
         }
         break;
       }
       case REACT_EVENT_TARGET_TYPE: {
-        const eventTarget = ((type: any): ReactEventTarget);
-        if (eventTarget.type === REACT_EVENT_TARGET_TOUCH_HIT) {
-          return 'TouchHitTarget';
-        } else if (eventTarget.type === REACT_EVENT_FOCUS_TARGET) {
-          return 'FocusTarget';
-        } else if (eventTarget.type === REACT_EVENT_PRESS_TARGET) {
-          return 'PressTarget';
-        }
-        const displayName = eventTarget.displayName;
-        if (displayName !== undefined) {
-          return displayName;
+        if (enableEventAPI) {
+          const eventTarget = ((type: any): ReactEventTarget);
+          if (eventTarget.type === REACT_EVENT_TARGET_TOUCH_HIT) {
+            return 'TouchHitTarget';
+          } else if (eventTarget.type === REACT_EVENT_FOCUS_TARGET) {
+            return 'FocusTarget';
+          } else if (eventTarget.type === REACT_EVENT_PRESS_TARGET) {
+            return 'PressTarget';
+          }
+          const displayName = eventTarget.displayName;
+          if (displayName !== undefined) {
+            return displayName;
+          }
         }
       }
     }

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -25,6 +25,8 @@ import {
   REACT_EVENT_COMPONENT_TYPE,
   REACT_EVENT_TARGET_TYPE,
   REACT_EVENT_TARGET_TOUCH_HIT,
+  REACT_EVENT_FOCUS_TARGET,
+  REACT_EVENT_PRESS_TARGET,
 } from 'shared/ReactSymbols';
 import {refineResolvedLazyComponent} from 'shared/ReactLazyComponent';
 import type {ReactEventComponent, ReactEventTarget} from 'shared/ReactTypes';
@@ -105,6 +107,10 @@ function getComponentName(type: mixed): string | null {
         const eventTarget = ((type: any): ReactEventTarget);
         if (eventTarget.type === REACT_EVENT_TARGET_TOUCH_HIT) {
           return 'TouchHitTarget';
+        } else if (eventTarget.type === REACT_EVENT_FOCUS_TARGET) {
+          return 'FocusTarget';
+        } else if (eventTarget.type === REACT_EVENT_PRESS_TARGET) {
+          return 'PressTarget';
         }
         const displayName = eventTarget.displayName;
         if (displayName !== undefined) {


### PR DESCRIPTION
Note: the experimental event API is for internal purposes only right now

This PR adds two new event targets that recently came up in discussion. They're not used or have any specific code paths yet, but they will do in the future. They are `FocusTarget` and `PressTarget`.

Furthermore, a new helper method on the event responder context has been added: `getEventTargetsFromTarget`. This method can query the internal fiber tree to find event targets and their associated host components and props – given the optional `type` and `key` query arguments.

Ref #15257