### PR TITLE
[Fresh] Prevent local variables from being used in the hook signature

### DIFF
--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -236,7 +236,7 @@ export default function(babel) {
     }
   }
 
-  function getHookCallsSignature(functionNode) {
+  function getHookCallsSignature(functionNode, scope) {
     const fnHookCalls = hookCalls.get(functionNode);
     if (fnHookCalls === undefined) {
       return null;
@@ -245,6 +245,7 @@ export default function(babel) {
       key: fnHookCalls.map(call => call.name + '{' + call.key + '}').join('\n'),
       customHooks: fnHookCalls
         .filter(call => !isBuiltinHook(call.name))
+        .filter(call => scope.parent.hasBinding(call.name))
         .map(call => t.cloneDeep(call.callee)),
     };
   }
@@ -488,7 +489,7 @@ export default function(babel) {
           if (id === null) {
             return;
           }
-          const signature = getHookCallsSignature(node);
+          const signature = getHookCallsSignature(node, path.scope);
           if (signature === null) {
             return;
           }
@@ -550,7 +551,7 @@ export default function(babel) {
       'ArrowFunctionExpression|FunctionExpression': {
         exit(path) {
           const node = path.node;
-          const signature = getHookCallsSignature(node);
+          const signature = getHookCallsSignature(node, path.scope);
           if (signature === null) {
             return;
           }

--- a/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -392,6 +392,20 @@ describe('ReactFreshBabelPlugin', () => {
     ).toMatchSnapshot();
   });
 
+  it('does not include non accessible custom hooks into the signatures', () => {
+    expect(
+      transform(`       
+        export default function App({useProp}) {
+          const useFancyEffect = () => {
+            React.useEffect(useProp);
+          };
+          const bar = useFancyState();
+          return <h1>{bar}</h1>;
+        }
+    `),
+    ).toMatchSnapshot();
+  });
+
   it('includes custom hooks into the signatures when commonjs target is used', () => {
     // this test is passing with Babel 6
     // but would fail for Babel 7 _without_ custom hook node being cloned for signature

--- a/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -22,6 +22,35 @@ var _c;
 $RefreshReg$(_c, 'App');
 `;
 
+exports[`ReactFreshBabelPlugin does not include non accessible custom hooks into the signatures 1`] = `
+var _s2 = $RefreshSig$();
+
+export default function App({ useProp }) {
+  _s2();
+
+  var _s = $RefreshSig$();
+
+  const useFancyEffect = () => {
+    _s();
+
+    React.useEffect(useProp);
+  };
+
+  _s(useFancyEffect, "useEffect{}");
+
+  const bar = useFancyState();
+  return <h1>{bar}</h1>;
+}
+
+_s2(App, "useFancyState{bar}");
+
+_c = App;
+
+var _c;
+
+$RefreshReg$(_c, "App");
+`;
+
 exports[`ReactFreshBabelPlugin generates signatures for function declarations calling hooks 1`] = `
 var _s = $RefreshSig$();
 


### PR DESCRIPTION
The current implementation of the babel plugin would move any `use*` to the hook signature, except the "builtin" hooks.
That could lead to a false positive, when something, which _ducks_ like hook could not be used in the signature.

```js
const Component = ({useTheForce}) => {
  const useInnerHook = () => {useTheForce();};

  useInnerHook();
}
```

### Solution
Check that variable is reachable from the `signature` scope. That would not let track the "real" hook composition, but, at least, would not lead to runtime error.