### PR TITLE
Remove 5 second safety limit

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -493,13 +493,8 @@ function scheduleCallbackForRoot(
       );
     } else {
       let options = null;
-      if (expirationTime !== Sync && expirationTime !== Never) {
+      if (expirationTime !== Never) {
         let timeout = expirationTimeToMs(expirationTime) - now();
-        if (timeout > 5000) {
-          // Sanity check. Should never take longer than 5 seconds.
-          // TODO: Add internal warning?
-          timeout = 5000;
-        }
         options = {timeout};
       }
 


### PR DESCRIPTION
expirationTime has already been checked if it's Sync so this condition is unnecessary.

timeout can now be longer than 5 seconds when a suspense config is used. We might want to adjust the heuristics but it's not internally consistent without this.