### PR TITLE
[Flare] Fix isTouchEvent

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -467,7 +467,7 @@ function calculateResponderRegion(
 }
 
 function isTouchEvent(nativeEvent: Event): boolean {
-  const changedTouches = nativeEvent.changedTouches;
+  const changedTouches = ((nativeEvent: any): TouchEvent).changedTouches;
   return changedTouches && typeof changedTouches.length === 'number';
 }
 

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -467,7 +467,8 @@ function calculateResponderRegion(
 }
 
 function isTouchEvent(nativeEvent: Event): boolean {
-  return Array.isArray((nativeEvent: any).changedTouches);
+  const changedTouches = nativeEvent.changedTouches;
+  return changedTouches && typeof changedTouches.length === 'number';
 }
 
 function getTouchFromPressEvent(nativeEvent: TouchEvent): Touch {


### PR DESCRIPTION
This PR fixes `isTouchEvent` where the logic of checking if `changedTouches` was an array was wrong. It's an "array-like" object, but never an array.