### PR TITLE
[Flare] event component displayName is now mandatory

### DIFF
--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -137,7 +137,7 @@ export type ReactEventComponentInstance = {|
 
 export type ReactEventComponent = {|
   $$typeof: Symbol | number,
-  displayName?: string,
+  displayName: string,
   props: null | Object,
   responder: ReactEventResponder,
 |};

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -95,10 +95,7 @@ function getComponentName(type: mixed): string | null {
       case REACT_EVENT_COMPONENT_TYPE: {
         if (enableEventAPI) {
           const eventComponent = ((type: any): ReactEventComponent);
-          const displayName = eventComponent.displayName;
-          if (displayName !== undefined) {
-            return displayName;
-          }
+          return eventComponent.displayName;
         }
         break;
       }


### PR DESCRIPTION
We made the `displayName` field mandatory with the introduction of the `React.unstable_createEventComponent` API. This enforces the Flow types are consistent and also that the `getComponentName` function aligns.