### PR TITLE
Add SuspenseList Component

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
@@ -34,7 +34,7 @@ function initModules() {
   };
 }
 
-const {resetModules, serverRender} = ReactDOMServerIntegrationUtils(
+const {resetModules, serverRender, itRenders} = ReactDOMServerIntegrationUtils(
   initModules,
 );
 
@@ -97,5 +97,25 @@ describe('ReactDOMServerSuspense', () => {
     expect(e.innerHTML).toBe(
       '<div>Children</div><!--$!--><div>Fallback</div><!--/$-->',
     );
+  });
+
+  itRenders('a SuspenseList component and its children', async render => {
+    const element = await render(
+      <React.unstable_SuspenseList>
+        <React.Suspense fallback="Loading A">
+          <div>A</div>
+        </React.Suspense>
+        <React.Suspense fallback="Loading B">
+          <div>B</div>
+        </React.Suspense>
+      </React.unstable_SuspenseList>,
+    );
+    const parent = element.parentNode;
+    const divA = parent.children[0];
+    expect(divA.tagName).toBe('DIV');
+    expect(divA.textContent).toBe('A');
+    const divB = parent.children[1];
+    expect(divB.tagName).toBe('DIV');
+    expect(divB.textContent).toBe('B');
   });
 });

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -31,6 +31,7 @@ import {
   REACT_STRICT_MODE_TYPE,
   REACT_CONCURRENT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
+  REACT_SUSPENSE_LIST_TYPE,
   REACT_PORTAL_TYPE,
   REACT_PROFILER_TYPE,
   REACT_PROVIDER_TYPE,
@@ -970,6 +971,7 @@ class ReactDOMServerRenderer {
         case REACT_STRICT_MODE_TYPE:
         case REACT_CONCURRENT_MODE_TYPE:
         case REACT_PROFILER_TYPE:
+        case REACT_SUSPENSE_LIST_TYPE:
         case REACT_FRAGMENT_TYPE: {
           const nextChildren = toArray(
             ((nextChild: any): ReactElement).props.children,

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -43,6 +43,7 @@ import {
   ContextConsumer,
   Profiler,
   SuspenseComponent,
+  SuspenseListComponent,
   FunctionComponent,
   MemoComponent,
   SimpleMemoComponent,
@@ -75,6 +76,7 @@ import {
   REACT_CONTEXT_TYPE,
   REACT_CONCURRENT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
+  REACT_SUSPENSE_LIST_TYPE,
   REACT_MEMO_TYPE,
   REACT_LAZY_TYPE,
   REACT_EVENT_COMPONENT_TYPE,
@@ -531,6 +533,13 @@ export function createFiberFromTypeAndProps(
         return createFiberFromProfiler(pendingProps, mode, expirationTime, key);
       case REACT_SUSPENSE_TYPE:
         return createFiberFromSuspense(pendingProps, mode, expirationTime, key);
+      case REACT_SUSPENSE_LIST_TYPE:
+        return createFiberFromSuspenseList(
+          pendingProps,
+          mode,
+          expirationTime,
+          key,
+        );
       default: {
         if (typeof type === 'object' && type !== null) {
           switch (type.$$typeof) {
@@ -726,6 +735,18 @@ export function createFiberFromSuspense(
   fiber.elementType = type;
   fiber.type = type;
 
+  fiber.expirationTime = expirationTime;
+  return fiber;
+}
+
+export function createFiberFromSuspenseList(
+  pendingProps: any,
+  mode: TypeOfMode,
+  expirationTime: ExpirationTime,
+  key: null | string,
+) {
+  const fiber = createFiber(SuspenseListComponent, pendingProps, key, mode);
+  fiber.elementType = REACT_SUSPENSE_LIST_TYPE;
   fiber.expirationTime = expirationTime;
   return fiber;
 }

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -731,9 +731,10 @@ export function createFiberFromSuspense(
   const fiber = createFiber(SuspenseComponent, pendingProps, key, mode);
 
   // TODO: The SuspenseComponent fiber shouldn't have a type. It has a tag.
-  const type = REACT_SUSPENSE_TYPE;
-  fiber.elementType = type;
-  fiber.type = type;
+  // This needs to be fixed in getComponentName so that it relies on the tag
+  // instead.
+  fiber.type = REACT_SUSPENSE_TYPE;
+  fiber.elementType = REACT_SUSPENSE_TYPE;
 
   fiber.expirationTime = expirationTime;
   return fiber;
@@ -746,6 +747,12 @@ export function createFiberFromSuspenseList(
   key: null | string,
 ) {
   const fiber = createFiber(SuspenseListComponent, pendingProps, key, mode);
+  if (__DEV__) {
+    // TODO: The SuspenseListComponent fiber shouldn't have a type. It has a tag.
+    // This needs to be fixed in getComponentName so that it relies on the tag
+    // instead.
+    fiber.type = REACT_SUSPENSE_LIST_TYPE;
+  }
   fiber.elementType = REACT_SUSPENSE_LIST_TYPE;
   fiber.expirationTime = expirationTime;
   return fiber;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -31,6 +31,7 @@ import {
   ContextConsumer,
   Profiler,
   SuspenseComponent,
+  SuspenseListComponent,
   DehydratedSuspenseComponent,
   MemoComponent,
   SimpleMemoComponent,
@@ -1918,6 +1919,22 @@ function updateDehydratedSuspenseComponent(
   }
 }
 
+function updateSuspenseListComponent(
+  current: Fiber | null,
+  workInProgress: Fiber,
+  renderExpirationTime: ExpirationTime,
+) {
+  // TODO
+  const nextChildren = workInProgress.pendingProps.children;
+  reconcileChildren(
+    current,
+    workInProgress,
+    nextChildren,
+    renderExpirationTime,
+  );
+  return workInProgress.child;
+}
+
 function updatePortalComponent(
   current: Fiber | null,
   workInProgress: Fiber,
@@ -2555,6 +2572,13 @@ function beginWork(
         );
       }
       break;
+    }
+    case SuspenseListComponent: {
+      return updateSuspenseListComponent(
+        current,
+        workInProgress,
+        renderExpirationTime,
+      );
     }
     case EventComponent: {
       if (enableEventAPI) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -185,6 +185,7 @@ let didWarnAboutGetDerivedStateOnFunctionComponent;
 let didWarnAboutFunctionRefs;
 export let didWarnAboutReassigningProps;
 let didWarnAboutMaxDuration;
+let didWarnAboutDisplayOrder;
 
 if (__DEV__) {
   didWarnAboutBadClass = {};
@@ -194,6 +195,7 @@ if (__DEV__) {
   didWarnAboutFunctionRefs = {};
   didWarnAboutReassigningProps = false;
   didWarnAboutMaxDuration = false;
+  didWarnAboutDisplayOrder = {};
 }
 
 export function reconcileChildren(
@@ -2051,8 +2053,20 @@ function updateSuspenseListComponent(
     default: {
       // The default display order is the same as not having
       // a boundary.
-      // TODO: Warn if displayOrder is not `undefined`, since anything
-      // else is an unsupported option.
+      if (__DEV__) {
+        if (
+          displayOrder !== undefined &&
+          !didWarnAboutDisplayOrder[displayOrder]
+        ) {
+          didWarnAboutDisplayOrder[displayOrder] = true;
+          warning(
+            false,
+            '"%s" is not a supported displayOrder on <SuspenseList />. ' +
+              'Did you mean "together"?',
+            displayOrder,
+          );
+        }
+      }
       // We mark this as having captured but it really just says to the
       // complete phase that we should treat this as done, whatever form
       // it is in. No need for a second pass.

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -185,7 +185,7 @@ let didWarnAboutGetDerivedStateOnFunctionComponent;
 let didWarnAboutFunctionRefs;
 export let didWarnAboutReassigningProps;
 let didWarnAboutMaxDuration;
-let didWarnAboutDisplayOrder;
+let didWarnAboutRevealOrder;
 
 if (__DEV__) {
   didWarnAboutBadClass = {};
@@ -195,7 +195,7 @@ if (__DEV__) {
   didWarnAboutFunctionRefs = {};
   didWarnAboutReassigningProps = false;
   didWarnAboutMaxDuration = false;
-  didWarnAboutDisplayOrder = {};
+  didWarnAboutRevealOrder = {};
 }
 
 export function reconcileChildren(
@@ -1980,7 +1980,7 @@ function propagateSuspenseContextChange(
   }
 }
 
-type SuspenseListDisplayOrder = 'together' | void;
+type SuspenseListRevealOrder = 'together' | void;
 
 function updateSuspenseListComponent(
   current: Fiber | null,
@@ -1988,7 +1988,7 @@ function updateSuspenseListComponent(
   renderExpirationTime: ExpirationTime,
 ) {
   const nextProps = workInProgress.pendingProps;
-  const displayOrder: SuspenseListDisplayOrder = nextProps.displayOrder;
+  const revealOrder: SuspenseListRevealOrder = nextProps.revealOrder;
   const nextChildren = nextProps.children;
 
   let nextChildFibers;
@@ -2045,25 +2045,25 @@ function updateSuspenseListComponent(
 
   pushSuspenseContext(workInProgress, suspenseContext);
 
-  switch (displayOrder) {
-    // TODO: For other display orders we'll need to split the nextChildFibers set.
+  switch (revealOrder) {
+    // TODO: For other reveal orders we'll need to split the nextChildFibers set.
     case 'together': {
       break;
     }
     default: {
-      // The default display order is the same as not having
+      // The default reveal order is the same as not having
       // a boundary.
       if (__DEV__) {
         if (
-          displayOrder !== undefined &&
-          !didWarnAboutDisplayOrder[displayOrder]
+          revealOrder !== undefined &&
+          !didWarnAboutRevealOrder[revealOrder]
         ) {
-          didWarnAboutDisplayOrder[displayOrder] = true;
+          didWarnAboutRevealOrder[revealOrder] = true;
           warning(
             false,
-            '"%s" is not a supported displayOrder on <SuspenseList />. ' +
+            '"%s" is not a supported revealOrder on <SuspenseList />. ' +
               'Did you mean "together"?',
-            displayOrder,
+            revealOrder,
           );
         }
       }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2045,6 +2045,14 @@ function updateSuspenseListComponent(
 
   pushSuspenseContext(workInProgress, suspenseContext);
 
+  if ((workInProgress.mode & BatchedMode) === NoMode) {
+    // Outside of batched mode, SuspenseList doesn't work so we just
+    // use make it a noop by treating it as the default revealOrder.
+    workInProgress.effectTag |= DidCapture;
+    workInProgress.child = nextChildFibers;
+    return nextChildFibers;
+  }
+
   switch (revealOrder) {
     // TODO: For other reveal orders we'll need to split the nextChildFibers set.
     case 'together': {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -46,6 +46,7 @@ import {
   SimpleMemoComponent,
   EventComponent,
   EventTarget,
+  SuspenseListComponent,
 } from 'shared/ReactWorkTags';
 import {
   invokeGuardedCallback,
@@ -590,6 +591,7 @@ function commitLifeCycles(
       return;
     }
     case SuspenseComponent:
+    case SuspenseListComponent:
     case IncompleteClassComponent:
       return;
     case EventTarget: {
@@ -1182,6 +1184,11 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       }
       case SuspenseComponent: {
         commitSuspenseComponent(finishedWork);
+        attachSuspenseRetryListeners(finishedWork);
+        return;
+      }
+      case SuspenseListComponent: {
+        attachSuspenseRetryListeners(finishedWork);
         return;
       }
     }
@@ -1256,6 +1263,11 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
     }
     case SuspenseComponent: {
       commitSuspenseComponent(finishedWork);
+      attachSuspenseRetryListeners(finishedWork);
+      return;
+    }
+    case SuspenseListComponent: {
+      attachSuspenseRetryListeners(finishedWork);
       return;
     }
     case IncompleteClassComponent: {
@@ -1290,7 +1302,9 @@ function commitSuspenseComponent(finishedWork: Fiber) {
   if (supportsMutation && primaryChildParent !== null) {
     hideOrUnhideAllChildren(primaryChildParent, newDidTimeout);
   }
+}
 
+function attachSuspenseRetryListeners(finishedWork: Fiber) {
   // If this boundary just timed out, then it will have a set of thenables.
   // For each thenable, attach a listener so that when it resolves, React
   // attempts to re-render the boundary in the primary (pre-timeout) state.

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -836,6 +836,7 @@ function completeWork(
       break;
     }
     case SuspenseListComponent: {
+      popSuspenseContext(workInProgress);
       // TODO
       break;
     }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -36,6 +36,7 @@ import {
   Mode,
   Profiler,
   SuspenseComponent,
+  SuspenseListComponent,
   DehydratedSuspenseComponent,
   MemoComponent,
   SimpleMemoComponent,
@@ -832,6 +833,10 @@ function completeWork(
           workInProgress.stateNode = null;
         }
       }
+      break;
+    }
+    case SuspenseListComponent: {
+      // TODO
       break;
     }
     case EventComponent: {

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -155,7 +155,7 @@ export function calculateChangedBits<T>(
   }
 }
 
-function scheduleWorkOnParentPath(
+export function scheduleWorkOnParentPath(
   parent: Fiber | null,
   renderExpirationTime: ExpirationTime,
 ) {

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -12,6 +12,10 @@ import type {Fiber} from './ReactFiber';
 // TODO: This is now an empty object. Should we switch this to a boolean?
 export type SuspenseState = {||};
 
+export type SuspenseListState = {|
+  didSuspend: boolean,
+|};
+
 export function shouldCaptureSuspense(
   workInProgress: Fiber,
   hasInvisibleParent: boolean,

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -17,6 +17,7 @@ import {
   HostPortal,
   ContextProvider,
   SuspenseComponent,
+  SuspenseListComponent,
   DehydratedSuspenseComponent,
   EventComponent,
   EventTarget,
@@ -95,6 +96,10 @@ function unwindWork(
       }
       return null;
     }
+    case SuspenseListComponent: {
+      // TODO
+      return null;
+    }
     case HostPortal:
       popHostContainer(workInProgress);
       return null;
@@ -141,6 +146,9 @@ function unwindInterruptedWork(interruptedWork: Fiber) {
         // TODO: popHydrationState
         popSuspenseContext(interruptedWork);
       }
+      break;
+    case SuspenseListComponent:
+      // TODO
       break;
     case ContextProvider:
       popProvider(interruptedWork);

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -97,7 +97,9 @@ function unwindWork(
       return null;
     }
     case SuspenseListComponent: {
-      // TODO
+      popSuspenseContext(workInProgress);
+      // SuspenseList doesn't actually catch anything. It should've been
+      // caught by a nested boundary. If not, it should bubble through.
       return null;
     }
     case HostPortal:
@@ -148,7 +150,7 @@ function unwindInterruptedWork(interruptedWork: Fiber) {
       }
       break;
     case SuspenseListComponent:
-      // TODO
+      popSuspenseContext(interruptedWork);
       break;
     case ContextProvider:
       popProvider(interruptedWork);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2092,10 +2092,10 @@ export function pingSuspendedRoot(
 }
 
 export function retryTimedOutBoundary(boundaryFiber: Fiber) {
-  // The boundary fiber (a Suspense component) previously timed out and was
-  // rendered in its fallback state. One of the promises that suspended it has
-  // resolved, which means at least part of the tree was likely unblocked. Try
-  // rendering again, at a new expiration time.
+  // The boundary fiber (a Suspense component or SuspenseList component)
+  // previously was rendered in its fallback state. One of the promises that
+  // suspended it has resolved, which means at least part of the tree was
+  // likely unblocked. Try rendering again, at a new expiration time.
   const currentTime = requestCurrentTime();
   const suspenseConfig = null; // Retries don't carry over the already committed update.
   const retryTime = computeExpirationForFiber(

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -401,4 +401,99 @@ describe('ReactSuspenseList', () => {
       </Fragment>,
     );
   });
+
+  it('avoided boundaries can be coordinate with SuspenseList', async () => {
+    let A = createAsyncText('A');
+    let B = createAsyncText('B');
+    let C = createAsyncText('C');
+
+    function Foo({showMore}) {
+      return (
+        <Suspense fallback={<Text text="Loading" />}>
+          <SuspenseList revealOrder="together">
+            <Suspense
+              unstable_avoidThisFallback={true}
+              fallback={<Text text="Loading A" />}>
+              <A />
+            </Suspense>
+            {showMore ? (
+              <Fragment>
+                <Suspense
+                  unstable_avoidThisFallback={true}
+                  fallback={<Text text="Loading B" />}>
+                  <B />
+                </Suspense>
+                <Suspense
+                  unstable_avoidThisFallback={true}
+                  fallback={<Text text="Loading C" />}>
+                  <C />
+                </Suspense>
+              </Fragment>
+            ) : null}
+          </SuspenseList>
+        </Suspense>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+
+    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading']);
+
+    expect(ReactNoop).toMatchRenderedOutput(<span>Loading</span>);
+
+    await A.resolve();
+
+    expect(Scheduler).toFlushAndYield(['A']);
+
+    expect(ReactNoop).toMatchRenderedOutput(<span>A</span>);
+
+    // Let's do an update that should consult the avoided boundaries.
+    ReactNoop.render(<Foo showMore={true} />);
+
+    expect(Scheduler).toFlushAndYield([
+      'A',
+      'Suspend! [B]',
+      'Loading B',
+      'Suspend! [C]',
+      'Loading C',
+    ]);
+
+    // This will suspend, since the boundaries are avoided. Give them
+    // time to display their loading states.
+    jest.advanceTimersByTime(500);
+
+    // A is already showing content so it doesn't turn into a fallback.
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>Loading B</span>
+        <span>Loading C</span>
+      </Fragment>,
+    );
+
+    await B.resolve();
+
+    expect(Scheduler).toFlushAndYield(['B']);
+
+    // Even though we could now show B, we're still waiting on C.
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>Loading B</span>
+        <span>Loading C</span>
+      </Fragment>,
+    );
+
+    await C.resolve();
+
+    expect(Scheduler).toFlushAndYield(['B', 'C']);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>C</span>
+      </Fragment>,
+    );
+  });
 });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -43,10 +43,10 @@ describe('ReactSuspenseList', () => {
     return Component;
   }
 
-  it('warns if an unsupported displayOrder option is used', () => {
+  it('warns if an unsupported revealOrder option is used', () => {
     function Foo() {
       return (
-        <SuspenseList displayOrder="something">
+        <SuspenseList revealOrder="something">
           <Suspense fallback="Loading">Content</Suspense>
         </SuspenseList>
       );
@@ -55,7 +55,7 @@ describe('ReactSuspenseList', () => {
     ReactNoop.render(<Foo />);
 
     expect(() => Scheduler.flushAll()).toWarnDev([
-      'Warning: "something" is not a supported displayOrder on ' +
+      'Warning: "something" is not a supported revealOrder on ' +
         '<SuspenseList />. Did you mean "together"?' +
         '\n    in SuspenseList (at **)' +
         '\n    in Foo (at **)',
@@ -135,7 +135,7 @@ describe('ReactSuspenseList', () => {
 
     function Foo() {
       return (
-        <SuspenseList displayOrder="together">
+        <SuspenseList revealOrder="together">
           <Suspense fallback={<Text text="Loading A" />}>
             <A />
           </Suspense>
@@ -204,7 +204,7 @@ describe('ReactSuspenseList', () => {
 
     function Foo() {
       return (
-        <SuspenseList displayOrder="together">
+        <SuspenseList revealOrder="together">
           <div>
             <Suspense fallback={<Text text="Loading A" />}>
               <A />
@@ -289,11 +289,11 @@ describe('ReactSuspenseList', () => {
 
     function Foo() {
       return (
-        <SuspenseList displayOrder="together">
+        <SuspenseList revealOrder="together">
           <Suspense fallback={<Text text="Loading A" />}>
             <A />
           </Suspense>
-          <SuspenseList displayOrder="together">
+          <SuspenseList revealOrder="together">
             <Suspense fallback={<Text text="Loading B" />}>
               <B />
             </Suspense>
@@ -350,7 +350,7 @@ describe('ReactSuspenseList', () => {
 
     function Foo() {
       return (
-        <SuspenseList displayOrder="together">
+        <SuspenseList revealOrder="together">
           <Suspense fallback={<Text text="Loading A" />}>
             <A />
           </Suspense>

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -43,6 +43,25 @@ describe('ReactSuspenseList', () => {
     return Component;
   }
 
+  it('warns if an unsupported displayOrder option is used', () => {
+    function Foo() {
+      return (
+        <SuspenseList displayOrder="something">
+          <Suspense fallback="Loading">Content</Suspense>
+        </SuspenseList>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+
+    expect(() => Scheduler.flushAll()).toWarnDev([
+      'Warning: "something" is not a supported displayOrder on ' +
+        '<SuspenseList />. Did you mean "together"?' +
+        '\n    in SuspenseList (at **)' +
+        '\n    in Foo (at **)',
+    ]);
+  });
+
   it('shows content independently by default', async () => {
     let A = createAsyncText('A');
     let B = createAsyncText('B');

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -1,0 +1,180 @@
+let React;
+let ReactFeatureFlags;
+let Fragment;
+let ReactNoop;
+let Scheduler;
+let Suspense;
+let SuspenseList;
+
+describe('ReactSuspenseList', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+    ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
+    React = require('react');
+    Fragment = React.Fragment;
+    ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
+    Suspense = React.Suspense;
+    SuspenseList = React.unstable_SuspenseList;
+  });
+
+  function Text(props) {
+    Scheduler.yieldValue(props.text);
+    return <span>{props.text}</span>;
+  }
+
+  function createAsyncText(text) {
+    let resolved = false;
+    let Component = function() {
+      if (!resolved) {
+        Scheduler.yieldValue('Suspend! [' + text + ']');
+        throw promise;
+      }
+      return <Text text={text} />;
+    };
+    let promise = new Promise(resolve => {
+      Component.resolve = function() {
+        resolved = true;
+        return resolve();
+      };
+    });
+    return Component;
+  }
+
+  it('shows content independently by default', async () => {
+    let A = createAsyncText('A');
+    let B = createAsyncText('B');
+    let C = createAsyncText('C');
+
+    function Foo() {
+      return (
+        <SuspenseList>
+          <Suspense fallback={<Text text="Loading A" />}>
+            <A />
+          </Suspense>
+          <Suspense fallback={<Text text="Loading B" />}>
+            <B />
+          </Suspense>
+          <Suspense fallback={<Text text="Loading C" />}>
+            <C />
+          </Suspense>
+        </SuspenseList>
+      );
+    }
+
+    await A.resolve();
+
+    ReactNoop.render(<Foo />);
+
+    expect(Scheduler).toFlushAndYield([
+      'A',
+      'Suspend! [B]',
+      'Loading B',
+      'Suspend! [C]',
+      'Loading C',
+    ]);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>Loading B</span>
+        <span>Loading C</span>
+      </Fragment>,
+    );
+
+    await C.resolve();
+
+    expect(Scheduler).toFlushAndYield(['C']);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>Loading B</span>
+        <span>C</span>
+      </Fragment>,
+    );
+
+    await B.resolve();
+
+    expect(Scheduler).toFlushAndYield(['B']);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>C</span>
+      </Fragment>,
+    );
+  });
+
+  it('displays all "together"', async () => {
+    let A = createAsyncText('A');
+    let B = createAsyncText('B');
+    let C = createAsyncText('C');
+
+    function Foo() {
+      return (
+        <SuspenseList displayOrder="together">
+          <Suspense fallback={<Text text="Loading A" />}>
+            <A />
+          </Suspense>
+          <Suspense fallback={<Text text="Loading B" />}>
+            <B />
+          </Suspense>
+          <Suspense fallback={<Text text="Loading C" />}>
+            <C />
+          </Suspense>
+        </SuspenseList>
+      );
+    }
+
+    await A.resolve();
+
+    ReactNoop.render(<Foo />);
+
+    expect(Scheduler).toFlushAndYield([
+      'A',
+      'Suspend! [B]',
+      'Loading B',
+      'Suspend! [C]',
+      'Loading C',
+      'Loading A',
+      'Loading B',
+      'Loading C',
+    ]);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>Loading A</span>
+        <span>Loading B</span>
+        <span>Loading C</span>
+      </Fragment>,
+    );
+
+    await B.resolve();
+
+    expect(Scheduler).toFlushAndYield(['A', 'B', 'Suspend! [C]']);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>Loading A</span>
+        <span>Loading B</span>
+        <span>Loading C</span>
+      </Fragment>,
+    );
+
+    await C.resolve();
+
+    expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>C</span>
+      </Fragment>,
+    );
+  });
+});

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -11,6 +11,7 @@ import {
   REACT_PROFILER_TYPE,
   REACT_STRICT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
+  REACT_SUSPENSE_LIST_TYPE,
 } from 'shared/ReactSymbols';
 
 import {Component, PureComponent} from './ReactBaseClasses';
@@ -88,6 +89,7 @@ const React = {
   Profiler: REACT_PROFILER_TYPE,
   StrictMode: REACT_STRICT_MODE_TYPE,
   Suspense: REACT_SUSPENSE_TYPE,
+  unstable_SuspenseList: REACT_SUSPENSE_LIST_TYPE,
 
   createElement: __DEV__ ? createElementWithValidation : createElement,
   cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -46,6 +46,9 @@ export const REACT_FORWARD_REF_TYPE = hasSymbol
 export const REACT_SUSPENSE_TYPE = hasSymbol
   ? Symbol.for('react.suspense')
   : 0xead1;
+export const REACT_SUSPENSE_LIST_TYPE = hasSymbol
+  ? Symbol.for('react.suspense_list')
+  : 0xead8;
 export const REACT_MEMO_TYPE = hasSymbol ? Symbol.for('react.memo') : 0xead3;
 export const REACT_LAZY_TYPE = hasSymbol ? Symbol.for('react.lazy') : 0xead4;
 export const REACT_EVENT_COMPONENT_TYPE = hasSymbol

--- a/packages/shared/ReactWorkTags.js
+++ b/packages/shared/ReactWorkTags.js
@@ -28,7 +28,8 @@ export type WorkTag =
   | 17
   | 18
   | 19
-  | 20;
+  | 20
+  | 21;
 
 export const FunctionComponent = 0;
 export const ClassComponent = 1;
@@ -51,3 +52,4 @@ export const IncompleteClassComponent = 17;
 export const DehydratedSuspenseComponent = 18;
 export const EventComponent = 19;
 export const EventTarget = 20;
+export const SuspenseListComponent = 21;

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -20,6 +20,7 @@ import {
   REACT_PROVIDER_TYPE,
   REACT_STRICT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
+  REACT_SUSPENSE_LIST_TYPE,
   REACT_LAZY_TYPE,
   REACT_EVENT_COMPONENT_TYPE,
   REACT_EVENT_TARGET_TYPE,
@@ -73,6 +74,8 @@ function getComponentName(type: mixed): string | null {
       return 'StrictMode';
     case REACT_SUSPENSE_TYPE:
       return 'Suspense';
+    case REACT_SUSPENSE_LIST_TYPE:
+      return 'SuspenseList';
   }
   if (typeof type === 'object') {
     switch (type.$$typeof) {

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -16,6 +16,7 @@ import {
   REACT_PROVIDER_TYPE,
   REACT_STRICT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
+  REACT_SUSPENSE_LIST_TYPE,
   REACT_MEMO_TYPE,
   REACT_LAZY_TYPE,
   REACT_EVENT_COMPONENT_TYPE,
@@ -32,6 +33,7 @@ export default function isValidElementType(type: mixed) {
     type === REACT_PROFILER_TYPE ||
     type === REACT_STRICT_MODE_TYPE ||
     type === REACT_SUSPENSE_TYPE ||
+    type === REACT_SUSPENSE_LIST_TYPE ||
     (typeof type === 'object' &&
       type !== null &&
       (type.$$typeof === REACT_LAZY_TYPE ||


### PR DESCRIPTION
This component lets you coordinate the loading sequence of nested Suspense boundaries. How this happens is defined by the `revealOrder` property. By default, it behaves like a noop so the nested boundaries just do what they normally would.

It operates on the nearest most Suspense boundary but you can actually have intermediate components and DOM nodes. If the nearest nested boundary is another SuspenseList, it operates on the nested Suspense boundary within that.

This first PR implements the `"together"` option which ensures that all boundaries resolve together. If any of them trigger a fallback, they all do.

Subsequent PRs will implement ordered rendering row-by-row. However, even in those options when there are insertions in the middle or existing rows triggering new fallbacks in the middle, there will be a "together" pass to resolve those first before the row-by-row kicks in. So the `"together"` mode is the primitive needed for those modes too.

The mechanism for this mode is that we do a full render pass first, and then scan the result to see if there are any fallbacks. If there are, we do a full second render pass (including re-reconciliation). There are many complex scenarios that can happen such as having existing trees staying in fallbacks, and new props coming in.

The second pass currently deletes all work that we did in the first pass so it's quite in efficient but this particular mode is expected to be rare and not have large subtrees. It's expected that there are not that many abstractions until we hit the first Suspense boundary. We're Suspended anyway.

Unfortunately this does a shallow scan even if we're just updating something nested inside the tree. I'd like to add an optimization if nothing has suspended during the first render pass and we know from previous results that nothing has suspended. Not quite sure exactly when that's safe yet.