### PR TITLE
[Flare] Press: fix middle-click handling

### DIFF
--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -893,6 +893,7 @@ const PressResponder: ReactDOMEventResponder = {
       case 'mouseup':
       case 'touchend': {
         if (isPressed) {
+          const button = nativeEvent.button;
           let isKeyboardEvent = false;
           let touchEvent;
           if (type === 'pointerup' && activePointerId !== pointerId) {
@@ -910,6 +911,9 @@ const PressResponder: ReactDOMEventResponder = {
               return;
             }
             isKeyboardEvent = true;
+            removeRootEventTypes(context, state);
+          } else if (button === 1) {
+            // Remove the root events here as no 'click' event is dispatched when this 'button' is pressed.
             removeRootEventTypes(context, state);
           }
 
@@ -968,10 +972,7 @@ const PressResponder: ReactDOMEventResponder = {
                 state,
               );
             }
-            if (
-              state.isPressWithinResponderRegion &&
-              nativeEvent.button !== 1
-            ) {
+            if (state.isPressWithinResponderRegion && button !== 1) {
               if (
                 !(
                   wasLongPressed &&

--- a/packages/react-events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Press-test.internal.js
@@ -150,6 +150,48 @@ describe('Event responder: Press', () => {
       );
     });
 
+    it('is not called after "pointermove" following auxillary-button press', () => {
+      ref.current.getBoundingClientRect = () => ({
+        top: 0,
+        left: 0,
+        bottom: 100,
+        right: 100,
+      });
+      ref.current.dispatchEvent(
+        createEvent('pointerdown', {
+          button: 1,
+          pointerType: 'mouse',
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+      ref.current.dispatchEvent(
+        createEvent('pointerup', {
+          button: 1,
+          pointerType: 'mouse',
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+      container.dispatchEvent(
+        createEvent('pointermove', {
+          button: 1,
+          pointerType: 'mouse',
+          clientX: 110,
+          clientY: 110,
+        }),
+      );
+      container.dispatchEvent(
+        createEvent('pointermove', {
+          button: 1,
+          pointerType: 'mouse',
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+      expect(onPressStart).toHaveBeenCalledTimes(1);
+    });
+
     it('ignores browser emulated events', () => {
       ref.current.dispatchEvent(createEvent('pointerdown'));
       ref.current.dispatchEvent(createEvent('touchstart'));


### PR DESCRIPTION
Make sure the root events are removed after middle-click completes.

(Wasn't able to create a failing unit test. Another reason to eventually move to browser functional tests.)

