### PR TITLE
[Fresh] Track unrecoverable errors

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -461,7 +461,7 @@ export function injectIntoGlobalHook(globalObject: any): void {
             failedRoots.set(root, alternate.memoizedState.element);
           }
         } else if (!wasMounted && !isMounted) {
-          if (didError) {
+          if (didError && !failedRoots.has(root)) {
             // The root had an error during the initial mount.
             // We can't read its last element from the memoized state
             // because there was no previously committed alternate.

--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -65,6 +65,7 @@ let findHostInstancesForRefresh: null | FindHostInstancesForRefresh = null;
 let mountedRoots: Set<FiberRoot> = new Set();
 // If a root captures an error, we add its element to this Map so we can retry on edit.
 let failedRoots: Map<FiberRoot, ReactNodeList> = new Map();
+let didSomeRootFailOnMount = false;
 
 function computeFullKey(signature: Signature): string {
   if (signature.fullKey !== null) {
@@ -459,6 +460,19 @@ export function injectIntoGlobalHook(globalObject: any): void {
             // Remember what was rendered so we can restore it.
             failedRoots.set(root, alternate.memoizedState.element);
           }
+        } else if (!wasMounted && !isMounted) {
+          if (didError) {
+            // The root had an error during the initial mount.
+            // We can't read its last element from the memoized state
+            // because there was no previously committed alternate.
+            // Ideally, it would be nice if we had a way to extract
+            // the last attempted rendered element, but accessing the update queue
+            // would tie this package too closely to the reconciler version.
+            // So instead, we just set a flag.
+            // TODO: Maybe we could fix this as the same time as when we fix
+            // DevTools to not depend on `alternate.memoizedState.element`.
+            didSomeRootFailOnMount = true;
+          }
         }
       } else {
         // Mount a new root.
@@ -472,6 +486,10 @@ export function injectIntoGlobalHook(globalObject: any): void {
       'Unexpected call to React Refresh in a production environment.',
     );
   }
+}
+
+export function hasUnrecoverableErrors() {
+  return didSomeRootFailOnMount;
 }
 
 // Exposed for testing.

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -2712,8 +2712,28 @@ describe('ReactFresh', () => {
     }
   });
 
+  // TODO: we can make this recoverable in the future
+  // if we add a way to track the last attempted element.
+  it('records an unrecoverable error if a root fails on mount', () => {
+    if (__DEV__) {
+      expect(ReactFreshRuntime.hasUnrecoverableErrors()).toBe(false);
+      expect(() => {
+        render(() => {
+          function Hello() {
+            throw new Error('No');
+          }
+          $RefreshReg$(Hello, 'Hello');
+
+          return Hello;
+        });
+      }).toThrow('No');
+      expect(ReactFreshRuntime.hasUnrecoverableErrors()).toBe(true);
+    }
+  });
+
   it('remounts a failed root on update', () => {
     if (__DEV__) {
+      expect(ReactFreshRuntime.hasUnrecoverableErrors()).toBe(false);
       render(() => {
         function Hello() {
           return <h1>Hi</h1>;
@@ -2723,6 +2743,7 @@ describe('ReactFresh', () => {
         return Hello;
       });
       expect(container.innerHTML).toBe('<h1>Hi</h1>');
+      expect(ReactFreshRuntime.hasUnrecoverableErrors()).toBe(false);
 
       // Perform a hot update that fails.
       // This removes the root.
@@ -2735,6 +2756,7 @@ describe('ReactFresh', () => {
         });
       }).toThrow('No');
       expect(container.innerHTML).toBe('');
+      expect(ReactFreshRuntime.hasUnrecoverableErrors()).toBe(false);
 
       // A bad retry
       expect(() => {
@@ -2746,6 +2768,7 @@ describe('ReactFresh', () => {
         });
       }).toThrow('Not yet');
       expect(container.innerHTML).toBe('');
+      expect(ReactFreshRuntime.hasUnrecoverableErrors()).toBe(false);
 
       // Perform a hot update that fixes the error.
       patch(() => {
@@ -2756,6 +2779,7 @@ describe('ReactFresh', () => {
       });
       // This should remount the root.
       expect(container.innerHTML).toBe('<h1>Fixed!</h1>');
+      expect(ReactFreshRuntime.hasUnrecoverableErrors()).toBe(false);
 
       // Verify next hot reload doesn't remount anything.
       let helloNode = container.firstChild;
@@ -2767,6 +2791,7 @@ describe('ReactFresh', () => {
       });
       expect(container.firstChild).toBe(helloNode);
       expect(helloNode.textContent).toBe('Nice.');
+      expect(ReactFreshRuntime.hasUnrecoverableErrors()).toBe(false);
 
       // Break again.
       expect(() => {
@@ -2778,6 +2803,7 @@ describe('ReactFresh', () => {
         });
       }).toThrow('Oops');
       expect(container.innerHTML).toBe('');
+      expect(ReactFreshRuntime.hasUnrecoverableErrors()).toBe(false);
 
       // Perform a hot update that fixes the error.
       patch(() => {
@@ -2788,6 +2814,7 @@ describe('ReactFresh', () => {
       });
       // This should remount the root.
       expect(container.innerHTML).toBe('<h1>At last.</h1>');
+      expect(ReactFreshRuntime.hasUnrecoverableErrors()).toBe(false);
 
       // Check we don't attempt to reverse an intentional unmount.
       ReactDOM.unmountComponentAtNode(container);
@@ -2799,6 +2826,7 @@ describe('ReactFresh', () => {
         $RefreshReg$(Hello, 'Hello');
       });
       expect(container.innerHTML).toBe('');
+      expect(ReactFreshRuntime.hasUnrecoverableErrors()).toBe(false);
     }
   });
 


### PR DESCRIPTION
We have a recovery mechanism in Fresh. If a mounted root fails during an update, we record the last attempted element (by reading it from the current memoized state), and retry rendering it after the next edit. This lets us quickly fix runtime errors that we introduce while editing.

However, this recovery mechanism doesn't work for the initial mount of an app with no error boundaries. In that case, we don't currently have a way to read the last attempted rendered element — because this root has never been committed yet.

Currently, in that case we just end up with a blank screen. This is annoying because you get used to just saving a file after seeing a redbox. But in this case you'll keep seeing the blank screen.

This PR adds a way for the module environment integration to check whether we have an unrecoverable error like this. In that case, the module environment may decide to do a full reload instead.

In the future, we can get rid of this special case if there is some way to know the last attempted rendered element for any given root. For example, we could add a new `onTryRenderRoot(root, element)` DevTools hook that does that. This would also be useful so that we can stop relying on comparing `alternate.memoizedState.element` and `current.memoizedState.element` in DevTools to figure out what happened. This is out of scope of this PR though.