### PR TITLE
Fix typo in error code map

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -1310,7 +1310,7 @@ function updateEventListener(
   invariant(
     responder && responder.$$typeof === REACT_RESPONDER_TYPE,
     'An invalid value was used as an event listener. Expect one or many event ' +
-      'listeners created via React.unstable_useResponer().',
+      'listeners created via React.unstable_useResponder().',
   );
   const listenerProps = ((props: any): Object);
   if (visistedResponders.has(responder)) {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -337,6 +337,5 @@
   "336": "The \"%s\" event responder cannot be used via the \"useEvent\" hook.",
   "337": "An invalid event responder was provided to host component",
   "338": "ReactDOMServer does not yet support the fundamental API.",
-  "339": "An invalid value was used as an event responder. Expect one or many event responders created via React.unstable_createResponer().",
-  "340": "An invalid value was used as an event listener. Expect one or many event listeners created via React.unstable_useResponer()."
+  "339": "An invalid value was used as an event listener. Expect one or many event listeners created via React.unstable_useResponder()."
 }


### PR DESCRIPTION
"responer" -> "responder"

I also removed an unused error code that never shipped.
