### PR TITLE
[Flare] Rename createEventComponent -> createEvent

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -42,7 +42,7 @@ import {
 } from 'react-reconciler/inline.dom';
 import {createPortal as createPortalImpl} from 'shared/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import createEventComponent from 'shared/createEventComponent';
+import createEvent from 'shared/createEventComponent';
 import {setBatchingImplementation} from 'events/ReactGenericBatching';
 import {
   setRestoreImplementation,
@@ -882,7 +882,7 @@ if (enableStableConcurrentModeAPIs) {
 }
 
 if (enableEventAPI) {
-  ReactDOM.unstable_createEventComponent = createEventComponent;
+  ReactDOM.unstable_createEvent = createEvent;
 }
 
 const foundDevTools = injectIntoDevTools({

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -42,12 +42,10 @@ function createReactEventComponent({
     allowMultipleHostChildren: allowMultipleHostChildren || false,
   };
 
-  return {
-    $$typeof: Symbol.for('react.event_component'),
-    displayName: 'TestEventComponent',
-    props: null,
-    responder: testEventResponder,
-  };
+  return ReactDOM.unstable_createEvent(
+    testEventResponder,
+    'TestEventComponent',
+  );
 }
 
 function dispatchEvent(element, type) {

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -70,6 +70,7 @@ import invariant from 'shared/invariant';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {enableStableConcurrentModeAPIs} from 'shared/ReactFeatureFlags';
+import createEvent from 'shared/createEventComponent';
 
 import {
   getInstanceFromNode,
@@ -86,6 +87,7 @@ import {
   DOCUMENT_FRAGMENT_NODE,
 } from '../shared/HTMLNodeType';
 import {ROOT_ATTRIBUTE_NAME} from '../shared/DOMProperty';
+import {enableEventAPI} from 'shared/ReactFeatureFlags';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
@@ -881,6 +883,10 @@ function warnIfReactDOMContainerInDEV(container) {
 if (enableStableConcurrentModeAPIs) {
   ReactDOM.createRoot = createRoot;
   ReactDOM.createSyncRoot = createSyncRoot;
+}
+
+if (enableEventAPI) {
+  ReactDOM.unstable_createEvent = createEvent;
 }
 
 const foundDevTools = injectIntoDevTools({

--- a/packages/react-events/README.md
+++ b/packages/react-events/README.md
@@ -12,10 +12,10 @@ can be found [here](./docs).
 
 ## EventComponent
 
-An Event Component is defined using `React.unstable_createEventComponent`:
+An Event Component is defined using `ReactDOM.unstable_createEvent`:
 
 ```js
-const EventComponent = React.unstable_createEventComponent(
+const EventComponent = ReactDOM.unstable_createEvent(
   responder: EventResponder,
   displayName: string
 );

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -259,4 +259,4 @@ const DragResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(DragResponder, 'Drag');
+export default ReactDOM.unstable_createEvent(DragResponder, 'Drag');

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -336,4 +336,4 @@ const FocusResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(FocusResponder, 'Focus');
+export default ReactDOM.unstable_createEvent(FocusResponder, 'Focus');

--- a/packages/react-events/src/FocusScope.js
+++ b/packages/react-events/src/FocusScope.js
@@ -157,7 +157,4 @@ const FocusScopeResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(
-  FocusScopeResponder,
-  'FocusScope',
-);
+export default ReactDOM.unstable_createEvent(FocusScopeResponder, 'FocusScope');

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -406,4 +406,4 @@ const HoverResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(HoverResponder, 'Hover');
+export default ReactDOM.unstable_createEvent(HoverResponder, 'Hover');

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -956,4 +956,4 @@ const PressResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(PressResponder, 'Press');
+export default ReactDOM.unstable_createEvent(PressResponder, 'Press');

--- a/packages/react-events/src/Scroll.js
+++ b/packages/react-events/src/Scroll.js
@@ -211,7 +211,4 @@ const ScrollResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(
-  ScrollResponder,
-  'Scroll',
-);
+export default ReactDOM.unstable_createEvent(ScrollResponder, 'Scroll');

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -262,4 +262,4 @@ const SwipeResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEventComponent(SwipeResponder, 'Swipe');
+export default ReactDOM.unstable_createEvent(SwipeResponder, 'Swipe');


### PR DESCRIPTION
This simply renames the `ReactDOM.unstable_createEventComponent` to `ReactDOM.unstable_createEvent`. Which unifies it with the hook version of using events in the new event system.