### PR TITLE
Enable soucemaps while run 'yarn debug-test'

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -43,6 +43,7 @@ const babelOptions = {
     require.resolve('../babel/transform-prevent-infinite-loops'),
   ],
   retainLines: true,
+  sourceMaps: 'inline',
 };
 
 module.exports = {


### PR DESCRIPTION
the question is :
when i ran 'yarn debug-test' and debug from chrome://inspect , i got minified codes like this:
`it('should return the only child', function () {
    var instance =
    React.createElement(WrapComponent, { __source: { fileName: _jsxFileName, lineNumber: 70 } },
      React.createElement('span', { __source: { fileName: _jsxFileName, lineNumber: 71 } }));
    expect(React.Children.only(instance.props.children)).toEqual(React.createElement('span', { __source: { fileName: _jsxFileName, lineNumber: 74 } }));
  });
`
actually,i want to get source code when i debug test , so i added  sourceMaps:"inline" to enable this feature