### PR TITLE
[Flare] Refactor of Press to fix various issues

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -394,26 +394,6 @@ const eventResponderContext: ReactResponderContext = {
   },
   getActiveDocument,
   objectAssign: Object.assign,
-  getEventPointerType(
-    event: ReactResponderEvent,
-  ): '' | 'mouse' | 'keyboard' | 'pen' | 'touch' {
-    validateResponderContext();
-    const nativeEvent: any = event.nativeEvent;
-    const {type, pointerType} = nativeEvent;
-    if (pointerType != null) {
-      return pointerType;
-    }
-    if (type.indexOf('mouse') === 0) {
-      return 'mouse';
-    }
-    if (type.indexOf('touch') === 0) {
-      return 'touch';
-    }
-    if (type.indexOf('key') === 0) {
-      return 'keyboard';
-    }
-    return '';
-  },
   getEventCurrentTarget(event: ReactResponderEvent): Element {
     validateResponderContext();
     const target = event.target;
@@ -583,12 +563,29 @@ function createResponderEvent(
   passive: boolean,
   passiveSupported: boolean,
 ): ReactResponderEvent {
+  const {pointerType} = (nativeEvent: any);
+  let eventPointerType = '';
+  let pointerId = null;
+
+  if (pointerType !== undefined) {
+    eventPointerType = pointerType;
+    pointerId = (nativeEvent: any).pointerId;
+  } else if (nativeEvent.key !== undefined) {
+    eventPointerType = 'keyboard';
+  } else if (nativeEvent.button !== undefined) {
+    eventPointerType = 'mouse';
+  } else if ((nativeEvent: any).changedTouches !== undefined) {
+    eventPointerType = 'touch';
+  }
+
   const responderEvent = {
     nativeEvent: nativeEvent,
-    target: nativeEventTarget,
-    type: topLevelType,
     passive,
     passiveSupported,
+    pointerId,
+    pointerType: eventPointerType,
+    target: nativeEventTarget,
+    type: topLevelType,
   };
   if (__DEV__) {
     Object.freeze(responderEvent);

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -8,6 +8,7 @@
  */
 
 import type {
+  PointerType,
   ReactResponderEvent,
   ReactResponderContext,
 } from 'shared/ReactTypes';
@@ -30,7 +31,6 @@ type FocusState = {
   pointerType: PointerType,
 };
 
-type PointerType = '' | 'mouse' | 'keyboard' | 'pen' | 'touch';
 type FocusEventType = 'focus' | 'blur' | 'focuschange' | 'focusvisiblechange';
 
 type FocusEvent = {|

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -294,7 +294,7 @@ const HoverResponder = {
     props: HoverProps,
     state: HoverState,
   ): void {
-    const {type} = event;
+    const {pointerType, type} = event;
 
     if (props.disabled) {
       if (state.isHovered) {
@@ -306,7 +306,6 @@ const HoverResponder = {
       }
       return;
     }
-    const pointerType = context.getEventPointerType(event);
 
     switch (type) {
       // START

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -789,10 +789,7 @@ const PressResponder = {
         if (state.pointerType !== pointerType) {
           return;
         }
-        if (
-          type === 'pointermove' &&
-          activePointerId !== pointerId
-        ) {
+        if (type === 'pointermove' && activePointerId !== pointerId) {
           return;
         } else if (type === 'touchmove') {
           touchEvent = getTouchById(nativeEvent, activePointerId);
@@ -854,10 +851,7 @@ const PressResponder = {
         if (isPressed) {
           let isKeyboardEvent = false;
           let touchEvent;
-          if (
-            type === 'pointerup' &&
-            activePointerId !== pointerId
-          ) {
+          if (type === 'pointerup' && activePointerId !== pointerId) {
             return;
           } else if (type === 'touchend') {
             touchEvent = getTouchById(nativeEvent, activePointerId);

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -8,6 +8,7 @@
  */
 
 import type {
+  PointerType,
   ReactResponderEvent,
   ReactResponderContext,
 } from 'shared/ReactTypes';
@@ -40,8 +41,6 @@ type PressProps = {
   stopPropagation: boolean,
 };
 
-type PointerType = '' | 'mouse' | 'keyboard' | 'pen' | 'touch';
-
 type PressState = {
   activationPosition: null | $ReadOnly<{|
     x: number,
@@ -71,7 +70,7 @@ type PressState = {
     top: number,
   |}>,
   ignoreEmulatedMouseEvents: boolean,
-  allowPressReentry: boolean,
+  activePointerId: null | number,
 };
 
 type PressEventType =
@@ -176,7 +175,7 @@ function createPressEvent(
     let eventObject;
     if (nativeEvent.clientX !== undefined) {
       eventObject = (nativeEvent: any);
-    } else if (isTouchEvent(nativeEvent)) {
+    } else if (isNativeTouchEvent(nativeEvent)) {
       eventObject = getTouchFromPressEvent(nativeEvent);
     }
     if (eventObject) {
@@ -482,7 +481,7 @@ function calculateResponderRegion(
   };
 }
 
-function isTouchEvent(nativeEvent: Event): boolean {
+function isNativeTouchEvent(nativeEvent: Event): boolean {
   const changedTouches = ((nativeEvent: any): TouchEvent).changedTouches;
   return changedTouches && typeof changedTouches.length === 'number';
 }
@@ -500,7 +499,7 @@ function getEventViewportCoords(
   nativeEvent: Event,
 ): {x: null | number, y: null | number} {
   let eventObject = (nativeEvent: any);
-  if (isTouchEvent(eventObject)) {
+  if (isNativeTouchEvent(eventObject)) {
     eventObject = getTouchFromPressEvent(eventObject);
   }
   const x = eventObject.clientX;
@@ -512,7 +511,7 @@ function getEventViewportCoords(
 }
 
 function isPressWithinResponderRegion(
-  nativeEvent: $PropertyType<ReactResponderEvent, 'nativeEvent'>,
+  nativeEventOrTouchEvent: Event | Touch,
   state: PressState,
 ): boolean {
   const {responderRegionOnActivation, responderRegionOnDeactivation} = state;
@@ -531,7 +530,7 @@ function isPressWithinResponderRegion(
       bottom = Math.max(bottom, responderRegionOnDeactivation.bottom);
     }
   }
-  const {x, y} = getEventViewportCoords(((nativeEvent: any): Event));
+  const {clientX: x, clientY: y} = (nativeEventOrTouchEvent: any);
 
   return (
     left != null &&
@@ -571,8 +570,53 @@ function removeRootEventTypes(
 ): void {
   if (state.addedRootEvents) {
     state.addedRootEvents = false;
-    state.allowPressReentry = false;
     context.removeRootEventTypes(rootEventTypes);
+  }
+}
+
+function getTouchById(
+  nativeEvent: TouchEvent,
+  pointerId: null | number,
+): null | Touch {
+  const changedTouches = nativeEvent.changedTouches;
+  for (let i = 0; i < changedTouches.length; i++) {
+    const touch = changedTouches[i];
+    if (touch.identifier === pointerId) {
+      return touch;
+    }
+  }
+  return null;
+}
+
+function getTouchTarget(context: ReactResponderContext, touchEvent: Touch) {
+  const doc = context.getActiveDocument();
+  return doc.elementFromPoint(touchEvent.clientX, touchEvent.clientY);
+}
+
+function updatePressResponderRegion(
+  target: Element | Document,
+  nativeEventOrTouchEvent: Event | Touch,
+  context: ReactResponderContext,
+  props: PressProps,
+  state: PressState,
+): void {
+  if (
+    state.pressTarget != null &&
+    !context.isTargetWithinElement(target, state.pressTarget)
+  ) {
+    // Calculate the responder region we use for deactivation if not
+    // already done during move event.
+    if (state.responderRegionOnDeactivation == null) {
+      state.responderRegionOnDeactivation = calculateResponderRegion(
+        context,
+        state.pressTarget,
+        props,
+      );
+    }
+    state.isPressWithinResponderRegion = isPressWithinResponderRegion(
+      nativeEventOrTouchEvent,
+      state,
+    );
   }
 }
 
@@ -596,7 +640,7 @@ const PressResponder = {
       responderRegionOnActivation: null,
       responderRegionOnDeactivation: null,
       ignoreEmulatedMouseEvents: false,
-      allowPressReentry: false,
+      activePointerId: null,
     };
   },
   allowMultipleHostChildren: false,
@@ -607,7 +651,7 @@ const PressResponder = {
     props: PressProps,
     state: PressState,
   ): void {
-    const {type} = event;
+    const {pointerType, type} = event;
 
     if (props.disabled) {
       removeRootEventTypes(context, state);
@@ -616,7 +660,7 @@ const PressResponder = {
       return;
     }
     const nativeEvent: any = event.nativeEvent;
-    const pointerType = context.getEventPointerType(event);
+    const isPressed = state.isPressed;
 
     if (props.stopPropagation === true) {
       nativeEvent.stopPropagation();
@@ -627,26 +671,27 @@ const PressResponder = {
       case 'keydown':
       case 'mousedown':
       case 'touchstart': {
-        if (!state.isPressed) {
-          if (type === 'pointerdown' || type === 'touchstart') {
-            state.ignoreEmulatedMouseEvents = true;
-          }
+        if (!isPressed) {
+          const isTouchEvent = type === 'touchstart';
+          const isPointerEvent = type === 'pointerdown';
+          const isKeyboardEvent = pointerType === 'keyboard';
+          const isMouseEvent = pointerType === 'mouse';
+          const isPenEvent = pointerType === 'pen';
 
-          // Ignore unrelated key events
-          if (pointerType === 'keyboard') {
+          if (isPointerEvent || isTouchEvent) {
+            state.ignoreEmulatedMouseEvents = true;
+          } else if (type === 'mousedown' && state.ignoreEmulatedMouseEvents) {
+            // Ignore emulated mouse events
+            return;
+          } else if (isKeyboardEvent) {
+            // Ignore unrelated key events
             if (!isValidKeyboardEvent(nativeEvent)) {
               return;
             }
           }
-
-          // Ignore emulated mouse events
-          if (type === 'mousedown' && state.ignoreEmulatedMouseEvents) {
-            return;
-          }
           // Ignore mouse/pen pressing on touch hit target area
-          const isMouseType = pointerType === 'mouse';
           if (
-            (isMouseType || pointerType === 'pen') &&
+            (isMouseEvent || isPenEvent) &&
             context.isEventWithinTouchHitTarget(event)
           ) {
             // We need to prevent the native event to block the focus
@@ -659,18 +704,23 @@ const PressResponder = {
           // data around for handling of the context menu
           state.pointerType = pointerType;
           state.pressTarget = context.getEventCurrentTarget(event);
+          if (isPointerEvent) {
+            state.activePointerId = (nativeEvent: any).pointerId;
+          } else if (isTouchEvent) {
+            const touchEvent = getTouchFromPressEvent(nativeEvent);
+            state.activePointerId = touchEvent.identifier;
+          }
 
           // Ignore any device buttons except left-mouse and touch/pen contact.
           // Additionally we ignore left-mouse + ctrl-key with Macs as that
           // acts like right-click and opens the contextmenu.
           if (
             nativeEvent.button > 0 ||
-            (isMac && isMouseType && nativeEvent.ctrlKey)
+            (isMac && isMouseEvent && nativeEvent.ctrlKey)
           ) {
             return;
           }
 
-          state.allowPressReentry = true;
           state.responderRegionOnActivation = calculateResponderRegion(
             context,
             state.pressTarget,
@@ -689,13 +739,13 @@ const PressResponder = {
       }
 
       case 'contextmenu': {
-        if (state.isPressed) {
-          dispatchCancel(event, context, props, state);
+        if (isPressed) {
           if (props.preventDefault !== false) {
             // Skip dispatching of onContextMenu below
             nativeEvent.preventDefault();
             return;
           }
+          dispatchCancel(event, context, props, state);
         }
         if (props.onContextMenu) {
           dispatchEvent(
@@ -719,10 +769,11 @@ const PressResponder = {
     props: PressProps,
     state: PressState,
   ): void {
-    const {target, type} = event;
+    let {pointerType, target, type} = event;
 
     const nativeEvent: any = event.nativeEvent;
-    const pointerType = context.getEventPointerType(event);
+    const isPressed = state.isPressed;
+    const activePointerId = state.activePointerId;
 
     if (props.stopPropagation === true) {
       nativeEvent.stopPropagation();
@@ -732,61 +783,65 @@ const PressResponder = {
       case 'pointermove':
       case 'mousemove':
       case 'touchmove': {
-        if (state.isPressed || state.allowPressReentry) {
-          // Ignore emulated events (pointermove will dispatch touch and mouse events)
-          // Ignore pointermove events during a keyboard press.
-          if (state.pointerType !== pointerType) {
+        let touchEvent;
+        // Ignore emulated events (pointermove will dispatch touch and mouse events)
+        // Ignore pointermove events during a keyboard press.
+        if (state.pointerType !== pointerType) {
+          return;
+        }
+        if (
+          type === 'pointermove' &&
+          activePointerId !== nativeEvent.pointerId
+        ) {
+          return;
+        } else if (type === 'touchmove') {
+          touchEvent = getTouchById(nativeEvent, activePointerId);
+          if (touchEvent === null) {
             return;
           }
+          target = getTouchTarget(context, touchEvent);
+        }
 
-          // Calculate the responder region we use for deactivation, as the
-          // element dimensions may have changed since activation.
-          if (
-            state.pressTarget !== null &&
-            state.responderRegionOnDeactivation == null
-          ) {
-            state.responderRegionOnDeactivation = calculateResponderRegion(
-              context,
-              state.pressTarget,
-              props,
-            );
-          }
-          state.isPressWithinResponderRegion = isPressWithinResponderRegion(
-            nativeEvent,
-            state,
-          );
+        // Calculate the responder region we use for deactivation, as the
+        // element dimensions may have changed since activation.
+        updatePressResponderRegion(
+          target,
+          touchEvent || nativeEvent,
+          context,
+          props,
+          state,
+        );
 
-          if (state.isPressWithinResponderRegion) {
-            if (state.isPressed) {
-              if (props.onPressMove) {
-                dispatchEvent(
-                  event,
-                  context,
-                  state,
-                  'pressmove',
-                  props.onPressMove,
-                  UserBlockingEvent,
-                );
-              }
+        if (state.isPressWithinResponderRegion) {
+          if (isPressed) {
+            if (props.onPressMove) {
+              dispatchEvent(
+                event,
+                context,
+                state,
+                'pressmove',
+                props.onPressMove,
+                UserBlockingEvent,
+              );
+            }
+            if (
+              state.activationPosition != null &&
+              state.longPressTimeout != null
+            ) {
+              const deltaX = state.activationPosition.x - nativeEvent.clientX;
+              const deltaY = state.activationPosition.y - nativeEvent.clientY;
               if (
-                state.activationPosition != null &&
+                Math.hypot(deltaX, deltaY) > 10 &&
                 state.longPressTimeout != null
               ) {
-                const deltaX = state.activationPosition.x - nativeEvent.clientX;
-                const deltaY = state.activationPosition.y - nativeEvent.clientY;
-                if (
-                  Math.hypot(deltaX, deltaY) > 10 &&
-                  state.longPressTimeout != null
-                ) {
-                  context.clearTimeout(state.longPressTimeout);
-                }
+                context.clearTimeout(state.longPressTimeout);
               }
-            } else {
-              dispatchPressStartEvents(event, context, props, state);
             }
           } else {
-            dispatchPressEndEvents(event, context, props, state);
+            dispatchPressStartEvents(event, context, props, state);
           }
+        } else {
+          dispatchPressEndEvents(event, context, props, state);
         }
         break;
       }
@@ -796,39 +851,44 @@ const PressResponder = {
       case 'keyup':
       case 'mouseup':
       case 'touchend': {
-        if (state.isPressed) {
-          // Ignore unrelated keyboard events and verify press is within
-          // responder region for non-keyboard events.
-          if (pointerType === 'keyboard') {
+        if (isPressed) {
+          let isKeyboardEvent = false;
+          let touchEvent;
+          if (
+            type === 'pointerup' &&
+            activePointerId !== nativeEvent.pointerId
+          ) {
+            return;
+          } else if (type === 'touchend') {
+            touchEvent = getTouchById(nativeEvent, activePointerId);
+            if (touchEvent === null) {
+              return;
+            }
+            target = getTouchTarget(context, touchEvent);
+          } else if (type === 'keyup') {
+            // Ignore unrelated keyboard events
             if (!isValidKeyboardEvent(nativeEvent)) {
               return;
             }
-            // If the event target isn't within the press target, check if we're still
-            // within the responder region. The region may have changed if the
-            // element's layout was modified after activation.
-          } else if (
-            state.pressTarget != null &&
-            !context.isTargetWithinElement(target, state.pressTarget)
-          ) {
-            // Calculate the responder region we use for deactivation if not
-            // already done during move event.
-            if (state.responderRegionOnDeactivation == null) {
-              state.responderRegionOnDeactivation = calculateResponderRegion(
-                context,
-                state.pressTarget,
-                props,
-              );
-            }
-            state.isPressWithinResponderRegion = isPressWithinResponderRegion(
-              nativeEvent,
-              state,
-            );
+            isKeyboardEvent = true;
           }
 
           const wasLongPressed = state.isLongPressed;
           dispatchPressEndEvents(event, context, props, state);
 
           if (state.pressTarget !== null && props.onPress) {
+            if (!isKeyboardEvent) {
+              // If the event target isn't within the press target, check if we're still
+              // within the responder region. The region may have changed if the
+              // element's layout was modified after activation.
+              updatePressResponderRegion(
+                target,
+                touchEvent || nativeEvent,
+                context,
+                props,
+                state,
+              );
+            }
             if (state.isPressWithinResponderRegion) {
               if (
                 !(

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -510,39 +510,6 @@ function getEventViewportCoords(
   };
 }
 
-function isPressWithinResponderRegion(
-  nativeEventOrTouchEvent: Event | Touch,
-  state: PressState,
-): boolean {
-  const {responderRegionOnActivation, responderRegionOnDeactivation} = state;
-  let left, top, right, bottom;
-
-  if (responderRegionOnActivation != null) {
-    left = responderRegionOnActivation.left;
-    top = responderRegionOnActivation.top;
-    right = responderRegionOnActivation.right;
-    bottom = responderRegionOnActivation.bottom;
-
-    if (responderRegionOnDeactivation != null) {
-      left = Math.min(left, responderRegionOnDeactivation.left);
-      top = Math.min(top, responderRegionOnDeactivation.top);
-      right = Math.max(right, responderRegionOnDeactivation.right);
-      bottom = Math.max(bottom, responderRegionOnDeactivation.bottom);
-    }
-  }
-  const {clientX: x, clientY: y} = (nativeEventOrTouchEvent: any);
-
-  return (
-    left != null &&
-    right != null &&
-    top != null &&
-    bottom != null &&
-    x !== null &&
-    y !== null &&
-    (x >= left && x <= right && y >= top && y <= bottom)
-  );
-}
-
 function unmountResponder(
   context: ReactResponderContext,
   props: PressProps,
@@ -593,7 +560,7 @@ function getTouchTarget(context: ReactResponderContext, touchEvent: Touch) {
   return doc.elementFromPoint(touchEvent.clientX, touchEvent.clientY);
 }
 
-function updatePressResponderRegion(
+function updateIsPressWithinResponderRegion(
   target: Element | Document,
   nativeEventOrTouchEvent: Event | Touch,
   context: ReactResponderContext,
@@ -613,10 +580,32 @@ function updatePressResponderRegion(
         props,
       );
     }
-    state.isPressWithinResponderRegion = isPressWithinResponderRegion(
-      nativeEventOrTouchEvent,
-      state,
-    );
+    const {responderRegionOnActivation, responderRegionOnDeactivation} = state;
+    let left, top, right, bottom;
+
+    if (responderRegionOnActivation != null) {
+      left = responderRegionOnActivation.left;
+      top = responderRegionOnActivation.top;
+      right = responderRegionOnActivation.right;
+      bottom = responderRegionOnActivation.bottom;
+
+      if (responderRegionOnDeactivation != null) {
+        left = Math.min(left, responderRegionOnDeactivation.left);
+        top = Math.min(top, responderRegionOnDeactivation.top);
+        right = Math.max(right, responderRegionOnDeactivation.right);
+        bottom = Math.max(bottom, responderRegionOnDeactivation.bottom);
+      }
+    }
+    const {clientX: x, clientY: y} = (nativeEventOrTouchEvent: any);
+
+    state.isPressWithinResponderRegion =
+      left != null &&
+      right != null &&
+      top != null &&
+      bottom != null &&
+      x !== null &&
+      y !== null &&
+      (x >= left && x <= right && y >= top && y <= bottom);
   }
 }
 
@@ -801,7 +790,7 @@ const PressResponder = {
 
         // Calculate the responder region we use for deactivation, as the
         // element dimensions may have changed since activation.
-        updatePressResponderRegion(
+        updateIsPressWithinResponderRegion(
           target,
           touchEvent || nativeEvent,
           context,
@@ -875,7 +864,7 @@ const PressResponder = {
               // If the event target isn't within the press target, check if we're still
               // within the responder region. The region may have changed if the
               // element's layout was modified after activation.
-              updatePressResponderRegion(
+              updateIsPressWithinResponderRegion(
                 target,
                 touchEvent || nativeEvent,
                 context,

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -651,7 +651,7 @@ const PressResponder = {
     props: PressProps,
     state: PressState,
   ): void {
-    const {pointerType, type} = event;
+    const {pointerId, pointerType, type} = event;
 
     if (props.disabled) {
       removeRootEventTypes(context, state);
@@ -705,7 +705,7 @@ const PressResponder = {
           state.pointerType = pointerType;
           state.pressTarget = context.getEventCurrentTarget(event);
           if (isPointerEvent) {
-            state.activePointerId = (nativeEvent: any).pointerId;
+            state.activePointerId = pointerId;
           } else if (isTouchEvent) {
             const touchEvent = getTouchFromPressEvent(nativeEvent);
             state.activePointerId = touchEvent.identifier;
@@ -769,7 +769,7 @@ const PressResponder = {
     props: PressProps,
     state: PressState,
   ): void {
-    let {pointerType, target, type} = event;
+    let {pointerId, pointerType, target, type} = event;
 
     const nativeEvent: any = event.nativeEvent;
     const isPressed = state.isPressed;
@@ -791,7 +791,7 @@ const PressResponder = {
         }
         if (
           type === 'pointermove' &&
-          activePointerId !== nativeEvent.pointerId
+          activePointerId !== pointerId
         ) {
           return;
         } else if (type === 'touchmove') {
@@ -856,7 +856,7 @@ const PressResponder = {
           let touchEvent;
           if (
             type === 'pointerup' &&
-            activePointerId !== nativeEvent.pointerId
+            activePointerId !== pointerId
           ) {
             return;
           } else if (type === 'touchend') {

--- a/packages/react-events/src/Scroll.js
+++ b/packages/react-events/src/Scroll.js
@@ -8,6 +8,7 @@
  */
 
 import type {
+  PointerType,
   ReactResponderEvent,
   ReactResponderContext,
 } from 'shared/ReactTypes';
@@ -37,8 +38,6 @@ type ScrollEventType =
   | 'scrolldragend'
   | 'scrollmomentumstart'
   | 'scrollmomentumend';
-
-type PointerType = '' | 'mouse' | 'keyboard' | 'pen' | 'touch';
 
 type ScrollDirection = '' | 'up' | 'down' | 'left' | 'right';
 
@@ -134,7 +133,7 @@ const ScrollResponder = {
     props: ScrollProps,
     state: ScrollState,
   ): void {
-    const {target, type} = event;
+    const {pointerType, target, type} = event;
 
     if (props.disabled) {
       if (state.isPointerDown) {
@@ -144,7 +143,6 @@ const ScrollResponder = {
       }
       return;
     }
-    const pointerType = context.getEventPointerType(event);
 
     switch (type) {
       case 'scroll': {
@@ -181,8 +179,7 @@ const ScrollResponder = {
     props: ScrollProps,
     state: ScrollState,
   ) {
-    const {type} = event;
-    const pointerType = context.getEventPointerType(event);
+    const {pointerType, type} = event;
 
     switch (type) {
       case 'pointercancel':

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -28,6 +28,17 @@ const createEvent = (type, data) => {
   return event;
 };
 
+function createTouchEvent(type, id, data) {
+  return createEvent(type, {
+    changedTouches: [
+      {
+        ...data,
+        identifier: id,
+      },
+    ],
+  });
+}
+
 const createKeyboardEvent = (type, data) => {
   return new KeyboardEvent(type, {
     bubbles: true,
@@ -108,6 +119,11 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'pen'}),
       );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressStart).toHaveBeenCalledTimes(1);
       expect(onPressStart).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'pen', type: 'pressstart'}),
@@ -156,14 +172,23 @@ describe('Event responder: Press', () => {
 
     // No PointerEvent fallbacks
     it('is called after "mousedown" event', () => {
-      ref.current.dispatchEvent(createEvent('mousedown'));
+      ref.current.dispatchEvent(
+        createEvent('mousedown', {
+          button: 0,
+        }),
+      );
       expect(onPressStart).toHaveBeenCalledTimes(1);
       expect(onPressStart).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'mouse', type: 'pressstart'}),
       );
     });
+
     it('is called after "touchstart" event', () => {
-      ref.current.dispatchEvent(createEvent('touchstart'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressStart).toHaveBeenCalledTimes(1);
       expect(onPressStart).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'touch', type: 'pressstart'}),
@@ -266,6 +291,16 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'pen'}),
       );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
+        }),
+      );
       ref.current.dispatchEvent(createEvent('pointerup'));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(
@@ -277,10 +312,20 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'touch'}),
       );
-      ref.current.dispatchEvent(createEvent('touchstart'));
-      ref.current.dispatchEvent(createEvent('pointerup'));
-      ref.current.dispatchEvent(createEvent('touchend'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
       ref.current.dispatchEvent(createEvent('mousedown'));
+      ref.current.dispatchEvent(
+        createEvent('pointerup', {pointerType: 'touch'}),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
+        }),
+      );
       ref.current.dispatchEvent(createEvent('mouseup'));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(
@@ -337,16 +382,33 @@ describe('Event responder: Press', () => {
 
     // No PointerEvent fallbacks
     it('is called after "mouseup" event', () => {
-      ref.current.dispatchEvent(createEvent('mousedown'));
-      ref.current.dispatchEvent(createEvent('mouseup'));
+      ref.current.dispatchEvent(
+        createEvent('mousedown', {
+          button: 0,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createEvent('mouseup', {
+          button: 0,
+        }),
+      );
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'mouse', type: 'pressend'}),
       );
     });
     it('is called after "touchend" event', () => {
-      ref.current.dispatchEvent(createEvent('touchstart'));
-      ref.current.dispatchEvent(createEvent('touchend'));
+      document.elementFromPoint = () => ref.current;
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'touch', type: 'pressend'}),
@@ -510,10 +572,18 @@ describe('Event responder: Press', () => {
       expect(onPressChange).toHaveBeenCalledWith(false);
     });
     it('is called after "touchstart" and "touchend" events', () => {
-      ref.current.dispatchEvent(createEvent('touchstart'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressChange).toHaveBeenCalledTimes(1);
       expect(onPressChange).toHaveBeenCalledWith(true);
-      ref.current.dispatchEvent(createEvent('touchend'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressChange).toHaveBeenCalledTimes(2);
       expect(onPressChange).toHaveBeenCalledWith(false);
     });
@@ -542,6 +612,16 @@ describe('Event responder: Press', () => {
     it('is called after "pointerup" event', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'pen'}),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
+        }),
       );
       ref.current.dispatchEvent(
         createEvent('pointerup', {clientX: 10, clientY: 10}),
@@ -623,6 +703,11 @@ describe('Event responder: Press', () => {
     it('is called if "pointerdown" lasts default delay', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'pen'}),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
       );
       jest.advanceTimersByTime(DEFAULT_LONG_PRESS_DELAY - 1);
       expect(onLongPress).not.toBeCalled();
@@ -815,18 +900,18 @@ describe('Event responder: Press', () => {
         right: 100,
       });
       ref.current.dispatchEvent(
-        createEvent('pointerdown', {pointerType: 'touch'}),
+        createEvent('pointerdown', {pointerType: 'mouse'}),
       );
       ref.current.dispatchEvent(
         createEvent('pointermove', {
-          pointerType: 'touch',
+          pointerType: 'mouse',
           clientX: 10,
           clientY: 10,
         }),
       );
       expect(onPressMove).toHaveBeenCalledTimes(1);
       expect(onPressMove).toHaveBeenCalledWith(
-        expect.objectContaining({pointerType: 'touch', type: 'pressmove'}),
+        expect.objectContaining({pointerType: 'mouse', type: 'pressmove'}),
       );
     });
 
@@ -876,7 +961,11 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(
         createEvent('pointerdown', {pointerType: 'touch'}),
       );
-      ref.current.dispatchEvent(createEvent('touchstart'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
       ref.current.dispatchEvent(
         createEvent('pointermove', {
           pointerType: 'touch',
@@ -884,7 +973,13 @@ describe('Event responder: Press', () => {
           clientY: 10,
         }),
       );
-      ref.current.dispatchEvent(createEvent('touchmove'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
+          target: ref.current,
+          clientX: 10,
+          clientY: 10,
+        }),
+      );
       ref.current.dispatchEvent(createEvent('mousemove'));
       expect(onPressMove).toHaveBeenCalledTimes(1);
     });
@@ -1345,9 +1440,20 @@ describe('Event responder: Press', () => {
         }),
       );
       ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
         createEvent('pointermove', {
           ...coordinatesInside,
           pointerType: 'touch',
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
+          ...coordinatesInside,
+          target: ref.current,
         }),
       );
       container.dispatchEvent(
@@ -1356,10 +1462,28 @@ describe('Event responder: Press', () => {
           pointerType: 'touch',
         }),
       );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
+          ...coordinatesOutside,
+          target: ref.current,
+        }),
+      );
       container.dispatchEvent(
         createEvent('pointermove', {
           ...coordinatesInside,
           pointerType: 'touch',
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
+          ...coordinatesInside,
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          ...coordinatesInside,
+          target: ref.current,
         }),
       );
       container.dispatchEvent(
@@ -1397,20 +1521,12 @@ describe('Event responder: Press', () => {
     const pressRectOffset = 20;
     const getBoundingClientRectMock = () => rectMock;
     const coordinatesInside = {
-      changedTouches: [
-        {
-          clientX: rectMock.left - pressRectOffset,
-          clientY: rectMock.top - pressRectOffset,
-        },
-      ],
+      clientX: rectMock.left - pressRectOffset,
+      clientY: rectMock.top - pressRectOffset,
     };
     const coordinatesOutside = {
-      changedTouches: [
-        {
-          clientX: rectMock.left - pressRectOffset - 1,
-          clientY: rectMock.top - pressRectOffset - 1,
-        },
-      ],
+      clientX: rectMock.left - pressRectOffset - 1,
+      clientY: rectMock.top - pressRectOffset - 1,
     };
 
     describe('within bounds of hit rect', () => {
@@ -1441,10 +1557,25 @@ describe('Event responder: Press', () => {
 
         ReactDOM.render(element, container);
 
+        document.elementFromPoint = () => ref.current;
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
-        ref.current.dispatchEvent(createEvent('touchmove', coordinatesInside));
-        ref.current.dispatchEvent(createEvent('touchend', coordinatesInside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
         jest.runAllTimers();
 
         expect(events).toEqual([
@@ -1478,9 +1609,19 @@ describe('Event responder: Press', () => {
 
         ReactDOM.render(element, container);
 
+        document.elementFromPoint = () => ref.current;
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
-        ref.current.dispatchEvent(createEvent('touchmove', coordinatesInside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
         jest.advanceTimersByTime(499);
         expect(events).toEqual(['onPressMove']);
         events = [];
@@ -1489,7 +1630,12 @@ describe('Event responder: Press', () => {
         expect(events).toEqual(['onPressStart', 'onPressChange']);
         events = [];
 
-        ref.current.dispatchEvent(createEvent('touchend', coordinatesInside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
         expect(events).toEqual(['onPressEnd', 'onPressChange', 'onPress']);
       });
 
@@ -1514,15 +1660,27 @@ describe('Event responder: Press', () => {
         );
 
         ReactDOM.render(element, container);
+
+        document.elementFromPoint = () => ref.current;
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
         ref.current.dispatchEvent(
-          createEvent('touchmove', {
-            clientX: rectMock.left - pressRetentionOffset.left,
-            clientY: rectMock.top - pressRetentionOffset.top,
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
           }),
         );
-        ref.current.dispatchEvent(createEvent('touchend', coordinatesInside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            clientX: rectMock.left - pressRetentionOffset.left,
+            clientY: rectMock.top - pressRetentionOffset.top,
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
         expect(events).toEqual([
           'onPressStart',
           'onPressChange',
@@ -1550,8 +1708,14 @@ describe('Event responder: Press', () => {
         );
 
         ReactDOM.render(element, container);
+
+        document.elementFromPoint = () => ref.current;
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
         // emulate smaller dimensions change on activation
         ref.current.getBoundingClientRect = () => ({
           width: 80,
@@ -1566,8 +1730,18 @@ describe('Event responder: Press', () => {
           clientY: rectMock.top,
         };
         // move to an area within the pre-activation region
-        ref.current.dispatchEvent(createEvent('touchmove', coordinates));
-        ref.current.dispatchEvent(createEvent('touchend', coordinates));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinates,
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinates,
+            target: ref.current,
+          }),
+        );
         expect(events).toEqual(['onPressStart', 'onPressEnd', 'onPress']);
       });
 
@@ -1588,8 +1762,14 @@ describe('Event responder: Press', () => {
         );
 
         ReactDOM.render(element, container);
+
+        document.elementFromPoint = () => ref.current;
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
         // emulate larger dimensions change on activation
         ref.current.getBoundingClientRect = () => ({
           width: 200,
@@ -1604,8 +1784,18 @@ describe('Event responder: Press', () => {
           clientY: rectMock.top - 50,
         };
         // move to an area within the post-activation region
-        ref.current.dispatchEvent(createEvent('touchmove', coordinates));
-        ref.current.dispatchEvent(createEvent('touchend', coordinates));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinates,
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinates,
+            target: ref.current,
+          }),
+        );
         expect(events).toEqual(['onPressStart', 'onPressEnd', 'onPress']);
       });
     });
@@ -1640,11 +1830,32 @@ describe('Event responder: Press', () => {
 
         ReactDOM.render(element, container);
 
+        document.elementFromPoint = () => ref.current;
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
-        ref.current.dispatchEvent(createEvent('touchmove', coordinatesInside));
-        container.dispatchEvent(createEvent('touchmove', coordinatesOutside));
-        container.dispatchEvent(createEvent('touchend', coordinatesOutside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
+        document.elementFromPoint = () => container;
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesOutside,
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinatesOutside,
+            target: ref.current,
+          }),
+        );
         jest.runAllTimers();
 
         expect(events).toEqual([
@@ -1679,14 +1890,35 @@ describe('Event responder: Press', () => {
 
         ReactDOM.render(element, container);
 
+        document.elementFromPoint = () => ref.current;
         ref.current.getBoundingClientRect = getBoundingClientRectMock;
-        ref.current.dispatchEvent(createEvent('touchstart'));
-        ref.current.dispatchEvent(createEvent('touchmove', coordinatesInside));
-        container.dispatchEvent(createEvent('touchmove', coordinatesOutside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchstart', 0, {
+            target: ref.current,
+          }),
+        );
+        ref.current.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesInside,
+            target: ref.current,
+          }),
+        );
+        document.elementFromPoint = () => container;
+        container.dispatchEvent(
+          createTouchEvent('touchmove', 0, {
+            ...coordinatesOutside,
+            target: container,
+          }),
+        );
         jest.runAllTimers();
         expect(events).toEqual(['onPressMove']);
         events = [];
-        container.dispatchEvent(createEvent('touchend', coordinatesOutside));
+        ref.current.dispatchEvent(
+          createTouchEvent('touchend', 0, {
+            ...coordinatesOutside,
+            target: ref.current,
+          }),
+        );
         jest.runAllTimers();
         expect(events).toEqual([]);
       });
@@ -1712,34 +1944,36 @@ describe('Event responder: Press', () => {
 
       ReactDOM.render(element, container);
 
+      document.elementFromPoint = () => ref.current;
       ref.current.getBoundingClientRect = getBoundingClientRectMock;
       ref.current.dispatchEvent(
-        createEvent('touchstart', {
-          pointerType: 'touch',
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
         }),
       );
       ref.current.dispatchEvent(
-        createEvent('touchmove', {
+        createTouchEvent('touchmove', 0, {
           ...coordinatesInside,
-          pointerType: 'touch',
+          target: ref.current,
         }),
       );
-      container.dispatchEvent(
-        createEvent('touchmove', {
+      document.elementFromPoint = () => container;
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
           ...coordinatesOutside,
-          pointerType: 'touch',
+          target: ref.current,
         }),
       );
-      container.dispatchEvent(
-        createEvent('touchmove', {
+      ref.current.dispatchEvent(
+        createTouchEvent('touchmove', 0, {
           ...coordinatesInside,
-          pointerType: 'touch',
+          target: ref.current,
         }),
       );
-      container.dispatchEvent(
-        createEvent('touchend', {
-          ...coordinatesInside,
-          pointerType: 'touch',
+      document.elementFromPoint = () => ref.current;
+      ref.current.dispatchEvent(
+        createTouchEvent('touchend', 0, {
+          target: ref.current,
         }),
       );
       jest.runAllTimers();
@@ -2094,8 +2328,16 @@ describe('Event responder: Press', () => {
       onPressEnd.mockReset();
 
       // When pointer events are supported
-      ref.current.dispatchEvent(createEvent('pointerdown'));
-      ref.current.dispatchEvent(createEvent('pointercancel'));
+      ref.current.dispatchEvent(
+        createEvent('pointerdown', {
+          pointerType: 'mouse',
+        }),
+      );
+      ref.current.dispatchEvent(
+        createEvent('pointercancel', {
+          pointerType: 'mouse',
+        }),
+      );
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       jest.runAllTimers();
       expect(onLongPress).not.toBeCalled();
@@ -2104,8 +2346,16 @@ describe('Event responder: Press', () => {
       onPressEnd.mockReset();
 
       // Touch fallback
-      ref.current.dispatchEvent(createEvent('touchstart'));
-      ref.current.dispatchEvent(createEvent('touchcancel'));
+      ref.current.dispatchEvent(
+        createTouchEvent('touchstart', 0, {
+          target: ref.current,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createTouchEvent('touchcancel', 0, {
+          target: ref.current,
+        }),
+      );
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       jest.runAllTimers();
       expect(onLongPress).not.toBeCalled();

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -301,7 +301,7 @@ describe('Event responder: Press', () => {
           target: ref.current,
         }),
       );
-      ref.current.dispatchEvent(createEvent('pointerup'));
+      ref.current.dispatchEvent(createEvent('pointerup', {pointerType: 'pen'}));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'pen', type: 'pressend'}),
@@ -623,9 +623,7 @@ describe('Event responder: Press', () => {
           target: ref.current,
         }),
       );
-      ref.current.dispatchEvent(
-        createEvent('pointerup', {clientX: 10, clientY: 10}),
-      );
+      ref.current.dispatchEvent(createEvent('pointerup', {pointerType: 'pen'}));
       expect(onPress).toHaveBeenCalledTimes(1);
       expect(onPress).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'pen', type: 'press'}),

--- a/packages/react-events/src/__tests__/Scroll-test.internal.js
+++ b/packages/react-events/src/__tests__/Scroll-test.internal.js
@@ -121,8 +121,16 @@ describe('Scroll event responder', () => {
       });
 
       it('with a keyboard pointerType', () => {
-        ref.current.dispatchEvent(createEvent('keydown'));
-        ref.current.dispatchEvent(createEvent('keyup'));
+        ref.current.dispatchEvent(
+          createEvent('keydown', {
+            key: 'A',
+          }),
+        );
+        ref.current.dispatchEvent(
+          createEvent('keyup', {
+            key: 'A',
+          }),
+        );
         ref.current.dispatchEvent(createEvent('scroll'));
         expect(onScroll).toHaveBeenCalledTimes(1);
         expect(onScroll).toHaveBeenCalledWith(

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -150,12 +150,22 @@ export type ReactEventTarget = {|
 
 type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | Touch;
 
+export type PointerType =
+  | ''
+  | 'mouse'
+  | 'keyboard'
+  | 'pen'
+  | 'touch'
+  | 'trackpad';
+
 export type ReactResponderEvent = {
   nativeEvent: AnyNativeEvent,
-  target: Element | Document,
-  type: string,
   passive: boolean,
   passiveSupported: boolean,
+  pointerId: null | number,
+  pointerType: PointerType,
+  target: Element | Document,
+  type: string,
 };
 
 export opaque type EventPriority = 0 | 1 | 2;
@@ -192,9 +202,6 @@ export type ReactResponderContext = {
   getFocusableElementsInScope(): Array<HTMLElement>,
   getActiveDocument(): Document,
   objectAssign: Function,
-  getEventPointerType(
-    event: ReactResponderEvent,
-  ): '' | 'mouse' | 'keyboard' | 'pen' | 'touch',
   getEventCurrentTarget(event: ReactResponderEvent): Element,
   getTimeStamp: () => number,
   isTargetWithinHostComponent: (


### PR DESCRIPTION
This PR is a follow up of https://github.com/facebook/react/pull/15871. I intended to break this all down into smaller PRs, but was unable to do it without breaking the tests. Everything is quite coupled. I was however, able to extract out the changes we wanted from #1571 without changing how everything fundamentally works. This PR does not drop using Pointer Events and switching to touch events like the other PR and works like everything does today – so this is far less risky.

Notably, the changes and fixes are as follows:

- We now check the `target` correctly from touch events using `document.elementFromPoint`, fixing several iOS issues.
- We now ensure both pointer and touch events match their ID. This allows for multiple touches to occur without causing them to conflict with one-another (this also applies to pointer events).
- There was a regression with `contextmenu` blocking long press on touch devices. This fixes that.
- We now expose `pointerId` and `pointerType` on the responder `event` object. This is far cleaner and faster than how we did this before, plus it's less code! For cases where we don't have a `pointerId`, the default is `null`.
- I cleaned up some parts of the code that duplicated conditions and tried to unify them into hoisted declarations with nice names.
- I pulled in the tests from #15871 (they have much better touch input mocking) and manually inlined `elementFromPoint` into the Jest tests because JSDOM doesn't have support for it.

Example URL: https://codesandbox.io/s/experimental-event-api-v2-2rqnr