### PR TITLE
Remove redundant test run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,8 +125,6 @@ jobs:
       - run: ./scripts/circleci/add_build_info_json.sh
       - run: ./scripts/circleci/update_package_versions.sh
       - run: ./scripts/circleci/build.sh
-      - run: yarn test-build --maxWorkers=2
-      - run: yarn test-build-prod --maxWorkers=2
       - run: cp ./scripts/rollup/results.json ./build/bundle-sizes.json
       - run: node ./scripts/tasks/danger
       - run: ./scripts/circleci/upload_build.sh


### PR DESCRIPTION
I moved `yarn test-build` and `yarn test-prod` to their own jobs but neglected to remove them from the build job, so right now they are running twice. Oops! This fixes that.