### PR TITLE
Added better error reporting for print-warnings errors

### DIFF
--- a/scripts/print-warnings/print-warnings.js
+++ b/scripts/print-warnings/print-warnings.js
@@ -38,7 +38,14 @@ function transform(file, enc, cb) {
       return;
     }
 
-    const ast = babylon.parse(source, babylonOptions);
+    let ast;
+    try {
+      ast = babylon.parse(source, babylonOptions);
+    } catch (error) {
+      console.error('Failed to parse source file:', file.path);
+      throw error;
+    }
+
     traverse(ast, {
       CallExpression: {
         exit: function(astPath) {


### PR DESCRIPTION
When parsing fails, at least show which file the parsing error pertains to. The line/col numbers aren't useful by themselves.

## Before
![Screen Shot 2019-08-14 at 1 51 15 PM](https://user-images.githubusercontent.com/29597/63055395-a5f44180-be9a-11e9-9341-f64709a77436.png)

## After
![Screen Shot 2019-08-14 at 1 51 22 PM](https://user-images.githubusercontent.com/29597/63055396-a5f44180-be9a-11e9-8093-30f543f51ed7.png)
