### PR TITLE
Bugfix:  Effects should never have higher than normal priority

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1488,7 +1488,7 @@ function commitRoot(root) {
   // If there are passive effects, schedule a callback to flush them. This goes
   // outside commitRootImpl so that it inherits the priority of the render.
   if (rootWithPendingPassiveEffects !== null) {
-    scheduleCallback(renderPriorityLevel, () => {
+    scheduleCallback(NormalPriority, () => {
       flushPassiveEffects();
       return null;
     });
@@ -1927,9 +1927,12 @@ export function flushPassiveEffects() {
   }
   const root = rootWithPendingPassiveEffects;
   const expirationTime = pendingPassiveEffectsExpirationTime;
-  const priorityLevel = pendingPassiveEffectsRenderPriority;
+  const renderPriorityLevel = pendingPassiveEffectsRenderPriority;
   rootWithPendingPassiveEffects = null;
   pendingPassiveEffectsExpirationTime = NoWork;
+  pendingPassiveEffectsRenderPriority = NoPriority;
+  const priorityLevel =
+    renderPriorityLevel > NormalPriority ? NormalPriority : renderPriorityLevel;
   return runWithPriority(
     priorityLevel,
     flushPassiveEffectsImpl.bind(null, root, expirationTime),

--- a/packages/react-reconciler/src/SchedulerWithReactIntegration.js
+++ b/packages/react-reconciler/src/SchedulerWithReactIntegration.js
@@ -43,7 +43,7 @@ if (enableSchedulerTracing) {
   );
 }
 
-export opaque type ReactPriorityLevel = 99 | 98 | 97 | 96 | 95 | 90;
+export type ReactPriorityLevel = 99 | 98 | 97 | 96 | 95 | 90;
 export type SchedulerCallback = (isSync: boolean) => SchedulerCallback | null;
 
 type SchedulerCallbackOptions = {


### PR DESCRIPTION
The priority of passive effects is supposed to be the same as the priority of the render. (That was the original intended behavior, at least.) The first commit fixes a bug where the priority is sometimes wrong if the effects are flushed early.

However, the priority should really never be higher than Normal Priority.

The second commit changes the behavior so that effects always have normal priority, or lower if the render priority is lower (e.g. offscreen prerendering).

The implementation is a bit awkward because of the way `renderRoot`, `commitRoot`, and `flushPassiveEffects` are split. This is a known factoring problem that I'm planning to address once 16.9 is released.