### PR TITLE
[Flare] Switch from currentTarget model to responderTarget model

### DIFF
--- a/packages/react-events/src/dom/Focus.js
+++ b/packages/react-events/src/dom/Focus.js
@@ -252,7 +252,7 @@ const FocusResponder: ReactDOMEventResponder = {
         if (!state.isFocused) {
           // Limit focus events to the direct child of the event component.
           // Browser focus is not expected to bubble.
-          state.focusTarget = event.currentTarget;
+          state.focusTarget = event.responderTarget;
           if (state.focusTarget === target) {
             state.isFocused = true;
             state.isLocalFocusVisible = isGlobalFocusVisible;

--- a/packages/react-events/src/dom/Hover.js
+++ b/packages/react-events/src/dom/Hover.js
@@ -321,7 +321,7 @@ const HoverResponder: ReactDOMEventResponder = {
           if (isEmulatedMouseEvent(event, state)) {
             return;
           }
-          state.hoverTarget = event.currentTarget;
+          state.hoverTarget = event.responderTarget;
           state.ignoreEmulatedMouseEvents = true;
           dispatchHoverStartEvents(event, context, props, state);
         }

--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -696,7 +696,7 @@ const PressResponder: ReactDOMEventResponder = {
           // We set these here, before the button check so we have this
           // data around for handling of the context menu
           state.pointerType = pointerType;
-          const pressTarget = (state.pressTarget = event.currentTarget);
+          const pressTarget = (state.pressTarget = event.responderTarget);
           if (isPointerEvent) {
             state.activePointerId = pointerId;
           } else if (isTouchEvent) {

--- a/packages/react-events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Press-test.internal.js
@@ -3119,6 +3119,34 @@ describe('Event responder: Press', () => {
     expect(pointerDownEvent).toHaveBeenCalledTimes(0);
   });
 
+  it('has the correct press target when used with event hook', () => {
+    const ref = React.createRef();
+    const onPress = jest.fn();
+    const Component = () => {
+      React.unstable_useEvent(Press, {onPress});
+
+      return (
+        <div>
+          <Press>
+            <a href="#" ref={ref} />
+          </Press>
+        </div>
+      );
+    };
+    ReactDOM.render(<Component />, container);
+
+    ref.current.dispatchEvent(
+      createEvent('pointerdown', {pointerType: 'mouse', button: 0}),
+    );
+    ref.current.dispatchEvent(
+      createEvent('pointerup', {pointerType: 'mouse', button: 0}),
+    );
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledWith(
+      expect.objectContaining({target: ref.current}),
+    );
+  });
+
   it('warns when stopPropagation is used in an event hook', () => {
     const ref = React.createRef();
     const Component = () => {

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -24,12 +24,12 @@ export type PointerType =
   | 'trackpad';
 
 export type ReactDOMResponderEvent = {
-  currentTarget: null | Element | Document,
   nativeEvent: AnyNativeEvent,
   passive: boolean,
   passiveSupported: boolean,
   pointerId: null | number,
   pointerType: PointerType,
+  responderTarget: null | Element | Document,
   target: Element | Document,
   type: string,
 };


### PR DESCRIPTION
This PR changes responder `event.currentTarget` to `event.responderTarget`. This also works a bit differently, in that it will give you the last `currentTarget` for the specific responder you're working with. This ensures that the `currentTarget` remains consistent between `onEvent` and `onRootEvent` as well usage via hooks.