### PR TITLE
React events: use passive events where possible

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -99,12 +99,7 @@ const targetEventTypes = [
   'pointerdown',
   'pointercancel',
 ];
-const rootEventTypes = [
-  {name: 'keyup', passive: false},
-  {name: 'pointerup', passive: false},
-  'pointermove',
-  'scroll',
-];
+const rootEventTypes = ['keyup', 'pointerup', 'pointermove', 'scroll'];
 
 // If PointerEvents is not supported (e.g., Safari), also listen to touch and mouse events.
 if (typeof window !== 'undefined' && window.PointerEvent === undefined) {


### PR DESCRIPTION
We can use passive events for these root event types as we're never calling `preventDefault` on the native events.