### PR TITLE
Update noop to closure function to up speed

### DIFF
--- a/packages/react/src/withComponentStack.js
+++ b/packages/react/src/withComponentStack.js
@@ -7,7 +7,7 @@
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
-function noop() {}
+const noop = () => {};
 
 let error = noop;
 let warn = noop;


### PR DESCRIPTION
```js
function noop1() {

}

const noop2 = () => {
}

console.time('test1')
for (let i = 0; i < 500000; i++) {
  noop1()
}
console.timeEnd('test1')


console.time('test2')
for (let i = 0; i < 500000; i++) {
  noop2()
}
console.timeEnd('test2')
```

```
test1: 5.570068359375ms
test2: 2.18701171875ms
```