### PR TITLE
[ESLint] Include functions instead of the objects they are part of when the result is unused

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1282,7 +1282,8 @@ function getDependency(node) {
     !(
       node.parent.parent != null &&
       node.parent.parent.type === 'CallExpression' &&
-      node.parent.parent.callee === node.parent
+      node.parent.parent.callee === node.parent &&
+      node.parent.parent.parent.type !== 'ExpressionStatement'
     )
   ) {
     return getDependency(node.parent);


### PR DESCRIPTION
This changes how `eslint-plugin-react-hooks/exhaustive-deps` works.

Take this component as an example:
```js
function App() {
  const myContext = useMyContext();
  useEffect(() => {
    myContext.setValue(e => e + 1);
  }, [myContext.setValue]);
  return null;
}
```

The exhaustive deps rule compains with the warning that `myContext` is missing from the deps array. However, because calling the function changes stuff in `myContext` adding it to the deps array would result in an endless re-render loop.

Please see #15924 for more information. For an interactive version, please see this CodeSandbox:
[![Edit react-issue-15924](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/react-issue-15924-yz8uq?fontsize=14)

As long as we don't use the result of a function, it's fine to include the function itself to the deps array instead of including the object it comes from.

If anything should work differently as how I implemented it, please let me know and I'll try to adjust my code.

This solves issues #15924 and #15448.