### PR TITLE
[react-events] Focus/FocusWithin responders with fallbacks

### DIFF
--- a/packages/react-events/src/dom/__tests__/ContextMenu-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/ContextMenu-test.internal.js
@@ -9,7 +9,13 @@
 
 'use strict';
 
-import {createEvent, platform, setPointerEvent} from '../test-utils';
+import {
+  dispatchLongPressContextMenu,
+  dispatchRightClickContextMenu,
+  dispatchModifiedClickContextMenu,
+  platform,
+  setPointerEvent,
+} from '../test-utils';
 
 let React;
 let ReactFeatureFlags;
@@ -25,44 +31,6 @@ function initializeModules(hasPointerEvents) {
   ReactDOM = require('react-dom');
   useContextMenuResponder = require('react-events/context-menu')
     .useContextMenuResponder;
-}
-
-function dispatchContextMenuEvents(ref, options) {
-  const preventDefault = options.preventDefault || function() {};
-  const variant = (options.variant: 'mouse' | 'touch' | 'modified');
-  const dispatchEvent = arg => ref.current.dispatchEvent(arg);
-
-  if (variant === 'mouse') {
-    // right-click
-    dispatchEvent(
-      createEvent('pointerdown', {pointerType: 'mouse', button: 2}),
-    );
-    dispatchEvent(createEvent('mousedown', {button: 2}));
-    dispatchEvent(createEvent('contextmenu', {button: 2, preventDefault}));
-  } else if (variant === 'modified') {
-    // left-click + ctrl
-    dispatchEvent(
-      createEvent('pointerdown', {pointerType: 'mouse', button: 0}),
-    );
-    dispatchEvent(createEvent('mousedown', {button: 0}));
-    if (platform.get() === 'mac') {
-      dispatchEvent(
-        createEvent('contextmenu', {button: 0, ctrlKey: true, preventDefault}),
-      );
-    }
-  } else if (variant === 'touch') {
-    // long-press
-    dispatchEvent(
-      createEvent('pointerdown', {pointerType: 'touch', button: 0}),
-    );
-    dispatchEvent(
-      createEvent('touchstart', {
-        changedTouches: [],
-        targetTouches: [],
-      }),
-    );
-    dispatchEvent(createEvent('contextmenu', {button: 0, preventDefault}));
-  }
 }
 
 const forcePointerEvents = true;
@@ -94,7 +62,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       };
       ReactDOM.render(<Component />, container);
 
-      dispatchContextMenuEvents(ref, {variant: 'mouse', preventDefault});
+      dispatchRightClickContextMenu(ref.current, {preventDefault});
       expect(preventDefault).toHaveBeenCalledTimes(1);
       expect(onContextMenu).toHaveBeenCalledTimes(1);
       expect(onContextMenu).toHaveBeenCalledWith(
@@ -112,7 +80,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       };
       ReactDOM.render(<Component />, container);
 
-      dispatchContextMenuEvents(ref, {variant: 'touch', preventDefault});
+      dispatchLongPressContextMenu(ref.current, {preventDefault});
       expect(preventDefault).toHaveBeenCalledTimes(1);
       expect(onContextMenu).toHaveBeenCalledTimes(1);
       expect(onContextMenu).toHaveBeenCalledWith(
@@ -132,7 +100,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       };
       ReactDOM.render(<Component />, container);
 
-      dispatchContextMenuEvents(ref, 'mouse');
+      dispatchRightClickContextMenu(ref.current);
       expect(onContextMenu).toHaveBeenCalledTimes(0);
     });
 
@@ -149,7 +117,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       };
       ReactDOM.render(<Component />, container);
 
-      dispatchContextMenuEvents(ref, {variant: 'mouse', preventDefault});
+      dispatchRightClickContextMenu(ref.current, {preventDefault});
       expect(preventDefault).toHaveBeenCalledTimes(0);
       expect(onContextMenu).toHaveBeenCalledTimes(1);
     });
@@ -174,7 +142,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       };
       ReactDOM.render(<Component />, container);
 
-      dispatchContextMenuEvents(ref, {variant: 'modified'});
+      dispatchModifiedClickContextMenu(ref.current);
       expect(onContextMenu).toHaveBeenCalledTimes(1);
       expect(onContextMenu).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'mouse', type: 'contextmenu'}),
@@ -201,7 +169,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       };
       ReactDOM.render(<Component />, container);
 
-      dispatchContextMenuEvents(ref, {variant: 'modified'});
+      dispatchModifiedClickContextMenu(ref.current);
       expect(onContextMenu).toHaveBeenCalledTimes(0);
     });
   });

--- a/packages/react-events/src/dom/__tests__/Hover-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Hover-test.internal.js
@@ -76,9 +76,10 @@ describe.each(table)('Hover responder', hasPointerEvents => {
       ReactDOM.render(<Component />, container);
     });
 
-    it('prevents custom events being dispatched', () => {
-      dispatchPointerHoverEnter(ref);
-      dispatchPointerHoverExit(ref);
+    it('does not call callbacks', () => {
+      const target = ref.current;
+      dispatchPointerHoverEnter(target);
+      dispatchPointerHoverExit(target);
       expect(onHoverChange).not.toBeCalled();
       expect(onHoverStart).not.toBeCalled();
       expect(onHoverMove).not.toBeCalled();
@@ -102,18 +103,21 @@ describe.each(table)('Hover responder', hasPointerEvents => {
     });
 
     it('is called for mouse pointers', () => {
-      dispatchPointerHoverEnter(ref);
+      const target = ref.current;
+      dispatchPointerHoverEnter(target);
       expect(onHoverStart).toHaveBeenCalledTimes(1);
     });
 
     it('is not called for touch pointers', () => {
-      dispatchTouchTap(ref);
+      const target = ref.current;
+      dispatchTouchTap(target);
       expect(onHoverStart).not.toBeCalled();
     });
 
     it('is called if a mouse pointer is used after a touch pointer', () => {
-      dispatchTouchTap(ref);
-      dispatchPointerHoverEnter(ref);
+      const target = ref.current;
+      dispatchTouchTap(target);
+      dispatchPointerHoverEnter(target);
       expect(onHoverStart).toHaveBeenCalledTimes(1);
     });
   });
@@ -134,16 +138,18 @@ describe.each(table)('Hover responder', hasPointerEvents => {
     });
 
     it('is called for mouse pointers', () => {
-      dispatchPointerHoverEnter(ref);
+      const target = ref.current;
+      dispatchPointerHoverEnter(target);
       expect(onHoverChange).toHaveBeenCalledTimes(1);
       expect(onHoverChange).toHaveBeenCalledWith(true);
-      dispatchPointerHoverExit(ref);
+      dispatchPointerHoverExit(target);
       expect(onHoverChange).toHaveBeenCalledTimes(2);
       expect(onHoverChange).toHaveBeenCalledWith(false);
     });
 
     it('is not called for touch pointers', () => {
-      dispatchTouchTap(ref);
+      const target = ref.current;
+      dispatchTouchTap(target);
       expect(onHoverChange).not.toBeCalled();
     });
   });
@@ -164,28 +170,31 @@ describe.each(table)('Hover responder', hasPointerEvents => {
     });
 
     it('is called for mouse pointers', () => {
-      dispatchPointerHoverEnter(ref);
-      dispatchPointerHoverExit(ref);
+      const target = ref.current;
+      dispatchPointerHoverEnter(target);
+      dispatchPointerHoverExit(target);
       expect(onHoverEnd).toHaveBeenCalledTimes(1);
     });
 
     if (hasPointerEvents) {
       it('is called once for cancelled mouse pointers', () => {
-        dispatchPointerHoverEnter(ref);
-        dispatchPointerCancel(ref);
+        const target = ref.current;
+        dispatchPointerHoverEnter(target);
+        dispatchPointerCancel(target);
         expect(onHoverEnd).toHaveBeenCalledTimes(1);
 
         // only called once if cancel follows exit
         onHoverEnd.mockReset();
-        dispatchPointerHoverEnter(ref);
-        dispatchPointerHoverExit(ref);
-        dispatchPointerCancel(ref);
+        dispatchPointerHoverEnter(target);
+        dispatchPointerHoverExit(target);
+        dispatchPointerCancel(target);
         expect(onHoverEnd).toHaveBeenCalledTimes(1);
       });
     }
 
     it('is not called for touch pointers', () => {
-      dispatchTouchTap(ref);
+      const target = ref.current;
+      dispatchTouchTap(target);
       expect(onHoverEnd).not.toBeCalled();
     });
   });
@@ -201,8 +210,10 @@ describe.each(table)('Hover responder', hasPointerEvents => {
         return <div ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
-      dispatchPointerHoverEnter(ref);
-      dispatchPointerHoverMove(ref, {from: {x: 0, y: 0}, to: {x: 1, y: 1}});
+
+      const target = ref.current;
+      dispatchPointerHoverEnter(target);
+      dispatchPointerHoverMove(target, {from: {x: 0, y: 0}, to: {x: 1, y: 1}});
       expect(onHoverMove).toHaveBeenCalledTimes(2);
       expect(onHoverMove).toHaveBeenCalledWith(
         expect.objectContaining({type: 'hovermove'}),
@@ -242,12 +253,15 @@ describe.each(table)('Hover responder', hasPointerEvents => {
       };
       ReactDOM.render(<Outer />, container);
 
-      dispatchPointerHoverEnter(outerRef, {relatedTarget: container});
-      dispatchPointerHoverExit(outerRef, {relatedTarget: innerRef.current});
-      dispatchPointerHoverEnter(innerRef, {relatedTarget: outerRef.current});
-      dispatchPointerHoverExit(innerRef, {relatedTarget: outerRef.current});
-      dispatchPointerHoverEnter(outerRef, {relatedTarget: innerRef.current});
-      dispatchPointerHoverExit(outerRef, {relatedTarget: container});
+      const innerTarget = innerRef.current;
+      const outerTarget = outerRef.current;
+
+      dispatchPointerHoverEnter(outerTarget, {relatedTarget: container});
+      dispatchPointerHoverExit(outerTarget, {relatedTarget: innerTarget});
+      dispatchPointerHoverEnter(innerTarget, {relatedTarget: outerTarget});
+      dispatchPointerHoverExit(innerTarget, {relatedTarget: outerTarget});
+      dispatchPointerHoverEnter(outerTarget, {relatedTarget: innerTarget});
+      dispatchPointerHoverExit(outerTarget, {relatedTarget: container});
 
       expect(events).toEqual([
         'outer: onHoverStart',
@@ -300,9 +314,14 @@ describe.each(table)('Hover responder', hasPointerEvents => {
     };
     ReactDOM.render(<Component />, container);
 
-    dispatchPointerHoverEnter(ref, {x: 10, y: 10});
-    dispatchPointerHoverMove(ref, {from: {x: 10, y: 10}, to: {x: 20, y: 20}});
-    dispatchPointerHoverExit(ref, {x: 20, y: 20});
+    const target = ref.current;
+
+    dispatchPointerHoverEnter(target, {x: 10, y: 10});
+    dispatchPointerHoverMove(target, {
+      from: {x: 10, y: 10},
+      to: {x: 20, y: 20},
+    });
+    dispatchPointerHoverExit(target, {x: 20, y: 20});
 
     expect(eventLog).toEqual([
       {
@@ -312,7 +331,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
         pageY: 10,
         clientX: 10,
         clientY: 10,
-        target: ref.current,
+        target,
         timeStamp: timeStamps[0],
         type: 'hoverstart',
         pointerType: 'mouse',
@@ -324,7 +343,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
         pageY: 10,
         clientX: 10,
         clientY: 10,
-        target: ref.current,
+        target,
         timeStamp: timeStamps[1],
         type: 'hovermove',
         pointerType: 'mouse',
@@ -336,7 +355,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
         pageY: 20,
         clientX: 20,
         clientY: 20,
-        target: ref.current,
+        target,
         timeStamp: timeStamps[2],
         type: 'hovermove',
         pointerType: 'mouse',
@@ -348,7 +367,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
         pageY: 20,
         clientX: 20,
         clientY: 20,
-        target: ref.current,
+        target,
         timeStamp: timeStamps[3],
         type: 'hoverend',
         pointerType: 'mouse',


### PR DESCRIPTION
Separate the PointerEvent and fallback implementations.
Fix the unit tests to cover both PointerEvent and non-PointerEvent environments.
Fix the focus-visible related callbacks to get called when keys other than "Tab" are used.