### PR TITLE
[Flare] Adds Keyboard event responder

### DIFF
--- a/packages/react-events/keyboard.js
+++ b/packages/react-events/keyboard.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+module.exports = require('./src/dom/Keyboard');

--- a/packages/react-events/npm/keyboard.js
+++ b/packages/react-events/npm/keyboard.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-events-keyboard.production.min.js');
+} else {
+  module.exports = require('./cjs/react-events-keyboard.development.js');
+}

--- a/packages/react-events/package.json
+++ b/packages/react-events/package.json
@@ -20,6 +20,7 @@
     "scroll.js",
     "focus-scope.js",
     "input.js",
+    "keyboard.js",
     "build-info.json",
     "cjs/",
     "umd/"

--- a/packages/react-events/src/dom/Keyboard.js
+++ b/packages/react-events/src/dom/Keyboard.js
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {
+  ReactDOMResponderEvent,
+  ReactDOMResponderContext,
+} from 'shared/ReactDOMTypes';
+
+import React from 'react';
+import {DiscreteEvent} from 'shared/ReactTypes';
+
+type KeyboardEventType = 'keydown' | 'keyup';
+
+type KeyboardListenerProps = {|
+  onKeyDown: (e: KeyboardEvent) => void,
+  onKeyUp: (e: KeyboardEvent) => void,
+|};
+
+type KeyboardResponderProps = {
+  disabled: boolean,
+};
+
+type KeyboardEvent = {|
+  altKey: boolean,
+  ctrlKey: boolean,
+  isComposing: boolean,
+  key: string,
+  location: number,
+  metaKey: boolean,
+  repeat: boolean,
+  shiftKey: boolean,
+  target: Element | Document,
+  type: KeyboardEventType,
+  timeStamp: number,
+|};
+
+const targetEventTypes = ['keydown', 'keyup'];
+
+/**
+ * Normalization of deprecated HTML5 `key` values
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+ */
+const normalizeKey = {
+  Esc: 'Escape',
+  Spacebar: ' ',
+  Left: 'ArrowLeft',
+  Up: 'ArrowUp',
+  Right: 'ArrowRight',
+  Down: 'ArrowDown',
+  Del: 'Delete',
+  Win: 'OS',
+  Menu: 'ContextMenu',
+  Apps: 'ContextMenu',
+  Scroll: 'ScrollLock',
+  MozPrintableKey: 'Unidentified',
+};
+
+/**
+ * Translation from legacy `keyCode` to HTML5 `key`
+ * Only special keys supported, all others depend on keyboard layout or browser
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+ */
+const translateToKey = {
+  '8': 'Backspace',
+  '9': 'Tab',
+  '12': 'Clear',
+  '13': 'Enter',
+  '16': 'Shift',
+  '17': 'Control',
+  '18': 'Alt',
+  '19': 'Pause',
+  '20': 'CapsLock',
+  '27': 'Escape',
+  '32': ' ',
+  '33': 'PageUp',
+  '34': 'PageDown',
+  '35': 'End',
+  '36': 'Home',
+  '37': 'ArrowLeft',
+  '38': 'ArrowUp',
+  '39': 'ArrowRight',
+  '40': 'ArrowDown',
+  '45': 'Insert',
+  '46': 'Delete',
+  '112': 'F1',
+  '113': 'F2',
+  '114': 'F3',
+  '115': 'F4',
+  '116': 'F5',
+  '117': 'F6',
+  '118': 'F7',
+  '119': 'F8',
+  '120': 'F9',
+  '121': 'F10',
+  '122': 'F11',
+  '123': 'F12',
+  '144': 'NumLock',
+  '145': 'ScrollLock',
+  '224': 'Meta',
+};
+
+function getEventKey(nativeEvent): string {
+  const nativeKey = nativeEvent.key;
+  if (nativeKey) {
+    // Normalize inconsistent values reported by browsers due to
+    // implementations of a working draft specification.
+
+    // FireFox implements `key` but returns `MozPrintableKey` for all
+    // printable characters (normalized to `Unidentified`), ignore it.
+    const key = normalizeKey[nativeKey] || nativeKey;
+    if (key !== 'Unidentified') {
+      return key;
+    }
+  }
+  return translateToKey[nativeEvent.keyCode] || 'Unidentified';
+}
+
+function createKeyboardEvent(
+  event: ReactDOMResponderEvent,
+  context: ReactDOMResponderContext,
+  type: KeyboardEventType,
+  target: Document | Element,
+): KeyboardEvent {
+  const nativeEvent = (event: any).nativeEvent;
+  const {
+    altKey,
+    ctrlKey,
+    isComposing,
+    location,
+    metaKey,
+    repeat,
+    shiftKey,
+  } = nativeEvent;
+
+  return {
+    altKey,
+    ctrlKey,
+    isComposing,
+    key: getEventKey(nativeEvent),
+    location,
+    metaKey,
+    repeat,
+    shiftKey,
+    target,
+    timeStamp: context.getTimeStamp(),
+    type,
+  };
+}
+
+function dispatchKeyboardEvent(
+  eventPropName: string,
+  event: ReactDOMResponderEvent,
+  context: ReactDOMResponderContext,
+  type: KeyboardEventType,
+  target: Element | Document,
+): void {
+  const syntheticEvent = createKeyboardEvent(event, context, type, target);
+  context.dispatchEvent(eventPropName, syntheticEvent, DiscreteEvent);
+}
+
+const keyboardResponderImpl = {
+  targetEventTypes,
+  onEvent(
+    event: ReactDOMResponderEvent,
+    context: ReactDOMResponderContext,
+    props: KeyboardResponderProps,
+  ): void {
+    const {responderTarget, type} = event;
+
+    if (props.disabled) {
+      return;
+    }
+    if (type === 'keydown') {
+      dispatchKeyboardEvent(
+        'onKeyDown',
+        event,
+        context,
+        'keydown',
+        ((responderTarget: any): Element | Document),
+      );
+    } else if (type === 'keyup') {
+      dispatchKeyboardEvent(
+        'onKeyUp',
+        event,
+        context,
+        'keyup',
+        ((responderTarget: any): Element | Document),
+      );
+    }
+  },
+};
+
+export const KeyboardResponder = React.unstable_createResponder(
+  'Keyboard',
+  keyboardResponderImpl,
+);
+
+export function useKeyboardListener(props: KeyboardListenerProps): void {
+  React.unstable_useListener(KeyboardResponder, props);
+}

--- a/packages/react-events/src/dom/__tests__/Keyboard-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Keyboard-test.internal.js
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactFeatureFlags;
+let ReactDOM;
+let KeyboardResponder;
+let useKeyboardListener;
+
+const createEvent = (type, data) => {
+  const event = document.createEvent('CustomEvent');
+  event.initCustomEvent(type, true, true);
+  if (data != null) {
+    Object.entries(data).forEach(([key, value]) => {
+      event[key] = value;
+    });
+  }
+  return event;
+};
+
+describe('Keyboard event responder', () => {
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableFlareAPI = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    KeyboardResponder = require('react-events/keyboard').KeyboardResponder;
+    useKeyboardListener = require('react-events/keyboard').useKeyboardListener;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    ReactDOM.render(null, container);
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  describe('disabled', () => {
+    let onKeyDown, onKeyUp, ref;
+
+    beforeEach(() => {
+      onKeyDown = jest.fn();
+      onKeyUp = jest.fn();
+      ref = React.createRef();
+      const Component = () => {
+        useKeyboardListener({
+          onKeyDown,
+          onKeyUp,
+        });
+        return (
+          <div ref={ref} responders={<KeyboardResponder disabled={true} />} />
+        );
+      };
+      ReactDOM.render(<Component />, container);
+    });
+
+    it('prevents custom events being dispatched', () => {
+      ref.current.dispatchEvent(createEvent('scroll'));
+      expect(onKeyDown).not.toBeCalled();
+      expect(onKeyUp).not.toBeCalled();
+    });
+  });
+
+  describe('onKeyDown', () => {
+    let onKeyDown, ref;
+
+    beforeEach(() => {
+      onKeyDown = jest.fn();
+      ref = React.createRef();
+      const Component = () => {
+        useKeyboardListener({
+          onKeyDown,
+        });
+        return <div ref={ref} responders={<KeyboardResponder />} />;
+      };
+      ReactDOM.render(<Component />, container);
+    });
+
+    it('is called after "keydown" event', () => {
+      ref.current.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          key: 'Q',
+        }),
+      );
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      expect(onKeyDown).toHaveBeenCalledWith(
+        expect.objectContaining({key: 'Q', type: 'keydown'}),
+      );
+    });
+  });
+
+  describe('onKeyUp', () => {
+    let onKeyDown, onKeyUp, ref;
+
+    beforeEach(() => {
+      onKeyDown = jest.fn();
+      onKeyUp = jest.fn();
+      ref = React.createRef();
+      const Component = () => {
+        useKeyboardListener({
+          onKeyDown,
+          onKeyUp,
+        });
+        return <div ref={ref} responders={<KeyboardResponder />} />;
+      };
+      ReactDOM.render(<Component />, container);
+    });
+
+    it('is called after "keydown" event', () => {
+      ref.current.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          key: 'Q',
+        }),
+      );
+      ref.current.dispatchEvent(
+        new KeyboardEvent('keyup', {
+          bubbles: true,
+          cancelable: true,
+          key: 'Q',
+        }),
+      );
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      expect(onKeyDown).toHaveBeenCalledWith(
+        expect.objectContaining({key: 'Q', type: 'keydown'}),
+      );
+      expect(onKeyUp).toHaveBeenCalledTimes(1);
+      expect(onKeyUp).toHaveBeenCalledWith(
+        expect.objectContaining({key: 'Q', type: 'keyup'}),
+      );
+    });
+  });
+});

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -538,6 +538,21 @@ const bundles = [
     global: 'ReactEventsScroll',
     externals: ['react'],
   },
+
+  {
+    bundleTypes: [
+      UMD_DEV,
+      UMD_PROD,
+      NODE_DEV,
+      NODE_PROD,
+      FB_WWW_DEV,
+      FB_WWW_PROD,
+    ],
+    moduleType: NON_FIBER_RENDERER,
+    entry: 'react-events/keyboard',
+    global: 'ReactEventsKeyboard',
+    externals: ['react'],
+  },
 ];
 
 // Based on deep-freeze by substack (public domain)


### PR DESCRIPTION
This adds the Keyboard event responder. It's mostly just a pass-through of `keyDown` and `keyUp`, with polyfills and normalization for browsers that don't fully support the right `event.key` value.