### PR TITLE
SuspenseList Optimizations

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -33,6 +33,7 @@ import warningWithoutStack from 'shared/warningWithoutStack';
 
 import {
   createWorkInProgress,
+  resetWorkInProgress,
   createFiberFromElement,
   createFiberFromFragment,
   createFiberFromText,
@@ -1385,4 +1386,16 @@ export function cloneChildFibers(
     newChild.return = workInProgress;
   }
   newChild.sibling = null;
+}
+
+// Reset a workInProgress child set to prepare it for a second pass.
+export function resetChildFibers(
+  workInProgress: Fiber,
+  renderExpirationTime: ExpirationTime,
+): void {
+  let child = workInProgress.child;
+  while (child !== null) {
+    resetWorkInProgress(child, renderExpirationTime);
+    child = child.sibling;
+  }
 }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2007,6 +2007,62 @@ function findLastContentRow(firstChild: null | Fiber): null | Fiber {
 
 type SuspenseListRevealOrder = 'forwards' | 'backwards' | 'together' | void;
 
+function validateRevealOrder(revealOrder: SuspenseListRevealOrder) {
+  if (__DEV__) {
+    if (
+      revealOrder !== undefined &&
+      revealOrder !== 'forwards' &&
+      revealOrder !== 'backwards' &&
+      revealOrder !== 'together' &&
+      !didWarnAboutRevealOrder[revealOrder]
+    ) {
+      didWarnAboutRevealOrder[revealOrder] = true;
+      if (typeof revealOrder === 'string') {
+        switch (revealOrder.toLowerCase()) {
+          case 'together':
+          case 'forwards':
+          case 'backwards': {
+            warning(
+              false,
+              '"%s" is not a valid value for revealOrder on <SuspenseList />. ' +
+                'Use lowercase "%s" instead.',
+              revealOrder,
+              revealOrder.toLowerCase(),
+            );
+            break;
+          }
+          case 'forward':
+          case 'backward': {
+            warning(
+              false,
+              '"%s" is not a valid value for revealOrder on <SuspenseList />. ' +
+                'React uses the -s suffix in the spelling. Use "%ss" instead.',
+              revealOrder,
+              revealOrder.toLowerCase(),
+            );
+            break;
+          }
+          default:
+            warning(
+              false,
+              '"%s" is not a supported revealOrder on <SuspenseList />. ' +
+                'Did you mean "together", "forwards" or "backwards"?',
+              revealOrder,
+            );
+            break;
+        }
+      } else {
+        warning(
+          false,
+          '%s is not a supported value for revealOrder on <SuspenseList />. ' +
+            'Did you mean "together", "forwards" or "backwards"?',
+          revealOrder,
+        );
+      }
+    }
+  }
+}
+
 // This can end up rendering this component multiple passes.
 // The first pass splits the children fibers into two sets. A head and tail.
 // We first render the head. If anything is in fallback state, we do another
@@ -2021,24 +2077,22 @@ function updateSuspenseListComponent(
 ) {
   const nextProps = workInProgress.pendingProps;
   const revealOrder: SuspenseListRevealOrder = nextProps.revealOrder;
-  const nextChildren = nextProps.children;
+  const newChildren = nextProps.children;
 
-  let nextChildFibers;
-  if (current === null) {
-    nextChildFibers = mountChildFibers(
-      workInProgress,
-      null,
-      nextChildren,
-      renderExpirationTime,
-    );
-  } else {
-    nextChildFibers = reconcileChildFibers(
-      workInProgress,
-      current.child,
-      nextChildren,
-      renderExpirationTime,
-    );
+  validateRevealOrder(revealOrder);
+
+  function printChildren(child) {
+    if (!child) {
+      return;
+    }
+    printChildren(child.sibling);
   }
+
+  printChildren(current && current.child);
+
+  reconcileChildren(current, workInProgress, newChildren, renderExpirationTime);
+
+  let suspenseListState: null | SuspenseListState = null;
 
   let suspenseContext: SuspenseContext = suspenseStackCursor.current;
 
@@ -2046,15 +2100,6 @@ function updateSuspenseListComponent(
     suspenseContext,
     (ForceSuspenseFallback: SuspenseContext),
   );
-
-  if ((workInProgress.effectTag & DidCapture) !== NoEffect) {
-    // This is the second pass. In this pass, we should force the
-    // fallbacks in place.
-    shouldForceFallback = true;
-  }
-
-  let suspenseListState: null | SuspenseListState = null;
-
   if (shouldForceFallback) {
     suspenseContext = setShallowSuspenseContext(
       suspenseContext,
@@ -2069,106 +2114,94 @@ function updateSuspenseListComponent(
       tailExpiration: 0,
     };
   } else {
-    let didForceFallback =
+    let didSuspendBefore =
       current !== null &&
       current.memoizedState !== null &&
       (current.memoizedState: SuspenseListState).didSuspend;
-    if (didForceFallback) {
+    if (didSuspendBefore) {
       // If we previously forced a fallback, we need to schedule work
       // on any nested boundaries to let them know to try to render
       // again. This is the same as context updating.
       propagateSuspenseContextChange(
         workInProgress,
-        nextChildFibers,
+        workInProgress.child,
         renderExpirationTime,
       );
     }
     suspenseContext = setDefaultShallowSuspenseContext(suspenseContext);
   }
-
   pushSuspenseContext(workInProgress, suspenseContext);
 
   if ((workInProgress.mode & BatchedMode) === NoMode) {
     // Outside of batched mode, SuspenseList doesn't work so we just
     // use make it a noop by treating it as the default revealOrder.
     workInProgress.effectTag |= DidCapture;
-    workInProgress.child = nextChildFibers;
-    return nextChildFibers;
+    return workInProgress.child;
   }
 
   switch (revealOrder) {
     case 'forwards': {
-      // If need to force fallbacks in this pass we're just going to
-      // force the whole set to suspend so we don't have to do anything
-      // further here.
-      if (!shouldForceFallback) {
-        let lastContentRow = findLastContentRow(nextChildFibers);
-        let tail;
-        if (lastContentRow === null) {
-          // The whole list is part of the tail.
-          // TODO: We could fast path by just rendering the tail now.
-          tail = nextChildFibers;
-          nextChildFibers = null;
-        } else {
-          // Disconnect the tail rows after the content row.
-          // We're going to render them separately later.
-          tail = lastContentRow.sibling;
-          lastContentRow.sibling = null;
-        }
-        if (suspenseListState === null) {
-          suspenseListState = {
-            didSuspend: false,
-            isBackwards: false,
-            rendering: null,
-            last: lastContentRow,
-            tail: tail,
-            tailExpiration: 0,
-          };
-        } else {
-          suspenseListState.tail = tail;
-        }
+      let lastContentRow = findLastContentRow(workInProgress.child);
+      let tail;
+      if (lastContentRow === null) {
+        // The whole list is part of the tail.
+        // TODO: We could fast path by just rendering the tail now.
+        tail = workInProgress.child;
+        workInProgress.child = null;
+      } else {
+        // Disconnect the tail rows after the content row.
+        // We're going to render them separately later.
+        tail = lastContentRow.sibling;
+        lastContentRow.sibling = null;
+      }
+      if (suspenseListState === null) {
+        suspenseListState = {
+          didSuspend: false,
+          isBackwards: false,
+          rendering: null,
+          last: lastContentRow,
+          tail: tail,
+          tailExpiration: 0,
+        };
+      } else {
+        suspenseListState.tail = tail;
       }
       break;
     }
     case 'backwards': {
-      // If need to force fallbacks in this pass we're just going to
-      // force the whole set to suspend so we don't have to do anything
-      // further here.
-      if (!shouldForceFallback) {
-        // We're going to find the first row that has existing content.
-        // At the same time we're going to reverse the list of everything
-        // we pass in the meantime. That's going to be our tail in reverse
-        // order.
-        let tail = null;
-        let row = nextChildFibers;
-        nextChildFibers = null;
-        while (row !== null) {
-          let currentRow = row.alternate;
-          // New rows can't be content rows.
-          if (currentRow !== null && !isShowingAnyFallbacks(currentRow)) {
-            // This is the beginning of the main content.
-            nextChildFibers = row;
-            break;
-          }
-          let nextRow = row.sibling;
-          row.sibling = tail;
-          tail = row;
-          row = nextRow;
+      // We're going to find the first row that has existing content.
+      // At the same time we're going to reverse the list of everything
+      // we pass in the meantime. That's going to be our tail in reverse
+      // order.
+      let tail = null;
+      let row = workInProgress.child;
+      workInProgress.child = null;
+      while (row !== null) {
+        let currentRow = row.alternate;
+        // New rows can't be content rows.
+        if (currentRow !== null && !isShowingAnyFallbacks(currentRow)) {
+          // This is the beginning of the main content.
+          workInProgress.child = row;
+          break;
         }
-        // TODO: If nextChildFibers is null, we can continue on the tail immediately.
-        if (suspenseListState === null) {
-          suspenseListState = {
-            didSuspend: false,
-            isBackwards: true,
-            rendering: null,
-            last: null,
-            tail: tail,
-            tailExpiration: 0,
-          };
-        } else {
-          suspenseListState.isBackwards = true;
-          suspenseListState.tail = tail;
-        }
+        let nextRow = row.sibling;
+        row.sibling = tail;
+        tail = row;
+        row = nextRow;
+      }
+      // TODO: If workInProgress.child is null, we can continue on the tail immediately.
+      if (suspenseListState === null) {
+        suspenseListState = {
+          didSuspend: false,
+          isBackwards: true,
+          rendering: null,
+          last: null,
+          tail: tail,
+          tailExpiration: 0,
+        };
+      } else {
+        suspenseListState.isBackwards = true;
+        suspenseListState.tail = tail;
       }
       break;
     }
@@ -2178,56 +2211,7 @@ function updateSuspenseListComponent(
     default: {
       // The default reveal order is the same as not having
       // a boundary.
-      if (__DEV__) {
-        if (
-          revealOrder !== undefined &&
-          !didWarnAboutRevealOrder[revealOrder]
-        ) {
-          didWarnAboutRevealOrder[revealOrder] = true;
-          if (typeof revealOrder === 'string') {
-            switch (revealOrder.toLowerCase()) {
-              case 'together':
-              case 'forwards':
-              case 'backwards': {
-                warning(
-                  false,
-                  '"%s" is not a valid value for revealOrder on <SuspenseList />. ' +
-                    'Use lowercase "%s" instead.',
-                  revealOrder,
-                  revealOrder.toLowerCase(),
-                );
-                break;
-              }
-              case 'forward':
-              case 'backward': {
-                warning(
-                  false,
-                  '"%s" is not a valid value for revealOrder on <SuspenseList />. ' +
-                    'React uses the -s suffix in the spelling. Use "%ss" instead.',
-                  revealOrder,
-                  revealOrder.toLowerCase(),
-                );
-                break;
-              }
-              default:
-                warning(
-                  false,
-                  '"%s" is not a supported revealOrder on <SuspenseList />. ' +
-                    'Did you mean "together", "forwards" or "backwards"?',
-                  revealOrder,
-                );
-                break;
-            }
-          } else {
-            warning(
-              false,
-              '%s is not a supported value for revealOrder on <SuspenseList />. ' +
-                'Did you mean "together", "forwards" or "backwards"?',
-              revealOrder,
-            );
-          }
-        }
-      }
+
       // We mark this as having captured but it really just says to the
       // complete phase that we should treat this as done, whatever form
       // it is in. No need for a second pass.
@@ -2235,8 +2219,7 @@ function updateSuspenseListComponent(
     }
   }
   workInProgress.memoizedState = suspenseListState;
-  workInProgress.child = nextChildFibers;
-  return nextChildFibers;
+  return workInProgress.child;
 }
 
 function updatePortalComponent(
@@ -2657,19 +2640,54 @@ function beginWork(
           break;
         }
         case SuspenseListComponent: {
-          // Check if the children have any pending work.
           const childExpirationTime = workInProgress.childExpirationTime;
           if (childExpirationTime < renderExpirationTime) {
+            // If none of the children had any work, that means that none of
+            // them got retried so they'll still be blocked in the same way
+            // as before. We can fast bail out.
             pushSuspenseContext(workInProgress, suspenseStackCursor.current);
-            // None of the children have any work, so we can do a fast bailout.
+            // We keep memoizedState as it is.
             return null;
           }
-          // Try the normal path.
-          return updateSuspenseListComponent(
-            current,
-            workInProgress,
-            renderExpirationTime,
-          );
+
+          const didSuspendBefore =
+            current.memoizedState !== null &&
+            (current.memoizedState: SuspenseListState).didSuspend;
+          if (didSuspendBefore) {
+            // If something was in fallback state last time, and we have all the
+            // same children then we're still in progressive loading state.
+            // Something might get unblocked by state updates or retries in the
+            // tree which will affect the tail. So we need to use the normal
+            // path to compute the correct tail.
+            return updateSuspenseListComponent(
+              current,
+              workInProgress,
+              renderExpirationTime,
+            );
+          }
+
+          // Figure out if we need to use the default mode.
+          if ((workInProgress.mode & BatchedMode) === NoMode) {
+            workInProgress.effectTag |= DidCapture;
+          } else {
+            switch ((newProps.revealOrder: SuspenseListRevealOrder)) {
+              case 'forwards':
+              case 'backwards':
+              case 'together':
+                break;
+              default: {
+                workInProgress.effectTag |= DidCapture;
+              }
+            }
+          }
+
+          // If nothing suspended before and we're rendering the same children,
+          // then the tail doesn't matter. Anything new that suspends will work
+          // in the "together" mode. Therefore, we can fast
+          pushSuspenseContext(workInProgress, suspenseStackCursor.current);
+          // We reset memoizedState as a precaution that the tail is reset.
+          workInProgress.memoizedState = null;
+          break;
         }
         case EventComponent:
           if (enableFlareAPI) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -13,7 +13,7 @@ import type {FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {
   SuspenseState,
-  SuspenseListState,
+  SuspenseListRenderState,
 } from './ReactFiberSuspenseComponent';
 import type {SuspenseContext} from './ReactFiberSuspenseContext';
 
@@ -2092,7 +2092,7 @@ function updateSuspenseListComponent(
 
   reconcileChildren(current, workInProgress, newChildren, renderExpirationTime);
 
-  let suspenseListState: null | SuspenseListState = null;
+  let renderState: null | SuspenseListRenderState = null;
 
   let suspenseContext: SuspenseContext = suspenseStackCursor.current;
 
@@ -2141,8 +2141,8 @@ function updateSuspenseListComponent(
           tail = lastContentRow.sibling;
           lastContentRow.sibling = null;
         }
-        if (suspenseListState === null) {
-          suspenseListState = {
+        if (renderState === null) {
+          renderState = {
             isBackwards: false,
             rendering: null,
             last: lastContentRow,
@@ -2150,7 +2150,7 @@ function updateSuspenseListComponent(
             tailExpiration: 0,
           };
         } else {
-          suspenseListState.tail = tail;
+          renderState.tail = tail;
         }
         break;
       }
@@ -2176,8 +2176,8 @@ function updateSuspenseListComponent(
           row = nextRow;
         }
         // TODO: If workInProgress.child is null, we can continue on the tail immediately.
-        if (suspenseListState === null) {
-          suspenseListState = {
+        if (renderState === null) {
+          renderState = {
             isBackwards: true,
             rendering: null,
             last: null,
@@ -2185,13 +2185,13 @@ function updateSuspenseListComponent(
             tailExpiration: 0,
           };
         } else {
-          suspenseListState.isBackwards = true;
-          suspenseListState.tail = tail;
+          renderState.isBackwards = true;
+          renderState.tail = tail;
         }
         break;
       }
       case 'together': {
-        suspenseListState = {
+        renderState = {
           isBackwards: false,
           rendering: null,
           last: null,
@@ -2206,7 +2206,7 @@ function updateSuspenseListComponent(
       }
     }
   }
-  workInProgress.memoizedState = suspenseListState;
+  workInProgress.memoizedState = renderState;
   return workInProgress.child;
 }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2107,15 +2107,6 @@ function updateSuspenseListComponent(
 
   validateRevealOrder(revealOrder);
 
-  function printChildren(child) {
-    if (!child) {
-      return;
-    }
-    printChildren(child.sibling);
-  }
-
-  printChildren(current && current.child);
-
   reconcileChildren(current, workInProgress, newChildren, renderExpirationTime);
 
   let suspenseContext: SuspenseContext = suspenseStackCursor.current;

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -11,9 +11,10 @@ import type {Fiber} from './ReactFiber';
 import {SuspenseComponent} from 'shared/ReactWorkTags';
 
 // TODO: This is now an empty object. Should we switch this to a boolean?
+// Alternatively we can make this use an effect tag similar to SuspenseList.
 export type SuspenseState = {||};
 
-export type SuspenseListState = {|
+export type SuspenseListRenderState = {|
   isBackwards: boolean,
   // The currently rendering tail row.
   rendering: null | Fiber,

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -14,7 +14,6 @@ import {SuspenseComponent} from 'shared/ReactWorkTags';
 export type SuspenseState = {||};
 
 export type SuspenseListState = {|
-  didSuspend: boolean,
   isBackwards: boolean,
   // The currently rendering tail row.
   rendering: null | Fiber,

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1201,6 +1201,14 @@ export function renderDidError() {
   }
 }
 
+// Called during render to determine if anything has suspended.
+// Returns false if we're not sure.
+export function renderHasNotSuspendedYet(): boolean {
+  // If something errored or completed, we can't really be sure,
+  // so those are false.
+  return workInProgressRootExitStatus === RootIncomplete;
+}
+
 function inferTimeFromExpirationTime(expirationTime: ExpirationTime): number {
   // We don't know exactly when the update was scheduled, but we can infer an
   // approximate start time from the expiration time.

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -578,7 +578,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B']);
+    expect(Scheduler).toFlushAndYield(['B', 'Suspend! [C]']);
 
     // Even though we could now show B, we're still waiting on C.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -780,7 +780,6 @@ describe('ReactSuspenseList', () => {
       'Suspend! [C]',
       'Loading C',
       'D',
-      'Suspend! [E]',
       'Loading E',
       'Loading F',
     ]);
@@ -958,7 +957,7 @@ describe('ReactSuspenseList', () => {
 
     await F.resolve();
 
-    expect(Scheduler).toFlushAndYield(['F']);
+    expect(Scheduler).toFlushAndYield(['Suspend! [D]', 'F']);
 
     // Even though we could show F, it is still in a fallback state because
     // E is not yet resolved. We need to resolve everything in the head first.

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -861,7 +861,7 @@ describe('ReactSuspenseList', () => {
     );
   });
 
-  it('displays added row at the top "together" and the bottom in "forwards" order', async () => {
+  it('displays added row at the top "together" and the bottom in "backwards" order', async () => {
     let A = createAsyncText('A');
     let B = createAsyncText('B');
     let D = createAsyncText('D');


### PR DESCRIPTION
This includes a bunch of refactoring and optimizations to SuspenseList. Individual commits help the review.

The biggest optimization focus on the common case of deep updates inside a fully completed tree.

In the case where nothing in the list was suspended and the children didn't change, we now avoid scanning through the list in the begin phase since we don't need to find a tail.

Additionally, if nothing new suspended in this whole render pass, we can also skip the scan in the complete phase.
