### PR TITLE
Parallelizes the build script across multiple processes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
   build:
     docker: *docker
     environment: *environment
+    parallelism: 20
     steps:
       - checkout
       - *restore_yarn_cache
@@ -125,8 +126,6 @@ jobs:
       - run: ./scripts/circleci/add_build_info_json.sh
       - run: ./scripts/circleci/update_package_versions.sh
       - run: yarn build
-      - store_artifacts:
-          path: ./scripts/error-codes/codes.json
       - persist_to_workspace:
           root: build
           paths:
@@ -153,6 +152,10 @@ jobs:
           path: ./build.tgz
       - store_artifacts:
           path: ./build/bundle-sizes.json
+      - store_artifacts:
+          # TODO: Update release script to use local file instead of pulling
+          # from artifacts.
+          path: ./scripts/error-codes/codes.json
 
   lint_build:
     docker: *docker
@@ -223,9 +226,6 @@ workflows:
       - test_source_fire:
           requires:
             - setup
-      - test_coverage:
-          requires:
-            - setup
       - build:
           requires:
             - setup
@@ -237,10 +237,10 @@ workflows:
             - build
       - test_build:
           requires:
-            - process_artifacts
+            - build
       - test_build_prod:
           requires:
-            - process_artifacts
+            - build
   hourly:
     triggers:
       - schedule:
@@ -252,5 +252,8 @@ workflows:
     jobs:
       - setup
       - test_fuzz:
+          requires:
+            - setup
+      - test_coverage:
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,15 +125,6 @@ jobs:
       - run: ./scripts/circleci/add_build_info_json.sh
       - run: ./scripts/circleci/update_package_versions.sh
       - run: yarn build
-      - run: cp ./scripts/rollup/results.json ./build/bundle-sizes.json
-      - run: ./scripts/circleci/upload_build.sh
-      - run: ./scripts/circleci/pack_and_store_artifact.sh
-      - store_artifacts:
-          path: ./node_modules.tgz
-      - store_artifacts:
-          path: ./build.tgz
-      - store_artifacts:
-          path: ./build/bundle-sizes.json
       - store_artifacts:
           path: ./scripts/error-codes/codes.json
       - persist_to_workspace:
@@ -142,9 +133,9 @@ jobs:
             - facebook-www
             - node_modules
             - react-native
-            - bundle-sizes.json
+            - sizes/*.json
 
-  sizebot:
+  process_artifacts:
     docker: *docker
     environment: *environment
     steps:
@@ -152,7 +143,16 @@ jobs:
       - attach_workspace: *attach_workspace
       - *restore_yarn_cache
       - *run_yarn
+      - run: node ./scripts/rollup/consolidateBundleSizes.js
       - run: node ./scripts/tasks/danger
+      - run: ./scripts/circleci/upload_build.sh
+      - run: ./scripts/circleci/pack_and_store_artifact.sh
+      - store_artifacts:
+          path: ./node_modules.tgz
+      - store_artifacts:
+          path: ./build.tgz
+      - store_artifacts:
+          path: ./build/bundle-sizes.json
 
   lint_build:
     docker: *docker
@@ -229,7 +229,7 @@ workflows:
       - build:
           requires:
             - setup
-      - sizebot:
+      - process_artifacts:
           requires:
             - build
       - lint_build:
@@ -237,10 +237,10 @@ workflows:
             - build
       - test_build:
           requires:
-            - build
+            - process_artifacts
       - test_build_prod:
           requires:
-            - build
+            - process_artifacts
   hourly:
     triggers:
       - schedule:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_STORE
 node_modules
 scripts/flow/*/.flowconfig
-scripts/rollup/results.json
 *~
 *.pyc
 .grunt

--- a/scripts/circleci/upload_build.sh
+++ b/scripts/circleci/upload_build.sh
@@ -10,7 +10,7 @@ if [ -z "$CI_PULL_REQUEST" ] && [ -n "$BUILD_SERVER_ENDPOINT" ]; then
     -F "react-dom.production.min=@build/dist/react-dom.production.min.js" \
     -F "react-dom-server.browser.development=@build/dist/react-dom-server.browser.development.js" \
     -F "react-dom-server.browser.production.min=@build/dist/react-dom-server.browser.production.min.js" \
-    -F "results.json=@build/../scripts/rollup/results.json" \
+    -F "results.json=@build/../build/bundle-sizes.json" \
     -F "commit=$CIRCLE_SHA1" \
     -F "date=$(git log --format='%ct' -1)" \
     -F "pull_request=false" \

--- a/scripts/rollup/consolidateBundleSizes.js
+++ b/scripts/rollup/consolidateBundleSizes.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Script that combines bundle size information for each build into a single
+// JSON file for easier storage and processing.
+
+const fs = require('fs');
+const path = require('path');
+
+const BUILD_DIR = path.join(__dirname, '../../build');
+
+const filenames = fs.readdirSync(path.join(BUILD_DIR, 'sizes'));
+
+let bundleSizes = [];
+for (let i = 0; i < filenames.length; i++) {
+  const filename = filenames[i];
+  if (filename.endsWith('.size.json')) {
+    const json = fs.readFileSync(path.join(BUILD_DIR, 'sizes', filename));
+    bundleSizes.push(JSON.parse(json));
+  }
+}
+
+const outputFilename = path.join(BUILD_DIR, 'bundle-sizes.json');
+const outputContents = JSON.stringify({bundleSizes}, null, 2);
+
+fs.writeFileSync(outputFilename, outputContents);


### PR DESCRIPTION
## Based on #15757  and #15758 

Parallelizes the build script across multiple processes.

<img width="813" alt="Screen Shot 2019-05-28 at 6 45 26 PM" src="https://user-images.githubusercontent.com/3624098/58523805-a3772b00-817a-11e9-9682-a5ddb317b598.png">

(Our CircleCI plan supports up to 300 parallel processes (!!!) per job, but there's no point making the build job faster than the test job, so I capped it at 20.)

To do this, I needed to change how we generate the bundle size JSON file. I changed the build script to generate a separate size file per build. A downstream CI job consolidates them into a single `bundle-sizes.json` that contains the combined size information for every build.