### PR TITLE
Add a feature flag to disable legacy context

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
@@ -38,6 +38,19 @@ function initModules() {
 
 const {resetModules, itRenders} = ReactDOMServerIntegrationUtils(initModules);
 
+function formatValue(val) {
+  if (val === null) {
+    return 'null';
+  }
+  if (val === undefined) {
+    return 'undefined';
+  }
+  if (typeof val === 'string') {
+    return val;
+  }
+  return JSON.stringify(val);
+}
+
 describe('ReactDOMServerIntegrationLegacyContextDisabled', () => {
   beforeEach(() => {
     resetModules();
@@ -72,17 +85,17 @@ describe('ReactDOMServerIntegrationLegacyContextDisabled', () => {
         lifecycleContextLog.push(nextContext);
       }
       render() {
-        return typeof this.context;
+        return formatValue(this.context);
       }
     }
 
     function LegacyFnConsumer(props, context) {
-      return typeof context;
+      return formatValue(context);
     }
     LegacyFnConsumer.contextTypes = {foo() {}};
 
     function RegularFn(props, context) {
-      return typeof context;
+      return formatValue(context);
     }
 
     const e = await render(
@@ -95,7 +108,7 @@ describe('ReactDOMServerIntegrationLegacyContextDisabled', () => {
       </LegacyProvider>,
       3,
     );
-    expect(e.textContent).toBe('undefinedundefinedundefined');
+    expect(e.textContent).toBe('{}undefinedundefined');
     expect(lifecycleContextLog).toEqual([]);
   });
 
@@ -114,7 +127,7 @@ describe('ReactDOMServerIntegrationLegacyContextDisabled', () => {
 
     class RenderPropConsumer extends React.Component {
       render() {
-        return <Ctx.Consumer>{value => value}</Ctx.Consumer>;
+        return <Ctx.Consumer>{value => formatValue(value)}</Ctx.Consumer>;
       }
     }
 
@@ -132,12 +145,12 @@ describe('ReactDOMServerIntegrationLegacyContextDisabled', () => {
         lifecycleContextLog.push(nextContext);
       }
       render() {
-        return this.context;
+        return formatValue(this.context);
       }
     }
 
     function FnConsumer() {
-      return React.useContext(Ctx);
+      return formatValue(React.useContext(Ctx));
     }
 
     const e = await render(

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+const ReactDOMServerIntegrationUtils = require('./utils/ReactDOMServerIntegrationTestUtils');
+
+let React;
+let ReactDOM;
+let ReactFeatureFlags;
+let ReactDOMServer;
+let ReactTestUtils;
+
+function initModules() {
+  // Reset warning cache.
+  jest.resetModuleRegistry();
+  React = require('react');
+  ReactDOM = require('react-dom');
+  ReactDOMServer = require('react-dom/server');
+  ReactTestUtils = require('react-dom/test-utils');
+
+  ReactFeatureFlags = require('shared/ReactFeatureFlags');
+  ReactFeatureFlags.disableLegacyContext = true;
+
+  // Make them available to the helpers.
+  return {
+    ReactDOM,
+    ReactDOMServer,
+    ReactTestUtils,
+  };
+}
+
+const {resetModules, itRenders} = ReactDOMServerIntegrationUtils(initModules);
+
+describe('ReactDOMServerIntegrationLegacyContextDisabled', () => {
+  beforeEach(() => {
+    resetModules();
+  });
+
+  itRenders('undefined legacy context with warning', async render => {
+    class LegacyProvider extends React.Component {
+      static childContextTypes = {
+        foo() {},
+      };
+      getChildContext() {
+        return {foo: 10};
+      }
+      render() {
+        return this.props.children;
+      }
+    }
+
+    let lifecycleContextLog = [];
+    class LegacyClsConsumer extends React.Component {
+      static contextTypes = {
+        foo() {},
+      };
+      shouldComponentUpdate(nextProps, nextState, nextContext) {
+        lifecycleContextLog.push(nextContext);
+        return true;
+      }
+      UNSAFE_componentWillReceiveProps(nextProps, nextContext) {
+        lifecycleContextLog.push(nextContext);
+      }
+      UNSAFE_componentWillUpdate(nextProps, nextState, nextContext) {
+        lifecycleContextLog.push(nextContext);
+      }
+      render() {
+        return typeof this.context;
+      }
+    }
+
+    function LegacyFnConsumer(props, context) {
+      return typeof context;
+    }
+    LegacyFnConsumer.contextTypes = {foo() {}};
+
+    function RegularFn(props, context) {
+      return typeof context;
+    }
+
+    const e = await render(
+      <LegacyProvider>
+        <span>
+          <LegacyClsConsumer />
+          <LegacyFnConsumer />
+          <RegularFn />
+        </span>
+      </LegacyProvider>,
+      3,
+    );
+    expect(e.textContent).toBe('undefinedundefinedundefined');
+    expect(lifecycleContextLog).toEqual([]);
+  });
+
+  itRenders('modern context', async render => {
+    let Ctx = React.createContext();
+
+    class Provider extends React.Component {
+      render() {
+        return (
+          <Ctx.Provider value={this.props.value}>
+            {this.props.children}
+          </Ctx.Provider>
+        );
+      }
+    }
+
+    class RenderPropConsumer extends React.Component {
+      render() {
+        return <Ctx.Consumer>{value => value}</Ctx.Consumer>;
+      }
+    }
+
+    let lifecycleContextLog = [];
+    class ContextTypeConsumer extends React.Component {
+      static contextType = Ctx;
+      shouldComponentUpdate(nextProps, nextState, nextContext) {
+        lifecycleContextLog.push(nextContext);
+        return true;
+      }
+      UNSAFE_componentWillReceiveProps(nextProps, nextContext) {
+        lifecycleContextLog.push(nextContext);
+      }
+      UNSAFE_componentWillUpdate(nextProps, nextState, nextContext) {
+        lifecycleContextLog.push(nextContext);
+      }
+      render() {
+        return this.context;
+      }
+    }
+
+    function FnConsumer() {
+      return React.useContext(Ctx);
+    }
+
+    const e = await render(
+      <Provider value="a">
+        <span>
+          <RenderPropConsumer />
+          <ContextTypeConsumer />
+          <FnConsumer />
+        </span>
+      </Provider>,
+    );
+    expect(e.textContent).toBe('aaa');
+    expect(lifecycleContextLog).toEqual([]);
+  });
+});

--- a/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
@@ -23,6 +23,19 @@ describe('ReactLegacyContextDisabled', () => {
     ReactFeatureFlags.disableLegacyContext = true;
   });
 
+  function formatValue(val) {
+    if (val === null) {
+      return 'null';
+    }
+    if (val === undefined) {
+      return 'undefined';
+    }
+    if (typeof val === 'string') {
+      return val;
+    }
+    return JSON.stringify(val);
+  }
+
   it('warns for legacy context', () => {
     class LegacyProvider extends React.Component {
       static childContextTypes = {
@@ -52,17 +65,17 @@ describe('ReactLegacyContextDisabled', () => {
         lifecycleContextLog.push(nextContext);
       }
       render() {
-        return typeof this.context;
+        return formatValue(this.context);
       }
     }
 
     function LegacyFnConsumer(props, context) {
-      return typeof context;
+      return formatValue(context);
     }
     LegacyFnConsumer.contextTypes = {foo() {}};
 
     function RegularFn(props, context) {
-      return typeof context;
+      return formatValue(context);
     }
 
     const container = document.createElement('div');
@@ -88,7 +101,7 @@ describe('ReactLegacyContextDisabled', () => {
       ],
       {withoutStack: true},
     );
-    expect(container.textContent).toBe('undefinedundefinedundefined');
+    expect(container.textContent).toBe('{}undefinedundefined');
     expect(lifecycleContextLog).toEqual([]);
 
     // Test update path.
@@ -102,8 +115,8 @@ describe('ReactLegacyContextDisabled', () => {
       </LegacyProvider>,
       container,
     );
-    expect(container.textContent).toBe('undefinedundefinedundefined');
-    expect(lifecycleContextLog).toEqual([undefined, undefined, undefined]);
+    expect(container.textContent).toBe('{}undefinedundefined');
+    expect(lifecycleContextLog).toEqual([{}, {}, {}]);
     ReactDOM.unmountComponentAtNode(container);
   });
 
@@ -122,7 +135,7 @@ describe('ReactLegacyContextDisabled', () => {
 
     class RenderPropConsumer extends React.Component {
       render() {
-        return <Ctx.Consumer>{value => value}</Ctx.Consumer>;
+        return <Ctx.Consumer>{value => formatValue(value)}</Ctx.Consumer>;
       }
     }
 
@@ -140,12 +153,12 @@ describe('ReactLegacyContextDisabled', () => {
         lifecycleContextLog.push(nextContext);
       }
       render() {
-        return this.context;
+        return formatValue(this.context);
       }
     }
 
     function FnConsumer() {
-      return React.useContext(Ctx);
+      return formatValue(React.useContext(Ctx));
     }
 
     const container = document.createElement('div');

--- a/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
@@ -36,10 +36,21 @@ describe('ReactLegacyContextDisabled', () => {
       }
     }
 
+    let lifecycleContextLog = [];
     class LegacyClsConsumer extends React.Component {
       static contextTypes = {
         foo() {},
       };
+      shouldComponentUpdate(nextProps, nextState, nextContext) {
+        lifecycleContextLog.push(nextContext);
+        return true;
+      }
+      UNSAFE_componentWillReceiveProps(nextProps, nextContext) {
+        lifecycleContextLog.push(nextContext);
+      }
+      UNSAFE_componentWillUpdate(nextProps, nextState, nextContext) {
+        lifecycleContextLog.push(nextContext);
+      }
       render() {
         return typeof this.context;
       }
@@ -78,6 +89,7 @@ describe('ReactLegacyContextDisabled', () => {
       {withoutStack: true},
     );
     expect(container.textContent).toBe('undefinedundefinedundefined');
+    expect(lifecycleContextLog).toEqual([]);
 
     // Test update path.
     ReactDOM.render(
@@ -91,6 +103,7 @@ describe('ReactLegacyContextDisabled', () => {
       container,
     );
     expect(container.textContent).toBe('undefinedundefinedundefined');
+    expect(lifecycleContextLog).toEqual([undefined, undefined, undefined]);
     ReactDOM.unmountComponentAtNode(container);
   });
 
@@ -113,8 +126,19 @@ describe('ReactLegacyContextDisabled', () => {
       }
     }
 
+    let lifecycleContextLog = [];
     class ContextTypeConsumer extends React.Component {
       static contextType = Ctx;
+      shouldComponentUpdate(nextProps, nextState, nextContext) {
+        lifecycleContextLog.push(nextContext);
+        return true;
+      }
+      UNSAFE_componentWillReceiveProps(nextProps, nextContext) {
+        lifecycleContextLog.push(nextContext);
+      }
+      UNSAFE_componentWillUpdate(nextProps, nextState, nextContext) {
+        lifecycleContextLog.push(nextContext);
+      }
       render() {
         return this.context;
       }
@@ -136,8 +160,23 @@ describe('ReactLegacyContextDisabled', () => {
       container,
     );
     expect(container.textContent).toBe('aaa');
+    expect(lifecycleContextLog).toEqual([]);
 
     // Test update path
+    ReactDOM.render(
+      <Provider value="a">
+        <span>
+          <RenderPropConsumer />
+          <ContextTypeConsumer />
+          <FnConsumer />
+        </span>
+      </Provider>,
+      container,
+    );
+    expect(container.textContent).toBe('aaa');
+    expect(lifecycleContextLog).toEqual(['a', 'a', 'a']);
+    lifecycleContextLog.length = 0;
+
     ReactDOM.render(
       <Provider value="b">
         <span>
@@ -149,6 +188,7 @@ describe('ReactLegacyContextDisabled', () => {
       container,
     );
     expect(container.textContent).toBe('bbb');
+    expect(lifecycleContextLog).toEqual(['b', 'b']); // sCU skipped due to changed context value.
     ReactDOM.unmountComponentAtNode(container);
   });
 });

--- a/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let ReactFeatureFlags;
+
+describe('ReactLegacyContextDisabled', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.disableLegacyContext = true;
+  });
+
+  it('throws for a legacy context provider', () => {
+    class Provider extends React.Component {
+      static childContextTypes = {
+        foo() {},
+      };
+      getChildContext() {
+        return {foo: 10};
+      }
+      render() {
+        return null;
+      }
+    }
+
+    const container = document.createElement('div');
+    expect(() => {
+      ReactDOM.render(<Provider />, container);
+    }).toThrow(
+      'The legacy childContextTypes API is no longer supported. ' +
+        'Use React.createContext() instead.',
+    );
+  });
+
+  it('throws for a legacy context consumer', () => {
+    class Consumer extends React.Component {
+      static contextTypes = {
+        foo() {},
+      };
+      render() {
+        return null;
+      }
+    }
+
+    const container = document.createElement('div');
+    expect(() => {
+      ReactDOM.render(<Consumer />, container);
+    }).toThrow(
+      'The legacy contextTypes API is no longer supported. ' +
+        'Use React.createContext() with contextType instead.',
+    );
+  });
+
+  it('renders a tree with modern context', () => {
+    let Ctx = React.createContext();
+
+    class Provider extends React.Component {
+      render() {
+        return (
+          <Ctx.Provider value={this.props.value}>
+            {this.props.children}
+          </Ctx.Provider>
+        );
+      }
+    }
+
+    class RenderPropConsumer extends React.Component {
+      render() {
+        return <Ctx.Consumer>{value => value}</Ctx.Consumer>;
+      }
+    }
+
+    class ContextTypeConsumer extends React.Component {
+      static contextType = Ctx;
+      render() {
+        return this.context;
+      }
+    }
+
+    function FnConsumer() {
+      return React.useContext(Ctx);
+    }
+
+    const container = document.createElement('div');
+    ReactDOM.render(
+      <Provider value="a">
+        <span>
+          <RenderPropConsumer />
+          <ContextTypeConsumer />
+          <FnConsumer />
+        </span>
+      </Provider>,
+      container,
+    );
+    expect(container.textContent).toBe('aaa');
+  });
+});

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -431,7 +431,8 @@ function resolve(
 
   // Extra closure so queue and replace can be captured properly
   function processChild(element, Component) {
-    let publicContext = processContext(Component, context, threadID);
+    const isClass = shouldConstruct(Component);
+    const publicContext = processContext(Component, context, threadID, isClass);
 
     let queue = [];
     let replace = false;
@@ -459,7 +460,7 @@ function resolve(
     };
 
     let inst;
-    if (shouldConstruct(Component)) {
+    if (isClass) {
       inst = new Component(element.props, publicContext, updater);
 
       if (typeof Component.getDerivedStateFromProps === 'function') {

--- a/packages/react-dom/src/server/ReactPartialRendererContext.js
+++ b/packages/react-dom/src/server/ReactPartialRendererContext.js
@@ -74,72 +74,89 @@ export function processContext(
   type: Function,
   context: Object,
   threadID: ThreadID,
+  isClass: boolean,
 ) {
-  const contextType = type.contextType;
-  if (__DEV__) {
-    if ('contextType' in (type: any)) {
-      let isValid =
-        // Allow null for conditional declaration
-        contextType === null ||
-        (contextType !== undefined &&
-          contextType.$$typeof === REACT_CONTEXT_TYPE &&
-          contextType._context === undefined); // Not a <Context.Consumer>
+  if (isClass) {
+    const contextType = type.contextType;
+    if (__DEV__) {
+      if ('contextType' in (type: any)) {
+        let isValid =
+          // Allow null for conditional declaration
+          contextType === null ||
+          (contextType !== undefined &&
+            contextType.$$typeof === REACT_CONTEXT_TYPE &&
+            contextType._context === undefined); // Not a <Context.Consumer>
 
-      if (!isValid && !didWarnAboutInvalidateContextType.has(type)) {
-        didWarnAboutInvalidateContextType.add(type);
+        if (!isValid && !didWarnAboutInvalidateContextType.has(type)) {
+          didWarnAboutInvalidateContextType.add(type);
 
-        let addendum = '';
-        if (contextType === undefined) {
-          addendum =
-            ' However, it is set to undefined. ' +
-            'This can be caused by a typo or by mixing up named and default imports. ' +
-            'This can also happen due to a circular dependency, so ' +
-            'try moving the createContext() call to a separate file.';
-        } else if (typeof contextType !== 'object') {
-          addendum = ' However, it is set to a ' + typeof contextType + '.';
-        } else if (contextType.$$typeof === REACT_PROVIDER_TYPE) {
-          addendum = ' Did you accidentally pass the Context.Provider instead?';
-        } else if (contextType._context !== undefined) {
-          // <Context.Consumer>
-          addendum = ' Did you accidentally pass the Context.Consumer instead?';
-        } else {
-          addendum =
-            ' However, it is set to an object with keys {' +
-            Object.keys(contextType).join(', ') +
-            '}.';
+          let addendum = '';
+          if (contextType === undefined) {
+            addendum =
+              ' However, it is set to undefined. ' +
+              'This can be caused by a typo or by mixing up named and default imports. ' +
+              'This can also happen due to a circular dependency, so ' +
+              'try moving the createContext() call to a separate file.';
+          } else if (typeof contextType !== 'object') {
+            addendum = ' However, it is set to a ' + typeof contextType + '.';
+          } else if (contextType.$$typeof === REACT_PROVIDER_TYPE) {
+            addendum =
+              ' Did you accidentally pass the Context.Provider instead?';
+          } else if (contextType._context !== undefined) {
+            // <Context.Consumer>
+            addendum =
+              ' Did you accidentally pass the Context.Consumer instead?';
+          } else {
+            addendum =
+              ' However, it is set to an object with keys {' +
+              Object.keys(contextType).join(', ') +
+              '}.';
+          }
+          warningWithoutStack(
+            false,
+            '%s defines an invalid contextType. ' +
+              'contextType should point to the Context object returned by React.createContext().%s',
+            getComponentName(type) || 'Component',
+            addendum,
+          );
         }
-        warningWithoutStack(
-          false,
-          '%s defines an invalid contextType. ' +
-            'contextType should point to the Context object returned by React.createContext().%s',
-          getComponentName(type) || 'Component',
-          addendum,
-        );
       }
     }
-  }
-  if (typeof contextType === 'object' && contextType !== null) {
-    validateContextBounds(contextType, threadID);
-    return contextType[threadID];
+    if (typeof contextType === 'object' && contextType !== null) {
+      validateContextBounds(contextType, threadID);
+      return contextType[threadID];
+    }
+    if (disableLegacyContext) {
+      if (__DEV__) {
+        if (type.contextTypes) {
+          warningWithoutStack(
+            false,
+            '%s uses the legacy contextTypes API which is no longer supported. ' +
+              'Use React.createContext() with static contextType instead.',
+            getComponentName(type) || 'Unknown',
+          );
+        }
+      }
+      return emptyObject;
+    } else {
+      const maskedContext = maskContext(type, context);
+      if (__DEV__) {
+        if (type.contextTypes) {
+          checkContextTypes(type.contextTypes, maskedContext, 'context');
+        }
+      }
+      return maskedContext;
+    }
   } else {
     if (disableLegacyContext) {
       if (__DEV__) {
         if (type.contextTypes) {
-          if (type.prototype && type.prototype.isReactComponent) {
-            warningWithoutStack(
-              false,
-              '%s uses the legacy contextTypes API which is no longer supported. ' +
-                'Use React.createContext() with static contextType instead.',
-              getComponentName(type) || 'Unknown',
-            );
-          } else {
-            warningWithoutStack(
-              false,
-              '%s uses the legacy contextTypes API which is no longer supported. ' +
-                'Use React.createContext() with React.useContext() instead.',
-              getComponentName(type) || 'Unknown',
-            );
-          }
+          warningWithoutStack(
+            false,
+            '%s uses the legacy contextTypes API which is no longer supported. ' +
+              'Use React.createContext() with React.useContext() instead.',
+            getComponentName(type) || 'Unknown',
+          );
         }
       }
       return undefined;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -57,6 +57,7 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
   debugRenderPhaseSideEffects,
   debugRenderPhaseSideEffectsForStrictMode,
+  disableLegacyContext,
   enableProfilerTimer,
   enableSchedulerTracing,
   enableSuspenseServerRenderer,
@@ -623,8 +624,11 @@ function updateFunctionComponent(
     }
   }
 
-  const unmaskedContext = getUnmaskedContext(workInProgress, Component, true);
-  const context = getMaskedContext(workInProgress, unmaskedContext);
+  let context;
+  if (!disableLegacyContext) {
+    const unmaskedContext = getUnmaskedContext(workInProgress, Component, true);
+    context = getMaskedContext(workInProgress, unmaskedContext);
+  }
 
   let nextChildren;
   prepareToReadContext(workInProgress, renderExpirationTime);
@@ -1244,8 +1248,15 @@ function mountIndeterminateComponent(
   }
 
   const props = workInProgress.pendingProps;
-  const unmaskedContext = getUnmaskedContext(workInProgress, Component, false);
-  const context = getMaskedContext(workInProgress, unmaskedContext);
+  let context;
+  if (!disableLegacyContext) {
+    const unmaskedContext = getUnmaskedContext(
+      workInProgress,
+      Component,
+      false,
+    );
+    context = getMaskedContext(workInProgress, unmaskedContext);
+  }
 
   prepareToReadContext(workInProgress, renderExpirationTime);
   if (enableFlareAPI) {
@@ -1366,6 +1377,15 @@ function mountIndeterminateComponent(
     // Proceed under the assumption that this is a function component
     workInProgress.tag = FunctionComponent;
     if (__DEV__) {
+      if (disableLegacyContext && Component.contextTypes) {
+        warningWithoutStack(
+          false,
+          '%s uses the legacy contextTypes API which is no longer supported. ' +
+            'Use React.createContext() with React.useContext() instead.',
+          getComponentName(Component) || 'Unknown',
+        );
+      }
+
       if (
         debugRenderPhaseSideEffects ||
         (debugRenderPhaseSideEffectsForStrictMode &&

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -555,7 +555,7 @@ function constructClassInstance(
 ): any {
   let isLegacyContextConsumer = false;
   let unmaskedContext = emptyContextObject;
-  let context;
+  let context = emptyContextObject;
   const contextType = ctor.contextType;
 
   if (__DEV__) {
@@ -719,11 +719,6 @@ function constructClassInstance(
   // Cache unmasked context so we can avoid recreating masked context unless necessary.
   // ReactFiberContext usually updates this cache but can't for newly-created instances.
   if (isLegacyContextConsumer) {
-    invariant(
-      context !== undefined,
-      'Expected legacy context to always be present. ' +
-        'This is likely a bug in React. Please file an issue.',
-    );
     cacheContext(workInProgress, unmaskedContext, context);
   }
 
@@ -811,7 +806,9 @@ function mountClassInstance(
   const contextType = ctor.contextType;
   if (typeof contextType === 'object' && contextType !== null) {
     instance.context = readContext(contextType);
-  } else if (!disableLegacyContext) {
+  } else if (disableLegacyContext) {
+    instance.context = emptyContextObject;
+  } else {
     const unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
     instance.context = getMaskedContext(workInProgress, unmaskedContext);
   }
@@ -911,7 +908,7 @@ function resumeMountClassInstance(
 
   const oldContext = instance.context;
   const contextType = ctor.contextType;
-  let nextContext;
+  let nextContext = emptyContextObject;
   if (typeof contextType === 'object' && contextType !== null) {
     nextContext = readContext(contextType);
   } else if (!disableLegacyContext) {
@@ -1060,7 +1057,7 @@ function updateClassInstance(
 
   const oldContext = instance.context;
   const contextType = ctor.contextType;
-  let nextContext;
+  let nextContext = emptyContextObject;
   if (typeof contextType === 'object' && contextType !== null) {
     nextContext = readContext(contextType);
   } else if (!disableLegacyContext) {

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -134,13 +134,11 @@ function hasContextChanged(): boolean {
 }
 
 function isContextProvider(type: Function): boolean {
-  const childContextTypes = type.childContextTypes;
-  const hasChildContextTypes =
-    childContextTypes !== null && childContextTypes !== undefined;
   if (disableLegacyContext) {
     return false;
   } else {
-    return hasChildContextTypes;
+    const childContextTypes = type.childContextTypes;
+    return childContextTypes !== null && childContextTypes !== undefined;
   }
 }
 
@@ -154,7 +152,9 @@ function popContext(fiber: Fiber): void {
 }
 
 function popTopLevelContextObject(fiber: Fiber): void {
-  if (!disableLegacyContext) {
+  if (disableLegacyContext) {
+    return;
+  } else {
     pop(didPerformWorkStackCursor, fiber);
     pop(contextStackCursor, fiber);
   }
@@ -165,7 +165,9 @@ function pushTopLevelContextObject(
   context: Object,
   didChange: boolean,
 ): void {
-  if (!disableLegacyContext) {
+  if (disableLegacyContext) {
+    return;
+  } else {
     invariant(
       contextStackCursor.current === emptyContextObject,
       'Unexpected context found on stack. ' +

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -11,6 +11,7 @@ import type {Fiber} from './ReactFiber';
 import type {StackCursor} from './ReactFiberStack';
 
 import {isFiberMounted} from 'react-reconciler/reflection';
+import {disableLegacyContext} from 'shared/ReactFeatureFlags';
 import {ClassComponent, HostRoot} from 'shared/ReactWorkTags';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
@@ -46,14 +47,18 @@ function getUnmaskedContext(
   Component: Function,
   didPushOwnContextIfProvider: boolean,
 ): Object {
-  if (didPushOwnContextIfProvider && isContextProvider(Component)) {
-    // If the fiber is a context provider itself, when we read its context
-    // we may have already pushed its own child context on the stack. A context
-    // provider should not "see" its own child context. Therefore we read the
-    // previous (parent) context instead for a context provider.
-    return previousContext;
+  if (disableLegacyContext) {
+    return emptyContextObject;
+  } else {
+    if (didPushOwnContextIfProvider && isContextProvider(Component)) {
+      // If the fiber is a context provider itself, when we read its context
+      // we may have already pushed its own child context on the stack. A context
+      // provider should not "see" its own child context. Therefore we read the
+      // previous (parent) context instead for a context provider.
+      return previousContext;
+    }
+    return contextStackCursor.current;
   }
-  return contextStackCursor.current;
 }
 
 function cacheContext(
@@ -61,74 +66,114 @@ function cacheContext(
   unmaskedContext: Object,
   maskedContext: Object,
 ): void {
-  const instance = workInProgress.stateNode;
-  instance.__reactInternalMemoizedUnmaskedChildContext = unmaskedContext;
-  instance.__reactInternalMemoizedMaskedChildContext = maskedContext;
+  if (disableLegacyContext) {
+    invariant(
+      false,
+      'The legacy contextTypes API is no longer supported. ' +
+        'Use React.createContext() with contextType instead.',
+    );
+  } else {
+    const instance = workInProgress.stateNode;
+    instance.__reactInternalMemoizedUnmaskedChildContext = unmaskedContext;
+    instance.__reactInternalMemoizedMaskedChildContext = maskedContext;
+  }
 }
 
 function getMaskedContext(
   workInProgress: Fiber,
   unmaskedContext: Object,
 ): Object {
-  const type = workInProgress.type;
-  const contextTypes = type.contextTypes;
-  if (!contextTypes) {
+  if (disableLegacyContext) {
     return emptyContextObject;
-  }
+  } else {
+    const type = workInProgress.type;
+    const contextTypes = type.contextTypes;
+    if (!contextTypes) {
+      return emptyContextObject;
+    }
 
-  // Avoid recreating masked context unless unmasked context has changed.
-  // Failing to do this will result in unnecessary calls to componentWillReceiveProps.
-  // This may trigger infinite loops if componentWillReceiveProps calls setState.
-  const instance = workInProgress.stateNode;
-  if (
-    instance &&
-    instance.__reactInternalMemoizedUnmaskedChildContext === unmaskedContext
-  ) {
-    return instance.__reactInternalMemoizedMaskedChildContext;
-  }
+    // Avoid recreating masked context unless unmasked context has changed.
+    // Failing to do this will result in unnecessary calls to componentWillReceiveProps.
+    // This may trigger infinite loops if componentWillReceiveProps calls setState.
+    const instance = workInProgress.stateNode;
+    if (
+      instance &&
+      instance.__reactInternalMemoizedUnmaskedChildContext === unmaskedContext
+    ) {
+      return instance.__reactInternalMemoizedMaskedChildContext;
+    }
 
-  const context = {};
-  for (let key in contextTypes) {
-    context[key] = unmaskedContext[key];
-  }
+    const context = {};
+    for (let key in contextTypes) {
+      context[key] = unmaskedContext[key];
+    }
 
-  if (__DEV__) {
-    const name = getComponentName(type) || 'Unknown';
-    checkPropTypes(
-      contextTypes,
-      context,
-      'context',
-      name,
-      getCurrentFiberStackInDev,
-    );
-  }
+    if (__DEV__) {
+      const name = getComponentName(type) || 'Unknown';
+      checkPropTypes(
+        contextTypes,
+        context,
+        'context',
+        name,
+        getCurrentFiberStackInDev,
+      );
+    }
 
-  // Cache unmasked context so we can avoid recreating masked context unless necessary.
-  // Context is created before the class component is instantiated so check for instance.
-  if (instance) {
-    cacheContext(workInProgress, unmaskedContext, context);
-  }
+    // Cache unmasked context so we can avoid recreating masked context unless necessary.
+    // Context is created before the class component is instantiated so check for instance.
+    if (instance) {
+      cacheContext(workInProgress, unmaskedContext, context);
+    }
 
-  return context;
+    return context;
+  }
 }
 
 function hasContextChanged(): boolean {
-  return didPerformWorkStackCursor.current;
+  if (disableLegacyContext) {
+    return false;
+  } else {
+    return didPerformWorkStackCursor.current;
+  }
 }
 
 function isContextProvider(type: Function): boolean {
   const childContextTypes = type.childContextTypes;
-  return childContextTypes !== null && childContextTypes !== undefined;
+  const hasChildContextTypes =
+    childContextTypes !== null && childContextTypes !== undefined;
+  if (disableLegacyContext) {
+    if (hasChildContextTypes) {
+      invariant(
+        false,
+        'The legacy childContextTypes API is no longer supported. ' +
+          'Use React.createContext() instead.',
+      );
+    } else {
+      return false;
+    }
+  } else {
+    return hasChildContextTypes;
+  }
 }
 
 function popContext(fiber: Fiber): void {
-  pop(didPerformWorkStackCursor, fiber);
-  pop(contextStackCursor, fiber);
+  if (disableLegacyContext) {
+    invariant(
+      false,
+      'The legacy childContextTypes API is no longer supported. ' +
+        'Use React.createContext() instead.',
+    );
+  } else {
+    pop(didPerformWorkStackCursor, fiber);
+    pop(contextStackCursor, fiber);
+  }
 }
 
 function popTopLevelContextObject(fiber: Fiber): void {
-  pop(didPerformWorkStackCursor, fiber);
-  pop(contextStackCursor, fiber);
+  if (!disableLegacyContext) {
+    pop(didPerformWorkStackCursor, fiber);
+    pop(contextStackCursor, fiber);
+  }
 }
 
 function pushTopLevelContextObject(
@@ -136,14 +181,16 @@ function pushTopLevelContextObject(
   context: Object,
   didChange: boolean,
 ): void {
-  invariant(
-    contextStackCursor.current === emptyContextObject,
-    'Unexpected context found on stack. ' +
-      'This error is likely caused by a bug in React. Please file an issue.',
-  );
+  if (!disableLegacyContext) {
+    invariant(
+      contextStackCursor.current === emptyContextObject,
+      'Unexpected context found on stack. ' +
+        'This error is likely caused by a bug in React. Please file an issue.',
+    );
 
-  push(contextStackCursor, context, fiber);
-  push(didPerformWorkStackCursor, didChange, fiber);
+    push(contextStackCursor, context, fiber);
+    push(didPerformWorkStackCursor, didChange, fiber);
+  }
 }
 
 function processChildContext(
@@ -151,87 +198,103 @@ function processChildContext(
   type: any,
   parentContext: Object,
 ): Object {
-  const instance = fiber.stateNode;
-  const childContextTypes = type.childContextTypes;
-
-  // TODO (bvaughn) Replace this behavior with an invariant() in the future.
-  // It has only been added in Fiber to match the (unintentional) behavior in Stack.
-  if (typeof instance.getChildContext !== 'function') {
-    if (__DEV__) {
-      const componentName = getComponentName(type) || 'Unknown';
-
-      if (!warnedAboutMissingGetChildContext[componentName]) {
-        warnedAboutMissingGetChildContext[componentName] = true;
-        warningWithoutStack(
-          false,
-          '%s.childContextTypes is specified but there is no getChildContext() method ' +
-            'on the instance. You can either define getChildContext() on %s or remove ' +
-            'childContextTypes from it.',
-          componentName,
-          componentName,
-        );
-      }
-    }
-    return parentContext;
-  }
-
-  let childContext;
-  if (__DEV__) {
-    setCurrentPhase('getChildContext');
-  }
-  startPhaseTimer(fiber, 'getChildContext');
-  childContext = instance.getChildContext();
-  stopPhaseTimer();
-  if (__DEV__) {
-    setCurrentPhase(null);
-  }
-  for (let contextKey in childContext) {
+  if (disableLegacyContext) {
     invariant(
-      contextKey in childContextTypes,
-      '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
-      getComponentName(type) || 'Unknown',
-      contextKey,
+      false,
+      'The legacy childContextTypes API is no longer supported. ' +
+        'Use React.createContext() instead.',
     );
-  }
-  if (__DEV__) {
-    const name = getComponentName(type) || 'Unknown';
-    checkPropTypes(
-      childContextTypes,
-      childContext,
-      'child context',
-      name,
-      // In practice, there is one case in which we won't get a stack. It's when
-      // somebody calls unstable_renderSubtreeIntoContainer() and we process
-      // context from the parent component instance. The stack will be missing
-      // because it's outside of the reconciliation, and so the pointer has not
-      // been set. This is rare and doesn't matter. We'll also remove that API.
-      getCurrentFiberStackInDev,
-    );
-  }
+  } else {
+    const instance = fiber.stateNode;
+    const childContextTypes = type.childContextTypes;
 
-  return {...parentContext, ...childContext};
+    // TODO (bvaughn) Replace this behavior with an invariant() in the future.
+    // It has only been added in Fiber to match the (unintentional) behavior in Stack.
+    if (typeof instance.getChildContext !== 'function') {
+      if (__DEV__) {
+        const componentName = getComponentName(type) || 'Unknown';
+
+        if (!warnedAboutMissingGetChildContext[componentName]) {
+          warnedAboutMissingGetChildContext[componentName] = true;
+          warningWithoutStack(
+            false,
+            '%s.childContextTypes is specified but there is no getChildContext() method ' +
+              'on the instance. You can either define getChildContext() on %s or remove ' +
+              'childContextTypes from it.',
+            componentName,
+            componentName,
+          );
+        }
+      }
+      return parentContext;
+    }
+
+    let childContext;
+    if (__DEV__) {
+      setCurrentPhase('getChildContext');
+    }
+    startPhaseTimer(fiber, 'getChildContext');
+    childContext = instance.getChildContext();
+    stopPhaseTimer();
+    if (__DEV__) {
+      setCurrentPhase(null);
+    }
+    for (let contextKey in childContext) {
+      invariant(
+        contextKey in childContextTypes,
+        '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
+        getComponentName(type) || 'Unknown',
+        contextKey,
+      );
+    }
+    if (__DEV__) {
+      const name = getComponentName(type) || 'Unknown';
+      checkPropTypes(
+        childContextTypes,
+        childContext,
+        'child context',
+        name,
+        // In practice, there is one case in which we won't get a stack. It's when
+        // somebody calls unstable_renderSubtreeIntoContainer() and we process
+        // context from the parent component instance. The stack will be missing
+        // because it's outside of the reconciliation, and so the pointer has not
+        // been set. This is rare and doesn't matter. We'll also remove that API.
+        getCurrentFiberStackInDev,
+      );
+    }
+
+    return {...parentContext, ...childContext};
+  }
 }
 
 function pushContextProvider(workInProgress: Fiber): boolean {
-  const instance = workInProgress.stateNode;
-  // We push the context as early as possible to ensure stack integrity.
-  // If the instance does not exist yet, we will push null at first,
-  // and replace it on the stack later when invalidating the context.
-  const memoizedMergedChildContext =
-    (instance && instance.__reactInternalMemoizedMergedChildContext) ||
-    emptyContextObject;
+  if (disableLegacyContext) {
+    invariant(
+      false,
+      'The legacy contextTypes API is no longer supported. ' +
+        'Use React.createContext() with contextType instead.',
+    );
+  } else {
+    const instance = workInProgress.stateNode;
+    // We push the context as early as possible to ensure stack integrity.
+    // If the instance does not exist yet, we will push null at first,
+    // and replace it on the stack later when invalidating the context.
+    const memoizedMergedChildContext =
+      (instance && instance.__reactInternalMemoizedMergedChildContext) ||
+      emptyContextObject;
 
-  // Remember the parent context so we can merge with it later.
-  // Inherit the parent's did-perform-work value to avoid inadvertently blocking updates.
-  previousContext = contextStackCursor.current;
-  push(contextStackCursor, memoizedMergedChildContext, workInProgress);
-  push(
-    didPerformWorkStackCursor,
-    didPerformWorkStackCursor.current,
-    workInProgress,
-  );
+    // Remember the parent context so we can merge with it later.
+    // Inherit the parent's did-perform-work value to avoid inadvertently blocking updates.
+    previousContext = contextStackCursor.current;
+    push(contextStackCursor, memoizedMergedChildContext, workInProgress);
+    push(
+      didPerformWorkStackCursor,
+      didPerformWorkStackCursor.current,
+      workInProgress,
+    );
 
-  return true;
+    return true;
+  }
 }
 
 function invalidateContextProvider(
@@ -239,66 +302,78 @@ function invalidateContextProvider(
   type: any,
   didChange: boolean,
 ): void {
-  const instance = workInProgress.stateNode;
-  invariant(
-    instance,
-    'Expected to have an instance by this point. ' +
-      'This error is likely caused by a bug in React. Please file an issue.',
-  );
-
-  if (didChange) {
-    // Merge parent and own context.
-    // Skip this if we're not updating due to sCU.
-    // This avoids unnecessarily recomputing memoized values.
-    const mergedContext = processChildContext(
-      workInProgress,
-      type,
-      previousContext,
+  if (disableLegacyContext) {
+    invariant(
+      false,
+      'The legacy contextTypes API is no longer supported. ' +
+        'Use React.createContext() with contextType instead.',
     );
-    instance.__reactInternalMemoizedMergedChildContext = mergedContext;
-
-    // Replace the old (or empty) context with the new one.
-    // It is important to unwind the context in the reverse order.
-    pop(didPerformWorkStackCursor, workInProgress);
-    pop(contextStackCursor, workInProgress);
-    // Now push the new context and mark that it has changed.
-    push(contextStackCursor, mergedContext, workInProgress);
-    push(didPerformWorkStackCursor, didChange, workInProgress);
   } else {
-    pop(didPerformWorkStackCursor, workInProgress);
-    push(didPerformWorkStackCursor, didChange, workInProgress);
+    const instance = workInProgress.stateNode;
+    invariant(
+      instance,
+      'Expected to have an instance by this point. ' +
+        'This error is likely caused by a bug in React. Please file an issue.',
+    );
+
+    if (didChange) {
+      // Merge parent and own context.
+      // Skip this if we're not updating due to sCU.
+      // This avoids unnecessarily recomputing memoized values.
+      const mergedContext = processChildContext(
+        workInProgress,
+        type,
+        previousContext,
+      );
+      instance.__reactInternalMemoizedMergedChildContext = mergedContext;
+
+      // Replace the old (or empty) context with the new one.
+      // It is important to unwind the context in the reverse order.
+      pop(didPerformWorkStackCursor, workInProgress);
+      pop(contextStackCursor, workInProgress);
+      // Now push the new context and mark that it has changed.
+      push(contextStackCursor, mergedContext, workInProgress);
+      push(didPerformWorkStackCursor, didChange, workInProgress);
+    } else {
+      pop(didPerformWorkStackCursor, workInProgress);
+      push(didPerformWorkStackCursor, didChange, workInProgress);
+    }
   }
 }
 
 function findCurrentUnmaskedContext(fiber: Fiber): Object {
-  // Currently this is only used with renderSubtreeIntoContainer; not sure if it
-  // makes sense elsewhere
-  invariant(
-    isFiberMounted(fiber) && fiber.tag === ClassComponent,
-    'Expected subtree parent to be a mounted class component. ' +
-      'This error is likely caused by a bug in React. Please file an issue.',
-  );
+  if (disableLegacyContext) {
+    return emptyContextObject;
+  } else {
+    // Currently this is only used with renderSubtreeIntoContainer; not sure if it
+    // makes sense elsewhere
+    invariant(
+      isFiberMounted(fiber) && fiber.tag === ClassComponent,
+      'Expected subtree parent to be a mounted class component. ' +
+        'This error is likely caused by a bug in React. Please file an issue.',
+    );
 
-  let node = fiber;
-  do {
-    switch (node.tag) {
-      case HostRoot:
-        return node.stateNode.context;
-      case ClassComponent: {
-        const Component = node.type;
-        if (isContextProvider(Component)) {
-          return node.stateNode.__reactInternalMemoizedMergedChildContext;
+    let node = fiber;
+    do {
+      switch (node.tag) {
+        case HostRoot:
+          return node.stateNode.context;
+        case ClassComponent: {
+          const Component = node.type;
+          if (isContextProvider(Component)) {
+            return node.stateNode.__reactInternalMemoizedMergedChildContext;
+          }
+          break;
         }
-        break;
       }
-    }
-    node = node.return;
-  } while (node !== null);
-  invariant(
-    false,
-    'Found unexpected detached subtree parent. ' +
-      'This error is likely caused by a bug in React. Please file an issue.',
-  );
+      node = node.return;
+    } while (node !== null);
+    invariant(
+      false,
+      'Found unexpected detached subtree parent. ' +
+        'This error is likely caused by a bug in React. Please file an issue.',
+    );
+  }
 }
 
 export {

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -67,11 +67,7 @@ function cacheContext(
   maskedContext: Object,
 ): void {
   if (disableLegacyContext) {
-    invariant(
-      false,
-      'The legacy contextTypes API is no longer supported. ' +
-        'Use React.createContext() with contextType instead.',
-    );
+    return;
   } else {
     const instance = workInProgress.stateNode;
     instance.__reactInternalMemoizedUnmaskedChildContext = unmaskedContext;
@@ -142,15 +138,7 @@ function isContextProvider(type: Function): boolean {
   const hasChildContextTypes =
     childContextTypes !== null && childContextTypes !== undefined;
   if (disableLegacyContext) {
-    if (hasChildContextTypes) {
-      invariant(
-        false,
-        'The legacy childContextTypes API is no longer supported. ' +
-          'Use React.createContext() instead.',
-      );
-    } else {
-      return false;
-    }
+    return false;
   } else {
     return hasChildContextTypes;
   }
@@ -158,11 +146,7 @@ function isContextProvider(type: Function): boolean {
 
 function popContext(fiber: Fiber): void {
   if (disableLegacyContext) {
-    invariant(
-      false,
-      'The legacy childContextTypes API is no longer supported. ' +
-        'Use React.createContext() instead.',
-    );
+    return;
   } else {
     pop(didPerformWorkStackCursor, fiber);
     pop(contextStackCursor, fiber);
@@ -199,11 +183,7 @@ function processChildContext(
   parentContext: Object,
 ): Object {
   if (disableLegacyContext) {
-    invariant(
-      false,
-      'The legacy childContextTypes API is no longer supported. ' +
-        'Use React.createContext() instead.',
-    );
+    return parentContext;
   } else {
     const instance = fiber.stateNode;
     const childContextTypes = type.childContextTypes;
@@ -269,11 +249,7 @@ function processChildContext(
 
 function pushContextProvider(workInProgress: Fiber): boolean {
   if (disableLegacyContext) {
-    invariant(
-      false,
-      'The legacy contextTypes API is no longer supported. ' +
-        'Use React.createContext() with contextType instead.',
-    );
+    return false;
   } else {
     const instance = workInProgress.stateNode;
     // We push the context as early as possible to ensure stack integrity.
@@ -303,11 +279,7 @@ function invalidateContextProvider(
   didChange: boolean,
 ): void {
   if (disableLegacyContext) {
-    invariant(
-      false,
-      'The legacy contextTypes API is no longer supported. ' +
-        'Use React.createContext() with contextType instead.',
-    );
+    return;
   } else {
     const instance = workInProgress.stateNode;
     invariant(

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -92,3 +92,5 @@ export const enableSuspenseCallback = false;
 // from React.createElement to React.jsx
 // https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md
 export const warnAboutDefaultPropsOnFunctionComponents = false;
+
+export const disableLegacyContext = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -40,6 +40,7 @@ export const flushSuspenseFallbacksInTests = true;
 export const enableUserBlockingEvents = false;
 export const enableSuspenseCallback = false;
 export const warnAboutDefaultPropsOnFunctionComponents = false;
+export const disableLegacyContext = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -35,6 +35,7 @@ export const flushSuspenseFallbacksInTests = true;
 export const enableUserBlockingEvents = false;
 export const enableSuspenseCallback = false;
 export const warnAboutDefaultPropsOnFunctionComponents = false;
+export const disableLegacyContext = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -35,6 +35,7 @@ export const flushSuspenseFallbacksInTests = true;
 export const enableUserBlockingEvents = false;
 export const enableSuspenseCallback = false;
 export const warnAboutDefaultPropsOnFunctionComponents = false;
+export const disableLegacyContext = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -35,6 +35,7 @@ export const flushSuspenseFallbacksInTests = true;
 export const enableUserBlockingEvents = false;
 export const enableSuspenseCallback = false;
 export const warnAboutDefaultPropsOnFunctionComponents = false;
+export const disableLegacyContext = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -35,6 +35,7 @@ export const flushSuspenseFallbacksInTests = true;
 export const enableUserBlockingEvents = false;
 export const enableSuspenseCallback = true;
 export const warnAboutDefaultPropsOnFunctionComponents = false;
+export const disableLegacyContext = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -21,6 +21,7 @@ export const {
   warnAboutDeprecatedSetNativeProps,
   revertPassiveEffectsChange,
   enableUserBlockingEvents,
+  disableLegacyContext,
 } = require('ReactFeatureFlags');
 
 // In www, we have experimental support for gathering data

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -338,6 +338,5 @@
   "337": "An invalid event responder was provided to host component",
   "338": "ReactDOMServer does not yet support the fundamental API.",
   "339": "An invalid value was used as an event responder. Expect one or many event responders created via React.unstable_createResponer().",
-  "340": "An invalid value was used as an event listener. Expect one or many event listeners created via React.unstable_useResponer().",
-  "341": "Expected legacy context to always be present. This is likely a bug in React. Please file an issue."
+  "340": "An invalid value was used as an event listener. Expect one or many event listeners created via React.unstable_useResponer()."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -338,6 +338,5 @@
   "337": "An invalid event responder was provided to host component",
   "338": "ReactDOMServer does not yet support the fundamental API.",
   "339": "An invalid value was used as an event responder. Expect one or many event responders created via React.unstable_createResponer().",
-  "340": "The legacy contextTypes API is no longer supported. Use React.createContext() with contextType instead.",
-  "341": "The legacy childContextTypes API is no longer supported. Use React.createContext() instead."
+  "340": "Expected legacy context to always be present. This is likely a bug in React. Please file an issue."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -337,5 +337,7 @@
   "336": "The \"%s\" event responder cannot be used via the \"useEvent\" hook.",
   "337": "An invalid event responder was provided to host component",
   "338": "ReactDOMServer does not yet support the fundamental API.",
-  "339": "An invalid value was used as an event responder. Expect one or many event responders created via React.unstable_createResponer()."
+  "339": "An invalid value was used as an event responder. Expect one or many event responders created via React.unstable_createResponer().",
+  "340": "The legacy contextTypes API is no longer supported. Use React.createContext() with contextType instead.",
+  "341": "The legacy childContextTypes API is no longer supported. Use React.createContext() instead."
 }


### PR DESCRIPTION
Adds a feature flag that disables the legacy context API. The feature flag is turned off in open source builds. Strict Mode is already a mechanism that warns about it, but this feature flag actually makes `this.context` always an empty object, and `context` argument to functions always `undefined`. So it's a way to enforce it. If we later offer "modern" builds, we can turn it on there by default. For now, I want to use this internally for newly written code.

No whitespace: https://github.com/facebook/react/compare/master...gaearon:ctx?expand=1&w=1