### PR TITLE
Use Map instead of object as map in ReactNativeComponentTree

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeComponentTree.js
+++ b/packages/react-native-renderer/src/ReactNativeComponentTree.js
@@ -7,20 +7,20 @@
 
 import invariant from 'shared/invariant';
 
-const instanceCache = {};
-const instanceProps = {};
+const instanceCache = new Map();
+const instanceProps = new Map();
 
 export function precacheFiberNode(hostInst, tag) {
-  instanceCache[tag] = hostInst;
+  instanceCache.set(tag, hostInst);
 }
 
 export function uncacheFiberNode(tag) {
-  delete instanceCache[tag];
-  delete instanceProps[tag];
+  instanceCache.delete(tag);
+  instanceProps.delete(tag);
 }
 
 function getInstanceFromTag(tag) {
-  return instanceCache[tag] || null;
+  return instanceCache.get(tag) || null;
 }
 
 function getTagFromInstance(inst) {
@@ -39,9 +39,9 @@ export {
 };
 
 export function getFiberCurrentPropsFromNode(stateNode) {
-  return instanceProps[stateNode._nativeTag] || null;
+  return instanceProps.get(stateNode._nativeTag) || null;
 }
 
 export function updateFiberProps(tag, props) {
-  instanceProps[tag] = props;
+  instanceProps.set(tag, props);
 }


### PR DESCRIPTION
Real Maps should now be used in RN JS engines. In theory this should be faster (but might not actually be in practice), and it avoids hitting upper bounds of property max counts.

~I haven't actually tested since we don't have integration tests in this repo.~ I actually failed some initial tests so we at least have some coverage here. Will need to be tested when we do a sync.

The case that I could imagine would be different is that this no longer ToStrings the keys so if there are some string keys getting passed here, they would no longer match. Nothing should do that though.

We don't use these types of Maps in Fabric.