### PR TITLE
[Scheduler] Bugfix: Cancelling a continuation

### DIFF
--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -144,14 +144,8 @@ function flushTask(task, currentTime) {
   // with the same priority and expiration as the just-finished callback.
   if (typeof continuationCallback === 'function') {
     var expirationTime = task.expirationTime;
-    var continuationTask = {
-      callback: continuationCallback,
-      priorityLevel: task.priorityLevel,
-      startTime: task.startTime,
-      expirationTime,
-      next: null,
-      previous: null,
-    };
+    var continuationTask = task;
+    continuationTask.callback = continuationCallback;
 
     // Insert the new callback into the list, sorted by its timeout. This is
     // almost the same as the code in `scheduleCallback`, except the callback

--- a/packages/scheduler/src/__tests__/Scheduler-test.js
+++ b/packages/scheduler/src/__tests__/Scheduler-test.js
@@ -275,6 +275,19 @@ describe('Scheduler', () => {
     },
   );
 
+  it('cancelling a continuation', () => {
+    const task = scheduleCallback(NormalPriority, () => {
+      Scheduler.unstable_yieldValue('Yield');
+      return () => {
+        Scheduler.unstable_yieldValue('Continuation');
+      };
+    });
+
+    expect(Scheduler).toFlushAndYieldThrough(['Yield']);
+    cancelCallback(task);
+    expect(Scheduler).toFlushWithoutYielding();
+  });
+
   it('top-level immediate callbacks fire in a subsequent task', () => {
     scheduleCallback(ImmediatePriority, () =>
       Scheduler.unstable_yieldValue('A'),


### PR DESCRIPTION
Cancelling the original task should also cancel its continuation.
