### PR TITLE
[Flare] createInitialState -> getInitialState

### DIFF
--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -20,7 +20,7 @@ const DiscreteEvent = 0;
 function createReactEventComponent({
   targetEventTypes,
   rootEventTypes,
-  createInitialState,
+  getInitialState,
   onEvent,
   onEventCapture,
   onRootEvent,
@@ -34,7 +34,7 @@ function createReactEventComponent({
     displayName: 'TestEventComponent',
     targetEventTypes,
     rootEventTypes,
-    createInitialState,
+    getInitialState,
     onEvent,
     onEventCapture,
     onRootEvent,
@@ -596,7 +596,7 @@ describe('DOMEventResponderSystem', () => {
 
     const EventComponent = createReactEventComponent({
       targetEventTypes: [],
-      createInitialState: () => ({
+      getInitialState: () => ({
         incrementAmount: 5,
       }),
       onUnmount: (context, props, state) => {

--- a/packages/react-events/README.md
+++ b/packages/react-events/README.md
@@ -48,7 +48,7 @@ type CustomEvent = {
 }
 ```
 
-### createInitialState?: (props: null | Object) => Object
+### getInitialState?: (props: null | Object) => Object
 
 The initial state of that the Event Component is created with.
 

--- a/packages/react-events/src/dom/Drag.js
+++ b/packages/react-events/src/dom/Drag.js
@@ -88,7 +88,7 @@ function dispatchDragEvent(
 const DragResponder: ReactDOMEventResponder = {
   displayName: 'Drag',
   targetEventTypes,
-  createInitialState(): DragState {
+  getInitialState(): DragState {
     return {
       dragTarget: null,
       isPointerDown: false,

--- a/packages/react-events/src/dom/Focus.js
+++ b/packages/react-events/src/dom/Focus.js
@@ -221,7 +221,7 @@ const FocusResponder: ReactDOMEventResponder = {
   displayName: 'Focus',
   targetEventTypes,
   rootEventTypes,
-  createInitialState(): FocusState {
+  getInitialState(): FocusState {
     return {
       focusTarget: null,
       isFocused: false,

--- a/packages/react-events/src/dom/FocusScope.js
+++ b/packages/react-events/src/dom/FocusScope.js
@@ -50,7 +50,7 @@ const FocusScopeResponder: ReactDOMEventResponder = {
   displayName: 'FocusScope',
   targetEventTypes,
   rootEventTypes,
-  createInitialState(): FocusScopeState {
+  getInitialState(): FocusScopeState {
     return {
       nodeToRestore: null,
       currentFocusedNode: null,

--- a/packages/react-events/src/dom/Hover.js
+++ b/packages/react-events/src/dom/Hover.js
@@ -274,7 +274,7 @@ function isEmulatedMouseEvent(event, state) {
 const HoverResponder: ReactDOMEventResponder = {
   displayName: 'Hover',
   targetEventTypes,
-  createInitialState() {
+  getInitialState() {
     return {
       isActiveHovered: false,
       isHovered: false,

--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -618,7 +618,7 @@ function handleStopPropagation(
 const PressResponder: ReactDOMEventResponder = {
   displayName: 'Press',
   targetEventTypes,
-  createInitialState(): PressState {
+  getInitialState(): PressState {
     return {
       activationPosition: null,
       addedRootEvents: false,

--- a/packages/react-events/src/dom/Scroll.js
+++ b/packages/react-events/src/dom/Scroll.js
@@ -131,7 +131,7 @@ function dispatchEvent(
 const ScrollResponder: ReactDOMEventResponder = {
   displayName: 'Scroll',
   targetEventTypes,
-  createInitialState() {
+  getInitialState() {
     return {
       direction: '',
       isTouching: false,

--- a/packages/react-events/src/dom/Swipe.js
+++ b/packages/react-events/src/dom/Swipe.js
@@ -92,7 +92,7 @@ type SwipeState = {
 const SwipeResponder: ReactDOMEventResponder = {
   displayName: 'Scroll',
   targetEventTypes,
-  createInitialState(): SwipeState {
+  getInitialState(): SwipeState {
     return {
       direction: 0,
       isSwiping: false,

--- a/packages/react-events/src/rn/Press.js
+++ b/packages/react-events/src/rn/Press.js
@@ -506,7 +506,7 @@ const PressResponder: ReactNativeEventResponder = {
   targetEventTypes,
   allowEventHooks: true,
   allowMultipleHostChildren: false,
-  createInitialState(): PressState {
+  getInitialState(): PressState {
     return {
       activationPosition: null,
       activePointerId: null,

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -1142,8 +1142,9 @@ function completeWork(
               getComponentName(workInProgress.type),
             );
           }
-          if (responder.createInitialState !== undefined) {
-            responderState = responder.createInitialState(newProps);
+          const getInitialState = responder.getInitialState;
+          if (getInitialState !== undefined) {
+            responderState = getInitialState(newProps);
           }
           eventComponentInstance = workInProgress.stateNode = createEventComponentInstance(
             workInProgress,

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -60,8 +60,9 @@ export function updateEventComponentInstance<T, E, C>(
   }
   if (currentEventComponentInstanceIndex === events.length) {
     let responderState = null;
-    if (responder.createInitialState !== undefined) {
-      responderState = responder.createInitialState(props);
+    const getInitialState = responder.getInitialState;
+    if (getInitialState !== undefined) {
+      responderState = getInitialState(props);
     }
     const eventComponentInstance = createEventComponentInstance(
       ((currentlyRenderingFiber: any): Fiber),

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -95,7 +95,7 @@ export type ReactEventResponder<T, E, C> = {
   displayName: string,
   targetEventTypes?: Array<T>,
   rootEventTypes?: Array<T>,
-  createInitialState?: (props: Object) => Object,
+  getInitialState?: (props: Object) => Object,
   allowMultipleHostChildren: boolean,
   allowEventHooks: boolean,
   onEvent?: (event: E, context: C, props: Object, state: Object) => void,


### PR DESCRIPTION
There was feedback that `createInitialState` on event responders made them seem like the old React component API and that responders might have a `this`. To be honest, the naming is probably better suited to be using `get` rather than `create` anyway, as the responder methods are not bound to an instance, but are rather static functions.