### PR TITLE
Do not warn when DOM attribute values are undefined

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
@@ -126,5 +126,14 @@ describe('ReactDOM unknown attribute', () => {
 
       expect(el.firstChild.getAttribute('helloworld')).toBe('something');
     });
+
+    it('does not warn on camelCase unknown attributes with value of undefined', () => {
+      const el = document.createElement('div');
+
+      ReactDOM.render(<div helloWorld={undefined} />, el);
+
+      expect(el.firstChild.getAttribute('helloworld')).toBeNull();
+      expect(el.firstChild.getAttribute('helloWorld')).toBeNull();
+    });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
@@ -133,7 +133,6 @@ describe('ReactDOM unknown attribute', () => {
       ReactDOM.render(<div helloWorld={undefined} />, el);
 
       expect(el.firstChild.getAttribute('helloworld')).toBeNull();
-      expect(el.firstChild.getAttribute('helloWorld')).toBeNull();
     });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -2375,8 +2375,6 @@ describe('ReactDOMComponent', () => {
 
     it('allows cased custom attributes and does not warn when value is undefined', function() {
       const el = ReactTestUtils.renderIntoDocument(<div fooBar={undefined} />);
-
-      expect(el.getAttribute('fooBar')).toBeNull();
       expect(el.getAttribute('foobar')).toBeNull();
     });
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -2373,6 +2373,13 @@ describe('ReactDOMComponent', () => {
       expect(el.getAttribute('foobar')).toBe('true');
     });
 
+    it('allows cased custom attributes and does not warn when value is undefined', function() {
+      const el = ReactTestUtils.renderIntoDocument(<div fooBar={undefined} />);
+
+      expect(el.getAttribute('fooBar')).toBeNull();
+      expect(el.getAttribute('foobar')).toBeNull();
+    });
+
     it('warns on NaN attributes', function() {
       let el;
       expect(() => {

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -151,7 +151,7 @@ if (__DEV__) {
         warnedProperties[name] = true;
         return true;
       }
-    } else if (!isReserved && name !== lowerCasedName) {
+    } else if (value !== undefined && !isReserved && name !== lowerCasedName) {
       // Unknown attributes should have lowercase casing since that's how they
       // will be cased anyway with server rendering.
       console.error(


### PR DESCRIPTION
Fixes #13381

Currently (React 16.8.6), passing `null` or `undefined` on a ReactDOMElement will result in that attribute being absent from the corresponding DOM element, however, the following warning still appears:

```
class App extends Component {
  render() {
    return <div helloWorld={undefined}> Hello World</div>;
  }
}
```
![image](https://user-images.githubusercontent.com/34415120/61594340-c81fda00-abe2-11e9-8d75-05a2da3e66e4.png)

As explained in the referenced issue, this leads to warnings in dev environments when trying to remove props by using `cloneElement` , despite the prop not appearing in the actual DOM.

This pull request takes the approach @sophiebits recommended in that issue and will not give the error, only when the value of the prop is `undefined` (ie, when the prop is `null` or some other value, the previous behavior will be maintained). 
