### PR TITLE
[Flare] Ensure getAbsoluteBoundingClientRect aligns with offsetParent

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -426,7 +426,7 @@ function calculateDelayMS(delay: ?number, min = 0, fallback = 0) {
   return Math.max(min, maybeNumber != null ? maybeNumber : fallback);
 }
 
-function isNodeScrollableAndFixedPositioned(node: Node | null | void): boolean {
+function isNodeFixedPositioned(node: Node | null | void): boolean {
   return (
     node != null &&
     (node: any).offsetParent === null &&
@@ -453,16 +453,16 @@ function getAbsoluteBoundingClientRect(
     const scrollTop = (node: any).scrollTop;
     const scrollLeft = (node: any).scrollLeft;
 
-    // Check if the current node is fixed position, by using
-    // offsetParent node for a fast-path. Then we need to
-    // check if it's a scrollable container by checking if
-    // either scrollLeft or scrollTop are not 0. If it is
-    // a scrollable container and the parent node is not
-    // the document, then we can stop traversing the tree.
+    // We first need to check if it's a scrollable container by
+    // checking if either scrollLeft or scrollTop are not 0.
+    // Then we check if either the current node or its parent
+    // are fixed position, using offsetParent node for a fast-path.
+    // We need to check both as offsetParent accounts for both
+    // itself and the parent; so we need to align with that API.
+    // If these all pass, we can stop traversing the tree.
     if (
       (scrollLeft !== 0 || scrollTop !== 0) &&
-      (isNodeScrollableAndFixedPositioned(parent) ||
-        isNodeScrollableAndFixedPositioned(node))
+      (isNodeFixedPositioned(parent) || isNodeFixedPositioned(node))
     ) {
       break;
     }

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -426,6 +426,18 @@ function calculateDelayMS(delay: ?number, min = 0, fallback = 0) {
   return Math.max(min, maybeNumber != null ? maybeNumber : fallback);
 }
 
+function isNodeScrollableAndFixedPositioned(node: Node | null | void): boolean {
+  return (
+    node != null &&
+    (node: any).offsetParent === null &&
+    !isNodeDocumentNode(node.parentNode)
+  );
+}
+
+function isNodeDocumentNode(node: Node | null | void): boolean {
+  return node != null && node.nodeType === Node.DOCUMENT_NODE;
+}
+
 function getAbsoluteBoundingClientRect(
   target: Element,
 ): {left: number, right: number, bottom: number, top: number} {
@@ -440,8 +452,6 @@ function getAbsoluteBoundingClientRect(
     const parent = node.parentNode;
     const scrollTop = (node: any).scrollTop;
     const scrollLeft = (node: any).scrollLeft;
-    const isParentDocumentNode =
-      parent != null && parent.nodeType === Node.DOCUMENT_NODE;
 
     // Check if the current node is fixed position, by using
     // offsetParent node for a fast-path. Then we need to
@@ -450,15 +460,15 @@ function getAbsoluteBoundingClientRect(
     // a scrollable container and the parent node is not
     // the document, then we can stop traversing the tree.
     if (
-      !isParentDocumentNode &&
-      (node: any).offsetParent === null &&
-      (scrollLeft !== 0 || scrollTop !== 0)
+      (scrollLeft !== 0 || scrollTop !== 0) &&
+      (isNodeScrollableAndFixedPositioned(parent) ||
+        isNodeScrollableAndFixedPositioned(node))
     ) {
       break;
     }
     offsetX += scrollLeft;
     offsetY += scrollTop;
-    if (isParentDocumentNode) {
+    if (isNodeDocumentNode(parent)) {
       break;
     }
     node = parent;

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -1167,6 +1167,7 @@ describe('Event responder: Press', () => {
 
         // The fixed container is not scrolled
         fixedDiv.scrollTop = 0;
+        fixedDiv.scrollLeft = 0;
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
         // Emulate the <html> element being offset with scroll
         document.firstElementChild.scrollTop = 1000;


### PR DESCRIPTION
This refines `getAbsoluteBoundingClientRect` so that we we align with the DOM `offsetParent` API. Specifically, `offsetParent` relates to both the current DOM node and its parent node – so we should also do the same to ensure we're making the right calculation in regards to bailing out.