### PR TITLE
update legacy context warning message

### DIFF
--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -347,9 +347,11 @@ if (__DEV__) {
         warningWithoutStack(
           false,
           'Legacy context API has been detected within a strict-mode tree: %s' +
+            '\n\nThe old API will be supported in all 16.x releases, but applications ' +
+            'using it should migrate to the new version.' +
             '\n\nPlease update the following components: %s' +
             '\n\nLearn more about this warning here:' +
-            '\nhttps://fb.me/react-strict-mode-warnings',
+            '\nhttps://fb.me/react-legacy-context',
           strictRootComponentStack,
           sortedNames,
         );

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -1914,6 +1914,8 @@ describe('ReactIncremental', () => {
       ]),
     ).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: Intl, ShowBoth, ShowLocale',
       {withoutStack: true},
     );
@@ -1969,6 +1971,8 @@ describe('ReactIncremental', () => {
       ]),
     ).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: Router, ShowRoute',
       {withoutStack: true},
     );
@@ -1998,6 +2002,8 @@ describe('ReactIncremental', () => {
     ReactNoop.render(<Recurse />);
     expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: Recurse',
       {withoutStack: true},
     );
@@ -2041,6 +2047,8 @@ describe('ReactIncremental', () => {
           '`Recurse.prototype = React.Component.prototype`. ' +
           "Don't use an arrow function since it cannot be called with `new` by React.",
         'Legacy context API has been detected within a strict-mode tree: \n\n' +
+          'The old API will be supported in all 16.x releases, but applications ' +
+          'using it should migrate to the new version.\n\n' +
           'Please update the following components: Recurse',
       ],
       {withoutStack: true},
@@ -2107,6 +2115,8 @@ describe('ReactIncremental', () => {
       ]),
     ).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: Intl, ShowLocale',
       {withoutStack: true},
     );
@@ -2186,6 +2196,8 @@ describe('ReactIncremental', () => {
     );
     expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: Intl, ShowLocaleClass, ShowLocaleFn',
       {withoutStack: true},
     );
@@ -2278,6 +2290,8 @@ describe('ReactIncremental', () => {
     );
     expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: Intl, ShowLocaleClass, ShowLocaleFn',
       {withoutStack: true},
     );
@@ -2347,6 +2361,8 @@ describe('ReactIncremental', () => {
     ReactNoop.render(<Root />);
     expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: Child',
       {withoutStack: true},
     );
@@ -2397,6 +2413,8 @@ describe('ReactIncremental', () => {
     ReactNoop.render(<Root />);
     expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: ContextProvider',
       {withoutStack: true},
     );
@@ -2448,6 +2466,8 @@ describe('ReactIncremental', () => {
       [
         'Using UNSAFE_componentWillReceiveProps in strict mode is not recommended',
         'Legacy context API has been detected within a strict-mode tree: \n\n' +
+          'The old API will be supported in all 16.x releases, but applications ' +
+          'using it should migrate to the new version.\n\n' +
           'Please update the following components: MyComponent',
       ],
       {withoutStack: true},
@@ -2595,6 +2615,8 @@ describe('ReactIncremental', () => {
 
     expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: Child, TopContextProvider',
       {withoutStack: true},
     );
@@ -2657,6 +2679,8 @@ describe('ReactIncremental', () => {
 
     expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: Child, MiddleContextProvider, TopContextProvider',
       {withoutStack: true},
     );
@@ -2728,6 +2752,8 @@ describe('ReactIncremental', () => {
 
     expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: Child, MiddleContextProvider, TopContextProvider',
       {withoutStack: true},
     );
@@ -2809,6 +2835,8 @@ describe('ReactIncremental', () => {
 
     expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but applications ' +
+        'using it should migrate to the new version.\n\n' +
         'Please update the following components: Child, MiddleContextProvider, TopContextProvider',
       {withoutStack: true},
     );

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1119,6 +1119,8 @@ describe('ReactIncrementalErrorHandling', () => {
     );
     expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
       'Legacy context API has been detected within a strict-mode tree: \n\n' +
+        'The old API will be supported in all 16.x releases, but ' +
+        'applications using it should migrate to the new version.\n\n' +
         'Please update the following components: Connector, Provider',
       {withoutStack: true},
     );
@@ -1620,6 +1622,8 @@ describe('ReactIncrementalErrorHandling', () => {
           '`Provider.prototype = React.Component.prototype`. ' +
           "Don't use an arrow function since it cannot be called with `new` by React.",
         'Legacy context API has been detected within a strict-mode tree: \n\n' +
+          'The old API will be supported in all 16.x releases, but ' +
+          'applications using it should migrate to the new version.\n\n' +
           'Please update the following components: Provider',
       ],
       {withoutStack: true},

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1197,6 +1197,8 @@ describe('ReactNewContext', () => {
         expect(Scheduler).toFlushAndYield(['LegacyProvider', 'App', 'Child']);
       }).toWarnDev(
         'Legacy context API has been detected within a strict-mode tree: \n\n' +
+          'The old API will be supported in all 16.x releases, but applications ' +
+          'using it should migrate to the new version.\n\n' +
           'Please update the following components: LegacyProvider',
         {withoutStack: true},
       );

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -817,10 +817,12 @@ Please update the following components: Parent`,
           '\n    in StrictMode (at **)' +
           '\n    in div (at **)' +
           '\n    in Root (at **)' +
+          '\n\nThe old API will be supported in all 16.x releases, but applications ' +
+          'using it should migrate to the new version.' +
           '\n\nPlease update the following components: ' +
           'FunctionalLegacyContextConsumer, LegacyContextConsumer, LegacyContextProvider' +
           '\n\nLearn more about this warning here:' +
-          '\nhttps://fb.me/react-strict-mode-warnings',
+          '\nhttps://fb.me/react-legacy-context',
       );
 
       // Dedupe


### PR DESCRIPTION
The link in the legacy context message doesn't point to anything related to context. This changes the link to point to https://fb.me/react-legacy-context, which points to https://reactjs.org/docs/context.html#legacy-api. Also adds a line that it'll probably be gone later.