### PR TITLE
[Scheduler][Bugfix] Multiple rAFs in same frame

### DIFF
--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -229,9 +229,10 @@ if (
   channel.port1.onmessage = performWorkUntilDeadline;
 
   const onAnimationFrame = rAFTime => {
+    isRAFLoopRunning = false;
+
     if (scheduledHostCallback === null) {
       // No scheduled work. Exit.
-      isRAFLoopRunning = false;
       prevRAFTime = -1;
       prevRAFInterval = -1;
       return;
@@ -255,6 +256,7 @@ if (
     // waited until the end of the frame to post the callback, we risk the
     // browser skipping a frame and not firing the callback until the frame
     // after that.
+    isRAFLoopRunning = true;
     requestAnimationFrame(nextRAFTime => {
       clearTimeout(rAFTimeoutID);
       onAnimationFrame(nextRAFTime);
@@ -303,9 +305,8 @@ if (
   requestHostCallback = function(callback) {
     scheduledHostCallback = callback;
     if (!isRAFLoopRunning) {
-      isRAFLoopRunning = true;
-
       // Start a rAF loop.
+      isRAFLoopRunning = true;
       requestAnimationFrame(rAFTime => {
         if (requestIdleCallbackBeforeFirstFrame) {
           cancelIdleCallback(idleCallbackID);


### PR DESCRIPTION
Always sets `isRAFLoopRunning` back to false when an animation frame is scheduled. Fixes a bug where two rAFs fire in the same frame, but the second one exits and fails to schedule a new rAF.

Fixes bug observed in Safari.

I'll figure out a better test plan later; need to land this to fix FB5.