### PR TITLE
refactor(getComponentName): Use element types instead of fiber types

### DIFF
--- a/packages/react-dom/src/client/ReactDOMLegacy.js
+++ b/packages/react-dom/src/client/ReactDOMLegacy.js
@@ -235,7 +235,7 @@ export function findDOMNode(
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
             'componentDidUpdate instead.',
-          getComponentName(owner.type) || 'A component',
+          getComponentName(owner.elementType) || 'A component',
         );
       }
       owner.stateNode._warnedAboutRefsInRender = true;

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1341,7 +1341,7 @@ class ReactDOMServerRenderer {
             "it's defined in, or you might have mixed up default and " +
             'named imports.';
         }
-        const ownerName = owner ? getComponentName(owner) : null;
+        const ownerName = owner ? getComponentName(owner.elementType) : null;
         if (ownerName) {
           info += '\n\nCheck the render method of `' + ownerName + '`.';
         }

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -57,7 +57,7 @@ function findHostInstance_DEPRECATED(
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
             'componentDidUpdate instead.',
-          getComponentName(owner.type) || 'A component',
+          getComponentName(owner.elementType) || 'A component',
         );
       }
 
@@ -104,7 +104,7 @@ function findNodeHandle(componentOrHandle: any): ?number {
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
             'componentDidUpdate instead.',
-          getComponentName(owner.type) || 'A component',
+          getComponentName(owner.elementType) || 'A component',
         );
       }
 

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -81,7 +81,7 @@ if (__DEV__) {
 
   const createHierarchy = function(fiberHierarchy) {
     return fiberHierarchy.map(fiber => ({
-      name: getComponentName(fiber.type),
+      name: getComponentName(fiber.elementType),
       getInspectorData: findNodeHandle => {
         return {
           props: getHostProps(fiber),

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -59,7 +59,7 @@ function findHostInstance_DEPRECATED(
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
             'componentDidUpdate instead.',
-          getComponentName(owner.type) || 'A component',
+          getComponentName(owner.elementType) || 'A component',
         );
       }
 
@@ -106,7 +106,7 @@ function findNodeHandle(componentOrHandle: any): ?number {
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
             'componentDidUpdate instead.',
-          getComponentName(owner.type) || 'A component',
+          getComponentName(owner.elementType) || 'A component',
         );
       }
 

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -127,7 +127,8 @@ function coerceRef(
           element._owner.stateNode !== element._self
         )
       ) {
-        const componentName = getComponentName(returnFiber.type) || 'Component';
+        const componentName =
+          getComponentName(returnFiber.elementType) || 'Component';
         if (!didWarnAboutStringRefs[componentName]) {
           if (warnAboutStringRefs) {
             console.error(

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -85,7 +85,8 @@ if (__DEV__) {
     );
     child._store.validated = true;
 
-    const componentName = getComponentName(returnFiber.type) || 'Component';
+    const componentName =
+      getComponentName(returnFiber.elementType) || 'Component';
 
     if (ownerHasKeyUseWarning[componentName]) {
       return;
@@ -127,7 +128,8 @@ function coerceRef(
           element._owner.stateNode !== element._self
         )
       ) {
-        const componentName = getComponentName(returnFiber.type) || 'Component';
+        const componentName =
+          getComponentName(returnFiber.elementType) || 'Component';
         if (!didWarnAboutStringRefs[componentName]) {
           if (warnAboutStringRefs) {
             console.error(
@@ -234,7 +236,8 @@ function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
 
 function warnOnFunctionType(returnFiber: Fiber) {
   if (__DEV__) {
-    const componentName = getComponentName(returnFiber.type) || 'Component';
+    const componentName =
+      getComponentName(returnFiber.elementType) || 'Component';
 
     if (ownerHasFunctionTypeWarning[componentName]) {
       return;

--- a/packages/react-reconciler/src/ReactCurrentFiber.js
+++ b/packages/react-reconciler/src/ReactCurrentFiber.js
@@ -25,7 +25,7 @@ export function getCurrentFiberOwnerNameInDevOrNull(): string | null {
     }
     const owner = current._debugOwner;
     if (owner !== null && typeof owner !== 'undefined') {
-      return getComponentName(owner.type);
+      return getComponentName(owner.elementType);
     }
   }
   return null;

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -559,7 +559,7 @@ export function createFiberFromTypeAndProps(
               "it's defined in, or you might have mixed up default and " +
               'named imports.';
           }
-          const ownerName = owner ? getComponentName(owner.type) : null;
+          const ownerName = owner ? getComponentName(owner.elementType) : null;
           if (ownerName) {
             info += '\n\nCheck the render method of `' + ownerName + '`.';
           }

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -559,7 +559,7 @@ export function createFiberFromTypeAndProps(
               "it's defined in, or you might have mixed up default and " +
               'named imports.';
           }
-          const ownerName = owner ? getComponentName(owner.type) : null;
+          const ownerName = owner ? getComponentName(owner.elementType) : null;
           if (ownerName) {
             info += '\n\nCheck the render method of `' + ownerName + '`.';
           }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -937,7 +937,7 @@ function updateClassComponent(
         console.error(
           'It looks like %s is reassigning its own `this.props` while rendering. ' +
             'This is not supported and can lead to confusing bugs.',
-          getComponentName(workInProgress.type) || 'a component',
+          getComponentName(workInProgress.elementType) || 'a component',
         );
       }
       didWarnAboutReassigningProps = true;
@@ -3391,7 +3391,7 @@ function beginWork(
               outerPropTypes,
               resolvedProps, // Resolved for outer only
               'prop',
-              getComponentName(type),
+              getComponentName(workInProgress.elementType),
             );
           }
         }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -937,7 +937,7 @@ function updateClassComponent(
         console.error(
           'It looks like %s is reassigning its own `this.props` while rendering. ' +
             'This is not supported and can lead to confusing bugs.',
-          getComponentName(workInProgress.type) || 'a component',
+          getComponentName(workInProgress.elementType) || 'a component',
         );
       }
       didWarnAboutReassigningProps = true;
@@ -3391,7 +3391,7 @@ function beginWork(
               outerPropTypes,
               resolvedProps, // Resolved for outer only
               'prop',
-              getComponentName(type),
+              getComponentName(workInProgress.elementType),
             );
           }
         }

--- a/packages/react-reconciler/src/ReactFiberClassComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.new.js
@@ -722,7 +722,7 @@ function callComponentWillMount(workInProgress, instance) {
         '%s.componentWillMount(): Assigning directly to this.state is ' +
           "deprecated (except inside a component's " +
           'constructor). Use setState instead.',
-        getComponentName(workInProgress.type) || 'Component',
+        getComponentName(workInProgress.elementType) || 'Component',
       );
     }
     classComponentUpdater.enqueueReplaceState(instance, instance.state, null);
@@ -746,7 +746,7 @@ function callComponentWillReceiveProps(
   if (instance.state !== oldState) {
     if (__DEV__) {
       const componentName =
-        getComponentName(workInProgress.type) || 'Component';
+        getComponentName(workInProgress.elementType) || 'Component';
       if (!didWarnAboutStateAssignmentForComponent.has(componentName)) {
         didWarnAboutStateAssignmentForComponent.add(componentName);
         console.error(

--- a/packages/react-reconciler/src/ReactFiberClassComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.old.js
@@ -768,7 +768,7 @@ function callComponentWillMount(workInProgress, instance) {
         '%s.componentWillMount(): Assigning directly to this.state is ' +
           "deprecated (except inside a component's " +
           'constructor). Use setState instead.',
-        getComponentName(workInProgress.type) || 'Component',
+        getComponentName(workInProgress.elementType) || 'Component',
       );
     }
     classComponentUpdater.enqueueReplaceState(instance, instance.state, null);
@@ -792,7 +792,7 @@ function callComponentWillReceiveProps(
   if (instance.state !== oldState) {
     if (__DEV__) {
       const componentName =
-        getComponentName(workInProgress.type) || 'Component';
+        getComponentName(workInProgress.elementType) || 'Component';
       if (!didWarnAboutStateAssignmentForComponent.has(componentName)) {
         didWarnAboutStateAssignmentForComponent.add(componentName);
         console.error(

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -251,7 +251,7 @@ function commitBeforeMutationLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.props`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
               if (instance.state !== finishedWork.memoizedState) {
@@ -261,7 +261,7 @@ function commitBeforeMutationLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.state`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
             }
@@ -279,7 +279,7 @@ function commitBeforeMutationLifeCycles(
               console.error(
                 '%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' +
                   'must be returned. You have returned undefined.',
-                getComponentName(finishedWork.type),
+                getComponentName(finishedWork.elementType),
               );
             }
           }
@@ -508,7 +508,7 @@ function commitLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.props`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
               if (instance.state !== finishedWork.memoizedState) {
@@ -518,7 +518,7 @@ function commitLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.state`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
             }
@@ -558,7 +558,7 @@ function commitLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.props`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
               if (instance.state !== finishedWork.memoizedState) {
@@ -568,7 +568,7 @@ function commitLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.state`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
             }
@@ -616,7 +616,7 @@ function commitLifeCycles(
                   'This might either be because of a bug in React, or because ' +
                   'a component reassigns its own `this.props`. ' +
                   'Please file an issue.',
-                getComponentName(finishedWork.type) || 'instance',
+                getComponentName(finishedWork.elementType) || 'instance',
               );
             }
             if (instance.state !== finishedWork.memoizedState) {
@@ -626,7 +626,7 @@ function commitLifeCycles(
                   'This might either be because of a bug in React, or because ' +
                   'a component reassigns its own `this.state`. ' +
                   'Please file an issue.',
-                getComponentName(finishedWork.type) || 'instance',
+                getComponentName(finishedWork.elementType) || 'instance',
               );
             }
           }
@@ -844,7 +844,7 @@ function commitAttachRef(finishedWork: Fiber) {
           console.error(
             'Unexpected ref object provided for %s. ' +
               'Use either a ref-setter function or React.createRef().',
-            getComponentName(finishedWork.type),
+            getComponentName(finishedWork.elementType),
           );
         }
       }
@@ -1542,7 +1542,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
         // as the newProps. The updatePayload will contain the real change in
         // this case.
         const oldProps = current !== null ? current.memoizedProps : newProps;
-        const type = finishedWork.type;
+        const type = finishedWork.elementType;
         // TODO: Type the updateQueue to be specific to host components.
         const updatePayload: null | UpdatePayload = (finishedWork.updateQueue: any);
         finishedWork.updateQueue = null;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -251,7 +251,7 @@ function commitBeforeMutationLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.props`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
               if (instance.state !== finishedWork.memoizedState) {
@@ -261,7 +261,7 @@ function commitBeforeMutationLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.state`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
             }
@@ -279,7 +279,7 @@ function commitBeforeMutationLifeCycles(
               console.error(
                 '%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' +
                   'must be returned. You have returned undefined.',
-                getComponentName(finishedWork.type),
+                getComponentName(finishedWork.elementType),
               );
             }
           }
@@ -508,7 +508,7 @@ function commitLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.props`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
               if (instance.state !== finishedWork.memoizedState) {
@@ -518,7 +518,7 @@ function commitLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.state`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
             }
@@ -558,7 +558,7 @@ function commitLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.props`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
               if (instance.state !== finishedWork.memoizedState) {
@@ -568,7 +568,7 @@ function commitLifeCycles(
                     'This might either be because of a bug in React, or because ' +
                     'a component reassigns its own `this.state`. ' +
                     'Please file an issue.',
-                  getComponentName(finishedWork.type) || 'instance',
+                  getComponentName(finishedWork.elementType) || 'instance',
                 );
               }
             }
@@ -616,7 +616,7 @@ function commitLifeCycles(
                   'This might either be because of a bug in React, or because ' +
                   'a component reassigns its own `this.props`. ' +
                   'Please file an issue.',
-                getComponentName(finishedWork.type) || 'instance',
+                getComponentName(finishedWork.elementType) || 'instance',
               );
             }
             if (instance.state !== finishedWork.memoizedState) {
@@ -626,7 +626,7 @@ function commitLifeCycles(
                   'This might either be because of a bug in React, or because ' +
                   'a component reassigns its own `this.state`. ' +
                   'Please file an issue.',
-                getComponentName(finishedWork.type) || 'instance',
+                getComponentName(finishedWork.elementType) || 'instance',
               );
             }
           }
@@ -844,7 +844,7 @@ function commitAttachRef(finishedWork: Fiber) {
           console.error(
             'Unexpected ref object provided for %s. ' +
               'Use either a ref-setter function or React.createRef().',
-            getComponentName(finishedWork.type),
+            getComponentName(finishedWork.elementType),
           );
         }
       }

--- a/packages/react-reconciler/src/ReactFiberContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberContext.new.js
@@ -104,7 +104,7 @@ function getMaskedContext(
     }
 
     if (__DEV__) {
-      const name = getComponentName(type) || 'Unknown';
+      const name = getComponentName(workInProgress.elementType) || 'Unknown';
       checkPropTypes(contextTypes, context, 'context', name);
     }
 

--- a/packages/react-reconciler/src/ReactFiberContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberContext.old.js
@@ -104,7 +104,7 @@ function getMaskedContext(
     }
 
     if (__DEV__) {
-      const name = getComponentName(type) || 'Unknown';
+      const name = getComponentName(workInProgress.elementType) || 'Unknown';
       checkPropTypes(contextTypes, context, 'context', name);
     }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -243,7 +243,7 @@ function checkDepsAreArrayDev(deps: mixed) {
 
 function warnOnHookMismatchInDev(currentHookName: HookType) {
   if (__DEV__) {
-    const componentName = getComponentName(currentlyRenderingFiber.type);
+    const componentName = getComponentName(currentlyRenderingFiber.elementType);
     if (!didWarnAboutMismatchedHooksForComponent.has(componentName)) {
       didWarnAboutMismatchedHooksForComponent.add(componentName);
 
@@ -1576,7 +1576,7 @@ export function getIsUpdatingOpaqueValueInRenderPhaseInDEV(): boolean | void {
 function warnOnOpaqueIdentifierAccessInDEV(fiber) {
   if (__DEV__) {
     // TODO: Should warn in effects and callbacks, too
-    const name = getComponentName(fiber.type) || 'Unknown';
+    const name = getComponentName(fiber.elementType) || 'Unknown';
     if (getIsRendering() && !didWarnAboutUseOpaqueIdentifier[name]) {
       console.error(
         'The object passed back from useOpaqueIdentifier is meant to be ' +

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -249,7 +249,7 @@ function checkDepsAreArrayDev(deps: mixed) {
 
 function warnOnHookMismatchInDev(currentHookName: HookType) {
   if (__DEV__) {
-    const componentName = getComponentName(currentlyRenderingFiber.type);
+    const componentName = getComponentName(currentlyRenderingFiber.elementType);
     if (!didWarnAboutMismatchedHooksForComponent.has(componentName)) {
       didWarnAboutMismatchedHooksForComponent.add(componentName);
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -197,7 +197,7 @@ function findHostInstanceWithWarning(
       return null;
     }
     if (hostFiber.mode & StrictMode) {
-      const componentName = getComponentName(fiber.type) || 'Component';
+      const componentName = getComponentName(fiber.elementType) || 'Component';
       if (!didWarnAboutFindNodeInStrictMode[componentName]) {
         didWarnAboutFindNodeInStrictMode[componentName] = true;
 
@@ -292,7 +292,7 @@ export function updateContainer(
           'triggering nested component updates from render is not allowed. ' +
           'If necessary, trigger nested updates in componentDidUpdate.\n\n' +
           'Check the render method of %s.',
-        getComponentName(ReactCurrentFiberCurrent.type) || 'Unknown',
+        getComponentName(ReactCurrentFiberCurrent.elementType) || 'Unknown',
       );
     }
   }

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -199,7 +199,7 @@ function findHostInstanceWithWarning(
       return null;
     }
     if (hostFiber.mode & StrictMode) {
-      const componentName = getComponentName(fiber.type) || 'Component';
+      const componentName = getComponentName(fiber.elementType) || 'Component';
       if (!didWarnAboutFindNodeInStrictMode[componentName]) {
         didWarnAboutFindNodeInStrictMode[componentName] = true;
 
@@ -298,7 +298,7 @@ export function updateContainer(
           'triggering nested component updates from render is not allowed. ' +
           'If necessary, trigger nested updates in componentDidUpdate.\n\n' +
           'Check the render method of %s.',
-        getComponentName(ReactCurrentFiberCurrent.type) || 'Unknown',
+        getComponentName(ReactCurrentFiberCurrent.elementType) || 'Unknown',
       );
     }
   }

--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -131,7 +131,7 @@ function createClassErrorUpdate(
             console.error(
               '%s: Error boundaries should implement getDerivedStateFromError(). ' +
                 'In that method, return a state update to display an error message or fallback UI.',
-              getComponentName(fiber.type) || 'Unknown',
+              getComponentName(fiber.elementType) || 'Unknown',
             );
           }
         }
@@ -327,7 +327,7 @@ function throwException(
     // No boundary was found. Fallthrough to error mode.
     // TODO: Use invariant so the message is stripped in prod?
     value = new Error(
-      (getComponentName(sourceFiber.type) || 'A React component') +
+      (getComponentName(sourceFiber.elementType) || 'A React component') +
         ' suspended while rendering, but no fallback UI was specified.\n' +
         '\n' +
         'Add a <Suspense fallback=...> component higher in the tree to ' +

--- a/packages/react-reconciler/src/ReactFiberThrow.old.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.old.js
@@ -137,7 +137,7 @@ function createClassErrorUpdate(
             console.error(
               '%s: Error boundaries should implement getDerivedStateFromError(). ' +
                 'In that method, return a state update to display an error message or fallback UI.',
-              getComponentName(fiber.type) || 'Unknown',
+              getComponentName(fiber.elementType) || 'Unknown',
             );
           }
         }
@@ -346,7 +346,7 @@ function throwException(
     // No boundary was found. Fallthrough to error mode.
     // TODO: Use invariant so the message is stripped in prod?
     value = new Error(
-      (getComponentName(sourceFiber.type) || 'A React component') +
+      (getComponentName(sourceFiber.elementType) || 'A React component') +
         ' suspended while rendering, but no fallback UI was specified.\n' +
         '\n' +
         'Add a <Suspense fallback=...> component higher in the tree to ' +

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -103,7 +103,7 @@ export function isMounted(component: React$Component<any, any>): boolean {
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
             'componentDidUpdate instead.',
-          getComponentName(ownerFiber.type) || 'A component',
+          getComponentName(ownerFiber.elementType) || 'A component',
         );
       }
       instance._warnedAboutRefsInRender = true;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2888,7 +2888,8 @@ function warnAboutUpdateOnNotYetMountedFiberInDEV(fiber) {
 
     // We show the whole stack but dedupe on the top component's name because
     // the problematic code almost always lies inside that component.
-    const componentName = getComponentName(fiber.type) || 'ReactComponent';
+    const componentName =
+      getComponentName(fiber.elementType) || 'ReactComponent';
     if (didWarnStateUpdateForNotYetMountedComponent !== null) {
       if (didWarnStateUpdateForNotYetMountedComponent.has(componentName)) {
         return;
@@ -2942,7 +2943,8 @@ function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
 
     // We show the whole stack but dedupe on the top component's name because
     // the problematic code almost always lies inside that component.
-    const componentName = getComponentName(fiber.type) || 'ReactComponent';
+    const componentName =
+      getComponentName(fiber.elementType) || 'ReactComponent';
     if (didWarnStateUpdateForUnmountedComponent !== null) {
       if (didWarnStateUpdateForUnmountedComponent.has(componentName)) {
         return;
@@ -3076,14 +3078,14 @@ function warnAboutRenderPhaseUpdatesInDEV(fiber) {
         case ForwardRef:
         case SimpleMemoComponent: {
           const renderingComponentName =
-            (workInProgress && getComponentName(workInProgress.type)) ||
+            (workInProgress && getComponentName(workInProgress.elementType)) ||
             'Unknown';
           // Dedupe by the rendering component because it's the one that needs to be fixed.
           const dedupeKey = renderingComponentName;
           if (!didWarnAboutUpdateInRenderForAnotherComponent.has(dedupeKey)) {
             didWarnAboutUpdateInRenderForAnotherComponent.add(dedupeKey);
             const setStateComponentName =
-              getComponentName(fiber.type) || 'Unknown';
+              getComponentName(fiber.elementType) || 'Unknown';
             console.error(
               'Cannot update a component (`%s`) while rendering a ' +
                 'different component (`%s`). To locate the bad setState() call inside `%s`, ' +
@@ -3171,7 +3173,7 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
           "This ensures that you're testing the behavior the user would see " +
           'in the browser.' +
           ' Learn more at https://fb.me/react-wrap-tests-with-act',
-        getComponentName(fiber.type),
+        getComponentName(fiber.elementType),
       );
     }
   }
@@ -3199,7 +3201,7 @@ function warnIfNotCurrentlyActingUpdatesInDEV(fiber: Fiber): void {
             "This ensures that you're testing the behavior the user would see " +
             'in the browser.' +
             ' Learn more at https://fb.me/react-wrap-tests-with-act',
-          getComponentName(fiber.type),
+          getComponentName(fiber.elementType),
         );
       } finally {
         if (previousFiber) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -3089,7 +3089,8 @@ function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
 
     // We show the whole stack but dedupe on the top component's name because
     // the problematic code almost always lies inside that component.
-    const componentName = getComponentName(fiber.type) || 'ReactComponent';
+    const componentName =
+      getComponentName(fiber.elementType) || 'ReactComponent';
     if (didWarnStateUpdateForUnmountedComponent !== null) {
       if (didWarnStateUpdateForUnmountedComponent.has(componentName)) {
         return;
@@ -3318,7 +3319,7 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
           "This ensures that you're testing the behavior the user would see " +
           'in the browser.' +
           ' Learn more at https://fb.me/react-wrap-tests-with-act',
-        getComponentName(fiber.type),
+        getComponentName(fiber.elementType),
       );
     }
   }
@@ -3346,7 +3347,7 @@ function warnIfNotCurrentlyActingUpdatesInDEV(fiber: Fiber): void {
             "This ensures that you're testing the behavior the user would see " +
             'in the browser.' +
             ' Learn more at https://fb.me/react-wrap-tests-with-act',
-          getComponentName(fiber.type),
+          getComponentName(fiber.elementType),
         );
       } finally {
         if (previousFiber) {

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
@@ -119,7 +119,7 @@ if (__DEV__) {
     if (pendingComponentWillMountWarnings.length > 0) {
       pendingComponentWillMountWarnings.forEach(fiber => {
         componentWillMountUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -130,7 +130,7 @@ if (__DEV__) {
     if (pendingUNSAFE_ComponentWillMountWarnings.length > 0) {
       pendingUNSAFE_ComponentWillMountWarnings.forEach(fiber => {
         UNSAFE_componentWillMountUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -141,7 +141,7 @@ if (__DEV__) {
     if (pendingComponentWillReceivePropsWarnings.length > 0) {
       pendingComponentWillReceivePropsWarnings.forEach(fiber => {
         componentWillReceivePropsUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -153,7 +153,7 @@ if (__DEV__) {
     if (pendingUNSAFE_ComponentWillReceivePropsWarnings.length > 0) {
       pendingUNSAFE_ComponentWillReceivePropsWarnings.forEach(fiber => {
         UNSAFE_componentWillReceivePropsUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -165,7 +165,7 @@ if (__DEV__) {
     if (pendingComponentWillUpdateWarnings.length > 0) {
       pendingComponentWillUpdateWarnings.forEach(fiber => {
         componentWillUpdateUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -177,7 +177,7 @@ if (__DEV__) {
     if (pendingUNSAFE_ComponentWillUpdateWarnings.length > 0) {
       pendingUNSAFE_ComponentWillUpdateWarnings.forEach(fiber => {
         UNSAFE_componentWillUpdateUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -333,7 +333,7 @@ if (__DEV__) {
 
         const uniqueNames = new Set();
         fiberArray.forEach(fiber => {
-          uniqueNames.add(getComponentName(fiber.type) || 'Component');
+          uniqueNames.add(getComponentName(fiber.elementType) || 'Component');
           didWarnAboutLegacyContext.add(fiber.type);
         });
 

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
@@ -119,7 +119,7 @@ if (__DEV__) {
     if (pendingComponentWillMountWarnings.length > 0) {
       pendingComponentWillMountWarnings.forEach(fiber => {
         componentWillMountUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -130,7 +130,7 @@ if (__DEV__) {
     if (pendingUNSAFE_ComponentWillMountWarnings.length > 0) {
       pendingUNSAFE_ComponentWillMountWarnings.forEach(fiber => {
         UNSAFE_componentWillMountUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -141,7 +141,7 @@ if (__DEV__) {
     if (pendingComponentWillReceivePropsWarnings.length > 0) {
       pendingComponentWillReceivePropsWarnings.forEach(fiber => {
         componentWillReceivePropsUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -153,7 +153,7 @@ if (__DEV__) {
     if (pendingUNSAFE_ComponentWillReceivePropsWarnings.length > 0) {
       pendingUNSAFE_ComponentWillReceivePropsWarnings.forEach(fiber => {
         UNSAFE_componentWillReceivePropsUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -165,7 +165,7 @@ if (__DEV__) {
     if (pendingComponentWillUpdateWarnings.length > 0) {
       pendingComponentWillUpdateWarnings.forEach(fiber => {
         componentWillUpdateUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -177,7 +177,7 @@ if (__DEV__) {
     if (pendingUNSAFE_ComponentWillUpdateWarnings.length > 0) {
       pendingUNSAFE_ComponentWillUpdateWarnings.forEach(fiber => {
         UNSAFE_componentWillUpdateUniqueNames.add(
-          getComponentName(fiber.type) || 'Component',
+          getComponentName(fiber.elementType) || 'Component',
         );
         didWarnAboutUnsafeLifecycles.add(fiber.type);
       });
@@ -333,7 +333,7 @@ if (__DEV__) {
 
         const uniqueNames = new Set();
         fiberArray.forEach(fiber => {
-          uniqueNames.add(getComponentName(fiber.type) || 'Component');
+          uniqueNames.add(getComponentName(fiber.elementType) || 'Component');
           didWarnAboutLegacyContext.add(fiber.type);
         });
 

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -60,7 +60,7 @@ const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 function getDeclarationErrorAddendum() {
   if (ReactCurrentOwner.current) {
-    const name = getComponentName(ReactCurrentOwner.current.type);
+    const name = getComponentName(ReactCurrentOwner.current.elementType);
     if (name) {
       return '\n\nCheck the render method of `' + name + '`.';
     }
@@ -140,7 +140,7 @@ function validateExplicitKey(element, parentType) {
   ) {
     // Give the component that originally created this child.
     childOwner = ` It was passed a child from ${getComponentName(
-      element._owner.type,
+      element._owner.elementType,
     )}.`;
   }
 

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -41,26 +41,27 @@ function getContextName(type: ReactContext<any>) {
   return type.displayName || 'Context';
 }
 
-function getComponentName(type: mixed): string | null {
-  if (type == null) {
+function getComponentName(elementType: mixed): string | null {
+  if (elementType == null) {
     // Host root, text node or just invalid type.
     return null;
   }
   if (__DEV__) {
-    if (typeof (type: any).tag === 'number') {
+    // TODO: protect against potential false positives from user-defined statics
+    if (typeof (elementType: any).tag === 'number') {
       console.error(
         'Received an unexpected object in getComponentName(). ' +
           'This is likely a bug in React. Please file an issue.',
       );
     }
   }
-  if (typeof type === 'function') {
-    return (type: any).displayName || type.name || null;
+  if (typeof elementType === 'function') {
+    return (elementType: any).displayName || elementType.name || null;
   }
-  if (typeof type === 'string') {
-    return type;
+  if (typeof elementType === 'string') {
+    return elementType;
   }
-  switch (type) {
+  switch (elementType) {
     case REACT_FRAGMENT_TYPE:
       return 'Fragment';
     case REACT_PORTAL_TYPE:
@@ -74,22 +75,22 @@ function getComponentName(type: mixed): string | null {
     case REACT_SUSPENSE_LIST_TYPE:
       return 'SuspenseList';
   }
-  if (typeof type === 'object') {
-    switch (type.$$typeof) {
+  if (typeof elementType === 'object') {
+    switch (elementType.$$typeof) {
       case REACT_CONTEXT_TYPE:
-        const context: ReactContext<any> = (type: any);
+        const context: ReactContext<any> = (elementType: any);
         return getContextName(context) + '.Consumer';
       case REACT_PROVIDER_TYPE:
-        const provider: ReactProviderType<any> = (type: any);
+        const provider: ReactProviderType<any> = (elementType: any);
         return getContextName(provider._context) + '.Provider';
       case REACT_FORWARD_REF_TYPE:
-        return getWrappedName(type, type.render, 'ForwardRef');
+        return getWrappedName(elementType, elementType.render, 'ForwardRef');
       case REACT_MEMO_TYPE:
-        return getComponentName(type.type);
+        return getComponentName(elementType.type);
       case REACT_BLOCK_TYPE:
-        return getComponentName(type._render);
+        return getComponentName(elementType._render);
       case REACT_LAZY_TYPE: {
-        const lazyComponent: LazyComponent<any, any> = (type: any);
+        const lazyComponent: LazyComponent<any, any> = (elementType: any);
         const payload = lazyComponent._payload;
         const init = lazyComponent._init;
         try {


### PR DESCRIPTION
Since fiber types can change during work (see MemoComponent -> SimpleMemoComponent) it seems more appropriate to use the elementType instead to determine a component name.

Makes #15313 easier (see https://github.com/facebook/react/pull/15313#discussion_r275157235). It would also enable #14319 since we no longer rely on internal data structures (fiber types) but public element types.