### PR TITLE
Add option to includeNegativeTabIndex in getFocusableElementsInScope

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -525,12 +525,6 @@ function releaseOwnershipForEventComponentInstance(
   return false;
 }
 
-function isInteger(value: any): boolean {
-  return (
-    typeof value === 'number' && isFinite(value) && Math.floor(value) === value
-  );
-}
-
 function isFiberHostComponentFocusable(
   fiber: Fiber,
   includeNegativeTabIndex: boolean,
@@ -539,13 +533,13 @@ function isFiberHostComponentFocusable(
     return false;
   }
   const {type, memoizedProps} = fiber;
-  if (memoizedProps.disabled) {
+  if (
+    (!includeNegativeTabIndex && memoizedProps.tabIndex === -1) ||
+    memoizedProps.disabled
+  ) {
     return false;
   }
-  if (isInteger(memoizedProps.tabIndex)) {
-    return includeNegativeTabIndex ? true : memoizedProps.tabIndex >= 0;
-  }
-  if (memoizedProps.contentEditable === true) {
+  if (memoizedProps.tabIndex === 0 || memoizedProps.contentEditable === true) {
     return true;
   }
   if (type === 'a' || type === 'area') {

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -1146,7 +1146,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonProps = [
       {id: 'button1', ref: React.createRef(), tabIndex: 0},
       {id: 'button2', ref: React.createRef(), tabIndex: -1},
-      {id: 'button3', ref: React.createRef(), tabIndex: 2},
+      {id: 'button3', ref: React.createRef()},
       {id: 'button4', ref: React.createRef(), disabled: true},
     ];
 

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -1128,4 +1128,50 @@ describe('DOMEventResponderSystem', () => {
       'hook 2b',
     ]);
   });
+
+  it('getFocusableElementsInScope works', () => {
+    let includeNegativeTabIndex = false;
+    let focusableElementsInScope = [];
+
+    const EventComponent = createReactEventComponent({
+      targetEventTypes: ['keydown'],
+      onEvent(event, context) {
+        focusableElementsInScope = context.getFocusableElementsInScope(
+          includeNegativeTabIndex,
+        );
+      },
+      allowMultipleHostChildren: true,
+    });
+
+    const buttonProps = [
+      {id: 'button1', ref: React.createRef(), tabIndex: 0},
+      {id: 'button2', ref: React.createRef(), tabIndex: -1},
+      {id: 'button3', ref: React.createRef(), tabIndex: 2},
+      {id: 'button4', ref: React.createRef(), disabled: true},
+    ];
+
+    const Test = () => (
+      <EventComponent>
+        {buttonProps.map((props, index) => <button {...props} key={index} />)}
+      </EventComponent>
+    );
+
+    ReactDOM.render(<Test />, container);
+
+    dispatchEvent(buttonProps[0].ref.current, 'keydown');
+    expect(focusableElementsInScope.length).toBe(2);
+    expect(focusableElementsInScope).toEqual([
+      buttonProps[0].ref.current,
+      buttonProps[2].ref.current,
+    ]);
+
+    includeNegativeTabIndex = true;
+    dispatchEvent(buttonProps[0].ref.current, 'keydown');
+    expect(focusableElementsInScope.length).toBe(3);
+    expect(focusableElementsInScope).toEqual([
+      buttonProps[0].ref.current,
+      buttonProps[1].ref.current,
+      buttonProps[2].ref.current,
+    ]);
+  });
 });

--- a/packages/react-events/src/dom/FocusScope.js
+++ b/packages/react-events/src/dom/FocusScope.js
@@ -40,7 +40,7 @@ function getFirstFocusableElement(
   context: ReactDOMResponderContext,
   state: FocusScopeState,
 ): ?HTMLElement {
-  const elements = context.getFocusableElementsInScope();
+  const elements = context.getFocusableElementsInScope(false);
   if (elements.length > 0) {
     return elements[0];
   }
@@ -77,7 +77,7 @@ const FocusScopeResponder: ReactDOMEventResponder = {
         if (altkey || ctrlKey || metaKey) {
           return;
         }
-        const elements = context.getFocusableElementsInScope();
+        const elements = context.getFocusableElementsInScope(false);
         const position = elements.indexOf(focusedElement);
         const lastPosition = elements.length - 1;
         let nextElement = null;

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -73,7 +73,9 @@ export type ReactDOMResponderContext = {
   releaseOwnership: () => boolean,
   setTimeout: (func: () => void, timeout: number) => number,
   clearTimeout: (timerId: number) => void,
-  getFocusableElementsInScope(): Array<HTMLElement>,
+  getFocusableElementsInScope(
+    includeNegativeTabIndex: boolean,
+  ): Array<HTMLElement>,
   getActiveDocument(): Document,
   objectAssign: Function,
   getEventCurrentTarget(event: ReactDOMResponderEvent): Element,


### PR DESCRIPTION
The idea for this pull request came up when @trueadm and I were talking about being able to differentiate between focusable and tabbable elements (to implement something like roving tabindex for focus management as recommended within aria best practices guide: https://www.w3.org/TR/wai-aria-practices/#kbd_roving_tabindex).

The current `getFocusableElementsInScope` implementation treats elements with `tabIndex === -1` as not focusable. This introduces as boolean flag (`includeNegativeTabIndex`) that disables the `tabIndex < 0` filter. Also made the logic more generic to accommodate for `tabIndex` values other than `-1` and `0`. And I added some tests :)