### PR TITLE
Fix TypeError in getActiveElement

### DIFF
--- a/packages/react-dom/src/client/getActiveElement.js
+++ b/packages/react-dom/src/client/getActiveElement.js
@@ -9,7 +9,7 @@
 
 export default function getActiveElement(doc: ?Document): ?Element {
   doc = doc || (typeof document !== 'undefined' ? document : undefined);
-  if (doc == null) {
+  if (doc === null || doc === undefined) {
     return null;
   }
   try {

--- a/packages/react-dom/src/client/getActiveElement.js
+++ b/packages/react-dom/src/client/getActiveElement.js
@@ -9,7 +9,7 @@
 
 export default function getActiveElement(doc: ?Document): ?Element {
   doc = doc || (typeof document !== 'undefined' ? document : undefined);
-  if (typeof doc === 'undefined') {
+  if (doc == null) {
     return null;
   }
   try {


### PR DESCRIPTION
During tests (with react-testing-library) a random test randomly fails
with "TypeError: Cannot read property 'body' of null" in the getActiveElement.
It appears that sometimes the `doc` is null but the check in the file only
checks for undefined. This proposed change checks for both `null` or `undefined`
which should prevent the failures.

https://github.com/facebook/react/issues/15691

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
10. If you haven't already, complete the CLA.

**Learn more about contributing:** https://reactjs.org/docs/how-to-contribute.html
