### PR TITLE
Fix priority of clean-up function on deletion

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1640,7 +1640,12 @@ function commitRootImpl(root, renderPriorityLevel) {
     nextEffect = firstEffect;
     do {
       if (__DEV__) {
-        invokeGuardedCallback(null, commitMutationEffects, null);
+        invokeGuardedCallback(
+          null,
+          commitMutationEffects,
+          null,
+          renderPriorityLevel,
+        );
         if (hasCaughtError()) {
           invariant(nextEffect !== null, 'Should be working on an effect.');
           const error = clearCaughtError();
@@ -1649,7 +1654,7 @@ function commitRootImpl(root, renderPriorityLevel) {
         }
       } else {
         try {
-          commitMutationEffects();
+          commitMutationEffects(renderPriorityLevel);
         } catch (error) {
           invariant(nextEffect !== null, 'Should be working on an effect.');
           captureCommitPhaseError(nextEffect, error);
@@ -1838,7 +1843,7 @@ function commitBeforeMutationEffects() {
   }
 }
 
-function commitMutationEffects() {
+function commitMutationEffects(renderPriorityLevel) {
   // TODO: Should probably move the bulk of this function to commitWork.
   while (nextEffect !== null) {
     setCurrentDebugFiberInDEV(nextEffect);
@@ -1889,7 +1894,7 @@ function commitMutationEffects() {
         break;
       }
       case Deletion: {
-        commitDeletion(nextEffect);
+        commitDeletion(nextEffect, renderPriorityLevel);
         break;
       }
     }


### PR DESCRIPTION
The clean-up function of a passive effect (`useEffect`) usually fires in a post-commit task, after the browser has painted. However, there is an exception when the component (or its parent) is deleted from the tree. In that case, we fire the clean-up function during the synchronous commit phase, the same phase we use for layout effects.

This is a concession to implementation complexity. Calling it in the passive effect phase would require either traversing the children of the deleted fiber again, or including unmount effects as part of the fiber effect list.

Because the functions are called during the sync phase in this case, the Scheduler priority is Immediate (the one used for layout) instead of Normal. We may want to reconsider this trade off later.

In practice, this should rarely matter because it's unusual to call `setState` inside a clean-up function. We might want to warn about this pattern.