### PR TITLE
[Flare] Fix nativeEvent.x/y for older browsers

### DIFF
--- a/packages/react-events/src/utils.js
+++ b/packages/react-events/src/utils.js
@@ -19,7 +19,7 @@ export function isEventPositionWithinTouchHitTarget(
   const nativeEvent: any = event.nativeEvent;
   return context.isPositionWithinTouchHitTarget(
     // x and y can be doubles, so ensure they are integers
-    parseInt(nativeEvent.x, 10),
-    parseInt(nativeEvent.y, 10),
+    parseInt(nativeEvent.clientX, 10),
+    parseInt(nativeEvent.clientY, 10),
   );
 }


### PR DESCRIPTION
This changes `nativeEvent.x` and `nativeEvent.y` to use their alias that should work in older versions of Firefox – `clientX` and `clientY`.