### PR TITLE
[Fresh] Handle changes at module boundaries

### DIFF
--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -21,6 +21,7 @@ let freshPlugin = require('react-refresh/babel');
 
 describe('ReactFreshIntegration', () => {
   let container;
+  let exportsObj;
 
   beforeEach(() => {
     if (__DEV__) {
@@ -32,6 +33,7 @@ describe('ReactFreshIntegration', () => {
       act = require('react-dom/test-utils').act;
       container = document.createElement('div');
       document.body.appendChild(container);
+      exportsObj = undefined;
     }
   });
 
@@ -63,7 +65,7 @@ describe('ReactFreshIntegration', () => {
           compileDestructuring && 'transform-es2015-destructuring',
         ].filter(Boolean),
       }).code;
-      const exportsObj = {};
+      exportsObj = {};
       // eslint-disable-next-line no-new-func
       new Function(
         'global',
@@ -73,6 +75,10 @@ describe('ReactFreshIntegration', () => {
         '$RefreshSig$',
         compiled,
       )(global, React, exportsObj, $RefreshReg$, $RefreshSig$);
+      // Module systems will register exports as a fallback.
+      // This is useful for cases when e.g. a class is exported,
+      // and we don't want to propagate the update beyond this module.
+      $RefreshReg$(exportsObj.default, 'exports.default');
       return exportsObj.default;
     }
 
@@ -86,9 +92,37 @@ describe('ReactFreshIntegration', () => {
     }
 
     function patch(source) {
+      const prevExports = exportsObj;
       execute(source);
+      const nextExports = exportsObj;
+
+      // Check if exported families have changed.
+      // (In a real module system we'd do this for *all* exports.)
+      // For example, this can happen if you convert a class to a function.
+      // Or if you wrap something in a HOC.
+      let didExportsChange =
+        ReactFreshRuntime.getFamilyByType(prevExports.default) !==
+        ReactFreshRuntime.getFamilyByType(nextExports.default);
+      if (didExportsChange) {
+        // In a real module system, we would propagate such updates upwards,
+        // and re-execute modules that imported this one. (Just like if we edited them.)
+        // This makes adding/removing/renaming exports re-render references to them.
+        // Here, we'll just force a re-render using the newer type to emulate this.
+        const NextComponent = nextExports.default;
+        act(() => {
+          ReactDOM.render(<NextComponent />, container);
+        });
+      }
       act(() => {
-        expect(ReactFreshRuntime.performReactRefresh()).not.toBe(null);
+        const result = ReactFreshRuntime.performReactRefresh();
+        if (!didExportsChange) {
+          // Normally we expect that some components got updated in our tests.
+          expect(result).not.toBe(null);
+        } else {
+          // However, we have tests where we convert functions to classes,
+          // and in those cases it's expected nothing would get updated.
+          // (Instead, the export change branch above would take care of it.)
+        }
       });
       expect(ReactFreshRuntime._getMountedRootCount()).toBe(1);
     }
@@ -941,6 +975,326 @@ describe('ReactFreshIntegration', () => {
         // Different initial state, so state is reset.
         expect(container.firstChild).not.toBe(el);
         el = container.firstChild;
+        expect(el.textContent).toBe('C2');
+      }
+    });
+
+    it('remounts when switching export from function to class', () => {
+      if (__DEV__) {
+        render(`
+          export default function App() {
+            return <h1>A1</h1>;
+          }
+        `);
+        let el = container.firstChild;
+        expect(el.textContent).toBe('A1');
+        patch(`
+          export default function App() {
+            return <h1>A2</h1>;
+          }
+        `);
+        // Keep state.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('A2');
+
+        patch(`
+          export default class App extends React.Component {
+            render() {
+              return <h1>B1</h1>
+            }
+          }
+        `);
+        // Reset (function -> class).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('B1');
+        patch(`
+          export default class App extends React.Component {
+            render() {
+              return <h1>B2</h1>
+            }
+          }
+        `);
+        // Reset (classes always do).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('B2');
+
+        patch(`
+          export default function App() {
+            return <h1>C1</h1>;
+          }
+        `);
+        // Reset (class -> function).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('C1');
+        patch(`
+          export default function App() {
+            return <h1>C2</h1>;
+          }
+        `);
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('C2');
+
+        patch(`
+          export default function App() {
+            return <h1>D1</h1>;
+          }
+        `);
+        el = container.firstChild;
+        expect(el.textContent).toBe('D1');
+        patch(`
+          export default function App() {
+            return <h1>D2</h1>;
+          }
+        `);
+        // Keep state.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('D2');
+      }
+    });
+
+    it('remounts when switching export from class to function', () => {
+      if (__DEV__) {
+        render(`
+          export default class App extends React.Component {
+            render() {
+              return <h1>A1</h1>
+            }
+          }
+        `);
+        let el = container.firstChild;
+        expect(el.textContent).toBe('A1');
+        patch(`
+          export default class App extends React.Component {
+            render() {
+              return <h1>A2</h1>
+            }
+          }
+        `);
+        // Reset (classes always do).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('A2');
+
+        patch(`
+          export default function App() {
+            return <h1>B1</h1>;
+          }
+        `);
+        // Reset (class -> function).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('B1');
+        patch(`
+          export default function App() {
+            return <h1>B2</h1>;
+          }
+        `);
+        // Keep state.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('B2');
+
+        patch(`
+          export default class App extends React.Component {
+            render() {
+              return <h1>C1</h1>
+            }
+          }
+        `);
+        // Reset (function -> class).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('C1');
+      }
+    });
+
+    it('remounts when wrapping export in a HOC', () => {
+      if (__DEV__) {
+        render(`
+          export default function App() {
+            return <h1>A1</h1>;
+          }
+        `);
+        let el = container.firstChild;
+        expect(el.textContent).toBe('A1');
+        patch(`
+          export default function App() {
+            return <h1>A2</h1>;
+          }
+        `);
+        // Keep state.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('A2');
+
+        patch(`
+          function hoc(Inner) {
+            return function Wrapper() {
+              return <Inner />;
+            }
+          }
+
+          function App() {
+            return <h1>B1</h1>;
+          }
+
+          export default hoc(App);
+        `);
+        // Reset (wrapped in HOC).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('B1');
+        patch(`
+          function hoc(Inner) {
+            return function Wrapper() {
+              return <Inner />;
+            }
+          }
+
+          function App() {
+            return <h1>B2</h1>;
+          }
+
+          export default hoc(App);
+        `);
+        // Keep state.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('B2');
+
+        patch(`
+          export default function App() {
+            return <h1>C1</h1>;
+          }
+        `);
+        // Reset (unwrapped).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('C1');
+        patch(`
+          export default function App() {
+            return <h1>C2</h1>;
+          }
+        `);
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('C2');
+      }
+    });
+
+    it('remounts when wrapping export in memo()', () => {
+      if (__DEV__) {
+        render(`
+          export default function App() {
+            return <h1>A1</h1>;
+          }
+        `);
+        let el = container.firstChild;
+        expect(el.textContent).toBe('A1');
+        patch(`
+          export default function App() {
+            return <h1>A2</h1>;
+          }
+        `);
+        // Keep state.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('A2');
+
+        patch(`
+          function App() {
+            return <h1>B1</h1>;
+          }
+
+          export default React.memo(App);
+        `);
+        // Reset (wrapped in HOC).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('B1');
+        patch(`
+          function App() {
+            return <h1>B2</h1>;
+          }
+
+          export default React.memo(App);
+        `);
+        // Keep state.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('B2');
+
+        patch(`
+          export default function App() {
+            return <h1>C1</h1>;
+          }
+        `);
+        // Reset (unwrapped).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('C1');
+        patch(`
+          export default function App() {
+            return <h1>C2</h1>;
+          }
+        `);
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('C2');
+      }
+    });
+
+    it('remounts when wrapping export in forwardRef()', () => {
+      if (__DEV__) {
+        render(`
+          export default function App() {
+            return <h1>A1</h1>;
+          }
+        `);
+        let el = container.firstChild;
+        expect(el.textContent).toBe('A1');
+        patch(`
+          export default function App() {
+            return <h1>A2</h1>;
+          }
+        `);
+        // Keep state.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('A2');
+
+        patch(`
+          function App() {
+            return <h1>B1</h1>;
+          }
+
+          export default React.forwardRef(App);
+        `);
+        // Reset (wrapped in HOC).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('B1');
+        patch(`
+          function App() {
+            return <h1>B2</h1>;
+          }
+
+          export default React.forwardRef(App);
+        `);
+        // Keep state.
+        expect(container.firstChild).toBe(el);
+        expect(el.textContent).toBe('B2');
+
+        patch(`
+          export default function App() {
+            return <h1>C1</h1>;
+          }
+        `);
+        // Reset (unwrapped).
+        expect(container.firstChild).not.toBe(el);
+        el = container.firstChild;
+        expect(el.textContent).toBe('C1');
+        patch(`
+          export default function App() {
+            return <h1>C2</h1>;
+          }
+        `);
+        expect(container.firstChild).toBe(el);
         expect(el.textContent).toBe('C2');
       }
     });


### PR DESCRIPTION
Normally we use the registration mechanism to "contain" changes. We edit a component, there's a new version of it, we update the registration. Cool. We don't want to re-evaluate the world. Just that file alone, if we can.

What if nothing registered during that file's evaluation? If there's nothing to register, there's nothing to update.. Right? Well, not quite.

If we had an `App` class, initially we registered it at the module boundary with a fallback `"[App.js] exports.default"` ID. But if we rewrite it to a function (imagine I'm a product developer moving to Hooks), in the new version we'll register it twice — first via transform with `"[App.js] App"` and then with `"[App.js] exports.default"` ID. First registration wins. As a result, `"[App.js] exports.default"` ID _keeps pointing to the old `App` class_. That happens on RN now.

As a result, when you convert a class to a function, you keep seeing the class.

We could patch over it in different ways. But I think the core problem here is that _if the families changed at the module boundary, we can't safely stop at that module_. (Especially in an environment without inline requires.) We need to re-evaluate parent modules, and apply the same algorithm to them, so that they re-render and use the latest versions of exports.

So I'm adding a mechanism that the module system can use to do this. The new method is `getFamilyByType`. The module system can compare the previous and next exports. If some were added or removed, we need to propagate the update. (This also helps fix the case where a parent references a deleted export from a child — that should become an error by re-rendering the parent.) The new method also lets us propagate the update if *registered family* becomes different for that export. So that catches cases like class-to-function, function-to-class, wrap-in-HOC, export-a-different-function-component-from-the-same-file.

I added some integration tests to show the intent although I won't be fully modeling it here. That code will live in the module system.