### PR TITLE
Increase parallelism again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
   build:
     docker: *docker
     environment: *environment
-    parallelism: 20
+    parallelism: 50
     steps:
       - checkout
       - *restore_yarn_cache


### PR DESCRIPTION
Increased to 50 because let's try it and see? Post-build jobs are still the last to finish so if this makes the build job faster it will decrease the total CI time, too.