### PR TITLE
Add tail="hidden" option to SuspenseList

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -27,7 +27,7 @@ import type {ReactEventComponentInstance} from 'shared/ReactTypes';
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {enableProfilerTimer, enableFlareAPI} from 'shared/ReactFeatureFlags';
-import {NoEffect} from 'shared/ReactSideEffectTags';
+import {NoEffect, Placement} from 'shared/ReactSideEffectTags';
 import {ConcurrentRoot, BatchedRoot} from 'shared/ReactRootTags';
 import {
   IndeterminateComponent,
@@ -494,8 +494,9 @@ export function resetWorkInProgress(
   // We assume pendingProps, index, key, ref, return are still untouched to
   // avoid doing another reconciliation.
 
-  // Reset the effect tag.
-  workInProgress.effectTag = NoEffect;
+  // Reset the effect tag but keep any Placement tags, since that's something
+  // that child fiber is setting, not the reconciliation.
+  workInProgress.effectTag &= Placement;
 
   // The effect list is no longer valid.
   workInProgress.nextEffect = null;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2072,12 +2072,12 @@ function validateTailOptions(
 ) {
   if (__DEV__) {
     if (tailMode !== undefined && !didWarnAboutTailOptions[tailMode]) {
-      if (tailMode !== 'collapsed') {
+      if (tailMode !== 'collapsed' && tailMode !== 'hidden') {
         didWarnAboutTailOptions[tailMode] = true;
         warning(
           false,
           '"%s" is not a supported value for tail on <SuspenseList />. ' +
-            'Did you mean "collapsed"?',
+            'Did you mean "collapsed" or "hidden"?',
           tailMode,
         );
       } else if (revealOrder !== 'forwards' && revealOrder !== 'backwards') {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2242,10 +2242,10 @@ function updateSuspenseListComponent(
   pushSuspenseContext(workInProgress, suspenseContext);
 
   if ((workInProgress.mode & BatchedMode) === NoMode) {
-    workInProgress.memoizedState = null;
-  } else {
     // Outside of batched mode, SuspenseList doesn't work so we just
     // use make it a noop by treating it as the default revealOrder.
+    workInProgress.memoizedState = null;
+  } else {
     switch (revealOrder) {
       case 'forwards': {
         let lastContentRow = findLastContentRow(workInProgress.child);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -125,7 +125,7 @@ import {
   addSubtreeSuspenseContext,
   setShallowSuspenseContext,
 } from './ReactFiberSuspenseContext';
-import {isShowingAnyFallbacks} from './ReactFiberSuspenseComponent';
+import {findFirstSuspended} from './ReactFiberSuspenseComponent';
 import {
   pushProvider,
   propagateContextChange,
@@ -2000,7 +2000,7 @@ function findLastContentRow(firstChild: null | Fiber): null | Fiber {
   while (row !== null) {
     let currentRow = row.alternate;
     // New rows can't be content rows.
-    if (currentRow !== null && !isShowingAnyFallbacks(currentRow)) {
+    if (currentRow !== null && findFirstSuspended(currentRow) === null) {
       lastContentRow = row;
     }
     row = row.sibling;
@@ -2281,7 +2281,7 @@ function updateSuspenseListComponent(
         while (row !== null) {
           let currentRow = row.alternate;
           // New rows can't be content rows.
-          if (currentRow !== null && !isShowingAnyFallbacks(currentRow)) {
+          if (currentRow !== null && findFirstSuspended(currentRow) === null) {
             // This is the beginning of the main content.
             workInProgress.child = row;
             break;

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -70,7 +70,12 @@ export function findFirstSuspended(row: Fiber): null | Fiber {
       if (state !== null) {
         return node;
       }
-    } else if (node.tag === SuspenseListComponent) {
+    } else if (
+      node.tag === SuspenseListComponent &&
+      // revealOrder undefined can't be trusted because it don't
+      // keep track of whether it suspended or not.
+      node.memoizedProps.revealOrder !== undefined
+    ) {
       let didSuspend = (node.effectTag & DidCapture) !== NoEffect;
       if (didSuspend) {
         return node;

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -14,7 +14,7 @@ import {SuspenseComponent} from 'shared/ReactWorkTags';
 // Alternatively we can make this use an effect tag similar to SuspenseList.
 export type SuspenseState = {||};
 
-export type SuspenseListTailMode = 'collapsed' | void;
+export type SuspenseListTailMode = 'collapsed' | 'hidden' | void;
 
 export type SuspenseListRenderState = {|
   isBackwards: boolean,
@@ -28,6 +28,9 @@ export type SuspenseListRenderState = {|
   tailExpiration: number,
   // Tail insertions setting.
   tailMode: SuspenseListTailMode,
+  // Last Effect before we rendered the "rendering" item.
+  // Used to remove new effects added by the rendered item.
+  lastEffect: null | Fiber,
 |};
 
 export function shouldCaptureSuspense(

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -640,6 +640,9 @@ describe('ReactSuspenseList', () => {
       'Loading B',
       'Suspend! [C]',
       'Loading C',
+      'A',
+      'Loading B',
+      'Loading C',
     ]);
 
     // This will suspend, since the boundaries are avoided. Give them
@@ -859,6 +862,10 @@ describe('ReactSuspenseList', () => {
       'Suspend! [C]',
       'Loading C',
       'D',
+      'Loading A',
+      'B',
+      'Loading C',
+      'D',
       'Loading E',
       'Loading F',
     ]);
@@ -1003,6 +1010,16 @@ describe('ReactSuspenseList', () => {
     );
 
     expect(Scheduler).toFlushAndYield([
+      'Suspend! [A]',
+      'Loading A',
+      'Suspend! [B]',
+      'Loading B',
+      'C',
+      'Suspend! [D]',
+      'Loading D',
+      'E',
+      'Suspend! [F]',
+      'Loading F',
       'Suspend! [A]',
       'Loading A',
       'Suspend! [B]',
@@ -1392,6 +1409,10 @@ describe('ReactSuspenseList', () => {
       'Suspend! [C]',
       'Loading C',
       'D',
+      'A',
+      'Loading B',
+      'Loading C',
+      'D',
       'Loading E',
     ]);
 
@@ -1516,6 +1537,10 @@ describe('ReactSuspenseList', () => {
       'Suspend! [E]',
       'Loading E',
       'F',
+      'C',
+      'Loading D',
+      'Loading E',
+      'F',
       'Loading B',
     ]);
 
@@ -1530,15 +1555,15 @@ describe('ReactSuspenseList', () => {
       </Fragment>,
     );
 
-    await E.resolve();
+    await D.resolve();
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [D]', 'E']);
+    expect(Scheduler).toFlushAndYield(['D', 'Suspend! [E]']);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
 
-    // Even though E is unsuspended, it's still in loading state because
-    // it is blocked by D.
+    // Even though D is unsuspended, it's still in loading state because
+    // it is blocked by E.
     expect(ReactNoop).toMatchRenderedOutput(
       <Fragment>
         <span>Loading B</span>
@@ -1647,6 +1672,11 @@ describe('ReactSuspenseList', () => {
       'Suspend! [B]',
       'Loading B',
       'Suspend! [C]',
+      'Loading C',
+      'Suspend! [D]',
+      'Loading D',
+      'A',
+      'Loading B',
       'Loading C',
       'Suspend! [D]',
       'Loading D',


### PR DESCRIPTION
Builds on top of #16007.

This is similar to `tail="collapsed"` except it hides all rows in the tail. The added complexity here is that sometimes we only know that we've hit the tail after we've already rendered this row. So we need undo the effects added by rendering the row.

Additionally, by not committing the boundary, there's nothing to retry. So we need to transfer the promise set to the list so that we get a retry if the only thing to ping was in the tail.