### PR TITLE
[Events] Nested discrete events across systems

### DIFF
--- a/packages/events/ReactSyntheticEventType.js
+++ b/packages/events/ReactSyntheticEventType.js
@@ -18,7 +18,7 @@ export type DispatchConfig = {
     captured: string,
   },
   registrationName?: string,
-  isInteractive?: boolean,
+  isDiscrete?: boolean,
 };
 
 export type ReactSyntheticEvent = {

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -610,7 +610,7 @@ export function processEventQueue(): void {
     return;
   }
   if (discrete) {
-    if (shouldflushDiscreteUpdates(currentTimeStamp)) {
+    if (shouldFlushDiscreteUpdates(currentTimeStamp)) {
       flushDiscreteUpdates();
     }
     discreteUpdates(() => {
@@ -1019,7 +1019,7 @@ export function generateListeningKey(
 
 let lastDiscreteEventTimeStamp = 0;
 
-export function shouldflushDiscreteUpdates(timeStamp: number): boolean {
+export function shouldFlushDiscreteUpdates(timeStamp: number): boolean {
   // event.timeStamp isn't overly reliable due to inconsistencies in
   // how different browsers have historically provided the time stamp.
   // Some browsers provide high-resolution time stamps for all events,

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -19,7 +19,7 @@ import {
 import {runExtractedPluginEventsInBatch} from 'events/EventPluginHub';
 import {
   dispatchEventForResponderEventSystem,
-  shouldflushDiscreteUpdates,
+  shouldFlushDiscreteUpdates,
 } from '../events/DOMEventResponderSystem';
 import {isFiberMounted} from 'react-reconciler/reflection';
 import {HostRoot} from 'shared/ReactWorkTags';
@@ -229,7 +229,7 @@ function trapEventForPluginEventSystem(
 }
 
 function dispatchDiscreteEvent(topLevelType, eventSystemFlags, nativeEvent) {
-  if (!enableEventAPI || shouldflushDiscreteUpdates(nativeEvent.timeStamp)) {
+  if (!enableEventAPI || shouldFlushDiscreteUpdates(nativeEvent.timeStamp)) {
     flushDiscreteUpdates();
   }
   discreteUpdates(dispatchEvent, topLevelType, eventSystemFlags, nativeEvent);

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -45,7 +45,7 @@ import {passiveBrowserEventsSupported} from './checkPassiveEvents';
 
 import {enableEventAPI} from 'shared/ReactFeatureFlags';
 
-const {isInteractiveTopLevelEventType} = SimpleEventPlugin;
+const {isDiscreteTopLevelEventType} = SimpleEventPlugin;
 
 const CALLBACK_BOOKKEEPING_POOL_SIZE = 10;
 const callbackBookkeepingPool = [];
@@ -215,11 +215,11 @@ function trapEventForPluginEventSystem(
   topLevelType: DOMTopLevelEventType,
   capture: boolean,
 ): void {
-  const dispatch = isInteractiveTopLevelEventType(topLevelType)
-    ? dispatchInteractiveEvent
+  const dispatch = isDiscreteTopLevelEventType(topLevelType)
+    ? dispatchDiscreteEvent
     : dispatchEvent;
   const rawEventName = getRawEventName(topLevelType);
-  // Check if interactive and wrap in discreteUpdates
+  // Check if discrete and wrap in discreteUpdates
   const listener = dispatch.bind(null, topLevelType, PLUGIN_EVENT_SYSTEM);
   if (capture) {
     addEventCaptureListener(element, rawEventName, listener);
@@ -228,7 +228,7 @@ function trapEventForPluginEventSystem(
   }
 }
 
-function dispatchInteractiveEvent(topLevelType, eventSystemFlags, nativeEvent) {
+function dispatchDiscreteEvent(topLevelType, eventSystemFlags, nativeEvent) {
   if (!enableEventAPI || shouldflushDiscreteUpdates(nativeEvent.timeStamp)) {
     flushDiscreteUpdates();
   }

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -14,13 +14,10 @@ import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
 import {
   batchedEventUpdates,
   discreteUpdates,
-  flushDiscreteUpdates,
+  flushDiscreteUpdatesIfNeeded,
 } from 'events/ReactGenericBatching';
 import {runExtractedPluginEventsInBatch} from 'events/EventPluginHub';
-import {
-  dispatchEventForResponderEventSystem,
-  shouldFlushDiscreteUpdates,
-} from '../events/DOMEventResponderSystem';
+import {dispatchEventForResponderEventSystem} from '../events/DOMEventResponderSystem';
 import {isFiberMounted} from 'react-reconciler/reflection';
 import {HostRoot} from 'shared/ReactWorkTags';
 import {
@@ -229,9 +226,7 @@ function trapEventForPluginEventSystem(
 }
 
 function dispatchDiscreteEvent(topLevelType, eventSystemFlags, nativeEvent) {
-  if (!enableEventAPI || shouldFlushDiscreteUpdates(nativeEvent.timeStamp)) {
-    flushDiscreteUpdates();
-  }
+  flushDiscreteUpdatesIfNeeded(nativeEvent.timeStamp);
   discreteUpdates(dispatchEvent, topLevelType, eventSystemFlags, nativeEvent);
 }
 

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -56,7 +56,7 @@ import getEventCharCode from './getEventCharCode';
  * ]);
  */
 type EventTuple = [DOMTopLevelEventType, string];
-const interactiveEventTypeNames: Array<EventTuple> = [
+const discreteEventTypeNames: Array<EventTuple> = [
   [DOMTopLevelEventTypes.TOP_BLUR, 'blur'],
   [DOMTopLevelEventTypes.TOP_CANCEL, 'cancel'],
   [DOMTopLevelEventTypes.TOP_CLICK, 'click'],
@@ -92,7 +92,7 @@ const interactiveEventTypeNames: Array<EventTuple> = [
   [DOMTopLevelEventTypes.TOP_TOUCH_START, 'touchStart'],
   [DOMTopLevelEventTypes.TOP_VOLUME_CHANGE, 'volumeChange'],
 ];
-const nonInteractiveEventTypeNames: Array<EventTuple> = [
+const continuousEventTypeNames: Array<EventTuple> = [
   [DOMTopLevelEventTypes.TOP_ABORT, 'abort'],
   [DOMTopLevelEventTypes.TOP_ANIMATION_END, 'animationEnd'],
   [DOMTopLevelEventTypes.TOP_ANIMATION_ITERATION, 'animationIteration'],
@@ -142,7 +142,7 @@ const topLevelEventsToDispatchConfig: {
 
 function addEventTypeNameToConfig(
   [topEvent, event]: EventTuple,
-  isInteractive: boolean,
+  isDiscrete: boolean,
 ) {
   const capitalizedEvent = event[0].toUpperCase() + event.slice(1);
   const onEvent = 'on' + capitalizedEvent;
@@ -153,16 +153,16 @@ function addEventTypeNameToConfig(
       captured: onEvent + 'Capture',
     },
     dependencies: [topEvent],
-    isInteractive,
+    isDiscrete,
   };
   eventTypes[event] = type;
   topLevelEventsToDispatchConfig[topEvent] = type;
 }
 
-interactiveEventTypeNames.forEach(eventTuple => {
+discreteEventTypeNames.forEach(eventTuple => {
   addEventTypeNameToConfig(eventTuple, true);
 });
-nonInteractiveEventTypeNames.forEach(eventTuple => {
+continuousEventTypeNames.forEach(eventTuple => {
   addEventTypeNameToConfig(eventTuple, false);
 });
 
@@ -202,13 +202,13 @@ const knownHTMLTopLevelTypes: Array<DOMTopLevelEventType> = [
 ];
 
 const SimpleEventPlugin: PluginModule<MouseEvent> & {
-  isInteractiveTopLevelEventType: (topLevelType: TopLevelType) => boolean,
+  isDiscreteTopLevelEventType: (topLevelType: TopLevelType) => boolean,
 } = {
   eventTypes: eventTypes,
 
-  isInteractiveTopLevelEventType(topLevelType: TopLevelType): boolean {
+  isDiscreteTopLevelEventType(topLevelType: TopLevelType): boolean {
     const config = topLevelEventsToDispatchConfig[topLevelType];
-    return config !== undefined && config.isInteractive === true;
+    return config !== undefined && config.isDiscrete === true;
   },
 
   extractEvents: function(

--- a/packages/react-dom/src/events/__tests__/ChangeEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/ChangeEventPlugin-test.internal.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const React = require('react');
+let React = require('react');
 let ReactDOM = require('react-dom');
 let ReactFeatureFlags;
 let Scheduler;
@@ -479,14 +479,16 @@ describe('ChangeEventPlugin', () => {
     }
   });
 
-  describe('async mode', () => {
+  describe('concurrent mode', () => {
     beforeEach(() => {
       jest.resetModules();
       ReactFeatureFlags = require('shared/ReactFeatureFlags');
       ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+      React = require('react');
       ReactDOM = require('react-dom');
       Scheduler = require('scheduler');
     });
+
     it('text input', () => {
       const root = ReactDOM.unstable_createRoot(container);
       let input;


### PR DESCRIPTION
## Based on #15794

If an event in the old system is dispatched synchronously within an event from the new system, or vice versa, and the inner event is a discrete update, React should not flush pending discrete updates before firing the inner event's handlers, even if the outer event is not discrete.

Another way of saying this is that nested events should never force React to flush discrete updates.

Arguably, if the outer event is not a discrete event, then the inner event _should_ flush the pending events. However, that would be a breaking change. I would argue this isn't so bad, however, given that nested events are pretty rare. They don't fit nicely into our event model regardless, since we don't support nested React renders. In the future we should consider warning when events are nested.