### PR TITLE
Include rootEventTypes in DOMEventResponderSystem stopPropagation tests

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -540,8 +540,8 @@ function traverseAndTriggerEventResponderInstances(
   let shouldStopPropagation = false;
   let responderEvent;
 
-  // Capture target phase
   if (length > 0) {
+    // Capture target phase
     responderEvent = createResponderEvent(
       ((topLevelType: any): string),
       nativeEvent,


### PR DESCRIPTION
Confirms that current logic correctly stops propagation of event type to the root.

We probably need to consider an alternative mechanism if we don't want event components to be able to influence the events received by event components of different types.