### PR TITLE
Event API: ensure simulated mouse events are not propagated

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -713,10 +713,6 @@ const PressResponder = {
             nativeEvent.preventDefault();
           }
         }
-        if (state.ignoreEmulatedMouseEvents) {
-          state.ignoreEmulatedMouseEvents = false;
-          nativeEvent.stopImmediatePropagation();
-        }
         break;
       }
     }
@@ -808,6 +804,7 @@ const PressResponder = {
       case 'touchend': {
         if (type === 'mouseup' && state.ignoreEmulatedMouseEvents) {
           nativeEvent.stopImmediatePropagation();
+          state.ignoreEmulatedMouseEvents = false;
           return;
         }
         if (state.isPressed) {

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -649,6 +649,11 @@ const PressResponder = {
 
           // Ignore emulated mouse events
           if (type === 'mousedown' && state.ignoreEmulatedMouseEvents) {
+            // In order to ensure that other event systems (including React's heritage event system).
+            // We need to be able to block these events from reaching them, otherwise, they
+            // might conflict with Flare and cause unwanted side-effects. So we use the
+            // stopImmediatePropagation to do this via the DOM event API. At some point,
+            // we may want to move this into the Flare event system, rather than have it in this module.
             nativeEvent.stopImmediatePropagation();
             return;
           }
@@ -803,6 +808,11 @@ const PressResponder = {
       case 'mouseup':
       case 'touchend': {
         if (type === 'mouseup' && state.ignoreEmulatedMouseEvents) {
+          // In order to ensure that other event systems (including React's heritage event system).
+            // We need to be able to block these events from reaching them, otherwise, they
+            // might conflict with Flare and cause unwanted side-effects. So we use the
+            // stopImmediatePropagation to do this via the DOM event API. At some point,
+            // we may want to move this into the Flare event system, rather than have it in this module.
           nativeEvent.stopImmediatePropagation();
           state.ignoreEmulatedMouseEvents = false;
           return;


### PR DESCRIPTION
When dealing with touch events, browsers "simulate" mouse events from them. This can be problematic for the experimental event API, as it means that when we've dispatched a "Press" during the "pointerup" event, a later "mouseup" or "click" event can cause side-effects that would never have happened by using "click" (as it's the last event). I've allowed "click" for now, only so that this doesn't affect tracking tooling that relies upon "click" working for touch events too; so only "mousedown" and "mouseup" and blocked when using Press.