### PR TITLE
Optimize objectIs

### DIFF
--- a/packages/shared/objectIs.js
+++ b/packages/shared/objectIs.js
@@ -17,4 +17,4 @@ function is(x: any, y: any) {
   );
 }
 
-export default is;
+export default typeof Object.is === 'function' ? Object.is :  is;

--- a/packages/shared/objectIs.js
+++ b/packages/shared/objectIs.js
@@ -17,6 +17,4 @@ function is(x: any, y: any) {
   );
 }
 
-export default typeof Object.is === 'function'
-  ? Object.is
-  : is;
+export default typeof Object.is === 'function' ? Object.is : is;

--- a/packages/shared/objectIs.js
+++ b/packages/shared/objectIs.js
@@ -17,4 +17,4 @@ function is(x: any, y: any) {
   );
 }
 
-export default typeof Object.is === 'function' ? Object.is : is;
+export default (typeof Object.is === 'function' ? Object.is : is);

--- a/packages/shared/objectIs.js
+++ b/packages/shared/objectIs.js
@@ -17,4 +17,6 @@ function is(x: any, y: any) {
   );
 }
 
-export default typeof Object.is === 'function' ? Object.is :  is;
+export default typeof Object.is === 'function'
+  ? Object.is
+  : is;


### PR DESCRIPTION
Native Object.is implementation is much faster than polyfill.

~~https://jsperf.com/object-is-vs-polyfill/1~~

https://jsperf.com/object-is-vs-polyfill-better/1

![Zrzut ekranu 2019-07-25 o 22 43 15](https://user-images.githubusercontent.com/16975059/61908076-2cb69e00-af2f-11e9-94ba-328c19e44c04.png)
