### PR TITLE
[Fresh] Clone a custom hook node before use

### DIFF
--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -245,7 +245,7 @@ export default function(babel) {
       key: fnHookCalls.map(call => call.name + '{' + call.key + '}').join('\n'),
       customHooks: fnHookCalls
         .filter(call => !isBuiltinHook(call.name))
-        .map(call => call.callee),
+        .map(call => t.cloneDeep(call.callee)),
     };
   }
 

--- a/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -15,7 +15,12 @@ function transform(input, options = {}) {
   return wrap(
     babel.transform(input, {
       babelrc: false,
-      plugins: ['syntax-jsx', 'syntax-dynamic-import', freshPlugin],
+      plugins: [
+        'syntax-jsx',
+        'syntax-dynamic-import',
+        freshPlugin,
+        ...(options.plugins || []),
+      ],
     }).code,
   );
 }
@@ -384,6 +389,26 @@ describe('ReactFreshBabelPlugin', () => {
           return <h1>{bar}</h1>;
         }
     `),
+    ).toMatchSnapshot();
+  });
+
+  it('includes custom hooks into the signatures when commonjs target is used', () => {
+    // this test is passing with Babel 6
+    // but would fail for Babel 7 _without_ custom hook node being cloned for signature
+    expect(
+      transform(
+        `
+        import {useFancyState} from './hooks';
+        
+        export default function App() {
+          const bar = useFancyState();
+          return <h1>{bar}</h1>;
+        }
+    `,
+        {
+          plugins: ['transform-es2015-modules-commonjs'],
+        },
+      ),
     ).toMatchSnapshot();
   });
 

--- a/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -218,6 +218,37 @@ var _c;
 $RefreshReg$(_c, "App");
 `;
 
+exports[`ReactFreshBabelPlugin includes custom hooks into the signatures when commonjs target is used 1`] = `
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _s = $RefreshSig$();
+
+exports.default = App;
+
+var _hooks = require('./hooks');
+
+function App() {
+  _s();
+
+  const bar = (0, _hooks.useFancyState)();
+  return <h1>{bar}</h1>;
+}
+
+_s(App, 'useFancyState{bar}', false, function () {
+  return [_hooks.useFancyState];
+});
+
+_c = App;
+
+var _c;
+
+$RefreshReg$(_c, 'App');
+`;
+
 exports[`ReactFreshBabelPlugin only registers pascal case functions 1`] = `
 
 function hello() {


### PR DESCRIPTION
This is a small patch to react-refresh babel plugin to fix a problem we found in [react-hot-loader](https://github.com/gaearon/react-hot-loader/issues/1268).

In short - refresh babel plugin is using the "original" _babel node_ to put a custom hook into `signature`, and `common-js` babel plugin has a logical condition not to transform any node twice. As a result - custom hook reference would not be transformed. @dgreensp did an amazing job finding the root cause.

Solution - just `clone` node before the use. Look like there is no need for deep clone in this case.

Keep in mind - __no tests were added__. Unfortunately, this bug is not reproducible with babel 6, and only babel 7 is affected. To be more concrete - I've added tests, but as long as they are not testing anything - they are passing initially - I've removed them.