### PR TITLE
allow nested `act()`s from different renderers

### DIFF
--- a/fixtures/dom/src/index.test.js
+++ b/fixtures/dom/src/index.test.js
@@ -14,7 +14,6 @@ import ARTSVGMode from 'art/modes/svg';
 import ARTCurrentMode from 'art/modes/current';
 import TestUtils from 'react-dom/test-utils';
 import TestRenderer from 'react-test-renderer';
-
 ARTCurrentMode.setCurrent(ARTSVGMode);
 
 global.__DEV__ = process.env.NODE_ENV !== 'production';
@@ -156,5 +155,13 @@ it('does not warn when nesting react-act inside react-dom', () => {
 it('does not warn when nesting react-act inside react-test-renderer', () => {
   TestRenderer.act(() => {
     TestRenderer.create(<ARTTest />);
+  });
+});
+
+it("doesn't warn if you use nested acts from different renderers", () => {
+  TestRenderer.act(() => {
+    TestUtils.act(() => {
+      TestRenderer.create(<App />);
+    });
   });
 });

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -86,17 +86,15 @@ let actingUpdatesScopeDepth = 0;
 
 function act(callback: () => Thenable) {
   let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
-  let previousActingUpdatesSigil;
   actingUpdatesScopeDepth++;
   if (__DEV__) {
-    previousActingUpdatesSigil = ReactCurrentActingRendererSigil.current;
-    ReactCurrentActingRendererSigil.current = ReactActingRendererSigil;
+    ReactCurrentActingRendererSigil.current.push(ReactActingRendererSigil);
   }
 
   function onDone() {
     actingUpdatesScopeDepth--;
     if (__DEV__) {
-      ReactCurrentActingRendererSigil.current = previousActingUpdatesSigil;
+      ReactCurrentActingRendererSigil.current.pop();
       if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
         // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
         warningWithoutStack(

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -615,17 +615,15 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
   function act(callback: () => Thenable) {
     let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
-    let previousActingUpdatesSigil;
     actingUpdatesScopeDepth++;
     if (__DEV__) {
-      previousActingUpdatesSigil = ReactCurrentActingRendererSigil.current;
-      ReactCurrentActingRendererSigil.current = ReactActingRendererSigil;
+      ReactCurrentActingRendererSigil.current.push(ReactActingRendererSigil);
     }
 
     function onDone() {
       actingUpdatesScopeDepth--;
       if (__DEV__) {
-        ReactCurrentActingRendererSigil.current = previousActingUpdatesSigil;
+        ReactCurrentActingRendererSigil.current.pop();
         if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
           // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
           warningWithoutStack(

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2422,8 +2422,10 @@ export function warnIfNotScopedWithMatchingAct(fiber: Fiber): void {
   if (__DEV__) {
     if (
       shouldWarnUnactedUpdates === true &&
-      ReactCurrentActingRendererSigil.current !== null &&
-      ReactCurrentActingRendererSigil.current !== ReactActingRendererSigil
+      ReactCurrentActingRendererSigil.current.length !== 0 &&
+      ReactCurrentActingRendererSigil.current.indexOf(
+        ReactActingRendererSigil,
+      ) === -1
     ) {
       warningWithoutStack(
         false,
@@ -2449,7 +2451,9 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
   if (__DEV__) {
     if (
       shouldWarnUnactedUpdates === true &&
-      ReactCurrentActingRendererSigil.current !== ReactActingRendererSigil
+      ReactCurrentActingRendererSigil.current.indexOf(
+        ReactActingRendererSigil,
+      ) === -1
     ) {
       warningWithoutStack(
         false,
@@ -2476,7 +2480,9 @@ function warnIfNotCurrentlyActingUpdatesInDEV(fiber: Fiber): void {
     if (
       shouldWarnUnactedUpdates === true &&
       executionContext === NoContext &&
-      ReactCurrentActingRendererSigil.current !== ReactActingRendererSigil
+      ReactCurrentActingRendererSigil.current.indexOf(
+        ReactActingRendererSigil,
+      ) === -1
     ) {
       warningWithoutStack(
         false,

--- a/packages/react-reconciler/src/__tests__/ReactNoopRendererAct-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNoopRendererAct-test.js
@@ -31,7 +31,6 @@ describe('ReactNoop.act()', () => {
         />,
       );
     });
-    expect(Scheduler).toFlushWithoutYielding();
     expect(calledLog).toEqual([0]);
   });
 
@@ -54,7 +53,6 @@ describe('ReactNoop.act()', () => {
       ReactNoop.render(<App />);
     });
     expect(Scheduler).toHaveYielded(['stage 1', 'stage 2']);
-    expect(Scheduler).toFlushWithoutYielding();
     expect(ReactNoop.getChildren()).toEqual([{text: '1', hidden: false}]);
   });
 });

--- a/packages/react-test-renderer/src/ReactTestRendererAct.js
+++ b/packages/react-test-renderer/src/ReactTestRendererAct.js
@@ -67,17 +67,15 @@ let actingUpdatesScopeDepth = 0;
 
 function act(callback: () => Thenable) {
   let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
-  let previousActingUpdatesSigil;
   actingUpdatesScopeDepth++;
   if (__DEV__) {
-    previousActingUpdatesSigil = ReactCurrentActingRendererSigil.current;
-    ReactCurrentActingRendererSigil.current = ReactActingRendererSigil;
+    ReactCurrentActingRendererSigil.current.push(ReactActingRendererSigil);
   }
 
   function onDone() {
     actingUpdatesScopeDepth--;
     if (__DEV__) {
-      ReactCurrentActingRendererSigil.current = previousActingUpdatesSigil;
+      ReactCurrentActingRendererSigil.current.pop();
       if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
         // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
         warningWithoutStack(

--- a/packages/react/src/ReactCurrentActingRendererSigil.js
+++ b/packages/react/src/ReactCurrentActingRendererSigil.js
@@ -8,12 +8,12 @@
  */
 
 /**
- * Used by act() to track whether you're outside an act() scope.
- * We use a renderer's flushPassiveEffects as the sigil value
- * so we can track identity of the renderer.
+ * We maintain a 'stack' of renderer specific sigils
+ * corresponding to act() calls, so we can track whenever an update
+ * happens inside/outside of one.
  */
 
 const ReactCurrentActingRendererSigil = {
-  current: (null: null | (() => boolean)),
+  current: ([]: Array<{}>),
 };
 export default ReactCurrentActingRendererSigil;


### PR DESCRIPTION
Sometimes apps can be tested with multiple renderers at once. Examples - 
- react-art being used inside react-dom. This was 'fixed' by disabling missing act warnings for embedded renders https://github.com/facebook/react/pull/15975
- ReactDOM.render being used inside another component tree. The parent component will be rendered using ReactTestRenderer.create for a snapshot test or something.
- a ReactDOM instance interacting with a ReactTestRenderer instance (like for the new devtools)

This PR is for the other 2 usecases. It replaces the sigil reference with a stack that holds all sigils as act scopes open/close, and compares against the stack for when to show the missing act() warning.
 
Open question - At what point should flushPassiveEffects be called? On exiting the last act of any type? Or for a given type?