### PR TITLE
Event API: isTargetWithinEventResponderScope on unmounted event components

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -197,7 +197,7 @@ const eventResponderContext: ReactResponderContext = {
         }
         if (
           fiber.tag === EventComponent &&
-          fiber.stateNode.responder === responder
+          (fiber.stateNode === null || fiber.stateNode.responder === responder)
         ) {
           return false;
         }


### PR DESCRIPTION
This PR fixes an issue where the EventComponent fiber's `stateNode` can be `null`, but this wasn't checked. The case for this is when an event component fiber gets unmounted (it's `stateNode` gets set to `null`). With nested event components, any calling `isTargetWithinEventResponderScope` might encounter this problem. I'll add a follow up test once I get a chance (probably next week).