### PR TITLE
Event API: ensure we pop context for event system fibers

### DIFF
--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -499,6 +499,12 @@ function unwindInterruptedWork(interruptedWork: Fiber) {
     case ContextProvider:
       popProvider(interruptedWork);
       break;
+    case EventComponent:
+    case EventTarget:
+      if (enableEventAPI) {
+        popHostContext(interruptedWork);
+      }
+      break;
     default:
       break;
   }


### PR DESCRIPTION
This PR fixes an issue I stumbled across when running this internally. I'm not sure how to repro this in a test, as I don't know what conditions are needed exactly with the test renderer to invoke the `unwindInterruptedWork` function. Will follow up with someone to figure one out.