### PR TITLE
Support `hidden` deprioritization in Batched Mode

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -84,13 +84,7 @@ import {
   Never,
   computeAsyncExpiration,
 } from './ReactFiberExpirationTime';
-import {
-  ConcurrentMode,
-  NoMode,
-  ProfileMode,
-  StrictMode,
-  BatchedMode,
-} from './ReactTypeOfMode';
+import {NoMode, ProfileMode, StrictMode, BatchedMode} from './ReactTypeOfMode';
 import {
   shouldSetTextContent,
   shouldDeprioritizeSubtree,
@@ -980,7 +974,7 @@ function updateHostComponent(current, workInProgress, renderExpirationTime) {
 
   // Check the host config to see if the children are offscreen/hidden.
   if (
-    workInProgress.mode & ConcurrentMode &&
+    workInProgress.mode & BatchedMode &&
     renderExpirationTime !== Never &&
     shouldDeprioritizeSubtree(type, nextProps)
   ) {
@@ -2257,7 +2251,7 @@ function beginWork(
         case HostComponent:
           pushHostContext(workInProgress);
           if (
-            workInProgress.mode & ConcurrentMode &&
+            workInProgress.mode & BatchedMode &&
             renderExpirationTime !== Never &&
             shouldDeprioritizeSubtree(workInProgress.type, newProps)
           ) {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -64,6 +64,7 @@ import {
   BatchedMode,
   ConcurrentMode,
 } from './ReactTypeOfMode';
+import {ConcurrentRoot} from 'shared/ReactRootTags';
 import {
   HostRoot,
   ClassComponent,
@@ -775,6 +776,10 @@ function renderRoot(
     workPhase !== RenderPhase && workPhase !== CommitPhase,
     'Should not already be working.',
   );
+
+  if (root.tag !== ConcurrentRoot) {
+    isSync = true;
+  }
 
   if (enableUserTimingAPI && expirationTime !== Sync) {
     const didExpire = isSync;


### PR DESCRIPTION
Hidden trees will tear and commit in a separate render, as in Concurrent Mode. Unlike Concurrent Mode, once the hidden tree begins, it will finish without yielding.