### PR TITLE
[Flare] Add currentTarget and unify RN and DOM codepaths

### DIFF
--- a/packages/react-events/src/dom/Focus.js
+++ b/packages/react-events/src/dom/Focus.js
@@ -207,8 +207,10 @@ function handleRootPointerEvent(
 
   // Focus should stop being visible if a pointer is used on the element
   // after it was focused using a keyboard.
+  const focusTarget = state.focusTarget;
   if (
-    state.focusTarget === context.getEventCurrentTarget(event) &&
+    focusTarget !== null &&
+    context.isTargetWithinNode(event.target, focusTarget) &&
     (type === 'mousedown' || type === 'touchstart' || type === 'pointerdown')
   ) {
     dispatchFocusVisibleOutEvent(context, props, state);
@@ -253,7 +255,7 @@ const FocusResponder: ReactDOMEventResponder = {
         if (!state.isFocused) {
           // Limit focus events to the direct child of the event component.
           // Browser focus is not expected to bubble.
-          state.focusTarget = context.getEventCurrentTarget(event);
+          state.focusTarget = event.currentTarget;
           if (state.focusTarget === target) {
             state.isFocused = true;
             state.isLocalFocusVisible = isGlobalFocusVisible;

--- a/packages/react-events/src/dom/Hover.js
+++ b/packages/react-events/src/dom/Hover.js
@@ -321,7 +321,7 @@ const HoverResponder: ReactDOMEventResponder = {
           if (isEmulatedMouseEvent(event, state)) {
             return;
           }
-          state.hoverTarget = context.getEventCurrentTarget(event);
+          state.hoverTarget = event.currentTarget;
           state.ignoreEmulatedMouseEvents = true;
           dispatchHoverStartEvents(event, context, props, state);
         }

--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -57,7 +57,7 @@ type PressState = {
   isPressWithinResponderRegion: boolean,
   longPressTimeout: null | number,
   pointerType: PointerType,
-  pressTarget: null | Element,
+  pressTarget: null | Element | Document,
   pressEndTimeout: null | number,
   pressStartTimeout: null | number,
   responderRegionOnActivation: null | $ReadOnly<{|
@@ -615,6 +615,11 @@ function handleStopPropagation(
   }
 }
 
+function targetIsDocument(target: null | Node): boolean {
+  // When target is null, it is the root
+  return target === null || target.nodeType === 9;
+}
+
 const PressResponder: ReactDOMEventResponder = {
   displayName: 'Press',
   targetEventTypes,
@@ -687,7 +692,7 @@ const PressResponder: ReactDOMEventResponder = {
           // We set these here, before the button check so we have this
           // data around for handling of the context menu
           state.pointerType = pointerType;
-          state.pressTarget = context.getEventCurrentTarget(event);
+          const pressTarget = (state.pressTarget = event.currentTarget);
           if (isPointerEvent) {
             state.activePointerId = pointerId;
           } else if (isTouchEvent) {
@@ -708,12 +713,14 @@ const PressResponder: ReactDOMEventResponder = {
           ) {
             return;
           }
-
-          state.responderRegionOnActivation = calculateResponderRegion(
-            context,
-            state.pressTarget,
-            props,
-          );
+          // Exclude document targets
+          if (!targetIsDocument(pressTarget)) {
+            state.responderRegionOnActivation = calculateResponderRegion(
+              context,
+              ((pressTarget: any): Element),
+              props,
+            );
+          }
           state.responderRegionOnDeactivation = null;
           state.isPressWithinResponderRegion = true;
           dispatchPressStartEvents(event, context, props, state);
@@ -820,11 +827,13 @@ const PressResponder: ReactDOMEventResponder = {
           }
           state.touchEvent = touchEvent;
         }
+        const pressTarget = state.pressTarget;
 
         if (
-          state.pressTarget !== null &&
+          pressTarget !== null &&
+          !targetIsDocument(pressTarget) &&
           (pointerType !== 'mouse' ||
-            !context.isTargetWithinNode(target, state.pressTarget))
+            !context.isTargetWithinNode(target, pressTarget))
         ) {
           // Calculate the responder region we use for deactivation, as the
           // element dimensions may have changed since activation.
@@ -930,14 +939,16 @@ const PressResponder: ReactDOMEventResponder = {
           }
 
           const wasLongPressed = state.isLongPressed;
+          const pressTarget = state.pressTarget;
           dispatchPressEndEvents(event, context, props, state);
 
-          if (state.pressTarget !== null && props.onPress) {
+          if (pressTarget !== null && props.onPress) {
             if (
               !isKeyboardEvent &&
-              state.pressTarget !== null &&
+              pressTarget !== null &&
+              !targetIsDocument(pressTarget) &&
               (pointerType !== 'mouse' ||
-                !context.isTargetWithinNode(target, state.pressTarget))
+                !context.isTargetWithinNode(target, pressTarget))
             ) {
               // If the event target isn't within the press target, check if we're still
               // within the responder region. The region may have changed if the

--- a/packages/react-events/src/rn/Press.js
+++ b/packages/react-events/src/rn/Press.js
@@ -537,9 +537,7 @@ const PressResponder: ReactNativeEventResponder = {
     if (type === 'topTouchStart') {
       if (!state.isPressed) {
         state.pointerType = 'touch';
-        const pressTarget = (state.pressTarget = context.getEventCurrentTarget(
-          event,
-        ));
+        const pressTarget = (state.pressTarget = event.currentTarget);
 
         const touchEvent = getTouchFromPressEvent(nativeEvent);
         if (touchEvent === null) {

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -199,6 +199,7 @@ export type ReactFaricEvent = {
 };
 
 export type ReactNativeResponderEvent = {
+  currentTarget: null | ReactNativeEventTarget,
   nativeEvent: ReactFaricEvent,
   target: null | ReactNativeEventTarget,
   type: ReactNativeEventResponderEventType,
@@ -229,9 +230,6 @@ export type ReactNativeResponderContext = {
   removeRootEventTypes: (
     rootEventTypes: Array<ReactNativeEventResponderEventType>,
   ) => void,
-  getEventCurrentTarget(
-    event: ReactNativeResponderEvent,
-  ): ReactNativeEventTarget,
   setTimeout: (func: () => void, timeout: number) => number,
   clearTimeout: (timerId: number) => void,
   getTimeStamp: () => number,

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -28,6 +28,7 @@ export type PointerType =
   | 'trackpad';
 
 export type ReactDOMResponderEvent = {
+  currentTarget: null | Element | Document,
   nativeEvent: AnyNativeEvent,
   passive: boolean,
   passiveSupported: boolean,
@@ -75,7 +76,6 @@ export type ReactDOMResponderContext = {
   getFocusableElementsInScope(): Array<HTMLElement>,
   getActiveDocument(): Document,
   objectAssign: Function,
-  getEventCurrentTarget(event: ReactDOMResponderEvent): Element,
   getTimeStamp: () => number,
   isTargetWithinHostComponent: (
     target: Element | Document,


### PR DESCRIPTION
Previously, we had to use the context method `getEventCurrentTarget` to find the current event target. We can optimize this significantly by providing it on the `event` responder object passed to responder method callbacks. This way, we don't need to call `getEventCurrentTarget` and do more work than needed. From this, I noticed that we also didn't guard against `document` elements being the target (rare, granted – but possible). You can't call a bunch of the methods we use on `document` so this would result in JS errors at runtime.

I also noticed that the RN codepath diverged from the ReactDOM version – so I took this opportunity to align them.