### PR TITLE
followup to #15763, fix failing test in ReactDOMTracing-test

### DIFF
--- a/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
+++ b/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
@@ -538,53 +538,55 @@ describe('ReactDOMTracing', () => {
         const root = ReactDOM.unstable_createRoot(container);
 
         let interaction;
-        SchedulerTracing.unstable_trace('initialization', 0, () => {
-          interaction = Array.from(SchedulerTracing.unstable_getCurrent())[0];
-          // This render is only CPU bound. Nothing suspends.
-          root.render(<App />);
+        TestUtils.act(() => {
+          SchedulerTracing.unstable_trace('initialization', 0, () => {
+            interaction = Array.from(SchedulerTracing.unstable_getCurrent())[0];
+            // This render is only CPU bound. Nothing suspends.
+            root.render(<App />);
+          });
+
+          expect(Scheduler).toFlushAndYieldThrough(['A']);
+
+          Scheduler.advanceTime(300);
+          jest.advanceTimersByTime(300);
+
+          expect(Scheduler).toFlushAndYieldThrough(['B']);
+
+          Scheduler.advanceTime(300);
+          jest.advanceTimersByTime(300);
+
+          // Time has now elapsed for so long that we're just going to give up
+          // rendering the rest of the content. So that we can at least show
+          // something.
+          expect(Scheduler).toFlushAndYieldThrough([
+            'Loading C',
+            'Commit A',
+            'Commit B',
+            'Commit Loading C',
+          ]);
+
+          // Schedule an unrelated low priority update that shouldn't be included
+          // in the previous interaction. This is meant to ensure that we don't
+          // rely on the whole tree completing to cover up bugs.
+          Scheduler.unstable_runWithPriority(
+            Scheduler.unstable_IdlePriority,
+            () => root.render(<App />),
+          );
+
+          expect(onInteractionTraced).toHaveBeenCalledTimes(1);
+          expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
+            interaction,
+          );
+          expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+
+          // Then we do a second pass to commit the last item.
+          expect(Scheduler).toFlushAndYieldThrough(['C', 'Commit C']);
+
+          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+          expect(
+            onInteractionScheduledWorkCompleted,
+          ).toHaveBeenLastNotifiedOfInteraction(interaction);
         });
-
-        expect(Scheduler).toFlushAndYieldThrough(['A']);
-
-        Scheduler.advanceTime(300);
-        jest.advanceTimersByTime(300);
-
-        expect(Scheduler).toFlushAndYieldThrough(['B']);
-
-        Scheduler.advanceTime(300);
-        jest.advanceTimersByTime(300);
-
-        // Time has now elapsed for so long that we're just going to give up
-        // rendering the rest of the content. So that we can at least show
-        // something.
-        expect(Scheduler).toFlushAndYieldThrough([
-          'Loading C',
-          'Commit A',
-          'Commit B',
-          'Commit Loading C',
-        ]);
-
-        // Schedule an unrelated low priority update that shouldn't be included
-        // in the previous interaction. This is meant to ensure that we don't
-        // rely on the whole tree completing to cover up bugs.
-        Scheduler.unstable_runWithPriority(
-          Scheduler.unstable_IdlePriority,
-          () => root.render(<App />),
-        );
-
-        expect(onInteractionTraced).toHaveBeenCalledTimes(1);
-        expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
-          interaction,
-        );
-        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
-
-        // Then we do a second pass to commit the last item.
-        expect(Scheduler).toFlushAndYieldThrough(['C', 'Commit C']);
-
-        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-        expect(
-          onInteractionScheduledWorkCompleted,
-        ).toHaveBeenLastNotifiedOfInteraction(interaction);
       });
     });
 

--- a/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
+++ b/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
@@ -538,6 +538,7 @@ describe('ReactDOMTracing', () => {
         const root = ReactDOM.unstable_createRoot(container);
 
         let interaction;
+
         TestUtils.act(() => {
           SchedulerTracing.unstable_trace('initialization', 0, () => {
             interaction = Array.from(SchedulerTracing.unstable_getCurrent())[0];


### PR DESCRIPTION
It was me. I broke the build.

I merged 15763 without testing a rebased version locally, which had a failing test. This PR fixes the test (by wrapping a section of the test with `act()`). 

