### PR TITLE
[Fresh] Implement missing features

### DIFF
--- a/packages/react-fresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-fresh/src/ReactFreshBabelPlugin.js
@@ -175,6 +175,17 @@ export default function(babel) {
       // TODO: if there is no LHS, consider some other heuristic.
       key = hookCallPath.parentPath.get('id').getSource();
     }
+
+    // Some built-in Hooks reset on edits to arguments.
+    const args = hookCallPath.get('arguments');
+    if (hookName === 'useState' && args.length > 0) {
+      // useState second argument is initial state.
+      key += '(' + args[0].getSource() + ')';
+    } else if (hookName === 'useReducer' && args.length > 1) {
+      // useReducer second argument is initial state.
+      key += '(' + args[1].getSource() + ')';
+    }
+
     hookCallsForFn.push({
       name: hookName,
       callee: hookCallPath.node.callee,

--- a/packages/react-fresh/src/ReactFreshRuntime.js
+++ b/packages/react-fresh/src/ReactFreshRuntime.js
@@ -115,7 +115,11 @@ function resolveFamily(type) {
   return familiesByType.get(type);
 }
 
-export function prepareUpdate(): HotUpdate {
+export function prepareUpdate(): HotUpdate | null {
+  if (pendingUpdates.length === 0) {
+    return null;
+  }
+
   const staleFamilies = new Set();
   const updatedFamilies = new Set();
 

--- a/packages/react-fresh/src/ReactFreshRuntime.js
+++ b/packages/react-fresh/src/ReactFreshRuntime.js
@@ -210,3 +210,7 @@ export function collectCustomHooksForSignature(type: any) {
     computeFullKey(signature);
   }
 }
+
+export function getFamilyByID(id: string): Family | void {
+  return allFamiliesByID.get(id);
+}

--- a/packages/react-fresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFresh-test.js
@@ -20,6 +20,7 @@ let act;
 describe('ReactFresh', () => {
   let container;
   let lastRoot;
+  let findHostNodesForHotUpdate;
   let scheduleHotUpdate;
 
   beforeEach(() => {
@@ -27,6 +28,7 @@ describe('ReactFresh', () => {
       supportsFiber: true,
       inject: injected => {
         scheduleHotUpdate = injected.scheduleHotUpdate;
+        findHostNodesForHotUpdate = injected.findHostNodesForHotUpdate;
       },
       onCommitFiberRoot: (id, root) => {
         lastRoot = root;
@@ -2934,4 +2936,112 @@ describe('ReactFresh', () => {
       expect(finalEl.textContent).toBe('1');
     }
   });
+
+  it('can find host nodes for a family', () => {
+    if (__DEV__) {
+      render(() => {
+        function Child({children}) {
+          return <div className="Child">{children}</div>;
+        }
+        __register__(Child, 'Child');
+
+        function Parent({children}) {
+          return (
+            <div className="Parent">
+              <div>
+                <Child />
+              </div>
+              <div>
+                <Child />
+              </div>
+            </div>
+          );
+        }
+        __register__(Parent, 'Parent');
+
+        function App() {
+          return (
+            <div className="App">
+              <Parent />
+              <Cls>
+                <Parent />
+              </Cls>
+              <Indirection>
+                <Empty />
+              </Indirection>
+            </div>
+          );
+        }
+        __register__(App, 'App');
+
+        class Cls extends React.Component {
+          render() {
+            return this.props.children;
+          }
+        }
+
+        function Indirection({children}) {
+          return children;
+        }
+
+        function Empty() {
+          return null;
+        }
+        __register__(Empty, 'Empty');
+
+        function Frag() {
+          return (
+            <React.Fragment>
+              <div className="Frag">
+                <div />
+              </div>
+              <div className="Frag">
+                <div />
+              </div>
+            </React.Fragment>
+          );
+        }
+        __register__(Frag, 'Frag');
+
+        return App;
+      });
+
+      const parentFamily = ReactFreshRuntime.getFamilyByID('Parent');
+      const childFamily = ReactFreshRuntime.getFamilyByID('Child');
+      const emptyFamily = ReactFreshRuntime.getFamilyByID('Empty');
+
+      testFindNodesForFamilies(
+        [parentFamily],
+        container.querySelectorAll('.Parent'),
+      );
+
+      testFindNodesForFamilies(
+        [childFamily],
+        container.querySelectorAll('.Child'),
+      );
+
+      // When searching for both Parent and Child,
+      // we'll stop visual highlighting at the Parent.
+      testFindNodesForFamilies(
+        [parentFamily, childFamily],
+        container.querySelectorAll('.Parent'),
+      );
+
+      // When we can't find host nodes, use the closest parent.
+      testFindNodesForFamilies(
+        [emptyFamily],
+        container.querySelectorAll('.App'),
+      );
+    }
+  });
+
+  function testFindNodesForFamilies(families, expectedNodes) {
+    const foundNodes = Array.from(
+      findHostNodesForHotUpdate(lastRoot, families),
+    );
+    expect(foundNodes.length).toEqual(expectedNodes.length);
+    foundNodes.forEach((node, i) => {
+      expect(node).toBe(expectedNodes[i]);
+    });
+  }
 });

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -784,8 +784,8 @@ describe('ReactFreshIntegration', () => {
         /* @hot reset */
 
         export default function App() {
-          const [bar, setBar] = useState(2);
-          return <h1>C{bar}</h1>;
+          const [foo, setFoo] = useState(2);
+          return <h1>C{foo}</h1>;
         }
       `);
       // Found remount annotation, so state is reset.
@@ -800,8 +800,8 @@ describe('ReactFreshIntegration', () => {
 
           // @hot reset
 
-          const [bar, setBar] = useState(3);
-          return <h1>D{bar}</h1>;
+          const [foo, setFoo] = useState(3);
+          return <h1>D{foo}</h1>;
         }
       `);
       // Found remount annotation, so state is reset.
@@ -813,8 +813,8 @@ describe('ReactFreshIntegration', () => {
         const {useState} = React;
 
         export default function App() {
-          const [bar, setBar] = useState(4);
-          return <h1>E{bar}</h1>;
+          const [foo, setFoo] = useState(4);
+          return <h1>E{foo}</h1>;
         }
       `);
       // There is no remount annotation anymore,
@@ -826,8 +826,8 @@ describe('ReactFreshIntegration', () => {
         const {useState} = React;
 
         export default function App() {
-          const [bar, setBar] = useState(4);
-          return <h1>F{bar}</h1>;
+          const [foo, setFoo] = useState(4);
+          return <h1>F{foo}</h1>;
         }
       `);
       // Continue editing.
@@ -841,8 +841,8 @@ describe('ReactFreshIntegration', () => {
 
           /* @hot reset */
 
-          const [bar, setBar] = useState(5);
-          return <h1>G{bar}</h1>;
+          const [foo, setFoo] = useState(5);
+          return <h1>G{foo}</h1>;
         }
       `);
       // Force remount one last time.

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -275,9 +275,10 @@ describe('ReactFreshIntegration', () => {
     if (__DEV__) {
       render(`
         const {useState} = React;
+        const S = 1;
 
         export default function App() {
-          const [foo, setFoo] = useState(1);
+          const [foo, setFoo] = useState(S);
           return <h1>A{foo}</h1>;
         }
       `);
@@ -286,9 +287,10 @@ describe('ReactFreshIntegration', () => {
 
       patch(`
         const {useState} = React;
+        const S = 2;
 
         export default function App() {
-          const [foo, setFoo] = useState('ignored');
+          const [foo, setFoo] = useState(S);
           return <h1>B{foo}</h1>;
         }
       `);
@@ -298,16 +300,17 @@ describe('ReactFreshIntegration', () => {
 
       patch(`
         const {useState} = React;
+        const S = 3;
 
         export default function App() {
-          const [bar, setBar] = useState(2);
+          const [bar, setBar] = useState(S);
           return <h1>C{bar}</h1>;
         }
       `);
       // Different state variable name, so state is reset.
       expect(container.firstChild).not.toBe(el);
       const newEl = container.firstChild;
-      expect(newEl.textContent).toBe('C2');
+      expect(newEl.textContent).toBe('C3');
     }
   });
 
@@ -315,10 +318,11 @@ describe('ReactFreshIntegration', () => {
     if (__DEV__) {
       render(`
         const {useState} = React;
+        const S = 1;
 
         function hoc(Wrapped) {
           return function Generated() {
-            const [foo, setFoo] = useState(1);
+            const [foo, setFoo] = useState(S);
             return <Wrapped value={foo} />;
           };
         }
@@ -332,10 +336,11 @@ describe('ReactFreshIntegration', () => {
 
       patch(`
         const {useState} = React;
+        const S = 2;
 
         function hoc(Wrapped) {
           return function Generated() {
-            const [foo, setFoo] = useState('ignored');
+            const [foo, setFoo] = useState(S);
             return <Wrapped value={foo} />;
           };
         }
@@ -350,10 +355,11 @@ describe('ReactFreshIntegration', () => {
 
       patch(`
         const {useState} = React;
+        const S = 3;
 
         function hoc(Wrapped) {
           return function Generated() {
-            const [bar, setBar] = useState(2);
+            const [bar, setBar] = useState(S);
             return <Wrapped value={bar} />;
           };
         }
@@ -365,7 +371,7 @@ describe('ReactFreshIntegration', () => {
       // Different state variable name, so state is reset.
       expect(container.firstChild).not.toBe(el);
       const newEl = container.firstChild;
-      expect(newEl.textContent).toBe('C2');
+      expect(newEl.textContent).toBe('C3');
     }
   });
 
@@ -373,10 +379,11 @@ describe('ReactFreshIntegration', () => {
     if (__DEV__) {
       render(`
         const {useState} = React;
+        const S = 1;
 
         function hoc(Wrapped) {
           return function Generated() {
-            const [foo, setFoo] = useState(1);
+            const [foo, setFoo] = useState(S);
             return <Wrapped value={foo} />;
           };
         }
@@ -392,10 +399,11 @@ describe('ReactFreshIntegration', () => {
 
       patch(`
         const {useState} = React;
+        const S = 2;
 
         function hoc(Wrapped) {
           return function Generated() {
-            const [foo, setFoo] = useState('ignored');
+            const [foo, setFoo] = useState(S);
             return <Wrapped value={foo} />;
           };
         }
@@ -412,10 +420,11 @@ describe('ReactFreshIntegration', () => {
 
       patch(`
         const {useState} = React;
+        const S = 3;
 
         function hoc(Wrapped) {
           return function Generated() {
-            const [bar, setBar] = useState(2);
+            const [bar, setBar] = useState(S);
             return <Wrapped value={bar} />;
           };
         }
@@ -429,7 +438,7 @@ describe('ReactFreshIntegration', () => {
       // Different state variable name, so state is reset.
       expect(container.firstChild).not.toBe(el);
       const newEl = container.firstChild;
-      expect(newEl.textContent).toBe('C2');
+      expect(newEl.textContent).toBe('C3');
     }
   });
 
@@ -757,6 +766,114 @@ describe('ReactFreshIntegration', () => {
     if (__DEV__) {
       render(`
         const {useState} = React;
+        const S = 1;
+
+        export default function App() {
+          const [foo, setFoo] = useState(S);
+          return <h1>A{foo}</h1>;
+        }
+      `);
+      let el = container.firstChild;
+      expect(el.textContent).toBe('A1');
+
+      patch(`
+        const {useState} = React;
+        const S = 2;
+
+        export default function App() {
+          const [foo, setFoo] = useState(S);
+          return <h1>B{foo}</h1>;
+        }
+      `);
+      // Same state variable name, so state is preserved.
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('B1');
+
+      patch(`
+        const {useState} = React;
+        const S = 3;
+
+        /* @hot reset */
+
+        export default function App() {
+          const [foo, setFoo] = useState(S);
+          return <h1>C{foo}</h1>;
+        }
+      `);
+      // Found remount annotation, so state is reset.
+      expect(container.firstChild).not.toBe(el);
+      el = container.firstChild;
+      expect(el.textContent).toBe('C3');
+
+      patch(`
+        const {useState} = React;
+        const S = 4;
+
+        export default function App() {
+
+          // @hot reset
+
+          const [foo, setFoo] = useState(S);
+          return <h1>D{foo}</h1>;
+        }
+      `);
+      // Found remount annotation, so state is reset.
+      expect(container.firstChild).not.toBe(el);
+      el = container.firstChild;
+      expect(el.textContent).toBe('D4');
+
+      patch(`
+        const {useState} = React;
+        const S = 5;
+
+        export default function App() {
+          const [foo, setFoo] = useState(S);
+          return <h1>E{foo}</h1>;
+        }
+      `);
+      // There is no remount annotation anymore,
+      // so preserve the previous state.
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('E4');
+
+      patch(`
+        const {useState} = React;
+        const S = 6;
+
+        export default function App() {
+          const [foo, setFoo] = useState(S);
+          return <h1>F{foo}</h1>;
+        }
+      `);
+      // Continue editing.
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('F4');
+
+      patch(`
+        const {useState} = React;
+        const S = 7;
+
+        export default function App() {
+
+          /* @hot reset */
+
+          const [foo, setFoo] = useState(S);
+          return <h1>G{foo}</h1>;
+        }
+      `);
+      // Force remount one last time.
+      expect(container.firstChild).not.toBe(el);
+      el = container.firstChild;
+      expect(el.textContent).toBe('G7');
+    }
+  });
+
+  // This is best effort for simple cases.
+  // We won't attempt to resolve identifiers.
+  it('resets state when useState initial state is edited', () => {
+    if (__DEV__) {
+      render(`
+        const {useState} = React;
 
         export default function App() {
           const [foo, setFoo] = useState(1);
@@ -770,85 +887,68 @@ describe('ReactFreshIntegration', () => {
         const {useState} = React;
 
         export default function App() {
-          const [foo, setFoo] = useState('ignored');
+          const [foo, setFoo] = useState(1);
           return <h1>B{foo}</h1>;
         }
       `);
-      // Same state variable name, so state is preserved.
+      // Same initial state, so it's preserved.
       expect(container.firstChild).toBe(el);
       expect(el.textContent).toBe('B1');
 
       patch(`
         const {useState} = React;
 
-        /* @hot reset */
-
         export default function App() {
           const [foo, setFoo] = useState(2);
           return <h1>C{foo}</h1>;
         }
       `);
-      // Found remount annotation, so state is reset.
+      // Different initial state, so state is reset.
       expect(container.firstChild).not.toBe(el);
       el = container.firstChild;
       expect(el.textContent).toBe('C2');
+    }
+  });
 
-      patch(`
-        const {useState} = React;
+  // This is best effort for simple cases.
+  // We won't attempt to resolve identifiers.
+  it('resets state when useReducer initial state is edited', () => {
+    if (__DEV__) {
+      render(`
+        const {useReducer} = React;
 
         export default function App() {
-
-          // @hot reset
-
-          const [foo, setFoo] = useState(3);
-          return <h1>D{foo}</h1>;
+          const [foo, setFoo] = useReducer(x => x, 1);
+          return <h1>A{foo}</h1>;
         }
       `);
-      // Found remount annotation, so state is reset.
+      let el = container.firstChild;
+      expect(el.textContent).toBe('A1');
+
+      patch(`
+        const {useReducer} = React;
+
+        export default function App() {
+          const [foo, setFoo] = useReducer(x => x, 1);
+          return <h1>B{foo}</h1>;
+        }
+      `);
+      // Same initial state, so it's preserved.
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('B1');
+
+      patch(`
+        const {useReducer} = React;
+
+        export default function App() {
+          const [foo, setFoo] = useReducer(x => x, 2);
+          return <h1>C{foo}</h1>;
+        }
+      `);
+      // Different initial state, so state is reset.
       expect(container.firstChild).not.toBe(el);
       el = container.firstChild;
-      expect(el.textContent).toBe('D3');
-
-      patch(`
-        const {useState} = React;
-
-        export default function App() {
-          const [foo, setFoo] = useState(4);
-          return <h1>E{foo}</h1>;
-        }
-      `);
-      // There is no remount annotation anymore,
-      // so preserve the previous state.
-      expect(container.firstChild).toBe(el);
-      expect(el.textContent).toBe('E3');
-
-      patch(`
-        const {useState} = React;
-
-        export default function App() {
-          const [foo, setFoo] = useState(4);
-          return <h1>F{foo}</h1>;
-        }
-      `);
-      // Continue editing.
-      expect(container.firstChild).toBe(el);
-      expect(el.textContent).toBe('F3');
-
-      patch(`
-        const {useState} = React;
-
-        export default function App() {
-
-          /* @hot reset */
-
-          const [foo, setFoo] = useState(5);
-          return <h1>G{foo}</h1>;
-        }
-      `);
-      // Force remount one last time.
-      expect(container.firstChild).not.toBe(el);
-      el = container.firstChild;
-      expect(el.textContent).toBe('G5');
+      expect(el.textContent).toBe('C2');
     }
   });
 

--- a/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-fresh/src/__tests__/ReactFreshIntegration-test.js
@@ -73,6 +73,8 @@ describe('ReactFreshIntegration', () => {
     act(() => {
       ReactDOM.render(<Component />, container);
     });
+    // Module initialization shouldn't be counted as a hot update.
+    expect(ReactFreshRuntime.prepareUpdate()).toBe(null);
   }
 
   function patch(source) {

--- a/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-fresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -11,7 +11,7 @@ export default function App() {
   return <h1>{foo}</h1>;
 }
 
-_s(App, "useState{[foo, setFoo]}\\nuseEffect{}");
+_s(App, "useState{[foo, setFoo](0)}\\nuseEffect{}");
 
 _c = App;
 
@@ -30,7 +30,7 @@ export const A = _c3 = React.memo(_c2 = React.forwardRef(_c = _s((props, ref) =>
   const [foo, setFoo] = useState(0);
   React.useEffect(() => {});
   return <h1 ref={ref}>{foo}</h1>;
-}, "useState{[foo, setFoo]}\\nuseEffect{}")));
+}, "useState{[foo, setFoo](0)}\\nuseEffect{}")));
 
 export const B = _c6 = React.memo(_c5 = React.forwardRef(_c4 = _s2(function (props, ref) {
   _s2();
@@ -38,7 +38,7 @@ export const B = _c6 = React.memo(_c5 = React.forwardRef(_c4 = _s2(function (pro
   const [foo, setFoo] = useState(0);
   React.useEffect(() => {});
   return <h1 ref={ref}>{foo}</h1>;
-}, "useState{[foo, setFoo]}\\nuseEffect{}")));
+}, "useState{[foo, setFoo](0)}\\nuseEffect{}")));
 
 function hoc() {
   var _s3 = __signature__();
@@ -49,7 +49,7 @@ function hoc() {
     const [foo, setFoo] = useState(0);
     React.useEffect(() => {});
     return <h1 ref={ref}>{foo}</h1>;
-  }, "useState{[foo, setFoo]}\\nuseEffect{}");
+  }, "useState{[foo, setFoo](0)}\\nuseEffect{}");
 }
 
 export let C = hoc();
@@ -87,7 +87,7 @@ export default function App() {
     return foo;
   }
 
-  _s(useFancyState, 'useState{[foo, setFoo]}\\nuseFancyEffect{}', true);
+  _s(useFancyState, 'useState{[foo, setFoo](0)}\\nuseFancyEffect{}', true);
 
   const bar = useFancyState();
   const baz = FancyHook.useThing();
@@ -169,7 +169,7 @@ function useFancyState() {
   return foo;
 }
 
-_s(useFancyState, "useState{[foo, setFoo]}\\nuseFancyEffect{}", false, () => [useFancyEffect]);
+_s(useFancyState, "useState{[foo, setFoo](0)}\\nuseFancyEffect{}", false, () => [useFancyEffect]);
 
 const useFancyEffect = () => {
   _s2();

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -70,7 +70,10 @@ import {StrictMode} from './ReactTypeOfMode';
 import {Sync} from './ReactFiberExpirationTime';
 import {revertPassiveEffectsChange} from 'shared/ReactFeatureFlags';
 import {requestCurrentSuspenseConfig} from './ReactFiberSuspenseConfig';
-import {scheduleHotUpdate} from './ReactFiberHotReloading';
+import {
+  scheduleHotUpdate,
+  findHostNodesForHotUpdate,
+} from './ReactFiberHotReloading';
 
 type OpaqueRoot = FiberRoot;
 
@@ -472,6 +475,7 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
 
   return injectInternals({
     ...devToolsConfig,
+    findHostNodesForHotUpdate: __DEV__ ? findHostNodesForHotUpdate : null,
     scheduleHotUpdate: __DEV__ ? scheduleHotUpdate : null,
     overrideHookState,
     overrideProps,


### PR DESCRIPTION
Those are technically separate but I figured I'd put them in one PR instead of many small ones. I can separate if you prefer.

Commits:
* e8f6894cabd018c07b250c1fd2ad28cbdadb68a0: Fixing an existing test to test the correct thing. It was supposed to test the annotation but I additionally had a variable rename there due to copy pasta. So I cleaned it up.

* 892930df25b2824ada260be54038eb0faf9dd293: This adds a new heuristic. If you edit `useState()` argument, like `useState(0)` -> `useState(1)`, we'll remount. This will reinitialize the state, as you'd expect. This heuristic isn't perfect, e.g. it won't capture edits to a constant outside the parens, but it's good enough for the common case. I had to adjust a bunch of existing tests which started failing because of it.

* 9e9a9ddedd588fdbf380b025a3166790fdf8a33b: This makes it easy for the module system integration to determine whether there's any hot update that needs to be applied.

* 6a062a3e96686c5300e173d0db025fcfdb52d0f5: A reincarnation of https://github.com/facebook/react/pull/15688. That approach was bad because it highlighted nodes *after* hot update. That is distracting because you just want to see the new thing. Instead, I'm going with highlighting likely affected component *before* hot update is applied. So we can highlight the "old version", wait for update to come in (~100-200ms), and then replace it. This commit doesn't add any actual highlighting, but it adds the infrastructure necessary for it. Such as ability to query closest host nodes by a set of families. I verified it works and is sufficient in my playground.

The theme of this PR is to get to feature complete on the React side. The rest is integration.