### PR TITLE
[Flare] Support legacy browser Spacebar key value

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -414,7 +414,8 @@ function dispatchCancel(
 
 function isValidKeyPress(key: string): boolean {
   // Accessibility for keyboards. Space and Enter only.
-  return key === ' ' || key === 'Enter';
+  // "Spacebar" is for IE 11
+  return key === 'Enter' || key === ' ' || key === 'Spacebar';
 }
 
 function calculateDelayMS(delay: ?number, min = 0, fallback = 0) {


### PR DESCRIPTION
IE 9,10,11 and Firefox < 37 can report spacebar key as `Spacebar`.