### PR TITLE
Fix useCallback not work properly in shallow renderer

### DIFF
--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -337,7 +337,7 @@ class ReactShallowRenderer {
 
     const useCallback = <T>(
       callback: T,
-      deps: Array<mixed> | void | null
+      deps: Array<mixed> | void | null,
     ): T => {
       this._validateCurrentlyRenderingComponent();
       this._createWorkInProgressHook();
@@ -361,7 +361,7 @@ class ReactShallowRenderer {
       (this._workInProgressHook: any).memoizedState = [nextValue, nextDeps];
       return nextValue;
     };
-        
+
     const useRef = <T>(initialValue: T): {current: T} => {
       this._validateCurrentlyRenderingComponent();
       this._createWorkInProgressHook();

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -335,6 +335,33 @@ class ReactShallowRenderer {
       return nextValue;
     };
 
+    const useCallback = <T>(
+      callback: T,
+      deps: Array<mixed> | void | null
+    ): T => {
+      this._validateCurrentlyRenderingComponent();
+      this._createWorkInProgressHook();
+
+      const nextDeps = deps !== undefined ? deps : null;
+
+      if (
+        this._workInProgressHook !== null &&
+        this._workInProgressHook.memoizedState !== null
+      ) {
+        const prevState = this._workInProgressHook.memoizedState;
+        const prevDeps = prevState[1];
+        if (nextDeps !== null) {
+          if (areHookInputsEqual(nextDeps, prevDeps)) {
+            return prevState[0];
+          }
+        }
+      }
+
+      const nextValue = callback;
+      (this._workInProgressHook: any).memoizedState = [nextValue, nextDeps];
+      return nextValue;
+    };
+        
     const useRef = <T>(initialValue: T): {current: T} => {
       this._validateCurrentlyRenderingComponent();
       this._createWorkInProgressHook();
@@ -362,13 +389,9 @@ class ReactShallowRenderer {
       this._validateCurrentlyRenderingComponent();
     };
 
-    const identity = (fn: Function): Function => {
-      return fn;
-    };
-
     return {
       readContext,
-      useCallback: (identity: any),
+      useCallback,
       useContext: <T>(context: ReactContext<T>): T => {
         this._validateCurrentlyRenderingComponent();
         return readContext(context);

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
@@ -294,9 +294,7 @@ describe('ReactShallowRenderer with hooks', () => {
     function SomeComponent() {
       const noop = React.useCallback(() => {}, []);
 
-      return (
-        <div onClick={noop} />
-      );
+      return <div onClick={noop} />;
     }
 
     const shallowRenderer = createRenderer();

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
@@ -290,6 +290,22 @@ describe('ReactShallowRenderer with hooks', () => {
     expect(firstResult).toEqual(secondResult);
   });
 
+  it('should work with useCallback', () => {
+    function SomeComponent() {
+      const noop = React.useCallback(() => {}, []);
+
+      return (
+        <div onClick={noop} />
+      );
+    }
+
+    const shallowRenderer = createRenderer();
+    let firstResult = shallowRenderer.render(<SomeComponent />);
+    let secondResult = shallowRenderer.render(<SomeComponent />);
+
+    expect(firstResult).toEqual(secondResult);
+  });
+
   it('should work with useContext', () => {
     const SomeContext = React.createContext('default');
 


### PR DESCRIPTION
Fix #15774 .
Just copy and paste the same logic as `useMemo` in shallow renderer; Not sure if it's better to extract the comparison logic into common function or just keep it repeat.