### PR TITLE
React events: fix press end event dispatching

### DIFF
--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -189,10 +189,22 @@ describe('Event responder: Press', () => {
         );
         ReactDOM.render(element, container);
 
+        ref.current.getBoundingClientRect = () => ({
+          top: 50,
+          left: 50,
+          bottom: 500,
+          right: 500,
+        });
+
         ref.current.dispatchEvent(createPointerEvent('pointerdown'));
         jest.advanceTimersByTime(499);
         expect(onPressStart).toHaveBeenCalledTimes(0);
-        ref.current.dispatchEvent(createPointerEvent('pointerup'));
+        ref.current.dispatchEvent(
+          createPointerEvent('pointerup', {
+            pageX: 55,
+            pageY: 55,
+          }),
+        );
         expect(onPressStart).toHaveBeenCalledTimes(1);
         jest.runAllTimers();
         expect(onPressStart).toHaveBeenCalledTimes(1);
@@ -420,9 +432,21 @@ describe('Event responder: Press', () => {
       );
       ReactDOM.render(element, container);
 
+      ref.current.getBoundingClientRect = () => ({
+        top: 50,
+        left: 50,
+        bottom: 500,
+        right: 500,
+      });
+
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
       jest.advanceTimersByTime(100);
-      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointerup', {
+          pageX: 55,
+          pageY: 55,
+        }),
+      );
       jest.advanceTimersByTime(10);
       expect(onPressChange).toHaveBeenCalledWith(true);
       expect(onPressChange).toHaveBeenCalledWith(false);
@@ -479,13 +503,21 @@ describe('Event responder: Press', () => {
         </Press>
       );
       ReactDOM.render(element, container);
+      ref.current.getBoundingClientRect = () => ({
+        top: 0,
+        left: 0,
+        bottom: 100,
+        right: 100,
+      });
     });
 
     it('is called after "pointerup" event', () => {
       ref.current.dispatchEvent(
         createPointerEvent('pointerdown', {pointerType: 'pen'}),
       );
-      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointerup', {pageX: 10, pageY: 10}),
+      );
       expect(onPress).toHaveBeenCalledTimes(1);
       expect(onPress).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'pen', type: 'press'}),
@@ -510,7 +542,9 @@ describe('Event responder: Press', () => {
       ReactDOM.render(element, container);
 
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
-      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointerup', {pageX: 10, pageY: 10}),
+      );
       expect(onPress).toHaveBeenCalledTimes(1);
     });
 
@@ -709,10 +743,10 @@ describe('Event responder: Press', () => {
       ReactDOM.render(element, container);
 
       ref.current.getBoundingClientRect = () => ({
-        top: 50,
-        left: 50,
-        bottom: 500,
-        right: 500,
+        top: 0,
+        left: 0,
+        bottom: 100,
+        right: 100,
       });
       ref.current.dispatchEvent(
         createPointerEvent('pointerdown', {pointerType: 'touch'}),
@@ -720,8 +754,8 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(
         createPointerEvent('pointermove', {
           pointerType: 'touch',
-          pageX: 55,
-          pageY: 55,
+          pageX: 10,
+          pageY: 10,
         }),
       );
       expect(onPressMove).toHaveBeenCalledTimes(1);
@@ -741,17 +775,17 @@ describe('Event responder: Press', () => {
       ReactDOM.render(element, container);
 
       ref.current.getBoundingClientRect = () => ({
-        top: 50,
-        left: 50,
-        bottom: 500,
-        right: 500,
+        top: 0,
+        left: 0,
+        bottom: 100,
+        right: 100,
       });
       ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
       ref.current.dispatchEvent(
         createPointerEvent('pointermove', {
           pointerType: 'mouse',
-          pageX: 55,
-          pageY: 55,
+          pageX: 10,
+          pageY: 10,
         }),
       );
       expect(onPressMove).not.toBeCalled();
@@ -768,10 +802,10 @@ describe('Event responder: Press', () => {
       ReactDOM.render(element, container);
 
       ref.current.getBoundingClientRect = () => ({
-        top: 50,
-        left: 50,
-        bottom: 500,
-        right: 500,
+        top: 0,
+        left: 0,
+        bottom: 100,
+        right: 100,
       });
       ref.current.dispatchEvent(
         createPointerEvent('pointerdown', {pointerType: 'touch'}),
@@ -780,8 +814,8 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(
         createPointerEvent('pointermove', {
           pointerType: 'touch',
-          pageX: 55,
-          pageY: 55,
+          pageX: 10,
+          pageY: 10,
         }),
       );
       ref.current.dispatchEvent(createPointerEvent('touchmove'));
@@ -843,7 +877,9 @@ describe('Event responder: Press', () => {
         ref.current.dispatchEvent(
           createPointerEvent('pointermove', coordinatesInside),
         );
-        ref.current.dispatchEvent(createPointerEvent('pointerup'));
+        ref.current.dispatchEvent(
+          createPointerEvent('pointerup', coordinatesInside),
+        );
         jest.runAllTimers();
 
         expect(events).toEqual([
@@ -890,7 +926,9 @@ describe('Event responder: Press', () => {
         expect(events).toEqual(['onPressStart', 'onPressChange']);
         events = [];
 
-        ref.current.dispatchEvent(createPointerEvent('pointerup'));
+        ref.current.dispatchEvent(
+          createPointerEvent('pointerup', coordinatesInside),
+        );
         expect(events).toEqual(['onPressEnd', 'onPressChange', 'onPress']);
       });
 
@@ -923,7 +961,9 @@ describe('Event responder: Press', () => {
             pageY: rectMock.top - pressRetentionOffset.top,
           }),
         );
-        ref.current.dispatchEvent(createPointerEvent('pointerup'));
+        ref.current.dispatchEvent(
+          createPointerEvent('pointerup', coordinatesInside),
+        );
         expect(events).toEqual([
           'onPressStart',
           'onPressChange',
@@ -932,6 +972,86 @@ describe('Event responder: Press', () => {
           'onPressChange',
           'onPress',
         ]);
+      });
+
+      it('responder region accounts for decrease in element dimensions', () => {
+        let events = [];
+        const ref = React.createRef();
+        const createEventHandler = msg => () => {
+          events.push(msg);
+        };
+
+        const element = (
+          <Press
+            onPress={createEventHandler('onPress')}
+            onPressStart={createEventHandler('onPressStart')}
+            onPressEnd={createEventHandler('onPressEnd')}>
+            <div ref={ref} />
+          </Press>
+        );
+
+        ReactDOM.render(element, container);
+        ref.current.getBoundingClientRect = getBoundingClientRectMock;
+        ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+        // emulate smaller dimensions change on activation
+        ref.current.getBoundingClientRect = () => ({
+          width: 80,
+          height: 80,
+          top: 60,
+          left: 60,
+          right: 490,
+          bottom: 490,
+        });
+        const coordinates = {
+          pageX: rectMock.left,
+          pageY: rectMock.top,
+        };
+        // move to an area within the pre-activation region
+        ref.current.dispatchEvent(
+          createPointerEvent('pointermove', coordinates),
+        );
+        ref.current.dispatchEvent(createPointerEvent('pointerup', coordinates));
+        expect(events).toEqual(['onPressStart', 'onPressEnd', 'onPress']);
+      });
+
+      it('responder region accounts for increase in element dimensions', () => {
+        let events = [];
+        const ref = React.createRef();
+        const createEventHandler = msg => () => {
+          events.push(msg);
+        };
+
+        const element = (
+          <Press
+            onPress={createEventHandler('onPress')}
+            onPressStart={createEventHandler('onPressStart')}
+            onPressEnd={createEventHandler('onPressEnd')}>
+            <div ref={ref} />
+          </Press>
+        );
+
+        ReactDOM.render(element, container);
+        ref.current.getBoundingClientRect = getBoundingClientRectMock;
+        ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+        // emulate larger dimensions change on activation
+        ref.current.getBoundingClientRect = () => ({
+          width: 200,
+          height: 200,
+          top: 0,
+          left: 0,
+          right: 550,
+          bottom: 550,
+        });
+        const coordinates = {
+          pageX: rectMock.left - 50,
+          pageY: rectMock.top - 50,
+        };
+        // move to an area within the post-activation region
+        ref.current.dispatchEvent(
+          createPointerEvent('pointermove', coordinates),
+        );
+        ref.current.dispatchEvent(createPointerEvent('pointerup', coordinates));
+        expect(events).toEqual(['onPressStart', 'onPressEnd', 'onPress']);
       });
     });
 
@@ -973,7 +1093,9 @@ describe('Event responder: Press', () => {
         ref.current.dispatchEvent(
           createPointerEvent('pointermove', coordinatesOutside),
         );
-        ref.current.dispatchEvent(createPointerEvent('pointerup'));
+        ref.current.dispatchEvent(
+          createPointerEvent('pointerup', coordinatesOutside),
+        );
         jest.runAllTimers();
 
         expect(events).toEqual([
@@ -1019,7 +1141,9 @@ describe('Event responder: Press', () => {
         jest.runAllTimers();
         expect(events).toEqual(['onPressMove']);
         events = [];
-        ref.current.dispatchEvent(createPointerEvent('pointerup'));
+        ref.current.dispatchEvent(
+          createPointerEvent('pointerup', coordinatesOutside),
+        );
         jest.runAllTimers();
         expect(events).toEqual([]);
       });
@@ -1049,13 +1173,23 @@ describe('Event responder: Press', () => {
       );
 
       ReactDOM.render(element, container);
+      ref.current.getBoundingClientRect = () => ({
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+      });
 
       // 1
       events = [];
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
-      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointerup', {pageX: 10, pageY: 10}),
+      );
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
-      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointerup', {pageX: 10, pageY: 10}),
+      );
       jest.runAllTimers();
 
       expect(events).toEqual([
@@ -1073,7 +1207,9 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
       jest.advanceTimersByTime(250);
       jest.advanceTimersByTime(500);
-      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointerup', {pageX: 10, pageY: 10}),
+      );
       jest.runAllTimers();
 
       expect(events).toEqual([
@@ -1121,9 +1257,17 @@ describe('Event responder: Press', () => {
       );
 
       ReactDOM.render(element, container);
+      ref.current.getBoundingClientRect = () => ({
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+      });
 
       ref.current.dispatchEvent(createPointerEvent('pointerdown'));
-      ref.current.dispatchEvent(createPointerEvent('pointerup'));
+      ref.current.dispatchEvent(
+        createPointerEvent('pointerup', {pageX: 10, pageY: 10}),
+      );
       expect(events).toEqual([
         'pointerdown',
         'inner: onPressStart',
@@ -1147,9 +1291,17 @@ describe('Event responder: Press', () => {
           </Press>
         );
         ReactDOM.render(element, container);
+        ref.current.getBoundingClientRect = () => ({
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0,
+        });
 
         ref.current.dispatchEvent(createPointerEvent('pointerdown'));
-        ref.current.dispatchEvent(createPointerEvent('pointerup'));
+        ref.current.dispatchEvent(
+          createPointerEvent('pointerup', {pageX: 10, pageY: 10}),
+        );
         expect(fn).toHaveBeenCalledTimes(1);
       });
 

--- a/packages/react-events/src/utils.js
+++ b/packages/react-events/src/utils.js
@@ -15,7 +15,7 @@ import type {
 export function getEventCurrentTarget(
   event: ReactResponderEvent,
   context: ReactResponderContext,
-) {
+): Element {
   const target: any = event.target;
   let currentTarget = target;
   while (


### PR DESCRIPTION
This patch fixes an issue related to determining whether the end event occurs
within the responder region. Previously we only checked if the event target was
within the responder region for moves, otherwise we checked if the target was
within the event component. Since the dimensions of the child element can
change after activation, we need to recalculate the responder region before
deactivation as well if the target is not within the event component.

Ref #15257