### PR TITLE
[Flare] Move createEvent back to React object

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -42,7 +42,6 @@ import {
 } from 'react-reconciler/inline.dom';
 import {createPortal as createPortalImpl} from 'shared/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import createEvent from 'shared/createEventComponent';
 import {setBatchingImplementation} from 'events/ReactGenericBatching';
 import {
   setRestoreImplementation,
@@ -64,10 +63,7 @@ import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 import warningWithoutStack from 'shared/warningWithoutStack';
-import {
-  enableStableConcurrentModeAPIs,
-  enableEventAPI,
-} from 'shared/ReactFeatureFlags';
+import {enableStableConcurrentModeAPIs} from 'shared/ReactFeatureFlags';
 
 import {
   getInstanceFromNode,
@@ -879,10 +875,6 @@ function warnIfReactDOMContainerInDEV(container) {
 if (enableStableConcurrentModeAPIs) {
   ReactDOM.createRoot = createRoot;
   ReactDOM.createSyncRoot = createSyncRoot;
-}
-
-if (enableEventAPI) {
-  ReactDOM.unstable_createEvent = createEvent;
 }
 
 const foundDevTools = injectIntoDevTools({

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -42,10 +42,7 @@ function createReactEventComponent({
     allowMultipleHostChildren: allowMultipleHostChildren || false,
   };
 
-  return ReactDOM.unstable_createEvent(
-    testEventResponder,
-    'TestEventComponent',
-  );
+  return React.unstable_createEvent(testEventResponder, 'TestEventComponent');
 }
 
 function dispatchEvent(element, type) {

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -70,7 +70,6 @@ import invariant from 'shared/invariant';
 import lowPriorityWarning from 'shared/lowPriorityWarning';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {enableStableConcurrentModeAPIs} from 'shared/ReactFeatureFlags';
-import createEvent from 'shared/createEventComponent';
 
 import {
   getInstanceFromNode,
@@ -87,7 +86,6 @@ import {
   DOCUMENT_FRAGMENT_NODE,
 } from '../shared/HTMLNodeType';
 import {ROOT_ATTRIBUTE_NAME} from '../shared/DOMProperty';
-import {enableEventAPI} from 'shared/ReactFeatureFlags';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
@@ -883,10 +881,6 @@ function warnIfReactDOMContainerInDEV(container) {
 if (enableStableConcurrentModeAPIs) {
   ReactDOM.createRoot = createRoot;
   ReactDOM.createSyncRoot = createSyncRoot;
-}
-
-if (enableEventAPI) {
-  ReactDOM.unstable_createEvent = createEvent;
 }
 
 const foundDevTools = injectIntoDevTools({

--- a/packages/react-events/README.md
+++ b/packages/react-events/README.md
@@ -12,10 +12,10 @@ can be found [here](./docs).
 
 ## EventComponent
 
-An Event Component is defined using `ReactDOM.unstable_createEvent`:
+An Event Component is defined using `React.unstable_createEvent`:
 
 ```js
-const EventComponent = ReactDOM.unstable_createEvent(
+const EventComponent = React.unstable_createEvent(
   responder: EventResponder,
   displayName: string
 );

--- a/packages/react-events/src/Drag.js
+++ b/packages/react-events/src/Drag.js
@@ -13,7 +13,7 @@ import type {
 } from 'shared/ReactDOMTypes';
 import type {EventPriority} from 'shared/ReactTypes';
 
-import ReactDOM from 'react-dom';
+import React from 'react';
 import {DiscreteEvent, UserBlockingEvent} from 'shared/ReactTypes';
 
 const targetEventTypes = ['pointerdown'];
@@ -259,4 +259,4 @@ const DragResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEvent(DragResponder, 'Drag');
+export default React.unstable_createEvent(DragResponder, 'Drag');

--- a/packages/react-events/src/Focus.js
+++ b/packages/react-events/src/Focus.js
@@ -13,7 +13,7 @@ import type {
   PointerType,
 } from 'shared/ReactDOMTypes';
 
-import ReactDOM from 'react-dom';
+import React from 'react';
 import {DiscreteEvent} from 'shared/ReactTypes';
 
 type FocusProps = {
@@ -336,4 +336,4 @@ const FocusResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEvent(FocusResponder, 'Focus');
+export default React.unstable_createEvent(FocusResponder, 'Focus');

--- a/packages/react-events/src/FocusScope.js
+++ b/packages/react-events/src/FocusScope.js
@@ -11,7 +11,7 @@ import type {
   ReactDOMResponderContext,
 } from 'shared/ReactDOMTypes';
 
-import ReactDOM from 'react-dom';
+import React from 'react';
 
 type FocusScopeProps = {
   autoFocus: Boolean,
@@ -157,4 +157,4 @@ const FocusScopeResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEvent(FocusScopeResponder, 'FocusScope');
+export default React.unstable_createEvent(FocusScopeResponder, 'FocusScope');

--- a/packages/react-events/src/Hover.js
+++ b/packages/react-events/src/Hover.js
@@ -12,7 +12,7 @@ import type {
   ReactDOMResponderContext,
 } from 'shared/ReactDOMTypes';
 
-import ReactDOM from 'react-dom';
+import React from 'react';
 import {UserBlockingEvent} from 'shared/ReactTypes';
 
 type HoverProps = {
@@ -406,4 +406,4 @@ const HoverResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEvent(HoverResponder, 'Hover');
+export default React.unstable_createEvent(HoverResponder, 'Hover');

--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -14,7 +14,7 @@ import type {
 } from 'shared/ReactDOMTypes';
 import type {EventPriority} from 'shared/ReactTypes';
 
-import ReactDOM from 'react-dom';
+import React from 'react';
 import {DiscreteEvent, UserBlockingEvent} from 'shared/ReactTypes';
 
 type PressProps = {
@@ -972,4 +972,4 @@ const PressResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEvent(PressResponder, 'Press');
+export default React.unstable_createEvent(PressResponder, 'Press');

--- a/packages/react-events/src/Scroll.js
+++ b/packages/react-events/src/Scroll.js
@@ -15,7 +15,7 @@ import type {
 import {UserBlockingEvent} from 'shared/ReactTypes';
 import type {EventPriority} from 'shared/ReactTypes';
 
-import ReactDOM from 'react-dom';
+import React from 'react';
 
 type ScrollProps = {
   disabled: boolean,
@@ -211,4 +211,4 @@ const ScrollResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEvent(ScrollResponder, 'Scroll');
+export default React.unstable_createEvent(ScrollResponder, 'Scroll');

--- a/packages/react-events/src/Swipe.js
+++ b/packages/react-events/src/Swipe.js
@@ -13,7 +13,7 @@ import type {
 } from 'shared/ReactDOMTypes';
 import type {EventPriority} from 'shared/ReactTypes';
 
-import ReactDOM from 'react-dom';
+import React from 'react';
 import {UserBlockingEvent, DiscreteEvent} from 'shared/ReactTypes';
 
 const targetEventTypes = ['pointerdown'];
@@ -262,4 +262,4 @@ const SwipeResponder = {
   },
 };
 
-export default ReactDOM.unstable_createEvent(SwipeResponder, 'Swipe');
+export default React.unstable_createEvent(SwipeResponder, 'Swipe');

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -51,7 +51,8 @@ import {
 } from './ReactElementValidator';
 import ReactSharedInternals from './ReactSharedInternals';
 import {error, warn} from './withComponentStack';
-import {enableJSXTransformAPI} from 'shared/ReactFeatureFlags';
+import createEvent from 'shared/createEventComponent';
+import {enableJSXTransformAPI, enableEventAPI} from 'shared/ReactFeatureFlags';
 const React = {
   Children: {
     map,
@@ -101,6 +102,10 @@ const React = {
 
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: ReactSharedInternals,
 };
+
+if (enableEventAPI) {
+  React.unstable_createEvent = createEvent;
+}
 
 // Note: some APIs are added with feature flags.
 // Make sure that stable builds for open source

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -465,7 +465,7 @@ const bundles = [
     moduleType: NON_FIBER_RENDERER,
     entry: 'react-events/press',
     global: 'ReactEventsPress',
-    externals: ['react-dom'],
+    externals: ['react'],
   },
 
   {
@@ -480,7 +480,7 @@ const bundles = [
     moduleType: NON_FIBER_RENDERER,
     entry: 'react-events/hover',
     global: 'ReactEventsHover',
-    externals: ['react-dom'],
+    externals: ['react'],
   },
 
   {
@@ -495,7 +495,7 @@ const bundles = [
     moduleType: NON_FIBER_RENDERER,
     entry: 'react-events/focus',
     global: 'ReactEventsFocus',
-    externals: ['react-dom'],
+    externals: ['react'],
   },
 
   {
@@ -510,7 +510,7 @@ const bundles = [
     moduleType: NON_FIBER_RENDERER,
     entry: 'react-events/focus-scope',
     global: 'ReactEventsFocusScope',
-    externals: ['react-dom'],
+    externals: ['react'],
   },
 
   {
@@ -525,7 +525,7 @@ const bundles = [
     moduleType: NON_FIBER_RENDERER,
     entry: 'react-events/swipe',
     global: 'ReactEventsSwipe',
-    externals: ['react-dom'],
+    externals: ['react'],
   },
 
   {
@@ -540,7 +540,7 @@ const bundles = [
     moduleType: NON_FIBER_RENDERER,
     entry: 'react-events/drag',
     global: 'ReactEventsDrag',
-    externals: ['react-dom'],
+    externals: ['react'],
   },
 
   {
@@ -555,7 +555,7 @@ const bundles = [
     moduleType: NON_FIBER_RENDERER,
     entry: 'react-events/scroll',
     global: 'ReactEventsScroll',
-    externals: ['react-dom'],
+    externals: ['react'],
   },
 ];
 


### PR DESCRIPTION
Internally, we ran into issues with exporting `createEvent` on `ReactDOM`. Moving this back to `React` fixes the issue. This is because the `ReactDOM` module has side-effects that occur upon initialization of the module, which breaks in cases such as server-side rendering.

Lately, given the `useEvent` hook, it might make more sense for us to keep `createEvent` on the `React` object. In the RN integration PR, I found better ways to ensure Flow type safety whilst doing so, so it might be worth while looking at how we can incorporate a polymorphic `createEvent` on the `React` object, where the `responder` field might relate to different responders depending on the platform.

The event responders exported should always be the same shape between platforms anyway, the only thing that differs is the props they receive – so this should be safe to do.

@sebmarkbage I'd really like it if you could chime in on this one too :)