### PR TITLE
React Events: extract shared functions

### DIFF
--- a/packages/react-events/src/utils.js
+++ b/packages/react-events/src/utils.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {
+  ReactResponderEvent,
+  ReactResponderContext,
+} from 'shared/ReactTypes';
+
+export function getEventCurrentTarget(
+  event: ReactResponderEvent,
+  context: ReactResponderContext,
+) {
+  const target: any = event.target;
+  let currentTarget = target;
+  while (
+    currentTarget.parentNode &&
+    currentTarget.parentNode.nodeType === Node.ELEMENT_NODE &&
+    context.isTargetWithinEventComponent(currentTarget.parentNode)
+  ) {
+    currentTarget = currentTarget.parentNode;
+  }
+  return currentTarget;
+}
+
+export function getEventPointerType(event: ReactResponderEvent) {
+  const nativeEvent: any = event.nativeEvent;
+  const {type, pointerType} = nativeEvent;
+  if (pointerType != null) {
+    return pointerType;
+  }
+  if (type.indexOf('mouse') === 0) {
+    return 'mouse';
+  }
+  if (type.indexOf('touch') === 0) {
+    return 'touch';
+  }
+  if (type.indexOf('key') === 0) {
+    return 'keyboard';
+  }
+  return '';
+}
+
+export function isEventPositionWithinTouchHitTarget(
+  event: ReactResponderEvent,
+  context: ReactResponderContext,
+) {
+  const nativeEvent: any = event.nativeEvent;
+  const target: any = event.target;
+  return context.isPositionWithinTouchHitTarget(
+    target.ownerDocument,
+    nativeEvent.x,
+    nativeEvent.y,
+  );
+}


### PR DESCRIPTION
Moving functions that are used across the event modules to a shared module. This is currently being inlined in each event module. We can determine which, if any, of these functions could be moved into the core and exposed via `context`. And we could avoid inlining any remaining shared code that doesn't belong in core.