### PR TITLE
[Events] Add support for events that are both user-blocking and continuous

### DIFF
--- a/packages/events/ReactSyntheticEventType.js
+++ b/packages/events/ReactSyntheticEventType.js
@@ -11,6 +11,12 @@
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {TopLevelType} from './TopLevelEventTypes';
 
+export opaque type EventPriority = 0 | 1 | 2;
+
+export const DiscreteEvent: EventPriority = 0;
+export const UserBlockingEvent: EventPriority = 1;
+export const ContinuousEvent: EventPriority = 2;
+
 export type DispatchConfig = {
   dependencies: Array<TopLevelType>,
   phasedRegistrationNames?: {
@@ -18,7 +24,7 @@ export type DispatchConfig = {
     captured: string,
   },
   registrationName?: string,
-  isDiscrete?: boolean,
+  eventPriority: EventPriority,
 };
 
 export type ReactSyntheticEvent = {

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -11,6 +11,10 @@ import type {AnyNativeEvent} from 'events/PluginModuleType';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
 
+// Intentionally not named imports because Rollup would use dynamic dispatch for
+// CommonJS interop named imports.
+import * as Scheduler from 'scheduler';
+
 import {
   batchedEventUpdates,
   discreteUpdates,
@@ -41,8 +45,18 @@ import {getRawEventName} from './DOMTopLevelEventTypes';
 import {passiveBrowserEventsSupported} from './checkPassiveEvents';
 
 import {enableEventAPI} from 'shared/ReactFeatureFlags';
+import {
+  UserBlockingEvent,
+  ContinuousEvent,
+  DiscreteEvent,
+} from 'events/ReactSyntheticEventType';
 
-const {isDiscreteTopLevelEventType} = SimpleEventPlugin;
+const {
+  unstable_UserBlockingPriority: UserBlockingPriority,
+  unstable_runWithPriority: runWithPriority,
+} = Scheduler;
+
+const {getEventPriority} = SimpleEventPlugin;
 
 const CALLBACK_BOOKKEEPING_POOL_SIZE = 10;
 const callbackBookkeepingPool = [];
@@ -212,12 +226,29 @@ function trapEventForPluginEventSystem(
   topLevelType: DOMTopLevelEventType,
   capture: boolean,
 ): void {
-  const dispatch = isDiscreteTopLevelEventType(topLevelType)
-    ? dispatchDiscreteEvent
-    : dispatchEvent;
+  let listener;
+  switch (getEventPriority(topLevelType)) {
+    case DiscreteEvent:
+      listener = dispatchDiscreteEvent.bind(
+        null,
+        topLevelType,
+        PLUGIN_EVENT_SYSTEM,
+      );
+      break;
+    case UserBlockingEvent:
+      listener = dispatchUserBlockingUpdate.bind(
+        null,
+        topLevelType,
+        PLUGIN_EVENT_SYSTEM,
+      );
+      break;
+    case ContinuousEvent:
+    default:
+      listener = dispatchEvent.bind(null, topLevelType, PLUGIN_EVENT_SYSTEM);
+      break;
+  }
+
   const rawEventName = getRawEventName(topLevelType);
-  // Check if discrete and wrap in discreteUpdates
-  const listener = dispatch.bind(null, topLevelType, PLUGIN_EVENT_SYSTEM);
   if (capture) {
     addEventCaptureListener(element, rawEventName, listener);
   } else {
@@ -228,6 +259,22 @@ function trapEventForPluginEventSystem(
 function dispatchDiscreteEvent(topLevelType, eventSystemFlags, nativeEvent) {
   flushDiscreteUpdatesIfNeeded(nativeEvent.timeStamp);
   discreteUpdates(dispatchEvent, topLevelType, eventSystemFlags, nativeEvent);
+}
+
+function dispatchUserBlockingUpdate(
+  topLevelType,
+  eventSystemFlags,
+  nativeEvent,
+) {
+  // TODO: Replace with feature flag
+  if (false) {
+    runWithPriority(
+      UserBlockingPriority,
+      dispatchEvent.bind(null, topLevelType, eventSystemFlags, nativeEvent),
+    );
+  } else {
+    dispatchEvent(topLevelType, eventSystemFlags, nativeEvent);
+  }
 }
 
 function dispatchEventForPluginEventSystem(

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -44,7 +44,10 @@ import SimpleEventPlugin from './SimpleEventPlugin';
 import {getRawEventName} from './DOMTopLevelEventTypes';
 import {passiveBrowserEventsSupported} from './checkPassiveEvents';
 
-import {enableEventAPI} from 'shared/ReactFeatureFlags';
+import {
+  enableEventAPI,
+  enableUserBlockingEvents,
+} from 'shared/ReactFeatureFlags';
 import {
   UserBlockingEvent,
   ContinuousEvent,
@@ -266,8 +269,7 @@ function dispatchUserBlockingUpdate(
   eventSystemFlags,
   nativeEvent,
 ) {
-  // TODO: Replace with feature flag
-  if (false) {
+  if (enableUserBlockingEvents) {
     runWithPriority(
       UserBlockingPriority,
       dispatchEvent.bind(null, topLevelType, eventSystemFlags, nativeEvent),

--- a/packages/react-dom/src/events/__tests__/ChangeEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/ChangeEventPlugin-test.internal.js
@@ -11,6 +11,7 @@
 
 let React = require('react');
 let ReactDOM = require('react-dom');
+let TestUtils = require('react-dom/test-utils');
 let ReactFeatureFlags;
 let Scheduler;
 
@@ -486,6 +487,7 @@ describe('ChangeEventPlugin', () => {
       ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
       React = require('react');
       ReactDOM = require('react-dom');
+      TestUtils = require('react-dom/test-utils');
       Scheduler = require('scheduler');
     });
 

--- a/packages/react-dom/src/events/__tests__/ChangeEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/ChangeEventPlugin-test.internal.js
@@ -752,5 +752,49 @@ describe('ChangeEventPlugin', () => {
       expect(ops).toEqual(['render: ']);
       expect(input.value).toBe('');
     });
+
+    it('mouse enter/leave should be user-blocking but not discrete', async () => {
+      // This is currently behind a feature flag
+      jest.resetModules();
+      ReactFeatureFlags = require('shared/ReactFeatureFlags');
+      ReactFeatureFlags.enableUserBlockingEvents = true;
+      React = require('react');
+      ReactDOM = require('react-dom');
+      TestUtils = require('react-dom/test-utils');
+      Scheduler = require('scheduler');
+
+      const {act} = TestUtils;
+      const {useState} = React;
+
+      const root = ReactDOM.unstable_createRoot(container);
+
+      const target = React.createRef(null);
+      function Foo() {
+        const [isHover, setHover] = useState(false);
+        return (
+          <div
+            ref={target}
+            onMouseEnter={() => setHover(true)}
+            onMouseLeave={() => setHover(false)}>
+            {isHover ? 'hovered' : 'not hovered'}
+          </div>
+        );
+      }
+
+      await act(async () => {
+        root.render(<Foo />);
+      });
+      expect(container.textContent).toEqual('not hovered');
+
+      await act(async () => {
+        const mouseOverEvent = document.createEvent('MouseEvents');
+        mouseOverEvent.initEvent('mouseover', true, true);
+        target.current.dispatchEvent(mouseOverEvent);
+
+        // 3s should be enough to expire the updates
+        Scheduler.advanceTime(3000);
+        expect(container.textContent).toEqual('hovered');
+      });
+    });
   });
 });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -73,3 +73,8 @@ export const enableJSXTransformAPI = false;
 export const warnAboutMissingMockScheduler = false;
 // Temporary flag to revert the fix in #15650
 export const revertPassiveEffectsChange = false;
+
+// Changes priority of some events like mousemove to user-blocking priority,
+// but without making them discrete. The flag exists in case it causes
+// starvation problems.
+export const enableUserBlockingEvents = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -36,6 +36,7 @@ export const enableEventAPI = false;
 export const enableJSXTransformAPI = false;
 export const warnAboutMissingMockScheduler = true;
 export const revertPassiveEffectsChange = false;
+export const enableUserBlockingEvents = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -31,6 +31,7 @@ export const enableEventAPI = false;
 export const enableJSXTransformAPI = false;
 export const warnAboutMissingMockScheduler = false;
 export const revertPassiveEffectsChange = false;
+export const enableUserBlockingEvents = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -31,6 +31,7 @@ export const enableEventAPI = false;
 export const enableJSXTransformAPI = false;
 export const warnAboutMissingMockScheduler = true;
 export const revertPassiveEffectsChange = false;
+export const enableUserBlockingEvents = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -31,6 +31,7 @@ export const enableEventAPI = false;
 export const enableJSXTransformAPI = false;
 export const warnAboutMissingMockScheduler = false;
 export const revertPassiveEffectsChange = false;
+export const enableUserBlockingEvents = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -31,6 +31,7 @@ export const disableYielding = false;
 export const enableEventAPI = true;
 export const enableJSXTransformAPI = true;
 export const warnAboutMissingMockScheduler = true;
+export const enableUserBlockingEvents = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -21,6 +21,7 @@ export const {
   warnAboutShorthandPropertyCollision,
   warnAboutDeprecatedSetNativeProps,
   revertPassiveEffectsChange,
+  enableUserBlockingEvents,
 } = require('ReactFeatureFlags');
 
 // In www, we have experimental support for gathering data


### PR DESCRIPTION
Some events, like hover, are more important than the default, but they are not discrete (i.e. they don't need to be processed serially).

I've only implemented this in the legacy event system. I'll leave Flare for a follow-up.

Absent resuming, I'm also not sure if this will cause starvation problems, so I put it behind a feature flag.