### PR TITLE
Event API: normalize event timeStamp property to be in event system

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -64,6 +64,7 @@ type ResponderTimer = {|
   instance: ReactEventComponentInstance,
   func: () => void,
   id: Symbol,
+  timeStamp: number,
 |};
 
 const activeTimeouts: Map<Symbol, ResponderTimeout> = new Map();
@@ -90,6 +91,7 @@ const responderOwners: Map<
 > = new Map();
 let globalOwner = null;
 
+let currentTimeStamp = 0;
 let currentTimers = new Map();
 let currentInstance: null | ReactEventComponentInstance = null;
 let currentEventQueue: null | EventQueue = null;
@@ -101,11 +103,11 @@ const eventResponderContext: ReactResponderContext = {
     {discrete}: ReactResponderDispatchEventOptions,
   ): void {
     validateResponderContext();
-    const {target, type} = possibleEventObject;
+    const {target, type, timeStamp} = possibleEventObject;
 
-    if (target == null || type == null) {
+    if (target == null || type == null || timeStamp == null) {
       throw new Error(
-        'context.dispatchEvent: "target" and "type" fields on event object are required.',
+        'context.dispatchEvent: "target", "timeStamp", and "type" fields on event object are required.',
       );
     }
     if (__DEV__) {
@@ -296,7 +298,7 @@ const eventResponderContext: ReactResponderContext = {
     if (timeout === undefined) {
       const timers = new Map();
       const id = setTimeout(() => {
-        processTimers(timers);
+        processTimers(timers, delay);
       }, delay);
       timeout = {
         id,
@@ -308,6 +310,7 @@ const eventResponderContext: ReactResponderContext = {
       instance: ((currentInstance: any): ReactEventComponentInstance),
       func,
       id: timerId,
+      timeStamp: currentTimeStamp,
     });
     activeTimeouts.set(timerId, timeout);
     return timerId;
@@ -391,6 +394,9 @@ const eventResponderContext: ReactResponderContext = {
     }
     return currentTarget;
   },
+  getTimeStamp(): number {
+    return currentTimeStamp;
+  },
 };
 
 function isTargetWithinEventComponent(target: Element | Document): boolean {
@@ -461,13 +467,17 @@ function isFiberHostComponentFocusable(fiber: Fiber): boolean {
   );
 }
 
-function processTimers(timers: Map<Symbol, ResponderTimer>): void {
+function processTimers(
+  timers: Map<Symbol, ResponderTimer>,
+  delay: number,
+): void {
   const timersArr = Array.from(timers.values());
   currentEventQueue = createEventQueue();
   try {
     for (let i = 0; i < timersArr.length; i++) {
-      const {instance, func, id} = timersArr[i];
+      const {instance, func, id, timeStamp} = timersArr[i];
       currentInstance = instance;
+      currentTimeStamp = timeStamp + delay;
       try {
         func();
       } finally {
@@ -479,6 +489,7 @@ function processTimers(timers: Map<Symbol, ResponderTimer>): void {
     currentTimers = null;
     currentInstance = null;
     currentEventQueue = null;
+    currentTimeStamp = 0;
   }
 }
 
@@ -844,8 +855,11 @@ export function dispatchEventForResponderEventSystem(
     const previousEventQueue = currentEventQueue;
     const previousInstance = currentInstance;
     const previousTimers = currentTimers;
+    const previousTimeStamp = currentTimeStamp;
     currentTimers = null;
     currentEventQueue = createEventQueue();
+    // We might want to control timeStamp another way here
+    currentTimeStamp = (nativeEvent: any).timeStamp;
     try {
       traverseAndHandleEventResponderInstances(
         topLevelType,
@@ -859,6 +873,7 @@ export function dispatchEventForResponderEventSystem(
       currentTimers = previousTimers;
       currentInstance = previousInstance;
       currentEventQueue = previousEventQueue;
+      currentTimeStamp = previousTimeStamp;
     }
   }
 }

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -422,6 +422,7 @@ describe('DOMEventResponderSystem', () => {
             target: event.target,
             type: 'magicclick',
             phase: 'bubble',
+            timeStamp: context.getTimeStamp(),
           };
           context.dispatchEvent(syntheticEvent, props.onMagicClick, {
             discrete: true,
@@ -434,6 +435,7 @@ describe('DOMEventResponderSystem', () => {
             target: event.target,
             type: 'magicclick',
             phase: 'capture',
+            timeStamp: context.getTimeStamp(),
           };
           context.dispatchEvent(syntheticEvent, props.onMagicClick, {
             discrete: true,
@@ -477,6 +479,7 @@ describe('DOMEventResponderSystem', () => {
         target: event.target,
         type: 'press',
         phase,
+        timeStamp: context.getTimeStamp(),
       };
       context.dispatchEvent(pressEvent, props.onPress, {discrete: true});
 
@@ -486,6 +489,7 @@ describe('DOMEventResponderSystem', () => {
             target: event.target,
             type: 'longpress',
             phase,
+            timeStamp: context.getTimeStamp(),
           };
           context.dispatchEvent(longPressEvent, props.onLongPress, {
             discrete: true,
@@ -497,6 +501,7 @@ describe('DOMEventResponderSystem', () => {
             target: event.target,
             type: 'longpresschange',
             phase,
+            timeStamp: context.getTimeStamp(),
           };
           context.dispatchEvent(longPressChangeEvent, props.onLongPressChange, {
             discrete: true,

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -906,6 +906,7 @@ describe('DOMEventResponderSystem', () => {
         const syntheticEvent = {
           target: event.target,
           type: 'click',
+          timeStamp: context.getTimeStamp(),
         };
         context.dispatchEvent(syntheticEvent, props.onClick, {
           discrete: true,

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -50,11 +50,13 @@ type DragEventType = 'dragstart' | 'dragend' | 'dragchange' | 'dragmove';
 type DragEvent = {|
   target: Element | Document,
   type: DragEventType,
+  timeStamp: number,
   diffX?: number,
   diffY?: number,
 |};
 
 function createDragEvent(
+  context: ReactResponderContext,
   type: DragEventType,
   target: Element | Document,
   eventData?: EventData,
@@ -62,6 +64,7 @@ function createDragEvent(
   return {
     target,
     type,
+    timeStamp: context.getTimeStamp(),
     ...eventData,
   };
 }
@@ -75,7 +78,7 @@ function dispatchDragEvent(
   eventData?: EventData,
 ): void {
   const target = ((state.dragTarget: any): Element | Document);
-  const syntheticEvent = createDragEvent(name, target, eventData);
+  const syntheticEvent = createDragEvent(context, name, target, eventData);
   context.dispatchEvent(syntheticEvent, listener, {discrete});
 }
 

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -33,6 +33,7 @@ type FocusEventType = 'focus' | 'blur' | 'focuschange' | 'focusvisiblechange';
 type FocusEvent = {|
   target: Element | Document,
   type: FocusEventType,
+  timeStamp: number,
 |};
 
 const targetEventTypes = [
@@ -56,12 +57,14 @@ const rootEventTypes = [
 ];
 
 function createFocusEvent(
+  context: ReactResponderContext,
   type: FocusEventType,
   target: Element | Document,
 ): FocusEvent {
   return {
     target,
     type,
+    timeStamp: context.getTimeStamp(),
   };
 }
 
@@ -72,21 +75,25 @@ function dispatchFocusInEvents(
 ) {
   const target = ((state.focusTarget: any): Element | Document);
   if (props.onFocus) {
-    const syntheticEvent = createFocusEvent('focus', target);
+    const syntheticEvent = createFocusEvent(context, 'focus', target);
     context.dispatchEvent(syntheticEvent, props.onFocus, {discrete: true});
   }
   if (props.onFocusChange) {
     const listener = () => {
       props.onFocusChange(true);
     };
-    const syntheticEvent = createFocusEvent('focuschange', target);
+    const syntheticEvent = createFocusEvent(context, 'focuschange', target);
     context.dispatchEvent(syntheticEvent, listener, {discrete: true});
   }
   if (props.onFocusVisibleChange && state.isLocalFocusVisible) {
     const listener = () => {
       props.onFocusVisibleChange(true);
     };
-    const syntheticEvent = createFocusEvent('focusvisiblechange', target);
+    const syntheticEvent = createFocusEvent(
+      context,
+      'focusvisiblechange',
+      target,
+    );
     context.dispatchEvent(syntheticEvent, listener, {discrete: true});
   }
 }
@@ -98,14 +105,14 @@ function dispatchFocusOutEvents(
 ) {
   const target = ((state.focusTarget: any): Element | Document);
   if (props.onBlur) {
-    const syntheticEvent = createFocusEvent('blur', target);
+    const syntheticEvent = createFocusEvent(context, 'blur', target);
     context.dispatchEvent(syntheticEvent, props.onBlur, {discrete: true});
   }
   if (props.onFocusChange) {
     const listener = () => {
       props.onFocusChange(false);
     };
-    const syntheticEvent = createFocusEvent('focuschange', target);
+    const syntheticEvent = createFocusEvent(context, 'focuschange', target);
     context.dispatchEvent(syntheticEvent, listener, {discrete: true});
   }
   dispatchFocusVisibleOutEvent(context, props, state);
@@ -121,7 +128,11 @@ function dispatchFocusVisibleOutEvent(
     const listener = () => {
       props.onFocusVisibleChange(false);
     };
-    const syntheticEvent = createFocusEvent('focusvisiblechange', target);
+    const syntheticEvent = createFocusEvent(
+      context,
+      'focusvisiblechange',
+      target,
+    );
     context.dispatchEvent(syntheticEvent, listener, {discrete: true});
     state.isLocalFocusVisible = false;
   }

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -42,6 +42,7 @@ type HoverEventType = 'hoverstart' | 'hoverend' | 'hoverchange' | 'hovermove';
 type HoverEvent = {|
   target: Element | Document,
   type: HoverEventType,
+  timeStamp: number,
 |};
 
 const DEFAULT_HOVER_END_DELAY_MS = 0;
@@ -60,12 +61,14 @@ if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
 }
 
 function createHoverEvent(
+  context: ReactResponderContext,
   type: HoverEventType,
   target: Element | Document,
 ): HoverEvent {
   return {
     target,
     type,
+    timeStamp: context.getTimeStamp(),
   };
 }
 
@@ -79,6 +82,7 @@ function dispatchHoverChangeEvent(
     props.onHoverChange(bool);
   };
   const syntheticEvent = createHoverEvent(
+    context,
     'hoverchange',
     ((state.hoverTarget: any): Element | Document),
   );
@@ -115,6 +119,7 @@ function dispatchHoverStartEvents(
 
     if (props.onHoverStart) {
       const syntheticEvent = createHoverEvent(
+        context,
         'hoverstart',
         ((target: any): Element | Document),
       );
@@ -174,6 +179,7 @@ function dispatchHoverEndEvents(
 
     if (props.onHoverEnd) {
       const syntheticEvent = createHoverEvent(
+        context,
         'hoverend',
         ((target: any): Element | Document),
       );
@@ -311,6 +317,7 @@ const HoverResponder = {
               } else {
                 if (props.onHoverMove && state.hoverTarget !== null) {
                   const syntheticEvent = createHoverEvent(
+                    context,
                     'hovermove',
                     state.hoverTarget,
                   );

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -40,11 +40,13 @@ type SwipeEventType = 'swipeleft' | 'swiperight' | 'swipeend' | 'swipemove';
 type SwipeEvent = {|
   target: Element | Document,
   type: SwipeEventType,
+  timeStamp: number,
   diffX?: number,
   diffY?: number,
 |};
 
 function createSwipeEvent(
+  context: ReactResponderContext,
   type: SwipeEventType,
   target: Element | Document,
   eventData?: EventData,
@@ -52,6 +54,7 @@ function createSwipeEvent(
   return {
     target,
     type,
+    timeStamp: context.getTimeStamp(),
     ...eventData,
   };
 }
@@ -65,7 +68,7 @@ function dispatchSwipeEvent(
   eventData?: EventData,
 ) {
   const target = ((state.swipeTarget: any): Element | Document);
-  const syntheticEvent = createSwipeEvent(name, target, eventData);
+  const syntheticEvent = createSwipeEvent(context, name, target, eventData);
   context.dispatchEvent(syntheticEvent, listener, {discrete});
 }
 

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -193,4 +193,5 @@ export type ReactResponderContext = {
     event: ReactResponderEvent,
   ): '' | 'mouse' | 'keyboard' | 'pen' | 'touch',
   getEventCurrentTarget(event: ReactResponderEvent): Element,
+  getTimeStamp: () => number,
 };


### PR DESCRIPTION
This is a follow up to the handling of event `timeStamp` properties in the experimental event system. After discussion with @necolas, it felt a bit messy to be passing around `delay` values and calculating `timeStamp`s in the responder modules themselves. This PR moves that logic so it can easily be handled by using `context.getTimeStamp()` – the event responder system deals with time stamps instead. For now it works like it did before, using the `nativeEvent`'s `timeStamp` value, but we can easily change this heuristic as it's now an implementation detail in `context`.

I also took the opportunity to add `timeStamp` to the other event responders and made it a mandatory field (as it should be).