### PR TITLE
Fix interaction tracing for batched update mounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@mattiasbuelens/web-streams-polyfill": "0.1.0"
   },
   "devEngines": {
-    "node": "8.x || 9.x || 10.x || 11.x"
+    "node": "8.x || 9.x || 10.x || 11.x || 12.x"
   },
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -331,6 +331,9 @@ export function scheduleUpdateOnFiber(
 
   if (expirationTime === Sync) {
     if (workPhase === LegacyUnbatchedPhase) {
+      // Register pending interactions on the root to avoid losing traced interaction data.
+      schedulePendingInteraction(root, expirationTime);
+
       // This is a legacy edge case. The initial mount of a ReactDOM.render-ed
       // root inside of batchedUpdates should be synchronous, but layout updates
       // should be deferred until the end of the batch.


### PR DESCRIPTION
When a root is _mounting_ inside of a batched update (including the `act` test helper) the interactions `Set` in of `ReactFiberScheduler` is empty. This does not impact _updates_, only _mounts_.

The reason for this is that in that case, we never recorded the pending interactions on the root.

Technically the bug was related to batched updates, not `act`, but it seemed worth adding test coverage for both just in case there were changes in the future.

I came across this while trying to write profiling tests for the new DevTools (https://github.com/bvaughn/react-devtools-experimental/pull/258). I've tested this change in that PR and verified that it fixes the disconnected interactions.

Resolves #15566