### PR TITLE
RFC: wrap react-test-renderer's .create and .update with act() by default

### DIFF
--- a/fixtures/dom/src/index.test.js
+++ b/fixtures/dom/src/index.test.js
@@ -76,25 +76,23 @@ it('warns when using the wrong act version - test + dom: updates', () => {
   ]);
 });
 
-it('warns when using the wrong act version - dom + test: .create()', () => {
+it('does *not* warn when using the wrong act version - dom + test: .create()', () => {
+  // since TestRenderer.create wraps its own act(), there's no warning to trigger
   expect(() => {
     TestUtils.act(() => {
       TestRenderer.create(<App />);
     });
-  }).toWarnDev(["It looks like you're using the wrong act()"], {
-    withoutStack: true,
-  });
+  }).toWarnDev([]);
 });
 
 it('warns when using the wrong act version - dom + test: .update()', () => {
+  // since TestRenderer.update wraps its own act(), there's no warning to trigger
   const root = TestRenderer.create(<App key="one" />);
   expect(() => {
     TestUtils.act(() => {
       root.update(<App key="two" />);
     });
-  }).toWarnDev(["It looks like you're using the wrong act()"], {
-    withoutStack: true,
-  });
+  }).toWarnDev([]);
 });
 
 it('warns when using the wrong act version - dom + test: updates', () => {

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -84,7 +84,7 @@ function flushWorkAndMicroTasks(onDone: (err: ?Error) => void) {
 
 let actingUpdatesScopeDepth = 0;
 
-function act(callback: () => Thenable) {
+function act(callback: () => Thenable | void) {
   let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
   let previousActingUpdatesSigil;
   actingUpdatesScopeDepth++;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -701,7 +701,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
   let actingUpdatesScopeDepth = 0;
 
-  function act(callback: () => Thenable) {
+  function act(callback: () => Thenable | void) {
     let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
     let previousActingUpdatesSigil;
     actingUpdatesScopeDepth++;

--- a/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberEvents-test-internal.js
@@ -807,23 +807,24 @@ describe('ReactFiberEvents', () => {
         Scheduler.yieldValue(props.text);
         return props.text;
       }
+      ReactTestRenderer.act(() => {
+        ReactTestRenderer.create(
+          <React.Suspense fallback={<Text text="Loading..." />}>
+            <EventComponent>
+              <div>
+                <Async />
+                <Text text="Sibling" />
+              </div>
+            </EventComponent>
+          </React.Suspense>,
+          {
+            unstable_isConcurrent: true,
+          },
+        );
 
-      ReactTestRenderer.create(
-        <React.Suspense fallback={<Text text="Loading..." />}>
-          <EventComponent>
-            <div>
-              <Async />
-              <Text text="Sibling" />
-            </div>
-          </EventComponent>
-        </React.Suspense>,
-        {
-          unstable_isConcurrent: true,
-        },
-      );
-
-      expect(Scheduler).toFlushAndYieldThrough(['Suspend!']);
-      resolveThenable();
+        expect(Scheduler).toFlushAndYieldThrough(['Suspend!']);
+        resolveThenable();
+      });
     });
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -79,90 +79,89 @@ describe('ReactHooks', () => {
       });
       return <Child text={text} />;
     }
-
-    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
-    root.update(<Parent />);
-    expect(Scheduler).toFlushAndYield([
-      'Parent: 0, 0',
-      'Child: 0, 0',
-      'Effect: 0, 0',
-    ]);
-    expect(root).toMatchRenderedOutput('0, 0');
-
-    // Normal update
     act(() => {
+      const root = ReactTestRenderer.create(null, {
+        unstable_isConcurrent: true,
+      });
+      root.update(<Parent />);
+      expect(Scheduler).toFlushAndYield([
+        'Parent: 0, 0',
+        'Child: 0, 0',
+        'Effect: 0, 0',
+      ]);
+      expect(root).toMatchRenderedOutput('0, 0');
+
+      // Normal update
+      act(() => {
+        setCounter1(1);
+        setCounter2(1);
+      });
+
+      expect(Scheduler).toFlushAndYield([
+        'Parent: 1, 1',
+        'Child: 1, 1',
+        'Effect: 1, 1',
+      ]);
+
+      // Update that bails out.
       setCounter1(1);
-      setCounter2(1);
-    });
+      expect(Scheduler).toFlushAndYield(['Parent: 1, 1']);
 
-    expect(Scheduler).toHaveYielded([
-      'Parent: 1, 1',
-      'Child: 1, 1',
-      'Effect: 1, 1',
-    ]);
+      // This time, one of the state updates but the other one doesn't. So we
+      // can't bail out.
 
-    // Update that bails out.
-    act(() => setCounter1(1));
-    expect(Scheduler).toHaveYielded(['Parent: 1, 1']);
-
-    // This time, one of the state updates but the other one doesn't. So we
-    // can't bail out.
-    act(() => {
       setCounter1(1);
       setCounter2(2);
-    });
 
-    expect(Scheduler).toHaveYielded([
-      'Parent: 1, 2',
-      'Child: 1, 2',
-      'Effect: 1, 2',
-    ]);
+      expect(Scheduler).toFlushAndYield([
+        'Parent: 1, 2',
+        'Child: 1, 2',
+        'Effect: 1, 2',
+      ]);
 
-    // Lots of updates that eventually resolve to the current values.
-    act(() => {
+      // Lots of updates that eventually resolve to the current values.
+
       setCounter1(9);
       setCounter2(3);
       setCounter1(4);
       setCounter2(7);
       setCounter1(1);
       setCounter2(2);
-    });
 
-    // Because the final values are the same as the current values, the
-    // component bails out.
-    expect(Scheduler).toHaveYielded(['Parent: 1, 2']);
+      // Because the final values are the same as the current values, the
+      // component bails out.
+      expect(Scheduler).toFlushAndYield(['Parent: 1, 2']);
 
-    // prepare to check SameValue
-    act(() => {
+      // prepare to check SameValue
+
       setCounter1(0 / -1);
       setCounter2(NaN);
-    });
 
-    expect(Scheduler).toHaveYielded([
-      'Parent: 0, NaN',
-      'Child: 0, NaN',
-      'Effect: 0, NaN',
-    ]);
+      expect(Scheduler).toFlushAndYield([
+        'Parent: 0, NaN',
+        'Child: 0, NaN',
+        'Effect: 0, NaN',
+      ]);
 
-    // check if re-setting to negative 0 / NaN still bails out
-    act(() => {
+      // check if re-setting to negative 0 / NaN still bails out
+
       setCounter1(0 / -1);
       setCounter2(NaN);
       setCounter2(Infinity);
       setCounter2(NaN);
-    });
 
-    expect(Scheduler).toHaveYielded(['Parent: 0, NaN']);
+      expect(Scheduler).toFlushAndYield(['Parent: 0, NaN']);
 
-    // check if changing negative 0 to positive 0 does not bail out
-    act(() => {
+      // check if changing negative 0 to positive 0 does not bail out
+
       setCounter1(0);
+
+      expect(Scheduler).toFlushAndYield([
+        'Parent: 0, NaN',
+        'Child: 0, NaN',
+        'Effect: 0, NaN',
+      ]);
     });
-    expect(Scheduler).toHaveYielded([
-      'Parent: 0, NaN',
-      'Child: 0, NaN',
-      'Effect: 0, NaN',
-    ]);
   });
 
   it('bails out in render phase if all the state is the same and props bail out with memo', () => {
@@ -187,63 +186,61 @@ describe('ReactHooks', () => {
     }
 
     Parent = memo(Parent);
-
-    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
-    root.update(<Parent theme="light" />);
-    expect(Scheduler).toFlushAndYield([
-      'Parent: 0, 0 (light)',
-      'Child: 0, 0 (light)',
-    ]);
-    expect(root).toMatchRenderedOutput('0, 0 (light)');
-
-    // Normal update
     act(() => {
+      const root = ReactTestRenderer.create(null, {
+        unstable_isConcurrent: true,
+      });
+      root.update(<Parent theme="light" />);
+      expect(Scheduler).toFlushAndYield([
+        'Parent: 0, 0 (light)',
+        'Child: 0, 0 (light)',
+      ]);
+      expect(root).toMatchRenderedOutput('0, 0 (light)');
+
+      // Normal update
+
       setCounter1(1);
       setCounter2(1);
-    });
 
-    expect(Scheduler).toHaveYielded([
-      'Parent: 1, 1 (light)',
-      'Child: 1, 1 (light)',
-    ]);
+      expect(Scheduler).toFlushAndYield([
+        'Parent: 1, 1 (light)',
+        'Child: 1, 1 (light)',
+      ]);
 
-    // Update that bails out.
-    act(() => setCounter1(1));
-    expect(Scheduler).toHaveYielded(['Parent: 1, 1 (light)']);
+      // Update that bails out.
+      setCounter1(1);
+      expect(Scheduler).toFlushAndYield(['Parent: 1, 1 (light)']);
 
-    // This time, one of the state updates but the other one doesn't. So we
-    // can't bail out.
-    act(() => {
+      // This time, one of the state updates but the other one doesn't. So we
+      // can't bail out.
+
       setCounter1(1);
       setCounter2(2);
-    });
 
-    expect(Scheduler).toHaveYielded([
-      'Parent: 1, 2 (light)',
-      'Child: 1, 2 (light)',
-    ]);
+      expect(Scheduler).toFlushAndYield([
+        'Parent: 1, 2 (light)',
+        'Child: 1, 2 (light)',
+      ]);
 
-    // Updates bail out, but component still renders because props
-    // have changed
-    act(() => {
+      // Updates bail out, but component still renders because props
+      // have changed
       setCounter1(1);
       setCounter2(2);
       root.update(<Parent theme="dark" />);
-    });
 
-    expect(Scheduler).toHaveYielded([
-      'Parent: 1, 2 (dark)',
-      'Child: 1, 2 (dark)',
-    ]);
+      expect(Scheduler).toFlushAndYield([
+        'Parent: 1, 2 (dark)',
+        'Child: 1, 2 (dark)',
+      ]);
 
-    // Both props and state bail out
-    act(() => {
+      // Both props and state bail out
+
       setCounter1(1);
       setCounter2(2);
       root.update(<Parent theme="dark" />);
-    });
 
-    expect(Scheduler).toHaveYielded(['Parent: 1, 2 (dark)']);
+      expect(Scheduler).toFlushAndYield(['Parent: 1, 2 (dark)']);
+    });
   });
 
   it('warns about setState second argument', () => {
@@ -257,27 +254,28 @@ describe('ReactHooks', () => {
       Scheduler.yieldValue(`Count: ${counter}`);
       return counter;
     }
+    act(() => {
+      const root = ReactTestRenderer.create(null, {
+        unstable_isConcurrent: true,
+      });
+      root.update(<Counter />);
+      expect(Scheduler).toFlushAndYield(['Count: 0']);
+      expect(root).toMatchRenderedOutput('0');
 
-    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
-    root.update(<Counter />);
-    expect(Scheduler).toFlushAndYield(['Count: 0']);
-    expect(root).toMatchRenderedOutput('0');
-
-    expect(() => {
-      act(() =>
+      expect(() => {
         setCounter(1, () => {
           throw new Error('Expected to ignore the callback.');
-        }),
+        });
+      }).toWarnDev(
+        'State updates from the useState() and useReducer() Hooks ' +
+          "don't support the second callback argument. " +
+          'To execute a side effect after rendering, ' +
+          'declare it in the component body with useEffect().',
+        {withoutStack: true},
       );
-    }).toWarnDev(
-      'State updates from the useState() and useReducer() Hooks ' +
-        "don't support the second callback argument. " +
-        'To execute a side effect after rendering, ' +
-        'declare it in the component body with useEffect().',
-      {withoutStack: true},
-    );
-    expect(Scheduler).toHaveYielded(['Count: 1']);
-    expect(root).toMatchRenderedOutput('1');
+      expect(Scheduler).toFlushAndYield(['Count: 1']);
+      expect(root).toMatchRenderedOutput('1');
+    });
   });
 
   it('warns about dispatch second argument', () => {
@@ -291,27 +289,28 @@ describe('ReactHooks', () => {
       Scheduler.yieldValue(`Count: ${counter}`);
       return counter;
     }
+    act(() => {
+      const root = ReactTestRenderer.create(null, {
+        unstable_isConcurrent: true,
+      });
+      root.update(<Counter />);
+      expect(Scheduler).toFlushAndYield(['Count: 0']);
+      expect(root).toMatchRenderedOutput('0');
 
-    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
-    root.update(<Counter />);
-    expect(Scheduler).toFlushAndYield(['Count: 0']);
-    expect(root).toMatchRenderedOutput('0');
-
-    expect(() => {
-      act(() =>
+      expect(() => {
         dispatch(1, () => {
           throw new Error('Expected to ignore the callback.');
-        }),
+        });
+      }).toWarnDev(
+        'State updates from the useState() and useReducer() Hooks ' +
+          "don't support the second callback argument. " +
+          'To execute a side effect after rendering, ' +
+          'declare it in the component body with useEffect().',
+        {withoutStack: true},
       );
-    }).toWarnDev(
-      'State updates from the useState() and useReducer() Hooks ' +
-        "don't support the second callback argument. " +
-        'To execute a side effect after rendering, ' +
-        'declare it in the component body with useEffect().',
-      {withoutStack: true},
-    );
-    expect(Scheduler).toHaveYielded(['Count: 1']);
-    expect(root).toMatchRenderedOutput('1');
+      expect(Scheduler).toFlushAndYield(['Count: 1']);
+      expect(root).toMatchRenderedOutput('1');
+    });
   });
 
   it('never bails out if context has changed', () => {
@@ -420,63 +419,64 @@ describe('ReactHooks', () => {
       return <Child text={counter} />;
     }
 
-    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
-    root.update(<Parent />);
-    expect(Scheduler).toFlushAndYield(['Parent: 0', 'Child: 0', 'Effect: 0']);
-    expect(root).toMatchRenderedOutput('0');
-
-    // Normal update
-    act(() => setCounter(1));
-    expect(Scheduler).toHaveYielded(['Parent: 1', 'Child: 1', 'Effect: 1']);
-    expect(root).toMatchRenderedOutput('1');
-
-    // Update to the same state. React doesn't know if the queue is empty
-    // because the alterate fiber has pending update priority, so we have to
-    // enter the render phase before we can bail out. But we bail out before
-    // rendering the child, and we don't fire any effects.
-    act(() => setCounter(1));
-    expect(Scheduler).toHaveYielded(['Parent: 1']);
-    expect(root).toMatchRenderedOutput('1');
-
-    // Update to the same state again. This times, neither fiber has pending
-    // update priority, so we can bail out before even entering the render phase.
-    act(() => setCounter(1));
-    expect(Scheduler).toFlushAndYield([]);
-    expect(root).toMatchRenderedOutput('1');
-
-    // This changes the state to something different so it renders normally.
-    act(() => setCounter(2));
-    expect(Scheduler).toHaveYielded(['Parent: 2', 'Child: 2', 'Effect: 2']);
-    expect(root).toMatchRenderedOutput('2');
-
-    // prepare to check SameValue
     act(() => {
+      const root = ReactTestRenderer.create(null, {
+        unstable_isConcurrent: true,
+      });
+      root.update(<Parent />);
+      expect(Scheduler).toFlushAndYield(['Parent: 0', 'Child: 0', 'Effect: 0']);
+      expect(root).toMatchRenderedOutput('0');
+
+      // Normal update
+      setCounter(1);
+      expect(Scheduler).toFlushAndYield(['Parent: 1', 'Child: 1', 'Effect: 1']);
+      expect(root).toMatchRenderedOutput('1');
+
+      // Update to the same state. React doesn't know if the queue is empty
+      // because the alterate fiber has pending update priority, so we have to
+      // enter the render phase before we can bail out. But we bail out before
+      // rendering the child, and we don't fire any effects.
+      setCounter(1);
+      expect(Scheduler).toFlushAndYield(['Parent: 1']);
+      expect(root).toMatchRenderedOutput('1');
+
+      // Update to the same state again. This times, neither fiber has pending
+      // update priority, so we can bail out before even entering the render phase.
+      setCounter(1);
+      expect(Scheduler).toFlushAndYield([]);
+      expect(root).toMatchRenderedOutput('1');
+
+      // This changes the state to something different so it renders normally.
+      setCounter(2);
+      expect(Scheduler).toFlushAndYield(['Parent: 2', 'Child: 2', 'Effect: 2']);
+      expect(root).toMatchRenderedOutput('2');
+
+      // prepare to check SameValue
+
       setCounter(0);
-    });
-    expect(Scheduler).toHaveYielded(['Parent: 0', 'Child: 0', 'Effect: 0']);
-    expect(root).toMatchRenderedOutput('0');
 
-    // Update to the same state for the first time to flush the queue
-    act(() => {
+      expect(Scheduler).toFlushAndYield(['Parent: 0', 'Child: 0', 'Effect: 0']);
+      expect(root).toMatchRenderedOutput('0');
+
+      // Update to the same state for the first time to flush the queue
+
       setCounter(0);
-    });
 
-    expect(Scheduler).toHaveYielded(['Parent: 0']);
-    expect(root).toMatchRenderedOutput('0');
+      expect(Scheduler).toFlushAndYield(['Parent: 0']);
+      expect(root).toMatchRenderedOutput('0');
 
-    // Update again to the same state. Should bail out.
-    act(() => {
+      // Update again to the same state. Should bail out.
       setCounter(0);
-    });
-    expect(Scheduler).toFlushAndYield([]);
-    expect(root).toMatchRenderedOutput('0');
+      expect(Scheduler).toFlushAndYield([]);
+      expect(root).toMatchRenderedOutput('0');
 
-    // Update to a different state (positive 0 to negative 0)
-    act(() => {
+      // Update to a different state (positive 0 to negative 0)
+
       setCounter(0 / -1);
+
+      expect(Scheduler).toFlushAndYield(['Parent: 0', 'Child: 0', 'Effect: 0']);
+      expect(root).toMatchRenderedOutput('0');
     });
-    expect(Scheduler).toHaveYielded(['Parent: 0', 'Child: 0', 'Effect: 0']);
-    expect(root).toMatchRenderedOutput('0');
   });
 
   it('bails out multiple times in a row without entering render phase', () => {
@@ -494,47 +494,48 @@ describe('ReactHooks', () => {
       Scheduler.yieldValue('Parent: ' + counter);
       return <Child text={counter} />;
     }
-
-    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
-    root.update(<Parent />);
-    expect(Scheduler).toFlushAndYield(['Parent: 0', 'Child: 0']);
-    expect(root).toMatchRenderedOutput('0');
-
-    const update = value => {
-      setCounter(previous => {
-        Scheduler.yieldValue(`Compute state (${previous} -> ${value})`);
-        return value;
+    act(() => {
+      const root = ReactTestRenderer.create(null, {
+        unstable_isConcurrent: true,
       });
-    };
-    ReactTestRenderer.unstable_batchedUpdates(() => {
+      root.update(<Parent />);
+      expect(Scheduler).toFlushAndYield(['Parent: 0', 'Child: 0']);
+      expect(root).toMatchRenderedOutput('0');
+
+      const update = value => {
+        setCounter(previous => {
+          Scheduler.yieldValue(`Compute state (${previous} -> ${value})`);
+          return value;
+        });
+      };
       update(0);
       update(0);
       update(0);
       update(1);
       update(2);
       update(3);
+
+      expect(Scheduler).toHaveYielded([
+        // The first four updates were eagerly computed, because the queue is
+        // empty before each one.
+        'Compute state (0 -> 0)',
+        'Compute state (0 -> 0)',
+        'Compute state (0 -> 0)',
+        // The fourth update doesn't bail out
+        'Compute state (0 -> 1)',
+        // so subsequent updates can't be eagerly computed.
+      ]);
+
+      // Now let's enter the render phase
+      expect(Scheduler).toFlushAndYield([
+        // We don't need to re-compute the first four updates. Only the final two.
+        'Compute state (1 -> 2)',
+        'Compute state (2 -> 3)',
+        'Parent: 3',
+        'Child: 3',
+      ]);
+      expect(root).toMatchRenderedOutput('3');
     });
-
-    expect(Scheduler).toHaveYielded([
-      // The first four updates were eagerly computed, because the queue is
-      // empty before each one.
-      'Compute state (0 -> 0)',
-      'Compute state (0 -> 0)',
-      'Compute state (0 -> 0)',
-      // The fourth update doesn't bail out
-      'Compute state (0 -> 1)',
-      // so subsequent updates can't be eagerly computed.
-    ]);
-
-    // Now let's enter the render phase
-    expect(Scheduler).toFlushAndYield([
-      // We don't need to re-compute the first four updates. Only the final two.
-      'Compute state (1 -> 2)',
-      'Compute state (2 -> 3)',
-      'Parent: 3',
-      'Child: 3',
-    ]);
-    expect(root).toMatchRenderedOutput('3');
   });
 
   it('can rebase on top of a previously skipped update', () => {
@@ -552,47 +553,50 @@ describe('ReactHooks', () => {
       Scheduler.yieldValue('Parent: ' + counter);
       return <Child text={counter} />;
     }
-
-    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
-    root.update(<Parent />);
-    expect(Scheduler).toFlushAndYield(['Parent: 1', 'Child: 1']);
-    expect(root).toMatchRenderedOutput('1');
-
-    const update = compute => {
-      setCounter(previous => {
-        const value = compute(previous);
-        Scheduler.yieldValue(`Compute state (${previous} -> ${value})`);
-        return value;
+    act(() => {
+      const root = ReactTestRenderer.create(null, {
+        unstable_isConcurrent: true,
       });
-    };
+      root.update(<Parent />);
+      expect(Scheduler).toFlushAndYield(['Parent: 1', 'Child: 1']);
+      expect(root).toMatchRenderedOutput('1');
 
-    // Update at normal priority
-    ReactTestRenderer.unstable_batchedUpdates(() => update(n => n * 100));
+      const update = compute => {
+        setCounter(previous => {
+          const value = compute(previous);
+          Scheduler.yieldValue(`Compute state (${previous} -> ${value})`);
+          return value;
+        });
+      };
 
-    // The new state is eagerly computed.
-    expect(Scheduler).toHaveYielded(['Compute state (1 -> 100)']);
+      // Update at normal priority
+      ReactTestRenderer.unstable_batchedUpdates(() => update(n => n * 100));
 
-    // but before it's flushed, a higher priority update interrupts it.
-    root.unstable_flushSync(() => {
-      update(n => n + 5);
+      // The new state is eagerly computed.
+      expect(Scheduler).toHaveYielded(['Compute state (1 -> 100)']);
+
+      // but before it's flushed, a higher priority update interrupts it.
+      root.unstable_flushSync(() => {
+        update(n => n + 5);
+      });
+      expect(Scheduler).toHaveYielded([
+        // The eagerly computed state was completely skipped
+        'Compute state (1 -> 6)',
+        'Parent: 6',
+        'Child: 6',
+      ]);
+      expect(root).toMatchRenderedOutput('6');
+
+      // Now when we finish the first update, the second update is rebased on top.
+      // Notice we didn't have to recompute the first update even though it was
+      // skipped in the previous render.
+      expect(Scheduler).toFlushAndYield([
+        'Compute state (100 -> 105)',
+        'Parent: 105',
+        'Child: 105',
+      ]);
+      expect(root).toMatchRenderedOutput('105');
     });
-    expect(Scheduler).toHaveYielded([
-      // The eagerly computed state was completely skipped
-      'Compute state (1 -> 6)',
-      'Parent: 6',
-      'Child: 6',
-    ]);
-    expect(root).toMatchRenderedOutput('6');
-
-    // Now when we finish the first update, the second update is rebased on top.
-    // Notice we didn't have to recompute the first update even though it was
-    // skipped in the previous render.
-    expect(Scheduler).toFlushAndYield([
-      'Compute state (100 -> 105)',
-      'Parent: 105',
-      'Child: 105',
-    ]);
-    expect(root).toMatchRenderedOutput('105');
   });
 
   it('warns about variable number of dependencies', () => {
@@ -773,7 +777,7 @@ describe('ReactHooks', () => {
     }
 
     const root = ReactTestRenderer.create(null);
-    ReactTestRenderer.act(() => {
+    act(() => {
       root.update(<Counter />);
     });
     expect(root).toMatchRenderedOutput('4');
@@ -797,7 +801,7 @@ describe('ReactHooks', () => {
     }
 
     const root = ReactTestRenderer.create(null);
-    ReactTestRenderer.act(() => {
+    act(() => {
       root.update(<Counter />);
     });
     expect(root).toMatchRenderedOutput('4');
@@ -820,7 +824,7 @@ describe('ReactHooks', () => {
     }
 
     const root = ReactTestRenderer.create(null);
-    ReactTestRenderer.act(() => {
+    act(() => {
       root.update(<Counter />);
     });
     expect(root).toMatchRenderedOutput('4');
@@ -1792,7 +1796,7 @@ describe('ReactHooks', () => {
       return null;
     }
 
-    ReactTestRenderer.act(() => {
+    act(() => {
       ReactTestRenderer.create(<A />);
     });
 

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -112,82 +112,86 @@ describe('ReactSuspense', () => {
       );
     }
 
-    // Render an empty shell
-    const root = ReactTestRenderer.create(<Foo />, {
-      unstable_isConcurrent: true,
+    act(() => {
+      // Render an empty shell
+      const root = ReactTestRenderer.create(<Foo />, {
+        unstable_isConcurrent: true,
+      });
+
+      expect(Scheduler).toFlushAndYield(['Foo']);
+      expect(root).toMatchRenderedOutput(null);
+
+      // Navigate the shell to now render the child content.
+      // This should suspend.
+      root.update(<Foo renderBar={true} />);
+
+      expect(Scheduler).toFlushAndYield([
+        'Foo',
+        'Bar',
+        // A suspends
+        'Suspend! [A]',
+        // But we keep rendering the siblings
+        'B',
+        'Loading...',
+      ]);
+      expect(root).toMatchRenderedOutput(null);
+
+      // Flush some of the time
+      jest.advanceTimersByTime(50);
+      // Still nothing...
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput(null);
+
+      // Flush the promise completely
+      jest.advanceTimersByTime(50);
+      // Renders successfully
+      expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+      expect(Scheduler).toFlushAndYield(['Foo', 'Bar', 'A', 'B']);
+      expect(root).toMatchRenderedOutput('AB');
     });
-
-    expect(Scheduler).toFlushAndYield(['Foo']);
-    expect(root).toMatchRenderedOutput(null);
-
-    // Navigate the shell to now render the child content.
-    // This should suspend.
-    root.update(<Foo renderBar={true} />);
-
-    expect(Scheduler).toFlushAndYield([
-      'Foo',
-      'Bar',
-      // A suspends
-      'Suspend! [A]',
-      // But we keep rendering the siblings
-      'B',
-      'Loading...',
-    ]);
-    expect(root).toMatchRenderedOutput(null);
-
-    // Flush some of the time
-    jest.advanceTimersByTime(50);
-    // Still nothing...
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(root).toMatchRenderedOutput(null);
-
-    // Flush the promise completely
-    jest.advanceTimersByTime(50);
-    // Renders successfully
-    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-    expect(Scheduler).toFlushAndYield(['Foo', 'Bar', 'A', 'B']);
-    expect(root).toMatchRenderedOutput('AB');
   });
 
   it('suspends siblings and later recovers each independently', () => {
-    // Render two sibling Suspense components
-    const root = ReactTestRenderer.create(
-      <React.Fragment>
-        <Suspense fallback={<Text text="Loading A..." />}>
-          <AsyncText text="A" ms={5000} />
-        </Suspense>
-        <Suspense fallback={<Text text="Loading B..." />}>
-          <AsyncText text="B" ms={6000} />
-        </Suspense>
-      </React.Fragment>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
+    act(() => {
+      // Render two sibling Suspense components
+      const root = ReactTestRenderer.create(
+        <React.Fragment>
+          <Suspense fallback={<Text text="Loading A..." />}>
+            <AsyncText text="A" ms={5000} />
+          </Suspense>
+          <Suspense fallback={<Text text="Loading B..." />}>
+            <AsyncText text="B" ms={6000} />
+          </Suspense>
+        </React.Fragment>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
 
-    expect(Scheduler).toFlushAndYield([
-      'Suspend! [A]',
-      'Loading A...',
-      'Suspend! [B]',
-      'Loading B...',
-    ]);
-    expect(root).toMatchRenderedOutput('Loading A...Loading B...');
+      expect(Scheduler).toFlushAndYield([
+        'Suspend! [A]',
+        'Loading A...',
+        'Suspend! [B]',
+        'Loading B...',
+      ]);
+      expect(root).toMatchRenderedOutput('Loading A...Loading B...');
 
-    // Advance time by enough that the first Suspense's promise resolves and
-    // switches back to the normal view. The second Suspense should still
-    // show the placeholder
-    jest.advanceTimersByTime(5000);
-    // TODO: Should we throw if you forget to call toHaveYielded?
-    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-    expect(Scheduler).toFlushAndYield(['A']);
-    expect(root).toMatchRenderedOutput('ALoading B...');
+      // Advance time by enough that the first Suspense's promise resolves and
+      // switches back to the normal view. The second Suspense should still
+      // show the placeholder
+      jest.advanceTimersByTime(5000);
+      // TODO: Should we throw if you forget to call toHaveYielded?
+      expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+      expect(Scheduler).toFlushAndYield(['A']);
+      expect(root).toMatchRenderedOutput('ALoading B...');
 
-    // Advance time by enough that the second Suspense's promise resolves
-    // and switches back to the normal view
-    jest.advanceTimersByTime(1000);
-    expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-    expect(Scheduler).toFlushAndYield(['B']);
-    expect(root).toMatchRenderedOutput('AB');
+      // Advance time by enough that the second Suspense's promise resolves
+      // and switches back to the normal view
+      jest.advanceTimersByTime(1000);
+      expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+      expect(Scheduler).toFlushAndYield(['B']);
+      expect(root).toMatchRenderedOutput('AB');
+    });
   });
 
   it('interrupts current render if promise resolves before current render phase', () => {
@@ -217,50 +221,51 @@ describe('ReactSuspense', () => {
       Scheduler.yieldValue('Async');
       return 'Async';
     }
+    act(() => {
+      const root = ReactTestRenderer.create(
+        <React.Fragment>
+          <Suspense fallback={<Text text="Loading..." />} />
+          <Text text="Initial" />
+        </React.Fragment>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
+      expect(Scheduler).toFlushAndYield(['Initial']);
+      expect(root).toMatchRenderedOutput('Initial');
 
-    const root = ReactTestRenderer.create(
-      <React.Fragment>
-        <Suspense fallback={<Text text="Loading..." />} />
-        <Text text="Initial" />
-      </React.Fragment>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
-    expect(Scheduler).toFlushAndYield(['Initial']);
-    expect(root).toMatchRenderedOutput('Initial');
+      // The update will suspend.
+      root.update(
+        <React.Fragment>
+          <Suspense fallback={<Text text="Loading..." />}>
+            <Async />
+          </Suspense>
+          <Text text="After Suspense" />
+          <Text text="Sibling" />
+        </React.Fragment>,
+      );
 
-    // The update will suspend.
-    root.update(
-      <React.Fragment>
-        <Suspense fallback={<Text text="Loading..." />}>
-          <Async />
-        </Suspense>
-        <Text text="After Suspense" />
-        <Text text="Sibling" />
-      </React.Fragment>,
-    );
+      // Yield past the Suspense boundary but don't complete the last sibling.
+      expect(Scheduler).toFlushAndYieldThrough([
+        'Suspend!',
+        'Loading...',
+        'After Suspense',
+      ]);
 
-    // Yield past the Suspense boundary but don't complete the last sibling.
-    expect(Scheduler).toFlushAndYieldThrough([
-      'Suspend!',
-      'Loading...',
-      'After Suspense',
-    ]);
+      // The promise resolves before the current render phase has completed
+      resolveThenable();
+      expect(Scheduler).toHaveYielded([]);
+      expect(root).toMatchRenderedOutput('Initial');
 
-    // The promise resolves before the current render phase has completed
-    resolveThenable();
-    expect(Scheduler).toHaveYielded([]);
-    expect(root).toMatchRenderedOutput('Initial');
-
-    // Start over from the root, instead of continuing.
-    expect(Scheduler).toFlushAndYield([
-      // Async renders again *before* Sibling
-      'Async',
-      'After Suspense',
-      'Sibling',
-    ]);
-    expect(root).toMatchRenderedOutput('AsyncAfter SuspenseSibling');
+      // Start over from the root, instead of continuing.
+      expect(Scheduler).toFlushAndYield([
+        // Async renders again *before* Sibling
+        'Async',
+        'After Suspense',
+        'Sibling',
+      ]);
+      expect(root).toMatchRenderedOutput('AsyncAfter SuspenseSibling');
+    });
   });
 
   it('mounts a lazy class component in non-concurrent mode', async () => {
@@ -298,48 +303,52 @@ describe('ReactSuspense', () => {
   });
 
   it('only captures if `fallback` is defined', () => {
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <Suspense>
-          <AsyncText text="Hi" ms={5000} />
-        </Suspense>
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
+    act(() => {
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <Suspense>
+            <AsyncText text="Hi" ms={5000} />
+          </Suspense>
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
 
-    expect(Scheduler).toFlushAndYield([
-      'Suspend! [Hi]',
-      // The outer fallback should be rendered, because the inner one does not
-      // have a `fallback` prop
-      'Loading...',
-    ]);
-    jest.advanceTimersByTime(1000);
-    expect(Scheduler).toHaveYielded([]);
-    expect(Scheduler).toFlushAndYield([]);
-    expect(root).toMatchRenderedOutput('Loading...');
+      expect(Scheduler).toFlushAndYield([
+        'Suspend! [Hi]',
+        // The outer fallback should be rendered, because the inner one does not
+        // have a `fallback` prop
+        'Loading...',
+      ]);
+      jest.advanceTimersByTime(1000);
+      expect(Scheduler).toHaveYielded([]);
+      expect(Scheduler).toFlushAndYield([]);
+      expect(root).toMatchRenderedOutput('Loading...');
 
-    jest.advanceTimersByTime(5000);
-    expect(Scheduler).toHaveYielded(['Promise resolved [Hi]']);
-    expect(Scheduler).toFlushAndYield(['Hi']);
-    expect(root).toMatchRenderedOutput('Hi');
+      jest.advanceTimersByTime(5000);
+      expect(Scheduler).toHaveYielded(['Promise resolved [Hi]']);
+      expect(Scheduler).toFlushAndYield(['Hi']);
+      expect(root).toMatchRenderedOutput('Hi');
+    });
   });
 
   it('throws if tree suspends and none of the Suspense ancestors have a fallback', () => {
-    ReactTestRenderer.create(
-      <Suspense>
-        <AsyncText text="Hi" ms={1000} />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
+    act(() => {
+      ReactTestRenderer.create(
+        <Suspense>
+          <AsyncText text="Hi" ms={1000} />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
 
-    expect(Scheduler).toFlushAndThrow(
-      'AsyncText suspended while rendering, but no fallback UI was specified.',
-    );
-    expect(Scheduler).toHaveYielded(['Suspend! [Hi]', 'Suspend! [Hi]']);
+      expect(Scheduler).toFlushAndThrow(
+        'AsyncText suspended while rendering, but no fallback UI was specified.',
+      );
+      expect(Scheduler).toHaveYielded(['Suspend! [Hi]', 'Suspend! [Hi]']);
+    });
   });
 
   describe('outside concurrent mode', () => {
@@ -668,36 +677,37 @@ describe('ReactSuspense', () => {
           </Suspense>
         );
       }
+      act(() => {
+        const root = ReactTestRenderer.create(<App />, {
+          unstable_isConcurrent: true,
+        });
 
-      const root = ReactTestRenderer.create(<App />, {
-        unstable_isConcurrent: true,
+        // Initial render
+        expect(Scheduler).toFlushAndYield(['Suspend! [Step: 1]', 'Loading...']);
+        jest.advanceTimersByTime(1000);
+        expect(Scheduler).toHaveYielded(['Promise resolved [Step: 1]']);
+        expect(Scheduler).toFlushAndYield(['Step: 1']);
+        expect(root).toMatchRenderedOutput('Step: 1');
+
+        // Update that suspends
+        instance.setState({step: 2});
+        expect(Scheduler).toFlushAndYield(['Suspend! [Step: 2]', 'Loading...']);
+        jest.advanceTimersByTime(500);
+        expect(root).toMatchRenderedOutput('Loading...');
+
+        // Update while still suspended
+        instance.setState({step: 3});
+        expect(Scheduler).toFlushAndYield(['Suspend! [Step: 3]']);
+        expect(root).toMatchRenderedOutput('Loading...');
+
+        jest.advanceTimersByTime(1000);
+        expect(Scheduler).toHaveYielded([
+          'Promise resolved [Step: 2]',
+          'Promise resolved [Step: 3]',
+        ]);
+        expect(Scheduler).toFlushAndYield(['Step: 3']);
+        expect(root).toMatchRenderedOutput('Step: 3');
       });
-
-      // Initial render
-      expect(Scheduler).toFlushAndYield(['Suspend! [Step: 1]', 'Loading...']);
-      jest.advanceTimersByTime(1000);
-      expect(Scheduler).toHaveYielded(['Promise resolved [Step: 1]']);
-      expect(Scheduler).toFlushAndYield(['Step: 1']);
-      expect(root).toMatchRenderedOutput('Step: 1');
-
-      // Update that suspends
-      instance.setState({step: 2});
-      expect(Scheduler).toFlushAndYield(['Suspend! [Step: 2]', 'Loading...']);
-      jest.advanceTimersByTime(500);
-      expect(root).toMatchRenderedOutput('Loading...');
-
-      // Update while still suspended
-      instance.setState({step: 3});
-      expect(Scheduler).toFlushAndYield(['Suspend! [Step: 3]']);
-      expect(root).toMatchRenderedOutput('Loading...');
-
-      jest.advanceTimersByTime(1000);
-      expect(Scheduler).toHaveYielded([
-        'Promise resolved [Step: 2]',
-        'Promise resolved [Step: 3]',
-      ]);
-      expect(Scheduler).toFlushAndYield(['Step: 3']);
-      expect(root).toMatchRenderedOutput('Step: 3');
     });
 
     it('does not remount the fallback while suspended children resolve in sync mode', () => {
@@ -765,23 +775,24 @@ describe('ReactSuspense', () => {
           </Suspense>
         );
       }
+      act(() => {
+        const root = ReactTestRenderer.create(<App />, {
+          unstable_isConcurrent: true,
+        });
 
-      const root = ReactTestRenderer.create(<App />, {
-        unstable_isConcurrent: true,
+        expect(Scheduler).toFlushAndYield([
+          'Suspend! [Child 1]',
+          'Suspend! [Child 2]',
+          'Loading...',
+        ]);
+        jest.advanceTimersByTime(1000);
+        expect(Scheduler).toHaveYielded(['Promise resolved [Child 1]']);
+        expect(Scheduler).toFlushAndYield(['Child 1', 'Suspend! [Child 2]']);
+        jest.advanceTimersByTime(6000);
+        expect(Scheduler).toHaveYielded(['Promise resolved [Child 2]']);
+        expect(Scheduler).toFlushAndYield(['Child 1', 'Child 2']);
+        expect(root).toMatchRenderedOutput(['Child 1', 'Child 2'].join(''));
       });
-
-      expect(Scheduler).toFlushAndYield([
-        'Suspend! [Child 1]',
-        'Suspend! [Child 2]',
-        'Loading...',
-      ]);
-      jest.advanceTimersByTime(1000);
-      expect(Scheduler).toHaveYielded(['Promise resolved [Child 1]']);
-      expect(Scheduler).toFlushAndYield(['Child 1', 'Suspend! [Child 2]']);
-      jest.advanceTimersByTime(6000);
-      expect(Scheduler).toHaveYielded(['Promise resolved [Child 2]']);
-      expect(Scheduler).toFlushAndYield(['Child 1', 'Child 2']);
-      expect(root).toMatchRenderedOutput(['Child 1', 'Child 2'].join(''));
     });
 
     it('reuses effects, including deletions, from the suspended tree', () => {

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -439,16 +439,19 @@ const ReactTestRendererFiber = {
       tag: 'CONTAINER',
     };
     let root: FiberRoot | null = null;
+    // make flow happy by retaining a reference to container
+    // before using it inside act()
+    const rootContainer = container;
     act(() => {
       root = createContainer(
-        container,
+        rootContainer,
         isConcurrent ? ConcurrentRoot : LegacyRoot,
         false,
       );
     });
 
-    invariant(root != null, 'something went wrong');
     act(() => {
+      invariant(root != null, 'something went wrong');
       updateContainer(element, root, null, null);
     });
 
@@ -498,22 +501,22 @@ const ReactTestRendererFiber = {
         return toTree(root.current);
       },
       update(newElement: React$Element<any>) {
-        if (root == null || root.current == null) {
-          return;
-        }
         act(() => {
+          if (root == null || root.current == null) {
+            return;
+          }
           updateContainer(newElement, root, null, null);
         });
       },
       unmount() {
-        if (root == null || root.current == null) {
-          return;
-        }
         act(() => {
+          if (root == null || root.current == null) {
+            return;
+          }
           updateContainer(null, root, null, null);
+          container = null;
+          root = null;
         });
-        container = null;
-        root = null;
       },
       getInstance() {
         if (root == null || root.current == null) {

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -438,13 +438,19 @@ const ReactTestRendererFiber = {
       createNodeMock,
       tag: 'CONTAINER',
     };
-    let root: FiberRoot | null = createContainer(
-      container,
-      isConcurrent ? ConcurrentRoot : LegacyRoot,
-      false,
-    );
+    let root: FiberRoot | null = null;
+    act(() => {
+      root = createContainer(
+        container,
+        isConcurrent ? ConcurrentRoot : LegacyRoot,
+        false,
+      );
+    });
+
     invariant(root != null, 'something went wrong');
-    updateContainer(element, root, null, null);
+    act(() => {
+      updateContainer(element, root, null, null);
+    });
 
     const entry = {
       _Scheduler: Scheduler,
@@ -495,13 +501,17 @@ const ReactTestRendererFiber = {
         if (root == null || root.current == null) {
           return;
         }
-        updateContainer(newElement, root, null, null);
+        act(() => {
+          updateContainer(newElement, root, null, null);
+        });
       },
       unmount() {
         if (root == null || root.current == null) {
           return;
         }
-        updateContainer(null, root, null, null);
+        act(() => {
+          updateContainer(null, root, null, null);
+        });
         container = null;
         root = null;
       },

--- a/packages/react-test-renderer/src/ReactTestRendererAct.js
+++ b/packages/react-test-renderer/src/ReactTestRendererAct.js
@@ -65,7 +65,7 @@ function flushWorkAndMicroTasks(onDone: (err: ?Error) => void) {
 
 let actingUpdatesScopeDepth = 0;
 
-function act(callback: () => Thenable) {
+function act(callback: () => Thenable | void) {
   let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
   let previousActingUpdatesSigil;
   actingUpdatesScopeDepth++;
@@ -127,10 +127,11 @@ function act(callback: () => Thenable) {
     // in the async case, the returned thenable runs the callback, flushes
     // effects and  microtasks in a loop until flushPassiveEffects() === false,
     // and cleans up
+
     return {
       then(resolve: () => void, reject: (?Error) => void) {
         called = true;
-        result.then(
+        ((result: any): Thenable).then(
           () => {
             if (actingUpdatesScopeDepth > 1) {
               onDone();

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -343,27 +343,28 @@ describe('ReactStrictMode', () => {
           return null;
         }
       }
+      ReactTestRenderer.act(() => {
+        const root = ReactTestRenderer.create(null, {
+          unstable_isConcurrent: true,
+        });
+        root.update(<AsyncRoot />);
+        expect(() => Scheduler.flushAll()).toWarnDev(
+          'Unsafe lifecycle methods were found within a strict-mode tree:' +
+            '\n\ncomponentWillMount: Please update the following components ' +
+            'to use componentDidMount instead: AsyncRoot' +
+            '\n\ncomponentWillReceiveProps: Please update the following components ' +
+            'to use static getDerivedStateFromProps instead: Bar, Foo' +
+            '\n\ncomponentWillUpdate: Please update the following components ' +
+            'to use componentDidUpdate instead: AsyncRoot' +
+            '\n\nLearn more about this warning here:' +
+            '\nhttps://fb.me/react-strict-mode-warnings',
+          {withoutStack: true},
+        );
 
-      const root = ReactTestRenderer.create(null, {
-        unstable_isConcurrent: true,
+        // Dedupe
+        root.update(<AsyncRoot />);
+        Scheduler.flushAll();
       });
-      root.update(<AsyncRoot />);
-      expect(() => Scheduler.flushAll()).toWarnDev(
-        'Unsafe lifecycle methods were found within a strict-mode tree:' +
-          '\n\ncomponentWillMount: Please update the following components ' +
-          'to use componentDidMount instead: AsyncRoot' +
-          '\n\ncomponentWillReceiveProps: Please update the following components ' +
-          'to use static getDerivedStateFromProps instead: Bar, Foo' +
-          '\n\ncomponentWillUpdate: Please update the following components ' +
-          'to use componentDidUpdate instead: AsyncRoot' +
-          '\n\nLearn more about this warning here:' +
-          '\nhttps://fb.me/react-strict-mode-warnings',
-        {withoutStack: true},
-      );
-
-      // Dedupe
-      root.update(<AsyncRoot />);
-      Scheduler.flushAll();
     });
 
     it('should coalesce warnings by lifecycle name', () => {
@@ -388,37 +389,38 @@ describe('ReactStrictMode', () => {
           return null;
         }
       }
+      ReactTestRenderer.act(() => {
+        const root = ReactTestRenderer.create(null, {
+          unstable_isConcurrent: true,
+        });
+        root.update(<AsyncRoot />);
 
-      const root = ReactTestRenderer.create(null, {
-        unstable_isConcurrent: true,
-      });
-      root.update(<AsyncRoot />);
-
-      expect(() => {
-        expect(() => Scheduler.flushAll()).toWarnDev(
-          'Unsafe lifecycle methods were found within a strict-mode tree:' +
-            '\n\ncomponentWillMount: Please update the following components ' +
-            'to use componentDidMount instead: AsyncRoot, Parent' +
-            '\n\ncomponentWillReceiveProps: Please update the following components ' +
-            'to use static getDerivedStateFromProps instead: Child, Parent' +
-            '\n\ncomponentWillUpdate: Please update the following components ' +
-            'to use componentDidUpdate instead: AsyncRoot, Parent' +
-            '\n\nLearn more about this warning here:' +
-            '\nhttps://fb.me/react-strict-mode-warnings',
+        expect(() => {
+          expect(() => Scheduler.flushAll()).toWarnDev(
+            'Unsafe lifecycle methods were found within a strict-mode tree:' +
+              '\n\ncomponentWillMount: Please update the following components ' +
+              'to use componentDidMount instead: AsyncRoot, Parent' +
+              '\n\ncomponentWillReceiveProps: Please update the following components ' +
+              'to use static getDerivedStateFromProps instead: Child, Parent' +
+              '\n\ncomponentWillUpdate: Please update the following components ' +
+              'to use componentDidUpdate instead: AsyncRoot, Parent' +
+              '\n\nLearn more about this warning here:' +
+              '\nhttps://fb.me/react-strict-mode-warnings',
+            {withoutStack: true},
+          );
+        }).toLowPriorityWarnDev(
+          [
+            'componentWillMount is deprecated',
+            'componentWillReceiveProps is deprecated',
+            'componentWillUpdate is deprecated',
+          ],
           {withoutStack: true},
         );
-      }).toLowPriorityWarnDev(
-        [
-          'componentWillMount is deprecated',
-          'componentWillReceiveProps is deprecated',
-          'componentWillUpdate is deprecated',
-        ],
-        {withoutStack: true},
-      );
 
-      // Dedupe
-      root.update(<AsyncRoot />);
-      Scheduler.flushAll();
+        // Dedupe
+        root.update(<AsyncRoot />);
+        Scheduler.flushAll();
+      });
     });
 
     it('should warn about components not present during the initial render', () => {
@@ -439,35 +441,36 @@ describe('ReactStrictMode', () => {
           return null;
         }
       }
+      ReactTestRenderer.act(() => {
+        const root = ReactTestRenderer.create(null, {
+          unstable_isConcurrent: true,
+        });
+        root.update(<AsyncRoot foo={true} />);
+        expect(() => Scheduler.flushAll()).toWarnDev(
+          'Unsafe lifecycle methods were found within a strict-mode tree:' +
+            '\n\ncomponentWillMount: Please update the following components ' +
+            'to use componentDidMount instead: Foo' +
+            '\n\nLearn more about this warning here:' +
+            '\nhttps://fb.me/react-strict-mode-warnings',
+          {withoutStack: true},
+        );
 
-      const root = ReactTestRenderer.create(null, {
-        unstable_isConcurrent: true,
+        root.update(<AsyncRoot foo={false} />);
+        expect(() => Scheduler.flushAll()).toWarnDev(
+          'Unsafe lifecycle methods were found within a strict-mode tree:' +
+            '\n\ncomponentWillMount: Please update the following components ' +
+            'to use componentDidMount instead: Bar' +
+            '\n\nLearn more about this warning here:' +
+            '\nhttps://fb.me/react-strict-mode-warnings',
+          {withoutStack: true},
+        );
+
+        // Dedupe
+        root.update(<AsyncRoot foo={true} />);
+        Scheduler.flushAll();
+        root.update(<AsyncRoot foo={false} />);
+        Scheduler.flushAll();
       });
-      root.update(<AsyncRoot foo={true} />);
-      expect(() => Scheduler.flushAll()).toWarnDev(
-        'Unsafe lifecycle methods were found within a strict-mode tree:' +
-          '\n\ncomponentWillMount: Please update the following components ' +
-          'to use componentDidMount instead: Foo' +
-          '\n\nLearn more about this warning here:' +
-          '\nhttps://fb.me/react-strict-mode-warnings',
-        {withoutStack: true},
-      );
-
-      root.update(<AsyncRoot foo={false} />);
-      expect(() => Scheduler.flushAll()).toWarnDev(
-        'Unsafe lifecycle methods were found within a strict-mode tree:' +
-          '\n\ncomponentWillMount: Please update the following components ' +
-          'to use componentDidMount instead: Bar' +
-          '\n\nLearn more about this warning here:' +
-          '\nhttps://fb.me/react-strict-mode-warnings',
-        {withoutStack: true},
-      );
-
-      // Dedupe
-      root.update(<AsyncRoot foo={true} />);
-      Scheduler.flushAll();
-      root.update(<AsyncRoot foo={false} />);
-      Scheduler.flushAll();
     });
 
     it('should also warn inside of "strict" mode trees', () => {


### PR DESCRIPTION
DO NOT MERGE: Doing a PR so I can test on fb first. 

You should read this whitespace changes off. 

This PR adds act() by default to react-test-renderer's `.create`, `.update`, and `.unmount` methods. 

We risk a major breaking change with having added warnings on unqueued effects outside of an act scope. Eg: A lot of people's snapshot tests will break; this would be good, if they didn't have to first wrap their renderer helper with `act()`, and then update snapshots.

Broadly, we could also make a case why this makes sense to any consumers; they'll be using it only in testing scenarios, which we'd want to wrap in `act()` anyway

For our internal tests, this had the effect that a larger portion of the test was just wrapped with an outer `act()`, letting us test incremental updates by advancing the `Scheduler` manually.

- In the second commit, I also fix act()'s flow signature
- in the third commit, I update our fixtures to account for the change