### PR TITLE
Inject ReactDebugCurrentFrame into DevTools

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -473,7 +473,7 @@ if (__DEV__) {
 
 export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
   const {findFiberByHostInstance} = devToolsConfig;
-  const {ReactCurrentDispatcher} = ReactSharedInternals;
+  const {ReactCurrentDispatcher, ReactDebugCurrentFrame} = ReactSharedInternals;
 
   return injectInternals({
     ...devToolsConfig,
@@ -501,5 +501,7 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
     scheduleRefresh: __DEV__ ? scheduleRefresh : null,
     scheduleRoot: __DEV__ ? scheduleRoot : null,
     setRefreshHandler: __DEV__ ? setRefreshHandler : null,
+    // Enables DevTools to append component stack to error messages in DEV mode.
+    debugCurrentFrame: ReactDebugCurrentFrame,
   });
 }


### PR DESCRIPTION
So it can append component stacks to warnings in DEV mode.

Related issues:
* https://github.com/facebook/react/pull/16126
* https://github.com/bvaughn/react-devtools-experimental/issues/347