### PR TITLE
Use Circle CI API v2 to get artifacts job ID

### DIFF
--- a/scripts/release/prepare-canary-commands/download-build-artifacts.js
+++ b/scripts/release/prepare-canary-commands/download-build-artifacts.js
@@ -2,32 +2,23 @@
 
 'use strict';
 
-const http = require('request-promise-json');
 const {exec} = require('child-process-promise');
 const {existsSync, readdirSync} = require('fs');
 const {readJsonSync} = require('fs-extra');
 const {join} = require('path');
-const {logPromise} = require('../utils');
+const {getArtifactsList, logPromise} = require('../utils');
 const theme = require('../theme');
 
 const run = async ({build, cwd}) => {
-  // https://circleci.com/docs/2.0/artifacts/#downloading-all-artifacts-for-a-build-on-circleci
-  const metadataURL = `https://circleci.com/api/v1.1/project/github/facebook/react/${build}/artifacts?circle-token=${
-    process.env.CIRCLE_CI_API_TOKEN
-  }`;
-  const metadata = await http.get(metadataURL, true);
-  const nodeModulesArtifact = metadata.find(
+  const artifacts = await getArtifactsList(build);
+  const nodeModulesArtifact = artifacts.find(
     entry => entry.path === 'home/circleci/project/node_modules.tgz'
   );
 
   if (!nodeModulesArtifact) {
     console.log(
-      theme`{error The specified build number does not contain any build artifacts}\n\n` +
-        'To get the correct build number from Circle CI, open the following URL:\n' +
-        theme`{link https://circleci.com/gh/facebook/react/${build}}\n\n` +
-        'Select the "commit" Workflow at the top of the page, then select the "process_artifacts" job.'
+      theme`{error The specified build (${build}) does not contain any build artifacts.}`
     );
-
     process.exit(1);
   }
 

--- a/scripts/release/publish-commands/download-error-codes-from-ci.js
+++ b/scripts/release/publish-commands/download-error-codes-from-ci.js
@@ -2,10 +2,9 @@
 
 'use strict';
 
-const http = require('request-promise-json');
 const {exec} = require('child-process-promise');
 const {readJsonSync} = require('fs-extra');
-const {logPromise} = require('../utils');
+const {getArtifactsList, logPromise} = require('../utils');
 const theme = require('../theme');
 
 const run = async ({cwd, tags}) => {
@@ -23,19 +22,14 @@ const run = async ({cwd, tags}) => {
   // If this release was created on Circle CI, grab the updated error codes from there.
   // Else the user will have to manually regenerate them.
   if (environment === 'ci') {
-    // https://circleci.com/docs/2.0/artifacts/#downloading-all-artifacts-for-a-build-on-circleci
-    // eslint-disable-next-line max-len
-    const metadataURL = `https://circleci.com/api/v1.1/project/github/facebook/react/${buildNumber}/artifacts?circle-token=${
-      process.env.CIRCLE_CI_API_TOKEN
-    }`;
-    const metadata = await http.get(metadataURL, true);
+    const artifacts = await getArtifactsList(buildNumber);
 
     // Each container stores an "error-codes" artifact, unfortunately.
     // We want to use the one that also ran `yarn build` since it may have modifications.
-    const {node_index} = metadata.find(
+    const {node_index} = artifacts.find(
       entry => entry.path === 'home/circleci/project/node_modules.tgz'
     );
-    const {url} = metadata.find(
+    const {url} = artifacts.find(
       entry =>
         entry.node_index === node_index &&
         entry.path === 'home/circleci/project/scripts/error-codes/codes.json'


### PR DESCRIPTION
Use v1.1 and v2 APIs to map from the Job ID to the build artifacts. Also updated the error code downloading script (which I missed previously).