### PR TITLE
Add function to find all host instances for fiber, not just the first

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -21,6 +21,7 @@ import type {ExpirationTime} from './ReactFiberExpirationTime';
 import {
   findCurrentHostFiber,
   findCurrentHostFiberWithNoPortals,
+  findAllCurrentHostFibers,
 } from 'react-reconciler/reflection';
 import {get as getInstance} from 'shared/ReactInstanceMap';
 import {HostComponent, ClassComponent} from 'shared/ReactWorkTags';
@@ -445,6 +446,10 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
         return null;
       }
       return hostFiber.stateNode;
+    },
+    findHostInstancesByFiber(fiber: Fiber): Array<Instance | TextInstance> {
+      const hostFibers = findAllCurrentHostFibers(fiber);
+      return hostFibers.map(hostFiber => hostFiber.stateNode).filter(Boolean);
     },
     findFiberByHostInstance(instance: Instance | TextInstance): Fiber | null {
       if (!findFiberByHostInstance) {


### PR DESCRIPTION
Modified package: `react-reconciler`
- `ReactFiberReconciler`'s `injectIntoDevTools` now injects one more function: `findHostInstancesByFiber`
- `ReactFiberTreeReflection` now exports one more function `findAllCurrentHostFibers`

This is required to support highlighting all corresponding DOM elements of Fragments in `react-devtools-experimental`:
https://github.com/bvaughn/react-devtools-experimental/issues/131

CC @bvaughn @sophiebits 