### PR TITLE
[Flare] Fix keyboard keyup regression

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -871,6 +871,7 @@ const PressResponder = {
               return;
             }
             isKeyboardEvent = true;
+            removeRootEventTypes(context, state);
           }
 
           // Determine whether to call preventDefault on subsequent native events.
@@ -940,7 +941,10 @@ const PressResponder = {
       }
 
       case 'click': {
-        removeRootEventTypes(context, state);
+        // "keyup" occurs after "click"
+        if (state.pointerType !== 'keyboard') {
+          removeRootEventTypes(context, state);
+        }
         if (state.shouldPreventClick) {
           nativeEvent.preventDefault();
         }

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -335,6 +335,8 @@ describe('Event responder: Press', () => {
 
     it('is called after "keyup" event for Enter', () => {
       ref.current.dispatchEvent(createKeyboardEvent('keydown', {key: 'Enter'}));
+      // click occurs before keyup
+      ref.current.dispatchEvent(createKeyboardEvent('click'));
       ref.current.dispatchEvent(createKeyboardEvent('keyup', {key: 'Enter'}));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(


### PR DESCRIPTION
This PR addresses a keyboard bug that was a recent regression found in https://github.com/facebook/react/issues/15930. The problem was that there was a false assumption made that `click` occurred after `keyup`, it's actually the other way around. I've also updated the unit test that tracks this logic and ensured it matched the browser behaviour correctly. @aweary This should work for you now, let me know if you have any other issues!