### PR TITLE
[Flare] Press events include defaultPrevented

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -171,14 +171,6 @@ const eventResponderContext: ReactDOMResponderContext = {
         }
       },
     });
-    // $FlowFixMe: we don't need value, Flow thinks we do
-    Object.defineProperty(possibleEventObject, 'defaultPrevented', {
-      get() {
-        if (__DEV__) {
-          showWarning('defaultPrevented');
-        }
-      },
-    });
 
     const eventObject = ((possibleEventObject: any): $Shape<
       PartialEventObject,

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -925,19 +925,6 @@ describe('DOMEventResponderSystem', () => {
         ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.nativeEvent }`',
       {withoutStack: true},
     );
-    expect(() => {
-      handler = event => {
-        return event.defaultPrevented;
-      };
-      ReactDOM.render(<Test />, container);
-      dispatchClickEvent(document.body);
-    }).toWarnDev(
-      'Warning: defaultPrevented is not available on event objects created from event responder modules ' +
-        '(React Flare).' +
-        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.defaultPrevented }`',
-      {withoutStack: true},
-    );
-
     expect(container.innerHTML).toBe('<button>Click me!</button>');
   });
 

--- a/packages/react-events/docs/Press.md
+++ b/packages/react-events/docs/Press.md
@@ -37,9 +37,34 @@ const Button = (props) => (
 
 ```js
 type PressEvent = {
-  pointerType: 'mouse' | 'touch' | 'pen' | 'trackpad' | 'keyboard',
+  altKey: boolean,
+  ctrlKey: boolean,
+  defaultPrevented: boolean,
+  metaKey: boolean,
+  pageX: number,
+  pageY: number,
+  pointerType:
+    | 'mouse'
+    | 'touch'
+    | 'pen'
+    | 'trackpad'
+    | 'keyboard',
+  screenX: number,
+  screenY: number,
+  shiftKey: boolean,
   target: Element,
-  type: 'press' | 'pressstart' | 'pressend' | 'presschange' | 'pressmove' | 'longpress' | 'longpresschange' | 'contextmenu'
+  timeStamp: number,
+  type:
+    | 'press'
+    | 'pressstart'
+    | 'pressend'
+    | 'presschange'
+    | 'pressmove'
+    | 'longpress'
+    | 'longpresschange'
+    | 'contextmenu',
+  x: number,
+  y: number
 }
 
 type PressOffset = {
@@ -70,11 +95,6 @@ released before the threshold is exceeded.
 ### disabled: boolean = false
 
 Disables all `Press` events.
-
-### disableContextMenu: boolean = false
-
-Disables the native context menu so that it is never shown and `onContextMenu`
-is never called.
 
 ### onContextMenu: (e: PressEvent) => void
 
@@ -134,6 +154,11 @@ element before it is deactivated. Once deactivated, the pointer (still held
 down) can be moved back within the bounds of the element to reactivate it.
 Ensure you pass in a constant to reduce memory allocations. Default is `20` for
 each offset.
+
+### preventContextMenu: boolean = false
+
+Prevents the native context menu from being shown, but `onContextMenu`
+is still called.
 
 ### preventDefault: boolean = true
 

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -2221,6 +2221,9 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(createEvent('pointerup'));
       ref.current.dispatchEvent(createEvent('click', {preventDefault}));
       expect(preventDefault).toBeCalled();
+      expect(onPress).toHaveBeenCalledWith(
+        expect.objectContaining({defaultPrevented: true}),
+      );
     });
 
     it('deeply prevents native behaviour by default', () => {
@@ -2259,6 +2262,9 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(createEvent('pointerup'));
       ref.current.dispatchEvent(createEvent('click', {preventDefault}));
       expect(preventDefault).toBeCalled();
+      expect(onPress).toHaveBeenCalledWith(
+        expect.objectContaining({defaultPrevented: true}),
+      );
     });
 
     it('uses native behaviour for interactions with modifier keys', () => {
@@ -2283,6 +2289,9 @@ describe('Event responder: Press', () => {
           createEvent('click', {[modifierKey]: true, preventDefault}),
         );
         expect(preventDefault).not.toBeCalled();
+        expect(onPress).toHaveBeenCalledWith(
+          expect.objectContaining({defaultPrevented: false}),
+        );
       });
     });
 
@@ -2301,6 +2310,9 @@ describe('Event responder: Press', () => {
       ref.current.dispatchEvent(createEvent('pointerup'));
       ref.current.dispatchEvent(createEvent('click', {preventDefault}));
       expect(preventDefault).not.toBeCalled();
+      expect(onPress).toHaveBeenCalledWith(
+        expect.objectContaining({defaultPrevented: false}),
+      );
     });
   });
 
@@ -2839,11 +2851,11 @@ describe('Event responder: Press', () => {
       expect(onContextMenu).toHaveBeenCalledTimes(0);
     });
 
-    it('is not called if "disableContextMenu" is true', () => {
+    it('is still called if "preventContextMenu" is true', () => {
       const onContextMenu = jest.fn();
       const ref = React.createRef();
       const element = (
-        <Press disableContextMenu={true} onContextMenu={onContextMenu}>
+        <Press onContextMenu={onContextMenu} preventContextMenu={true}>
           <div ref={ref} />
         </Press>
       );
@@ -2852,7 +2864,10 @@ describe('Event responder: Press', () => {
         createEvent('pointerdown', {pointerType: 'mouse', button: 2}),
       );
       ref.current.dispatchEvent(createEvent('contextmenu'));
-      expect(onContextMenu).toHaveBeenCalledTimes(0);
+      expect(onContextMenu).toHaveBeenCalledTimes(1);
+      expect(onContextMenu).toHaveBeenCalledWith(
+        expect.objectContaining({defaultPrevented: true}),
+      );
     });
   });
 


### PR DESCRIPTION
Also changes the behaviour of 'disableContextMenu' so that 'onContextMenu' is still called.