### PR TITLE
Event API: follow up fixes for FocusScope + context changes

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -896,8 +896,8 @@ export function mountEventComponent(
   eventComponentInstance: ReactEventComponentInstance,
 ): void {
   if (enableEventAPI) {
-    mountEventResponder(eventComponentInstance);
     updateEventComponent(eventComponentInstance);
+    mountEventResponder(eventComponentInstance);
   }
 }
 

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -86,7 +86,7 @@ const eventListeners:
     > = new PossiblyWeakMap();
 
 let currentTimers = new Map();
-let currentLocalOwners = new Map();
+let currentResponderOwners = new Map();
 let currentOwner = null;
 let currentInstance: null | ReactEventComponentInstance = null;
 let currentEventQueue: null | EventQueue = null;
@@ -289,7 +289,7 @@ const eventResponderContext: ReactResponderContext = {
       .responder;
     return (
       currentOwner === currentInstance ||
-      currentLocalOwners.get(responder) === currentInstance
+      currentResponderOwners.get(responder) === currentInstance
     );
   },
   requestGlobalOwnership(): boolean {
@@ -301,14 +301,14 @@ const eventResponderContext: ReactResponderContext = {
     triggerOwnershipListeners(null);
     return true;
   },
-  requestLocalOwnership(): boolean {
+  requestResponderOwnership(): boolean {
     validateResponderContext();
     const responder = ((currentInstance: any): ReactEventComponentInstance)
       .responder;
-    if (currentLocalOwners.has(responder)) {
+    if (currentResponderOwners.has(responder)) {
       return false;
     }
-    currentLocalOwners.set(responder, currentInstance);
+    currentResponderOwners.set(responder, currentInstance);
     triggerOwnershipListeners(responder);
     return true;
   },
@@ -405,8 +405,8 @@ function releaseOwnershipForEventComponentInstance(
 ): boolean {
   const responder = eventComponentInstance.responder;
   let triggerOwnershipListenersWith;
-  if (currentLocalOwners.get(responder) === eventComponentInstance) {
-    currentLocalOwners.delete(responder);
+  if (currentResponderOwners.get(responder) === eventComponentInstance) {
+    currentResponderOwners.delete(responder);
     triggerOwnershipListenersWith = responder;
   }
   if (currentOwner === eventComponentInstance) {
@@ -600,8 +600,8 @@ function shouldSkipEventComponent(
     return true;
   }
   if (
-    currentLocalOwners.has(responder) &&
-    currentLocalOwners.get(responder) !== eventResponderInstance
+    currentResponderOwners.has(responder) &&
+    currentResponderOwners.get(responder) !== eventResponderInstance
   ) {
     return true;
   }

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -378,12 +378,14 @@ function isFiberHostComponentFocusable(fiber: Fiber): boolean {
     return true;
   }
   if (type === 'a' || type === 'area') {
-    return !!memoizedProps.href;
+    return !!memoizedProps.href && memoizedProps.rel !== 'ignore';
+  }
+  if (type === 'input') {
+    return memoizedProps.type !== 'hidden' && memoizedProps.type !== 'file';
   }
   return (
     type === 'button' ||
     type === 'textarea' ||
-    type === 'input' ||
     type === 'object' ||
     type === 'select' ||
     type === 'iframe' ||

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -638,7 +638,7 @@ describe('DOMEventResponderSystem', () => {
       undefined,
       undefined,
       (event, context, props, state) => {
-        ownershipGained = context.requestOwnership();
+        ownershipGained = context.requestGlobalOwnership();
       },
       undefined,
       undefined,

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -129,7 +129,7 @@ const DragResponder = {
             );
           }
 
-          context.addRootEventTypes(target.ownerDocument, rootEventTypes);
+          context.addRootEventTypes(rootEventTypes);
         }
         break;
       }

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -166,7 +166,7 @@ const DragResponder = {
               props.onShouldClaimOwnership &&
               props.onShouldClaimOwnership()
             ) {
-              shouldEnableDragging = context.requestOwnership();
+              shouldEnableDragging = context.requestGlobalOwnership();
             }
             if (shouldEnableDragging) {
               state.isDragging = true;

--- a/packages/react-events/src/FocusScope.js
+++ b/packages/react-events/src/FocusScope.js
@@ -24,10 +24,8 @@ type FocusScopeState = {
   currentFocusedNode: null | HTMLElement,
 };
 
-const rootEventTypes = [
-  {name: 'focus', passive: true, capture: true},
-  {name: 'keydown', passive: false},
-];
+const targetEventTypes = [{name: 'keydown', passive: false}];
+const rootEventTypes = [{name: 'focus', passive: true, capture: true}];
 
 function focusFirstChildEventTarget(
   context: ReactResponderContext,
@@ -37,24 +35,11 @@ function focusFirstChildEventTarget(
   if (elements.length > 0) {
     const firstElement = elements[0];
     firstElement.focus();
-    state.currentFocusedNode = firstElement;
-  }
-}
-
-function focusLastChildEventTarget(
-  context: ReactResponderContext,
-  state: FocusScopeState,
-): void {
-  const elements = context.getFocusableElementsInScope();
-  const length = elements.length;
-  if (elements.length > 0) {
-    const lastElement = elements[length - 1];
-    lastElement.focus();
-    state.currentFocusedNode = lastElement;
   }
 }
 
 const FocusScopeResponder = {
+  targetEventTypes,
   rootEventTypes,
   createInitialState(): FocusScopeState {
     return {
@@ -62,60 +47,90 @@ const FocusScopeResponder = {
       currentFocusedNode: null,
     };
   },
-  onRootEvent(
+  onEvent(
     event: ReactResponderEvent,
     context: ReactResponderContext,
     props: FocusScopeProps,
     state: FocusScopeState,
   ) {
-    const {type, target, nativeEvent} = event;
+    const {type, nativeEvent} = event;
+    const hasOwnership =
+      context.hasOwnership() || context.requestLocalOwnership();
 
-    if (type === 'focus') {
-      if (context.isTargetWithinEventComponent(target)) {
-        state.currentFocusedNode = ((target: any): HTMLElement);
-      } else if (props.trap) {
-        if (state.currentFocusedNode !== null) {
-          state.currentFocusedNode.focus();
-        } else {
-          focusFirstChildEventTarget(context, state);
-        }
-      }
-    } else if (type === 'keydown' && nativeEvent.key === 'Tab') {
-      const currentFocusedNode = state.currentFocusedNode;
-      if (currentFocusedNode !== null) {
+    if (!hasOwnership) {
+      return;
+    }
+    if (type === 'keydown' && nativeEvent.key === 'Tab') {
+      const focusedElement = context.getActiveDocument().activeElement;
+      if (
+        focusedElement !== null &&
+        context.isTargetWithinEventComponent(focusedElement)
+      ) {
         const {altkey, ctrlKey, metaKey, shiftKey} = (nativeEvent: any);
         // Skip if any of these keys are being pressed
         if (altkey || ctrlKey || metaKey) {
           return;
         }
         const elements = context.getFocusableElementsInScope();
-        const position = elements.indexOf(currentFocusedNode);
+        const position = elements.indexOf(focusedElement);
+        const lastPosition = elements.length - 1;
+        let nextElement = null;
+
         if (shiftKey) {
           if (position === 0) {
             if (props.trap) {
-              focusLastChildEventTarget(context, state);
+              nextElement = elements[lastPosition];
             } else {
+              // Out of bounds
+              context.releaseOwnership();
               return;
             }
           } else {
-            const previousElement = elements[position - 1];
-            previousElement.focus();
-            state.currentFocusedNode = previousElement;
+            nextElement = elements[position - 1];
           }
         } else {
-          if (position === elements.length - 1) {
+          if (position === lastPosition) {
             if (props.trap) {
-              focusFirstChildEventTarget(context, state);
+              nextElement = elements[0];
             } else {
+              // Out of bounds
+              context.releaseOwnership();
               return;
             }
           } else {
-            const nextElement = elements[position + 1];
-            nextElement.focus();
-            state.currentFocusedNode = nextElement;
+            nextElement = elements[position + 1];
           }
         }
-        ((nativeEvent: any): KeyboardEvent).preventDefault();
+        // If this element is possibly inside the scope of another
+        // FocusScope responder or is out of bounds, then we release ownership.
+        if (nextElement !== null) {
+          if (!context.isTargetWithinEventResponderScope(nextElement)) {
+            context.releaseOwnership();
+          }
+          nextElement.focus();
+          state.currentFocusedNode = nextElement;
+          ((nativeEvent: any): KeyboardEvent).preventDefault();
+        }
+      }
+    }
+  },
+  onRootEvent(
+    event: ReactResponderEvent,
+    context: ReactResponderContext,
+    props: FocusScopeProps,
+    state: FocusScopeState,
+  ) {
+    const {target} = event;
+
+    // Handle global trapping
+    if (props.trap) {
+      if (!context.isTargetWithinEventComponent(target)) {
+        const currentFocusedNode = state.currentFocusedNode;
+        if (currentFocusedNode !== null) {
+          currentFocusedNode.focus();
+        } else if (props.autoFocus) {
+          focusFirstChildEventTarget(context, state);
+        }
       }
     }
   },
@@ -123,7 +138,7 @@ const FocusScopeResponder = {
     context: ReactResponderContext,
     props: FocusScopeProps,
     state: FocusScopeState,
-  ) {
+  ): void {
     if (props.restoreFocus) {
       state.nodeToRestore = context.getActiveDocument().activeElement;
     }
@@ -135,8 +150,12 @@ const FocusScopeResponder = {
     context: ReactResponderContext,
     props: FocusScopeProps,
     state: FocusScopeState,
-  ) {
-    if (props.restoreFocus && state.nodeToRestore !== null) {
+  ): void {
+    if (
+      props.restoreFocus &&
+      state.nodeToRestore !== null &&
+      context.hasOwnership()
+    ) {
       state.nodeToRestore.focus();
     }
   },
@@ -144,8 +163,10 @@ const FocusScopeResponder = {
     context: ReactResponderContext,
     props: FocusScopeProps,
     state: FocusScopeState,
-  ) {
-    // unmountResponder(context, props, state);
+  ): void {
+    if (!context.hasOwnership()) {
+      state.currentFocusedNode = null;
+    }
   },
 };
 

--- a/packages/react-events/src/FocusScope.js
+++ b/packages/react-events/src/FocusScope.js
@@ -125,7 +125,7 @@ const FocusScopeResponder = {
     state: FocusScopeState,
   ) {
     if (props.restoreFocus) {
-      state.nodeToRestore = document.activeElement;
+      state.nodeToRestore = context.getActiveDocument().activeElement;
     }
     if (props.autoFocus) {
       focusFirstChildEventTarget(context, state);

--- a/packages/react-events/src/FocusScope.js
+++ b/packages/react-events/src/FocusScope.js
@@ -55,7 +55,7 @@ const FocusScopeResponder = {
   ) {
     const {type, nativeEvent} = event;
     const hasOwnership =
-      context.hasOwnership() || context.requestLocalOwnership();
+      context.hasOwnership() || context.requestResponderOwnership();
 
     if (!hasOwnership) {
       return;

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -472,7 +472,7 @@ const PressResponder = {
           state.pressTarget = target;
           state.isPressWithinResponderRegion = true;
           dispatchPressStartEvents(context, props, state);
-          context.addRootEventTypes(target.ownerDocument, rootEventTypes);
+          context.addRootEventTypes(rootEventTypes);
         } else {
           // Prevent spacebar press from scrolling the window
           if (isValidKeyPress(nativeEvent.key) && nativeEvent.key === ' ') {

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -120,7 +120,7 @@ const SwipeResponder = {
           let shouldEnableSwiping = true;
 
           if (props.onShouldClaimOwnership && props.onShouldClaimOwnership()) {
-            shouldEnableSwiping = context.requestOwnership();
+            shouldEnableSwiping = context.requestGlobalOwnership();
           }
           if (shouldEnableSwiping) {
             state.isSwiping = true;

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -129,7 +129,7 @@ const SwipeResponder = {
             state.x = x;
             state.y = y;
             state.swipeTarget = target;
-            context.addRootEventTypes(target.ownerDocument, rootEventTypes);
+            context.addRootEventTypes(rootEventTypes);
           } else {
             state.touchId = null;
           }

--- a/packages/react-events/src/__tests__/Drag-test.internal.js
+++ b/packages/react-events/src/__tests__/Drag-test.internal.js
@@ -29,6 +29,7 @@ describe('Drag event responder', () => {
   });
 
   afterEach(() => {
+    ReactDOM.render(null, container);
     document.body.removeChild(container);
     container = null;
   });

--- a/packages/react-events/src/__tests__/Focus-test.internal.js
+++ b/packages/react-events/src/__tests__/Focus-test.internal.js
@@ -36,6 +36,7 @@ describe('Focus event responder', () => {
   });
 
   afterEach(() => {
+    ReactDOM.render(null, container);
     document.body.removeChild(container);
     container = null;
   });

--- a/packages/react-events/src/__tests__/FocusScope-test.internal.js
+++ b/packages/react-events/src/__tests__/FocusScope-test.internal.js
@@ -49,11 +49,12 @@ describe('FocusScope event responder', () => {
   });
 
   afterEach(() => {
+    ReactDOM.render(null, container);
     document.body.removeChild(container);
     container = null;
   });
 
-  it('when using a simple focus scope with autofocus', () => {
+  it('should work as expected with autofocus', () => {
     const inputRef = React.createRef();
     const input2Ref = React.createRef();
     const buttonRef = React.createRef();
@@ -74,17 +75,17 @@ describe('FocusScope event responder', () => {
 
     ReactDOM.render(<SimpleFocusScope />, container);
     expect(document.activeElement).toBe(inputRef.current);
-    document.dispatchEvent(createTabForward());
+    document.activeElement.dispatchEvent(createTabForward());
     expect(document.activeElement).toBe(buttonRef.current);
-    document.dispatchEvent(createTabForward());
+    document.activeElement.dispatchEvent(createTabForward());
     expect(document.activeElement).toBe(divRef.current);
-    document.dispatchEvent(createTabForward());
+    document.activeElement.dispatchEvent(createTabForward());
     expect(document.activeElement).toBe(butto2nRef.current);
-    document.dispatchEvent(createTabBackward());
+    document.activeElement.dispatchEvent(createTabBackward());
     expect(document.activeElement).toBe(divRef.current);
   });
 
-  it('when using a simple focus scope with autofocus and trapping', () => {
+  it('should work as expected with autofocus and trapping', () => {
     const inputRef = React.createRef();
     const input2Ref = React.createRef();
     const buttonRef = React.createRef();
@@ -103,15 +104,91 @@ describe('FocusScope event responder', () => {
 
     ReactDOM.render(<SimpleFocusScope />, container);
     expect(document.activeElement).toBe(buttonRef.current);
-    document.dispatchEvent(createTabForward());
+    document.activeElement.dispatchEvent(createTabForward());
     expect(document.activeElement).toBe(button2Ref.current);
-    document.dispatchEvent(createTabForward());
+    document.activeElement.dispatchEvent(createTabForward());
     expect(document.activeElement).toBe(buttonRef.current);
-    document.dispatchEvent(createTabForward());
+    document.activeElement.dispatchEvent(createTabForward());
     expect(document.activeElement).toBe(button2Ref.current);
-    document.dispatchEvent(createTabBackward());
+    document.activeElement.dispatchEvent(createTabBackward());
     expect(document.activeElement).toBe(buttonRef.current);
-    document.dispatchEvent(createTabBackward());
+    document.activeElement.dispatchEvent(createTabBackward());
+    expect(document.activeElement).toBe(button2Ref.current);
+  });
+
+  it('should work as expected when nested', () => {
+    const inputRef = React.createRef();
+    const input2Ref = React.createRef();
+    const buttonRef = React.createRef();
+    const button2Ref = React.createRef();
+    const button3Ref = React.createRef();
+    const button4Ref = React.createRef();
+
+    const SimpleFocusScope = () => (
+      <div>
+        <FocusScope>
+          <input ref={inputRef} tabIndex={-1} />
+          <button ref={buttonRef} id={1} />
+          <FocusScope>
+            <button ref={button2Ref} id={2} />
+            <button ref={button3Ref} id={3} />
+          </FocusScope>
+          <input ref={input2Ref} tabIndex={-1} />
+          <button ref={button4Ref} id={4} />
+        </FocusScope>
+      </div>
+    );
+
+    ReactDOM.render(<SimpleFocusScope />, container);
+    buttonRef.current.focus();
+    expect(document.activeElement).toBe(buttonRef.current);
+    document.activeElement.dispatchEvent(createTabForward());
+    expect(document.activeElement).toBe(button2Ref.current);
+    document.activeElement.dispatchEvent(createTabForward());
+    expect(document.activeElement).toBe(button3Ref.current);
+    document.activeElement.dispatchEvent(createTabForward());
+    expect(document.activeElement).toBe(button4Ref.current);
+    document.activeElement.dispatchEvent(createTabBackward());
+    expect(document.activeElement).toBe(button3Ref.current);
+    document.activeElement.dispatchEvent(createTabBackward());
+    expect(document.activeElement).toBe(button2Ref.current);
+  });
+
+  it('should work as expected when nested with scope that is trapped', () => {
+    const inputRef = React.createRef();
+    const input2Ref = React.createRef();
+    const buttonRef = React.createRef();
+    const button2Ref = React.createRef();
+    const button3Ref = React.createRef();
+    const button4Ref = React.createRef();
+
+    const SimpleFocusScope = () => (
+      <div>
+        <FocusScope>
+          <input ref={inputRef} tabIndex={-1} />
+          <button ref={buttonRef} id={1} />
+          <FocusScope trap={true}>
+            <button ref={button2Ref} id={2} />
+            <button ref={button3Ref} id={3} />
+          </FocusScope>
+          <input ref={input2Ref} tabIndex={-1} />
+          <button ref={button4Ref} id={4} />
+        </FocusScope>
+      </div>
+    );
+
+    ReactDOM.render(<SimpleFocusScope />, container);
+    buttonRef.current.focus();
+    expect(document.activeElement).toBe(buttonRef.current);
+    document.activeElement.dispatchEvent(createTabForward());
+    expect(document.activeElement).toBe(button2Ref.current);
+    document.activeElement.dispatchEvent(createTabForward());
+    expect(document.activeElement).toBe(button3Ref.current);
+    document.activeElement.dispatchEvent(createTabForward());
+    expect(document.activeElement).toBe(button2Ref.current);
+    document.activeElement.dispatchEvent(createTabBackward());
+    expect(document.activeElement).toBe(button3Ref.current);
+    document.activeElement.dispatchEvent(createTabBackward());
     expect(document.activeElement).toBe(button2Ref.current);
   });
 });

--- a/packages/react-events/src/__tests__/Hover-test.internal.js
+++ b/packages/react-events/src/__tests__/Hover-test.internal.js
@@ -41,6 +41,7 @@ describe('Hover event responder', () => {
   });
 
   afterEach(() => {
+    ReactDOM.render(null, container);
     document.body.removeChild(container);
     container = null;
   });

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -51,6 +51,7 @@ describe('Event responder: Press', () => {
   });
 
   afterEach(() => {
+    ReactDOM.render(null, container);
     document.body.removeChild(container);
     container = null;
   });

--- a/packages/react-events/src/utils.js
+++ b/packages/react-events/src/utils.js
@@ -51,5 +51,9 @@ export function isEventPositionWithinTouchHitTarget(
   context: ReactResponderContext,
 ) {
   const nativeEvent: any = event.nativeEvent;
-  return context.isPositionWithinTouchHitTarget(nativeEvent.x, nativeEvent.y);
+  return context.isPositionWithinTouchHitTarget(
+    // x and y can be doubles, so ensure they are integers
+    parseInt(nativeEvent.x, 10),
+    parseInt(nativeEvent.y, 10),
+  );
 }

--- a/packages/react-events/src/utils.js
+++ b/packages/react-events/src/utils.js
@@ -51,10 +51,5 @@ export function isEventPositionWithinTouchHitTarget(
   context: ReactResponderContext,
 ) {
   const nativeEvent: any = event.nativeEvent;
-  const target: any = event.target;
-  return context.isPositionWithinTouchHitTarget(
-    target.ownerDocument,
-    nativeEvent.x,
-    nativeEvent.y,
-  );
+  return context.isPositionWithinTouchHitTarget(nativeEvent.x, nativeEvent.y);
 }

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -182,7 +182,7 @@ export type ReactResponderContext = {
     rootEventTypes: Array<ReactEventResponderEventType>,
   ) => void,
   hasOwnership: () => boolean,
-  requestLocalOwnership: () => boolean,
+  requestResponderOwnership: () => boolean,
   requestGlobalOwnership: () => boolean,
   releaseOwnership: () => boolean,
   setTimeout: (func: () => void, timeout: number) => Symbol,

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -173,13 +173,8 @@ export type ReactResponderContext = {
   ) => boolean,
   isTargetWithinEventComponent: (Element | Document) => boolean,
   isTargetDirectlyWithinEventComponent: (Element | Document) => boolean,
-  isPositionWithinTouchHitTarget: (
-    doc: Document,
-    x: number,
-    y: number,
-  ) => boolean,
+  isPositionWithinTouchHitTarget: (x: number, y: number) => boolean,
   addRootEventTypes: (
-    document: Document,
     rootEventTypes: Array<ReactEventResponderEventType>,
   ) => void,
   removeRootEventTypes: (
@@ -191,4 +186,5 @@ export type ReactResponderContext = {
   setTimeout: (func: () => void, timeout: number) => Symbol,
   clearTimeout: (timerId: Symbol) => void,
   getFocusableElementsInScope(): Array<HTMLElement>,
+  getActiveDocument(): Document,
 };

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -173,6 +173,7 @@ export type ReactResponderContext = {
   ) => boolean,
   isTargetWithinEventComponent: (Element | Document) => boolean,
   isTargetDirectlyWithinEventComponent: (Element | Document) => boolean,
+  isTargetWithinEventResponderScope: (Element | Document) => boolean,
   isPositionWithinTouchHitTarget: (x: number, y: number) => boolean,
   addRootEventTypes: (
     rootEventTypes: Array<ReactEventResponderEventType>,
@@ -181,7 +182,8 @@ export type ReactResponderContext = {
     rootEventTypes: Array<ReactEventResponderEventType>,
   ) => void,
   hasOwnership: () => boolean,
-  requestOwnership: () => boolean,
+  requestLocalOwnership: () => boolean,
+  requestGlobalOwnership: () => boolean,
   releaseOwnership: () => boolean,
   setTimeout: (func: () => void, timeout: number) => Symbol,
   clearTimeout: (timerId: Symbol) => void,


### PR DESCRIPTION
This PR contains some follow up fixes as per comments in https://github.com/facebook/react/pull/15487 from @giuseppeg. This also adds a new helper method for getting the current active document `context.getActiveDocument`, which removes a bunch of code in places. I also added `context.isTargetWithinEventResponderScope` and `context.requestResponderOwnership` to deal with ownership control of the same responder.