### PR TITLE
[Fresh] Throw in prod and change annotation

### DIFF
--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -8,6 +8,19 @@
 'use strict';
 
 export default function(babel) {
+  if (typeof babel.getEnv === 'function') {
+    // Only available in Babel 7.
+    const env = babel.getEnv();
+    if (env !== 'development') {
+      throw new Error(
+        'React Refresh Babel transform should only be enabled in development environment. ' +
+          'Instead, the environment is: "' +
+          env +
+          '".',
+      );
+    }
+  }
+
   const {types: t} = babel;
 
   const registrationsByProgramPath = new Map();

--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -219,7 +219,7 @@ export default function(babel) {
 
   let hasForceResetCommentByFile = new WeakMap();
 
-  // We let user do /* @hot reset */ to reset state in the whole file.
+  // We let user do /* @refresh reset */ to reset state in the whole file.
   function hasForceResetComment(path) {
     const file = path.hub.file;
     let hasForceReset = hasForceResetCommentByFile.get(file);
@@ -231,7 +231,7 @@ export default function(babel) {
     const comments = file.ast.comments;
     for (let i = 0; i < comments.length; i++) {
       const cmt = comments[i];
-      if (cmt.value.indexOf('@hot reset') !== -1) {
+      if (cmt.value.indexOf('@refresh reset') !== -1) {
         hasForceReset = true;
         break;
       }

--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -27,6 +27,12 @@ type Signature = {|
   getCustomHooks: () => Array<Function>,
 |};
 
+if (!__DEV__) {
+  throw new Error(
+    'React Refresh runtime should not be included in the production bundle.',
+  );
+}
+
 // In old environments, we'll leak previous types after every edit.
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 const PossiblyWeakSet = typeof WeakSet === 'function' ? WeakSet : Set;

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -755,7 +755,7 @@ describe('ReactFreshIntegration', () => {
       }
     });
 
-    it('resets state on every edit with @hot reset annotation', () => {
+    it('resets state on every edit with @refresh reset annotation', () => {
       if (__DEV__) {
         render(`
           const {useState} = React;
@@ -786,7 +786,7 @@ describe('ReactFreshIntegration', () => {
           const {useState} = React;
           const S = 3;
 
-          /* @hot reset */
+          /* @refresh reset */
 
           export default function App() {
             const [foo, setFoo] = useState(S);
@@ -804,7 +804,7 @@ describe('ReactFreshIntegration', () => {
 
           export default function App() {
 
-            // @hot reset
+            // @refresh reset
 
             const [foo, setFoo] = useState(S);
             return <h1>D{foo}</h1>;
@@ -848,7 +848,7 @@ describe('ReactFreshIntegration', () => {
 
           export default function App() {
 
-            /* @hot reset */
+            /* @refresh reset */
 
             const [foo, setFoo] = useState(S);
             return <h1>G{foo}</h1>;


### PR DESCRIPTION
1. Babel transform now refuses to run in any environment other than `development`. This is to detect misconfiguration early.
2. The runtime now throws at initialization if it's included in a production mode bundle. This should never happen and usually points at misconfiguration. I'll verify this doesn't happen in RN.
3. Changes `@hot reset` annotation to `@refresh reset` to match overall naming.