### PR TITLE
Separate Offscreen and Idle expiration times

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -80,7 +80,8 @@ import {
 import {processUpdateQueue} from './ReactUpdateQueue';
 import {
   NoWork,
-  Never,
+  Offscreen,
+  Idle,
   computeAsyncExpiration,
 } from './ReactFiberExpirationTime';
 import {
@@ -973,12 +974,12 @@ function updateHostComponent(current, workInProgress, renderExpirationTime) {
 
   // Check the host config to see if the children are offscreen/hidden.
   if (
-    renderExpirationTime !== Never &&
+    renderExpirationTime !== Offscreen &&
     workInProgress.mode & ConcurrentMode &&
     shouldDeprioritizeSubtree(type, nextProps)
   ) {
     // Schedule this fiber to re-render at offscreen priority. Then bailout.
-    workInProgress.expirationTime = workInProgress.childExpirationTime = Never;
+    workInProgress.expirationTime = workInProgress.childExpirationTime = Offscreen;
     return null;
   }
 
@@ -1797,9 +1798,9 @@ function updateDehydratedSuspenseComponent(
       // Schedule a normal pri update to render this content.
       workInProgress.expirationTime = computeAsyncExpiration(serverDisplayTime);
     } else {
-      // We'll continue hydrating the rest at offscreen priority since we'll already
+      // We'll continue hydrating the rest at idle priority since we'll already
       // be showing the right content coming from the server, it is no rush.
-      workInProgress.expirationTime = Never;
+      workInProgress.expirationTime = Idle;
     }
     return null;
   }

--- a/packages/react-reconciler/src/ReactFiberExpirationTime.js
+++ b/packages/react-reconciler/src/ReactFiberExpirationTime.js
@@ -21,7 +21,8 @@ import {
 export type ExpirationTime = number;
 
 export const NoWork = 0;
-export const Never = 1;
+export const Idle = 1;
+export const Offscreen = 2;
 export const Sync = MAX_SIGNED_31_BIT_INT;
 export const Batched = Sync - 1;
 
@@ -108,7 +109,7 @@ export function inferPriorityFromExpirationTime(
   if (expirationTime === Sync) {
     return ImmediatePriority;
   }
-  if (expirationTime === Never) {
+  if (expirationTime === Idle) {
     return IdlePriority;
   }
   const msUntil =

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -239,8 +239,9 @@ function throwException(
         }
 
         // If the boundary is outside of batched mode, we should *not*
-        // suspend the commit. Pretend as if the suspended component rendered
-        // null and keep rendering. In the commit phase, we'll schedule a
+        // suspend the commit. Pretend as if the suspended component bailed out
+        // and keep rendering. We'll reuse the current children, even though
+        // they are inconsistent. In the commit phase, we'll schedule a
         // subsequent synchronous update to re-render the Suspense.
         //
         // Note: It doesn't matter whether the component that suspended was


### PR DESCRIPTION
Offscreen work has some special semantics regarding tearing and Suspense. We don't necessarily want these semantics when scheduling an update at Scheduler's "idle" priority level. This splits the `Never` expiration time into separate `Offscreen` and `Idle` expiration times.