### PR TITLE
Flare: ensure discrete event flush is disabled during initial DOM mount

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -474,7 +474,7 @@ describe('ReactDOMEventListener', () => {
     }
   });
 
-  it.only('should not warn when setting media attributes that trigger discrete events', () => {
+  it('should not warn when setting media attributes that trigger discrete events', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
 

--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -473,4 +473,15 @@ describe('ReactDOMEventListener', () => {
       document.body.removeChild(container);
     }
   });
+
+  it.only('should not warn when setting media attributes that trigger discrete events', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    try {
+      ReactDOM.render(<audio muted={true} />, container);
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -1026,14 +1026,8 @@ describe('ReactDOMFiber', () => {
 
   it('should not update event handlers until commit', () => {
     let ops = [];
-    let eventErrors = [];
     const handlerA = () => ops.push('A');
     const handlerB = () => ops.push('B');
-
-    spyOnProd(console, 'error');
-    window.addEventListener('error', e => {
-      eventErrors.push(e.message);
-    });
 
     class Example extends React.Component {
       state = {flip: false, count: 0};
@@ -1052,7 +1046,11 @@ describe('ReactDOMFiber', () => {
     class Click extends React.Component {
       constructor() {
         super();
-        node.click();
+        expect(() => {
+          node.click();
+        }).toWarnDev(
+          'Warning: unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering.',
+        );
       }
       render() {
         return null;
@@ -1096,16 +1094,12 @@ describe('ReactDOMFiber', () => {
 
     // Because the new click handler has not yet committed, we should still
     // invoke B.
-    expect(ops).toEqual([]);
+    expect(ops).toEqual(['B']);
     ops = [];
 
     // Any click that happens after commit, should invoke A.
     node.click();
     expect(ops).toEqual(['A']);
-    expect(eventErrors[0]).toEqual(
-      'unstable_flushDiscreteUpdates: Cannot flush ' +
-        'updates when React is already rendering.',
-    );
   });
 
   it('should not crash encountering low-priority tree', () => {

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -34,7 +34,10 @@ import {
   setEnabled as ReactBrowserEventEmitterSetEnabled,
 } from '../events/ReactBrowserEventEmitter';
 import {Namespaces, getChildNamespace} from '../shared/DOMNamespaces';
-import {addRootEventTypesForComponentInstance} from '../events/DOMEventResponderSystem';
+import {
+  addRootEventTypesForComponentInstance,
+  setSkipDiscreteUpdateFlushing,
+} from '../events/DOMEventResponderSystem';
 import {
   ELEMENT_NODE,
   TEXT_NODE,
@@ -320,7 +323,9 @@ export function finalizeInitialChildren(
   rootContainerInstance: Container,
   hostContext: HostContext,
 ): boolean {
+  setSkipDiscreteUpdateFlushing(true);
   setInitialProperties(domElement, type, props, rootContainerInstance);
+  setSkipDiscreteUpdateFlushing(false);
   return shouldAutoFocusHostComponent(type, props);
 }
 

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -617,7 +617,7 @@ export function processEventQueue(): void {
   }
   if (discrete) {
     if (
-      !shouldSkipDiscreteUpdateFlushing() &&
+      !skipDiscreteUpdateFlushing &&
       shouldflushDiscreteUpdates(currentTimeStamp)
     ) {
       flushDiscreteUpdates();

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -42,12 +42,21 @@ import {
 
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
 
-export let listenToResponderEventTypesImpl;
+let listenToResponderEventTypesImpl;
+let skipDiscreteUpdateFlushing = false;
 
 export function setListenToResponderEventTypes(
   _listenToResponderEventTypesImpl: Function,
 ) {
   listenToResponderEventTypesImpl = _listenToResponderEventTypesImpl;
+}
+
+export function setSkipDiscreteUpdateFlushing(_skipDiscreteUpdateFlushing: boolean): void {
+  skipDiscreteUpdateFlushing = _skipDiscreteUpdateFlushing;
+}
+
+export function shouldSkipDiscreteUpdateFlushing(): boolean {
+  return skipDiscreteUpdateFlushing;
 }
 
 type EventObjectType = $Shape<PartialEventObject>;
@@ -605,7 +614,10 @@ export function processEventQueue(): void {
     return;
   }
   if (discrete) {
-    if (shouldflushDiscreteUpdates(currentTimeStamp)) {
+    if (
+      !shouldSkipDiscreteUpdateFlushing() &&
+      shouldflushDiscreteUpdates(currentTimeStamp)
+    ) {
       flushDiscreteUpdates();
     }
     discreteUpdates(() => {

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -51,7 +51,9 @@ export function setListenToResponderEventTypes(
   listenToResponderEventTypesImpl = _listenToResponderEventTypesImpl;
 }
 
-export function setSkipDiscreteUpdateFlushing(_skipDiscreteUpdateFlushing: boolean): void {
+export function setSkipDiscreteUpdateFlushing(
+  _skipDiscreteUpdateFlushing: boolean,
+): void {
   skipDiscreteUpdateFlushing = _skipDiscreteUpdateFlushing;
 }
 

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -20,6 +20,7 @@ import {runExtractedPluginEventsInBatch} from 'events/EventPluginHub';
 import {
   dispatchEventForResponderEventSystem,
   shouldflushDiscreteUpdates,
+  shouldSkipDiscreteUpdateFlushing,
 } from '../events/DOMEventResponderSystem';
 import {isFiberMounted} from 'react-reconciler/reflection';
 import {HostRoot} from 'shared/ReactWorkTags';
@@ -38,10 +39,11 @@ import {
   addEventCaptureListenerWithPassiveFlag,
 } from './EventListener';
 import getEventTarget from './getEventTarget';
-import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
 import SimpleEventPlugin from './SimpleEventPlugin';
 import {getRawEventName} from './DOMTopLevelEventTypes';
 import {passiveBrowserEventsSupported} from './checkPassiveEvents';
+
+import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
 
 import {enableEventAPI} from 'shared/ReactFeatureFlags';
 
@@ -229,7 +231,10 @@ function trapEventForPluginEventSystem(
 }
 
 function dispatchInteractiveEvent(topLevelType, eventSystemFlags, nativeEvent) {
-  if (!enableEventAPI || shouldflushDiscreteUpdates(nativeEvent.timeStamp)) {
+  if (
+    !shouldSkipDiscreteUpdateFlushing() &&
+    (!enableEventAPI || shouldflushDiscreteUpdates(nativeEvent.timeStamp))
+  ) {
     flushDiscreteUpdates();
   }
   discreteUpdates(dispatchEvent, topLevelType, eventSystemFlags, nativeEvent);

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -577,11 +577,14 @@ export function flushDiscreteUpdates() {
     return;
   }
   if (workPhase === RenderPhase) {
-    invariant(
-      false,
-      'unstable_flushDiscreteUpdates: Cannot flush updates when React is ' +
-        'already rendering.',
-    );
+    if (__DEV__) {
+      warning(
+        false,
+        'unstable_flushDiscreteUpdates: Cannot flush updates when React is ' +
+          'already rendering.',
+      );
+    }
+    return;
   }
   flushPendingDiscreteUpdates();
   if (!revertPassiveEffectsChange) {


### PR DESCRIPTION
When testing https://github.com/facebook/react/pull/15687 internally, we encountered some issues where the invariant in `flushDiscreteUpdates` fired during legit tests.

The reason for this was because ReactDOM sets properties and attributes on elements on initial mount, which can also fire events on the DOM. We don't want these events to flush discrete events, so we now set a flag for this that we enable before setting DOM properties and then disable after setting them.

Furthermore, we felt that the `invariant` was maybe too strong, so this has been downgraded to a warning in DEV.