### PR TITLE
[React Native] Inline calls to FabricUIManager in shared code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -125,6 +125,12 @@ module.exports = {
         // https://github.com/jest-community/eslint-plugin-jest
         'jest/no-focused-tests': ERROR,
       }
+    },
+    {
+      files: ['packages/react-native-renderer/**/*.js'],
+      globals: {
+        nativeFabricUIManager: true,
+      }
     }
   ],
 

--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -88,7 +88,7 @@ export default function(
         // We can't call FabricUIManager here because it won't be loaded in paper
         // at initialization time. See https://github.com/facebook/react/pull/15490
         // for more info.
-        global.nativeFabricUIManager.measure(
+        nativeFabricUIManager.measure(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );
@@ -136,7 +136,7 @@ export default function(
         // We can't call FabricUIManager here because it won't be loaded in paper
         // at initialization time. See https://github.com/facebook/react/pull/15490
         // for more info.
-        global.nativeFabricUIManager.measureInWindow(
+        nativeFabricUIManager.measureInWindow(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );

--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -85,8 +85,10 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        // Must be inlined to avoid loading this before Fabric is set up
-        require('FabricUIManager').measure(
+        // We can't call FabricUIManager here because it won't be loaded in paper
+        // at initialization time. See https://github.com/facebook/react/pull/15490
+        // for more info.
+        global.nativeFabricUIManager.measure(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );
@@ -131,7 +133,10 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        require('FabricUIManager').measureInWindow(
+        // We can't call FabricUIManager here because it won't be loaded in paper
+        // at initialization time. See https://github.com/facebook/react/pull/15490
+        // for more info.
+        global.nativeFabricUIManager.measureInWindow(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );

--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -18,7 +18,6 @@ import type {
 import invariant from 'shared/invariant';
 // Modules provided by RN:
 import TextInputState from 'TextInputState';
-import * as FabricUIManager from 'FabricUIManager';
 import UIManager from 'UIManager';
 
 import {create} from './ReactNativeAttributePayload';
@@ -86,7 +85,8 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        FabricUIManager.measure(
+        // Must be inlined to avoid loading this before Fabric is set up
+        require('FabricUIManager').measure(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );
@@ -131,7 +131,7 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        FabricUIManager.measureInWindow(
+        require('FabricUIManager').measureInWindow(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );

--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -100,8 +100,10 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        // Must be inlined to avoid loading this before Fabric is set up
-        require('FabricUIManager').measure(
+        // We can't call FabricUIManager here because it won't be loaded in paper
+        // at initialization time. See https://github.com/facebook/react/pull/15490
+        // for more info.
+        global.nativeFabricUIManager.measure(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );
@@ -144,8 +146,10 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        // Must be inlined to avoid loading this before Fabric is set up
-        require('FabricUIManager').measureInWindow(
+        // We can't call FabricUIManager here because it won't be loaded in paper
+        // at initialization time. See https://github.com/facebook/react/pull/15490
+        // for more info.
+        global.nativeFabricUIManager.measureInWindow(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );

--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -103,7 +103,7 @@ export default function(
         // We can't call FabricUIManager here because it won't be loaded in paper
         // at initialization time. See https://github.com/facebook/react/pull/15490
         // for more info.
-        global.nativeFabricUIManager.measure(
+        nativeFabricUIManager.measure(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );
@@ -149,7 +149,7 @@ export default function(
         // We can't call FabricUIManager here because it won't be loaded in paper
         // at initialization time. See https://github.com/facebook/react/pull/15490
         // for more info.
-        global.nativeFabricUIManager.measureInWindow(
+        nativeFabricUIManager.measureInWindow(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );

--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -19,7 +19,6 @@ import type {
 import React from 'react';
 // Modules provided by RN:
 import TextInputState from 'TextInputState';
-import * as FabricUIManager from 'FabricUIManager';
 import UIManager from 'UIManager';
 
 import {create} from './ReactNativeAttributePayload';
@@ -101,7 +100,8 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        FabricUIManager.measure(
+        // Must be inlined to avoid loading this before Fabric is set up
+        require('FabricUIManager').measure(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );
@@ -144,7 +144,8 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        FabricUIManager.measureInWindow(
+        // Must be inlined to avoid loading this before Fabric is set up
+        require('FabricUIManager').measureInWindow(
           maybeInstance.node,
           mountSafeCallback_NOT_REALLY_SAFE(this, callback),
         );

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -48,6 +48,11 @@ describe('ReactFabric', () => {
     NativeMethodsMixin =
       ReactFabric.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
         .NativeMethodsMixin;
+
+    global.nativeFabricUIManager = {
+      measure: FabricUIManager.measure,
+      measureInWindow: FabricUIManager.measureInWindow,
+    };
   });
 
   it('should be able to create and render a native component', () => {

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -144,6 +144,19 @@ declare module 'FabricUIManager' {
   ): void;
 }
 
+// This is needed for a short term solution.
+// See https://github.com/facebook/react/pull/15490 for more info
+declare var nativeFabricUIManager: {
+  measure(
+    node: Node,
+    callback: MeasureOnSuccessCallback,
+  ): void;
+  measureInWindow(
+    node: Node,
+    callback: MeasureInWindowOnSuccessCallback,
+  ): void;
+}
+
 declare module 'View' {
   declare module.exports: typeof React$Component;
 }

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -147,15 +147,9 @@ declare module 'FabricUIManager' {
 // This is needed for a short term solution.
 // See https://github.com/facebook/react/pull/15490 for more info
 declare var nativeFabricUIManager: {
-  measure(
-    node: Node,
-    callback: MeasureOnSuccessCallback,
-  ): void;
-  measureInWindow(
-    node: Node,
-    callback: MeasureInWindowOnSuccessCallback,
-  ): void;
-}
+  measure(node: Node, callback: MeasureOnSuccessCallback): void,
+  measureInWindow(node: Node, callback: MeasureInWindowOnSuccessCallback): void,
+};
 
 declare module 'View' {
   declare module.exports: typeof React$Component;

--- a/scripts/rollup/validate/eslintrc.rn.js
+++ b/scripts/rollup/validate/eslintrc.rn.js
@@ -18,6 +18,9 @@ module.exports = {
     __REACT_DEVTOOLS_GLOBAL_HOOK__: true,
     // FB
     __DEV__: true,
+    // Fabric. See https://github.com/facebook/react/pull/15490
+    // for more information
+    nativeFabricUIManager: true,
   },
   parserOptions: {
     ecmaVersion: 5,


### PR DESCRIPTION
My previous commit (https://github.com/facebook/react/commit/1b2159acc34d9ca2c950e53bfc46db385a75dbad) caused crashes when running in Fabric when navigating from a paper screen to a fabric screen. 

The NativeMethodsMixin and ReactNativeComponent code is shared in both the Paper renderer and Fabric renderer. The previous commit caused the top of the paper renderer to include `require('FabricUIManager')`. 

`FabricUIManager.js` is essentially just:
```
module.exports = global.nativeFabricUIManager;
```

Because this code was getting called at the top of the paper renderer, `FabricUIManager` was exporting `undefined`. 

When transitioning to a Fabric screen, c++ installs that global, and then the FabricRenderer has this check:

```
if (FabricUIManager.registerEventHandler) {
  ...
}
```

This manifested as a crash `cannot access registerEventHandle of undefined`. This is because FabricUIManager was cached from being accessed too early. 

## The "right" fix
We will fix this correctly by having native always, on startup, define and set the object:
```
global.nativeFabricUIManager = {
  createNode,
  cloneNode,
  measure,
  measureInWindow,
  // ...
} 
```

When starting with the paper renderer, these functions will just throw.

Then, when Fabric is loaded, it will replace the implementation of those functions with the actual correct implementation.

This will ensure there is no timing issues with when JavaScript reads and caches the value of the global or any of the functions.

We will need to ensure we replace the implementations of the functions and not redefine them because we will need to support JS reading the functions early like this:

```
const {createNode, measure} = global.nativeFabricUIManager;
```
Reading them early, and then calling them after Fabric has loaded will need to work. 

## The "short term" fix

This PR includes the short term fix which is to inline these requires so that it isn't called early. Normally this would happen by default as we run everything inline requires however this file is blacklisted from inline requires in React Native as it is faster this way. 

## Test Plan:
Opened Marketplace (this worked before this change)
Navigating from Catalyst (paper) to Fabric RNTester (fabric). This crashed before with the error above and no longer crashes. 