### PR TITLE
Event API: Add responder allowMultipleHostChildren flag

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -35,8 +35,6 @@ import invariant from 'shared/invariant';
 import {
   isFiberSuspenseAndTimedOut,
   getSuspenseFallbackChild,
-  isFiberSuspenseTimedOutChild,
-  getSuspenseFiberFromTimedOutChild,
 } from 'react-reconciler/src/ReactFiberEvents';
 
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -16,7 +16,6 @@ import {
   EventComponent,
   EventTarget as EventTargetWorkTag,
   HostComponent,
-  SuspenseComponent,
 } from 'shared/ReactWorkTags';
 import type {
   ReactEventResponder,
@@ -36,9 +35,8 @@ import invariant from 'shared/invariant';
 import {
   isFiberSuspenseAndTimedOut,
   getSuspenseFallbackChild,
-  getSuspenseChild,
-  isFiberSuspenseChild,
-  getSuspenseFiberFromChild,
+  isFiberSuspenseTimedOutChild,
+  getSuspenseFiberFromTimedOutChild,
 } from 'react-reconciler/src/ReactFiberEvents';
 
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
@@ -360,12 +358,10 @@ const eventResponderContext: ReactResponderContext = {
     let node = ((eventComponentInstance.currentFiber: any): Fiber).child;
 
     while (node !== null) {
-      if (node.tag === SuspenseComponent) {
-        const suspendedChild = isFiberSuspenseAndTimedOut(node)
-          ? getSuspenseFallbackChild(node)
-          : getSuspenseChild(node);
-        if (suspendedChild !== null) {
-          node = suspendedChild;
+      if (isFiberSuspenseAndTimedOut(node)) {
+        const fallbackChild = getSuspenseFallbackChild(node);
+        if (fallbackChild !== null) {
+          node = fallbackChild;
           continue;
         }
       } else {
@@ -387,8 +383,8 @@ const eventResponderContext: ReactResponderContext = {
         continue;
       }
       let parent;
-      if (isFiberSuspenseChild(node)) {
-        parent = getSuspenseFiberFromChild(node);
+      if (isFiberSuspenseTimedOutChild(node)) {
+        parent = getSuspenseFiberFromTimedOutChild(node);
       } else {
         parent = node.return;
         if (parent === null) {

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -17,7 +17,6 @@ import {
   EventTarget as EventTargetWorkTag,
   HostComponent,
   SuspenseComponent,
-  Fragment,
 } from 'shared/ReactWorkTags';
 import type {
   ReactEventResponder,
@@ -34,6 +33,13 @@ import warning from 'shared/warning';
 import {enableEventAPI} from 'shared/ReactFeatureFlags';
 import {invokeGuardedCallbackAndCatchFirstError} from 'shared/ReactErrorUtils';
 import invariant from 'shared/invariant';
+import {
+  isFiberSuspenseAndTimedOut,
+  getSuspenseFallbackChild,
+  getSuspenseChild,
+  isFiberSuspenseChild,
+  getSuspenseFiberFromChild,
+} from 'react-reconciler/src/ReactFiberEvents';
 
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
 
@@ -603,41 +609,6 @@ export function processEventQueue(): void {
   } else {
     batchedUpdates(processEvents, events);
   }
-}
-
-function isFiberSuspenseAndTimedOut(fiber: Fiber): boolean {
-  return fiber.tag === SuspenseComponent && fiber.memoizedState !== null;
-}
-
-function isFiberSuspenseChild(fiber: Fiber | null): boolean {
-  if (fiber === null) {
-    return false;
-  }
-  const parent = fiber.return;
-  if (parent !== null && parent.tag === Fragment) {
-    const grandParent = parent.return;
-
-    if (
-      grandParent !== null &&
-      grandParent.tag === SuspenseComponent &&
-      grandParent.stateNode !== null
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function getSuspenseFiberFromChild(fiber: Fiber): Fiber {
-  return ((((fiber.return: any): Fiber).return: any): Fiber);
-}
-
-function getSuspenseFallbackChild(fiber: Fiber): Fiber | null {
-  return ((((fiber.child: any): Fiber).sibling: any): Fiber).child;
-}
-
-function getSuspenseChild(fiber: Fiber): Fiber | null {
-  return (((fiber.child: any): Fiber): Fiber).child;
 }
 
 function getTargetEventTypesSet(

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -924,7 +924,7 @@ describe('DOMEventResponderSystem', () => {
     expect(container.innerHTML).toBe('<button>Click me!</button>');
   });
 
-  it('should warn if multiple host components are detected and allowMultipleHostChildren is false', () => {
+  it('should warn if multiple host components are detected without allowMultipleHostChildren', () => {
     const EventComponent = createReactEventComponent({
       targetEventTypes: [],
       onEvent: () => {},
@@ -962,7 +962,66 @@ describe('DOMEventResponderSystem', () => {
     );
   });
 
-  it('should not warn if multiple host components are detected and allowMultipleHostChildren is true', () => {
+  it('should handle suspended nodes correctly when detecting host components without allowMultipleHostChildren', () => {
+    const EventComponent = createReactEventComponent({
+      targetEventTypes: [],
+      onEvent: () => {},
+      allowMultipleHostChildren: false,
+    });
+
+    function SuspendedComponent() {
+      throw Promise.resolve();
+    }
+
+    function Component() {
+      return (
+        <React.Fragment>
+          <div />
+          <SuspendedComponent />
+        </React.Fragment>
+      );
+    }
+
+    const Test = () => (
+      <EventComponent>
+        <React.Suspense fallback={<div>Loading...</div>}>
+          <Component />
+        </React.Suspense>
+      </EventComponent>
+    );
+
+    ReactDOM.render(<Test />, container);
+
+    function Component2() {
+      return (
+        <React.Fragment>
+          <SuspendedComponent />
+        </React.Fragment>
+      );
+    }
+
+    const Test2 = () => (
+      <EventComponent>
+        <React.Suspense
+          fallback={
+            <React.Fragment>
+              <div />
+              <div />
+            </React.Fragment>
+          }>
+          <Component2 />
+        </React.Suspense>
+      </EventComponent>
+    );
+
+    expect(() => {
+      ReactDOM.render(<Test2 />, container);
+    }).toWarnDev(
+      'Warning: An event component "TestEventComponent" was found to have multiple host children.',
+    );
+  });
+
+  it('should not warn if multiple host components are detected with allowMultipleHostChildren', () => {
     const EventComponent = createReactEventComponent({
       targetEventTypes: [],
       onEvent: () => {},

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -940,8 +940,8 @@ describe('DOMEventResponderSystem', () => {
 
     expect(() => {
       ReactDOM.render(<Test />, container);
-    }).toThrowError(
-      'A "<TestEventComponent>" event component cannot contain multiple host children.',
+    }).toWarnDev(
+      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
     );
 
     function Component() {
@@ -957,8 +957,8 @@ describe('DOMEventResponderSystem', () => {
 
     expect(() => {
       ReactDOM.render(<Test2 />, container);
-    }).toThrowError(
-      'A "<TestEventComponent>" event component cannot contain multiple host children.',
+    }).toWarnDev(
+      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
     );
   });
 
@@ -1016,8 +1016,8 @@ describe('DOMEventResponderSystem', () => {
 
     expect(() => {
       ReactDOM.render(<Test2 />, container);
-    }).toThrowError(
-      'A "<TestEventComponent>" event component cannot contain multiple host children.',
+    }).toWarnDev(
+      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
     );
   });
 

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -940,8 +940,8 @@ describe('DOMEventResponderSystem', () => {
 
     expect(() => {
       ReactDOM.render(<Test />, container);
-    }).toWarnDev(
-      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
+    }).toThrowError(
+      'A "<TestEventComponent>" event component cannot contain multiple host children.',
     );
 
     function Component() {
@@ -957,8 +957,8 @@ describe('DOMEventResponderSystem', () => {
 
     expect(() => {
       ReactDOM.render(<Test2 />, container);
-    }).toWarnDev(
-      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
+    }).toThrowError(
+      'A "<TestEventComponent>" event component cannot contain multiple host children.',
     );
   });
 
@@ -1016,8 +1016,8 @@ describe('DOMEventResponderSystem', () => {
 
     expect(() => {
       ReactDOM.render(<Test2 />, container);
-    }).toWarnDev(
-      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
+    }).toThrowError(
+      'A "<TestEventComponent>" event component cannot contain multiple host children.',
     );
   });
 

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -13,7 +13,7 @@ let React;
 let ReactFeatureFlags;
 let ReactDOM;
 
-function createReactEventComponent(
+function createReactEventComponent({
   targetEventTypes,
   rootEventTypes,
   createInitialState,
@@ -24,7 +24,8 @@ function createReactEventComponent(
   onUnmount,
   onOwnershipChange,
   stopLocalPropagation,
-) {
+  allowMultipleHostChildren,
+}) {
   const testEventResponder = {
     targetEventTypes,
     rootEventTypes,
@@ -36,6 +37,7 @@ function createReactEventComponent(
     onUnmount,
     onOwnershipChange,
     stopLocalPropagation: stopLocalPropagation || false,
+    allowMultipleHostChildren: allowMultipleHostChildren || false,
   };
 
   return {
@@ -81,11 +83,9 @@ describe('DOMEventResponderSystem', () => {
     let eventLog = [];
     const buttonRef = React.createRef();
 
-    const ClickEventComponent = createReactEventComponent(
-      ['click'],
-      undefined,
-      undefined,
-      (event, context, props) => {
+    const ClickEventComponent = createReactEventComponent({
+      targetEventTypes: ['click'],
+      onEvent: (event, context, props) => {
         eventResponderFiredCount++;
         eventLog.push({
           name: event.type,
@@ -94,7 +94,7 @@ describe('DOMEventResponderSystem', () => {
           phase: 'bubble',
         });
       },
-      (event, context, props) => {
+      onEventCapture: (event, context, props) => {
         eventResponderFiredCount++;
         eventLog.push({
           name: event.type,
@@ -103,7 +103,7 @@ describe('DOMEventResponderSystem', () => {
           phase: 'capture',
         });
       },
-    );
+    });
 
     const Test = () => (
       <ClickEventComponent>
@@ -155,11 +155,9 @@ describe('DOMEventResponderSystem', () => {
     let eventLog = [];
     const buttonRef = React.createRef();
 
-    const ClickEventComponent = createReactEventComponent(
-      ['click'],
-      undefined,
-      undefined,
-      (event, context, props) => {
+    const ClickEventComponent = createReactEventComponent({
+      targetEventTypes: ['click'],
+      onEvent: (event, context, props) => {
         eventLog.push({
           name: event.type,
           passive: event.passive,
@@ -167,7 +165,7 @@ describe('DOMEventResponderSystem', () => {
           phase: 'bubble',
         });
       },
-      (event, context, props) => {
+      onEventCapture: (event, context, props) => {
         eventLog.push({
           name: event.type,
           passive: event.passive,
@@ -175,7 +173,7 @@ describe('DOMEventResponderSystem', () => {
           phase: 'capture',
         });
       },
-    );
+    });
 
     const Test = () => (
       <ClickEventComponent>
@@ -210,11 +208,9 @@ describe('DOMEventResponderSystem', () => {
     let eventLog = [];
     const buttonRef = React.createRef();
 
-    const ClickEventComponent = createReactEventComponent(
-      ['click'],
-      undefined,
-      undefined,
-      (event, context, props) => {
+    const ClickEventComponent = createReactEventComponent({
+      targetEventTypes: ['click'],
+      onEvent: (event, context, props) => {
         eventResponderFiredCount++;
         eventLog.push({
           name: event.type,
@@ -223,7 +219,7 @@ describe('DOMEventResponderSystem', () => {
           phase: 'bubble',
         });
       },
-      (event, context, props) => {
+      onEventCapture: (event, context, props) => {
         eventResponderFiredCount++;
         eventLog.push({
           name: event.type,
@@ -232,7 +228,7 @@ describe('DOMEventResponderSystem', () => {
           phase: 'capture',
         });
       },
-    );
+    });
 
     const Test = () => (
       <ClickEventComponent>
@@ -282,29 +278,25 @@ describe('DOMEventResponderSystem', () => {
     let eventLog = [];
     const buttonRef = React.createRef();
 
-    const ClickEventComponentA = createReactEventComponent(
-      ['click'],
-      undefined,
-      undefined,
-      (event, context, props) => {
+    const ClickEventComponentA = createReactEventComponent({
+      targetEventTypes: ['click'],
+      onEvent: (event, context, props) => {
         eventLog.push(`A [bubble]`);
       },
-      (event, context, props) => {
+      onEventCapture: (event, context, props) => {
         eventLog.push(`A [capture]`);
       },
-    );
+    });
 
-    const ClickEventComponentB = createReactEventComponent(
-      ['click'],
-      undefined,
-      undefined,
-      (event, context, props) => {
+    const ClickEventComponentB = createReactEventComponent({
+      targetEventTypes: ['click'],
+      onEvent: (event, context, props) => {
         eventLog.push(`B [bubble]`);
       },
-      (event, context, props) => {
+      onEventCapture: (event, context, props) => {
         eventLog.push(`B [capture]`);
       },
-    );
+    });
 
     const Test = () => (
       <ClickEventComponentA>
@@ -332,21 +324,16 @@ describe('DOMEventResponderSystem', () => {
     let eventLog = [];
     const buttonRef = React.createRef();
 
-    const ClickEventComponent = createReactEventComponent(
-      ['click'],
-      undefined,
-      undefined,
-      (event, context, props) => {
+    const ClickEventComponent = createReactEventComponent({
+      targetEventTypes: ['click'],
+      onEvent: (event, context, props) => {
         eventLog.push(`${props.name} [bubble]`);
       },
-      (event, context, props) => {
+      onEventCapture: (event, context, props) => {
         eventLog.push(`${props.name} [capture]`);
       },
-      undefined,
-      undefined,
-      undefined,
-      false,
-    );
+      stopLocalPropagation: false,
+    });
 
     const Test = () => (
       <ClickEventComponent name="A">
@@ -374,22 +361,16 @@ describe('DOMEventResponderSystem', () => {
     let eventLog = [];
     const buttonRef = React.createRef();
 
-    const ClickEventComponent = createReactEventComponent(
-      ['click'],
-      undefined,
-      undefined,
-      (event, context, props) => {
+    const ClickEventComponent = createReactEventComponent({
+      targetEventTypes: ['click'],
+      onEvent: (event, context, props) => {
         eventLog.push(`${props.name} [bubble]`);
       },
-      (event, context, props) => {
+      onEventCapture: (event, context, props) => {
         eventLog.push(`${props.name} [capture]`);
       },
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      true,
-    );
+      stopLocalPropagation: true,
+    });
 
     const Test = () => (
       <ClickEventComponent name="A">
@@ -412,11 +393,9 @@ describe('DOMEventResponderSystem', () => {
     let eventLog = [];
     const buttonRef = React.createRef();
 
-    const ClickEventComponent = createReactEventComponent(
-      ['click'],
-      undefined,
-      undefined,
-      (event, context, props) => {
+    const ClickEventComponent = createReactEventComponent({
+      targetEventTypes: ['click'],
+      onEvent: (event, context, props) => {
         if (props.onMagicClick) {
           const syntheticEvent = {
             target: event.target,
@@ -429,7 +408,7 @@ describe('DOMEventResponderSystem', () => {
           });
         }
       },
-      (event, context, props) => {
+      onEventCapture: (event, context, props) => {
         if (props.onMagicClick) {
           const syntheticEvent = {
             target: event.target,
@@ -442,7 +421,7 @@ describe('DOMEventResponderSystem', () => {
           });
         }
       },
-    );
+    });
 
     function handleMagicEvent(e) {
       eventLog.push('magic event fired', e.type, e.phase);
@@ -510,17 +489,15 @@ describe('DOMEventResponderSystem', () => {
       }, 500);
     }
 
-    const LongPressEventComponent = createReactEventComponent(
-      ['click'],
-      undefined,
-      undefined,
-      (event, context, props) => {
+    const LongPressEventComponent = createReactEventComponent({
+      targetEventTypes: ['click'],
+      onEvent: (event, context, props) => {
         handleEvent(event, context, props, 'bubble');
       },
-      (event, context, props) => {
+      onEventCapture: (event, context, props) => {
         handleEvent(event, context, props, 'capture');
       },
-    );
+    });
 
     function log(msg) {
       eventLog.push(msg);
@@ -555,17 +532,12 @@ describe('DOMEventResponderSystem', () => {
   it('the event responder onMount() function should fire', () => {
     let onMountFired = 0;
 
-    const EventComponent = createReactEventComponent(
-      [],
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      () => {
+    const EventComponent = createReactEventComponent({
+      targetEventTypes: [],
+      onMount: () => {
         onMountFired++;
       },
-    );
+    });
 
     const Test = () => (
       <EventComponent>
@@ -580,18 +552,12 @@ describe('DOMEventResponderSystem', () => {
   it('the event responder onUnmount() function should fire', () => {
     let onUnmountFired = 0;
 
-    const EventComponent = createReactEventComponent(
-      [],
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      () => {
+    const EventComponent = createReactEventComponent({
+      targetEventTypes: [],
+      onUnmount: () => {
         onUnmountFired++;
       },
-    );
+    });
 
     const Test = () => (
       <EventComponent>
@@ -607,20 +573,15 @@ describe('DOMEventResponderSystem', () => {
   it('the event responder onUnmount() function should fire with state', () => {
     let counter = 0;
 
-    const EventComponent = createReactEventComponent(
-      [],
-      undefined,
-      () => ({
+    const EventComponent = createReactEventComponent({
+      targetEventTypes: [],
+      createInitialState: () => ({
         incrementAmount: 5,
       }),
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      (context, props, state) => {
+      onUnmount: (context, props, state) => {
         counter += state.incrementAmount;
       },
-    );
+    });
 
     const Test = () => (
       <EventComponent>
@@ -638,21 +599,15 @@ describe('DOMEventResponderSystem', () => {
     let ownershipGained = false;
     const buttonRef = React.createRef();
 
-    const EventComponent = createReactEventComponent(
-      ['click'],
-      undefined,
-      undefined,
-      (event, context, props, state) => {
+    const EventComponent = createReactEventComponent({
+      targetEventTypes: ['click'],
+      onEvent: (event, context, props, state) => {
         ownershipGained = context.requestGlobalOwnership();
       },
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      () => {
+      onOwnershipChange: () => {
         onOwnershipChangeFired++;
       },
-    );
+    });
 
     const Test = () => (
       <EventComponent>
@@ -675,13 +630,9 @@ describe('DOMEventResponderSystem', () => {
     let eventResponderFiredCount = 0;
     let eventLog = [];
 
-    const ClickEventComponent = createReactEventComponent(
-      undefined,
-      ['click'],
-      undefined,
-      undefined,
-      undefined,
-      event => {
+    const ClickEventComponent = createReactEventComponent({
+      rootEventTypes: ['click'],
+      onRootEvent: event => {
         eventResponderFiredCount++;
         eventLog.push({
           name: event.type,
@@ -690,7 +641,7 @@ describe('DOMEventResponderSystem', () => {
           phase: 'root',
         });
       },
-    );
+    });
 
     const Test = () => (
       <ClickEventComponent>
@@ -720,17 +671,16 @@ describe('DOMEventResponderSystem', () => {
     const divRef = React.createRef();
     const log = [];
 
-    const EventComponent = createReactEventComponent(
-      ['pointerout'],
-      undefined,
-      undefined,
-      (event, context) => {
+    const EventComponent = createReactEventComponent({
+      targetEventTypes: ['pointerout'],
+      onEvent: (event, context) => {
         const isWithin = context.isTargetWithinEventResponderScope(
           event.nativeEvent.relatedTarget,
         );
         log.push(isWithin);
       },
-    );
+      allowMultipleHostChildren: true,
+    });
 
     const Test = () => (
       <EventComponent>
@@ -769,11 +719,9 @@ describe('DOMEventResponderSystem', () => {
     let eventLog = [];
     const buttonRef = React.createRef();
 
-    const ClickEventComponent1 = createReactEventComponent(
-      [{name: 'click', passive: false, capture: false}],
-      undefined,
-      undefined,
-      event => {
+    const ClickEventComponent1 = createReactEventComponent({
+      targetEventTypes: [{name: 'click', passive: false, capture: false}],
+      onEvent: event => {
         clickEventComponent1Fired++;
         eventLog.push({
           name: event.type,
@@ -781,13 +729,11 @@ describe('DOMEventResponderSystem', () => {
           passiveSupported: event.passiveSupported,
         });
       },
-    );
+    });
 
-    const ClickEventComponent2 = createReactEventComponent(
-      [{name: 'click', passive: true, capture: false}],
-      undefined,
-      undefined,
-      event => {
+    const ClickEventComponent2 = createReactEventComponent({
+      targetEventTypes: [{name: 'click', passive: true, capture: false}],
+      onEvent: event => {
         clickEventComponent2Fired++;
         eventLog.push({
           name: event.type,
@@ -795,7 +741,7 @@ describe('DOMEventResponderSystem', () => {
           passiveSupported: event.passiveSupported,
         });
       },
-    );
+    });
 
     const Test = () => (
       <ClickEventComponent1>
@@ -832,13 +778,9 @@ describe('DOMEventResponderSystem', () => {
     let clickEventComponent2Fired = 0;
     let eventLog = [];
 
-    const ClickEventComponent1 = createReactEventComponent(
-      undefined,
-      [{name: 'click', passive: false, capture: false}],
-      undefined,
-      undefined,
-      undefined,
-      event => {
+    const ClickEventComponent1 = createReactEventComponent({
+      rootEventTypes: [{name: 'click', passive: false, capture: false}],
+      onRootEvent: event => {
         clickEventComponent1Fired++;
         eventLog.push({
           name: event.type,
@@ -846,15 +788,11 @@ describe('DOMEventResponderSystem', () => {
           passiveSupported: event.passiveSupported,
         });
       },
-    );
+    });
 
-    const ClickEventComponent2 = createReactEventComponent(
-      undefined,
-      [{name: 'click', passive: true, capture: false}],
-      undefined,
-      undefined,
-      undefined,
-      event => {
+    const ClickEventComponent2 = createReactEventComponent({
+      rootEventTypes: [{name: 'click', passive: true, capture: false}],
+      onRootEvent: event => {
         clickEventComponent2Fired++;
         eventLog.push({
           name: event.type,
@@ -862,7 +800,7 @@ describe('DOMEventResponderSystem', () => {
           passiveSupported: event.passiveSupported,
         });
       },
-    );
+    });
 
     const Test = () => (
       <ClickEventComponent1>
@@ -896,13 +834,9 @@ describe('DOMEventResponderSystem', () => {
   });
 
   it('the event responder system should warn on accessing invalid properties', () => {
-    const ClickEventComponent = createReactEventComponent(
-      undefined,
-      ['click'],
-      undefined,
-      undefined,
-      undefined,
-      (event, context, props) => {
+    const ClickEventComponent = createReactEventComponent({
+      rootEventTypes: ['click'],
+      onRootEvent: (event, context, props) => {
         const syntheticEvent = {
           target: event.target,
           type: 'click',
@@ -912,7 +846,7 @@ describe('DOMEventResponderSystem', () => {
           discrete: true,
         });
       },
-    );
+    });
 
     let handler;
     const Test = () => (
@@ -988,5 +922,73 @@ describe('DOMEventResponderSystem', () => {
     );
 
     expect(container.innerHTML).toBe('<button>Click me!</button>');
+  });
+
+  it('should warn if multiple host components are detected and allowMultipleHostChildren is false', () => {
+    const EventComponent = createReactEventComponent({
+      targetEventTypes: [],
+      onEvent: () => {},
+      allowMultipleHostChildren: false,
+    });
+
+    const Test = () => (
+      <EventComponent>
+        <div />
+        <div />
+      </EventComponent>
+    );
+
+    expect(() => {
+      ReactDOM.render(<Test />, container);
+    }).toWarnDev(
+      'Warning: An event component "TestEventComponent" was found to have multiple host children.',
+    );
+
+    function Component() {
+      return <div />;
+    }
+
+    const Test2 = () => (
+      <EventComponent>
+        <div />
+        <Component />
+      </EventComponent>
+    );
+
+    expect(() => {
+      ReactDOM.render(<Test2 />, container);
+    }).toWarnDev(
+      'Warning: An event component "TestEventComponent" was found to have multiple host children.',
+    );
+  });
+
+  it('should not warn if multiple host components are detected and allowMultipleHostChildren is true', () => {
+    const EventComponent = createReactEventComponent({
+      targetEventTypes: [],
+      onEvent: () => {},
+      allowMultipleHostChildren: true,
+    });
+
+    const Test = () => (
+      <EventComponent>
+        <div />
+        <div />
+      </EventComponent>
+    );
+
+    ReactDOM.render(<Test />, container);
+
+    function Component() {
+      return <div />;
+    }
+
+    const Test2 = () => (
+      <EventComponent>
+        <div />
+        <Component />
+      </EventComponent>
+    );
+
+    ReactDOM.render(<Test2 />, container);
   });
 });

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -941,7 +941,7 @@ describe('DOMEventResponderSystem', () => {
     expect(() => {
       ReactDOM.render(<Test />, container);
     }).toWarnDev(
-      'Warning: An event component "TestEventComponent" was found to have multiple host children.',
+      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
     );
 
     function Component() {
@@ -958,7 +958,7 @@ describe('DOMEventResponderSystem', () => {
     expect(() => {
       ReactDOM.render(<Test2 />, container);
     }).toWarnDev(
-      'Warning: An event component "TestEventComponent" was found to have multiple host children.',
+      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
     );
   });
 
@@ -1017,7 +1017,7 @@ describe('DOMEventResponderSystem', () => {
     expect(() => {
       ReactDOM.render(<Test2 />, container);
     }).toWarnDev(
-      'Warning: An event component "TestEventComponent" was found to have multiple host children.',
+      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
     );
   });
 

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -95,6 +95,7 @@ const DragResponder = {
       y: 0,
     };
   },
+  allowMultipleHostChildren: false,
   stopLocalPropagation: true,
   onEvent(
     event: ReactResponderEvent,

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -160,6 +160,7 @@ const FocusResponder = {
       isLocalFocusVisible: false,
     };
   },
+  allowMultipleHostChildren: false,
   stopLocalPropagation: true,
   onEvent(
     event: ReactResponderEvent,

--- a/packages/react-events/src/FocusScope.js
+++ b/packages/react-events/src/FocusScope.js
@@ -55,6 +55,8 @@ const FocusScopeResponder = {
       currentFocusedNode: null,
     };
   },
+  allowMultipleHostChildren: true,
+  stopLocalPropagation: false,
   onEvent(
     event: ReactResponderEvent,
     context: ReactResponderContext,

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -247,6 +247,7 @@ const HoverResponder = {
       ignoreEmulatedMouseEvents: false,
     };
   },
+  allowMultipleHostChildren: false,
   stopLocalPropagation: true,
   onEvent(
     event: ReactResponderEvent,

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -586,6 +586,7 @@ const PressResponder = {
       allowPressReentry: false,
     };
   },
+  allowMultipleHostChildren: false,
   stopLocalPropagation: true,
   onEvent(
     event: ReactResponderEvent,

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -99,6 +99,7 @@ const SwipeResponder = {
       y: 0,
     };
   },
+  allowMultipleHostChildren: false,
   stopLocalPropagation: true,
   onEvent(
     event: ReactResponderEvent,

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -851,7 +851,7 @@ function completeWork(
             }
             warning(
               hostChildrenCount < 2,
-              'An event component "%s" was found to have multiple host children.',
+              'A "<%s>" event component cannot contain multiple host children.',
               getComponentName(workInProgress.type),
             );
           }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -97,6 +97,7 @@ import {
 import {markRenderEventTime, renderDidSuspend} from './ReactFiberScheduler';
 import {getEventComponentHostChildrenCount} from './ReactFiberEvents';
 import getComponentName from 'shared/getComponentName';
+import warning from 'shared/warning';
 
 function markUpdate(workInProgress: Fiber) {
   // Tag the fiber with an update effect. This turns a Placement into
@@ -813,11 +814,11 @@ function completeWork(
 
         if (eventComponentInstance === null) {
           let responderState = null;
-          if (!responder.allowMultipleHostChildren) {
+          if (__DEV__ && !responder.allowMultipleHostChildren) {
             const hostChildrenCount = getEventComponentHostChildrenCount(
               workInProgress,
             );
-            invariant(
+            warning(
               hostChildrenCount < 2,
               'A "<%s>" event component cannot contain multiple host children.',
               getComponentName(workInProgress.type),

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -827,6 +827,12 @@ function completeWork(
                   return;
                 }
                 node = fallbackNode;
+              } else if (node.tag === SuspenseComponent) {
+                const fallbackNode = ((node.child: any): Fiber).child;
+                if (fallbackNode === null) {
+                  return;
+                }
+                node = fallbackNode;
               }
               if (
                 node.tag === HostComponent ||

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -820,15 +820,10 @@ function completeWork(
           if (__DEV__ && !responder.allowMultipleHostChildren) {
             let hostChildrenCount = 0;
             const findAllHostChildren = node => {
-              if (isFiberSuspenseAndTimedOut(node)) {
-                const fallbackNode = ((((node.child: any): Fiber)
-                  .sibling: any): Fiber).child;
-                if (fallbackNode === null) {
-                  return;
-                }
-                node = fallbackNode;
-              } else if (node.tag === SuspenseComponent) {
-                const fallbackNode = ((node.child: any): Fiber).child;
+              if (node.tag === SuspenseComponent) {
+                const fallbackNode = isFiberSuspenseAndTimedOut(node)
+                  ? ((((node.child: any): Fiber).sibling: any): Fiber).child
+                  : ((node.child: any): Fiber).child;
                 if (fallbackNode === null) {
                   return;
                 }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -108,6 +108,10 @@ function markRef(workInProgress: Fiber) {
   workInProgress.effectTag |= Ref;
 }
 
+function isFiberSuspenseAndTimedOut(fiber: Fiber): boolean {
+  return fiber.tag === SuspenseComponent && fiber.memoizedState !== null;
+}
+
 let appendAllChildren;
 let updateHostContainer;
 let updateHostComponent;
@@ -816,6 +820,14 @@ function completeWork(
           if (__DEV__ && !responder.allowMultipleHostChildren) {
             let hostChildrenCount = 0;
             const findAllHostChildren = node => {
+              if (isFiberSuspenseAndTimedOut(node)) {
+                const fallbackNode = ((((node.child: any): Fiber)
+                  .sibling: any): Fiber).child;
+                if (fallbackNode === null) {
+                  return;
+                }
+                node = fallbackNode;
+              }
               if (
                 node.tag === HostComponent ||
                 node.tag === HostText ||

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -815,9 +815,7 @@ function completeWork(
           let responderState = null;
           if (__DEV__ && !responder.allowMultipleHostChildren) {
             let hostChildrenCount = 0;
-            let node = workInProgress.child;
-
-            mainLoop: while (node !== null) {
+            const findAllHostChildren = node => {
               if (
                 node.tag === HostComponent ||
                 node.tag === HostText ||
@@ -827,25 +825,16 @@ function completeWork(
               } else {
                 const child = node.child;
                 if (child !== null) {
-                  node = child;
-                  continue;
+                  findAllHostChildren(child);
                 }
               }
               const sibling = node.sibling;
               if (sibling !== null) {
-                node = sibling;
-                continue;
+                findAllHostChildren(sibling);
               }
-              while (node !== null) {
-                node = node.return;
-                if ((node = workInProgress)) {
-                  break mainLoop;
-                }
-                if (node.sibling) {
-                  node = node.sibling;
-                  break;
-                }
-              }
+            };
+            if (workInProgress.child !== null) {
+              findAllHostChildren(workInProgress.child);
             }
             warning(
               hostChildrenCount < 2,

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -819,7 +819,7 @@ function completeWork(
               workInProgress,
             );
             warning(
-              hostChildrenCount < 2,
+              (hostChildrenCount || 0) < 2,
               'A "<%s>" event component cannot contain multiple host children.',
               getComponentName(workInProgress.type),
             );

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -50,35 +50,37 @@ export function getSuspenseFiberFromTimedOutChild(fiber: Fiber): Fiber {
 
 export function getEventComponentHostChildrenCount(
   eventComponentFiber: Fiber,
-): number {
-  let hostChildrenCount = 0;
-
-  const getHostChildrenCount = node => {
-    if (isFiberSuspenseAndTimedOut(node)) {
-      const fallbackChild = getSuspenseFallbackChild(node);
-      if (fallbackChild !== null) {
-        getHostChildrenCount(fallbackChild);
+): ?number {
+  if (__DEV__) {
+    let hostChildrenCount = 0;
+    const getHostChildrenCount = node => {
+      if (isFiberSuspenseAndTimedOut(node)) {
+        const fallbackChild = getSuspenseFallbackChild(node);
+        if (fallbackChild !== null) {
+          getHostChildrenCount(fallbackChild);
+        }
+      } else if (
+        node.tag === HostComponent ||
+        node.tag === HostText ||
+        node.tag === HostPortal
+      ) {
+        hostChildrenCount++;
+      } else {
+        const child = node.child;
+        if (child !== null) {
+          getHostChildrenCount(child);
+        }
       }
-    } else if (
-      node.tag === HostComponent ||
-      node.tag === HostText ||
-      node.tag === HostPortal
-    ) {
-      hostChildrenCount++;
-    } else {
-      const child = node.child;
-      if (child !== null) {
-        getHostChildrenCount(child);
+      const sibling = node.sibling;
+      if (sibling !== null) {
+        getHostChildrenCount(sibling);
       }
-    }
-    const sibling = node.sibling;
-    if (sibling !== null) {
-      getHostChildrenCount(sibling);
-    }
-  };
+    };
 
-  if (eventComponentFiber.child !== null) {
-    getHostChildrenCount(eventComponentFiber.child);
+    if (eventComponentFiber.child !== null) {
+      getHostChildrenCount(eventComponentFiber.child);
+    }
+
+    return hostChildrenCount;
   }
-  return hostChildrenCount;
 }

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Fiber} from './ReactFiber';
+
+import {
+  HostComponent,
+  HostText,
+  HostPortal,
+  SuspenseComponent,
+  Fragment,
+} from 'shared/ReactWorkTags';
+
+export function isFiberSuspenseAndTimedOut(fiber: Fiber): boolean {
+  return fiber.tag === SuspenseComponent && fiber.memoizedState !== null;
+}
+
+export function getSuspenseFallbackChild(fiber: Fiber): Fiber | null {
+  return ((((fiber.child: any): Fiber).sibling: any): Fiber).child;
+}
+
+export function getSuspenseChild(fiber: Fiber): Fiber | null {
+  return (((fiber.child: any): Fiber): Fiber).child;
+}
+
+export function isFiberSuspenseChild(fiber: Fiber | null): boolean {
+  if (fiber === null) {
+    return false;
+  }
+  const parent = fiber.return;
+  if (parent !== null && parent.tag === Fragment) {
+    const grandParent = parent.return;
+
+    if (
+      grandParent !== null &&
+      grandParent.tag === SuspenseComponent &&
+      grandParent.stateNode !== null
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function getSuspenseFiberFromChild(fiber: Fiber): Fiber {
+  return ((((fiber.return: any): Fiber).return: any): Fiber);
+}
+
+export function getEventComponentHostChildrenCount(
+  eventComponentFiber: Fiber,
+): number {
+  const eventComponentInstance = eventComponentFiber.stateNode;
+  let hostChildrenCount = 0;
+  let node = eventComponentFiber.child;
+  while (node !== null) {
+    if (node.tag === SuspenseComponent) {
+      const suspendedChild = isFiberSuspenseAndTimedOut(node)
+        ? getSuspenseFallbackChild(node)
+        : getSuspenseChild(node);
+      if (suspendedChild !== null) {
+        node = suspendedChild;
+        continue;
+      }
+    } else if (
+      node.tag === HostComponent ||
+      node.tag === HostText ||
+      node.tag === HostPortal
+    ) {
+      hostChildrenCount++;
+    } else {
+      const child = node.child;
+      if (child !== null) {
+        node = child;
+        continue;
+      }
+    }
+    const sibling = node.sibling;
+    if (sibling !== null) {
+      node = sibling;
+      continue;
+    }
+    let parent;
+    if (isFiberSuspenseChild(node)) {
+      parent = getSuspenseFiberFromChild(node);
+    } else {
+      parent = node.return;
+      if (parent === null) {
+        break;
+      }
+    }
+    if (parent.stateNode === eventComponentInstance) {
+      break;
+    }
+    node = parent.sibling;
+  }
+  return hostChildrenCount;
+}

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -48,7 +48,6 @@ export function getSuspenseFiberFromTimedOutChild(fiber: Fiber): Fiber {
   return ((((fiber.return: any): Fiber).return: any): Fiber);
 }
 
-// TODO: should this be under a DEV onlyflag in the future?
 export function getEventComponentHostChildrenCount(
   eventComponentFiber: Fiber,
 ): number {

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -89,6 +89,7 @@ export type ReactEventResponder = {
   targetEventTypes?: Array<ReactEventResponderEventType>,
   rootEventTypes?: Array<ReactEventResponderEventType>,
   createInitialState?: (props: null | Object) => Object,
+  allowMultipleHostChildren: boolean,
   stopLocalPropagation: boolean,
   onEvent?: (
     event: ReactResponderEvent,


### PR DESCRIPTION
This PR adds the `allowMultipleHostChildren` option to event responder modules. This allows for DEV time validation of event components and their respective host component children (if they have any). This is required for `Press`, `Hover` and other core event modules where there is a hard constraint on the amount of host components a responder supports.