### PR TITLE
React events: add a test for focusable descendants of Focus component

### DIFF
--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -12,6 +12,7 @@ import type {
   ReactResponderContext,
 } from 'shared/ReactTypes';
 import {REACT_EVENT_COMPONENT_TYPE} from 'shared/ReactSymbols';
+import {getEventCurrentTarget} from './utils.js';
 
 const CAPTURE_PHASE = 2;
 
@@ -120,21 +121,17 @@ const FocusResponder = {
     if (phase === CAPTURE_PHASE) {
       return false;
     }
+
     switch (type) {
       case 'focus': {
         if (!state.isFocused) {
           // Limit focus events to the direct child of the event component.
           // Browser focus is not expected to bubble.
-          let currentTarget = (target: any);
-          if (
-            currentTarget.parentNode &&
-            context.isTargetWithinEventComponent(currentTarget.parentNode)
-          ) {
-            break;
+          state.focusTarget = getEventCurrentTarget(event, context);
+          if (state.focusTarget === target) {
+            dispatchFocusInEvents(context, props, state);
+            state.isFocused = true;
           }
-          state.focusTarget = currentTarget;
-          dispatchFocusInEvents(context, props, state);
-          state.isFocused = true;
         }
         break;
       }

--- a/packages/react-events/src/__tests__/Focus-test.internal.js
+++ b/packages/react-events/src/__tests__/Focus-test.internal.js
@@ -62,14 +62,17 @@ describe('Focus event responder', () => {
   });
 
   describe('onFocus', () => {
-    let onFocus, ref;
+    let onFocus, ref, innerRef;
 
     beforeEach(() => {
       onFocus = jest.fn();
       ref = React.createRef();
+      innerRef = React.createRef();
       const element = (
         <Focus onFocus={onFocus}>
-          <div ref={ref} />
+          <div ref={ref}>
+            <a ref={innerRef} />
+          </div>
         </Focus>
       );
       ReactDOM.render(element, container);
@@ -78,6 +81,12 @@ describe('Focus event responder', () => {
     it('is called after "focus" event', () => {
       ref.current.dispatchEvent(createFocusEvent('focus'));
       expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not called if descendants of target receive focus', () => {
+      const target = innerRef.current;
+      target.dispatchEvent(createFocusEvent('focus'));
+      expect(onFocus).not.toBeCalled();
     });
   });
 


### PR DESCRIPTION
Makes sure that focusing descendants doesn't register as a focus of the intended focus target (i.e., the only child of `Focus`)

Ref #15257