### PR TITLE
React events: ignore device buttons that aren't for primary interactions

### DIFF
--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -85,6 +85,13 @@ describe('Event responder: Press', () => {
       expect(onPressStart).toHaveBeenCalledTimes(1);
     });
 
+    it('ignores any events not caused by left-click or touch/pen contact', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerdown', {button: 1}));
+      ref.current.dispatchEvent(createPointerEvent('pointerdown', {button: 5}));
+      ref.current.dispatchEvent(createPointerEvent('mousedown', {button: 2}));
+      expect(onPressStart).toHaveBeenCalledTimes(0);
+    });
+
     it('is called once after "keydown" events for Enter', () => {
       ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
       ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));


### PR DESCRIPTION
The Pointer Events spec mentions that the value of `button` in a nativeEvent
can be anything between 0 and 5 for "down" events. We only care about those
with a value of 0.