### PR TITLE
[Flare] Remove references to EventComponent

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -192,7 +192,7 @@ const eventResponderContext: ReactDOMResponderContext = {
     validateResponderContext();
     for (let i = 0; i < rootEventTypes.length; i++) {
       const rootEventType = rootEventTypes[i];
-      let rootEventComponents = rootEventTypesToEventResponderInstances.get(
+      let rootEventResponders = rootEventTypesToEventResponderInstances.get(
         rootEventType,
       );
       let rootEventTypesSet = ((currentInstance: any): ReactDOMEventResponderInstance)
@@ -200,8 +200,8 @@ const eventResponderContext: ReactDOMResponderContext = {
       if (rootEventTypesSet !== null) {
         rootEventTypesSet.delete(rootEventType);
       }
-      if (rootEventComponents !== undefined) {
-        rootEventComponents.delete(
+      if (rootEventResponders !== undefined) {
+        rootEventResponders.delete(
           ((currentInstance: any): ReactDOMEventResponderInstance),
         );
       }

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -28,7 +28,7 @@ function createEventResponder({
   onOwnershipChange,
   getInitialState,
 }) {
-  return React.unstable_createResponder('TestEventComponent', {
+  return React.unstable_createResponder('TestEventResponder', {
     targetEventTypes,
     rootEventTypes,
     onEvent,

--- a/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
+++ b/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
@@ -156,8 +156,8 @@ const eventResponderContext: ReactNativeResponderContext = {
     validateResponderContext();
     for (let i = 0; i < rootEventTypes.length; i++) {
       const rootEventType = rootEventTypes[i];
-      const eventComponentInstance = ((currentInstance: any): ReactNativeEventResponderInstance);
-      registerRootEventType(rootEventType, eventComponentInstance);
+      const eventResponderInstance = ((currentInstance: any): ReactNativeEventResponderInstance);
+      registerRootEventType(rootEventType, eventResponderInstance);
     }
   },
   removeRootEventTypes(rootEventTypes: Array<string>): void {
@@ -165,7 +165,7 @@ const eventResponderContext: ReactNativeResponderContext = {
     for (let i = 0; i < rootEventTypes.length; i++) {
       const rootEventType = rootEventTypes[i];
 
-      let rootEventComponents = rootEventTypesToEventResponderInstances.get(
+      let rootEventResponders = rootEventTypesToEventResponderInstances.get(
         rootEventType,
       );
       let rootEventTypesSet = ((currentInstance: any): ReactNativeEventResponderInstance)
@@ -173,8 +173,8 @@ const eventResponderContext: ReactNativeResponderContext = {
       if (rootEventTypesSet !== null) {
         rootEventTypesSet.delete(rootEventType);
       }
-      if (rootEventComponents !== undefined) {
-        rootEventComponents.delete(
+      if (rootEventResponders !== undefined) {
+        rootEventResponders.delete(
           ((currentInstance: any): ReactNativeEventResponderInstance),
         );
       }
@@ -696,21 +696,21 @@ export function unmountEventResponder(
 
 function registerRootEventType(
   rootEventType: string,
-  eventComponentInstance: ReactNativeEventResponderInstance,
+  responderInstance: ReactNativeEventResponderInstance,
 ) {
-  let rootEventComponentInstances = rootEventTypesToEventResponderInstances.get(
+  let rootEventResponderInstances = rootEventTypesToEventResponderInstances.get(
     rootEventType,
   );
-  if (rootEventComponentInstances === undefined) {
-    rootEventComponentInstances = new Set();
+  if (rootEventResponderInstances === undefined) {
+    rootEventResponderInstances = new Set();
     rootEventTypesToEventResponderInstances.set(
       rootEventType,
-      rootEventComponentInstances,
+      rootEventResponderInstances,
     );
   }
-  let rootEventTypesSet = eventComponentInstance.rootEventTypes;
+  let rootEventTypesSet = responderInstance.rootEventTypes;
   if (rootEventTypesSet === null) {
-    rootEventTypesSet = eventComponentInstance.rootEventTypes = new Set();
+    rootEventTypesSet = responderInstance.rootEventTypes = new Set();
   }
   invariant(
     !rootEventTypesSet.has(rootEventType),
@@ -720,15 +720,15 @@ function registerRootEventType(
     rootEventType,
   );
   rootEventTypesSet.add(rootEventType);
-  rootEventComponentInstances.add(eventComponentInstance);
+  rootEventResponderInstances.add(responderInstance);
 }
 
 export function addRootEventTypesForResponderInstance(
-  eventComponentInstance: ReactNativeEventResponderInstance,
+  responderInstance: ReactNativeEventResponderInstance,
   rootEventTypes: Array<string>,
 ): void {
   for (let i = 0; i < rootEventTypes.length; i++) {
     const rootEventType = rootEventTypes[i];
-    registerRootEventType(rootEventType, eventComponentInstance);
+    registerRootEventType(rootEventType, responderInstance);
   }
 }

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -13,8 +13,7 @@ export type ReactNode =
   | ReactText
   | ReactFragment
   | ReactProvider<any>
-  | ReactConsumer<any>
-  | ReactEventComponent<any, any>;
+  | ReactConsumer<any>;
 
 export type ReactEmpty = null | void | boolean;
 
@@ -107,11 +106,6 @@ export type ReactEventResponder<E, C> = {
     | null
     | ((context: C, props: Object, state: Object) => void),
 };
-
-export type ReactEventComponent<E, C> = {|
-  $$typeof: Symbol | number,
-  responder: ReactEventResponder<E, C>,
-|};
 
 export type EventPriority = 0 | 1 | 2;
 


### PR DESCRIPTION
Event Components were removed from the codebase with the new event system design – this renames cases which I missed and removes dangling cases that are not used.