### PR TITLE
flush suspense fallbacks at the end of act() calls.

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -39,6 +39,7 @@ import {
   findHostInstanceWithWarning,
   flushPassiveEffects,
   ReactActingRendererSigil,
+  flushSuspenseTimeouts,
 } from 'react-reconciler/inline.dom';
 import {createPortal as createPortalImpl} from 'shared/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
@@ -818,6 +819,7 @@ const ReactDOM: Object = {
       runEventsInBatch,
       flushPassiveEffects,
       ReactActingRendererSigil,
+      flushSuspenseTimeouts,
     ],
   },
 };

--- a/packages/react-dom/src/fire/ReactFire.js
+++ b/packages/react-dom/src/fire/ReactFire.js
@@ -44,6 +44,7 @@ import {
   findHostInstanceWithWarning,
   flushPassiveEffects,
   ReactActingRendererSigil,
+  flushSuspenseTimeouts,
 } from 'react-reconciler/inline.fire';
 import {createPortal as createPortalImpl} from 'shared/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
@@ -824,6 +825,7 @@ const ReactDOM: Object = {
       runEventsInBatch,
       flushPassiveEffects,
       ReactActingRendererSigil,
+      flushSuspenseTimeouts,
     ],
   },
 };

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -45,6 +45,7 @@ const [
   /* eslint-disable no-unused-vars */
   flushPassiveEffects,
   ReactActingRendererSigil,
+  flushSuspenseTimeouts,
   /* eslint-enable no-unused-vars */
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
 

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -34,6 +34,7 @@ const [
   /* eslint-enable no-unused-vars */
   flushPassiveEffects,
   ReactActingRendererSigil,
+  flushSuspenseTimeouts,
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
 
 const batchedUpdates = ReactDOM.unstable_batchedUpdates;
@@ -67,6 +68,7 @@ const flushWork =
 function flushWorkAndMicroTasks(onDone: (err: ?Error) => void) {
   try {
     flushWork();
+    flushSuspenseTimeouts();
     enqueueTask(() => {
       if (flushWork()) {
         flushWorkAndMicroTasks(onDone);
@@ -190,6 +192,7 @@ function act(callback: () => Thenable) {
         // we're about to exit the act() scope,
         // now's the time to flush effects
         flushWork();
+        flushSuspenseTimeouts();
       }
       onDone();
     } catch (err) {

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -567,6 +567,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     flushPassiveEffects,
     batchedUpdates,
     ReactActingRendererSigil,
+    flushSuspenseTimeouts,
   } = NoopRenderer;
 
   // this act() implementation should be exactly the same in
@@ -596,6 +597,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
   function flushWorkAndMicroTasks(onDone: (err: ?Error) => void) {
     try {
       flushWork();
+      flushSuspenseTimeouts();
       enqueueTask(() => {
         if (flushWork()) {
           flushWorkAndMicroTasks(onDone);
@@ -719,6 +721,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
           // we're about to exit the act() scope,
           // now's the time to flush effects
           flushWork();
+          flushSuspenseTimeouts();
         }
         onDone();
       } catch (err) {

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -56,6 +56,7 @@ import {
   discreteUpdates,
   flushDiscreteUpdates,
   flushPassiveEffects,
+  flushSuspenseTimeouts,
   warnIfNotScopedWithMatchingAct,
   ReactActingRendererSigil,
 } from './ReactFiberWorkLoop';
@@ -345,6 +346,7 @@ export {
   flushControlled,
   flushSync,
   flushPassiveEffects,
+  flushSuspenseTimeouts,
   ReactActingRendererSigil,
 };
 

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -2329,10 +2329,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       expect(Scheduler).toFlushAndYield(['Suspend! [First update]']);
       // Should not display a fallback
       expect(root).toMatchRenderedOutput(<span prop="Initial" />);
-    });
 
-    // Update again. This should also suspend for a bit.
-    await ReactNoop.act(async () => {
+      // Update again. This should also suspend for a bit.
       root.render(<App text="Second update" />);
 
       expect(Scheduler).toFlushAndYield(['Suspend! [Second update]']);

--- a/packages/react-test-renderer/src/ReactTestRendererAct.js
+++ b/packages/react-test-renderer/src/ReactTestRendererAct.js
@@ -12,6 +12,7 @@ import {
   batchedUpdates,
   flushPassiveEffects,
   ReactActingRendererSigil,
+  flushSuspenseTimeouts,
 } from 'react-reconciler/inline.test';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import warningWithoutStack from 'shared/warningWithoutStack';
@@ -48,6 +49,7 @@ const flushWork =
 function flushWorkAndMicroTasks(onDone: (err: ?Error) => void) {
   try {
     flushWork();
+    flushSuspenseTimeouts();
     enqueueTask(() => {
       if (flushWork()) {
         flushWorkAndMicroTasks(onDone);
@@ -171,6 +173,7 @@ function act(callback: () => Thenable) {
         // we're about to exit the act() scope,
         // now's the time to flush effects
         flushWork();
+        flushSuspenseTimeouts();
       }
       onDone();
     } catch (err) {


### PR DESCRIPTION
- 'Saves' a reference to the handle+root in a Map whenever `scheduleTimeout` is called
- On exiting an `act()` scope, flushes them out, and clears the Map entry
- Added a test for the same, and updated another that expected differently. 

I wrote just the one test for this, but I'm keen to add more coverage. Any pointers to what other tests could be useful?