### PR TITLE
Add ReactDOM.unstable_createSyncRoot

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
@@ -661,6 +661,37 @@ describe('ReactDOMFiberAsync', () => {
     });
   });
 
+  describe('createSyncRoot', () => {
+    it('updates flush without yielding in the next event', () => {
+      const root = ReactDOM.unstable_createSyncRoot(container);
+
+      function Text(props) {
+        Scheduler.yieldValue(props.text);
+        return props.text;
+      }
+
+      root.render(
+        <React.Fragment>
+          <Text text="A" />
+          <Text text="B" />
+          <Text text="C" />
+        </React.Fragment>,
+      );
+
+      // Nothing should have rendered yet
+      expect(container.textContent).toEqual('');
+
+      // Everything should render immediately in the next event
+      expect(Scheduler).toFlushExpired(['A', 'B', 'C']);
+      expect(container.textContent).toEqual('ABC');
+    });
+
+    it('does not support createBatch', () => {
+      const root = ReactDOM.unstable_createSyncRoot(container);
+      expect(root.createBatch).toBe(undefined);
+    });
+  });
+
   describe('Disable yielding', () => {
     beforeEach(() => {
       jest.resetModules();

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -53,7 +53,7 @@ import {
   accumulateTwoPhaseDispatches,
   accumulateDirectDispatches,
 } from 'events/EventPropagators';
-import {LegacyRoot, ConcurrentRoot} from 'shared/ReactRootTags';
+import {LegacyRoot, ConcurrentRoot, BatchedRoot} from 'shared/ReactRootTags';
 import {has as hasInstance} from 'shared/ReactInstanceMap';
 import ReactVersion from 'shared/ReactVersion';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -186,17 +186,15 @@ type Batch = FiberRootBatch & {
 type Root = {
   render(children: ReactNodeList, callback: ?() => mixed): Work,
   unmount(callback: ?() => mixed): Work,
-  legacy_renderSubtreeIntoContainer(
-    parentComponent: ?React$Component<any, any>,
-    children: ReactNodeList,
-    callback: ?() => mixed,
-  ): Work,
-  createBatch(): Batch,
 
   _internalRoot: FiberRoot,
 };
 
-function ReactBatch(root: ReactRoot) {
+type RootWithBatchingAPI = Root & {
+  createBatch(): Batch,
+};
+
+function ReactBatch(root: Root) {
   const expirationTime = computeUniqueAsyncExpiration();
   this._expirationTime = expirationTime;
   this._root = root;
@@ -363,11 +361,22 @@ ReactWork.prototype._onCommit = function(): void {
   }
 };
 
-function ReactRoot(container: DOMContainer, tag: RootTag, hydrate: boolean) {
+function ReactSyncRoot(
+  container: DOMContainer,
+  tag: RootTag,
+  hydrate: boolean,
+) {
+  // Tag is either LegacyRoot or Concurrent Root
   const root = createContainer(container, tag, hydrate);
   this._internalRoot = root;
 }
-ReactRoot.prototype.render = function(
+
+function ReactRoot(container: DOMContainer, hydrate: boolean) {
+  const root = createContainer(container, ConcurrentRoot, hydrate);
+  this._internalRoot = root;
+}
+
+ReactRoot.prototype.render = ReactSyncRoot.prototype.render = function(
   children: ReactNodeList,
   callback: ?() => mixed,
 ): Work {
@@ -383,7 +392,10 @@ ReactRoot.prototype.render = function(
   updateContainer(children, root, null, work._onCommit);
   return work;
 };
-ReactRoot.prototype.unmount = function(callback: ?() => mixed): Work {
+
+ReactRoot.prototype.unmount = ReactSyncRoot.prototype.unmount = function(
+  callback: ?() => mixed,
+): Work {
   const root = this._internalRoot;
   const work = new ReactWork();
   callback = callback === undefined ? null : callback;
@@ -396,23 +408,8 @@ ReactRoot.prototype.unmount = function(callback: ?() => mixed): Work {
   updateContainer(null, root, null, work._onCommit);
   return work;
 };
-ReactRoot.prototype.legacy_renderSubtreeIntoContainer = function(
-  parentComponent: ?React$Component<any, any>,
-  children: ReactNodeList,
-  callback: ?() => mixed,
-): Work {
-  const root = this._internalRoot;
-  const work = new ReactWork();
-  callback = callback === undefined ? null : callback;
-  if (__DEV__) {
-    warnOnInvalidCallback(callback, 'render');
-  }
-  if (callback !== null) {
-    work.then(callback);
-  }
-  updateContainer(children, root, parentComponent, work._onCommit);
-  return work;
-};
+
+// Sync roots cannot create batches. Only concurrent ones.
 ReactRoot.prototype.createBatch = function(): Batch {
   const batch = new ReactBatch(this);
   const expirationTime = batch._expirationTime;
@@ -529,7 +526,9 @@ function legacyCreateRootFromDOMContainer(
       );
     }
   }
-  return new ReactRoot(container, LegacyRoot, shouldHydrate);
+
+  // Legacy roots are not batched.
+  return new ReactSyncRoot(container, LegacyRoot, shouldHydrate);
 }
 
 function legacyRenderSubtreeIntoContainer(
@@ -541,56 +540,44 @@ function legacyRenderSubtreeIntoContainer(
 ) {
   if (__DEV__) {
     topLevelUpdateWarnings(container);
+    warnOnInvalidCallback(callback === undefined ? null : callback, 'render');
   }
 
   // TODO: Without `any` type, Flow says "Property cannot be accessed on any
   // member of intersection type." Whyyyyyy.
   let root: Root = (container._reactRootContainer: any);
+  let fiberRoot;
   if (!root) {
     // Initial mount
     root = container._reactRootContainer = legacyCreateRootFromDOMContainer(
       container,
       forceHydrate,
     );
+    fiberRoot = root._internalRoot;
     if (typeof callback === 'function') {
       const originalCallback = callback;
       callback = function() {
-        const instance = getPublicRootInstance(root._internalRoot);
+        const instance = getPublicRootInstance(fiberRoot);
         originalCallback.call(instance);
       };
     }
     // Initial mount should not be batched.
     unbatchedUpdates(() => {
-      if (parentComponent != null) {
-        root.legacy_renderSubtreeIntoContainer(
-          parentComponent,
-          children,
-          callback,
-        );
-      } else {
-        root.render(children, callback);
-      }
+      updateContainer(children, fiberRoot, parentComponent, callback);
     });
   } else {
+    fiberRoot = root._internalRoot;
     if (typeof callback === 'function') {
       const originalCallback = callback;
       callback = function() {
-        const instance = getPublicRootInstance(root._internalRoot);
+        const instance = getPublicRootInstance(fiberRoot);
         originalCallback.call(instance);
       };
     }
     // Update
-    if (parentComponent != null) {
-      root.legacy_renderSubtreeIntoContainer(
-        parentComponent,
-        children,
-        callback,
-      );
-    } else {
-      root.render(children, callback);
-    }
+    updateContainer(children, fiberRoot, parentComponent, callback);
   }
-  return getPublicRootInstance(root._internalRoot);
+  return getPublicRootInstance(fiberRoot);
 }
 
 function createPortal(
@@ -800,6 +787,7 @@ const ReactDOM: Object = {
   flushSync: flushSync,
 
   unstable_createRoot: createRoot,
+  unstable_createSyncRoot: createSyncRoot,
   unstable_flushControlled: flushControlled,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
@@ -826,7 +814,10 @@ type RootOptions = {
   hydrate?: boolean,
 };
 
-function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
+function createRoot(
+  container: DOMContainer,
+  options?: RootOptions,
+): RootWithBatchingAPI {
   const functionName = enableStableConcurrentModeAPIs
     ? 'createRoot'
     : 'unstable_createRoot';
@@ -835,6 +826,26 @@ function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
     '%s(...): Target container is not a DOM element.',
     functionName,
   );
+  warnIfReactDOMContainerInDEV(container);
+  const hydrate = options != null && options.hydrate === true;
+  return new ReactRoot(container, hydrate);
+}
+
+function createSyncRoot(container: DOMContainer, options?: RootOptions): Root {
+  const functionName = enableStableConcurrentModeAPIs
+    ? 'createRoot'
+    : 'unstable_createRoot';
+  invariant(
+    isValidContainer(container),
+    '%s(...): Target container is not a DOM element.',
+    functionName,
+  );
+  warnIfReactDOMContainerInDEV(container);
+  const hydrate = options != null && options.hydrate === true;
+  return new ReactSyncRoot(container, BatchedRoot, hydrate);
+}
+
+function warnIfReactDOMContainerInDEV(container) {
   if (__DEV__) {
     warningWithoutStack(
       !container._reactRootContainer,
@@ -844,13 +855,11 @@ function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
     );
     container._reactHasBeenPassedToCreateRootDEV = true;
   }
-  const hydrate = options != null && options.hydrate === true;
-  return new ReactRoot(container, ConcurrentRoot, hydrate);
 }
 
 if (enableStableConcurrentModeAPIs) {
   ReactDOM.createRoot = createRoot;
-  ReactDOM.unstable_createRoot = undefined;
+  ReactDOM.createSyncRoot = createSyncRoot;
 }
 
 const foundDevTools = injectIntoDevTools({

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -59,7 +59,7 @@ import {
   accumulateTwoPhaseDispatches,
   accumulateDirectDispatches,
 } from 'events/EventPropagators';
-import {LegacyRoot, ConcurrentRoot} from 'shared/ReactRootTags';
+import {LegacyRoot, ConcurrentRoot, BatchedRoot} from 'shared/ReactRootTags';
 import {has as hasInstance} from 'shared/ReactInstanceMap';
 import ReactVersion from 'shared/ReactVersion';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -192,17 +192,15 @@ type Batch = FiberRootBatch & {
 type Root = {
   render(children: ReactNodeList, callback: ?() => mixed): Work,
   unmount(callback: ?() => mixed): Work,
-  legacy_renderSubtreeIntoContainer(
-    parentComponent: ?React$Component<any, any>,
-    children: ReactNodeList,
-    callback: ?() => mixed,
-  ): Work,
-  createBatch(): Batch,
 
   _internalRoot: FiberRoot,
 };
 
-function ReactBatch(root: ReactRoot) {
+type RootWithBatchingAPI = Root & {
+  createBatch(): Batch,
+};
+
+function ReactBatch(root: Root) {
   const expirationTime = computeUniqueAsyncExpiration();
   this._expirationTime = expirationTime;
   this._root = root;
@@ -369,11 +367,22 @@ ReactWork.prototype._onCommit = function(): void {
   }
 };
 
-function ReactRoot(container: DOMContainer, tag: RootTag, hydrate: boolean) {
+function ReactSyncRoot(
+  container: DOMContainer,
+  tag: RootTag,
+  hydrate: boolean,
+) {
+  // Tag is either LegacyRoot or Concurrent Root
   const root = createContainer(container, tag, hydrate);
   this._internalRoot = root;
 }
-ReactRoot.prototype.render = function(
+
+function ReactRoot(container: DOMContainer, hydrate: boolean) {
+  const root = createContainer(container, ConcurrentRoot, hydrate);
+  this._internalRoot = root;
+}
+
+ReactRoot.prototype.render = ReactSyncRoot.prototype.render = function(
   children: ReactNodeList,
   callback: ?() => mixed,
 ): Work {
@@ -389,7 +398,10 @@ ReactRoot.prototype.render = function(
   updateContainer(children, root, null, work._onCommit);
   return work;
 };
-ReactRoot.prototype.unmount = function(callback: ?() => mixed): Work {
+
+ReactRoot.prototype.unmount = ReactSyncRoot.prototype.unmount = function(
+  callback: ?() => mixed,
+): Work {
   const root = this._internalRoot;
   const work = new ReactWork();
   callback = callback === undefined ? null : callback;
@@ -402,23 +414,8 @@ ReactRoot.prototype.unmount = function(callback: ?() => mixed): Work {
   updateContainer(null, root, null, work._onCommit);
   return work;
 };
-ReactRoot.prototype.legacy_renderSubtreeIntoContainer = function(
-  parentComponent: ?React$Component<any, any>,
-  children: ReactNodeList,
-  callback: ?() => mixed,
-): Work {
-  const root = this._internalRoot;
-  const work = new ReactWork();
-  callback = callback === undefined ? null : callback;
-  if (__DEV__) {
-    warnOnInvalidCallback(callback, 'render');
-  }
-  if (callback !== null) {
-    work.then(callback);
-  }
-  updateContainer(children, root, parentComponent, work._onCommit);
-  return work;
-};
+
+// Sync roots cannot create batches. Only concurrent ones.
 ReactRoot.prototype.createBatch = function(): Batch {
   const batch = new ReactBatch(this);
   const expirationTime = batch._expirationTime;
@@ -535,7 +532,9 @@ function legacyCreateRootFromDOMContainer(
       );
     }
   }
-  return new ReactRoot(container, LegacyRoot, shouldHydrate);
+
+  // Legacy roots are not batched.
+  return new ReactSyncRoot(container, LegacyRoot, shouldHydrate);
 }
 
 function legacyRenderSubtreeIntoContainer(
@@ -547,56 +546,44 @@ function legacyRenderSubtreeIntoContainer(
 ) {
   if (__DEV__) {
     topLevelUpdateWarnings(container);
+    warnOnInvalidCallback(callback === undefined ? null : callback, 'render');
   }
 
   // TODO: Without `any` type, Flow says "Property cannot be accessed on any
   // member of intersection type." Whyyyyyy.
   let root: Root = (container._reactRootContainer: any);
+  let fiberRoot;
   if (!root) {
     // Initial mount
     root = container._reactRootContainer = legacyCreateRootFromDOMContainer(
       container,
       forceHydrate,
     );
+    fiberRoot = root._internalRoot;
     if (typeof callback === 'function') {
       const originalCallback = callback;
       callback = function() {
-        const instance = getPublicRootInstance(root._internalRoot);
+        const instance = getPublicRootInstance(fiberRoot);
         originalCallback.call(instance);
       };
     }
     // Initial mount should not be batched.
     unbatchedUpdates(() => {
-      if (parentComponent != null) {
-        root.legacy_renderSubtreeIntoContainer(
-          parentComponent,
-          children,
-          callback,
-        );
-      } else {
-        root.render(children, callback);
-      }
+      updateContainer(children, fiberRoot, parentComponent, callback);
     });
   } else {
+    fiberRoot = root._internalRoot;
     if (typeof callback === 'function') {
       const originalCallback = callback;
       callback = function() {
-        const instance = getPublicRootInstance(root._internalRoot);
+        const instance = getPublicRootInstance(fiberRoot);
         originalCallback.call(instance);
       };
     }
     // Update
-    if (parentComponent != null) {
-      root.legacy_renderSubtreeIntoContainer(
-        parentComponent,
-        children,
-        callback,
-      );
-    } else {
-      root.render(children, callback);
-    }
+    updateContainer(children, fiberRoot, parentComponent, callback);
   }
-  return getPublicRootInstance(root._internalRoot);
+  return getPublicRootInstance(fiberRoot);
 }
 
 function createPortal(
@@ -806,11 +793,12 @@ const ReactDOM: Object = {
   flushSync: flushSync,
 
   unstable_createRoot: createRoot,
+  unstable_createSyncRoot: createSyncRoot,
   unstable_flushControlled: flushControlled,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
     // Keep in sync with ReactDOMUnstableNativeDependencies.js
-    // and ReactTestUtils.js. This is an array for better minification.
+    // ReactTestUtils.js, and ReactTestUtilsAct.js. This is an array for better minification.
     Events: [
       getInstanceFromNode,
       getNodeFromInstance,
@@ -832,7 +820,10 @@ type RootOptions = {
   hydrate?: boolean,
 };
 
-function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
+function createRoot(
+  container: DOMContainer,
+  options?: RootOptions,
+): RootWithBatchingAPI {
   const functionName = enableStableConcurrentModeAPIs
     ? 'createRoot'
     : 'unstable_createRoot';
@@ -841,6 +832,26 @@ function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
     '%s(...): Target container is not a DOM element.',
     functionName,
   );
+  warnIfReactDOMContainerInDEV(container);
+  const hydrate = options != null && options.hydrate === true;
+  return new ReactRoot(container, hydrate);
+}
+
+function createSyncRoot(container: DOMContainer, options?: RootOptions): Root {
+  const functionName = enableStableConcurrentModeAPIs
+    ? 'createRoot'
+    : 'unstable_createRoot';
+  invariant(
+    isValidContainer(container),
+    '%s(...): Target container is not a DOM element.',
+    functionName,
+  );
+  warnIfReactDOMContainerInDEV(container);
+  const hydrate = options != null && options.hydrate === true;
+  return new ReactSyncRoot(container, BatchedRoot, hydrate);
+}
+
+function warnIfReactDOMContainerInDEV(container) {
   if (__DEV__) {
     warningWithoutStack(
       !container._reactRootContainer,
@@ -850,13 +861,11 @@ function createRoot(container: DOMContainer, options?: RootOptions): ReactRoot {
     );
     container._reactHasBeenPassedToCreateRootDEV = true;
   }
-  const hydrate = options != null && options.hydrate === true;
-  return new ReactRoot(container, ConcurrentRoot, hydrate);
 }
 
 if (enableStableConcurrentModeAPIs) {
   ReactDOM.createRoot = createRoot;
-  ReactDOM.unstable_createRoot = undefined;
+  ReactDOM.createSyncRoot = createSyncRoot;
 }
 
 const foundDevTools = injectIntoDevTools({

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -165,11 +165,11 @@ setRestoreImplementation(restoreControlledState);
 
 export type DOMContainer =
   | (Element & {
-      _reactRootContainer: ?Root,
+      _reactRootContainer: ?(_ReactRoot | _ReactSyncRoot),
       _reactHasBeenPassedToCreateRootDEV: ?boolean,
     })
   | (Document & {
-      _reactRootContainer: ?Root,
+      _reactRootContainer: ?(_ReactRoot | _ReactSyncRoot),
       _reactHasBeenPassedToCreateRootDEV: ?boolean,
     });
 
@@ -181,7 +181,7 @@ type Batch = FiberRootBatch & {
   // The ReactRoot constructor is hoisted but the prototype methods are not. If
   // we move ReactRoot to be above ReactBatch, the inverse error occurs.
   // $FlowFixMe Hoisting issue.
-  _root: Root,
+  _root: _ReactRoot | _ReactSyncRoot,
   _hasChildren: boolean,
   _children: ReactNodeList,
 
@@ -189,18 +189,18 @@ type Batch = FiberRootBatch & {
   _didComplete: boolean,
 };
 
-type Root = {
+type _ReactSyncRoot = {
   render(children: ReactNodeList, callback: ?() => mixed): Work,
   unmount(callback: ?() => mixed): Work,
 
   _internalRoot: FiberRoot,
 };
 
-type RootWithBatchingAPI = Root & {
+type _ReactRoot = _ReactSyncRoot & {
   createBatch(): Batch,
 };
 
-function ReactBatch(root: Root) {
+function ReactBatch(root: _ReactRoot | _ReactSyncRoot) {
   const expirationTime = computeUniqueAsyncExpiration();
   this._expirationTime = expirationTime;
   this._root = root;
@@ -495,7 +495,7 @@ let warnedAboutHydrateAPI = false;
 function legacyCreateRootFromDOMContainer(
   container: DOMContainer,
   forceHydrate: boolean,
-): Root {
+): _ReactSyncRoot {
   const shouldHydrate =
     forceHydrate || shouldHydrateDueToLegacyHeuristic(container);
   // First clear any existing content.
@@ -551,7 +551,7 @@ function legacyRenderSubtreeIntoContainer(
 
   // TODO: Without `any` type, Flow says "Property cannot be accessed on any
   // member of intersection type." Whyyyyyy.
-  let root: Root = (container._reactRootContainer: any);
+  let root: _ReactSyncRoot = (container._reactRootContainer: any);
   let fiberRoot;
   if (!root) {
     // Initial mount
@@ -823,7 +823,7 @@ type RootOptions = {
 function createRoot(
   container: DOMContainer,
   options?: RootOptions,
-): RootWithBatchingAPI {
+): _ReactRoot {
   const functionName = enableStableConcurrentModeAPIs
     ? 'createRoot'
     : 'unstable_createRoot';
@@ -837,7 +837,10 @@ function createRoot(
   return new ReactRoot(container, hydrate);
 }
 
-function createSyncRoot(container: DOMContainer, options?: RootOptions): Root {
+function createSyncRoot(
+  container: DOMContainer,
+  options?: RootOptions,
+): _ReactSyncRoot {
   const functionName = enableStableConcurrentModeAPIs
     ? 'createRoot'
     : 'unstable_createRoot';


### PR DESCRIPTION
- `ReactDOM.unstable_createRoot` creates a Concurrent Mode root.
- `ReactDOM.unstable_createSyncRoot` creates a Batched Mode root. It
does not support `createBatch`.
- `ReactDOM.render` creates a Legacy Mode root. It will eventually be
deprecated and possibly moved to a separate entry point, like
`react-dom/legacy`.