### PR TITLE
[Fresh] Track mounted roots via DevTools Hook

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -71,8 +71,9 @@ import {Sync} from './ReactFiberExpirationTime';
 import {revertPassiveEffectsChange} from 'shared/ReactFeatureFlags';
 import {requestCurrentSuspenseConfig} from './ReactFiberSuspenseConfig';
 import {
-  scheduleHotUpdate,
-  findHostInstancesForHotUpdate,
+  scheduleRefresh,
+  setRefreshHandler,
+  findHostInstancesForRefresh,
 } from './ReactFiberHotReloading';
 
 type OpaqueRoot = FiberRoot;
@@ -475,10 +476,6 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
 
   return injectInternals({
     ...devToolsConfig,
-    findHostInstancesForHotUpdate: __DEV__
-      ? findHostInstancesForHotUpdate
-      : null,
-    scheduleHotUpdate: __DEV__ ? scheduleHotUpdate : null,
     overrideHookState,
     overrideProps,
     setSuspenseHandler,
@@ -498,5 +495,9 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
       }
       return findFiberByHostInstance(instance);
     },
+    // React Refresh
+    findHostInstancesForRefresh: __DEV__ ? findHostInstancesForRefresh : null,
+    scheduleRefresh: __DEV__ ? scheduleRefresh : null,
+    setRefreshHandler: __DEV__ ? setRefreshHandler : null,
   });
 }

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -22,24 +22,28 @@ describe('ReactFresh', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
-    React = require('react');
-    ReactFreshRuntime = require('react-refresh/runtime');
-    ReactFreshRuntime.injectIntoGlobalHook(global);
-    ReactDOM = require('react-dom');
-    Scheduler = require('scheduler');
-    act = require('react-dom/test-utils').act;
-    createReactClass = require('create-react-class/factory')(
-      React.Component,
-      React.isValidElement,
-      new React.Component().updater,
-    );
-    container = document.createElement('div');
-    document.body.appendChild(container);
+    if (__DEV__) {
+      jest.resetModules();
+      React = require('react');
+      ReactFreshRuntime = require('react-refresh/runtime');
+      ReactFreshRuntime.injectIntoGlobalHook(global);
+      ReactDOM = require('react-dom');
+      Scheduler = require('scheduler');
+      act = require('react-dom/test-utils').act;
+      createReactClass = require('create-react-class/factory')(
+        React.Component,
+        React.isValidElement,
+        new React.Component().updater,
+      );
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    }
   });
 
   afterEach(() => {
-    document.body.removeChild(container);
+    if (__DEV__) {
+      document.body.removeChild(container);
+    }
   });
 
   function prepare(version) {
@@ -3157,66 +3161,23 @@ describe('ReactFresh', () => {
   // or to stop at the current module because it's a component.
   // This can't and doesn't need to be 100% precise.
   it('can detect likely component types', () => {
-    expect(ReactFreshRuntime.isLikelyComponentType(false)).toBe(false);
-    expect(ReactFreshRuntime.isLikelyComponentType(null)).toBe(false);
-    expect(ReactFreshRuntime.isLikelyComponentType('foo')).toBe(false);
-
-    // We need to hit a balance here.
-    // If we lean towards assuming everything is a component,
-    // editing modules that export plain functions won't trigger
-    // a proper reload because we will bottle up the update.
-    // So we're being somewhat conservative.
-    expect(ReactFreshRuntime.isLikelyComponentType(() => {})).toBe(false);
-    expect(ReactFreshRuntime.isLikelyComponentType(function() {})).toBe(false);
-    expect(
-      ReactFreshRuntime.isLikelyComponentType(function lightenColor() {}),
-    ).toBe(false);
-    const loadUser = () => {};
-    expect(ReactFreshRuntime.isLikelyComponentType(loadUser)).toBe(false);
-    const useStore = () => {};
-    expect(ReactFreshRuntime.isLikelyComponentType(useStore)).toBe(false);
     function useTheme() {}
-    expect(ReactFreshRuntime.isLikelyComponentType(useTheme)).toBe(false);
-
-    // These seem like function components.
-    let Button = () => {};
-    expect(ReactFreshRuntime.isLikelyComponentType(Button)).toBe(true);
     function Widget() {}
-    expect(ReactFreshRuntime.isLikelyComponentType(Widget)).toBe(true);
-    let anon = (() => () => {})();
-    anon.displayName = 'Foo';
-    expect(ReactFreshRuntime.isLikelyComponentType(anon)).toBe(true);
 
-    // These seem like class components.
-    class Btn extends React.Component {}
-    class PureBtn extends React.PureComponent {}
-    expect(ReactFreshRuntime.isLikelyComponentType(Btn)).toBe(true);
-    expect(ReactFreshRuntime.isLikelyComponentType(PureBtn)).toBe(true);
-    expect(
-      ReactFreshRuntime.isLikelyComponentType(createReactClass({render() {}})),
-    ).toBe(true);
+    if (__DEV__) {
+      expect(ReactFreshRuntime.isLikelyComponentType(false)).toBe(false);
+      expect(ReactFreshRuntime.isLikelyComponentType(null)).toBe(false);
+      expect(ReactFreshRuntime.isLikelyComponentType('foo')).toBe(false);
 
-    // These don't.
-    class Figure {
-      move() {}
-    }
-    expect(ReactFreshRuntime.isLikelyComponentType(Figure)).toBe(false);
-    class Point extends Figure {}
-    expect(ReactFreshRuntime.isLikelyComponentType(Point)).toBe(false);
-
-    // Run the same tests without Babel.
-    // This tests real arrow functions and classes, as implemented in Node.
-
-    // eslint-disable-next-line no-new-func
-    new Function(
-      'global',
-      'React',
-      'ReactFreshRuntime',
-      'expect',
-      'createReactClass',
-      `
+      // We need to hit a balance here.
+      // If we lean towards assuming everything is a component,
+      // editing modules that export plain functions won't trigger
+      // a proper reload because we will bottle up the update.
+      // So we're being somewhat conservative.
       expect(ReactFreshRuntime.isLikelyComponentType(() => {})).toBe(false);
-      expect(ReactFreshRuntime.isLikelyComponentType(function() {})).toBe(false);
+      expect(ReactFreshRuntime.isLikelyComponentType(function() {})).toBe(
+        false,
+      );
       expect(
         ReactFreshRuntime.isLikelyComponentType(function lightenColor() {}),
       ).toBe(false);
@@ -3224,13 +3185,11 @@ describe('ReactFresh', () => {
       expect(ReactFreshRuntime.isLikelyComponentType(loadUser)).toBe(false);
       const useStore = () => {};
       expect(ReactFreshRuntime.isLikelyComponentType(useStore)).toBe(false);
-      function useTheme() {}
       expect(ReactFreshRuntime.isLikelyComponentType(useTheme)).toBe(false);
 
       // These seem like function components.
       let Button = () => {};
       expect(ReactFreshRuntime.isLikelyComponentType(Button)).toBe(true);
-      function Widget() {}
       expect(ReactFreshRuntime.isLikelyComponentType(Widget)).toBe(true);
       let anon = (() => () => {})();
       anon.displayName = 'Foo';
@@ -3242,7 +3201,9 @@ describe('ReactFresh', () => {
       expect(ReactFreshRuntime.isLikelyComponentType(Btn)).toBe(true);
       expect(ReactFreshRuntime.isLikelyComponentType(PureBtn)).toBe(true);
       expect(
-        ReactFreshRuntime.isLikelyComponentType(createReactClass({render() {}})),
+        ReactFreshRuntime.isLikelyComponentType(
+          createReactClass({render() {}}),
+        ),
       ).toBe(true);
 
       // These don't.
@@ -3252,7 +3213,57 @@ describe('ReactFresh', () => {
       expect(ReactFreshRuntime.isLikelyComponentType(Figure)).toBe(false);
       class Point extends Figure {}
       expect(ReactFreshRuntime.isLikelyComponentType(Point)).toBe(false);
-    `,
-    )(global, React, ReactFreshRuntime, expect, createReactClass);
+
+      // Run the same tests without Babel.
+      // This tests real arrow functions and classes, as implemented in Node.
+
+      // eslint-disable-next-line no-new-func
+      new Function(
+        'global',
+        'React',
+        'ReactFreshRuntime',
+        'expect',
+        'createReactClass',
+        `
+        expect(ReactFreshRuntime.isLikelyComponentType(() => {})).toBe(false);
+        expect(ReactFreshRuntime.isLikelyComponentType(function() {})).toBe(false);
+        expect(
+          ReactFreshRuntime.isLikelyComponentType(function lightenColor() {}),
+        ).toBe(false);
+        const loadUser = () => {};
+        expect(ReactFreshRuntime.isLikelyComponentType(loadUser)).toBe(false);
+        const useStore = () => {};
+        expect(ReactFreshRuntime.isLikelyComponentType(useStore)).toBe(false);
+        function useTheme() {}
+        expect(ReactFreshRuntime.isLikelyComponentType(useTheme)).toBe(false);
+
+        // These seem like function components.
+        let Button = () => {};
+        expect(ReactFreshRuntime.isLikelyComponentType(Button)).toBe(true);
+        function Widget() {}
+        expect(ReactFreshRuntime.isLikelyComponentType(Widget)).toBe(true);
+        let anon = (() => () => {})();
+        anon.displayName = 'Foo';
+        expect(ReactFreshRuntime.isLikelyComponentType(anon)).toBe(true);
+
+        // These seem like class components.
+        class Btn extends React.Component {}
+        class PureBtn extends React.PureComponent {}
+        expect(ReactFreshRuntime.isLikelyComponentType(Btn)).toBe(true);
+        expect(ReactFreshRuntime.isLikelyComponentType(PureBtn)).toBe(true);
+        expect(
+          ReactFreshRuntime.isLikelyComponentType(createReactClass({render() {}})),
+        ).toBe(true);
+
+        // These don't.
+        class Figure {
+          move() {}
+        }
+        expect(ReactFreshRuntime.isLikelyComponentType(Figure)).toBe(false);
+        class Point extends Figure {}
+        expect(ReactFreshRuntime.isLikelyComponentType(Point)).toBe(false);
+      `,
+      )(global, React, ReactFreshRuntime, expect, createReactClass);
+    }
   });
 });

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -94,29 +94,7 @@ describe('ReactFreshIntegration', () => {
     }
 
     function __signature__() {
-      let call = 0;
-      let savedType;
-      let hasCustomHooks;
-      return function(type, key, forceReset, getCustomHooks) {
-        switch (call++) {
-          case 0:
-            savedType = type;
-            hasCustomHooks = typeof getCustomHooks === 'function';
-            ReactFreshRuntime.setSignature(
-              type,
-              key,
-              forceReset,
-              getCustomHooks,
-            );
-            break;
-          case 1:
-            if (hasCustomHooks) {
-              ReactFreshRuntime.collectCustomHooksForSignature(savedType);
-            }
-            break;
-        }
-        return type;
-      };
+      return ReactFreshRuntime.createSignatureFunctionForTransform();
     }
 
     it('reloads function declarations', () => {

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -23,21 +23,25 @@ describe('ReactFreshIntegration', () => {
   let container;
 
   beforeEach(() => {
-    jest.resetModules();
-    React = require('react');
-    ReactFreshRuntime = require('react-refresh/runtime');
-    ReactFreshRuntime.injectIntoGlobalHook(global);
-    ReactDOM = require('react-dom');
-    act = require('react-dom/test-utils').act;
-    container = document.createElement('div');
-    document.body.appendChild(container);
+    if (__DEV__) {
+      jest.resetModules();
+      React = require('react');
+      ReactFreshRuntime = require('react-refresh/runtime');
+      ReactFreshRuntime.injectIntoGlobalHook(global);
+      ReactDOM = require('react-dom');
+      act = require('react-dom/test-utils').act;
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    }
   });
 
   afterEach(() => {
-    ReactDOM.unmountComponentAtNode(container);
-    // Ensure we don't leak memory by holding onto dead roots.
-    expect(ReactFreshRuntime._getMountedRootCount()).toBe(0);
-    document.body.removeChild(container);
+    if (__DEV__) {
+      ReactDOM.unmountComponentAtNode(container);
+      // Ensure we don't leak memory by holding onto dead roots.
+      expect(ReactFreshRuntime._getMountedRootCount()).toBe(0);
+      document.body.removeChild(container);
+    }
   });
 
   describe('with compiled destructuring', () => {


### PR DESCRIPTION
The previous Fresh runtime API forced you to pass a root handle. However, that presumes that the module runtime (such as Metro) somehow is aware of all roots on the page. This isn't the case.

We could have React keep track of mounted roots. However, that might not be necessary. Here's why.

We still need some way to let the module runtime schedule refreshes. Currently this is done via DevTools Global Hook injection. DevTools (or module runtime) can set up the Global Hook. The renderer injects `scheduleHotUpdate` in it. As a result, the module runtime can schedule refreshes.

**Since we already rely on the DevTools Hook for communication, we might as well use the fact that this Hook gives us information about all roots.** Indeed, that's how DevTools itself works.

## The Goal

This PR lets the module runtime do 

```js
ReactRefreshRuntime.injectIntoGlobalHook(window);
```

and then

```js
ReactRefreshRuntime.performReactRefresh(update);
```

without worrying about how to track mounted roots.

## Implementation

#### Adding `injectIntoGlobalHook` to Refresh Runtime

  - This either sets up a shimmed tiny version of the Global Hook (for web users without extension).
  - Or, if the Global Hook is already set up (for web users with extension, or for RN which always sets it up), monkeypatches it.

The goal in both cases is to grab the scheduling functionality and to track roots in the Runtime. This lets the module system (e.g. Metro) simply call `ReactRefreshRuntime.performReactRefresh()` and not worry about how this connects to React.

The only constraint is that `ReactRefreshRuntime.injectIntoGlobalHook()` needs to run before the renderer code. The module system can guarantee it because it owns the execution order.

I have added regression tests for tracking roots.

#### Tweaking the API exposed to DevTools

Previously, we had `scheduleHotUpdate(root, update)` which included the resolution function. However, I realized this doesn't really work if you don't have a `root`. For example, if you hot update a component, but no roots are mounted yet, you still want its *next* render to use the updated version. So  you _need_ to inject the resolution function anyway.

I changed the API to:

* `setRefreshHandler(handler)` — This sets up the family resolution function. It is called on first edit even if there are no roots.
* `scheduleRefresh(root, update)` — renamed from `scheduleHotReload`
* `findHostInstancesForRefresh` — renamed from `findHostInstancesForHotReload`

## Follow-ups

There's a few things I plan to change here later. One is to use host config for getting client rect. But this isn't critical to get in now, since I don't plan to implement this in the first Metro integration. The second one is to add a few convenience helpers to move more React-related logic out of the module runtime (e.g. Metro). I might push that a bit later but it doesn't block this PR.