### PR TITLE
Event API: ensure calculateResponderRegion accounts for page offset

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -428,6 +428,25 @@ function calculateDelayMS(delay: ?number, min = 0, fallback = 0) {
   return Math.max(min, maybeNumber != null ? maybeNumber : fallback);
 }
 
+function getAbsoluteBoundingClientRect(
+  target: Element,
+): {left: number, right: number, bottom: number, top: number} {
+  const clientRect = target.getBoundingClientRect();
+  let {left, right, bottom, top} = clientRect;
+  let node = target;
+  // Traverse through all offset nodes
+  while (node != null) {
+    const offsetX = (node: any).offsetLeft || 0;
+    const offsetY = (node: any).offsetTop || 0;
+    left += offsetX;
+    right += offsetX;
+    top += offsetY;
+    bottom += offsetY;
+    node = (node: any).offsetParent;
+  }
+  return {left, right, bottom, top};
+}
+
 // TODO: account for touch hit slop
 function calculateResponderRegion(
   context: ReactResponderContext,
@@ -440,14 +459,8 @@ function calculateResponderRegion(
     props.pressRetentionOffset,
   );
 
-  const clientRect = target.getBoundingClientRect();
-  const viewportOffsetX = window.pageXOffset;
-  const viewportOffsetY = window.pageYOffset;
-
-  let bottom = clientRect.bottom + viewportOffsetY;
-  let top = clientRect.top + viewportOffsetY;
-  let left = clientRect.left + viewportOffsetX;
-  let right = clientRect.right + viewportOffsetX;
+  const clientRect = getAbsoluteBoundingClientRect(target);
+  let {left, right, bottom, top} = clientRect;
 
   if (pressRetentionOffset) {
     if (pressRetentionOffset.bottom != null) {

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -441,11 +441,13 @@ function calculateResponderRegion(
   );
 
   const clientRect = target.getBoundingClientRect();
+  const viewportOffsetX = window.pageXOffset;
+  const viewportOffsetY = window.pageYOffset;
 
-  let bottom = clientRect.bottom;
-  let left = clientRect.left;
-  let right = clientRect.right;
-  let top = clientRect.top;
+  let bottom = clientRect.bottom + viewportOffsetY;
+  let top = clientRect.top + viewportOffsetY;
+  let left = clientRect.left + viewportOffsetX;
+  let right = clientRect.right + viewportOffsetX;
 
   if (pressRetentionOffset) {
     if (pressRetentionOffset.bottom != null) {

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -433,18 +433,22 @@ function getAbsoluteBoundingClientRect(
 ): {left: number, right: number, bottom: number, top: number} {
   const clientRect = target.getBoundingClientRect();
   let {left, right, bottom, top} = clientRect;
-  let node = target;
+  let node = target.parentNode;
+  let offsetX = 0;
+  let offsetY = 0;
+
   // Traverse through all offset nodes
-  while (node != null) {
-    const offsetX = (node: any).offsetLeft || 0;
-    const offsetY = (node: any).offsetTop || 0;
-    left += offsetX;
-    right += offsetX;
-    top += offsetY;
-    bottom += offsetY;
-    node = (node: any).offsetParent;
+  while (node != null && node.nodeType !== Node.DOCUMENT_NODE) {
+    offsetX += (node: any).scrollLeft;
+    offsetY += (node: any).scrollTop;
+    node = node.parentNode;
   }
-  return {left, right, bottom, top};
+  return {
+    left: left + offsetX,
+    right: right + offsetX,
+    bottom: bottom + offsetY,
+    top: top + offsetY,
+  };
 }
 
 // TODO: account for touch hit slop

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -1108,9 +1108,7 @@ describe('Event responder: Press', () => {
 
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
         // Emulate the element being offset
-        Object.defineProperty(ref.current, 'offsetTop', {
-          value: 1000,
-        });
+        document.body.scrollTop = 1000;
         const updatedCoordinatesInside = {
           pageX: coordinatesInside.pageX,
           pageY: coordinatesInside.pageY + 1000,
@@ -1125,6 +1123,7 @@ describe('Event responder: Press', () => {
           createEvent('pointerup', updatedCoordinatesInside),
         );
         jest.runAllTimers();
+        document.body.scrollTop = 0;
 
         expect(events).toEqual([
           'onPressStart',

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -1107,7 +1107,10 @@ describe('Event responder: Press', () => {
         ReactDOM.render(element, container);
 
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        window.pageYOffset = 1000;
+        // Emulate the element being offset
+        Object.defineProperty(ref.current, 'offsetTop', {
+          value: 1000,
+        });
         const updatedCoordinatesInside = {
           pageX: coordinatesInside.pageX,
           pageY: coordinatesInside.pageY + 1000,
@@ -1122,7 +1125,6 @@ describe('Event responder: Press', () => {
           createEvent('pointerup', updatedCoordinatesInside),
         );
         jest.runAllTimers();
-        window.pageYOffset = 0;
 
         expect(events).toEqual([
           'onPressStart',

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -1085,6 +1085,56 @@ describe('Event responder: Press', () => {
       });
     });
 
+    describe('the page offset changes', () => {
+      it('"onPress" is called on release', () => {
+        let events = [];
+        const ref = React.createRef();
+        const createEventHandler = msg => () => {
+          events.push(msg);
+        };
+
+        const element = (
+          <Press
+            onPress={createEventHandler('onPress')}
+            onPressChange={createEventHandler('onPressChange')}
+            onPressMove={createEventHandler('onPressMove')}
+            onPressStart={createEventHandler('onPressStart')}
+            onPressEnd={createEventHandler('onPressEnd')}>
+            <div ref={ref} />
+          </Press>
+        );
+
+        ReactDOM.render(element, container);
+
+        ref.current.getBoundingClientRect = getBoundingClientRectMock;
+        window.pageYOffset = 1000;
+        const updatedCoordinatesInside = {
+          pageX: coordinatesInside.pageX,
+          pageY: coordinatesInside.pageY + 1000,
+        };
+        ref.current.dispatchEvent(
+          createEvent('pointerdown', updatedCoordinatesInside),
+        );
+        container.dispatchEvent(
+          createEvent('pointermove', updatedCoordinatesInside),
+        );
+        container.dispatchEvent(
+          createEvent('pointerup', updatedCoordinatesInside),
+        );
+        jest.runAllTimers();
+        window.pageYOffset = 0;
+
+        expect(events).toEqual([
+          'onPressStart',
+          'onPressChange',
+          'onPressMove',
+          'onPressEnd',
+          'onPressChange',
+          'onPress',
+        ]);
+      });
+    });
+
     describe('beyond bounds of hit rect', () => {
       /** ┌──────────────────┐
        *  │  ┌────────────┐  │


### PR DESCRIPTION
This PR fixes issues where `Press` was not getting fired correctly due to co-ords of the responder not correctly accounting for the fact `getBoundingClientRect`'s position is relative to the viewport, not the page. This adds the page offsets to the calculations to ensure consistency when scrolling etc.