### PR TITLE
[Flare] Provide an escape hatch for native event propagation

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -38,6 +38,7 @@ type PressProps = {
     left: number,
   },
   preventDefault: boolean,
+  preventNativePropagation: boolean,
 };
 
 type PointerType = '' | 'mouse' | 'keyboard' | 'pen' | 'touch';
@@ -685,6 +686,9 @@ const PressResponder = {
       }
 
       case 'contextmenu': {
+        if (props.preventNativePropagation) {
+          nativeEvent.stopImmediatePropagation();
+        }
         if (state.isPressed) {
           dispatchCancel(event, context, props, state);
           if (props.preventDefault !== false) {
@@ -707,6 +711,9 @@ const PressResponder = {
       }
 
       case 'click': {
+        if (props.preventNativePropagation) {
+          nativeEvent.stopImmediatePropagation();
+        }
         if (context.isTargetWithinHostComponent(target, 'a', true)) {
           const {
             altKey,
@@ -819,6 +826,8 @@ const PressResponder = {
           if (pointerType === 'keyboard') {
             if (!isValidKeyboardEvent(nativeEvent)) {
               return;
+            } else if (props.preventNativePropagation) {
+              nativeEvent.stopImmediatePropagation();
             }
             // If the event target isn't within the press target, check if we're still
             // within the responder region. The region may have changed if the


### PR DESCRIPTION
We've found that there's a bunch of edge-cases that require propagation to be immediately stopped for `click`, `keyup` and `contextmenu`, so that events do not traverse to other event handlers. These cases are rare and should probably be addressed with a different product design, but in order to unblock product code, this functionality has been added.

Note: we will likely remove this functionality at some point in the future.