### PR TITLE
Support React.createContext in ReactShallowRenderer

### DIFF
--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -536,7 +536,10 @@ class ReactShallowRenderer {
     this._element = element;
 
     if (elementType.contextType) {
-      this._context = context !== emptyObject ? context : elementType.contextType._currentValue;
+      this._context =
+        context !== emptyObject
+          ? context
+          : elementType.contextType._currentValue;
     } else {
       this._context = getMaskedContext(elementType.contextTypes, context);
     }

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -534,7 +534,12 @@ class ReactShallowRenderer {
 
     this._rendering = true;
     this._element = element;
-    this._context = getMaskedContext(elementType.contextTypes, context);
+
+    if (elementType.contextType) {
+      this._context = context !== emptyObject ? context : elementType.contextType._currentValue;
+    } else {
+      this._context = getMaskedContext(elementType.contextTypes, context);
+    }
 
     // Inner memo component props aren't currently validated in createElement.
     if (isMemo(element.type) && elementType.propTypes) {

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -1137,6 +1137,38 @@ describe('ReactShallowRenderer', () => {
     expect(result).toEqual(<div>foo</div>);
   });
 
+  it('can pass context when shallowly rendering with contextType', () => {
+    const TestContext = React.createContext('none');
+    class SimpleComponent extends React.Component {
+      static contextType = TestContext;
+
+      render() {
+        return <div>{this.context.name}</div>;
+      }
+    }
+
+    const shallowRenderer = createRenderer();
+    const result = shallowRenderer.render(<SimpleComponent />, {
+      name: 'foo',
+    });
+    expect(result).toEqual(<div>foo</div>);
+  });
+
+  it('should shallow render components with contextType', () => {
+    const TestContext = React.createContext({ name: 'foo' });
+    class SimpleComponent extends React.Component {
+      static contextType = TestContext;
+
+      render() {
+        return <div>{this.context.name}</div>;
+      }
+    }
+
+    const shallowRenderer = createRenderer();
+    const result = shallowRenderer.render(<SimpleComponent />);
+    expect(result).toEqual(<div>foo</div>);
+  });
+
   it('should track context across updates', () => {
     class SimpleComponent extends React.Component {
       static contextTypes = {

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -1155,7 +1155,7 @@ describe('ReactShallowRenderer', () => {
   });
 
   it('should shallow render components with contextType', () => {
-    const TestContext = React.createContext({ name: 'foo' });
+    const TestContext = React.createContext({name: 'foo'});
     class SimpleComponent extends React.Component {
       static contextType = TestContext;
 


### PR DESCRIPTION
Fixes #14442

- Adds support for `React.createContext` and `contextType` in React.ShallowRenderer.

- We're still supporting [contextTypes](https://reactjs.org/docs/context.html#legacy-api) in React 16.x releases, so the code for that was not removed.