### PR TITLE
[Suspense] Add Batched Mode variant to fuzz tester

### DIFF
--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -969,10 +969,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           NoopRenderer.updateContainer(children, fiberRoot, null, null);
         },
         getChildren() {
-          return getChildren(fiberRoot);
+          return getChildren(container);
         },
         getChildrenAsJSX() {
-          return getChildrenAsJSX(fiberRoot);
+          return getChildrenAsJSX(container);
         },
       };
     },


### PR DESCRIPTION
Right now the Suspense fuzz tester only tests Legacy Sync Mode and Concurrent Mode. This adds Batched Sync Mode, too.