### PR TITLE
Remove unnecessary lines for `hasBadMapPolyfill` issue for rollup

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -101,13 +101,10 @@ if (__DEV__) {
   hasBadMapPolyfill = false;
   try {
     const nonExtensibleObject = Object.preventExtensions({});
-    const testMap = new Map([[nonExtensibleObject, null]]);
-    const testSet = new Set([nonExtensibleObject]);
-    // This is necessary for Rollup to not consider these unused.
-    // https://github.com/rollup/rollup/issues/1771
-    // TODO: we can remove these if Rollup fixes the bug.
-    testMap.set(0, 0);
-    testSet.add(0);
+    /* eslint-disable no-new */
+    new Map([[nonExtensibleObject, null]]);
+    new Set([nonExtensibleObject]);
+    /* eslint-enable no-new */
   } catch (e) {
     // TODO: Consider warning about bad polyfills
     hasBadMapPolyfill = true;

--- a/packages/react/src/BadMapPolyfill.js
+++ b/packages/react/src/BadMapPolyfill.js
@@ -12,13 +12,10 @@ if (__DEV__) {
   hasBadMapPolyfill = false;
   try {
     const frozenObject = Object.freeze({});
-    const testMap = new Map([[frozenObject, null]]);
-    const testSet = new Set([frozenObject]);
-    // This is necessary for Rollup to not consider these unused.
-    // https://github.com/rollup/rollup/issues/1771
-    // TODO: we can remove these if Rollup fixes the bug.
-    testMap.set(0, 0);
-    testSet.add(0);
+    /* eslint-disable no-new */
+    new Map([[frozenObject, null]]);
+    new Set([frozenObject]);
+    /* eslint-enable no-new */
   } catch (e) {
     // TODO: Consider warning about bad polyfills
     hasBadMapPolyfill = true;


### PR DESCRIPTION
The removed lines in this PR were added by @gaearon in #11745. The reason was a tree-shaking [bug][1] in the rollup.

According to @lukastaegert, this bug has been [fixed][2] and added to rollup in [v1.14.0][3]

I was not sure whether to use the rollup version `1.14.0` or to upgrade it to the latest, so I updated it the latest (`1.17.0`).

**Note**: One odd observation was that I ran the test with version `0.52.1` and they all still seem to pass.

[1]: https://github.com/rollup/rollup/issues/1771
[2]: https://github.com/rollup/rollup/pull/2892
[3]: https://github.com/rollup/rollup/releases/tag/v1.14.0