### PR TITLE
[Flare] Add more functionality to Scroll event responder

### DIFF
--- a/packages/react-events/src/dom/__tests__/Scroll-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Scroll-test.internal.js
@@ -90,7 +90,31 @@ describe('Scroll event responder', () => {
         ref.current.dispatchEvent(createEvent('scroll'));
         expect(onScroll).toHaveBeenCalledTimes(1);
         expect(onScroll).toHaveBeenCalledWith(
-          expect.objectContaining({pointerType: 'mouse', type: 'scroll'}),
+          expect.objectContaining({
+            pointerType: 'mouse',
+            type: 'scroll',
+            direction: '',
+          }),
+        );
+        onScroll.mockReset();
+        ref.current.scrollTop = -1;
+        ref.current.dispatchEvent(createEvent('scroll'));
+        expect(onScroll).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pointerType: 'mouse',
+            type: 'scroll',
+            direction: 'up',
+          }),
+        );
+        onScroll.mockReset();
+        ref.current.scrollTop = 1;
+        ref.current.dispatchEvent(createEvent('scroll'));
+        expect(onScroll).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pointerType: 'mouse',
+            type: 'scroll',
+            direction: 'down',
+          }),
         );
       });
 
@@ -103,7 +127,31 @@ describe('Scroll event responder', () => {
         ref.current.dispatchEvent(createEvent('scroll'));
         expect(onScroll).toHaveBeenCalledTimes(1);
         expect(onScroll).toHaveBeenCalledWith(
-          expect.objectContaining({pointerType: 'touch', type: 'scroll'}),
+          expect.objectContaining({
+            pointerType: 'touch',
+            type: 'scroll',
+            direction: '',
+          }),
+        );
+        onScroll.mockReset();
+        ref.current.scrollTop = -1;
+        ref.current.dispatchEvent(createEvent('scroll'));
+        expect(onScroll).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pointerType: 'touch',
+            type: 'scroll',
+            direction: 'up',
+          }),
+        );
+        onScroll.mockReset();
+        ref.current.scrollTop = 1;
+        ref.current.dispatchEvent(createEvent('scroll'));
+        expect(onScroll).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pointerType: 'touch',
+            type: 'scroll',
+            direction: 'down',
+          }),
         );
       });
 
@@ -116,7 +164,31 @@ describe('Scroll event responder', () => {
         ref.current.dispatchEvent(createEvent('scroll'));
         expect(onScroll).toHaveBeenCalledTimes(1);
         expect(onScroll).toHaveBeenCalledWith(
-          expect.objectContaining({pointerType: 'pen', type: 'scroll'}),
+          expect.objectContaining({
+            pointerType: 'pen',
+            type: 'scroll',
+            direction: '',
+          }),
+        );
+        onScroll.mockReset();
+        ref.current.scrollTop = -1;
+        ref.current.dispatchEvent(createEvent('scroll'));
+        expect(onScroll).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pointerType: 'pen',
+            type: 'scroll',
+            direction: 'up',
+          }),
+        );
+        onScroll.mockReset();
+        ref.current.scrollTop = 1;
+        ref.current.dispatchEvent(createEvent('scroll'));
+        expect(onScroll).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pointerType: 'pen',
+            type: 'scroll',
+            direction: 'down',
+          }),
         );
       });
 
@@ -134,9 +206,80 @@ describe('Scroll event responder', () => {
         ref.current.dispatchEvent(createEvent('scroll'));
         expect(onScroll).toHaveBeenCalledTimes(1);
         expect(onScroll).toHaveBeenCalledWith(
-          expect.objectContaining({pointerType: 'keyboard', type: 'scroll'}),
+          expect.objectContaining({
+            pointerType: 'keyboard',
+            type: 'scroll',
+            direction: '',
+          }),
         );
       });
+    });
+  });
+
+  describe('onScrollDragStart', () => {
+    let onScrollDragStart, ref;
+
+    beforeEach(() => {
+      onScrollDragStart = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Scroll onScrollDragStart={onScrollDragStart}>
+          <div ref={ref} />
+        </Scroll>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('works as expected with touch events', () => {
+      ref.current.dispatchEvent(
+        createEvent('pointerdown', {
+          pointerType: 'touch',
+        }),
+      );
+      ref.current.dispatchEvent(createEvent('touchstart'));
+      ref.current.dispatchEvent(createEvent('scroll'));
+      expect(onScrollDragStart).toHaveBeenCalledTimes(1);
+      expect(onScrollDragStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pointerType: 'touch',
+          type: 'scrolldragstart',
+          direction: '',
+        }),
+      );
+    });
+  });
+
+  describe('onScrollDragEnd', () => {
+    let onScrollDragEnd, ref;
+
+    beforeEach(() => {
+      onScrollDragEnd = jest.fn();
+      ref = React.createRef();
+      const element = (
+        <Scroll onScrollDragEnd={onScrollDragEnd}>
+          <div ref={ref} />
+        </Scroll>
+      );
+      ReactDOM.render(element, container);
+    });
+
+    it('works as expected with touch events', () => {
+      ref.current.dispatchEvent(
+        createEvent('pointerdown', {
+          pointerType: 'touch',
+        }),
+      );
+      ref.current.dispatchEvent(createEvent('touchstart'));
+      ref.current.dispatchEvent(createEvent('scroll'));
+      ref.current.dispatchEvent(createEvent('touchend'));
+      expect(onScrollDragEnd).toHaveBeenCalledTimes(1);
+      expect(onScrollDragEnd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pointerType: 'touch',
+          type: 'scrolldragend',
+          direction: '',
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
This PR adds more functionality to the `Scroll` event responder. Specifically:

- Adds the direction property on the event object
- Adds `onScrollDragStart` and `onScrollDragEnd`
- Removes `onMomentumScrollStart` and `onMomentumScrollEnd` Flow prop types.
- Fixed a bug when disabled never removed root events

I looked into how we might implement the momentum scroll events and ultimately decided it wasn't worth the logic to support. The issue is that trackpad events fire `wheel` and `scroll` for each bit of momentum and thus it's not possible to know if the user is doing this – or if it's a system setting (like on MacOS).

Furthermore, working out the difference in delta between scrolls and mousewheels is one possibility (as other third party libraries try do), but the amount of code it requires and the complexity in handling edge cases makes it non-trivial. Adding support for touch based momentum is simpler but then this feature feels half-baked. I'd much rather leave it as a TODO for later work.