### PR TITLE
[Partial Hydration] Remove SuspenseInstance boundaries upon hydration

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
@@ -127,7 +127,7 @@ describe('ReactDOMServerSuspense', () => {
       root.render(example);
     });
 
-    const parent2 = element.parentNode;
+    const parent2 = parent;
     const divA2 = parent2.children[0];
     const divB2 = parent2.children[1];
     expect(divA).toBe(divA2);

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -673,9 +673,9 @@ export function hydrateTextInstance(
   return diffHydratedText(textInstance, text);
 }
 
-export function getNextHydratableInstanceAfterSuspenseInstance(
+export function getSuspenseInstanceEndBoundary(
   suspenseInstance: SuspenseInstance,
-): null | HydratableInstance {
+): null | SuspenseInstance {
   let node = suspenseInstance.nextSibling;
   // Skip past all nodes within this suspense boundary.
   // There might be nested nodes so we need to keep track of how
@@ -686,7 +686,8 @@ export function getNextHydratableInstanceAfterSuspenseInstance(
       let data = ((node: any).data: string);
       if (data === SUSPENSE_END_DATA) {
         if (depth === 0) {
-          return getNextHydratableSibling((node: any));
+          // This has now been refined to a suspense node.
+          return ((node: any): SuspenseInstance);
         } else {
           depth--;
         }
@@ -702,6 +703,16 @@ export function getNextHydratableInstanceAfterSuspenseInstance(
   }
   // TODO: Warn, we didn't find the end comment boundary.
   return null;
+}
+
+export function getNextHydratableInstanceAfterSuspenseInstance(
+  suspenseInstance: SuspenseInstance,
+): null | HydratableInstance {
+  const node = getSuspenseInstanceEndBoundary(suspenseInstance);
+  if (node === null) {
+    return null;
+  }
+  return getNextHydratableSibling(node);
 }
 
 export function didNotMatchHydratedContainerTextInstance(

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -112,6 +112,7 @@ import {
 } from './ReactFiberContext';
 import {popProvider} from './ReactFiberNewContext';
 import {
+  deleteSuspenseInstanceBoundary,
   prepareToHydrateHostInstance,
   prepareToHydrateHostTextInstance,
   popHydrationState,
@@ -858,6 +859,7 @@ function completeWork(
             resetHydrationState();
             if ((workInProgress.effectTag & DidCapture) === NoEffect) {
               // This boundary did not suspend so it's now hydrated and unsuspended.
+              deleteSuspenseInstanceBoundary(workInProgress);
               workInProgress.memoizedState = null;
             } else {
               // Something suspended. Schedule an effect to attach retry listeners.

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -126,6 +126,8 @@ export const getNextHydratableSibling = $$$hostConfig.getNextHydratableSibling;
 export const getFirstHydratableChild = $$$hostConfig.getFirstHydratableChild;
 export const hydrateInstance = $$$hostConfig.hydrateInstance;
 export const hydrateTextInstance = $$$hostConfig.hydrateTextInstance;
+export const getSuspenseInstanceEndBoundary =
+  $$$hostConfig.getSuspenseInstanceEndBoundary;
 export const getNextHydratableInstanceAfterSuspenseInstance =
   $$$hostConfig.getNextHydratableInstanceAfterSuspenseInstance;
 export const clearSuspenseBoundary = $$$hostConfig.clearSuspenseBoundary;

--- a/packages/shared/HostConfigWithNoHydration.js
+++ b/packages/shared/HostConfigWithNoHydration.js
@@ -34,6 +34,7 @@ export const getNextHydratableSibling = shim;
 export const getFirstHydratableChild = shim;
 export const hydrateInstance = shim;
 export const hydrateTextInstance = shim;
+export const getSuspenseInstanceEndBoundary = shim;
 export const getNextHydratableInstanceAfterSuspenseInstance = shim;
 export const clearSuspenseBoundary = shim;
 export const clearSuspenseBoundaryFromContainer = shim;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -339,5 +339,7 @@
   "338": "ReactDOMServer does not yet support the fundamental API.",
   "339": "An invalid value was used as an event listener. Expect one or many event listeners created via React.unstable_useResponder().",
   "340": "Threw in newly mounted dehydrated component. This is likely a bug in React. Please file an issue.",
-  "341": "We just came from a parent so we must have had a parent. This is a bug in React."
+  "341": "We just came from a parent so we must have had a parent. This is a bug in React.",
+  "342": "Expected deleteSuspenseInstanceBoundary() to never be called. This error is likely caused by a bug in React. Please file an issue.",
+  "343": "Expected to find closing boundary for suspense instance. This error is likely caused by a bug in React. Please file an issue."
 }


### PR DESCRIPTION
I've modified the partial hydration logic to remove suspense instance boundary nodes after hydrating. This will provide a mechanism to determine when hydration happens (and that works with concurrent). I imagine we'll have a real API for this in the future, but at the very least this will clean up the high number of boundary nodes in the DOM, while also providing a visual signal to developers as to when hydration happens.