### PR TITLE
[Flare] Remove responder flags

### DIFF
--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -26,8 +26,6 @@ function createReactEventComponent({
   onMount,
   onUnmount,
   onOwnershipChange,
-  allowMultipleHostChildren,
-  allowEventHooks,
 }) {
   const testEventResponder = {
     displayName: 'TestEventComponent',
@@ -39,8 +37,6 @@ function createReactEventComponent({
     onMount,
     onUnmount,
     onOwnershipChange,
-    allowMultipleHostChildren: allowMultipleHostChildren || false,
-    allowEventHooks: allowEventHooks || true,
   };
 
   return React.unstable_createEvent(testEventResponder);
@@ -820,133 +816,6 @@ describe('DOMEventResponderSystem', () => {
       {withoutStack: true},
     );
     expect(container.innerHTML).toBe('<button>Click me!</button>');
-  });
-
-  it('should warn if multiple host components are detected without allowMultipleHostChildren', () => {
-    const EventComponent = createReactEventComponent({
-      targetEventTypes: [],
-      onEvent: () => {},
-      allowMultipleHostChildren: false,
-    });
-
-    const Test = () => (
-      <EventComponent>
-        <div />
-        <div />
-      </EventComponent>
-    );
-
-    expect(() => {
-      ReactDOM.render(<Test />, container);
-    }).toWarnDev(
-      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
-    );
-
-    function Component() {
-      return <div />;
-    }
-
-    const Test2 = () => (
-      <EventComponent>
-        <div />
-        <Component />
-      </EventComponent>
-    );
-
-    expect(() => {
-      ReactDOM.render(<Test2 />, container);
-    }).toWarnDev(
-      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
-    );
-  });
-
-  it('should handle suspended nodes correctly when detecting host components without allowMultipleHostChildren', () => {
-    const EventComponent = createReactEventComponent({
-      targetEventTypes: [],
-      onEvent: () => {},
-      allowMultipleHostChildren: false,
-    });
-
-    function SuspendedComponent() {
-      throw Promise.resolve();
-    }
-
-    function Component() {
-      return (
-        <React.Fragment>
-          <div />
-          <SuspendedComponent />
-        </React.Fragment>
-      );
-    }
-
-    const Test = () => (
-      <EventComponent>
-        <React.Suspense fallback={<div>Loading...</div>}>
-          <Component />
-        </React.Suspense>
-      </EventComponent>
-    );
-
-    ReactDOM.render(<Test />, container);
-
-    function Component2() {
-      return (
-        <React.Fragment>
-          <SuspendedComponent />
-        </React.Fragment>
-      );
-    }
-
-    const Test2 = () => (
-      <EventComponent>
-        <React.Suspense
-          fallback={
-            <React.Fragment>
-              <div />
-              <div />
-            </React.Fragment>
-          }>
-          <Component2 />
-        </React.Suspense>
-      </EventComponent>
-    );
-
-    expect(() => {
-      ReactDOM.render(<Test2 />, container);
-    }).toWarnDev(
-      'Warning: A "<TestEventComponent>" event component cannot contain multiple host children.',
-    );
-  });
-
-  it('should not warn if multiple host components are detected with allowMultipleHostChildren', () => {
-    const EventComponent = createReactEventComponent({
-      targetEventTypes: [],
-      onEvent: () => {},
-      allowMultipleHostChildren: true,
-    });
-
-    const Test = () => (
-      <EventComponent>
-        <div />
-        <div />
-      </EventComponent>
-    );
-
-    ReactDOM.render(<Test />, container);
-
-    function Component() {
-      return <div />;
-    }
-
-    const Test2 = () => (
-      <EventComponent>
-        <div />
-        <Component />
-      </EventComponent>
-    );
-
-    ReactDOM.render(<Test2 />, container);
   });
 
   it('should work with event component hooks', () => {

--- a/packages/react-events/src/dom/Drag.js
+++ b/packages/react-events/src/dom/Drag.js
@@ -98,8 +98,6 @@ const DragResponder: ReactDOMEventResponder = {
       y: 0,
     };
   },
-  allowMultipleHostChildren: false,
-  allowEventHooks: false,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,

--- a/packages/react-events/src/dom/Focus.js
+++ b/packages/react-events/src/dom/Focus.js
@@ -228,8 +228,6 @@ const FocusResponder: ReactDOMEventResponder = {
       pointerType: '',
     };
   },
-  allowMultipleHostChildren: false,
-  allowEventHooks: true,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,

--- a/packages/react-events/src/dom/FocusScope.js
+++ b/packages/react-events/src/dom/FocusScope.js
@@ -56,8 +56,6 @@ const FocusScopeResponder: ReactDOMEventResponder = {
       currentFocusedNode: null,
     };
   },
-  allowMultipleHostChildren: true,
-  allowEventHooks: false,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,

--- a/packages/react-events/src/dom/Hover.js
+++ b/packages/react-events/src/dom/Hover.js
@@ -332,20 +332,18 @@ const HoverResponder: ReactDOMEventResponder = {
       case 'pointermove':
       case 'mousemove': {
         if (state.isHovered && !isEmulatedMouseEvent(event, state)) {
-          if (state.isHovered) {
-            if (props.onHoverMove && state.hoverTarget !== null) {
-              const syntheticEvent = createHoverEvent(
-                event,
-                context,
-                'hovermove',
-                state.hoverTarget,
-              );
-              context.dispatchEvent(
-                syntheticEvent,
-                props.onHoverMove,
-                UserBlockingEvent,
-              );
-            }
+          if (props.onHoverMove && state.hoverTarget !== null) {
+            const syntheticEvent = createHoverEvent(
+              event,
+              context,
+              'hovermove',
+              state.hoverTarget,
+            );
+            context.dispatchEvent(
+              syntheticEvent,
+              props.onHoverMove,
+              UserBlockingEvent,
+            );
           }
         }
         return;

--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -649,8 +649,6 @@ const PressResponder: ReactDOMEventResponder = {
       touchEvent: null,
     };
   },
-  allowMultipleHostChildren: false,
-  allowEventHooks: true,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,

--- a/packages/react-events/src/dom/Scroll.js
+++ b/packages/react-events/src/dom/Scroll.js
@@ -141,8 +141,6 @@ const ScrollResponder: ReactDOMEventResponder = {
       scrollTarget: null,
     };
   },
-  allowMultipleHostChildren: true,
-  allowEventHooks: true,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,

--- a/packages/react-events/src/dom/Swipe.js
+++ b/packages/react-events/src/dom/Swipe.js
@@ -104,8 +104,6 @@ const SwipeResponder: ReactDOMEventResponder = {
       y: 0,
     };
   },
-  allowMultipleHostChildren: false,
-  allowEventHooks: false,
   onEvent(
     event: ReactDOMResponderEvent,
     context: ReactDOMResponderContext,

--- a/packages/react-events/src/rn/Press.js
+++ b/packages/react-events/src/rn/Press.js
@@ -502,8 +502,6 @@ function dispatchPressEndEvents(event, context, props, state): void {
 const PressResponder: ReactNativeEventResponder = {
   displayName: 'Press',
   targetEventTypes,
-  allowEventHooks: true,
-  allowMultipleHostChildren: false,
   getInitialState(): PressState {
     return {
       activationPosition: null,

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -116,12 +116,7 @@ import {
   renderDidSuspendDelayIfPossible,
   renderHasNotSuspendedYet,
 } from './ReactFiberWorkLoop';
-import {
-  getEventComponentHostChildrenCount,
-  createEventComponentInstance,
-} from './ReactFiberEvents';
-import getComponentName from 'shared/getComponentName';
-import warning from 'shared/warning';
+import {createEventComponentInstance} from './ReactFiberEvents';
 import {Never} from './ReactFiberExpirationTime';
 import {resetChildFibers} from './ReactChildFiber';
 
@@ -1131,16 +1126,6 @@ function completeWork(
 
         if (eventComponentInstance === null) {
           let responderState = null;
-          if (__DEV__ && !responder.allowMultipleHostChildren) {
-            const hostChildrenCount = getEventComponentHostChildrenCount(
-              workInProgress,
-            );
-            warning(
-              (hostChildrenCount || 0) < 2,
-              'A "<%s>" event component cannot contain multiple host children.',
-              getComponentName(workInProgress.type),
-            );
-          }
           const getInitialState = responder.getInitialState;
           if (getInitialState !== undefined) {
             responderState = getInitialState(newProps);

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -22,7 +22,6 @@ import {
   Fragment,
 } from 'shared/ReactWorkTags';
 import {NoWork} from './ReactFiberExpirationTime';
-import invariant from 'shared/invariant';
 
 let currentlyRenderingFiber: null | Fiber = null;
 let currentEventComponentInstanceIndex: number = 0;
@@ -37,11 +36,6 @@ export function updateEventComponentInstance<E, C>(
   props: Object,
 ): void {
   const responder = eventComponent.responder;
-  invariant(
-    responder.allowEventHooks,
-    'The "%s" event responder cannot be used via the "useEvent" hook.',
-    responder.displayName,
-  );
   let events;
   let dependencies: Dependencies | null = ((currentlyRenderingFiber: any): Fiber)
     .dependencies;

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -95,8 +95,6 @@ export type ReactEventResponder<E, C> = {
   targetEventTypes?: Array<string>,
   rootEventTypes?: Array<string>,
   getInitialState?: (props: Object) => Object,
-  allowMultipleHostChildren: boolean,
-  allowEventHooks: boolean,
   onEvent?: (event: E, context: C, props: Object, state: Object) => void,
   onRootEvent?: (event: E, context: C, props: Object, state: Object) => void,
   onMount?: (context: C, props: Object, state: Object) => void,


### PR DESCRIPTION
This PR removes `allowMultipleHostChildren` and `allowEventHooks` – so all event responders have better defaults and universal behaviour.