### PR TITLE
[Flare] Press: fix keyboard interactions

### DIFF
--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -685,14 +685,35 @@ const PressResponder: ReactDOMEventResponder = {
           const isKeyboardEvent = pointerType === 'keyboard';
           const isMouseEvent = pointerType === 'mouse';
 
+          // Ignore emulated mouse events
+          if (type === 'mousedown' && state.ignoreEmulatedMouseEvents) {
+            return;
+          }
+
+          state.shouldPreventClick = false;
           if (isPointerEvent || isTouchEvent) {
             state.ignoreEmulatedMouseEvents = true;
-          } else if (type === 'mousedown' && state.ignoreEmulatedMouseEvents) {
-            // Ignore emulated mouse events
-            return;
           } else if (isKeyboardEvent) {
             // Ignore unrelated key events
-            if (!isValidKeyboardEvent(nativeEvent)) {
+            if (isValidKeyboardEvent(nativeEvent)) {
+              const {
+                altKey,
+                ctrlKey,
+                metaKey,
+                shiftKey,
+              } = (nativeEvent: MouseEvent);
+              if (nativeEvent.key === ' ') {
+                nativeEvent.preventDefault();
+              } else if (
+                props.preventDefault !== false &&
+                !shiftKey &&
+                !metaKey &&
+                !ctrlKey &&
+                !altKey
+              ) {
+                state.shouldPreventClick = true;
+              }
+            } else {
               return;
             }
           }
@@ -920,7 +941,6 @@ const PressResponder: ReactDOMEventResponder = {
           }
 
           // Determine whether to call preventDefault on subsequent native events.
-          state.shouldPreventClick = false;
           if (
             context.isTargetWithinEventComponent(target) &&
             context.isTargetWithinHostComponent(target, 'a', true)


### PR DESCRIPTION
Prevents Spacebar from scrolling the window.
Prevents Enter from triggering a navigation if `preventDefault` is true.
Fixes the emulated events unit test.

Demo: https://codesandbox.io/s/admiring-ride-rz96j30rp