### PR TITLE
Fixed setValueForStyles error

### DIFF
--- a/packages/react-dom/src/shared/CSSPropertyOperations.js
+++ b/packages/react-dom/src/shared/CSSPropertyOperations.js
@@ -78,7 +78,7 @@ export function setValueForStyles(node, styles) {
     }
     if (styleName === undefined) {
       try {
-        throw new Error("Stylename is undefined. Probably, you are using a code pattern for style passing which is not supported by React DOM.");
+        throw new Error('Stylename is undefined. Probably, you are using a code pattern which is not supported by React DOM.');
       } catch (x) {}
     }
     if (isCustomProperty) {

--- a/packages/react-dom/src/shared/CSSPropertyOperations.js
+++ b/packages/react-dom/src/shared/CSSPropertyOperations.js
@@ -76,6 +76,11 @@ export function setValueForStyles(node, styles) {
     if (styleName === 'float') {
       styleName = 'cssFloat';
     }
+    if (styleName === undefined) {
+      try {
+        throw new Error("Stylename is undefined. Probably, you are using a code pattern for style passing which is not supported by React DOM.");
+      } catch (x) {}
+    }
     if (isCustomProperty) {
       style.setProperty(styleName, styleValue);
     } else {


### PR DESCRIPTION
I believe that function setValueForStyles throws incomprehensible error on some browsers. That's because of stylename being undefined on these browsers when passing like an object, and I added an error message for this.