### PR TITLE
Inject getCurrentFiber() function to DevTools

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -473,7 +473,7 @@ if (__DEV__) {
 
 export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
   const {findFiberByHostInstance} = devToolsConfig;
-  const {ReactCurrentDispatcher, ReactDebugCurrentFrame} = ReactSharedInternals;
+  const {ReactCurrentDispatcher} = ReactSharedInternals;
 
   return injectInternals({
     ...devToolsConfig,
@@ -501,7 +501,7 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
     scheduleRefresh: __DEV__ ? scheduleRefresh : null,
     scheduleRoot: __DEV__ ? scheduleRoot : null,
     setRefreshHandler: __DEV__ ? setRefreshHandler : null,
-    // Enables DevTools to append component stack to error messages in DEV mode.
-    debugCurrentFrame: ReactDebugCurrentFrame,
+    // Enables DevTools to append owner stacks to error messages in DEV mode.
+    getCurrentFiber: __DEV__ ? () => ReactCurrentFiberCurrent : null,
   });
 }


### PR DESCRIPTION
This returns the current value of ReactCurrentFiber and enables DevTools to append a custom (owner-only) component stack to warnings and errors in DEV mode.

This is an attempt to address concerns about component stacks being overly noisy in certain environments. It does feel like an improvement based on even my own test harness, e.g.
![image](https://user-images.githubusercontent.com/29597/61191333-030f9400-a65e-11e9-86ed-377201a1aefb.png)

Supersedes #16127
