### PR TITLE
Flare: simplify dispatchEvent discrete argument

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -23,7 +23,6 @@ import type {
   ReactEventComponentInstance,
   ReactResponderContext,
   ReactResponderEvent,
-  ReactResponderDispatchEventOptions,
 } from 'shared/ReactTypes';
 import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
 import {batchedUpdates, interactiveUpdates} from 'events/ReactGenericBatching';
@@ -104,7 +103,7 @@ const eventResponderContext: ReactResponderContext = {
   dispatchEvent(
     possibleEventObject: Object,
     listener: ($Shape<PartialEventObject>) => void,
-    {discrete}: ReactResponderDispatchEventOptions,
+    discrete: boolean,
   ): void {
     validateResponderContext();
     const {target, type, timeStamp} = possibleEventObject;

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -403,9 +403,7 @@ describe('DOMEventResponderSystem', () => {
             phase: 'bubble',
             timeStamp: context.getTimeStamp(),
           };
-          context.dispatchEvent(syntheticEvent, props.onMagicClick, {
-            discrete: true,
-          });
+          context.dispatchEvent(syntheticEvent, props.onMagicClick, true);
         }
       },
       onEventCapture: (event, context, props) => {
@@ -416,9 +414,7 @@ describe('DOMEventResponderSystem', () => {
             phase: 'capture',
             timeStamp: context.getTimeStamp(),
           };
-          context.dispatchEvent(syntheticEvent, props.onMagicClick, {
-            discrete: true,
-          });
+          context.dispatchEvent(syntheticEvent, props.onMagicClick, true);
         }
       },
     });
@@ -460,7 +456,7 @@ describe('DOMEventResponderSystem', () => {
         phase,
         timeStamp: context.getTimeStamp(),
       };
-      context.dispatchEvent(pressEvent, props.onPress, {discrete: true});
+      context.dispatchEvent(pressEvent, props.onPress, true);
 
       context.setTimeout(() => {
         if (props.onLongPress) {
@@ -470,9 +466,7 @@ describe('DOMEventResponderSystem', () => {
             phase,
             timeStamp: context.getTimeStamp(),
           };
-          context.dispatchEvent(longPressEvent, props.onLongPress, {
-            discrete: true,
-          });
+          context.dispatchEvent(longPressEvent, props.onLongPress, true);
         }
 
         if (props.onLongPressChange) {
@@ -482,9 +476,11 @@ describe('DOMEventResponderSystem', () => {
             phase,
             timeStamp: context.getTimeStamp(),
           };
-          context.dispatchEvent(longPressChangeEvent, props.onLongPressChange, {
-            discrete: true,
-          });
+          context.dispatchEvent(
+            longPressChangeEvent,
+            props.onLongPressChange,
+            true,
+          );
         }
       }, 500);
     }
@@ -842,9 +838,7 @@ describe('DOMEventResponderSystem', () => {
           type: 'click',
           timeStamp: context.getTimeStamp(),
         };
-        context.dispatchEvent(syntheticEvent, props.onClick, {
-          discrete: true,
-        });
+        context.dispatchEvent(syntheticEvent, props.onClick, true);
       },
     });
 

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -79,7 +79,7 @@ function dispatchDragEvent(
 ): void {
   const target = ((state.dragTarget: any): Element | Document);
   const syntheticEvent = createDragEvent(context, name, target, eventData);
-  context.dispatchEvent(syntheticEvent, listener, {discrete});
+  context.dispatchEvent(syntheticEvent, listener, discrete);
 }
 
 const DragResponder = {

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -93,7 +93,7 @@ function dispatchFocusInEvents(
       target,
       pointerType,
     );
-    context.dispatchEvent(syntheticEvent, props.onFocus, {discrete: true});
+    context.dispatchEvent(syntheticEvent, props.onFocus, true);
   }
   if (props.onFocusChange) {
     const listener = () => {
@@ -105,7 +105,7 @@ function dispatchFocusInEvents(
       target,
       pointerType,
     );
-    context.dispatchEvent(syntheticEvent, listener, {discrete: true});
+    context.dispatchEvent(syntheticEvent, listener, true);
   }
   if (props.onFocusVisibleChange && state.isLocalFocusVisible) {
     const listener = () => {
@@ -117,7 +117,7 @@ function dispatchFocusInEvents(
       target,
       pointerType,
     );
-    context.dispatchEvent(syntheticEvent, listener, {discrete: true});
+    context.dispatchEvent(syntheticEvent, listener, true);
   }
 }
 
@@ -135,7 +135,7 @@ function dispatchFocusOutEvents(
       target,
       pointerType,
     );
-    context.dispatchEvent(syntheticEvent, props.onBlur, {discrete: true});
+    context.dispatchEvent(syntheticEvent, props.onBlur, true);
   }
   if (props.onFocusChange) {
     const listener = () => {
@@ -147,7 +147,7 @@ function dispatchFocusOutEvents(
       target,
       pointerType,
     );
-    context.dispatchEvent(syntheticEvent, listener, {discrete: true});
+    context.dispatchEvent(syntheticEvent, listener, true);
   }
   dispatchFocusVisibleOutEvent(context, props, state);
 }
@@ -169,7 +169,7 @@ function dispatchFocusVisibleOutEvent(
       target,
       pointerType,
     );
-    context.dispatchEvent(syntheticEvent, listener, {discrete: true});
+    context.dispatchEvent(syntheticEvent, listener, true);
     state.isLocalFocusVisible = false;
   }
 }

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -86,7 +86,7 @@ function dispatchHoverChangeEvent(
     'hoverchange',
     ((state.hoverTarget: any): Element | Document),
   );
-  context.dispatchEvent(syntheticEvent, listener, {discrete: true});
+  context.dispatchEvent(syntheticEvent, listener, true);
 }
 
 function dispatchHoverStartEvents(
@@ -123,9 +123,7 @@ function dispatchHoverStartEvents(
         'hoverstart',
         ((target: any): Element | Document),
       );
-      context.dispatchEvent(syntheticEvent, props.onHoverStart, {
-        discrete: true,
-      });
+      context.dispatchEvent(syntheticEvent, props.onHoverStart, true);
     }
     if (props.onHoverChange) {
       dispatchHoverChangeEvent(context, props, state);
@@ -183,7 +181,7 @@ function dispatchHoverEndEvents(
         'hoverend',
         ((target: any): Element | Document),
       );
-      context.dispatchEvent(syntheticEvent, props.onHoverEnd, {discrete: true});
+      context.dispatchEvent(syntheticEvent, props.onHoverEnd, true);
     }
     if (props.onHoverChange) {
       dispatchHoverChangeEvent(context, props, state);
@@ -322,9 +320,11 @@ const HoverResponder = {
                     'hovermove',
                     state.hoverTarget,
                   );
-                  context.dispatchEvent(syntheticEvent, props.onHoverMove, {
-                    discrete: false,
-                  });
+                  context.dispatchEvent(
+                    syntheticEvent,
+                    props.onHoverMove,
+                    true,
+                  );
                 }
               }
             }

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -211,9 +211,7 @@ function dispatchEvent(
     pointerType,
     event,
   );
-  context.dispatchEvent(syntheticEvent, listener, {
-    discrete,
-  });
+  context.dispatchEvent(syntheticEvent, listener, discrete);
 }
 
 function dispatchPressChangeEvent(

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -69,7 +69,7 @@ function dispatchSwipeEvent(
 ) {
   const target = ((state.swipeTarget: any): Element | Document);
   const syntheticEvent = createSwipeEvent(context, name, target, eventData);
-  context.dispatchEvent(syntheticEvent, listener, {discrete});
+  context.dispatchEvent(syntheticEvent, listener, discrete);
 }
 
 type SwipeState = {

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -158,15 +158,11 @@ export type ReactResponderEvent = {
   passiveSupported: boolean,
 };
 
-export type ReactResponderDispatchEventOptions = {
-  discrete?: boolean,
-};
-
 export type ReactResponderContext = {
   dispatchEvent: (
     eventObject: Object,
     listener: (Object) => void,
-    options: ReactResponderDispatchEventOptions,
+    discrete: boolean,
   ) => void,
   isTargetWithinElement: (
     childTarget: Element | Document,


### PR DESCRIPTION
This PR simplifies the `dispatchEvent` API, so the third argument is no longer an options object, but rather a boolean to signal whether the event should be dispatched as a discrete event or not. This should improve code size slightly.