### PR TITLE
Ensure Fundamental flags are added to more locations

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1043,7 +1043,7 @@ function commitPlacement(finishedWork: Fiber): void {
   let node: Fiber = finishedWork;
   while (true) {
     const isHost = node.tag === HostComponent || node.tag === HostText;
-    if (isHost || node.tag === FundamentalComponent) {
+    if (isHost || (enableFundamentalAPI && node.tag === FundamentalComponent)) {
       const stateNode = isHost ? node.stateNode : node.stateNode.instance;
       if (before) {
         if (isContainer) {
@@ -1144,7 +1144,7 @@ function unmountHostComponents(current, renderPriorityLevel): void {
         );
       }
       // Don't visit children because we already visited them.
-    } else if (node.tag === FundamentalComponent) {
+    } else if (enableFundamentalAPI && node.tag === FundamentalComponent) {
       const fundamentalNode = node.stateNode.instance;
       commitNestedUnmounts(node, renderPriorityLevel);
       // After all the children have unmounted, it is now safe to remove the

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -168,7 +168,7 @@ if (supportsMutation) {
     while (node !== null) {
       if (node.tag === HostComponent || node.tag === HostText) {
         appendInitialChild(parent, node.stateNode);
-      } else if (node.tag === FundamentalComponent) {
+      } else if (enableFundamentalAPI && node.tag === FundamentalComponent) {
         appendInitialChild(parent, node.stateNode.instance);
       } else if (node.tag === HostPortal) {
         // If we have a portal child, then we don't want to traverse

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -24,6 +24,7 @@ import {
   FundamentalComponent,
 } from 'shared/ReactWorkTags';
 import {NoEffect, Placement} from 'shared/ReactSideEffectTags';
+import {enableFundamentalAPI} from 'shared/ReactFeatureFlags';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
@@ -281,7 +282,7 @@ export function findCurrentHostFiberWithNoPortals(parent: Fiber): Fiber | null {
     if (
       node.tag === HostComponent ||
       node.tag === HostText ||
-      node.tag === FundamentalComponent
+      (enableFundamentalAPI && node.tag === FundamentalComponent)
     ) {
       return node;
     } else if (node.child && node.tag !== HostPortal) {


### PR DESCRIPTION
This wraps the fundamental build flag around more call-sites that were missed from when the code was merged. I scanned through the UMD prod build and confirmed that no more locations existed too.