### PR TITLE
Make React compatible with ES Modules and Pika

### DIFF
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -3,6 +3,7 @@
   "version": "16.8.6",
   "description": "React package for working with the DOM.",
   "main": "index.js",
+  "module": "src/client/ReactDOM.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,6 +8,7 @@
   "homepage": "https://reactjs.org/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",
+  "module": "src/React.js",
   "files": [
     "LICENSE",
     "README.md",


### PR DESCRIPTION
See https://www.pika.dev/about/ for basic information about Pika.

When searching for React (https://www.pika.dev/search?q=react) in Pika's interface, it shows:

> EXACT MATCH!
> react      
> Package found! However, no ES "module" entrypoint was detected in its package.json manifest. If possible, explore the site for a more web-friendly alternative.

It looks like this commit in my PR is all that's needed, because React is fortunately already written using ES Module syntax.