### PR TITLE
[Flare] Relable Press preventDefault + stopPropagation props

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -19,7 +19,9 @@ import {DiscreteEvent, UserBlockingEvent} from 'shared/ReactTypes';
 
 type PressProps = {
   disabled: boolean,
-  disableContextMenu: boolean,
+  preventNativeDefault: boolean,
+  disableNativeContextMenu: boolean,
+  disableNativePropagation: boolean,
   delayLongPress: number,
   delayPressEnd: number,
   delayPressStart: number,
@@ -38,8 +40,6 @@ type PressProps = {
     bottom: number,
     left: number,
   },
-  preventDefault: boolean,
-  stopPropagation: boolean,
 };
 
 type PressState = {
@@ -651,7 +651,7 @@ const PressResponder = {
     const nativeEvent: any = event.nativeEvent;
     const isPressed = state.isPressed;
 
-    if (props.stopPropagation === true) {
+    if (props.disableNativePropagation === true) {
       nativeEvent.stopPropagation();
     }
     switch (type) {
@@ -728,14 +728,11 @@ const PressResponder = {
       }
 
       case 'contextmenu': {
-        if (props.disableContextMenu) {
+        if (props.disableNativeContextMenu === true) {
           // Skip dispatching of onContextMenu below
           nativeEvent.preventDefault();
-          return;
-        }
-
-        if (isPressed) {
-          if (props.preventDefault !== false) {
+        } else if (isPressed) {
+          if (props.preventNativeDefault !== false) {
             // Skip dispatching of onContextMenu below
             nativeEvent.preventDefault();
             return;
@@ -771,7 +768,7 @@ const PressResponder = {
     const isPressed = state.isPressed;
     const activePointerId = state.activePointerId;
 
-    if (props.stopPropagation === true) {
+    if (props.disableNativePropagation === true) {
       nativeEvent.stopPropagation();
     }
     switch (type) {
@@ -917,9 +914,9 @@ const PressResponder = {
             shiftKey,
           } = (nativeEvent: MouseEvent);
           // Check "open in new window/tab" and "open context menu" key modifiers
-          const preventDefault = props.preventDefault;
+          const preventNativeDefault = props.preventNativeDefault;
           if (
-            preventDefault !== false &&
+            preventNativeDefault !== false &&
             !shiftKey &&
             !metaKey &&
             !ctrlKey &&

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -2286,12 +2286,12 @@ describe('Event responder: Press', () => {
       });
     });
 
-    it('uses native behaviour if preventDefault is false', () => {
+    it('uses native behaviour if preventNativeDefault is false', () => {
       const onPress = jest.fn();
       const preventDefault = jest.fn();
       const ref = React.createRef();
       const element = (
-        <Press onPress={onPress} preventDefault={false}>
+        <Press onPress={onPress} preventNativeDefault={false}>
           <a href="#" ref={ref} />
         </Press>
       );
@@ -2839,11 +2839,11 @@ describe('Event responder: Press', () => {
       expect(onContextMenu).toHaveBeenCalledTimes(0);
     });
 
-    it('is not called if "disableContextMenu" is true', () => {
+    it('is still called if "disableNativeContextMenu" is true', () => {
       const onContextMenu = jest.fn();
       const ref = React.createRef();
       const element = (
-        <Press disableContextMenu={true} onContextMenu={onContextMenu}>
+        <Press disableNativeContextMenu={true} onContextMenu={onContextMenu}>
           <div ref={ref} />
         </Press>
       );
@@ -2852,14 +2852,14 @@ describe('Event responder: Press', () => {
         createEvent('pointerdown', {pointerType: 'mouse', button: 2}),
       );
       ref.current.dispatchEvent(createEvent('contextmenu'));
-      expect(onContextMenu).toHaveBeenCalledTimes(0);
+      expect(onContextMenu).toHaveBeenCalledTimes(1);
     });
   });
 
-  it('should work correctly with stopPropagation set to true', () => {
+  it('should work correctly with "disableNativePropagation" set to true', () => {
     const ref = React.createRef();
     const element = (
-      <Press stopPropagation={true}>
+      <Press disableNativePropagation={true}>
         <div ref={ref} />
       </Press>
     );


### PR DESCRIPTION
This PR does the follow:

- Renames`disableContextMenu` to `disableNativeContextMenu` and no longer prevents the `onContextMenu` event from firing if the prop is `false`.
- Renames `preventDefault` to `disableNativePropagation`
- Renames `stopPropagation` to `disableNativePropagation`

The idea being, is that using a slightly different name from the native DOM methods makes it clear that these work in slightly different ways that fit this new event system's needs, rather than needs of the user writing imperative DOM event handling.