### PR TITLE
Fix: fixed cursor jumping for multiple email input

### DIFF
--- a/packages/react-dom/src/client/ReactDOMInput.js
+++ b/packages/react-dom/src/client/ReactDOMInput.js
@@ -412,9 +412,10 @@ export function setDefaultValue(
   type: ?string,
   value: *,
 ) {
+  const isMultipleEmail = type === 'email' && node.hasAttribute('multiple');
   if (
-    // Focused number inputs synchronize on blur. See ChangeEventPlugin.js
-    type !== 'number' ||
+    // Focused number and email inputs synchronize on blur. See ChangeEventPlugin.js
+    (type !== 'number' && !isMultipleEmail) ||
     node.ownerDocument.activeElement !== node
   ) {
     if (value == null) {

--- a/packages/react-dom/src/events/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/ChangeEventPlugin.js
@@ -235,13 +235,17 @@ function getTargetInstForInputOrChangeEvent(topLevelType, targetInst) {
 function handleControlledInputBlur(node) {
   let state = node._wrapperState;
 
-  if (!state || !state.controlled || node.type !== 'number') {
+  if (
+    !state ||
+    !state.controlled ||
+    (node.type !== 'number' && node.type !== 'email')
+  ) {
     return;
   }
 
   if (!disableInputAttributeSyncing) {
     // If controlled, assign the value attribute to the current value on blur
-    setDefaultValue(node, 'number', node.value);
+    setDefaultValue(node, node.type, node.value);
   }
 }
 


### PR DESCRIPTION
Fixed: #15418

I should mention that it is not the perfect solution because the bug itself is created by specific browsers (chrome, safari, opera):

If input's type is "email" and it contains comma and whitespace, the browsers give the wrong input's value: `a, b` =>  `a,b`, although the specification shows that multiple email input can contain whitespace between comma and the next email: https://html.spec.whatwg.org/multipage/input.html#the-multiple-attribute. And even if we try to set the right value programmatically  it won't.

So when React tries to set defaultValue on input while user's typing, it breaks browser's understanding of where caret should be. 

Considering React already contains the similar handling for number input, I suggest to make it for multiple email inputs too. Of course, on input blur input all spaces after commas will be removed, but at least it doesn't interrupt user's typing and provides much better UX experience. 

P.S. Is it such necessary to set defaultValue for input on blur? Maybe we can turn it off for this case until browsers don't fix this bug? 