### PR TITLE
[Flare] Small Swipe/Drag fixes

### DIFF
--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -166,6 +166,9 @@ const DragResponder = {
           const y = (obj: any).screenY;
           state.x = x;
           state.y = y;
+          if (x === state.startX && y === state.startY) {
+            return;
+          }
           if (!state.isDragging) {
             let shouldEnableDragging = true;
 

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -166,7 +166,7 @@ const DragResponder = {
           const y = (obj: any).screenY;
           state.x = x;
           state.y = y;
-          if (!state.isDragging && x !== state.startX && y !== state.startY) {
+          if (!state.isDragging) {
             let shouldEnableDragging = true;
 
             if (

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -53,12 +53,14 @@ function createSwipeEvent(
   target: Element | Document,
   eventData?: EventData,
 ): SwipeEvent {
-  return {
-    target,
-    type,
-    timeStamp: context.getTimeStamp(),
-    ...eventData,
-  };
+  return context.objectAssign(
+    {
+      target,
+      type,
+      timeStamp: context.getTimeStamp(),
+    },
+    eventData,
+  );
 }
 
 function dispatchSwipeEvent(

--- a/packages/react-events/src/__tests__/Drag-test.internal.js
+++ b/packages/react-events/src/__tests__/Drag-test.internal.js
@@ -155,7 +155,7 @@ describe('Drag event responder', () => {
     ReactDOM.render(<Component />, container);
 
     const mouseOverEvent = document.createEvent('MouseEvents');
-    mouseOverEvent.initEvent('mousedown', true, true);
+    mouseOverEvent.initEvent('mousedown', true, true, window, 1, 0, 0);
     divRef.current.dispatchEvent(mouseOverEvent);
 
     const mouseMoveEvent = document.createEvent('MouseEvents');
@@ -166,8 +166,8 @@ describe('Drag event responder', () => {
         true,
         window,
         1,
-        index,
-        index,
+        index + 1,
+        index + 1,
         50,
         50,
       );
@@ -178,12 +178,15 @@ describe('Drag event responder', () => {
     mouseUpEvent.initEvent('mouseup', true, true);
     divRef.current.dispatchEvent(mouseUpEvent);
     expect(events).toHaveLength(20);
-    let index = 0;
     expect(events).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          diffX: index,
-          diffY: index++,
+          diffX: 2,
+          diffY: 2,
+        }),
+        expect.objectContaining({
+          diffX: 21,
+          diffY: 21,
         }),
       ]),
     );


### PR DESCRIPTION
This fixes various bugs that I encountered in my local sandbox this week when using the `Swipe` and `Drag` responders. I thought I'd quickly fix them now whilst I remember what they were.