### PR TITLE
add useStateObject

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1814,4 +1814,23 @@ describe('ReactHooks', () => {
     Scheduler.flushAll();
     expect(root).toMatchRenderedOutput('hello');
   });
+          
+  it('useStateObject: builds a state object', () => {
+    const {useStateObject, useEffect} = React;
+
+    function Counter() {
+      const state = useStateObject({ count1: 0, count2: 0});
+      useEffect( () => {
+        state.count1 ++;
+        state.count2 += 2;
+      });
+      return state.count1 + state.count2;
+    }
+
+    const root = ReactTestRenderer.create(null);
+    ReactTestRenderer.act(() => {
+      root.update(<Counter />);
+    });
+    expect(root).toMatchRenderedOutput('3');
+  });
 });

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -74,6 +74,15 @@ export function useState<S>(initialState: (() => S) | S) {
   return dispatcher.useState(initialState);
 }
 
+export function useStateObject<S>(initialState: (() => S) | S) {
+  const dispatcher = resolveDispatcher();
+  const initState = typeof initialState === 'function' ? initialState() : initialState;
+  return Object.keys(initState).reduce((a,c) => {
+    const [value, setValue] = dispatcher.useState(initState[c]);
+    return Object.defineProperty(a, c, { get: () => value, set: setValue });
+  }, {});
+}
+
 export function useReducer<S, I, A>(
   reducer: (S, A) => S,
   initialArg: I,


### PR DESCRIPTION
useStateObject is using useState for create single object and exposing it's properties as accessors.
It removes the use of [val, setVal] array and use property accessor for both get and set.

Usage:
`const state = getStateObject({ test: 1 });

const update = (val) => {
	state.test = val;
}
return <div>{state.test}</div>`

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
10. If you haven't already, complete the CLA.

**Learn more about contributing:** https://reactjs.org/docs/how-to-contribute.html
