### PR TITLE
[Flare] Fix SSR issue with serializing responders prop

### DIFF
--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -12,6 +12,7 @@
 let React;
 let ReactFeatureFlags;
 let ReactDOM;
+let ReactDOMServer;
 let ReactTestRenderer;
 
 // FIXME: What should the public API be for setting an event's priority? Right
@@ -72,6 +73,7 @@ describe('DOMEventResponderSystem', () => {
     ReactFeatureFlags.enableFlareAPI = true;
     React = require('react');
     ReactDOM = require('react-dom');
+    ReactDOMServer = require('react-dom/server');
     container = document.createElement('div');
     document.body.appendChild(container);
   });
@@ -91,6 +93,14 @@ describe('DOMEventResponderSystem', () => {
       <div responders={<TestResponder />}>Hello world</div>,
     );
     expect(renderer).toMatchRenderedOutput(<div>Hello world</div>);
+  });
+
+  it('can render correctly with the ReactDOMServer', () => {
+    const TestResponder = createEventResponder({});
+    const output = ReactDOMServer.renderToString(
+      <div responders={<TestResponder />}>Hello world</div>,
+    );
+    expect(output).toBe(`<div data-reactroot="">Hello world</div>`);
   });
 
   it('the event responders should fire on click event', () => {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -346,11 +346,6 @@ const RESERVED_PROPS = {
   suppressHydrationWarning: null,
 };
 
-if (enableFlareAPI) {
-  // $FlowFixMe: Flow doesn't like this, it's temp until we remove the flag anyway
-  RESERVED_PROPS.responders = null;
-}
-
 function createOpenTagMarkup(
   tagVerbatim: string,
   tagLowercase: string,
@@ -363,6 +358,9 @@ function createOpenTagMarkup(
 
   for (const propKey in props) {
     if (!hasOwnProperty.call(props, propKey)) {
+      continue;
+    }
+    if (enableFlareAPI && propKey === 'responders') {
       continue;
     }
     let propValue = props[propKey];


### PR DESCRIPTION
We need to ensure that we don't serialize the `responders` prop in the HTML output when React Flare is enabled on server-side rendering.