### PR TITLE
[Fresh] Rename _getMountedRootCount to getMountedRootCount

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -474,8 +474,7 @@ export function injectIntoGlobalHook(globalObject: any): void {
   }
 }
 
-// Exposed for testing.
-export function _getMountedRootCount() {
+export function getMountedRootCount() {
   if (__DEV__) {
     return mountedRoots.size;
   } else {

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -41,7 +41,7 @@ describe('ReactFreshIntegration', () => {
     if (__DEV__) {
       ReactDOM.unmountComponentAtNode(container);
       // Ensure we don't leak memory by holding onto dead roots.
-      expect(ReactFreshRuntime._getMountedRootCount()).toBe(0);
+      expect(ReactFreshRuntime.getMountedRootCount()).toBe(0);
       document.body.removeChild(container);
     }
   });
@@ -124,7 +124,7 @@ describe('ReactFreshIntegration', () => {
           // (Instead, the export change branch above would take care of it.)
         }
       });
-      expect(ReactFreshRuntime._getMountedRootCount()).toBe(1);
+      expect(ReactFreshRuntime.getMountedRootCount()).toBe(1);
     }
 
     function $RefreshReg$(type, id) {


### PR DESCRIPTION
I planned to initially only use it for testing. But I think it may also be useful to force a full reload if all roots are gone. Such as if the first mount failed and never committed. So I'm exposing it more officially.