### PR TITLE
[Flare] More fixes for getAbsoluteBoundingClientRect

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -459,12 +459,18 @@ function getAbsoluteBoundingClientRect(
     // are fixed position, using offsetParent node for a fast-path.
     // We need to check both as offsetParent accounts for both
     // itself and the parent; so we need to align with that API.
-    // If these all pass, we can stop traversing the tree.
-    if (
-      (scrollLeft !== 0 || scrollTop !== 0) &&
-      (isNodeFixedPositioned(parent) || isNodeFixedPositioned(node))
-    ) {
-      break;
+    // If these all pass, we can skip traversing the relevant
+    // node and go directly to its parent.
+    if (scrollLeft !== 0 || scrollTop !== 0) {
+      debugger;
+      if (isNodeFixedPositioned(parent)) {
+        node = ((parent: any): Node).parentNode;
+        continue;
+      }
+      if (isNodeFixedPositioned(node)) {
+        node = parent;
+        continue;
+      }
     }
     offsetX += scrollLeft;
     offsetY += scrollTop;

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -462,7 +462,6 @@ function getAbsoluteBoundingClientRect(
     // If these all pass, we can skip traversing the relevant
     // node and go directly to its parent.
     if (scrollLeft !== 0 || scrollTop !== 0) {
-      debugger;
       if (isNodeFixedPositioned(parent)) {
         node = ((parent: any): Node).parentNode;
         continue;

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -1232,7 +1232,7 @@ describe('Event responder: Press', () => {
         document.firstElementChild.scrollTop = 1000;
         const updatedCoordinatesInside = {
           pageX: coordinatesInside.pageX,
-          pageY: coordinatesInside.pageY + 100,
+          pageY: coordinatesInside.pageY + 1100,
         };
         ref.current.dispatchEvent(
           createEvent('pointerdown', updatedCoordinatesInside),


### PR DESCRIPTION
After more internal testing, another issue cropped up with the logic involved in`getAbsoluteBoundingClientRect`. Specifically, if an element is scrolled inside a container that is fixed, and the window gets scrolled – then we need to account for those nodes and we want to skip the processing of any the `scrollLeft` and `scrollTop` of fixed nodes and their parents (determined by `offsetParent`).

Ultimately, this all kind of sucks that we can't properly test this with Jest. JSDOM just isn't applicable when in comes to measuring layout, scroll and other browser quirks. We should definitely invest time into using headless browser testing next half so this functionality is properly validated.