### PR TITLE
Add withSuspenseConfig API

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -220,6 +220,7 @@ ReactBatch.prototype.render = function(children: ReactNodeList) {
     internalRoot,
     null,
     expirationTime,
+    null,
     work._onCommit,
   );
   return work;

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -226,6 +226,7 @@ ReactBatch.prototype.render = function(children: ReactNodeList) {
     internalRoot,
     null,
     expirationTime,
+    null,
     work._onCommit,
   );
   return work;

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -55,6 +55,7 @@ import {
   flushPassiveEffects,
 } from './ReactFiberScheduler';
 import {revertPassiveEffectsChange} from 'shared/ReactFeatureFlags';
+import {requestCurrentSuspenseConfig} from './ReactFiberSuspenseConfig';
 
 const fakeInternalInstance = {};
 const isArray = Array.isArray;
@@ -184,9 +185,14 @@ const classComponentUpdater = {
   enqueueSetState(inst, payload, callback) {
     const fiber = getInstance(inst);
     const currentTime = requestCurrentTime();
-    const expirationTime = computeExpirationForFiber(currentTime, fiber);
+    const suspenseConfig = requestCurrentSuspenseConfig();
+    const expirationTime = computeExpirationForFiber(
+      currentTime,
+      fiber,
+      suspenseConfig,
+    );
 
-    const update = createUpdate(expirationTime);
+    const update = createUpdate(expirationTime, suspenseConfig);
     update.payload = payload;
     if (callback !== undefined && callback !== null) {
       if (__DEV__) {
@@ -204,9 +210,14 @@ const classComponentUpdater = {
   enqueueReplaceState(inst, payload, callback) {
     const fiber = getInstance(inst);
     const currentTime = requestCurrentTime();
-    const expirationTime = computeExpirationForFiber(currentTime, fiber);
+    const suspenseConfig = requestCurrentSuspenseConfig();
+    const expirationTime = computeExpirationForFiber(
+      currentTime,
+      fiber,
+      suspenseConfig,
+    );
 
-    const update = createUpdate(expirationTime);
+    const update = createUpdate(expirationTime, suspenseConfig);
     update.tag = ReplaceState;
     update.payload = payload;
 
@@ -226,9 +237,14 @@ const classComponentUpdater = {
   enqueueForceUpdate(inst, callback) {
     const fiber = getInstance(inst);
     const currentTime = requestCurrentTime();
-    const expirationTime = computeExpirationForFiber(currentTime, fiber);
+    const suspenseConfig = requestCurrentSuspenseConfig();
+    const expirationTime = computeExpirationForFiber(
+      currentTime,
+      fiber,
+      suspenseConfig,
+    );
 
-    const update = createUpdate(expirationTime);
+    const update = createUpdate(expirationTime, suspenseConfig);
     update.tag = ForceUpdate;
 
     if (callback !== undefined && callback !== null) {

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -737,8 +737,11 @@ function completeWork(
         // in the concurrent tree already suspended during this render.
         // This is a known bug.
         if ((workInProgress.mode & BatchedMode) !== NoMode) {
+          const hasInvisibleChildContext =
+            current === null &&
+            workInProgress.memoizedProps.unstable_avoidThisFallback !== true;
           if (
-            current === null ||
+            hasInvisibleChildContext ||
             hasSuspenseContext(
               suspenseStackCursor.current,
               (InvisibleParentSuspenseContext: SuspenseContext),

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -94,7 +94,10 @@ import {
   enableSuspenseServerRenderer,
   enableEventAPI,
 } from 'shared/ReactFeatureFlags';
-import {markRenderEventTime, renderDidSuspend} from './ReactFiberScheduler';
+import {
+  markRenderEventTimeAndConfig,
+  renderDidSuspend,
+} from './ReactFiberScheduler';
 import {getEventComponentHostChildrenCount} from './ReactFiberEvents';
 import getComponentName from 'shared/getComponentName';
 import warning from 'shared/warning';
@@ -698,7 +701,7 @@ function completeWork(
           // was given a normal pri expiration time at the time it was shown.
           const fallbackExpirationTime: ExpirationTime =
             prevState.fallbackExpirationTime;
-          markRenderEventTime(fallbackExpirationTime);
+          markRenderEventTimeAndConfig(fallbackExpirationTime, null);
 
           // Delete the fallback.
           // TODO: Would it be better to store the fallback fragment on

--- a/packages/react-reconciler/src/ReactFiberExpirationTime.js
+++ b/packages/react-reconciler/src/ReactFiberExpirationTime.js
@@ -71,6 +71,18 @@ export function computeAsyncExpiration(
   );
 }
 
+export function computeSuspenseExpiration(
+  currentTime: ExpirationTime,
+  timeoutMs: number,
+): ExpirationTime {
+  // TODO: Should we warn if timeoutMs is lower than the normal pri expiration time?
+  return computeExpirationBucket(
+    currentTime,
+    timeoutMs,
+    LOW_PRIORITY_BATCH_SIZE,
+  );
+}
+
 // Same as computeAsyncExpiration but without the bucketing logic. This is
 // used to compute timestamps instead of actual expiration times.
 export function computeAsyncExpirationNoBucket(

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -44,7 +44,7 @@ import is from 'shared/objectIs';
 import {markWorkInProgressReceivedUpdate} from './ReactFiberBeginWork';
 import {revertPassiveEffectsChange} from 'shared/ReactFeatureFlags';
 
-const {ReactCurrentDispatcher} = ReactSharedInternals;
+const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
 
 export type Dispatcher = {
   readContext<T>(
@@ -1087,6 +1087,7 @@ function dispatchAction<S, A>(
     // queue -> linked list of updates. After this render pass, we'll restart
     // and apply the stashed updates on top of the work-in-progress hook.
     didScheduleRenderPhaseUpdate = true;
+    console.log(ReactCurrentBatchConfig.suspense);
     const update: Update<S, A> = {
       expirationTime: renderExpirationTime,
       action,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -35,7 +35,7 @@ import {
   flushPassiveEffects,
   requestCurrentTime,
   warnIfNotCurrentlyActingUpdatesInDev,
-  markRenderEventTime,
+  markRenderEventTimeAndConfig,
 } from './ReactFiberScheduler';
 
 import invariant from 'shared/invariant';
@@ -731,7 +731,10 @@ function updateReducer<S, I, A>(
         // TODO: We should skip this update if it was already committed but currently
         // we have no way of detecting the difference between a committed and suspended
         // update here.
-        markRenderEventTime(updateExpirationTime);
+        markRenderEventTimeAndConfig(
+          updateExpirationTime,
+          update.suspenseConfig,
+        );
 
         // Process this update.
         if (update.eagerReducer === reducer) {

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -216,7 +216,7 @@ export function propagateContextChange(
 
           if (fiber.tag === ClassComponent) {
             // Schedule a force update on the work-in-progress.
-            const update = createUpdate(renderExpirationTime);
+            const update = createUpdate(renderExpirationTime, null);
             update.tag = ForceUpdate;
             // TODO: Because we don't have a work-in-progress, this will add the
             // update to the current fiber, too, which means it will persist even if

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -288,7 +288,7 @@ export function computeExpirationForFiber(
     // Compute an expiration time based on the Suspense timeout.
     expirationTime = computeSuspenseExpiration(
       currentTime,
-      suspenseConfig.timeoutMs | 0,
+      suspenseConfig.timeoutMs | 0 || LOW_PRIORITY_EXPIRATION,
     );
   } else {
     // Compute an expiration time based on the Scheduler priority.
@@ -1056,7 +1056,7 @@ function inferTimeFromExpirationTime(
   return (
     earliestExpirationTimeMs -
     (suspenseConfig !== null
-      ? suspenseConfig.timeoutMs | 0
+      ? suspenseConfig.timeoutMs | 0 || LOW_PRIORITY_EXPIRATION
       : LOW_PRIORITY_EXPIRATION)
   );
 }

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -15,6 +15,7 @@ import type {
   SchedulerCallback,
 } from './SchedulerWithReactIntegration';
 import type {Interaction} from 'scheduler/src/Tracing';
+import type {SuspenseConfig} from './ReactFiberSuspenseConfig';
 
 import {
   warnAboutDeprecatedLifecycles,
@@ -262,6 +263,7 @@ export function requestCurrentTime() {
 export function computeExpirationForFiber(
   currentTime: ExpirationTime,
   fiber: Fiber,
+  suspenseConfig: null | SuspenseConfig,
 ): ExpirationTime {
   const mode = fiber.mode;
   if ((mode & BatchedMode) === NoMode) {
@@ -1834,7 +1836,12 @@ export function retryTimedOutBoundary(boundaryFiber: Fiber) {
   // resolved, which means at least part of the tree was likely unblocked. Try
   // rendering again, at a new expiration time.
   const currentTime = requestCurrentTime();
-  const retryTime = computeExpirationForFiber(currentTime, boundaryFiber);
+  const suspenseConfig = null; // Retries don't carry over the already committed update.
+  const retryTime = computeExpirationForFiber(
+    currentTime,
+    boundaryFiber,
+    suspenseConfig,
+  );
   // TODO: Special case idle priority?
   const priorityLevel = inferPriorityFromExpirationTime(currentTime, retryTime);
   const root = markUpdateTimeFromFiberToRoot(boundaryFiber, retryTime);

--- a/packages/react-reconciler/src/ReactFiberSuspenseConfig.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseConfig.js
@@ -7,8 +7,16 @@
  * @flow
  */
 
+import ReactSharedInternals from 'shared/ReactSharedInternals';
+
+const {ReactCurrentBatchConfig} = ReactSharedInternals;
+
 export type SuspenseConfig = {|
   timeoutMs: number,
   loadingDelayMs?: number,
   minLoadingDurationMs?: number,
 |};
+
+export function requestCurrentSuspenseConfig(): null | SuspenseConfig {
+  return ReactCurrentBatchConfig.suspense;
+}

--- a/packages/react-reconciler/src/ReactFiberSuspenseConfig.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseConfig.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export type SuspenseConfig = {|
+  timeoutMs: number,
+  loadingDelayMs?: number,
+  minLoadingDurationMs?: number,
+|};

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -90,7 +90,7 @@ function createRootErrorUpdate(
   errorInfo: CapturedValue<mixed>,
   expirationTime: ExpirationTime,
 ): Update<mixed> {
-  const update = createUpdate(expirationTime);
+  const update = createUpdate(expirationTime, null);
   // Unmount the root by rendering null.
   update.tag = CaptureUpdate;
   // Caution: React DevTools currently depends on this property
@@ -109,7 +109,7 @@ function createClassErrorUpdate(
   errorInfo: CapturedValue<mixed>,
   expirationTime: ExpirationTime,
 ): Update<mixed> {
-  const update = createUpdate(expirationTime);
+  const update = createUpdate(expirationTime, null);
   update.tag = CaptureUpdate;
   const getDerivedStateFromError = fiber.type.getDerivedStateFromError;
   if (typeof getDerivedStateFromError === 'function') {
@@ -265,7 +265,7 @@ function throwException(
               // When we try rendering again, we should not reuse the current fiber,
               // since it's known to be in an inconsistent state. Use a force updte to
               // prevent a bail out.
-              const update = createUpdate(Sync);
+              const update = createUpdate(Sync, null);
               update.tag = ForceUpdate;
               enqueueUpdate(sourceFiber, update);
             }

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -287,12 +287,6 @@ function throwException(
         workInProgress.effectTag |= ShouldCapture;
         workInProgress.expirationTime = renderExpirationTime;
 
-        if (!hasInvisibleParentBoundary) {
-          // TODO: If we're not in an invisible subtree, then we need to mark this render
-          // pass as needing to suspend for longer to avoid showing this fallback state.
-          // We could do it here or when we render the fallback.
-        }
-
         return;
       } else if (
         enableSuspenseServerRenderer &&

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -102,7 +102,7 @@ import {
 } from 'shared/ReactFeatureFlags';
 
 import {StrictMode} from './ReactTypeOfMode';
-import {markRenderEventTime} from './ReactFiberScheduler';
+import {markRenderEventTimeAndConfig} from './ReactFiberScheduler';
 
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
@@ -469,7 +469,7 @@ export function processUpdateQueue<State>(
       // TODO: We should skip this update if it was already committed but currently
       // we have no way of detecting the difference between a committed and suspended
       // update here.
-      markRenderEventTime(updateExpirationTime);
+      markRenderEventTimeAndConfig(updateExpirationTime, update.suspenseConfig);
 
       // Process it and compute a new result.
       resultState = getStateFromUpdate(

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -86,6 +86,7 @@
 
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
+import type {SuspenseConfig} from './ReactFiberSuspenseConfig';
 
 import {NoWork} from './ReactFiberExpirationTime';
 import {
@@ -108,6 +109,7 @@ import warningWithoutStack from 'shared/warningWithoutStack';
 
 export type Update<State> = {
   expirationTime: ExpirationTime,
+  suspenseConfig: null | SuspenseConfig,
 
   tag: 0 | 1 | 2 | 3,
   payload: any,
@@ -191,9 +193,13 @@ function cloneUpdateQueue<State>(
   return queue;
 }
 
-export function createUpdate(expirationTime: ExpirationTime): Update<*> {
+export function createUpdate(
+  expirationTime: ExpirationTime,
+  suspenseConfig: null | SuspenseConfig,
+): Update<*> {
   return {
-    expirationTime: expirationTime,
+    expirationTime,
+    suspenseConfig,
 
     tag: UpdateState,
     payload: null,

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -745,9 +745,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     expect(Scheduler).toFlushAndYield(['S']);
 
     // Schedule an update, and suspend for up to 5 seconds.
-    React.unstable_suspendIfNeeded(() => ReactNoop.render(<App text="A" />), {
-      timeoutMs: 5000,
-    });
+    React.unstable_withSuspenseConfig(
+      () => ReactNoop.render(<App text="A" />),
+      {
+        timeoutMs: 5000,
+      },
+    );
     // The update should suspend.
     expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([span('S')]);
@@ -759,9 +762,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     expect(ReactNoop.getChildren()).toEqual([span('S')]);
 
     // Schedule another low priority update.
-    React.unstable_suspendIfNeeded(() => ReactNoop.render(<App text="B" />), {
-      timeoutMs: 10000,
-    });
+    React.unstable_withSuspenseConfig(
+      () => ReactNoop.render(<App text="B" />),
+      {
+        timeoutMs: 10000,
+      },
+    );
     // This update should also suspend.
     expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([span('S')]);
@@ -1665,7 +1671,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.render(<Foo />);
 
     // Took a long time to render. This is to ensure we get a long suspense time.
-    // Could also use something like suspendIfNeeded to simulate this.
+    // Could also use something like withSuspenseConfig to simulate this.
     Scheduler.advanceTime(1500);
     await advanceTimers(1500);
 

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -40,6 +40,7 @@ import {
   useRef,
   useState,
 } from './ReactHooks';
+import {suspendIfNeeded} from './ReactBatchConfig';
 import {
   createElementWithValidation,
   createFactoryWithValidation,
@@ -94,6 +95,8 @@ const React = {
   isValidElement: isValidElement,
 
   version: ReactVersion,
+
+  unstable_suspendIfNeeded: suspendIfNeeded,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: ReactSharedInternals,
 };

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -40,7 +40,7 @@ import {
   useRef,
   useState,
 } from './ReactHooks';
-import {suspendIfNeeded} from './ReactBatchConfig';
+import {withSuspenseConfig} from './ReactBatchConfig';
 import {
   createElementWithValidation,
   createFactoryWithValidation,
@@ -96,7 +96,7 @@ const React = {
 
   version: ReactVersion,
 
-  unstable_suspendIfNeeded: suspendIfNeeded,
+  unstable_withSuspenseConfig: withSuspenseConfig,
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: ReactSharedInternals,
 };

--- a/packages/react/src/ReactBatchConfig.js
+++ b/packages/react/src/ReactBatchConfig.js
@@ -11,16 +11,10 @@ import type {SuspenseConfig} from 'react-reconciler/src/ReactFiberSuspenseConfig
 
 import ReactCurrentBatchConfig from './ReactCurrentBatchConfig';
 
-const DefaultSuspenseConfig: SuspenseConfig = {
-  timeoutMs: 5000,
-  loadingDelayMs: 0,
-  minLoadingDurationMs: 0,
-};
-
 // Within the scope of the callback, mark all updates as being allowed to suspend.
-export function suspendIfNeeded(scope: () => void, config?: SuspenseConfig) {
+export function withSuspenseConfig(scope: () => void, config?: SuspenseConfig) {
   const previousConfig = ReactCurrentBatchConfig.suspense;
-  ReactCurrentBatchConfig.suspense = config || DefaultSuspenseConfig;
+  ReactCurrentBatchConfig.suspense = config === undefined ? null : config;
   try {
     scope();
   } finally {

--- a/packages/react/src/ReactBatchConfig.js
+++ b/packages/react/src/ReactBatchConfig.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {SuspenseConfig} from 'react-reconciler/src/ReactFiberSuspenseConfig';
+
+import ReactCurrentBatchConfig from './ReactCurrentBatchConfig';
+
+const DefaultSuspenseConfig: SuspenseConfig = {
+  timeoutMs: 5000,
+  loadingDelayMs: 0,
+  minLoadingDurationMs: 0,
+};
+
+// Within the scope of the callback, mark all updates as being allowed to suspend.
+export function suspendIfNeeded(scope: () => void, config?: SuspenseConfig) {
+  const previousConfig = ReactCurrentBatchConfig.suspense;
+  ReactCurrentBatchConfig.suspense = config || DefaultSuspenseConfig;
+  try {
+    scope();
+  } finally {
+    ReactCurrentBatchConfig.suspense = previousConfig;
+  }
+}

--- a/packages/react/src/ReactCurrentBatchConfig.js
+++ b/packages/react/src/ReactCurrentBatchConfig.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {SuspenseConfig} from 'react-reconciler/src/ReactFiberSuspenseConfig';
+
+/**
+ * Keeps track of the current batch's configuration such as how long an update
+ * should suspend for if it needs to.
+ */
+const ReactCurrentBatchConfig = {
+  suspense: (null: null | SuspenseConfig),
+};
+
+export default ReactCurrentBatchConfig;

--- a/packages/react/src/ReactSharedInternals.js
+++ b/packages/react/src/ReactSharedInternals.js
@@ -7,11 +7,13 @@
 
 import assign from 'object-assign';
 import ReactCurrentDispatcher from './ReactCurrentDispatcher';
+import ReactCurrentBatchConfig from './ReactCurrentBatchConfig';
 import ReactCurrentOwner from './ReactCurrentOwner';
 import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
 
 const ReactSharedInternals = {
   ReactCurrentDispatcher,
+  ReactCurrentBatchConfig,
   ReactCurrentOwner,
   // used by act()
   ReactShouldWarnActingUpdates: {current: false},

--- a/packages/shared/ReactSharedInternals.js
+++ b/packages/shared/ReactSharedInternals.js
@@ -18,5 +18,10 @@ if (!ReactSharedInternals.hasOwnProperty('ReactCurrentDispatcher')) {
     current: null,
   };
 }
+if (!ReactSharedInternals.hasOwnProperty('ReactCurrentBatchConfig')) {
+  ReactSharedInternals.ReactCurrentBatchConfig = {
+    suspense: null,
+  };
+}
 
 export default ReactSharedInternals;


### PR DESCRIPTION
This adds `unstable_withSuspenseConfig(callback, config)` to the `react` package. This is a primitive that can be used to implement "busy spinners". __I recommend reviewing the code commit by commit.__

This sets the config as a global state available to all React renderers during the scope of the synchronously executed callback (first arg). If you don't pass a config, it disables suspense (for longer than the default JND).

If any updates are scheduled (render, setState, dispatch) during this scope, then they get this "suspense config" associated with the update.

If during a render pass, we process one of those updates, we mark this render pass as having a "suspense config".

If during a render pass, we are forced to turn already visible content back into a fallback, we mark this render as suspended with a delay if possible. (This doesn't not happen during initial render of new content.)

If we have both marked this render as having a suspense config and it was suspended with delay, then we extend the suspended time beyond JND all the way to the timeout defined in the suspense config.

The suspense config has these options:

```
{
  timeoutMs: number,
  loadingDelayMs?: number,
  minLoadingDurationMs?: number,
}
```

The last two are used when we have actually completed a render fairly quickly. If we have exceeded `loadingDelayMs` but have not yet exceeded `loadingDelayMs + minLoadingDurationMs` then we suspend the commit until that time even though we could commit early. This can be used to implement busy spinners that delay when they first show but want to stay visible for a minimum time if they do show, to avoid flickering.

Tasks:
- [x] Implementation
- [ ] Tests