### PR TITLE
[React Fresh] Return host nodes for visual feedback

### DIFF
--- a/packages/react-dom/src/__tests__/ReactFresh-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactFresh-test.internal.js
@@ -2985,4 +2985,58 @@ describe('ReactFresh', () => {
       ]);
     }
   });
+
+  it('reports visual feedback for parents of deleted nodes', () => {
+    if (__DEV__) {
+      render(() => {
+        function Child({children}) {
+          return <div className="Child">{children}</div>;
+        }
+        __register__(Child, 'Child');
+        __signature__(Child, '1');
+
+        function Parent({children}) {
+          return (
+            <div className="Parent">
+              <div className="Parent-childWrapper">
+                <Child />
+              </div>
+              <div className="Parent-childWrapper">
+                <Child />
+              </div>
+            </div>
+          );
+        }
+        __register__(Parent, 'Parent');
+
+        function App() {
+          return (
+            <div className="App">
+              <Parent />
+              <Parent />
+            </div>
+          );
+        }
+        __register__(App, 'App');
+
+        return App;
+      });
+
+      // This edit will remount the Child component.
+      // As a result, we should highlight the wrappers instead.
+      patch(() => {
+        function Child({children}) {
+          return <div className="Child">{children}</div>;
+        }
+        __register__(Child, 'Child');
+        __signature__(Child, '2'); // This will force a remount.
+      });
+      expect(hostNodesForVisualFeedback.map(node => node.className)).toEqual([
+        'Parent-childWrapper',
+        'Parent-childWrapper',
+        'Parent-childWrapper',
+        'Parent-childWrapper',
+      ]);
+    }
+  });
 });

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -71,6 +71,7 @@ import {onCommitUnmount} from './ReactFiberDevToolsHook';
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
 import {getStackByFiberInDevAndProd} from './ReactCurrentFiber';
 import {logCapturedError} from './ReactFiberErrorLogger';
+import {markDeletedFiberForHotReloading} from './ReactFiberHotReloading';
 import {resolveDefaultProps} from './ReactFiberLazyComponent';
 import {getCommitTime} from './ReactProfilerTimer';
 import {commitUpdateQueue} from './ReactUpdateQueue';
@@ -738,6 +739,9 @@ function commitDetachRef(current: Fiber) {
 // interrupt deletion, so it's okay
 function commitUnmount(current: Fiber): void {
   onCommitUnmount(current);
+  if (__DEV__) {
+    markDeletedFiberForHotReloading(current);
+  }
 
   switch (current.tag) {
     case FunctionComponent:


### PR DESCRIPTION
This PR adds a return value to `scheduleHotUpdate`:

```js
{|
  hostNodesForVisualFeedback: Array<Instance>
|}
```

This is an array of host nodes which can be used by the hot reloading runtime to show visual feedback related to the edited UI. Here's a gif to give you an idea of a possible way to use this. Note how the updated components are briefly highlighted in the browser right after edit:

![Screen Recording 2019-05-20 at 08 25 PM](https://user-images.githubusercontent.com/810438/58046570-9ab0a480-7b3d-11e9-8a28-4d975ab9c7fb.gif)

(Don't pay too much attention to the concrete visual feedback here; this is something we'll play more with. If this contextual feedback ends up being too much, we can always remove it and use a simple indicator, but I want to experiment more with it.)

The implementation goes as follows:

* We mark "affected fibers" as we traverse the tree to schedule hot updates.
  * We only mark them one level deep. If `Parent` and `Child` were edited in the same file, we'll only mark the `Parent`. This is because in the visual indication we'll likely want to coalesce children with parents anyway.
* During the hot update, we keep track of unmounted fibers, and their return references.
  * This will let us walk the parent path for disconnected fibers if necessary (see below why).
* After the hot update batch is flushed, we determine the host nodes:
  * If a fiber has host nodes below it, we add them to the set.
  * If a fiber has no host nodes below it, we add its closest parent host node to the set.
  * If a fiber has been unmounted, we perform this procedure for its closest still mounted parent instead.
  * If a fiber's parent is root, we use the root host node.

## Alternatives

### No Component-Specific Visual Feedback

Maybe this is overkill and we just want an indicator in the screen corner or something. Then we can delete this code. I'm not sure and I wanted to play more with this.

### Move It Into Consuming Runtime

We could just return `affectedFibers` and call it a day. Then the consuming code could find the host nodes by copy pasting a similar implementation. That's actually how I started this. However, it's annoying to keep in sync with work tags. And the implementation is a bit tricky (e.g. tracking deletions). So if this is the workflow we want, we'd probably need to centralize it. Why not put it with the rest of the logic we're already testing then? So I put it here.