### PR TITLE
flush pending passive effects early on an interactive update

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
@@ -11,7 +11,6 @@
 
 let React;
 let ReactDOM;
-let act;
 let Scheduler;
 
 describe('ReactDOMHooks', () => {
@@ -23,7 +22,6 @@ describe('ReactDOMHooks', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     Scheduler = require('scheduler');
-    act = require('react-dom/test-utils').act;
 
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -187,8 +185,8 @@ describe('ReactDOMHooks', () => {
     // (the effect would flush on start and the clicks would never set state)
     // but it does model setting state in an effect clean up that removes a previous handler
 
-    // users should probably wrap their code with unstable_interactiveUpdates? or 
-    // use emitEffect? 
+    // users should probably wrap their code with unstable_interactiveUpdates? or
+    // use emitEffect?
     const {useState, useEffect} = React;
 
     function Foo() {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -539,6 +539,7 @@ export function flushInteractiveUpdates() {
     // an input event inside an effect, like with `element.click()`.
     return;
   }
+  flushPassiveEffects();
   flushPendingDiscreteUpdates();
 }
 
@@ -575,7 +576,7 @@ export function interactiveUpdates<A, B, C, R>(
   if (workPhase === NotWorking) {
     // TODO: Remove this call. Instead of doing this automatically, the caller
     // should explicitly call flushInteractiveUpdates.
-    flushPendingDiscreteUpdates();
+    flushInteractiveUpdates();
   }
   return runWithPriority(UserBlockingPriority, fn.bind(null, a, b, c));
 }


### PR DESCRIPTION
related to #15057

ported over Dan's PR from https://github.com/facebook/react/pull/15067 to discuss this. 

- is our recommendation to folks to use `interactiveUpdates(() => {...})` for all 'outside' updates?
- alternately, what should the OP code look like? this situation of 'do something when a value becomes something' comes up often. `emitEffect`?