### PR TITLE
[Flare] Update interactiveUpdates flushing heuristics

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -1030,6 +1030,7 @@ describe('ReactDOMFiber', () => {
     const handlerA = () => ops.push('A');
     const handlerB = () => ops.push('B');
 
+    spyOnProd(console, 'error');
     window.addEventListener('error', e => {
       eventErrors.push(e.message);
     });

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -1026,8 +1026,13 @@ describe('ReactDOMFiber', () => {
 
   it('should not update event handlers until commit', () => {
     let ops = [];
+    let eventErrors = [];
     const handlerA = () => ops.push('A');
     const handlerB = () => ops.push('B');
+
+    window.addEventListener('error', e => {
+      eventErrors.push(e.message);
+    });
 
     class Example extends React.Component {
       state = {flip: false, count: 0};
@@ -1090,12 +1095,16 @@ describe('ReactDOMFiber', () => {
 
     // Because the new click handler has not yet committed, we should still
     // invoke B.
-    expect(ops).toEqual(['B']);
+    expect(ops).toEqual([]);
     ops = [];
 
     // Any click that happens after commit, should invoke A.
     node.click();
     expect(ops).toEqual(['A']);
+    expect(eventErrors[0]).toEqual(
+      'unstable_flushDiscreteUpdates: Cannot flush ' +
+        'updates when React is already rendering.',
+    );
   });
 
   it('should not crash encountering low-priority tree', () => {

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -83,7 +83,7 @@ function runActTests(label, render, unmount) {
         expect(Scheduler).toHaveYielded([100]);
       });
 
-      it('flushes effects on every call', () => {
+      it.only('flushes effects on every call', () => {
         function App() {
           let [ctr, setCtr] = React.useState(0);
           React.useEffect(() => {

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -83,7 +83,7 @@ function runActTests(label, render, unmount) {
         expect(Scheduler).toHaveYielded([100]);
       });
 
-      it.only('flushes effects on every call', () => {
+      it('flushes effects on every call', () => {
         function App() {
           let [ctr, setCtr] = React.useState(0);
           React.useEffect(() => {

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -28,8 +28,8 @@ import {
   updateContainer,
   batchedUpdates,
   unbatchedUpdates,
-  interactiveUpdates,
-  flushInteractiveUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
   flushSync,
   flushControlled,
   injectIntoDevTools,
@@ -481,8 +481,8 @@ function shouldHydrateDueToLegacyHeuristic(container) {
 
 setBatchingImplementation(
   batchedUpdates,
-  interactiveUpdates,
-  flushInteractiveUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
 );
 
 let warnedAboutHydrateAPI = false;
@@ -783,7 +783,10 @@ const ReactDOM: Object = {
 
   unstable_batchedUpdates: batchedUpdates,
 
-  unstable_interactiveUpdates: interactiveUpdates,
+  unstable_interactiveUpdates: (fn, a, b, c) => {
+    flushDiscreteUpdates();
+    return discreteUpdates(fn, a, b, c);
+  },
 
   flushSync: flushSync,
 

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -26,6 +26,7 @@ import {
   flushRoot,
   createContainer,
   updateContainer,
+  batchedEventUpdates,
   batchedUpdates,
   unbatchedUpdates,
   discreteUpdates,
@@ -483,6 +484,7 @@ setBatchingImplementation(
   batchedUpdates,
   discreteUpdates,
   flushDiscreteUpdates,
+  batchedEventUpdates,
 );
 
 let warnedAboutHydrateAPI = false;
@@ -783,10 +785,14 @@ const ReactDOM: Object = {
 
   unstable_batchedUpdates: batchedUpdates,
 
+  // TODO remove this legacy method, unstable_discreteUpdates replaces it
   unstable_interactiveUpdates: (fn, a, b, c) => {
     flushDiscreteUpdates();
     return discreteUpdates(fn, a, b, c);
   },
+
+  unstable_discreteUpdates: discreteUpdates,
+  unstable_flushDiscreteUpdates: flushDiscreteUpdates,
 
   flushSync: flushSync,
 

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -1001,6 +1001,16 @@ export function generateListeningKey(
 let lastDiscreteEventTimeStamp = 0;
 
 export function shouldflushDiscreteUpdates(timeStamp: number): boolean {
+  // event.timeStamp isn't overly reliable due to inconsistencies in
+  // how different browsers have historically provided the time stamp.
+  // Some browsers provide high-resolution time stamps for all events,
+  // some provide low-resoltion time stamps for all events. FF < 52
+  // even mixes both time stamps together. Some browsers even report
+  // negative time stamps or time stamps that are 0 (iOS9) in some cases.
+  // Given we are only comparing two time stamps with equality (!==),
+  // we are safe from the resolution differences. If the time stamp is 0
+  // we bail-out of preventing the flush, which shouldn't have any
+  // effect on the desired output, other than we over-flush.
   if (timeStamp === 0 || lastDiscreteEventTimeStamp !== timeStamp) {
     lastDiscreteEventTimeStamp = timeStamp;
     return true;

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -1009,8 +1009,10 @@ export function shouldflushDiscreteUpdates(timeStamp: number): boolean {
   // negative time stamps or time stamps that are 0 (iOS9) in some cases.
   // Given we are only comparing two time stamps with equality (!==),
   // we are safe from the resolution differences. If the time stamp is 0
-  // we bail-out of preventing the flush, which shouldn't have any
-  // effect on the desired output, other than we over-flush.
+  // we bail-out of preventing the flush, which can affect semantics,
+  // such as if an earlier flush removes or adds event listeners that
+  // are fired in the subsequent flush. However, this is the same
+  // behaviour as we had before this change, so the risks are low.
   if (timeStamp === 0 || lastDiscreteEventTimeStamp !== timeStamp) {
     lastDiscreteEventTimeStamp = timeStamp;
     return true;

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -1009,8 +1009,6 @@ if (canUseDOM) {
     const firefoxVersion = firefoxUA[1].split('.');
     if (parseInt(firefoxVersion[0], 10) < 53) {
       useTimeStampHeuristic = false;
-    } else {
-      console.log(firefoxVersion[0]);
     }
   }
 }

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -36,7 +36,6 @@ import warning from 'shared/warning';
 import {enableEventAPI} from 'shared/ReactFeatureFlags';
 import {invokeGuardedCallbackAndCatchFirstError} from 'shared/ReactErrorUtils';
 import invariant from 'shared/invariant';
-import {canUseDOM} from 'shared/ExecutionEnvironment';
 import {
   isFiberSuspenseAndTimedOut,
   getSuspenseFallbackChild,
@@ -1000,25 +999,9 @@ export function generateListeningKey(
 }
 
 let lastDiscreteEventTimeStamp = 0;
-let useTimeStampHeuristic = true;
-
-if (canUseDOM) {
-  const firefoxUA = navigator.userAgent.match(/Firefox\/(.*)$/);
-
-  if (firefoxUA && firefoxUA.length === 2) {
-    const firefoxVersion = firefoxUA[1].split('.');
-    if (parseInt(firefoxVersion[0], 10) < 53) {
-      useTimeStampHeuristic = false;
-    }
-  }
-}
 
 export function shouldflushDiscreteUpdates(timeStamp: number): boolean {
-  if (
-    !useTimeStampHeuristic ||
-    timeStamp === 0 ||
-    lastDiscreteEventTimeStamp !== timeStamp
-  ) {
+  if (timeStamp === 0 || lastDiscreteEventTimeStamp !== timeStamp) {
     lastDiscreteEventTimeStamp = timeStamp;
     return true;
   }

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -26,7 +26,11 @@ import type {
   ReactResponderDispatchEventOptions,
 } from 'shared/ReactTypes';
 import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
-import {batchedUpdates, interactiveUpdates} from 'events/ReactGenericBatching';
+import {
+  batchedUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
+} from 'events/ReactGenericBatching';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import warning from 'shared/warning';
 import {enableEventAPI} from 'shared/ReactFeatureFlags';
@@ -587,7 +591,8 @@ export function processEventQueue(): void {
     return;
   }
   if (discrete) {
-    interactiveUpdates(() => {
+    flushDiscreteUpdates(currentTimeStamp);
+    discreteUpdates(() => {
       batchedUpdates(processEvents, events);
     });
   } else {

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -36,6 +36,7 @@ import warning from 'shared/warning';
 import {enableEventAPI} from 'shared/ReactFeatureFlags';
 import {invokeGuardedCallbackAndCatchFirstError} from 'shared/ReactErrorUtils';
 import invariant from 'shared/invariant';
+import {canUseDOM} from 'shared/ExecutionEnvironment';
 import {
   isFiberSuspenseAndTimedOut,
   getSuspenseFallbackChild,
@@ -999,9 +1000,27 @@ export function generateListeningKey(
 }
 
 let lastDiscreteEventTimeStamp = 0;
+let useTimeStampHeuristic = true;
+
+if (canUseDOM) {
+  const firefoxUA = navigator.userAgent.match(/Firefox\/(.*)$/);
+
+  if (firefoxUA && firefoxUA.length === 2) {
+    const firefoxVersion = firefoxUA[1].split('.');
+    if (parseInt(firefoxVersion[0], 10) < 53) {
+      useTimeStampHeuristic = false;
+    } else {
+      console.log(firefoxVersion[0]);
+    }
+  }
+}
 
 export function shouldflushDiscreteUpdates(timeStamp: number): boolean {
-  if (lastDiscreteEventTimeStamp !== timeStamp) {
+  if (
+    !useTimeStampHeuristic ||
+    timeStamp === 0 ||
+    lastDiscreteEventTimeStamp !== timeStamp
+  ) {
     lastDiscreteEventTimeStamp = timeStamp;
     return true;
   }

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -33,8 +33,8 @@ import {
   updateContainer,
   batchedUpdates,
   unbatchedUpdates,
-  interactiveUpdates,
-  flushInteractiveUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
   flushSync,
   flushControlled,
   injectIntoDevTools,
@@ -487,8 +487,8 @@ function shouldHydrateDueToLegacyHeuristic(container) {
 
 setBatchingImplementation(
   batchedUpdates,
-  interactiveUpdates,
-  flushInteractiveUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
 );
 
 let warnedAboutHydrateAPI = false;
@@ -789,7 +789,10 @@ const ReactDOM: Object = {
 
   unstable_batchedUpdates: batchedUpdates,
 
-  unstable_interactiveUpdates: interactiveUpdates,
+  unstable_interactiveUpdates: (fn, a, b, c) => {
+    flushDiscreteUpdates();
+    return discreteUpdates(fn, a, b, c);
+  },
 
   flushSync: flushSync,
 

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -31,6 +31,7 @@ import {
   flushRoot,
   createContainer,
   updateContainer,
+  batchedEventUpdates,
   batchedUpdates,
   unbatchedUpdates,
   discreteUpdates,
@@ -489,6 +490,7 @@ setBatchingImplementation(
   batchedUpdates,
   discreteUpdates,
   flushDiscreteUpdates,
+  batchedEventUpdates,
 );
 
 let warnedAboutHydrateAPI = false;
@@ -789,10 +791,14 @@ const ReactDOM: Object = {
 
   unstable_batchedUpdates: batchedUpdates,
 
+  // TODO remove this legacy method, unstable_discreteUpdates replaces it
   unstable_interactiveUpdates: (fn, a, b, c) => {
     flushDiscreteUpdates();
     return discreteUpdates(fn, a, b, c);
   },
+
+  unstable_discreteUpdates: discreteUpdates,
+  unstable_flushDiscreteUpdates: flushDiscreteUpdates,
 
   flushSync: flushSync,
 

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -2304,17 +2304,17 @@ describe('Event responder: Press', () => {
     ]);
   });
 
+  function dispatchEventWithTimeStamp(elem, name, timeStamp) {
+    const event = createEvent(name);
+    Object.defineProperty(event, 'timeStamp', {
+      value: timeStamp,
+    });
+    elem.dispatchEvent(event);
+  }
+
   it('should properly only flush sync once when the event systems are mixed', () => {
     const ref = React.createRef();
     let renderCounts = 0;
-
-    function dispatchEvent(name, timeStamp) {
-      const event = createEvent(name);
-      Object.defineProperty(event, 'timeStamp', {
-        value: timeStamp,
-      });
-      ref.current.dispatchEvent(event);
-    }
 
     function MyComponent() {
       const [, updateCounter] = React.useState(0);
@@ -2345,9 +2345,9 @@ describe('Event responder: Press', () => {
     root.render(<MyComponent />);
     Scheduler.flushAll();
 
-    dispatchEvent('pointerdown', 100);
-    dispatchEvent('pointerup', 100);
-    dispatchEvent('click', 100);
+    dispatchEventWithTimeStamp(ref.current, 'pointerdown', 100);
+    dispatchEventWithTimeStamp(ref.current, 'pointerup', 100);
+    dispatchEventWithTimeStamp(ref.current, 'click', 100);
 
     if (__DEV__) {
       expect(renderCounts).toBe(2);
@@ -2361,10 +2361,10 @@ describe('Event responder: Press', () => {
       expect(renderCounts).toBe(2);
     }
 
-    dispatchEvent('pointerdown', 100);
-    dispatchEvent('pointerup', 100);
+    dispatchEventWithTimeStamp(ref.current, 'pointerdown', 100);
+    dispatchEventWithTimeStamp(ref.current, 'pointerup', 100);
     // Ensure the timeStamp logic works
-    dispatchEvent('click', 101);
+    dispatchEventWithTimeStamp(ref.current, 'click', 101);
 
     if (__DEV__) {
       expect(renderCounts).toBe(6);
@@ -2372,6 +2372,73 @@ describe('Event responder: Press', () => {
       expect(renderCounts).toBe(3);
     }
 
+    Scheduler.flushAll();
+    document.body.removeChild(newContainer);
+  });
+
+  it('should properly flush sync when the event systems are mixed with unstable_flushDiscreteUpdates', () => {
+    const ref = React.createRef();
+    let renderCounts = 0;
+
+    function MyComponent() {
+      const [, updateCounter] = React.useState(0);
+      renderCounts++;
+
+      function handlePress() {
+        updateCounter(count => count + 1);
+      }
+
+      return (
+        <div>
+          <Press onPress={handlePress}>
+            <button
+              ref={ref}
+              onClick={() => {
+                // This should flush synchronously
+                ReactDOM.unstable_flushDiscreteUpdates();
+                updateCounter(count => count + 1);
+              }}>
+              Press me
+            </button>
+          </Press>
+        </div>
+      );
+    }
+
+    const newContainer = document.createElement('div');
+    const root = ReactDOM.unstable_createRoot(newContainer);
+    document.body.appendChild(newContainer);
+    root.render(<MyComponent />);
+    Scheduler.flushAll();
+
+    dispatchEventWithTimeStamp(ref.current, 'pointerdown', 100);
+    dispatchEventWithTimeStamp(ref.current, 'pointerup', 100);
+    dispatchEventWithTimeStamp(ref.current, 'click', 100);
+
+    if (__DEV__) {
+      expect(renderCounts).toBe(4);
+    } else {
+      expect(renderCounts).toBe(2);
+    }
+    Scheduler.flushAll();
+    if (__DEV__) {
+      expect(renderCounts).toBe(6);
+    } else {
+      expect(renderCounts).toBe(3);
+    }
+
+    dispatchEventWithTimeStamp(ref.current, 'pointerdown', 100);
+    dispatchEventWithTimeStamp(ref.current, 'pointerup', 100);
+    // Ensure the timeStamp logic works
+    dispatchEventWithTimeStamp(ref.current, 'click', 101);
+
+    if (__DEV__) {
+      expect(renderCounts).toBe(8);
+    } else {
+      expect(renderCounts).toBe(4);
+    }
+
+    Scheduler.flushAll();
     document.body.removeChild(newContainer);
   });
 });

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -2308,14 +2308,12 @@ describe('Event responder: Press', () => {
     const ref = React.createRef();
     let renderCounts = 0;
 
-    function dispatchEvent(name) {
+    function dispatchEvent(name, timeStamp) {
       const event = createEvent(name);
       Object.defineProperty(event, 'timeStamp', {
-        value: 100,
+        value: timeStamp,
       });
-      window.event = event;
       ref.current.dispatchEvent(event);
-      window.event = null;
     }
 
     function MyComponent() {
@@ -2347,13 +2345,32 @@ describe('Event responder: Press', () => {
     root.render(<MyComponent />);
     Scheduler.flushAll();
 
-    dispatchEvent('pointerdown');
-    dispatchEvent('pointerup');
-    dispatchEvent('click');
+    dispatchEvent('pointerdown', 100);
+    dispatchEvent('pointerup', 100);
+    dispatchEvent('click', 100);
 
-    expect(renderCounts).toBe(2);
+    if (__DEV__) {
+      expect(renderCounts).toBe(2);
+    } else {
+      expect(renderCounts).toBe(1);
+    }
     Scheduler.flushAll();
-    expect(renderCounts).toBe(4);
+    if (__DEV__) {
+      expect(renderCounts).toBe(4);
+    } else {
+      expect(renderCounts).toBe(2);
+    }
+
+    dispatchEvent('pointerdown', 100);
+    dispatchEvent('pointerup', 100);
+    // Ensure the timeStamp logic works
+    dispatchEvent('click', 101);
+
+    if (__DEV__) {
+      expect(renderCounts).toBe(6);
+    } else {
+      expect(renderCounts).toBe(3);
+    }
 
     document.body.removeChild(newContainer);
   });

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -16,8 +16,8 @@ import {
   findHostInstance,
   findHostInstanceWithWarning,
   batchedUpdates as batchedUpdatesImpl,
-  interactiveUpdates,
-  flushInteractiveUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
   createContainer,
   updateContainer,
   injectIntoDevTools,
@@ -94,8 +94,8 @@ function findNodeHandle(componentOrHandle: any): ?number {
 
 setBatchingImplementation(
   batchedUpdatesImpl,
-  interactiveUpdates,
-  flushInteractiveUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
 );
 
 const roots = new Map();

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -15,6 +15,7 @@ import './ReactFabricInjection';
 import {
   findHostInstance,
   findHostInstanceWithWarning,
+  batchedEventUpdates,
   batchedUpdates as batchedUpdatesImpl,
   discreteUpdates,
   flushDiscreteUpdates,
@@ -96,6 +97,7 @@ setBatchingImplementation(
   batchedUpdatesImpl,
   discreteUpdates,
   flushDiscreteUpdates,
+  batchedEventUpdates,
 );
 
 const roots = new Map();

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -16,6 +16,7 @@ import {
   findHostInstance,
   findHostInstanceWithWarning,
   batchedUpdates as batchedUpdatesImpl,
+  batchedEventUpdates,
   discreteUpdates,
   flushDiscreteUpdates,
   createContainer,
@@ -101,6 +102,7 @@ setBatchingImplementation(
   batchedUpdatesImpl,
   discreteUpdates,
   flushDiscreteUpdates,
+  batchedEventUpdates,
 );
 
 function computeComponentStackForErrorReporting(reactTag: number): string {

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -16,8 +16,8 @@ import {
   findHostInstance,
   findHostInstanceWithWarning,
   batchedUpdates as batchedUpdatesImpl,
-  interactiveUpdates,
-  flushInteractiveUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
   createContainer,
   updateContainer,
   injectIntoDevTools,
@@ -99,8 +99,8 @@ function findNodeHandle(componentOrHandle: any): ?number {
 
 setBatchingImplementation(
   batchedUpdatesImpl,
-  interactiveUpdates,
-  flushInteractiveUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
 );
 
 function computeComponentStackForErrorReporting(reactTag: number): string {

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -1114,7 +1114,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
     unbatchedUpdates: NoopRenderer.unbatchedUpdates,
 
-    interactiveUpdates: NoopRenderer.interactiveUpdates,
+    interactiveUpdates: <A, B, C>(fn: () => void, a: A, b: B, c: C) => {
+      NoopRenderer.flushDiscreteUpdates();
+      return NoopRenderer.discreteUpdates(fn, a, b, c);
+    },
 
     flushSync(fn: () => mixed) {
       NoopRenderer.flushSync(fn);

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -1114,10 +1114,9 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
     unbatchedUpdates: NoopRenderer.unbatchedUpdates,
 
-    interactiveUpdates: <A, B, C>(fn: () => void, a: A, b: B, c: C) => {
-      NoopRenderer.flushDiscreteUpdates();
-      return NoopRenderer.discreteUpdates(fn, a, b, c);
-    },
+    discreteUpdates: NoopRenderer.discreteUpdates,
+
+    flushDiscreteUpdates: NoopRenderer.flushDiscreteUpdates,
 
     flushSync(fn: () => mixed) {
       NoopRenderer.flushSync(fn);

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -46,6 +46,7 @@ import {
   computeExpirationForFiber,
   scheduleWork,
   flushRoot,
+  batchedEventUpdates,
   batchedUpdates,
   unbatchedUpdates,
   flushSync,
@@ -321,6 +322,7 @@ export function updateContainer(
 export {
   flushRoot,
   computeUniqueAsyncExpiration,
+  batchedEventUpdates,
   batchedUpdates,
   unbatchedUpdates,
   deferredUpdates,

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -52,8 +52,8 @@ import {
   flushControlled,
   deferredUpdates,
   syncUpdates,
-  interactiveUpdates,
-  flushInteractiveUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
   flushPassiveEffects,
 } from './ReactFiberScheduler';
 import {createUpdate, enqueueUpdate} from './ReactUpdateQueue';
@@ -325,8 +325,8 @@ export {
   unbatchedUpdates,
   deferredUpdates,
   syncUpdates,
-  interactiveUpdates,
-  flushInteractiveUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
   flushControlled,
   flushSync,
   flushPassiveEffects,

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -605,7 +605,6 @@ export function deferredUpdates<A>(fn: () => A): A {
   return runWithPriority(NormalPriority, fn);
 }
 
-let interactiveUpdatesDepth = 0;
 let interactiveEventTimeStamp = 0;
 
 export function interactiveUpdates<A, B, C, R>(
@@ -615,9 +614,9 @@ export function interactiveUpdates<A, B, C, R>(
   c: C,
 ): R {
   const currentEvent = typeof window !== 'undefined' && window.event;
-  let skipFlushing = enableEventAPI && interactiveUpdatesDepth !== 0;
+  let skipFlushing = false;
 
-  if (!skipFlushing && currentEvent) {
+  if (enableEventAPI && currentEvent) {
     if (currentEvent.timeStamp === interactiveEventTimeStamp) {
       skipFlushing = true;
     }
@@ -634,12 +633,7 @@ export function interactiveUpdates<A, B, C, R>(
       flushPassiveEffects();
     }
   }
-  interactiveUpdatesDepth++;
-  try {
-    return runWithPriority(UserBlockingPriority, fn.bind(null, a, b, c));
-  } finally {
-    interactiveUpdatesDepth--;
-  }
+  return runWithPriority(UserBlockingPriority, fn.bind(null, a, b, c));
 }
 
 export function syncUpdates<A, B, C, R>(

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -567,7 +567,11 @@ export function flushRoot(root: FiberRoot, expirationTime: ExpirationTime) {
 }
 
 export function flushDiscreteUpdates() {
-  if (workPhase !== NotWorking) {
+  if (
+    workPhase === RenderPhase ||
+    workPhase === CommitPhase ||
+    workPhase === BatchedPhase
+  ) {
     // Can't synchronously flush interactive updates if React is already
     // working. This is currently a no-op.
     // TODO: Should we fire a warning? This happens if you synchronously invoke
@@ -610,10 +614,6 @@ export function discreteUpdates<A, B, C, R>(
   b: B,
   c: C,
 ): R {
-  if (!revertPassiveEffectsChange) {
-    // TODO: Remove this call for the same reason as above.
-    flushPassiveEffects();
-  }
   return runWithPriority(UserBlockingPriority, fn.bind(null, a, b, c));
 }
 

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -568,6 +568,8 @@ export function flushRoot(root: FiberRoot, expirationTime: ExpirationTime) {
 }
 
 export function flushDiscreteUpdates() {
+  // TODO: we ideally do not want to early reurn for BatchedPhase here either.
+  // Removing this causes act() tests to fail, so we should follow up.
   if (workPhase === CommitPhase || workPhase === BatchedPhase) {
     // We're inside the commit phase or batched phase, so we can't
     // synchronously flush pending work. This is probably a nested event

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -885,7 +885,8 @@ describe('ReactHooksWithNoopRenderer', () => {
       // A discrete event forces the passive effect to be flushed --
       // updateCount(1) happens first, so 2 wins.
 
-      ReactNoop.interactiveUpdates(() => {
+      ReactNoop.flushDiscreteUpdates();
+      ReactNoop.discreteUpdates(() => {
         // (use batchedUpdates to silence the act() warning)
         ReactNoop.batchedUpdates(() => {
           _updateCount(2);
@@ -939,7 +940,8 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       // A discrete event forces the passive effect to be flushed --
       // updateCount(1) happens first, so 2 wins.
-      ReactNoop.interactiveUpdates(() => {
+      ReactNoop.flushDiscreteUpdates();
+      ReactNoop.discreteUpdates(() => {
         // use batchedUpdates to silence the act warning
         ReactNoop.batchedUpdates(() => _updateCount(2));
       });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -431,7 +431,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Schedule a high pri update and a low pri update, without rendering in
     // between.
-    ReactNoop.interactiveUpdates(() => {
+    ReactNoop.discreteUpdates(() => {
       // High pri
       ReactNoop.render(<App />);
     });
@@ -1443,7 +1443,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
     }
 
-    ReactNoop.interactiveUpdates(() => ReactNoop.render(<Foo />));
+    ReactNoop.discreteUpdates(() => ReactNoop.render(<Foo />));
     expect(Scheduler).toFlushAndYieldThrough(['Foo']);
 
     // Advance some time.
@@ -1504,7 +1504,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
     }
 
-    ReactNoop.interactiveUpdates(() => ReactNoop.render(<App />));
+    ReactNoop.discreteUpdates(() => ReactNoop.render(<App />));
     Scheduler.flushAll();
 
     // Warning is not flushed until the commit phase


### PR DESCRIPTION
This PR changes the logic that occurs in `interactiveUpdates`, to account for a scenario that proved problematic in the testing of React Flare – the mixing of both event systems on the same app. Note: this change is behind the experimental event API. Also included in this PR are:

- `interactiveUpdates` -> `discreteUpdates`
- `flushInteractiveUpdates` -> `flushDiscreteUpdates`
- Adds `batchedEventUpdates` and a new `BatchedEventPhase` to scheduler

## Discrete events use timeStamp to manage flushing

Now that the Flare event system and the existing event system co-exists, we've noticed far more flushing is occurring; which is problematic for cases where this behaviour was non-existant with only the existing event system. To counter this a `timeStamp` heuristic has been added by reading the `timeStamp` from the `window` object. We will probably want to change this to be an argument (rather than reading from window) in the future, but I didn't want to introduce too many changes in this PR.

The `timeStamp` is an important field on events, as it allows us to tell what events were part of the same real-world interaction. For example: `mouseup`, `pointerup` and `click` all should have the same `timeStamp`. If we know that they're all the same `timeStamp`, we can do a single flush for them all, which improves compatibility with Flare and also should improve runtime performance as we're flushing sync less.