### PR TITLE
Revert "Bump scheduler version to 0.14.0"

### DIFF
--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scheduler",
-  "version": "0.14.0",
+  "version": "0.13.6",
   "description": "Cooperative scheduler for the browser environment.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This reverts commit 687e4fb6f7dcb13ca3c668bf5f3df4c0b281f58c.