### PR TITLE
Experimental Event API: various bug fixes with HitTargets

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -966,6 +966,13 @@ export function handleEventTarget(
   rootContainerInstance: Container,
   internalInstanceHandle: Object,
 ): boolean {
+  if (
+    __DEV__ &&
+    type === REACT_EVENT_TARGET_TOUCH_HIT &&
+    (props.left || props.right || props.top || props.bottom)
+  ) {
+    return true;
+  }
   return false;
 }
 
@@ -992,9 +999,9 @@ export function commitEventTarget(
             'value of "relative".',
         );
         warning(
-          computedStyles.getPropertyValue('zIndex') !== '',
+          computedStyles.getPropertyValue('z-index') !== '',
           '<TouchHitTarget> inserts an empty <div> with "z-index" of "-1". ' +
-            'This requires its parent DOM node to have a "z-index" great than "-1",' +
+            'This requires its parent DOM node to have a "z-index" greater than "-1",' +
             'but the parent DOM node was found to no "z-index" value set.' +
             ' Try using a "z-index" value of "0" or greater.',
         );

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -108,7 +108,7 @@ const FocusResponder = {
   onEvent(
     event: ReactResponderEvent,
     context: ReactResponderContext,
-    props: Object,
+    props: FocusProps,
     state: FocusState,
   ): void {
     const {type, target} = event;

--- a/packages/react-events/src/__tests__/TouchHitTarget-test.internal.js
+++ b/packages/react-events/src/__tests__/TouchHitTarget-test.internal.js
@@ -318,7 +318,7 @@ describe('TouchHitTarget', () => {
 
       const Test = () => (
         <EventComponent>
-          <div>
+          <div style={{position: 'relative', zIndex: 0}}>
             {cond ? null : (
               <TouchHitTarget top={10} left={10} right={10} bottom={10} />
             )}
@@ -330,14 +330,16 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; z-index: -1; bottom: -10px; ' +
+        '<div style="position: relative; z-index: 0;"><div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: -10px; right: -10px; top: -10px;"></div></div>',
       );
 
       cond = true;
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
-      expect(container.innerHTML).toBe('<div></div>');
+      expect(container.innerHTML).toBe(
+        '<div style="position: relative; z-index: 0;"></div>',
+      );
     });
 
     it('should render a conditional TouchHitTarget correctly (true -> false)', () => {
@@ -345,7 +347,7 @@ describe('TouchHitTarget', () => {
 
       const Test = () => (
         <EventComponent>
-          <div>
+          <div style={{position: 'relative', zIndex: 0}}>
             {cond ? null : (
               <TouchHitTarget top={10} left={10} right={10} bottom={10} />
             )}
@@ -356,13 +358,15 @@ describe('TouchHitTarget', () => {
       const container = document.createElement('div');
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
-      expect(container.innerHTML).toBe('<div></div>');
+      expect(container.innerHTML).toBe(
+        '<div style="position: relative; z-index: 0;"></div>',
+      );
 
       cond = false;
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; z-index: -1; bottom: -10px; ' +
+        '<div style="position: relative; z-index: 0;"><div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: -10px; right: -10px; top: -10px;"></div></div>',
       );
     });
@@ -372,7 +376,7 @@ describe('TouchHitTarget', () => {
 
       const Test = () => (
         <EventComponent>
-          <div>
+          <div style={{position: 'relative', zIndex: 0}}>
             {cond ? (
               <TouchHitTarget />
             ) : (
@@ -386,14 +390,16 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; z-index: -1; bottom: -10px; ' +
+        '<div style="position: relative; z-index: 0;"><div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: -10px; right: -10px; top: -10px;"></div></div>',
       );
 
       cond = true;
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
-      expect(container.innerHTML).toBe('<div></div>');
+      expect(container.innerHTML).toBe(
+        '<div style="position: relative; z-index: 0;"></div>',
+      );
     });
 
     it('should render a conditional TouchHitTarget hit slop correctly (true -> false)', () => {
@@ -401,7 +407,7 @@ describe('TouchHitTarget', () => {
 
       const Test = () => (
         <EventComponent>
-          <div>
+          <div style={{position: 'relative', zIndex: 0}}>
             <span>Random span 1</span>
             {cond ? (
               <TouchHitTarget />
@@ -417,14 +423,15 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><span>Random span 2</span></div>',
+        '<div style="position: relative; z-index: 0;"><span>Random span 1</span><span>Random span 2</span></div>',
       );
 
       cond = false;
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; z-index: -1; bottom: -10px; ' +
+        '<div style="position: relative; z-index: 0;"><span>Random span 1</span>' +
+          '<div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: -10px; right: -10px; top: -10px;"></div><span>Random span 2</span></div>',
       );
     });
@@ -434,7 +441,7 @@ describe('TouchHitTarget', () => {
 
       const Test = () => (
         <EventComponent>
-          <div>
+          <div style={{position: 'relative', zIndex: 0}}>
             <span>Random span 1</span>
             {cond ? (
               <TouchHitTarget top={10} left={null} right={10} bottom={10} />
@@ -455,7 +462,8 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; z-index: -1; bottom: 0px; ' +
+        '<div style="position: relative; z-index: 0;"><span>Random span 1</span>' +
+          '<div style="position: absolute; z-index: -1; bottom: 0px; ' +
           'left: -20px; right: 0px; top: 0px;"></div><span>Random span 2</span></div>',
       );
 
@@ -463,7 +471,8 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; z-index: -1; bottom: 0px; ' +
+        '<div style="position: relative; z-index: 0;"><span>Random span 1</span>' +
+          '<div style="position: absolute; z-index: -1; bottom: 0px; ' +
           'left: -20px; right: 0px; top: 0px;"></div><span>Random span 2</span></div>',
       );
     });
@@ -473,7 +482,7 @@ describe('TouchHitTarget', () => {
 
       const Test = () => (
         <EventComponent>
-          <div>
+          <div style={{position: 'relative', zIndex: 0}}>
             <span>Random span 1</span>
             {cond ? (
               <TouchHitTarget top={10} left={null} right={10} bottom={10} />
@@ -494,7 +503,8 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; z-index: -1; bottom: -10px; ' +
+        '<div style="position: relative; z-index: 0;"><span>Random span 1</span>' +
+          '<div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: 0px; right: -10px; top: -10px;"></div><span>Random span 2</span></div>',
       );
 
@@ -502,7 +512,8 @@ describe('TouchHitTarget', () => {
       ReactDOM.render(<Test />, container);
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><span>Random span 1</span><div style="position: absolute; z-index: -1; bottom: -10px; ' +
+        '<div style="position: relative; z-index: 0;"><span>Random span 1</span>' +
+          '<div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: 0px; right: -10px; top: -10px;"></div><span>Random span 2</span></div>',
       );
     });
@@ -510,14 +521,15 @@ describe('TouchHitTarget', () => {
     it('should hydrate TouchHitTarget hit slop elements correcty and patch them', () => {
       const Test = () => (
         <EventComponent>
-          <div>
+          <div style={{position: 'relative', zIndex: 0}}>
             <TouchHitTarget top={10} left={10} right={10} bottom={10} />
           </div>
         </EventComponent>
       );
 
       const container = document.createElement('div');
-      container.innerHTML = '<div></div>';
+      container.innerHTML =
+        '<div style="position: relative; z-index: 0"></div>';
       expect(() => {
         ReactDOM.hydrate(<Test />, container);
         expect(Scheduler).toFlushWithoutYielding();
@@ -527,7 +539,7 @@ describe('TouchHitTarget', () => {
       );
       expect(Scheduler).toFlushWithoutYielding();
       expect(container.innerHTML).toBe(
-        '<div><div style="position: absolute; z-index: -1; bottom: -10px; ' +
+        '<div style="position: relative; z-index: 0"><div style="position: absolute; z-index: -1; bottom: -10px; ' +
           'left: -10px; right: -10px; top: -10px;"></div></div>',
       );
     });


### PR DESCRIPTION
This PR contains a selection of bug fixes for the experimental event API. Notably:

- The `commitEventTarget` and `onMount` renderer callbacks are now called during the lifecycle phase so that we now can properly access the element after it's been attached to the document.
- Fixed a typo in detection of `zIndex` checking.
- Updated all tests to properly account for the functionality now working correctly.
- Fixed `Press` handling of hit targets. It was broken before and was allowing `mouse` and `pen` events to incorrectly trigger the event target. Furthermore, the `focus` event is now correctly blocked.