### PR TITLE
Fix missing return pointer assignment

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1561,8 +1561,10 @@ function updateSuspenseComponent(
             ? (workInProgress.child: any).child
             : (workInProgress.child: any);
         primaryChildFragment.child = progressedPrimaryChild;
-        if (progressedPrimaryChild !== null) {
-          progressedPrimaryChild.return = primaryChildFragment;
+        let progressedChild = progressedPrimaryChild;
+        while (progressedChild !== null) {
+          progressedChild.return = primaryChildFragment;
+          progressedChild = progressedChild.sibling;
         }
       }
 
@@ -1619,9 +1621,11 @@ function updateSuspenseComponent(
               : (workInProgress.child: any);
           if (progressedPrimaryChild !== currentPrimaryChildFragment.child) {
             primaryChildFragment.child = progressedPrimaryChild;
-          }
-          if (progressedPrimaryChild !== null) {
-            progressedPrimaryChild.return = primaryChildFragment;
+            let progressedChild = progressedPrimaryChild;
+            while (progressedChild !== null) {
+              progressedChild.return = primaryChildFragment;
+              progressedChild = progressedChild.sibling;
+            }
           }
         }
 
@@ -1709,8 +1713,10 @@ function updateSuspenseComponent(
               ? (workInProgress.child: any).child
               : (workInProgress.child: any);
           primaryChildFragment.child = progressedPrimaryChild;
-          if (progressedPrimaryChild !== null) {
-            progressedPrimaryChild.return = primaryChildFragment;
+          let progressedChild = progressedPrimaryChild;
+          while (progressedChild !== null) {
+            progressedChild.return = primaryChildFragment;
+            progressedChild = progressedChild.sibling;
           }
         }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1550,6 +1550,7 @@ function updateSuspenseComponent(
         NoWork,
         null,
       );
+      primaryChildFragment.return = workInProgress;
 
       if ((workInProgress.mode & BatchedMode) === NoMode) {
         // Outside of batched mode, we commit the effects from the
@@ -1560,6 +1561,9 @@ function updateSuspenseComponent(
             ? (workInProgress.child: any).child
             : (workInProgress.child: any);
         primaryChildFragment.child = progressedPrimaryChild;
+        if (progressedPrimaryChild !== null) {
+          progressedPrimaryChild.return = primaryChildFragment;
+        }
       }
 
       const fallbackChildFragment = createFiberFromFragment(
@@ -1568,12 +1572,12 @@ function updateSuspenseComponent(
         renderExpirationTime,
         null,
       );
+      fallbackChildFragment.return = workInProgress;
       primaryChildFragment.sibling = fallbackChildFragment;
       child = primaryChildFragment;
       // Skip the primary children, and continue working on the
       // fallback children.
       next = fallbackChildFragment;
-      child.return = next.return = workInProgress;
     } else {
       // Mount the primary children without an intermediate fragment fiber.
       const nextPrimaryChildren = nextProps.children;
@@ -1603,6 +1607,7 @@ function updateSuspenseComponent(
           currentPrimaryChildFragment.pendingProps,
           NoWork,
         );
+        primaryChildFragment.return = workInProgress;
 
         if ((workInProgress.mode & BatchedMode) === NoMode) {
           // Outside of batched mode, we commit the effects from the
@@ -1614,6 +1619,9 @@ function updateSuspenseComponent(
               : (workInProgress.child: any);
           if (progressedPrimaryChild !== currentPrimaryChildFragment.child) {
             primaryChildFragment.child = progressedPrimaryChild;
+          }
+          if (progressedPrimaryChild !== null) {
+            progressedPrimaryChild.return = primaryChildFragment;
           }
         }
 
@@ -1632,17 +1640,18 @@ function updateSuspenseComponent(
 
         // Clone the fallback child fragment, too. These we'll continue
         // working on.
-        const fallbackChildFragment = (primaryChildFragment.sibling = createWorkInProgress(
+        const fallbackChildFragment = createWorkInProgress(
           currentFallbackChildFragment,
           nextFallbackChildren,
           currentFallbackChildFragment.expirationTime,
-        ));
+        );
+        fallbackChildFragment.return = workInProgress;
+        primaryChildFragment.sibling = fallbackChildFragment;
         child = primaryChildFragment;
         primaryChildFragment.childExpirationTime = NoWork;
         // Skip the primary children, and continue working on the
         // fallback children.
         next = fallbackChildFragment;
-        child.return = next.return = workInProgress;
       } else {
         // No longer suspended. Switch back to showing the primary children,
         // and remove the intermediate fragment fiber.
@@ -1680,7 +1689,11 @@ function updateSuspenseComponent(
           NoWork,
           null,
         );
+        primaryChildFragment.return = workInProgress;
         primaryChildFragment.child = currentPrimaryChild;
+        if (currentPrimaryChild !== null) {
+          currentPrimaryChild.return = primaryChildFragment;
+        }
 
         // Even though we're creating a new fiber, there are no new children,
         // because we're reusing an already mounted tree. So we don't need to
@@ -1696,6 +1709,9 @@ function updateSuspenseComponent(
               ? (workInProgress.child: any).child
               : (workInProgress.child: any);
           primaryChildFragment.child = progressedPrimaryChild;
+          if (progressedPrimaryChild !== null) {
+            progressedPrimaryChild.return = primaryChildFragment;
+          }
         }
 
         // Because primaryChildFragment is a new fiber that we're inserting as the
@@ -1712,19 +1728,20 @@ function updateSuspenseComponent(
         }
 
         // Create a fragment from the fallback children, too.
-        const fallbackChildFragment = (primaryChildFragment.sibling = createFiberFromFragment(
+        const fallbackChildFragment = createFiberFromFragment(
           nextFallbackChildren,
           mode,
           renderExpirationTime,
           null,
-        ));
+        );
+        fallbackChildFragment.return = workInProgress;
+        primaryChildFragment.sibling = fallbackChildFragment;
         fallbackChildFragment.effectTag |= Placement;
         child = primaryChildFragment;
         primaryChildFragment.childExpirationTime = NoWork;
         // Skip the primary children, and continue working on the
         // fallback children.
         next = fallbackChildFragment;
-        child.return = next.return = workInProgress;
       } else {
         // Still haven't timed out.  Continue rendering the children, like we
         // normally do.

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
@@ -5,7 +5,7 @@ let Scheduler;
 let ReactFeatureFlags;
 let Random;
 
-const SEED = 0;
+const SEED = process.env.TEST_SEED || 'default';
 
 const prettyFormatPkg = require('pretty-format');
 
@@ -322,28 +322,6 @@ describe('ReactSuspenseFuzz', () => {
     );
   });
 
-  it('hard-coded cases', () => {
-    const {Text, testResolvedOutput} = createFuzzer();
-
-    testResolvedOutput(
-      <React.Fragment>
-        <Text
-          initialDelay={20}
-          text="A"
-          updates={[{beginAfter: 10, suspendFor: 20}]}
-        />
-        <Suspense fallback="Loading... (B)">
-          <Text
-            initialDelay={10}
-            text="B"
-            updates={[{beginAfter: 30, suspendFor: 50}]}
-          />
-          <Text text="C" />
-        </Suspense>
-      </React.Fragment>,
-    );
-  });
-
   it('generative tests', () => {
     const {generateTestCase, testResolvedOutput} = createFuzzer();
 
@@ -366,5 +344,46 @@ ${prettyFormat(randomTestCase)}
         throw e;
       }
     }
+  });
+
+  describe('hard-coded cases', () => {
+    it('1', () => {
+      const {Text, testResolvedOutput} = createFuzzer();
+      testResolvedOutput(
+        <React.Fragment>
+          <Text
+            initialDelay={20}
+            text="A"
+            updates={[{beginAfter: 10, suspendFor: 20}]}
+          />
+          <Suspense fallback="Loading... (B)">
+            <Text
+              initialDelay={10}
+              text="B"
+              updates={[{beginAfter: 30, suspendFor: 50}]}
+            />
+            <Text text="C" />
+          </Suspense>
+        </React.Fragment>,
+      );
+    });
+
+    it('2', () => {
+      const {Text, Container, testResolvedOutput} = createFuzzer();
+      testResolvedOutput(
+        <React.Fragment>
+          <Suspense fallback="Loading...">
+            <Text initialDelay={7200} text="A" />
+          </Suspense>
+          <Suspense fallback="Loading...">
+            <Container>
+              <Text initialDelay={1000} text="B" />
+              <Text initialDelay={7200} text="C" />
+              <Text initialDelay={9000} text="D" />
+            </Container>
+          </Suspense>
+        </React.Fragment>,
+      );
+    });
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
@@ -5,7 +5,7 @@ let Scheduler;
 let ReactFeatureFlags;
 let Random;
 
-const SEED = process.env.TEST_SEED || 'default';
+const SEED = 0;
 
 const prettyFormatPkg = require('pretty-format');
 
@@ -382,6 +382,40 @@ ${prettyFormat(randomTestCase)}
               <Text initialDelay={9000} text="D" />
             </Container>
           </Suspense>
+        </React.Fragment>,
+      );
+    });
+
+    it('3', () => {
+      const {Text, Container, testResolvedOutput} = createFuzzer();
+      testResolvedOutput(
+        <React.Fragment>
+          <Suspense fallback="Loading...">
+            <Text
+              initialDelay={3183}
+              text="A"
+              updates={[
+                {
+                  beginAfter: 2256,
+                  suspendFor: 6696,
+                },
+              ]}
+            />
+            <Text initialDelay={3251} text="B" />
+          </Suspense>
+          <Container>
+            <Text
+              initialDelay={2700}
+              text="C"
+              updates={[
+                {
+                  beginAfter: 3266,
+                  suspendFor: 9139,
+                },
+              ]}
+            />
+            <Text initialDelay={6732} text="D" />
+          </Container>
         </React.Fragment>,
       );
     });


### PR DESCRIPTION
I found a bug using the fuzz tester that manifested as incorrect ordering of children in the host tree, but whose root cause was a missing `return` pointer assignment on a work-in-progress fiber.

Usually return pointers are set during reconciliation (`reconcileChildFibers`) but this particular assignment happens inside the custom reconciliation implementation used by Suspense boundaries.

I would not be surprised if there were similar bugs related to incorrect return pointers. You're supposed to update the return pointer whenever a work-in-progress fiber is created, but there's nothing in the contract of the `createFiber` or `createWorkInProgress` function that implies this. I propose that we update their signatures to accept the return fiber as an argument. I will do this in a follow-up.

In this commit, I rearranged `updateSuspenseComponent` slightly so that every call to `createWorkInProgress` or a `createFiber*` function is immediately followed by a return pointer assignment.

I hardcoded the fuzz test case that surfaced the bug.