### PR TITLE
[Flare] Add useEvent hook implementation

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -215,6 +215,10 @@ function useMemo<T>(
   return value;
 }
 
+function useEvent() {
+  throw new Error('TODO: not yet implemented');
+}
+
 const Dispatcher: DispatcherType = {
   readContext,
   useCallback,
@@ -227,6 +231,7 @@ const Dispatcher: DispatcherType = {
   useReducer,
   useRef,
   useState,
+  useEvent,
 };
 
 // Inspect

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -709,7 +709,7 @@ function getTargetEventResponderInstances(
   while (node !== null) {
     // Traverse up the fiber tree till we find event component fibers.
     const tag = node.tag;
-    const events = node.events;
+    const events = node.dependencies.events;
 
     if (tag === EventComponent) {
       const eventComponentInstance = node.stateNode;

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -16,6 +16,7 @@ import {
   EventComponent,
   EventTarget as EventTargetWorkTag,
   HostComponent,
+  FunctionComponent,
 } from 'shared/ReactWorkTags';
 import type {
   ReactEventComponentInstance,
@@ -117,6 +118,7 @@ let currentTimers = new Map();
 let currentInstance: null | ReactEventComponentInstance = null;
 let currentEventQueue: null | EventQueue = null;
 let currentTimerIDCounter = 0;
+let currentDocument: null | Document = null;
 
 const eventResponderContext: ReactDOMResponderContext = {
   dispatchEvent(
@@ -217,15 +219,41 @@ const eventResponderContext: ReactDOMResponderContext = {
     }
     return false;
   },
-  isTargetWithinEventComponent,
-  isTargetWithinEventResponderScope(target: Element | Document): boolean {
+  isTargetWithinEventComponent(target: Element | Document): boolean {
     validateResponderContext();
-    const responder = ((currentInstance: any): ReactEventComponentInstance)
-      .responder;
     if (target != null) {
       let fiber = getClosestInstanceFromNode(target);
+      const currentFiber = ((currentInstance: any): ReactEventComponentInstance)
+        .currentFiber;
+
       while (fiber !== null) {
-        if (fiber.stateNode === currentInstance) {
+        if (fiber.tag === EventComponent) {
+          // Switch to the current fiber tree
+          fiber = fiber.stateNode.currentFiber;
+        }
+        if (fiber === currentFiber || fiber.stateNode === currentInstance) {
+          return true;
+        }
+        fiber = fiber.return;
+      }
+    }
+    return false;
+  },
+  isTargetWithinEventResponderScope(target: Element | Document): boolean {
+    validateResponderContext();
+    const componentInstance = ((currentInstance: any): ReactEventComponentInstance);
+    const responder = componentInstance.responder;
+
+    if (target != null) {
+      let fiber = getClosestInstanceFromNode(target);
+      const currentFiber = ((currentInstance: any): ReactEventComponentInstance)
+        .currentFiber;
+      while (fiber !== null) {
+        if (fiber.tag === EventComponent) {
+          // Switch to the current fiber tree
+          fiber = fiber.stateNode.currentFiber;
+        }
+        if (fiber === currentFiber || fiber.stateNode === currentInstance) {
           return true;
         }
         if (
@@ -384,9 +412,15 @@ const eventResponderContext: ReactDOMResponderContext = {
     const target = event.target;
     let fiber = getClosestInstanceFromNode(target);
     let hostComponent = target;
+    const currentResponder = ((currentInstance: any): ReactEventComponentInstance)
+      .responder;
 
     while (fiber !== null) {
-      if (fiber.stateNode === currentInstance) {
+      const stateNode = fiber.stateNode;
+      if (
+        fiber.tag === EventComponent &&
+        (stateNode === null || stateNode.responder === currentResponder)
+      ) {
         break;
       }
       if (fiber.tag === HostComponent) {
@@ -407,8 +441,16 @@ const eventResponderContext: ReactDOMResponderContext = {
   ): boolean {
     validateResponderContext();
     let fiber = getClosestInstanceFromNode(target);
+    const currentResponder = ((currentInstance: any): ReactEventComponentInstance)
+      .responder;
+
     while (fiber !== null) {
-      if (!deep && fiber.stateNode === currentInstance) {
+      const stateNode = fiber.stateNode;
+      if (
+        !deep &&
+        (fiber.tag === EventComponent &&
+          (stateNode === null || stateNode.responder === currentResponder))
+      ) {
         return false;
       }
       if (fiber.tag === HostComponent && fiber.type === elementType) {
@@ -451,24 +493,8 @@ function collectFocusableElements(
   }
 }
 
-function isTargetWithinEventComponent(target: Element | Document): boolean {
-  validateResponderContext();
-  if (target != null) {
-    let fiber = getClosestInstanceFromNode(target);
-    while (fiber !== null) {
-      if (fiber.stateNode === currentInstance) {
-        return true;
-      }
-      fiber = fiber.return;
-    }
-  }
-  return false;
-}
-
 function getActiveDocument(): Document {
-  const eventComponentInstance = ((currentInstance: any): ReactEventComponentInstance);
-  const rootElement = ((eventComponentInstance.rootInstance: any): Element);
-  return rootElement.ownerDocument;
+  return ((currentDocument: any): Document);
 }
 
 function releaseOwnershipForEventComponentInstance(
@@ -659,23 +685,60 @@ function getDOMTargetEventTypesSet(
   return cachedSet;
 }
 
+function storeTargetEventResponderInstance(
+  listeningName: string,
+  eventComponentInstance: ReactEventComponentInstance,
+  eventResponderInstances: Array<ReactEventComponentInstance>,
+  eventComponentResponders: null | Set<ReactDOMEventResponder>,
+): void {
+  const responder = eventComponentInstance.responder;
+  const targetEventTypes = responder.targetEventTypes;
+  // Validate the target event type exists on the responder
+  if (targetEventTypes !== undefined) {
+    const targetEventTypesSet = getDOMTargetEventTypesSet(targetEventTypes);
+    if (targetEventTypesSet.has(listeningName)) {
+      eventResponderInstances.push(eventComponentInstance);
+      if (eventComponentResponders !== null) {
+        eventComponentResponders.add(responder);
+      }
+    }
+  }
+}
+
 function getTargetEventResponderInstances(
   listeningName: string,
   targetFiber: null | Fiber,
 ): Array<ReactEventComponentInstance> {
+  // We use this to know if we should check add hooks. If there are
+  // no event targets, then we don't add the hook forms.
+  const eventComponentResponders = new Set();
   const eventResponderInstances = [];
   let node = targetFiber;
   while (node !== null) {
     // Traverse up the fiber tree till we find event component fibers.
-    if (node.tag === EventComponent) {
+    const tag = node.tag;
+    const events = node.events;
+
+    if (tag === EventComponent) {
       const eventComponentInstance = node.stateNode;
-      const responder = eventComponentInstance.responder;
-      const targetEventTypes = responder.targetEventTypes;
-      // Validate the target event type exists on the responder
-      if (targetEventTypes !== undefined) {
-        const targetEventTypesSet = getDOMTargetEventTypesSet(targetEventTypes);
-        if (targetEventTypesSet.has(listeningName)) {
-          eventResponderInstances.push(eventComponentInstance);
+      // Switch to the current fiber tree
+      node = eventComponentInstance.currentFiber;
+      storeTargetEventResponderInstance(
+        listeningName,
+        eventComponentInstance,
+        eventResponderInstances,
+        eventComponentResponders,
+      );
+    } else if (tag === FunctionComponent && events !== null) {
+      for (let i = 0; i < events.length; i++) {
+        const eventComponentInstance = events[i];
+        if (eventComponentResponders.has(eventComponentInstance.responder)) {
+          storeTargetEventResponderInstance(
+            listeningName,
+            eventComponentInstance,
+            eventResponderInstances,
+            null,
+          );
         }
       }
     }
@@ -706,8 +769,9 @@ function shouldSkipEventComponent(
   eventResponderInstance: ReactEventComponentInstance,
   responder: ReactDOMEventResponder,
   propagatedEventResponders: null | Set<ReactDOMEventResponder>,
+  localPropagation: boolean,
 ): boolean {
-  if (propagatedEventResponders !== null) {
+  if (propagatedEventResponders !== null && localPropagation) {
     if (propagatedEventResponders.has(responder)) {
       return true;
     }
@@ -772,7 +836,12 @@ function traverseAndHandleEventResponderInstances(
     // Capture target phase
     for (i = length; i-- > 0; ) {
       const targetEventResponderInstance = targetEventResponderInstances[i];
-      const {responder, props, state} = targetEventResponderInstance;
+      const {
+        localPropagation,
+        props,
+        responder,
+        state,
+      } = targetEventResponderInstance;
       const eventListener = responder.onEventCapture;
       if (eventListener !== undefined) {
         if (
@@ -780,16 +849,19 @@ function traverseAndHandleEventResponderInstances(
             targetEventResponderInstance,
             responder,
             propagatedEventResponders,
+            localPropagation,
           )
         ) {
           continue;
         }
         currentInstance = targetEventResponderInstance;
         eventListener(responderEvent, eventResponderContext, props, state);
-        checkForLocalPropagationContinuation(
-          responder,
-          propagatedEventResponders,
-        );
+        if (localPropagation) {
+          checkForLocalPropagationContinuation(
+            responder,
+            propagatedEventResponders,
+          );
+        }
       }
     }
     // We clean propagated event responders between phases.
@@ -797,7 +869,12 @@ function traverseAndHandleEventResponderInstances(
     // Bubble target phase
     for (i = 0; i < length; i++) {
       const targetEventResponderInstance = targetEventResponderInstances[i];
-      const {responder, props, state} = targetEventResponderInstance;
+      const {
+        localPropagation,
+        props,
+        responder,
+        state,
+      } = targetEventResponderInstance;
       const eventListener = responder.onEvent;
       if (eventListener !== undefined) {
         if (
@@ -805,16 +882,19 @@ function traverseAndHandleEventResponderInstances(
             targetEventResponderInstance,
             responder,
             propagatedEventResponders,
+            localPropagation,
           )
         ) {
           continue;
         }
         currentInstance = targetEventResponderInstance;
         eventListener(responderEvent, eventResponderContext, props, state);
-        checkForLocalPropagationContinuation(
-          responder,
-          propagatedEventResponders,
-        );
+        if (localPropagation) {
+          checkForLocalPropagationContinuation(
+            responder,
+            propagatedEventResponders,
+          );
+        }
       }
     }
   }
@@ -826,11 +906,21 @@ function traverseAndHandleEventResponderInstances(
   if (length > 0) {
     for (i = 0; i < length; i++) {
       const rootEventResponderInstance = rootEventResponderInstances[i];
-      const {responder, props, state} = rootEventResponderInstance;
+      const {
+        localPropagation,
+        props,
+        responder,
+        state,
+      } = rootEventResponderInstance;
       const eventListener = responder.onRootEvent;
       if (eventListener !== undefined) {
         if (
-          shouldSkipEventComponent(rootEventResponderInstance, responder, null)
+          shouldSkipEventComponent(
+            rootEventResponderInstance,
+            responder,
+            null,
+            localPropagation,
+          )
         ) {
           continue;
         }
@@ -944,8 +1034,10 @@ export function dispatchEventForResponderEventSystem(
     const previousInstance = currentInstance;
     const previousTimers = currentTimers;
     const previousTimeStamp = currentTimeStamp;
+    const previousDocument = currentDocument;
     currentTimers = null;
     currentEventQueue = createEventQueue();
+    currentDocument = (nativeEventTarget: any).ownerDocument;
     // We might want to control timeStamp another way here
     currentTimeStamp = (nativeEvent: any).timeStamp;
     try {
@@ -962,6 +1054,7 @@ export function dispatchEventForResponderEventSystem(
       currentInstance = previousInstance;
       currentEventQueue = previousEventQueue;
       currentTimeStamp = previousTimeStamp;
+      currentDocument = previousDocument;
     }
   }
 }

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -1116,5 +1116,25 @@ describe('DOMEventResponderSystem', () => {
     buttonRef.current.dispatchEvent(createEvent('foo'));
     // No events shold fire, as there are no event components in the branch
     expect(eventLogs).toEqual([]);
+
+    const Test3 = () => {
+      React.unstable_useEvent(EventComponent.responder, {
+        onFoo: e => eventLogs.push('hook 2a'),
+      });
+      React.unstable_useEvent(EventComponent.responder, {
+        onFoo: e => eventLogs.push('hook 2b'),
+      });
+      return (
+        <EventComponent onFoo={e => eventLogs.push('should not fire')}>
+          <EventComponent onFoo={e => eventLogs.push('prop 2')}>
+            <button ref={buttonRef} />
+          </EventComponent>
+        </EventComponent>
+      );
+    };
+
+    ReactDOM.render(<Test3 />, container);
+    buttonRef.current.dispatchEvent(createEvent('foo'));
+    expect(eventLogs).toEqual(['prop 2', 'hook 2a', 'hook 2b']);
   });
 });

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -470,4 +470,5 @@ export const Dispatcher: DispatcherType = {
   useEffect: noop,
   // Debugging effect
   useDebugValue: noop,
+  useEvent: noop,
 };

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -85,6 +85,7 @@ function dispatchDragEvent(
 }
 
 const DragResponder = {
+  displayName: 'Drag',
   targetEventTypes,
   createInitialState(): DragState {
     return {
@@ -98,6 +99,7 @@ const DragResponder = {
     };
   },
   allowMultipleHostChildren: false,
+  allowEventHooks: false,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,
@@ -259,4 +261,4 @@ const DragResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(DragResponder, 'Drag');
+export default ReactDOM.unstable_createEventComponent(DragResponder);

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -217,6 +217,7 @@ function handleRootPointerEvent(
 let isGlobalFocusVisible = true;
 
 const FocusResponder = {
+  displayName: 'Focus',
   targetEventTypes,
   rootEventTypes,
   createInitialState(): FocusState {
@@ -228,6 +229,7 @@ const FocusResponder = {
     };
   },
   allowMultipleHostChildren: false,
+  allowEventHooks: true,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,
@@ -336,4 +338,4 @@ const FocusResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(FocusResponder, 'Focus');
+export default ReactDOM.unstable_createEventComponent(FocusResponder);

--- a/packages/react-events/src/FocusScope.js
+++ b/packages/react-events/src/FocusScope.js
@@ -46,6 +46,7 @@ function getFirstFocusableElement(
 }
 
 const FocusScopeResponder = {
+  displayName: 'FocusScope',
   targetEventTypes,
   rootEventTypes,
   createInitialState(): FocusScopeState {
@@ -55,6 +56,7 @@ const FocusScopeResponder = {
     };
   },
   allowMultipleHostChildren: true,
+  allowEventHooks: false,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,
@@ -157,7 +159,4 @@ const FocusScopeResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(
-  FocusScopeResponder,
-  'FocusScope',
-);
+export default ReactDOM.unstable_createEventComponent(FocusScopeResponder);

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -274,6 +274,7 @@ function isEmulatedMouseEvent(event, state) {
 }
 
 const HoverResponder = {
+  displayName: 'Hover',
   targetEventTypes,
   createInitialState() {
     return {
@@ -287,6 +288,7 @@ const HoverResponder = {
     };
   },
   allowMultipleHostChildren: false,
+  allowEventHooks: true,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,
@@ -406,4 +408,4 @@ const HoverResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(HoverResponder, 'Hover');
+export default ReactDOM.unstable_createEventComponent(HoverResponder);

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -611,6 +611,7 @@ function updateIsPressWithinResponderRegion(
 }
 
 const PressResponder = {
+  displayName: 'Press',
   targetEventTypes,
   createInitialState(): PressState {
     return {
@@ -634,6 +635,7 @@ const PressResponder = {
     };
   },
   allowMultipleHostChildren: false,
+  allowEventHooks: true,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,
@@ -956,4 +958,4 @@ const PressResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(PressResponder, 'Press');
+export default ReactDOM.unstable_createEventComponent(PressResponder);

--- a/packages/react-events/src/Scroll.js
+++ b/packages/react-events/src/Scroll.js
@@ -117,6 +117,7 @@ function dispatchEvent(
 }
 
 const ScrollResponder = {
+  displayName: 'Scroll',
   targetEventTypes,
   createInitialState() {
     return {
@@ -126,6 +127,7 @@ const ScrollResponder = {
     };
   },
   allowMultipleHostChildren: true,
+  allowEventHooks: true,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,
@@ -211,7 +213,4 @@ const ScrollResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(
-  ScrollResponder,
-  'Scroll',
-);
+export default ReactDOM.unstable_createEventComponent(ScrollResponder);

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -89,6 +89,7 @@ type SwipeState = {
 };
 
 const SwipeResponder = {
+  displayName: 'Scroll',
   targetEventTypes,
   createInitialState(): SwipeState {
     return {
@@ -104,6 +105,7 @@ const SwipeResponder = {
     };
   },
   allowMultipleHostChildren: false,
+  allowEventHooks: false,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,
@@ -262,4 +264,4 @@ const SwipeResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(SwipeResponder, 'Swipe');
+export default ReactDOM.unstable_createEventComponent(SwipeResponder);

--- a/packages/react-events/src/__tests__/Focus-test.internal.js
+++ b/packages/react-events/src/__tests__/Focus-test.internal.js
@@ -354,6 +354,6 @@ describe('Focus event responder', () => {
   });
 
   it('expect displayName to show up for event component', () => {
-    expect(Focus.displayName).toBe('Focus');
+    expect(Focus.responder.displayName).toBe('Focus');
   });
 });

--- a/packages/react-events/src/__tests__/Hover-test.internal.js
+++ b/packages/react-events/src/__tests__/Hover-test.internal.js
@@ -546,7 +546,7 @@ describe('Hover event responder', () => {
   });
 
   it('expect displayName to show up for event component', () => {
-    expect(Hover.displayName).toBe('Hover');
+    expect(Hover.responder.displayName).toBe('Hover');
   });
 
   it('should correctly pass through event properties', () => {

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -2371,7 +2371,7 @@ describe('Event responder: Press', () => {
   });
 
   it('expect displayName to show up for event component', () => {
-    expect(Press.displayName).toBe('Press');
+    expect(Press.responder.displayName).toBe('Press');
   });
 
   it('should not trigger an invariant in addRootEventTypes()', () => {

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -21,7 +21,7 @@ import type {TypeOfMode} from './ReactTypeOfMode';
 import type {SideEffectTag} from 'shared/ReactSideEffectTags';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {UpdateQueue} from './ReactUpdateQueue';
-import type {ContextDependencyList} from './ReactFiberNewContext';
+import type {ContextDependency} from './ReactFiberNewContext';
 import type {HookType} from './ReactFiberHooks';
 import type {ReactEventComponentInstance} from 'shared/ReactTypes';
 
@@ -103,6 +103,12 @@ if (__DEV__) {
   }
 }
 
+export type Dependencies = {
+  expirationTime: ExpirationTime,
+  firstContext: ContextDependency<mixed> | null,
+  events: Array<ReactEventComponentInstance> | null,
+};
+
 // A Fiber is work on a Component that needs to be done or was done. There can
 // be more than one per component.
 export type Fiber = {|
@@ -163,11 +169,8 @@ export type Fiber = {|
   // The state used to create the output
   memoizedState: any,
 
-  // A linked-list of contexts that this fiber depends on
-  contextDependencies: ContextDependencyList | null,
-
-  // An array of event component instances for this fiber
-  events: Array<ReactEventComponentInstance> | null,
+  // An object of dependencies for this fiber
+  dependencies: Dependencies,
 
   // Bitfield that describes properties about the fiber and its subtree. E.g.
   // the ConcurrentMode flag indicates whether the subtree should be async-by-
@@ -267,8 +270,11 @@ function FiberNode(
   this.memoizedProps = null;
   this.updateQueue = null;
   this.memoizedState = null;
-  this.contextDependencies = null;
-  this.events = null;
+  this.dependencies = {
+    expirationTime: 0,
+    firstContext: null,
+    events: null,
+  };
 
   this.mode = mode;
 
@@ -437,8 +443,7 @@ export function createWorkInProgress(
   workInProgress.memoizedProps = current.memoizedProps;
   workInProgress.memoizedState = current.memoizedState;
   workInProgress.updateQueue = current.updateQueue;
-  workInProgress.contextDependencies = current.contextDependencies;
-  workInProgress.events = current.events;
+  workInProgress.dependencies = current.dependencies;
 
   // These will be overridden during the parent's reconciliation
   workInProgress.sibling = current.sibling;
@@ -829,8 +834,7 @@ export function assignFiberPropertiesInDEV(
   target.memoizedProps = source.memoizedProps;
   target.updateQueue = source.updateQueue;
   target.memoizedState = source.memoizedState;
-  target.contextDependencies = source.contextDependencies;
-  target.events = source.events;
+  target.dependencies = source.dependencies;
   target.mode = source.mode;
   target.effectTag = source.effectTag;
   target.nextEffect = source.nextEffect;

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -23,6 +23,7 @@ import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {UpdateQueue} from './ReactUpdateQueue';
 import type {ContextDependencyList} from './ReactFiberNewContext';
 import type {HookType} from './ReactFiberHooks';
+import type {ReactEventComponentInstance} from 'shared/ReactTypes';
 
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
@@ -163,6 +164,9 @@ export type Fiber = {|
   // A linked-list of contexts that this fiber depends on
   contextDependencies: ContextDependencyList | null,
 
+  // An array of event component instances for this fiber
+  events: Array<ReactEventComponentInstance> | null,
+
   // Bitfield that describes properties about the fiber and its subtree. E.g.
   // the ConcurrentMode flag indicates whether the subtree should be async-by-
   // default. When a fiber is created, it inherits the mode of its
@@ -262,6 +266,7 @@ function FiberNode(
   this.updateQueue = null;
   this.memoizedState = null;
   this.contextDependencies = null;
+  this.events = null;
 
   this.mode = mode;
 
@@ -431,6 +436,7 @@ export function createWorkInProgress(
   workInProgress.memoizedState = current.memoizedState;
   workInProgress.updateQueue = current.updateQueue;
   workInProgress.contextDependencies = current.contextDependencies;
+  workInProgress.events = current.events;
 
   // These will be overridden during the parent's reconciliation
   workInProgress.sibling = current.sibling;
@@ -796,6 +802,7 @@ export function assignFiberPropertiesInDEV(
   target.updateQueue = source.updateQueue;
   target.memoizedState = source.memoizedState;
   target.contextDependencies = source.contextDependencies;
+  target.events = source.events;
   target.mode = source.mode;
   target.effectTag = source.effectTag;
   target.nextEffect = source.nextEffect;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2312,9 +2312,8 @@ function bailoutOnAlreadyFinishedWork(
   cancelWorkTimer(workInProgress);
 
   if (current !== null) {
-    // Reuse previous context list and event component list
-    workInProgress.contextDependencies = current.contextDependencies;
-    workInProgress.events = current.events;
+    // Reuse previous dependencies
+    workInProgress.dependencies = current.dependencies;
   }
 
   if (enableProfilerTimer) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -170,6 +170,7 @@ import {
   requestCurrentTime,
   retryTimedOutBoundary,
 } from './ReactFiberWorkLoop';
+import {prepareToReadEventComponents} from './ReactFiberEvents';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
@@ -292,6 +293,7 @@ function updateForwardRef(
   // The rest is a fork of updateFunctionComponent
   let nextChildren;
   prepareToReadContext(workInProgress, renderExpirationTime);
+  prepareToReadEventComponents(workInProgress);
   if (__DEV__) {
     ReactCurrentOwner.current = workInProgress;
     setCurrentPhase('render');
@@ -612,6 +614,7 @@ function updateFunctionComponent(
 
   let nextChildren;
   prepareToReadContext(workInProgress, renderExpirationTime);
+  prepareToReadEventComponents(workInProgress);
   if (__DEV__) {
     ReactCurrentOwner.current = workInProgress;
     setCurrentPhase('render');
@@ -1226,7 +1229,7 @@ function mountIndeterminateComponent(
   const context = getMaskedContext(workInProgress, unmaskedContext);
 
   prepareToReadContext(workInProgress, renderExpirationTime);
-
+  prepareToReadEventComponents(workInProgress);
   let value;
 
   if (__DEV__) {
@@ -2132,8 +2135,9 @@ function bailoutOnAlreadyFinishedWork(
   cancelWorkTimer(workInProgress);
 
   if (current !== null) {
-    // Reuse previous context list
+    // Reuse previous context list and event component list
     workInProgress.contextDependencies = current.contextDependencies;
+    workInProgress.events = current.events;
   }
 
   if (enableProfilerTimer) {

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -106,7 +106,10 @@ import {
   renderDidSuspend,
   renderDidSuspendDelayIfPossible,
 } from './ReactFiberWorkLoop';
-import {getEventComponentHostChildrenCount} from './ReactFiberEvents';
+import {
+  getEventComponentHostChildrenCount,
+  createEventComponentInstance,
+} from './ReactFiberEvents';
 import getComponentName from 'shared/getComponentName';
 import warning from 'shared/warning';
 
@@ -857,20 +860,18 @@ function completeWork(
           if (responder.createInitialState !== undefined) {
             responderState = responder.createInitialState(newProps);
           }
-          eventComponentInstance = workInProgress.stateNode = {
-            currentFiber: workInProgress,
-            props: newProps,
+          eventComponentInstance = workInProgress.stateNode = createEventComponentInstance(
+            workInProgress,
+            newProps,
             responder,
-            rootEventTypes: null,
-            rootInstance: rootContainerInstance,
-            state: responderState,
-          };
+            rootContainerInstance,
+            responderState,
+            true,
+          );
           markUpdate(workInProgress);
         } else {
           // Update the props on the event component state node
           eventComponentInstance.props = newProps;
-          // Update the root container, so we can properly unmount events at some point
-          eventComponentInstance.rootInstance = rootContainerInstance;
           // Update the current fiber
           eventComponentInstance.currentFiber = workInProgress;
           updateEventComponent(eventComponentInstance);

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -37,9 +37,10 @@ export function updateEventComponentInstance(
     'The "%s" event responder cannot be used via the "useEvent" hook.',
     responder.displayName,
   );
-  let events = ((currentlyRenderingFiber: any): Fiber).events;
+  const dependencies = ((currentlyRenderingFiber: any): Fiber).dependencies;
+  let events = dependencies.events;
   if (events === null) {
-    ((currentlyRenderingFiber: any): Fiber).events = events = [];
+    dependencies.events = events = [];
   }
   if (currentEventComponentInstanceIndex === events.length) {
     let responderState = null;

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -8,6 +8,8 @@
  */
 
 import type {Fiber} from './ReactFiber';
+import type {ReactEventComponentInstance} from 'shared/ReactTypes';
+import type {EventResponder} from 'react-reconciler/src/ReactFiberHostConfig';
 
 import {
   HostComponent,
@@ -16,6 +18,70 @@ import {
   SuspenseComponent,
   Fragment,
 } from 'shared/ReactWorkTags';
+import invariant from 'shared/invariant';
+
+let currentlyRenderingFiber: null | Fiber = null;
+let currentEventComponentInstanceIndex: number = 0;
+
+export function prepareToReadEventComponents(workInProgress: Fiber): void {
+  currentlyRenderingFiber = workInProgress;
+  currentEventComponentInstanceIndex = 0;
+}
+
+export function updateEventComponentInstance(
+  responder: EventResponder,
+  props: null | Object,
+): void {
+  invariant(
+    responder.allowEventHooks,
+    'The "%s" event responder cannot be used via the "useEvent" hook.',
+    responder.displayName,
+  );
+  let events = ((currentlyRenderingFiber: any): Fiber).events;
+  if (events === null) {
+    ((currentlyRenderingFiber: any): Fiber).events = events = [];
+  }
+  if (currentEventComponentInstanceIndex === events.length) {
+    let responderState = null;
+    if (responder.createInitialState !== undefined) {
+      responderState = responder.createInitialState(props);
+    }
+    const eventComponentInstance = createEventComponentInstance(
+      ((currentlyRenderingFiber: any): Fiber),
+      props,
+      responder,
+      null,
+      responderState,
+      false,
+    );
+    events.push(eventComponentInstance);
+    currentEventComponentInstanceIndex++;
+  } else {
+    const eventComponentInstance = events[currentEventComponentInstanceIndex++];
+    eventComponentInstance.responder = responder;
+    eventComponentInstance.props = props;
+    eventComponentInstance.currentFiber = ((currentlyRenderingFiber: any): Fiber);
+  }
+}
+
+export function createEventComponentInstance(
+  currentFiber: Fiber,
+  props: null | Object,
+  responder: EventResponder,
+  rootInstance: mixed,
+  state: null | Object,
+  localPropagation: boolean,
+): ReactEventComponentInstance {
+  return {
+    currentFiber,
+    localPropagation,
+    props,
+    responder,
+    rootEventTypes: null,
+    rootInstance,
+    state,
+  };
+}
 
 export function isFiberSuspenseAndTimedOut(fiber: Fiber): boolean {
   return fiber.tag === SuspenseComponent && fiber.memoizedState !== null;

--- a/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
@@ -22,6 +22,7 @@ let EventTarget;
 let ReactSymbols;
 
 const noOpResponder = {
+  displayName: 'TestEventComponent',
   targetEventTypes: [],
   handleEvent() {},
 };
@@ -29,7 +30,6 @@ const noOpResponder = {
 function createReactEventComponent() {
   return {
     $$typeof: ReactSymbols.REACT_EVENT_COMPONENT_TYPE,
-    displayName: 'TestEventComponent',
     props: null,
     responder: noOpResponder,
   };

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -381,6 +381,7 @@ class ReactShallowRenderer {
       useReducer,
       useRef,
       useState,
+      useEvent: noOp,
     };
   }
 

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -38,6 +38,7 @@ import {
   useReducer,
   useRef,
   useState,
+  useEvent,
 } from './ReactHooks';
 import {withSuspenseConfig} from './ReactBatchConfig';
 import {
@@ -50,7 +51,7 @@ import {
 } from './ReactElementValidator';
 import ReactSharedInternals from './ReactSharedInternals';
 import {error, warn} from './withComponentStack';
-import {enableJSXTransformAPI} from 'shared/ReactFeatureFlags';
+import {enableJSXTransformAPI, enableEventAPI} from 'shared/ReactFeatureFlags';
 const React = {
   Children: {
     map,
@@ -116,6 +117,10 @@ if (enableJSXTransformAPI) {
     // for now we can ship identical prod functions
     React.jsxs = jsx;
   }
+}
+
+if (enableEventAPI) {
+  React.unstable_useEvent = useEvent;
 }
 
 export default React;

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -8,6 +8,7 @@
  */
 
 import type {ReactContext} from 'shared/ReactTypes';
+import type {EventResponder} from 'react-reconciler/src/ReactFiberHostConfig';
 import invariant from 'shared/invariant';
 import warning from 'shared/warning';
 
@@ -134,4 +135,9 @@ export function useDebugValue(value: any, formatterFn: ?(value: any) => any) {
     const dispatcher = resolveDispatcher();
     return dispatcher.useDebugValue(value, formatterFn);
   }
+}
+
+export function useEvent(responder: EventResponder, props: null | Object) {
+  const dispatcher = resolveDispatcher();
+  return dispatcher.useEvent(responder, props);
 }

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -34,11 +34,12 @@ export type ReactDOMResponderEvent = {
 };
 
 export type ReactDOMEventResponder = {
+  displayName: string,
   targetEventTypes?: Array<ReactDOMEventResponderEventType>,
   rootEventTypes?: Array<ReactDOMEventResponderEventType>,
   createInitialState?: (props: null | Object) => Object,
   allowMultipleHostChildren: boolean,
-  stopLocalPropagation: boolean,
+  allowEventHooks: boolean,
   onEvent?: (
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -85,16 +85,16 @@ export type RefObject = {|
 
 export type ReactEventComponentInstance = {|
   currentFiber: mixed,
+  localPropagation: boolean,
   props: null | Object,
   responder: EventResponder,
   rootEventTypes: null | Set<string>,
-  rootInstance: mixed,
+  rootInstance: null | mixed,
   state: null | Object,
 |};
 
 export type ReactEventComponent = {|
   $$typeof: Symbol | number,
-  displayName: string,
   props: null | Object,
   responder: EventResponder,
 |};

--- a/packages/shared/createEventComponent.js
+++ b/packages/shared/createEventComponent.js
@@ -31,7 +31,6 @@ if (__DEV__) {
 
 export default function createEventComponent(
   responder: EventResponder,
-  displayName: string,
 ): ReactEventComponent {
   // We use responder as a Map key later on. When we have a bad
   // polyfill, then we can't use it as a key as the polyfill tries
@@ -41,7 +40,6 @@ export default function createEventComponent(
   }
   const eventComponent = {
     $$typeof: REACT_EVENT_COMPONENT_TYPE,
-    displayName: displayName,
     props: null,
     responder: responder,
   };

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -95,7 +95,7 @@ function getComponentName(type: mixed): string | null {
       case REACT_EVENT_COMPONENT_TYPE: {
         if (enableEventAPI) {
           const eventComponent = ((type: any): ReactEventComponent);
-          return eventComponent.displayName;
+          return eventComponent.responder.displayName;
         }
         break;
       }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -333,5 +333,6 @@
   "332": "Unknown priority level.",
   "333": "This should have a parent host component initialized. This error is likely caused by a bug in React. Please file an issue.",
   "334": "accumulate(...): Accumulated items must not be null or undefined.",
-  "335": "ReactDOMServer does not yet support the event API."
+  "335": "ReactDOMServer does not yet support the event API.",
+  "336": "The \"%s\" event responder cannot be used via the \"useEvent\" hook."
 }


### PR DESCRIPTION
This PR adds a new primitive hook to React called `useEvent`. For now it's behind the React Flare flag and is labelled `unstabled_useEvent` on the React object. This implementation might have bugs in, as it's not been hooked up and tested with the various event responder modules, like Press, Hover etc. This isn't intended to be a bug-free PR, more it's an initial implementation that should aim to get the wiring right between fibers and the hook.

The principal way of using this, is to leverage existing event components within a component. For example:

```jsx
import React, {unstable_useEvent} from 'react';
import Press from 'react-events/press';

function MyComponent() {
  unstable_useEvent(Press, {onPress: handlePressFromHook});

  function handlePressFromHook() {
    console.log('hook');
  } 
  function handlePressFromEventComponent() {
    console.log('event component');
  } 
  
  return (
    <Press onPress={handlePressFromEventComponent}>
      <div>Press me</div>
    </Press>
  );
}
```

Any event components in the **same** branch of an event component (not above the event component), will fire for the same type of event component. If there are no event components used in the branch of the function component that has the hooks, then the hook props will never fire. So this won't work:

```jsx
function MyComponent() {
  unstable_useEvent(Press, {onPress: handlePressFromHook});
  
  // You need to use a <Press> somewhere in this branch
  return (
    <div>Press me</div>
  );
}
```

What is powerful about the hook form of event components, is that they can track events occurring in their tree without needing to worry about propagation rules. All events will propagate to the hook form of these events, which is different to the event component form, where events stop propagation to the same type of event components.

Event responders can opt out of support hooks, for example `FocusScope` will not support hook form right now, so the responder module has `allowEventHooks` set to `false`.

The hook forms thus allow for control of events on children, where their implementation is not fully known or controller by the parent component. The only exception to this, is if an event responder takes global ownership, then no other events components or hooks will fire – this is intentional.

Furthermore, `displayName` is now no longer on event components and has instead been moved to the responders. This is to allow for hooks to have display names, via the responder.