### PR TITLE
[React Native] Remove eventTypes from ReactNativeBridgeEventPlugin

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
+++ b/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
@@ -22,11 +22,10 @@ import {ReactNativeViewConfigRegistry} from 'react-native/Libraries/ReactPrivate
 const {
   customBubblingEventTypes,
   customDirectEventTypes,
-  eventTypes,
 } = ReactNativeViewConfigRegistry;
 
 const ReactNativeBridgeEventPlugin = {
-  eventTypes: eventTypes,
+  eventTypes: {},
 
   /**
    * @see {EventPluginHub.extractEvents}

--- a/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
+++ b/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
@@ -22,11 +22,9 @@ const invariant = require('invariant');
 // Event configs
 const customBubblingEventTypes = {};
 const customDirectEventTypes = {};
-const eventTypes = {};
 
 exports.customBubblingEventTypes = customBubblingEventTypes;
 exports.customDirectEventTypes = customDirectEventTypes;
-exports.eventTypes = eventTypes;
 
 const viewConfigCallbacks = new Map();
 const viewConfigs = new Map();
@@ -51,7 +49,7 @@ function processEventTypes(
   if (bubblingEventTypes != null) {
     for (const topLevelType in bubblingEventTypes) {
       if (customBubblingEventTypes[topLevelType] == null) {
-        eventTypes[topLevelType] = customBubblingEventTypes[topLevelType] =
+        customBubblingEventTypes[topLevelType] =
           bubblingEventTypes[topLevelType];
       }
     }
@@ -60,8 +58,7 @@ function processEventTypes(
   if (directEventTypes != null) {
     for (const topLevelType in directEventTypes) {
       if (customDirectEventTypes[topLevelType] == null) {
-        eventTypes[topLevelType] = customDirectEventTypes[topLevelType] =
-          directEventTypes[topLevelType];
+        customDirectEventTypes[topLevelType] = directEventTypes[topLevelType];
       }
     }
   }


### PR DESCRIPTION
## Overview
This PR fixes an issue with switching between paper and fabric in React Native.

## Explanation
On first initialization of React Native, `ReactNativeBridgeEventPlugin.eventTypes` is empty because view configs are lazily loaded. This means that the `EventPluginRegistry` does not run checks on events, and does not error when registering [here](https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/events/EventPluginRegistry.js#L134-L139).

If there is a second initialization (e.g. loading the fabric bundle after the paper bundle), then the `eventTypes` may be populated with host component events from view configs loaded at runtime.

This means that the `EventPluginRegistry` can error when registering the plugin if there are colliding registration names, even though these events were already in use.

This change allows the EventPluginRegistry to perform the same on initial load between all of the bundles by forcing the eventTypes to an empty object.

## Justification
From the [EventPluginHub doc comments](https://fburl.com/ctr48aew), eventTypes are optional:

```
`eventTypes` {object}
      Optional, plugins that fire events must publish a mapping of registration
      names that are used to register listeners. Values of this mapping must
      be objects that contain `registrationName` or `phasedRegistrationNames`.
```

For ReactNative, we register our own top level listeners in our native host components so there is no need to register them in the EventPluginHub.

## Testing

See https://fburl.com/diff/5l6zql59 for test plan.
