### PR TITLE
[Flare] Revise responder event types

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -428,19 +428,19 @@ export function unhideTextInstance(textInstance, text): void {
 }
 
 export function mountEventComponent(
-  eventComponentInstance: ReactEventComponentInstance<any, any, any>,
+  eventComponentInstance: ReactEventComponentInstance<any, any>,
 ) {
   throw new Error('Not yet implemented.');
 }
 
 export function updateEventComponent(
-  eventComponentInstance: ReactEventComponentInstance<any, any, any>,
+  eventComponentInstance: ReactEventComponentInstance<any, any>,
 ) {
   throw new Error('Not yet implemented.');
 }
 
 export function unmountEventComponent(
-  eventComponentInstance: ReactEventComponentInstance<any, any, any>,
+  eventComponentInstance: ReactEventComponentInstance<any, any>,
 ): void {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -334,7 +334,7 @@ export function dispatchEvent(
     } else {
       // React Flare event system
       dispatchEventForResponderEventSystem(
-        topLevelType,
+        (topLevelType: any),
         targetInst,
         nativeEvent,
         nativeEventTarget,

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -627,7 +627,7 @@ describe('DOMEventResponderSystem', () => {
     const buttonRef = React.createRef();
 
     const ClickEventComponent1 = createReactEventComponent({
-      targetEventTypes: [{name: 'click', passive: false, capture: false}],
+      targetEventTypes: ['click_active'],
       onEvent: event => {
         clickEventComponent1Fired++;
         eventLog.push({
@@ -639,7 +639,7 @@ describe('DOMEventResponderSystem', () => {
     });
 
     const ClickEventComponent2 = createReactEventComponent({
-      targetEventTypes: [{name: 'click', passive: true, capture: false}],
+      targetEventTypes: ['click'],
       onEvent: event => {
         clickEventComponent2Fired++;
         eventLog.push({
@@ -686,7 +686,7 @@ describe('DOMEventResponderSystem', () => {
     let eventLog = [];
 
     const ClickEventComponent1 = createReactEventComponent({
-      rootEventTypes: [{name: 'click', passive: false, capture: false}],
+      rootEventTypes: ['click_active'],
       onRootEvent: event => {
         clickEventComponent1Fired++;
         eventLog.push({
@@ -698,7 +698,7 @@ describe('DOMEventResponderSystem', () => {
     });
 
     const ClickEventComponent2 = createReactEventComponent({
-      rootEventTypes: [{name: 'click', passive: true, capture: false}],
+      rootEventTypes: ['click'],
       onRootEvent: event => {
         clickEventComponent2Fired++;
         eventLog.push({

--- a/packages/react-events/src/dom/Drag.js
+++ b/packages/react-events/src/dom/Drag.js
@@ -18,11 +18,7 @@ import React from 'react';
 import {DiscreteEvent, UserBlockingEvent} from 'shared/ReactTypes';
 
 const targetEventTypes = ['pointerdown'];
-const rootEventTypes = [
-  'pointerup',
-  'pointercancel',
-  {name: 'pointermove', passive: false},
-];
+const rootEventTypes = ['pointerup', 'pointercancel', 'pointermove_active'];
 
 type DragState = {
   dragTarget: null | Element | Document,
@@ -38,10 +34,13 @@ type DragState = {
 // too
 if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
   targetEventTypes.push('touchstart', 'mousedown');
-  rootEventTypes.push('mouseup', 'mousemove', 'touchend', 'touchcancel', {
-    name: 'touchmove',
-    passive: false,
-  });
+  rootEventTypes.push(
+    'mouseup',
+    'mousemove',
+    'touchend',
+    'touchcancel',
+    'touchmove_active',
+  );
 }
 
 type EventData = {

--- a/packages/react-events/src/dom/Focus.js
+++ b/packages/react-events/src/dom/Focus.js
@@ -46,10 +46,7 @@ const isMac =
     ? /^Mac/.test(window.navigator.platform)
     : false;
 
-const targetEventTypes = [
-  {name: 'focus', passive: true},
-  {name: 'blur', passive: true},
-];
+const targetEventTypes = ['focus', 'blur'];
 
 const rootEventTypes = [
   'keydown',

--- a/packages/react-events/src/dom/FocusScope.js
+++ b/packages/react-events/src/dom/FocusScope.js
@@ -25,8 +25,8 @@ type FocusScopeState = {
   currentFocusedNode: null | HTMLElement,
 };
 
-const targetEventTypes = [{name: 'keydown', passive: false}];
-const rootEventTypes = [{name: 'focus', passive: true}];
+const targetEventTypes = ['keydown_active'];
+const rootEventTypes = ['focus'];
 
 function focusElement(element: ?HTMLElement) {
   if (element != null) {

--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -123,12 +123,12 @@ const DEFAULT_PRESS_RETENTION_OFFSET = {
 };
 
 const targetEventTypes = [
-  {name: 'keydown', passive: false},
-  {name: 'contextmenu', passive: false},
+  'keydown_active',
+  'contextmenu_active',
   // We need to preventDefault on pointerdown for mouse/pen events
   // that are in hit target area but not the element area.
-  {name: 'pointerdown', passive: false},
-  {name: 'click', passive: false},
+  'pointerdown_active',
+  'click_active',
 ];
 const rootEventTypes = [
   'click',
@@ -139,7 +139,7 @@ const rootEventTypes = [
   'pointercancel',
   // We listen to this here so stopPropagation can
   // block other mouseup events used internally
-  {name: 'mouseup', passive: false},
+  'mouseup_active',
   'touchend',
 ];
 

--- a/packages/react-events/src/dom/Swipe.js
+++ b/packages/react-events/src/dom/Swipe.js
@@ -18,20 +18,19 @@ import React from 'react';
 import {UserBlockingEvent, DiscreteEvent} from 'shared/ReactTypes';
 
 const targetEventTypes = ['pointerdown'];
-const rootEventTypes = [
-  'pointerup',
-  'pointercancel',
-  {name: 'pointermove', passive: false},
-];
+const rootEventTypes = ['pointerup', 'pointercancel', 'pointermove_active'];
 
 // In the case we don't have PointerEvents (Safari), we listen to touch events
 // too
 if (typeof window !== 'undefined' && window.PointerEvent === undefined) {
   targetEventTypes.push('touchstart', 'mousedown');
-  rootEventTypes.push('mouseup', 'mousemove', 'touchend', 'touchcancel', {
-    name: 'touchmove',
-    passive: false,
-  });
+  rootEventTypes.push(
+    'mouseup',
+    'mousemove',
+    'touchend',
+    'touchcancel',
+    'touchmove_active',
+  );
 }
 
 type EventData = {

--- a/packages/react-events/src/rn/Press.js
+++ b/packages/react-events/src/rn/Press.js
@@ -10,7 +10,6 @@
 import type {
   ReactNativeResponderEvent,
   ReactNativeResponderContext,
-  ReactNativeEventResponderEventType,
   ReactNativeEventTarget,
   PointerType,
   ReactFaricEventTouch,
@@ -24,7 +23,6 @@ import {
 } from 'react-native-renderer/src/ReactNativeTypes';
 
 type ReactNativeEventResponder = ReactEventResponder<
-  ReactNativeEventResponderEventType,
   ReactNativeResponderEvent,
   ReactNativeResponderContext,
 >;

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -13,7 +13,6 @@ import type {
   MeasureOnSuccessCallback,
   NativeMethodsMixinType,
   ReactNativeBaseComponentViewConfig,
-  ReactNativeEventResponderEventType,
   ReactNativeResponderEvent,
   ReactNativeResponderContext,
 } from './ReactNativeTypes';
@@ -66,7 +65,6 @@ const {get: getViewConfigForType} = ReactNativeViewConfigRegistry;
 let nextReactTag = 2;
 
 type ReactNativeEventComponentInstance = ReactEventComponentInstance<
-  ReactNativeEventResponderEventType,
   ReactNativeResponderEvent,
   ReactNativeResponderContext,
 >;

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -9,7 +9,6 @@
 
 import type {
   ReactNativeBaseComponentViewConfig,
-  ReactNativeEventResponderEventType,
   ReactNativeResponderEvent,
   ReactNativeResponderContext,
 } from './ReactNativeTypes';
@@ -35,7 +34,6 @@ import ReactNativeFiberHostComponent from './ReactNativeFiberHostComponent';
 const {get: getViewConfigForType} = ReactNativeViewConfigRegistry;
 
 type ReactNativeEventComponentInstance = ReactEventComponentInstance<
-  ReactNativeEventResponderEventType,
   ReactNativeResponderEvent,
   ReactNativeResponderContext,
 >;

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -157,17 +157,6 @@ export type ReactFabricType = {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: SecretInternalsFabricType,
 };
 
-export type ReactNativeEventResponderEventType =
-  | 'topMouseDown'
-  | 'topMouseMove'
-  | 'topMouseUp'
-  | 'topScroll'
-  | 'topSelectionChange'
-  | 'topTouchCancel'
-  | 'topTouchEnd'
-  | 'topTouchMove'
-  | 'topTouchStart';
-
 export type ReactNativeEventTarget = {
   node: Object,
   canonical: {
@@ -202,7 +191,7 @@ export type ReactNativeResponderEvent = {
   currentTarget: null | ReactNativeEventTarget,
   nativeEvent: ReactFaricEvent,
   target: null | ReactNativeEventTarget,
-  type: ReactNativeEventResponderEventType,
+  type: string,
 };
 
 export type ReactNativeResponderContext = {
@@ -224,12 +213,8 @@ export type ReactNativeResponderContext = {
       bottom: number,
     }) => void,
   ): void,
-  addRootEventTypes: (
-    rootEventTypes: Array<ReactNativeEventResponderEventType>,
-  ) => void,
-  removeRootEventTypes: (
-    rootEventTypes: Array<ReactNativeEventResponderEventType>,
-  ) => void,
+  addRootEventTypes: (rootEventTypes: Array<string>) => void,
+  removeRootEventTypes: (rootEventTypes: Array<string>) => void,
   setTimeout: (func: () => void, timeout: number) => number,
   clearTimeout: (timerId: number) => void,
   getTimeStamp: () => number,

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -103,7 +103,7 @@ if (__DEV__) {
 export type Dependencies = {
   expirationTime: ExpirationTime,
   firstContext: ContextDependency<mixed> | null,
-  events: Array<ReactEventComponentInstance<any, any, any>> | null,
+  events: Array<ReactEventComponentInstance<any, any>> | null,
 };
 
 // A Fiber is work on a Component that needs to be done or was done. There can

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -1126,7 +1126,6 @@ function completeWork(
         let eventComponentInstance: ReactEventComponentInstance<
           any,
           any,
-          any,
         > | null =
           workInProgress.stateNode;
 

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -32,8 +32,8 @@ export function prepareToReadEventComponents(workInProgress: Fiber): void {
   currentEventComponentInstanceIndex = 0;
 }
 
-export function updateEventComponentInstance<T, E, C>(
-  eventComponent: ReactEventComponent<T, E, C>,
+export function updateEventComponentInstance<E, C>(
+  eventComponent: ReactEventComponent<E, C>,
   props: Object,
 ): void {
   const responder = eventComponent.responder;
@@ -82,14 +82,14 @@ export function updateEventComponentInstance<T, E, C>(
   }
 }
 
-export function createEventComponentInstance<T, E, C>(
+export function createEventComponentInstance<E, C>(
   currentFiber: Fiber,
   props: Object,
-  responder: ReactEventResponder<T, E, C>,
+  responder: ReactEventResponder<E, C>,
   rootInstance: mixed,
   state: Object,
   isHook: boolean,
-): ReactEventComponentInstance<T, E, C> {
+): ReactEventComponentInstance<E, C> {
   return {
     currentFiber,
     isHook,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -83,8 +83,8 @@ export type Dispatcher = {
     deps: Array<mixed> | void | null,
   ): void,
   useDebugValue<T>(value: T, formatterFn: ?(value: T) => mixed): void,
-  useEvent<T, E, C>(
-    eventComponent: ReactEventComponent<T, E, C>,
+  useEvent<E, C>(
+    eventComponent: ReactEventComponent<E, C>,
     props: Object,
   ): void,
 };
@@ -1416,7 +1416,7 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountDebugValue(value, formatterFn);
     },
-    useEvent<T, E, C>(eventComponent: ReactEventComponent<T, E, C>, props) {
+    useEvent<E, C>(eventComponent: ReactEventComponent<E, C>, props) {
       currentHookNameInDev = 'useEvent';
       mountHookTypesDev();
       updateEventComponentInstance(eventComponent, props);
@@ -1518,7 +1518,7 @@ if (__DEV__) {
       updateHookTypesDev();
       return mountDebugValue(value, formatterFn);
     },
-    useEvent<T, E, C>(eventComponent: ReactEventComponent<T, E, C>, props) {
+    useEvent<E, C>(eventComponent: ReactEventComponent<E, C>, props) {
       currentHookNameInDev = 'useEvent';
       updateHookTypesDev();
       updateEventComponentInstance(eventComponent, props);
@@ -1620,7 +1620,7 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateDebugValue(value, formatterFn);
     },
-    useEvent<T, E, C>(eventComponent: ReactEventComponent<T, E, C>, props) {
+    useEvent<E, C>(eventComponent: ReactEventComponent<E, C>, props) {
       currentHookNameInDev = 'useEvent';
       updateHookTypesDev();
       updateEventComponentInstance(eventComponent, props);
@@ -1733,7 +1733,7 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountDebugValue(value, formatterFn);
     },
-    useEvent<T, E, C>(eventComponent: ReactEventComponent<T, E, C>, props) {
+    useEvent<E, C>(eventComponent: ReactEventComponent<E, C>, props) {
       currentHookNameInDev = 'useEvent';
       warnInvalidHookAccess();
       mountHookTypesDev();
@@ -1847,7 +1847,7 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateDebugValue(value, formatterFn);
     },
-    useEvent<T, E, C>(eventComponent: ReactEventComponent<T, E, C>, props) {
+    useEvent<E, C>(eventComponent: ReactEventComponent<E, C>, props) {
       currentHookNameInDev = 'useEvent';
       warnInvalidHookAccess();
       updateHookTypesDev();

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -286,19 +286,19 @@ export function unhideTextInstance(
 }
 
 export function mountEventComponent(
-  eventComponentInstance: ReactEventComponentInstance<any, any, any>,
+  eventComponentInstance: ReactEventComponentInstance<any, any>,
 ): void {
   // noop
 }
 
 export function updateEventComponent(
-  eventComponentInstance: ReactEventComponentInstance<any, any, any>,
+  eventComponentInstance: ReactEventComponentInstance<any, any>,
 ): void {
   // noop
 }
 
 export function unmountEventComponent(
-  eventComponentInstance: ReactEventComponentInstance<any, any, any>,
+  eventComponentInstance: ReactEventComponentInstance<any, any>,
 ): void {
   // noop
 }

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -138,8 +138,8 @@ export function useDebugValue(value: any, formatterFn: ?(value: any) => any) {
 
 export const emptyObject = {};
 
-export function useEvent<T, E, C>(
-  eventComponent: ReactEventComponent<T, E, C>,
+export function useEvent<E, C>(
+  eventComponent: ReactEventComponent<E, C>,
   props: null | Object,
 ) {
   const dispatcher = resolveDispatcher();

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -15,10 +15,6 @@ import type {
 
 type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | Touch;
 
-export type ReactDOMEventResponderEventType =
-  | string
-  | {name: string, passive?: boolean};
-
 export type PointerType =
   | ''
   | 'mouse'
@@ -39,13 +35,11 @@ export type ReactDOMResponderEvent = {
 };
 
 export type ReactDOMEventResponder = ReactEventResponder<
-  ReactDOMEventResponderEventType,
   ReactDOMResponderEvent,
   ReactDOMResponderContext,
 >;
 
 export type ReactDOMEventComponentInstance = ReactEventComponentInstance<
-  ReactDOMEventResponderEventType,
   ReactDOMResponderEvent,
   ReactDOMResponderContext,
 >;
@@ -62,12 +56,8 @@ export type ReactDOMResponderContext = {
   ) => boolean,
   isTargetWithinEventComponent: (Element | Document) => boolean,
   isTargetWithinEventResponderScope: (Element | Document) => boolean,
-  addRootEventTypes: (
-    rootEventTypes: Array<ReactDOMEventResponderEventType>,
-  ) => void,
-  removeRootEventTypes: (
-    rootEventTypes: Array<ReactDOMEventResponderEventType>,
-  ) => void,
+  addRootEventTypes: (rootEventTypes: Array<string>) => void,
+  removeRootEventTypes: (rootEventTypes: Array<string>) => void,
   hasOwnership: () => boolean,
   requestGlobalOwnership: () => boolean,
   releaseOwnership: () => boolean,

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -14,7 +14,7 @@ export type ReactNode =
   | ReactFragment
   | ReactProvider<any>
   | ReactConsumer<any>
-  | ReactEventComponent<any, any, any>;
+  | ReactEventComponent<any, any>;
 
 export type ReactEmpty = null | void | boolean;
 
@@ -80,20 +80,20 @@ export type RefObject = {|
   current: any,
 |};
 
-export type ReactEventComponentInstance<T, E, C> = {|
+export type ReactEventComponentInstance<E, C> = {|
   currentFiber: mixed,
   isHook: boolean,
   props: Object,
-  responder: ReactEventResponder<T, E, C>,
+  responder: ReactEventResponder<E, C>,
   rootEventTypes: null | Set<string>,
   rootInstance: null | mixed,
   state: Object,
 |};
 
-export type ReactEventResponder<T, E, C> = {
+export type ReactEventResponder<E, C> = {
   displayName: string,
-  targetEventTypes?: Array<T>,
-  rootEventTypes?: Array<T>,
+  targetEventTypes?: Array<string>,
+  rootEventTypes?: Array<string>,
   getInitialState?: (props: Object) => Object,
   allowMultipleHostChildren: boolean,
   allowEventHooks: boolean,
@@ -104,9 +104,9 @@ export type ReactEventResponder<T, E, C> = {
   onOwnershipChange?: (context: C, props: Object, state: Object) => void,
 };
 
-export type ReactEventComponent<T, E, C> = {|
+export type ReactEventComponent<E, C> = {|
   $$typeof: Symbol | number,
-  responder: ReactEventResponder<T, E, C>,
+  responder: ReactEventResponder<E, C>,
 |};
 
 export opaque type EventPriority = 0 | 1 | 2;

--- a/packages/shared/createEventComponent.js
+++ b/packages/shared/createEventComponent.js
@@ -28,9 +28,9 @@ if (__DEV__) {
   }
 }
 
-export default function createEventComponent<T, E, C>(
-  responder: ReactEventResponder<T, E, C>,
-): ReactEventComponent<T, E, C> {
+export default function createEventComponent<E, C>(
+  responder: ReactEventResponder<E, C>,
+): ReactEventComponent<E, C> {
   // We use responder as a Map key later on. When we have a bad
   // polyfill, then we can't use it as a key as the polyfill tries
   // to add a property to the object.

--- a/packages/shared/endsWith.js
+++ b/packages/shared/endsWith.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export default function endsWith(subject: string, search: string): boolean {
+  const length = subject.length;
+  return subject.substring(length - search.length, length) === search;
+}


### PR DESCRIPTION
This changes responder event types to always be strings, rather than the confusing mix of either string or object (for when something needs to be marked as passive). So previously, you'd do this `{name: 'click', passive: false}`. With this change, you'd do `"click_active"`.

From doing this, we can get rid of a bunch of confusing branch code and unify the event targets of both DOM and RN responders so they're just `Array<string>`. So this also removes a lot of Flow generics abstraction too.

The net result is less memory used and faster runtime performance as we no longer generate sets and listening keys, instead we loop over the small array. Looping over a small array of strings (< 10 elements) was 5x faster than converting to a key and using that as a key to lookup existence within a Set.