### PR TITLE
Fix error logging in getDerivedStateFromProps

### DIFF
--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
@@ -37,9 +37,14 @@ describe('ReactErrorBoundaries', () => {
   let RetryErrorBoundary;
   let Normal;
 
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
   beforeEach(() => {
     jest.useFakeTimers();
     jest.resetModules();
+    jest.spyOn(console, 'error');
     PropTypes = require('prop-types');
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
@@ -653,6 +658,13 @@ describe('ReactErrorBoundaries', () => {
       container,
     );
     expect(container.firstChild.textContent).toBe('Caught an error: Hello.');
+    expect(console.error).toHaveBeenCalledWith(
+      __DEV__
+        ? expect.stringMatching(
+            /^The above error occurred in the <BrokenRender> component/,
+          )
+        : new Error('Hello'),
+    );
     expect(log).toEqual([
       'ErrorBoundary constructor',
       'ErrorBoundary componentWillMount',

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -102,6 +102,7 @@ function createClassErrorUpdate(
   if (typeof getDerivedStateFromError === 'function') {
     const error = errorInfo.value;
     update.payload = () => {
+      logError(fiber, errorInfo);
       return getDerivedStateFromError(error);
     };
   }

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -119,10 +119,12 @@ function createClassErrorUpdate(
         // TODO: Warn in strict mode if getDerivedStateFromError is
         // not defined.
         markLegacyErrorBoundaryAsFailed(this);
+
+        // Only log here if componentDidCatch is the only error boundary method defined
+        logError(fiber, errorInfo);
       }
       const error = errorInfo.value;
       const stack = errorInfo.stack;
-      logError(fiber, errorInfo);
       this.componentDidCatch(error, {
         componentStack: stack !== null ? stack : '',
       });

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -38,6 +38,7 @@ const createMatcherFor = consoleMethod =>
       }
 
       const withoutStack = options.withoutStack;
+      const logAllErrors = options.logAllErrors;
       const warningsWithoutComponentStack = [];
       const warningsWithComponentStack = [];
       const unexpectedWarnings = [];
@@ -58,6 +59,7 @@ const createMatcherFor = consoleMethod =>
         // Ignore uncaught errors reported by jsdom
         // and React addendums because they're too noisy.
         if (
+          !logAllErrors &&
           consoleMethod === 'error' &&
           shouldIgnoreConsoleError(format, args)
         ) {


### PR DESCRIPTION
## Overview

This PR fixes an bug in `getDerivedStateFromError` where errors are not logged when an error occurs.

## Motivation

In React Native, when using `componentDidCatch`, any error that is caught will display a RedBox and on dismiss show the error boundary:

![cDC](https://user-images.githubusercontent.com/2440089/58740693-bc494000-8409-11e9-9460-d5805f101195.gif)

When using `getDerivedStateFromError`, no RedBox is shown, only the error boundary:

![gDSFE](https://user-images.githubusercontent.com/2440089/58740708-d4b95a80-8409-11e9-8e00-6bb8c071c79c.gif)

With this fix, `getDerivedStateFromError` performs the same as `componentDidCatch` with a RedBox that dismisses to reveal the error boundary:

![gDSFE_fixed](https://user-images.githubusercontent.com/2440089/58740728-f286bf80-8409-11e9-97d2-6eaa0c8f48b1.gif)

## Testing

I want to confirm the testing strategy before adding all of the tests in these files, so I've added two example tests:

- **ReactLegacyErrorBoundaries** test will pass without this change
- **ReactErrorBoundaries** test will **fail** without this change