### PR TITLE
[Scheduler] Use continuation pattern for posting host callback

### DIFF
--- a/packages/scheduler/src/__tests__/Scheduler-test.js
+++ b/packages/scheduler/src/__tests__/Scheduler-test.js
@@ -227,7 +227,7 @@ describe('Scheduler', () => {
   });
 
   it(
-    'continutations are interrupted by higher priority work scheduled ' +
+    'continuations are interrupted by higher priority work scheduled ' +
       'inside an executing callback',
     () => {
       const tasks = [['A', 100], ['B', 100], ['C', 100], ['D', 100]];
@@ -237,7 +237,7 @@ describe('Scheduler', () => {
           const [label, ms] = task;
           Scheduler.advanceTime(ms);
           Scheduler.yieldValue(label);
-          if (task[0] === 'B') {
+          if (label === 'B') {
             // Schedule high pri work from inside another callback
             Scheduler.yieldValue('Schedule high pri');
             scheduleCallback(UserBlockingPriority, () => {


### PR DESCRIPTION
As I prepare to implement integrated timers, I noticed some peculiarities in the Scheduler implementation that could afford to be cleaned up.

This is a refactor and shouldn't affect any observable behavior (except maybe accidental bugs); mostly it removes some concepts that existed in earlier iterations of Scheduler and are no longer needed.

The main change is to how the DOM implementation schedules an additional callback before yielding to the main thread. It used to follow the same code path for scheduling task; now it has its own branch directly inside the message event handler. The special case for error handling — where we call `postMessage` immediately without waiting for rAF — has similarly been localized inside the catch block of the message event handler.

It probably helps to read the commits one at a time.