### PR TITLE
Event API: remove isTargetDirectlyWithinEventComponent

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -176,22 +176,6 @@ const eventResponderContext: ReactResponderContext = {
     }
     return false;
   },
-  isTargetDirectlyWithinEventComponent(target: Element | Document): boolean {
-    validateResponderContext();
-    if (target != null) {
-      let fiber = getClosestInstanceFromNode(target);
-      while (fiber !== null) {
-        if (fiber.stateNode === currentInstance) {
-          return true;
-        }
-        if (fiber.tag === EventComponent) {
-          return false;
-        }
-        fiber = fiber.return;
-      }
-    }
-    return false;
-  },
   isTargetWithinEventResponderScope(target: Element | Document): boolean {
     validateResponderContext();
     const responder = ((currentInstance: any): ReactEventComponentInstance)

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -710,7 +710,7 @@ describe('DOMEventResponderSystem', () => {
     ]);
   });
 
-  it('isTargetDirectlyWithinEventComponent works', () => {
+  it('isTargetWithinEventResponderScope works', () => {
     const buttonRef = React.createRef();
     const divRef = React.createRef();
     const log = [];
@@ -720,7 +720,7 @@ describe('DOMEventResponderSystem', () => {
       undefined,
       undefined,
       (event, context) => {
-        const isWithin = context.isTargetDirectlyWithinEventComponent(
+        const isWithin = context.isTargetWithinEventResponderScope(
           event.nativeEvent.relatedTarget,
         );
         log.push(isWithin);

--- a/packages/react-events/README.md
+++ b/packages/react-events/README.md
@@ -134,10 +134,6 @@ Returns `true` if the instance has taken ownership of the responder.
 
 Returns `true` if the global coordinates lie within the TouchHitTarget.
 
-### isTargetDirectlyWithinEventComponent(target: Element): boolean
-
-Returns `true` is the target element is within the direct subtree of the Event Component instance, i.e., the target is not nested within an Event Component instance that is a descendant of the current instance.
-
 ### isTargetWithinElement(target: Element, element: Element): boolean
 
 Returns `true` if `target` is a child of `element`.

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -98,7 +98,7 @@ function dispatchHoverStartEvents(
   if (event !== null) {
     const {nativeEvent} = event;
     if (
-      context.isTargetDirectlyWithinEventComponent(
+      context.isTargetWithinEventResponderScope(
         (nativeEvent: any).relatedTarget,
       )
     ) {
@@ -157,7 +157,7 @@ function dispatchHoverEndEvents(
   if (event !== null) {
     const {nativeEvent} = event;
     if (
-      context.isTargetDirectlyWithinEventComponent(
+      context.isTargetWithinEventResponderScope(
         (nativeEvent: any).relatedTarget,
       )
     ) {

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -172,7 +172,6 @@ export type ReactResponderContext = {
     parentTarget: Element | Document,
   ) => boolean,
   isTargetWithinEventComponent: (Element | Document) => boolean,
-  isTargetDirectlyWithinEventComponent: (Element | Document) => boolean,
   isTargetWithinEventResponderScope: (Element | Document) => boolean,
   isPositionWithinTouchHitTarget: (x: number, y: number) => boolean,
   addRootEventTypes: (


### PR DESCRIPTION
With the event API, we have a context method called `isTargetDirectlyWithinEventComponent` that is only used in `Hover.js`. It turns out, this isn't the behaviour we want and we already have a better context method called `isTargetWithinEventResponderScope`. If we switch to using this, we get the desired behaviour, meaning we can remove `isTargetDirectlyWithinEventComponent` from the codebase – saving bytes and removing one more API on context.

Ref #15257