### PR TITLE
A failing test for the revertPassiveEffectsChange, er,  change

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -166,6 +166,7 @@ function scheduleRootUpdate(
     update.callback = callback;
   }
 
+  // this appears to be the offending call
   if (revertPassiveEffectsChange) {
     flushPassiveEffects();
   }

--- a/packages/react-test-renderer/src/__tests__/revertPassiveEffects-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/revertPassiveEffects-test.internal.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+
+const React = require('react');
+const ReactTestRenderer = require('react-test-renderer');
+const ReactFeatureFlags = require('shared/ReactFeatureFlags');
+const Scheduler = require('scheduler');
+
+// changing this to true passes the test
+ReactFeatureFlags.revertPassiveEffectsChange = false;
+
+function renderApp(name) {
+  function App() {
+    const [, setState] = React.useState(0);
+    React.useEffect(() => {
+      Scheduler.unstable_yieldValue(`inside effect ${name}`);
+      setState(1);
+    }, []);
+    return null;
+  }
+  ReactTestRenderer.create(<App />);
+}
+
+it('should work', () => {
+  renderApp('a');
+  expect(Scheduler).toHaveYielded([]);
+
+  renderApp('b');
+  expect(Scheduler).toHaveYielded(['inside effect a']);
+  // this fails, instead yielding ['inside effect a', 'inside effect b']
+
+  renderApp('c');
+  expect(Scheduler).toHaveYielded(['inside effect b']);
+});


### PR DESCRIPTION
Disabling the feature flag changed some behaviour that broke some fb tests. This is a reproduction of the issue as I understand it: A setState inside an effect, will cause an 'early' flush of all effects on second render.

Toggling the `revertPassiveEffectsChange` feature flag passes/fails the test.

Q: What is the expected behaviour in this case?
