### PR TITLE
Event API: ensure getFocusableElementsInScope handles suspended trees

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -360,6 +360,12 @@ const eventResponderContext: ReactResponderContext = {
           node = suspendedChild;
           continue;
         }
+      } else if (node.tag === SuspenseComponent) {
+        const suspendedChild = getSuspenseChild(node);
+        if (suspendedChild !== null) {
+          node = suspendedChild;
+          continue;
+        }
       } else {
         if (isFiberHostComponentFocusable(node)) {
           focusableElements.push(node.stateNode);
@@ -379,8 +385,8 @@ const eventResponderContext: ReactResponderContext = {
         continue;
       }
       let parent;
-      if (isFiberSuspenseFallbackChild(node)) {
-        parent = getTimedOutSuspenseFiberFromChild(node);
+      if (isFiberSuspenseChild(node)) {
+        parent = getSuspenseFiberFromChild(node);
       } else {
         parent = node.return;
         if (parent === null) {
@@ -607,7 +613,7 @@ function isFiberSuspenseAndTimedOut(fiber: Fiber): boolean {
   return fiber.tag === SuspenseComponent && fiber.memoizedState !== null;
 }
 
-function isFiberSuspenseFallbackChild(fiber: Fiber | null): boolean {
+function isFiberSuspenseChild(fiber: Fiber | null): boolean {
   if (fiber === null) {
     return false;
   }
@@ -626,12 +632,16 @@ function isFiberSuspenseFallbackChild(fiber: Fiber | null): boolean {
   return false;
 }
 
-function getTimedOutSuspenseFiberFromChild(fiber: Fiber): Fiber {
+function getSuspenseFiberFromChild(fiber: Fiber): Fiber {
   return ((((fiber.return: any): Fiber).return: any): Fiber);
 }
 
 function getSuspenseFallbackChild(fiber: Fiber): Fiber | null {
   return ((((fiber.child: any): Fiber).sibling: any): Fiber).child;
+}
+
+function getSuspenseChild(fiber: Fiber): Fiber | null {
+  return (((fiber.child: any): Fiber): Fiber).child;
 }
 
 function getTargetEventTypesSet(

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -354,14 +354,10 @@ const eventResponderContext: ReactResponderContext = {
     let node = ((eventComponentInstance.currentFiber: any): Fiber).child;
 
     while (node !== null) {
-      if (isFiberSuspenseAndTimedOut(node)) {
-        const suspendedChild = getSuspenseFallbackChild(node);
-        if (suspendedChild !== null) {
-          node = suspendedChild;
-          continue;
-        }
-      } else if (node.tag === SuspenseComponent) {
-        const suspendedChild = getSuspenseChild(node);
+      if (node.tag === SuspenseComponent) {
+        const suspendedChild = isFiberSuspenseAndTimedOut(node)
+          ? getSuspenseFallbackChild(node)
+          : getSuspenseChild(node);
         if (suspendedChild !== null) {
           node = suspendedChild;
           continue;

--- a/packages/react-dom/src/shared/assertValidProps.js
+++ b/packages/react-dom/src/shared/assertValidProps.js
@@ -31,6 +31,7 @@ function assertValidProps(tag: string, props: ?Object) {
     invariant(
       (props.children == null ||
         (enableEventAPI &&
+          props.children.type &&
           props.children.type.$$typeof === REACT_EVENT_TARGET_TYPE)) &&
         props.dangerouslySetInnerHTML == null,
       '%s is a void element tag and must neither have `children` nor ' +

--- a/packages/react-events/src/__tests__/FocusScope-test.internal.js
+++ b/packages/react-events/src/__tests__/FocusScope-test.internal.js
@@ -192,7 +192,7 @@ describe('FocusScope event responder', () => {
     expect(document.activeElement).toBe(button2Ref.current);
   });
 
-  it.only('should work as expected with suspense fallbacks', () => {
+  it('should work as expected with suspense fallbacks', () => {
     const buttonRef = React.createRef();
     const button2Ref = React.createRef();
     const button3Ref = React.createRef();

--- a/packages/react-events/src/__tests__/FocusScope-test.internal.js
+++ b/packages/react-events/src/__tests__/FocusScope-test.internal.js
@@ -191,4 +191,54 @@ describe('FocusScope event responder', () => {
     document.activeElement.dispatchEvent(createTabBackward());
     expect(document.activeElement).toBe(button2Ref.current);
   });
+
+  it.only('should work as expected with suspense fallbacks', () => {
+    const buttonRef = React.createRef();
+    const button2Ref = React.createRef();
+    const button3Ref = React.createRef();
+    const button4Ref = React.createRef();
+    const button5Ref = React.createRef();
+
+    function SuspendedComponent() {
+      throw new Promise(() => {
+        // Never resolve
+      });
+    }
+
+    function Component() {
+      return (
+        <React.Fragment>
+          <button ref={button5Ref} id={5} />
+          <SuspendedComponent />
+        </React.Fragment>
+      );
+    }
+
+    const SimpleFocusScope = () => (
+      <div>
+        <FocusScope>
+          <button ref={buttonRef} id={1} />
+          <button ref={button2Ref} id={2} />
+          <React.Suspense fallback={<button ref={button3Ref} id={3} />}>
+            <Component />
+          </React.Suspense>
+          <button ref={button4Ref} id={4} />
+        </FocusScope>
+      </div>
+    );
+
+    ReactDOM.render(<SimpleFocusScope />, container);
+    buttonRef.current.focus();
+    expect(document.activeElement).toBe(buttonRef.current);
+    document.activeElement.dispatchEvent(createTabForward());
+    expect(document.activeElement).toBe(button2Ref.current);
+    document.activeElement.dispatchEvent(createTabForward());
+    expect(document.activeElement).toBe(button3Ref.current);
+    document.activeElement.dispatchEvent(createTabForward());
+    expect(document.activeElement).toBe(button4Ref.current);
+    document.activeElement.dispatchEvent(createTabBackward());
+    expect(document.activeElement).toBe(button3Ref.current);
+    document.activeElement.dispatchEvent(createTabBackward());
+    expect(document.activeElement).toBe(button2Ref.current);
+  });
 });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -63,7 +63,7 @@ export const warnAboutShorthandPropertyCollision = false;
 export const warnAboutDeprecatedSetNativeProps = false;
 
 // Experimental React Events support. Only used in www builds for now.
-export const enableEventAPI = false;
+export const enableEventAPI = true;
 
 // New API for JSX transforms to target - https://github.com/reactjs/rfcs/pull/107
 export const enableJSXTransformAPI = false;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -63,7 +63,7 @@ export const warnAboutShorthandPropertyCollision = false;
 export const warnAboutDeprecatedSetNativeProps = false;
 
 // Experimental React Events support. Only used in www builds for now.
-export const enableEventAPI = true;
+export const enableEventAPI = false;
 
 // New API for JSX transforms to target - https://github.com/reactjs/rfcs/pull/107
 export const enableJSXTransformAPI = false;


### PR DESCRIPTION
This PR fixes a bug in `getFocusableElementsInScope` where suspense trees weren't correctly handled during fiber tree traversal. With these changes, `getFocusableElementsInScope` now properly collects focusable elements in regards to Suspense fallbacks.