### PR TITLE
Remove outdated comment about gcc

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -370,10 +370,6 @@ function getPlugins(
           // Don't let it create global variables in the browser.
           // https://github.com/facebook/react/issues/10909
           assume_function_wrapper: !isUMDBundle,
-          // Works because `google-closure-compiler-js` is forked in Yarn lockfile.
-          // We can remove this if GCC merges my PR:
-          // https://github.com/google/closure-compiler/pull/2707
-          // and then the compiled version is released via `google-closure-compiler-js`.
           renaming: !shouldStayReadable,
         })
       ),


### PR DESCRIPTION
```
          // Works because `google-closure-compiler-js` is forked in Yarn lockfile.	
          // We can remove this if GCC merges my PR:	
          // https://github.com/google/closure-compiler/pull/2707	
          // and then the compiled version is released via `google-closure-compiler-js`.
```

It looks like the PR mentioned in that comment was merged quite some time ago, and React is no longer using a forked version of google-closure-compiler-js.