### PR TITLE
Warn when textarea switches between controlled and uncontrolled

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
@@ -178,7 +178,7 @@ describe('ReactDOMComponentTree', () => {
     const component = <Controlled />;
     const instance = ReactDOM.render(component, container);
     expect(() => simulateInput(instance.a, finishValue)).toWarnDev(
-      'Warning: A component is changing an uncontrolled input of ' +
+      'Warning: Controlled is changing an uncontrolled input of ' +
         'type text to be controlled. Input elements should not ' +
         'switch from uncontrolled to controlled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -696,7 +696,8 @@ describe('ReactDOMSelect', () => {
         </select>,
       ),
     ).toWarnDev(
-      'Select elements must be either controlled or uncontrolled ' +
+      'A component contains a select element with both value and defaultValue props. ' +
+        'Select elements must be either controlled or uncontrolled ' +
         '(specify either the value prop, or the defaultValue prop, but not ' +
         'both). Decide between using a controlled or uncontrolled select ' +
         'element and remove one of these props. More info: ' +

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -471,6 +471,12 @@ describe('ReactDOMTextarea', () => {
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<textarea defaultValue="uncontrolled" />, container),
+    ).toWarnDev(
+      'Warning: A component is changing a controlled textarea to be uncontrolled. ' +
+        'Textarea elements should not switch from controlled to uncontrolled (or vice versa). ' +
+        'Decide between using a controlled or uncontrolled textarea ' +
+        'element for the lifetime of the component. More info: https://fb.me/react-controlled-components\n' +
+        '    in textarea (at **)',
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -436,9 +436,7 @@ describe('ReactDOMTextarea', () => {
 
   it('should warn if controlled textarea switches to uncontrolled (value is undefined)', () => {
     const container = document.createElement('div');
-    const stub = (
-      <textarea value="controlled" onChange={emptyFunction} />
-    );
+    const stub = <textarea value="controlled" onChange={emptyFunction} />;
     ReactDOM.render(stub, container);
     expect(() => ReactDOM.render(<textarea />, container)).toWarnDev(
       'Warning: A component is changing a controlled textarea to be uncontrolled. ' +
@@ -451,9 +449,7 @@ describe('ReactDOMTextarea', () => {
 
   it('should warn if controlled textarea switches to uncontrolled (value is null)', () => {
     const container = document.createElement('div');
-    const stub = (
-      <textarea value="controlled" onChange={emptyFunction} />
-    );
+    const stub = <textarea value="controlled" onChange={emptyFunction} />;
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<textarea value={null} />, container),
@@ -465,22 +461,16 @@ describe('ReactDOMTextarea', () => {
         'Textarea elements should not switch from controlled to uncontrolled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled textarea ' +
         'element for the lifetime of the component. More info: https://fb.me/react-controlled-components\n' +
-        '    in textarea (at **)'
-        ,
+        '    in textarea (at **)',
     ]);
   });
 
   it('should warn if controlled textarea switches to uncontrolled with defaultValue', () => {
     const container = document.createElement('div');
-    const stub = (
-      <textarea value="controlled" onChange={emptyFunction} />
-    );
+    const stub = <textarea value="controlled" onChange={emptyFunction} />;
     ReactDOM.render(stub, container);
     expect(() =>
-      ReactDOM.render(
-        <textarea defaultValue="uncontrolled" />,
-        container,
-      ),
+      ReactDOM.render(<textarea defaultValue="uncontrolled" />, container),
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -288,8 +288,15 @@ describe('ReactDOMTextarea', () => {
 
     expect(node.value).toBe('kitten');
 
-    ReactDOM.render(<textarea defaultValue="gorilla" />, container);
-
+    expect(() =>
+      ReactDOM.render(<textarea defaultValue="gorilla" />, container),
+    ).toWarnDev(
+      'Warning: A component is changing a controlled textarea to be uncontrolled. ' +
+        'Textarea elements should not switch from controlled to uncontrolled (or vice versa). ' +
+        'Decide between using a controlled or uncontrolled textarea ' +
+        'element for the lifetime of the component. More info: https://fb.me/react-controlled-components\n' +
+        '    in textarea (at **)',
+    );
     expect(node.value).toEqual('kitten');
   });
 
@@ -310,7 +317,15 @@ describe('ReactDOMTextarea', () => {
 
     expect(node.value).toBe('puppies');
 
-    ReactDOM.render(<textarea defaultValue="gorilla" />, container);
+    expect(() =>
+      ReactDOM.render(<textarea defaultValue="gorilla" />, container),
+    ).toWarnDev(
+      'Warning: A component is changing a controlled textarea to be uncontrolled. ' +
+        'Textarea elements should not switch from controlled to uncontrolled (or vice versa). ' +
+        'Decide between using a controlled or uncontrolled textarea ' +
+        'element for the lifetime of the component. More info: https://fb.me/react-controlled-components\n' +
+        '    in textarea (at **)',
+    );
 
     expect(node.value).toEqual('puppies');
   });
@@ -400,7 +415,7 @@ describe('ReactDOMTextarea', () => {
     ReactTestUtils.renderIntoDocument(<textarea value={null} />);
   });
 
-  it('should warn if value and defaultValue are specified', () => {
+  it('should warn if value and defaultValue props are specified', () => {
     const InvalidComponent = () => (
       <textarea value="foo" defaultValue="bar" readOnly={true} />
     );
@@ -417,6 +432,90 @@ describe('ReactDOMTextarea', () => {
 
     // No additional warnings are expected
     ReactTestUtils.renderIntoDocument(<InvalidComponent />);
+  });
+
+  it('should warn if controlled textarea switches to uncontrolled (value is undefined)', () => {
+    const container = document.createElement('div');
+    const stub = (
+      <textarea value="controlled" onChange={emptyFunction} />
+    );
+    ReactDOM.render(stub, container);
+    expect(() => ReactDOM.render(<textarea />, container)).toWarnDev(
+      'Warning: A component is changing a controlled textarea to be uncontrolled. ' +
+        'Textarea elements should not switch from controlled to uncontrolled (or vice versa). ' +
+        'Decide between using a controlled or uncontrolled textarea ' +
+        'element for the lifetime of the component. More info: https://fb.me/react-controlled-components\n' +
+        '    in textarea (at **)',
+    );
+  });
+
+  it('should warn if controlled textarea switches to uncontrolled (value is null)', () => {
+    const container = document.createElement('div');
+    const stub = (
+      <textarea value="controlled" onChange={emptyFunction} />
+    );
+    ReactDOM.render(stub, container);
+    expect(() =>
+      ReactDOM.render(<textarea value={null} />, container),
+    ).toWarnDev([
+      '`value` prop on `textarea` should not be null. ' +
+        'Consider using an empty string to clear the component or `undefined` ' +
+        'for uncontrolled components.',
+      'Warning: A component is changing a controlled textarea to be uncontrolled. ' +
+        'Textarea elements should not switch from controlled to uncontrolled (or vice versa). ' +
+        'Decide between using a controlled or uncontrolled textarea ' +
+        'element for the lifetime of the component. More info: https://fb.me/react-controlled-components\n' +
+        '    in textarea (at **)'
+        ,
+    ]);
+  });
+
+  it('should warn if controlled textarea switches to uncontrolled with defaultValue', () => {
+    const container = document.createElement('div');
+    const stub = (
+      <textarea value="controlled" onChange={emptyFunction} />
+    );
+    ReactDOM.render(stub, container);
+    expect(() =>
+      ReactDOM.render(
+        <textarea defaultValue="uncontrolled" />,
+        container,
+      ),
+    );
+  });
+
+  it('should warn if uncontrolled textarea (value is undefined) switches to controlled', () => {
+    const container = document.createElement('div');
+    const stub = <textarea />;
+    ReactDOM.render(stub, container);
+    expect(() =>
+      ReactDOM.render(<textarea value="controlled" />, container),
+    ).toWarnDev(
+      'Warning: A component is changing an uncontrolled textarea to be controlled. ' +
+        'Textarea elements should not switch from uncontrolled to controlled (or vice versa). ' +
+        'Decide between using a controlled or uncontrolled textarea ' +
+        'element for the lifetime of the component. More info: https://fb.me/react-controlled-components\n' +
+        '    in textarea (at **)',
+    );
+  });
+
+  it('should warn if uncontrolled textarea (value is null) switches to controlled', () => {
+    const container = document.createElement('div');
+    const stub = <textarea value={null} />;
+    expect(() => ReactDOM.render(stub, container)).toWarnDev(
+      '`value` prop on `textarea` should not be null. ' +
+        'Consider using an empty string to clear the component or `undefined` ' +
+        'for uncontrolled components.',
+    );
+    expect(() =>
+      ReactDOM.render(<textarea value="controlled" />, container),
+    ).toWarnDev(
+      'Warning: A component is changing an uncontrolled textarea to be controlled. ' +
+        'Textarea elements should not switch from uncontrolled to controlled (or vice versa). ' +
+        'Decide between using a controlled or uncontrolled textarea ' +
+        'element for the lifetime of the component. More info: https://fb.me/react-controlled-components\n' +
+        '    in textarea (at **)',
+    );
   });
 
   it('should not warn about missing onChange in uncontrolled textareas', () => {

--- a/packages/react-dom/src/client/ReactDOMInput.js
+++ b/packages/react-dom/src/client/ReactDOMInput.js
@@ -145,10 +145,11 @@ export function updateWrapper(element: Element, props: Object) {
     ) {
       warning(
         false,
-        'A component is changing an uncontrolled input of type %s to be controlled. ' +
+        '%s is changing an uncontrolled input of type %s to be controlled. ' +
           'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
           'Decide between using a controlled or uncontrolled input ' +
           'element for the lifetime of the component. More info: https://fb.me/react-controlled-components',
+        getCurrentFiberOwnerNameInDevOrNull() || 'A component',
         props.type,
       );
       didWarnUncontrolledToControlled = true;
@@ -160,10 +161,11 @@ export function updateWrapper(element: Element, props: Object) {
     ) {
       warning(
         false,
-        'A component is changing a controlled input of type %s to be uncontrolled. ' +
+        '%s is changing a controlled input of type %s to be uncontrolled. ' +
           'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
           'Decide between using a controlled or uncontrolled input ' +
           'element for the lifetime of the component. More info: https://fb.me/react-controlled-components',
+        getCurrentFiberOwnerNameInDevOrNull() || 'A component',
         props.type,
       );
       didWarnControlledToUncontrolled = true;

--- a/packages/react-dom/src/client/ReactDOMSelect.js
+++ b/packages/react-dom/src/client/ReactDOMSelect.js
@@ -158,11 +158,13 @@ export function initWrapperState(element: Element, props: Object) {
     ) {
       warning(
         false,
-        'Select elements must be either controlled or uncontrolled ' +
+        '%s contains a select element with both value and defaultValue props. ' +
+          'Select elements must be either controlled or uncontrolled ' +
           '(specify either the value prop, or the defaultValue prop, but not ' +
           'both). Decide between using a controlled or uncontrolled select ' +
           'element and remove one of these props. More info: ' +
           'https://fb.me/react-controlled-components',
+        getCurrentFiberOwnerNameInDevOrNull() || 'A component',
       );
       didWarnValueDefaultValue = true;
     }

--- a/packages/react-dom/src/client/ReactDOMTextarea.js
+++ b/packages/react-dom/src/client/ReactDOMTextarea.js
@@ -142,10 +142,11 @@ export function updateWrapper(element: Element, props: Object) {
     ) {
       warning(
         false,
-        'A component is changing an uncontrolled textarea to be controlled. ' +
+        '%s is changing an uncontrolled textarea to be controlled. ' +
           'Textarea elements should not switch from uncontrolled to controlled (or vice versa). ' +
           'Decide between using a controlled or uncontrolled textarea ' +
           'element for the lifetime of the component. More info: https://fb.me/react-controlled-components',
+        getCurrentFiberOwnerNameInDevOrNull() || 'A component',
       );
       didWarnUncontrolledToControlled = true;
     }
@@ -156,10 +157,11 @@ export function updateWrapper(element: Element, props: Object) {
     ) {
       warning(
         false,
-        'A component is changing a controlled textarea to be uncontrolled. ' +
+        '%s is changing a controlled textarea to be uncontrolled. ' +
           'Textarea elements should not switch from controlled to uncontrolled (or vice versa). ' +
           'Decide between using a controlled or uncontrolled textarea ' +
           'element for the lifetime of the component. More info: https://fb.me/react-controlled-components',
+        getCurrentFiberOwnerNameInDevOrNull() || 'A component',
       );
       didWarnControlledToUncontrolled = true;
     }

--- a/packages/react-dom/src/client/ReactDOMTextarea.js
+++ b/packages/react-dom/src/client/ReactDOMTextarea.js
@@ -16,10 +16,13 @@ import {getToStringValue, toString} from './ToStringValue';
 import type {ToStringValue} from './ToStringValue';
 
 let didWarnValDefaultVal = false;
+let didWarnControlledToUncontrolled = false;
+let didWarnUncontrolledToControlled = false;
 
 type TextAreaWithWrapperState = HTMLTextAreaElement & {
   _wrapperState: {
     initialValue: ToStringValue,
+    controlled?: boolean,
   },
 };
 
@@ -122,11 +125,46 @@ export function initWrapperState(element: Element, props: Object) {
 
   node._wrapperState = {
     initialValue: getToStringValue(initialValue),
+    controlled: props.value != null,
   };
 }
 
 export function updateWrapper(element: Element, props: Object) {
   const node = ((element: any): TextAreaWithWrapperState);
+
+  if (__DEV__) {
+    const controlled = props.value != null;
+
+    if (
+      !node._wrapperState.controlled &&
+      controlled &&
+      !didWarnUncontrolledToControlled
+    ) {
+      warning(
+        false,
+        'A component is changing an uncontrolled textarea to be controlled. ' +
+          'Textarea elements should not switch from uncontrolled to controlled (or vice versa). ' +
+          'Decide between using a controlled or uncontrolled textarea ' +
+          'element for the lifetime of the component. More info: https://fb.me/react-controlled-components',
+      );
+      didWarnUncontrolledToControlled = true;
+    }
+    if (
+      node._wrapperState.controlled &&
+      !controlled &&
+      !didWarnControlledToUncontrolled
+    ) {
+      warning(
+        false,
+        'A component is changing a controlled textarea to be uncontrolled. ' +
+          'Textarea elements should not switch from controlled to uncontrolled (or vice versa). ' +
+          'Decide between using a controlled or uncontrolled textarea ' +
+          'element for the lifetime of the component. More info: https://fb.me/react-controlled-components',
+      );
+      didWarnControlledToUncontrolled = true;
+    }
+  }
+
   const value = getToStringValue(props.value);
   const defaultValue = getToStringValue(props.defaultValue);
   if (value != null) {


### PR DESCRIPTION
Fixes issue #16342 

I think the select element may need this warning as well. If so I will probably create a PR for that shortly.
