### PR TITLE
Give unresolved lazy() a name in component stack

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -1183,4 +1183,85 @@ describe('ReactLazy', () => {
       expect(Scheduler).toFlushAndYield([]);
     }).toErrorDev('Function components cannot be given refs');
   });
+
+  it('should error with a component stack naming the resolved component', async () => {
+    let componentStackMessage;
+
+    const LazyText = lazy(() =>
+      fakeImport(function ResolvedText() {
+        throw new Error('oh no');
+      }),
+    );
+
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+
+      componentDidCatch(error, errMessage) {
+        componentStackMessage = errMessage.componentStack;
+        this.setState({
+          error,
+        });
+      }
+
+      render() {
+        return this.state.error ? null : this.props.children;
+      }
+    }
+
+    ReactTestRenderer.create(
+      <ErrorBoundary>
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText text="Hi" />
+        </Suspense>
+      </ErrorBoundary>,
+      {unstable_isConcurrent: true},
+    );
+
+    expect(Scheduler).toFlushAndYield(['Loading...']);
+
+    try {
+      await Promise.resolve();
+    } catch (e) {}
+
+    expect(Scheduler).toFlushAndYield([]);
+
+    expect(componentStackMessage).toContain('in ResolvedText');
+  });
+
+  it('should error with a component stack containing Lazy if unresolved', () => {
+    let componentStackMessage;
+
+    const LazyText = lazy(() => ({
+      then(resolve, reject) {
+        reject(new Error('oh no'));
+      },
+    }));
+
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+
+      componentDidCatch(error, errMessage) {
+        componentStackMessage = errMessage.componentStack;
+        this.setState({
+          error,
+        });
+      }
+
+      render() {
+        return this.state.error ? null : this.props.children;
+      }
+    }
+
+    ReactTestRenderer.create(
+      <ErrorBoundary>
+        <Suspense fallback={<Text text="Loading..." />}>
+          <LazyText text="Hi" />
+        </Suspense>
+      </ErrorBoundary>,
+    );
+
+    expect(Scheduler).toHaveYielded([]);
+
+    expect(componentStackMessage).toContain('in Lazy');
+  });
 });

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -6,6 +6,15 @@ let ReactFeatureFlags;
 let Suspense;
 let lazy;
 
+function normalizeCodeLocInfo(str) {
+  return (
+    str &&
+    str.replace(/\n +(?:at|in) ([\S]+)[^\n]*/g, function(m, name) {
+      return '\n    in ' + name + ' (at **)';
+    })
+  );
+}
+
 describe('ReactLazy', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -1197,7 +1206,7 @@ describe('ReactLazy', () => {
       state = {error: null};
 
       componentDidCatch(error, errMessage) {
-        componentStackMessage = errMessage.componentStack;
+        componentStackMessage = normalizeCodeLocInfo(errMessage.componentStack);
         this.setState({
           error,
         });
@@ -1241,7 +1250,7 @@ describe('ReactLazy', () => {
       state = {error: null};
 
       componentDidCatch(error, errMessage) {
-        componentStackMessage = errMessage.componentStack;
+        componentStackMessage = normalizeCodeLocInfo(errMessage.componentStack);
         this.setState({
           error,
         });


### PR DESCRIPTION
Currently, if a `React.lazy(...)` component fails to load, React reports the error with a component stack in which the lazy component is represented as `Unknown` ([example](https://codesandbox.io/s/unresolved-lazy-component-stack-qjsb3)).

With this PR, the name reported will instead be `Lazy` while the lazy component is unresolved. This PR also adds a test covering the (unchanged) case of a *resolved* lazy component that throws an error during rendering.