### PR TITLE
React Events: add onFocusVisibleChange to Focus

### DIFF
--- a/packages/react-events/docs/Focus.md
+++ b/packages/react-events/docs/Focus.md
@@ -1,21 +1,31 @@
 # Focus
 
 The `Focus` module responds to focus and blur events on its child. Focus events
-are dispatched for `mouse`, `pen`, `touch`, and `keyboard`
-pointer types.
+are dispatched for all input types, with the exception of `onFocusVisibleChange`
+which is only dispatched when focusing with a keyboard.
 
 Focus events do not propagate between `Focus` event responders.
 
 ```js
 // Example
-const TextField = (props) => (
-  <Focus
-    onBlur={props.onBlur}
-    onFocus={props.onFocus}
-  >
-    <textarea></textarea>
-  </Focus>
-);
+const Button = (props) => {
+  const [ focusVisible, setFocusVisible ] = useState(false);
+
+  return (
+    <Focus
+      onBlur={props.onBlur}
+      onFocus={props.onFocus}
+      onFocusVisibleChange={setFocusVisible}
+    >
+      <button
+        children={props.children}
+        style={{
+          ...(focusVisible && focusVisibleStyles)
+        }}
+      >
+    </Focus>
+  );
+};
 ```
 
 ## Types
@@ -23,7 +33,7 @@ const TextField = (props) => (
 ```js
 type FocusEvent = {
   target: Element,
-  type: 'blur' | 'focus' | 'focuschange'
+  type: 'blur' | 'focus' | 'focuschange' | 'focusvisiblechange'
 }
 ```
 
@@ -43,5 +53,10 @@ Called when the element gains focus.
 
 ### onFocusChange: boolean => void
 
-Called when the element changes hover state (i.e., after `onBlur` and
+Called when the element changes focus state (i.e., after `onBlur` and
 `onFocus`).
+
+### onFocusVisibleChange: boolean => void
+
+Called when the element receives or loses focus following keyboard navigation.
+This can be used to display focus styles only for keyboard interactions.

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -1090,10 +1090,10 @@ describe('Event responder: Press', () => {
         ref.current.dispatchEvent(
           createPointerEvent('pointermove', coordinatesInside),
         );
-        ref.current.dispatchEvent(
+        container.dispatchEvent(
           createPointerEvent('pointermove', coordinatesOutside),
         );
-        ref.current.dispatchEvent(
+        container.dispatchEvent(
           createPointerEvent('pointerup', coordinatesOutside),
         );
         jest.runAllTimers();
@@ -1135,13 +1135,13 @@ describe('Event responder: Press', () => {
         ref.current.dispatchEvent(
           createPointerEvent('pointermove', coordinatesInside),
         );
-        ref.current.dispatchEvent(
+        container.dispatchEvent(
           createPointerEvent('pointermove', coordinatesOutside),
         );
         jest.runAllTimers();
         expect(events).toEqual(['onPressMove']);
         events = [];
-        ref.current.dispatchEvent(
+        container.dispatchEvent(
           createPointerEvent('pointerup', coordinatesOutside),
         );
         jest.runAllTimers();


### PR DESCRIPTION
Called when focus visibility changes. Focus is only considered visible if a
focus event occurs after keyboard navigation. This provides a way for people to
provide visual focus styles for keyboard accessible UIs without those styles
appearing if focus is triggered by mouse, touch, pen.

Still working on incorporating a couple more details around when focus is considered visible.

Ref #15257