### PR TITLE
Fixed potential interaction tracing leak in Suspense memoization

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1317,10 +1317,10 @@ function commitSuspenseComponent(finishedWork: Fiber) {
     thenables.forEach(thenable => {
       // Memoize using the boundary fiber to prevent redundant listeners.
       let retry = resolveRetryThenable.bind(null, finishedWork, thenable);
-      if (enableSchedulerTracing) {
-        retry = Schedule_tracing_wrap(retry);
-      }
       if (!retryCache.has(thenable)) {
+        if (enableSchedulerTracing) {
+          retry = Schedule_tracing_wrap(retry);
+        }
         retryCache.add(thenable);
         thenable.then(retry, retry);
       }

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -2607,7 +2607,11 @@ describe('Profiler', () => {
         ]);
         onRender.mockClear();
 
-        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+        expect(
+          onInteractionScheduledWorkCompleted.mock.calls[0][0],
+        ).toMatchInteraction(highPriUpdateInteraction);
+        onInteractionScheduledWorkCompleted.mockClear();
 
         Scheduler.advanceTime(100);
         jest.advanceTimersByTime(100);


### PR DESCRIPTION
I also audited the other places we call `unstable_wrap()` in the React DOM bundle and verified that they didn't have a similar problem. We have pretty good suspense test coverage and pretty good tracing test coverage, but it seems like our test coverage of the overlap may be a little weak. (Although to be fair, one of the profiler tests would have caught this if I hadn't mistakenly overlooked it.)

This code has been around for a long time (PR #14429) but only started causing a noticeable problem after a recent React sync.