### PR TITLE
[Fresh] Fall back to Map/Set if Weak equivalents are not available

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -21,14 +21,25 @@ type Signature = {|
   getCustomHooks: () => Array<Function>,
 |};
 
+// In old environments, we'll leak previous types after every edit.
+const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
+const PossiblyWeakSet = typeof WeakSet === 'function' ? WeakSet : Set;
+
 // We never remove these associations.
 // It's OK to reference families, but use WeakMap/Set for types.
 const allFamiliesByID: Map<string, Family> = new Map();
-const allTypes: WeakSet<any> = new WeakSet();
-const allSignaturesByType: WeakMap<any, Signature> = new WeakMap();
+// $FlowIssue
+const allTypes: WeakSet<any> | Set<any> = new PossiblyWeakSet();
+// $FlowIssue
+const allSignaturesByType:
+  | WeakMap<any, Signature>
+  | Map<any, Signature> = new PossiblyWeakMap();
 // This WeakMap is read by React, so we only put families
 // that have actually been edited here. This keeps checks fast.
-const familiesByType: WeakMap<any, Family> = new WeakMap();
+// $FlowIssue
+const familiesByType:
+  | WeakMap<any, Family>
+  | Map<any, Family> = new PossiblyWeakMap();
 
 // This is cleared on every prepareUpdate() call.
 // It is an array of [Family, NextType] tuples.

--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -30,16 +30,13 @@ const PossiblyWeakSet = typeof WeakSet === 'function' ? WeakSet : Set;
 const allFamiliesByID: Map<string, Family> = new Map();
 // $FlowIssue
 const allTypes: WeakSet<any> | Set<any> = new PossiblyWeakSet();
-// $FlowIssue
-const allSignaturesByType:
-  | WeakMap<any, Signature>
-  | Map<any, Signature> = new PossiblyWeakMap();
+const allSignaturesByType: // $FlowIssue
+WeakMap<any, Signature> | Map<any, Signature> = new PossiblyWeakMap();
 // This WeakMap is read by React, so we only put families
 // that have actually been edited here. This keeps checks fast.
 // $FlowIssue
-const familiesByType:
-  | WeakMap<any, Family>
-  | Map<any, Family> = new PossiblyWeakMap();
+const familiesByType: // $FlowIssue
+WeakMap<any, Family> | Map<any, Family> = new PossiblyWeakMap();
 
 // This is cleared on every prepareUpdate() call.
 // It is an array of [Family, NextType] tuples.


### PR DESCRIPTION
I'm running into this in an older RN environment. Modern ones look fine (including the today's RN open source). So this is a temporary solution until everything is modern internally.

We rely on `WeakMap` and `WeakSet` to avoid holding onto previous versions of any type after a hot reload edit. So this change makes us leak some memory in old environments. I think it's fine because it only affects really old environments (e.g. IE) and the cost is DEV-only (and only comes into play if you actually do a hot reload).

The Flow issues are the same we've ran into before. It's a Flow bug but I don't know if it'll get fixed.