### PR TITLE
Wrap ReactTestRenderer .create and .update with act() by default

### DIFF
--- a/fixtures/dom/src/index.test.js
+++ b/fixtures/dom/src/index.test.js
@@ -42,10 +42,10 @@ it('resets correctly across renderers', () => {
     React.useEffect(() => {}, []);
     return null;
   }
-  TestUtils.act(() => {
-    TestRenderer.act(() => {});
+  TestRenderer.act(() => {
+    TestUtils.act(() => {});
     expect(() => {
-      TestRenderer.create(<Effecty />);
+      ReactDOM.render(<Effecty />, document.createElement('div'));
     }).toWarnDev(["It looks like you're using the wrong act()"], {
       withoutStack: true,
     });
@@ -88,25 +88,23 @@ it('warns when using the wrong act version - test + dom: updates', () => {
   }).toWarnDev(["It looks like you're using the wrong act()"]);
 });
 
-it('warns when using the wrong act version - dom + test: .create()', () => {
+it('does not warn with - dom + test: .create()', () => {
+  // since TestRenderer.create wraps its own act(), there's no warning to trigger
   expect(() => {
     TestUtils.act(() => {
       TestRenderer.create(<App />);
     });
-  }).toWarnDev(["It looks like you're using the wrong act()"], {
-    withoutStack: true,
-  });
+  }).toWarnDev([]);
 });
 
-it('warns when using the wrong act version - dom + test: .update()', () => {
+it('does not warn with - dom + test: .update()', () => {
   const root = TestRenderer.create(<App key="one" />);
+  // since TestRenderer.update wraps its own act(), there's no warning to trigger
   expect(() => {
     TestUtils.act(() => {
       root.update(<App key="two" />);
     });
-  }).toWarnDev(["It looks like you're using the wrong act()"], {
-    withoutStack: true,
-  });
+  }).toWarnDev([]);
 });
 
 it('warns when using the wrong act version - dom + test: updates', () => {

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -84,7 +84,7 @@ function flushWorkAndMicroTasks(onDone: (err: ?Error) => void) {
 
 let actingUpdatesScopeDepth = 0;
 
-function act(callback: () => Thenable) {
+function act(callback: () => Thenable | void) {
   let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
   let previousIsSomeRendererActing;
   let previousIsThisRendererActing;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -613,7 +613,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
   let actingUpdatesScopeDepth = 0;
 
-  function act(callback: () => Thenable) {
+  function act(callback: () => Thenable | void) {
     let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
     let previousIsSomeRendererActing;
     let previousIsThisRendererActing;

--- a/packages/react-reconciler/src/__tests__/ReactFiberEvents-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberEvents-test.internal.js
@@ -508,40 +508,42 @@ describe('ReactFiberEvents', () => {
     });
 
     it('should handle unwinding event component fibers in concurrent mode', () => {
-      let resolveThenable;
+      ReactTestRenderer.act(() => {
+        let resolveThenable;
 
-      const thenable = {
-        then(resolve) {
-          resolveThenable = resolve;
-        },
-      };
+        const thenable = {
+          then(resolve) {
+            resolveThenable = resolve;
+          },
+        };
 
-      function Async() {
-        Scheduler.unstable_yieldValue('Suspend!');
-        throw thenable;
-      }
+        function Async() {
+          Scheduler.unstable_yieldValue('Suspend!');
+          throw thenable;
+        }
 
-      function Text(props) {
-        Scheduler.unstable_yieldValue(props.text);
-        return props.text;
-      }
+        function Text(props) {
+          Scheduler.unstable_yieldValue(props.text);
+          return props.text;
+        }
 
-      ReactTestRenderer.create(
-        <React.Suspense fallback={<Text text="Loading..." />}>
-          <EventComponent>
-            <div>
-              <Async />
-              <Text text="Sibling" />
-            </div>
-          </EventComponent>
-        </React.Suspense>,
-        {
-          unstable_isConcurrent: true,
-        },
-      );
+        ReactTestRenderer.create(
+          <React.Suspense fallback={<Text text="Loading..." />}>
+            <EventComponent>
+              <div>
+                <Async />
+                <Text text="Sibling" />
+              </div>
+            </EventComponent>
+          </React.Suspense>,
+          {
+            unstable_isConcurrent: true,
+          },
+        );
 
-      expect(Scheduler).toFlushAndYieldThrough(['Suspend!']);
-      resolveThenable();
+        expect(Scheduler).toFlushAndYieldThrough(['Suspend!']);
+        resolveThenable();
+      });
     });
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -1,6 +1,7 @@
 let PropTypes;
 let React;
 let ReactTestRenderer;
+let act;
 let Scheduler;
 let ReactFeatureFlags;
 let Suspense;
@@ -17,6 +18,7 @@ describe('ReactLazy', () => {
     Suspense = React.Suspense;
     lazy = React.lazy;
     ReactTestRenderer = require('react-test-renderer');
+    act = ReactTestRenderer.act;
     Scheduler = require('scheduler');
   });
 
@@ -34,33 +36,35 @@ describe('ReactLazy', () => {
   }
 
   it('suspends until module has loaded', async () => {
-    const LazyText = lazy(() => fakeImport(Text));
+    await act(async () => {
+      const LazyText = lazy(() => fakeImport(Text));
 
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyText text="Hi" />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText text="Hi" />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
 
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('Hi');
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('Hi');
 
-    await Promise.resolve();
+      await Promise.resolve();
 
-    expect(Scheduler).toFlushAndYield(['Hi']);
-    expect(root).toMatchRenderedOutput('Hi');
+      expect(Scheduler).toFlushAndYield(['Hi']);
+      expect(root).toMatchRenderedOutput('Hi');
 
-    // Should not suspend on update
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyText text="Hi again" />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushAndYield(['Hi again']);
-    expect(root).toMatchRenderedOutput('Hi again');
+      // Should not suspend on update
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText text="Hi again" />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushAndYield(['Hi again']);
+      expect(root).toMatchRenderedOutput('Hi again');
+    });
   });
 
   it('can resolve synchronously without suspending', async () => {
@@ -111,340 +115,356 @@ describe('ReactLazy', () => {
   });
 
   it('multiple lazy components', async () => {
-    function Foo() {
-      return <Text text="Foo" />;
-    }
+    await act(async () => {
+      function Foo() {
+        return <Text text="Foo" />;
+      }
 
-    function Bar() {
-      return <Text text="Bar" />;
-    }
+      function Bar() {
+        return <Text text="Bar" />;
+      }
 
-    const promiseForFoo = delay(100).then(() => fakeImport(Foo));
-    const promiseForBar = delay(500).then(() => fakeImport(Bar));
+      const promiseForFoo = delay(100).then(() => fakeImport(Foo));
+      const promiseForBar = delay(500).then(() => fakeImport(Bar));
 
-    const LazyFoo = lazy(() => promiseForFoo);
-    const LazyBar = lazy(() => promiseForBar);
+      const LazyFoo = lazy(() => promiseForFoo);
+      const LazyBar = lazy(() => promiseForBar);
 
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyFoo />
-        <LazyBar />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyFoo />
+          <LazyBar />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
 
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('FooBar');
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('FooBar');
 
-    jest.advanceTimersByTime(100);
-    await promiseForFoo;
+      jest.advanceTimersByTime(100);
+      await promiseForFoo;
 
-    expect(Scheduler).toFlushAndYield(['Foo']);
-    expect(root).not.toMatchRenderedOutput('FooBar');
+      expect(Scheduler).toFlushAndYield(['Foo']);
+      expect(root).not.toMatchRenderedOutput('FooBar');
 
-    jest.advanceTimersByTime(500);
-    await promiseForBar;
+      jest.advanceTimersByTime(500);
+      await promiseForBar;
 
-    expect(Scheduler).toFlushAndYield(['Foo', 'Bar']);
-    expect(root).toMatchRenderedOutput('FooBar');
+      expect(Scheduler).toFlushAndYield(['Foo', 'Bar']);
+      expect(root).toMatchRenderedOutput('FooBar');
+    });
   });
 
   it('does not support arbitrary promises, only module objects', async () => {
-    spyOnDev(console, 'error');
+    await act(async () => {
+      spyOnDev(console, 'error');
 
-    const LazyText = lazy(async () => Text);
+      const LazyText = lazy(async () => Text);
 
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyText text="Hi" />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('Hi');
-
-    await Promise.resolve();
-
-    if (__DEV__) {
-      expect(console.error).toHaveBeenCalledTimes(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Expected the result of a dynamic import() call',
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText text="Hi" />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
       );
-    }
-    expect(Scheduler).toFlushAndThrow('Element type is invalid');
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('Hi');
+
+      await Promise.resolve();
+
+      if (__DEV__) {
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error.calls.argsFor(0)[0]).toContain(
+          'Expected the result of a dynamic import() call',
+        );
+      }
+      expect(Scheduler).toFlushAndThrow('Element type is invalid');
+    });
   });
 
   it('throws if promise rejects', async () => {
-    const LazyText = lazy(async () => {
-      throw new Error('Bad network');
+    await act(async () => {
+      const LazyText = lazy(async () => {
+        throw new Error('Bad network');
+      });
+
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText text="Hi" />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
+
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('Hi');
+
+      try {
+        await Promise.resolve();
+      } catch (e) {}
+
+      expect(Scheduler).toFlushAndThrow('Bad network');
     });
-
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyText text="Hi" />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
-
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('Hi');
-
-    try {
-      await Promise.resolve();
-    } catch (e) {}
-
-    expect(Scheduler).toFlushAndThrow('Bad network');
   });
 
   it('mount and reorder', async () => {
-    class Child extends React.Component {
-      componentDidMount() {
-        Scheduler.unstable_yieldValue('Did mount: ' + this.props.label);
+    await act(async () => {
+      class Child extends React.Component {
+        componentDidMount() {
+          Scheduler.unstable_yieldValue('Did mount: ' + this.props.label);
+        }
+        componentDidUpdate() {
+          Scheduler.unstable_yieldValue('Did update: ' + this.props.label);
+        }
+        render() {
+          return <Text text={this.props.label} />;
+        }
       }
-      componentDidUpdate() {
-        Scheduler.unstable_yieldValue('Did update: ' + this.props.label);
+
+      const LazyChildA = lazy(() => fakeImport(Child));
+      const LazyChildB = lazy(() => fakeImport(Child));
+
+      function Parent({swap}) {
+        return (
+          <Suspense fallback={<Text text="Loading..." />}>
+            {swap
+              ? [
+                  <LazyChildB key="B" label="B" />,
+                  <LazyChildA key="A" label="A" />,
+                ]
+              : [
+                  <LazyChildA key="A" label="A" />,
+                  <LazyChildB key="B" label="B" />,
+                ]}
+          </Suspense>
+        );
       }
-      render() {
-        return <Text text={this.props.label} />;
-      }
-    }
 
-    const LazyChildA = lazy(() => fakeImport(Child));
-    const LazyChildB = lazy(() => fakeImport(Child));
+      const root = ReactTestRenderer.create(<Parent swap={false} />, {
+        unstable_isConcurrent: true,
+      });
 
-    function Parent({swap}) {
-      return (
-        <Suspense fallback={<Text text="Loading..." />}>
-          {swap
-            ? [
-                <LazyChildB key="B" label="B" />,
-                <LazyChildA key="A" label="A" />,
-              ]
-            : [
-                <LazyChildA key="A" label="A" />,
-                <LazyChildB key="B" label="B" />,
-              ]}
-        </Suspense>
-      );
-    }
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('AB');
 
-    const root = ReactTestRenderer.create(<Parent swap={false} />, {
-      unstable_isConcurrent: true,
+      await LazyChildA;
+      await LazyChildB;
+
+      expect(Scheduler).toFlushAndYield([
+        'A',
+        'B',
+        'Did mount: A',
+        'Did mount: B',
+      ]);
+      expect(root).toMatchRenderedOutput('AB');
+
+      // Swap the position of A and B
+      root.update(<Parent swap={true} />);
+      expect(Scheduler).toFlushAndYield([
+        'B',
+        'A',
+        'Did update: B',
+        'Did update: A',
+      ]);
+      expect(root).toMatchRenderedOutput('BA');
     });
-
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('AB');
-
-    await LazyChildA;
-    await LazyChildB;
-
-    expect(Scheduler).toFlushAndYield([
-      'A',
-      'B',
-      'Did mount: A',
-      'Did mount: B',
-    ]);
-    expect(root).toMatchRenderedOutput('AB');
-
-    // Swap the position of A and B
-    root.update(<Parent swap={true} />);
-    expect(Scheduler).toFlushAndYield([
-      'B',
-      'A',
-      'Did update: B',
-      'Did update: A',
-    ]);
-    expect(root).toMatchRenderedOutput('BA');
   });
 
   it('resolves defaultProps, on mount and update', async () => {
-    function T(props) {
-      return <Text {...props} />;
-    }
-    T.defaultProps = {text: 'Hi'};
-    const LazyText = lazy(() => fakeImport(T));
+    await act(async () => {
+      function T(props) {
+        return <Text {...props} />;
+      }
+      T.defaultProps = {text: 'Hi'};
+      const LazyText = lazy(() => fakeImport(T));
 
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyText />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
 
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('Hi');
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('Hi');
 
-    await Promise.resolve();
+      await Promise.resolve();
 
-    expect(Scheduler).toFlushAndYield(['Hi']);
-    expect(root).toMatchRenderedOutput('Hi');
+      expect(Scheduler).toFlushAndYield(['Hi']);
+      expect(root).toMatchRenderedOutput('Hi');
 
-    T.defaultProps = {text: 'Hi again'};
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyText />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushAndYield(['Hi again']);
-    expect(root).toMatchRenderedOutput('Hi again');
+      T.defaultProps = {text: 'Hi again'};
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushAndYield(['Hi again']);
+      expect(root).toMatchRenderedOutput('Hi again');
+    });
   });
 
   it('resolves defaultProps without breaking memoization', async () => {
-    function LazyImpl(props) {
-      Scheduler.unstable_yieldValue('Lazy');
-      return (
-        <React.Fragment>
-          <Text text={props.siblingText} />
-          {props.children}
-        </React.Fragment>
-      );
-    }
-    LazyImpl.defaultProps = {siblingText: 'Sibling'};
-    const Lazy = lazy(() => fakeImport(LazyImpl));
-
-    class Stateful extends React.Component {
-      state = {text: 'A'};
-      render() {
-        return <Text text={this.state.text} />;
+    await act(async () => {
+      function LazyImpl(props) {
+        Scheduler.unstable_yieldValue('Lazy');
+        return (
+          <React.Fragment>
+            <Text text={props.siblingText} />
+            {props.children}
+          </React.Fragment>
+        );
       }
-    }
+      LazyImpl.defaultProps = {siblingText: 'Sibling'};
+      const Lazy = lazy(() => fakeImport(LazyImpl));
 
-    const stateful = React.createRef(null);
+      class Stateful extends React.Component {
+        state = {text: 'A'};
+        render() {
+          return <Text text={this.state.text} />;
+        }
+      }
 
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <Lazy>
-          <Stateful ref={stateful} />
-        </Lazy>
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('SiblingA');
+      const stateful = React.createRef(null);
 
-    await Promise.resolve();
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <Lazy>
+            <Stateful ref={stateful} />
+          </Lazy>
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('SiblingA');
 
-    expect(Scheduler).toFlushAndYield(['Lazy', 'Sibling', 'A']);
-    expect(root).toMatchRenderedOutput('SiblingA');
+      await Promise.resolve();
 
-    // Lazy should not re-render
-    stateful.current.setState({text: 'B'});
-    expect(Scheduler).toFlushAndYield(['B']);
-    expect(root).toMatchRenderedOutput('SiblingB');
+      expect(Scheduler).toFlushAndYield(['Lazy', 'Sibling', 'A']);
+      expect(root).toMatchRenderedOutput('SiblingA');
+
+      // Lazy should not re-render
+      stateful.current.setState({text: 'B'});
+      expect(Scheduler).toFlushAndYield(['B']);
+      expect(root).toMatchRenderedOutput('SiblingB');
+    });
   });
 
   it('sets defaultProps for modern lifecycles', async () => {
-    class C extends React.Component {
-      static defaultProps = {text: 'A'};
-      state = {};
+    await act(async () => {
+      class C extends React.Component {
+        static defaultProps = {text: 'A'};
+        state = {};
 
-      static getDerivedStateFromProps(props) {
-        Scheduler.unstable_yieldValue(
-          `getDerivedStateFromProps: ${props.text}`,
-        );
-        return null;
+        static getDerivedStateFromProps(props) {
+          Scheduler.unstable_yieldValue(
+            `getDerivedStateFromProps: ${props.text}`,
+          );
+          return null;
+        }
+
+        constructor(props) {
+          super(props);
+          Scheduler.unstable_yieldValue(`constructor: ${this.props.text}`);
+        }
+
+        componentDidMount() {
+          Scheduler.unstable_yieldValue(
+            `componentDidMount: ${this.props.text}`,
+          );
+        }
+
+        componentDidUpdate(prevProps) {
+          Scheduler.unstable_yieldValue(
+            `componentDidUpdate: ${prevProps.text} -> ${this.props.text}`,
+          );
+        }
+
+        componentWillUnmount() {
+          Scheduler.unstable_yieldValue(
+            `componentWillUnmount: ${this.props.text}`,
+          );
+        }
+
+        shouldComponentUpdate(nextProps) {
+          Scheduler.unstable_yieldValue(
+            `shouldComponentUpdate: ${this.props.text} -> ${nextProps.text}`,
+          );
+          return true;
+        }
+
+        getSnapshotBeforeUpdate(prevProps) {
+          Scheduler.unstable_yieldValue(
+            `getSnapshotBeforeUpdate: ${prevProps.text} -> ${this.props.text}`,
+          );
+          return null;
+        }
+
+        render() {
+          return <Text text={this.props.text + this.props.num} />;
+        }
       }
 
-      constructor(props) {
-        super(props);
-        Scheduler.unstable_yieldValue(`constructor: ${this.props.text}`);
-      }
+      const LazyClass = lazy(() => fakeImport(C));
 
-      componentDidMount() {
-        Scheduler.unstable_yieldValue(`componentDidMount: ${this.props.text}`);
-      }
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyClass num={1} />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
 
-      componentDidUpdate(prevProps) {
-        Scheduler.unstable_yieldValue(
-          `componentDidUpdate: ${prevProps.text} -> ${this.props.text}`,
-        );
-      }
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('A1');
 
-      componentWillUnmount() {
-        Scheduler.unstable_yieldValue(
-          `componentWillUnmount: ${this.props.text}`,
-        );
-      }
+      await Promise.resolve();
 
-      shouldComponentUpdate(nextProps) {
-        Scheduler.unstable_yieldValue(
-          `shouldComponentUpdate: ${this.props.text} -> ${nextProps.text}`,
-        );
-        return true;
-      }
+      expect(Scheduler).toFlushAndYield([
+        'constructor: A',
+        'getDerivedStateFromProps: A',
+        'A1',
+        'componentDidMount: A',
+      ]);
 
-      getSnapshotBeforeUpdate(prevProps) {
-        Scheduler.unstable_yieldValue(
-          `getSnapshotBeforeUpdate: ${prevProps.text} -> ${this.props.text}`,
-        );
-        return null;
-      }
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyClass num={2} />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushAndYield([
+        'getDerivedStateFromProps: A',
+        'shouldComponentUpdate: A -> A',
+        'A2',
+        'getSnapshotBeforeUpdate: A -> A',
+        'componentDidUpdate: A -> A',
+      ]);
+      expect(root).toMatchRenderedOutput('A2');
 
-      render() {
-        return <Text text={this.props.text + this.props.num} />;
-      }
-    }
-
-    const LazyClass = lazy(() => fakeImport(C));
-
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyClass num={1} />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
-
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('A1');
-
-    await Promise.resolve();
-
-    expect(Scheduler).toFlushAndYield([
-      'constructor: A',
-      'getDerivedStateFromProps: A',
-      'A1',
-      'componentDidMount: A',
-    ]);
-
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyClass num={2} />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushAndYield([
-      'getDerivedStateFromProps: A',
-      'shouldComponentUpdate: A -> A',
-      'A2',
-      'getSnapshotBeforeUpdate: A -> A',
-      'componentDidUpdate: A -> A',
-    ]);
-    expect(root).toMatchRenderedOutput('A2');
-
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyClass num={3} />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushAndYield([
-      'getDerivedStateFromProps: A',
-      'shouldComponentUpdate: A -> A',
-      'A3',
-      'getSnapshotBeforeUpdate: A -> A',
-      'componentDidUpdate: A -> A',
-    ]);
-    expect(root).toMatchRenderedOutput('A3');
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyClass num={3} />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushAndYield([
+        'getDerivedStateFromProps: A',
+        'shouldComponentUpdate: A -> A',
+        'A3',
+        'getSnapshotBeforeUpdate: A -> A',
+        'componentDidUpdate: A -> A',
+      ]);
+      expect(root).toMatchRenderedOutput('A3');
+    });
   });
 
   it('sets defaultProps for legacy lifecycles', async () => {
@@ -517,109 +537,115 @@ describe('ReactLazy', () => {
   });
 
   it('resolves defaultProps on the outer wrapper but warns', async () => {
-    function T(props) {
-      Scheduler.unstable_yieldValue(props.inner + ' ' + props.outer);
-      return props.inner + ' ' + props.outer;
-    }
-    T.defaultProps = {inner: 'Hi'};
-    const LazyText = lazy(() => fakeImport(T));
-    expect(() => {
-      LazyText.defaultProps = {outer: 'Bye'};
-    }).toWarnDev(
-      'React.lazy(...): It is not supported to assign `defaultProps` to ' +
-        'a lazy component import. Either specify them where the component ' +
-        'is defined, or create a wrapping component around it.',
-      {withoutStack: true},
-    );
+    await act(async () => {
+      function T(props) {
+        Scheduler.unstable_yieldValue(props.inner + ' ' + props.outer);
+        return props.inner + ' ' + props.outer;
+      }
+      T.defaultProps = {inner: 'Hi'};
+      const LazyText = lazy(() => fakeImport(T));
+      expect(() => {
+        LazyText.defaultProps = {outer: 'Bye'};
+      }).toWarnDev(
+        'React.lazy(...): It is not supported to assign `defaultProps` to ' +
+          'a lazy component import. Either specify them where the component ' +
+          'is defined, or create a wrapping component around it.',
+        {withoutStack: true},
+      );
 
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyText />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
 
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('Hi Bye');
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('Hi Bye');
 
-    await Promise.resolve();
-    expect(Scheduler).toFlushAndYield(['Hi Bye']);
-    expect(root).toMatchRenderedOutput('Hi Bye');
+      await Promise.resolve();
+      expect(Scheduler).toFlushAndYield(['Hi Bye']);
+      expect(root).toMatchRenderedOutput('Hi Bye');
 
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyText outer="World" />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushAndYield(['Hi World']);
-    expect(root).toMatchRenderedOutput('Hi World');
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText outer="World" />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushAndYield(['Hi World']);
+      expect(root).toMatchRenderedOutput('Hi World');
 
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyText inner="Friends" />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushAndYield(['Friends Bye']);
-    expect(root).toMatchRenderedOutput('Friends Bye');
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText inner="Friends" />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushAndYield(['Friends Bye']);
+      expect(root).toMatchRenderedOutput('Friends Bye');
+    });
   });
 
   it('throws with a useful error when wrapping invalid type with lazy()', async () => {
-    const BadLazy = lazy(() => fakeImport(42));
+    await act(async () => {
+      const BadLazy = lazy(() => fakeImport(42));
 
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <BadLazy />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <BadLazy />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
 
-    expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(Scheduler).toFlushAndYield(['Loading...']);
 
-    await Promise.resolve();
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <BadLazy />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushAndThrow(
-      'Element type is invalid. Received a promise that resolves to: 42. ' +
-        'Lazy element type must resolve to a class or function.',
-    );
+      await Promise.resolve();
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <BadLazy />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushAndThrow(
+        'Element type is invalid. Received a promise that resolves to: 42. ' +
+          'Lazy element type must resolve to a class or function.',
+      );
+    });
   });
 
   it('throws with a useful error when wrapping lazy() multiple times', async () => {
-    const Lazy1 = lazy(() => fakeImport(Text));
-    const Lazy2 = lazy(() => fakeImport(Lazy1));
+    await act(async () => {
+      const Lazy1 = lazy(() => fakeImport(Text));
+      const Lazy2 = lazy(() => fakeImport(Lazy1));
 
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <Lazy2 text="Hello" />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <Lazy2 text="Hello" />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
 
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('Hello');
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('Hello');
 
-    await Promise.resolve();
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <Lazy2 text="Hello" />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushAndThrow(
-      'Element type is invalid. Received a promise that resolves to: [object Object]. ' +
-        'Lazy element type must resolve to a class or function.' +
-        (__DEV__
-          ? ' Did you wrap a component in React.lazy() more than once?'
-          : ''),
-    );
+      await Promise.resolve();
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <Lazy2 text="Hello" />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushAndThrow(
+        'Element type is invalid. Received a promise that resolves to: [object Object]. ' +
+          'Lazy element type must resolve to a class or function.' +
+          (__DEV__
+            ? ' Did you wrap a component in React.lazy() more than once?'
+            : ''),
+      );
+    });
   });
 
   it('warns about defining propTypes on the outer wrapper', () => {
@@ -684,409 +710,443 @@ describe('ReactLazy', () => {
   // Note: all "with defaultProps" tests below also verify defaultProps works as expected.
   // If we ever delete or move propTypes-related tests, make sure not to delete these.
   it('respects propTypes on function component with defaultProps', async () => {
-    function Add(props) {
-      expect(props.innerWithDefault).toBe(42);
-      return props.inner + props.outer;
-    }
-    Add.propTypes = {
-      inner: PropTypes.number.isRequired,
-      innerWithDefault: PropTypes.number.isRequired,
-    };
-    Add.defaultProps = {
-      innerWithDefault: 42,
-    };
-    await verifyInnerPropTypesAreChecked(Add);
+    await act(async () => {
+      function Add(props) {
+        expect(props.innerWithDefault).toBe(42);
+        return props.inner + props.outer;
+      }
+      Add.propTypes = {
+        inner: PropTypes.number.isRequired,
+        innerWithDefault: PropTypes.number.isRequired,
+      };
+      Add.defaultProps = {
+        innerWithDefault: 42,
+      };
+      await verifyInnerPropTypesAreChecked(Add);
+    });
   });
 
   it('respects propTypes on function component without defaultProps', async () => {
-    function Add(props) {
-      return props.inner + props.outer;
-    }
-    Add.propTypes = {
-      inner: PropTypes.number.isRequired,
-    };
-    await verifyInnerPropTypesAreChecked(Add);
+    await act(async () => {
+      function Add(props) {
+        return props.inner + props.outer;
+      }
+      Add.propTypes = {
+        inner: PropTypes.number.isRequired,
+      };
+      await verifyInnerPropTypesAreChecked(Add);
+    });
   });
 
   it('respects propTypes on class component with defaultProps', async () => {
-    class Add extends React.Component {
-      render() {
-        expect(this.props.innerWithDefault).toBe(42);
-        return this.props.inner + this.props.outer;
+    await act(async () => {
+      class Add extends React.Component {
+        render() {
+          expect(this.props.innerWithDefault).toBe(42);
+          return this.props.inner + this.props.outer;
+        }
       }
-    }
-    Add.propTypes = {
-      inner: PropTypes.number.isRequired,
-      innerWithDefault: PropTypes.number.isRequired,
-    };
-    Add.defaultProps = {
-      innerWithDefault: 42,
-    };
-    await verifyInnerPropTypesAreChecked(Add);
+      Add.propTypes = {
+        inner: PropTypes.number.isRequired,
+        innerWithDefault: PropTypes.number.isRequired,
+      };
+      Add.defaultProps = {
+        innerWithDefault: 42,
+      };
+      await verifyInnerPropTypesAreChecked(Add);
+    });
   });
 
   it('respects propTypes on class component without defaultProps', async () => {
-    class Add extends React.Component {
-      render() {
-        return this.props.inner + this.props.outer;
+    await act(async () => {
+      class Add extends React.Component {
+        render() {
+          return this.props.inner + this.props.outer;
+        }
       }
-    }
-    Add.propTypes = {
-      inner: PropTypes.number.isRequired,
-    };
-    await verifyInnerPropTypesAreChecked(Add);
+      Add.propTypes = {
+        inner: PropTypes.number.isRequired,
+      };
+      await verifyInnerPropTypesAreChecked(Add);
+    });
   });
 
   it('respects propTypes on forwardRef component with defaultProps', async () => {
-    const Add = React.forwardRef((props, ref) => {
-      expect(props.innerWithDefault).toBe(42);
-      return props.inner + props.outer;
+    await act(async () => {
+      const Add = React.forwardRef((props, ref) => {
+        expect(props.innerWithDefault).toBe(42);
+        return props.inner + props.outer;
+      });
+      Add.displayName = 'Add';
+      Add.propTypes = {
+        inner: PropTypes.number.isRequired,
+        innerWithDefault: PropTypes.number.isRequired,
+      };
+      Add.defaultProps = {
+        innerWithDefault: 42,
+      };
+      await verifyInnerPropTypesAreChecked(Add);
     });
-    Add.displayName = 'Add';
-    Add.propTypes = {
-      inner: PropTypes.number.isRequired,
-      innerWithDefault: PropTypes.number.isRequired,
-    };
-    Add.defaultProps = {
-      innerWithDefault: 42,
-    };
-    await verifyInnerPropTypesAreChecked(Add);
   });
 
   it('respects propTypes on forwardRef component without defaultProps', async () => {
-    const Add = React.forwardRef((props, ref) => {
-      return props.inner + props.outer;
+    await act(async () => {
+      const Add = React.forwardRef((props, ref) => {
+        return props.inner + props.outer;
+      });
+      Add.displayName = 'Add';
+      Add.propTypes = {
+        inner: PropTypes.number.isRequired,
+      };
+      await verifyInnerPropTypesAreChecked(Add);
     });
-    Add.displayName = 'Add';
-    Add.propTypes = {
-      inner: PropTypes.number.isRequired,
-    };
-    await verifyInnerPropTypesAreChecked(Add);
   });
 
   it('respects propTypes on outer memo component with defaultProps', async () => {
-    let Add = props => {
-      expect(props.innerWithDefault).toBe(42);
-      return props.inner + props.outer;
-    };
-    Add = React.memo(Add);
-    Add.propTypes = {
-      inner: PropTypes.number.isRequired,
-      innerWithDefault: PropTypes.number.isRequired,
-    };
-    Add.defaultProps = {
-      innerWithDefault: 42,
-    };
-    await verifyInnerPropTypesAreChecked(Add);
+    await act(async () => {
+      let Add = props => {
+        expect(props.innerWithDefault).toBe(42);
+        return props.inner + props.outer;
+      };
+      Add = React.memo(Add);
+      Add.propTypes = {
+        inner: PropTypes.number.isRequired,
+        innerWithDefault: PropTypes.number.isRequired,
+      };
+      Add.defaultProps = {
+        innerWithDefault: 42,
+      };
+      await verifyInnerPropTypesAreChecked(Add);
+    });
   });
 
   it('respects propTypes on outer memo component without defaultProps', async () => {
-    let Add = props => {
-      return props.inner + props.outer;
-    };
-    Add = React.memo(Add);
-    Add.propTypes = {
-      inner: PropTypes.number.isRequired,
-    };
-    await verifyInnerPropTypesAreChecked(Add);
+    await act(async () => {
+      let Add = props => {
+        return props.inner + props.outer;
+      };
+      Add = React.memo(Add);
+      Add.propTypes = {
+        inner: PropTypes.number.isRequired,
+      };
+      await verifyInnerPropTypesAreChecked(Add);
+    });
   });
 
   it('respects propTypes on inner memo component with defaultProps', async () => {
-    const Add = props => {
-      expect(props.innerWithDefault).toBe(42);
-      return props.inner + props.outer;
-    };
-    Add.displayName = 'Add';
-    Add.propTypes = {
-      inner: PropTypes.number.isRequired,
-      innerWithDefault: PropTypes.number.isRequired,
-    };
-    Add.defaultProps = {
-      innerWithDefault: 42,
-    };
-    await verifyInnerPropTypesAreChecked(React.memo(Add));
+    await act(async () => {
+      const Add = props => {
+        expect(props.innerWithDefault).toBe(42);
+        return props.inner + props.outer;
+      };
+      Add.displayName = 'Add';
+      Add.propTypes = {
+        inner: PropTypes.number.isRequired,
+        innerWithDefault: PropTypes.number.isRequired,
+      };
+      Add.defaultProps = {
+        innerWithDefault: 42,
+      };
+      await verifyInnerPropTypesAreChecked(React.memo(Add));
+    });
   });
 
   it('respects propTypes on inner memo component without defaultProps', async () => {
-    const Add = props => {
-      return props.inner + props.outer;
-    };
-    Add.displayName = 'Add';
-    Add.propTypes = {
-      inner: PropTypes.number.isRequired,
-    };
-    await verifyInnerPropTypesAreChecked(React.memo(Add));
+    await act(async () => {
+      const Add = props => {
+        return props.inner + props.outer;
+      };
+      Add.displayName = 'Add';
+      Add.propTypes = {
+        inner: PropTypes.number.isRequired,
+      };
+      await verifyInnerPropTypesAreChecked(React.memo(Add));
+    });
   });
 
   it('uses outer resolved props for validating propTypes on memo', async () => {
-    let T = props => {
-      return <Text text={props.text} />;
-    };
-    T.defaultProps = {
-      text: 'Inner default text',
-    };
-    T = React.memo(T);
-    T.propTypes = {
-      // Should not be satisfied by the *inner* defaultProps.
-      text: PropTypes.string.isRequired,
-    };
-    const LazyText = lazy(() => fakeImport(T));
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyText />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
-
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('Inner default text');
-
-    // Mount
-    await Promise.resolve();
-    expect(() => {
-      expect(Scheduler).toFlushAndYield(['Inner default text']);
-    }).toWarnDev(
-      'The prop `text` is marked as required in `T`, but its value is `undefined`',
-    );
-    expect(root).toMatchRenderedOutput('Inner default text');
-
-    // Update
-    expect(() => {
-      root.update(
+    await act(async () => {
+      let T = props => {
+        return <Text text={props.text} />;
+      };
+      T.defaultProps = {
+        text: 'Inner default text',
+      };
+      T = React.memo(T);
+      T.propTypes = {
+        // Should not be satisfied by the *inner* defaultProps.
+        text: PropTypes.string.isRequired,
+      };
+      const LazyText = lazy(() => fakeImport(T));
+      const root = ReactTestRenderer.create(
         <Suspense fallback={<Text text="Loading..." />}>
-          <LazyText text={null} />
+          <LazyText />
         </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
       );
-      expect(Scheduler).toFlushAndYield([null]);
-    }).toWarnDev(
-      'The prop `text` is marked as required in `T`, but its value is `null`',
-    );
-    expect(root).toMatchRenderedOutput(null);
+
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('Inner default text');
+
+      // Mount
+      await Promise.resolve();
+      expect(() => {
+        expect(Scheduler).toFlushAndYield(['Inner default text']);
+      }).toWarnDev(
+        'The prop `text` is marked as required in `T`, but its value is `undefined`',
+      );
+      expect(root).toMatchRenderedOutput('Inner default text');
+
+      // Update
+      expect(() => {
+        root.update(
+          <Suspense fallback={<Text text="Loading..." />}>
+            <LazyText text={null} />
+          </Suspense>,
+        );
+        expect(Scheduler).toFlushAndYield([null]);
+      }).toWarnDev(
+        'The prop `text` is marked as required in `T`, but its value is `null`',
+      );
+      expect(root).toMatchRenderedOutput(null);
+    });
   });
 
   it('includes lazy-loaded component in warning stack', async () => {
-    const LazyFoo = lazy(() => {
-      Scheduler.unstable_yieldValue('Started loading');
-      const Foo = props => <div>{[<Text text="A" />, <Text text="B" />]}</div>;
-      return fakeImport(Foo);
+    await act(async () => {
+      const LazyFoo = lazy(() => {
+        Scheduler.unstable_yieldValue('Started loading');
+        const Foo = props => (
+          <div>{[<Text text="A" />, <Text text="B" />]}</div>
+        );
+        return fakeImport(Foo);
+      });
+
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyFoo />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
+
+      expect(Scheduler).toFlushAndYield(['Started loading', 'Loading...']);
+      expect(root).not.toMatchRenderedOutput(<div>AB</div>);
+
+      await Promise.resolve();
+
+      expect(() => {
+        expect(Scheduler).toFlushAndYield(['A', 'B']);
+      }).toWarnDev('    in Text (at **)\n' + '    in Foo (at **)');
+      expect(root).toMatchRenderedOutput(<div>AB</div>);
     });
-
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyFoo />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
-
-    expect(Scheduler).toFlushAndYield(['Started loading', 'Loading...']);
-    expect(root).not.toMatchRenderedOutput(<div>AB</div>);
-
-    await Promise.resolve();
-
-    expect(() => {
-      expect(Scheduler).toFlushAndYield(['A', 'B']);
-    }).toWarnDev('    in Text (at **)\n' + '    in Foo (at **)');
-    expect(root).toMatchRenderedOutput(<div>AB</div>);
   });
 
   it('supports class and forwardRef components', async () => {
-    const LazyClass = lazy(() => {
-      class Foo extends React.Component {
-        render() {
-          return <Text text="Foo" />;
+    await act(async () => {
+      const LazyClass = lazy(() => {
+        class Foo extends React.Component {
+          render() {
+            return <Text text="Foo" />;
+          }
         }
-      }
-      return fakeImport(Foo);
-    });
+        return fakeImport(Foo);
+      });
 
-    const LazyForwardRef = lazy(() => {
-      class Bar extends React.Component {
-        render() {
-          return <Text text="Bar" />;
+      const LazyForwardRef = lazy(() => {
+        class Bar extends React.Component {
+          render() {
+            return <Text text="Bar" />;
+          }
         }
-      }
-      return fakeImport(
-        React.forwardRef((props, ref) => {
-          Scheduler.unstable_yieldValue('forwardRef');
-          return <Bar ref={ref} />;
-        }),
+        return fakeImport(
+          React.forwardRef((props, ref) => {
+            Scheduler.unstable_yieldValue('forwardRef');
+            return <Bar ref={ref} />;
+          }),
+        );
+      });
+
+      const ref = React.createRef();
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyClass />
+          <LazyForwardRef ref={ref} />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
       );
+
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('FooBar');
+      expect(ref.current).toBe(null);
+
+      await Promise.resolve();
+
+      expect(Scheduler).toFlushAndYield(['Foo', 'forwardRef', 'Bar']);
+      expect(root).toMatchRenderedOutput('FooBar');
+      expect(ref.current).not.toBe(null);
     });
-
-    const ref = React.createRef();
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyClass />
-        <LazyForwardRef ref={ref} />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
-
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('FooBar');
-    expect(ref.current).toBe(null);
-
-    await Promise.resolve();
-
-    expect(Scheduler).toFlushAndYield(['Foo', 'forwardRef', 'Bar']);
-    expect(root).toMatchRenderedOutput('FooBar');
-    expect(ref.current).not.toBe(null);
   });
 
   // Regression test for #14310
   it('supports defaultProps defined on the memo() return value', async () => {
-    const Add = React.memo(props => {
-      return props.inner + props.outer;
+    await act(async () => {
+      const Add = React.memo(props => {
+        return props.inner + props.outer;
+      });
+      Add.defaultProps = {
+        inner: 2,
+      };
+      const LazyAdd = lazy(() => fakeImport(Add));
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyAdd outer={2} />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('4');
+
+      // Mount
+      await Promise.resolve();
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput('4');
+
+      // Update (shallowly equal)
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyAdd outer={2} />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput('4');
+
+      // Update
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyAdd outer={3} />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput('5');
+
+      // Update (shallowly equal)
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyAdd outer={3} />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput('5');
+
+      // Update (explicit props)
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyAdd outer={1} inner={1} />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput('2');
+
+      // Update (explicit props, shallowly equal)
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyAdd outer={1} inner={1} />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput('2');
+
+      // Update
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyAdd outer={1} />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput('3');
     });
-    Add.defaultProps = {
-      inner: 2,
-    };
-    const LazyAdd = lazy(() => fakeImport(Add));
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyAdd outer={2} />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('4');
-
-    // Mount
-    await Promise.resolve();
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(root).toMatchRenderedOutput('4');
-
-    // Update (shallowly equal)
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyAdd outer={2} />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(root).toMatchRenderedOutput('4');
-
-    // Update
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyAdd outer={3} />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(root).toMatchRenderedOutput('5');
-
-    // Update (shallowly equal)
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyAdd outer={3} />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(root).toMatchRenderedOutput('5');
-
-    // Update (explicit props)
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyAdd outer={1} inner={1} />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(root).toMatchRenderedOutput('2');
-
-    // Update (explicit props, shallowly equal)
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyAdd outer={1} inner={1} />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(root).toMatchRenderedOutput('2');
-
-    // Update
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyAdd outer={1} />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(root).toMatchRenderedOutput('3');
   });
 
   it('merges defaultProps in the correct order', async () => {
-    let Add = React.memo(props => {
-      return props.inner + props.outer;
+    await act(async () => {
+      let Add = React.memo(props => {
+        return props.inner + props.outer;
+      });
+      Add.defaultProps = {
+        inner: 100,
+      };
+      Add = React.memo(Add);
+      Add.defaultProps = {
+        inner: 2,
+        outer: 0,
+      };
+      const LazyAdd = lazy(() => fakeImport(Add));
+      const root = ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyAdd outer={2} />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      expect(root).not.toMatchRenderedOutput('4');
+
+      // Mount
+      await Promise.resolve();
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput('4');
+
+      // Update
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyAdd outer={3} />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput('5');
+
+      // Update
+      root.update(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyAdd />
+        </Suspense>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(root).toMatchRenderedOutput('2');
     });
-    Add.defaultProps = {
-      inner: 100,
-    };
-    Add = React.memo(Add);
-    Add.defaultProps = {
-      inner: 2,
-      outer: 0,
-    };
-    const LazyAdd = lazy(() => fakeImport(Add));
-    const root = ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyAdd outer={2} />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    expect(root).not.toMatchRenderedOutput('4');
-
-    // Mount
-    await Promise.resolve();
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(root).toMatchRenderedOutput('4');
-
-    // Update
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyAdd outer={3} />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(root).toMatchRenderedOutput('5');
-
-    // Update
-    root.update(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyAdd />
-      </Suspense>,
-    );
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(root).toMatchRenderedOutput('2');
   });
 
   it('warns about ref on functions for lazy-loaded components', async () => {
-    const LazyFoo = lazy(() => {
-      const Foo = props => <div />;
-      return fakeImport(Foo);
+    await act(async () => {
+      const LazyFoo = lazy(() => {
+        const Foo = props => <div />;
+        return fakeImport(Foo);
+      });
+
+      const ref = React.createRef();
+      ReactTestRenderer.create(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyFoo ref={ref} />
+        </Suspense>,
+        {
+          unstable_isConcurrent: true,
+        },
+      );
+
+      expect(Scheduler).toFlushAndYield(['Loading...']);
+      await Promise.resolve();
+      expect(() => {
+        expect(Scheduler).toFlushAndYield([]);
+      }).toWarnDev('Function components cannot be given refs');
     });
-
-    const ref = React.createRef();
-    ReactTestRenderer.create(
-      <Suspense fallback={<Text text="Loading..." />}>
-        <LazyFoo ref={ref} />
-      </Suspense>,
-      {
-        unstable_isConcurrent: true,
-      },
-    );
-
-    expect(Scheduler).toFlushAndYield(['Loading...']);
-    await Promise.resolve();
-    expect(() => {
-      expect(Scheduler).toFlushAndYield([]);
-    }).toWarnDev('Function components cannot be given refs');
   });
 });

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -438,13 +438,19 @@ const ReactTestRendererFiber = {
       createNodeMock,
       tag: 'CONTAINER',
     };
+    // make flow happy by retaining a reference to container
+    // before using it inside act()
+    const rootContainer = container;
     let root: FiberRoot | null = createContainer(
-      container,
+      rootContainer,
       isConcurrent ? ConcurrentRoot : LegacyRoot,
       false,
     );
-    invariant(root != null, 'something went wrong');
-    updateContainer(element, root, null, null);
+
+    act(() => {
+      invariant(root != null, 'something went wrong');
+      updateContainer(element, root, null, null);
+    });
 
     const entry = {
       _Scheduler: Scheduler,
@@ -492,16 +498,20 @@ const ReactTestRendererFiber = {
         return toTree(root.current);
       },
       update(newElement: React$Element<any>) {
-        if (root == null || root.current == null) {
-          return;
-        }
-        updateContainer(newElement, root, null, null);
+        act(() => {
+          if (root == null || root.current == null) {
+            return;
+          }
+          updateContainer(newElement, root, null, null);
+        });
       },
       unmount() {
-        if (root == null || root.current == null) {
-          return;
-        }
-        updateContainer(null, root, null, null);
+        act(() => {
+          if (root == null || root.current == null) {
+            return;
+          }
+          updateContainer(null, root, null, null);
+        });
         container = null;
         root = null;
       },

--- a/packages/react-test-renderer/src/ReactTestRendererAct.js
+++ b/packages/react-test-renderer/src/ReactTestRendererAct.js
@@ -65,7 +65,7 @@ function flushWorkAndMicroTasks(onDone: (err: ?Error) => void) {
 
 let actingUpdatesScopeDepth = 0;
 
-function act(callback: () => Thenable) {
+function act(callback: () => Thenable | void) {
   let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
   let previousIsSomeRendererActing;
   let previousIsThisRendererActing;
@@ -134,7 +134,7 @@ function act(callback: () => Thenable) {
     return {
       then(resolve: () => void, reject: (?Error) => void) {
         called = true;
-        result.then(
+        ((result: any): Thenable).then(
           () => {
             if (actingUpdatesScopeDepth > 1) {
               onDone();

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
@@ -12,6 +12,7 @@
 
 let React;
 let ReactTestRenderer;
+let act;
 let Scheduler;
 
 describe('ReactTestRendererAsync', () => {
@@ -19,220 +20,253 @@ describe('ReactTestRendererAsync', () => {
     jest.resetModules();
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
+    act = ReactTestRenderer.act;
     Scheduler = require('scheduler');
   });
 
   it('flushAll flushes all work', () => {
-    function Foo(props) {
-      return props.children;
-    }
-    const renderer = ReactTestRenderer.create(<Foo>Hi</Foo>, {
-      unstable_isConcurrent: true,
+    act(() => {
+      function Foo(props) {
+        return props.children;
+      }
+      const renderer = ReactTestRenderer.create(<Foo>Hi</Foo>, {
+        unstable_isConcurrent: true,
+      });
+
+      // Before flushing, nothing has mounted.
+      expect(renderer.toJSON()).toEqual(null);
+
+      // Flush initial mount.
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(renderer.toJSON()).toEqual('Hi');
+
+      // Update
+      renderer.update(<Foo>Bye</Foo>);
+      // Not yet updated.
+      expect(renderer.toJSON()).toEqual('Hi');
+      // Flush update.
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(renderer.toJSON()).toEqual('Bye');
     });
-
-    // Before flushing, nothing has mounted.
-    expect(renderer.toJSON()).toEqual(null);
-
-    // Flush initial mount.
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(renderer.toJSON()).toEqual('Hi');
-
-    // Update
-    renderer.update(<Foo>Bye</Foo>);
-    // Not yet updated.
-    expect(renderer.toJSON()).toEqual('Hi');
-    // Flush update.
-    expect(Scheduler).toFlushWithoutYielding();
-    expect(renderer.toJSON()).toEqual('Bye');
   });
 
   it('flushAll returns array of yielded values', () => {
-    function Child(props) {
-      Scheduler.unstable_yieldValue(props.children);
-      return props.children;
-    }
-    function Parent(props) {
-      return (
-        <React.Fragment>
-          <Child>{'A:' + props.step}</Child>
-          <Child>{'B:' + props.step}</Child>
-          <Child>{'C:' + props.step}</Child>
-        </React.Fragment>
-      );
-    }
-    const renderer = ReactTestRenderer.create(<Parent step={1} />, {
-      unstable_isConcurrent: true,
-    });
-
-    expect(Scheduler).toFlushAndYield(['A:1', 'B:1', 'C:1']);
-    expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
-
-    renderer.update(<Parent step={2} />);
-    expect(Scheduler).toFlushAndYield(['A:2', 'B:2', 'C:2']);
-    expect(renderer.toJSON()).toEqual(['A:2', 'B:2', 'C:2']);
-  });
-
-  it('flushThrough flushes until the expected values is yielded', () => {
-    function Child(props) {
-      Scheduler.unstable_yieldValue(props.children);
-      return props.children;
-    }
-    function Parent(props) {
-      return (
-        <React.Fragment>
-          <Child>{'A:' + props.step}</Child>
-          <Child>{'B:' + props.step}</Child>
-          <Child>{'C:' + props.step}</Child>
-        </React.Fragment>
-      );
-    }
-    const renderer = ReactTestRenderer.create(<Parent step={1} />, {
-      unstable_isConcurrent: true,
-    });
-
-    // Flush the first two siblings
-    expect(Scheduler).toFlushAndYieldThrough(['A:1', 'B:1']);
-    // Did not commit yet.
-    expect(renderer.toJSON()).toEqual(null);
-
-    // Flush the remaining work
-    expect(Scheduler).toFlushAndYield(['C:1']);
-    expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
-  });
-
-  it('supports high priority interruptions', () => {
-    function Child(props) {
-      Scheduler.unstable_yieldValue(props.children);
-      return props.children;
-    }
-
-    class Example extends React.Component {
-      componentDidMount() {
-        expect(this.props.step).toEqual(2);
+    act(() => {
+      function Child(props) {
+        Scheduler.unstable_yieldValue(props.children);
+        return props.children;
       }
-      componentDidUpdate() {
-        throw Error('Unexpected update');
-      }
-      render() {
+      function Parent(props) {
         return (
           <React.Fragment>
-            <Child>{'A:' + this.props.step}</Child>
-            <Child>{'B:' + this.props.step}</Child>
+            <Child>{'A:' + props.step}</Child>
+            <Child>{'B:' + props.step}</Child>
+            <Child>{'C:' + props.step}</Child>
           </React.Fragment>
         );
       }
-    }
+      const renderer = ReactTestRenderer.create(<Parent step={1} />, {
+        unstable_isConcurrent: true,
+      });
 
-    const renderer = ReactTestRenderer.create(<Example step={1} />, {
-      unstable_isConcurrent: true,
+      expect(Scheduler).toFlushAndYield(['A:1', 'B:1', 'C:1']);
+      expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
+
+      renderer.update(<Parent step={2} />);
+      expect(Scheduler).toFlushAndYield(['A:2', 'B:2', 'C:2']);
+      expect(renderer.toJSON()).toEqual(['A:2', 'B:2', 'C:2']);
     });
+  });
 
-    // Flush the some of the changes, but don't commit
-    expect(Scheduler).toFlushAndYieldThrough(['A:1']);
-    expect(renderer.toJSON()).toEqual(null);
+  it('flushThrough flushes until the expected values is yielded', () => {
+    act(() => {
+      function Child(props) {
+        Scheduler.unstable_yieldValue(props.children);
+        return props.children;
+      }
+      function Parent(props) {
+        return (
+          <React.Fragment>
+            <Child>{'A:' + props.step}</Child>
+            <Child>{'B:' + props.step}</Child>
+            <Child>{'C:' + props.step}</Child>
+          </React.Fragment>
+        );
+      }
+      const renderer = ReactTestRenderer.create(<Parent step={1} />, {
+        unstable_isConcurrent: true,
+      });
 
-    // Interrupt with higher priority properties
-    renderer.unstable_flushSync(() => {
-      renderer.update(<Example step={2} />);
+      // Flush the first two siblings
+      expect(Scheduler).toFlushAndYieldThrough(['A:1', 'B:1']);
+      // Did not commit yet.
+      expect(renderer.toJSON()).toEqual(null);
+
+      // Flush the remaining work
+      expect(Scheduler).toFlushAndYield(['C:1']);
+      expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
     });
+  });
 
-    // Only the higher priority properties have been committed
-    expect(renderer.toJSON()).toEqual(['A:2', 'B:2']);
+  it('supports high priority interruptions', () => {
+    act(() => {
+      function Child(props) {
+        Scheduler.unstable_yieldValue(props.children);
+        return props.children;
+      }
+
+      class Example extends React.Component {
+        componentDidMount() {
+          expect(this.props.step).toEqual(2);
+        }
+        componentDidUpdate() {
+          throw Error('Unexpected update');
+        }
+        render() {
+          return (
+            <React.Fragment>
+              <Child>{'A:' + this.props.step}</Child>
+              <Child>{'B:' + this.props.step}</Child>
+            </React.Fragment>
+          );
+        }
+      }
+
+      const renderer = ReactTestRenderer.create(<Example step={1} />, {
+        unstable_isConcurrent: true,
+      });
+
+      // Flush the some of the changes, but don't commit
+      expect(Scheduler).toFlushAndYieldThrough(['A:1']);
+      expect(renderer.toJSON()).toEqual(null);
+
+      // Interrupt with higher priority properties
+      renderer.unstable_flushSync(() => {
+        renderer.update(<Example step={2} />);
+      });
+
+      // Only the higher priority properties have been committed
+      expect(renderer.toJSON()).toEqual(['A:2', 'B:2']);
+    });
   });
 
   describe('Jest matchers', () => {
     it('toFlushAndYieldThrough', () => {
-      const Yield = ({id}) => {
-        Scheduler.unstable_yieldValue(id);
-        return id;
-      };
+      act(() => {
+        const Yield = ({id}) => {
+          Scheduler.unstable_yieldValue(id);
+          return id;
+        };
 
-      ReactTestRenderer.create(
-        <div>
-          <Yield id="foo" />
-          <Yield id="bar" />
-          <Yield id="baz" />
-        </div>,
-        {
-          unstable_isConcurrent: true,
-        },
-      );
+        ReactTestRenderer.create(
+          <div>
+            <Yield id="foo" />
+            <Yield id="bar" />
+            <Yield id="baz" />
+          </div>,
+          {
+            unstable_isConcurrent: true,
+          },
+        );
 
-      expect(() =>
-        expect(Scheduler).toFlushAndYieldThrough(['foo', 'baz']),
-      ).toThrow('Expected value to equal:');
+        expect(() =>
+          expect(Scheduler).toFlushAndYieldThrough(['foo', 'baz']),
+        ).toThrow('Expected value to equal:');
+      });
     });
 
     it('toFlushAndYield', () => {
-      const Yield = ({id}) => {
-        Scheduler.unstable_yieldValue(id);
-        return id;
-      };
+      act(() => {
+        const Yield = ({id}) => {
+          Scheduler.unstable_yieldValue(id);
+          return id;
+        };
 
-      const renderer = ReactTestRenderer.create(
-        <div>
-          <Yield id="foo" />
-          <Yield id="bar" />
-          <Yield id="baz" />
-        </div>,
-        {
-          unstable_isConcurrent: true,
-        },
-      );
+        const renderer = ReactTestRenderer.create(
+          <div>
+            <Yield id="foo" />
+            <Yield id="bar" />
+            <Yield id="baz" />
+          </div>,
+          {
+            unstable_isConcurrent: true,
+          },
+        );
 
-      expect(() => expect(Scheduler).toFlushWithoutYielding()).toThrowError(
-        'Expected value to equal:',
-      );
+        expect(() => expect(Scheduler).toFlushWithoutYielding()).toThrowError(
+          'Expected value to equal:',
+        );
 
-      renderer.update(
-        <div>
-          <Yield id="foo" />
-          <Yield id="bar" />
-          <Yield id="baz" />
-        </div>,
-      );
+        renderer.update(
+          <div>
+            <Yield id="foo" />
+            <Yield id="bar" />
+            <Yield id="baz" />
+          </div>,
+        );
 
-      expect(() => expect(Scheduler).toFlushAndYield(['foo', 'baz'])).toThrow(
-        'Expected value to equal:',
-      );
+        expect(() => expect(Scheduler).toFlushAndYield(['foo', 'baz'])).toThrow(
+          'Expected value to equal:',
+        );
+      });
     });
 
     it('toFlushAndThrow', () => {
-      const Yield = ({id}) => {
-        Scheduler.unstable_yieldValue(id);
-        return id;
-      };
+      act(() => {
+        const Yield = ({id}) => {
+          Scheduler.unstable_yieldValue(id);
+          return id;
+        };
 
-      function BadRender() {
-        throw new Error('Oh no!');
-      }
+        function BadRender() {
+          throw new Error('Oh no!');
+        }
 
-      function App() {
-        return (
-          <div>
-            <Yield id="A" />
-            <Yield id="B" />
-            <BadRender />
-            <Yield id="C" />
-            <Yield id="D" />
-          </div>
-        );
-      }
+        function App() {
+          return (
+            <div>
+              <Yield id="A" />
+              <Yield id="B" />
+              <BadRender />
+              <Yield id="C" />
+              <Yield id="D" />
+            </div>
+          );
+        }
 
-      const renderer = ReactTestRenderer.create(<App />, {
-        unstable_isConcurrent: true,
+        const renderer = ReactTestRenderer.create(<App />, {
+          unstable_isConcurrent: true,
+        });
+
+        expect(Scheduler).toFlushAndThrow('Oh no!');
+        expect(Scheduler).toHaveYielded([
+          'A',
+          'B',
+          'C',
+          'D',
+          'A',
+          'B',
+          'C',
+          'D',
+        ]);
+
+        renderer.update(<App />);
+
+        expect(Scheduler).toFlushAndThrow('Oh no!');
+        expect(Scheduler).toHaveYielded([
+          'A',
+          'B',
+          'C',
+          'D',
+          'A',
+          'B',
+          'C',
+          'D',
+        ]);
+
+        renderer.update(<App />);
+        expect(Scheduler).toFlushAndThrow('Oh no!');
       });
-
-      expect(Scheduler).toFlushAndThrow('Oh no!');
-      expect(Scheduler).toHaveYielded(['A', 'B', 'C', 'D', 'A', 'B', 'C', 'D']);
-
-      renderer.update(<App />);
-
-      expect(Scheduler).toFlushAndThrow('Oh no!');
-      expect(Scheduler).toHaveYielded(['A', 'B', 'C', 'D', 'A', 'B', 'C', 'D']);
-
-      renderer.update(<App />);
-      expect(Scheduler).toFlushAndThrow('Oh no!');
     });
   });
 

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -16,6 +16,7 @@ let ReactNoop;
 let Scheduler;
 let ReactCache;
 let ReactTestRenderer;
+let act;
 let SchedulerTracing;
 let AdvanceTime;
 let AsyncText;
@@ -43,10 +44,12 @@ function loadModules({
 
   if (useNoopRenderer) {
     ReactNoop = require('react-noop-renderer');
+    act = ReactNoop.act;
     ReactTestRenderer = null;
   } else {
     ReactNoop = null;
     ReactTestRenderer = require('react-test-renderer');
+    act = ReactTestRenderer.act;
   }
 
   AdvanceTime = class extends React.Component {
@@ -234,28 +237,30 @@ describe('Profiler', () => {
       });
 
       it('is not invoked until the commit phase', () => {
-        const callback = jest.fn();
+        act(() => {
+          const callback = jest.fn();
 
-        const Yield = ({value}) => {
-          Scheduler.unstable_yieldValue(value);
-          return null;
-        };
+          const Yield = ({value}) => {
+            Scheduler.unstable_yieldValue(value);
+            return null;
+          };
 
-        ReactTestRenderer.create(
-          <React.Profiler id="test" onRender={callback}>
-            <Yield value="first" />
-            <Yield value="last" />
-          </React.Profiler>,
-          {
-            unstable_isConcurrent: true,
-          },
-        );
+          ReactTestRenderer.create(
+            <React.Profiler id="test" onRender={callback}>
+              <Yield value="first" />
+              <Yield value="last" />
+            </React.Profiler>,
+            {
+              unstable_isConcurrent: true,
+            },
+          );
 
-        // Times are logged until a render is committed.
-        expect(Scheduler).toFlushAndYieldThrough(['first']);
-        expect(callback).toHaveBeenCalledTimes(0);
-        expect(Scheduler).toFlushAndYield(['last']);
-        expect(callback).toHaveBeenCalledTimes(1);
+          // Times are logged until a render is committed.
+          expect(Scheduler).toFlushAndYieldThrough(['first']);
+          expect(callback).toHaveBeenCalledTimes(0);
+          expect(Scheduler).toFlushAndYield(['last']);
+          expect(callback).toHaveBeenCalledTimes(1);
+        });
       });
 
       it('does not record times for components outside of Profiler tree', () => {
@@ -616,330 +621,342 @@ describe('Profiler', () => {
 
       describe('with regard to interruptions', () => {
         it('should accumulate actual time after a scheduling interruptions', () => {
-          const callback = jest.fn();
+          act(() => {
+            const callback = jest.fn();
 
-          const Yield = ({renderTime}) => {
-            Scheduler.unstable_advanceTime(renderTime);
-            Scheduler.unstable_yieldValue('Yield:' + renderTime);
-            return null;
-          };
+            const Yield = ({renderTime}) => {
+              Scheduler.unstable_advanceTime(renderTime);
+              Scheduler.unstable_yieldValue('Yield:' + renderTime);
+              return null;
+            };
 
-          Scheduler.unstable_advanceTime(5); // 0 -> 5
+            Scheduler.unstable_advanceTime(5); // 0 -> 5
 
-          // Render partially, but run out of time before completing.
-          ReactTestRenderer.create(
-            <React.Profiler id="test" onRender={callback}>
-              <Yield renderTime={2} />
-              <Yield renderTime={3} />
-            </React.Profiler>,
-            {unstable_isConcurrent: true},
-          );
-          expect(Scheduler).toFlushAndYieldThrough(['Yield:2']);
-          expect(callback).toHaveBeenCalledTimes(0);
+            // Render partially, but run out of time before completing.
+            ReactTestRenderer.create(
+              <React.Profiler id="test" onRender={callback}>
+                <Yield renderTime={2} />
+                <Yield renderTime={3} />
+              </React.Profiler>,
+              {unstable_isConcurrent: true},
+            );
+            expect(Scheduler).toFlushAndYieldThrough(['Yield:2']);
+            expect(callback).toHaveBeenCalledTimes(0);
 
-          // Resume render for remaining children.
-          expect(Scheduler).toFlushAndYield(['Yield:3']);
+            // Resume render for remaining children.
+            expect(Scheduler).toFlushAndYield(['Yield:3']);
 
-          // Verify that logged times include both durations above.
-          expect(callback).toHaveBeenCalledTimes(1);
-          const [call] = callback.mock.calls;
-          expect(call[2]).toBe(5); // actual time
-          expect(call[3]).toBe(5); // base time
-          expect(call[4]).toBe(5); // start time
-          expect(call[5]).toBe(10); // commit time
+            // Verify that logged times include both durations above.
+            expect(callback).toHaveBeenCalledTimes(1);
+            const [call] = callback.mock.calls;
+            expect(call[2]).toBe(5); // actual time
+            expect(call[3]).toBe(5); // base time
+            expect(call[4]).toBe(5); // start time
+            expect(call[5]).toBe(10); // commit time
+          });
         });
 
         it('should not include time between frames', () => {
-          const callback = jest.fn();
+          act(() => {
+            const callback = jest.fn();
 
-          const Yield = ({renderTime}) => {
-            Scheduler.unstable_advanceTime(renderTime);
-            Scheduler.unstable_yieldValue('Yield:' + renderTime);
-            return null;
-          };
+            const Yield = ({renderTime}) => {
+              Scheduler.unstable_advanceTime(renderTime);
+              Scheduler.unstable_yieldValue('Yield:' + renderTime);
+              return null;
+            };
 
-          Scheduler.unstable_advanceTime(5); // 0 -> 5
+            Scheduler.unstable_advanceTime(5); // 0 -> 5
 
-          // Render partially, but don't finish.
-          // This partial render should take 5ms of simulated time.
-          ReactTestRenderer.create(
-            <React.Profiler id="outer" onRender={callback}>
-              <Yield renderTime={5} />
-              <Yield renderTime={10} />
-              <React.Profiler id="inner" onRender={callback}>
-                <Yield renderTime={17} />
-              </React.Profiler>
-            </React.Profiler>,
-            {unstable_isConcurrent: true},
-          );
-          expect(Scheduler).toFlushAndYieldThrough(['Yield:5']);
-          expect(callback).toHaveBeenCalledTimes(0);
+            // Render partially, but don't finish.
+            // This partial render should take 5ms of simulated time.
+            ReactTestRenderer.create(
+              <React.Profiler id="outer" onRender={callback}>
+                <Yield renderTime={5} />
+                <Yield renderTime={10} />
+                <React.Profiler id="inner" onRender={callback}>
+                  <Yield renderTime={17} />
+                </React.Profiler>
+              </React.Profiler>,
+              {unstable_isConcurrent: true},
+            );
+            expect(Scheduler).toFlushAndYieldThrough(['Yield:5']);
+            expect(callback).toHaveBeenCalledTimes(0);
 
-          // Simulate time moving forward while frame is paused.
-          Scheduler.unstable_advanceTime(50); // 10 -> 60
+            // Simulate time moving forward while frame is paused.
+            Scheduler.unstable_advanceTime(50); // 10 -> 60
 
-          // Flush the remaining work,
-          // Which should take an additional 10ms of simulated time.
-          expect(Scheduler).toFlushAndYield(['Yield:10', 'Yield:17']);
-          expect(callback).toHaveBeenCalledTimes(2);
+            // Flush the remaining work,
+            // Which should take an additional 10ms of simulated time.
+            expect(Scheduler).toFlushAndYield(['Yield:10', 'Yield:17']);
+            expect(callback).toHaveBeenCalledTimes(2);
 
-          const [innerCall, outerCall] = callback.mock.calls;
+            const [innerCall, outerCall] = callback.mock.calls;
 
-          // Verify that the actual time includes all work times,
-          // But not the time that elapsed between frames.
-          expect(innerCall[0]).toBe('inner');
-          expect(innerCall[2]).toBe(17); // actual time
-          expect(innerCall[3]).toBe(17); // base time
-          expect(innerCall[4]).toBe(70); // start time
-          expect(innerCall[5]).toBe(87); // commit time
-          expect(outerCall[0]).toBe('outer');
-          expect(outerCall[2]).toBe(32); // actual time
-          expect(outerCall[3]).toBe(32); // base time
-          expect(outerCall[4]).toBe(5); // start time
-          expect(outerCall[5]).toBe(87); // commit time
+            // Verify that the actual time includes all work times,
+            // But not the time that elapsed between frames.
+            expect(innerCall[0]).toBe('inner');
+            expect(innerCall[2]).toBe(17); // actual time
+            expect(innerCall[3]).toBe(17); // base time
+            expect(innerCall[4]).toBe(70); // start time
+            expect(innerCall[5]).toBe(87); // commit time
+            expect(outerCall[0]).toBe('outer');
+            expect(outerCall[2]).toBe(32); // actual time
+            expect(outerCall[3]).toBe(32); // base time
+            expect(outerCall[4]).toBe(5); // start time
+            expect(outerCall[5]).toBe(87); // commit time
+          });
         });
 
         it('should report the expected times when a high-pri update replaces a mount in-progress', () => {
-          const callback = jest.fn();
+          act(() => {
+            const callback = jest.fn();
 
-          const Yield = ({renderTime}) => {
-            Scheduler.unstable_advanceTime(renderTime);
-            Scheduler.unstable_yieldValue('Yield:' + renderTime);
-            return null;
-          };
+            const Yield = ({renderTime}) => {
+              Scheduler.unstable_advanceTime(renderTime);
+              Scheduler.unstable_yieldValue('Yield:' + renderTime);
+              return null;
+            };
 
-          Scheduler.unstable_advanceTime(5); // 0 -> 5
+            Scheduler.unstable_advanceTime(5); // 0 -> 5
 
-          // Render a partially update, but don't finish.
-          // This partial render should take 10ms of simulated time.
-          const renderer = ReactTestRenderer.create(
-            <React.Profiler id="test" onRender={callback}>
-              <Yield renderTime={10} />
-              <Yield renderTime={20} />
-            </React.Profiler>,
-            {unstable_isConcurrent: true},
-          );
-          expect(Scheduler).toFlushAndYieldThrough(['Yield:10']);
-          expect(callback).toHaveBeenCalledTimes(0);
-
-          // Simulate time moving forward while frame is paused.
-          Scheduler.unstable_advanceTime(100); // 15 -> 115
-
-          // Interrupt with higher priority work.
-          // The interrupted work simulates an additional 5ms of time.
-          renderer.unstable_flushSync(() => {
-            renderer.update(
+            // Render a partially update, but don't finish.
+            // This partial render should take 10ms of simulated time.
+            const renderer = ReactTestRenderer.create(
               <React.Profiler id="test" onRender={callback}>
-                <Yield renderTime={5} />
+                <Yield renderTime={10} />
+                <Yield renderTime={20} />
               </React.Profiler>,
+              {unstable_isConcurrent: true},
             );
+            expect(Scheduler).toFlushAndYieldThrough(['Yield:10']);
+            expect(callback).toHaveBeenCalledTimes(0);
+
+            // Simulate time moving forward while frame is paused.
+            Scheduler.unstable_advanceTime(100); // 15 -> 115
+
+            // Interrupt with higher priority work.
+            // The interrupted work simulates an additional 5ms of time.
+            renderer.unstable_flushSync(() => {
+              renderer.update(
+                <React.Profiler id="test" onRender={callback}>
+                  <Yield renderTime={5} />
+                </React.Profiler>,
+              );
+            });
+            expect(Scheduler).toHaveYielded(['Yield:5']);
+
+            // The initial work was thrown away in this case,
+            // So the actual and base times should only include the final rendered tree times.
+            expect(callback).toHaveBeenCalledTimes(1);
+            let call = callback.mock.calls[0];
+            expect(call[2]).toBe(5); // actual time
+            expect(call[3]).toBe(5); // base time
+            expect(call[4]).toBe(115); // start time
+            expect(call[5]).toBe(120); // commit time
+
+            callback.mockReset();
+
+            // Verify no more unexpected callbacks from low priority work
+            expect(Scheduler).toFlushWithoutYielding();
+            expect(callback).toHaveBeenCalledTimes(0);
           });
-          expect(Scheduler).toHaveYielded(['Yield:5']);
-
-          // The initial work was thrown away in this case,
-          // So the actual and base times should only include the final rendered tree times.
-          expect(callback).toHaveBeenCalledTimes(1);
-          let call = callback.mock.calls[0];
-          expect(call[2]).toBe(5); // actual time
-          expect(call[3]).toBe(5); // base time
-          expect(call[4]).toBe(115); // start time
-          expect(call[5]).toBe(120); // commit time
-
-          callback.mockReset();
-
-          // Verify no more unexpected callbacks from low priority work
-          expect(Scheduler).toFlushWithoutYielding();
-          expect(callback).toHaveBeenCalledTimes(0);
         });
 
         it('should report the expected times when a high-priority update replaces a low-priority update', () => {
-          const callback = jest.fn();
+          act(() => {
+            const callback = jest.fn();
 
-          const Yield = ({renderTime}) => {
-            Scheduler.unstable_advanceTime(renderTime);
-            Scheduler.unstable_yieldValue('Yield:' + renderTime);
-            return null;
-          };
+            const Yield = ({renderTime}) => {
+              Scheduler.unstable_advanceTime(renderTime);
+              Scheduler.unstable_yieldValue('Yield:' + renderTime);
+              return null;
+            };
 
-          Scheduler.unstable_advanceTime(5); // 0 -> 5
+            Scheduler.unstable_advanceTime(5); // 0 -> 5
 
-          const renderer = ReactTestRenderer.create(
-            <React.Profiler id="test" onRender={callback}>
-              <Yield renderTime={6} />
-              <Yield renderTime={15} />
-            </React.Profiler>,
-            {unstable_isConcurrent: true},
-          );
+            const renderer = ReactTestRenderer.create(
+              <React.Profiler id="test" onRender={callback}>
+                <Yield renderTime={6} />
+                <Yield renderTime={15} />
+              </React.Profiler>,
+              {unstable_isConcurrent: true},
+            );
 
-          // Render everything initially.
-          // This should take 21 seconds of actual and base time.
-          expect(Scheduler).toFlushAndYield(['Yield:6', 'Yield:15']);
-          expect(callback).toHaveBeenCalledTimes(1);
-          let call = callback.mock.calls[0];
-          expect(call[2]).toBe(21); // actual time
-          expect(call[3]).toBe(21); // base time
-          expect(call[4]).toBe(5); // start time
-          expect(call[5]).toBe(26); // commit time
+            // Render everything initially.
+            // This should take 21 seconds of actual and base time.
+            expect(Scheduler).toFlushAndYield(['Yield:6', 'Yield:15']);
+            expect(callback).toHaveBeenCalledTimes(1);
+            let call = callback.mock.calls[0];
+            expect(call[2]).toBe(21); // actual time
+            expect(call[3]).toBe(21); // base time
+            expect(call[4]).toBe(5); // start time
+            expect(call[5]).toBe(26); // commit time
 
-          callback.mockReset();
+            callback.mockReset();
 
-          Scheduler.unstable_advanceTime(30); // 26 -> 56
+            Scheduler.unstable_advanceTime(30); // 26 -> 56
 
-          // Render a partially update, but don't finish.
-          // This partial render should take 3ms of simulated time.
-          renderer.update(
-            <React.Profiler id="test" onRender={callback}>
-              <Yield renderTime={3} />
-              <Yield renderTime={5} />
-              <Yield renderTime={9} />
-            </React.Profiler>,
-          );
-          expect(Scheduler).toFlushAndYieldThrough(['Yield:3']);
-          expect(callback).toHaveBeenCalledTimes(0);
-
-          // Simulate time moving forward while frame is paused.
-          Scheduler.unstable_advanceTime(100); // 59 -> 159
-
-          // Render another 5ms of simulated time.
-          expect(Scheduler).toFlushAndYieldThrough(['Yield:5']);
-          expect(callback).toHaveBeenCalledTimes(0);
-
-          // Simulate time moving forward while frame is paused.
-          Scheduler.unstable_advanceTime(100); // 164 -> 264
-
-          // Interrupt with higher priority work.
-          // The interrupted work simulates an additional 11ms of time.
-          renderer.unstable_flushSync(() => {
+            // Render a partially update, but don't finish.
+            // This partial render should take 3ms of simulated time.
             renderer.update(
               <React.Profiler id="test" onRender={callback}>
-                <Yield renderTime={11} />
+                <Yield renderTime={3} />
+                <Yield renderTime={5} />
+                <Yield renderTime={9} />
               </React.Profiler>,
             );
+            expect(Scheduler).toFlushAndYieldThrough(['Yield:3']);
+            expect(callback).toHaveBeenCalledTimes(0);
+
+            // Simulate time moving forward while frame is paused.
+            Scheduler.unstable_advanceTime(100); // 59 -> 159
+
+            // Render another 5ms of simulated time.
+            expect(Scheduler).toFlushAndYieldThrough(['Yield:5']);
+            expect(callback).toHaveBeenCalledTimes(0);
+
+            // Simulate time moving forward while frame is paused.
+            Scheduler.unstable_advanceTime(100); // 164 -> 264
+
+            // Interrupt with higher priority work.
+            // The interrupted work simulates an additional 11ms of time.
+            renderer.unstable_flushSync(() => {
+              renderer.update(
+                <React.Profiler id="test" onRender={callback}>
+                  <Yield renderTime={11} />
+                </React.Profiler>,
+              );
+            });
+            expect(Scheduler).toHaveYielded(['Yield:11']);
+
+            // The actual time should include only the most recent render,
+            // Because this lets us avoid a lot of commit phase reset complexity.
+            // The base time includes only the final rendered tree times.
+            expect(callback).toHaveBeenCalledTimes(1);
+            call = callback.mock.calls[0];
+            expect(call[2]).toBe(11); // actual time
+            expect(call[3]).toBe(11); // base time
+            expect(call[4]).toBe(264); // start time
+            expect(call[5]).toBe(275); // commit time
+
+            // Verify no more unexpected callbacks from low priority work
+            expect(Scheduler).toFlushAndYield([]);
+            expect(callback).toHaveBeenCalledTimes(1);
           });
-          expect(Scheduler).toHaveYielded(['Yield:11']);
-
-          // The actual time should include only the most recent render,
-          // Because this lets us avoid a lot of commit phase reset complexity.
-          // The base time includes only the final rendered tree times.
-          expect(callback).toHaveBeenCalledTimes(1);
-          call = callback.mock.calls[0];
-          expect(call[2]).toBe(11); // actual time
-          expect(call[3]).toBe(11); // base time
-          expect(call[4]).toBe(264); // start time
-          expect(call[5]).toBe(275); // commit time
-
-          // Verify no more unexpected callbacks from low priority work
-          expect(Scheduler).toFlushAndYield([]);
-          expect(callback).toHaveBeenCalledTimes(1);
         });
 
         it('should report the expected times when a high-priority update interrupts a low-priority update', () => {
-          const callback = jest.fn();
+          act(() => {
+            const callback = jest.fn();
 
-          const Yield = ({renderTime}) => {
-            Scheduler.unstable_advanceTime(renderTime);
-            Scheduler.unstable_yieldValue('Yield:' + renderTime);
-            return null;
-          };
+            const Yield = ({renderTime}) => {
+              Scheduler.unstable_advanceTime(renderTime);
+              Scheduler.unstable_yieldValue('Yield:' + renderTime);
+              return null;
+            };
 
-          let first;
-          class FirstComponent extends React.Component {
-            state = {renderTime: 1};
-            render() {
-              first = this;
-              Scheduler.unstable_advanceTime(this.state.renderTime);
-              Scheduler.unstable_yieldValue(
-                'FirstComponent:' + this.state.renderTime,
-              );
-              return <Yield renderTime={4} />;
+            let first;
+            class FirstComponent extends React.Component {
+              state = {renderTime: 1};
+              render() {
+                first = this;
+                Scheduler.unstable_advanceTime(this.state.renderTime);
+                Scheduler.unstable_yieldValue(
+                  'FirstComponent:' + this.state.renderTime,
+                );
+                return <Yield renderTime={4} />;
+              }
             }
-          }
-          let second;
-          class SecondComponent extends React.Component {
-            state = {renderTime: 2};
-            render() {
-              second = this;
-              Scheduler.unstable_advanceTime(this.state.renderTime);
-              Scheduler.unstable_yieldValue(
-                'SecondComponent:' + this.state.renderTime,
-              );
-              return <Yield renderTime={7} />;
+            let second;
+            class SecondComponent extends React.Component {
+              state = {renderTime: 2};
+              render() {
+                second = this;
+                Scheduler.unstable_advanceTime(this.state.renderTime);
+                Scheduler.unstable_yieldValue(
+                  'SecondComponent:' + this.state.renderTime,
+                );
+                return <Yield renderTime={7} />;
+              }
             }
-          }
 
-          Scheduler.unstable_advanceTime(5); // 0 -> 5
+            Scheduler.unstable_advanceTime(5); // 0 -> 5
 
-          const renderer = ReactTestRenderer.create(
-            <React.Profiler id="test" onRender={callback}>
-              <FirstComponent />
-              <SecondComponent />
-            </React.Profiler>,
-            {unstable_isConcurrent: true},
-          );
+            const renderer = ReactTestRenderer.create(
+              <React.Profiler id="test" onRender={callback}>
+                <FirstComponent />
+                <SecondComponent />
+              </React.Profiler>,
+              {unstable_isConcurrent: true},
+            );
 
-          // Render everything initially.
-          // This simulates a total of 14ms of actual render time.
-          // The base render time is also 14ms for the initial render.
-          expect(Scheduler).toFlushAndYield([
-            'FirstComponent:1',
-            'Yield:4',
-            'SecondComponent:2',
-            'Yield:7',
-          ]);
-          expect(callback).toHaveBeenCalledTimes(1);
-          let call = callback.mock.calls[0];
-          expect(call[2]).toBe(14); // actual time
-          expect(call[3]).toBe(14); // base time
-          expect(call[4]).toBe(5); // start time
-          expect(call[5]).toBe(19); // commit time
+            // Render everything initially.
+            // This simulates a total of 14ms of actual render time.
+            // The base render time is also 14ms for the initial render.
+            expect(Scheduler).toFlushAndYield([
+              'FirstComponent:1',
+              'Yield:4',
+              'SecondComponent:2',
+              'Yield:7',
+            ]);
+            expect(callback).toHaveBeenCalledTimes(1);
+            let call = callback.mock.calls[0];
+            expect(call[2]).toBe(14); // actual time
+            expect(call[3]).toBe(14); // base time
+            expect(call[4]).toBe(5); // start time
+            expect(call[5]).toBe(19); // commit time
 
-          callback.mockClear();
+            callback.mockClear();
 
-          Scheduler.unstable_advanceTime(100); // 19 -> 119
+            Scheduler.unstable_advanceTime(100); // 19 -> 119
 
-          // Render a partially update, but don't finish.
-          // This partial render will take 10ms of actual render time.
-          first.setState({renderTime: 10});
-          expect(Scheduler).toFlushAndYieldThrough(['FirstComponent:10']);
-          expect(callback).toHaveBeenCalledTimes(0);
+            // Render a partially update, but don't finish.
+            // This partial render will take 10ms of actual render time.
+            first.setState({renderTime: 10});
+            expect(Scheduler).toFlushAndYieldThrough(['FirstComponent:10']);
+            expect(callback).toHaveBeenCalledTimes(0);
 
-          // Simulate time moving forward while frame is paused.
-          Scheduler.unstable_advanceTime(100); // 129 -> 229
+            // Simulate time moving forward while frame is paused.
+            Scheduler.unstable_advanceTime(100); // 129 -> 229
 
-          // Interrupt with higher priority work.
-          // This simulates a total of 37ms of actual render time.
-          renderer.unstable_flushSync(() => second.setState({renderTime: 30}));
-          expect(Scheduler).toHaveYielded(['SecondComponent:30', 'Yield:7']);
+            // Interrupt with higher priority work.
+            // This simulates a total of 37ms of actual render time.
+            renderer.unstable_flushSync(() =>
+              second.setState({renderTime: 30}),
+            );
+            expect(Scheduler).toHaveYielded(['SecondComponent:30', 'Yield:7']);
 
-          // The actual time should include only the most recent render (37ms),
-          // Because this greatly simplifies the commit phase logic.
-          // The base time should include the more recent times for the SecondComponent subtree,
-          // As well as the original times for the FirstComponent subtree.
-          expect(callback).toHaveBeenCalledTimes(1);
-          call = callback.mock.calls[0];
-          expect(call[2]).toBe(37); // actual time
-          expect(call[3]).toBe(42); // base time
-          expect(call[4]).toBe(229); // start time
-          expect(call[5]).toBe(266); // commit time
+            // The actual time should include only the most recent render (37ms),
+            // Because this greatly simplifies the commit phase logic.
+            // The base time should include the more recent times for the SecondComponent subtree,
+            // As well as the original times for the FirstComponent subtree.
+            expect(callback).toHaveBeenCalledTimes(1);
+            call = callback.mock.calls[0];
+            expect(call[2]).toBe(37); // actual time
+            expect(call[3]).toBe(42); // base time
+            expect(call[4]).toBe(229); // start time
+            expect(call[5]).toBe(266); // commit time
 
-          callback.mockClear();
+            callback.mockClear();
 
-          // Simulate time moving forward while frame is paused.
-          Scheduler.unstable_advanceTime(100); // 266 -> 366
+            // Simulate time moving forward while frame is paused.
+            Scheduler.unstable_advanceTime(100); // 266 -> 366
 
-          // Resume the original low priority update, with rebased state.
-          // This simulates a total of 14ms of actual render time,
-          // And does not include the original (interrupted) 10ms.
-          // The tree contains 42ms of base render time at this point,
-          // Reflecting the most recent (longer) render durations.
-          // TODO: This actual time should decrease by 10ms once the scheduler supports resuming.
-          expect(Scheduler).toFlushAndYield(['FirstComponent:10', 'Yield:4']);
-          expect(callback).toHaveBeenCalledTimes(1);
-          call = callback.mock.calls[0];
-          expect(call[2]).toBe(14); // actual time
-          expect(call[3]).toBe(51); // base time
-          expect(call[4]).toBe(366); // start time
-          expect(call[5]).toBe(380); // commit time
+            // Resume the original low priority update, with rebased state.
+            // This simulates a total of 14ms of actual render time,
+            // And does not include the original (interrupted) 10ms.
+            // The tree contains 42ms of base render time at this point,
+            // Reflecting the most recent (longer) render durations.
+            // TODO: This actual time should decrease by 10ms once the scheduler supports resuming.
+            expect(Scheduler).toFlushAndYield(['FirstComponent:10', 'Yield:4']);
+            expect(callback).toHaveBeenCalledTimes(1);
+            call = callback.mock.calls[0];
+            expect(call[2]).toBe(14); // actual time
+            expect(call[3]).toBe(51); // base time
+            expect(call[4]).toBe(366); // start time
+            expect(call[5]).toBe(380); // commit time
+          });
         });
 
         [true, false].forEach(
@@ -1338,152 +1355,168 @@ describe('Profiler', () => {
 
     describe('error handling', () => {
       it('should cover errors thrown in onWorkScheduled', () => {
-        function Component({children}) {
-          Scheduler.unstable_yieldValue('Component:' + children);
-          return children;
-        }
+        act(() => {
+          function Component({children}) {
+            Scheduler.unstable_yieldValue('Component:' + children);
+            return children;
+          }
 
-        let renderer;
+          let renderer;
 
-        // Errors that happen inside of a subscriber should throw,
-        throwInOnWorkScheduled = true;
-        expect(() => {
+          // Errors that happen inside of a subscriber should throw,
+          throwInOnWorkScheduled = true;
+          expect(() => {
+            SchedulerTracing.unstable_trace(
+              'event',
+              Scheduler.unstable_now(),
+              () => {
+                renderer = ReactTestRenderer.create(
+                  <Component>fail</Component>,
+                  {
+                    unstable_isConcurrent: true,
+                  },
+                );
+              },
+            );
+          }).toThrow('Expected error onWorkScheduled');
+          expect(Scheduler).toFlushAndYield(['Component:fail']);
+          throwInOnWorkScheduled = false;
+          expect(onWorkScheduled).toHaveBeenCalled();
+
+          // But should not leave React in a broken state for subsequent renders.
+          renderer = ReactTestRenderer.create(<Component>succeed</Component>, {
+            unstable_isConcurrent: true,
+          });
+          expect(Scheduler).toFlushAndYield(['Component:succeed']);
+          const tree = renderer.toTree();
+          expect(tree.type).toBe(Component);
+          expect(tree.props.children).toBe('succeed');
+        });
+      });
+
+      it('should cover errors thrown in onWorkStarted', () => {
+        act(() => {
+          function Component({children}) {
+            Scheduler.unstable_yieldValue('Component:' + children);
+            return children;
+          }
+
+          let renderer;
           SchedulerTracing.unstable_trace(
             'event',
             Scheduler.unstable_now(),
             () => {
-              renderer = ReactTestRenderer.create(<Component>fail</Component>, {
+              renderer = ReactTestRenderer.create(<Component>text</Component>, {
                 unstable_isConcurrent: true,
               });
             },
           );
-        }).toThrow('Expected error onWorkScheduled');
-        expect(Scheduler).toFlushAndYield(['Component:fail']);
-        throwInOnWorkScheduled = false;
-        expect(onWorkScheduled).toHaveBeenCalled();
+          onWorkStarted.mockClear();
 
-        // But should not leave React in a broken state for subsequent renders.
-        renderer = ReactTestRenderer.create(<Component>succeed</Component>, {
-          unstable_isConcurrent: true,
+          // Errors that happen inside of a subscriber should throw,
+          throwInOnWorkStarted = true;
+          expect(Scheduler).toFlushAndThrow('Expected error onWorkStarted');
+          // Rendering was interrupted by the error that was thrown
+          expect(Scheduler).toHaveYielded([]);
+          // Rendering continues in the next task
+          expect(Scheduler).toFlushAndYield(['Component:text']);
+          throwInOnWorkStarted = false;
+          expect(onWorkStarted).toHaveBeenCalled();
+
+          // But the React work should have still been processed.
+          expect(Scheduler).toFlushAndYield([]);
+          const tree = renderer.toTree();
+          expect(tree.type).toBe(Component);
+          expect(tree.props.children).toBe('text');
         });
-        expect(Scheduler).toFlushAndYield(['Component:succeed']);
-        const tree = renderer.toTree();
-        expect(tree.type).toBe(Component);
-        expect(tree.props.children).toBe('succeed');
-      });
-
-      it('should cover errors thrown in onWorkStarted', () => {
-        function Component({children}) {
-          Scheduler.unstable_yieldValue('Component:' + children);
-          return children;
-        }
-
-        let renderer;
-        SchedulerTracing.unstable_trace(
-          'event',
-          Scheduler.unstable_now(),
-          () => {
-            renderer = ReactTestRenderer.create(<Component>text</Component>, {
-              unstable_isConcurrent: true,
-            });
-          },
-        );
-        onWorkStarted.mockClear();
-
-        // Errors that happen inside of a subscriber should throw,
-        throwInOnWorkStarted = true;
-        expect(Scheduler).toFlushAndThrow('Expected error onWorkStarted');
-        // Rendering was interrupted by the error that was thrown
-        expect(Scheduler).toHaveYielded([]);
-        // Rendering continues in the next task
-        expect(Scheduler).toFlushAndYield(['Component:text']);
-        throwInOnWorkStarted = false;
-        expect(onWorkStarted).toHaveBeenCalled();
-
-        // But the React work should have still been processed.
-        expect(Scheduler).toFlushAndYield([]);
-        const tree = renderer.toTree();
-        expect(tree.type).toBe(Component);
-        expect(tree.props.children).toBe('text');
       });
 
       it('should cover errors thrown in onWorkStopped', () => {
-        function Component({children}) {
-          Scheduler.unstable_yieldValue('Component:' + children);
-          return children;
-        }
+        act(() => {
+          function Component({children}) {
+            Scheduler.unstable_yieldValue('Component:' + children);
+            return children;
+          }
 
-        let renderer;
-        SchedulerTracing.unstable_trace(
-          'event',
-          Scheduler.unstable_now(),
-          () => {
-            renderer = ReactTestRenderer.create(<Component>text</Component>, {
-              unstable_isConcurrent: true,
-            });
-          },
-        );
-        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+          let renderer;
+          SchedulerTracing.unstable_trace(
+            'event',
+            Scheduler.unstable_now(),
+            () => {
+              renderer = ReactTestRenderer.create(<Component>text</Component>, {
+                unstable_isConcurrent: true,
+              });
+            },
+          );
+          expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
 
-        // Errors that happen in an on-stopped callback,
-        throwInOnWorkStopped = true;
-        expect(() => {
-          expect(Scheduler).toFlushAndYield(['Component:text']);
-        }).toThrow('Expected error onWorkStopped');
-        throwInOnWorkStopped = false;
-        expect(onWorkStopped).toHaveBeenCalledTimes(2);
+          // Errors that happen in an on-stopped callback,
+          throwInOnWorkStopped = true;
+          expect(() => {
+            expect(Scheduler).toFlushAndYield(['Component:text']);
+          }).toThrow('Expected error onWorkStopped');
+          throwInOnWorkStopped = false;
+          expect(onWorkStopped).toHaveBeenCalledTimes(2);
 
-        // Should still commit the update,
-        const tree = renderer.toTree();
-        expect(tree.type).toBe(Component);
-        expect(tree.props.children).toBe('text');
+          // Should still commit the update,
+          const tree = renderer.toTree();
+          expect(tree.type).toBe(Component);
+          expect(tree.props.children).toBe('text');
 
-        // And still call onInteractionScheduledWorkCompleted if the interaction is finished.
-        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+          // And still call onInteractionScheduledWorkCompleted if the interaction is finished.
+          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+        });
       });
 
       it('should cover errors thrown in onInteractionScheduledWorkCompleted', () => {
-        function Component({children}) {
-          Scheduler.unstable_yieldValue('Component:' + children);
-          return children;
-        }
+        expect(() => {
+          act(() => {
+            function Component({children}) {
+              Scheduler.unstable_yieldValue('Component:' + children);
+              return children;
+            }
 
-        const eventOne = {
-          id: 0,
-          name: 'event one',
-          timestamp: Scheduler.unstable_now(),
-        };
-        const eventTwo = {
-          id: 1,
-          name: 'event two',
-          timestamp: Scheduler.unstable_now(),
-        };
+            const eventOne = {
+              id: 0,
+              name: 'event one',
+              timestamp: Scheduler.unstable_now(),
+            };
+            const eventTwo = {
+              id: 1,
+              name: 'event two',
+              timestamp: Scheduler.unstable_now(),
+            };
 
-        SchedulerTracing.unstable_trace(
-          eventOne.name,
-          Scheduler.unstable_now(),
-          () => {
             SchedulerTracing.unstable_trace(
-              eventTwo.name,
+              eventOne.name,
               Scheduler.unstable_now(),
               () => {
-                ReactTestRenderer.create(<Component>text</Component>, {
-                  unstable_isConcurrent: true,
-                });
+                SchedulerTracing.unstable_trace(
+                  eventTwo.name,
+                  Scheduler.unstable_now(),
+                  () => {
+                    ReactTestRenderer.create(<Component>text</Component>, {
+                      unstable_isConcurrent: true,
+                    });
+                  },
+                );
               },
             );
-          },
-        );
-        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+            expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
 
-        throwInOnInteractionScheduledWorkCompleted = true;
-        expect(() => {
-          expect(Scheduler).toFlushAndYield(['Component:text']);
-        }).toThrow('Expected error onInteractionScheduledWorkCompleted');
+            throwInOnInteractionScheduledWorkCompleted = true;
+            expect(() => {
+              expect(Scheduler).toFlushAndYield(['Component:text']);
+            }).toThrow('Expected error onInteractionScheduledWorkCompleted');
 
-        // Even though an error is thrown for one completed interaction,
-        // The completed callback should be called for all completed interactions.
-        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
+            // Even though an error is thrown for one completed interaction,
+            // The completed callback should be called for all completed interactions.
+            expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(
+              2,
+            );
+            throw new Error('Finished test');
+          });
+        }).toThrow('Finished test');
       });
     });
 
@@ -1516,741 +1549,760 @@ describe('Profiler', () => {
     });
 
     it('should associate traced events with their subsequent commits', () => {
-      let instance = null;
+      act(() => {
+        let instance = null;
 
-      const Yield = ({duration = 10, value}) => {
-        Scheduler.unstable_advanceTime(duration);
-        Scheduler.unstable_yieldValue(value);
-        return null;
-      };
-
-      class Example extends React.Component {
-        state = {
-          count: 0,
+        const Yield = ({duration = 10, value}) => {
+          Scheduler.unstable_advanceTime(duration);
+          Scheduler.unstable_yieldValue(value);
+          return null;
         };
-        render() {
-          instance = this;
-          return (
-            <React.Fragment>
-              <Yield value="first" />
-              {this.state.count}
-              <Yield value="last" />
-            </React.Fragment>
-          );
-        }
-      }
 
-      Scheduler.unstable_advanceTime(1);
-
-      const interactionCreation = {
-        id: 0,
-        name: 'creation event',
-        timestamp: Scheduler.unstable_now(),
-      };
-
-      const onRender = jest.fn();
-      let renderer;
-      SchedulerTracing.unstable_trace(
-        interactionCreation.name,
-        Scheduler.unstable_now(),
-        () => {
-          renderer = ReactTestRenderer.create(
-            <React.Profiler id="test-profiler" onRender={onRender}>
-              <Example />
-            </React.Profiler>,
-            {
-              unstable_isConcurrent: true,
-            },
-          );
-        },
-      );
-
-      expect(onInteractionTraced).toHaveBeenCalledTimes(1);
-      expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
-        interactionCreation,
-      );
-      expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
-
-      // The scheduler/tracing package will notify of work started for the default thread,
-      // But React shouldn't notify until it's been flushed.
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
-
-      // Work may have been scheduled multiple times.
-      // We only care that the subscriber was notified at least once.
-      // As for the thread ID- the actual value isn't important, only that there was one.
-      expect(onWorkScheduled).toHaveBeenCalled();
-      expect(onWorkScheduled.mock.calls[0][0]).toMatchInteractions([
-        interactionCreation,
-      ]);
-      expect(onWorkScheduled.mock.calls[0][1] > 0).toBe(true);
-
-      // Mount
-      expect(Scheduler).toFlushAndYield(['first', 'last']);
-      expect(onRender).toHaveBeenCalledTimes(1);
-      let call = onRender.mock.calls[0];
-      expect(call[0]).toEqual('test-profiler');
-      expect(call[5]).toEqual(Scheduler.unstable_now());
-      if (ReactFeatureFlags.enableSchedulerTracing) {
-        expect(call[6]).toMatchInteractions([interactionCreation]);
-      }
-
-      expect(onInteractionTraced).toHaveBeenCalledTimes(1);
-      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-      expect(
-        onInteractionScheduledWorkCompleted,
-      ).toHaveBeenLastNotifiedOfInteraction(interactionCreation);
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
-      expect(getWorkForReactThreads(onWorkStarted)[0][0]).toMatchInteractions([
-        interactionCreation,
-      ]);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(1);
-      expect(getWorkForReactThreads(onWorkStopped)[0][0]).toMatchInteractions([
-        interactionCreation,
-      ]);
-
-      onRender.mockClear();
-      onWorkScheduled.mockClear();
-      onWorkStarted.mockClear();
-      onWorkStopped.mockClear();
-
-      Scheduler.unstable_advanceTime(3);
-
-      let didRunCallback = false;
-
-      const interactionOne = {
-        id: 1,
-        name: 'initial event',
-        timestamp: Scheduler.unstable_now(),
-      };
-      SchedulerTracing.unstable_trace(
-        interactionOne.name,
-        Scheduler.unstable_now(),
-        () => {
-          instance.setState({count: 1});
-
-          // Update state again to verify our traced interaction isn't registered twice
-          instance.setState({count: 2});
-
-          // The scheduler/tracing package will notify of work started for the default thread,
-          // But React shouldn't notify until it's been flushed.
-          expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
-          expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
-
-          // Work may have been scheduled multiple times.
-          // We only care that the subscriber was notified at least once.
-          // As for the thread ID- the actual value isn't important, only that there was one.
-          expect(onWorkScheduled).toHaveBeenCalled();
-          expect(onWorkScheduled.mock.calls[0][0]).toMatchInteractions([
-            interactionOne,
-          ]);
-          expect(onWorkScheduled.mock.calls[0][1] > 0).toBe(true);
-
-          expect(Scheduler).toFlushAndYieldThrough(['first']);
-          expect(onRender).not.toHaveBeenCalled();
-
-          expect(onInteractionTraced).toHaveBeenCalledTimes(2);
-          expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
-            interactionOne,
-          );
-          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-          expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
-          expect(
-            getWorkForReactThreads(onWorkStarted)[0][0],
-          ).toMatchInteractions([interactionOne]);
-          expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
-
-          expect(Scheduler).toFlushAndYield(['last']);
-          expect(onRender).toHaveBeenCalledTimes(1);
-
-          call = onRender.mock.calls[0];
-          expect(call[0]).toEqual('test-profiler');
-          expect(call[5]).toEqual(Scheduler.unstable_now());
-          if (ReactFeatureFlags.enableSchedulerTracing) {
-            expect(call[6]).toMatchInteractions([interactionOne]);
+        class Example extends React.Component {
+          state = {
+            count: 0,
+          };
+          render() {
+            instance = this;
+            return (
+              <React.Fragment>
+                <Yield value="first" />
+                {this.state.count}
+                <Yield value="last" />
+              </React.Fragment>
+            );
           }
+        }
 
-          didRunCallback = true;
+        Scheduler.unstable_advanceTime(1);
 
-          expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
-          expect(
-            getWorkForReactThreads(onWorkStarted)[0][0],
-          ).toMatchInteractions([interactionOne]);
-          expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(1);
-          expect(
-            getWorkForReactThreads(onWorkStopped)[0][0],
-          ).toMatchInteractions([interactionOne]);
-        },
-      );
+        const interactionCreation = {
+          id: 0,
+          name: 'creation event',
+          timestamp: Scheduler.unstable_now(),
+        };
 
-      expect(didRunCallback).toBe(true);
+        const onRender = jest.fn();
+        let renderer;
+        SchedulerTracing.unstable_trace(
+          interactionCreation.name,
+          Scheduler.unstable_now(),
+          () => {
+            renderer = ReactTestRenderer.create(
+              <React.Profiler id="test-profiler" onRender={onRender}>
+                <Example />
+              </React.Profiler>,
+              {
+                unstable_isConcurrent: true,
+              },
+            );
+          },
+        );
 
-      onRender.mockClear();
-      onWorkScheduled.mockClear();
-      onWorkStarted.mockClear();
-      onWorkStopped.mockClear();
+        expect(onInteractionTraced).toHaveBeenCalledTimes(1);
+        expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
+          interactionCreation,
+        );
+        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
 
-      Scheduler.unstable_advanceTime(17);
+        // The scheduler/tracing package will notify of work started for the default thread,
+        // But React shouldn't notify until it's been flushed.
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
 
-      // Verify that updating state again does not re-log our interaction.
-      instance.setState({count: 3});
-      expect(Scheduler).toFlushAndYield(['first', 'last']);
+        // Work may have been scheduled multiple times.
+        // We only care that the subscriber was notified at least once.
+        // As for the thread ID- the actual value isn't important, only that there was one.
+        expect(onWorkScheduled).toHaveBeenCalled();
+        expect(onWorkScheduled.mock.calls[0][0]).toMatchInteractions([
+          interactionCreation,
+        ]);
+        expect(onWorkScheduled.mock.calls[0][1] > 0).toBe(true);
 
-      expect(onRender).toHaveBeenCalledTimes(1);
-      call = onRender.mock.calls[0];
-      expect(call[0]).toEqual('test-profiler');
-      expect(call[5]).toEqual(Scheduler.unstable_now());
-      if (ReactFeatureFlags.enableSchedulerTracing) {
-        expect(call[6]).toMatchInteractions([]);
-      }
+        // Mount
+        expect(Scheduler).toFlushAndYield(['first', 'last']);
+        expect(onRender).toHaveBeenCalledTimes(1);
+        let call = onRender.mock.calls[0];
+        expect(call[0]).toEqual('test-profiler');
+        expect(call[5]).toEqual(Scheduler.unstable_now());
+        if (ReactFeatureFlags.enableSchedulerTracing) {
+          expect(call[6]).toMatchInteractions([interactionCreation]);
+        }
 
-      expect(onInteractionTraced).toHaveBeenCalledTimes(2);
-      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
-      expect(
-        onInteractionScheduledWorkCompleted,
-      ).toHaveBeenLastNotifiedOfInteraction(interactionOne);
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
+        expect(onInteractionTraced).toHaveBeenCalledTimes(1);
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+        expect(
+          onInteractionScheduledWorkCompleted,
+        ).toHaveBeenLastNotifiedOfInteraction(interactionCreation);
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
+        expect(getWorkForReactThreads(onWorkStarted)[0][0]).toMatchInteractions(
+          [interactionCreation],
+        );
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(1);
+        expect(getWorkForReactThreads(onWorkStopped)[0][0]).toMatchInteractions(
+          [interactionCreation],
+        );
 
-      onRender.mockClear();
+        onRender.mockClear();
+        onWorkScheduled.mockClear();
+        onWorkStarted.mockClear();
+        onWorkStopped.mockClear();
 
-      Scheduler.unstable_advanceTime(3);
+        Scheduler.unstable_advanceTime(3);
 
-      // Verify that root updates are also associated with traced events.
-      const interactionTwo = {
-        id: 2,
-        name: 'root update event',
-        timestamp: Scheduler.unstable_now(),
-      };
-      SchedulerTracing.unstable_trace(
-        interactionTwo.name,
-        Scheduler.unstable_now(),
-        () => {
-          renderer.update(
-            <React.Profiler id="test-profiler" onRender={onRender}>
-              <Example />
-            </React.Profiler>,
-          );
-        },
-      );
+        let didRunCallback = false;
 
-      expect(onInteractionTraced).toHaveBeenCalledTimes(3);
-      expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
-        interactionTwo,
-      );
-      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
+        const interactionOne = {
+          id: 1,
+          name: 'initial event',
+          timestamp: Scheduler.unstable_now(),
+        };
+        SchedulerTracing.unstable_trace(
+          interactionOne.name,
+          Scheduler.unstable_now(),
+          () => {
+            instance.setState({count: 1});
 
-      // The scheduler/tracing package will notify of work started for the default thread,
-      // But React shouldn't notify until it's been flushed.
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
+            // Update state again to verify our traced interaction isn't registered twice
+            instance.setState({count: 2});
 
-      // Work may have been scheduled multiple times.
-      // We only care that the subscriber was notified at least once.
-      // As for the thread ID- the actual value isn't important, only that there was one.
-      expect(onWorkScheduled).toHaveBeenCalled();
-      expect(onWorkScheduled.mock.calls[0][0]).toMatchInteractions([
-        interactionTwo,
-      ]);
-      expect(onWorkScheduled.mock.calls[0][1] > 0).toBe(true);
+            // The scheduler/tracing package will notify of work started for the default thread,
+            // But React shouldn't notify until it's been flushed.
+            expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
+            expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
 
-      expect(Scheduler).toFlushAndYield(['first', 'last']);
+            // Work may have been scheduled multiple times.
+            // We only care that the subscriber was notified at least once.
+            // As for the thread ID- the actual value isn't important, only that there was one.
+            expect(onWorkScheduled).toHaveBeenCalled();
+            expect(onWorkScheduled.mock.calls[0][0]).toMatchInteractions([
+              interactionOne,
+            ]);
+            expect(onWorkScheduled.mock.calls[0][1] > 0).toBe(true);
 
-      expect(onRender).toHaveBeenCalledTimes(1);
-      call = onRender.mock.calls[0];
-      expect(call[0]).toEqual('test-profiler');
-      expect(call[5]).toEqual(Scheduler.unstable_now());
-      if (ReactFeatureFlags.enableSchedulerTracing) {
-        expect(call[6]).toMatchInteractions([interactionTwo]);
-      }
+            expect(Scheduler).toFlushAndYieldThrough(['first']);
+            expect(onRender).not.toHaveBeenCalled();
 
-      expect(onInteractionTraced).toHaveBeenCalledTimes(3);
-      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(3);
-      expect(
-        onInteractionScheduledWorkCompleted,
-      ).toHaveBeenLastNotifiedOfInteraction(interactionTwo);
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
-      expect(getWorkForReactThreads(onWorkStarted)[0][0]).toMatchInteractions([
-        interactionTwo,
-      ]);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(1);
-      expect(getWorkForReactThreads(onWorkStopped)[0][0]).toMatchInteractions([
-        interactionTwo,
-      ]);
+            expect(onInteractionTraced).toHaveBeenCalledTimes(2);
+            expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
+              interactionOne,
+            );
+            expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(
+              1,
+            );
+            expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
+            expect(
+              getWorkForReactThreads(onWorkStarted)[0][0],
+            ).toMatchInteractions([interactionOne]);
+            expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
+
+            expect(Scheduler).toFlushAndYield(['last']);
+            expect(onRender).toHaveBeenCalledTimes(1);
+
+            call = onRender.mock.calls[0];
+            expect(call[0]).toEqual('test-profiler');
+            expect(call[5]).toEqual(Scheduler.unstable_now());
+            if (ReactFeatureFlags.enableSchedulerTracing) {
+              expect(call[6]).toMatchInteractions([interactionOne]);
+            }
+
+            didRunCallback = true;
+
+            expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
+            expect(
+              getWorkForReactThreads(onWorkStarted)[0][0],
+            ).toMatchInteractions([interactionOne]);
+            expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(1);
+            expect(
+              getWorkForReactThreads(onWorkStopped)[0][0],
+            ).toMatchInteractions([interactionOne]);
+          },
+        );
+
+        expect(didRunCallback).toBe(true);
+
+        onRender.mockClear();
+        onWorkScheduled.mockClear();
+        onWorkStarted.mockClear();
+        onWorkStopped.mockClear();
+
+        Scheduler.unstable_advanceTime(17);
+
+        // Verify that updating state again does not re-log our interaction.
+        instance.setState({count: 3});
+        expect(Scheduler).toFlushAndYield(['first', 'last']);
+
+        expect(onRender).toHaveBeenCalledTimes(1);
+        call = onRender.mock.calls[0];
+        expect(call[0]).toEqual('test-profiler');
+        expect(call[5]).toEqual(Scheduler.unstable_now());
+        if (ReactFeatureFlags.enableSchedulerTracing) {
+          expect(call[6]).toMatchInteractions([]);
+        }
+
+        expect(onInteractionTraced).toHaveBeenCalledTimes(2);
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
+        expect(
+          onInteractionScheduledWorkCompleted,
+        ).toHaveBeenLastNotifiedOfInteraction(interactionOne);
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
+
+        onRender.mockClear();
+
+        Scheduler.unstable_advanceTime(3);
+
+        // Verify that root updates are also associated with traced events.
+        const interactionTwo = {
+          id: 2,
+          name: 'root update event',
+          timestamp: Scheduler.unstable_now(),
+        };
+        SchedulerTracing.unstable_trace(
+          interactionTwo.name,
+          Scheduler.unstable_now(),
+          () => {
+            renderer.update(
+              <React.Profiler id="test-profiler" onRender={onRender}>
+                <Example />
+              </React.Profiler>,
+            );
+          },
+        );
+
+        expect(onInteractionTraced).toHaveBeenCalledTimes(3);
+        expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
+          interactionTwo,
+        );
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
+
+        // The scheduler/tracing package will notify of work started for the default thread,
+        // But React shouldn't notify until it's been flushed.
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
+
+        // Work may have been scheduled multiple times.
+        // We only care that the subscriber was notified at least once.
+        // As for the thread ID- the actual value isn't important, only that there was one.
+        expect(onWorkScheduled).toHaveBeenCalled();
+        expect(onWorkScheduled.mock.calls[0][0]).toMatchInteractions([
+          interactionTwo,
+        ]);
+        expect(onWorkScheduled.mock.calls[0][1] > 0).toBe(true);
+
+        expect(Scheduler).toFlushAndYield(['first', 'last']);
+
+        expect(onRender).toHaveBeenCalledTimes(1);
+        call = onRender.mock.calls[0];
+        expect(call[0]).toEqual('test-profiler');
+        expect(call[5]).toEqual(Scheduler.unstable_now());
+        if (ReactFeatureFlags.enableSchedulerTracing) {
+          expect(call[6]).toMatchInteractions([interactionTwo]);
+        }
+
+        expect(onInteractionTraced).toHaveBeenCalledTimes(3);
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(3);
+        expect(
+          onInteractionScheduledWorkCompleted,
+        ).toHaveBeenLastNotifiedOfInteraction(interactionTwo);
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
+        expect(getWorkForReactThreads(onWorkStarted)[0][0]).toMatchInteractions(
+          [interactionTwo],
+        );
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(1);
+        expect(getWorkForReactThreads(onWorkStopped)[0][0]).toMatchInteractions(
+          [interactionTwo],
+        );
+      });
     });
 
     it('should report the expected times when a high-priority update interrupts a low-priority update', () => {
-      const onRender = jest.fn();
+      act(() => {
+        const onRender = jest.fn();
 
-      let first;
-      class FirstComponent extends React.Component {
-        state = {count: 0};
-        render() {
-          first = this;
-          Scheduler.unstable_yieldValue('FirstComponent');
-          return null;
+        let first;
+        class FirstComponent extends React.Component {
+          state = {count: 0};
+          render() {
+            first = this;
+            Scheduler.unstable_yieldValue('FirstComponent');
+            return null;
+          }
         }
-      }
-      let second;
-      class SecondComponent extends React.Component {
-        state = {count: 0};
-        render() {
-          second = this;
-          Scheduler.unstable_yieldValue('SecondComponent');
-          return null;
+        let second;
+        class SecondComponent extends React.Component {
+          state = {count: 0};
+          render() {
+            second = this;
+            Scheduler.unstable_yieldValue('SecondComponent');
+            return null;
+          }
         }
-      }
 
-      Scheduler.unstable_advanceTime(5);
+        Scheduler.unstable_advanceTime(5);
 
-      const renderer = ReactTestRenderer.create(
-        <React.Profiler id="test" onRender={onRender}>
-          <FirstComponent />
-          <SecondComponent />
-        </React.Profiler>,
-        {unstable_isConcurrent: true},
-      );
+        const renderer = ReactTestRenderer.create(
+          <React.Profiler id="test" onRender={onRender}>
+            <FirstComponent />
+            <SecondComponent />
+          </React.Profiler>,
+          {unstable_isConcurrent: true},
+        );
 
-      // Initial mount.
-      expect(Scheduler).toFlushAndYield(['FirstComponent', 'SecondComponent']);
+        // Initial mount.
+        expect(Scheduler).toFlushAndYield([
+          'FirstComponent',
+          'SecondComponent',
+        ]);
 
-      expect(onInteractionTraced).not.toHaveBeenCalled();
-      expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+        expect(onInteractionTraced).not.toHaveBeenCalled();
+        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
 
-      onRender.mockClear();
+        onRender.mockClear();
 
-      Scheduler.unstable_advanceTime(100);
+        Scheduler.unstable_advanceTime(100);
 
-      const interactionLowPri = {
-        id: 0,
-        name: 'lowPri',
-        timestamp: Scheduler.unstable_now(),
-      };
+        const interactionLowPri = {
+          id: 0,
+          name: 'lowPri',
+          timestamp: Scheduler.unstable_now(),
+        };
 
-      SchedulerTracing.unstable_trace(
-        interactionLowPri.name,
-        Scheduler.unstable_now(),
-        () => {
-          // Render a partially update, but don't finish.
-          first.setState({count: 1});
+        SchedulerTracing.unstable_trace(
+          interactionLowPri.name,
+          Scheduler.unstable_now(),
+          () => {
+            // Render a partially update, but don't finish.
+            first.setState({count: 1});
 
-          expect(onWorkScheduled).toHaveBeenCalled();
-          expect(onWorkScheduled.mock.calls[0][0]).toMatchInteractions([
-            interactionLowPri,
-          ]);
+            expect(onWorkScheduled).toHaveBeenCalled();
+            expect(onWorkScheduled.mock.calls[0][0]).toMatchInteractions([
+              interactionLowPri,
+            ]);
 
-          expect(Scheduler).toFlushAndYieldThrough(['FirstComponent']);
-          expect(onRender).not.toHaveBeenCalled();
+            expect(Scheduler).toFlushAndYieldThrough(['FirstComponent']);
+            expect(onRender).not.toHaveBeenCalled();
 
-          expect(onInteractionTraced).toHaveBeenCalledTimes(1);
-          expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
-            interactionLowPri,
-          );
-          expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
-          expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
-          expect(
-            getWorkForReactThreads(onWorkStarted)[0][0],
-          ).toMatchInteractions([interactionLowPri]);
-          expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
-
-          Scheduler.unstable_advanceTime(100);
-
-          const interactionHighPri = {
-            id: 1,
-            name: 'highPri',
-            timestamp: Scheduler.unstable_now(),
-          };
-
-          // Interrupt with higher priority work.
-          // This simulates a total of 37ms of actual render time.
-          renderer.unstable_flushSync(() => {
-            SchedulerTracing.unstable_trace(
-              interactionHighPri.name,
-              Scheduler.unstable_now(),
-              () => {
-                second.setState({count: 1});
-
-                expect(onInteractionTraced).toHaveBeenCalledTimes(2);
-                expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
-                  interactionHighPri,
-                );
-                expect(
-                  onInteractionScheduledWorkCompleted,
-                ).not.toHaveBeenCalled();
-
-                expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
-                expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
-              },
+            expect(onInteractionTraced).toHaveBeenCalledTimes(1);
+            expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
+              interactionLowPri,
             );
-          });
-          expect(Scheduler).toHaveYielded(['SecondComponent']);
+            expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+            expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
+            expect(
+              getWorkForReactThreads(onWorkStarted)[0][0],
+            ).toMatchInteractions([interactionLowPri]);
+            expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
 
-          expect(onInteractionTraced).toHaveBeenCalledTimes(2);
-          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-          expect(
-            onInteractionScheduledWorkCompleted,
-          ).toHaveBeenLastNotifiedOfInteraction(interactionHighPri);
+            Scheduler.unstable_advanceTime(100);
 
-          // Verify the high priority update was associated with the high priority event.
-          expect(onRender).toHaveBeenCalledTimes(1);
-          let call = onRender.mock.calls[0];
-          expect(call[0]).toEqual('test');
-          expect(call[5]).toEqual(Scheduler.unstable_now());
-          expect(call[6]).toMatchInteractions(
-            ReactFeatureFlags.enableSchedulerTracing
-              ? [interactionLowPri, interactionHighPri]
-              : [],
-          );
+            const interactionHighPri = {
+              id: 1,
+              name: 'highPri',
+              timestamp: Scheduler.unstable_now(),
+            };
 
-          onRender.mockClear();
+            // Interrupt with higher priority work.
+            // This simulates a total of 37ms of actual render time.
+            renderer.unstable_flushSync(() => {
+              SchedulerTracing.unstable_trace(
+                interactionHighPri.name,
+                Scheduler.unstable_now(),
+                () => {
+                  second.setState({count: 1});
 
-          Scheduler.unstable_advanceTime(100);
+                  expect(onInteractionTraced).toHaveBeenCalledTimes(2);
+                  expect(
+                    onInteractionTraced,
+                  ).toHaveBeenLastNotifiedOfInteraction(interactionHighPri);
+                  expect(
+                    onInteractionScheduledWorkCompleted,
+                  ).not.toHaveBeenCalled();
 
-          // Resume the original low priority update, with rebased state.
-          // Verify the low priority update was retained.
-          expect(Scheduler).toFlushAndYield(['FirstComponent']);
-          expect(onRender).toHaveBeenCalledTimes(1);
-          call = onRender.mock.calls[0];
-          expect(call[0]).toEqual('test');
-          expect(call[5]).toEqual(Scheduler.unstable_now());
-          expect(call[6]).toMatchInteractions(
-            ReactFeatureFlags.enableSchedulerTracing ? [interactionLowPri] : [],
-          );
+                  expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
+                  expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
+                },
+              );
+            });
+            expect(Scheduler).toHaveYielded(['SecondComponent']);
 
-          expect(onInteractionTraced).toHaveBeenCalledTimes(2);
-          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+            expect(onInteractionTraced).toHaveBeenCalledTimes(2);
+            expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(
+              1,
+            );
+            expect(
+              onInteractionScheduledWorkCompleted,
+            ).toHaveBeenLastNotifiedOfInteraction(interactionHighPri);
 
-          // Work might be started multiple times before being completed.
-          // This is okay; it's part of the scheduler/tracing contract.
-          expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(3);
-          expect(
-            getWorkForReactThreads(onWorkStarted)[1][0],
-          ).toMatchInteractions([interactionLowPri, interactionHighPri]);
-          expect(
-            getWorkForReactThreads(onWorkStarted)[2][0],
-          ).toMatchInteractions([interactionLowPri]);
-          expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(2);
-          expect(
-            getWorkForReactThreads(onWorkStopped)[0][0],
-          ).toMatchInteractions([interactionLowPri, interactionHighPri]);
-          expect(
-            getWorkForReactThreads(onWorkStopped)[1][0],
-          ).toMatchInteractions([interactionLowPri]);
-        },
-      );
+            // Verify the high priority update was associated with the high priority event.
+            expect(onRender).toHaveBeenCalledTimes(1);
+            let call = onRender.mock.calls[0];
+            expect(call[0]).toEqual('test');
+            expect(call[5]).toEqual(Scheduler.unstable_now());
+            expect(call[6]).toMatchInteractions(
+              ReactFeatureFlags.enableSchedulerTracing
+                ? [interactionLowPri, interactionHighPri]
+                : [],
+            );
 
-      expect(onInteractionTraced).toHaveBeenCalledTimes(2);
-      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
-      expect(
-        onInteractionScheduledWorkCompleted,
-      ).toHaveBeenLastNotifiedOfInteraction(interactionLowPri);
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(3);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(2);
+            onRender.mockClear();
+
+            Scheduler.unstable_advanceTime(100);
+
+            // Resume the original low priority update, with rebased state.
+            // Verify the low priority update was retained.
+            expect(Scheduler).toFlushAndYield(['FirstComponent']);
+            expect(onRender).toHaveBeenCalledTimes(1);
+            call = onRender.mock.calls[0];
+            expect(call[0]).toEqual('test');
+            expect(call[5]).toEqual(Scheduler.unstable_now());
+            expect(call[6]).toMatchInteractions(
+              ReactFeatureFlags.enableSchedulerTracing
+                ? [interactionLowPri]
+                : [],
+            );
+
+            expect(onInteractionTraced).toHaveBeenCalledTimes(2);
+            expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(
+              1,
+            );
+
+            // Work might be started multiple times before being completed.
+            // This is okay; it's part of the scheduler/tracing contract.
+            expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(3);
+            expect(
+              getWorkForReactThreads(onWorkStarted)[1][0],
+            ).toMatchInteractions([interactionLowPri, interactionHighPri]);
+            expect(
+              getWorkForReactThreads(onWorkStarted)[2][0],
+            ).toMatchInteractions([interactionLowPri]);
+            expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(2);
+            expect(
+              getWorkForReactThreads(onWorkStopped)[0][0],
+            ).toMatchInteractions([interactionLowPri, interactionHighPri]);
+            expect(
+              getWorkForReactThreads(onWorkStopped)[1][0],
+            ).toMatchInteractions([interactionLowPri]);
+          },
+        );
+
+        expect(onInteractionTraced).toHaveBeenCalledTimes(2);
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
+        expect(
+          onInteractionScheduledWorkCompleted,
+        ).toHaveBeenLastNotifiedOfInteraction(interactionLowPri);
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(3);
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(2);
+      });
     });
 
     it('should trace work spawned by a commit phase lifecycle and setState callback', () => {
-      let instance;
-      class Example extends React.Component {
-        state = {
-          count: 0,
-        };
-        componentDidMount() {
-          Scheduler.unstable_advanceTime(10); // Advance timer to keep commits separate
-          this.setState({count: 1}); // Intentional cascading update
-        }
-        componentDidUpdate(prevProps, prevState) {
-          if (this.state.count === 2 && prevState.count === 1) {
+      act(() => {
+        let instance;
+        class Example extends React.Component {
+          state = {
+            count: 0,
+          };
+          componentDidMount() {
             Scheduler.unstable_advanceTime(10); // Advance timer to keep commits separate
-            this.setState({count: 3}); // Intentional cascading update
+            this.setState({count: 1}); // Intentional cascading update
+          }
+          componentDidUpdate(prevProps, prevState) {
+            if (this.state.count === 2 && prevState.count === 1) {
+              Scheduler.unstable_advanceTime(10); // Advance timer to keep commits separate
+              this.setState({count: 3}); // Intentional cascading update
+            }
+          }
+          render() {
+            instance = this;
+            Scheduler.unstable_yieldValue('Example:' + this.state.count);
+            return null;
           }
         }
-        render() {
-          instance = this;
-          Scheduler.unstable_yieldValue('Example:' + this.state.count);
-          return null;
+
+        const interactionOne = {
+          id: 0,
+          name: 'componentDidMount test',
+          timestamp: Scheduler.unstable_now(),
+        };
+
+        // Initial mount.
+        const onRender = jest.fn();
+        let firstCommitTime = Scheduler.unstable_now();
+        SchedulerTracing.unstable_trace(
+          interactionOne.name,
+          Scheduler.unstable_now(),
+          () => {
+            ReactTestRenderer.create(
+              <React.Profiler id="test" onRender={onRender}>
+                <Example />
+              </React.Profiler>,
+              {unstable_isConcurrent: true},
+            );
+          },
+        );
+
+        expect(onInteractionTraced).toHaveBeenCalledTimes(1);
+        expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
+          interactionOne,
+        );
+        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
+
+        expect(Scheduler).toFlushAndYield(['Example:0', 'Example:1']);
+
+        expect(onInteractionTraced).toHaveBeenCalledTimes(1);
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+        expect(
+          onInteractionScheduledWorkCompleted,
+        ).toHaveBeenLastNotifiedOfInteraction(interactionOne);
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(2);
+        expect(getWorkForReactThreads(onWorkStarted)[0][0]).toMatchInteractions(
+          [interactionOne],
+        );
+        expect(getWorkForReactThreads(onWorkStarted)[1][0]).toMatchInteractions(
+          [interactionOne],
+        );
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(2);
+        expect(getWorkForReactThreads(onWorkStopped)[0][0]).toMatchInteractions(
+          [interactionOne],
+        );
+        expect(getWorkForReactThreads(onWorkStopped)[1][0]).toMatchInteractions(
+          [interactionOne],
+        );
+
+        expect(onRender).toHaveBeenCalledTimes(2);
+        let call = onRender.mock.calls[0];
+        expect(call[0]).toEqual('test');
+        expect(call[5]).toEqual(firstCommitTime);
+        expect(call[6]).toMatchInteractions(
+          ReactFeatureFlags.enableSchedulerTracing ? [interactionOne] : [],
+        );
+        call = onRender.mock.calls[1];
+        expect(call[0]).toEqual('test');
+        expect(call[5]).toEqual(Scheduler.unstable_now());
+        expect(call[6]).toMatchInteractions(
+          ReactFeatureFlags.enableSchedulerTracing ? [interactionOne] : [],
+        );
+
+        onRender.mockClear();
+
+        const interactionTwo = {
+          id: 1,
+          name: 'componentDidUpdate test',
+          timestamp: Scheduler.unstable_now(),
+        };
+
+        // Cause an traced, async update
+        SchedulerTracing.unstable_trace(
+          interactionTwo.name,
+          Scheduler.unstable_now(),
+          () => {
+            instance.setState({count: 2});
+          },
+        );
+        expect(onRender).not.toHaveBeenCalled();
+        expect(onInteractionTraced).toHaveBeenCalledTimes(2);
+        expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
+          interactionTwo,
+        );
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(2);
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(2);
+
+        Scheduler.unstable_advanceTime(5);
+
+        // Flush async work (outside of traced scope)
+        // This will cause an intentional cascading update from did-update
+        firstCommitTime = Scheduler.unstable_now();
+        expect(Scheduler).toFlushAndYield(['Example:2', 'Example:3']);
+
+        expect(onInteractionTraced).toHaveBeenCalledTimes(2);
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
+        expect(
+          onInteractionScheduledWorkCompleted,
+        ).toHaveBeenLastNotifiedOfInteraction(interactionTwo);
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(4);
+        expect(getWorkForReactThreads(onWorkStarted)[2][0]).toMatchInteractions(
+          [interactionTwo],
+        );
+        expect(getWorkForReactThreads(onWorkStarted)[3][0]).toMatchInteractions(
+          [interactionTwo],
+        );
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(4);
+        expect(getWorkForReactThreads(onWorkStopped)[2][0]).toMatchInteractions(
+          [interactionTwo],
+        );
+        expect(getWorkForReactThreads(onWorkStopped)[3][0]).toMatchInteractions(
+          [interactionTwo],
+        );
+
+        // Verify the cascading commit is associated with the origin event
+        expect(onRender).toHaveBeenCalledTimes(2);
+        call = onRender.mock.calls[0];
+        expect(call[0]).toEqual('test');
+        expect(call[5]).toEqual(firstCommitTime);
+        expect(call[6]).toMatchInteractions(
+          ReactFeatureFlags.enableSchedulerTracing ? [interactionTwo] : [],
+        );
+        call = onRender.mock.calls[1];
+        expect(call[0]).toEqual('test');
+        expect(call[5]).toEqual(Scheduler.unstable_now());
+        expect(call[6]).toMatchInteractions(
+          ReactFeatureFlags.enableSchedulerTracing ? [interactionTwo] : [],
+        );
+
+        onRender.mockClear();
+
+        const interactionThree = {
+          id: 2,
+          name: 'setState callback test',
+          timestamp: Scheduler.unstable_now(),
+        };
+
+        // Cause a cascading update from the setState callback
+        function callback() {
+          instance.setState({count: 6});
         }
-      }
+        SchedulerTracing.unstable_trace(
+          interactionThree.name,
+          Scheduler.unstable_now(),
+          () => {
+            instance.setState({count: 5}, callback);
+          },
+        );
+        expect(onRender).not.toHaveBeenCalled();
 
-      const interactionOne = {
-        id: 0,
-        name: 'componentDidMount test',
-        timestamp: Scheduler.unstable_now(),
-      };
+        expect(onInteractionTraced).toHaveBeenCalledTimes(3);
+        expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
+          interactionThree,
+        );
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(4);
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(4);
 
-      // Initial mount.
-      const onRender = jest.fn();
-      let firstCommitTime = Scheduler.unstable_now();
-      SchedulerTracing.unstable_trace(
-        interactionOne.name,
-        Scheduler.unstable_now(),
-        () => {
-          ReactTestRenderer.create(
-            <React.Profiler id="test" onRender={onRender}>
-              <Example />
-            </React.Profiler>,
-            {unstable_isConcurrent: true},
-          );
-        },
-      );
+        // Flush async work (outside of traced scope)
+        // This will cause an intentional cascading update from the setState callback
+        firstCommitTime = Scheduler.unstable_now();
+        expect(Scheduler).toFlushAndYield(['Example:5', 'Example:6']);
 
-      expect(onInteractionTraced).toHaveBeenCalledTimes(1);
-      expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
-        interactionOne,
-      );
-      expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
+        expect(onInteractionTraced).toHaveBeenCalledTimes(3);
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(3);
+        expect(
+          onInteractionScheduledWorkCompleted,
+        ).toHaveBeenLastNotifiedOfInteraction(interactionThree);
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(6);
+        expect(getWorkForReactThreads(onWorkStarted)[4][0]).toMatchInteractions(
+          [interactionThree],
+        );
+        expect(getWorkForReactThreads(onWorkStarted)[5][0]).toMatchInteractions(
+          [interactionThree],
+        );
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(6);
+        expect(getWorkForReactThreads(onWorkStopped)[4][0]).toMatchInteractions(
+          [interactionThree],
+        );
+        expect(getWorkForReactThreads(onWorkStopped)[5][0]).toMatchInteractions(
+          [interactionThree],
+        );
 
-      expect(Scheduler).toFlushAndYield(['Example:0', 'Example:1']);
-
-      expect(onInteractionTraced).toHaveBeenCalledTimes(1);
-      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-      expect(
-        onInteractionScheduledWorkCompleted,
-      ).toHaveBeenLastNotifiedOfInteraction(interactionOne);
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(2);
-      expect(getWorkForReactThreads(onWorkStarted)[0][0]).toMatchInteractions([
-        interactionOne,
-      ]);
-      expect(getWorkForReactThreads(onWorkStarted)[1][0]).toMatchInteractions([
-        interactionOne,
-      ]);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(2);
-      expect(getWorkForReactThreads(onWorkStopped)[0][0]).toMatchInteractions([
-        interactionOne,
-      ]);
-      expect(getWorkForReactThreads(onWorkStopped)[1][0]).toMatchInteractions([
-        interactionOne,
-      ]);
-
-      expect(onRender).toHaveBeenCalledTimes(2);
-      let call = onRender.mock.calls[0];
-      expect(call[0]).toEqual('test');
-      expect(call[5]).toEqual(firstCommitTime);
-      expect(call[6]).toMatchInteractions(
-        ReactFeatureFlags.enableSchedulerTracing ? [interactionOne] : [],
-      );
-      call = onRender.mock.calls[1];
-      expect(call[0]).toEqual('test');
-      expect(call[5]).toEqual(Scheduler.unstable_now());
-      expect(call[6]).toMatchInteractions(
-        ReactFeatureFlags.enableSchedulerTracing ? [interactionOne] : [],
-      );
-
-      onRender.mockClear();
-
-      const interactionTwo = {
-        id: 1,
-        name: 'componentDidUpdate test',
-        timestamp: Scheduler.unstable_now(),
-      };
-
-      // Cause an traced, async update
-      SchedulerTracing.unstable_trace(
-        interactionTwo.name,
-        Scheduler.unstable_now(),
-        () => {
-          instance.setState({count: 2});
-        },
-      );
-      expect(onRender).not.toHaveBeenCalled();
-      expect(onInteractionTraced).toHaveBeenCalledTimes(2);
-      expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
-        interactionTwo,
-      );
-      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(2);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(2);
-
-      Scheduler.unstable_advanceTime(5);
-
-      // Flush async work (outside of traced scope)
-      // This will cause an intentional cascading update from did-update
-      firstCommitTime = Scheduler.unstable_now();
-      expect(Scheduler).toFlushAndYield(['Example:2', 'Example:3']);
-
-      expect(onInteractionTraced).toHaveBeenCalledTimes(2);
-      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
-      expect(
-        onInteractionScheduledWorkCompleted,
-      ).toHaveBeenLastNotifiedOfInteraction(interactionTwo);
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(4);
-      expect(getWorkForReactThreads(onWorkStarted)[2][0]).toMatchInteractions([
-        interactionTwo,
-      ]);
-      expect(getWorkForReactThreads(onWorkStarted)[3][0]).toMatchInteractions([
-        interactionTwo,
-      ]);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(4);
-      expect(getWorkForReactThreads(onWorkStopped)[2][0]).toMatchInteractions([
-        interactionTwo,
-      ]);
-      expect(getWorkForReactThreads(onWorkStopped)[3][0]).toMatchInteractions([
-        interactionTwo,
-      ]);
-
-      // Verify the cascading commit is associated with the origin event
-      expect(onRender).toHaveBeenCalledTimes(2);
-      call = onRender.mock.calls[0];
-      expect(call[0]).toEqual('test');
-      expect(call[5]).toEqual(firstCommitTime);
-      expect(call[6]).toMatchInteractions(
-        ReactFeatureFlags.enableSchedulerTracing ? [interactionTwo] : [],
-      );
-      call = onRender.mock.calls[1];
-      expect(call[0]).toEqual('test');
-      expect(call[5]).toEqual(Scheduler.unstable_now());
-      expect(call[6]).toMatchInteractions(
-        ReactFeatureFlags.enableSchedulerTracing ? [interactionTwo] : [],
-      );
-
-      onRender.mockClear();
-
-      const interactionThree = {
-        id: 2,
-        name: 'setState callback test',
-        timestamp: Scheduler.unstable_now(),
-      };
-
-      // Cause a cascading update from the setState callback
-      function callback() {
-        instance.setState({count: 6});
-      }
-      SchedulerTracing.unstable_trace(
-        interactionThree.name,
-        Scheduler.unstable_now(),
-        () => {
-          instance.setState({count: 5}, callback);
-        },
-      );
-      expect(onRender).not.toHaveBeenCalled();
-
-      expect(onInteractionTraced).toHaveBeenCalledTimes(3);
-      expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
-        interactionThree,
-      );
-      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(4);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(4);
-
-      // Flush async work (outside of traced scope)
-      // This will cause an intentional cascading update from the setState callback
-      firstCommitTime = Scheduler.unstable_now();
-      expect(Scheduler).toFlushAndYield(['Example:5', 'Example:6']);
-
-      expect(onInteractionTraced).toHaveBeenCalledTimes(3);
-      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(3);
-      expect(
-        onInteractionScheduledWorkCompleted,
-      ).toHaveBeenLastNotifiedOfInteraction(interactionThree);
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(6);
-      expect(getWorkForReactThreads(onWorkStarted)[4][0]).toMatchInteractions([
-        interactionThree,
-      ]);
-      expect(getWorkForReactThreads(onWorkStarted)[5][0]).toMatchInteractions([
-        interactionThree,
-      ]);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(6);
-      expect(getWorkForReactThreads(onWorkStopped)[4][0]).toMatchInteractions([
-        interactionThree,
-      ]);
-      expect(getWorkForReactThreads(onWorkStopped)[5][0]).toMatchInteractions([
-        interactionThree,
-      ]);
-
-      // Verify the cascading commit is associated with the origin event
-      expect(onRender).toHaveBeenCalledTimes(2);
-      call = onRender.mock.calls[0];
-      expect(call[0]).toEqual('test');
-      expect(call[5]).toEqual(firstCommitTime);
-      expect(call[6]).toMatchInteractions(
-        ReactFeatureFlags.enableSchedulerTracing ? [interactionThree] : [],
-      );
-      call = onRender.mock.calls[1];
-      expect(call[0]).toEqual('test');
-      expect(call[5]).toEqual(Scheduler.unstable_now());
-      expect(call[6]).toMatchInteractions(
-        ReactFeatureFlags.enableSchedulerTracing ? [interactionThree] : [],
-      );
+        // Verify the cascading commit is associated with the origin event
+        expect(onRender).toHaveBeenCalledTimes(2);
+        call = onRender.mock.calls[0];
+        expect(call[0]).toEqual('test');
+        expect(call[5]).toEqual(firstCommitTime);
+        expect(call[6]).toMatchInteractions(
+          ReactFeatureFlags.enableSchedulerTracing ? [interactionThree] : [],
+        );
+        call = onRender.mock.calls[1];
+        expect(call[0]).toEqual('test');
+        expect(call[5]).toEqual(Scheduler.unstable_now());
+        expect(call[6]).toMatchInteractions(
+          ReactFeatureFlags.enableSchedulerTracing ? [interactionThree] : [],
+        );
+      });
     });
 
     it('should trace interactions associated with a parent component state update', () => {
-      const onRender = jest.fn();
-      let parentInstance = null;
+      act(() => {
+        const onRender = jest.fn();
+        let parentInstance = null;
 
-      class Child extends React.Component {
-        render() {
-          Scheduler.unstable_yieldValue('Child:' + this.props.count);
-          return null;
+        class Child extends React.Component {
+          render() {
+            Scheduler.unstable_yieldValue('Child:' + this.props.count);
+            return null;
+          }
         }
-      }
 
-      class Parent extends React.Component {
-        state = {
-          count: 0,
+        class Parent extends React.Component {
+          state = {
+            count: 0,
+          };
+          render() {
+            parentInstance = this;
+            return (
+              <React.Profiler id="test-profiler" onRender={onRender}>
+                <Child count={this.state.count} />
+              </React.Profiler>
+            );
+          }
+        }
+
+        Scheduler.unstable_advanceTime(1);
+
+        ReactTestRenderer.create(<Parent />, {
+          unstable_isConcurrent: true,
+        });
+        expect(Scheduler).toFlushAndYield(['Child:0']);
+        onRender.mockClear();
+
+        const interaction = {
+          id: 0,
+          name: 'parent interaction',
+          timestamp: Scheduler.unstable_now(),
         };
-        render() {
-          parentInstance = this;
-          return (
-            <React.Profiler id="test-profiler" onRender={onRender}>
-              <Child count={this.state.count} />
-            </React.Profiler>
-          );
-        }
-      }
 
-      Scheduler.unstable_advanceTime(1);
+        SchedulerTracing.unstable_trace(
+          interaction.name,
+          Scheduler.unstable_now(),
+          () => {
+            parentInstance.setState({count: 1});
+          },
+        );
 
-      ReactTestRenderer.create(<Parent />, {
-        unstable_isConcurrent: true,
+        expect(onInteractionTraced).toHaveBeenCalledTimes(1);
+        expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
+          interaction,
+        );
+        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
+
+        expect(onRender).not.toHaveBeenCalled();
+        expect(Scheduler).toFlushAndYield(['Child:1']);
+        expect(onRender).toHaveBeenCalledTimes(1);
+        let call = onRender.mock.calls[0];
+        expect(call[0]).toEqual('test-profiler');
+        expect(call[6]).toMatchInteractions(
+          ReactFeatureFlags.enableSchedulerTracing ? [interaction] : [],
+        );
+
+        expect(onInteractionTraced).toHaveBeenCalledTimes(1);
+        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+        expect(
+          onInteractionScheduledWorkCompleted,
+        ).toHaveBeenLastNotifiedOfInteraction(interaction);
+        expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
+        expect(getWorkForReactThreads(onWorkStarted)[0][0]).toMatchInteractions(
+          [interaction],
+        );
+        expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(1);
+        expect(getWorkForReactThreads(onWorkStopped)[0][0]).toMatchInteractions(
+          [interaction],
+        );
       });
-      expect(Scheduler).toFlushAndYield(['Child:0']);
-      onRender.mockClear();
-
-      const interaction = {
-        id: 0,
-        name: 'parent interaction',
-        timestamp: Scheduler.unstable_now(),
-      };
-
-      SchedulerTracing.unstable_trace(
-        interaction.name,
-        Scheduler.unstable_now(),
-        () => {
-          parentInstance.setState({count: 1});
-        },
-      );
-
-      expect(onInteractionTraced).toHaveBeenCalledTimes(1);
-      expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
-        interaction,
-      );
-      expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(0);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(0);
-
-      expect(onRender).not.toHaveBeenCalled();
-      expect(Scheduler).toFlushAndYield(['Child:1']);
-      expect(onRender).toHaveBeenCalledTimes(1);
-      let call = onRender.mock.calls[0];
-      expect(call[0]).toEqual('test-profiler');
-      expect(call[6]).toMatchInteractions(
-        ReactFeatureFlags.enableSchedulerTracing ? [interaction] : [],
-      );
-
-      expect(onInteractionTraced).toHaveBeenCalledTimes(1);
-      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-      expect(
-        onInteractionScheduledWorkCompleted,
-      ).toHaveBeenLastNotifiedOfInteraction(interaction);
-      expect(getWorkForReactThreads(onWorkStarted)).toHaveLength(1);
-      expect(getWorkForReactThreads(onWorkStarted)[0][0]).toMatchInteractions([
-        interaction,
-      ]);
-      expect(getWorkForReactThreads(onWorkStopped)).toHaveLength(1);
-      expect(getWorkForReactThreads(onWorkStopped)[0][0]).toMatchInteractions([
-        interaction,
-      ]);
     });
 
     describe('suspense', () => {
@@ -2348,40 +2400,45 @@ describe('Profiler', () => {
       });
 
       it('does not prematurely complete for suspended sync renders', async () => {
-        const interaction = {
-          id: 0,
-          name: 'initial render',
-          timestamp: Scheduler.unstable_now(),
-        };
+        await act(async () => {
+          const interaction = {
+            id: 0,
+            name: 'initial render',
+            timestamp: Scheduler.unstable_now(),
+          };
 
-        const onRender = jest.fn();
-        SchedulerTracing.unstable_trace(
-          interaction.name,
-          interaction.timestamp,
-          () => {
-            ReactTestRenderer.create(
-              <React.Profiler id="app" onRender={onRender}>
-                <React.Suspense fallback={<Text text="loading" />}>
-                  <AsyncText text="loaded" ms={500} />
-                </React.Suspense>
-              </React.Profiler>,
-            );
-          },
-        );
+          const onRender = jest.fn();
+          SchedulerTracing.unstable_trace(
+            interaction.name,
+            interaction.timestamp,
+            () => {
+              ReactTestRenderer.create(
+                <React.Profiler id="app" onRender={onRender}>
+                  <React.Suspense fallback={<Text text="loading" />}>
+                    <AsyncText text="loaded" ms={500} />
+                  </React.Suspense>
+                </React.Profiler>,
+              );
+            },
+          );
 
-        expect(Scheduler).toHaveYielded(['Suspend [loaded]', 'Text [loading]']);
+          expect(Scheduler).toFlushAndYield([
+            'Suspend [loaded]',
+            'Text [loading]',
+          ]);
 
-        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+          expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
 
-        jest.runAllTimers();
-        await resourcePromise;
+          jest.runAllTimers();
+          await resourcePromise;
 
-        expect(Scheduler).toHaveYielded(['Promise resolved [loaded]']);
-        expect(Scheduler).toFlushExpired(['AsyncText [loaded]']);
-        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-        expect(
-          onInteractionScheduledWorkCompleted,
-        ).toHaveBeenLastNotifiedOfInteraction(interaction);
+          expect(Scheduler).toHaveYielded(['Promise resolved [loaded]']);
+          expect(Scheduler).toFlushExpired(['AsyncText [loaded]']);
+          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+          expect(
+            onInteractionScheduledWorkCompleted,
+          ).toHaveBeenLastNotifiedOfInteraction(interaction);
+        });
       });
 
       it('traces cascading work after suspended sync renders', async () => {
@@ -2446,88 +2503,92 @@ describe('Profiler', () => {
       });
 
       it('does not prematurely complete for suspended renders that have exceeded their deadline', async () => {
-        const interaction = {
-          id: 0,
-          name: 'initial render',
-          timestamp: Scheduler.unstable_now(),
-        };
+        await act(async () => {
+          const interaction = {
+            id: 0,
+            name: 'initial render',
+            timestamp: Scheduler.unstable_now(),
+          };
 
-        const onRender = jest.fn();
-        SchedulerTracing.unstable_trace(
-          interaction.name,
-          interaction.timestamp,
-          () => {
-            ReactTestRenderer.create(
-              <React.Profiler id="app" onRender={onRender}>
-                <React.Suspense fallback={<Text text="loading" />}>
-                  <AsyncText text="loaded" ms={500} />
-                </React.Suspense>
-              </React.Profiler>,
-              {
-                unstable_isConcurrent: true,
-              },
-            );
-          },
-        );
+          const onRender = jest.fn();
+          SchedulerTracing.unstable_trace(
+            interaction.name,
+            interaction.timestamp,
+            () => {
+              ReactTestRenderer.create(
+                <React.Profiler id="app" onRender={onRender}>
+                  <React.Suspense fallback={<Text text="loading" />}>
+                    <AsyncText text="loaded" ms={500} />
+                  </React.Suspense>
+                </React.Profiler>,
+                {
+                  unstable_isConcurrent: true,
+                },
+              );
+            },
+          );
 
-        Scheduler.unstable_advanceTime(400);
-        await awaitableAdvanceTimers(400);
+          Scheduler.unstable_advanceTime(400);
+          await awaitableAdvanceTimers(400);
 
-        expect(Scheduler).toFlushAndYield([
-          'Suspend [loaded]',
-          'Text [loading]',
-        ]);
-        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+          expect(Scheduler).toFlushAndYield([
+            'Suspend [loaded]',
+            'Text [loading]',
+          ]);
+          expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
 
-        Scheduler.unstable_advanceTime(500);
-        await awaitableAdvanceTimers(500);
+          Scheduler.unstable_advanceTime(500);
+          await awaitableAdvanceTimers(500);
 
-        expect(Scheduler).toHaveYielded(['Promise resolved [loaded]']);
-        expect(Scheduler).toFlushAndYield(['AsyncText [loaded]']);
-        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-        expect(
-          onInteractionScheduledWorkCompleted,
-        ).toHaveBeenLastNotifiedOfInteraction(interaction);
+          expect(Scheduler).toHaveYielded(['Promise resolved [loaded]']);
+          expect(Scheduler).toFlushAndYield(['AsyncText [loaded]']);
+          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+          expect(
+            onInteractionScheduledWorkCompleted,
+          ).toHaveBeenLastNotifiedOfInteraction(interaction);
+        });
       });
 
       it('decrements interaction count correctly if suspense loads before placeholder is shown', async () => {
-        const interaction = {
-          id: 0,
-          name: 'initial render',
-          timestamp: Scheduler.unstable_now(),
-        };
+        await act(async () => {
+          const interaction = {
+            id: 0,
+            name: 'initial render',
+            timestamp: Scheduler.unstable_now(),
+          };
 
-        const onRender = jest.fn();
-        SchedulerTracing.unstable_trace(
-          interaction.name,
-          interaction.timestamp,
-          () => {
-            ReactTestRenderer.create(
-              <React.Profiler id="app" onRender={onRender}>
-                <React.Suspense fallback={<Text text="loading" />}>
-                  <AsyncText text="loaded" ms={100} />
-                </React.Suspense>
-              </React.Profiler>,
-              {unstable_isConcurrent: true},
-            );
-          },
-        );
-        expect(Scheduler).toFlushAndYield([
-          'Suspend [loaded]',
-          'Text [loading]',
-        ]);
+          const onRender = jest.fn();
+          SchedulerTracing.unstable_trace(
+            interaction.name,
+            interaction.timestamp,
+            () => {
+              ReactTestRenderer.create(
+                <React.Profiler id="app" onRender={onRender}>
+                  <React.Suspense fallback={<Text text="loading" />}>
+                    <AsyncText text="loaded" ms={100} />
+                  </React.Suspense>
+                </React.Profiler>,
+                {unstable_isConcurrent: true},
+              );
+            },
+          );
+          expect(Scheduler).toFlushAndYield([
+            'Suspend [loaded]',
+            'Text [loading]',
+          ]);
 
-        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+          expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
 
-        jest.advanceTimersByTime(100);
-        await resourcePromise;
-        expect(Scheduler).toHaveYielded(['Promise resolved [loaded]']);
-        expect(Scheduler).toFlushAndYield(['AsyncText [loaded]']);
+          jest.advanceTimersByTime(100);
+          await resourcePromise;
+          expect(Scheduler).toHaveYielded(['Promise resolved [loaded]']);
+          expect(Scheduler).toFlushAndYield(['AsyncText [loaded]']);
 
-        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-        expect(
-          onInteractionScheduledWorkCompleted,
-        ).toHaveBeenLastNotifiedOfInteraction(interaction);
+          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+          expect(
+            onInteractionScheduledWorkCompleted,
+          ).toHaveBeenLastNotifiedOfInteraction(interaction);
+        });
       });
 
       it('handles high-pri renderers between suspended and resolved (sync) trees', async () => {
@@ -2628,108 +2689,110 @@ describe('Profiler', () => {
       });
 
       it('handles high-pri renderers between suspended and resolved (async) trees', async () => {
-        // Set up an initial shell. We need to set this up before the test sceanrio
-        // because we want initial render to suspend on navigation to the initial state.
-        let renderer = ReactTestRenderer.create(
-          <React.Profiler id="app" onRender={() => {}}>
-            <React.Suspense fallback={<Text text="loading" />} />
-          </React.Profiler>,
-          {unstable_isConcurrent: true},
-        );
-        expect(Scheduler).toFlushAndYield([]);
+        await act(async () => {
+          // Set up an initial shell. We need to set this up before the test sceanrio
+          // because we want initial render to suspend on navigation to the initial state.
+          let renderer = ReactTestRenderer.create(
+            <React.Profiler id="app" onRender={() => {}}>
+              <React.Suspense fallback={<Text text="loading" />} />
+            </React.Profiler>,
+            {unstable_isConcurrent: true},
+          );
+          expect(Scheduler).toFlushAndYield([]);
 
-        const initialRenderInteraction = {
-          id: 0,
-          name: 'initial render',
-          timestamp: Scheduler.unstable_now(),
-        };
+          const initialRenderInteraction = {
+            id: 0,
+            name: 'initial render',
+            timestamp: Scheduler.unstable_now(),
+          };
 
-        const onRender = jest.fn();
-        SchedulerTracing.unstable_trace(
-          initialRenderInteraction.name,
-          initialRenderInteraction.timestamp,
-          () => {
-            renderer.update(
-              <React.Profiler id="app" onRender={onRender}>
-                <React.Suspense fallback={<Text text="loading" />}>
-                  <AsyncText text="loaded" ms={100} />
-                </React.Suspense>
-                <Text text="initial" />
-              </React.Profiler>,
-            );
-          },
-        );
-        expect(Scheduler).toFlushAndYield([
-          'Suspend [loaded]',
-          'Text [loading]',
-          'Text [initial]',
-        ]);
-
-        expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
-        expect(onRender).not.toHaveBeenCalled();
-
-        Scheduler.unstable_advanceTime(50);
-        jest.advanceTimersByTime(50);
-
-        const highPriUpdateInteraction = {
-          id: 1,
-          name: 'hiPriUpdate',
-          timestamp: Scheduler.unstable_now(),
-        };
-
-        const originalPromise = resourcePromise;
-
-        renderer.unstable_flushSync(() => {
+          const onRender = jest.fn();
           SchedulerTracing.unstable_trace(
-            highPriUpdateInteraction.name,
-            highPriUpdateInteraction.timestamp,
+            initialRenderInteraction.name,
+            initialRenderInteraction.timestamp,
             () => {
               renderer.update(
                 <React.Profiler id="app" onRender={onRender}>
                   <React.Suspense fallback={<Text text="loading" />}>
                     <AsyncText text="loaded" ms={100} />
                   </React.Suspense>
-                  <Text text="updated" />
+                  <Text text="initial" />
                 </React.Profiler>,
               );
             },
           );
+          expect(Scheduler).toFlushAndYield([
+            'Suspend [loaded]',
+            'Text [loading]',
+            'Text [initial]',
+          ]);
+
+          expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
+          expect(onRender).not.toHaveBeenCalled();
+
+          Scheduler.unstable_advanceTime(50);
+          jest.advanceTimersByTime(50);
+
+          const highPriUpdateInteraction = {
+            id: 1,
+            name: 'hiPriUpdate',
+            timestamp: Scheduler.unstable_now(),
+          };
+
+          const originalPromise = resourcePromise;
+
+          renderer.unstable_flushSync(() => {
+            SchedulerTracing.unstable_trace(
+              highPriUpdateInteraction.name,
+              highPriUpdateInteraction.timestamp,
+              () => {
+                renderer.update(
+                  <React.Profiler id="app" onRender={onRender}>
+                    <React.Suspense fallback={<Text text="loading" />}>
+                      <AsyncText text="loaded" ms={100} />
+                    </React.Suspense>
+                    <Text text="updated" />
+                  </React.Profiler>,
+                );
+              },
+            );
+          });
+          expect(Scheduler).toHaveYielded([
+            'Suspend [loaded]',
+            'Text [loading]',
+            'Text [updated]',
+          ]);
+          expect(renderer.toJSON()).toEqual(['loading', 'updated']);
+
+          expect(onRender).toHaveBeenCalledTimes(1);
+          expect(onRender.mock.calls[0][6]).toMatchInteractions([
+            highPriUpdateInteraction,
+          ]);
+          onRender.mockClear();
+
+          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(0);
+
+          Scheduler.unstable_advanceTime(50);
+          jest.advanceTimersByTime(50);
+          await originalPromise;
+          expect(Scheduler).toHaveYielded(['Promise resolved [loaded]']);
+          expect(Scheduler).toFlushAndYield(['AsyncText [loaded]']);
+          expect(renderer.toJSON()).toEqual(['loaded', 'updated']);
+
+          expect(onRender).toHaveBeenCalledTimes(1);
+          expect(onRender.mock.calls[0][6]).toMatchInteractions([
+            initialRenderInteraction,
+            highPriUpdateInteraction,
+          ]);
+
+          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
+          expect(
+            onInteractionScheduledWorkCompleted.mock.calls[0][0],
+          ).toMatchInteraction(initialRenderInteraction);
+          expect(
+            onInteractionScheduledWorkCompleted.mock.calls[1][0],
+          ).toMatchInteraction(highPriUpdateInteraction);
         });
-        expect(Scheduler).toHaveYielded([
-          'Suspend [loaded]',
-          'Text [loading]',
-          'Text [updated]',
-        ]);
-        expect(renderer.toJSON()).toEqual(['loading', 'updated']);
-
-        expect(onRender).toHaveBeenCalledTimes(1);
-        expect(onRender.mock.calls[0][6]).toMatchInteractions([
-          highPriUpdateInteraction,
-        ]);
-        onRender.mockClear();
-
-        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(0);
-
-        Scheduler.unstable_advanceTime(50);
-        jest.advanceTimersByTime(50);
-        await originalPromise;
-        expect(Scheduler).toHaveYielded(['Promise resolved [loaded]']);
-        expect(Scheduler).toFlushAndYield(['AsyncText [loaded]']);
-        expect(renderer.toJSON()).toEqual(['loaded', 'updated']);
-
-        expect(onRender).toHaveBeenCalledTimes(1);
-        expect(onRender.mock.calls[0][6]).toMatchInteractions([
-          initialRenderInteraction,
-          highPriUpdateInteraction,
-        ]);
-
-        expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(2);
-        expect(
-          onInteractionScheduledWorkCompleted.mock.calls[0][0],
-        ).toMatchInteraction(initialRenderInteraction);
-        expect(
-          onInteractionScheduledWorkCompleted.mock.calls[1][0],
-        ).toMatchInteraction(highPriUpdateInteraction);
       });
     });
   });


### PR DESCRIPTION
Read this PR with `?w=1`

(I had an older version of this PR, made a fresh one to get out of conflict hell)

This PR adds `act()` by default to react-test-renderer's `.create`, `.update`, and `.unmount` methods.

We risk a major breaking change with having added warnings on unqueued effects outside of an act scope. Eg: A lot of people's snapshot tests will break; this would be good, if they didn't have to first wrap their renderer helper with `act()`, and then update snapshots.

Broadly, we could also make a case why this makes sense to any consumers; they'll be using it only in testing scenarios, which we'd want to wrap in `act()` anyway

For our internal tests, this had the effect that a larger portion of the test was just wrapped with an outer `act()`, letting us test incremental updates by advancing the `Scheduler` manually.
