### PR TITLE
[Flare] Do not block mouse presses on scroll

### DIFF
--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -797,6 +797,7 @@ const PressResponder: ReactDOMEventResponder = {
     const nativeEvent: any = event.nativeEvent;
     const isPressed = state.isPressed;
     const activePointerId = state.activePointerId;
+    const previousPointerType = state.pointerType;
 
     handleStopPropagation(props, context, nativeEvent);
     switch (type) {
@@ -807,7 +808,7 @@ const PressResponder: ReactDOMEventResponder = {
         let touchEvent;
         // Ignore emulated events (pointermove will dispatch touch and mouse events)
         // Ignore pointermove events during a keyboard press.
-        if (state.pointerType !== pointerType) {
+        if (previousPointerType !== pointerType) {
           return;
         }
         if (type === 'pointermove' && activePointerId !== pointerId) {
@@ -976,7 +977,7 @@ const PressResponder: ReactDOMEventResponder = {
 
       case 'click': {
         // "keyup" occurs after "click"
-        if (state.pointerType !== 'keyboard') {
+        if (previousPointerType !== 'keyboard') {
           removeRootEventTypes(context, state);
         }
         break;
@@ -984,6 +985,10 @@ const PressResponder: ReactDOMEventResponder = {
 
       // CANCEL
       case 'scroll': {
+        // We ignore incoing scroll events when using mouse events
+        if (previousPointerType === 'mouse') {
+          return;
+        }
         const pressTarget = state.pressTarget;
         const scrollTarget = nativeEvent.target;
         const doc = context.getActiveDocument();

--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -985,7 +985,7 @@ const PressResponder: ReactDOMEventResponder = {
 
       // CANCEL
       case 'scroll': {
-        // We ignore incoing scroll events when using mouse events
+        // We ignore incoming scroll events when using mouse events
         if (previousPointerType === 'mouse') {
           return;
         }

--- a/packages/react-events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Press-test.internal.js
@@ -2445,14 +2445,30 @@ describe('Event responder: Press', () => {
       );
       ReactDOM.render(element, container);
 
-      ref.current.dispatchEvent(createEvent('pointerdown'));
+      // Should cancel for non-mouse events
+      ref.current.dispatchEvent(
+        createEvent('pointerdown', {
+          pointerType: 'touch',
+        }),
+      );
       ref.current.dispatchEvent(createEvent('scroll'));
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       jest.runAllTimers();
       expect(onLongPress).not.toBeCalled();
 
-      onLongPress.mockReset();
       onPressEnd.mockReset();
+
+      // Should not cancel for mouse events
+      ref.current.dispatchEvent(
+        createEvent('pointerdown', {
+          pointerType: 'mouse',
+        }),
+      );
+      ref.current.dispatchEvent(createEvent('scroll'));
+      expect(onPressEnd).toHaveBeenCalledTimes(0);
+      jest.runAllTimers();
+
+      onLongPress.mockReset();
 
       // When pointer events are supported
       ref.current.dispatchEvent(


### PR DESCRIPTION
This PR changes the existing behaviour in `Press` so that `mouse` pointer events no longer get cancelled when a `scroll` event occurs. This matches the expected behaviour on platforms that use mouse interactions. Unlike `touch`, which is expected to have a connection with `scroll`, mouse events are detached from scrolling (aside from `mousewheel`).