### PR TITLE
Updated release script to be Workflow aware

### DIFF
--- a/scripts/release/prepare-canary-commands/download-build-artifacts.js
+++ b/scripts/release/prepare-canary-commands/download-build-artifacts.js
@@ -16,9 +16,22 @@ const run = async ({build, cwd}) => {
     process.env.CIRCLE_CI_API_TOKEN
   }`;
   const metadata = await http.get(metadataURL, true);
-  const nodeModulesURL = metadata.find(
+  const nodeModulesArtifact = metadata.find(
     entry => entry.path === 'home/circleci/project/node_modules.tgz'
-  ).url;
+  );
+
+  if (!nodeModulesArtifact) {
+    console.log(
+      theme`{error The specified build number does not contain any build artifacts}\n\n` +
+        'To get the correct build number from Circle CI, open the following URL:\n' +
+        theme`{link https://circleci.com/gh/facebook/react/${build}}\n\n` +
+        'Select the "commit" Workflow at the top of the page, then select the "process_artifacts" job.'
+    );
+
+    process.exit(1);
+  }
+
+  const nodeModulesURL = nodeModulesArtifact.url;
 
   if (!existsSync(join(cwd, 'build'))) {
     await exec(`mkdir ./build`, {cwd});

--- a/scripts/release/prepare-canary-commands/get-latest-master-build-number.js
+++ b/scripts/release/prepare-canary-commands/get-latest-master-build-number.js
@@ -10,7 +10,10 @@ const run = async () => {
   const metadataURL = `https://circleci.com/api/v1.1/project/github/facebook/react/tree/master`;
   const metadata = await http.get(metadataURL, true);
   const build = metadata.find(
-    entry => entry.branch === 'master' && entry.status === 'success'
+    entry =>
+      entry.branch === 'master' &&
+      entry.status === 'success' &&
+      entry.workflows.job_name === 'process_artifacts'
   ).build_num;
 
   return build;


### PR DESCRIPTION
Looks like the API is missing some workflow features for now (see [this thread](https://twitter.com/drazisil/status/1135647277647892480)).

So I've updated the build script as best I can to find the correct build number. If you specify the incorrect one, it prints instructions on how to get the right one using the UI:

![Screen Shot 2019-06-03 at 1 50 54 PM](https://user-images.githubusercontent.com/29597/58833907-f03d8480-8606-11e9-8b01-22b646d3daeb.png)

I was able to publish a new canary (0.0.0-[fa1e8df11](https://github.com/facebook/react/commit/fa1e8df11)) after making these changes.