### PR TITLE
React Events: FocusScope tweaks and docs

### DIFF
--- a/packages/react-events/docs/Focus.md
+++ b/packages/react-events/docs/Focus.md
@@ -1,4 +1,4 @@
-## Focus
+# Focus
 
 The `Focus` module responds to focus and blur events on its child. Focus events
 are dispatched for `mouse`, `pen`, `touch`, and `keyboard`
@@ -18,15 +18,18 @@ const TextField = (props) => (
 );
 ```
 
+## Types
+
 ```js
-// Types
 type FocusEvent = {
   target: Element,
   type: 'blur' | 'focus' | 'focuschange'
 }
 ```
 
-### disabled: boolean
+## Props
+
+### disabled: boolean = false
 
 Disables all `Focus` events.
 

--- a/packages/react-events/docs/FocusScope.md
+++ b/packages/react-events/docs/FocusScope.md
@@ -1,0 +1,37 @@
+# FocusScope
+
+The `FocusScope` module can be used to manage focus within its subtree.
+
+```js
+// Example
+const Modal = () => (
+  <FocusScope
+    autoFocus={true}     
+    contain={true}
+    restoreFocus={true}
+  >
+    <h1>Focus contained within modal</h1>
+    <input placeholder="Focusable input" />
+    <div role="button" tabIndex={0}>Focusable element</div>
+    <input placeholder="Non-focusable input" tabIndex={-1} />
+    <Press onPress={onPressClose}>
+      <div role="button" tabIndex={0}>Close</div>
+    </Press>
+  </FocusScope>
+);
+```
+
+## Props
+
+### autoFocus: boolean = false
+
+Automatically moves focus to the first focusable element within scope.
+
+### contain: boolean = false
+
+Contain focus within the subtree of the `FocusScope` instance.
+
+### restoreFocus: boolean = false
+
+Automatically restores focus to element that was last focused before focus moved
+within the scope.

--- a/packages/react-events/docs/Hover.md
+++ b/packages/react-events/docs/Hover.md
@@ -1,8 +1,8 @@
-## Hover
+# Hover
 
 The `Hover` module responds to hover events on the element it wraps. Hover
-events are only dispatched for `mouse` pointer types. Hover begins when the
-pointer enters the element's bounds and ends when the pointer leaves.
+events are only dispatched for `mouse` and `pen` pointer types. Hover begins
+when the pointer enters the element's bounds and ends when the pointer leaves.
 
 Hover events do not propagate between `Hover` event responders.
 
@@ -25,14 +25,17 @@ const Link = (props) => (
 );
 ```
 
+## Types
+
 ```js
-// Types
 type HoverEvent = {
   pointerType: 'mouse' | 'pen',
   target: Element,
   type: 'hoverstart' | 'hoverend' | 'hovermove' | 'hoverchange'
 }
 ```
+
+## Props
 
 ### delayHoverEnd: number
 

--- a/packages/react-events/docs/Press.md
+++ b/packages/react-events/docs/Press.md
@@ -1,4 +1,4 @@
-## Press
+# Press
 
 The `Press` module responds to press events on the element it wraps. Press
 events are dispatched for `mouse`, `pen`, `touch`, and `keyboard` pointer types.
@@ -33,8 +33,9 @@ const Button = (props) => (
 );
 ```
 
+## Types
+
 ```js
-// Types
 type PressEvent = {
   pointerType: 'mouse' | 'touch' | 'pen' | 'keyboard',
   target: Element,
@@ -42,12 +43,14 @@ type PressEvent = {
 }
 
 type PressOffset = {
-  top: number,
-  right: number,
-  bottom: number,
-  right: number
+  top?: number,
+  right?: number,
+  bottom?: number,
+  right?: number
 };
 ```
+
+## Props
 
 ### delayLongPress: number = 500ms
 
@@ -64,7 +67,7 @@ The duration of a delay between when the press starts and when `onPressStart` is
 called. This delay is cut short (and `onPressStart` is called) if the press is
 released before the threshold is exceeded.
 
-### disabled: boolean
+### disabled: boolean = false
 
 Disables all `Press` events.
 
@@ -118,7 +121,7 @@ Called once the element is pressed down. If the press is released before the
 
 Defines how far the pointer (while held down) may move outside the bounds of the
 element before it is deactivated. Ensure you pass in a constant to reduce memory
-allocations.
+allocations. Default is `20` for each offset.
 
 ### preventDefault: boolean = true
 

--- a/packages/react-events/src/__tests__/FocusScope-test.internal.js
+++ b/packages/react-events/src/__tests__/FocusScope-test.internal.js
@@ -85,7 +85,7 @@ describe('FocusScope event responder', () => {
     expect(document.activeElement).toBe(divRef.current);
   });
 
-  it('should work as expected with autofocus and trapping', () => {
+  it('should work as expected with autoFocus and contain', () => {
     const inputRef = React.createRef();
     const input2Ref = React.createRef();
     const buttonRef = React.createRef();
@@ -93,7 +93,7 @@ describe('FocusScope event responder', () => {
 
     const SimpleFocusScope = () => (
       <div>
-        <FocusScope autoFocus={true} trap={true}>
+        <FocusScope autoFocus={true} contain={true}>
           <input ref={inputRef} tabIndex={-1} />
           <button ref={buttonRef} id={1} />
           <button ref={button2Ref} id={2} />
@@ -154,7 +154,7 @@ describe('FocusScope event responder', () => {
     expect(document.activeElement).toBe(button2Ref.current);
   });
 
-  it('should work as expected when nested with scope that is trapped', () => {
+  it('should work as expected when nested with scope that is contained', () => {
     const inputRef = React.createRef();
     const input2Ref = React.createRef();
     const buttonRef = React.createRef();
@@ -167,7 +167,7 @@ describe('FocusScope event responder', () => {
         <FocusScope>
           <input ref={inputRef} tabIndex={-1} />
           <button ref={buttonRef} id={1} />
-          <FocusScope trap={true}>
+          <FocusScope contain={true}>
             <button ref={button2Ref} id={2} />
             <button ref={button3Ref} id={3} />
           </FocusScope>


### PR DESCRIPTION
* FocusScope: rename `trap` to `contain`.
* FocusScope: avoid potential for `el.focus()` errors.
* FocusScope: add docs,
* Update docs formatting,