### PR TITLE
[Shallow] Implement callEffects option to call effects from shallow renderer (#15275)

### DIFF
--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -349,7 +349,7 @@ class ReactShallowRenderer {
             cleanup: memoizedState.cleanup,
             run:
               inputs == null ||
-              shouldRunEffectsBasedOnInputs(memoizedState.inputs, inputs),
+              !areHookInputsEqual(inputs, memoizedState.inputs),
           };
         }
       }
@@ -688,7 +688,10 @@ class ReactShallowRenderer {
             ReactCurrentDispatcher.current = prevDispatcher;
           }
           this._finishHooks(element, context);
-          this._callEffectsIfDesired();
+          if (this._options.callEffects) {
+            this._callEffects(true);
+            this._callEffects(false);
+          }
         }
       }
     }
@@ -747,15 +750,6 @@ class ReactShallowRenderer {
     this._rendered = this._instance.render();
     // Intentionally do not call componentDidMount()
     // because DOM refs are not available.
-  }
-
-  _callEffectsIfDesired() {
-    if (!this._options.callEffects) {
-      return;
-    }
-
-    this._callEffects(true);
-    this._callEffects(false);
   }
 
   _callEffects(callLayoutEffects: boolean) {
@@ -920,17 +914,6 @@ function getMaskedContext(contextTypes, unmaskedContext) {
     context[key] = unmaskedContext[key];
   }
   return context;
-}
-
-function shouldRunEffectsBasedOnInputs(
-  before: Array<mixed> | void | null,
-  after: Array<mixed>,
-) {
-  if (before == null || before.length !== after.length) {
-    return true;
-  }
-
-  return before.some((value, i) => after[i] !== value);
 }
 
 export default ReactShallowRenderer;

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -336,7 +336,7 @@ class ReactShallowRenderer {
             isLayoutEffect,
             create,
             inputs,
-            cleanup: null,
+            destroy: null,
             run: true,
           };
         } else {
@@ -346,7 +346,7 @@ class ReactShallowRenderer {
             isLayoutEffect,
             create,
             inputs,
-            cleanup: memoizedState.cleanup,
+            destroy: memoizedState.destroy,
             run:
               inputs == null ||
               !areHookInputsEqual(inputs, memoizedState.inputs),
@@ -765,10 +765,10 @@ class ReactShallowRenderer {
         memoizedState.isLayoutEffect === callLayoutEffects &&
         memoizedState.run
       ) {
-        if (memoizedState.cleanup) {
-          memoizedState.cleanup();
+        if (memoizedState.destroy) {
+          memoizedState.destroy();
         }
-        memoizedState.cleanup = memoizedState.create();
+        memoizedState.destroy = memoizedState.create();
       }
     }
   }

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
@@ -280,6 +280,81 @@ describe('ReactShallowRenderer with hooks', () => {
         'call effect',
       ]);
     });
+
+    it('should trigger effects and cleanup depending on inputs', () => {
+      let _setFriend;
+      const happenings = [];
+
+      function SomeComponent() {
+        const [friend, setFriend] = React.useState('Bons');
+        const [cat] = React.useState('Muskus');
+        _setFriend = setFriend;
+
+        React.useEffect(
+          () => {
+            happenings.push('call friend effect');
+            return () => {
+              happenings.push('cleanup friend effect');
+            };
+          },
+          [friend],
+        );
+
+        React.useEffect(() => {
+          happenings.push('call empty effect');
+          return () => {
+            happenings.push('cleanup empty effect');
+          };
+        });
+
+        React.useEffect(
+          () => {
+            happenings.push('call cat effect');
+            return () => {
+              happenings.push('cleanup cat effect');
+            };
+          },
+          [cat],
+        );
+
+        React.useEffect(
+          () => {
+            happenings.push('call both effect');
+            return () => {
+              happenings.push('cleanup both effect');
+            };
+          },
+          [friend, cat],
+        );
+
+        return (
+          <div>
+            Hello {friend} with {cat}
+          </div>
+        );
+      }
+
+      const shallowRenderer = createRenderer({callEffects: true});
+      shallowRenderer.render(<SomeComponent />);
+
+      expect(happenings).toEqual([
+        'call friend effect',
+        'call empty effect',
+        'call cat effect',
+        'call both effect',
+      ]);
+
+      happenings.splice(0);
+      _setFriend('Maryam');
+      expect(happenings).toEqual([
+        'cleanup friend effect',
+        'call friend effect',
+        'cleanup empty effect',
+        'call empty effect',
+        'cleanup both effect',
+        'call both effect',
+      ]);
+    });
   });
 
   it('should work with useRef', () => {

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
@@ -258,11 +258,11 @@ describe('ReactShallowRenderer with hooks', () => {
 
       function SomeComponent({defaultName}) {
         React.useEffect(() => {
-          happenings.push('call effect');
+          happenings.push('create effect');
         });
 
         React.useLayoutEffect(() => {
-          happenings.push('call layout effect');
+          happenings.push('create layout effect');
         });
 
         happenings.push('render');
@@ -276,42 +276,42 @@ describe('ReactShallowRenderer with hooks', () => {
       // Note the layout effect is triggered first.
       expect(happenings).toEqual([
         'render',
-        'call layout effect',
-        'call effect',
+        'create layout effect',
+        'create effect',
       ]);
     });
 
-    it('should trigger effects and cleanup depending on inputs', () => {
+    it('should trigger effects and destroy depending on inputs', () => {
       let _setFriend;
       const happenings = [];
 
       function SomeComponent() {
         const [friend, setFriend] = React.useState('Bons');
-        const [cat] = React.useState('Muskus');
+        const cat = 'Muskus';
         _setFriend = setFriend;
 
         React.useEffect(
           () => {
-            happenings.push('call friend effect');
+            happenings.push('create friend effect');
             return () => {
-              happenings.push('cleanup friend effect');
+              happenings.push('destroy friend effect');
             };
           },
           [friend],
         );
 
         React.useEffect(() => {
-          happenings.push('call empty effect');
+          happenings.push('create empty effect');
           return () => {
-            happenings.push('cleanup empty effect');
+            happenings.push('destroy empty effect');
           };
         });
 
         React.useEffect(
           () => {
-            happenings.push('call cat effect');
+            happenings.push('create cat effect');
             return () => {
-              happenings.push('cleanup cat effect');
+              happenings.push('destroy cat effect');
             };
           },
           [cat],
@@ -319,9 +319,9 @@ describe('ReactShallowRenderer with hooks', () => {
 
         React.useEffect(
           () => {
-            happenings.push('call both effect');
+            happenings.push('create both effect');
             return () => {
-              happenings.push('cleanup both effect');
+              happenings.push('destroy both effect');
             };
           },
           [friend, cat],
@@ -338,21 +338,21 @@ describe('ReactShallowRenderer with hooks', () => {
       shallowRenderer.render(<SomeComponent />);
 
       expect(happenings).toEqual([
-        'call friend effect',
-        'call empty effect',
-        'call cat effect',
-        'call both effect',
+        'create friend effect',
+        'create empty effect',
+        'create cat effect',
+        'create both effect',
       ]);
 
       happenings.splice(0);
       _setFriend('Maryam');
       expect(happenings).toEqual([
-        'cleanup friend effect',
-        'call friend effect',
-        'cleanup empty effect',
-        'call empty effect',
-        'cleanup both effect',
-        'call both effect',
+        'destroy friend effect',
+        'create friend effect',
+        'destroy empty effect',
+        'create empty effect',
+        'destroy both effect',
+        'create both effect',
       ]);
     });
   });

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
@@ -231,8 +231,8 @@ describe('ReactShallowRenderer with hooks', () => {
     );
   });
 
-  it('should not trigger effects', () => {
-    let effectsCalled = [];
+  it('should not trigger effects by default', () => {
+    const effectsCalled = [];
 
     function SomeComponent({defaultName}) {
       React.useEffect(() => {
@@ -250,6 +250,36 @@ describe('ReactShallowRenderer with hooks', () => {
     shallowRenderer.render(<SomeComponent />);
 
     expect(effectsCalled).toEqual([]);
+  });
+
+  describe('when callEffects option is used', () => {
+    it('should trigger effects after render', () => {
+      const happenings = [];
+
+      function SomeComponent({defaultName}) {
+        React.useEffect(() => {
+          happenings.push('call effect');
+        });
+
+        React.useLayoutEffect(() => {
+          happenings.push('call layout effect');
+        });
+
+        happenings.push('render');
+
+        return <div>Hello world</div>;
+      }
+
+      const shallowRenderer = createRenderer({callEffects: true});
+      shallowRenderer.render(<SomeComponent />);
+
+      // Note the layout effect is triggered first.
+      expect(happenings).toEqual([
+        'render',
+        'call layout effect',
+        'call effect',
+      ]);
+    });
   });
 
   it('should work with useRef', () => {


### PR DESCRIPTION
Fixes the effects related part of #15275 by allowing the user to tell the shallow renderer to call effect hooks.

~It could do with a couple more tests but I wanted to get feedback on the approach and was also worried about putting any more time into it given that the maintainers have not responded to the corresponding issue in the months it's been open.~

Added a full set of tests.