### PR TITLE
Treat Namespace.use() as a React Hook

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -97,6 +97,7 @@ eslintTester.run('react-hooks', ReactHooksESLintRule, {
       ({useHook() { useState(); }});
       const {useHook = () => { useState(); }} = {};
       ({useHook = () => { useState(); }} = {});
+      namespace.use = () => { useState(); };
     `,
     `
       // Valid because hooks can call hooks.

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -14,8 +14,12 @@
  * character to exclude identifiers like "user".
  */
 
-function isHookName(s) {
-  return /^use[A-Z0-9].*$/.test(s);
+function isHookName(s, isNamespaced) {
+  if (isNamespaced) {
+    return /^(use|use[A-Z0-9].*)$/.test(s);
+  } else {
+    return /^use[A-Z0-9].*$/.test(s);
+  }
 }
 
 /**
@@ -23,18 +27,11 @@ function isHookName(s) {
  * containing a hook name.
  */
 
-function isHook(node) {
+function isHook(node, isNamespaced = false) {
   if (node.type === 'Identifier') {
-    return isHookName(node.name);
-  } else if (
-    node.type === 'MemberExpression' &&
-    !node.computed &&
-    isHook(node.property)
-  ) {
-    // Only consider React.useFoo() to be namespace hooks for now to avoid false positives.
-    // We can expand this check later.
-    const obj = node.object;
-    return obj.type === 'Identifier' && obj.name === 'React';
+    return isHookName(node.name, isNamespaced);
+  } else if (node.type === 'MemberExpression' && !node.computed) {
+    return isHook(node.property, true);
   } else {
     return false;
   }


### PR DESCRIPTION
In watching the [presentation about building the new facebook.com](https://developers.facebook.com/videos/2019/building-the-new-facebookcom-with-react-graphql-and-relay/) I saw a reference to a method called:

```js
Feature.use()
```

That was used conditionally, which was confusing because it looked like a hook to me.

I was actually surprised to find out that React does not consider `Namespace.use()` to be a hook at all, and even `Namespace.useHook()` was not considered a hook by the ESLint plugin because it isn't `React.useHook()`.

I want to propose two things:

1. `Namespace.useHook()` should be considered a hook by the ESLint plugin
2. `Namespace.use()` should be considered a hook by React/ESLint plugin

I've opened this PR with both changes. Although I can easily update it to only include `Namespace.useHook()` if that is preferred.

But I would like to argue for also including `Namespace.use()` because the alternative for people wanting to write that is `Namespace.useNamespace()` which is just silly to write.