### PR TITLE
[Flare] Clear pressStart timeout on pointercancel

### DIFF
--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -434,6 +434,10 @@ function dispatchCancel(
   state: PressState,
 ): void {
   state.touchEvent = null;
+  if (state.pressStartTimeout !== null) {
+    context.clearTimeout(state.pressStartTimeout);
+    state.pressStartTimeout = null;
+  }
   if (state.isPressed) {
     state.ignoreEmulatedMouseEvents = false;
     dispatchPressEndEvents(event, context, props, state);

--- a/packages/react-events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Press-test.internal.js
@@ -257,6 +257,22 @@ describe('Event responder: Press', () => {
         ref.current.dispatchEvent(createEvent('pointerdown'));
         expect(onPressStart).toHaveBeenCalledTimes(1);
       });
+
+      it('onPressStart should not be called if pointerCancel is fired before delayPressStart is finished', () => {
+        const element = (
+          <Press delayPressStart={500} onPressStart={onPressStart}>
+            <div ref={ref} />
+          </Press>
+        );
+        ReactDOM.render(element, container);
+
+        ref.current.dispatchEvent(createEvent('pointerdown'));
+        jest.advanceTimersByTime(499);
+        expect(onPressStart).toHaveBeenCalledTimes(0);
+        ref.current.dispatchEvent(createEvent('pointercancel'));
+        jest.runAllTimers();
+        expect(onPressStart).toHaveBeenCalledTimes(0);
+      });
     });
 
     describe('delayPressEnd', () => {


### PR DESCRIPTION
While using the Press component on a touchscreen device, if you started a press and subsequently used that press to scroll, any press feedback triggered by pressStart/pressChange still fires which causes some confusing UX. This diff prevents that by clearing the `pressStartTimeout` on `pointercancel`.