### PR TITLE
[Fresh] Don't traverse remounted trees

### DIFF
--- a/packages/react-dom/src/__tests__/ReactFresh-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactFresh-test.internal.js
@@ -1549,6 +1549,47 @@ describe('ReactFresh', () => {
     }
   });
 
+  it('batches re-renders during a hot update', () => {
+    if (__DEV__) {
+      let helloRenders = 0;
+
+      render(() => {
+        function Hello({children}) {
+          helloRenders++;
+          return <div>X{children}X</div>;
+        }
+        __register__(Hello, 'Hello');
+
+        function App() {
+          return (
+            <Hello>
+              <Hello>
+                <Hello />
+              </Hello>
+              <Hello>
+                <Hello />
+              </Hello>
+            </Hello>
+          );
+        }
+        return App;
+      });
+      expect(helloRenders).toBe(5);
+      expect(container.textContent).toBe('XXXXXXXXXX');
+      helloRenders = 0;
+
+      patch(() => {
+        function Hello({children}) {
+          helloRenders++;
+          return <div>O{children}O</div>;
+        }
+        __register__(Hello, 'Hello');
+      });
+      expect(helloRenders).toBe(5);
+      expect(container.textContent).toBe('OOOOOOOOOO');
+    }
+  });
+
   it('does not leak state between components', () => {
     if (__DEV__) {
       const AppV1 = render(

--- a/packages/react-reconciler/src/ReactFiberHotReloading.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.js
@@ -224,29 +224,34 @@ function scheduleFibersWithFamiliesRecursively(
       throw new Error('Expected familiesByType to be set during hot reload.');
     }
 
+    let needsRender = false;
+    let needsRemount = false;
     if (candidateType !== null) {
       const family = familiesByType.get(candidateType);
       if (family !== undefined) {
         if (staleFamilies.has(family)) {
-          fiber._debugNeedsRemount = true;
-          scheduleWork(fiber, Sync);
+          needsRemount = true;
         } else if (updatedFamilies.has(family)) {
-          scheduleWork(fiber, Sync);
+          needsRender = true;
         }
       }
     }
-
     if (failedBoundaries !== null) {
       if (
         failedBoundaries.has(fiber) ||
         (alternate !== null && failedBoundaries.has(alternate))
       ) {
-        fiber._debugNeedsRemount = true;
-        scheduleWork(fiber, Sync);
+        needsRemount = true;
       }
     }
 
-    if (child !== null) {
+    if (needsRemount) {
+      fiber._debugNeedsRemount = true;
+    }
+    if (needsRemount || needsRender) {
+      scheduleWork(fiber, Sync);
+    }
+    if (child !== null && !needsRemount) {
       scheduleFibersWithFamiliesRecursively(
         child,
         updatedFamilies,


### PR DESCRIPTION
If a tree is marked as needing a remount, there is no use traversing it to schedule more work inside it. It will be thrown away in either case.

This PR restructures the code a little bit to implement this optimization. It also adds a test that verifies we always batch hot reload updates. This was already the case, but the test makes me feel more confident that we won't accidentally remove batching. Batching is important because otherwise we'll have a deep cascading update that will be super slow.