### PR TITLE
[react-events] Press: improve test coverage

### DIFF
--- a/packages/react-events/src/dom/__tests__/Focus-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Focus-test.internal.js
@@ -15,8 +15,8 @@ import {
   keydown,
   setPointerEvent,
   platform,
-  dispatchPointerPressDown,
-  dispatchPointerPressRelease,
+  dispatchPointerDown,
+  dispatchPointerUp,
 } from '../test-utils';
 
 let React;
@@ -138,8 +138,8 @@ describe.each(table)('Focus responder', hasPointerEvents => {
 
     it('is called with the correct pointerType: mouse', () => {
       const target = ref.current;
-      dispatchPointerPressDown(target, {pointerType: 'mouse'});
-      dispatchPointerPressRelease(target, {pointerType: 'mouse'});
+      dispatchPointerDown(target, {pointerType: 'mouse'});
+      dispatchPointerUp(target, {pointerType: 'mouse'});
       expect(onFocus).toHaveBeenCalledTimes(1);
       expect(onFocus).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'mouse'}),
@@ -148,8 +148,8 @@ describe.each(table)('Focus responder', hasPointerEvents => {
 
     it('is called with the correct pointerType: touch', () => {
       const target = ref.current;
-      dispatchPointerPressDown(target, {pointerType: 'touch'});
-      dispatchPointerPressRelease(target, {pointerType: 'touch'});
+      dispatchPointerDown(target, {pointerType: 'touch'});
+      dispatchPointerUp(target, {pointerType: 'touch'});
       expect(onFocus).toHaveBeenCalledTimes(1);
       expect(onFocus).toHaveBeenCalledWith(
         expect.objectContaining({pointerType: 'touch'}),
@@ -159,8 +159,8 @@ describe.each(table)('Focus responder', hasPointerEvents => {
     if (hasPointerEvents) {
       it('is called with the correct pointerType: pen', () => {
         const target = ref.current;
-        dispatchPointerPressDown(target, {pointerType: 'pen'});
-        dispatchPointerPressRelease(target, {pointerType: 'pen'});
+        dispatchPointerDown(target, {pointerType: 'pen'});
+        dispatchPointerUp(target, {pointerType: 'pen'});
         expect(onFocus).toHaveBeenCalledTimes(1);
         expect(onFocus).toHaveBeenCalledWith(
           expect.objectContaining({pointerType: 'pen'}),
@@ -278,7 +278,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
       expect(onFocusVisibleChange).toHaveBeenCalledTimes(1);
       expect(onFocusVisibleChange).toHaveBeenCalledWith(true);
       // then use pointer on the target, focus should no longer be visible
-      dispatchPointerPressDown(target);
+      dispatchPointerDown(target);
       expect(onFocusVisibleChange).toHaveBeenCalledTimes(2);
       expect(onFocusVisibleChange).toHaveBeenCalledWith(false);
       // onFocusVisibleChange should not be called again
@@ -288,9 +288,9 @@ describe.each(table)('Focus responder', hasPointerEvents => {
 
     it('is not called after "focus" and "blur" events without keyboard', () => {
       const target = ref.current;
-      dispatchPointerPressDown(target);
-      dispatchPointerPressRelease(target);
-      dispatchPointerPressDown(container);
+      dispatchPointerDown(target);
+      dispatchPointerUp(target);
+      dispatchPointerDown(container);
       target.dispatchEvent(blur({relatedTarget: container}));
       expect(onFocusVisibleChange).toHaveBeenCalledTimes(0);
     });

--- a/packages/react-events/src/dom/__tests__/FocusWithin-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/FocusWithin-test.internal.js
@@ -14,8 +14,8 @@ import {
   focus,
   keydown,
   setPointerEvent,
-  dispatchPointerPressDown,
-  dispatchPointerPressRelease,
+  dispatchPointerDown,
+  dispatchPointerUp,
 } from '../test-utils';
 
 let React;
@@ -203,7 +203,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(1);
       expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(true);
       // then use pointer on the next target, focus should no longer be visible
-      dispatchPointerPressDown(innerTarget2);
+      dispatchPointerDown(innerTarget2);
       innerTarget1.dispatchEvent(blur({relatedTarget: innerTarget2}));
       innerTarget2.dispatchEvent(focus());
       expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(2);
@@ -215,7 +215,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(3);
       expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(true);
       // then use pointer on the target, focus should no longer be visible
-      dispatchPointerPressDown(innerTarget1);
+      dispatchPointerDown(innerTarget1);
       expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(4);
       expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(false);
       // onFocusVisibleChange should not be called again
@@ -225,8 +225,8 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
 
     it('is not called after "focus" and "blur" events without keyboard', () => {
       const innerTarget = innerRef.current;
-      dispatchPointerPressDown(innerTarget);
-      dispatchPointerPressRelease(innerTarget);
+      dispatchPointerDown(innerTarget);
+      dispatchPointerUp(innerTarget);
       innerTarget.dispatchEvent(blur({relatedTarget: container}));
       expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(0);
     });

--- a/packages/react-events/src/dom/__tests__/Hover-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Hover-test.internal.js
@@ -213,7 +213,8 @@ describe.each(table)('Hover responder', hasPointerEvents => {
 
       const target = ref.current;
       dispatchPointerHoverEnter(target);
-      dispatchPointerHoverMove(target, {from: {x: 0, y: 0}, to: {x: 1, y: 1}});
+      dispatchPointerHoverMove(target, {x: 0, y: 0});
+      dispatchPointerHoverMove(target, {x: 1, y: 1});
       expect(onHoverMove).toHaveBeenCalledTimes(2);
       expect(onHoverMove).toHaveBeenCalledWith(
         expect.objectContaining({type: 'hovermove'}),
@@ -317,10 +318,8 @@ describe.each(table)('Hover responder', hasPointerEvents => {
     const target = ref.current;
 
     dispatchPointerHoverEnter(target, {x: 10, y: 10});
-    dispatchPointerHoverMove(target, {
-      from: {x: 10, y: 10},
-      to: {x: 20, y: 20},
-    });
+    dispatchPointerHoverMove(target, {x: 10, y: 10});
+    dispatchPointerHoverMove(target, {x: 20, y: 20});
     dispatchPointerHoverExit(target, {x: 20, y: 20});
 
     expect(eventLog).toEqual([


### PR DESCRIPTION
1. Run the tests in environments with and without PointerEvent support.
2. Improve test coverage to include both mouse and touch pointers.
3. Change `Press` responder so that it only listens to either pointer events or fallbacks events.

Demo: https://codesandbox.io/s/latest-responder-build-rz96j30rp