### PR TITLE
[Fresh] Initial Babel plugin implementation

### DIFF
--- a/packages/react-fresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-fresh/src/ReactFreshBabelPlugin.js
@@ -29,7 +29,7 @@ export default function(babel) {
   }
 
   const buildRegistrationCall = template(`
-    __register__(HANDLE, PERSISTENT_ID)
+    __register__(HANDLE, PERSISTENT_ID);
   `);
 
   function isComponentishName(name) {
@@ -39,7 +39,7 @@ export default function(babel) {
   function isComponentish(node) {
     switch (node.type) {
       case 'FunctionDeclaration':
-        return isComponentishName(node.id.name);
+        return node.id !== null && isComponentishName(node.id.name);
       case 'VariableDeclarator':
         return (
           isComponentishName(node.id.name) &&
@@ -78,7 +78,9 @@ export default function(babel) {
         const functionName = path.node.id.name;
         const handle = createRegistration(programPath, functionName);
         insertAfterPath.insertAfter(
-          t.assignmentExpression('=', handle, path.node.id),
+          t.expressionStatement(
+            t.assignmentExpression('=', handle, path.node.id),
+          ),
         );
       },
       VariableDeclaration(path) {

--- a/packages/react-fresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-fresh/src/ReactFreshBabelPlugin.js
@@ -94,10 +94,6 @@ export default function(babel) {
           default:
             return;
         }
-        const declarations = path.node.declarations;
-        if (declarations.length !== 1) {
-          return;
-        }
         const declPath = path.get('declarations');
         if (declPath.length !== 1) {
           return;

--- a/packages/react-fresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-fresh/src/ReactFreshBabelPlugin.js
@@ -16,10 +16,6 @@ export default function(babel) {
     if (!registrationsByProgramPath.has(programPath)) {
       registrationsByProgramPath.set(programPath, []);
     }
-    programPath.pushContainer(
-      'body',
-      t.variableDeclaration('var', [t.variableDeclarator(handle)]),
-    );
     const registrations = registrationsByProgramPath.get(programPath);
     registrations.push({
       handle,
@@ -119,6 +115,8 @@ export default function(babel) {
             return;
           }
           registrationsByProgramPath.delete(path);
+          const declarators = [];
+          path.pushContainer('body', t.variableDeclaration('var', declarators));
           registrations.forEach(({handle, persistentID}) => {
             path.pushContainer(
               'body',
@@ -127,6 +125,7 @@ export default function(babel) {
                 PERSISTENT_ID: t.stringLiteral(persistentID),
               }),
             );
+            declarators.push(t.variableDeclarator(handle));
           });
         },
       },

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -35,6 +35,50 @@ describe('ReactFreshBabelPlugin', () => {
     ).toMatchSnapshot();
   });
 
+  it('registers top-level exported function declarations', () => {
+    expect(
+      transform(`
+        export function Hello() {
+          function handleClick() {}
+          return <h1 onClick={handleClick}>Hi</h1>;
+        }
+
+        export default function Bar() {
+          return <Hello />;
+        }
+
+        function Baz() {
+          return <h1>OK</h1>;
+        }
+
+        const NotAComp = 'hi';
+        export { Baz, NotAComp };
+
+        export function sum() {}
+        export const Bad = 42;
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('registers top-level exported named arrow functions', () => {
+    expect(
+      transform(`
+        export const Hello = () => {
+          function handleClick() {}
+          return <h1 onClick={handleClick}>Hi</h1>;
+        };
+
+        export let Bar = (props) => <Hello />;
+
+        export default () => {
+          // This one should be ignored.
+          // You should name your components.
+          return <Hello />;
+        };
+    `),
+    ).toMatchSnapshot();
+  });
+
   it('uses original function declaration if it get reassigned', () => {
     // This should register the original version.
     // TODO: in the future, we may *also* register the wrapped one.

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -12,12 +12,127 @@ let freshPlugin = require('react-fresh/babel');
 
 function transform(input, options = {}) {
   return babel.transform(input, {
-    plugins: [[freshPlugin]],
+    babelrc: false,
+    plugins: ['syntax-jsx', freshPlugin],
+    filename: 'MyFile.js',
   }).code;
 }
 
 describe('ReactFreshBabelPlugin', () => {
-  it('hello world', () => {
-    expect(transform(`hello()`)).toMatchSnapshot();
+  it('registers top-level function declarations', () => {
+    // Hello and Bar should be registered, handleClick shouldn't.
+    expect(
+      transform(`
+        function Hello() {
+          function handleClick() {}
+          return <h1 onClick={handleClick}>Hi</h1>;
+        }
+
+        function Bar() {
+          return <Hello />;
+        }
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('uses original function declaration if it get reassigned', () => {
+    // This should register the original version.
+    // TODO: in the future, we may *also* register the wrapped one.
+    expect(
+      transform(`
+        function Hello() {
+          return <h1>Hi</h1>;
+        }
+        Hello = connect(Hello);
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('only registers pascal case functions', () => {
+    // Should not get registered.
+    expect(
+      transform(`
+        function hello() {
+          return 2 * 2;
+        }
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('registers top-level variable declarations with function expressions', () => {
+    // Hello and Bar should be registered; handleClick, sum, Baz, and Qux shouldn't.
+    expect(
+      transform(`
+        let Hello = function() {
+          function handleClick() {}
+          return <h1 onClick={handleClick}>Hi</h1>;
+        };
+        const Bar = function Baz() {
+          return <Hello />;
+        };
+        function sum() {}
+        let Baz = 10;
+        var Qux;
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('registers top-level variable declarations with arrow functions', () => {
+    // Hello, Bar, and Baz should be registered; handleClick and sum shouldn't.
+    expect(
+      transform(`
+        let Hello = () => {
+          const handleClick = () => {};
+          return <h1 onClick={handleClick}>Hi</h1>;
+        }
+        const Bar = () => {
+          return <Hello />;
+        };
+        var Baz = () => <div />;
+        var sum = () => {};
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('ignores HOC definitions', () => {
+    // TODO: we might want to handle HOCs at usage site, however.
+    // TODO: it would be nice if we could always avoid registering
+    // a function that is known to return a function or other non-node.
+    expect(
+      transform(`
+        let connect = () => {
+          function Comp() {
+            const handleClick = () => {};
+            return <h1 onClick={handleClick}>Hi</h1>;
+          }
+          return Comp;
+        };
+        function withRouter() {
+          return function Child() {
+            const handleClick = () => {};
+            return <h1 onClick={handleClick}>Hi</h1>;
+          }
+        };
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('ignores complex definitions', () => {
+    expect(
+      transform(`
+      let A = foo ? () => {
+        return <h1>Hi</h1>;
+      } : null
+      const B = (function Foo() {
+        return <h1>Hi</h1>;
+      })();
+      let C = () => () => {
+        return <h1>Hi</h1>;
+      };
+      let D = bar && (() => {
+        return <h1>Hi</h1>;
+      });
+    `),
+    ).toMatchSnapshot();
   });
 });

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -14,7 +14,6 @@ function transform(input, options = {}) {
   return babel.transform(input, {
     babelrc: false,
     plugins: ['syntax-jsx', freshPlugin],
-    filename: 'MyFile.js',
   }).code;
 }
 

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -163,18 +163,26 @@ describe('ReactFreshBabelPlugin', () => {
   it('ignores complex definitions', () => {
     expect(
       transform(`
-      let A = foo ? () => {
-        return <h1>Hi</h1>;
-      } : null
-      const B = (function Foo() {
-        return <h1>Hi</h1>;
-      })();
-      let C = () => () => {
-        return <h1>Hi</h1>;
-      };
-      let D = bar && (() => {
-        return <h1>Hi</h1>;
-      });
+        let A = foo ? () => {
+          return <h1>Hi</h1>;
+        } : null
+        const B = (function Foo() {
+          return <h1>Hi</h1>;
+        })();
+        let C = () => () => {
+          return <h1>Hi</h1>;
+        };
+        let D = bar && (() => {
+          return <h1>Hi</h1>;
+        });
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('ignores unnamed function declarations', () => {
+    expect(
+      transform(`
+        export default function() {}
     `),
     ).toMatchSnapshot();
   });

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -40,6 +40,57 @@ function hello() {
 }"
 `;
 
+exports[`ReactFreshBabelPlugin registers top-level exported function declarations 1`] = `
+"
+export function Hello() {
+  function handleClick() {}
+  return <h1 onClick={handleClick}>Hi</h1>;
+}
+
+var _c = Hello;
+export default function Bar() {
+  return <Hello />;
+}
+
+var _c2 = Bar;
+function Baz() {
+  return <h1>OK</h1>;
+}
+
+var _c3 = Baz;
+const NotAComp = 'hi';
+export { Baz, NotAComp };
+
+export function sum() {}
+export const Bad = 42;
+
+__register__(_c, 'Hello');
+
+__register__(_c2, 'Bar');
+
+__register__(_c3, 'Baz');"
+`;
+
+exports[`ReactFreshBabelPlugin registers top-level exported named arrow functions 1`] = `
+"
+export const Hello = _c = () => {
+  function handleClick() {}
+  return <h1 onClick={handleClick}>Hi</h1>;
+};
+
+export let Bar = _c2 = props => <Hello />;
+
+export default (() => {
+  // This one should be ignored.
+  // You should name your components.
+  return <Hello />;
+});
+
+__register__(_c, \\"Hello\\");
+
+__register__(_c2, \\"Bar\\");"
+`;
+
 exports[`ReactFreshBabelPlugin registers top-level function declarations 1`] = `
 "
 function Hello() {

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -69,11 +69,7 @@ export { Baz, NotAComp };
 export function sum() {}
 export const Bad = 42;
 
-var _c;
-
-var _c2;
-
-var _c3;
+var _c, _c2, _c3;
 
 __register__(_c, 'Hello');
 
@@ -97,9 +93,7 @@ export default (() => {
   return <Hello />;
 });
 
-var _c;
-
-var _c2;
+var _c, _c2;
 
 __register__(_c, \\"Hello\\");
 
@@ -119,9 +113,7 @@ function Bar() {
 }
 _c2 = Bar;
 
-var _c;
-
-var _c2;
+var _c, _c2;
 
 __register__(_c, \\"Hello\\");
 
@@ -140,11 +132,7 @@ const Bar = _c2 = () => {
 var Baz = _c3 = () => <div />;
 var sum = () => {};
 
-var _c;
-
-var _c2;
-
-var _c3;
+var _c, _c2, _c3;
 
 __register__(_c, \\"Hello\\");
 
@@ -166,9 +154,7 @@ function sum() {}
 let Baz = 10;
 var Qux;
 
-var _c;
-
-var _c2;
+var _c, _c2;
 
 __register__(_c, \\"Hello\\");
 

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -33,6 +33,11 @@ let D = bar && (() => {
 });"
 `;
 
+exports[`ReactFreshBabelPlugin ignores unnamed function declarations 1`] = `
+"
+export default function () {}"
+`;
+
 exports[`ReactFreshBabelPlugin only registers pascal case functions 1`] = `
 "
 function hello() {
@@ -47,17 +52,17 @@ export function Hello() {
   return <h1 onClick={handleClick}>Hi</h1>;
 }
 
-_c = Hello
+_c = Hello;
 export default function Bar() {
   return <Hello />;
 }
 
-_c2 = Bar
+_c2 = Bar;
 function Baz() {
   return <h1>OK</h1>;
 }
 
-_c3 = Baz
+_c3 = Baz;
 const NotAComp = 'hi';
 export { Baz, NotAComp };
 
@@ -108,11 +113,11 @@ function Hello() {
   return <h1 onClick={handleClick}>Hi</h1>;
 }
 
-_c = Hello
+_c = Hello;
 function Bar() {
   return <Hello />;
 }
-_c2 = Bar
+_c2 = Bar;
 
 var _c;
 
@@ -175,7 +180,7 @@ exports[`ReactFreshBabelPlugin uses original function declaration if it get reas
 function Hello() {
   return <h1>Hi</h1>;
 }
-_c = Hello
+_c = Hello;
 Hello = connect(Hello);
 
 var _c;

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -47,22 +47,28 @@ export function Hello() {
   return <h1 onClick={handleClick}>Hi</h1>;
 }
 
-var _c = Hello;
+_c = Hello
 export default function Bar() {
   return <Hello />;
 }
 
-var _c2 = Bar;
+_c2 = Bar
 function Baz() {
   return <h1>OK</h1>;
 }
 
-var _c3 = Baz;
+_c3 = Baz
 const NotAComp = 'hi';
 export { Baz, NotAComp };
 
 export function sum() {}
 export const Bad = 42;
+
+var _c;
+
+var _c2;
+
+var _c3;
 
 __register__(_c, 'Hello');
 
@@ -86,6 +92,10 @@ export default (() => {
   return <Hello />;
 });
 
+var _c;
+
+var _c2;
+
 __register__(_c, \\"Hello\\");
 
 __register__(_c2, \\"Bar\\");"
@@ -98,11 +108,15 @@ function Hello() {
   return <h1 onClick={handleClick}>Hi</h1>;
 }
 
-var _c = Hello;
+_c = Hello
 function Bar() {
   return <Hello />;
 }
-var _c2 = Bar;
+_c2 = Bar
+
+var _c;
+
+var _c2;
 
 __register__(_c, \\"Hello\\");
 
@@ -120,6 +134,12 @@ const Bar = _c2 = () => {
 };
 var Baz = _c3 = () => <div />;
 var sum = () => {};
+
+var _c;
+
+var _c2;
+
+var _c3;
 
 __register__(_c, \\"Hello\\");
 
@@ -141,6 +161,10 @@ function sum() {}
 let Baz = 10;
 var Qux;
 
+var _c;
+
+var _c2;
+
 __register__(_c, \\"Hello\\");
 
 __register__(_c2, \\"Bar\\");"
@@ -151,8 +175,10 @@ exports[`ReactFreshBabelPlugin uses original function declaration if it get reas
 function Hello() {
   return <h1>Hi</h1>;
 }
-var _c = Hello;
+_c = Hello
 Hello = connect(Hello);
+
+var _c;
 
 __register__(_c, \\"Hello\\");"
 `;

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -1,3 +1,107 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ReactFreshBabelPlugin hello world 1`] = `"hello();"`;
+exports[`ReactFreshBabelPlugin ignores HOC definitions 1`] = `
+"
+let connect = () => {
+  function Comp() {
+    const handleClick = () => {};
+    return <h1 onClick={handleClick}>Hi</h1>;
+  }
+  return Comp;
+};
+function withRouter() {
+  return function Child() {
+    const handleClick = () => {};
+    return <h1 onClick={handleClick}>Hi</h1>;
+  };
+};"
+`;
+
+exports[`ReactFreshBabelPlugin ignores complex definitions 1`] = `
+"
+let A = foo ? () => {
+  return <h1>Hi</h1>;
+} : null;
+const B = function Foo() {
+  return <h1>Hi</h1>;
+}();
+let C = () => () => {
+  return <h1>Hi</h1>;
+};
+let D = bar && (() => {
+  return <h1>Hi</h1>;
+});"
+`;
+
+exports[`ReactFreshBabelPlugin only registers pascal case functions 1`] = `
+"
+function hello() {
+  return 2 * 2;
+}"
+`;
+
+exports[`ReactFreshBabelPlugin registers top-level function declarations 1`] = `
+"
+function Hello() {
+  function handleClick() {}
+  return <h1 onClick={handleClick}>Hi</h1>;
+}
+
+var _c = Hello;
+function Bar() {
+  return <Hello />;
+}
+var _c2 = Bar;
+
+__register__(_c, \\"Hello\\");
+
+__register__(_c2, \\"Bar\\");"
+`;
+
+exports[`ReactFreshBabelPlugin registers top-level variable declarations with arrow functions 1`] = `
+"
+let Hello = _c = () => {
+  const handleClick = () => {};
+  return <h1 onClick={handleClick}>Hi</h1>;
+};
+const Bar = _c2 = () => {
+  return <Hello />;
+};
+var Baz = _c3 = () => <div />;
+var sum = () => {};
+
+__register__(_c, \\"Hello\\");
+
+__register__(_c2, \\"Bar\\");
+
+__register__(_c3, \\"Baz\\");"
+`;
+
+exports[`ReactFreshBabelPlugin registers top-level variable declarations with function expressions 1`] = `
+"
+let Hello = _c = function () {
+  function handleClick() {}
+  return <h1 onClick={handleClick}>Hi</h1>;
+};
+const Bar = _c2 = function Baz() {
+  return <Hello />;
+};
+function sum() {}
+let Baz = 10;
+var Qux;
+
+__register__(_c, \\"Hello\\");
+
+__register__(_c2, \\"Bar\\");"
+`;
+
+exports[`ReactFreshBabelPlugin uses original function declaration if it get reassigned 1`] = `
+"
+function Hello() {
+  return <h1>Hi</h1>;
+}
+var _c = Hello;
+Hello = connect(Hello);
+
+__register__(_c, \\"Hello\\");"
+`;


### PR DESCRIPTION
This adds a basic implementation of the Babel plugin. It's incomplete and will be expanded as we go.

Its takes code like

```js
function Foo() {
  // ...
}

let Bar = () => {
  // ...
}
```

and turns it into something like

```js
function Foo() {
  // ...
}
_c = Foo;

let Bar = _c2 = () => {
  // ...
}

var _c;
var _c2;

__register__(_c, 'Foo');
__register__(_c2, 'Bar');
```

We rely on var and function declaration hoisting here. The registration all happens at the bottom so that if module init throws, we throw away the broken components.

The transform handles some basic cases like top-level functions and arrows (normal or exported). In the future I'll add support for some HOC patterns like `memo`. The transform intentionally injects variable in the middle of assignment so that in theory we could even do things like `_c3 = forwardRef(_c2 = memo(_c1 = function() { }))` without changing code semantics.

In the follow-ups, I'll handle more cases and tie this with our integration tests so we can verify the whole thing works as expected.