### PR TITLE
[Fresh] Babel plugin now handles HOCs + add integration tests

### DIFF
--- a/packages/react-fresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-fresh/src/ReactFreshBabelPlugin.js
@@ -126,7 +126,8 @@ export default function(babel) {
         for (let i = 0; i < referencePaths.length; i++) {
           const ref = referencePaths[i];
           if (
-            ref.node.type === 'JSXIdentifier' &&
+            (ref.node.type === 'JSXIdentifier' ||
+              ref.node.type === 'Identifier') &&
             ref.parent.type === 'JSXOpeningElement'
           ) {
             // const X = ... + later <X />

--- a/packages/react-fresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-fresh/src/ReactFreshBabelPlugin.js
@@ -165,7 +165,7 @@ export default function(babel) {
         const decl = node.declaration;
         const declPath = path.get('declaration');
         if (decl.type !== 'CallExpression') {
-          // For now, we only support process possible HOC calls here.
+          // For now, we only support possible HOC calls here.
           // Named function declarations are handled in FunctionDeclaration.
           // Anonymous direct exports like export default function() {}
           // are currently ignored.
@@ -175,6 +175,8 @@ export default function(babel) {
         // export default memo(() => {})
         // In those cases it is more plausible people will omit names
         // so they're worth handling despite possible false positives.
+        // More importantly, it handles the named case:
+        // export default memo(function Named() {})
         const inferredName = '%default%';
         const programPath = path.parentPath;
         findInnerComponents(

--- a/packages/react-fresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-fresh/src/ReactFreshBabelPlugin.js
@@ -191,8 +191,6 @@ export default function(babel) {
           default:
             return;
         }
-        // While we reuse this function, in this case it won't
-        // go more than one level deep because we're at the leaf.
         findInnerComponents(inferredName, path, (persistentID, targetExpr) => {
           const handle = createRegistration(programPath, persistentID);
           insertAfterPath.insertAfter(

--- a/packages/react-fresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFresh-test.js
@@ -16,10 +16,10 @@ let ReactDOM;
 let ReactFreshRuntime;
 let Scheduler;
 let act;
-let lastRoot;
 
 describe('ReactFresh', () => {
   let container;
+  let lastRoot;
   let scheduleHotUpdate;
 
   beforeEach(() => {

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -247,4 +247,42 @@ describe('ReactFreshBabelPlugin', () => {
     `),
     ).toMatchSnapshot();
   });
+
+  it('registers identifiers used in React.createElement at definition site', () => {
+    // When in doubt, register variables that were used in JSX.
+    // Foo, Header, and B get registered.
+    // A doesn't get registered because it's not declared locally.
+    // Alias doesn't get registered because its definition is just an identifier.
+    expect(
+      transform(`
+        import A from './A';
+        import Store from './Store';
+
+        Store.subscribe();
+
+        const Header = styled.div\`color: red\`
+        const Factory = funny.factory\`\`;
+
+        let Alias1 = A;
+        let Alias2 = A.Foo;
+        const Dict = {};
+
+        function Foo() {
+          return [
+            React.createElement(A),
+            React.createElement(B),
+            React.createElement(Alias1),
+            React.createElement(Alias2),
+            jsx(Header),
+            React.createElement(Dict.X),
+          ];
+        }
+
+        React.createContext(Store);
+
+        const B = hoc(A);
+        const NotAComponent = wow(A);
+    `),
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -186,4 +186,34 @@ describe('ReactFreshBabelPlugin', () => {
     `),
     ).toMatchSnapshot();
   });
+
+  it('registers likely HOCs with inline functions', () => {
+    expect(
+      transform(`
+        const A = forwardRef(function() {
+          return <h1>Foo</h1>;
+        });
+        const B = memo(React.forwardRef(() => {
+          return <h1>Foo</h1>;
+        }));
+        export default React.memo(forwardRef((props, ref) => {
+          return <h1>Foo</h1>;
+        }))
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('ignores higher-order functions that are not HOCs', () => {
+    expect(
+      transform(`
+        const throttledAlert = throttle(function() {
+          alert('Hi');
+        });
+        const TooComplex = (function() { return hello })(() => {});
+        if (cond) {
+          const Foo = thing(() => {});
+        }
+    `),
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -216,4 +216,35 @@ describe('ReactFreshBabelPlugin', () => {
     `),
     ).toMatchSnapshot();
   });
+
+  it('registers identifiers used in JSX at definition site', () => {
+    // When in doubt, register variables that were used in JSX.
+    // Foo, Header, and B get registered.
+    // A doesn't get registered because it's not declared locally.
+    // Alias doesn't get registered because its definition is just an identifier.
+    expect(
+      transform(`
+        import A from './A';
+        import Store from './Store';
+
+        Store.subscribe();
+
+        const Header = styled.div\`color: red\`
+        const Factory = funny.factory\`\`;
+
+        let Alias1 = A;
+        let Alias2 = A.Foo;
+        const Dict = {};
+
+        function Foo() {
+          return (
+            <div><A /><B /><Alias1 /><Alias2 /><Header /><Dict.X /></div>
+          );
+        }
+
+        const B = hoc(A);
+        const NotAComponent = wow(A);
+    `),
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -198,7 +198,21 @@ describe('ReactFreshBabelPlugin', () => {
         }));
         export default React.memo(forwardRef((props, ref) => {
           return <h1>Foo</h1>;
-        }))
+        }));
+    `),
+    ).toMatchSnapshot();
+    expect(
+      transform(`
+        export default React.memo(forwardRef(function (props, ref) {
+          return <h1>Foo</h1>;
+        }));
+    `),
+    ).toMatchSnapshot();
+    expect(
+      transform(`
+        export default React.memo(forwardRef(function Named(props, ref) {
+          return <h1>Foo</h1>;
+        }));
     `),
     ).toMatchSnapshot();
   });

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -116,29 +116,29 @@ describe('ReactFreshIntegration', () => {
   it('reloads arrow functions', () => {
     if (__DEV__) {
       render(`
-      const Parent = () => {
-        return <Child prop="A" />;
-      };
+        const Parent = () => {
+          return <Child prop="A" />;
+        };
 
-      const Child = ({prop}) => {
-        return <h1>{prop}1</h1>;
-      };
+        const Child = ({prop}) => {
+          return <h1>{prop}1</h1>;
+        };
 
-      export default Parent;
-    `);
+        export default Parent;
+      `);
       const el = container.firstChild;
       expect(el.textContent).toBe('A1');
       patch(`
-      const Parent = () => {
-        return <Child prop="B" />;
-      };
+        const Parent = () => {
+          return <Child prop="B" />;
+        };
 
-      const Child = ({prop}) => {
-        return <h1>{prop}2</h1>;
-      };
+        const Child = ({prop}) => {
+          return <h1>{prop}2</h1>;
+        };
 
-      export default Parent;
-    `);
+        export default Parent;
+      `);
       expect(container.firstChild).toBe(el);
       expect(el.textContent).toBe('B2');
     }
@@ -147,33 +147,33 @@ describe('ReactFreshIntegration', () => {
   it('reloads a combination of memo and forwardRef', () => {
     if (__DEV__) {
       render(`
-      const {memo} = React;
+        const {memo} = React;
 
-      const Parent = memo(React.forwardRef(function (props, ref) {
-        return <Child prop="A" ref={ref} />;
-      }));
+        const Parent = memo(React.forwardRef(function (props, ref) {
+          return <Child prop="A" ref={ref} />;
+        }));
 
-      const Child = React.memo(({prop}) => {
-        return <h1>{prop}1</h1>;
-      });
+        const Child = React.memo(({prop}) => {
+          return <h1>{prop}1</h1>;
+        });
 
-      export default React.memo(Parent);
-    `);
+        export default React.memo(Parent);
+      `);
       const el = container.firstChild;
       expect(el.textContent).toBe('A1');
       patch(`
-      const {memo} = React;
+        const {memo} = React;
 
-      const Parent = memo(React.forwardRef(function (props, ref) {
-        return <Child prop="B" ref={ref} />;
-      }));
+        const Parent = memo(React.forwardRef(function (props, ref) {
+          return <Child prop="B" ref={ref} />;
+        }));
 
-      const Child = React.memo(({prop}) => {
-        return <h1>{prop}2</h1>;
-      });
+        const Child = React.memo(({prop}) => {
+          return <h1>{prop}2</h1>;
+        });
 
-      export default React.memo(Parent);
-    `);
+        export default React.memo(Parent);
+      `);
       expect(container.firstChild).toBe(el);
       expect(el.textContent).toBe('B2');
     }
@@ -182,29 +182,29 @@ describe('ReactFreshIntegration', () => {
   it('reloads anonymous memo default export', () => {
     if (__DEV__) {
       render(`
-      const {memo} = React;
+        const {memo} = React;
 
-      export default memo(React.forwardRef(function (props, ref) {
-        return <Child prop="A" ref={ref} />;
-      }));
+        export default memo(React.forwardRef(function (props, ref) {
+          return <Child prop="A" ref={ref} />;
+        }));
 
-      const Child = React.memo(({prop}) => {
-        return <h1>{prop}1</h1>;
-      });
-    `);
+        const Child = React.memo(({prop}) => {
+          return <h1>{prop}1</h1>;
+        });
+      `);
       const el = container.firstChild;
       expect(el.textContent).toBe('A1');
       patch(`
-      const {memo} = React;
+        const {memo} = React;
 
-      export default memo(React.forwardRef(function (props, ref) {
-        return <Child prop="B" ref={ref} />;
-      }));
+        export default memo(React.forwardRef(function (props, ref) {
+          return <Child prop="B" ref={ref} />;
+        }));
 
-      const Child = React.memo(({prop}) => {
-        return <h1>{prop}2</h1>;
-      });
-    `);
+        const Child = React.memo(({prop}) => {
+          return <h1>{prop}2</h1>;
+        });
+      `);
       expect(container.firstChild).toBe(el);
       expect(el.textContent).toBe('B2');
     }
@@ -213,33 +213,33 @@ describe('ReactFreshIntegration', () => {
   it('reloads HOCs if they return functions', () => {
     if (__DEV__) {
       render(`
-      function hoc(letter) {
-        return function() {
-          return <h1>{letter}1</h1>;
+        function hoc(letter) {
+          return function() {
+            return <h1>{letter}1</h1>;
+          }
         }
-      }
 
-      export default function Parent() {
-        return <Child />;
-      }
+        export default function Parent() {
+          return <Child />;
+        }
 
-      const Child = hoc('A');
-    `);
+        const Child = hoc('A');
+      `);
       const el = container.firstChild;
       expect(el.textContent).toBe('A1');
       patch(`
-      function hoc(letter) {
-        return function() {
-          return <h1>{letter}2</h1>;
+        function hoc(letter) {
+          return function() {
+            return <h1>{letter}2</h1>;
+          }
         }
-      }
 
-      export default function Parent() {
-        return React.createElement(Child);
-      }
+        export default function Parent() {
+          return React.createElement(Child);
+        }
 
-      const Child = hoc('B');
-    `);
+        const Child = hoc('B');
+      `);
       expect(container.firstChild).toBe(el);
       expect(el.textContent).toBe('B2');
     }

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -83,36 +83,39 @@ describe('ReactFreshIntegration', () => {
   }
 
   it('reloads function declarations', () => {
-    render(`
-      function Parent() {
-        return <Child prop="A" />;
-      };
+    if (__DEV__) {
+      render(`
+        function Parent() {
+          return <Child prop="A" />;
+        };
 
-      function Child({prop}) {
-        return <h1>{prop}1</h1>;
-      };
+        function Child({prop}) {
+          return <h1>{prop}1</h1>;
+        };
 
-      export default Parent;
-    `);
-    const el = container.firstChild;
-    expect(el.textContent).toBe('A1');
-    patch(`
-      function Parent() {
-        return <Child prop="B" />;
-      };
+        export default Parent;
+      `);
+      const el = container.firstChild;
+      expect(el.textContent).toBe('A1');
+      patch(`
+        function Parent() {
+          return <Child prop="B" />;
+        };
 
-      function Child({prop}) {
-        return <h1>{prop}2</h1>;
-      };
+        function Child({prop}) {
+          return <h1>{prop}2</h1>;
+        };
 
-      export default Parent;
-    `);
-    expect(container.firstChild).toBe(el);
-    expect(el.textContent).toBe('B2');
+        export default Parent;
+      `);
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('B2');
+    }
   });
 
   it('reloads arrow functions', () => {
-    render(`
+    if (__DEV__) {
+      render(`
       const Parent = () => {
         return <Child prop="A" />;
       };
@@ -123,9 +126,9 @@ describe('ReactFreshIntegration', () => {
 
       export default Parent;
     `);
-    const el = container.firstChild;
-    expect(el.textContent).toBe('A1');
-    patch(`
+      const el = container.firstChild;
+      expect(el.textContent).toBe('A1');
+      patch(`
       const Parent = () => {
         return <Child prop="B" />;
       };
@@ -136,12 +139,14 @@ describe('ReactFreshIntegration', () => {
 
       export default Parent;
     `);
-    expect(container.firstChild).toBe(el);
-    expect(el.textContent).toBe('B2');
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('B2');
+    }
   });
 
   it('reloads a combination of memo and forwardRef', () => {
-    render(`
+    if (__DEV__) {
+      render(`
       const {memo} = React;
 
       const Parent = memo(React.forwardRef(function (props, ref) {
@@ -154,9 +159,9 @@ describe('ReactFreshIntegration', () => {
 
       export default React.memo(Parent);
     `);
-    const el = container.firstChild;
-    expect(el.textContent).toBe('A1');
-    patch(`
+      const el = container.firstChild;
+      expect(el.textContent).toBe('A1');
+      patch(`
       const {memo} = React;
 
       const Parent = memo(React.forwardRef(function (props, ref) {
@@ -169,12 +174,14 @@ describe('ReactFreshIntegration', () => {
 
       export default React.memo(Parent);
     `);
-    expect(container.firstChild).toBe(el);
-    expect(el.textContent).toBe('B2');
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('B2');
+    }
   });
 
   it('reloads HOCs if they return functions', () => {
-    render(`
+    if (__DEV__) {
+      render(`
       function hoc(letter) {
         return function() {
           return <h1>{letter}1</h1>;
@@ -187,9 +194,9 @@ describe('ReactFreshIntegration', () => {
 
       const Child = hoc('A');
     `);
-    const el = container.firstChild;
-    expect(el.textContent).toBe('A1');
-    patch(`
+      const el = container.firstChild;
+      expect(el.textContent).toBe('A1');
+      patch(`
       function hoc(letter) {
         return function() {
           return <h1>{letter}2</h1>;
@@ -202,7 +209,8 @@ describe('ReactFreshIntegration', () => {
 
       const Child = hoc('B');
     `);
-    expect(container.firstChild).toBe(el);
-    expect(el.textContent).toBe('B2');
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('B2');
+    }
   });
 });

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -179,6 +179,37 @@ describe('ReactFreshIntegration', () => {
     }
   });
 
+  it('reloads anonymous memo default export', () => {
+    if (__DEV__) {
+      render(`
+      const {memo} = React;
+
+      export default memo(React.forwardRef(function (props, ref) {
+        return <Child prop="A" ref={ref} />;
+      }));
+
+      const Child = React.memo(({prop}) => {
+        return <h1>{prop}1</h1>;
+      });
+    `);
+      const el = container.firstChild;
+      expect(el.textContent).toBe('A1');
+      patch(`
+      const {memo} = React;
+
+      export default memo(React.forwardRef(function (props, ref) {
+        return <Child prop="B" ref={ref} />;
+      }));
+
+      const Child = React.memo(({prop}) => {
+        return <h1>{prop}2</h1>;
+      });
+    `);
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('B2');
+    }
+  });
+
   it('reloads HOCs if they return functions', () => {
     if (__DEV__) {
       render(`

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -197,7 +197,7 @@ describe('ReactFreshIntegration', () => {
       }
 
       export default function Parent() {
-        return <Child />;
+        return React.createElement(Child);
       }
 
       const Child = hoc('B');

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+/* eslint-disable no-for-of-loops/no-for-of-loops */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let ReactFreshRuntime;
+let act;
+
+let babel = require('babel-core');
+let freshPlugin = require('react-fresh/babel');
+
+describe('ReactFreshIntegration', () => {
+  let container;
+  let lastRoot;
+  let scheduleHotUpdate;
+
+  beforeEach(() => {
+    global.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+      supportsFiber: true,
+      inject: injected => {
+        scheduleHotUpdate = injected.scheduleHotUpdate;
+      },
+      onCommitFiberRoot: (id, root) => {
+        lastRoot = root;
+      },
+      onCommitFiberUnmount: () => {},
+    };
+
+    jest.resetModules();
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactFreshRuntime = require('react-fresh/runtime');
+    act = require('react-dom/test-utils').act;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  function execute(source) {
+    const compiled = babel.transform(source, {
+      babelrc: false,
+      presets: ['react'],
+      plugins: [freshPlugin, 'transform-es2015-modules-commonjs'],
+    }).code;
+    const exportsObj = {};
+    // eslint-disable-next-line no-new-func
+    new Function('React', 'exports', '__register__', compiled)(
+      React,
+      exportsObj,
+      __register__,
+    );
+    return exportsObj.default;
+  }
+
+  function render(source) {
+    const Component = execute(source);
+    act(() => {
+      ReactDOM.render(<Component />, container);
+    });
+  }
+
+  function patch(source) {
+    execute(source);
+    const hotUpdate = ReactFreshRuntime.prepareUpdate();
+    scheduleHotUpdate(lastRoot, hotUpdate);
+  }
+
+  function __register__(type, id) {
+    ReactFreshRuntime.register(type, id);
+  }
+
+  it('reloads function declarations', () => {
+    render(`
+      function Parent() {
+        return <Child prop="A" />;
+      };
+
+      function Child({prop}) {
+        return <h1>{prop}1</h1>;
+      };
+
+      export default Parent;
+    `);
+    const el = container.firstChild;
+    expect(el.textContent).toBe('A1');
+    patch(`
+      function Parent() {
+        return <Child prop="B" />;
+      };
+
+      function Child({prop}) {
+        return <h1>{prop}2</h1>;
+      };
+
+      export default Parent;
+    `);
+    expect(container.firstChild).toBe(el);
+    expect(el.textContent).toBe('B2');
+  });
+
+  it('reloads arrow functions', () => {
+    render(`
+      const Parent = () => {
+        return <Child prop="A" />;
+      };
+
+      const Child = ({prop}) => {
+        return <h1>{prop}1</h1>;
+      };
+
+      export default Parent;
+    `);
+    const el = container.firstChild;
+    expect(el.textContent).toBe('A1');
+    patch(`
+      const Parent = () => {
+        return <Child prop="B" />;
+      };
+
+      const Child = ({prop}) => {
+        return <h1>{prop}2</h1>;
+      };
+
+      export default Parent;
+    `);
+    expect(container.firstChild).toBe(el);
+    expect(el.textContent).toBe('B2');
+  });
+
+  it('reloads a combination of memo and forwardRef', () => {
+    render(`
+      const {memo} = React;
+
+      const Parent = memo(React.forwardRef(function (props, ref) {
+        return <Child prop="A" ref={ref} />;
+      }));
+
+      const Child = React.memo(({prop}) => {
+        return <h1>{prop}1</h1>;
+      });
+
+      export default React.memo(Parent);
+    `);
+    const el = container.firstChild;
+    expect(el.textContent).toBe('A1');
+    patch(`
+      const {memo} = React;
+
+      const Parent = memo(React.forwardRef(function (props, ref) {
+        return <Child prop="B" ref={ref} />;
+      }));
+
+      const Child = React.memo(({prop}) => {
+        return <h1>{prop}2</h1>;
+      });
+
+      export default React.memo(Parent);
+    `);
+    expect(container.firstChild).toBe(el);
+    expect(el.textContent).toBe('B2');
+  });
+});

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -172,4 +172,37 @@ describe('ReactFreshIntegration', () => {
     expect(container.firstChild).toBe(el);
     expect(el.textContent).toBe('B2');
   });
+
+  it('reloads HOCs if they return functions', () => {
+    render(`
+      function hoc(letter) {
+        return function() {
+          return <h1>{letter}1</h1>;
+        }
+      }
+
+      export default function Parent() {
+        return <Child />;
+      }
+
+      const Child = hoc('A');
+    `);
+    const el = container.firstChild;
+    expect(el.textContent).toBe('A1');
+    patch(`
+      function hoc(letter) {
+        return function() {
+          return <h1>{letter}2</h1>;
+        }
+      }
+
+      export default function Parent() {
+        return <Child />;
+      }
+
+      const Child = hoc('B');
+    `);
+    expect(container.firstChild).toBe(el);
+    expect(el.textContent).toBe('B2');
+  });
 });

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -179,31 +179,31 @@ describe('ReactFreshIntegration', () => {
     }
   });
 
-  it('reloads anonymous memo default export', () => {
+  it('reloads default export with named memo', () => {
     if (__DEV__) {
       render(`
         const {memo} = React;
 
-        export default memo(React.forwardRef(function (props, ref) {
-          return <Child prop="A" ref={ref} />;
-        }));
-
         const Child = React.memo(({prop}) => {
           return <h1>{prop}1</h1>;
         });
+
+        export default memo(React.forwardRef(function Parent(props, ref) {
+          return <Child prop="A" ref={ref} />;
+        }));
       `);
       const el = container.firstChild;
       expect(el.textContent).toBe('A1');
       patch(`
         const {memo} = React;
 
-        export default memo(React.forwardRef(function (props, ref) {
-          return <Child prop="B" ref={ref} />;
-        }));
-
         const Child = React.memo(({prop}) => {
           return <h1>{prop}2</h1>;
         });
+
+        export default memo(React.forwardRef(function Parent(props, ref) {
+          return <Child prop="B" ref={ref} />;
+        }));
       `);
       expect(container.firstChild).toBe(el);
       expect(el.textContent).toBe('B2');

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -89,6 +89,39 @@ __register__(_c2, 'Foo');
 __register__(_c3, 'B');"
 `;
 
+exports[`ReactFreshBabelPlugin registers identifiers used in React.createElement at definition site 1`] = `
+"
+import A from './A';
+import Store from './Store';
+
+Store.subscribe();
+
+const Header = _c = styled.div\`color: red\`;
+const Factory = funny.factory\`\`;
+
+let Alias1 = A;
+let Alias2 = A.Foo;
+const Dict = {};
+
+function Foo() {
+  return [React.createElement(A), React.createElement(B), React.createElement(Alias1), React.createElement(Alias2), jsx(Header), React.createElement(Dict.X)];
+}
+
+_c2 = Foo;
+React.createContext(Store);
+
+const B = _c3 = hoc(A);
+const NotAComponent = wow(A);
+
+var _c, _c2, _c3;
+
+__register__(_c, 'Header');
+
+__register__(_c2, 'Foo');
+
+__register__(_c3, 'B');"
+`;
+
 exports[`ReactFreshBabelPlugin registers likely HOCs with inline functions 1`] = `
 "
 const A = _c2 = forwardRef(_c = function () {

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -33,6 +33,19 @@ let D = bar && (() => {
 });"
 `;
 
+exports[`ReactFreshBabelPlugin ignores higher-order functions that are not HOCs 1`] = `
+"
+const throttledAlert = throttle(function () {
+  alert('Hi');
+});
+const TooComplex = function () {
+  return hello;
+}(() => {});
+if (cond) {
+  const Foo = thing(() => {});
+}"
+`;
+
 exports[`ReactFreshBabelPlugin ignores unnamed function declarations 1`] = `
 "
 export default function () {}"
@@ -43,6 +56,31 @@ exports[`ReactFreshBabelPlugin only registers pascal case functions 1`] = `
 function hello() {
   return 2 * 2;
 }"
+`;
+
+exports[`ReactFreshBabelPlugin registers likely HOCs with inline functions 1`] = `
+"
+const A = _c2 = forwardRef(_c = function () {
+  return <h1>Foo</h1>;
+});
+const B = _c5 = memo(_c4 = React.forwardRef(_c3 = () => {
+  return <h1>Foo</h1>;
+}));
+export default React.memo(forwardRef((props, ref) => {
+  return <h1>Foo</h1>;
+}));
+
+var _c, _c2, _c3, _c4, _c5;
+
+__register__(_c, \\"A$forwardRef\\");
+
+__register__(_c2, \\"A\\");
+
+__register__(_c3, \\"B$memo$React.forwardRef\\");
+
+__register__(_c4, \\"B$memo\\");
+
+__register__(_c5, \\"B\\");"
 `;
 
 exports[`ReactFreshBabelPlugin registers top-level exported function declarations 1`] = `

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -58,6 +58,37 @@ function hello() {
 }"
 `;
 
+exports[`ReactFreshBabelPlugin registers identifiers used in JSX at definition site 1`] = `
+"
+import A from './A';
+import Store from './Store';
+
+Store.subscribe();
+
+const Header = _c = styled.div\`color: red\`;
+const Factory = funny.factory\`\`;
+
+let Alias1 = A;
+let Alias2 = A.Foo;
+const Dict = {};
+
+function Foo() {
+  return <div><A /><B /><Alias1 /><Alias2 /><Header /><Dict.X /></div>;
+}
+
+_c2 = Foo;
+const B = _c3 = hoc(A);
+const NotAComponent = wow(A);
+
+var _c, _c2, _c3;
+
+__register__(_c, 'Header');
+
+__register__(_c2, 'Foo');
+
+__register__(_c3, 'B');"
+`;
+
 exports[`ReactFreshBabelPlugin registers likely HOCs with inline functions 1`] = `
 "
 const A = _c2 = forwardRef(_c = function () {

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -130,11 +130,11 @@ const A = _c2 = forwardRef(_c = function () {
 const B = _c5 = memo(_c4 = React.forwardRef(_c3 = () => {
   return <h1>Foo</h1>;
 }));
-export default React.memo(forwardRef((props, ref) => {
+export default _c8 = React.memo(_c7 = forwardRef(_c6 = (props, ref) => {
   return <h1>Foo</h1>;
 }));
 
-var _c, _c2, _c3, _c4, _c5;
+var _c, _c2, _c3, _c4, _c5, _c6, _c7, _c8;
 
 __register__(_c, \\"A$forwardRef\\");
 
@@ -144,7 +144,43 @@ __register__(_c3, \\"B$memo$React.forwardRef\\");
 
 __register__(_c4, \\"B$memo\\");
 
-__register__(_c5, \\"B\\");"
+__register__(_c5, \\"B\\");
+
+__register__(_c6, \\"%default%$React.memo$forwardRef\\");
+
+__register__(_c7, \\"%default%$React.memo\\");
+
+__register__(_c8, \\"%default%\\");"
+`;
+
+exports[`ReactFreshBabelPlugin registers likely HOCs with inline functions 2`] = `
+"
+export default _c3 = React.memo(_c2 = forwardRef(_c = function (props, ref) {
+  return <h1>Foo</h1>;
+}));
+
+var _c, _c2, _c3;
+
+__register__(_c, \\"%default%$React.memo$forwardRef\\");
+
+__register__(_c2, \\"%default%$React.memo\\");
+
+__register__(_c3, \\"%default%\\");"
+`;
+
+exports[`ReactFreshBabelPlugin registers likely HOCs with inline functions 3`] = `
+"
+export default _c3 = React.memo(_c2 = forwardRef(_c = function Named(props, ref) {
+  return <h1>Foo</h1>;
+}));
+
+var _c, _c2, _c3;
+
+__register__(_c, \\"%default%$React.memo$forwardRef\\");
+
+__register__(_c2, \\"%default%$React.memo\\");
+
+__register__(_c3, \\"%default%\\");"
 `;
 
 exports[`ReactFreshBabelPlugin registers top-level exported function declarations 1`] = `


### PR DESCRIPTION
This is a follow-up to https://github.com/facebook/react/pull/15711 that teaches the Babel plugin to handle more cases including common patterns for higher-order components like `memo()`, `styled`, or chains of them. Concretely, we:

* Consider `A` declaration a likely component if it was used in `<A />` JSX call or `createElement(A)`
* Recognize patterns like `hoc1(hoc2(hoc3(() => { })))` and register each of them, as long as the outer definition is PascalCase.

Keep in mind registering is a no-op if something never gets rendered so false positives are acceptable. We might want to reconsider that later when we use the information about registrations to decide whether hot reload should propagate or stop at a module boundary (because all exports were registered). In that case false positives are not ideal. We can add smarter heuristics later, such as bailing out for functions that obviously aren't components. (E.g. when `prototype` is accessed or there's unexpected arguments or return value.)

I'm also adding a first integration test file. This one is different because it tests _both_ React, the runtime, and the Babel plugin together. It's as close as we have to an end-to-end test now. It's a bit harder to debug when it breaks (more moving pieces) but it also gives us more confidence that complex patterns actually work, and a way to reliably track regressions.