### PR TITLE
Experimental Event API: add `rootEventTypes` support to event responders

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -1302,7 +1302,7 @@ export function listenToEventResponderEventTypes(
         if (__DEV__) {
           warning(
             typeof targetEventType === 'object' && targetEventType !== null,
-            'Event Responder: invalid entry in targetEventTypes array. ' +
+            'Event Responder: invalid entry in event types array. ' +
               'Entry must be string or an object. Instead, got %s.',
             targetEventType,
           );

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -34,6 +34,7 @@ import {
   setEnabled as ReactBrowserEventEmitterSetEnabled,
 } from '../events/ReactBrowserEventEmitter';
 import {Namespaces, getChildNamespace} from '../shared/DOMNamespaces';
+import {addRootEventTypesForComponentInstance} from '../events/DOMEventResponderSystem';
 import {
   ELEMENT_NODE,
   TEXT_NODE,
@@ -906,10 +907,18 @@ export function updateEventComponent(
   if (enableEventAPI) {
     const rootContainerInstance = ((eventComponentInstance.rootInstance: any): Container);
     const rootElement = rootContainerInstance.ownerDocument;
-    listenToEventResponderEventTypes(
-      eventComponentInstance.responder.targetEventTypes,
-      rootElement,
-    );
+    const responder = eventComponentInstance.responder;
+    const {rootEventTypes, targetEventTypes} = responder;
+    if (targetEventTypes !== undefined) {
+      listenToEventResponderEventTypes(targetEventTypes, rootElement);
+    }
+    if (rootEventTypes !== undefined) {
+      addRootEventTypesForComponentInstance(
+        eventComponentInstance,
+        rootEventTypes,
+      );
+      listenToEventResponderEventTypes(rootEventTypes, rootElement);
+    }
   }
 }
 

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -212,13 +212,13 @@ const eventResponderContext: ReactResponderContext = {
         rootEventTypesSet = componentInstance.rootEventTypes = new Set();
       }
       invariant(
-        !rootEventTypesSet.has(rootEventType),
+        !rootEventTypesSet.has(topLevelEventType),
         'addRootEventTypes() found a duplicate root event ' +
           'type of "%s". This might be because the event type exists in the event responder "rootEventTypes" ' +
           'array or because of a previous addRootEventTypes() using this root event type.',
         rootEventType,
       );
-      rootEventTypesSet.add(rootEventType);
+      rootEventTypesSet.add(topLevelEventType);
       rootEventComponentInstances.add(componentInstance);
     }
   },
@@ -236,7 +236,7 @@ const eventResponderContext: ReactResponderContext = {
       let rootEventTypesSet = ((currentInstance: any): ReactEventComponentInstance)
         .rootEventTypes;
       if (rootEventTypesSet !== null) {
-        rootEventTypesSet.delete(rootEventType);
+        rootEventTypesSet.delete(topLevelEventType);
       }
       if (rootEventComponents !== undefined) {
         rootEventComponents.delete(

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -211,7 +211,14 @@ const eventResponderContext: ReactResponderContext = {
       if (rootEventTypesSet === null) {
         rootEventTypesSet = componentInstance.rootEventTypes = new Set();
       }
-      rootEventTypesSet.add(topLevelEventType);
+      invariant(
+        !rootEventTypesSet.has(rootEventType),
+        'addRootEventTypes() found a duplicate root event ' +
+          'type of "%s". This might be because the event type exists in the event responder "rootEventTypes" ' +
+          'array or because of a previous addRootEventTypes() using this root event type.',
+        rootEventType,
+      );
+      rootEventTypesSet.add(rootEventType);
       rootEventComponentInstances.add(componentInstance);
     }
   },
@@ -229,7 +236,7 @@ const eventResponderContext: ReactResponderContext = {
       let rootEventTypesSet = ((currentInstance: any): ReactEventComponentInstance)
         .rootEventTypes;
       if (rootEventTypesSet !== null) {
-        rootEventTypesSet.delete(topLevelEventType);
+        rootEventTypesSet.delete(rootEventType);
       }
       if (rootEventComponents !== undefined) {
         rootEventComponents.delete(

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -206,9 +206,13 @@ const eventResponderContext: ReactResponderContext = {
           rootEventComponentInstances,
         );
       }
-      rootEventComponentInstances.add(
-        ((currentInstance: any): ReactEventComponentInstance),
-      );
+      const componentInstance = ((currentInstance: any): ReactEventComponentInstance);
+      let rootEventTypesSet = componentInstance.rootEventTypes;
+      if (rootEventTypesSet === null) {
+        rootEventTypesSet = componentInstance.rootEventTypes = new Set();
+      }
+      rootEventTypesSet.add(topLevelEventType);
+      rootEventComponentInstances.add(componentInstance);
     }
   },
   removeRootEventTypes(
@@ -222,6 +226,11 @@ const eventResponderContext: ReactResponderContext = {
       let rootEventComponents = rootEventTypesToEventComponentInstances.get(
         topLevelEventType,
       );
+      let rootEventTypesSet = ((currentInstance: any): ReactEventComponentInstance)
+        .rootEventTypes;
+      if (rootEventTypesSet !== null) {
+        rootEventTypesSet.delete(topLevelEventType);
+      }
       if (rootEventComponents !== undefined) {
         rootEventComponents.delete(
           ((currentInstance: any): ReactEventComponentInstance),
@@ -636,6 +645,20 @@ export function unmountEventResponder(
   if (responder.onOwnershipChange !== undefined) {
     ownershipChangeListeners.delete(eventComponentInstance);
   }
+  const rootEventTypesSet = eventComponentInstance.rootEventTypes;
+  if (rootEventTypesSet !== null) {
+    const rootEventTypes = Array.from(rootEventTypesSet);
+
+    for (let i = 0; i < rootEventTypes.length; i++) {
+      const topLevelEventType = rootEventTypes[i];
+      let rootEventComponentInstances = rootEventTypesToEventComponentInstances.get(
+        topLevelEventType,
+      );
+      if (rootEventComponentInstances !== undefined) {
+        rootEventComponentInstances.delete(eventComponentInstance);
+      }
+    }
+  }
 }
 
 function validateResponderContext(): void {
@@ -669,5 +692,34 @@ export function dispatchEventForResponderEventSystem(
       currentInstance = null;
       currentEventQueue = null;
     }
+  }
+}
+
+export function addRootEventTypesForComponentInstance(
+  eventComponentInstance: ReactEventComponentInstance,
+  rootEventTypes: Array<ReactEventResponderEventType>,
+): void {
+  for (let i = 0; i < rootEventTypes.length; i++) {
+    const rootEventType = rootEventTypes[i];
+    const topLevelEventType =
+      typeof rootEventType === 'string' ? rootEventType : rootEventType.name;
+    let rootEventComponentInstances = rootEventTypesToEventComponentInstances.get(
+      topLevelEventType,
+    );
+    if (rootEventComponentInstances === undefined) {
+      rootEventComponentInstances = new Set();
+      rootEventTypesToEventComponentInstances.set(
+        topLevelEventType,
+        rootEventComponentInstances,
+      );
+    }
+    let rootEventTypesSet = eventComponentInstance.rootEventTypes;
+    if (rootEventTypesSet === null) {
+      rootEventTypesSet = eventComponentInstance.rootEventTypes = new Set();
+    }
+    rootEventTypesSet.add(topLevelEventType);
+    rootEventComponentInstances.add(
+      ((eventComponentInstance: any): ReactEventComponentInstance),
+    );
   }
 }

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -16,6 +16,7 @@ let ReactSymbols;
 
 function createReactEventComponent(
   targetEventTypes,
+  rootEventTypes,
   createInitialState,
   onEvent,
   onEventCapture,
@@ -26,6 +27,7 @@ function createReactEventComponent(
 ) {
   const testEventResponder = {
     targetEventTypes,
+    rootEventTypes,
     createInitialState,
     onEvent,
     onEventCapture,
@@ -89,6 +91,7 @@ describe('DOMEventResponderSystem', () => {
 
     const ClickEventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       undefined,
       (event, context, props) => {
         eventResponderFiredCount++;
@@ -163,6 +166,7 @@ describe('DOMEventResponderSystem', () => {
     const ClickEventComponent = createReactEventComponent(
       ['click'],
       undefined,
+      undefined,
       (event, context, props) => {
         eventLog.push({
           name: event.type,
@@ -216,6 +220,7 @@ describe('DOMEventResponderSystem', () => {
 
     const ClickEventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       undefined,
       (event, context, props) => {
         eventResponderFiredCount++;
@@ -288,6 +293,7 @@ describe('DOMEventResponderSystem', () => {
     const ClickEventComponentA = createReactEventComponent(
       ['click'],
       undefined,
+      undefined,
       (event, context, props) => {
         eventLog.push(`A [bubble]`);
       },
@@ -298,6 +304,7 @@ describe('DOMEventResponderSystem', () => {
 
     const ClickEventComponentB = createReactEventComponent(
       ['click'],
+      undefined,
       undefined,
       (event, context, props) => {
         eventLog.push(`B [bubble]`);
@@ -335,6 +342,7 @@ describe('DOMEventResponderSystem', () => {
 
     const ClickEventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       undefined,
       (event, context, props) => {
         eventLog.push(`${props.name} [bubble]`);
@@ -377,6 +385,7 @@ describe('DOMEventResponderSystem', () => {
     const ClickEventComponent = createReactEventComponent(
       ['click'],
       undefined,
+      undefined,
       (event, context, props) => {
         eventLog.push(`${props.name} [bubble]`);
       },
@@ -412,6 +421,7 @@ describe('DOMEventResponderSystem', () => {
 
     const ClickEventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       undefined,
       (event, context, props) => {
         if (props.onMagicClick) {
@@ -505,6 +515,7 @@ describe('DOMEventResponderSystem', () => {
     const LongPressEventComponent = createReactEventComponent(
       ['click'],
       undefined,
+      undefined,
       (event, context, props) => {
         handleEvent(event, context, props, 'bubble');
       },
@@ -551,6 +562,7 @@ describe('DOMEventResponderSystem', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       (event, context, props, state) => {},
       () => {
         onUnmountFired++;
@@ -573,6 +585,7 @@ describe('DOMEventResponderSystem', () => {
 
     const EventComponent = createReactEventComponent(
       [],
+      undefined,
       () => ({
         incrementAmount: 5,
       }),
@@ -602,6 +615,7 @@ describe('DOMEventResponderSystem', () => {
 
     const EventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       undefined,
       (event, context, props, state) => {
         ownershipGained = context.requestOwnership();
@@ -640,6 +654,7 @@ describe('DOMEventResponderSystem', () => {
 
     const EventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       undefined,
       (event, context, props, state) => {
         queryResult = Array.from(
@@ -696,6 +711,7 @@ describe('DOMEventResponderSystem', () => {
     const EventComponent = createReactEventComponent(
       ['click'],
       undefined,
+      undefined,
       (event, context, props, state) => {
         queryResult = context.getEventTargetsFromTarget(
           event.target,
@@ -742,6 +758,7 @@ describe('DOMEventResponderSystem', () => {
 
     const EventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       undefined,
       (event, context, props, state) => {
         queryResult = context.getEventTargetsFromTarget(
@@ -794,6 +811,7 @@ describe('DOMEventResponderSystem', () => {
 
     const EventComponent = createReactEventComponent(
       ['click'],
+      undefined,
       undefined,
       (event, context, props, state) => {
         queryResult = context.getEventTargetsFromTarget(
@@ -854,5 +872,49 @@ describe('DOMEventResponderSystem', () => {
       },
     ]);
     expect(queryResult3).toEqual([]);
+  });
+
+  it('the event responder root listeners should fire on a root click event', () => {
+    let eventResponderFiredCount = 0;
+    let eventLog = [];
+
+    const ClickEventComponent = createReactEventComponent(
+      undefined,
+      ['click'],
+      undefined,
+      undefined,
+      undefined,
+      event => {
+        eventResponderFiredCount++;
+        eventLog.push({
+          name: event.type,
+          passive: event.passive,
+          passiveSupported: event.passiveSupported,
+          phase: 'root',
+        });
+      },
+    );
+
+    const Test = () => (
+      <ClickEventComponent>
+        <button>Click me!</button>
+      </ClickEventComponent>
+    );
+
+    ReactDOM.render(<Test />, container);
+    expect(container.innerHTML).toBe('<button>Click me!</button>');
+
+    // Clicking the button should trigger the event responder onEvent() twice
+    dispatchClickEvent(document.body);
+    expect(eventResponderFiredCount).toBe(1);
+    expect(eventLog.length).toBe(1);
+    expect(eventLog).toEqual([
+      {
+        name: 'click',
+        passive: false,
+        passiveSupported: false,
+        phase: 'root',
+      },
+    ]);
   });
 });

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -816,6 +816,7 @@ function completeWork(
             context: null,
             props: newProps,
             responder,
+            rootEventTypes: null,
             rootInstance: rootContainerInstance,
             state: responderState,
           };

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -86,7 +86,8 @@ export type ReactEventResponderEventType =
   | {name: string, passive?: boolean, capture?: boolean};
 
 export type ReactEventResponder = {
-  targetEventTypes: Array<ReactEventResponderEventType>,
+  targetEventTypes?: Array<ReactEventResponderEventType>,
+  rootEventTypes?: Array<ReactEventResponderEventType>,
   createInitialState?: (props: null | Object) => Object,
   stopLocalPropagation: boolean,
   onEvent?: (
@@ -123,6 +124,7 @@ export type ReactEventComponentInstance = {|
   context: null | Object,
   props: null | Object,
   responder: ReactEventResponder,
+  rootEventTypes: null | Set<string>,
   rootInstance: mixed,
   state: null | Object,
 |};


### PR DESCRIPTION
This PR adds support for event responder having `rootEventTypes` without needing to dynamically add them during a target event type in `onEvent`.

Like `targetEventTypes`, event responders now support `rootEventTypes` as an array of possible events. To properly track these and unmount them, the event component instance object has a `rootEventTypes` property that we use for tracking the mounting/unmounting of root events. Also and `invariant` has been added to ensure we don't add duplicate root event types – otherwise, when we remove a root event type things will fall out of sync.