### PR TITLE
Update sizebot to match name of CircleCI build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,6 @@ jobs:
       - run: ./scripts/circleci/update_package_versions.sh
       - run: ./scripts/circleci/build.sh
       - run: cp ./scripts/rollup/results.json ./build/bundle-sizes.json
-      - run: node ./scripts/tasks/danger
       - run: ./scripts/circleci/upload_build.sh
       - run: ./scripts/circleci/pack_and_store_artifact.sh
       - store_artifacts:
@@ -143,6 +142,18 @@ jobs:
             - facebook-www
             - node_modules
             - react-native
+            - bundle-sizes.json
+
+  sizebot:
+    build:
+    docker: *docker
+    environment: *environment
+    steps:
+      - checkout
+      - attach_workspace: *attach_workspace
+      - *restore_yarn_cache
+      - *run_yarn
+      - run: node ./scripts/tasks/danger
 
   test_build:
     docker: *docker
@@ -193,6 +204,9 @@ workflows:
       - build:
           requires:
             - setup
+      - sizebot:
+          requires:
+            - build
       - test_build:
           requires:
             - build

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -36,6 +36,10 @@ if (!existsSync('./build/bundle-sizes.json')) {
   // This indicates the build failed previously.
   // In that case, there's nothing for the Dangerfile to do.
   // Exit early to avoid leaving a redundant (and potentially confusing) PR comment.
+  warn(
+    'No bundle size information found. This indicates the build ' +
+      'job failed.'
+  );
   process.exit(0);
 }
 
@@ -127,7 +131,8 @@ function git(args) {
     const statuses = await statusesResponse.json();
     for (let i = 0; i < statuses.length; i++) {
       const status = statuses[i];
-      if (status.context === 'ci/circleci') {
+      // This must match the name of the CI job that creates the build artifacts
+      if (status.context === 'ci/circleci: build') {
         if (status.state === 'success') {
           baseCIBuildId = /\/facebook\/react\/([0-9]+)/.exec(
             status.target_url
@@ -271,5 +276,7 @@ function git(args) {
   </details>
   `;
     markdown(summary);
+  } else {
+    markdown('No significant bundle size changes to report.');
   }
 })();


### PR DESCRIPTION
The sizebot scrapes the GitHub `/statuses` endpoint to get the latest CircleCI build number for master, in order to fetch the bundle size info for that build, which are stored as build artifacts. (There's gotta be a better way to do this, but that's what we have for now.) This updates the script to match the name of the updated CircleCI job that generates the bundle sizes.