### PR TITLE
[Flare] Ensure Press event hook does not execute side-effects

### DIFF
--- a/packages/react-events/src/Press.js
+++ b/packages/react-events/src/Press.js
@@ -14,6 +14,7 @@ import type {
   PointerType,
 } from 'shared/ReactDOMTypes';
 import type {EventPriority} from 'shared/ReactTypes';
+import warning from 'shared/warning';
 
 import React from 'react';
 import {DiscreteEvent, UserBlockingEvent} from 'shared/ReactTypes';
@@ -623,6 +624,24 @@ function updateIsPressWithinResponderRegion(
   state.isPressWithinResponderRegion = isPressWithinResponderRegion;
 }
 
+function handleStopPropagation(
+  props: PressProps,
+  context: ReactDOMResponderContext,
+  nativeEvent,
+): void {
+  const stopPropagation = props.stopPropagation;
+  if (stopPropagation !== undefined && context.isRespondingToHook()) {
+    if (__DEV__) {
+      warning(
+        false,
+        '"stopPropagation" prop cannot be passed to Press event hooks. This will result in a no-op.',
+      );
+    }
+  } else if (stopPropagation === true) {
+    nativeEvent.stopPropagation();
+  }
+}
+
 const PressResponder: ReactDOMEventResponder = {
   displayName: 'Press',
   targetEventTypes,
@@ -667,9 +686,7 @@ const PressResponder: ReactDOMEventResponder = {
     const nativeEvent: any = event.nativeEvent;
     const isPressed = state.isPressed;
 
-    if (props.stopPropagation === true) {
-      nativeEvent.stopPropagation();
-    }
+    handleStopPropagation(props, context, nativeEvent);
     switch (type) {
       // START
       case 'pointerdown':
@@ -745,13 +762,34 @@ const PressResponder: ReactDOMEventResponder = {
       }
 
       case 'contextmenu': {
-        if (props.preventContextMenu) {
+        const preventContextMenu = props.preventContextMenu;
+
+        if (preventContextMenu !== undefined && context.isRespondingToHook()) {
+          if (__DEV__) {
+            warning(
+              false,
+              '"preventContextMenu" prop cannot be passed to Press event hooks. This will result in a no-op.',
+            );
+          }
+        } else if (preventContextMenu === true) {
           // Skip dispatching of onContextMenu below
           nativeEvent.preventDefault();
         }
 
         if (isPressed) {
-          if (props.preventDefault !== false && !nativeEvent.defaultPrevented) {
+          const preventDefault = props.preventDefault;
+
+          if (preventDefault !== undefined && context.isRespondingToHook()) {
+            if (__DEV__) {
+              warning(
+                false,
+                '"preventDefault" prop cannot be passed to Press event hooks. This will result in a no-op.',
+              );
+            }
+          } else if (
+            preventDefault !== false &&
+            !nativeEvent.defaultPrevented
+          ) {
             // Skip dispatching of onContextMenu below
             nativeEvent.preventDefault();
             return;
@@ -787,9 +825,7 @@ const PressResponder: ReactDOMEventResponder = {
     const isPressed = state.isPressed;
     const activePointerId = state.activePointerId;
 
-    if (props.stopPropagation === true) {
-      nativeEvent.stopPropagation();
-    }
+    handleStopPropagation(props, context, nativeEvent);
     switch (type) {
       // MOVE
       case 'pointermove':
@@ -894,7 +930,15 @@ const PressResponder: ReactDOMEventResponder = {
             } = (nativeEvent: MouseEvent);
             // Check "open in new window/tab" and "open context menu" key modifiers
             const preventDefault = props.preventDefault;
-            if (
+
+            if (preventDefault !== undefined && context.isRespondingToHook()) {
+              if (__DEV__) {
+                warning(
+                  false,
+                  '"preventDefault" prop cannot be passed to Press event hooks. This will result in a no-op.',
+                );
+              }
+            } else if (
               preventDefault !== false &&
               !shiftKey &&
               !metaKey &&

--- a/packages/react-events/src/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/__tests__/Press-test.internal.js
@@ -2365,6 +2365,31 @@ describe('Event responder: Press', () => {
         expect.objectContaining({defaultPrevented: false}),
       );
     });
+
+    it('warns when preventDefault is used in an event hook', () => {
+      const onPress = jest.fn();
+      const preventDefault = jest.fn();
+      const ref = React.createRef();
+      const Component = () => {
+        React.unstable_useEvent(Press, {preventDefault: false});
+
+        return (
+          <Press onPress={onPress}>
+            <a href="#" ref={ref} />
+          </Press>
+        );
+      };
+      ReactDOM.render(<Component />, container);
+
+      expect(() => {
+        ref.current.dispatchEvent(createEvent('pointerdown'));
+        ref.current.dispatchEvent(createEvent('pointerup'));
+        ref.current.dispatchEvent(createEvent('click', {preventDefault}));
+      }).toWarnDev(
+        '"preventDefault" prop cannot be passed to Press event hooks. This will result in a no-op.',
+        {withoutStack: true},
+      );
+    });
   });
 
   describe('responder cancellation', () => {
@@ -2922,6 +2947,30 @@ describe('Event responder: Press', () => {
     });
   });
 
+  it('warns when preventContextMenu is used in an event hook', () => {
+    const ref = React.createRef();
+    const Component = () => {
+      React.unstable_useEvent(Press, {preventContextMenu: false});
+
+      return (
+        <Press preventContextMenu={true}>
+          <div ref={ref} />
+        </Press>
+      );
+    };
+    ReactDOM.render(<Component />, container);
+
+    expect(() => {
+      ref.current.dispatchEvent(
+        createEvent('pointerdown', {pointerType: 'mouse', button: 2}),
+      );
+      ref.current.dispatchEvent(createEvent('contextmenu'));
+    }).toWarnDev(
+      '"preventContextMenu" prop cannot be passed to Press event hooks. This will result in a no-op.',
+      {withoutStack: true},
+    );
+  });
+
   it('should work correctly with stopPropagation set to true', () => {
     const ref = React.createRef();
     const element = (
@@ -2935,6 +2984,33 @@ describe('Event responder: Press', () => {
 
     ref.current.dispatchEvent(
       createEvent('pointerdown', {pointerType: 'mouse', button: 0}),
+    );
+    container.removeEventListener('pointerdown', pointerDownEvent);
+    expect(pointerDownEvent).toHaveBeenCalledTimes(0);
+  });
+
+  it('warns when stopPropagation is used in an event hook', () => {
+    const ref = React.createRef();
+    const Component = () => {
+      React.unstable_useEvent(Press, {stopPropagation: false});
+
+      return (
+        <Press stopPropagation={true}>
+          <a href="#" ref={ref} />
+        </Press>
+      );
+    };
+    const pointerDownEvent = jest.fn();
+    container.addEventListener('pointerdown', pointerDownEvent);
+    ReactDOM.render(<Component />, container);
+
+    expect(() => {
+      ref.current.dispatchEvent(
+        createEvent('pointerdown', {pointerType: 'mouse', button: 0}),
+      );
+    }).toWarnDev(
+      '"stopPropagation" prop cannot be passed to Press event hooks. This will result in a no-op.',
+      {withoutStack: true},
     );
     container.removeEventListener('pointerdown', pointerDownEvent);
     expect(pointerDownEvent).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
The `Press` event responder allow for certain props with side-effects to be passed. These props alter how the browser handles certain DOM operations. They are:

- `preventDefault`
- `preventContextMenu`
- `stopPropagation`

These props are special cases for when escape hatches are needed and should be specific to event components, not to event hooks. Having them in event hooks could cause unexpected behaviour that won't be trivial to debug and find. This PR changes them all to be no-ops in the case of being used in an event hook. They also have DEV time warnings.