### PR TITLE
Remove scheduler from React package dependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,8 +28,7 @@
   "dependencies": {
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.2",
-    "scheduler": "^0.14.0"
+    "prop-types": "^15.6.2"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Scheduler is used by the renderers, but not the isomorphic package.

I checked the history to figure out why it was originally added as a dep. It looks like it was because the UMD build of `react` includes Scheduler inline instead of treating it as an external: https://github.com/facebook/react/pull/13509

We may need to reconsider our UMD strategy later once the public Scheduler API is stable. (Personally I would prefer to drop UMD support entirely.)

Regardless we can remove it from `package.json`. I confirmed that the UMD bundle still includes Scheduler.