### PR TITLE
Use dynamic flag in test renderer in www

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -12,6 +12,9 @@ import invariant from 'shared/invariant';
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as PersistentFeatureFlagsType from './ReactFeatureFlags.persistent';
 
+// Re-export dynamic flags from the www version.
+export const {revertPassiveEffectsChange} = require('ReactFeatureFlags');
+
 export const debugRenderPhaseSideEffects = false;
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableUserTimingAPI = __DEV__;
@@ -27,7 +30,6 @@ export const disableJavaScriptURLs = false;
 export const disableYielding = false;
 export const enableEventAPI = true;
 export const enableJSXTransformAPI = true;
-export const revertPassiveEffectsChange = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {


### PR DESCRIPTION
Uses a dynamic flag in www's test renderer build so we can conditionally disable the passive effects bugfix. Matches the dynamic flag used in the www React DOM build.