### PR TITLE
[Fresh] Don't consider require-like calls to be likely HOCs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-jest": "^23.0.1",
     "babel-plugin-check-es2015-constants": "^6.5.0",
     "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
     "babel-plugin-transform-async-to-generator": "^6.22.0",
     "babel-plugin-transform-class-properties": "^6.11.5",

--- a/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ReactFreshBabelPlugin does not consider require-like methods to be HOCs 1`] = `
+
+const A = require('A');
+const B = foo ? require('X') : require('Y');
+const C = requireCond(gk, 'C');
+const D = import('D');
+
+export default function App() {
+  return <div>
+              <A />
+              <B />
+              <C />
+              <D />
+            </div>;
+}
+_c = App;
+
+var _c;
+
+__register__(_c, 'App');
+`;
+
 exports[`ReactFreshBabelPlugin generates signatures for function declarations calling hooks 1`] = `
 var _s = __signature__();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -620,6 +620,11 @@ babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+  integrity sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=
+
 babel-plugin-syntax-flow@^6.18.0, babel-plugin-syntax-flow@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"


### PR DESCRIPTION
I tried running Fresh transform on FB5 to verify it doesn't introduce semantic differences. There is a case where that happens due to inline requires.

We currently consider calls like `const Foo = bar()` to be likely component factory calls when `Foo` is used in JSX. E.g. it could be `const Foo = createFluxContainer()`. So we register those with Fresh runtime.

However, in CommonJS those might be *imports*. `const Foo = require('Foo')`. In that case registering them is a bad idea. Both because it's redundant (their own module will register them first anyway), and because this triggers inline requires early. We don't want to trigger inline requires early because that can introduce module cycles in our environment.

As a solution, I'm making the heuristic stricter. The dynamic `import()` or function that start with `require` are no longer considered likely component factories, and their result won't be registered even if it's used in JSX. We'll also completely bail out for more complex expressions (e.g. ternaries). We will, however, explicitly whitelist template literals because they're used for things like Styled Components, e.g.

```js
const Foo = styled.div`...`
```

See snapshots.