### PR TITLE
[React Native] Replace touch discrepancy errors to warnings

### DIFF
--- a/packages/events/ResponderTouchHistoryStore.js
+++ b/packages/events/ResponderTouchHistoryStore.js
@@ -129,7 +129,7 @@ function recordTouchMove(touch: Touch): void {
     touchRecord.currentTimeStamp = timestampForTouch(touch);
     touchHistory.mostRecentTimeStamp = timestampForTouch(touch);
   } else {
-    console.error(
+    console.warn(
       'Cannot record touch move without a touch start.\n' + 'Touch Move: %s\n',
       'Touch Bank: %s',
       printTouch(touch),
@@ -150,7 +150,7 @@ function recordTouchEnd(touch: Touch): void {
     touchRecord.currentTimeStamp = timestampForTouch(touch);
     touchHistory.mostRecentTimeStamp = timestampForTouch(touch);
   } else {
-    console.error(
+    console.warn(
       'Cannot record touch end without a touch start.\n' + 'Touch End: %s\n',
       'Touch Bank: %s',
       printTouch(touch),


### PR DESCRIPTION
Replaces `console.error` with `console.warn` so that we do not trigger RedBox in React Native.