### PR TITLE
[Flare] Clean up of Press responder + better touch support

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -189,10 +189,9 @@ const eventResponderContext: ReactResponderContext = {
     eventListeners.set(eventObject, listener);
     eventQueue.events.push(eventObject);
   },
-  isEventWithinTouchHitTarget(event: ReactResponderEvent): boolean {
+  isEventWithinTouchHitTarget(nativeEvent: Event | Touch): boolean {
     validateResponderContext();
-    const target = event.target;
-    const nativeEvent = event.nativeEvent;
+    const target = ((nativeEvent.target: any): Node);
     // We should always be dealing with a mouse event or touch event here.
     // If we are not, these won't exist and we can early return.
     const x = (nativeEvent: any).clientX;
@@ -414,9 +413,8 @@ const eventResponderContext: ReactResponderContext = {
     }
     return '';
   },
-  getEventCurrentTarget(event: ReactResponderEvent): Element {
+  getCurrentTargetFromTarget(target: Element | Document): Element {
     validateResponderContext();
-    const target = event.target;
     let fiber = getClosestInstanceFromNode(target);
     let hostComponent = target;
 

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -207,7 +207,7 @@ function handleRootPointerEvent(
   // Focus should stop being visible if a pointer is used on the element
   // after it was focused using a keyboard.
   if (
-    state.focusTarget === context.getEventCurrentTarget(event) &&
+    state.focusTarget === context.getCurrentTargetFromTarget(target) &&
     (type === 'mousedown' || type === 'touchstart' || type === 'pointerdown')
   ) {
     dispatchFocusVisibleOutEvent(context, props, state);
@@ -251,7 +251,7 @@ const FocusResponder = {
         if (!state.isFocused) {
           // Limit focus events to the direct child of the event component.
           // Browser focus is not expected to bubble.
-          state.focusTarget = context.getEventCurrentTarget(event);
+          state.focusTarget = context.getCurrentTargetFromTarget(target);
           if (state.focusTarget === target) {
             state.isFocused = true;
             state.isLocalFocusVisible = isGlobalFocusVisible;

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -294,7 +294,7 @@ const HoverResponder = {
     props: HoverProps,
     state: HoverState,
   ): void {
-    const {type} = event;
+    const {nativeEvent, target, type} = event;
 
     if (props.disabled) {
       if (state.isHovered) {
@@ -325,11 +325,11 @@ const HoverResponder = {
             return;
           }
 
-          if (context.isEventWithinTouchHitTarget(event)) {
+          if (context.isEventWithinTouchHitTarget(nativeEvent)) {
             state.isOverTouchHitTarget = true;
             return;
           }
-          state.hoverTarget = context.getEventCurrentTarget(event);
+          state.hoverTarget = context.getCurrentTargetFromTarget(target);
           state.ignoreEmulatedMouseEvents = true;
           dispatchHoverStartEvents(event, context, props, state);
         }
@@ -344,14 +344,14 @@ const HoverResponder = {
             if (state.isOverTouchHitTarget) {
               // If we were moving over the TouchHitTarget and have now moved
               // over the Responder target
-              if (!context.isEventWithinTouchHitTarget(event)) {
+              if (!context.isEventWithinTouchHitTarget(nativeEvent)) {
                 dispatchHoverStartEvents(event, context, props, state);
                 state.isOverTouchHitTarget = false;
               }
             } else {
               // If we were moving over the Responder target and have now moved
               // over the TouchHitTarget
-              if (context.isEventWithinTouchHitTarget(event)) {
+              if (context.isEventWithinTouchHitTarget(nativeEvent)) {
                 dispatchHoverEndEvents(event, context, props, state);
                 state.isOverTouchHitTarget = true;
               } else {

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -693,9 +693,9 @@ function processPressEnd(
 ): void {
   const wasLongPressed = state.isLongPressed;
   dispatchPressEndEvents(nativeEvent, touchEvent, context, props, state);
-  if (state.pressTarget !== null) {
+  if (state.pressTarget !== null && props.onPress) {
     processPressResponderRegion(nativeEvent, touchEvent, context, props, state);
-    if (state.isPressWithinResponderRegion && props.onPress) {
+    if (state.isPressWithinResponderRegion) {
       if (
         !(
           wasLongPressed &&

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -28,6 +28,17 @@ const createEvent = (type, data) => {
   return event;
 };
 
+function createTouchEvent(type, id, data) {
+  return createEvent(type, {
+    changedTouches: [
+      {
+        ...data,
+        identifier: id,
+      },
+    ],
+  });
+}
+
 const createKeyboardEvent = (type, data) => {
   return new KeyboardEvent(type, {
     bubbles: true,
@@ -108,6 +119,11 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'pen'}),
       );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressStart).toHaveBeenCalledTimes(1);
       expect(onPressStart).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'pen', type: 'pressstart'}),
@@ -163,7 +179,11 @@ describe('Event responder: Press', () => {
       );
     });
     it('is called after "touchstart" event', () => {
-      ref.current.dispatchEvent(createEvent('touchstart'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressStart).toHaveBeenCalledTimes(1);
       expect(onPressStart).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'touch', type: 'pressstart'}),
@@ -266,6 +286,16 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'pen'}),
       );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
+        }),
+      );
       ref.current.dispatchEvent(createEvent('pointerup'));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(
@@ -277,10 +307,20 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'touch'}),
       );
-      ref.current.dispatchEvent(createEvent('touchstart'));
-      ref.current.dispatchEvent(createEvent('pointerup'));
-      ref.current.dispatchEvent(createEvent('touchend'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
       ref.current.dispatchEvent(createEvent('mousedown'));
+      ref.current.dispatchEvent(
+        createEvent('pointerup', {pointerType: 'touch'}),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
+        }),
+      );
       ref.current.dispatchEvent(createEvent('mouseup'));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(
@@ -345,8 +385,16 @@ describe('Event responder: Press', () => {
       );
     });
     it('is called after "touchend" event', () => {
-      ref.current.dispatchEvent(createEvent('touchstart'));
-      ref.current.dispatchEvent(createEvent('touchend'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'touch', type: 'pressend'}),
@@ -510,10 +558,18 @@ describe('Event responder: Press', () => {
       expect(onPressChange).toHaveBeenCalledWith(false);
     });
     it('is called after "touchstart" and "touchend" events', () => {
-      ref.current.dispatchEvent(createEvent('touchstart'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressChange).toHaveBeenCalledTimes(1);
       expect(onPressChange).toHaveBeenCalledWith(true);
-      ref.current.dispatchEvent(createEvent('touchend'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressChange).toHaveBeenCalledTimes(2);
       expect(onPressChange).toHaveBeenCalledWith(false);
     });
@@ -542,6 +598,16 @@ describe('Event responder: Press', () => {
     it('is called after "pointerup" event', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'pen'}),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
+        }),
       );
       ref.current.dispatchEvent(
         createEvent('pointerup', {clientX: 10, clientY: 10}),
@@ -623,6 +689,11 @@ describe('Event responder: Press', () => {
     it('is called if "pointerdown" lasts default delay', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'pen'}),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
       );
       jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DELAY - 1);
       expect(onLongPress).not.toBeCalled();
@@ -815,18 +886,18 @@ describe('Event responder: Press', () => {
         right: 100,
       });
       ref.current.dispatchEvent(
-        createEvent('pointerdown', {pointerType: 'touch'}),
+        createEvent('pointerdown', {pointerType: 'mouse'}),
       );
       ref.current.dispatchEvent(
         createEvent('pointermove', {
-          pointerType: 'touch',
+          pointerType: 'mouse',
           clientX: 10,
           clientY: 10,
         }),
       );
       expect(onPressMove).toHaveBeenCalledTimes(1);
       expect(onPressMove).toHaveBeenCalledWith(
-        expect.objectContaining({pointerType: 'touch', type: 'pressmove'}),
+        expect.objectContaining({pointerType: 'mouse', type: 'pressmove'}),
       );
     });
 
@@ -876,7 +947,11 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'touch'}),
       );
-      ref.current.dispatchEvent(createEvent('touchstart'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
       ref.current.dispatchEvent(
         createEvent('pointermove', {
           pointerType: 'touch',
@@ -884,7 +959,13 @@ describe('Event responder: Press', () => {
           clientY: 10,
         }),
       );
-      ref.current.dispatchEvent(createEvent('touchmove'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
+          target: ref.current,
+          clientX: 10,
+          clientY: 10,
+        }),
+      );
       ref.current.dispatchEvent(createEvent('mousemove'));
       expect(onPressMove).toHaveBeenCalledTimes(1);
     });
@@ -1345,9 +1426,20 @@ describe('Event responder: Press', () => {
         }),
       );
       ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
         createEvent('pointermove', {
           ...coordinatesInside,
           pointerType: 'touch',
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
+          ...coordinatesInside,
+          target: ref.current,
         }),
       );
       container.dispatchEvent(
@@ -1356,10 +1448,28 @@ describe('Event responder: Press', () => {
           pointerType: 'touch',
         }),
       );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
+          ...coordinatesOutside,
+          target: ref.current,
+        }),
+      );
       container.dispatchEvent(
         createEvent('pointermove', {
           ...coordinatesInside,
           pointerType: 'touch',
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
+          ...coordinatesInside,
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          ...coordinatesInside,
+          target: ref.current,
         }),
       );
       container.dispatchEvent(
@@ -1397,20 +1507,12 @@ describe('Event responder: Press', () => {
     const pressRectOffset = 20;
     const getBoundingClientRectMock = () => rectMock;
     const coordinatesInside = {
-      changedTouches: [
-        {
-          clientX: rectMock.left - pressRectOffset,
-          clientY: rectMock.top - pressRectOffset,
-        },
-      ],
+      clientX: rectMock.left - pressRectOffset,
+      clientY: rectMock.top - pressRectOffset,
     };
     const coordinatesOutside = {
-      changedTouches: [
-        {
-          clientX: rectMock.left - pressRectOffset - 1,
-          clientY: rectMock.top - pressRectOffset - 1,
-        },
-      ],
+      clientX: rectMock.left - pressRectOffset - 1,
+      clientY: rectMock.top - pressRectOffset - 1,
     };
 
     describe('within bounds of hit rect', () => {
@@ -1442,9 +1544,23 @@ describe('Event responder: Press', () => {
         ReactDOM.render(element, container);
 
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
-        ref.current.dispatchEvent(createEvent('touchmove', coordinatesInside));
-        ref.current.dispatchEvent(createEvent('touchend', coordinatesInside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
         jest.runAllTimers();
 
         expect(events).toEqual([
@@ -1479,8 +1595,17 @@ describe('Event responder: Press', () => {
         ReactDOM.render(element, container);
 
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
-        ref.current.dispatchEvent(createEvent('touchmove', coordinatesInside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
         jest.advanceTimersByTime(499);
         expect(events).toEqual(['onPressMove']);
         events = [];
@@ -1489,7 +1614,12 @@ describe('Event responder: Press', () => {
         expect(events).toEqual(['onPressStart', 'onPressChange']);
         events = [];
 
-        ref.current.dispatchEvent(createEvent('touchend', coordinatesInside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
         expect(events).toEqual(['onPressEnd', 'onPressChange', 'onPress']);
       });
 
@@ -1515,14 +1645,24 @@ describe('Event responder: Press', () => {
 
         ReactDOM.render(element, container);
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
         ref.current.dispatchEvent(
-          createEvent('touchmove', {
-            clientX: rectMock.left - pressRetentionOffset.left,
-            clientY: rectMock.top - pressRetentionOffset.top,
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
           }),
         );
-        ref.current.dispatchEvent(createEvent('touchend', coordinatesInside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            clientX: rectMock.left - pressRetentionOffset.left,
+            clientY: rectMock.top - pressRetentionOffset.top,
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
         expect(events).toEqual([
           'onPressStart',
           'onPressChange',
@@ -1551,7 +1691,11 @@ describe('Event responder: Press', () => {
 
         ReactDOM.render(element, container);
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
         // emulate smaller dimensions change on activation
         ref.current.getBoundingClientRect = () => ({
           width: 80,
@@ -1566,8 +1710,18 @@ describe('Event responder: Press', () => {
           clientY: rectMock.top,
         };
         // move to an area within the pre-activation region
-        ref.current.dispatchEvent(createEvent('touchmove', coordinates));
-        ref.current.dispatchEvent(createEvent('touchend', coordinates));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinates,
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinates,
+            target: ref.current,
+          }),
+        );
         expect(events).toEqual(['onPressStart', 'onPressEnd', 'onPress']);
       });
 
@@ -1589,7 +1743,11 @@ describe('Event responder: Press', () => {
 
         ReactDOM.render(element, container);
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
         // emulate larger dimensions change on activation
         ref.current.getBoundingClientRect = () => ({
           width: 200,
@@ -1604,8 +1762,18 @@ describe('Event responder: Press', () => {
           clientY: rectMock.top - 50,
         };
         // move to an area within the post-activation region
-        ref.current.dispatchEvent(createEvent('touchmove', coordinates));
-        ref.current.dispatchEvent(createEvent('touchend', coordinates));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinates,
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinates,
+            target: ref.current,
+          }),
+        );
         expect(events).toEqual(['onPressStart', 'onPressEnd', 'onPress']);
       });
     });
@@ -1641,10 +1809,29 @@ describe('Event responder: Press', () => {
         ReactDOM.render(element, container);
 
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
-        ref.current.dispatchEvent(createEvent('touchmove', coordinatesInside));
-        container.dispatchEvent(createEvent('touchmove', coordinatesOutside));
-        container.dispatchEvent(createEvent('touchend', coordinatesOutside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesOutside,
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinatesOutside,
+            target: ref.current,
+          }),
+        );
         jest.runAllTimers();
 
         expect(events).toEqual([
@@ -1680,13 +1867,32 @@ describe('Event responder: Press', () => {
         ReactDOM.render(element, container);
 
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
-        ref.current.dispatchEvent(createEvent('touchmove', coordinatesInside));
-        container.dispatchEvent(createEvent('touchmove', coordinatesOutside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
+        container.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesOutside,
+            target: container,
+          }),
+        );
         jest.runAllTimers();
         expect(events).toEqual(['onPressMove']);
         events = [];
-        container.dispatchEvent(createEvent('touchend', coordinatesOutside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinatesOutside,
+            target: ref.current,
+          }),
+        );
         jest.runAllTimers();
         expect(events).toEqual([]);
       });
@@ -1714,32 +1920,31 @@ describe('Event responder: Press', () => {
 
       ref.current.getBoundingClientRect = getBoundingClientRectMock;
       ref.current.dispatchEvent(
-        createEvent('touchstart', {
-          pointerType: 'touch',
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
         }),
       );
       ref.current.dispatchEvent(
-        createEvent('touchmove', {
+        createTouchEvent('touchmove', 0, {
           ...coordinatesInside,
-          pointerType: 'touch',
+          target: ref.current,
         }),
       );
-      container.dispatchEvent(
-        createEvent('touchmove', {
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
           ...coordinatesOutside,
-          pointerType: 'touch',
+          target: ref.current,
         }),
       );
-      container.dispatchEvent(
-        createEvent('touchmove', {
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
           ...coordinatesInside,
-          pointerType: 'touch',
+          target: ref.current,
         }),
       );
-      container.dispatchEvent(
-        createEvent('touchend', {
-          ...coordinatesInside,
-          pointerType: 'touch',
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
         }),
       );
       jest.runAllTimers();
@@ -2094,8 +2299,16 @@ describe('Event responder: Press', () => {
       onPressEnd.mockReset();
 
       // When pointer events are supported
-      ref.current.dispatchEvent(createEvent('pointerdown'));
-      ref.current.dispatchEvent(createEvent('pointercancel'));
+      ref.current.dispatchEvent(
+        createEvent('pointerdown', {
+          pointerType: 'mouse',
+        }),
+      );
+      ref.current.dispatchEvent(
+        createEvent('pointercancel', {
+          pointerType: 'mouse',
+        }),
+      );
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       jest.runAllTimers();
       expect(onLongPress).not.toBeCalled();
@@ -2104,8 +2317,16 @@ describe('Event responder: Press', () => {
       onPressEnd.mockReset();
 
       // Touch fallback
-      ref.current.dispatchEvent(createEvent('touchstart'));
-      ref.current.dispatchEvent(createEvent('touchcancel'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchcancel', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       jest.runAllTimers();
       expect(onLongPress).not.toBeCalled();

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -176,7 +176,7 @@ export type ReactResponderContext = {
   ) => boolean,
   isTargetWithinEventComponent: (Element | Document) => boolean,
   isTargetWithinEventResponderScope: (Element | Document) => boolean,
-  isEventWithinTouchHitTarget: (event: ReactResponderEvent) => boolean,
+  isEventWithinTouchHitTarget: (nativeEvent: Event | Touch) => boolean,
   addRootEventTypes: (
     rootEventTypes: Array<ReactEventResponderEventType>,
   ) => void,
@@ -195,7 +195,7 @@ export type ReactResponderContext = {
   getEventPointerType(
     event: ReactResponderEvent,
   ): '' | 'mouse' | 'keyboard' | 'pen' | 'touch',
-  getEventCurrentTarget(event: ReactResponderEvent): Element,
+  getCurrentTargetFromTarget(target: Element | Document): Element,
   getTimeStamp: () => number,
   isTargetWithinHostComponent: (
     target: Element | Document,


### PR DESCRIPTION
This PR aims at fixed a bunch of bugs with iOS in `Press`. Notably: ensuring the responder region is correctly adhered to and also accounting for multiple presses for all browsers. There have also been numerous small performance optimizations and now the runtime of a press to the `onPress` firing is around 20% less.

Another area I've tackled is the behaviour of pointer events. Previously, we used to fully leverage pointer events, but this ended up not being what we really wanted. `pointercancel` fires too frequently in most cases and makes for a detached user-experience when "touching" the UI compared to native "touching". We now switch to using `touchstart`, `touchmove` and `touchend` again, with `pointerType` co-ordination so we don't lose the pointer types.

I've also added basic support for `trackpad` pointer events. More testing is needed for this on iOS 13 though.

Demo URL: https://bxlrc.codesandbox.io/