### PR TITLE
[Fresh] Support classes by force-remounting them on edit

### DIFF
--- a/packages/react-fresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-fresh/src/ReactFreshBabelPlugin.js
@@ -250,6 +250,7 @@ export default function(babel) {
   function createArgumentsForSignature(node, signature, scope) {
     const {key, customHooks} = signature;
 
+    let forceReset = hasForceResetComment(scope.path);
     let customHooksInScope = [];
     customHooks.forEach(callee => {
       // Check if a correponding binding exists where we emit the signature.
@@ -268,13 +269,12 @@ export default function(babel) {
         customHooksInScope.push(callee);
       } else {
         // We don't have anything to put in the array because Hook is out of scope.
-        // But we can still mark that it exists. This will cause remount on edits.
-        customHooksInScope.push(null);
+        // Since it could potentially have been edited, remount the component.
+        forceReset = true;
       }
     });
 
     const args = [node, t.stringLiteral(key)];
-    const forceReset = hasForceResetComment(scope.path);
     if (forceReset || customHooksInScope.length > 0) {
       args.push(t.booleanLiteral(forceReset));
     }

--- a/packages/react-fresh/src/ReactFreshRuntime.js
+++ b/packages/react-fresh/src/ReactFreshRuntime.js
@@ -55,6 +55,12 @@ function haveEqualSignatures(prevType, nextType) {
   }
 
   for (let i = 0; i < nextCustomHooks.length; i++) {
+    if (prevCustomHooks[i] === undefined || nextCustomHooks[i] === undefined) {
+      // We used a custom Hook, but it isn't in the scope of the signature.
+      // For example this would happen if you define a Hook inline in the component.
+      // This is an edge case, but we'll treat it as always different signature.
+      return false;
+    }
     if (!haveEqualSignatures(prevCustomHooks[i], nextCustomHooks[i])) {
       return false;
     }

--- a/packages/react-fresh/src/ReactFreshRuntime.js
+++ b/packages/react-fresh/src/ReactFreshRuntime.js
@@ -59,12 +59,6 @@ function haveEqualSignatures(prevType, nextType) {
   }
 
   for (let i = 0; i < nextCustomHooks.length; i++) {
-    if (prevCustomHooks[i] === undefined || nextCustomHooks[i] === undefined) {
-      // We used a custom Hook, but it isn't in the scope of the signature.
-      // For example this would happen if you define a Hook inline in the component.
-      // This is an edge case, but we'll treat it as always different signature.
-      return false;
-    }
     if (!haveEqualSignatures(prevCustomHooks[i], nextCustomHooks[i])) {
       return false;
     }

--- a/packages/react-fresh/src/ReactFreshRuntime.js
+++ b/packages/react-fresh/src/ReactFreshRuntime.js
@@ -63,6 +63,20 @@ function haveEqualSignatures(prevType, nextType) {
   return true;
 }
 
+function isReactClass(type) {
+  return type.prototype && type.prototype.isReactComponent;
+}
+
+function areCompatible(prevType, nextType) {
+  if (isReactClass(prevType) || isReactClass(nextType)) {
+    return false;
+  }
+  if (haveEqualSignatures(prevType, nextType)) {
+    return true;
+  }
+  return false;
+}
+
 export function prepareUpdate(): HotUpdate {
   const staleFamilies = new Set();
   const updatedFamilies = new Set();
@@ -78,7 +92,7 @@ export function prepareUpdate(): HotUpdate {
     family.current = nextType;
 
     // Determine whether this should be a re-render or a re-mount.
-    if (haveEqualSignatures(prevType, nextType)) {
+    if (areCompatible(prevType, nextType)) {
       updatedFamilies.add(family);
     } else {
       staleFamilies.add(family);

--- a/packages/react-fresh/src/ReactFreshRuntime.js
+++ b/packages/react-fresh/src/ReactFreshRuntime.js
@@ -73,7 +73,7 @@ function isReactClass(type) {
   return type.prototype && type.prototype.isReactComponent;
 }
 
-function areCompatible(prevType, nextType) {
+function canPreserveStateBetween(prevType, nextType) {
   if (isReactClass(prevType) || isReactClass(nextType)) {
     return false;
   }
@@ -98,7 +98,7 @@ export function prepareUpdate(): HotUpdate {
     family.current = nextType;
 
     // Determine whether this should be a re-render or a re-mount.
-    if (areCompatible(prevType, nextType)) {
+    if (canPreserveStateBetween(prevType, nextType)) {
       updatedFamilies.add(family);
     } else {
       staleFamilies.add(family);

--- a/packages/react-fresh/src/ReactFreshRuntime.js
+++ b/packages/react-fresh/src/ReactFreshRuntime.js
@@ -87,6 +87,10 @@ function canPreserveStateBetween(prevType, nextType) {
   return false;
 }
 
+function resolveFamily(type) {
+  return familiesByType.get(type);
+}
+
 export function prepareUpdate(): HotUpdate {
   const staleFamilies = new Set();
   const updatedFamilies = new Set();
@@ -110,7 +114,7 @@ export function prepareUpdate(): HotUpdate {
   });
 
   return {
-    familiesByType,
+    resolveFamily,
     updatedFamilies,
     staleFamilies,
   };

--- a/packages/react-fresh/src/ReactFreshRuntime.js
+++ b/packages/react-fresh/src/ReactFreshRuntime.js
@@ -16,6 +16,7 @@ import {REACT_MEMO_TYPE, REACT_FORWARD_REF_TYPE} from 'shared/ReactSymbols';
 
 type Signature = {|
   key: string,
+  forceReset: boolean,
   getCustomHooks: () => Array<Function>,
 |};
 
@@ -43,6 +44,9 @@ function haveEqualSignatures(prevType, nextType) {
     return false;
   }
   if (prevSignature.key !== nextSignature.key) {
+    return false;
+  }
+  if (nextSignature.forceReset) {
     return false;
   }
 
@@ -155,10 +159,12 @@ export function register(type: any, id: string): void {
 export function setSignature(
   type: any,
   key: string,
+  forceReset?: boolean = false,
   getCustomHooks?: () => Array<Function>,
 ): void {
   allSignaturesByType.set(type, {
     key,
+    forceReset,
     getCustomHooks: getCustomHooks || (() => []),
   });
 }

--- a/packages/react-fresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFresh-test.js
@@ -2709,4 +2709,229 @@ describe('ReactFresh', () => {
       expect(helloNode.textContent).toBe('Nice.');
     }
   });
+
+  it('remounts classes on every edit', () => {
+    if (__DEV__) {
+      let HelloV1 = render(() => {
+        class Hello extends React.Component {
+          state = {count: 0};
+          handleClick = () => {
+            this.setState(prev => ({
+              count: prev.count + 1,
+            }));
+          };
+          render() {
+            return (
+              <p style={{color: 'blue'}} onClick={this.handleClick}>
+                {this.state.count}
+              </p>
+            );
+          }
+        }
+        // For classes, we wouldn't do this call via Babel plugin.
+        // Instead, we'd do it at module boundaries.
+        // Normally classes would get a different type and remount anyway,
+        // but at module boundaries we may want to prevent propagation.
+        // However we still want to force a remount and use latest version.
+        __register__(Hello, 'Hello');
+        return Hello;
+      });
+
+      // Bump the state before patching.
+      const el = container.firstChild;
+      expect(el.textContent).toBe('0');
+      expect(el.style.color).toBe('blue');
+      act(() => {
+        el.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+      });
+      expect(el.textContent).toBe('1');
+
+      // Perform a hot update.
+      let HelloV2 = patch(() => {
+        class Hello extends React.Component {
+          state = {count: 0};
+          handleClick = () => {
+            this.setState(prev => ({
+              count: prev.count + 1,
+            }));
+          };
+          render() {
+            return (
+              <p style={{color: 'red'}} onClick={this.handleClick}>
+                {this.state.count}
+              </p>
+            );
+          }
+        }
+        __register__(Hello, 'Hello');
+        return Hello;
+      });
+
+      // It should have remounted the class.
+      expect(container.firstChild).not.toBe(el);
+      const newEl = container.firstChild;
+      expect(newEl.textContent).toBe('0');
+      expect(newEl.style.color).toBe('red');
+      act(() => {
+        newEl.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+      });
+      expect(newEl.textContent).toBe('1');
+
+      // Now top-level renders of both types resolve to latest.
+      render(() => HelloV1);
+      render(() => HelloV2);
+      expect(container.firstChild).toBe(newEl);
+      expect(newEl.style.color).toBe('red');
+      expect(newEl.textContent).toBe('1');
+
+      let HelloV3 = patch(() => {
+        class Hello extends React.Component {
+          state = {count: 0};
+          handleClick = () => {
+            this.setState(prev => ({
+              count: prev.count + 1,
+            }));
+          };
+          render() {
+            return (
+              <p style={{color: 'orange'}} onClick={this.handleClick}>
+                {this.state.count}
+              </p>
+            );
+          }
+        }
+        __register__(Hello, 'Hello');
+        return Hello;
+      });
+
+      // It should have remounted the class again.
+      expect(container.firstChild).not.toBe(el);
+      const finalEl = container.firstChild;
+      expect(finalEl.textContent).toBe('0');
+      expect(finalEl.style.color).toBe('orange');
+      act(() => {
+        finalEl.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+      });
+      expect(finalEl.textContent).toBe('1');
+
+      render(() => HelloV3);
+      render(() => HelloV2);
+      render(() => HelloV1);
+      expect(container.firstChild).toBe(finalEl);
+      expect(finalEl.style.color).toBe('orange');
+      expect(finalEl.textContent).toBe('1');
+    }
+  });
+
+  it('remounts on conversion from class to function and back', () => {
+    if (__DEV__) {
+      let HelloV1 = render(() => {
+        function Hello() {
+          const [val, setVal] = React.useState(0);
+          return (
+            <p style={{color: 'blue'}} onClick={() => setVal(val + 1)}>
+              {val}
+            </p>
+          );
+        }
+        __register__(Hello, 'Hello');
+        return Hello;
+      });
+
+      // Bump the state before patching.
+      const el = container.firstChild;
+      expect(el.textContent).toBe('0');
+      expect(el.style.color).toBe('blue');
+      act(() => {
+        el.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+      });
+      expect(el.textContent).toBe('1');
+
+      // Perform a hot update that turns it into a class.
+      let HelloV2 = patch(() => {
+        class Hello extends React.Component {
+          state = {count: 0};
+          handleClick = () => {
+            this.setState(prev => ({
+              count: prev.count + 1,
+            }));
+          };
+          render() {
+            return (
+              <p style={{color: 'red'}} onClick={this.handleClick}>
+                {this.state.count}
+              </p>
+            );
+          }
+        }
+        __register__(Hello, 'Hello');
+        return Hello;
+      });
+
+      // It should have remounted.
+      expect(container.firstChild).not.toBe(el);
+      const newEl = container.firstChild;
+      expect(newEl.textContent).toBe('0');
+      expect(newEl.style.color).toBe('red');
+      act(() => {
+        newEl.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+      });
+      expect(newEl.textContent).toBe('1');
+
+      // Now top-level renders of both types resolve to latest.
+      render(() => HelloV1);
+      render(() => HelloV2);
+      expect(container.firstChild).toBe(newEl);
+      expect(newEl.style.color).toBe('red');
+      expect(newEl.textContent).toBe('1');
+
+      // Now convert it back to a function.
+      let HelloV3 = patch(() => {
+        function Hello() {
+          const [val, setVal] = React.useState(0);
+          return (
+            <p style={{color: 'orange'}} onClick={() => setVal(val + 1)}>
+              {val}
+            </p>
+          );
+        }
+        __register__(Hello, 'Hello');
+        return Hello;
+      });
+
+      // It should have remounted again.
+      expect(container.firstChild).not.toBe(el);
+      const finalEl = container.firstChild;
+      expect(finalEl.textContent).toBe('0');
+      expect(finalEl.style.color).toBe('orange');
+      act(() => {
+        finalEl.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+      });
+      expect(finalEl.textContent).toBe('1');
+
+      render(() => HelloV3);
+      render(() => HelloV2);
+      render(() => HelloV1);
+      expect(container.firstChild).toBe(finalEl);
+      expect(finalEl.style.color).toBe('orange');
+      expect(finalEl.textContent).toBe('1');
+
+      // Now that it's a function, verify edits keep state.
+      patch(() => {
+        function Hello() {
+          const [val, setVal] = React.useState(0);
+          return (
+            <p style={{color: 'purple'}} onClick={() => setVal(val + 1)}>
+              {val}
+            </p>
+          );
+        }
+        __register__(Hello, 'Hello');
+        return Hello;
+      });
+      expect(container.firstChild).toBe(finalEl);
+      expect(finalEl.style.color).toBe('purple');
+      expect(finalEl.textContent).toBe('1');
+    }
+  });
 });

--- a/packages/react-fresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFresh-test.js
@@ -72,8 +72,8 @@ describe('ReactFresh', () => {
     ReactFreshRuntime.register(type, id);
   }
 
-  function __signature__(type, key, getCustomHooks) {
-    ReactFreshRuntime.setSignature(type, key, getCustomHooks);
+  function __signature__(type, key, forceReset, getCustomHooks) {
+    ReactFreshRuntime.setSignature(type, key, forceReset, getCustomHooks);
     return type;
   }
 

--- a/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -386,4 +386,25 @@ describe('ReactFreshBabelPlugin', () => {
     `),
     ).toMatchSnapshot();
   });
+
+  it('generates valid signature for exotic ways to call Hooks', () => {
+    expect(
+      transform(`
+        import FancyHook from 'fancy';
+
+        export default function App() {
+          function useFancyState() {
+            const [foo, setFoo] = React.useState(0);
+            useFancyEffect();
+            return foo;
+          }
+          const bar = useFancyState();
+          const baz = FancyHook.useThing();
+          React.useState();
+          useThePlatform();
+          return <h1>{bar}{baz}</h1>;
+        }
+    `),
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -85,8 +85,8 @@ describe('ReactFreshIntegration', () => {
     ReactFreshRuntime.register(type, id);
   }
 
-  function __signature__(type, key, getCustomHooks) {
-    ReactFreshRuntime.setSignature(type, key, getCustomHooks);
+  function __signature__(type, key, forceReset, getCustomHooks) {
+    ReactFreshRuntime.setSignature(type, key, forceReset, getCustomHooks);
     return type;
   }
 
@@ -732,6 +732,105 @@ describe('ReactFreshIntegration', () => {
         export default Parent;
       `);
       expect(container.textContent).toBe('Parent Child useMyThing');
+    }
+  });
+
+  it('resets state on every edit with @hot reset annotation', () => {
+    if (__DEV__) {
+      render(`
+        const {useState} = React;
+
+        export default function App() {
+          const [foo, setFoo] = useState(1);
+          return <h1>A{foo}</h1>;
+        }
+      `);
+      let el = container.firstChild;
+      expect(el.textContent).toBe('A1');
+
+      patch(`
+        const {useState} = React;
+
+        export default function App() {
+          const [foo, setFoo] = useState('ignored');
+          return <h1>B{foo}</h1>;
+        }
+      `);
+      // Same state variable name, so state is preserved.
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('B1');
+
+      patch(`
+        const {useState} = React;
+
+        /* @hot reset */
+
+        export default function App() {
+          const [bar, setBar] = useState(2);
+          return <h1>C{bar}</h1>;
+        }
+      `);
+      // Found remount annotation, so state is reset.
+      expect(container.firstChild).not.toBe(el);
+      el = container.firstChild;
+      expect(el.textContent).toBe('C2');
+
+      patch(`
+        const {useState} = React;
+
+        export default function App() {
+
+          // @hot reset
+
+          const [bar, setBar] = useState(3);
+          return <h1>D{bar}</h1>;
+        }
+      `);
+      // Found remount annotation, so state is reset.
+      expect(container.firstChild).not.toBe(el);
+      el = container.firstChild;
+      expect(el.textContent).toBe('D3');
+
+      patch(`
+        const {useState} = React;
+
+        export default function App() {
+          const [bar, setBar] = useState(4);
+          return <h1>E{bar}</h1>;
+        }
+      `);
+      // There is no remount annotation anymore,
+      // so preserve the previous state.
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('E3');
+
+      patch(`
+        const {useState} = React;
+
+        export default function App() {
+          const [bar, setBar] = useState(4);
+          return <h1>F{bar}</h1>;
+        }
+      `);
+      // Continue editing.
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('F3');
+
+      patch(`
+        const {useState} = React;
+
+        export default function App() {
+
+          /* @hot reset */
+
+          const [bar, setBar] = useState(5);
+          return <h1>G{bar}</h1>;
+        }
+      `);
+      // Force remount one last time.
+      expect(container.firstChild).not.toBe(el);
+      el = container.firstChild;
+      expect(el.textContent).toBe('G5');
     }
   });
 });

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -67,7 +67,7 @@ export default function App() {
     return foo;
   }
 
-  __signature__(useFancyState, 'useState{[foo, setFoo]}\\nuseFancyEffect{}', false, () => [,]);
+  __signature__(useFancyState, 'useState{[foo, setFoo]}\\nuseFancyEffect{}', true);
 
   const bar = useFancyState();
   const baz = FancyHook.useThing();
@@ -76,7 +76,7 @@ export default function App() {
   return <h1>{bar}{baz}</h1>;
 }
 
-__signature__(App, 'useFancyState{bar}\\nuseThing{baz}\\nuseState{}\\nuseThePlatform{}', false, () => [, FancyHook.useThing,,]);
+__signature__(App, 'useFancyState{bar}\\nuseThing{baz}\\nuseState{}\\nuseThePlatform{}', true, () => [FancyHook.useThing]);
 
 _c = App;
 

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -67,7 +67,7 @@ export default function App() {
     return foo;
   }
 
-  __signature__(useFancyState, 'useState{[foo, setFoo]}\\nuseFancyEffect{}', () => [,]);
+  __signature__(useFancyState, 'useState{[foo, setFoo]}\\nuseFancyEffect{}', false, () => [,]);
 
   const bar = useFancyState();
   const baz = FancyHook.useThing();
@@ -76,7 +76,7 @@ export default function App() {
   return <h1>{bar}{baz}</h1>;
 }
 
-__signature__(App, 'useFancyState{bar}\\nuseThing{baz}\\nuseState{}\\nuseThePlatform{}', () => [, FancyHook.useThing,,]);
+__signature__(App, 'useFancyState{bar}\\nuseThing{baz}\\nuseState{}\\nuseThePlatform{}', false, () => [, FancyHook.useThing,,]);
 
 _c = App;
 
@@ -144,7 +144,7 @@ function useFancyState() {
   return foo;
 }
 
-__signature__(useFancyState, "useState{[foo, setFoo]}\\nuseFancyEffect{}", () => [useFancyEffect]);
+__signature__(useFancyState, "useState{[foo, setFoo]}\\nuseFancyEffect{}", false, () => [useFancyEffect]);
 
 const useFancyEffect = () => {
   React.useEffect(() => {});
@@ -157,7 +157,7 @@ export default function App() {
   return <h1>{bar}</h1>;
 }
 
-__signature__(App, "useFancyState{bar}", () => [useFancyState]);
+__signature__(App, "useFancyState{bar}", false, () => [useFancyState]);
 
 _c = App;
 

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -56,6 +56,35 @@ __register__(_c5, "B$React.memo");
 __register__(_c6, "B");
 `;
 
+exports[`ReactFreshBabelPlugin generates valid signature for exotic ways to call Hooks 1`] = `
+
+import FancyHook from 'fancy';
+
+export default function App() {
+  function useFancyState() {
+    const [foo, setFoo] = React.useState(0);
+    useFancyEffect();
+    return foo;
+  }
+
+  __signature__(useFancyState, 'useState{[foo, setFoo]}\\nuseFancyEffect{}', () => [,]);
+
+  const bar = useFancyState();
+  const baz = FancyHook.useThing();
+  React.useState();
+  useThePlatform();
+  return <h1>{bar}{baz}</h1>;
+}
+
+__signature__(App, 'useFancyState{bar}\\nuseThing{baz}\\nuseState{}\\nuseThePlatform{}', () => [, FancyHook.useThing,,]);
+
+_c = App;
+
+var _c;
+
+__register__(_c, 'App');
+`;
+
 exports[`ReactFreshBabelPlugin ignores HOC definitions 1`] = `
 
 let connect = () => {

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -54,6 +54,7 @@ import getComponentName from 'shared/getComponentName';
 
 import {isDevToolsPresent} from './ReactFiberDevToolsHook';
 import {
+  resolveClassForHotReloading,
   resolveFunctionForHotReloading,
   resolveForwardRefForHotReloading,
 } from './ReactFiberHotReloading';
@@ -449,6 +450,9 @@ export function createWorkInProgress(
       case SimpleMemoComponent:
         workInProgress.type = resolveFunctionForHotReloading(current.type);
         break;
+      case ClassComponent:
+        workInProgress.type = resolveClassForHotReloading(current.type);
+        break;
       case ForwardRef:
         workInProgress.type = resolveForwardRefForHotReloading(current.type);
         break;
@@ -496,6 +500,9 @@ export function createFiberFromTypeAndProps(
   if (typeof type === 'function') {
     if (shouldConstruct(type)) {
       fiberTag = ClassComponent;
+      if (__DEV__) {
+        resolvedType = resolveClassForHotReloading(resolvedType);
+      }
     } else {
       if (__DEV__) {
         resolvedType = resolveFunctionForHotReloading(resolvedType);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -73,6 +73,7 @@ import {
 import {startWorkTimer, cancelWorkTimer} from './ReactDebugFiberPerf';
 import {
   resolveFunctionForHotReloading,
+  resolveForwardRefForHotReloading,
   resolveClassForHotReloading,
 } from './ReactFiberHotReloading';
 
@@ -1073,7 +1074,7 @@ function mountLazyComponent(
     }
     case ForwardRef: {
       if (__DEV__) {
-        workInProgress.type = Component = resolveFunctionForHotReloading(
+        workInProgress.type = Component = resolveForwardRefForHotReloading(
           Component,
         );
       }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -71,7 +71,10 @@ import {
   getCurrentFiberStackInDev,
 } from './ReactCurrentFiber';
 import {startWorkTimer, cancelWorkTimer} from './ReactDebugFiberPerf';
-import {resolveFunctionForHotReloading} from './ReactFiberHotReloading';
+import {
+  resolveFunctionForHotReloading,
+  resolveClassForHotReloading,
+} from './ReactFiberHotReloading';
 
 import {
   mountChildFibers,
@@ -1054,6 +1057,11 @@ function mountLazyComponent(
       break;
     }
     case ClassComponent: {
+      if (__DEV__) {
+        workInProgress.type = Component = resolveClassForHotReloading(
+          Component,
+        );
+      }
       child = updateClassComponent(
         null,
         workInProgress,

--- a/packages/react-reconciler/src/ReactFiberHotReloading.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.js
@@ -35,22 +35,22 @@ export type Family = {|
 |};
 
 export type HotUpdate = {|
-  familiesByType: WeakMap<any, Family>,
+  resolveFamily: (any => Family | void) | null,
   staleFamilies: Set<Family>,
   updatedFamilies: Set<Family>,
 |};
 
-let familiesByType: WeakMap<any, Family> | null = null;
+let resolveFamily: (any => Family | void) | null = null;
 // $FlowFixMe Flow gets confused by a WeakSet feature check below.
 let failedBoundaries: WeakSet<Fiber> | null = null;
 
 export function resolveFunctionForHotReloading(type: any): any {
   if (__DEV__) {
-    if (familiesByType === null) {
+    if (resolveFamily === null) {
       // Hot reloading is disabled.
       return type;
     }
-    let family = familiesByType.get(type);
+    let family = resolveFamily(type);
     if (family === undefined) {
       return type;
     }
@@ -68,11 +68,11 @@ export function resolveClassForHotReloading(type: any): any {
 
 export function resolveForwardRefForHotReloading(type: any): any {
   if (__DEV__) {
-    if (familiesByType === null) {
+    if (resolveFamily === null) {
       // Hot reloading is disabled.
       return type;
     }
-    let family = familiesByType.get(type);
+    let family = resolveFamily(type);
     if (family === undefined) {
       // Check if we're dealing with a real forwardRef. Don't want to crash early.
       if (
@@ -109,7 +109,7 @@ export function isCompatibleFamilyForHotReloading(
   element: ReactElement,
 ): boolean {
   if (__DEV__) {
-    if (familiesByType === null) {
+    if (resolveFamily === null) {
       // Hot reloading is disabled.
       return false;
     }
@@ -174,11 +174,8 @@ export function isCompatibleFamilyForHotReloading(
       // If we unwrapped and compared the inner types for wrappers instead,
       // then we would risk falsely saying two separate memo(Foo)
       // calls are equivalent because they wrap the same Foo function.
-      const prevFamily = familiesByType.get(prevType);
-      if (
-        prevFamily !== undefined &&
-        prevFamily === familiesByType.get(nextType)
-      ) {
+      const prevFamily = resolveFamily(prevType);
+      if (prevFamily !== undefined && prevFamily === resolveFamily(nextType)) {
         return true;
       }
     }
@@ -190,7 +187,7 @@ export function isCompatibleFamilyForHotReloading(
 
 export function markFailedErrorBoundaryForHotReloading(fiber: Fiber) {
   if (__DEV__) {
-    if (familiesByType === null) {
+    if (resolveFamily === null) {
       // Not hot reloading.
       return;
     }
@@ -207,7 +204,7 @@ export function markFailedErrorBoundaryForHotReloading(fiber: Fiber) {
 export function scheduleHotUpdate(root: FiberRoot, hotUpdate: HotUpdate): void {
   if (__DEV__) {
     // TODO: warn if its identity changes over time?
-    familiesByType = hotUpdate.familiesByType;
+    resolveFamily = hotUpdate.resolveFamily;
 
     const {staleFamilies, updatedFamilies} = hotUpdate;
     flushPassiveEffects();
@@ -243,14 +240,14 @@ function scheduleFibersWithFamiliesRecursively(
         break;
     }
 
-    if (familiesByType === null) {
-      throw new Error('Expected familiesByType to be set during hot reload.');
+    if (resolveFamily === null) {
+      throw new Error('Expected resolveFamily to be set during hot reload.');
     }
 
     let needsRender = false;
     let needsRemount = false;
     if (candidateType !== null) {
-      const family = familiesByType.get(candidateType);
+      const family = resolveFamily(candidateType);
       if (family !== undefined) {
         if (staleFamilies.has(family)) {
           needsRemount = true;

--- a/packages/react-reconciler/src/ReactFiberHotReloading.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.js
@@ -18,6 +18,7 @@ import {
 } from './ReactFiberWorkLoop';
 import {Sync} from './ReactFiberExpirationTime';
 import {
+  ClassComponent,
   FunctionComponent,
   ForwardRef,
   MemoComponent,
@@ -58,6 +59,11 @@ export function resolveFunctionForHotReloading(type: any): any {
   } else {
     return type;
   }
+}
+
+export function resolveClassForHotReloading(type: any): any {
+  // No implementation differences.
+  return resolveFunctionForHotReloading(type);
 }
 
 export function resolveForwardRefForHotReloading(type: any): any {
@@ -120,6 +126,12 @@ export function isCompatibleFamilyForHotReloading(
         : null;
 
     switch (fiber.tag) {
+      case ClassComponent: {
+        if (typeof nextType === 'function') {
+          needsCompareFamilies = true;
+        }
+        break;
+      }
       case FunctionComponent: {
         if (typeof nextType === 'function') {
           needsCompareFamilies = true;
@@ -221,6 +233,7 @@ function scheduleFibersWithFamiliesRecursively(
     switch (tag) {
       case FunctionComponent:
       case SimpleMemoComponent:
+      case ClassComponent:
         candidateType = type;
         break;
       case ForwardRef:


### PR DESCRIPTION
The first commit adds support for classes.

We don't need state preservation for classes. But we do need the opposite. When you edit a class, we want to remount its instances (and reset their state).

Remounting seems like it should already work. Because the type changes, and React is doing its thing. However, there is a case where that's not enough. If I edit `Button.js` that happens to be a class, other modules won't "see" the new export unless the update "propagates upwards". So if `Modal.js` imports it, we'd have to re-execute `Modal.js` too. But that might also be a class. So we lose the locality of the edit — and in some cases it's even unsafe to re-execute arbitrary code above. (E.g. that breaks React Native once you get too close to top-level modules.) Inline requires or ES live imports sort of solve that, but not in all cases. Such as a cached element in state that already has a specific type. 

To solve that, we can stop update propagation at modules where all exports look like React components. (Functions or classes.) In case of classes, we want to remount all instances — and mount new versions. This should happen even for stale `<OldButton />` references in the tree. That's why I added the resolving mechanism to classes too. However, they would never attempt to preserve state.
