### PR TITLE
[Flare] Move Press root event removal till click phase

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -713,7 +713,6 @@ const PressResponder = {
       }
 
       case 'click': {
-        removeRootEventTypes(context, state);
         if (context.isTargetWithinHostComponent(target, 'a', true)) {
           const {
             altKey,
@@ -875,7 +874,8 @@ const PressResponder = {
               }
             }
           }
-        } else if (type === 'mouseup' && state.ignoreEmulatedMouseEvents) {
+        } else if (type === 'mouseup') {
+          removeRootEventTypes(context, state);
           state.ignoreEmulatedMouseEvents = false;
         } else if (state.allowPressReentry) {
           removeRootEventTypes(context, state);

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -118,7 +118,6 @@ const DEFAULT_PRESS_RETENTION_OFFSET = {
 };
 
 const targetEventTypes = [
-  {name: 'click', passive: false},
   {name: 'keydown', passive: false},
   {name: 'contextmenu', passive: false},
   // We need to preventDefault on pointerdown for mouse/pen events
@@ -126,6 +125,7 @@ const targetEventTypes = [
   {name: 'pointerdown', passive: false},
 ];
 const rootEventTypes = [
+  {name: 'click', passive: false},
   'keyup',
   'pointerup',
   'pointermove',
@@ -609,7 +609,7 @@ const PressResponder = {
     props: PressProps,
     state: PressState,
   ): void {
-    const {target, type} = event;
+    const {type} = event;
 
     if (props.disabled) {
       removeRootEventTypes(context, state);
@@ -708,29 +708,6 @@ const PressResponder = {
             props.onContextMenu,
             DiscreteEvent,
           );
-        }
-        break;
-      }
-
-      case 'click': {
-        if (context.isTargetWithinHostComponent(target, 'a', true)) {
-          const {
-            altKey,
-            ctrlKey,
-            metaKey,
-            shiftKey,
-          } = (nativeEvent: MouseEvent);
-          // Check "open in new window/tab" and "open context menu" key modifiers
-          const preventDefault = props.preventDefault;
-          if (
-            preventDefault !== false &&
-            !shiftKey &&
-            !metaKey &&
-            !ctrlKey &&
-            !altKey
-          ) {
-            nativeEvent.preventDefault();
-          }
         }
         break;
       }
@@ -875,10 +852,36 @@ const PressResponder = {
             }
           }
         } else if (type === 'mouseup') {
-          removeRootEventTypes(context, state);
           state.ignoreEmulatedMouseEvents = false;
         } else if (state.allowPressReentry) {
           removeRootEventTypes(context, state);
+        }
+        break;
+      }
+
+      case 'click': {
+        removeRootEventTypes(context, state);
+        if (
+          context.isTargetWithinEventComponent(target) &&
+          context.isTargetWithinHostComponent(target, 'a', true)
+        ) {
+          const {
+            altKey,
+            ctrlKey,
+            metaKey,
+            shiftKey,
+          } = (nativeEvent: MouseEvent);
+          // Check "open in new window/tab" and "open context menu" key modifiers
+          const preventDefault = props.preventDefault;
+          if (
+            preventDefault !== false &&
+            !shiftKey &&
+            !metaKey &&
+            !ctrlKey &&
+            !altKey
+          ) {
+            nativeEvent.preventDefault();
+          }
         }
         break;
       }

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -652,6 +652,7 @@ const PressResponder = {
             context.isEventWithinTouchHitTarget(event)
           ) {
             // We need to prevent the native event to block the focus
+            removeRootEventTypes(context, state);
             nativeEvent.preventDefault();
             return;
           }
@@ -712,6 +713,7 @@ const PressResponder = {
       }
 
       case 'click': {
+        removeRootEventTypes(context, state);
         if (context.isTargetWithinHostComponent(target, 'a', true)) {
           const {
             altKey,
@@ -851,7 +853,6 @@ const PressResponder = {
           }
 
           const wasLongPressed = state.isLongPressed;
-          removeRootEventTypes(context, state);
           dispatchPressEndEvents(event, context, props, state);
 
           if (state.pressTarget !== null && props.onPress) {

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -422,11 +422,9 @@ function dispatchCancel(
 ): void {
   if (state.isPressed) {
     state.ignoreEmulatedMouseEvents = false;
-    removeRootEventTypes(context, state);
     dispatchPressEndEvents(event, context, props, state);
-  } else if (state.allowPressReentry) {
-    removeRootEventTypes(context, state);
   }
+  removeRootEventTypes(context, state);
 }
 
 function isValidKeyboardEvent(nativeEvent: Object): boolean {
@@ -785,9 +783,6 @@ const PressResponder = {
               dispatchPressStartEvents(event, context, props, state);
             }
           } else {
-            if (!state.allowPressReentry) {
-              removeRootEventTypes(context, state);
-            }
             dispatchPressEndEvents(event, context, props, state);
           }
         }
@@ -853,8 +848,6 @@ const PressResponder = {
           }
         } else if (type === 'mouseup') {
           state.ignoreEmulatedMouseEvents = false;
-        } else if (state.allowPressReentry) {
-          removeRootEventTypes(context, state);
         }
         break;
       }


### PR DESCRIPTION
This PR does two things:

- The `removeRootEventTypes` calls in `Press` have been moved around. Previously they always occurred after dispatching an event during `pointerup` (among other events). Instead we now do this during the `click` event. This allows us to use the `stopPropagation` feature to apply to other root events; otherwise we stop short of handling them.

- `click` has also been made a root event. Given we add root events and remove them conditionally, this should slightly improve runtime performance.