### PR TITLE
[Flare] Ensure Flare components are no-ops for TestRenderer

### DIFF
--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -12,6 +12,7 @@
 let React;
 let ReactFeatureFlags;
 let ReactDOM;
+let ReactTestRenderer;
 
 // FIXME: What should the public API be for setting an event's priority? Right
 // now it's an enum but is that what we want? Hard coding this for now.
@@ -78,6 +79,18 @@ describe('DOMEventResponderSystem', () => {
   afterEach(() => {
     document.body.removeChild(container);
     container = null;
+  });
+
+  it('can mount and render correctly with the ReactTestRenderer', () => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableFlareAPI = true;
+    ReactTestRenderer = require('react-test-renderer');
+    const TestResponder = createEventResponder({});
+    const renderer = ReactTestRenderer.create(
+      <div responders={<TestResponder />}>Hello world</div>,
+    );
+    expect(renderer).toMatchRenderedOutput(<div>Hello world</div>);
   });
 
   it('the event responders should fire on click event', () => {

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -140,9 +140,19 @@ export function createInstance(
   hostContext: Object,
   internalInstanceHandle: Object,
 ): Instance {
+  let propsToUse = props;
+  if (enableFlareAPI) {
+    if (props.responders != null) {
+      // We want to remove the "responders" prop
+      // as we don't want it into the test renderer instance's
+      // props object.
+      const {responders, ...otherProps} = props; // eslint-disable-line
+      propsToUse = otherProps;
+    }
+  }
   return {
     type,
-    props,
+    props: propsToUse,
     isHidden: false,
     children: [],
     rootContainerInstance,
@@ -288,13 +298,13 @@ export function mountResponderInstance(
   instance: Instance,
   rootContainerInstance: Container,
 ) {
-  throw new Error('Not yet implemented.');
+  // noop
 }
 
 export function unmountResponderInstance(
   responderInstance: ReactEventResponderInstance<any, any>,
 ): void {
-  throw new Error('Not yet implemented.');
+  // noop
 }
 
 export function getFundamentalComponentInstance(fundamentalInstance): Instance {


### PR DESCRIPTION
This PR makes some changes to the TestRenderer to support Flare's new event system design. Specifically:

- Previous errors are now no-ops.
- We remove the `responders` prop from test instances so they don't affect JSON output in snapshots.