### PR TITLE
[Flare] Remove deprecated keypress event

### DIFF
--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -51,7 +51,6 @@ const targetEventTypes = [
 
 const rootEventTypes = [
   'keydown',
-  'keypress',
   'keyup',
   'pointermove',
   'pointerdown',
@@ -304,7 +303,6 @@ const FocusResponder = {
       }
 
       case 'keydown':
-      case 'keypress':
       case 'keyup': {
         const nativeEvent = event.nativeEvent;
         if (

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -118,7 +118,6 @@ const DEFAULT_PRESS_RETENTION_OFFSET = {
 const targetEventTypes = [
   {name: 'click', passive: false},
   {name: 'keydown', passive: false},
-  {name: 'keypress', passive: false},
   {name: 'contextmenu', passive: false},
   // We need to preventDefault on pointerdown for mouse/pen events
   // that are in hit target area but not the element area.
@@ -663,7 +662,6 @@ const PressResponder = {
       // START
       case 'pointerdown':
       case 'keydown':
-      case 'keypress':
       case 'mousedown':
       case 'touchstart': {
         if (!state.isPressed) {

--- a/packages/react-events/src/__tests__/Focus-test.internal.js
+++ b/packages/react-events/src/__tests__/Focus-test.internal.js
@@ -200,7 +200,7 @@ describe('Focus event responder', () => {
     it('is called with the correct pointerType using a keyboard', () => {
       // Keyboard tab
       ref.current.dispatchEvent(
-        createPointerEvent('keypress', {
+        createPointerEvent('keydown', {
           key: 'Tab',
         }),
       );
@@ -219,7 +219,7 @@ describe('Focus event responder', () => {
       componentInit();
 
       ref.current.dispatchEvent(
-        createPointerEvent('keypress', {
+        createPointerEvent('keydown', {
           key: 'Tab',
           altKey: true,
         }),


### PR DESCRIPTION
`keypress` is a deprecated event and we don't need to use it