### PR TITLE
[Fresh] Generate signatures for Hooks

### DIFF
--- a/packages/react-fresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-fresh/src/ReactFreshBabelPlugin.js
@@ -196,8 +196,14 @@ export default function(babel) {
       case 'React.useMemo':
       case 'useCallback':
       case 'React.useCallback':
+      case 'useRef':
+      case 'React.useRef':
+      case 'useContext':
+      case 'React.useContext':
       case 'useImperativeMethods':
       case 'React.useImperativeMethods':
+      case 'useDebugValue':
+      case 'React.useDebugValue':
         return true;
       default:
         return false;

--- a/packages/react-fresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFresh-test.js
@@ -74,6 +74,7 @@ describe('ReactFresh', () => {
 
   function __signature__(type, id) {
     ReactFreshRuntime.setSignature(type, id);
+    return type;
   }
 
   it('can preserve state for compatible types', () => {

--- a/packages/react-fresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFresh-test.js
@@ -72,8 +72,8 @@ describe('ReactFresh', () => {
     ReactFreshRuntime.register(type, id);
   }
 
-  function __signature__(type, id) {
-    ReactFreshRuntime.setSignature(type, id);
+  function __signature__(type, key, getCustomHooks) {
+    ReactFreshRuntime.setSignature(type, key, getCustomHooks);
     return type;
   }
 

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -257,7 +257,9 @@ describe('ReactFreshBabelPlugin', () => {
         }
 
         const B = hoc(A);
+        // This is currently registered as a false positive:
         const NotAComponent = wow(A);
+        // We could avoid it but it also doesn't hurt.
     `),
     ).toMatchSnapshot();
   });
@@ -295,7 +297,23 @@ describe('ReactFreshBabelPlugin', () => {
         React.createContext(Store);
 
         const B = hoc(A);
+        // This is currently registered as a false positive:
         const NotAComponent = wow(A);
+        // We could avoid it but it also doesn't hurt.
+    `),
+    ).toMatchSnapshot();
+  });
+
+  it('registers capitalized identifiers in HOC calls', () => {
+    expect(
+      transform(`
+        function Foo() {
+          return <h1>Hi</h1>;
+        }
+
+        export default hoc(Foo);
+        export const A = hoc(Foo);
+        const B = hoc(Foo);
     `),
     ).toMatchSnapshot();
   });

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -344,4 +344,25 @@ describe('ReactFreshBabelPlugin', () => {
     `),
     ).toMatchSnapshot();
   });
+
+  it('includes custom hooks into the signatures', () => {
+    expect(
+      transform(`
+        function useFancyState() {
+          const [foo, setFoo] = React.useState(0);
+          useFancyEffect();
+          return foo;
+        }
+
+        const useFancyEffect = () => {
+          React.useEffect(() => {});
+        };
+
+        export default function App() {
+          const bar = useFancyState();
+          return <h1>{bar}</h1>;
+        }
+    `),
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -305,7 +305,7 @@ describe('ReactFreshBabelPlugin', () => {
       transform(`
         export default function App() {
           const [foo, setFoo] = useState(0);
-          useEffect(() => {});
+          React.useEffect(() => {});
           return <h1>{foo}</h1>;
         }
     `),
@@ -322,20 +322,20 @@ describe('ReactFreshBabelPlugin', () => {
       transform(`
         export const A = React.memo(React.forwardRef((props, ref) => {
           const [foo, setFoo] = useState(0);
-          useEffect(() => {});
+          React.useEffect(() => {});
           return <h1 ref={ref}>{foo}</h1>;
         }));
 
         export const B = React.memo(React.forwardRef(function(props, ref) {
           const [foo, setFoo] = useState(0);
-          useEffect(() => {});
+          React.useEffect(() => {});
           return <h1 ref={ref}>{foo}</h1>;
         }));
 
         function hoc() {
           return function Inner() {
             const [foo, setFoo] = useState(0);
-            useEffect(() => {});
+            React.useEffect(() => {});
             return <h1 ref={ref}>{foo}</h1>;
           };
         }

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -297,7 +297,7 @@ describe('ReactFreshIntegration', () => {
         const {useState} = React;
 
         function hoc(Wrapped) {
-          return function GeneratedV1() {
+          return function Generated() {
             const [foo, setFoo] = useState(1);
             return <Wrapped value={foo} />;
           };
@@ -314,7 +314,7 @@ describe('ReactFreshIntegration', () => {
         const {useState} = React;
 
         function hoc(Wrapped) {
-          return function GeneratedV2() {
+          return function Generated() {
             const [foo, setFoo] = useState('ignored');
             return <Wrapped value={foo} />;
           };
@@ -332,7 +332,7 @@ describe('ReactFreshIntegration', () => {
         const {useState} = React;
 
         function hoc(Wrapped) {
-          return function GeneratedV3() {
+          return function Generated() {
             const [bar, setBar] = useState(2);
             return <Wrapped value={bar} />;
           };

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -583,4 +583,48 @@ describe('ReactFreshIntegration', () => {
       expect(el.textContent).toBe('DXY');
     }
   });
+
+  it('does not lose the inferred arrow names', () => {
+    if (__DEV__) {
+      render(`
+        const Parent = () => {
+          return <Child/>;
+        };
+
+        const Child = () => {
+          useMyThing();
+          return <h1>{Parent.name} {Child.name} {useMyThing.name}</h1>;
+        };
+
+        const useMyThing = () => {
+          React.useState();
+        };
+
+        export default Parent;
+      `);
+      expect(container.textContent).toBe('Parent Child useMyThing');
+    }
+  });
+
+  it('does not lose the inferred function names', () => {
+    if (__DEV__) {
+      render(`
+        var Parent = function() {
+          return <Child/>;
+        };
+
+        var Child = function() {
+          useMyThing();
+          return <h1>{Parent.name} {Child.name} {useMyThing.name}</h1>;
+        };
+
+        var useMyThing = function() {
+          React.useState();
+        };
+
+        export default Parent;
+      `);
+      expect(container.textContent).toBe('Parent Child useMyThing');
+    }
+  });
 });

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -117,9 +117,11 @@ function useFancyState() {
 
 __signature__(useFancyState, \\"useState{[foo, setFoo]}\\\\nuseFancyEffect{}\\", () => [useFancyEffect]);
 
-const useFancyEffect = __signature__(() => {
+const useFancyEffect = () => {
   React.useEffect(() => {});
-}, \\"useEffect{}\\");
+};
+
+__signature__(useFancyEffect, \\"useEffect{}\\");
 
 export default function App() {
   const bar = useFancyState();
@@ -302,13 +304,15 @@ __register__(_c3, 'Baz');"
 
 exports[`ReactFreshBabelPlugin registers top-level exported named arrow functions 1`] = `
 "
-export const Hello = _c = () => {
+export const Hello = () => {
   function handleClick() {}
   return <h1 onClick={handleClick}>Hi</h1>;
 };
 
-export let Bar = _c2 = props => <Hello />;
+_c = Hello;
+export let Bar = props => <Hello />;
 
+_c2 = Bar;
 export default (() => {
   // This one should be ignored.
   // You should name your components.
@@ -344,14 +348,17 @@ __register__(_c2, \\"Bar\\");"
 
 exports[`ReactFreshBabelPlugin registers top-level variable declarations with arrow functions 1`] = `
 "
-let Hello = _c = () => {
+let Hello = () => {
   const handleClick = () => {};
   return <h1 onClick={handleClick}>Hi</h1>;
 };
-const Bar = _c2 = () => {
+_c = Hello;
+const Bar = () => {
   return <Hello />;
 };
-var Baz = _c3 = () => <div />;
+_c2 = Bar;
+var Baz = () => <div />;
+_c3 = Baz;
 var sum = () => {};
 
 var _c, _c2, _c3;

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -107,6 +107,34 @@ exports[`ReactFreshBabelPlugin ignores unnamed function declarations 1`] = `
 export default function () {}"
 `;
 
+exports[`ReactFreshBabelPlugin includes custom hooks into the signatures 1`] = `
+"
+function useFancyState() {
+  const [foo, setFoo] = React.useState(0);
+  useFancyEffect();
+  return foo;
+}
+
+__signature__(useFancyState, \\"useState{[foo, setFoo]}\\\\nuseFancyEffect{}\\", () => [useFancyEffect]);
+
+const useFancyEffect = __signature__(() => {
+  React.useEffect(() => {});
+}, \\"useEffect{}\\");
+
+export default function App() {
+  const bar = useFancyState();
+  return <h1>{bar}</h1>;
+}
+
+__signature__(App, \\"useFancyState{bar}\\", () => [useFancyState]);
+
+_c = App;
+
+var _c;
+
+__register__(_c, \\"App\\");"
+`;
+
 exports[`ReactFreshBabelPlugin only registers pascal case functions 1`] = `
 "
 function hello() {

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -144,6 +144,28 @@ function hello() {
 }"
 `;
 
+exports[`ReactFreshBabelPlugin registers capitalized identifiers in HOC calls 1`] = `
+"
+function Foo() {
+  return <h1>Hi</h1>;
+}
+
+_c = Foo;
+export default _c2 = hoc(Foo);
+export const A = _c3 = hoc(Foo);
+const B = _c4 = hoc(Foo);
+
+var _c, _c2, _c3, _c4;
+
+__register__(_c, \\"Foo\\");
+
+__register__(_c2, \\"%default%\\");
+
+__register__(_c3, \\"A\\");
+
+__register__(_c4, \\"B\\");"
+`;
+
 exports[`ReactFreshBabelPlugin registers identifiers used in JSX at definition site 1`] = `
 "
 import A from './A';
@@ -164,15 +186,19 @@ function Foo() {
 
 _c2 = Foo;
 const B = _c3 = hoc(A);
-const NotAComponent = wow(A);
+// This is currently registered as a false positive:
+const NotAComponent = _c4 = wow(A);
+// We could avoid it but it also doesn't hurt.
 
-var _c, _c2, _c3;
+var _c, _c2, _c3, _c4;
 
 __register__(_c, 'Header');
 
 __register__(_c2, 'Foo');
 
-__register__(_c3, 'B');"
+__register__(_c3, 'B');
+
+__register__(_c4, 'NotAComponent');"
 `;
 
 exports[`ReactFreshBabelPlugin registers identifiers used in React.createElement at definition site 1`] = `
@@ -197,15 +223,19 @@ _c2 = Foo;
 React.createContext(Store);
 
 const B = _c3 = hoc(A);
-const NotAComponent = wow(A);
+// This is currently registered as a false positive:
+const NotAComponent = _c4 = wow(A);
+// We could avoid it but it also doesn't hurt.
 
-var _c, _c2, _c3;
+var _c, _c2, _c3, _c4;
 
 __register__(_c, 'Header');
 
 __register__(_c2, 'Foo');
 
-__register__(_c3, 'B');"
+__register__(_c3, 'B');
+
+__register__(_c4, 'NotAComponent');"
 `;
 
 exports[`ReactFreshBabelPlugin registers likely HOCs with inline functions 1`] = `
@@ -372,13 +402,15 @@ __register__(_c3, \\"Baz\\");"
 
 exports[`ReactFreshBabelPlugin registers top-level variable declarations with function expressions 1`] = `
 "
-let Hello = _c = function () {
+let Hello = function () {
   function handleClick() {}
   return <h1 onClick={handleClick}>Hi</h1>;
 };
-const Bar = _c2 = function Baz() {
+_c = Hello;
+const Bar = function Baz() {
   return <Hello />;
 };
+_c2 = Bar;
 function sum() {}
 let Baz = 10;
 var Qux;

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -4,7 +4,7 @@ exports[`ReactFreshBabelPlugin generates signatures for function declarations ca
 "
 export default function App() {
   const [foo, setFoo] = useState(0);
-  useEffect(() => {});
+  React.useEffect(() => {});
   return <h1>{foo}</h1>;
 }
 
@@ -21,20 +21,20 @@ exports[`ReactFreshBabelPlugin generates signatures for function expressions cal
 "
 export const A = _c3 = React.memo(_c2 = React.forwardRef(_c = __signature__((props, ref) => {
   const [foo, setFoo] = useState(0);
-  useEffect(() => {});
+  React.useEffect(() => {});
   return <h1 ref={ref}>{foo}</h1>;
 }, \\"useState{[foo, setFoo]}\\\\nuseEffect{}\\")));
 
 export const B = _c6 = React.memo(_c5 = React.forwardRef(_c4 = __signature__(function (props, ref) {
   const [foo, setFoo] = useState(0);
-  useEffect(() => {});
+  React.useEffect(() => {});
   return <h1 ref={ref}>{foo}</h1>;
 }, \\"useState{[foo, setFoo]}\\\\nuseEffect{}\\")));
 
 function hoc() {
   return __signature__(function Inner() {
     const [foo, setFoo] = useState(0);
-    useEffect(() => {});
+    React.useEffect(() => {});
     return <h1 ref={ref}>{foo}</h1>;
   }, \\"useState{[foo, setFoo]}\\\\nuseEffect{}\\");
 }

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -1,5 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ReactFreshBabelPlugin generates signatures for function declarations calling hooks 1`] = `
+"
+export default function App() {
+  const [foo, setFoo] = useState(0);
+  useEffect(() => {});
+  return <h1>{foo}</h1>;
+}
+
+__signature__(App, \\"useState{[foo, setFoo]}\\\\nuseEffect{}\\");
+
+_c = App;
+
+var _c;
+
+__register__(_c, \\"App\\");"
+`;
+
+exports[`ReactFreshBabelPlugin generates signatures for function expressions calling hooks 1`] = `
+"
+export const A = _c3 = React.memo(_c2 = React.forwardRef(_c = __signature__((props, ref) => {
+  const [foo, setFoo] = useState(0);
+  useEffect(() => {});
+  return <h1 ref={ref}>{foo}</h1>;
+}, \\"useState{[foo, setFoo]}\\\\nuseEffect{}\\")));
+
+export const B = _c6 = React.memo(_c5 = React.forwardRef(_c4 = __signature__(function (props, ref) {
+  const [foo, setFoo] = useState(0);
+  useEffect(() => {});
+  return <h1 ref={ref}>{foo}</h1>;
+}, \\"useState{[foo, setFoo]}\\\\nuseEffect{}\\")));
+
+function hoc() {
+  return __signature__(function Inner() {
+    const [foo, setFoo] = useState(0);
+    useEffect(() => {});
+    return <h1 ref={ref}>{foo}</h1>;
+  }, \\"useState{[foo, setFoo]}\\\\nuseEffect{}\\");
+}
+
+export let C = hoc();
+
+var _c, _c2, _c3, _c4, _c5, _c6;
+
+__register__(_c, \\"A$React.memo$React.forwardRef\\");
+
+__register__(_c2, \\"A$React.memo\\");
+
+__register__(_c3, \\"A\\");
+
+__register__(_c4, \\"B$React.memo$React.forwardRef\\");
+
+__register__(_c5, \\"B$React.memo\\");
+
+__register__(_c6, \\"B\\");"
+`;
+
 exports[`ReactFreshBabelPlugin ignores HOC definitions 1`] = `
 "
 let connect = () => {


### PR DESCRIPTION
This adds support for editing components with Hooks.

State preservation already works by default. The goal here is to _not_ preserve state in cases where it is known to lead to problems. Such as reordering or deleting Hooks. We want to detect when that happens and remount.

This is implemented by generating `__signature__` calls for functions that contains calls to Hooks:

```js
function ButtonV1() {
  const [pressed, setPressed] = useState(false)
}
__signature__(ButtonV1, 'useState{[pressed, setPressed]}')

// -----------
// After edit
// -----------

function ButtonV1() {
  const [hover, setHover] = useState(false)
  const [pressed, setPressed] = useState(false)
  // ...
}
__signature__(ButtonV1, 'useState{[hover, setHover]}\nuseState{[pressed, setPressed]}')
```

If a signature changes, the Fresh runtime will tell React to remount that component type.

The signature contains names of all Hooks. Hooks that have a left hand side like `const [foo, setFoo]` have its source embedded in the signature. This catches renames (which often indicate invasive edits like changing state variable type).

If you use custom Hooks, we add them as the last argument:

```js
import useMyStuff from './useMyStuff'

function Foo() {
  const stuff = useMyStuff()
}
__signature__(
  Foo,
  'useMyStuff{stuff}',
  () => [useMyStuff] // <--- references, not strings!
);
```

This lets us recurse into each custom Hook when comparing signatures, so that if `useMyStuff` itself gets edited, we can remount the components using it.

The last argument is lazily evaluated (a function) for two reasons:

1. The reference might not be valid at the definition time because the Hook itself could be declared later in the file.
2. In React Native, we'll want to avoid triggering inline requires at module init time to avoid differences with production behavior.

The PR is easier to [read without whitespace](https://github.com/facebook/react/pull/15733/files?w=1) because some logic moved. You might also want to check commits separately.