### PR TITLE
[Scheduler] Support inferring priority from stack

### DIFF
--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -56,6 +56,22 @@ var isPerformingWork = false;
 var isHostCallbackScheduled = false;
 var isHostTimeoutScheduled = false;
 
+function scheduler_flushTaskAtPriority_Immediate(callback, didTimeout) {
+  return callback(didTimeout);
+}
+function scheduler_flushTaskAtPriority_UserBlocking(callback, didTimeout) {
+  return callback(didTimeout);
+}
+function scheduler_flushTaskAtPriority_Normal(callback, didTimeout) {
+  return callback(didTimeout);
+}
+function scheduler_flushTaskAtPriority_Low(callback, didTimeout) {
+  return callback(didTimeout);
+}
+function scheduler_flushTaskAtPriority_Idle(callback, didTimeout) {
+  return callback(didTimeout);
+}
+
 function flushTask(task, currentTime) {
   // Remove the task from the list before calling the callback. That way the
   // list is in a consistent state even if the callback throws.
@@ -83,7 +99,40 @@ function flushTask(task, currentTime) {
   var continuationCallback;
   try {
     var didUserCallbackTimeout = task.expirationTime <= currentTime;
-    continuationCallback = callback(didUserCallbackTimeout);
+    // Add an extra function to the callstack. Profiling tools can use this
+    // to infer the priority of work that appears higher in the stack.
+    switch (currentPriorityLevel) {
+      case ImmediatePriority:
+        continuationCallback = scheduler_flushTaskAtPriority_Immediate(
+          callback,
+          didUserCallbackTimeout,
+        );
+        break;
+      case UserBlockingPriority:
+        continuationCallback = scheduler_flushTaskAtPriority_UserBlocking(
+          callback,
+          didUserCallbackTimeout,
+        );
+        break;
+      case NormalPriority:
+        continuationCallback = scheduler_flushTaskAtPriority_Normal(
+          callback,
+          didUserCallbackTimeout,
+        );
+        break;
+      case LowPriority:
+        continuationCallback = scheduler_flushTaskAtPriority_Low(
+          callback,
+          didUserCallbackTimeout,
+        );
+        break;
+      case IdlePriority:
+        continuationCallback = scheduler_flushTaskAtPriority_Idle(
+          callback,
+          didUserCallbackTimeout,
+        );
+        break;
+    }
   } catch (error) {
     throw error;
   } finally {


### PR DESCRIPTION
When executing a task, wraps the callback in an extra function whose name includes the current priority level. Profiling tools with access to function names can use this to determine the priority of the task.