### PR TITLE
Fix sizebot

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -21,7 +21,7 @@ const useForks = require('./plugins/use-forks-plugin');
 const stripUnusedImports = require('./plugins/strip-unused-imports');
 const extractErrorCodes = require('../error-codes/extract-errors');
 const Packaging = require('./packaging');
-const {asyncCopyTo} = require('./utils');
+const {asyncCopyTo, asyncRimRaf} = require('./utils');
 const codeFrame = require('babel-code-frame');
 const Wrappers = require('./wrappers');
 
@@ -634,6 +634,8 @@ function handleRollupError(error) {
 }
 
 async function buildEverything() {
+  await asyncRimRaf('build');
+
   // Run them serially for better console output
   // and to avoid any potential race conditions.
 

--- a/scripts/rollup/consolidateBundleSizes.js
+++ b/scripts/rollup/consolidateBundleSizes.js
@@ -13,9 +13,9 @@ const filenames = fs.readdirSync(path.join(BUILD_DIR, 'sizes'));
 let bundleSizes = [];
 for (let i = 0; i < filenames.length; i++) {
   const filename = filenames[i];
-  if (filename.endsWith('.size.json')) {
+  if (filename.endsWith('.json')) {
     const json = fs.readFileSync(path.join(BUILD_DIR, 'sizes', filename));
-    bundleSizes.push(JSON.parse(json));
+    bundleSizes.push(...JSON.parse(json).bundleSizes);
   }
 }
 


### PR DESCRIPTION
The previous naming scheme for the partial size info files used the filename of the bundle. However, there are cases where multiple bundles have the same filename. This meant whichever bundle finishes last overwrites the previous ones with the same name.

The updated naming scheme is `bundle-sizes-<CI_NODE_INDEX>.json`. Instead of generating a separate info file per bundle, it now creates one per process.