### PR TITLE
Event API: Fix bug where Press root events were not being cleared

### DIFF
--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -1428,4 +1428,21 @@ describe('Event responder: Press', () => {
   it('expect displayName to show up for event component', () => {
     expect(Press.displayName).toBe('Press');
   });
+
+  it('should not trigger an invariant in addRootEventTypes()', () => {
+    const ref = React.createRef();
+    const element = (
+      <Press>
+        <button ref={ref} />
+      </Press>
+    );
+    ReactDOM.render(element, container);
+
+    ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+    jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DELAY);
+    ref.current.dispatchEvent(createPointerEvent('pointermove'));
+    ref.current.dispatchEvent(createPointerEvent('pointerup'));
+    ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+    ReactDOM.render(element, container);
+  });
 });


### PR DESCRIPTION
This PR fixes a bug that we discovered earlier this week. It was hard to pint-point until the recent `invariant` was added to detect duplicate root event types being added (when they've already been added). I tracked the issue down to the fact that we don't always clear the root event types in `Press`. Furthermore, I was able to make a regression test that fails before this fix.

https://github.com/facebook/react/issues/15257