### PR TITLE
using the wrong renderer's act() should warn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,7 @@ jobs:
       - *restore_yarn_cache
       - *run_yarn
       - run: yarn test-build --maxWorkers=2
+      - run: yarn test-dom-fixture
 
   test_fuzz:
     docker: *docker

--- a/fixtures/dom/package.json
+++ b/fixtures/dom/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "prestart": "cp ../../build/node_modules/scheduler/umd/scheduler-unstable_mock.development.js ../../build/node_modules/scheduler/umd/scheduler-unstable_mock.production.min.js ../../build/node_modules/react/umd/react.development.js ../../build/node_modules/react-dom/umd/react-dom.development.js ../../build/node_modules/react/umd/react.production.min.js ../../build/node_modules/react-dom/umd/react-dom.production.min.js ../../build/node_modules/react-dom/umd/react-dom-server.browser.development.js ../../build/node_modules/react-dom/umd/react-dom-server.browser.production.min.js ../../build/node_modules/react-dom/umd/react-dom-test-utils.development.js ../../build/node_modules/react-dom/umd/react-dom-test-utils.production.min.js public/",
+    "prestart": "cp ../../build/node_modules/scheduler/umd/scheduler-unstable_mock.development.js ../../build/node_modules/scheduler/umd/scheduler-unstable_mock.production.min.js ../../build/node_modules/react/umd/react.development.js ../../build/node_modules/react-dom/umd/react-dom.development.js ../../build/node_modules/react/umd/react.production.min.js ../../build/node_modules/react-dom/umd/react-dom.production.min.js ../../build/node_modules/react-dom/umd/react-dom-server.browser.development.js ../../build/node_modules/react-dom/umd/react-dom-server.browser.production.min.js ../../build/node_modules/react-dom/umd/react-dom-test-utils.development.js ../../build/node_modules/react-dom/umd/react-dom-test-utils.production.min.js public/ && cp -a ../../build/node_modules/. node_modules",
     "build": "react-scripts build && cp build/index.html build/200.html",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/fixtures/dom/public/act-dom.html
+++ b/fixtures/dom/public/act-dom.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>sanity test for ReactTestUtils.act</title>
-</head>
-<body>
-  this page tests whether act runs properly in a browser.
-  <br/>
-  your console should say "5"
-  <script src='scheduler-unstable_mock.development.js'></script>
-  <script src='react.development.js'></script>
-  <script type="text/javascript">    
-    window.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler = window.SchedulerMock
-  </script>
-  <script src='react-dom.development.js'></script>
-  <script src='react-dom-test-utils.development.js'></script>
-  <script>
-    async function run(){
+  <head>
+    <title>sanity test for ReactTestUtils.act</title>
+  </head>
+  <body>
+    this page tests whether act runs properly in a browser.
+    <br />
+    your console should say "5"
+    <script src="scheduler-unstable_mock.development.js"></script>
+    <script src="react.development.js"></script>
+    <script type="text/javascript">
+      window.React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler =
+        window.SchedulerMock;
+    </script>
+    <script src="react-dom.development.js"></script>
+    <script src="react-dom-test-utils.development.js"></script>
+    <script>
       // from ReactTestUtilsAct-test.js
       function App() {
         let [state, setState] = React.useState(0);
@@ -23,23 +23,22 @@
           await null;
           setState(x => x + 1);
         }
-        React.useEffect(
-          () => {
-            ticker();
-          },
-          [Math.min(state, 4)],
-        );
+        React.useEffect(() => {
+          ticker();
+        }, [Math.min(state, 4)]);
         return state;
       }
-      const el = document.createElement('div');
-      await ReactTestUtils.act(async () => {
-        ReactDOM.render(React.createElement(App), el);
-      });
-      // all 5 ticks present and accounted for
-      console.log(el.innerHTML);
-    }
-    run();
-    
-  </script>
-</body>
+
+      async function testAsyncAct() {
+        const el = document.createElement("div");
+        await ReactTestUtils.act(async () => {
+          ReactDOM.render(React.createElement(App), el);
+        });
+        // all 5 ticks present and accounted for
+        console.log(el.innerHTML);
+      }
+
+      testAsyncAct();
+    </script>
+  </body>
 </html>

--- a/fixtures/dom/src/index.test.js
+++ b/fixtures/dom/src/index.test.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
+import TestRenderer from 'react-test-renderer';
+
+let spy;
+beforeEach(() => {
+  spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+function confirmWarning() {
+  expect(spy).toHaveBeenCalledWith(
+    expect.stringContaining(
+      "It looks like you're using the wrong act() around your test interactions."
+    ),
+    ''
+  );
+}
+
+function App(props) {
+  return 'hello world';
+}
+
+it("doesn't warn when you use the right act + renderer: dom", () => {
+  TestUtils.act(() => {
+    TestUtils.renderIntoDocument(<App />);
+  });
+  expect(spy).not.toHaveBeenCalled();
+});
+
+it("doesn't warn when you use the right act + renderer: test", () => {
+  TestRenderer.act(() => {
+    TestRenderer.create(<App />);
+  });
+  expect(spy).not.toHaveBeenCalled();
+});
+
+it('works with createRoot().render combo', () => {
+  const root = ReactDOM.unstable_createRoot(document.createElement('div'));
+  TestRenderer.act(() => {
+    root.render(<App />);
+  });
+  confirmWarning();
+});
+
+it('warns when using the wrong act version - test + dom: render', () => {
+  TestRenderer.act(() => {
+    TestUtils.renderIntoDocument(<App />);
+  });
+  confirmWarning();
+});
+
+it('warns when using the wrong act version - test + dom: updates', () => {
+  let setCtr;
+  function Counter(props) {
+    const [ctr, _setCtr] = React.useState(0);
+    setCtr = _setCtr;
+    return ctr;
+  }
+  TestUtils.renderIntoDocument(<Counter />);
+  TestRenderer.act(() => {
+    setCtr(1);
+  });
+  confirmWarning();
+});
+
+it('warns when using the wrong act version - dom + test: .create()', () => {
+  TestUtils.act(() => {
+    TestRenderer.create(<App />);
+  });
+  confirmWarning();
+});
+
+it('warns when using the wrong act version - dom + test: .update()', () => {
+  let root;
+  // use the right one here so we don't get the first warning
+  TestRenderer.act(() => {
+    root = TestRenderer.create(<App key="one" />);
+  });
+  TestUtils.act(() => {
+    root.update(<App key="two" />);
+  });
+  confirmWarning();
+});
+
+it('warns when using the wrong act version - dom + test: updates', () => {
+  let setCtr;
+  function Counter(props) {
+    const [ctr, _setCtr] = React.useState(0);
+    setCtr = _setCtr;
+    return ctr;
+  }
+  const root = TestRenderer.create(<Counter />);
+  TestUtils.act(() => {
+    setCtr(1);
+  });
+  confirmWarning();
+});

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "test-prod-build": "yarn test-build-prod",
     "test-build": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.build.js",
     "test-build-prod": "cross-env NODE_ENV=production jest --config ./scripts/jest/config.build.js",
+    "test-dom-fixture": "cd fixtures/dom && yarn && yarn prestart && yarn test",
     "flow": "node ./scripts/tasks/flow.js",
     "flow-ci": "node ./scripts/tasks/flow-ci.js",
     "prettier": "node ./scripts/prettier/index.js write-changed",

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -38,6 +38,7 @@ import {
   findHostInstance,
   findHostInstanceWithWarning,
   flushPassiveEffects,
+  ReactActingRendererSigil,
 } from 'react-reconciler/inline.dom';
 import {createPortal as createPortalImpl} from 'shared/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
@@ -816,6 +817,7 @@ const ReactDOM: Object = {
       dispatchEvent,
       runEventsInBatch,
       flushPassiveEffects,
+      ReactActingRendererSigil,
     ],
   },
 };

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -43,6 +43,7 @@ import {
   findHostInstance,
   findHostInstanceWithWarning,
   flushPassiveEffects,
+  ReactActingRendererSigil,
 } from 'react-reconciler/inline.fire';
 import {createPortal as createPortalImpl} from 'shared/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
@@ -822,6 +823,7 @@ const ReactDOM: Object = {
       dispatchEvent,
       runEventsInBatch,
       flushPassiveEffects,
+      ReactActingRendererSigil,
     ],
   },
 };

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -42,8 +42,10 @@ const [
   restoreStateIfNeeded,
   dispatchEvent,
   runEventsInBatch,
-  // eslint-disable-next-line no-unused-vars
+  /* eslint-disable no-unused-vars */
   flushPassiveEffects,
+  ReactActingRendererSigil,
+  /* eslint-enable no-unused-vars */
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
 
 function Event(suffix) {}

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -85,16 +85,19 @@ let actingUpdatesScopeDepth = 0;
 
 function act(callback: () => Thenable) {
   let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
-  let previousActingUpdatesSigil = ReactActingRendererSigil.current;
+  let previousActingUpdatesSigil;
   actingUpdatesScopeDepth++;
   // we use the function flushPassiveEffects directly as the sigil,
   // since it's unique to a renderer
-  ReactActingRendererSigil.current = flushPassiveEffects;
+  if (__DEV__) {
+    previousActingUpdatesSigil = ReactActingRendererSigil.current;
+    ReactActingRendererSigil.current = flushPassiveEffects;
+  }
 
   function onDone() {
     actingUpdatesScopeDepth--;
-    ReactActingRendererSigil.current = previousActingUpdatesSigil;
     if (__DEV__) {
+      ReactActingRendererSigil.current = previousActingUpdatesSigil;
       if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
         // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
         warningWithoutStack(

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -37,7 +37,7 @@ const [
 
 const batchedUpdates = ReactDOM.unstable_batchedUpdates;
 
-const {ReactShouldWarnActingUpdates} = ReactSharedInternals;
+const {ReactActingRendererSigil} = ReactSharedInternals;
 
 // this implementation should be exactly the same in
 // ReactTestUtilsAct.js, ReactTestRendererAct.js, createReactNoop.js
@@ -85,17 +85,16 @@ let actingUpdatesScopeDepth = 0;
 
 function act(callback: () => Thenable) {
   let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
+  let previousActingUpdatesSigil = ReactActingRendererSigil.current;
   actingUpdatesScopeDepth++;
-  if (__DEV__) {
-    ReactShouldWarnActingUpdates.current = true;
-  }
+  // we use the function flushPassiveEffects directly as the sigil,
+  // since it's unique to a renderer
+  ReactActingRendererSigil.current = flushPassiveEffects;
 
   function onDone() {
     actingUpdatesScopeDepth--;
+    ReactActingRendererSigil.current = previousActingUpdatesSigil;
     if (__DEV__) {
-      if (actingUpdatesScopeDepth === 0) {
-        ReactShouldWarnActingUpdates.current = false;
-      }
       if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
         // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
         warningWithoutStack(

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -33,11 +33,12 @@ const [
   runEventsInBatch,
   /* eslint-enable no-unused-vars */
   flushPassiveEffects,
+  ReactActingRendererSigil,
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
 
 const batchedUpdates = ReactDOM.unstable_batchedUpdates;
 
-const {ReactActingRendererSigil} = ReactSharedInternals;
+const {ReactCurrentActingRendererSigil} = ReactSharedInternals;
 
 // this implementation should be exactly the same in
 // ReactTestUtilsAct.js, ReactTestRendererAct.js, createReactNoop.js
@@ -87,17 +88,15 @@ function act(callback: () => Thenable) {
   let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
   let previousActingUpdatesSigil;
   actingUpdatesScopeDepth++;
-  // we use the function flushPassiveEffects directly as the sigil,
-  // since it's unique to a renderer
   if (__DEV__) {
-    previousActingUpdatesSigil = ReactActingRendererSigil.current;
-    ReactActingRendererSigil.current = flushPassiveEffects;
+    previousActingUpdatesSigil = ReactCurrentActingRendererSigil.current;
+    ReactCurrentActingRendererSigil.current = ReactActingRendererSigil;
   }
 
   function onDone() {
     actingUpdatesScopeDepth--;
     if (__DEV__) {
-      ReactActingRendererSigil.current = previousActingUpdatesSigil;
+      ReactCurrentActingRendererSigil.current = previousActingUpdatesSigil;
       if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
         // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
         warningWithoutStack(

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -698,16 +698,19 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
   function act(callback: () => Thenable) {
     let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
-    let previousActingUpdatesSigil = ReactActingRendererSigil.current;
+    let previousActingUpdatesSigil;
     actingUpdatesScopeDepth++;
     // we use the function flushPassiveEffects directly as the sigil,
     // since it's unique to a renderer
-    ReactActingRendererSigil.current = flushPassiveEffects;
+    if (__DEV__) {
+      previousActingUpdatesSigil = ReactActingRendererSigil.current;
+      ReactActingRendererSigil.current = flushPassiveEffects;
+    }
 
     function onDone() {
       actingUpdatesScopeDepth--;
-      ReactActingRendererSigil.current = previousActingUpdatesSigil;
       if (__DEV__) {
+        ReactActingRendererSigil.current = previousActingUpdatesSigil;
         if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
           // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
           warningWithoutStack(

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -81,7 +81,7 @@ type TextInstance = {|
 |};
 type HostContext = Object;
 
-const {ReactActingRendererSigil} = ReactSharedInternals;
+const {ReactCurrentActingRendererSigil} = ReactSharedInternals;
 
 const NO_CONTEXT = {};
 const UPPERCASE_CONTEXT = {};
@@ -650,7 +650,11 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
   const roots = new Map();
   const DEFAULT_ROOT_ID = '<default>';
 
-  const {flushPassiveEffects, batchedUpdates} = NoopRenderer;
+  const {
+    flushPassiveEffects,
+    batchedUpdates,
+    ReactActingRendererSigil,
+  } = NoopRenderer;
 
   // this act() implementation should be exactly the same in
   // ReactTestUtilsAct.js, ReactTestRendererAct.js, createReactNoop.js
@@ -700,17 +704,15 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
     let previousActingUpdatesSigil;
     actingUpdatesScopeDepth++;
-    // we use the function flushPassiveEffects directly as the sigil,
-    // since it's unique to a renderer
     if (__DEV__) {
-      previousActingUpdatesSigil = ReactActingRendererSigil.current;
-      ReactActingRendererSigil.current = flushPassiveEffects;
+      previousActingUpdatesSigil = ReactCurrentActingRendererSigil.current;
+      ReactCurrentActingRendererSigil.current = ReactActingRendererSigil;
     }
 
     function onDone() {
       actingUpdatesScopeDepth--;
       if (__DEV__) {
-        ReactActingRendererSigil.current = previousActingUpdatesSigil;
+        ReactCurrentActingRendererSigil.current = previousActingUpdatesSigil;
         if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
           // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
           warningWithoutStack(

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1208,9 +1208,7 @@ function dispatchAction<S, A>(
       }
     }
     if (__DEV__) {
-      // jest isn't a 'global', it's just exposed to tests via a wrapped function
-      // further, this isn't a test file, so flow doesn't recognize the symbol. So...
-      // $FlowExpectedError - because requirements don't give a damn about your type sigs.
+      // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
       if ('undefined' !== typeof jest) {
         warnIfNotScopedWithMatchingAct(fiber);
         warnIfNotCurrentlyActingUpdatesInDev(fiber);

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -35,6 +35,7 @@ import {
   flushPassiveEffects,
   requestCurrentTime,
   warnIfNotCurrentlyActingUpdatesInDev,
+  warnIfNotScopedWithMatchingAct,
   markRenderEventTimeAndConfig,
 } from './ReactFiberWorkLoop';
 
@@ -1211,6 +1212,7 @@ function dispatchAction<S, A>(
       // further, this isn't a test file, so flow doesn't recognize the symbol. So...
       // $FlowExpectedError - because requirements don't give a damn about your type sigs.
       if ('undefined' !== typeof jest) {
+        warnIfNotScopedWithMatchingAct(fiber);
         warnIfNotCurrentlyActingUpdatesInDev(fiber);
       }
     }

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -56,6 +56,7 @@ import {
   discreteUpdates,
   flushDiscreteUpdates,
   flushPassiveEffects,
+  warnIfNotScopedWithMatchingAct,
 } from './ReactFiberWorkLoop';
 import {createUpdate, enqueueUpdate} from './ReactUpdateQueue';
 import ReactFiberInstrumentation from './ReactFiberInstrumentation';
@@ -303,6 +304,12 @@ export function updateContainer(
 ): ExpirationTime {
   const current = container.current;
   const currentTime = requestCurrentTime();
+  if (__DEV__) {
+    // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+    if ('undefined' !== typeof jest) {
+      warnIfNotScopedWithMatchingAct(current);
+    }
+  }
   const suspenseConfig = requestCurrentSuspenseConfig();
   const expirationTime = computeExpirationForFiber(
     currentTime,

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -57,6 +57,7 @@ import {
   flushDiscreteUpdates,
   flushPassiveEffects,
   warnIfNotScopedWithMatchingAct,
+  ReactActingRendererSigil,
 } from './ReactFiberWorkLoop';
 import {createUpdate, enqueueUpdate} from './ReactUpdateQueue';
 import ReactFiberInstrumentation from './ReactFiberInstrumentation';
@@ -339,6 +340,7 @@ export {
   flushControlled,
   flushSync,
   flushPassiveEffects,
+  ReactActingRendererSigil,
 };
 
 export function getPublicRootInstance(

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -173,7 +173,7 @@ const ceil = Math.ceil;
 const {
   ReactCurrentDispatcher,
   ReactCurrentOwner,
-  ReactActingRendererSigil,
+  ReactCurrentActingRendererSigil,
 } = ReactSharedInternals;
 
 type WorkPhase = 0 | 1 | 2 | 3 | 4 | 5 | 6;
@@ -2276,13 +2276,19 @@ function warnAboutInvalidUpdatesOnClassComponentsInDEV(fiber) {
   }
 }
 
+// We export a simple object here to be used by a renderer/test-utils
+// as the value of ReactCurrentActingRendererSigil.current
+// This identity lets us identify (ha!) when the wrong renderer's act()
+// wraps anothers' updates/effects
+export const ReactActingRendererSigil = {};
+
 export function warnIfNotScopedWithMatchingAct(fiber: Fiber): void {
   if (__DEV__) {
     if (
-      ReactActingRendererSigil.current !== null &&
+      ReactCurrentActingRendererSigil.current !== null &&
       // use the function flushPassiveEffects directly as the sigil
       // so this comparison is expected here
-      ReactActingRendererSigil.current !== flushPassiveEffects
+      ReactCurrentActingRendererSigil.current !== ReactActingRendererSigil
     ) {
       // it looks like we're using the wrong matching act(), so log a warning
       warningWithoutStack(
@@ -2309,7 +2315,7 @@ function warnIfNotCurrentlyActingUpdatesInDEV(fiber: Fiber): void {
   if (__DEV__) {
     if (
       workPhase === NotWorking &&
-      ReactActingRendererSigil.current !== flushPassiveEffects
+      ReactCurrentActingRendererSigil.current !== ReactActingRendererSigil
     ) {
       warningWithoutStack(
         false,

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2305,13 +2305,6 @@ export function warnIfNotScopedWithMatchingAct(fiber: Fiber): void {
   }
 }
 
-// in a test-like environment, we want to warn if dispatchAction() is
-// called outside of a TestUtils.act(...)/batchedUpdates/render call.
-// so we have a a step counter for when we descend/ascend from
-// act() calls, and test on it for when to warn
-// It's a tuple with a single value. Look into ReactTestUtilsAct as an
-// example of how we change the value
-
 function warnIfNotCurrentlyActingUpdatesInDEV(fiber: Fiber): void {
   if (__DEV__) {
     if (

--- a/packages/react-test-renderer/src/ReactTestRendererAct.js
+++ b/packages/react-test-renderer/src/ReactTestRendererAct.js
@@ -18,7 +18,7 @@ import {warnAboutMissingMockScheduler} from 'shared/ReactFeatureFlags';
 import enqueueTask from 'shared/enqueueTask';
 import * as Scheduler from 'scheduler';
 
-const {ReactShouldWarnActingUpdates} = ReactSharedInternals;
+const {ReactActingRendererSigil} = ReactSharedInternals;
 
 // this implementation should be exactly the same in
 // ReactTestUtilsAct.js, ReactTestRendererAct.js, createReactNoop.js
@@ -66,17 +66,16 @@ let actingUpdatesScopeDepth = 0;
 
 function act(callback: () => Thenable) {
   let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
+  let previousActingUpdatesSigil = ReactActingRendererSigil.current;
   actingUpdatesScopeDepth++;
-  if (__DEV__) {
-    ReactShouldWarnActingUpdates.current = true;
-  }
+  // we use the function flushPassiveEffects directly as the sigil,
+  // since it's unique to a renderer
+  ReactActingRendererSigil.current = flushPassiveEffects;
 
   function onDone() {
     actingUpdatesScopeDepth--;
+    ReactActingRendererSigil.current = previousActingUpdatesSigil;
     if (__DEV__) {
-      if (actingUpdatesScopeDepth === 0) {
-        ReactShouldWarnActingUpdates.current = false;
-      }
       if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
         // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
         warningWithoutStack(

--- a/packages/react-test-renderer/src/ReactTestRendererAct.js
+++ b/packages/react-test-renderer/src/ReactTestRendererAct.js
@@ -66,16 +66,19 @@ let actingUpdatesScopeDepth = 0;
 
 function act(callback: () => Thenable) {
   let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
-  let previousActingUpdatesSigil = ReactActingRendererSigil.current;
+  let previousActingUpdatesSigil;
   actingUpdatesScopeDepth++;
   // we use the function flushPassiveEffects directly as the sigil,
   // since it's unique to a renderer
-  ReactActingRendererSigil.current = flushPassiveEffects;
+  if (__DEV__) {
+    previousActingUpdatesSigil = ReactActingRendererSigil.current;
+    ReactActingRendererSigil.current = flushPassiveEffects;
+  }
 
   function onDone() {
     actingUpdatesScopeDepth--;
-    ReactActingRendererSigil.current = previousActingUpdatesSigil;
     if (__DEV__) {
+      ReactActingRendererSigil.current = previousActingUpdatesSigil;
       if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
         // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
         warningWithoutStack(

--- a/packages/react/src/ReactActingRendererSigil.js
+++ b/packages/react/src/ReactActingRendererSigil.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Used by act() to track whether you're outside an act() scope.
+ * We use a renderer's flushPassiveEffects as the sigil value
+ * so we can track identity of the renderer.
+ */
+
+const ReactActingRendererSigil = {
+  current: (null: null | (() => boolean)),
+};
+export default ReactActingRendererSigil;

--- a/packages/react/src/ReactCurrentActingRendererSigil.js
+++ b/packages/react/src/ReactCurrentActingRendererSigil.js
@@ -13,7 +13,7 @@
  * so we can track identity of the renderer.
  */
 
-const ReactActingRendererSigil = {
+const ReactCurrentActingRendererSigil = {
   current: (null: null | (() => boolean)),
 };
-export default ReactActingRendererSigil;
+export default ReactCurrentActingRendererSigil;

--- a/packages/react/src/ReactSharedInternals.js
+++ b/packages/react/src/ReactSharedInternals.js
@@ -10,13 +10,13 @@ import ReactCurrentDispatcher from './ReactCurrentDispatcher';
 import ReactCurrentBatchConfig from './ReactCurrentBatchConfig';
 import ReactCurrentOwner from './ReactCurrentOwner';
 import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
-import ReactActingRendererSigil from './ReactActingRendererSigil';
+import ReactCurrentActingRendererSigil from './ReactCurrentActingRendererSigil';
 
 const ReactSharedInternals = {
   ReactCurrentDispatcher,
   ReactCurrentBatchConfig,
   ReactCurrentOwner,
-  ReactActingRendererSigil,
+  ReactCurrentActingRendererSigil,
   // Used by renderers to avoid bundling object-assign twice in UMD bundles:
   assign,
 };

--- a/packages/react/src/ReactSharedInternals.js
+++ b/packages/react/src/ReactSharedInternals.js
@@ -10,13 +10,13 @@ import ReactCurrentDispatcher from './ReactCurrentDispatcher';
 import ReactCurrentBatchConfig from './ReactCurrentBatchConfig';
 import ReactCurrentOwner from './ReactCurrentOwner';
 import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
+import ReactActingRendererSigil from './ReactActingRendererSigil';
 
 const ReactSharedInternals = {
   ReactCurrentDispatcher,
   ReactCurrentBatchConfig,
   ReactCurrentOwner,
-  // used by act()
-  ReactShouldWarnActingUpdates: {current: false},
+  ReactActingRendererSigil,
   // Used by renderers to avoid bundling object-assign twice in UMD bundles:
   assign,
 };


### PR DESCRIPTION
via #15319

(redid #15399, removed the changes that didn't even belong in it.)

So tl;dr this PR -

- uses a renderer specific object as the value of ReactCurrentActingRendererSigil.current
- checks this value on 'updateContainer`
- checks this value when setting a state hook's value
- adds a fixture folder for act() (which is run on CI)

This solves 2 specific problems -

- using the wrong act() shouldn't silence the 'missing act' warning
- using the wrong act() logs a warning tha you're, er, using the wrong act()

(Please see  #15399 for the long spiel on the mechanics for this.)
