### PR TITLE
[fail] Only warn on unacted effects for strict / non sync modes

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
@@ -53,32 +53,23 @@ describe('ReactDOMHooks', () => {
       return 3 * n;
     }
 
-    // we explicitly catch the missing act() warnings
-    // to simulate this tricky repro
-    expect(() => {
-      ReactDOM.render(<Example1 n={1} />, container);
-      expect(container.textContent).toBe('1');
-      expect(container2.textContent).toBe('');
-      expect(container3.textContent).toBe('');
-      Scheduler.unstable_flushAll();
-      expect(container.textContent).toBe('1');
-      expect(container2.textContent).toBe('2');
-      expect(container3.textContent).toBe('3');
+    ReactDOM.render(<Example1 n={1} />, container);
+    expect(container.textContent).toBe('1');
+    expect(container2.textContent).toBe('');
+    expect(container3.textContent).toBe('');
+    Scheduler.unstable_flushAll();
+    expect(container.textContent).toBe('1');
+    expect(container2.textContent).toBe('2');
+    expect(container3.textContent).toBe('3');
 
-      ReactDOM.render(<Example1 n={2} />, container);
-      expect(container.textContent).toBe('2');
-      expect(container2.textContent).toBe('2'); // Not flushed yet
-      expect(container3.textContent).toBe('3'); // Not flushed yet
-      Scheduler.unstable_flushAll();
-      expect(container.textContent).toBe('2');
-      expect(container2.textContent).toBe('4');
-      expect(container3.textContent).toBe('6');
-    }).toWarnDev([
-      'An update to Example1 ran an effect',
-      'An update to Example2 ran an effect',
-      'An update to Example1 ran an effect',
-      'An update to Example2 ran an effect',
-    ]);
+    ReactDOM.render(<Example1 n={2} />, container);
+    expect(container.textContent).toBe('2');
+    expect(container2.textContent).toBe('2'); // Not flushed yet
+    expect(container3.textContent).toBe('3'); // Not flushed yet
+    Scheduler.unstable_flushAll();
+    expect(container.textContent).toBe('2');
+    expect(container2.textContent).toBe('4');
+    expect(container3.textContent).toBe('6');
   });
 
   it('should not bail out when an update is scheduled from within an event handler', () => {

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -62,6 +62,59 @@ describe('ReactTestUtils.act()', () => {
     }
   }
   runActTests('batched mode', renderBatched, unmountBatched);
+
+  describe('unacted effects', () => {
+    function App() {
+      React.useEffect(() => {}, []);
+      return null;
+    }
+
+    it('does not warn in legacy sync mode', () => {
+      expect(() => {
+        ReactDOM.render(<App />, document.createElement('div'));
+      }).toWarnDev([]);
+    });
+
+    it('warns in strict mode', () => {
+      expect(() => {
+        ReactDOM.render(
+          <React.StrictMode>
+            <App />
+          </React.StrictMode>,
+          document.createElement('div'),
+        );
+      }).toWarnDev([
+        'An update to App ran an effect, but was not wrapped in act(...)',
+        'An update to App ran an effect, but was not wrapped in act(...)',
+      ]);
+    });
+
+    it('warns in batched mode', () => {
+      expect(() => {
+        const root = ReactDOM.unstable_createSyncRoot(
+          document.createElement('div'),
+        );
+        root.render(<App />);
+        Scheduler.unstable_flushAll();
+      }).toWarnDev([
+        'An update to App ran an effect, but was not wrapped in act(...)',
+        'An update to App ran an effect, but was not wrapped in act(...)',
+      ]);
+    });
+
+    it('warns in concurrent mode', () => {
+      expect(() => {
+        const root = ReactDOM.unstable_createRoot(
+          document.createElement('div'),
+        );
+        root.render(<App />);
+        Scheduler.unstable_flushAll();
+      }).toWarnDev([
+        'An update to App ran an effect, but was not wrapped in act(...)',
+        'An update to App ran an effect, but was not wrapped in act(...)',
+      ]);
+    });
+  });
 });
 
 function runActTests(label, render, unmount) {
@@ -82,26 +135,6 @@ function runActTests(label, render, unmount) {
       document.body.removeChild(container);
     });
     describe('sync', () => {
-      it('warns if an effect is queued outside an act scope, except in legacy sync+non-strict mode', () => {
-        function App() {
-          React.useEffect(() => {}, []);
-          return null;
-        }
-        expect(() => {
-          render(<App />, container);
-          // flush all queued work
-          Scheduler.unstable_flushAll();
-        }).toWarnDev(
-          label !== 'legacy sync mode'
-            ? [
-                // warns twice because we're in strict+dev mode
-                'An update to App ran an effect, but was not wrapped in act(...)',
-                'An update to App ran an effect, but was not wrapped in act(...)',
-              ]
-            : [],
-        );
-      });
-
       it('can use act to flush effects', () => {
         function App() {
           React.useEffect(() => {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -61,6 +61,7 @@ import {
 import {createWorkInProgress, assignFiberPropertiesInDEV} from './ReactFiber';
 import {
   NoMode,
+  StrictMode,
   ProfileMode,
   BatchedMode,
   ConcurrentMode,
@@ -2453,7 +2454,10 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
   if (__DEV__) {
     if (
       warnsIfNotActing === true &&
-      fiber.mode &&
+      (fiber.mode & StrictMode ||
+        fiber.mode & ProfileMode ||
+        fiber.mode & BatchedMode ||
+        fiber.mode & ConcurrentMode) &&
       IsSomeRendererActing.current === false &&
       IsThisRendererActing.current === false
     ) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2453,6 +2453,7 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
   if (__DEV__) {
     if (
       warnsIfNotActing === true &&
+      fiber.mode &&
       IsSomeRendererActing.current === false &&
       IsThisRendererActing.current === false
     ) {

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1806,7 +1806,6 @@ describe('ReactHooks', () => {
       globalListener();
       globalListener();
     }).toWarnDev([
-      'An update to C ran an effect',
       'An update to C inside a test was not wrapped in act',
       'An update to C inside a test was not wrapped in act',
       // Note: should *not* warn about updates on unmounted component.


### PR DESCRIPTION
(basically, when `fiber.mode !== 0b0000`)

Warnings on unacted effects may be too noisy, especially for legacy apps. This PR fires the warning only when in a non sync mode (concurrent/batched), or when in strict mode. This should make gradually updating codebases easier too.

I also added batched mode tests to the act() suite.