### PR TITLE
[Flare] Refinements to useEvent hook

### DIFF
--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -1067,11 +1067,12 @@ describe('DOMEventResponderSystem', () => {
           };
           context.dispatchEvent(fooEvent, props.onFoo, DiscreteEvent);
         }
+        eventLogs.push(context.isRespondingToHook() ? '[hook]' : '[component]');
       },
     });
 
     const Test = () => {
-      React.unstable_useEvent(EventComponent.responder, {
+      React.unstable_useEvent(EventComponent, {
         onFoo: e => eventLogs.push('hook'),
       });
       return (
@@ -1083,13 +1084,13 @@ describe('DOMEventResponderSystem', () => {
 
     ReactDOM.render(<Test />, container);
     buttonRef.current.dispatchEvent(createEvent('foo'));
-    expect(eventLogs).toEqual(['prop', 'hook']);
+    expect(eventLogs).toEqual(['[component]', '[hook]', 'prop', 'hook']);
 
     // Clear events
     eventLogs.length = 0;
 
     const Test2 = () => {
-      React.unstable_useEvent(EventComponent.responder, {
+      React.unstable_useEvent(EventComponent, {
         onFoo: e => eventLogs.push('hook'),
       });
       return <button ref={buttonRef} />;
@@ -1101,10 +1102,10 @@ describe('DOMEventResponderSystem', () => {
     expect(eventLogs).toEqual([]);
 
     const Test3 = () => {
-      React.unstable_useEvent(EventComponent.responder, {
+      React.unstable_useEvent(EventComponent, {
         onFoo: e => eventLogs.push('hook 2a'),
       });
-      React.unstable_useEvent(EventComponent.responder, {
+      React.unstable_useEvent(EventComponent, {
         onFoo: e => eventLogs.push('hook 2b'),
       });
       return (
@@ -1118,6 +1119,13 @@ describe('DOMEventResponderSystem', () => {
 
     ReactDOM.render(<Test3 />, container);
     buttonRef.current.dispatchEvent(createEvent('foo'));
-    expect(eventLogs).toEqual(['prop 2', 'hook 2a', 'hook 2b']);
+    expect(eventLogs).toEqual([
+      '[component]',
+      '[hook]',
+      '[hook]',
+      'prop 2',
+      'hook 2a',
+      'hook 2b',
+    ]);
   });
 });

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -1041,7 +1041,7 @@ function completeWork(
             responder,
             rootContainerInstance,
             responderState || {},
-            true,
+            false,
           );
           markUpdate(workInProgress);
         } else {

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -9,6 +9,7 @@
 
 import type {Fiber, Dependencies} from './ReactFiber';
 import type {
+  ReactEventComponent,
   ReactEventResponder,
   ReactEventComponentInstance,
 } from 'shared/ReactTypes';
@@ -32,9 +33,10 @@ export function prepareToReadEventComponents(workInProgress: Fiber): void {
 }
 
 export function updateEventComponentInstance<T, E, C>(
-  responder: ReactEventResponder<T, E, C>,
+  eventComponent: ReactEventComponent<T, E, C>,
   props: Object,
 ): void {
+  const responder = eventComponent.responder;
   invariant(
     responder.allowEventHooks,
     'The "%s" event responder cannot be used via the "useEvent" hook.',
@@ -67,7 +69,7 @@ export function updateEventComponentInstance<T, E, C>(
       responder,
       null,
       responderState || {},
-      false,
+      true,
     );
     events.push(eventComponentInstance);
     currentEventComponentInstanceIndex++;
@@ -85,11 +87,11 @@ export function createEventComponentInstance<T, E, C>(
   responder: ReactEventResponder<T, E, C>,
   rootInstance: mixed,
   state: Object,
-  localPropagation: boolean,
+  isHook: boolean,
 ): ReactEventComponentInstance<T, E, C> {
   return {
     currentFiber,
-    localPropagation,
+    isHook,
     props,
     responder,
     rootEventTypes: null,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ReactEventResponder, ReactContext} from 'shared/ReactTypes';
+import type {ReactEventComponent, ReactContext} from 'shared/ReactTypes';
 import type {SideEffectTag} from 'shared/ReactSideEffectTags';
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
@@ -83,7 +83,7 @@ export type Dispatcher = {
   ): void,
   useDebugValue<T>(value: T, formatterFn: ?(value: T) => mixed): void,
   useEvent<T, E, C>(
-    responder: ReactEventResponder<T, E, C>,
+    eventComponent: ReactEventComponent<T, E, C>,
     props: Object,
   ): void,
 };
@@ -1399,10 +1399,10 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountDebugValue(value, formatterFn);
     },
-    useEvent<T, E, C>(responder: ReactEventResponder<T, E, C>, props) {
+    useEvent<T, E, C>(eventComponent: ReactEventComponent<T, E, C>, props) {
       currentHookNameInDev = 'useEvent';
       mountHookTypesDev();
-      updateEventComponentInstance(responder, props);
+      updateEventComponentInstance(eventComponent, props);
     },
   };
 
@@ -1501,10 +1501,10 @@ if (__DEV__) {
       updateHookTypesDev();
       return mountDebugValue(value, formatterFn);
     },
-    useEvent<T, E, C>(responder: ReactEventResponder<T, E, C>, props) {
+    useEvent<T, E, C>(eventComponent: ReactEventComponent<T, E, C>, props) {
       currentHookNameInDev = 'useEvent';
       updateHookTypesDev();
-      updateEventComponentInstance(responder, props);
+      updateEventComponentInstance(eventComponent, props);
     },
   };
 
@@ -1603,10 +1603,10 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateDebugValue(value, formatterFn);
     },
-    useEvent<T, E, C>(responder: ReactEventResponder<T, E, C>, props) {
+    useEvent<T, E, C>(eventComponent: ReactEventComponent<T, E, C>, props) {
       currentHookNameInDev = 'useEvent';
       updateHookTypesDev();
-      updateEventComponentInstance(responder, props);
+      updateEventComponentInstance(eventComponent, props);
     },
   };
 
@@ -1716,11 +1716,11 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountDebugValue(value, formatterFn);
     },
-    useEvent<T, E, C>(responder: ReactEventResponder<T, E, C>, props) {
+    useEvent<T, E, C>(eventComponent: ReactEventComponent<T, E, C>, props) {
       currentHookNameInDev = 'useEvent';
       warnInvalidHookAccess();
       mountHookTypesDev();
-      updateEventComponentInstance(responder, props);
+      updateEventComponentInstance(eventComponent, props);
     },
   };
 
@@ -1830,11 +1830,11 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateDebugValue(value, formatterFn);
     },
-    useEvent<T, E, C>(responder: ReactEventResponder<T, E, C>, props) {
+    useEvent<T, E, C>(eventComponent: ReactEventComponent<T, E, C>, props) {
       currentHookNameInDev = 'useEvent';
       warnInvalidHookAccess();
       updateHookTypesDev();
-      updateEventComponentInstance(responder, props);
+      updateEventComponentInstance(eventComponent, props);
     },
   };
 }

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ReactEventResponder, ReactContext} from 'shared/ReactTypes';
+import type {ReactEventComponent, ReactContext} from 'shared/ReactTypes';
 import invariant from 'shared/invariant';
 import warning from 'shared/warning';
 
@@ -139,9 +139,9 @@ export function useDebugValue(value: any, formatterFn: ?(value: any) => any) {
 export const emptyObject = {};
 
 export function useEvent<T, E, C>(
-  responder: ReactEventResponder<T, E, C>,
+  eventComponent: ReactEventComponent<T, E, C>,
   props: null | Object,
 ) {
   const dispatcher = resolveDispatcher();
-  return dispatcher.useEvent(responder, props || emptyObject);
+  return dispatcher.useEvent(eventComponent, props || emptyObject);
 }

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -84,4 +84,5 @@ export type ReactDOMResponderContext = {
     deep: boolean,
   ) => boolean,
   continueLocalPropagation(): void,
+  isRespondingToHook(): boolean,
 };

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -83,7 +83,7 @@ export type RefObject = {|
 
 export type ReactEventComponentInstance<T, E, C> = {|
   currentFiber: mixed,
-  localPropagation: boolean,
+  isHook: boolean,
   props: Object,
   responder: ReactEventResponder<T, E, C>,
   rootEventTypes: null | Set<string>,


### PR DESCRIPTION
This PR makes some refinements to the `useEvent` hook API and also adds in a way to provide the responder a way of finding out if it is responding to an event hook (`context.isRespondingToHook()`).

`useEvent` now takes an `EventComponent` rather than an `EventResponder`. This was an open question on the original PR and I wasn't sure what people would prefer to use when defining how hooks can be formed, but the general consensus is that it makes more sense to provide the event components instead of their raw event responders.

As a follow up, it would be great if someone could leverage the `isRespondingToHook` method to ensure `<Press>` side-effectful props (`preventDefault`, `stopPropagation`, `preventContextMenu`) become no-ops in the event responder when used with hooks – probably with a nice warning too.