### PR TITLE
Add Batched Mode

### DIFF
--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import ReactVersion from 'shared/ReactVersion';
+import {LegacyRoot} from 'shared/ReactRootTags';
 import {
   createContainer,
   updateContainer,
@@ -65,7 +66,7 @@ class Surface extends React.Component {
 
     this._surface = Mode.Surface(+width, +height, this._tagRef);
 
-    this._mountNode = createContainer(this._surface);
+    this._mountNode = createContainer(this._surface, LegacyRoot, false);
     updateContainer(this.props.children, this._mountNode, this);
   }
 

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -366,7 +366,8 @@ function ReactRoot(
   isConcurrent: boolean,
   hydrate: boolean,
 ) {
-  const root = createContainer(container, isConcurrent, hydrate);
+  const isBatched = false;
+  const root = createContainer(container, isBatched, isConcurrent, hydrate);
   this._internalRoot = root;
 }
 ReactRoot.prototype.render = function(

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -8,6 +8,7 @@
  */
 
 import type {ReactNodeList} from 'shared/ReactTypes';
+import type {RootTag} from 'shared/ReactRootTags';
 // TODO: This type is shared between the reconciler and ReactDOM, but will
 // eventually be lifted out to the renderer.
 import type {
@@ -52,6 +53,7 @@ import {
   accumulateTwoPhaseDispatches,
   accumulateDirectDispatches,
 } from 'events/EventPropagators';
+import {LegacyRoot, ConcurrentRoot} from 'shared/ReactRootTags';
 import {has as hasInstance} from 'shared/ReactInstanceMap';
 import ReactVersion from 'shared/ReactVersion';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -361,13 +363,8 @@ ReactWork.prototype._onCommit = function(): void {
   }
 };
 
-function ReactRoot(
-  container: DOMContainer,
-  isConcurrent: boolean,
-  hydrate: boolean,
-) {
-  const isBatched = false;
-  const root = createContainer(container, isBatched, isConcurrent, hydrate);
+function ReactRoot(container: DOMContainer, tag: RootTag, hydrate: boolean) {
+  const root = createContainer(container, tag, hydrate);
   this._internalRoot = root;
 }
 ReactRoot.prototype.render = function(
@@ -532,9 +529,7 @@ function legacyCreateRootFromDOMContainer(
       );
     }
   }
-  // Legacy roots are not async by default.
-  const isConcurrent = false;
-  return new ReactRoot(container, isConcurrent, shouldHydrate);
+  return new ReactRoot(container, LegacyRoot, shouldHydrate);
 }
 
 function legacyRenderSubtreeIntoContainer(
@@ -850,7 +845,7 @@ function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
     container._reactHasBeenPassedToCreateRootDEV = true;
   }
   const hydrate = options != null && options.hydrate === true;
-  return new ReactRoot(container, true, hydrate);
+  return new ReactRoot(container, ConcurrentRoot, hydrate);
 }
 
 if (enableStableConcurrentModeAPIs) {

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -13,6 +13,7 @@
 // console.log('Hello from Fire entry point.');
 
 import type {ReactNodeList} from 'shared/ReactTypes';
+import type {RootTag} from 'shared/ReactRootTags';
 // TODO: This type is shared between the reconciler and ReactDOM, but will
 // eventually be lifted out to the renderer.
 import type {
@@ -58,6 +59,7 @@ import {
   accumulateTwoPhaseDispatches,
   accumulateDirectDispatches,
 } from 'events/EventPropagators';
+import {LegacyRoot, ConcurrentRoot} from 'shared/ReactRootTags';
 import {has as hasInstance} from 'shared/ReactInstanceMap';
 import ReactVersion from 'shared/ReactVersion';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -367,13 +369,8 @@ ReactWork.prototype._onCommit = function(): void {
   }
 };
 
-function ReactRoot(
-  container: DOMContainer,
-  isConcurrent: boolean,
-  hydrate: boolean,
-) {
-  const isBatched = false;
-  const root = createContainer(container, isBatched, isConcurrent, hydrate);
+function ReactRoot(container: DOMContainer, tag: RootTag, hydrate: boolean) {
+  const root = createContainer(container, tag, hydrate);
   this._internalRoot = root;
 }
 ReactRoot.prototype.render = function(
@@ -538,9 +535,7 @@ function legacyCreateRootFromDOMContainer(
       );
     }
   }
-  // Legacy roots are not async by default.
-  const isConcurrent = false;
-  return new ReactRoot(container, isConcurrent, shouldHydrate);
+  return new ReactRoot(container, LegacyRoot, shouldHydrate);
 }
 
 function legacyRenderSubtreeIntoContainer(
@@ -856,7 +851,7 @@ function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
     container._reactHasBeenPassedToCreateRootDEV = true;
   }
   const hydrate = options != null && options.hydrate === true;
-  return new ReactRoot(container, true, hydrate);
+  return new ReactRoot(container, ConcurrentRoot, hydrate);
 }
 
 if (enableStableConcurrentModeAPIs) {

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -372,7 +372,8 @@ function ReactRoot(
   isConcurrent: boolean,
   hydrate: boolean,
 ) {
-  const root = createContainer(container, isConcurrent, hydrate);
+  const isBatched = false;
+  const root = createContainer(container, isBatched, isConcurrent, hydrate);
   this._internalRoot = root;
 }
 ReactRoot.prototype.render = function(

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -119,7 +119,7 @@ const ReactFabric: ReactFabricType = {
     if (!root) {
       // TODO (bvaughn): If we decide to keep the wrapper component,
       // We could create a wrapper for containerTag as well to reduce special casing.
-      root = createContainer(containerTag, false, false);
+      root = createContainer(containerTag, false, false, false);
       roots.set(containerTag, root);
     }
     updateContainer(element, root, null, callback);

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -33,6 +33,7 @@ import ReactNativeComponent from './ReactNativeComponent';
 import {getClosestInstanceFromNode} from './ReactFabricComponentTree';
 import {getInspectorDataForViewTag} from './ReactNativeFiberInspector';
 
+import {LegacyRoot} from 'shared/ReactRootTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import getComponentName from 'shared/getComponentName';
 import warningWithoutStack from 'shared/warningWithoutStack';
@@ -119,7 +120,7 @@ const ReactFabric: ReactFabricType = {
     if (!root) {
       // TODO (bvaughn): If we decide to keep the wrapper component,
       // We could create a wrapper for containerTag as well to reduce special casing.
-      root = createContainer(containerTag, false, false, false);
+      root = createContainer(containerTag, LegacyRoot, false);
       roots.set(containerTag, root);
     }
     updateContainer(element, root, null, callback);

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -125,7 +125,7 @@ const ReactNativeRenderer: ReactNativeType = {
     if (!root) {
       // TODO (bvaughn): If we decide to keep the wrapper component,
       // We could create a wrapper for containerTag as well to reduce special casing.
-      root = createContainer(containerTag, false, false);
+      root = createContainer(containerTag, false, false, false);
       roots.set(containerTag, root);
     }
     updateContainer(element, root, null, callback);

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -40,6 +40,7 @@ import {getClosestInstanceFromNode} from './ReactNativeComponentTree';
 import {getInspectorDataForViewTag} from './ReactNativeFiberInspector';
 import {setNativeProps} from './ReactNativeRendererSharedExports';
 
+import {LegacyRoot} from 'shared/ReactRootTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import getComponentName from 'shared/getComponentName';
 import warningWithoutStack from 'shared/warningWithoutStack';
@@ -125,7 +126,7 @@ const ReactNativeRenderer: ReactNativeType = {
     if (!root) {
       // TODO (bvaughn): If we decide to keep the wrapper component,
       // We could create a wrapper for containerTag as well to reduce special casing.
-      root = createContainer(containerTag, false, false, false);
+      root = createContainer(containerTag, LegacyRoot, false);
       roots.set(containerTag, root);
     }
     updateContainer(element, root, null, callback);

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -52,10 +52,11 @@ import getComponentName from 'shared/getComponentName';
 import {isDevToolsPresent} from './ReactFiberDevToolsHook';
 import {NoWork} from './ReactFiberExpirationTime';
 import {
-  NoContext,
+  NoMode,
   ConcurrentMode,
   ProfileMode,
   StrictMode,
+  BatchedMode,
 } from './ReactTypeOfMode';
 import {
   REACT_FORWARD_REF_TYPE,
@@ -434,8 +435,18 @@ export function createWorkInProgress(
   return workInProgress;
 }
 
-export function createHostRootFiber(isConcurrent: boolean): Fiber {
-  let mode = isConcurrent ? ConcurrentMode | StrictMode : NoContext;
+export function createHostRootFiber(
+  isBatched: boolean,
+  isConcurrent: boolean,
+): Fiber {
+  let mode;
+  if (isConcurrent) {
+    mode = ConcurrentMode | BatchedMode | StrictMode;
+  } else if (isBatched) {
+    mode = BatchedMode | StrictMode;
+  } else {
+    mode = NoMode;
+  }
 
   if (enableProfilerTimer && isDevToolsPresent) {
     // Always collect profile timings when DevTools are present.
@@ -476,19 +487,13 @@ export function createFiberFromTypeAndProps(
           key,
         );
       case REACT_CONCURRENT_MODE_TYPE:
-        return createFiberFromMode(
-          pendingProps,
-          mode | ConcurrentMode | StrictMode,
-          expirationTime,
-          key,
-        );
+        fiberTag = Mode;
+        mode |= ConcurrentMode | BatchedMode | StrictMode;
+        break;
       case REACT_STRICT_MODE_TYPE:
-        return createFiberFromMode(
-          pendingProps,
-          mode | StrictMode,
-          expirationTime,
-          key,
-        );
+        fiberTag = Mode;
+        mode |= StrictMode;
+        break;
       case REACT_PROFILER_TYPE:
         return createFiberFromProfiler(pendingProps, mode, expirationTime, key);
       case REACT_SUSPENSE_TYPE:
@@ -672,26 +677,6 @@ function createFiberFromProfiler(
   return fiber;
 }
 
-function createFiberFromMode(
-  pendingProps: any,
-  mode: TypeOfMode,
-  expirationTime: ExpirationTime,
-  key: null | string,
-): Fiber {
-  const fiber = createFiber(Mode, pendingProps, key, mode);
-
-  // TODO: The Mode fiber shouldn't have a type. It has a tag.
-  const type =
-    (mode & ConcurrentMode) === NoContext
-      ? REACT_STRICT_MODE_TYPE
-      : REACT_CONCURRENT_MODE_TYPE;
-  fiber.elementType = type;
-  fiber.type = type;
-
-  fiber.expirationTime = expirationTime;
-  return fiber;
-}
-
 export function createFiberFromSuspense(
   pendingProps: any,
   mode: TypeOfMode,
@@ -720,7 +705,7 @@ export function createFiberFromText(
 }
 
 export function createFiberFromHostInstanceForDeletion(): Fiber {
-  const fiber = createFiber(HostComponent, null, null, NoContext);
+  const fiber = createFiber(HostComponent, null, null, NoMode);
   // TODO: These should not need a type.
   fiber.elementType = 'DELETED';
   fiber.type = 'DELETED';
@@ -751,7 +736,7 @@ export function assignFiberPropertiesInDEV(
   if (target === null) {
     // This Fiber's initial properties will always be overwritten.
     // We only use a Fiber to ensure the same hidden class so DEV isn't slow.
-    target = createFiber(IndeterminateComponent, null, null, NoContext);
+    target = createFiber(IndeterminateComponent, null, null, NoMode);
   }
 
   // This is intentionally written as a list of all properties.

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -15,6 +15,7 @@ import type {
   ReactEventComponent,
   ReactEventTarget,
 } from 'shared/ReactTypes';
+import type {RootTag} from 'shared/ReactRootTags';
 import type {WorkTag} from 'shared/ReactWorkTags';
 import type {TypeOfMode} from './ReactTypeOfMode';
 import type {SideEffectTag} from 'shared/ReactSideEffectTags';
@@ -27,6 +28,7 @@ import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {enableProfilerTimer, enableEventAPI} from 'shared/ReactFeatureFlags';
 import {NoEffect} from 'shared/ReactSideEffectTags';
+import {ConcurrentRoot, BatchedRoot} from 'shared/ReactRootTags';
 import {
   IndeterminateComponent,
   ClassComponent,
@@ -435,14 +437,11 @@ export function createWorkInProgress(
   return workInProgress;
 }
 
-export function createHostRootFiber(
-  isBatched: boolean,
-  isConcurrent: boolean,
-): Fiber {
+export function createHostRootFiber(tag: RootTag): Fiber {
   let mode;
-  if (isConcurrent) {
+  if (tag === ConcurrentRoot) {
     mode = ConcurrentMode | BatchedMode | StrictMode;
-  } else if (isBatched) {
+  } else if (tag === BatchedRoot) {
     mode = BatchedMode | StrictMode;
   } else {
     mode = NoMode;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -84,7 +84,7 @@ import {
 } from './ReactFiberExpirationTime';
 import {
   ConcurrentMode,
-  NoContext,
+  NoMode,
   ProfileMode,
   StrictMode,
 } from './ReactTypeOfMode';
@@ -1493,7 +1493,7 @@ function updateSuspenseComponent(
         null,
       );
 
-      if ((workInProgress.mode & ConcurrentMode) === NoContext) {
+      if ((workInProgress.mode & ConcurrentMode) === NoMode) {
         // Outside of concurrent mode, we commit the effects from the
         // partially completed, timed-out tree, too.
         const progressedState: SuspenseState = workInProgress.memoizedState;
@@ -1546,7 +1546,7 @@ function updateSuspenseComponent(
           NoWork,
         );
 
-        if ((workInProgress.mode & ConcurrentMode) === NoContext) {
+        if ((workInProgress.mode & ConcurrentMode) === NoMode) {
           // Outside of concurrent mode, we commit the effects from the
           // partially completed, timed-out tree, too.
           const progressedState: SuspenseState = workInProgress.memoizedState;
@@ -1629,7 +1629,7 @@ function updateSuspenseComponent(
         // schedule a placement.
         // primaryChildFragment.effectTag |= Placement;
 
-        if ((workInProgress.mode & ConcurrentMode) === NoContext) {
+        if ((workInProgress.mode & ConcurrentMode) === NoMode) {
           // Outside of concurrent mode, we commit the effects from the
           // partially completed, timed-out tree, too.
           const progressedState: SuspenseState = workInProgress.memoizedState;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -87,6 +87,7 @@ import {
   NoMode,
   ProfileMode,
   StrictMode,
+  BatchedMode,
 } from './ReactTypeOfMode';
 import {
   shouldSetTextContent,
@@ -1493,8 +1494,8 @@ function updateSuspenseComponent(
         null,
       );
 
-      if ((workInProgress.mode & ConcurrentMode) === NoMode) {
-        // Outside of concurrent mode, we commit the effects from the
+      if ((workInProgress.mode & BatchedMode) === NoMode) {
+        // Outside of batched mode, we commit the effects from the
         // partially completed, timed-out tree, too.
         const progressedState: SuspenseState = workInProgress.memoizedState;
         const progressedPrimaryChild: Fiber | null =
@@ -1546,8 +1547,8 @@ function updateSuspenseComponent(
           NoWork,
         );
 
-        if ((workInProgress.mode & ConcurrentMode) === NoMode) {
-          // Outside of concurrent mode, we commit the effects from the
+        if ((workInProgress.mode & BatchedMode) === NoMode) {
+          // Outside of batched mode, we commit the effects from the
           // partially completed, timed-out tree, too.
           const progressedState: SuspenseState = workInProgress.memoizedState;
           const progressedPrimaryChild: Fiber | null =
@@ -1629,8 +1630,8 @@ function updateSuspenseComponent(
         // schedule a placement.
         // primaryChildFragment.effectTag |= Placement;
 
-        if ((workInProgress.mode & ConcurrentMode) === NoMode) {
-          // Outside of concurrent mode, we commit the effects from the
+        if ((workInProgress.mode & BatchedMode) === NoMode) {
+          // Outside of batched mode, we commit the effects from the
           // partially completed, timed-out tree, too.
           const progressedState: SuspenseState = workInProgress.memoizedState;
           const progressedPrimaryChild: Fiber | null =

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -43,7 +43,7 @@ import {
   EventComponent,
   EventTarget,
 } from 'shared/ReactWorkTags';
-import {ConcurrentMode, NoContext} from './ReactTypeOfMode';
+import {ConcurrentMode, NoMode} from './ReactTypeOfMode';
 import {
   Placement,
   Ref,
@@ -721,7 +721,7 @@ function completeWork(
         // TODO: This will still suspend a synchronous tree if anything
         // in the concurrent tree already suspended during this render.
         // This is a known bug.
-        if ((workInProgress.mode & ConcurrentMode) !== NoContext) {
+        if ((workInProgress.mode & ConcurrentMode) !== NoMode) {
           renderDidSuspend();
         }
       }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -43,7 +43,7 @@ import {
   EventComponent,
   EventTarget,
 } from 'shared/ReactWorkTags';
-import {ConcurrentMode, NoMode} from './ReactTypeOfMode';
+import {NoMode, BatchedMode} from './ReactTypeOfMode';
 import {
   Placement,
   Ref,
@@ -716,12 +716,12 @@ function completeWork(
       }
 
       if (nextDidTimeout && !prevDidTimeout) {
-        // If this subtreee is running in concurrent mode we can suspend,
+        // If this subtreee is running in batched mode we can suspend,
         // otherwise we won't suspend.
         // TODO: This will still suspend a synchronous tree if anything
         // in the concurrent tree already suspended during this render.
         // This is a known bug.
-        if ((workInProgress.mode & ConcurrentMode) !== NoMode) {
+        if ((workInProgress.mode & BatchedMode) !== NoMode) {
           renderDidSuspend();
         }
       }

--- a/packages/react-reconciler/src/ReactFiberExpirationTime.js
+++ b/packages/react-reconciler/src/ReactFiberExpirationTime.js
@@ -23,9 +23,10 @@ export type ExpirationTime = number;
 export const NoWork = 0;
 export const Never = 1;
 export const Sync = MAX_SIGNED_31_BIT_INT;
+export const Batched = Sync - 1;
 
 const UNIT_SIZE = 10;
-const MAGIC_NUMBER_OFFSET = MAX_SIGNED_31_BIT_INT - 1;
+const MAGIC_NUMBER_OFFSET = Batched - 1;
 
 // 1 unit of expiration time represents 10ms.
 export function msToExpirationTime(ms: number): ExpirationTime {

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -9,6 +9,7 @@
 
 import type {Fiber} from './ReactFiber';
 import type {FiberRoot} from './ReactFiberRoot';
+import type {RootTag} from 'shared/ReactRootTags';
 import type {
   Instance,
   TextInstance,
@@ -273,11 +274,10 @@ function findHostInstanceWithWarning(
 
 export function createContainer(
   containerInfo: Container,
-  isBatched: boolean,
-  isConcurrent: boolean,
+  tag: RootTag,
   hydrate: boolean,
 ): OpaqueRoot {
-  return createFiberRoot(containerInfo, isBatched, isConcurrent, hydrate);
+  return createFiberRoot(containerInfo, tag, hydrate);
 }
 
 export function updateContainer(

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -273,10 +273,11 @@ function findHostInstanceWithWarning(
 
 export function createContainer(
   containerInfo: Container,
+  isBatched: boolean,
   isConcurrent: boolean,
   hydrate: boolean,
 ): OpaqueRoot {
-  return createFiberRoot(containerInfo, isConcurrent, hydrate);
+  return createFiberRoot(containerInfo, isBatched, isConcurrent, hydrate);
 }
 
 export function updateContainer(

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -116,6 +116,7 @@ function FiberRootNode(containerInfo, hydrate) {
 
 export function createFiberRoot(
   containerInfo: any,
+  isBatched: boolean,
   isConcurrent: boolean,
   hydrate: boolean,
 ): FiberRoot {
@@ -123,7 +124,7 @@ export function createFiberRoot(
 
   // Cyclic construction. This cheats the type system right now because
   // stateNode is any.
-  const uninitializedFiber = createHostRootFiber(isConcurrent);
+  const uninitializedFiber = createHostRootFiber(isBatched, isConcurrent);
   root.current = uninitializedFiber;
   uninitializedFiber.stateNode = root;
 

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -9,6 +9,7 @@
 
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
+import type {RootTag} from 'shared/ReactRootTags';
 import type {TimeoutHandle, NoTimeout} from './ReactFiberHostConfig';
 import type {Thenable} from './ReactFiberScheduler';
 import type {Interaction} from 'scheduler/src/Tracing';
@@ -30,6 +31,9 @@ export type Batch = {
 export type PendingInteractionMap = Map<ExpirationTime, Set<Interaction>>;
 
 type BaseFiberRootProperties = {|
+  // The type of root (legacy, batched, concurrent, etc.)
+  tag: RootTag,
+
   // Any additional information from the host associated with this root.
   containerInfo: any,
   // Used only by persistent updates.
@@ -89,7 +93,8 @@ export type FiberRoot = {
   ...ProfilingOnlyFiberRootProperties,
 };
 
-function FiberRootNode(containerInfo, hydrate) {
+function FiberRootNode(containerInfo, tag, hydrate) {
+  this.tag = tag;
   this.current = null;
   this.containerInfo = containerInfo;
   this.pendingChildren = null;
@@ -116,15 +121,14 @@ function FiberRootNode(containerInfo, hydrate) {
 
 export function createFiberRoot(
   containerInfo: any,
-  isBatched: boolean,
-  isConcurrent: boolean,
+  tag: RootTag,
   hydrate: boolean,
 ): FiberRoot {
-  const root: FiberRoot = (new FiberRootNode(containerInfo, hydrate): any);
+  const root: FiberRoot = (new FiberRootNode(containerInfo, tag, hydrate): any);
 
   // Cyclic construction. This cheats the type system right now because
   // stateNode is any.
-  const uninitializedFiber = createHostRootFiber(isBatched, isConcurrent);
+  const uninitializedFiber = createHostRootFiber(tag);
   root.current = uninitializedFiber;
   uninitializedFiber.stateNode = root;
 

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -41,7 +41,7 @@ import {
   enableSuspenseServerRenderer,
   enableEventAPI,
 } from 'shared/ReactFeatureFlags';
-import {ConcurrentMode, NoContext} from './ReactTypeOfMode';
+import {ConcurrentMode, NoMode} from './ReactTypeOfMode';
 import {shouldCaptureSuspense} from './ReactFiberSuspenseComponent';
 
 import {createCapturedValue} from './ReactCapturedValue';
@@ -231,7 +231,7 @@ function throwException(
         // Note: It doesn't matter whether the component that suspended was
         // inside a concurrent mode tree. If the Suspense is outside of it, we
         // should *not* suspend the commit.
-        if ((workInProgress.mode & ConcurrentMode) === NoContext) {
+        if ((workInProgress.mode & ConcurrentMode) === NoMode) {
           workInProgress.effectTag |= DidCapture;
 
           // We're going to commit this fiber even though it didn't complete.

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -41,7 +41,7 @@ import {
   enableSuspenseServerRenderer,
   enableEventAPI,
 } from 'shared/ReactFeatureFlags';
-import {ConcurrentMode, NoMode} from './ReactTypeOfMode';
+import {NoMode, BatchedMode} from './ReactTypeOfMode';
 import {shouldCaptureSuspense} from './ReactFiberSuspenseComponent';
 
 import {createCapturedValue} from './ReactCapturedValue';
@@ -223,15 +223,15 @@ function throwException(
           thenables.add(thenable);
         }
 
-        // If the boundary is outside of concurrent mode, we should *not*
+        // If the boundary is outside of batched mode, we should *not*
         // suspend the commit. Pretend as if the suspended component rendered
         // null and keep rendering. In the commit phase, we'll schedule a
         // subsequent synchronous update to re-render the Suspense.
         //
         // Note: It doesn't matter whether the component that suspended was
-        // inside a concurrent mode tree. If the Suspense is outside of it, we
+        // inside a batched mode tree. If the Suspense is outside of it, we
         // should *not* suspend the commit.
-        if ((workInProgress.mode & ConcurrentMode) === NoMode) {
+        if ((workInProgress.mode & BatchedMode) === NoMode) {
           workInProgress.effectTag |= DidCapture;
 
           // We're going to commit this fiber even though it didn't complete.

--- a/packages/react-reconciler/src/ReactTypeOfMode.js
+++ b/packages/react-reconciler/src/ReactTypeOfMode.js
@@ -11,6 +11,8 @@ export type TypeOfMode = number;
 
 export const NoMode = 0b0000;
 export const StrictMode = 0b0001;
+// TODO: Remove BatchedMode and ConcurrentMode by reading from the root
+// tag instead
 export const BatchedMode = 0b0010;
 export const ConcurrentMode = 0b0100;
 export const ProfileMode = 0b1000;

--- a/packages/react-reconciler/src/ReactTypeOfMode.js
+++ b/packages/react-reconciler/src/ReactTypeOfMode.js
@@ -9,7 +9,8 @@
 
 export type TypeOfMode = number;
 
-export const NoContext = 0b000;
-export const ConcurrentMode = 0b001;
-export const StrictMode = 0b010;
-export const ProfileMode = 0b100;
+export const NoMode = 0b0000;
+export const StrictMode = 0b0001;
+export const BatchedMode = 0b0010;
+export const ConcurrentMode = 0b0100;
+export const ProfileMode = 0b1000;

--- a/packages/react-reconciler/src/SchedulerWithReactIntegration.js
+++ b/packages/react-reconciler/src/SchedulerWithReactIntegration.js
@@ -69,9 +69,9 @@ export const shouldYield = disableYielding
   ? () => false // Never yield when `disableYielding` is on
   : Scheduler_shouldYield;
 
-let immediateQueue: Array<SchedulerCallback> | null = null;
+let syncQueue: Array<SchedulerCallback> | null = null;
 let immediateQueueCallbackNode: mixed | null = null;
-let isFlushingImmediate: boolean = false;
+let isFlushingSyncQueue: boolean = false;
 let initialTimeMs: number = Scheduler_now();
 
 // If the initial timestamp is reasonably small, use Scheduler's `now` directly.
@@ -131,26 +131,26 @@ export function scheduleCallback(
   callback: SchedulerCallback,
   options: SchedulerCallbackOptions | void | null,
 ) {
-  if (reactPriorityLevel === ImmediatePriority) {
-    // Push this callback into an internal queue. We'll flush these either in
-    // the next tick, or earlier if something calls `flushImmediateQueue`.
-    if (immediateQueue === null) {
-      immediateQueue = [callback];
-      // Flush the queue in the next tick, at the earliest.
-      immediateQueueCallbackNode = Scheduler_scheduleCallback(
-        Scheduler_ImmediatePriority,
-        flushImmediateQueueImpl,
-      );
-    } else {
-      // Push onto existing queue. Don't need to schedule a callback because
-      // we already scheduled one when we created the queue.
-      immediateQueue.push(callback);
-    }
-    return fakeCallbackNode;
-  }
-  // Otherwise pass through to Scheduler.
   const priorityLevel = reactPriorityToSchedulerPriority(reactPriorityLevel);
   return Scheduler_scheduleCallback(priorityLevel, callback, options);
+}
+
+export function scheduleSyncCallback(callback: SchedulerCallback) {
+  // Push this callback into an internal queue. We'll flush these either in
+  // the next tick, or earlier if something calls `flushSyncCallbackQueue`.
+  if (syncQueue === null) {
+    syncQueue = [callback];
+    // Flush the queue in the next tick, at the earliest.
+    immediateQueueCallbackNode = Scheduler_scheduleCallback(
+      Scheduler_ImmediatePriority,
+      flushSyncCallbackQueueImpl,
+    );
+  } else {
+    // Push onto existing queue. Don't need to schedule a callback because
+    // we already scheduled one when we created the queue.
+    syncQueue.push(callback);
+  }
+  return fakeCallbackNode;
 }
 
 export function cancelCallback(callbackNode: mixed) {
@@ -159,40 +159,40 @@ export function cancelCallback(callbackNode: mixed) {
   }
 }
 
-export function flushImmediateQueue() {
+export function flushSyncCallbackQueue() {
   if (immediateQueueCallbackNode !== null) {
     Scheduler_cancelCallback(immediateQueueCallbackNode);
   }
-  flushImmediateQueueImpl();
+  flushSyncCallbackQueueImpl();
 }
 
-function flushImmediateQueueImpl() {
-  if (!isFlushingImmediate && immediateQueue !== null) {
+function flushSyncCallbackQueueImpl() {
+  if (!isFlushingSyncQueue && syncQueue !== null) {
     // Prevent re-entrancy.
-    isFlushingImmediate = true;
+    isFlushingSyncQueue = true;
     let i = 0;
     try {
       const isSync = true;
-      for (; i < immediateQueue.length; i++) {
-        let callback = immediateQueue[i];
+      for (; i < syncQueue.length; i++) {
+        let callback = syncQueue[i];
         do {
           callback = callback(isSync);
         } while (callback !== null);
       }
-      immediateQueue = null;
+      syncQueue = null;
     } catch (error) {
       // If something throws, leave the remaining callbacks on the queue.
-      if (immediateQueue !== null) {
-        immediateQueue = immediateQueue.slice(i + 1);
+      if (syncQueue !== null) {
+        syncQueue = syncQueue.slice(i + 1);
       }
       // Resume flushing in the next tick
       Scheduler_scheduleCallback(
         Scheduler_ImmediatePriority,
-        flushImmediateQueue,
+        flushSyncCallbackQueue,
       );
       throw error;
     } finally {
-      isFlushingImmediate = false;
+      isFlushingSyncQueue = false;
     }
   }
 }

--- a/packages/react-reconciler/src/__tests__/ReactBatchedMode-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactBatchedMode-test.internal.js
@@ -1,0 +1,58 @@
+let React;
+let ReactFeatureFlags;
+let ReactNoop;
+let Scheduler;
+
+describe('ReactBatchedMode', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+    ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
+  });
+
+  function Text(props) {
+    Scheduler.yieldValue(props.text);
+    return props.text;
+  }
+
+  it('updates flush without yielding in the next event', () => {
+    const root = ReactNoop.createSyncRoot();
+
+    root.render(
+      <React.Fragment>
+        <Text text="A" />
+        <Text text="B" />
+        <Text text="C" />
+      </React.Fragment>,
+    );
+
+    // Nothing should have rendered yet
+    expect(root).toMatchRenderedOutput(null);
+
+    // Everything should render immediately in the next event
+    expect(Scheduler).toFlushExpired(['A', 'B', 'C']);
+    expect(root).toMatchRenderedOutput('ABC');
+  });
+
+  it('layout updates flush synchronously in same event', () => {
+    const {useLayoutEffect} = React;
+
+    function App() {
+      useLayoutEffect(() => {
+        Scheduler.yieldValue('Layout effect');
+      });
+      return <Text text="Hi" />;
+    }
+
+    const root = ReactNoop.createSyncRoot();
+    root.render(<App />);
+    expect(root).toMatchRenderedOutput(null);
+
+    expect(Scheduler).toFlushExpired(['Hi', 'Layout effect']);
+    expect(root).toMatchRenderedOutput('Hi');
+  });
+});

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
@@ -12,12 +12,14 @@
 
 let React;
 let ReactFiberReconciler;
+let ConcurrentRoot;
 
 describe('ReactFiberHostContext', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
     ReactFiberReconciler = require('react-reconciler');
+    ConcurrentRoot = require('shared/ReactRootTags');
   });
 
   it('works with null host context', () => {
@@ -58,7 +60,11 @@ describe('ReactFiberHostContext', () => {
       supportsMutation: true,
     });
 
-    const container = Renderer.createContainer(/* root: */ null);
+    const container = Renderer.createContainer(
+      /* root: */ null,
+      ConcurrentRoot,
+      false,
+    );
     Renderer.updateContainer(
       <a>
         <b />
@@ -106,7 +112,11 @@ describe('ReactFiberHostContext', () => {
       supportsMutation: true,
     });
 
-    const container = Renderer.createContainer(rootContext);
+    const container = Renderer.createContainer(
+      rootContext,
+      ConcurrentRoot,
+      false,
+    );
     Renderer.updateContainer(
       <a>
         <b />

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -941,7 +941,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     });
 
     it(
-      'in sync mode, useEffect is deferred and updates finish synchronously ' +
+      'in legacy mode, useEffect is deferred and updates finish synchronously ' +
         '(in a single batch)',
       () => {
         function Counter(props) {

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
@@ -175,8 +175,8 @@ describe('ReactSuspenseFuzz', () => {
       resetCache();
       ReactNoop.renderLegacySyncRoot(children);
       resolveAllTasks();
-      const syncOutput = ReactNoop.getChildrenAsJSX();
-      expect(syncOutput).toEqual(expectedOutput);
+      const legacyOutput = ReactNoop.getChildrenAsJSX();
+      expect(legacyOutput).toEqual(expectedOutput);
       ReactNoop.renderLegacySyncRoot(null);
 
       resetCache();

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -303,7 +303,7 @@ describe('ReactSuspensePlaceholder', () => {
     });
 
     describe('when suspending during mount', () => {
-      it('properly accounts for base durations when a suspended times out in a sync tree', () => {
+      it('properly accounts for base durations when a suspended times out in a legacy tree', () => {
         ReactNoop.renderLegacySyncRoot(<App shouldSuspend={true} />);
         expect(Scheduler).toHaveYielded([
           'App',
@@ -373,7 +373,7 @@ describe('ReactSuspensePlaceholder', () => {
     });
 
     describe('when suspending during update', () => {
-      it('properly accounts for base durations when a suspended times out in a sync tree', () => {
+      it('properly accounts for base durations when a suspended times out in a legacy tree', () => {
         ReactNoop.renderLegacySyncRoot(
           <App shouldSuspend={false} textRenderDuration={5} />,
         );

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -869,7 +869,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     );
   });
 
-  describe('sync mode', () => {
+  describe('legacy mode mode', () => {
     it('times out immediately', async () => {
       function App() {
         return (
@@ -977,7 +977,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     it(
       'continues rendering asynchronously even if a promise is captured by ' +
-        'a sync boundary (default mode)',
+        'a sync boundary (legacy mode)',
       async () => {
         class UpdatingText extends React.Component {
           state = {text: this.props.initialText};
@@ -1109,7 +1109,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     it(
       'continues rendering asynchronously even if a promise is captured by ' +
-        'a sync boundary (strict, non-concurrent)',
+        'a sync boundary (strict, legacy)',
       async () => {
         class UpdatingText extends React.Component {
           state = {text: this.props.initialText};

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -43,6 +43,7 @@ import ReactVersion from 'shared/ReactVersion';
 import act from './ReactTestRendererAct';
 
 import {getPublicInstance} from './ReactTestHostConfig';
+import {ConcurrentRoot, LegacyRoot} from 'shared/ReactRootTags';
 
 type TestRendererOptions = {
   createNodeMock: (element: React$Element<any>) => any,
@@ -437,11 +438,9 @@ const ReactTestRendererFiber = {
       createNodeMock,
       tag: 'CONTAINER',
     };
-    const isBatched = false;
     let root: FiberRoot | null = createContainer(
       container,
-      isBatched,
-      isConcurrent,
+      isConcurrent ? ConcurrentRoot : LegacyRoot,
       false,
     );
     invariant(root != null, 'something went wrong');

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -437,8 +437,10 @@ const ReactTestRendererFiber = {
       createNodeMock,
       tag: 'CONTAINER',
     };
+    const isBatched = false;
     let root: FiberRoot | null = createContainer(
       container,
+      isBatched,
       isConcurrent,
       false,
     );

--- a/packages/shared/ReactRootTags.js
+++ b/packages/shared/ReactRootTags.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export type RootTag = 0 | 1 | 2;
+
+export const LegacyRoot = 0;
+export const BatchedRoot = 1;
+export const ConcurrentRoot = 2;


### PR DESCRIPTION
React has an unfortunate quirk where updates are sometimes synchronous — where React starts rendering immediately within the call stack of `setState` — and sometimes batched, where updates are flushed at the end of the current event. Any update that originates within the call stack of the React event system is batched. This encompasses most updates, since most updates originate from an event handler like `onClick` or `onChange`. It also includes updates triggered by lifecycle methods or effects. But there are also updates that originate outside React's event system, like timer events, network events, and microtasks (promise resolution handlers). These are not batched, which results in both worse performance (multiple render passes instead of single one) and confusing semantics.

Ideally all updates would be batched by default. Unfortunately, it's easy for components to accidentally rely on this behavior, so changing it could break existing apps in subtle ways.

One way to move to a batched-by-default model is to opt into Concurrent Mode (still experimental). But Concurrent Mode introduces additional semantic changes that apps may not be ready to adopt.

This commit introduces an additional mode called Batched Mode. Batched Mode enables a batched-by-default model that defers all updates to the next React event. Once it begins rendering, React will not yield to the browser until the entire render is finished.

Batched Mode is superset of Strict Mode. It fires all the same warnings. It also drops the forked Suspense behavior used by Legacy Mode, in favor of the proper semantics used by Concurrent Mode.

I have not added any public APIs that expose the new mode yet. I'll do that in subsequent commits.