### PR TITLE
Bail out of updates in offscreen trees

### DIFF
--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1323,18 +1323,27 @@ describe('ReactUpdates', () => {
 
     const root = ReactDOM.unstable_createRoot(container);
     root.render(<Foo />);
-    expect(Scheduler).toFlushAndYieldThrough(
-      ['Foo', __DEV__ && 'Foo', 'Baz', 'Foo#effect'].filter(Boolean),
-    );
+    if (__DEV__) {
+      expect(Scheduler).toFlushAndYieldThrough([
+        'Foo',
+        'Foo',
+        'Baz',
+        'Foo#effect',
+      ]);
+    } else {
+      expect(Scheduler).toFlushAndYieldThrough(['Foo', 'Baz', 'Foo#effect']);
+    }
 
     const hiddenDiv = container.firstChild.firstChild;
     expect(hiddenDiv.hidden).toBe(true);
     expect(hiddenDiv.innerHTML).toBe('');
 
     // Run offscreen update
-    expect(Scheduler).toFlushAndYield(
-      ['Bar', __DEV__ && 'Bar'].filter(Boolean),
-    );
+    if (__DEV__) {
+      expect(Scheduler).toFlushAndYield(['Bar', 'Bar']);
+    } else {
+      expect(Scheduler).toFlushAndYield(['Bar']);
+    }
     expect(hiddenDiv.hidden).toBe(true);
     expect(hiddenDiv.innerHTML).toBe('<p>bar 0</p>');
 
@@ -1345,9 +1354,11 @@ describe('ReactUpdates', () => {
     expect(hiddenDiv.innerHTML).toBe('<p>bar 0</p>');
 
     // Run offscreen update
-    expect(Scheduler).toFlushAndYield(
-      ['Bar', __DEV__ && 'Bar'].filter(Boolean),
-    );
+    if (__DEV__) {
+      expect(Scheduler).toFlushAndYield(['Bar', 'Bar']);
+    } else {
+      expect(Scheduler).toFlushAndYield(['Bar']);
+    }
     expect(hiddenDiv.innerHTML).toBe('<p>bar 1</p>');
   });
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2132,6 +2132,7 @@ function beginWork(
           resetHydrationState();
           break;
         case HostComponent:
+          pushHostContext(workInProgress);
           if (
             workInProgress.mode & ConcurrentMode &&
             renderExpirationTime !== Never &&
@@ -2141,7 +2142,6 @@ function beginWork(
             workInProgress.expirationTime = workInProgress.childExpirationTime = Never;
             return null;
           }
-          pushHostContext(workInProgress);
           break;
         case ClassComponent: {
           const Component = workInProgress.type;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -973,8 +973,8 @@ function updateHostComponent(current, workInProgress, renderExpirationTime) {
 
   // Check the host config to see if the children are offscreen/hidden.
   if (
-    renderExpirationTime !== Never &&
     workInProgress.mode & ConcurrentMode &&
+    renderExpirationTime !== Never &&
     shouldDeprioritizeSubtree(type, nextProps)
   ) {
     // Schedule this fiber to re-render at offscreen priority. Then bailout.
@@ -2132,6 +2132,15 @@ function beginWork(
           resetHydrationState();
           break;
         case HostComponent:
+          if (
+            workInProgress.mode & ConcurrentMode &&
+            renderExpirationTime !== Never &&
+            shouldDeprioritizeSubtree(workInProgress.type, newProps)
+          ) {
+            // Schedule this fiber to re-render at offscreen priority. Then bailout.
+            workInProgress.expirationTime = workInProgress.childExpirationTime = Never;
+            return null;
+          }
           pushHostContext(workInProgress);
           break;
         case ClassComponent: {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
@@ -966,7 +966,7 @@ describe('ReactIncrementalSideEffects', () => {
 
     // However, once we render fully, we will have enough time to finish it all
     // at once.
-    expect(Scheduler).toFlushAndYield(['Bar', 'Bar', 'Bar']);
+    expect(Scheduler).toFlushAndYield(['Bar', 'Bar']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(
       <div>
         <span prop={1} />


### PR DESCRIPTION
Currently `setState` inside `flushSync` will flush within an offscreen tree. This is because our offscreen bailout is buried into `updateHostComponent` which doesn't run in the jump-over bailout codepath as we go towards the deep update. This duplicates the check there. The new test fails on master. (I'm not sure I understand the change needed in another test so this needs some caution.)

I've also flipped the condition in both places to check the mode first. Since this is likely a more common first check that will be false.

Note this adds some overhead in CM to the jump-over bailout codepath. Maybe this is the time to add `<Offscreen />` instead?