### PR TITLE
Create ReactFabric.stopSurface and use that for bridgeless mode binding

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -152,7 +152,13 @@ const ReactFabric: ReactFabricType = {
     return getPublicRootInstance(root);
   },
 
+  // Deprecated - this function is being renamed to stopSurface, use that instead.
+  // TODO (T47576999): Delete this once it's no longer called from native code.
   unmountComponentAtNode(containerTag: number) {
+    this.stopSurface(containerTag);
+  },
+
+  stopSurface(containerTag: number) {
     const root = roots.get(containerTag);
     if (root) {
       // TODO: Is it safe to reset this now or should I wait since this unmount could be deferred?

--- a/scripts/rollup/shims/react-native/ReactFabric.js
+++ b/scripts/rollup/shims/react-native/ReactFabric.js
@@ -23,6 +23,10 @@ if (__DEV__) {
   ReactFabric = require('../implementations/ReactFabric-prod');
 }
 
-BatchedBridge.registerCallableModule('ReactFabric', ReactFabric);
+if (global.RN$Bridgeless) {
+  global.RN$stopSurface = ReactFabric.stopSurface;
+} else {
+  BatchedBridge.registerCallableModule('ReactFabric', ReactFabric);
+}
 
 module.exports = (ReactFabric: ReactNativeType);


### PR DESCRIPTION
For Fabric we want to rename `unmountComponentAtNode` to `stopSurface` to be consistent with `startSurface`. Because `unmountComponentAtNode` is called from native code (see ReactInstanceManager), we can't just delete it yet. Once this change syncs, I'll clean up usage of `unmountComponentAtNode` in native code, then I'll come back and remove it completely.

For more context, see https://github.com/facebook/react-native/commit/305058178e144d4709606ea42d0edb9d864b33c5 (and additional discussion on D16273720 for fb employees). This PR also updates the binding I create in that diff for bridgeless mode to refer only to stopSurface.