### PR TITLE
[fail] reset IsThisRendererActing correctly

### DIFF
--- a/fixtures/dom/src/index.test.js
+++ b/fixtures/dom/src/index.test.js
@@ -37,6 +37,21 @@ it("doesn't warn when you use the right act + renderer: test", () => {
   });
 });
 
+it('resets correctly across renderers', () => {
+  function Effecty() {
+    React.useEffect(() => {}, []);
+    return null;
+  }
+  TestUtils.act(() => {
+    TestRenderer.act(() => {});
+    expect(() => {
+      TestRenderer.create(<Effecty />);
+    }).toWarnDev(["It looks like you're using the wrong act()"], {
+      withoutStack: true,
+    });
+  });
+});
+
 it('warns when using createRoot() + .render', () => {
   const root = ReactDOM.unstable_createRoot(document.createElement('div'));
   expect(() => {

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -91,7 +91,7 @@ function act(callback: () => Thenable) {
   actingUpdatesScopeDepth++;
   if (__DEV__) {
     previousIsSomeRendererActing = IsSomeRendererActing.current;
-    previousIsThisRendererActing = IsSomeRendererActing.current;
+    previousIsThisRendererActing = IsThisRendererActing.current;
     IsSomeRendererActing.current = true;
     IsThisRendererActing.current = true;
   }

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -620,7 +620,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     actingUpdatesScopeDepth++;
     if (__DEV__) {
       previousIsSomeRendererActing = IsSomeRendererActing.current;
-      previousIsThisRendererActing = IsSomeRendererActing.current;
+      previousIsThisRendererActing = IsThisRendererActing.current;
       IsSomeRendererActing.current = true;
       IsThisRendererActing.current = true;
     }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2454,10 +2454,7 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
   if (__DEV__) {
     if (
       warnsIfNotActing === true &&
-      (fiber.mode & StrictMode ||
-        fiber.mode & ProfileMode ||
-        fiber.mode & BatchedMode ||
-        fiber.mode & ConcurrentMode) &&
+      (fiber.mode & StrictMode) !== NoMode &&
       IsSomeRendererActing.current === false &&
       IsThisRendererActing.current === false
     ) {

--- a/packages/react-test-renderer/src/ReactTestRendererAct.js
+++ b/packages/react-test-renderer/src/ReactTestRendererAct.js
@@ -72,7 +72,7 @@ function act(callback: () => Thenable) {
   actingUpdatesScopeDepth++;
   if (__DEV__) {
     previousIsSomeRendererActing = IsSomeRendererActing.current;
-    previousIsThisRendererActing = IsSomeRendererActing.current;
+    previousIsThisRendererActing = IsThisRendererActing.current;
     IsSomeRendererActing.current = true;
     IsThisRendererActing.current = true;
   }


### PR DESCRIPTION
I missed this in https://github.com/facebook/react/pull/16039. I'd pointed at the wrong previous state, corrupting it in further use. This PR fixes that, and adds a test to make sure it doesn't happen again.

Also applies suggested change from https://github.com/facebook/react/pull/16041#discussion_r299748307