### PR TITLE
Add additional check in warning for changed bits so users can use bigint in their code

### DIFF
--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -145,13 +145,14 @@ export function calculateChangedBits<T>(
 
     if (__DEV__) {
       warning(
-        (changedBits & MAX_SIGNED_31_BIT_INT) === changedBits,
+        typeof changedBits === 'number' &&
+          (changedBits & MAX_SIGNED_31_BIT_INT) === changedBits,
         'calculateChangedBits: Expected the return value to be a ' +
           '31-bit integer. Instead received: %s',
         changedBits,
       );
     }
-    return changedBits | 0;
+    return Math.floor(changedBits);
   }
 }
 


### PR DESCRIPTION
I wanted to use big int in my context value but it seems that some minor checks will throw an error but it seems to be pretty minor check which will allow end user to try big int for observed bits
