### PR TITLE
[Flare] Add RN build step for ReactTypes

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -13,6 +13,7 @@ import type {
   MeasureOnSuccessCallback,
   NativeMethodsMixinType,
   ReactNativeBaseComponentViewConfig,
+  ReactNativeEventResponder,
 } from './ReactNativeTypes';
 import type {ReactEventComponentInstance} from 'shared/ReactTypes';
 
@@ -76,7 +77,7 @@ export type UpdatePayload = Object;
 
 export type TimeoutHandle = TimeoutID;
 export type NoTimeout = -1;
-export type EventResponder = any;
+export type EventResponder = ReactNativeEventResponder;
 
 // TODO: Remove this conditional once all changes have propagated.
 if (registerEventHandler) {

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
-import type {ReactNativeBaseComponentViewConfig} from './ReactNativeTypes';
+import type {
+  ReactNativeBaseComponentViewConfig,
+  ReactNativeEventResponder,
+} from './ReactNativeTypes';
 import type {ReactEventComponentInstance} from 'shared/ReactTypes';
 
 import invariant from 'shared/invariant';
@@ -48,7 +51,7 @@ export type ChildSet = void; // Unused
 
 export type TimeoutHandle = TimeoutID;
 export type NoTimeout = -1;
-export type EventResponder = any;
+export type EventResponder = ReactNativeEventResponder;
 
 const UPDATE_SIGNAL = {};
 if (__DEV__) {

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -157,3 +157,6 @@ export type ReactFabricType = {
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: SecretInternalsFabricType,
 };
+
+// TODO will be addressed with upcoming React Flare support
+export type ReactNativeEventResponder = any;

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+// NOTE: this line is changed in the RN build, see: copyRNShims in packaging.js
 import type {EventResponder} from 'react-reconciler/src/ReactFiberHostConfig';
 
 export type ReactNode =


### PR DESCRIPTION
When we build for React Native, we have a packaging task that copies `ReactTypes` to the shims directory. The issue is that, because event responders are renderer specific, they import from the `react-reconciler`. When this is used in RN, there is no `react-reconciler` package, so this results in a Flow type error. To address this, we modify the `import` line at build time and change it to the RN specific renderer so that this doesn't cause a Flow error.