### PR TITLE
[eslint-plugin-react-hooks] Fixed crash when referencing arguments in arrow functions.

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1024,7 +1024,7 @@ const tests = {
         }
       `,
     },
-    // Ignore arguments  keyword for arrow functions.
+    // Ignore arguments keyword for arrow functions.
     {
       code: `
         function Example() {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1024,6 +1024,37 @@ const tests = {
         }
       `,
     },
+    // TODO: Write description - arguments in arrow functions
+    {
+      code: `
+        function Example() {
+          useEffect(function() {
+            arguments
+          }, [])
+        }
+      `,
+    },
+    {
+      code: `
+        function Example() {
+          useEffect(() => {
+            arguments
+          }, [])
+        }
+      `,
+    },
+    {
+      code: `
+        function Example() {
+          useEffect(() => {
+            const bar = () => {
+              arguments;
+            };
+            bar();
+          }, [])
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1024,16 +1024,7 @@ const tests = {
         }
       `,
     },
-    // TODO: Write description - arguments in arrow functions
-    {
-      code: `
-        function Example() {
-          useEffect(function() {
-            arguments
-          }, [])
-        }
-      `,
-    },
+    // Ignore arguments  keyword for arrow functions.
     {
       code: `
         function Example() {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -399,7 +399,6 @@ export default {
 
           const def = reference.resolved.defs[0];
 
-          // Ignore if def is undefined - e.g. `arguments` binding.
           if (def == null) {
             continue;
           }

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -405,10 +405,7 @@ export default {
           }
 
           // Ignore references to the function itself as it's not defined yet.
-          if (
-            def.node != null &&
-            def.node.init === node.parent
-          ) {
+          if (def.node != null && def.node.init === node.parent) {
             continue;
           }
 

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -400,13 +400,12 @@ export default {
           const def = reference.resolved.defs[0];
 
           // Ignore if def is undefined - e.g. `arguments` binding.
-          if (def === undefined) {
+          if (def == null) {
             continue;
           }
 
           // Ignore references to the function itself as it's not defined yet.
           if (
-            def != null &&
             def.node != null &&
             def.node.init === node.parent
           ) {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -397,8 +397,14 @@ export default {
             });
           }
 
-          // Ignore references to the function itself as it's not defined yet.
           const def = reference.resolved.defs[0];
+
+          // Ignore if def is undefined - e.g. `arguments` binding.
+          if (def === undefined) {
+            continue;
+          }
+
+          // Ignore references to the function itself as it's not defined yet.
           if (
             def != null &&
             def.node != null &&


### PR DESCRIPTION
**Description**:
Referencing arguments from inside an arrow function caused a crash.

Fixes issue: #16003 


