### PR TITLE
Flare: update invalid accessor warnings + add no-ops

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -118,7 +118,9 @@ const eventResponderContext: ReactResponderContext = {
       const showWarning = name => {
         warning(
           false,
-          '%s is not available on event objects created from event responder modules (React Flare).',
+          '%s is not available on event objects created from event responder modules (React Flare). ' +
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.%s }`',
+          name,
           name,
         );
       };
@@ -145,6 +147,21 @@ const eventResponderContext: ReactResponderContext = {
         get() {
           showWarning('defaultPrevented');
         },
+      });
+    } else {
+      // For prod, these are all no-ops
+      const noOp = () => {};
+      possibleEventObject.preventDefault = noOp;
+      possibleEventObject.stopPropagation = noOp;
+      possibleEventObject.isDefaultPrevented = noOp;
+      possibleEventObject.isPropagationStopped = noOp;
+      // $FlowFixMe: we don't need value, Flow thinks we do
+      Object.defineProperty(possibleEventObject, 'nativeEvent', {
+        get() {},
+      });
+      // $FlowFixMe: we don't need value, Flow thinks we do
+      Object.defineProperty(possibleEventObject, 'defaultPrevented', {
+        get() {},
       });
     }
     const eventObject = ((possibleEventObject: any): $Shape<

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -114,9 +114,8 @@ const eventResponderContext: ReactResponderContext = {
         'context.dispatchEvent: "target", "timeStamp", and "type" fields on event object are required.',
       );
     }
-    let showWarning;
-    if (__DEV__) {
-      showWarning = name => {
+    const showWarning = name => {
+      if (__DEV__) {
         warning(
           false,
           '%s is not available on event objects created from event responder modules (React Flare). ' +
@@ -124,8 +123,8 @@ const eventResponderContext: ReactResponderContext = {
           name,
           name,
         );
-      };
-    }
+      }
+    };
     possibleEventObject.preventDefault = () => {
       if (__DEV__) {
         showWarning('preventDefault()');

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -114,8 +114,9 @@ const eventResponderContext: ReactResponderContext = {
         'context.dispatchEvent: "target", "timeStamp", and "type" fields on event object are required.',
       );
     }
+    let showWarning;
     if (__DEV__) {
-      const showWarning = name => {
+      showWarning = name => {
         warning(
           false,
           '%s is not available on event objects created from event responder modules (React Flare). ' +
@@ -124,46 +125,44 @@ const eventResponderContext: ReactResponderContext = {
           name,
         );
       };
-      possibleEventObject.preventDefault = () => {
-        showWarning('preventDefault()');
-      };
-      possibleEventObject.stopPropagation = () => {
-        showWarning('stopPropagation()');
-      };
-      possibleEventObject.isDefaultPrevented = () => {
-        showWarning('isDefaultPrevented()');
-      };
-      possibleEventObject.isPropagationStopped = () => {
-        showWarning('isPropagationStopped()');
-      };
-      // $FlowFixMe: we don't need value, Flow thinks we do
-      Object.defineProperty(possibleEventObject, 'nativeEvent', {
-        get() {
-          showWarning('nativeEvent');
-        },
-      });
-      // $FlowFixMe: we don't need value, Flow thinks we do
-      Object.defineProperty(possibleEventObject, 'defaultPrevented', {
-        get() {
-          showWarning('defaultPrevented');
-        },
-      });
-    } else {
-      // For prod, these are all no-ops
-      const noOp = () => {};
-      possibleEventObject.preventDefault = noOp;
-      possibleEventObject.stopPropagation = noOp;
-      possibleEventObject.isDefaultPrevented = noOp;
-      possibleEventObject.isPropagationStopped = noOp;
-      // $FlowFixMe: we don't need value, Flow thinks we do
-      Object.defineProperty(possibleEventObject, 'nativeEvent', {
-        get() {},
-      });
-      // $FlowFixMe: we don't need value, Flow thinks we do
-      Object.defineProperty(possibleEventObject, 'defaultPrevented', {
-        get() {},
-      });
     }
+    possibleEventObject.preventDefault = () => {
+      if (__DEV__) {
+        showWarning('preventDefault()');
+      }
+    };
+    possibleEventObject.stopPropagation = () => {
+      if (__DEV__) {
+        showWarning('stopPropagation()');
+      }
+    };
+    possibleEventObject.isDefaultPrevented = () => {
+      if (__DEV__) {
+        showWarning('isDefaultPrevented()');
+      }
+    };
+    possibleEventObject.isPropagationStopped = () => {
+      if (__DEV__) {
+        showWarning('isPropagationStopped()');
+      }
+    };
+    // $FlowFixMe: we don't need value, Flow thinks we do
+    Object.defineProperty(possibleEventObject, 'nativeEvent', {
+      get() {
+        if (__DEV__) {
+          showWarning('nativeEvent');
+        }
+      },
+    });
+    // $FlowFixMe: we don't need value, Flow thinks we do
+    Object.defineProperty(possibleEventObject, 'defaultPrevented', {
+      get() {
+        if (__DEV__) {
+          showWarning('defaultPrevented');
+        }
+      },
+    });
+
     const eventObject = ((possibleEventObject: any): $Shape<
       PartialEventObject,
     >);

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -861,8 +861,9 @@ describe('DOMEventResponderSystem', () => {
       ReactDOM.render(<Test />, container);
       dispatchClickEvent(document.body);
     }).toWarnDev(
-      'Warning: preventDefault() is not available on event objects created ' +
-        'from event responder modules (React Flare).',
+      'Warning: preventDefault() is not available on event objects created from event responder modules ' +
+        '(React Flare).' +
+        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`',
       {withoutStack: true},
     );
     expect(() => {
@@ -872,8 +873,9 @@ describe('DOMEventResponderSystem', () => {
       ReactDOM.render(<Test />, container);
       dispatchClickEvent(document.body);
     }).toWarnDev(
-      'Warning: stopPropagation() is not available on event objects created ' +
-        'from event responder modules (React Flare).',
+      'Warning: stopPropagation() is not available on event objects created from event responder modules ' +
+        '(React Flare).' +
+        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`',
       {withoutStack: true},
     );
     expect(() => {
@@ -883,8 +885,9 @@ describe('DOMEventResponderSystem', () => {
       ReactDOM.render(<Test />, container);
       dispatchClickEvent(document.body);
     }).toWarnDev(
-      'Warning: isDefaultPrevented() is not available on event objects created ' +
-        'from event responder modules (React Flare).',
+      'Warning: isDefaultPrevented() is not available on event objects created from event responder modules ' +
+        '(React Flare).' +
+        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.isDefaultPrevented() }`',
       {withoutStack: true},
     );
     expect(() => {
@@ -894,8 +897,9 @@ describe('DOMEventResponderSystem', () => {
       ReactDOM.render(<Test />, container);
       dispatchClickEvent(document.body);
     }).toWarnDev(
-      'Warning: isPropagationStopped() is not available on event objects created ' +
-        'from event responder modules (React Flare).',
+      'Warning: isPropagationStopped() is not available on event objects created from event responder modules ' +
+        '(React Flare).' +
+        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.isPropagationStopped() }`',
       {withoutStack: true},
     );
     expect(() => {
@@ -905,8 +909,9 @@ describe('DOMEventResponderSystem', () => {
       ReactDOM.render(<Test />, container);
       dispatchClickEvent(document.body);
     }).toWarnDev(
-      'Warning: nativeEvent is not available on event objects created ' +
-        'from event responder modules (React Flare).',
+      'Warning: nativeEvent is not available on event objects created from event responder modules ' +
+        '(React Flare).' +
+        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.nativeEvent }`',
       {withoutStack: true},
     );
     expect(() => {
@@ -916,8 +921,9 @@ describe('DOMEventResponderSystem', () => {
       ReactDOM.render(<Test />, container);
       dispatchClickEvent(document.body);
     }).toWarnDev(
-      'Warning: defaultPrevented is not available on event objects created ' +
-        'from event responder modules (React Flare).',
+      'Warning: defaultPrevented is not available on event objects created from event responder modules ' +
+        '(React Flare).' +
+        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.defaultPrevented }`',
       {withoutStack: true},
     );
 


### PR DESCRIPTION
This PR updates the event warnings for DEV to better explain what should be done to avoid this warning from appearing. Furthermore, the PROD versions of these methods are no-ops, this is to prevent runtime errors from mismatching the behaviour from DEV. In the coming weeks, we expect to switch these warnings to invariants.