### PR TITLE
[Fresh] Capture Hook signatures lazily on first render

### DIFF
--- a/packages/react-fresh/src/ReactFreshRuntime.js
+++ b/packages/react-fresh/src/ReactFreshRuntime.js
@@ -15,8 +15,9 @@ import type {
 import {REACT_MEMO_TYPE, REACT_FORWARD_REF_TYPE} from 'shared/ReactSymbols';
 
 type Signature = {|
-  key: string,
+  ownKey: string,
   forceReset: boolean,
+  fullKey: string | null, // Contains keys of nested Hooks. Computed lazily.
   getCustomHooks: () => Array<Function>,
 |};
 
@@ -33,6 +34,49 @@ const familiesByType: WeakMap<any, Family> = new WeakMap();
 // It is an array of [Family, NextType] tuples.
 let pendingUpdates: Array<[Family, any]> = [];
 
+function computeFullKey(signature: Signature): string {
+  if (signature.fullKey !== null) {
+    return signature.fullKey;
+  }
+
+  let fullKey: string = signature.ownKey;
+  let hooks;
+  try {
+    hooks = signature.getCustomHooks();
+  } catch (err) {
+    // This can happen in an edge case, e.g. if expression like Foo.useSomething
+    // depends on Foo which is lazily initialized during rendering.
+    // In that case just assume we'll have to remount.
+    signature.forceReset = true;
+    signature.fullKey = fullKey;
+    return fullKey;
+  }
+
+  for (let i = 0; i < hooks.length; i++) {
+    const hook = hooks[i];
+    if (typeof hook !== 'function') {
+      // Something's wrong. Assume we need to remount.
+      signature.forceReset = true;
+      signature.fullKey = fullKey;
+      return fullKey;
+    }
+    const nestedHookSignature = allSignaturesByType.get(hook);
+    if (nestedHookSignature === undefined) {
+      // No signature means Hook wasn't in the source code, e.g. in a library.
+      // We'll skip it because we can assume it won't change during this session.
+      continue;
+    }
+    const nestedHookKey = computeFullKey(nestedHookSignature);
+    if (nestedHookSignature.forceReset) {
+      signature.forceReset = true;
+    }
+    fullKey += '\n---\n' + nestedHookKey;
+  }
+
+  signature.fullKey = fullKey;
+  return fullKey;
+}
+
 function haveEqualSignatures(prevType, nextType) {
   const prevSignature = allSignaturesByType.get(prevType);
   const nextSignature = allSignaturesByType.get(nextType);
@@ -43,33 +87,11 @@ function haveEqualSignatures(prevType, nextType) {
   if (prevSignature === undefined || nextSignature === undefined) {
     return false;
   }
-  if (prevSignature.key !== nextSignature.key) {
+  if (computeFullKey(prevSignature) !== computeFullKey(nextSignature)) {
     return false;
   }
   if (nextSignature.forceReset) {
     return false;
-  }
-
-  let prevCustomHooks;
-  let nextCustomHooks;
-  try {
-    prevCustomHooks = prevSignature.getCustomHooks();
-    nextCustomHooks = nextSignature.getCustomHooks();
-  } catch (err) {
-    // This can happen in an edge case, e.g. if expression like Foo.useSomething
-    // depends on Foo which is lazily initialized during rendering.
-    // In that case just assume we'll have to remount.
-    return false;
-  }
-
-  if (prevCustomHooks.length !== nextCustomHooks.length) {
-    return false;
-  }
-
-  for (let i = 0; i < nextCustomHooks.length; i++) {
-    if (!haveEqualSignatures(prevCustomHooks[i], nextCustomHooks[i])) {
-      return false;
-    }
   }
 
   return true;
@@ -169,8 +191,9 @@ export function setSignature(
   getCustomHooks?: () => Array<Function>,
 ): void {
   allSignaturesByType.set(type, {
-    key,
     forceReset,
+    ownKey: key,
+    fullKey: null,
     getCustomHooks: getCustomHooks || (() => []),
   });
 }
@@ -179,19 +202,7 @@ export function setSignature(
 // It captures Hook list at that time so inline requires don't break comparisons.
 export function collectCustomHooksForSignature(type: any) {
   const signature = allSignaturesByType.get(type);
-  if (signature === undefined) {
-    return;
+  if (signature !== undefined) {
+    computeFullKey(signature);
   }
-  let hooks;
-  try {
-    hooks = signature.getCustomHooks();
-  } catch (err) {
-    // This can happen in an edge case, e.g. if expression like Foo.useSomething
-    // depends on Foo which is lazily initialized during rendering.
-    // In that case just assume we'll have to remount.
-    signature.forceReset = true;
-    return;
-  }
-  // Capture Hooks at this time.
-  signature.getCustomHooks = () => hooks;
 }

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -90,14 +90,18 @@ describe('ReactFreshIntegration', () => {
   function __signature__() {
     let call = 0;
     let savedType;
+    let hasCustomHooks;
     return function(type, key, forceReset, getCustomHooks) {
       switch (call++) {
         case 0:
           savedType = type;
+          hasCustomHooks = typeof getCustomHooks === 'function';
           ReactFreshRuntime.setSignature(type, key, forceReset, getCustomHooks);
           break;
         case 1:
-          ReactFreshRuntime.collectCustomHooksForSignature(savedType);
+          if (hasCustomHooks) {
+            ReactFreshRuntime.collectCustomHooksForSignature(savedType);
+          }
           break;
       }
       return type;

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -85,9 +85,17 @@ describe('ReactFreshIntegration', () => {
     ReactFreshRuntime.register(type, id);
   }
 
-  function __signature__(type, key, forceReset, getCustomHooks) {
-    ReactFreshRuntime.setSignature(type, key, forceReset, getCustomHooks);
-    return type;
+  function __signature__() {
+    let call = 0;
+    return function(type, key, forceReset, getCustomHooks) {
+      call++;
+      if (call === 1) {
+        ReactFreshRuntime.setSignature(type, key, forceReset, getCustomHooks);
+      } else if (call === 2) {
+        // TODO: lazily traverse custom Hooks here for first render.
+      }
+      return type;
+    };
   }
 
   it('reloads function declarations', () => {

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -57,12 +57,14 @@ describe('ReactFreshIntegration', () => {
     }).code;
     const exportsObj = {};
     // eslint-disable-next-line no-new-func
-    new Function('React', 'exports', '__register__', '__signature__', compiled)(
-      React,
-      exportsObj,
-      __register__,
-      __signature__,
-    );
+    new Function(
+      'global',
+      'React',
+      'exports',
+      '__register__',
+      '__signature__',
+      compiled,
+    )(global, React, exportsObj, __register__, __signature__);
     return exportsObj.default;
   }
 
@@ -87,12 +89,16 @@ describe('ReactFreshIntegration', () => {
 
   function __signature__() {
     let call = 0;
+    let savedType;
     return function(type, key, forceReset, getCustomHooks) {
-      call++;
-      if (call === 1) {
-        ReactFreshRuntime.setSignature(type, key, forceReset, getCustomHooks);
-      } else if (call === 2) {
-        // TODO: lazily traverse custom Hooks here for first render.
+      switch (call++) {
+        case 0:
+          savedType = type;
+          ReactFreshRuntime.setSignature(type, key, forceReset, getCustomHooks);
+          break;
+        case 1:
+          ReactFreshRuntime.collectCustomHooksForSignature(savedType);
+          break;
       }
       return type;
     };
@@ -840,5 +846,304 @@ describe('ReactFreshIntegration', () => {
       el = container.firstChild;
       expect(el.textContent).toBe('G5');
     }
+  });
+
+  describe('with inline requires', () => {
+    beforeEach(() => {
+      global.FakeModuleSystem = {};
+    });
+
+    afterEach(() => {
+      delete global.FakeModuleSystem;
+    });
+
+    it('remounts component if custom hook it uses changes order on first edit', () => {
+      // This test verifies that remounting works even if calls to custom Hooks
+      // were transformed with an inline requires transform, like we have on RN.
+      // Inline requires make it harder to compare previous and next signatures
+      // because useFancyState inline require always resolves to the newest version.
+      // We're not actually using inline requires in the test, but it has similar semantics.
+      if (__DEV__) {
+        render(`
+          const FakeModuleSystem = global.FakeModuleSystem;
+
+          FakeModuleSystem.useFancyState = function(initialState) {
+            return React.useState(initialState);
+          };
+
+          const App = () => {
+            const [x, setX] = FakeModuleSystem.useFancyState('X');
+            const [y, setY] = FakeModuleSystem.useFancyState('Y');
+            return <h1>A{x}{y}</h1>;
+          };
+
+          export default App;
+        `);
+        let el = container.firstChild;
+        expect(el.textContent).toBe('AXY');
+
+        patch(`
+          const FakeModuleSystem = global.FakeModuleSystem;
+
+          FakeModuleSystem.useFancyState = function(initialState) {
+            React.useEffect(() => {});
+            return React.useState(initialState);
+          };
+
+          const App = () => {
+            const [x, setX] = FakeModuleSystem.useFancyState('X');
+            const [y, setY] = FakeModuleSystem.useFancyState('Y');
+            return <h1>B{x}{y}</h1>;
+          };
+
+          export default App;
+        `);
+        // The useFancyState Hook added an effect,
+        // so we had to remount the component.
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('BXY');
+
+        patch(`
+          const FakeModuleSystem = global.FakeModuleSystem;
+
+          FakeModuleSystem.useFancyState = function(initialState) {
+            React.useEffect(() => {});
+            return React.useState(initialState);
+          };
+
+          const App = () => {
+            const [x, setX] = FakeModuleSystem.useFancyState('X');
+            const [y, setY] = FakeModuleSystem.useFancyState('Y');
+            return <h1>C{x}{y}</h1>;
+          };
+
+          export default App;
+        `);
+        // We didn't change anything except the header text.
+        // So we don't expect a remount.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('CXY');
+      }
+    });
+
+    it('remounts component if custom hook it uses changes order on second edit', () => {
+      if (__DEV__) {
+        render(`
+          const FakeModuleSystem = global.FakeModuleSystem;
+
+          FakeModuleSystem.useFancyState = function(initialState) {
+            return React.useState(initialState);
+          };
+
+          const App = () => {
+            const [x, setX] = FakeModuleSystem.useFancyState('X');
+            const [y, setY] = FakeModuleSystem.useFancyState('Y');
+            return <h1>A{x}{y}</h1>;
+          };
+
+          export default App;
+        `);
+        let el = container.firstChild;
+        expect(el.textContent).toBe('AXY');
+
+        patch(`
+          const FakeModuleSystem = global.FakeModuleSystem;
+
+          FakeModuleSystem.useFancyState = function(initialState) {
+            return React.useState(initialState);
+          };
+
+          const App = () => {
+            const [x, setX] = FakeModuleSystem.useFancyState('X');
+            const [y, setY] = FakeModuleSystem.useFancyState('Y');
+            return <h1>B{x}{y}</h1>;
+          };
+
+          export default App;
+        `);
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('BXY');
+
+        patch(`
+          const FakeModuleSystem = global.FakeModuleSystem;
+
+          FakeModuleSystem.useFancyState = function(initialState) {
+            React.useEffect(() => {});
+            return React.useState(initialState);
+          };
+
+          const App = () => {
+            const [x, setX] = FakeModuleSystem.useFancyState('X');
+            const [y, setY] = FakeModuleSystem.useFancyState('Y');
+            return <h1>C{x}{y}</h1>;
+          };
+
+          export default App;
+        `);
+        // The useFancyState Hook added an effect,
+        // so we had to remount the component.
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('CXY');
+
+        patch(`
+          const FakeModuleSystem = global.FakeModuleSystem;
+
+          FakeModuleSystem.useFancyState = function(initialState) {
+            React.useEffect(() => {});
+            return React.useState(initialState);
+          };
+
+          const App = () => {
+            const [x, setX] = FakeModuleSystem.useFancyState('X');
+            const [y, setY] = FakeModuleSystem.useFancyState('Y');
+            return <h1>D{x}{y}</h1>;
+          };
+
+          export default App;
+        `);
+        // We didn't change anything except the header text.
+        // So we don't expect a remount.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('DXY');
+      }
+    });
+
+    it('recovers if evaluating Hook list throws', () => {
+      if (__DEV__) {
+        render(`
+        let FakeModuleSystem = null;
+
+        global.FakeModuleSystem.useFancyState = function(initialState) {
+          return React.useState(initialState);
+        };
+
+        const App = () => {
+          FakeModuleSystem = global.FakeModuleSystem;
+          const [x, setX] = FakeModuleSystem.useFancyState('X');
+          const [y, setY] = FakeModuleSystem.useFancyState('Y');
+          return <h1>A{x}{y}</h1>;
+        };
+
+        export default App;
+      `);
+        let el = container.firstChild;
+        expect(el.textContent).toBe('AXY');
+
+        patch(`
+        let FakeModuleSystem = null;
+
+        global.FakeModuleSystem.useFancyState = function(initialState) {
+          React.useEffect(() => {});
+          return React.useState(initialState);
+        };
+
+        const App = () => {
+          FakeModuleSystem = global.FakeModuleSystem;
+          const [x, setX] = FakeModuleSystem.useFancyState('X');
+          const [y, setY] = FakeModuleSystem.useFancyState('Y');
+          return <h1>B{x}{y}</h1>;
+        };
+
+        export default App;
+      `);
+        // We couldn't evaluate the Hook signatures
+        // so we had to remount the component.
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('BXY');
+      }
+    });
+
+    it('remounts component if custom hook it uses changes order behind an indirection', () => {
+      if (__DEV__) {
+        render(`
+          const FakeModuleSystem = global.FakeModuleSystem;
+
+          FakeModuleSystem.useFancyState = function(initialState) {
+            return FakeModuleSystem.useIndirection(initialState);
+          };
+
+          FakeModuleSystem.useIndirection = function(initialState) {
+            return FakeModuleSystem.useOtherIndirection(initialState);
+          };
+
+          FakeModuleSystem.useOtherIndirection = function(initialState) {
+            return React.useState(initialState);
+          };
+
+          const App = () => {
+            const [x, setX] = FakeModuleSystem.useFancyState('X');
+            const [y, setY] = FakeModuleSystem.useFancyState('Y');
+            return <h1>A{x}{y}</h1>;
+          };
+
+          export default App;
+        `);
+        let el = container.firstChild;
+        expect(el.textContent).toBe('AXY');
+
+        patch(`
+          const FakeModuleSystem = global.FakeModuleSystem;
+
+          FakeModuleSystem.useFancyState = function(initialState) {
+            return FakeModuleSystem.useIndirection(initialState);
+          };
+
+          FakeModuleSystem.useIndirection = function(initialState) {
+            return FakeModuleSystem.useOtherIndirection(initialState);
+          };
+
+          FakeModuleSystem.useOtherIndirection = function(initialState) {
+            React.useEffect(() => {});
+            return React.useState(initialState);
+          };
+
+          const App = () => {
+            const [x, setX] = FakeModuleSystem.useFancyState('X');
+            const [y, setY] = FakeModuleSystem.useFancyState('Y');
+            return <h1>B{x}{y}</h1>;
+          };
+
+          export default App;
+        `);
+
+        // The useFancyState Hook added an effect,
+        // so we had to remount the component.
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('BXY');
+
+        patch(`
+          const FakeModuleSystem = global.FakeModuleSystem;
+
+          FakeModuleSystem.useFancyState = function(initialState) {
+            return FakeModuleSystem.useIndirection(initialState);
+          };
+
+          FakeModuleSystem.useIndirection = function(initialState) {
+            return FakeModuleSystem.useOtherIndirection(initialState);
+          };
+
+          FakeModuleSystem.useOtherIndirection = function(initialState) {
+            React.useEffect(() => {});
+            return React.useState(initialState);
+          };
+
+          const App = () => {
+            const [x, setX] = FakeModuleSystem.useFancyState('X');
+            const [y, setY] = FakeModuleSystem.useFancyState('Y');
+            return <h1>C{x}{y}</h1>;
+          };
+
+          export default App;
+        `);
+        // We didn't change anything except the header text.
+        // So we don't expect a remount.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('CXY');
+      }
+    });
   });
 });

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -1,14 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReactFreshBabelPlugin generates signatures for function declarations calling hooks 1`] = `
+var _s = __signature__();
 
 export default function App() {
+  _s();
+
   const [foo, setFoo] = useState(0);
   React.useEffect(() => {});
   return <h1>{foo}</h1>;
 }
 
-__signature__(App, "useState{[foo, setFoo]}\\nuseEffect{}");
+_s(App, "useState{[foo, setFoo]}\\nuseEffect{}");
 
 _c = App;
 
@@ -18,21 +21,31 @@ __register__(_c, "App");
 `;
 
 exports[`ReactFreshBabelPlugin generates signatures for function expressions calling hooks 1`] = `
+var _s = __signature__(),
+    _s2 = __signature__();
 
-export const A = _c3 = React.memo(_c2 = React.forwardRef(_c = __signature__((props, ref) => {
+export const A = _c3 = React.memo(_c2 = React.forwardRef(_c = _s((props, ref) => {
+  _s();
+
   const [foo, setFoo] = useState(0);
   React.useEffect(() => {});
   return <h1 ref={ref}>{foo}</h1>;
 }, "useState{[foo, setFoo]}\\nuseEffect{}")));
 
-export const B = _c6 = React.memo(_c5 = React.forwardRef(_c4 = __signature__(function (props, ref) {
+export const B = _c6 = React.memo(_c5 = React.forwardRef(_c4 = _s2(function (props, ref) {
+  _s2();
+
   const [foo, setFoo] = useState(0);
   React.useEffect(() => {});
   return <h1 ref={ref}>{foo}</h1>;
 }, "useState{[foo, setFoo]}\\nuseEffect{}")));
 
 function hoc() {
-  return __signature__(function Inner() {
+  var _s3 = __signature__();
+
+  return _s3(function Inner() {
+    _s3();
+
     const [foo, setFoo] = useState(0);
     React.useEffect(() => {});
     return <h1 ref={ref}>{foo}</h1>;
@@ -57,17 +70,24 @@ __register__(_c6, "B");
 `;
 
 exports[`ReactFreshBabelPlugin generates valid signature for exotic ways to call Hooks 1`] = `
+var _s2 = __signature__();
 
 import FancyHook from 'fancy';
 
 export default function App() {
+  _s2();
+
+  var _s = __signature__();
+
   function useFancyState() {
+    _s();
+
     const [foo, setFoo] = React.useState(0);
     useFancyEffect();
     return foo;
   }
 
-  __signature__(useFancyState, 'useState{[foo, setFoo]}\\nuseFancyEffect{}', true);
+  _s(useFancyState, 'useState{[foo, setFoo]}\\nuseFancyEffect{}', true);
 
   const bar = useFancyState();
   const baz = FancyHook.useThing();
@@ -76,7 +96,7 @@ export default function App() {
   return <h1>{bar}{baz}</h1>;
 }
 
-__signature__(App, 'useFancyState{bar}\\nuseThing{baz}\\nuseState{}\\nuseThePlatform{}', true, () => [FancyHook.useThing]);
+_s2(App, 'useFancyState{bar}\\nuseThing{baz}\\nuseState{}\\nuseThePlatform{}', true, () => [FancyHook.useThing]);
 
 _c = App;
 
@@ -137,27 +157,36 @@ export default function () {}
 `;
 
 exports[`ReactFreshBabelPlugin includes custom hooks into the signatures 1`] = `
+var _s = __signature__(),
+    _s2 = __signature__(),
+    _s3 = __signature__();
 
 function useFancyState() {
+  _s();
+
   const [foo, setFoo] = React.useState(0);
   useFancyEffect();
   return foo;
 }
 
-__signature__(useFancyState, "useState{[foo, setFoo]}\\nuseFancyEffect{}", false, () => [useFancyEffect]);
+_s(useFancyState, "useState{[foo, setFoo]}\\nuseFancyEffect{}", false, () => [useFancyEffect]);
 
 const useFancyEffect = () => {
+  _s2();
+
   React.useEffect(() => {});
 };
 
-__signature__(useFancyEffect, "useEffect{}");
+_s2(useFancyEffect, "useEffect{}");
 
 export default function App() {
+  _s3();
+
   const bar = useFancyState();
   return <h1>{bar}</h1>;
 }
 
-__signature__(App, "useFancyState{bar}", false, () => [useFancyState]);
+_s3(App, "useFancyState{bar}", false, () => [useFancyState]);
 
 _c = App;
 


### PR DESCRIPTION
We compare "signatures" of components on a hot update to decide whether to preserve or throw away the state. Signatures are created from the order of Hook calls at build time. They include references to nested Hooks themselves, since a reorder inside a custom Hook should remount components containing it. But when do we read those references?

Previously, nested Hook call signatures were computed during the hot update, just before comparison with the next version. However, it's too late on React Native because of inline requires. `[useFoo]` becomes `[require('useFoo')]` so during hot update, we compare the next version with itself.

The fix is to make the signing resilient to timing. We now capture the list of Hooks during the first render of a component of a given type, instead of during the next hot update. To do this, I'm introducing another function call layer. The wrapper function is still used for wrapping — but also repurposed for marking the first render (and forcing signature calculation at that time). On next renders it becomes a noop. You can see the new compiled output in snapshots.

I verified this solves the problem on RN. Editing Hooks in another file now correctly resets state, but only if you change the inner Hook call order.