### PR TITLE
[Flare] Unsure root events are removed on contextmenu

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -707,6 +707,8 @@ const PressResponder = {
             DiscreteEvent,
           );
         }
+        // Click won't occur, so we need to remove root events
+        removeRootEventTypes(context, state);
         break;
       }
     }


### PR DESCRIPTION
In Press, we should stop listening to root events if `contextmenu` opens, as `click` will never fire.