### PR TITLE
React Events: fix hover state of element with descendants

### DIFF
--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -98,7 +98,7 @@ function dispatchHoverStartEvents(
   if (event !== null) {
     const {nativeEvent} = event;
     if (
-      context.isTargetDirectlyWithinEventComponent(
+      context.isTargetWithinEventResponderScope(
         (nativeEvent: any).relatedTarget,
       )
     ) {
@@ -157,7 +157,7 @@ function dispatchHoverEndEvents(
   if (event !== null) {
     const {nativeEvent} = event;
     if (
-      context.isTargetDirectlyWithinEventComponent(
+      context.isTargetWithinEventResponderScope(
         (nativeEvent: any).relatedTarget,
       )
     ) {


### PR DESCRIPTION
Ensure the hover state is preserved while moving the pointer over descendants
of a Hover component.

Ref #15257