### PR TITLE
[Flare] Remove capture phase Flare events

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -796,7 +796,7 @@ function traverseAndHandleEventResponderInstances(
   // Bubbled event phases have the notion of local propagation.
   // This means that the propgation chain can be stopped part of the the way
   // through processing event component instances. The major difference to other
-  // events systems is that the stopping of propgation is localized to a single
+  // events systems is that the stopping of propagation is localized to a single
   // phase, rather than both phases.
   if (length > 0) {
     // Bubble target phase

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -552,7 +552,7 @@ function createDOMResponderEvent(
     eventPointerType = 'touch';
   }
 
-  const responderEvent = {
+  return {
     nativeEvent: nativeEvent,
     passive,
     passiveSupported,
@@ -561,10 +561,6 @@ function createDOMResponderEvent(
     target: nativeEventTarget,
     type: topLevelType,
   };
-  if (__DEV__) {
-    Object.freeze(responderEvent);
-  }
-  return responderEvent;
 }
 
 function createEventQueue(): EventQueue {
@@ -779,7 +775,6 @@ function traverseAndHandleEventResponderInstances(
   );
 
   // Trigger event responders in this order:
-  // - Capture target phase
   // - Bubble target phase
   // - Root phase
 
@@ -798,41 +793,12 @@ function traverseAndHandleEventResponderInstances(
   let length = targetEventResponderInstances.length;
   let i;
 
-  // Captured and bubbled event phases have the notion of local propagation.
+  // Bubbled event phases have the notion of local propagation.
   // This means that the propgation chain can be stopped part of the the way
   // through processing event component instances. The major difference to other
   // events systems is that the stopping of propgation is localized to a single
   // phase, rather than both phases.
   if (length > 0) {
-    // Capture target phase
-    for (i = length; i-- > 0; ) {
-      const targetEventResponderInstance = targetEventResponderInstances[i];
-      const {isHook, props, responder, state} = targetEventResponderInstance;
-      const eventListener = responder.onEventCapture;
-      if (eventListener !== undefined) {
-        if (
-          shouldSkipEventComponent(
-            targetEventResponderInstance,
-            ((responder: any): ReactDOMEventResponder),
-            propagatedEventResponders,
-            isHook,
-          )
-        ) {
-          continue;
-        }
-        currentInstance = targetEventResponderInstance;
-        currentlyInHook = isHook;
-        eventListener(responderEvent, eventResponderContext, props, state);
-        if (!isHook) {
-          checkForLocalPropagationContinuation(
-            responder,
-            propagatedEventResponders,
-          );
-        }
-      }
-    }
-    // We clean propagated event responders between phases.
-    propagatedEventResponders.clear();
     // Bubble target phase
     for (i = 0; i < length; i++) {
       const targetEventResponderInstance = targetEventResponderInstances[i];

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -22,7 +22,6 @@ function createReactEventComponent({
   rootEventTypes,
   createInitialState,
   onEvent,
-  onEventCapture,
   onRootEvent,
   onMount,
   onUnmount,
@@ -36,7 +35,6 @@ function createReactEventComponent({
     rootEventTypes,
     createInitialState,
     onEvent,
-    onEventCapture,
     onRootEvent,
     onMount,
     onUnmount,
@@ -105,15 +103,6 @@ describe('DOMEventResponderSystem', () => {
           phase: 'bubble',
         });
       },
-      onEventCapture: (event, context, props) => {
-        eventResponderFiredCount++;
-        eventLog.push({
-          name: event.type,
-          passive: event.passive,
-          passiveSupported: event.passiveSupported,
-          phase: 'capture',
-        });
-      },
     });
 
     const Test = () => (
@@ -128,16 +117,10 @@ describe('DOMEventResponderSystem', () => {
     // Clicking the button should trigger the event responder onEvent() twice
     let buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
-    expect(eventResponderFiredCount).toBe(2);
-    expect(eventLog.length).toBe(2);
+    expect(eventResponderFiredCount).toBe(1);
+    expect(eventLog.length).toBe(1);
     // JSDOM does not support passive events, so this will be false
     expect(eventLog).toEqual([
-      {
-        name: 'click',
-        passive: false,
-        passiveSupported: false,
-        phase: 'capture',
-      },
       {
         name: 'click',
         passive: false,
@@ -149,13 +132,13 @@ describe('DOMEventResponderSystem', () => {
     // Unmounting the container and clicking should not increment anything
     ReactDOM.render(null, container);
     dispatchClickEvent(buttonElement);
-    expect(eventResponderFiredCount).toBe(2);
+    expect(eventResponderFiredCount).toBe(1);
 
     // Re-rendering the container and clicking should increase the counters again
     ReactDOM.render(<Test />, container);
     buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
-    expect(eventResponderFiredCount).toBe(4);
+    expect(eventResponderFiredCount).toBe(2);
   });
 
   it('the event responder event listeners should fire on click event (passive events forced)', () => {
@@ -176,14 +159,6 @@ describe('DOMEventResponderSystem', () => {
           phase: 'bubble',
         });
       },
-      onEventCapture: (event, context, props) => {
-        eventLog.push({
-          name: event.type,
-          passive: event.passive,
-          passiveSupported: event.passiveSupported,
-          phase: 'capture',
-        });
-      },
     });
 
     const Test = () => (
@@ -197,14 +172,8 @@ describe('DOMEventResponderSystem', () => {
     // Clicking the button should trigger the event responder onEvent()
     let buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
-    expect(eventLog.length).toBe(2);
+    expect(eventLog.length).toBe(1);
     expect(eventLog).toEqual([
-      {
-        name: 'click',
-        passive: true,
-        passiveSupported: true,
-        phase: 'capture',
-      },
       {
         name: 'click',
         passive: true,
@@ -231,16 +200,6 @@ describe('DOMEventResponderSystem', () => {
           phase: 'bubble',
         });
       },
-      onEventCapture: (event, context, props) => {
-        context.continueLocalPropagation();
-        eventResponderFiredCount++;
-        eventLog.push({
-          name: event.type,
-          passive: event.passive,
-          passiveSupported: event.passiveSupported,
-          phase: 'capture',
-        });
-      },
     });
 
     const Test = () => (
@@ -256,22 +215,10 @@ describe('DOMEventResponderSystem', () => {
     // Clicking the button should trigger the event responder onEvent()
     let buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
-    expect(eventResponderFiredCount).toBe(4);
-    expect(eventLog.length).toBe(4);
+    expect(eventResponderFiredCount).toBe(2);
+    expect(eventLog.length).toBe(2);
     // JSDOM does not support passive events, so this will be false
     expect(eventLog).toEqual([
-      {
-        name: 'click',
-        passive: false,
-        passiveSupported: false,
-        phase: 'capture',
-      },
-      {
-        name: 'click',
-        passive: false,
-        passiveSupported: false,
-        phase: 'capture',
-      },
       {
         name: 'click',
         passive: false,
@@ -296,18 +243,12 @@ describe('DOMEventResponderSystem', () => {
       onEvent: (event, context, props) => {
         eventLog.push(`A [bubble]`);
       },
-      onEventCapture: (event, context, props) => {
-        eventLog.push(`A [capture]`);
-      },
     });
 
     const ClickEventComponentB = createReactEventComponent({
       targetEventTypes: ['click'],
       onEvent: (event, context, props) => {
         eventLog.push(`B [bubble]`);
-      },
-      onEventCapture: (event, context, props) => {
-        eventLog.push(`B [capture]`);
       },
     });
 
@@ -325,12 +266,7 @@ describe('DOMEventResponderSystem', () => {
     let buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
 
-    expect(eventLog).toEqual([
-      'A [capture]',
-      'B [capture]',
-      'B [bubble]',
-      'A [bubble]',
-    ]);
+    expect(eventLog).toEqual(['B [bubble]', 'A [bubble]']);
   });
 
   it('nested event responders should fire in the correct order with continueLocalPropagation', () => {
@@ -343,10 +279,6 @@ describe('DOMEventResponderSystem', () => {
         context.continueLocalPropagation();
         eventLog.push(`${props.name} [bubble]`);
       },
-      onEventCapture: (event, context, props) => {
-        context.continueLocalPropagation();
-        eventLog.push(`${props.name} [capture]`);
-      },
     });
 
     const Test = () => (
@@ -363,12 +295,7 @@ describe('DOMEventResponderSystem', () => {
     let buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
 
-    expect(eventLog).toEqual([
-      'A [capture]',
-      'B [capture]',
-      'B [bubble]',
-      'A [bubble]',
-    ]);
+    expect(eventLog).toEqual(['B [bubble]', 'A [bubble]']);
   });
 
   it('nested event responders should fire in the correct order', () => {
@@ -380,9 +307,6 @@ describe('DOMEventResponderSystem', () => {
       onEvent: (event, context, props) => {
         eventLog.push(`${props.name} [bubble]`);
       },
-      onEventCapture: (event, context, props) => {
-        eventLog.push(`${props.name} [capture]`);
-      },
     });
 
     const Test = () => (
@@ -399,7 +323,7 @@ describe('DOMEventResponderSystem', () => {
     let buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
 
-    expect(eventLog).toEqual(['A [capture]', 'B [bubble]']);
+    expect(eventLog).toEqual(['B [bubble]']);
   });
 
   it('custom event dispatching for click -> magicClick works', () => {
@@ -414,21 +338,6 @@ describe('DOMEventResponderSystem', () => {
             target: event.target,
             type: 'magicclick',
             phase: 'bubble',
-            timeStamp: context.getTimeStamp(),
-          };
-          context.dispatchEvent(
-            syntheticEvent,
-            props.onMagicClick,
-            DiscreteEvent,
-          );
-        }
-      },
-      onEventCapture: (event, context, props) => {
-        if (props.onMagicClick) {
-          const syntheticEvent = {
-            target: event.target,
-            type: 'magicclick',
-            phase: 'capture',
             timeStamp: context.getTimeStamp(),
           };
           context.dispatchEvent(
@@ -456,14 +365,7 @@ describe('DOMEventResponderSystem', () => {
     let buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
 
-    expect(eventLog).toEqual([
-      'magic event fired',
-      'magicclick',
-      'capture',
-      'magic event fired',
-      'magicclick',
-      'bubble',
-    ]);
+    expect(eventLog).toEqual(['magic event fired', 'magicclick', 'bubble']);
   });
 
   it('async event dispatching works', () => {
@@ -515,9 +417,6 @@ describe('DOMEventResponderSystem', () => {
       onEvent: (event, context, props) => {
         handleEvent(event, context, props, 'bubble');
       },
-      onEventCapture: (event, context, props) => {
-        handleEvent(event, context, props, 'capture');
-      },
     });
 
     function log(msg) {
@@ -541,10 +440,7 @@ describe('DOMEventResponderSystem', () => {
     jest.runAllTimers();
 
     expect(eventLog).toEqual([
-      'press capture',
       'press bubble',
-      'longpress capture',
-      'longpresschange capture',
       'longpress bubble',
       'longpresschange bubble',
     ]);

--- a/packages/react-events/README.md
+++ b/packages/react-events/README.md
@@ -57,11 +57,6 @@ The initial state of that the Event Component is created with.
 Called during the bubble phase of the `targetEventTypes` dispatched on DOM
 elements within the Event Component.
 
-### onEventCapture?: (event: ResponderEvent, context: ResponderContext, props, state)
-
-Called during the capture phase of the `targetEventTypes` dispatched on DOM
-elements within the Event Component.
-
 ### onMount?: (context: ResponderContext, props, state)
 
 Called after an Event Component in mounted.

--- a/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
+++ b/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
@@ -598,7 +598,7 @@ function traverseAndHandleEventResponderInstances(
   // Bubbled event phases have the notion of local propagation.
   // This means that the propgation chain can be stopped part of the the way
   // through processing event component instances. The major difference to other
-  // events systems is that the stopping of propgation is localized to a single
+  // events systems is that the stopping of propagation is localized to a single
   // phase, rather than both phases.
   if (length > 0) {
     // Bubble target phase

--- a/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
+++ b/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
@@ -577,7 +577,6 @@ function traverseAndHandleEventResponderInstances(
   nativeEvent: ReactFaricEvent,
 ): void {
   // Trigger event responders in this order:
-  // - Capture target phase
   // - Bubble target phase
   // - Root phase
 
@@ -596,42 +595,12 @@ function traverseAndHandleEventResponderInstances(
   let length = targetEventResponderInstances.length;
   let i;
 
-  // Captured and bubbled event phases have the notion of local propagation.
+  // Bubbled event phases have the notion of local propagation.
   // This means that the propgation chain can be stopped part of the the way
   // through processing event component instances. The major difference to other
   // events systems is that the stopping of propgation is localized to a single
   // phase, rather than both phases.
   if (length > 0) {
-    // Capture target phase
-    for (i = length; i-- > 0; ) {
-      const targetEventResponderInstance = targetEventResponderInstances[i];
-      const {isHook, responder, props, state} = targetEventResponderInstance;
-      const eventListener = ((responder: any): ReactNativeEventResponder)
-        .onEventCapture;
-      if (eventListener !== undefined) {
-        if (
-          shouldSkipEventComponent(
-            targetEventResponderInstance,
-            ((responder: any): ReactNativeEventResponder),
-            propagatedEventResponders,
-            isHook,
-          )
-        ) {
-          continue;
-        }
-        currentInstance = targetEventResponderInstance;
-        currentlyInHook = isHook;
-        eventListener(responderEvent, eventResponderContext, props, state);
-        if (!isHook) {
-          checkForLocalPropagationContinuation(
-            ((responder: any): ReactNativeEventResponder),
-            propagatedEventResponders,
-          );
-        }
-      }
-    }
-    // We clean propagated event responders between phases.
-    propagatedEventResponders.clear();
     // Bubble target phase
     for (i = 0; i < length; i++) {
       const targetEventResponderInstance = targetEventResponderInstances[i];

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -99,7 +99,6 @@ export type ReactEventResponder<T, E, C> = {
   allowMultipleHostChildren: boolean,
   allowEventHooks: boolean,
   onEvent?: (event: E, context: C, props: Object, state: Object) => void,
-  onEventCapture?: (event: E, context: C, props: Object, state: Object) => void,
   onRootEvent?: (event: E, context: C, props: Object, state: Object) => void,
   onMount?: (context: C, props: Object, state: Object) => void,
   onUnmount?: (context: C, props: Object, state: Object) => void,


### PR DESCRIPTION
This PR removes the capture phase from the Flare event system. It was never used or needed internally and only added code-size and complexity to the codebase.