### PR TITLE
Add tail="collapsed" option to SuspenseList

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -14,6 +14,7 @@ import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {
   SuspenseState,
   SuspenseListRenderState,
+  SuspenseListTailMode,
 } from './ReactFiberSuspenseComponent';
 import type {SuspenseContext} from './ReactFiberSuspenseContext';
 
@@ -188,6 +189,7 @@ let didWarnAboutFunctionRefs;
 export let didWarnAboutReassigningProps;
 let didWarnAboutMaxDuration;
 let didWarnAboutRevealOrder;
+let didWarnAboutTailOptions;
 
 if (__DEV__) {
   didWarnAboutBadClass = {};
@@ -198,6 +200,7 @@ if (__DEV__) {
   didWarnAboutReassigningProps = false;
   didWarnAboutMaxDuration = false;
   didWarnAboutRevealOrder = {};
+  didWarnAboutTailOptions = {};
 }
 
 export function reconcileChildren(
@@ -2063,11 +2066,40 @@ function validateRevealOrder(revealOrder: SuspenseListRevealOrder) {
   }
 }
 
+function validateTailOptions(
+  tailMode: SuspenseListTailMode,
+  revealOrder: SuspenseListRevealOrder,
+) {
+  if (__DEV__) {
+    if (tailMode !== undefined && !didWarnAboutTailOptions[tailMode]) {
+      if (tailMode !== 'collapsed') {
+        didWarnAboutTailOptions[tailMode] = true;
+        warning(
+          false,
+          '"%s" is not a supported value for tail on <SuspenseList />. ' +
+            'Did you mean "collapsed"?',
+          tailMode,
+        );
+      } else if (revealOrder !== 'forwards' && revealOrder !== 'backwards') {
+        didWarnAboutTailOptions[tailMode] = true;
+        warning(
+          false,
+          '<SuspenseList tail="%s" /> is only valid if revealOrder is ' +
+            '"forwards" or "backwards". ' +
+            'Did you mean to specify revealOrder="forwards"?',
+          tailMode,
+        );
+      }
+    }
+  }
+}
+
 function initSuspenseListRenderState(
   workInProgress: Fiber,
   isBackwards: boolean,
   tail: null | Fiber,
   lastContentRow: null | Fiber,
+  tailMode: SuspenseListTailMode,
 ): void {
   let renderState: null | SuspenseListRenderState =
     workInProgress.memoizedState;
@@ -2078,6 +2110,7 @@ function initSuspenseListRenderState(
       last: lastContentRow,
       tail: tail,
       tailExpiration: 0,
+      tailMode: tailMode,
     };
   } else {
     // We can reuse the existing object from previous renders.
@@ -2086,6 +2119,7 @@ function initSuspenseListRenderState(
     renderState.last = lastContentRow;
     renderState.tail = tail;
     renderState.tailExpiration = 0;
+    renderState.tailMode = tailMode;
   }
 }
 
@@ -2103,9 +2137,11 @@ function updateSuspenseListComponent(
 ) {
   const nextProps = workInProgress.pendingProps;
   const revealOrder: SuspenseListRevealOrder = nextProps.revealOrder;
+  const tailMode: SuspenseListTailMode = nextProps.tail;
   const newChildren = nextProps.children;
 
   validateRevealOrder(revealOrder);
+  validateTailOptions(tailMode, revealOrder);
 
   reconcileChildren(current, workInProgress, newChildren, renderExpirationTime);
 
@@ -2163,6 +2199,7 @@ function updateSuspenseListComponent(
           false, // isBackwards
           tail,
           lastContentRow,
+          tailMode,
         );
         break;
       }
@@ -2193,6 +2230,7 @@ function updateSuspenseListComponent(
           true, // isBackwards
           tail,
           null, // last
+          tailMode,
         );
         break;
       }
@@ -2202,6 +2240,7 @@ function updateSuspenseListComponent(
           false, // isBackwards
           null, // tail
           null, // last
+          undefined,
         );
         break;
       }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -537,6 +537,43 @@ if (supportsMutation) {
   };
 }
 
+function cutOffTailIfNeeded(renderState: SuspenseListRenderState) {
+  switch (renderState.tailMode) {
+    case 'collapsed': {
+      // Any insertions at the end of the tail list after this point
+      // should be invisible. If there are already mounted boundaries
+      // anything before them are not considered for collapsing.
+      // Therefore we need to go through the whole tail to find if
+      // there are any.
+      let tailNode = renderState.tail;
+      let lastTailNode = null;
+      while (tailNode !== null) {
+        if (tailNode.alternate !== null) {
+          lastTailNode = tailNode;
+        }
+        tailNode = tailNode.sibling;
+      }
+      // Next we're simply going to delete all insertions after the
+      // last rendered item.
+      if (lastTailNode === null) {
+        // All remaining items in the tail are insertions.
+        if (renderState.rendering === null && renderState.tail !== null) {
+          // We suspended during the head. We want to show at least one
+          // row at the tail. So we'll keep on and cut off the rest.
+          renderState.tail.sibling = null;
+        } else {
+          renderState.tail = null;
+        }
+      } else {
+        // Detach the insertion after the last node that was already
+        // inserted.
+        lastTailNode.sibling = null;
+      }
+      break;
+    }
+  }
+}
+
 // Note this, might mutate the workInProgress passed in.
 function hasSuspendedChildrenAndNewContent(
   workInProgress: Fiber,
@@ -991,6 +1028,9 @@ function completeWork(
           didSuspendAlready =
             (workInProgress.effectTag & DidCapture) !== NoEffect;
         }
+        if (didSuspendAlready) {
+          cutOffTailIfNeeded(renderState);
+        }
         // Next we're going to render the tail.
       } else {
         // Append the rendered row to the child list.
@@ -1004,6 +1044,9 @@ function completeWork(
             // The assumption is that this is usually faster.
             workInProgress.effectTag |= DidCapture;
             didSuspendAlready = true;
+
+            cutOffTailIfNeeded(renderState);
+
             // Since nothing actually suspended, there will nothing to ping this
             // to get it started back up to attempt the next item. If we can show
             // them, then they really have the same priority as this render.
@@ -1018,6 +1061,7 @@ function completeWork(
           } else if (isShowingAnyFallbacks(renderedTail)) {
             workInProgress.effectTag |= DidCapture;
             didSuspendAlready = true;
+            cutOffTailIfNeeded(renderState);
           }
         }
         if (renderState.isBackwards) {

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -14,6 +14,8 @@ import {SuspenseComponent} from 'shared/ReactWorkTags';
 // Alternatively we can make this use an effect tag similar to SuspenseList.
 export type SuspenseState = {||};
 
+export type SuspenseListTailMode = 'collapsed' | void;
+
 export type SuspenseListRenderState = {|
   isBackwards: boolean,
   // The currently rendering tail row.
@@ -24,6 +26,8 @@ export type SuspenseListRenderState = {|
   tail: null | Fiber,
   // The absolute time in ms that we'll expire the tail rendering.
   tailExpiration: number,
+  // Tail insertions setting.
+  tailMode: SuspenseListTailMode,
 |};
 
 export function shouldCaptureSuspense(

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -1088,4 +1088,503 @@ describe('ReactSuspenseList', () => {
       </Fragment>,
     );
   });
+
+  it('only shows one loading state at a time for "collapsed" tail insertions', async () => {
+    let A = createAsyncText('A');
+    let B = createAsyncText('B');
+    let C = createAsyncText('C');
+
+    function Foo() {
+      return (
+        <SuspenseList revealOrder="forwards" tail="collapsed">
+          <Suspense fallback={<Text text="Loading A" />}>
+            <A />
+          </Suspense>
+          <Suspense fallback={<Text text="Loading B" />}>
+            <B />
+          </Suspense>
+          <Suspense fallback={<Text text="Loading C" />}>
+            <C />
+          </Suspense>
+        </SuspenseList>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+
+    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading A']);
+
+    expect(ReactNoop).toMatchRenderedOutput(<span>Loading A</span>);
+
+    await A.resolve();
+
+    expect(Scheduler).toFlushAndYield(['A', 'Suspend! [B]', 'Loading B']);
+
+    // Incremental loading is suspended.
+    jest.advanceTimersByTime(500);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>Loading B</span>
+      </Fragment>,
+    );
+
+    await B.resolve();
+
+    expect(Scheduler).toFlushAndYield(['B', 'Suspend! [C]', 'Loading C']);
+
+    // Incremental loading is suspended.
+    jest.advanceTimersByTime(500);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>Loading C</span>
+      </Fragment>,
+    );
+
+    await C.resolve();
+
+    expect(Scheduler).toFlushAndYield(['C']);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>C</span>
+      </Fragment>,
+    );
+  });
+
+  it('warns if an unsupported tail option is used', () => {
+    function Foo() {
+      return (
+        <SuspenseList revealOrder="forwards" tail="collapse">
+          <Suspense fallback="Loading">Content</Suspense>
+        </SuspenseList>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+
+    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+      'Warning: "collapse" is not a supported value for tail on ' +
+        '<SuspenseList />. Did you mean "collapsed"?' +
+        '\n    in SuspenseList (at **)' +
+        '\n    in Foo (at **)',
+    ]);
+  });
+
+  it('warns if a tail option is used with "together"', () => {
+    function Foo() {
+      return (
+        <SuspenseList revealOrder="together" tail="collapsed">
+          <Suspense fallback="Loading">Content</Suspense>
+        </SuspenseList>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+
+    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+      'Warning: <SuspenseList tail="collapsed" /> is only valid if ' +
+        'revealOrder is "forwards" or "backwards". ' +
+        'Did you mean to specify revealOrder="forwards"?' +
+        '\n    in SuspenseList (at **)' +
+        '\n    in Foo (at **)',
+    ]);
+  });
+
+  it('adding to the middle does not collapse insertions (forwards)', async () => {
+    let A = createAsyncText('A');
+    let B = createAsyncText('B');
+    let C = createAsyncText('C');
+    let D = createAsyncText('D');
+    let E = createAsyncText('E');
+    let F = createAsyncText('F');
+
+    function Foo({items}) {
+      return (
+        <SuspenseList revealOrder="forwards" tail="collapsed">
+          {items.map(([key, Component]) => (
+            <Suspense key={key} fallback={<Text text={'Loading ' + key} />}>
+              <Component />
+            </Suspense>
+          ))}
+        </SuspenseList>
+      );
+    }
+
+    ReactNoop.render(<Foo items={[['A', A], ['D', D]]} />);
+
+    await A.resolve();
+    await D.resolve();
+
+    expect(Scheduler).toFlushAndYield(['A', 'D']);
+
+    // First render commits A and D.
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>D</span>
+      </Fragment>,
+    );
+
+    // For the second render, we're going to insert items in the middle and end.
+    ReactNoop.render(
+      <Foo
+        items={[['A', A], ['B', B], ['C', C], ['D', D], ['E', E], ['F', F]]}
+      />,
+    );
+
+    expect(Scheduler).toFlushAndYield([
+      'A',
+      'Suspend! [B]',
+      'Loading B',
+      'Suspend! [C]',
+      'Loading C',
+      'D',
+      'Loading E',
+    ]);
+
+    // B and C don't get collapsed, but F gets collapsed with E.
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>Loading B</span>
+        <span>Loading C</span>
+        <span>D</span>
+        <span>Loading E</span>
+      </Fragment>,
+    );
+
+    await B.resolve();
+
+    expect(Scheduler).toFlushAndYield(['B', 'Suspend! [C]']);
+
+    // Incremental loading is suspended.
+    jest.advanceTimersByTime(500);
+
+    // Even though B is unsuspended, it's still in loading state because
+    // it is blocked by C.
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>Loading B</span>
+        <span>Loading C</span>
+        <span>D</span>
+        <span>Loading E</span>
+      </Fragment>,
+    );
+
+    await C.resolve();
+    await E.resolve();
+
+    expect(Scheduler).toFlushAndYield([
+      'B',
+      'C',
+      'E',
+      'Suspend! [F]',
+      'Loading F',
+    ]);
+
+    jest.advanceTimersByTime(500);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>C</span>
+        <span>D</span>
+        <span>E</span>
+        <span>Loading F</span>
+      </Fragment>,
+    );
+
+    await F.resolve();
+
+    expect(Scheduler).toFlushAndYield(['F']);
+
+    jest.advanceTimersByTime(500);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>C</span>
+        <span>D</span>
+        <span>E</span>
+        <span>F</span>
+      </Fragment>,
+    );
+  });
+
+  it('adding to the middle does not collapse insertions (backwards)', async () => {
+    let A = createAsyncText('A');
+    let B = createAsyncText('B');
+    let C = createAsyncText('C');
+    let D = createAsyncText('D');
+    let E = createAsyncText('E');
+    let F = createAsyncText('F');
+
+    function Foo({items}) {
+      return (
+        <SuspenseList revealOrder="backwards" tail="collapsed">
+          {items.map(([key, Component]) => (
+            <Suspense key={key} fallback={<Text text={'Loading ' + key} />}>
+              <Component />
+            </Suspense>
+          ))}
+        </SuspenseList>
+      );
+    }
+
+    ReactNoop.render(<Foo items={[['C', C], ['F', F]]} />);
+
+    await C.resolve();
+    await F.resolve();
+
+    expect(Scheduler).toFlushAndYield(['F', 'C']);
+
+    // First render commits C and F.
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>C</span>
+        <span>F</span>
+      </Fragment>,
+    );
+
+    // For the second render, we're going to insert items in the middle and end.
+    ReactNoop.render(
+      <Foo
+        items={[['A', A], ['B', B], ['C', C], ['D', D], ['E', E], ['F', F]]}
+      />,
+    );
+
+    expect(Scheduler).toFlushAndYield([
+      'C',
+      'Suspend! [D]',
+      'Loading D',
+      'Suspend! [E]',
+      'Loading E',
+      'F',
+      'Loading B',
+    ]);
+
+    // D and E don't get collapsed, but A gets collapsed with B.
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>Loading B</span>
+        <span>C</span>
+        <span>Loading D</span>
+        <span>Loading E</span>
+        <span>F</span>
+      </Fragment>,
+    );
+
+    await E.resolve();
+
+    expect(Scheduler).toFlushAndYield(['Suspend! [D]', 'E']);
+
+    // Incremental loading is suspended.
+    jest.advanceTimersByTime(500);
+
+    // Even though E is unsuspended, it's still in loading state because
+    // it is blocked by D.
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>Loading B</span>
+        <span>C</span>
+        <span>Loading D</span>
+        <span>Loading E</span>
+        <span>F</span>
+      </Fragment>,
+    );
+
+    await C.resolve();
+    await E.resolve();
+
+    await B.resolve();
+    await C.resolve();
+    await D.resolve();
+    await E.resolve();
+
+    expect(Scheduler).toFlushAndYield([
+      'D',
+      'E',
+      'B',
+      'Suspend! [A]',
+      'Loading A',
+    ]);
+
+    jest.advanceTimersByTime(500);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>Loading A</span>
+        <span>B</span>
+        <span>C</span>
+        <span>D</span>
+        <span>E</span>
+        <span>F</span>
+      </Fragment>,
+    );
+
+    await A.resolve();
+
+    expect(Scheduler).toFlushAndYield(['A']);
+
+    jest.advanceTimersByTime(500);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>C</span>
+        <span>D</span>
+        <span>E</span>
+        <span>F</span>
+      </Fragment>,
+    );
+  });
+
+  it('adding to the middle of committeed tail does not collapse insertions', async () => {
+    let A = createAsyncText('A');
+    let B = createAsyncText('B');
+    let C = createAsyncText('C');
+    let D = createAsyncText('D');
+    let E = createAsyncText('E');
+    let F = createAsyncText('F');
+
+    function SyncD() {
+      return <Text text="D" />;
+    }
+
+    function Foo({items}) {
+      return (
+        <SuspenseList revealOrder="forwards" tail="collapsed">
+          {items.map(([key, Component]) => (
+            <Suspense key={key} fallback={<Text text={'Loading ' + key} />}>
+              <Component />
+            </Suspense>
+          ))}
+        </SuspenseList>
+      );
+    }
+
+    ReactNoop.render(<Foo items={[['A', A], ['D', SyncD]]} />);
+
+    await A.resolve();
+
+    expect(Scheduler).toFlushAndYield(['A', 'D']);
+
+    // First render commits A and D.
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>D</span>
+      </Fragment>,
+    );
+
+    // For the second render, we're going to insert items in the middle and end.
+    // Note that D now suspends even though it didn't in the first pass.
+    ReactNoop.render(
+      <Foo
+        items={[['A', A], ['B', B], ['C', C], ['D', D], ['E', E], ['F', F]]}
+      />,
+    );
+
+    expect(Scheduler).toFlushAndYield([
+      'A',
+      'Suspend! [B]',
+      'Loading B',
+      'Suspend! [C]',
+      'Loading C',
+      'Suspend! [D]',
+      'Loading D',
+      'Loading E',
+    ]);
+
+    // This is suspended due to the update to D causing a loading state.
+    jest.advanceTimersByTime(500);
+
+    // B and C don't get collapsed, but F gets collapsed with E.
+    // Even though everything in the bottom of the list is suspended, we don't
+    // collapse them because D was an update. Not an insertion.
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>Loading B</span>
+        <span>Loading C</span>
+        <span hidden={true}>D</span>
+        <span>Loading D</span>
+        <span>Loading E</span>
+      </Fragment>,
+    );
+
+    await B.resolve();
+
+    expect(Scheduler).toFlushAndYield(['B', 'Suspend! [C]']);
+
+    // Incremental loading is suspended.
+    jest.advanceTimersByTime(500);
+
+    // B is able to unblock here because it's part of the tail.
+    // If D was still visible it wouldn't be part of the tail
+    // and would be blocked on C like in the other test.
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>Loading C</span>
+        <span hidden={true}>D</span>
+        <span>Loading D</span>
+        <span>Loading E</span>
+      </Fragment>,
+    );
+
+    await C.resolve();
+    await D.resolve();
+    await E.resolve();
+
+    expect(Scheduler).toFlushAndYield([
+      'C',
+      'D',
+      'E',
+      'Suspend! [F]',
+      'Loading F',
+    ]);
+
+    jest.advanceTimersByTime(500);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>C</span>
+        <span>D</span>
+        <span>E</span>
+        <span>Loading F</span>
+      </Fragment>,
+    );
+
+    await F.resolve();
+
+    expect(Scheduler).toFlushAndYield(['F']);
+
+    jest.advanceTimersByTime(500);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>C</span>
+        <span>D</span>
+        <span>E</span>
+        <span>F</span>
+      </Fragment>,
+    );
+  });
 });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -1197,6 +1197,72 @@ describe('ReactSuspenseList', () => {
     ]);
   });
 
+  it('renders one "collapsed" fallback even if CPU time elapsed', async () => {
+    function Foo() {
+      return (
+        <SuspenseList revealOrder="forwards" tail="collapsed">
+          <Suspense fallback={<Text text="Loading A" />}>
+            <Text text="A" />
+          </Suspense>
+          <Suspense fallback={<Text text="Loading B" />}>
+            <Text text="B" />
+          </Suspense>
+          <Suspense fallback={<Text text="Loading C" />}>
+            <Text text="C" />
+          </Suspense>
+          <Suspense fallback={<Text text="Loading D" />}>
+            <Text text="D" />
+          </Suspense>
+        </SuspenseList>
+      );
+    }
+
+    // This render is only CPU bound. Nothing suspends.
+    ReactNoop.render(<Foo />);
+
+    expect(Scheduler).toFlushAndYieldThrough(['A']);
+
+    Scheduler.unstable_advanceTime(300);
+    jest.advanceTimersByTime(300);
+
+    expect(Scheduler).toFlushAndYieldThrough(['B']);
+
+    Scheduler.unstable_advanceTime(300);
+    jest.advanceTimersByTime(300);
+
+    // We've still not been able to show anything on the screen even though
+    // we have two items ready.
+    expect(ReactNoop).toMatchRenderedOutput(null);
+
+    // Time has now elapsed for so long that we're just going to give up
+    // rendering the rest of the content. So that we can at least show
+    // something.
+    expect(Scheduler).toFlushAndYieldThrough([
+      'Loading C',
+      'C', // I'll flush through into the next render so that the first commits.
+    ]);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>Loading C</span>
+      </Fragment>,
+    );
+
+    // Then we do a second pass to commit the last two items.
+    expect(Scheduler).toFlushAndYield(['D']);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <Fragment>
+        <span>A</span>
+        <span>B</span>
+        <span>C</span>
+        <span>D</span>
+      </Fragment>,
+    );
+  });
+
   it('adding to the middle does not collapse insertions (forwards)', async () => {
     let A = createAsyncText('A');
     let B = createAsyncText('B');


### PR DESCRIPTION
Builds on top of #16005.

This add an option to SuspenseList which ensures that we avoid inserting any new rows at the tail of the list past some point.

The first option is "collapsed" which means that there is only one row visible at the end of the list. I plan on adding a "hidden" option which ensures that zero visible rows are at the end.

Note that the tail in terms of unfolding row-by-row is defined as any insertions at the bottom or any rows that updated to become suspended or were already inserted from previous commits. This option doesn't actually remove or hide those. However, this is a rare edge cases. Typically you're expected to clear the list for these cases.

The use case here is for streaming rendering of items. This lets you provide more rows to React than you have available yet. The main purpose of this is for server rendering where you can't update to add more. However, it also is useful so that React can prerender later rows while blocked on previous rows. This PR doesn't actually do that yet tho.

This option also allows to render CPU bound work, one item at a time without showing all the fallbacks. Thanks to the tail expiration time.

## Collapsing to the last row

The `tail="collapsed"` option uses the first new row for showing the fallback state. That's fairly efficient because we've rendered it when we tried the last row.

If you want to instead show the last row, you have to use a nested suspense list and the "hidden" option of the inner one:

```
<SuspenseList revealOrder="forward">
  <SuspenseList revealOrder="forward" tail="hidden">
    ...
  </SuspenseList>
  <Tail />
</SuspenseList>
```

Tail in this case can be a Suspense boundary that unsuspends when we're not expected to get more items added to the list.

```
function Blocker({suspendOn}) {
  if (!suspendOn.isResolved()) throw something();
  return null;
}
function Tail() {
  return <Suspense fallback={<Shimmer />}>
    <Blocker suspendOn={endOfTheList} />
  </Suspend>;
}
```

This technique ensures that if `endOfTheList` resolves on the server, the SSR streaming can hide the tail shimmer. No need for client rerenders. Placing it in an outer SuspenseList also ensures that once `endOfTheList` is resolved we don't hide the Shimmer before the rows in the list are fully loaded. Otherwise, the shimmer would hide first and then we'd wait for the inner rows but they're hidden.

This is a bit unfortunate since I think this is a pretty common use case for visualizing a tail load differently from suspended existing boundaries.

In theory we could add an option to collapse into the last row but it gets tricky. Because after the first commit, that row would now be mounted and now it's not a new insertion anymore. That complicates the semantics a bit. The collapsed tail would have to be something like everything after the last committed row that isn't the last one.

This approach doesn’t actually work:

```
<SuspenseList>
  {rows}
  <Tail />
</SuspenseList>
```

Because that’s actually just two rows since the fragment in that case is treated as a single row.

I feel like it's just clearer with two lists. That also makes it clearer what a "row" means. E.g. if your tail has multiple rows, it kind of just works.

I also suspect that at some point SuspenseList will accept a custom streaming data type and in that case it might be easier to think of the inner list as one stream and the outer as another.

Although a counter point is that virtualization might make this api difficult/impossible to use.

A possible option would be to add an explicit tail component:

```
<SuspenseList tailMarker={<Tail />}>
  ...
</SuspenseList>
```

However, that would require two fibers to be stored similar to how Suspense inserts extra fibers.