### PR TITLE
remove redundent renderRoot

### DIFF
--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -757,26 +757,7 @@ function renderRoot(
     startWorkLoopTimer(workInProgress);
 
     // TODO: Fork renderRoot into renderRootSync and renderRootAsync
-    if (isSync) {
-      if (expirationTime !== Sync) {
-        // An async update expired. There may be other expired updates on
-        // this root. We should render all the expired work in a
-        // single batch.
-        const currentTime = requestCurrentTime();
-        if (currentTime < expirationTime) {
-          // Restart at the current time.
-          workPhase = prevWorkPhase;
-          resetContextDependencies();
-          ReactCurrentDispatcher.current = prevDispatcher;
-          if (enableSchedulerTracing) {
-            __interactionsRef.current = ((prevInteractions: any): Set<
-              Interaction,
-            >);
-          }
-          return renderRoot.bind(null, root, currentTime);
-        }
-      }
-    } else {
+    if (!isSync) {
       // Since we know we're in a React event, we can clear the current
       // event time. The next update will compute a new event time.
       currentEventTime = NoWork;

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -537,7 +537,15 @@ describe('ReactIncrementalUpdates', () => {
 
     // All the updates should render and commit in a single batch.
     Scheduler.advanceTime(10000);
-    expect(Scheduler).toHaveYielded(['Render: goodbye']);
+    expect(Scheduler).toHaveYielded([
+      'Render: ',
+      'Commit: ',
+      'Render: go',
+      'Commit: go',
+      'Render: good',
+      'Commit: good',
+      'Render: goodbye',
+    ]);
     // Passive effect
     expect(Scheduler).toFlushAndYield(['Commit: goodbye']);
   });
@@ -640,6 +648,18 @@ describe('ReactIncrementalUpdates', () => {
     // All the updates should render and commit in a single batch.
     Scheduler.advanceTime(10000);
     expect(Scheduler).toHaveYielded([
+      'Render: ',
+      'Commit: ',
+      'Render: ',
+      'Commit: ',
+      'Render: go',
+      'Commit: go',
+      'Render: go',
+      'Commit: go',
+      'Render: good',
+      'Commit: good',
+      'Render: good',
+      'Commit: good',
       'Render: goodbye',
       'Commit: goodbye',
       'Render: goodbye',

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -446,6 +446,9 @@ exports[`ReactDebugFiberPerf warns if an in-progress update is interrupted 1`] =
 exports[`ReactDebugFiberPerf warns if async work expires (starvation) 1`] = `
 "⛔ (Waiting for async callback...) Warning: Update expired; will flush synchronously
 
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Foo [mount]
+
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)
   ⚛ (Committing Host Effects: 1 Total)


### PR DESCRIPTION
When I put a breakpoint on [currentTime < expirationTime](https://github.com/facebook/react/compare/master...NE-SmallTown:rm-bad-logic?expand=1#diff-24152ba0b2ac251decb6a12f41bdf116L766), It seems will happen that we were **wasting** time to wait the current time elapse to make [currentTime < expirationTime](https://github.com/facebook/react/compare/master...NE-SmallTown:rm-bad-logic?expand=1#diff-24152ba0b2ac251decb6a12f41bdf116L766) be `true`,  so there would execute **many many times** `onmessage -> flushFirstCallback -> onRootCallback -> renderRoot` all these can increase `performance.now()`?(until I remove the breakpoint or there will be a infinity loop)

I could be wrong probably, feel free to correct me :)