### PR TITLE
Expire rendering the tail of SuspenseList after a timeout

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2069,6 +2069,7 @@ function updateSuspenseListComponent(
       rendering: null,
       last: null,
       tail: null,
+      tailExpiration: 0,
     };
   } else {
     let didForceFallback =
@@ -2124,6 +2125,7 @@ function updateSuspenseListComponent(
             rendering: null,
             last: lastContentRow,
             tail: tail,
+            tailExpiration: 0,
           };
         } else {
           suspenseListState.tail = tail;
@@ -2164,6 +2166,7 @@ function updateSuspenseListComponent(
             rendering: null,
             last: null,
             tail: tail,
+            tailExpiration: 0,
           };
         } else {
           suspenseListState.isBackwards = true;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -173,7 +173,7 @@ import {
   isSimpleFunctionComponent,
 } from './ReactFiber';
 import {
-  markDidDeprioritizeIdleSubtree,
+  markSpawnedWork,
   requestCurrentTime,
   retryTimedOutBoundary,
 } from './ReactFiberWorkLoop';
@@ -1006,7 +1006,7 @@ function updateHostComponent(current, workInProgress, renderExpirationTime) {
     shouldDeprioritizeSubtree(type, nextProps)
   ) {
     if (enableSchedulerTracing) {
-      markDidDeprioritizeIdleSubtree();
+      markSpawnedWork(Never);
     }
     // Schedule this fiber to re-render at offscreen priority. Then bailout.
     workInProgress.expirationTime = workInProgress.childExpirationTime = Never;
@@ -2598,7 +2598,7 @@ function beginWork(
             shouldDeprioritizeSubtree(workInProgress.type, newProps)
           ) {
             if (enableSchedulerTracing) {
-              markDidDeprioritizeIdleSubtree();
+              markSpawnedWork(Never);
             }
             // Schedule this fiber to re-render at offscreen priority. Then bailout.
             workInProgress.expirationTime = workInProgress.childExpirationTime = Never;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -113,7 +113,7 @@ import {
   enableEventAPI,
 } from 'shared/ReactFeatureFlags';
 import {
-  markDidDeprioritizeIdleSubtree,
+  markSpawnedWork,
   renderDidSuspend,
   renderDidSuspendDelayIfPossible,
 } from './ReactFiberWorkLoop';
@@ -911,7 +911,7 @@ function completeWork(
               'This is probably a bug in React.',
           );
           if (enableSchedulerTracing) {
-            markDidDeprioritizeIdleSubtree();
+            markSpawnedWork(Never);
           }
           skipPastDehydratedSuspenseInstance(workInProgress);
         } else if ((workInProgress.effectTag & DidCapture) === NoEffect) {
@@ -974,8 +974,12 @@ function completeWork(
               // them, then they really have the same priority as this render.
               // So we'll pick it back up the very next render pass once we've had
               // an opportunity to yield for paint.
-              workInProgress.expirationTime = workInProgress.childExpirationTime =
-                renderExpirationTime - 1;
+
+              const nextPriority = renderExpirationTime - 1;
+              workInProgress.expirationTime = workInProgress.childExpirationTime = nextPriority;
+              if (enableSchedulerTracing) {
+                markSpawnedWork(nextPriority);
+              }
             } else {
               suspenseListState.didSuspend = isShowingAnyFallbacks(rendered);
             }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -24,6 +24,8 @@ import type {
 } from './ReactFiberSuspenseComponent';
 import type {SuspenseContext} from './ReactFiberSuspenseContext';
 
+import {now} from './SchedulerWithReactIntegration';
+
 import {
   IndeterminateComponent,
   FunctionComponent,
@@ -121,6 +123,7 @@ import {
 } from './ReactFiberEvents';
 import getComponentName from 'shared/getComponentName';
 import warning from 'shared/warning';
+import {Never} from './ReactFiberExpirationTime';
 
 function markUpdate(workInProgress: Fiber) {
   // Tag the fiber with an update effect. This turns a Placement into
@@ -958,7 +961,24 @@ function completeWork(
           // Append the rendered row to the child list.
           let rendered = suspenseListState.rendering;
           if (!suspenseListState.didSuspend) {
-            suspenseListState.didSuspend = isShowingAnyFallbacks(rendered);
+            if (
+              now() > suspenseListState.tailExpiration &&
+              renderExpirationTime > Never
+            ) {
+              // We have now passed our CPU deadline and we'll just give up further
+              // attempts to render the main content and only render fallbacks.
+              // The assumption is that this is usually faster.
+              suspenseListState.didSuspend = true;
+              // Since nothing actually suspended, there will nothing to ping this
+              // to get it started back up to attempt the next item. If we can show
+              // them, then they really have the same priority as this render.
+              // So we'll pick it back up the very next render pass once we've had
+              // an opportunity to yield for paint.
+              workInProgress.expirationTime = workInProgress.childExpirationTime =
+                renderExpirationTime - 1;
+            } else {
+              suspenseListState.didSuspend = isShowingAnyFallbacks(rendered);
+            }
           }
           if (suspenseListState.isBackwards) {
             // The effect list of the backwards tail will have been added
@@ -981,6 +1001,13 @@ function completeWork(
 
         if (suspenseListState !== null && suspenseListState.tail !== null) {
           // We still have tail rows to render.
+          if (suspenseListState.tailExpiration === 0) {
+            // Heuristic for how long we're willing to spend rendering rows
+            // until we just give up and show what we have so far.
+            const TAIL_EXPIRATION_TIMEOUT_MS = 500;
+            suspenseListState.tailExpiration =
+              now() + TAIL_EXPIRATION_TIMEOUT_MS;
+          }
           // Pop a row.
           let next = suspenseListState.tail;
           suspenseListState.rendering = next;

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -22,6 +22,8 @@ export type SuspenseListState = {|
   last: null | Fiber,
   // Remaining rows on the tail of the list.
   tail: null | Fiber,
+  // The absolute time in ms that we'll expire the tail rendering.
+  tailExpiration: number,
 |};
 
 export function shouldCaptureSuspense(

--- a/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
+++ b/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
@@ -507,6 +507,85 @@ describe('ReactDOMTracing', () => {
           );
         });
       });
+
+      it('should properly trace interactions through a multi-pass SuspenseList render', () => {
+        const SuspenseList = React.unstable_SuspenseList;
+        const Suspense = React.Suspense;
+        function Text({text}) {
+          Scheduler.yieldValue(text);
+          React.useEffect(() => {
+            Scheduler.yieldValue('Commit ' + text);
+          });
+          return <span>{text}</span>;
+        }
+        function App() {
+          return (
+            <SuspenseList revealOrder="forwards">
+              <Suspense fallback={<Text text="Loading A" />}>
+                <Text text="A" />
+              </Suspense>
+              <Suspense fallback={<Text text="Loading B" />}>
+                <Text text="B" />
+              </Suspense>
+              <Suspense fallback={<Text text="Loading C" />}>
+                <Text text="C" />
+              </Suspense>
+            </SuspenseList>
+          );
+        }
+
+        const container = document.createElement('div');
+        const root = ReactDOM.unstable_createRoot(container);
+
+        let interaction;
+        SchedulerTracing.unstable_trace('initialization', 0, () => {
+          interaction = Array.from(SchedulerTracing.unstable_getCurrent())[0];
+          // This render is only CPU bound. Nothing suspends.
+          root.render(<App />);
+        });
+
+        expect(Scheduler).toFlushAndYieldThrough(['A']);
+
+        Scheduler.advanceTime(300);
+        jest.advanceTimersByTime(300);
+
+        expect(Scheduler).toFlushAndYieldThrough(['B']);
+
+        Scheduler.advanceTime(300);
+        jest.advanceTimersByTime(300);
+
+        // Time has now elapsed for so long that we're just going to give up
+        // rendering the rest of the content. So that we can at least show
+        // something.
+        expect(Scheduler).toFlushAndYieldThrough([
+          'Loading C',
+          'Commit A',
+          'Commit B',
+          'Commit Loading C',
+        ]);
+
+        // Schedule an unrelated low priority update that shouldn't be included
+        // in the previous interaction. This is meant to ensure that we don't
+        // rely on the whole tree completing to cover up bugs.
+        Scheduler.unstable_runWithPriority(
+          Scheduler.unstable_IdlePriority,
+          () => root.render(<App />),
+        );
+
+        expect(onInteractionTraced).toHaveBeenCalledTimes(1);
+        expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
+          interaction,
+        );
+        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+
+        // Then we do a second pass to commit the last item.
+        expect(Scheduler).toFlushAndYieldThrough(['C', 'Commit C']);
+
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+        expect(
+          onInteractionScheduledWorkCompleted,
+        ).toHaveBeenLastNotifiedOfInteraction(interaction);
+      });
     });
 
     describe('hydration', () => {


### PR DESCRIPTION
This is the first Suspense feature that isn't actually dependent on IO.

The thinking here is that it's normal for a SuspenseList to show loading states, and it'll be designed to handle it one at a time.

However, sometimes there are lists with really big items that take a long time to CPU render. Since data can become available as we do that, it is likely that we have all the data and become CPU bound.

In that case, the list would naively just render until the end and then display all items at once. I think that's actually what you want for fast lists. However, for slow ones (like News Feed), you're better off showing a few rows at a time.

It's not necessarily one at a time because if you can do many in a short period of time and fit them all on the screen, then it's better to do them all at once than pop them in one at a time very quickly.

Therefore, I use a heuristic of trying to render as many rows as I can in 500ms before giving up. I originally thought of making it configurable or having a special revealOrder mode for this but I have sense that this is not something people should have to think about too much and there are other possible heuristics we can add here later (such as if it will be below the fold or not). It seems like this would mostly just carry over to most cases.

This timer starts before the first row of the tail and we only check it after. This ensures that we always make a little progress each attempt. An alternative approach could be to start the time before doing the head of the list but we don't want that being slow prevent us from making further progress.

Currently, I disable this optimization at Never priority because there's nothing intermediate that becomes visible anyway.
