### PR TITLE
[Fresh] Support re-rendering lazy() without losing state

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHotReloading.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.js
@@ -23,7 +23,11 @@ import {
   MemoComponent,
   SimpleMemoComponent,
 } from 'shared/ReactWorkTags';
-import {REACT_FORWARD_REF_TYPE, REACT_MEMO_TYPE} from 'shared/ReactSymbols';
+import {
+  REACT_FORWARD_REF_TYPE,
+  REACT_MEMO_TYPE,
+  REACT_LAZY_TYPE,
+} from 'shared/ReactSymbols';
 
 type Family = {|
   currentType: any,
@@ -108,39 +112,47 @@ export function isCompatibleFamilyForHotReloading(
 
     const prevType = fiber.elementType;
     const nextType = element.type;
+
     // If we got here, we know types aren't === equal.
     let needsCompareFamilies = false;
+
+    const nextTypeOf =
+      typeof nextType === 'object' && nextType !== null
+        ? nextType.$$typeof
+        : null;
+
     switch (fiber.tag) {
       case FunctionComponent: {
         if (typeof nextType === 'function') {
+          needsCompareFamilies = true;
+        } else if (nextTypeOf === REACT_LAZY_TYPE) {
+          // We don't know the inner type yet.
+          // We're going to assume that the lazy inner type is stable,
+          // and so it is sufficient to avoid reconciling it away.
+          // We're not going to unwrap or actually use the new lazy type.
           needsCompareFamilies = true;
         }
         break;
       }
       case ForwardRef: {
-        if (
-          typeof nextType === 'object' &&
-          nextType !== null &&
-          nextType.$$typeof === REACT_FORWARD_REF_TYPE
-        ) {
+        if (nextTypeOf === REACT_FORWARD_REF_TYPE) {
+          needsCompareFamilies = true;
+        } else if (nextTypeOf === REACT_LAZY_TYPE) {
           needsCompareFamilies = true;
         }
         break;
       }
       case MemoComponent:
       case SimpleMemoComponent: {
-        if (
-          typeof nextType === 'object' &&
-          nextType !== null &&
-          nextType.$$typeof === REACT_MEMO_TYPE
-        ) {
+        if (nextTypeOf === REACT_MEMO_TYPE) {
           // TODO: if it was but can no longer be simple,
           // we shouldn't set this.
+          needsCompareFamilies = true;
+        } else if (nextTypeOf === REACT_LAZY_TYPE) {
           needsCompareFamilies = true;
         }
         break;
       }
-      // TODO: maybe support lazy?
       default:
         return false;
     }

--- a/packages/react-reconciler/src/ReactFiberHotReloading.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.js
@@ -116,7 +116,7 @@ export function isCompatibleFamilyForHotReloading(
     // If we got here, we know types aren't === equal.
     let needsCompareFamilies = false;
 
-    const nextTypeOf =
+    const $$typeofNextType =
       typeof nextType === 'object' && nextType !== null
         ? nextType.$$typeof
         : null;
@@ -125,7 +125,7 @@ export function isCompatibleFamilyForHotReloading(
       case FunctionComponent: {
         if (typeof nextType === 'function') {
           needsCompareFamilies = true;
-        } else if (nextTypeOf === REACT_LAZY_TYPE) {
+        } else if ($$typeofNextType === REACT_LAZY_TYPE) {
           // We don't know the inner type yet.
           // We're going to assume that the lazy inner type is stable,
           // and so it is sufficient to avoid reconciling it away.
@@ -135,20 +135,20 @@ export function isCompatibleFamilyForHotReloading(
         break;
       }
       case ForwardRef: {
-        if (nextTypeOf === REACT_FORWARD_REF_TYPE) {
+        if ($$typeofNextType === REACT_FORWARD_REF_TYPE) {
           needsCompareFamilies = true;
-        } else if (nextTypeOf === REACT_LAZY_TYPE) {
+        } else if ($$typeofNextType === REACT_LAZY_TYPE) {
           needsCompareFamilies = true;
         }
         break;
       }
       case MemoComponent:
       case SimpleMemoComponent: {
-        if (nextTypeOf === REACT_MEMO_TYPE) {
+        if ($$typeofNextType === REACT_MEMO_TYPE) {
           // TODO: if it was but can no longer be simple,
           // we shouldn't set this.
           needsCompareFamilies = true;
-        } else if (nextTypeOf === REACT_LAZY_TYPE) {
+        } else if ($$typeofNextType === REACT_LAZY_TYPE) {
           needsCompareFamilies = true;
         }
         break;


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/15681.

Say you have `App.js` which imports `Button.js` using a lazy dynamic import.

```js
// In App.js
const Button = lazy(() => import('./Button'));
```

With https://github.com/facebook/react/pull/15681 alone, you can edit `Button.js` and that will preserve Button's state. However, before this PR editing `App.js` would always remount Button. This is because `newLazyType !== prevLazyType`.

This PR solves it in the same way we solve it for `forwardRef` and `memo`. We expect that the transform will "register" the wrapped type separately *at the callsite*:

```js
const Button = lazy(() => import('./Button'));
__register__(Button, 'App.js$Button'); // Generated by the transform
```

When reconciling, we'll always check families when `element.type` is a lazy wrapper, and if the family matches, avoid blowing away the state.

Note that we don't do anything with a new Promise factory. We just ignore it, as we expect in the vast majority of cases the Promise factory to be stable and a thin wrapper over an `import` call. (If desired, we could later make it more cautious by attaching some kind of signature — similar to how we handle Hooks.) By ignoring the Promise factory, we rely on the inner type registration in `Button.js` to actually reflect the hot update.

In theory we could simply allow it to Suspend for a little bit, and then somehow make it work with the normal lazy resolution codepath. This would let us gracefully handle changes to the inner expression. However that would only work in Concurrent Mode. It doesn't seem worth it, especially given that we can already do something similar using build-time signatures.