### PR TITLE
[Flare] Rename target/root events on event responders

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -16,7 +16,7 @@ import warningWithoutStack from 'shared/warningWithoutStack';
 import type {ReactDOMEventResponderEventType} from 'shared/ReactDOMTypes';
 import type {DOMTopLevelEventType} from 'events/TopLevelEventTypes';
 import {
-  setListenToResponderEventTypes,
+  setListenToResponderHostEvents,
   generateListeningKey,
 } from '../events/DOMEventResponderSystem';
 
@@ -1283,8 +1283,8 @@ export function restoreControlledState(
   }
 }
 
-export function listenToEventResponderEventTypes(
-  eventTypes: Array<ReactDOMEventResponderEventType>,
+export function listenToEventResponderHostEvents(
+  hostEvents: Array<ReactDOMEventResponderEventType>,
   element: Element | Document,
 ): void {
   if (enableFlareAPI) {
@@ -1293,8 +1293,8 @@ export function listenToEventResponderEventTypes(
     const listeningSet = getListeningSetForElement(element);
 
     // Go through each target event type of the event responder
-    for (let i = 0, length = eventTypes.length; i < length; ++i) {
-      const targetEventType = eventTypes[i];
+    for (let i = 0, length = hostEvents.length; i < length; ++i) {
+      const targetEventType = hostEvents[i];
       let topLevelType;
       let passive = true;
 
@@ -1335,5 +1335,5 @@ export function listenToEventResponderEventTypes(
 
 // We can remove this once the event API is stable and out of a flag
 if (enableFlareAPI) {
-  setListenToResponderEventTypes(listenToEventResponderEventTypes);
+  setListenToResponderHostEvents(listenToEventResponderHostEvents);
 }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -22,7 +22,7 @@ import {
   warnForDeletedHydratableText,
   warnForInsertedHydratedElement,
   warnForInsertedHydratedText,
-  listenToEventResponderEventTypes,
+  listenToEventResponderHostEvents,
 } from './ReactDOMComponent';
 import {getSelectionInformation, restoreSelection} from './ReactInputSelection';
 import setTextContent from './setTextContent';
@@ -47,7 +47,7 @@ import type {
   ReactDOMEventComponentInstance,
 } from 'shared/ReactDOMTypes';
 import {
-  addRootEventTypesForComponentInstance,
+  addHostRootEventsForComponentInstance,
   mountEventResponder,
   unmountEventResponder,
 } from '../events/DOMEventResponderSystem';
@@ -851,18 +851,18 @@ export function mountEventComponent(
     const documentBody = doc.body || doc;
     const responder = eventComponentInstance.responder;
     const {
-      rootEventTypes,
-      targetEventTypes,
+      hostRootEvents,
+      hostTargetEvents,
     } = ((responder: any): ReactDOMEventResponder);
-    if (targetEventTypes !== undefined) {
-      listenToEventResponderEventTypes(targetEventTypes, documentBody);
+    if (hostTargetEvents !== undefined) {
+      listenToEventResponderHostEvents(hostTargetEvents, documentBody);
     }
-    if (rootEventTypes !== undefined) {
-      addRootEventTypesForComponentInstance(
+    if (hostRootEvents !== undefined) {
+      addHostRootEventsForComponentInstance(
         eventComponentInstance,
-        rootEventTypes,
+        hostRootEvents,
       );
-      listenToEventResponderEventTypes(rootEventTypes, documentBody);
+      listenToEventResponderHostEvents(hostRootEvents, documentBody);
     }
     mountEventResponder(eventComponentInstance);
   }
@@ -878,7 +878,7 @@ export function unmountEventComponent(
   eventComponentInstance: ReactDOMEventComponentInstance,
 ): void {
   if (enableFlareAPI) {
-    // TODO stop listening to targetEventTypes
+    // TODO stop listening to hostTargetEvents
     unmountEventResponder(eventComponentInstance);
   }
 }

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -18,8 +18,8 @@ let ReactDOM;
 const DiscreteEvent = 0;
 
 function createReactEventComponent({
-  targetEventTypes,
-  rootEventTypes,
+  hostTargetEvents,
+  hostRootEvents,
   createInitialState,
   onEvent,
   onEventCapture,
@@ -32,8 +32,8 @@ function createReactEventComponent({
 }) {
   const testEventResponder = {
     displayName: 'TestEventComponent',
-    targetEventTypes,
-    rootEventTypes,
+    hostTargetEvents,
+    hostRootEvents,
     createInitialState,
     onEvent,
     onEventCapture,
@@ -95,7 +95,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonRef = React.createRef();
 
     const ClickEventComponent = createReactEventComponent({
-      targetEventTypes: ['click'],
+      hostTargetEvents: ['click'],
       onEvent: (event, context, props) => {
         eventResponderFiredCount++;
         eventLog.push({
@@ -167,7 +167,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonRef = React.createRef();
 
     const ClickEventComponent = createReactEventComponent({
-      targetEventTypes: ['click'],
+      hostTargetEvents: ['click'],
       onEvent: (event, context, props) => {
         eventLog.push({
           name: event.type,
@@ -220,7 +220,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonRef = React.createRef();
 
     const ClickEventComponent = createReactEventComponent({
-      targetEventTypes: ['click'],
+      hostTargetEvents: ['click'],
       onEvent: (event, context, props) => {
         context.continueLocalPropagation();
         eventResponderFiredCount++;
@@ -292,7 +292,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonRef = React.createRef();
 
     const ClickEventComponentA = createReactEventComponent({
-      targetEventTypes: ['click'],
+      hostTargetEvents: ['click'],
       onEvent: (event, context, props) => {
         eventLog.push(`A [bubble]`);
       },
@@ -302,7 +302,7 @@ describe('DOMEventResponderSystem', () => {
     });
 
     const ClickEventComponentB = createReactEventComponent({
-      targetEventTypes: ['click'],
+      hostTargetEvents: ['click'],
       onEvent: (event, context, props) => {
         eventLog.push(`B [bubble]`);
       },
@@ -338,7 +338,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonRef = React.createRef();
 
     const ClickEventComponent = createReactEventComponent({
-      targetEventTypes: ['click'],
+      hostTargetEvents: ['click'],
       onEvent: (event, context, props) => {
         context.continueLocalPropagation();
         eventLog.push(`${props.name} [bubble]`);
@@ -376,7 +376,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonRef = React.createRef();
 
     const ClickEventComponent = createReactEventComponent({
-      targetEventTypes: ['click'],
+      hostTargetEvents: ['click'],
       onEvent: (event, context, props) => {
         eventLog.push(`${props.name} [bubble]`);
       },
@@ -407,7 +407,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonRef = React.createRef();
 
     const ClickEventComponent = createReactEventComponent({
-      targetEventTypes: ['click'],
+      hostTargetEvents: ['click'],
       onEvent: (event, context, props) => {
         if (props.onMagicClick) {
           const syntheticEvent = {
@@ -511,7 +511,7 @@ describe('DOMEventResponderSystem', () => {
     }
 
     const LongPressEventComponent = createReactEventComponent({
-      targetEventTypes: ['click'],
+      hostTargetEvents: ['click'],
       onEvent: (event, context, props) => {
         handleEvent(event, context, props, 'bubble');
       },
@@ -554,7 +554,7 @@ describe('DOMEventResponderSystem', () => {
     let onMountFired = 0;
 
     const EventComponent = createReactEventComponent({
-      targetEventTypes: [],
+      hostTargetEvents: [],
       onMount: () => {
         onMountFired++;
       },
@@ -574,7 +574,7 @@ describe('DOMEventResponderSystem', () => {
     let onUnmountFired = 0;
 
     const EventComponent = createReactEventComponent({
-      targetEventTypes: [],
+      hostTargetEvents: [],
       onUnmount: () => {
         onUnmountFired++;
       },
@@ -595,7 +595,7 @@ describe('DOMEventResponderSystem', () => {
     let counter = 0;
 
     const EventComponent = createReactEventComponent({
-      targetEventTypes: [],
+      hostTargetEvents: [],
       createInitialState: () => ({
         incrementAmount: 5,
       }),
@@ -621,7 +621,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonRef = React.createRef();
 
     const EventComponent = createReactEventComponent({
-      targetEventTypes: ['click'],
+      hostTargetEvents: ['click'],
       onEvent: (event, context, props, state) => {
         ownershipGained = context.requestGlobalOwnership();
       },
@@ -652,7 +652,7 @@ describe('DOMEventResponderSystem', () => {
     let eventLog = [];
 
     const ClickEventComponent = createReactEventComponent({
-      rootEventTypes: ['click'],
+      hostRootEvents: ['click'],
       onRootEvent: event => {
         eventResponderFiredCount++;
         eventLog.push({
@@ -693,7 +693,7 @@ describe('DOMEventResponderSystem', () => {
     const log = [];
 
     const EventComponent = createReactEventComponent({
-      targetEventTypes: ['pointerout'],
+      hostTargetEvents: ['pointerout'],
       onEvent: (event, context) => {
         context.continueLocalPropagation();
         const isWithin = context.isTargetWithinEventResponderScope(
@@ -731,7 +731,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonRef = React.createRef();
 
     const ClickEventComponent1 = createReactEventComponent({
-      targetEventTypes: [{name: 'click', passive: false, capture: false}],
+      hostTargetEvents: [{name: 'click', passive: false, capture: false}],
       onEvent: event => {
         clickEventComponent1Fired++;
         eventLog.push({
@@ -743,7 +743,7 @@ describe('DOMEventResponderSystem', () => {
     });
 
     const ClickEventComponent2 = createReactEventComponent({
-      targetEventTypes: [{name: 'click', passive: true, capture: false}],
+      hostTargetEvents: [{name: 'click', passive: true, capture: false}],
       onEvent: event => {
         clickEventComponent2Fired++;
         eventLog.push({
@@ -790,7 +790,7 @@ describe('DOMEventResponderSystem', () => {
     let eventLog = [];
 
     const ClickEventComponent1 = createReactEventComponent({
-      rootEventTypes: [{name: 'click', passive: false, capture: false}],
+      hostRootEvents: [{name: 'click', passive: false, capture: false}],
       onRootEvent: event => {
         clickEventComponent1Fired++;
         eventLog.push({
@@ -802,7 +802,7 @@ describe('DOMEventResponderSystem', () => {
     });
 
     const ClickEventComponent2 = createReactEventComponent({
-      rootEventTypes: [{name: 'click', passive: true, capture: false}],
+      hostRootEvents: [{name: 'click', passive: true, capture: false}],
       onRootEvent: event => {
         clickEventComponent2Fired++;
         eventLog.push({
@@ -846,7 +846,7 @@ describe('DOMEventResponderSystem', () => {
 
   it('the event responder system should warn on accessing invalid properties', () => {
     const ClickEventComponent = createReactEventComponent({
-      rootEventTypes: ['click'],
+      hostRootEvents: ['click'],
       onRootEvent: (event, context, props) => {
         const syntheticEvent = {
           target: event.target,
@@ -928,7 +928,7 @@ describe('DOMEventResponderSystem', () => {
 
   it('should warn if multiple host components are detected without allowMultipleHostChildren', () => {
     const EventComponent = createReactEventComponent({
-      targetEventTypes: [],
+      hostTargetEvents: [],
       onEvent: () => {},
       allowMultipleHostChildren: false,
     });
@@ -966,7 +966,7 @@ describe('DOMEventResponderSystem', () => {
 
   it('should handle suspended nodes correctly when detecting host components without allowMultipleHostChildren', () => {
     const EventComponent = createReactEventComponent({
-      targetEventTypes: [],
+      hostTargetEvents: [],
       onEvent: () => {},
       allowMultipleHostChildren: false,
     });
@@ -1025,7 +1025,7 @@ describe('DOMEventResponderSystem', () => {
 
   it('should not warn if multiple host components are detected with allowMultipleHostChildren', () => {
     const EventComponent = createReactEventComponent({
-      targetEventTypes: [],
+      hostTargetEvents: [],
       onEvent: () => {},
       allowMultipleHostChildren: true,
     });
@@ -1057,7 +1057,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonRef = React.createRef();
     const eventLogs = [];
     const EventComponent = createReactEventComponent({
-      targetEventTypes: ['foo'],
+      hostTargetEvents: ['foo'],
       onEvent: (event, context, props) => {
         if (props.onFoo) {
           const fooEvent = {

--- a/packages/react-events/README.md
+++ b/packages/react-events/README.md
@@ -92,7 +92,7 @@ Defines the DOM events to listen to within the Event Component subtree.
 The Event Responder Context is exposed via the `context` argument for certain methods
 on the `EventResponder` object.
 
-### addRootEventTypes(eventTypes: Array<ResponderEventType>)
+### addHostRootEvents(hostEvents: Array<ResponderEventType>)
 
 This can be used to dynamically listen to events on the root of the app only
 when it is necessary to do so.
@@ -138,9 +138,9 @@ is within the scope of the same responder, but owned by another Event Component 
 
 Returns `true` if the instance released ownership of the Event Component instance.
 
-### removeRootEventTypes(eventTypes: Array<ResponderEventType>)
+### removeHostRootEvents(hostEvents: Array<ResponderEventType>)
 
-Remove the root event types added with `addRootEventTypes`.
+Remove the root event types added with `addHostRootEvents`.
 
 ### requestGlobalOwnership(): boolean
 

--- a/packages/react-events/src/dom/Drag.js
+++ b/packages/react-events/src/dom/Drag.js
@@ -17,8 +17,8 @@ import type {EventPriority} from 'shared/ReactTypes';
 import React from 'react';
 import {DiscreteEvent, UserBlockingEvent} from 'shared/ReactTypes';
 
-const targetEventTypes = ['pointerdown'];
-const rootEventTypes = [
+const hostTargetEvents = ['pointerdown'];
+const hostRootEvents = [
   'pointerup',
   'pointercancel',
   {name: 'pointermove', passive: false},
@@ -37,8 +37,8 @@ type DragState = {
 // In the case we don't have PointerEvents (Safari), we listen to touch events
 // too
 if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
-  targetEventTypes.push('touchstart', 'mousedown');
-  rootEventTypes.push('mouseup', 'mousemove', 'touchend', 'touchcancel', {
+  hostTargetEvents.push('touchstart', 'mousedown');
+  hostRootEvents.push('mouseup', 'mousemove', 'touchend', 'touchcancel', {
     name: 'touchmove',
     passive: false,
   });
@@ -87,7 +87,7 @@ function dispatchDragEvent(
 
 const DragResponder: ReactDOMEventResponder = {
   displayName: 'Drag',
-  targetEventTypes,
+  hostTargetEvents,
   createInitialState(): DragState {
     return {
       dragTarget: null,
@@ -138,7 +138,7 @@ const DragResponder: ReactDOMEventResponder = {
             );
           }
 
-          context.addRootEventTypes(rootEventTypes);
+          context.addHostRootEvents(hostRootEvents);
         }
         break;
       }
@@ -197,7 +197,7 @@ const DragResponder: ReactDOMEventResponder = {
             } else {
               state.dragTarget = null;
               state.isPointerDown = false;
-              context.removeRootEventTypes(rootEventTypes);
+              context.removeHostRootEvents(hostRootEvents);
             }
           } else {
             if (props.onDragMove) {
@@ -254,7 +254,7 @@ const DragResponder: ReactDOMEventResponder = {
         if (state.isPointerDown) {
           state.dragTarget = null;
           state.isPointerDown = false;
-          context.removeRootEventTypes(rootEventTypes);
+          context.removeHostRootEvents(hostRootEvents);
         }
         break;
       }

--- a/packages/react-events/src/dom/Focus.js
+++ b/packages/react-events/src/dom/Focus.js
@@ -46,12 +46,12 @@ const isMac =
     ? /^Mac/.test(window.navigator.platform)
     : false;
 
-const targetEventTypes = [
+const hostTargetEvents = [
   {name: 'focus', passive: true},
   {name: 'blur', passive: true},
 ];
 
-const rootEventTypes = [
+const hostRootEvents = [
   'keydown',
   'keyup',
   'pointermove',
@@ -61,7 +61,7 @@ const rootEventTypes = [
 
 // If PointerEvents is not supported (e.g., Safari), also listen to touch and mouse events.
 if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
-  rootEventTypes.push(
+  hostRootEvents.push(
     'mousemove',
     'mousedown',
     'mouseup',
@@ -219,8 +219,8 @@ let isGlobalFocusVisible = true;
 
 const FocusResponder: ReactDOMEventResponder = {
   displayName: 'Focus',
-  targetEventTypes,
-  rootEventTypes,
+  hostTargetEvents,
+  hostRootEvents,
   createInitialState(): FocusState {
     return {
       focusTarget: null,

--- a/packages/react-events/src/dom/FocusScope.js
+++ b/packages/react-events/src/dom/FocusScope.js
@@ -25,8 +25,8 @@ type FocusScopeState = {
   currentFocusedNode: null | HTMLElement,
 };
 
-const targetEventTypes = [{name: 'keydown', passive: false}];
-const rootEventTypes = [{name: 'focus', passive: true}];
+const hostTargetEvents = [{name: 'keydown', passive: false}];
+const hostRootEvents = [{name: 'focus', passive: true}];
 
 function focusElement(element: ?HTMLElement) {
   if (element != null) {
@@ -48,8 +48,8 @@ function getFirstFocusableElement(
 
 const FocusScopeResponder: ReactDOMEventResponder = {
   displayName: 'FocusScope',
-  targetEventTypes,
-  rootEventTypes,
+  hostTargetEvents,
+  hostRootEvents,
   createInitialState(): FocusScopeState {
     return {
       nodeToRestore: null,

--- a/packages/react-events/src/dom/Hover.js
+++ b/packages/react-events/src/dom/Hover.js
@@ -56,7 +56,7 @@ type HoverEvent = {|
 const DEFAULT_HOVER_END_DELAY_MS = 0;
 const DEFAULT_HOVER_START_DELAY_MS = 0;
 
-const targetEventTypes = [
+const hostTargetEvents = [
   'pointerover',
   'pointermove',
   'pointerout',
@@ -65,7 +65,7 @@ const targetEventTypes = [
 
 // If PointerEvents is not supported (e.g., Safari), also listen to touch and mouse events.
 if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
-  targetEventTypes.push('touchstart', 'mouseover', 'mousemove', 'mouseout');
+  hostTargetEvents.push('touchstart', 'mouseover', 'mousemove', 'mouseout');
 }
 
 function createHoverEvent(
@@ -273,7 +273,7 @@ function isEmulatedMouseEvent(event, state) {
 
 const HoverResponder: ReactDOMEventResponder = {
   displayName: 'Hover',
-  targetEventTypes,
+  hostTargetEvents,
   createInitialState() {
     return {
       isActiveHovered: false,

--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -122,7 +122,7 @@ const DEFAULT_PRESS_RETENTION_OFFSET = {
   right: 20,
 };
 
-const targetEventTypes = [
+const hostTargetEvents = [
   {name: 'keydown', passive: false},
   {name: 'contextmenu', passive: false},
   // We need to preventDefault on pointerdown for mouse/pen events
@@ -130,7 +130,7 @@ const targetEventTypes = [
   {name: 'pointerdown', passive: false},
   {name: 'click', passive: false},
 ];
-const rootEventTypes = [
+const hostRootEvents = [
   'click',
   'keyup',
   'pointerup',
@@ -145,8 +145,8 @@ const rootEventTypes = [
 
 // If PointerEvents is not supported (e.g., Safari), also listen to touch and mouse events.
 if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
-  targetEventTypes.push('touchstart', 'mousedown');
-  rootEventTypes.push(
+  hostTargetEvents.push('touchstart', 'mousedown');
+  hostRootEvents.push(
     'mousemove',
     'touchmove',
     'touchcancel',
@@ -438,7 +438,7 @@ function dispatchCancel(
     state.ignoreEmulatedMouseEvents = false;
     dispatchPressEndEvents(event, context, props, state);
   }
-  removeRootEventTypes(context, state);
+  removeHostRootEvents(context, state);
 }
 
 function isValidKeyboardEvent(nativeEvent: Object): boolean {
@@ -510,28 +510,28 @@ function unmountResponder(
   state: PressState,
 ): void {
   if (state.isPressed) {
-    removeRootEventTypes(context, state);
+    removeHostRootEvents(context, state);
     dispatchPressEndEvents(null, context, props, state);
   }
 }
 
-function addRootEventTypes(
+function addHostRootEvents(
   context: ReactDOMResponderContext,
   state: PressState,
 ): void {
   if (!state.addedRootEvents) {
     state.addedRootEvents = true;
-    context.addRootEventTypes(rootEventTypes);
+    context.addHostRootEvents(hostRootEvents);
   }
 }
 
-function removeRootEventTypes(
+function removeHostRootEvents(
   context: ReactDOMResponderContext,
   state: PressState,
 ): void {
   if (state.addedRootEvents) {
     state.addedRootEvents = false;
-    context.removeRootEventTypes(rootEventTypes);
+    context.removeHostRootEvents(hostRootEvents);
   }
 }
 
@@ -617,7 +617,7 @@ function handleStopPropagation(
 
 const PressResponder: ReactDOMEventResponder = {
   displayName: 'Press',
-  targetEventTypes,
+  hostTargetEvents,
   createInitialState(): PressState {
     return {
       activationPosition: null,
@@ -651,7 +651,7 @@ const PressResponder: ReactDOMEventResponder = {
     const {pointerId, pointerType, type} = event;
 
     if (props.disabled) {
-      removeRootEventTypes(context, state);
+      removeHostRootEvents(context, state);
       dispatchPressEndEvents(event, context, props, state);
       state.ignoreEmulatedMouseEvents = false;
       return;
@@ -717,7 +717,7 @@ const PressResponder: ReactDOMEventResponder = {
           state.responderRegionOnDeactivation = null;
           state.isPressWithinResponderRegion = true;
           dispatchPressStartEvents(event, context, props, state);
-          addRootEventTypes(context, state);
+          addHostRootEvents(context, state);
         } else {
           // Prevent spacebar press from scrolling the window
           if (isValidKeyboardEvent(nativeEvent) && nativeEvent.key === ' ') {
@@ -774,7 +774,7 @@ const PressResponder: ReactDOMEventResponder = {
           );
         }
         // Click won't occur, so we need to remove root events
-        removeRootEventTypes(context, state);
+        removeHostRootEvents(context, state);
         break;
       }
 
@@ -893,7 +893,7 @@ const PressResponder: ReactDOMEventResponder = {
               return;
             }
             isKeyboardEvent = true;
-            removeRootEventTypes(context, state);
+            removeHostRootEvents(context, state);
           }
 
           // Determine whether to call preventDefault on subsequent native events.
@@ -978,7 +978,7 @@ const PressResponder: ReactDOMEventResponder = {
       case 'click': {
         // "keyup" occurs after "click"
         if (previousPointerType !== 'keyboard') {
-          removeRootEventTypes(context, state);
+          removeHostRootEvents(context, state);
         }
         break;
       }

--- a/packages/react-events/src/dom/Scroll.js
+++ b/packages/react-events/src/dom/Scroll.js
@@ -60,14 +60,14 @@ type ScrollEvent = {|
   y: null | number,
 |};
 
-const targetEventTypes = [
+const hostTargetEvents = [
   'scroll',
   'pointerdown',
   'touchstart',
   'keyup',
   'wheel',
 ];
-const rootEventTypes = ['touchcancel', 'touchend'];
+const hostRootEvents = ['touchcancel', 'touchend'];
 
 function createScrollEvent(
   event: ?ReactDOMResponderEvent,
@@ -130,7 +130,7 @@ function dispatchEvent(
 
 const ScrollResponder: ReactDOMEventResponder = {
   displayName: 'Scroll',
-  targetEventTypes,
+  hostTargetEvents,
   createInitialState() {
     return {
       direction: '',
@@ -157,7 +157,7 @@ const ScrollResponder: ReactDOMEventResponder = {
         state.scrollTarget = null;
         state.isDragging = false;
         state.direction = '';
-        context.removeRootEventTypes(rootEventTypes);
+        context.removeHostRootEvents(hostRootEvents);
       }
       return;
     }
@@ -241,7 +241,7 @@ const ScrollResponder: ReactDOMEventResponder = {
       case 'touchstart': {
         if (!state.isTouching) {
           state.isTouching = true;
-          context.addRootEventTypes(rootEventTypes);
+          context.addHostRootEvents(hostRootEvents);
         }
       }
     }
@@ -272,7 +272,7 @@ const ScrollResponder: ReactDOMEventResponder = {
           state.isDragging = false;
           state.scrollTarget = null;
           state.pointerType = '';
-          context.removeRootEventTypes(rootEventTypes);
+          context.removeHostRootEvents(hostRootEvents);
         }
       }
     }

--- a/packages/react-events/src/dom/Swipe.js
+++ b/packages/react-events/src/dom/Swipe.js
@@ -17,8 +17,8 @@ import type {EventPriority} from 'shared/ReactTypes';
 import React from 'react';
 import {UserBlockingEvent, DiscreteEvent} from 'shared/ReactTypes';
 
-const targetEventTypes = ['pointerdown'];
-const rootEventTypes = [
+const hostTargetEvents = ['pointerdown'];
+const hostRootEvents = [
   'pointerup',
   'pointercancel',
   {name: 'pointermove', passive: false},
@@ -27,8 +27,8 @@ const rootEventTypes = [
 // In the case we don't have PointerEvents (Safari), we listen to touch events
 // too
 if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
-  targetEventTypes.push('touchstart', 'mousedown');
-  rootEventTypes.push('mouseup', 'mousemove', 'touchend', 'touchcancel', {
+  hostTargetEvents.push('touchstart', 'mousedown');
+  hostRootEvents.push('mouseup', 'mousemove', 'touchend', 'touchcancel', {
     name: 'touchmove',
     passive: false,
   });
@@ -91,7 +91,7 @@ type SwipeState = {
 
 const SwipeResponder: ReactDOMEventResponder = {
   displayName: 'Scroll',
-  targetEventTypes,
+  hostTargetEvents,
   createInitialState(): SwipeState {
     return {
       direction: 0,
@@ -140,7 +140,7 @@ const SwipeResponder: ReactDOMEventResponder = {
             state.x = x;
             state.y = y;
             state.swipeTarget = target;
-            context.addRootEventTypes(rootEventTypes);
+            context.addHostRootEvents(hostRootEvents);
           } else {
             state.touchId = null;
           }
@@ -181,7 +181,7 @@ const SwipeResponder: ReactDOMEventResponder = {
             state.isSwiping = false;
             state.swipeTarget = null;
             state.touchId = null;
-            context.removeRootEventTypes(rootEventTypes);
+            context.removeHostRootEvents(hostRootEvents);
             return;
           }
           const x = (obj: any).screenX;
@@ -257,7 +257,7 @@ const SwipeResponder: ReactDOMEventResponder = {
           state.isSwiping = false;
           state.swipeTarget = null;
           state.touchId = null;
-          context.removeRootEventTypes(rootEventTypes);
+          context.removeHostRootEvents(hostRootEvents);
         }
         break;
       }

--- a/packages/react-events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Press-test.internal.js
@@ -2573,7 +2573,7 @@ describe('Event responder: Press', () => {
     expect(Press.responder.displayName).toBe('Press');
   });
 
-  it('should not trigger an invariant in addRootEventTypes()', () => {
+  it('should not trigger an invariant in addHostRootEvents()', () => {
     const ref = React.createRef();
     const element = (
       <Press>

--- a/packages/react-events/src/rn/Press.js
+++ b/packages/react-events/src/rn/Press.js
@@ -116,8 +116,8 @@ const DEFAULT_PRESS_RETENTION_OFFSET = {
   right: 20,
 };
 
-const targetEventTypes = ['topTouchStart'];
-const rootEventTypes = ['topTouchMove', 'topTouchEnd', 'topTouchCancel'];
+const hostTargetEvents = ['topTouchStart'];
+const hostRootEvents = ['topTouchMove', 'topTouchEnd', 'topTouchCancel'];
 
 function calculateDelayMS(delay: ?number, min = 0, fallback = 0) {
   const maybeNumber = delay == null ? null : delay;
@@ -192,20 +192,20 @@ function dispatchCancel(event, context, props, state): void {
   if (state.isPressed) {
     dispatchPressEndEvents(event, context, props, state);
   }
-  removeRootEventTypes(context, state);
+  removeHostRootEvents(context, state);
 }
 
-function addRootEventTypes(context, state): void {
+function addHostRootEvents(context, state): void {
   if (!state.addedRootEvents) {
     state.addedRootEvents = true;
-    context.addRootEventTypes(rootEventTypes);
+    context.addHostRootEvents(hostRootEvents);
   }
 }
 
-function removeRootEventTypes(context, state): void {
+function removeHostRootEvents(context, state): void {
   if (state.addedRootEvents) {
     state.addedRootEvents = false;
-    context.removeRootEventTypes(rootEventTypes);
+    context.removeHostRootEvents(hostRootEvents);
   }
 }
 
@@ -503,7 +503,7 @@ function dispatchPressEndEvents(event, context, props, state): void {
 
 const PressResponder: ReactNativeEventResponder = {
   displayName: 'Press',
-  targetEventTypes,
+  hostTargetEvents,
   allowEventHooks: true,
   allowMultipleHostChildren: false,
   createInitialState(): PressState {
@@ -559,7 +559,7 @@ const PressResponder: ReactNativeEventResponder = {
         state.isPressWithinResponderRegion = true;
 
         dispatchPressStartEvents(event, context, props, state);
-        addRootEventTypes(context, state);
+        addHostRootEvents(context, state);
       }
     }
   },
@@ -666,7 +666,7 @@ const PressResponder: ReactNativeEventResponder = {
           }
         }
         state.touchEvent = null;
-        removeRootEventTypes(context, state);
+        removeHostRootEvents(context, state);
         break;
       }
       case 'topTouchCancel': {

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -27,7 +27,7 @@ import warningWithoutStack from 'shared/warningWithoutStack';
 
 import {dispatchEvent} from './ReactFabricEventEmitter';
 import {
-  addRootEventTypesForComponentInstance,
+  addHostRootEventsForComponentInstance,
   mountEventResponder,
   unmountEventResponder,
 } from './ReactFabricEventResponderSystem';
@@ -449,11 +449,11 @@ export function mountEventComponent(
 ) {
   if (enableFlareAPI) {
     const responder = eventComponentInstance.responder;
-    const {rootEventTypes} = responder;
-    if (rootEventTypes !== undefined) {
-      addRootEventTypesForComponentInstance(
+    const {hostRootEvents} = responder;
+    if (hostRootEvents !== undefined) {
+      addHostRootEventsForComponentInstance(
         eventComponentInstance,
-        rootEventTypes,
+        hostRootEvents,
       );
     }
     mountEventResponder(eventComponentInstance);
@@ -470,7 +470,7 @@ export function unmountEventComponent(
   eventComponentInstance: ReactNativeEventComponentInstance,
 ): void {
   if (enableFlareAPI) {
-    // TODO stop listening to targetEventTypes
+    // TODO stop listening to hostTargetEvents
     unmountEventResponder(eventComponentInstance);
   }
 }

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -223,11 +223,11 @@ export type ReactNativeResponderContext = {
       bottom: number,
     }) => void,
   ): void,
-  addRootEventTypes: (
-    rootEventTypes: Array<ReactNativeEventResponderEventType>,
+  addHostRootEvents: (
+    hostRootEvents: Array<ReactNativeEventResponderEventType>,
   ) => void,
-  removeRootEventTypes: (
-    rootEventTypes: Array<ReactNativeEventResponderEventType>,
+  removeHostRootEvents: (
+    hostRootEvents: Array<ReactNativeEventResponderEventType>,
   ) => void,
   getEventCurrentTarget(
     event: ReactNativeResponderEvent,

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -91,10 +91,10 @@ export function createEventComponentInstance<T, E, C>(
 ): ReactEventComponentInstance<T, E, C> {
   return {
     currentFiber,
+    hostRootEvents: null,
     isHook,
     props,
     responder,
-    rootEventTypes: null,
     rootInstance,
     state,
   };

--- a/packages/react-reconciler/src/__tests__/ReactFiberEvents-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberEvents-test.internal.js
@@ -21,7 +21,7 @@ let ReactTestUtils;
 
 const noOpResponder = {
   displayName: 'TestEventComponent',
-  targetEventTypes: [],
+  hostTargetEvents: [],
   handleEvent() {},
 };
 

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -61,11 +61,11 @@ export type ReactDOMResponderContext = {
   ) => boolean,
   isTargetWithinEventComponent: (Element | Document) => boolean,
   isTargetWithinEventResponderScope: (Element | Document) => boolean,
-  addRootEventTypes: (
-    rootEventTypes: Array<ReactDOMEventResponderEventType>,
+  addHostRootEvents: (
+    hostRootEvents: Array<ReactDOMEventResponderEventType>,
   ) => void,
-  removeRootEventTypes: (
-    rootEventTypes: Array<ReactDOMEventResponderEventType>,
+  removeHostRootEvents: (
+    hostRootEvents: Array<ReactDOMEventResponderEventType>,
   ) => void,
   hasOwnership: () => boolean,
   requestGlobalOwnership: () => boolean,

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -85,15 +85,15 @@ export type ReactEventComponentInstance<T, E, C> = {|
   isHook: boolean,
   props: Object,
   responder: ReactEventResponder<T, E, C>,
-  rootEventTypes: null | Set<string>,
+  hostRootEvents: null | Set<string>,
   rootInstance: null | mixed,
   state: Object,
 |};
 
 export type ReactEventResponder<T, E, C> = {
   displayName: string,
-  targetEventTypes?: Array<T>,
-  rootEventTypes?: Array<T>,
+  hostTargetEvents?: Array<T>,
+  hostRootEvents?: Array<T>,
   createInitialState?: (props: Object) => Object,
   allowMultipleHostChildren: boolean,
   allowEventHooks: boolean,

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -334,5 +334,6 @@
   "333": "This should have a parent host component initialized. This error is likely caused by a bug in React. Please file an issue.",
   "334": "accumulate(...): Accumulated items must not be null or undefined.",
   "335": "ReactDOMServer does not yet support the event API.",
-  "336": "The \"%s\" event responder cannot be used via the \"useEvent\" hook."
+  "336": "The \"%s\" event responder cannot be used via the \"useEvent\" hook.",
+  "337": "addHostRootEvents() found a duplicate root event type of \"%s\". This might be because the event type exists in the event responder \"hostRootEvents\" array or because of a previous addHostRootEvents() using this root event type."
 }


### PR DESCRIPTION
With the very likely addition of first-class event targets, the existing naming of `targetEventTypes` and `rootEventTypes` becomes a bit confusing. This PR renames them to include `host`, which is exactly what they are – host events that we register on the specific platform. Event "types" was also a bit confusing too, as originally they were only strings, but then became objects where you could define if something was passive etc. This should hopefully make things easier to understand.