### PR TITLE
[flow] replace React$Element<any> -> React$Element<React$ElementType>

### DIFF
--- a/packages/create-subscription/src/createSubscription.js
+++ b/packages/create-subscription/src/createSubscription.js
@@ -46,7 +46,7 @@ export function createSubscription<Property, Value>(
   );
 
   type Props = {
-    children: (value: Value) => React$Element<any>,
+    children: (value: Value) => React$Element<React$ElementType>,
     source: Property,
   };
   type State = {

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -657,7 +657,7 @@ const ReactDOM: Object = {
   },
 
   render(
-    element: React$Element<any>,
+    element: React$Element<React$ElementType>,
     container: DOMContainer,
     callback: ?Function,
   ) {
@@ -685,7 +685,7 @@ const ReactDOM: Object = {
 
   unstable_renderSubtreeIntoContainer(
     parentComponent: React$Component<any, any>,
-    element: React$Element<any>,
+    element: React$Element<React$ElementType>,
     containerNode: DOMContainer,
     callback: ?Function,
   ) {

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -663,7 +663,7 @@ const ReactDOM: Object = {
   },
 
   render(
-    element: React$Element<any>,
+    element: React$Element<React$ElementType>,
     container: DOMContainer,
     callback: ?Function,
   ) {
@@ -691,7 +691,7 @@ const ReactDOM: Object = {
 
   unstable_renderSubtreeIntoContainer(
     parentComponent: React$Component<any, any>,
-    element: React$Element<any>,
+    element: React$Element<React$ElementType>,
     containerNode: DOMContainer,
     callback: ?Function,
   ) {

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -116,7 +116,7 @@ const ReactFabric: ReactFabricType = {
     return;
   },
 
-  render(element: React$Element<any>, containerTag: any, callback: ?Function) {
+  render(element: React$Element<React$ElementType>, containerTag: any, callback: ?Function) {
     let root = roots.get(containerTag);
 
     if (!root) {

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -116,7 +116,11 @@ const ReactFabric: ReactFabricType = {
     return;
   },
 
-  render(element: React$Element<React$ElementType>, containerTag: any, callback: ?Function) {
+  render(
+    element: React$Element<React$ElementType>,
+    containerTag: any,
+    callback: ?Function,
+  ) {
     let root = roots.get(containerTag);
 
     if (!root) {

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -122,7 +122,11 @@ const ReactNativeRenderer: ReactNativeType = {
 
   setNativeProps,
 
-  render(element: React$Element<React$ElementType>, containerTag: any, callback: ?Function) {
+  render(
+    element: React$Element<React$ElementType>,
+    containerTag: any,
+    callback: ?Function,
+  ) {
     let root = roots.get(containerTag);
 
     if (!root) {

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -122,7 +122,7 @@ const ReactNativeRenderer: ReactNativeType = {
 
   setNativeProps,
 
-  render(element: React$Element<any>, containerTag: any, callback: ?Function) {
+  render(element: React$Element<React$ElementType>, containerTag: any, callback: ?Function) {
     let root = roots.get(containerTag);
 
     if (!root) {

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -133,7 +133,7 @@ export type ReactNativeType = {
   findNodeHandle(componentOrHandle: any): ?number,
   setNativeProps(handle: any, nativeProps: Object): void,
   render(
-    element: React$Element<any>,
+    element: React$Element<React$ElementType>,
     containerTag: any,
     callback: ?Function,
   ): any,
@@ -149,7 +149,7 @@ export type ReactFabricType = {
   findNodeHandle(componentOrHandle: any): ?number,
   setNativeProps(handle: any, nativeProps: Object): void,
   render(
-    element: React$Element<any>,
+    element: React$Element<React$ElementType>,
     containerTag: any,
     callback: ?Function,
   ): any,

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -37,7 +37,7 @@ const ReactNoopServer = ReactFizzStreamer({
   },
 });
 
-function render(children: React$Element<any>): Destination {
+function render(children: React$Element<React$ElementType>): Destination {
   let destination: Destination = [];
   let request = ReactNoopServer.createRequest(children, destination);
   ReactNoopServer.startWork(request);

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -1029,7 +1029,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       ReactNoop.renderToRootWithID(element, DEFAULT_ROOT_ID, callback);
     },
 
-    renderLegacySyncRoot(element: React$Element<React$ElementType>, callback: ?Function) {
+    renderLegacySyncRoot(
+      element: React$Element<React$ElementType>,
+      callback: ?Function,
+    ) {
       const rootID = DEFAULT_ROOT_ID;
       const container = ReactNoop.getOrCreateRootContainer(rootID, LegacyRoot);
       const root = roots.get(container.rootID);

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -1025,11 +1025,11 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     },
 
     // Shortcut for testing a single root
-    render(element: React$Element<any>, callback: ?Function) {
+    render(element: React$Element<React$ElementType>, callback: ?Function) {
       ReactNoop.renderToRootWithID(element, DEFAULT_ROOT_ID, callback);
     },
 
-    renderLegacySyncRoot(element: React$Element<any>, callback: ?Function) {
+    renderLegacySyncRoot(element: React$Element<React$ElementType>, callback: ?Function) {
       const rootID = DEFAULT_ROOT_ID;
       const container = ReactNoop.getOrCreateRootContainer(rootID, LegacyRoot);
       const root = roots.get(container.rootID);
@@ -1037,7 +1037,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     },
 
     renderToRootWithID(
-      element: React$Element<any>,
+      element: React$Element<React$ElementType>,
       rootID: string,
       callback: ?Function,
     ) {

--- a/packages/shared/ReactElementType.js
+++ b/packages/shared/ReactElementType.js
@@ -24,7 +24,7 @@ export type ReactElement = {
   _store: {
     validated: boolean,
   },
-  _self: React$Element<any>,
+  _self: React$Element<React$ElementType>,
   _shadowChildren: any,
   _source: Source,
 };

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -8,7 +8,7 @@
  */
 
 export type ReactNode =
-  | React$Element<any>
+  | React$Element<React$ElementType>
   | ReactPortal
   | ReactText
   | ReactFragment


### PR DESCRIPTION
## Tweek Enhancement
because React$Element generics expected React$ElementType.
According to flow@0.72 lib definitions. 

https://github.com/facebook/flow/blob/95a50419fcd7ef4bc12576f5ff7d6593add0921f/lib/react.js#L167-L183

Thanks👏