### PR TITLE
Experimental Event API: Redesign event responder propagation

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -42,11 +42,10 @@ export function setListenToResponderEventTypes(
   listenToResponderEventTypesImpl = _listenToResponderEventTypesImpl;
 }
 
-type EventObjectTypes = {|stopPropagation: true|} | $Shape<PartialEventObject>;
+type EventObjectType = $Shape<PartialEventObject>;
 
 type EventQueue = {
-  bubble: null | Array<EventObjectTypes>,
-  capture: null | Array<EventObjectTypes>,
+  events: Array<EventObjectType>,
   discrete: boolean,
 };
 
@@ -62,10 +61,13 @@ type ResponderTimeout = {|
 
 type ResponderTimer = {|
   instance: ReactEventComponentInstance,
-  func: () => void,
+  func: () => boolean,
   id: Symbol,
 |};
 
+const ROOT_PHASE = 0;
+const BUBBLE_PHASE = 1;
+const CAPTURE_PHASE = 2;
 const activeTimeouts: Map<Symbol, ResponderTimeout> = new Map();
 const rootEventTypesToEventComponentInstances: Map<
   DOMTopLevelEventType | string,
@@ -122,17 +124,12 @@ const eventResponderContext: ReactResponderContext = {
     const eventObject = ((possibleEventObject: any): $Shape<
       PartialEventObject,
     >);
-    const events = getEventsFromEventQueue(capture);
+    const eventQueue = ((currentEventQueue: any): EventQueue);
     if (discrete) {
-      ((currentEventQueue: any): EventQueue).discrete = true;
+      eventQueue.discrete = true;
     }
     eventListeners.set(eventObject, listener);
-    events.push(eventObject);
-  },
-  dispatchStopPropagation(capture?: boolean) {
-    validateResponderContext();
-    const events = getEventsFromEventQueue();
-    events.push({stopPropagation: true});
+    eventQueue.events.push(eventObject);
   },
   isPositionWithinTouchHitTarget(doc: Document, x: number, y: number): boolean {
     validateResponderContext();
@@ -256,7 +253,7 @@ const eventResponderContext: ReactResponderContext = {
     triggerOwnershipListeners();
     return false;
   },
-  setTimeout(func: () => void, delay): Symbol {
+  setTimeout(func: () => boolean, delay): Symbol {
     validateResponderContext();
     if (currentTimers === null) {
       currentTimers = new Map();
@@ -350,32 +347,18 @@ const eventResponderContext: ReactResponderContext = {
   },
 };
 
-function getEventsFromEventQueue(capture?: boolean): Array<EventObjectTypes> {
-  const eventQueue = ((currentEventQueue: any): EventQueue);
-  let events;
-  if (capture) {
-    events = eventQueue.capture;
-    if (events === null) {
-      events = eventQueue.capture = [];
-    }
-  } else {
-    events = eventQueue.bubble;
-    if (events === null) {
-      events = eventQueue.bubble = [];
-    }
-  }
-  return events;
-}
-
 function processTimers(timers: Map<Symbol, ResponderTimer>): void {
   const timersArr = Array.from(timers.values());
+  let shouldStopPropagation = false;
   currentEventQueue = createEventQueue();
   try {
     for (let i = 0; i < timersArr.length; i++) {
       const {instance, func, id} = timersArr[i];
       currentInstance = instance;
       try {
-        func();
+        if (!shouldStopPropagation) {
+          shouldStopPropagation = func();
+        }
       } finally {
         activeTimeouts.delete(id);
       }
@@ -407,20 +390,25 @@ function createResponderEvent(
   nativeEvent: AnyNativeEvent,
   nativeEventTarget: Element | Document,
   eventSystemFlags: EventSystemFlags,
+  phase: 0 | 1 | 2,
 ): ReactResponderEvent {
-  return {
+  const responderEvent = {
     nativeEvent: nativeEvent,
     target: nativeEventTarget,
     type: topLevelType,
     passive: (eventSystemFlags & IS_PASSIVE) !== 0,
     passiveSupported: (eventSystemFlags & PASSIVE_NOT_SUPPORTED) === 0,
+    phase,
   };
+  if (__DEV__) {
+    Object.freeze(responderEvent);
+  }
+  return responderEvent;
 }
 
 function createEventQueue(): EventQueue {
   return {
-    bubble: null,
-    capture: null,
+    events: [],
     discrete: false,
   };
 }
@@ -433,41 +421,24 @@ function processEvent(event: $Shape<PartialEventObject>): void {
   invokeGuardedCallbackAndCatchFirstError(type, listener, undefined, event);
 }
 
-function processEvents(
-  bubble: null | Array<EventObjectTypes>,
-  capture: null | Array<EventObjectTypes>,
-): void {
-  let i, length;
-
-  if (capture !== null) {
-    for (i = capture.length; i-- > 0; ) {
-      const event = capture[i];
-      if (event.stopPropagation === true) {
-        return;
-      }
-      processEvent(((event: any): $Shape<PartialEventObject>));
-    }
-  }
-  if (bubble !== null) {
-    for (i = 0, length = bubble.length; i < length; ++i) {
-      const event = bubble[i];
-      if (event.stopPropagation === true) {
-        return;
-      }
-      processEvent(((event: any): $Shape<PartialEventObject>));
-    }
+function processEvents(events: Array<EventObjectType>): void {
+  for (let i = 0, length = events.length; i < length; i++) {
+    processEvent(events[i]);
   }
 }
 
 export function processEventQueue(): void {
-  const {bubble, capture, discrete} = ((currentEventQueue: any): EventQueue);
+  const {events, discrete} = ((currentEventQueue: any): EventQueue);
 
+  if (events.length === 0) {
+    return;
+  }
   if (discrete) {
     interactiveUpdates(() => {
-      processEvents(bubble, capture);
+      processEvents(events);
     });
   } else {
-    processEvents(bubble, capture);
+    processEvents(events);
   }
 }
 
@@ -489,77 +460,141 @@ function getTargetEventTypes(
   return cachedSet;
 }
 
-function handleTopLevelType(
+function getTargetEventResponderInstances(
   topLevelType: DOMTopLevelEventType,
-  responderEvent: ReactResponderEvent,
-  eventComponentInstance: ReactEventComponentInstance,
-  isRootLevelEvent: boolean,
-): void {
-  let {props, responder, state} = eventComponentInstance;
-  if (!isRootLevelEvent) {
-    // Validate the target event type exists on the responder
-    const targetEventTypes = getTargetEventTypes(responder.targetEventTypes);
-    if (!targetEventTypes.has(topLevelType)) {
-      return;
+  targetFiber: null | Fiber,
+): Array<ReactEventComponentInstance> {
+  const eventResponderInstances = [];
+  let node = targetFiber;
+  while (node !== null) {
+    // Traverse up the fiber tree till we find event component fibers.
+    if (node.tag === EventComponent) {
+      const eventComponentInstance = node.stateNode;
+      if (currentOwner === null || currentOwner === eventComponentInstance) {
+        const responder = eventComponentInstance.responder;
+        // Validate the target event type exists on the responder
+        const targetEventTypes = getTargetEventTypes(
+          responder.targetEventTypes,
+        );
+        if (targetEventTypes.has(topLevelType)) {
+          eventResponderInstances.push(eventComponentInstance);
+        }
+      }
     }
+    node = node.return;
   }
-  currentInstance = eventComponentInstance;
-  responder.onEvent(responderEvent, eventResponderContext, props, state);
+  return eventResponderInstances;
 }
 
-export function runResponderEventsInBatch(
+function getRootEventResponderInstances(
+  topLevelType: DOMTopLevelEventType,
+): Array<ReactEventComponentInstance> {
+  const eventResponderInstances = [];
+  const rootEventInstances = rootEventTypesToEventComponentInstances.get(
+    topLevelType,
+  );
+  if (rootEventInstances !== undefined) {
+    const rootEventComponentInstances = Array.from(rootEventInstances);
+
+    for (let i = 0; i < rootEventComponentInstances.length; i++) {
+      const rootEventComponentInstance = rootEventComponentInstances[i];
+
+      if (
+        currentOwner === null ||
+        currentOwner === rootEventComponentInstance
+      ) {
+        eventResponderInstances.push(rootEventComponentInstance);
+      }
+    }
+  }
+  return eventResponderInstances;
+}
+
+function triggerEventResponderEventListener(
+  responderEvent: ReactResponderEvent,
+  eventComponentInstance: ReactEventComponentInstance,
+): boolean {
+  const {responder, props, state} = eventComponentInstance;
+  currentInstance = eventComponentInstance;
+  return responder.onEvent(responderEvent, eventResponderContext, props, state);
+}
+
+function traverseAndTriggerEventResponderInstances(
   topLevelType: DOMTopLevelEventType,
   targetFiber: null | Fiber,
   nativeEvent: AnyNativeEvent,
   nativeEventTarget: EventTarget,
   eventSystemFlags: EventSystemFlags,
 ): void {
-  if (enableEventAPI) {
-    currentEventQueue = createEventQueue();
+  // Trigger event responders in this order:
+  // - Capture target phase
+  // - Bubble target phase
+  // - Root phase
+
+  const targetEventResponderInstances = getTargetEventResponderInstances(
+    topLevelType,
+    targetFiber,
+  );
+  let length = targetEventResponderInstances.length;
+  let i;
+  let shouldStopPropagation = false;
+
+  // Capture target phase
+  for (i = length; i-- > 0; ) {
+    const targetEventResponderInstance = targetEventResponderInstances[i];
     const responderEvent = createResponderEvent(
       ((topLevelType: any): string),
       nativeEvent,
       ((nativeEventTarget: any): Element | Document),
       eventSystemFlags,
+      CAPTURE_PHASE,
     );
-
-    try {
-      let node = targetFiber;
-      // Traverse up the fiber tree till we find event component fibers.
-      while (node !== null) {
-        if (node.tag === EventComponent) {
-          const eventComponentInstance = node.stateNode;
-          handleTopLevelType(
-            topLevelType,
-            responderEvent,
-            eventComponentInstance,
-            false,
-          );
-        }
-        node = node.return;
-      }
-      // Handle root level events
-      const rootEventInstances = rootEventTypesToEventComponentInstances.get(
-        topLevelType,
-      );
-      if (rootEventInstances !== undefined) {
-        const rootEventComponentInstances = Array.from(rootEventInstances);
-
-        for (let i = 0; i < rootEventComponentInstances.length; i++) {
-          const rootEventComponentInstance = rootEventComponentInstances[i];
-          handleTopLevelType(
-            topLevelType,
-            responderEvent,
-            rootEventComponentInstance,
-            true,
-          );
-        }
-      }
-      processEventQueue();
-    } finally {
-      currentTimers = null;
-      currentInstance = null;
-      currentEventQueue = null;
+    shouldStopPropagation = triggerEventResponderEventListener(
+      responderEvent,
+      targetEventResponderInstance,
+    );
+    if (shouldStopPropagation) {
+      return;
+    }
+  }
+  // Bubble target phase
+  for (i = 0; i < length; i++) {
+    const targetEventResponderInstance = targetEventResponderInstances[i];
+    const responderEvent = createResponderEvent(
+      ((topLevelType: any): string),
+      nativeEvent,
+      ((nativeEventTarget: any): Element | Document),
+      eventSystemFlags,
+      BUBBLE_PHASE,
+    );
+    shouldStopPropagation = triggerEventResponderEventListener(
+      responderEvent,
+      targetEventResponderInstance,
+    );
+    if (shouldStopPropagation) {
+      return;
+    }
+  }
+  // Root phase
+  const rootEventResponderInstances = getRootEventResponderInstances(
+    topLevelType,
+  );
+  length = rootEventResponderInstances.length;
+  for (i = 0; i < length; i++) {
+    const targetEventResponderInstance = rootEventResponderInstances[i];
+    const responderEvent = createResponderEvent(
+      ((topLevelType: any): string),
+      nativeEvent,
+      ((nativeEventTarget: any): Element | Document),
+      eventSystemFlags,
+      ROOT_PHASE,
+    );
+    shouldStopPropagation = triggerEventResponderEventListener(
+      responderEvent,
+      targetEventResponderInstance,
+    );
+    if (shouldStopPropagation) {
+      return;
     }
   }
 }
@@ -620,4 +655,30 @@ function validateResponderContext(): void {
     'An event responder context was used outside of an event cycle. ' +
       'Use context.setTimeout() to use asynchronous responder context outside of event cycle .',
   );
+}
+
+export function dispatchEventForResponderEventSystem(
+  topLevelType: DOMTopLevelEventType,
+  targetFiber: null | Fiber,
+  nativeEvent: AnyNativeEvent,
+  nativeEventTarget: EventTarget,
+  eventSystemFlags: EventSystemFlags,
+): void {
+  if (enableEventAPI) {
+    currentEventQueue = createEventQueue();
+    try {
+      traverseAndTriggerEventResponderInstances(
+        topLevelType,
+        targetFiber,
+        nativeEvent,
+        nativeEventTarget,
+        eventSystemFlags,
+      );
+      processEventQueue();
+    } finally {
+      currentTimers = null;
+      currentInstance = null;
+      currentEventQueue = null;
+    }
+  }
 }

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -363,7 +363,7 @@ function processTimers(timers: Map<Symbol, ResponderTimer>): void {
         activeTimeouts.delete(id);
       }
     }
-    batchedUpdates(processEventQueue, currentEventQueue);
+    processEventQueue();
   } finally {
     currentTimers = null;
     currentInstance = null;
@@ -435,10 +435,10 @@ export function processEventQueue(): void {
   }
   if (discrete) {
     interactiveUpdates(() => {
-      processEvents(events);
+      batchedUpdates(processEvents, events);
     });
   } else {
-    processEvents(events);
+    batchedUpdates(processEvents, events);
   }
 }
 

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -95,7 +95,7 @@ const eventResponderContext: ReactResponderContext = {
   dispatchEvent(
     possibleEventObject: Object,
     listener: ($Shape<PartialEventObject>) => void,
-    {capture, discrete}: ReactResponderDispatchEventOptions,
+    {discrete}: ReactResponderDispatchEventOptions,
   ): void {
     validateResponderContext();
     const {target, type} = possibleEventObject;

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -538,41 +538,44 @@ function traverseAndTriggerEventResponderInstances(
   let length = targetEventResponderInstances.length;
   let i;
   let shouldStopPropagation = false;
+  let responderEvent;
 
   // Capture target phase
-  for (i = length; i-- > 0; ) {
-    const targetEventResponderInstance = targetEventResponderInstances[i];
-    const responderEvent = createResponderEvent(
+  if (length > 0) {
+    responderEvent = createResponderEvent(
       ((topLevelType: any): string),
       nativeEvent,
       ((nativeEventTarget: any): Element | Document),
       eventSystemFlags,
       CAPTURE_PHASE,
     );
-    shouldStopPropagation = triggerEventResponderEventListener(
-      responderEvent,
-      targetEventResponderInstance,
-    );
-    if (shouldStopPropagation) {
-      return;
+    for (i = length; i-- > 0; ) {
+      const targetEventResponderInstance = targetEventResponderInstances[i];
+      shouldStopPropagation = triggerEventResponderEventListener(
+        responderEvent,
+        targetEventResponderInstance,
+      );
+      if (shouldStopPropagation) {
+        return;
+      }
     }
-  }
-  // Bubble target phase
-  for (i = 0; i < length; i++) {
-    const targetEventResponderInstance = targetEventResponderInstances[i];
-    const responderEvent = createResponderEvent(
+    // Bubble target phase
+    responderEvent = createResponderEvent(
       ((topLevelType: any): string),
       nativeEvent,
       ((nativeEventTarget: any): Element | Document),
       eventSystemFlags,
       BUBBLE_PHASE,
     );
-    shouldStopPropagation = triggerEventResponderEventListener(
-      responderEvent,
-      targetEventResponderInstance,
-    );
-    if (shouldStopPropagation) {
-      return;
+    for (i = 0; i < length; i++) {
+      const targetEventResponderInstance = targetEventResponderInstances[i];
+      shouldStopPropagation = triggerEventResponderEventListener(
+        responderEvent,
+        targetEventResponderInstance,
+      );
+      if (shouldStopPropagation) {
+        return;
+      }
     }
   }
   // Root phase
@@ -580,21 +583,23 @@ function traverseAndTriggerEventResponderInstances(
     topLevelType,
   );
   length = rootEventResponderInstances.length;
-  for (i = 0; i < length; i++) {
-    const targetEventResponderInstance = rootEventResponderInstances[i];
-    const responderEvent = createResponderEvent(
+  if (length > 0) {
+    responderEvent = createResponderEvent(
       ((topLevelType: any): string),
       nativeEvent,
       ((nativeEventTarget: any): Element | Document),
       eventSystemFlags,
       ROOT_PHASE,
     );
-    shouldStopPropagation = triggerEventResponderEventListener(
-      responderEvent,
-      targetEventResponderInstance,
-    );
-    if (shouldStopPropagation) {
-      return;
+    for (i = 0; i < length; i++) {
+      const targetEventResponderInstance = rootEventResponderInstances[i];
+      shouldStopPropagation = triggerEventResponderEventListener(
+        responderEvent,
+        targetEventResponderInstance,
+      );
+      if (shouldStopPropagation) {
+        return;
+      }
     }
   }
 }

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -13,6 +13,7 @@ import type {
 } from 'shared/ReactTypes';
 import {REACT_EVENT_COMPONENT_TYPE} from 'shared/ReactSymbols';
 
+const CAPTURE_PHASE = 2;
 const targetEventTypes = ['pointerdown', 'pointercancel'];
 const rootEventTypes = ['pointerup', {name: 'pointermove', passive: false}];
 
@@ -92,9 +93,13 @@ const DragResponder = {
     context: ReactResponderContext,
     props: Object,
     state: DragState,
-  ): void {
-    const {target, type, nativeEvent} = event;
+  ): boolean {
+    const {target, phase, type, nativeEvent} = event;
 
+    // Drag doesn't handle capture target events at this point
+    if (phase === CAPTURE_PHASE) {
+      return false;
+    }
     switch (type) {
       case 'touchstart':
       case 'mousedown':
@@ -132,7 +137,7 @@ const DragResponder = {
       case 'mousemove':
       case 'pointermove': {
         if (event.passive) {
-          return;
+          return false;
         }
         if (state.isPointerDown) {
           const obj =
@@ -225,6 +230,7 @@ const DragResponder = {
         break;
       }
     }
+    return false;
   },
 };
 

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -13,6 +13,8 @@ import type {
 } from 'shared/ReactTypes';
 import {REACT_EVENT_COMPONENT_TYPE} from 'shared/ReactSymbols';
 
+const CAPTURE_PHASE = 2;
+
 type FocusProps = {
   disabled: boolean,
   onBlur: (e: FocusEvent) => void,
@@ -136,12 +138,16 @@ const FocusResponder = {
     context: ReactResponderContext,
     props: Object,
     state: FocusState,
-  ): void {
-    const {type, target} = event;
+  ): boolean {
+    const {type, phase, target} = event;
 
+    // Focus doesn't handle capture target events at this point
+    if (phase === CAPTURE_PHASE) {
+      return false;
+    }
     switch (type) {
       case 'focus': {
-        if (!state.isFocused && !context.hasOwnership()) {
+        if (!state.isFocused) {
           state.focusTarget = target;
           dispatchFocusInEvents(event, context, props, state);
           state.isFocused = true;
@@ -157,6 +163,7 @@ const FocusResponder = {
         break;
       }
     }
+    return false;
   },
   onUnmount(
     context: ReactResponderContext,

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -93,7 +93,7 @@ export type ReactEventResponder = {
     context: ReactResponderContext,
     props: null | Object,
     state: null | Object,
-  ) => void,
+  ) => boolean,
   onUnmount: (
     context: ReactResponderContext,
     props: null | Object,
@@ -135,6 +135,7 @@ export type ReactResponderEvent = {
   type: string,
   passive: boolean,
   passiveSupported: boolean,
+  phase: 0 | 1 | 2,
 };
 
 export type ReactResponderDispatchEventOptions = {
@@ -148,7 +149,6 @@ export type ReactResponderContext = {
     listener: (Object) => void,
     otpions: ReactResponderDispatchEventOptions,
   ) => void,
-  dispatchStopPropagation: (passive?: boolean) => void,
   isTargetWithinElement: (
     childTarget: Element | Document,
     parentTarget: Element | Document,
@@ -169,7 +169,7 @@ export type ReactResponderContext = {
   hasOwnership: () => boolean,
   requestOwnership: () => boolean,
   releaseOwnership: () => boolean,
-  setTimeout: (func: () => void, timeout: number) => Symbol,
+  setTimeout: (func: () => boolean, timeout: number) => Symbol,
   clearTimeout: (timerId: Symbol) => void,
   getEventTargetsFromTarget: (
     target: Element | Document,

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -139,7 +139,6 @@ export type ReactResponderEvent = {
 };
 
 export type ReactResponderDispatchEventOptions = {
-  capture?: boolean,
   discrete?: boolean,
 };
 


### PR DESCRIPTION
This PR aims at tackling a class of issues, confusion and bugs with how event responder propagate in the different phases and how `stopPropagation` works. The previous implementation didn't correctly ensure event components in the capture phase were fired in the right order. This PR revamps the entire process, cleaning up code along the way and improving performance significantly compared to before.

This also fixes a bunch of bugs along the way, which now have tests added to ensure we don't regress. Another big change is that it is expected the the event responder `onEvent` returns a `boolean` indicating if the event module itself should prevent propagation after. Rather than before, where you'd use `dispatchStopPropagation`, which didn't make a lot of sense. Furthermore, the responder `event` object passed to the callbacks (like `onEvent`) now has a `phase` integer property. The phase property indicates what the current phase is:

- `0`: root phase
- `1`: bubble phase
- `2`: capture phase

The ordering of these phases, when events come in:

`Capture target event types` -> `Bubble target event types` -> `Root event types`

This can be used to properly dispatch events in their relative phases, rather than passing `capture` on the config object of `dispatchEvent`. So, if you want to dispatch an event in the capture phase, you need to check the current phase that the event `onEvent` is in and ensure you're in the same phase as what you want to dispatch in.

I also removed the new responder event system from using the plugin event system's bookkeeping logic – it was never actually needed and just added overhead on each event pass. So now the fork for the different event systems happens in `dispatchEvent`.