### PR TITLE
Flare: change flushDiscreteUpdates invariant to warning

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -1026,14 +1026,8 @@ describe('ReactDOMFiber', () => {
 
   it('should not update event handlers until commit', () => {
     let ops = [];
-    let eventErrors = [];
     const handlerA = () => ops.push('A');
     const handlerB = () => ops.push('B');
-
-    spyOnProd(console, 'error');
-    window.addEventListener('error', e => {
-      eventErrors.push(e.message);
-    });
 
     class Example extends React.Component {
       state = {flip: false, count: 0};
@@ -1052,7 +1046,11 @@ describe('ReactDOMFiber', () => {
     class Click extends React.Component {
       constructor() {
         super();
-        node.click();
+        expect(() => {
+          node.click();
+        }).toWarnDev(
+          'Warning: unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering.',
+        );
       }
       render() {
         return null;
@@ -1096,16 +1094,12 @@ describe('ReactDOMFiber', () => {
 
     // Because the new click handler has not yet committed, we should still
     // invoke B.
-    expect(ops).toEqual([]);
+    expect(ops).toEqual(['B']);
     ops = [];
 
     // Any click that happens after commit, should invoke A.
     node.click();
     expect(ops).toEqual(['A']);
-    expect(eventErrors[0]).toEqual(
-      'unstable_flushDiscreteUpdates: Cannot flush ' +
-        'updates when React is already rendering.',
-    );
   });
 
   it('should not crash encountering low-priority tree', () => {

--- a/packages/react-reconciler/src/ReactFiberScheduler.js
+++ b/packages/react-reconciler/src/ReactFiberScheduler.js
@@ -577,11 +577,14 @@ export function flushDiscreteUpdates() {
     return;
   }
   if (workPhase === RenderPhase) {
-    invariant(
-      false,
-      'unstable_flushDiscreteUpdates: Cannot flush updates when React is ' +
-        'already rendering.',
-    );
+    if (__DEV__) {
+      warning(
+        false,
+        'unstable_flushDiscreteUpdates: Cannot flush updates when React is ' +
+          'already rendering.',
+      );
+    }
+    return;
   }
   flushPendingDiscreteUpdates();
   if (!revertPassiveEffectsChange) {


### PR DESCRIPTION
When testing #15687 internally, we encountered some issues where the invariant in flushDiscreteUpdates fired during legit tests. On further inspection, using `invariant` was maybe too strong, so this has been downgraded to a `warning` in DEV.