### PR TITLE
[Flare] remove stopLocalPropagation option + modify responder ownership

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -107,11 +107,8 @@ const eventListeners:
       ($Shape<PartialEventObject>) => void,
     > = new PossiblyWeakMap();
 
-const responderOwners: Map<
-  ReactEventResponder,
-  ReactEventComponentInstance,
-> = new Map();
 let globalOwner = null;
+let continueLocalPropagation = false;
 
 let currentTimeStamp = 0;
 let currentTimers = new Map();
@@ -308,12 +305,7 @@ const eventResponderContext: ReactResponderContext = {
   },
   hasOwnership(): boolean {
     validateResponderContext();
-    const responder = ((currentInstance: any): ReactEventComponentInstance)
-      .responder;
-    return (
-      globalOwner === currentInstance ||
-      responderOwners.get(responder) === currentInstance
-    );
+    return globalOwner === currentInstance;
   },
   requestGlobalOwnership(): boolean {
     validateResponderContext();
@@ -321,18 +313,7 @@ const eventResponderContext: ReactResponderContext = {
       return false;
     }
     globalOwner = currentInstance;
-    triggerOwnershipListeners(null);
-    return true;
-  },
-  requestResponderOwnership(): boolean {
-    validateResponderContext();
-    const eventComponentInstance = ((currentInstance: any): ReactEventComponentInstance);
-    const responder = eventComponentInstance.responder;
-    if (responderOwners.has(responder)) {
-      return false;
-    }
-    responderOwners.set(responder, eventComponentInstance);
-    triggerOwnershipListeners(responder);
+    triggerOwnershipListeners();
     return true;
   },
   releaseOwnership(): boolean {
@@ -453,6 +434,10 @@ const eventResponderContext: ReactResponderContext = {
     }
     return false;
   },
+  cotinueLocalPropagation() {
+    validateResponderContext();
+    continueLocalPropagation = true;
+  },
 };
 
 function collectFocusableElements(
@@ -505,22 +490,12 @@ function getActiveDocument(): Document {
 function releaseOwnershipForEventComponentInstance(
   eventComponentInstance: ReactEventComponentInstance,
 ): boolean {
-  const responder = eventComponentInstance.responder;
-  let triggerOwnershipListenersWith;
-  if (responderOwners.get(responder) === eventComponentInstance) {
-    responderOwners.delete(responder);
-    triggerOwnershipListenersWith = responder;
-  }
   if (globalOwner === eventComponentInstance) {
     globalOwner = null;
-    triggerOwnershipListenersWith = null;
-  }
-  if (triggerOwnershipListenersWith !== undefined) {
-    triggerOwnershipListeners(triggerOwnershipListenersWith);
+    triggerOwnershipListeners();
     return true;
-  } else {
-    return false;
   }
+  return false;
 }
 
 function isFiberHostComponentFocusable(fiber: Fiber): boolean {
@@ -728,10 +703,10 @@ function getRootEventResponderInstances(
 
 function shouldSkipEventComponent(
   eventResponderInstance: ReactEventComponentInstance,
+  responder: ReactEventResponder,
   propagatedEventResponders: null | Set<ReactEventResponder>,
 ): boolean {
-  const responder = eventResponderInstance.responder;
-  if (propagatedEventResponders !== null && responder.stopLocalPropagation) {
+  if (propagatedEventResponders !== null) {
     if (propagatedEventResponders.has(responder)) {
       return true;
     }
@@ -740,13 +715,17 @@ function shouldSkipEventComponent(
   if (globalOwner && globalOwner !== eventResponderInstance) {
     return true;
   }
-  if (
-    responderOwners.has(responder) &&
-    responderOwners.get(responder) !== eventResponderInstance
-  ) {
-    return true;
-  }
   return false;
+}
+
+function checkForLocalPropagationContinuation(
+  responder: ReactEventResponder,
+  propagatedEventResponders: Set<ReactEventResponder>,
+) {
+  if (continueLocalPropagation === true) {
+    propagatedEventResponders.delete(responder);
+    continueLocalPropagation = false;
+  }
 }
 
 function traverseAndHandleEventResponderInstances(
@@ -798,6 +777,7 @@ function traverseAndHandleEventResponderInstances(
         if (
           shouldSkipEventComponent(
             targetEventResponderInstance,
+            responder,
             propagatedEventResponders,
           )
         ) {
@@ -805,6 +785,10 @@ function traverseAndHandleEventResponderInstances(
         }
         currentInstance = targetEventResponderInstance;
         eventListener(responderEvent, eventResponderContext, props, state);
+        checkForLocalPropagationContinuation(
+          responder,
+          propagatedEventResponders,
+        );
       }
     }
     // We clean propagated event responders between phases.
@@ -818,6 +802,7 @@ function traverseAndHandleEventResponderInstances(
         if (
           shouldSkipEventComponent(
             targetEventResponderInstance,
+            responder,
             propagatedEventResponders,
           )
         ) {
@@ -825,6 +810,10 @@ function traverseAndHandleEventResponderInstances(
         }
         currentInstance = targetEventResponderInstance;
         eventListener(responderEvent, eventResponderContext, props, state);
+        checkForLocalPropagationContinuation(
+          responder,
+          propagatedEventResponders,
+        );
       }
     }
   }
@@ -839,7 +828,9 @@ function traverseAndHandleEventResponderInstances(
       const {responder, props, state} = rootEventResponderInstance;
       const eventListener = responder.onRootEvent;
       if (eventListener !== undefined) {
-        if (shouldSkipEventComponent(rootEventResponderInstance, null)) {
+        if (
+          shouldSkipEventComponent(rootEventResponderInstance, responder, null)
+        ) {
           continue;
         }
         currentInstance = rootEventResponderInstance;
@@ -849,18 +840,13 @@ function traverseAndHandleEventResponderInstances(
   }
 }
 
-function triggerOwnershipListeners(
-  limitByResponder: null | ReactEventResponder,
-): void {
+function triggerOwnershipListeners(): void {
   const listeningInstances = Array.from(ownershipChangeListeners);
   const previousInstance = currentInstance;
   try {
     for (let i = 0; i < listeningInstances.length; i++) {
       const instance = listeningInstances[i];
       const {props, responder, state} = instance;
-      if (limitByResponder !== null && limitByResponder !== responder) {
-        continue;
-      }
       currentInstance = instance;
       const onOwnershipChange = responder.onOwnershipChange;
       if (onOwnershipChange !== undefined) {

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -434,7 +434,7 @@ const eventResponderContext: ReactResponderContext = {
     }
     return false;
   },
-  cotinueLocalPropagation() {
+  continueLocalPropagation() {
     validateResponderContext();
     continueLocalPropagation = true;
   },

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -213,7 +213,7 @@ describe('DOMEventResponderSystem', () => {
     const ClickEventComponent = createReactEventComponent({
       targetEventTypes: ['click'],
       onEvent: (event, context, props) => {
-        context.cotinueLocalPropagation();
+        context.continueLocalPropagation();
         eventResponderFiredCount++;
         eventLog.push({
           name: event.type,
@@ -223,7 +223,7 @@ describe('DOMEventResponderSystem', () => {
         });
       },
       onEventCapture: (event, context, props) => {
-        context.cotinueLocalPropagation();
+        context.continueLocalPropagation();
         eventResponderFiredCount++;
         eventLog.push({
           name: event.type,
@@ -324,18 +324,18 @@ describe('DOMEventResponderSystem', () => {
     ]);
   });
 
-  it('nested event responders should fire in the correct order with cotinueLocalPropagation', () => {
+  it('nested event responders should fire in the correct order with continueLocalPropagation', () => {
     let eventLog = [];
     const buttonRef = React.createRef();
 
     const ClickEventComponent = createReactEventComponent({
       targetEventTypes: ['click'],
       onEvent: (event, context, props) => {
-        context.cotinueLocalPropagation();
+        context.continueLocalPropagation();
         eventLog.push(`${props.name} [bubble]`);
       },
       onEventCapture: (event, context, props) => {
-        context.cotinueLocalPropagation();
+        context.continueLocalPropagation();
         eventLog.push(`${props.name} [capture]`);
       },
     });
@@ -686,7 +686,7 @@ describe('DOMEventResponderSystem', () => {
     const EventComponent = createReactEventComponent({
       targetEventTypes: ['pointerout'],
       onEvent: (event, context) => {
-        context.cotinueLocalPropagation();
+        context.continueLocalPropagation();
         const isWithin = context.isTargetWithinEventResponderScope(
           event.nativeEvent.relatedTarget,
         );

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -27,7 +27,6 @@ function createReactEventComponent({
   onMount,
   onUnmount,
   onOwnershipChange,
-  stopLocalPropagation,
   allowMultipleHostChildren,
 }) {
   const testEventResponder = {
@@ -40,7 +39,6 @@ function createReactEventComponent({
     onMount,
     onUnmount,
     onOwnershipChange,
-    stopLocalPropagation: stopLocalPropagation || false,
     allowMultipleHostChildren: allowMultipleHostChildren || false,
   };
 
@@ -215,6 +213,7 @@ describe('DOMEventResponderSystem', () => {
     const ClickEventComponent = createReactEventComponent({
       targetEventTypes: ['click'],
       onEvent: (event, context, props) => {
+        context.cotinueLocalPropagation();
         eventResponderFiredCount++;
         eventLog.push({
           name: event.type,
@@ -224,6 +223,7 @@ describe('DOMEventResponderSystem', () => {
         });
       },
       onEventCapture: (event, context, props) => {
+        context.cotinueLocalPropagation();
         eventResponderFiredCount++;
         eventLog.push({
           name: event.type,
@@ -324,19 +324,20 @@ describe('DOMEventResponderSystem', () => {
     ]);
   });
 
-  it('nested event responders should fire in the correct order without stopLocalPropagation', () => {
+  it('nested event responders should fire in the correct order with cotinueLocalPropagation', () => {
     let eventLog = [];
     const buttonRef = React.createRef();
 
     const ClickEventComponent = createReactEventComponent({
       targetEventTypes: ['click'],
       onEvent: (event, context, props) => {
+        context.cotinueLocalPropagation();
         eventLog.push(`${props.name} [bubble]`);
       },
       onEventCapture: (event, context, props) => {
+        context.cotinueLocalPropagation();
         eventLog.push(`${props.name} [capture]`);
       },
-      stopLocalPropagation: false,
     });
 
     const Test = () => (
@@ -361,7 +362,7 @@ describe('DOMEventResponderSystem', () => {
     ]);
   });
 
-  it('nested event responders should fire in the correct order with stopLocalPropagation', () => {
+  it('nested event responders should fire in the correct order', () => {
     let eventLog = [];
     const buttonRef = React.createRef();
 
@@ -373,7 +374,6 @@ describe('DOMEventResponderSystem', () => {
       onEventCapture: (event, context, props) => {
         eventLog.push(`${props.name} [capture]`);
       },
-      stopLocalPropagation: true,
     });
 
     const Test = () => (
@@ -686,6 +686,7 @@ describe('DOMEventResponderSystem', () => {
     const EventComponent = createReactEventComponent({
       targetEventTypes: ['pointerout'],
       onEvent: (event, context) => {
+        context.cotinueLocalPropagation();
         const isWithin = context.isTargetWithinEventResponderScope(
           event.nativeEvent.relatedTarget,
         );

--- a/packages/react-events/README.md
+++ b/packages/react-events/README.md
@@ -82,12 +82,6 @@ Called before an Event Component in unmounted.
 
 Defines the DOM events to listen to on the root of the app.
 
-### stopLocalPropagation: boolean
-
-Defines whether or not synthetic events propagate to other Event Components *of
-the same type*. This has no effect on propagation of the source DOM events or
-the synthetic events dispatched to Event Components of different types.
-
 ### targetEventTypes?: Array<ResponderEventType>
 
 Defines the DOM events to listen to within the Event Component subtree.
@@ -158,14 +152,6 @@ The current Event Component instance can request global ownership of the event s
 has global ownership, only that instance and its responder are active. To release ownership to other event responders,
 either `releaseOwnership()` must be called or the Event Component instance that had global ownership must be
 unmounted. Calling `requestGlobalOwnership` also returns `true`/`false` if the request was successful.
-
-### requestResponderOwnership(): boolean
-
-The current Event Component instance can request responder ownership within the event system. When an Event Component
-instance has responder ownership, all other Event Component instances that have the same responder as the Event Component
-instance will no longer be active. To release ownership to other event responders, either `releaseOwnership()` must be
-called or the Event Component instance that had global ownership must be unmounted. Calling `requestResponderOwnership`
-also returns `true`/`false` if the request was successful.
 
 ### setTimeout(func: () => void, delay: number): Symbol
 

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -98,7 +98,6 @@ const DragResponder = {
     };
   },
   allowMultipleHostChildren: false,
-  stopLocalPropagation: true,
   onEvent(
     event: ReactResponderEvent,
     context: ReactResponderContext,

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -228,7 +228,6 @@ const FocusResponder = {
     };
   },
   allowMultipleHostChildren: false,
-  stopLocalPropagation: true,
   onEvent(
     event: ReactResponderEvent,
     context: ReactResponderContext,

--- a/packages/react-events/src/FocusScope.js
+++ b/packages/react-events/src/FocusScope.js
@@ -84,7 +84,7 @@ const FocusScopeResponder = {
               nextElement = elements[lastPosition];
             } else {
               // Out of bounds
-              context.cotinueLocalPropagation();
+              context.continueLocalPropagation();
               return;
             }
           } else {
@@ -96,7 +96,7 @@ const FocusScopeResponder = {
               nextElement = elements[0];
             } else {
               // Out of bounds
-              context.cotinueLocalPropagation();
+              context.continueLocalPropagation();
               return;
             }
           } else {

--- a/packages/react-events/src/FocusScope.js
+++ b/packages/react-events/src/FocusScope.js
@@ -6,12 +6,10 @@
  *
  * @flow
  */
-
 import type {
   ReactResponderEvent,
   ReactResponderContext,
 } from 'shared/ReactTypes';
-
 import React from 'react';
 
 type FocusScopeProps = {
@@ -56,7 +54,6 @@ const FocusScopeResponder = {
     };
   },
   allowMultipleHostChildren: true,
-  stopLocalPropagation: false,
   onEvent(
     event: ReactResponderEvent,
     context: ReactResponderContext,
@@ -64,12 +61,7 @@ const FocusScopeResponder = {
     state: FocusScopeState,
   ) {
     const {type, nativeEvent} = event;
-    const hasOwnership =
-      context.hasOwnership() || context.requestResponderOwnership();
 
-    if (!hasOwnership) {
-      return;
-    }
     if (type === 'keydown' && nativeEvent.key === 'Tab') {
       const focusedElement = context.getActiveDocument().activeElement;
       if (
@@ -92,7 +84,7 @@ const FocusScopeResponder = {
               nextElement = elements[lastPosition];
             } else {
               // Out of bounds
-              context.releaseOwnership();
+              context.cotinueLocalPropagation();
               return;
             }
           } else {
@@ -104,19 +96,14 @@ const FocusScopeResponder = {
               nextElement = elements[0];
             } else {
               // Out of bounds
-              context.releaseOwnership();
+              context.cotinueLocalPropagation();
               return;
             }
           } else {
             nextElement = elements[position + 1];
           }
         }
-        // If this element is possibly inside the scope of another
-        // FocusScope responder or is out of bounds, then we release ownership.
         if (nextElement !== null) {
-          if (!context.isTargetWithinEventResponderScope(nextElement)) {
-            context.releaseOwnership();
-          }
           focusElement(nextElement);
           state.currentFocusedNode = nextElement;
           ((nativeEvent: any): KeyboardEvent).preventDefault();
@@ -163,21 +150,8 @@ const FocusScopeResponder = {
     props: FocusScopeProps,
     state: FocusScopeState,
   ): void {
-    if (
-      props.restoreFocus &&
-      state.nodeToRestore !== null &&
-      context.hasOwnership()
-    ) {
+    if (props.restoreFocus && state.nodeToRestore !== null) {
       focusElement(state.nodeToRestore);
-    }
-  },
-  onOwnershipChange(
-    context: ReactResponderContext,
-    props: FocusScopeProps,
-    state: FocusScopeState,
-  ): void {
-    if (!context.hasOwnership()) {
-      state.currentFocusedNode = null;
     }
   },
 };

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -287,7 +287,6 @@ const HoverResponder = {
     };
   },
   allowMultipleHostChildren: false,
-  stopLocalPropagation: true,
   onEvent(
     event: ReactResponderEvent,
     context: ReactResponderContext,

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -600,7 +600,6 @@ const PressResponder = {
     };
   },
   allowMultipleHostChildren: false,
-  stopLocalPropagation: true,
   onEvent(
     event: ReactResponderEvent,
     context: ReactResponderContext,

--- a/packages/react-events/src/Scroll.js
+++ b/packages/react-events/src/Scroll.js
@@ -127,7 +127,6 @@ const ScrollResponder = {
     };
   },
   allowMultipleHostChildren: true,
-  stopLocalPropagation: true,
   onEvent(
     event: ReactResponderEvent,
     context: ReactResponderContext,

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -104,7 +104,6 @@ const SwipeResponder = {
     };
   },
   allowMultipleHostChildren: false,
-  stopLocalPropagation: true,
   onEvent(
     event: ReactResponderEvent,
     context: ReactResponderContext,

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -90,7 +90,6 @@ export type ReactEventResponder = {
   rootEventTypes?: Array<ReactEventResponderEventType>,
   createInitialState?: (props: null | Object) => Object,
   allowMultipleHostChildren: boolean,
-  stopLocalPropagation: boolean,
   onEvent?: (
     event: ReactResponderEvent,
     context: ReactResponderContext,
@@ -184,7 +183,6 @@ export type ReactResponderContext = {
     rootEventTypes: Array<ReactEventResponderEventType>,
   ) => void,
   hasOwnership: () => boolean,
-  requestResponderOwnership: () => boolean,
   requestGlobalOwnership: () => boolean,
   releaseOwnership: () => boolean,
   setTimeout: (func: () => void, timeout: number) => number,
@@ -202,4 +200,5 @@ export type ReactResponderContext = {
     elementType: string,
     deep: boolean,
   ) => boolean,
+  cotinueLocalPropagation(): void,
 };

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -200,5 +200,5 @@ export type ReactResponderContext = {
     elementType: string,
     deep: boolean,
   ) => boolean,
-  cotinueLocalPropagation(): void,
+  continueLocalPropagation(): void,
 };


### PR DESCRIPTION
After lots of internal discussion and also quite a lot of discussion on GitHub in relation to Focus, it occurred to me that the model that React Flare tries to keep consistent can easily be broken by a few features that leave the architecture up to abuse. Notably, the notion of event components not leaking propagation to other event components of the same type. It has fixed many issues that the system it replaced so rather than make it `optional`, this PR makes it the always default. `stopLocalPropagation` flag has been removed and now it applies to all event responders.

That also means that we no longer have any need for responder ownership, because by having `stopLocalPropagation` be the default, we also get that for free – so lots of code to kill off!

In the case of `FocusScope` and some tests that need to bypass the local propagation in very defined cases (a FocusScope loses focus, and needs to focus to bubble to the next FocusScope), there is a new context method called `continueLocalPropagation`.

Overall, this PR simplifies many of the concepts of this event system and keeps things more rigid, leading people to question their ideas before they try and hack the system to work like the heritage event system.