### PR TITLE
React Events: fix cancel events for Press

### DIFF
--- a/packages/react-events/docs/Press.md
+++ b/packages/react-events/docs/Press.md
@@ -100,10 +100,10 @@ Called when the element changes press state (i.e., after `onPressStart` and
 
 ### onPressEnd: (e: PressEvent) => void
 
-Called once the element is no longer pressed (because it was released, or moved
-beyond the hit bounds). If the press starts again before the `delayPressEnd`
-threshold is exceeded then the delay is reset to prevent `onPressEnd` being
-called during a press.
+Called once the element is no longer pressed (because the press was released,
+cancelled, or moved beyond the hit bounds). If the press starts again before the
+`delayPressEnd` threshold is exceeded then the delay is reset to prevent
+`onPressEnd` being called during a press.
 
 ### onPressMove: (e: PressEvent) => void
 
@@ -120,8 +120,10 @@ Called once the element is pressed down. If the press is released before the
 ### pressRetentionOffset: PressOffset
 
 Defines how far the pointer (while held down) may move outside the bounds of the
-element before it is deactivated. Ensure you pass in a constant to reduce memory
-allocations. Default is `20` for each offset.
+element before it is deactivated. Once deactivated, the pointer (still held
+down) can be moved back within the bounds of the element to reactivate it.
+Ensure you pass in a constant to reduce memory allocations. Default is `20` for
+each offset.
 
 ### preventDefault: boolean = true
 

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -1629,6 +1629,56 @@ describe('Event responder: Press', () => {
     });
   });
 
+  describe('responder cancellation', () => {
+    it('ends on "pointercancel", "touchcancel", "scroll", and "dragstart"', () => {
+      const onLongPress = jest.fn();
+      const onPressEnd = jest.fn();
+      const ref = React.createRef();
+      const element = (
+        <Press onLongPress={onLongPress} onPressEnd={onPressEnd}>
+          <a href="#" ref={ref} />
+        </Press>
+      );
+      ReactDOM.render(element, container);
+
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createPointerEvent('scroll'));
+      expect(onPressEnd).toHaveBeenCalledTimes(1);
+      jest.runAllTimers();
+      expect(onLongPress).not.toBeCalled();
+
+      onLongPress.mockReset();
+      onPressEnd.mockReset();
+
+      // When pointer events are supported
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createPointerEvent('pointercancel'));
+      expect(onPressEnd).toHaveBeenCalledTimes(1);
+      jest.runAllTimers();
+      expect(onLongPress).not.toBeCalled();
+
+      onLongPress.mockReset();
+      onPressEnd.mockReset();
+
+      // Touch fallback
+      ref.current.dispatchEvent(createPointerEvent('touchstart'));
+      ref.current.dispatchEvent(createPointerEvent('touchcancel'));
+      expect(onPressEnd).toHaveBeenCalledTimes(1);
+      jest.runAllTimers();
+      expect(onLongPress).not.toBeCalled();
+
+      onLongPress.mockReset();
+      onPressEnd.mockReset();
+
+      // Mouse fallback
+      ref.current.dispatchEvent(createPointerEvent('mousedown'));
+      ref.current.dispatchEvent(createPointerEvent('dragstart'));
+      expect(onPressEnd).toHaveBeenCalledTimes(1);
+      jest.runAllTimers();
+      expect(onLongPress).not.toBeCalled();
+    });
+  });
+
   it('expect displayName to show up for event component', () => {
     expect(Press.displayName).toBe('Press');
   });


### PR DESCRIPTION
* Fixes a bug in the cancellation logic. The cancel events are now correctly listened to on the root.
* Fixes cancellation in Safari by using the `dragstart` event as a proxy for cancellation (i.e., the event dispatched when move-during-press occurs on an anchor tag)

Ref #15257