### PR TITLE
Dev tools inject get component name and describe component frame

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -26,6 +26,7 @@ import {
 } from 'react-reconciler/reflection';
 import {get as getInstance} from 'shared/ReactInstanceMap';
 import {HostComponent, ClassComponent} from 'shared/ReactWorkTags';
+import describeComponentFrame from 'shared/describeComponentFrame';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
@@ -502,6 +503,8 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
     scheduleRoot: __DEV__ ? scheduleRoot : null,
     setRefreshHandler: __DEV__ ? setRefreshHandler : null,
     // Enables DevTools to append owner stacks to error messages in DEV mode.
+    describeComponentFrame: __DEV__ ? describeComponentFrame : null,
+    getComponentName: __DEV__ ? getComponentName : null,
     getCurrentFiber: __DEV__ ? () => ReactCurrentFiberCurrent : null,
   });
 }


### PR DESCRIPTION
This change is being made to enable DevTools to eagerly patch the console (before a renderer has been attached to the frontend) so that e.g. React Native developers can still get component stacks even if they aren't using the DevTools UI.

We don't strictly _need_ to inject these methods, but since the logic for getting the display name of a component is tied to the renderer version, this simplifies things for DevTools.

At this point, it would be much easier to just inject `ReactDebugCurrentFrame` and let it create the stacks for us- _but_ that would prevent DevTools from being able to create an owners-only stack, which I think is rather nice to have.