### PR TITLE
React events: Press event fixes

### DIFF
--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -72,8 +72,9 @@ function dispatchHoverChangeEvent(
   props: HoverProps,
   state: HoverState,
 ): void {
+  const bool = state.isActiveHovered;
   const listener = () => {
-    props.onHoverChange(state.isActiveHovered);
+    props.onHoverChange(bool);
   };
   const syntheticEvent = createHoverEvent(
     'hoverchange',

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -354,16 +354,17 @@ function calculateResponderRegion(target, props) {
 }
 
 function getPointerType(nativeEvent: any) {
-  if (nativeEvent.pointerType != null) {
-    return nativeEvent.pointerType;
+  const {type, pointerType} = nativeEvent;
+  if (pointerType != null) {
+    return pointerType;
   }
-  if (nativeEvent.type.indexOf('mouse') > -1) {
+  if (type.indexOf('mouse') > -1) {
     return 'mouse';
   }
-  if (nativeEvent.type.indexOf('touch') > -1) {
+  if (type.indexOf('touch') > -1) {
     return 'touch';
   }
-  if (nativeEvent.type.indexOf('key') > -1) {
+  if (type.indexOf('key') > -1) {
     return 'keyboard';
   }
   return '';

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -654,9 +654,9 @@ const PressResponder = {
       case 'click': {
         if (isAnchorTagElement(target)) {
           const {ctrlKey, metaKey, shiftKey} = ((nativeEvent: any): MouseEvent);
-          // Check "open in new window/tab" key modifiers
+          // Check "open in new window/tab" and "open context menu" key modifiers
           const preventDefault = props.preventDefault;
-          if (preventDefault !== false && !shiftKey && !ctrlKey && !metaKey) {
+          if (preventDefault !== false && !shiftKey && !metaKey && !ctrlKey) {
             (nativeEvent: any).preventDefault();
           }
         }

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -261,6 +261,7 @@ function dispatchPressEndEvents(
   state: PressState,
 ): void {
   const wasActivePressStart = state.isActivePressStart;
+  let activationWasForced = false;
 
   state.isActivePressStart = false;
   state.isPressed = false;
@@ -277,13 +278,17 @@ function dispatchPressEndEvents(
     if (state.isPressWithinResponderRegion) {
       // if we haven't yet activated (due to delays), activate now
       activate(context, props, state);
+      activationWasForced = true;
     }
   }
 
   if (state.isActivePressed) {
     const delayPressEnd = calculateDelayMS(
       props.delayPressEnd,
-      0,
+      // if activation and deactivation occur during the same event there's no
+      // time for visual user feedback therefore a small delay is added before
+      // deactivating.
+      activationWasForced ? 10 : 0,
       DEFAULT_PRESS_END_DELAY_MS,
     );
     if (delayPressEnd > 0) {

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -1131,6 +1131,67 @@ describe('Event responder: Press', () => {
     });
   });
 
+  describe('link components', () => {
+    it('prevents native behaviour by default', () => {
+      const onPress = jest.fn();
+      const preventDefault = jest.fn();
+      const ref = React.createRef();
+      const element = (
+        <Press onPress={onPress}>
+          <a href="#" ref={ref} />
+        </Press>
+      );
+      ReactDOM.render(element, container);
+
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(createPointerEvent('click', {preventDefault}));
+      expect(preventDefault).toBeCalled();
+    });
+
+    it('uses native behaviour for interactions with modifier keys', () => {
+      const onPress = jest.fn();
+      const preventDefault = jest.fn();
+      const ref = React.createRef();
+      const element = (
+        <Press onPress={onPress}>
+          <a href="#" ref={ref} />
+        </Press>
+      );
+      ReactDOM.render(element, container);
+
+      ['metaKey', 'ctrlKey', 'shiftKey'].forEach(modifierKey => {
+        ref.current.dispatchEvent(
+          createPointerEvent('pointerdown', {[modifierKey]: true}),
+        );
+        ref.current.dispatchEvent(
+          createPointerEvent('pointerup', {[modifierKey]: true}),
+        );
+        ref.current.dispatchEvent(
+          createPointerEvent('click', {[modifierKey]: true, preventDefault}),
+        );
+        expect(preventDefault).not.toBeCalled();
+      });
+    });
+
+    it('uses native behaviour if preventDefault is false', () => {
+      const onPress = jest.fn();
+      const preventDefault = jest.fn();
+      const ref = React.createRef();
+      const element = (
+        <Press onPress={onPress} preventDefault={false}>
+          <a href="#" ref={ref} />
+        </Press>
+      );
+      ReactDOM.render(element, container);
+
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(createPointerEvent('click', {preventDefault}));
+      expect(preventDefault).not.toBeCalled();
+    });
+  });
+
   it('expect displayName to show up for event component', () => {
     expect(Press.displayName).toBe('Press');
   });

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -70,8 +70,13 @@ describe('Event responder: Press', () => {
     });
 
     it('is called after "pointerdown" event', () => {
-      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointerdown', {pointerType: 'pen'}),
+      );
       expect(onPressStart).toHaveBeenCalledTimes(1);
+      expect(onPressStart).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'pen', type: 'pressstart'}),
+      );
     });
 
     it('ignores browser emulated "mousedown" event', () => {
@@ -85,13 +90,20 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
       ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
       expect(onPressStart).toHaveBeenCalledTimes(1);
+      expect(onPressStart).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'keyboard', type: 'pressstart'}),
+      );
     });
 
     it('is called once after "keydown" events for Spacebar', () => {
       ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: ' '}));
+      ref.current.dispatchEvent(createKeyboardEvent('keypress', {key: ' '}));
       ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: ' '}));
-      ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: ' '}));
+      ref.current.dispatchEvent(createKeyboardEvent('keypress', {key: ' '}));
       expect(onPressStart).toHaveBeenCalledTimes(1);
+      expect(onPressStart).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'keyboard', type: 'pressstart'}),
+      );
     });
 
     it('is not called after "keydown" for other keys', () => {
@@ -103,10 +115,16 @@ describe('Event responder: Press', () => {
     it('is called after "mousedown" event', () => {
       ref.current.dispatchEvent(createPointerEvent('mousedown'));
       expect(onPressStart).toHaveBeenCalledTimes(1);
+      expect(onPressStart).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'mouse', type: 'pressstart'}),
+      );
     });
     it('is called after "touchstart" event', () => {
       ref.current.dispatchEvent(createPointerEvent('touchstart'));
       expect(onPressStart).toHaveBeenCalledTimes(1);
+      expect(onPressStart).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'touch', type: 'pressstart'}),
+      );
     });
 
     describe('delayPressStart', () => {
@@ -191,8 +209,13 @@ describe('Event responder: Press', () => {
 
     it('is called after "pointerup" event', () => {
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
-      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointerup', {pointerType: 'pen'}),
+      );
       expect(onPressEnd).toHaveBeenCalledTimes(1);
+      expect(onPressEnd).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'pen', type: 'pressend'}),
+      );
     });
 
     it('ignores browser emulated "mouseup" event', () => {
@@ -200,18 +223,27 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(createPointerEvent('touchend'));
       ref.current.dispatchEvent(createPointerEvent('mouseup'));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
+      expect(onPressEnd).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'touch', type: 'pressend'}),
+      );
     });
 
     it('is called after "keyup" event for Enter', () => {
       ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
       ref.current.dispatchEvent(createKeyboardEvent('keyup', {key: 'Enter'}));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
+      expect(onPressEnd).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'keyboard', type: 'pressend'}),
+      );
     });
 
     it('is called after "keyup" event for Spacebar', () => {
       ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: ' '}));
       ref.current.dispatchEvent(createKeyboardEvent('keyup', {key: ' '}));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
+      expect(onPressEnd).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'keyboard', type: 'pressend'}),
+      );
     });
 
     it('is not called after "keyup" event for other keys', () => {
@@ -225,11 +257,17 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(createPointerEvent('mousedown'));
       ref.current.dispatchEvent(createPointerEvent('mouseup'));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
+      expect(onPressEnd).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'mouse', type: 'pressend'}),
+      );
     });
     it('is called after "touchend" event', () => {
       ref.current.dispatchEvent(createPointerEvent('touchstart'));
       ref.current.dispatchEvent(createPointerEvent('touchend'));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
+      expect(onPressEnd).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'touch', type: 'pressend'}),
+      );
     });
 
     describe('delayPressEnd', () => {
@@ -342,6 +380,9 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
       jest.advanceTimersByTime(100);
       ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      jest.advanceTimersByTime(10);
+      expect(onPressChange).toHaveBeenCalledWith(true);
+      expect(onPressChange).toHaveBeenCalledWith(false);
       expect(onPressChange).toHaveBeenCalledTimes(2);
     });
 
@@ -431,14 +472,22 @@ describe('Event responder: Press', () => {
 
     it('is called after "pointerup" event', () => {
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
-      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointerup', {pointerType: 'pen'}),
+      );
       expect(onPress).toHaveBeenCalledTimes(1);
+      expect(onPress).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'pen', type: 'press'}),
+      );
     });
 
     it('is called after valid "keyup" event', () => {
       ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
       ref.current.dispatchEvent(createKeyboardEvent('keyup', {key: 'Enter'}));
       expect(onPress).toHaveBeenCalledTimes(1);
+      expect(onPress).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'keyboard', type: 'press'}),
+      );
     });
 
     it('is always called immediately after press is released', () => {
@@ -508,11 +557,16 @@ describe('Event responder: Press', () => {
     });
 
     it('is called if "pointerdown" lasts default delay', () => {
-      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointerdown', {pointerType: 'pen'}),
+      );
       jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DELAY - 1);
       expect(onLongPress).not.toBeCalled();
       jest.advanceTimersByTime(1);
       expect(onLongPress).toHaveBeenCalledTimes(1);
+      expect(onLongPress).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'pen', type: 'longpress'}),
+      );
     });
 
     it('is not called if "pointerup" is dispatched before delay', () => {
@@ -529,6 +583,9 @@ describe('Event responder: Press', () => {
       expect(onLongPress).not.toBeCalled();
       jest.advanceTimersByTime(1);
       expect(onLongPress).toHaveBeenCalledTimes(1);
+      expect(onLongPress).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'keyboard', type: 'longpress'}),
+      );
     });
 
     it('is not called if valid "keyup" is dispatched before delay', () => {
@@ -688,6 +745,38 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(createPointerEvent('pointerup'));
       expect(onPress).not.toBeCalled();
       expect(onPressChange).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('onPressMove', () => {
+    it('is called after "pointermove"', () => {
+      const onPressMove = jest.fn();
+      const ref = React.createRef();
+      const element = (
+        <Press onPressMove={onPressMove}>
+          <div ref={ref} />
+        </Press>
+      );
+      ReactDOM.render(element, container);
+
+      ref.current.getBoundingClientRect = () => ({
+        top: 50,
+        left: 50,
+        bottom: 500,
+        right: 500,
+      });
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointermove', {
+          pointerType: 'touch',
+          pageX: 55,
+          pageY: 55,
+        }),
+      );
+      expect(onPressMove).toHaveBeenCalledTimes(1);
+      expect(onPressMove).toHaveBeenCalledWith(
+        expect.objectContaining({pointerType: 'touch', type: 'pressmove'}),
+      );
     });
   });
 


### PR DESCRIPTION
1. Fix hiding context menu for longpress via touch.
2. Fix scrolling of viewport for longpress via spacebar key.
3. Add tests for anchor-related behaviour and preventDefault.
4. Add a deactivation delay for forced activation
5. Add `pointerType` to Press events.

NOTE: this currently extends `pointerType` with non-standard types. We could consider using a different name, like `inputMode` or something.

NOTE: React Native doesn't have a deactivation delay for forced activation, but this is possibly because of the async bridge meaning that the events aren't dispatched sync.

Ref #15257