### PR TITLE
[FIX] - ReactDOM Add back version property to client

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -159,6 +159,8 @@ const ReactDOM: Object = {
       IsThisRendererActing,
     ],
   },
+
+  version: ReactVersion,
 };
 
 if (exposeConcurrentModeAPIs) {


### PR DESCRIPTION
### Change details
Adding back `.version` property to ReactDOM. It [used to exist in React15](https://github.com/facebook/react/blob/15-stable/src/renderers/dom/ReactDOM.js#L32) and got deleted. It still [exists in ReactDOM/server](https://github.com/facebook/react/blob/3b2302253f13c9cd049fac10784e10b6c582e3b6/packages/react-dom/src/server/ReactDOMServerNode.js#L22), and it appears to be [typed in @typed/react-dom](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-dom/index.d.ts#L25) so I am assuming it got deleted by mistake.