### PR TITLE
Event API: Focus onFocusVisble

### DIFF
--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -29,7 +29,12 @@ type FocusState = {
   isLocalFocusVisible: boolean,
 };
 
-type FocusEventType = 'focus' | 'blur' | 'focuschange' | 'focusvisiblechange';
+type FocusEventType =
+  | 'focus'
+  | 'blur'
+  | 'focuschange'
+  | 'focusvisiblechange'
+  | 'focusvisible';
 
 type FocusEvent = {|
   target: Element | Document,

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -18,6 +18,7 @@ type FocusProps = {
   disabled: boolean,
   onBlur: (e: FocusEvent) => void,
   onFocus: (e: FocusEvent) => void,
+  onFocusVisible: (e: FocusEvent) => void,
   onFocusChange: boolean => void,
   onFocusVisibleChange: boolean => void,
 };
@@ -85,16 +86,24 @@ function dispatchFocusInEvents(
     const syntheticEvent = createFocusEvent(context, 'focuschange', target);
     context.dispatchEvent(syntheticEvent, listener, {discrete: true});
   }
-  if (props.onFocusVisibleChange && state.isLocalFocusVisible) {
-    const listener = () => {
-      props.onFocusVisibleChange(true);
-    };
-    const syntheticEvent = createFocusEvent(
-      context,
-      'focusvisiblechange',
-      target,
-    );
-    context.dispatchEvent(syntheticEvent, listener, {discrete: true});
+  if (state.isLocalFocusVisible) {
+    if (props.onFocusVisible) {
+      const syntheticEvent = createFocusEvent(context, 'focusvisible', target);
+      context.dispatchEvent(syntheticEvent, props.onFocusVisible, {
+        discrete: true,
+      });
+    }
+    if (props.onFocusVisibleChange) {
+      const listener = () => {
+        props.onFocusVisibleChange(true);
+      };
+      const syntheticEvent = createFocusEvent(
+        context,
+        'focusvisiblechange',
+        target,
+      );
+      context.dispatchEvent(syntheticEvent, listener, {discrete: true});
+    }
   }
 }
 

--- a/packages/react-events/src/__tests__/Focus-test.internal.js
+++ b/packages/react-events/src/__tests__/Focus-test.internal.js
@@ -206,6 +206,59 @@ describe('Focus event responder', () => {
     });
   });
 
+  describe('onFocusVisible', () => {
+    let onFocusVisible, ref;
+
+    beforeEach(() => {
+      onFocusVisible = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Focus onFocusVisible={onFocusVisible}>
+          <div ref={ref} />
+        </Focus>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('is called after "focus" and "blur" if keyboard navigation is active', () => {
+      // use keyboard first
+      container.dispatchEvent(createKeyboardEvent('keydown', {key: 'Tab'}));
+      ref.current.dispatchEvent(createFocusEvent('focus'));
+      expect(onFocusVisible).toHaveBeenCalledTimes(1);
+      expect(onFocusVisible).toHaveBeenCalledWith(
+        expect.objectContaining({target: ref.current, type: 'focusvisible'}),
+      );
+      ref.current.dispatchEvent(createFocusEvent('blur'));
+      // onFocusVisible should not be called again
+      expect(onFocusVisible).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called if non-keyboard event is dispatched on target previously focused with keyboard', () => {
+      // use keyboard first
+      container.dispatchEvent(createKeyboardEvent('keydown', {key: 'Tab'}));
+      ref.current.dispatchEvent(createFocusEvent('focus'));
+      expect(onFocusVisible).toHaveBeenCalledTimes(1);
+      expect(onFocusVisible).toHaveBeenCalledWith(
+        expect.objectContaining({target: ref.current, type: 'focusvisible'}),
+      );
+      // then use pointer on the target, focus should no longer be visible
+      // onFocusVisible should not be called again
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      expect(onFocusVisible).toHaveBeenCalledTimes(1);
+      // onFocusVisible should not be called again
+      ref.current.dispatchEvent(createFocusEvent('blur'));
+      expect(onFocusVisible).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not called after "focus" and "blur" events without keyboard', () => {
+      ref.current.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createFocusEvent('focus'));
+      container.dispatchEvent(createPointerEvent('pointerdown'));
+      ref.current.dispatchEvent(createFocusEvent('blur'));
+      expect(onFocusVisible).toHaveBeenCalledTimes(0);
+    });
+  });
+
   describe('nested Focus components', () => {
     it('do not propagate events by default', () => {
       const events = [];


### PR DESCRIPTION
This PR adds `onFocusVisble` to the Focus module. We already have `onFocusVisbleChange`, so there wasn't much needed to add this. Added relevant tests to confirm it works as intended too. We may not need this – we could add `pointerType` to `focus` and `blur` event objects instead.