### PR TITLE
[Suspense] Change Suspending and Restarting Heuristics

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -1413,6 +1413,9 @@ function validateFunctionComponentInDev(workInProgress: Fiber, Component: any) {
   }
 }
 
+// TODO: This is now an empty object. Should we just make it a boolean?
+const SUSPENDED_MARKER: SuspenseState = ({}: any);
+
 function updateSuspenseComponent(
   current,
   workInProgress,
@@ -1440,17 +1443,9 @@ function updateSuspenseComponent(
       (ForceSuspenseFallback: SuspenseContext),
     )
   ) {
-    // This either already captured or is a new mount that was forced into its fallback
-    // state by a parent.
-    const attemptedState: SuspenseState | null = workInProgress.memoizedState;
     // Something in this boundary's subtree already suspended. Switch to
     // rendering the fallback children.
-    nextState = {
-      fallbackExpirationTime:
-        attemptedState !== null
-          ? attemptedState.fallbackExpirationTime
-          : NoWork,
-    };
+    nextState = SUSPENDED_MARKER;
     nextDidTimeout = true;
     workInProgress.effectTag &= ~DidCapture;
   } else {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -63,10 +63,6 @@ import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import warning from 'shared/warning';
 
-import {
-  NoWork,
-  computeAsyncExpirationNoBucket,
-} from './ReactFiberExpirationTime';
 import {onCommitUnmount} from './ReactFiberDevToolsHook';
 import {startPhaseTimer, stopPhaseTimer} from './ReactDebugFiberPerf';
 import {getStackByFiberInDevAndProd} from './ReactCurrentFiber';
@@ -102,8 +98,8 @@ import {
 } from './ReactFiberHostConfig';
 import {
   captureCommitPhaseError,
-  requestCurrentTime,
   resolveRetryThenable,
+  markCommitTimeOfFallback,
 } from './ReactFiberWorkLoop';
 import {
   NoEffect as NoHookEffect,
@@ -1288,16 +1284,7 @@ function commitSuspenseComponent(finishedWork: Fiber) {
   } else {
     newDidTimeout = true;
     primaryChildParent = finishedWork.child;
-    if (newState.fallbackExpirationTime === NoWork) {
-      // If the children had not already timed out, record the time.
-      // This is used to compute the elapsed time during subsequent
-      // attempts to render the children.
-      // We model this as a normal pri expiration time since that's
-      // how we infer start time for updates.
-      newState.fallbackExpirationTime = computeAsyncExpirationNoBucket(
-        requestCurrentTime(),
-      );
-    }
+    markCommitTimeOfFallback();
   }
 
   if (supportsMutation && primaryChildParent !== null) {

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -101,7 +101,6 @@ import {
   enableEventAPI,
 } from 'shared/ReactFeatureFlags';
 import {
-  markRenderEventTimeAndConfig,
   renderDidSuspend,
   renderDidSuspendDelayIfPossible,
 } from './ReactFiberWorkLoop';
@@ -702,14 +701,6 @@ function completeWork(
         prevDidTimeout = prevState !== null;
         if (!nextDidTimeout && prevState !== null) {
           // We just switched from the fallback to the normal children.
-
-          // Mark the event time of the switching from fallback to normal children,
-          // based on the start of when we first showed the fallback. This time
-          // was given a normal pri expiration time at the time it was shown.
-          const fallbackExpirationTime: ExpirationTime =
-            prevState.fallbackExpirationTime;
-          markRenderEventTimeAndConfig(fallbackExpirationTime, null);
-
           // Delete the fallback.
           // TODO: Would it be better to store the fallback fragment on
           // the stateNode during the begin phase?

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -728,6 +728,13 @@ function completeWork(
         // in the concurrent tree already suspended during this render.
         // This is a known bug.
         if ((workInProgress.mode & BatchedMode) !== NoMode) {
+          // TODO: Move this back to throwException because this is too late
+          // if this is a large tree which is common for initial loads. We
+          // don't know if we should restart a render or not until we get
+          // this marker, and this is too late.
+          // If this render already had a ping or lower pri updates,
+          // and this is the first time we know we're going to suspend we
+          // should be able to immediately restart from within throwException.
           const hasInvisibleChildContext =
             current === null &&
             workInProgress.memoizedProps.unstable_avoidThisFallback !== true;

--- a/packages/react-reconciler/src/ReactFiberExpirationTime.js
+++ b/packages/react-reconciler/src/ReactFiberExpirationTime.js
@@ -83,14 +83,6 @@ export function computeSuspenseExpiration(
   );
 }
 
-// Same as computeAsyncExpiration but without the bucketing logic. This is
-// used to compute timestamps instead of actual expiration times.
-export function computeAsyncExpirationNoBucket(
-  currentTime: ExpirationTime,
-): ExpirationTime {
-  return currentTime - LOW_PRIORITY_EXPIRATION / UNIT_SIZE;
-}
-
 // We intentionally set a higher expiration time for interactive updates in
 // dev than in production.
 //

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -8,11 +8,9 @@
  */
 
 import type {Fiber} from './ReactFiber';
-import type {ExpirationTime} from './ReactFiberExpirationTime';
 
-export type SuspenseState = {|
-  fallbackExpirationTime: ExpirationTime,
-|};
+// TODO: This is now an empty object. Should we switch this to a boolean?
+export type SuspenseState = {||};
 
 export function shouldCaptureSuspense(
   workInProgress: Fiber,

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -275,6 +275,45 @@ function throwException(
 
         // Confirmed that the boundary is in a concurrent mode tree. Continue
         // with the normal suspend path.
+        //
+        // After this we'll use a set of heuristics to determine whether this
+        // render pass will run to completion or restart or "suspend" the commit.
+        // The actual logic for this is spread out in different places.
+        //
+        // This first principle is that if we're going to suspend when we complete
+        // a root, then we should also restart if we get an update or ping that
+        // might unsuspend it, and vice versa. The only reason to suspend is
+        // because you think you might want to restart before committing. However,
+        // it doesn't make sense to restart only while in the period we're suspended.
+        //
+        // Restarting too aggressively is also not good because it starves out any
+        // intermediate loading state. So we use heuristics to determine when.
+
+        // Suspense Heuristics
+        //
+        // If nothing threw a Promise or all the same fallbacks are already showing,
+        // then don't suspend/restart.
+        //
+        // If this is an initial render of a new tree of Suspense boundaries and
+        // those trigger a fallback, then don't suspend/restart. We want to ensure
+        // that we can show the initial loading state as quickly as possible.
+        //
+        // If we hit a "Delayed" case, such as when we'd switch from content back into
+        // a fallback, then we should always suspend/restart. SuspenseConfig applies to
+        // this case. If none is defined, JND is used instead.
+        //
+        // If we're already showing a fallback and it gets "retried", allowing us to show
+        // another level, but there's still an inner boundary that would show a fallback,
+        // then we suspend/restart for 500ms since the last time we showed a fallback
+        // anywhere in the tree. This effectively throttles progressive loading into a
+        // consistent train of commits. This also gives us an opportunity to restart to
+        // get to the completed state slightly earlier.
+        //
+        // If there's ambiguity due to batching it's resolved in preference of:
+        // 1) "delayed", 2) "initial render", 3) "retry".
+        //
+        // We want to ensure that a "busy" state doesn't get force committed. We want to
+        // ensure that new initial loading states can commit as soon as possible.
 
         attachPingListener(root, renderExpirationTime, thenable);
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -951,7 +951,7 @@ function renderRoot(
       // An error was thrown. First check if there is lower priority work
       // scheduled on this root.
       const lastPendingTime = root.lastPendingTime;
-      if (root.lastPendingTime < expirationTime) {
+      if (lastPendingTime < expirationTime) {
         // There's lower priority work. Before raising the error, try rendering
         // at the lower priority to see if it fixes it. Use a continuation to
         // maintain the existing priority and position in the queue.
@@ -990,7 +990,7 @@ function renderRoot(
         // Don't bother with a very short suspense time.
         if (msUntilTimeout > 10) {
           const lastPendingTime = root.lastPendingTime;
-          if (root.lastPendingTime < expirationTime) {
+          if (lastPendingTime < expirationTime) {
             // There's lower priority work. It might be unsuspended. Try rendering
             // at that level.
             return renderRoot.bind(null, root, lastPendingTime);
@@ -1013,7 +1013,7 @@ function renderRoot(
         // We're suspended in a state that should be avoided. We'll try to avoid committing
         // it for as long as the timeouts let us.
         const lastPendingTime = root.lastPendingTime;
-        if (root.lastPendingTime < expirationTime) {
+        if (lastPendingTime < expirationTime) {
           // There's lower priority work. It might be unsuspended. Try rendering
           // at that level immediately.
           return renderRoot.bind(null, root, lastPendingTime);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -213,6 +213,9 @@ let workInProgressRootExitStatus: RootExitStatus = RootIncomplete;
 let workInProgressRootLatestProcessedExpirationTime: ExpirationTime = Sync;
 let workInProgressRootLatestSuspenseTimeout: ExpirationTime = Sync;
 let workInProgressRootCanSuspendUsingConfig: null | SuspenseConfig = null;
+// The most recent time we committed a fallback. This lets us ensure a train
+// model where we don't commit new loading states in too quick succession.
+let globalMostRecentFallbackTime: number = 0;
 
 let nextEffect: Fiber | null = null;
 let hasUncaughtError = false;
@@ -1017,6 +1020,10 @@ function renderRoot(
       invariant(false, 'Unknown root exit status.');
     }
   }
+}
+
+export function markCommitTimeOfFallback() {
+  globalMostRecentFallbackTime = now();
 }
 
 export function markRenderEventTimeAndConfig(

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -595,6 +595,16 @@ describe('ReactDebugFiberPerf', () => {
         }),
     );
 
+    // Initial render
+    ReactNoop.render(
+      <Parent>
+        <React.Suspense fallback={<Spinner />} />
+      </Parent>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getFlameChart()).toMatchSnapshot();
+
+    // Update that suspends
     ReactNoop.render(
       <Parent>
         <React.Suspense fallback={<Spinner />}>

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -46,7 +46,7 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('Hi');
 
     await Promise.resolve();
 
@@ -136,13 +136,13 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('FooBar');
 
     jest.advanceTimersByTime(100);
     await promiseForFoo;
 
-    expect(Scheduler).toFlushAndYield(['Foo', 'Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(Scheduler).toFlushAndYield(['Foo']);
+    expect(root).not.toMatchRenderedOutput('FooBar');
 
     jest.advanceTimersByTime(500);
     await promiseForBar;
@@ -165,7 +165,7 @@ describe('ReactLazy', () => {
       },
     );
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('Hi');
 
     await Promise.resolve();
 
@@ -193,7 +193,7 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('Hi');
 
     try {
       await Promise.resolve();
@@ -239,7 +239,7 @@ describe('ReactLazy', () => {
     });
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('AB');
 
     await LazyChildA;
     await LazyChildB;
@@ -280,7 +280,7 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('Hi');
 
     await Promise.resolve();
 
@@ -330,7 +330,7 @@ describe('ReactLazy', () => {
       },
     );
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('SiblingA');
 
     await Promise.resolve();
 
@@ -403,7 +403,7 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('A1');
 
     await Promise.resolve();
 
@@ -536,7 +536,7 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('Hi Bye');
 
     await Promise.resolve();
     expect(Scheduler).toFlushAndYield(['Hi Bye']);
@@ -572,7 +572,6 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
 
     await Promise.resolve();
     root.update(
@@ -600,7 +599,7 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('Hello');
 
     await Promise.resolve();
     root.update(
@@ -650,7 +649,7 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('22');
 
     // Mount
     await Promise.resolve();
@@ -836,7 +835,7 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('Inner default text');
 
     // Mount
     await Promise.resolve();
@@ -878,7 +877,7 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Started loading', 'Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput(<div>AB</div>);
 
     await Promise.resolve();
 
@@ -924,7 +923,7 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('FooBar');
     expect(ref.current).toBe(null);
 
     await Promise.resolve();
@@ -952,7 +951,7 @@ describe('ReactLazy', () => {
       },
     );
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('4');
 
     // Mount
     await Promise.resolve();
@@ -1036,7 +1035,7 @@ describe('ReactLazy', () => {
       },
     );
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
+    expect(root).not.toMatchRenderedOutput('4');
 
     // Mount
     await Promise.resolve();
@@ -1069,7 +1068,7 @@ describe('ReactLazy', () => {
     });
 
     const ref = React.createRef();
-    const root = ReactTestRenderer.create(
+    ReactTestRenderer.create(
       <Suspense fallback={<Text text="Loading..." />}>
         <LazyFoo ref={ref} />
       </Suspense>,
@@ -1079,7 +1078,6 @@ describe('ReactLazy', () => {
     );
 
     expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).toMatchRenderedOutput(null);
     await Promise.resolve();
     expect(() => {
       expect(Scheduler).toFlushAndYield([]);

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -114,19 +114,26 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       return props.children;
     }
 
-    function Foo() {
+    function Foo({renderBar}) {
       Scheduler.yieldValue('Foo');
       return (
         <Suspense fallback={<Text text="Loading..." />}>
-          <Bar>
-            <AsyncText text="A" ms={100} />
-            <Text text="B" />
-          </Bar>
+          {renderBar ? (
+            <Bar>
+              <AsyncText text="A" ms={100} />
+              <Text text="B" />
+            </Bar>
+          ) : null}
         </Suspense>
       );
     }
 
+    // Render empty shell.
     ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYield(['Foo']);
+
+    // The update will suspend.
+    ReactNoop.render(<Foo renderBar={true} />);
     expect(Scheduler).toFlushAndYield([
       'Foo',
       'Bar',
@@ -170,13 +177,6 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'Suspend! [B]',
       'Loading B...',
     ]);
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    // Advance time by enough to timeout both components and commit their placeholders
-    ReactNoop.expire(4000);
-    await advanceTimers(4000);
-
-    expect(Scheduler).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([
       span('Loading A...'),
       span('Loading B...'),
@@ -185,8 +185,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Advance time by enough that the first Suspense's promise resolves and
     // switches back to the normal view. The second Suspense should still
     // show the placeholder
-    ReactNoop.expire(1000);
-    await advanceTimers(1000);
+    ReactNoop.expire(5000);
+    await advanceTimers(5000);
 
     expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
     expect(Scheduler).toFlushAndYield(['A']);
@@ -203,6 +203,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   });
 
   it('continues rendering siblings after suspending', async () => {
+    // A shell is needed. The update cause it to suspend.
+    ReactNoop.render(<Suspense fallback={<Text text="Loading..." />} />);
+    expect(Scheduler).toFlushAndYield([]);
+    // B suspends. Continue rendering the remaining siblings.
     ReactNoop.render(
       <Suspense fallback={<Text text="Loading..." />}>
         <Text text="A" />
@@ -253,17 +257,23 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     const errorBoundary = React.createRef();
-    function App() {
+    function App({renderContent}) {
       return (
         <Suspense fallback={<Text text="Loading..." />}>
-          <ErrorBoundary ref={errorBoundary}>
-            <AsyncText text="Result" ms={1000} />
-          </ErrorBoundary>
+          {renderContent ? (
+            <ErrorBoundary ref={errorBoundary}>
+              <AsyncText text="Result" ms={1000} />
+            </ErrorBoundary>
+          ) : null}
         </Suspense>
       );
     }
 
     ReactNoop.render(<App />);
+    expect(Scheduler).toFlushAndYield([]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.render(<App renderContent={true} />);
     expect(Scheduler).toFlushAndYield(['Suspend! [Result]', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([]);
 
@@ -318,16 +328,11 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     ReactNoop.render(<App />);
     expect(Scheduler).toFlushAndYield(['Suspend! [Result]', 'Loading...']);
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    ReactNoop.expire(2000);
-    await advanceTimers(2000);
-    expect(Scheduler).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
 
     textResourceShouldFail = true;
-    ReactNoop.expire(1000);
-    await advanceTimers(1000);
+    ReactNoop.expire(3000);
+    await advanceTimers(3000);
     textResourceShouldFail = false;
 
     expect(Scheduler).toHaveYielded(['Promise rejected [Result]']);
@@ -394,20 +399,24 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     function App(props) {
       return (
         <Suspense fallback={<Text text="Loading..." />}>
-          <AsyncText text="A" />
+          {props.showA && <AsyncText text="A" />}
           {props.showB && <Text text="B" />}
         </Suspense>
       );
     }
 
-    ReactNoop.render(<App showB={false} />);
+    ReactNoop.render(<App showA={false} showB={false} />);
+    expect(Scheduler).toFlushAndYield([]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.render(<App showA={true} showB={false} />);
     expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([]);
 
     // Advance React's virtual time by enough to fall into a new async bucket,
     // but not enough to expire the suspense timeout.
     ReactNoop.expire(120);
-    ReactNoop.render(<App showB={true} />);
+    ReactNoop.render(<App showA={true} showB={true} />);
     expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'B', 'Loading...']);
     expect(ReactNoop.getChildren()).toEqual([]);
 
@@ -450,6 +459,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   it('forces an expiration after an update times out', async () => {
     ReactNoop.render(
       <Fragment>
+        <Suspense fallback={<Text text="Loading..." />} />
+      </Fragment>,
+    );
+    expect(Scheduler).toFlushAndYield([]);
+
+    ReactNoop.render(
+      <Fragment>
         <Suspense fallback={<Text text="Loading..." />}>
           <AsyncText text="Async" ms={20000} />
         </Suspense>
@@ -485,7 +501,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
   });
 
-  it('switches to an inner fallback even if it expires later', async () => {
+  it('switches to an inner fallback after suspending for a while', async () => {
     // Advance the virtual time so that we're closer to the edge of a bucket.
     ReactNoop.expire(200);
 
@@ -509,26 +525,15 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'Loading inner...',
       'Loading outer...',
     ]);
-    // The update hasn't expired yet, so we commit nothing.
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    // Expire the outer timeout, but don't expire the inner one.
-    // We should see the outer loading placeholder.
-    ReactNoop.expire(250);
-    await advanceTimers(250);
-    expect(Scheduler).toFlushWithoutYielding();
+    // The outer loading state finishes immediately.
     expect(ReactNoop.getChildren()).toEqual([
       span('Sync'),
       span('Loading outer...'),
     ]);
 
     // Resolve the outer promise.
-    ReactNoop.expire(50);
-    await advanceTimers(50);
-    // At this point, 250ms have elapsed total. The outer placeholder
-    // timed out at around 150-200ms. So, 50-100ms have elapsed since the
-    // placeholder timed out. That means we still haven't reached the 150ms
-    // threshold of the inner placeholder.
+    ReactNoop.expire(300);
+    await advanceTimers(300);
     expect(Scheduler).toHaveYielded(['Promise resolved [Outer content]']);
     expect(Scheduler).toFlushAndYield([
       'Outer content',
@@ -620,6 +625,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   it('expires early by default', async () => {
     ReactNoop.render(
       <Fragment>
+        <Suspense fallback={<Text text="Loading..." />} />
+      </Fragment>,
+    );
+    expect(Scheduler).toFlushAndYield([]);
+
+    ReactNoop.render(
+      <Fragment>
         <Suspense fallback={<Text text="Loading..." />}>
           <AsyncText text="Async" ms={3000} />
         </Suspense>
@@ -654,17 +666,33 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
   it('resolves successfully even if fallback render is pending', async () => {
     ReactNoop.render(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <AsyncText text="Async" ms={3000} />
-      </Suspense>,
+      <React.Fragment>
+        <Suspense fallback={<Text text="Loading..." />} />
+      </React.Fragment>,
+    );
+    expect(Scheduler).toFlushAndYield([]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+    ReactNoop.render(
+      <React.Fragment>
+        <Suspense fallback={<Text text="Loading..." />}>
+          <AsyncText text="Async" ms={3000} />
+        </Suspense>
+      </React.Fragment>,
     );
     expect(ReactNoop.flushNextYield()).toEqual(['Suspend! [Async]']);
     await advanceTimers(1500);
     expect(Scheduler).toHaveYielded([]);
+    expect(ReactNoop.getChildren()).toEqual([]);
     // Before we have a chance to flush, the promise resolves.
     await advanceTimers(2000);
     expect(Scheduler).toHaveYielded(['Promise resolved [Async]']);
-    expect(Scheduler).toFlushAndYield(['Async']);
+    expect(Scheduler).toFlushAndYield([
+      // We've now pinged the boundary but we don't know if we should restart yet,
+      // because we haven't completed the suspense boundary.
+      'Loading...',
+      // Once we've completed the boundary we restarted.
+      'Async',
+    ]);
     expect(ReactNoop.getChildren()).toEqual([span('Async')]);
   });
 
@@ -702,6 +730,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   });
 
   it('can resume rendering earlier than a timeout', async () => {
+    ReactNoop.render(<Suspense fallback={<Text text="Loading..." />} />);
+    expect(Scheduler).toFlushAndYield([]);
+
     ReactNoop.render(
       <Suspense fallback={<Text text="Loading..." />}>
         <AsyncText text="Async" ms={100} />
@@ -1314,16 +1345,19 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   });
 
   it('suspends for longer if something took a long (CPU bound) time to render', async () => {
-    function Foo() {
+    function Foo({renderContent}) {
       Scheduler.yieldValue('Foo');
       return (
         <Suspense fallback={<Text text="Loading..." />}>
-          <AsyncText text="A" ms={5000} />
+          {renderContent ? <AsyncText text="A" ms={5000} /> : null}
         </Suspense>
       );
     }
 
     ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYield(['Foo']);
+
+    ReactNoop.render(<Foo renderContent={true} />);
     Scheduler.advanceTime(100);
     await advanceTimers(100);
     // Start rendering
@@ -1363,7 +1397,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     expect(ReactNoop.getChildren()).toEqual([span('A')]);
   });
 
-  it('suspends for longer if a fallback has been shown for a long time', async () => {
+  it('does not suspends if a fallback has been shown for a long time', async () => {
     function Foo() {
       Scheduler.yieldValue('Foo');
       return (
@@ -1387,13 +1421,6 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'Loading more...',
       'Loading...',
     ]);
-    // We're now suspended and we haven't shown anything yet.
-    expect(ReactNoop.getChildren()).toEqual([]);
-
-    // Show the fallback.
-    Scheduler.advanceTime(400);
-    await advanceTimers(400);
-    expect(Scheduler).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
 
     // Wait a long time.
@@ -1408,25 +1435,16 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'Suspend! [B]',
       'Loading more...',
     ]);
-    // Because we've already been waiting for so long we can
-    // wait a bit longer. Still nothing...
-    Scheduler.advanceTime(600);
-    await advanceTimers(600);
-    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-    // Eventually we'll show more content with inner fallback.
-    Scheduler.advanceTime(3000);
-    await advanceTimers(3000);
-    // No need to rerender.
-    expect(Scheduler).toFlushWithoutYielding();
+    // Because we've already been waiting for so long we've exceeded
+    // our threshold and we show the next level immediately.
     expect(ReactNoop.getChildren()).toEqual([
       span('A'),
       span('Loading more...'),
     ]);
 
     // Flush the last promise completely
-    Scheduler.advanceTime(4500);
-    await advanceTimers(4500);
+    Scheduler.advanceTime(5000);
+    await advanceTimers(5000);
     // Renders successfully
     expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
     expect(Scheduler).toFlushAndYield(['B']);
@@ -1434,16 +1452,21 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   });
 
   it('does not suspend for very long after a higher priority update', async () => {
-    function Foo() {
+    function Foo({renderContent}) {
       Scheduler.yieldValue('Foo');
       return (
         <Suspense fallback={<Text text="Loading..." />}>
-          <AsyncText text="A" ms={5000} />
+          {renderContent ? <AsyncText text="A" ms={5000} /> : null}
         </Suspense>
       );
     }
 
-    ReactNoop.discreteUpdates(() => ReactNoop.render(<Foo />));
+    ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYield(['Foo']);
+
+    ReactNoop.discreteUpdates(() =>
+      ReactNoop.render(<Foo renderContent={true} />),
+    );
     expect(Scheduler).toFlushAndYieldThrough(['Foo']);
 
     // Advance some time.
@@ -1478,6 +1501,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
   it('warns when suspending inside discrete update', async () => {
     function A() {
+      Scheduler.yieldValue('A');
       TextResource.read(['A', 1000]);
       return 'A';
     }
@@ -1505,13 +1529,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.discreteUpdates(() => ReactNoop.render(<App />));
-    Scheduler.flushAll();
+    expect(Scheduler).toFlushAndYieldThrough(['A']);
 
     // Warning is not flushed until the commit phase
 
     // Timeout and commit the fallback
     expect(() => {
-      jest.advanceTimersByTime(1000);
+      Scheduler.flushAll();
     }).toWarnDev(
       'The following components suspended during a user-blocking update: A, C',
       {withoutStack: true},
@@ -1541,11 +1565,6 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'B',
       'Initial load...',
     ]);
-    // We're still suspended.
-    expect(ReactNoop.getChildren()).toEqual([]);
-    // Flush to skip suspended time.
-    Scheduler.advanceTime(600);
-    await advanceTimers(600);
     expect(ReactNoop.getChildren()).toEqual([span('Initial load...')]);
 
     // Eventually we resolve and show the data.
@@ -1658,17 +1677,20 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   });
 
   it('commits a suspended idle pri render within a reasonable time', async () => {
-    function Foo({something}) {
+    function Foo({renderContent}) {
       return (
         <Fragment>
           <Suspense fallback={<Text text="Loading A..." />}>
-            <AsyncText text="A" ms={10000} />
+            {renderContent ? <AsyncText text="A" ms={10000} /> : null}
           </Suspense>
         </Fragment>
       );
     }
 
     ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYield([]);
+
+    ReactNoop.render(<Foo renderContent={1} />);
 
     // Took a long time to render. This is to ensure we get a long suspense time.
     // Could also use something like withSuspenseConfig to simulate this.
@@ -1681,7 +1703,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Schedule an update at idle pri.
     Scheduler.unstable_runWithPriority(Scheduler.unstable_IdlePriority, () =>
-      ReactNoop.render(<Foo something={true} />),
+      ReactNoop.render(<Foo renderContent={2} />),
     );
     expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading A...']);
 

--- a/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
+++ b/packages/react-reconciler/src/__tests__/__snapshots__/ReactIncrementalPerf-test.internal.js.snap
@@ -363,9 +363,12 @@ exports[`ReactDebugFiberPerf supports Suspense and lazy 1`] = `
 
 ⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
-    ⛔ Suspense [mount] Warning: Rendering was suspended
     ⚛ Suspense [mount]
-      ⚛ Spinner [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
 "
 `;
 
@@ -374,21 +377,54 @@ exports[`ReactDebugFiberPerf supports Suspense and lazy 2`] = `
 
 ⚛ (React Tree Reconciliation: Completed Root)
   ⚛ Parent [mount]
-    ⛔ Suspense [mount] Warning: Rendering was suspended
     ⚛ Suspense [mount]
-      ⚛ Spinner [mount]
-
-⚛ (Waiting for async callback...)
-
-⚛ (React Tree Reconciliation: Completed Root)
-  ⚛ Parent [mount]
-    ⚛ Suspense [mount]
-      ⚛ Foo [mount]
 
 ⚛ (Committing Changes)
   ⚛ (Committing Snapshot Effects: 0 Total)
   ⚛ (Committing Host Effects: 1 Total)
   ⚛ (Calling Lifecycle Methods: 0 Total)
+
+⚛ (Waiting for async callback...)
+
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [update]
+    ⛔ Suspense [update] Warning: Rendering was suspended
+    ⚛ Suspense [update]
+      ⚛ Spinner [mount]
+"
+`;
+
+exports[`ReactDebugFiberPerf supports Suspense and lazy 3`] = `
+"⚛ (Waiting for async callback...)
+
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [mount]
+    ⚛ Suspense [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 1 Total)
+  ⚛ (Calling Lifecycle Methods: 0 Total)
+
+⚛ (Waiting for async callback...)
+
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [update]
+    ⛔ Suspense [update] Warning: Rendering was suspended
+    ⚛ Suspense [update]
+      ⚛ Spinner [mount]
+
+⚛ (Waiting for async callback...)
+
+⚛ (React Tree Reconciliation: Completed Root)
+  ⚛ Parent [update]
+    ⚛ Suspense [update]
+      ⚛ Foo [mount]
+
+⚛ (Committing Changes)
+  ⚛ (Committing Snapshot Effects: 0 Total)
+  ⚛ (Committing Host Effects: 2 Total)
+  ⚛ (Calling Lifecycle Methods: 1 Total)
 "
 `;
 


### PR DESCRIPTION
This introduces a new principle for when we restart a render instead of continuing to completion. The principle is that *if* we're going to suspend when we complete a root, then we should also restart if we get an update or ping that might unsuspend it, and vice versa. The only reason to suspend is because you think you might want to restart before committing. However, it doesn't make sense to restart only while in the period we're suspended. That's just a race condition depending on how long it took to render. We should also be able to restart before that.

However, restarting too aggressively is also not good because it starves out any intermediate loading state. So this PR uses a set of heuristics.

## Heuristics

If nothing threw a Promise or all the same fallbacks are already showing, then don't suspend/restart.

If this is an initial render of a new tree of Suspense boundaries and those trigger a fallback, then don't suspend/restart. We want to ensure that we can show the initial loading state as quickly as possible.

If we hit a "Delayed" case, such as when we'd switch from content back into a fallback, then we should always suspend/restart. SuspenseConfig applies to this case. If none is defined, JND is used instead.

If we're already showing a fallback and it gets "retried", allowing us to show another level, but there's still an inner boundary that would show a fallback, then we suspend/restart for 500ms since the last time we showed a fallback anywhere in the tree. This effectively throttles progressive loading into a consistent train of commits. This also gives us an opportunity to restart to get to the completed state slightly earlier.

If there's ambiguity due to batching it's resolved in preference of: "delayed", "initial render", "retry". We want to ensure that a "busy" state doesn't get force committed. We want to ensure that new initial loading states can commit as soon as possible.

More info about the mechanisms in the individual commits.

## Tests

This PR needed to adjust a lot of tests.

Most of them is because initial render no longer suspends in the traditional way. I fixed this mostly by first rendering an empty Suspense boundary and then updating it. This transition works mostly the traditional way.

Another quirk is that restarting doesn't happen until we know that this render is going to suspend. Currently, we only know that once we complete the Suspense boundary. Pings can happen before or after this. If we never yield after completing it, we don't restart until we get to the root. I left a comment to fix that. In the meantime I had to rewrite the tests to continue render past the Suspense boundary before pausing so that it can restart after that.