### PR TITLE
Clear canceled task node early

### DIFF
--- a/packages/react-reconciler/src/SchedulerWithReactIntegration.js
+++ b/packages/react-reconciler/src/SchedulerWithReactIntegration.js
@@ -160,7 +160,9 @@ export function cancelCallback(callbackNode: mixed) {
 
 export function flushSyncCallbackQueue() {
   if (immediateQueueCallbackNode !== null) {
-    Scheduler_cancelCallback(immediateQueueCallbackNode);
+    const node = immediateQueueCallbackNode;
+    immediateQueueCallbackNode = null;
+    Scheduler_cancelCallback(node);
   }
   flushSyncCallbackQueueImpl();
 }


### PR DESCRIPTION
This is unobservable. There should be no need to repeatedly clear it if we already did that once.