### PR TITLE
Fix message loop behavior when host callback is cancelled

### DIFF
--- a/packages/scheduler/src/__tests__/SchedulerBrowser-test.internal.js
+++ b/packages/scheduler/src/__tests__/SchedulerBrowser-test.internal.js
@@ -15,6 +15,7 @@
 let Scheduler;
 let runtime;
 let performance;
+let cancelCallback;
 let scheduleCallback;
 let NormalPriority;
 
@@ -52,6 +53,7 @@ describe('SchedulerBrowser', () => {
       performance = window.performance;
       require('scheduler/src/SchedulerFeatureFlags').enableMessageLoopImplementation = enableMessageLoopImplementation;
       Scheduler = require('scheduler');
+      cancelCallback = Scheduler.unstable_cancelCallback;
       scheduleCallback = Scheduler.unstable_scheduleCallback;
       NormalPriority = Scheduler.unstable_NormalPriority;
     });
@@ -410,6 +412,25 @@ describe('SchedulerBrowser', () => {
       runtime.assertLog(['Post Message']);
       runtime.fireMessageEvent();
       runtime.assertLog(['Message Event', 'A']);
+
+      scheduleCallback(NormalPriority, () => {
+        runtime.log('B');
+      });
+      runtime.assertLog(['Post Message']);
+      runtime.fireMessageEvent();
+      runtime.assertLog(['Message Event', 'B']);
+    });
+
+    it('schedule new task after a cancellation', () => {
+      let handle = scheduleCallback(NormalPriority, () => {
+        runtime.log('A');
+      });
+
+      runtime.assertLog(['Post Message']);
+      cancelCallback(handle);
+
+      runtime.fireMessageEvent();
+      runtime.assertLog(['Message Event']);
 
       scheduleCallback(NormalPriority, () => {
         runtime.log('B');

--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -235,6 +235,8 @@ if (
           port.postMessage(null);
           throw error;
         }
+      } else {
+        isMessageLoopRunning = false;
       }
       // Yielding to the browser will give it a chance to paint, so we can
       // reset this.


### PR DESCRIPTION
# https://github.com/facebook/react/pull/16407/commits/c2a1a771c6323c1b8256c3ca7c2834bd2b40c3a7

New test.

This works on master but would have been broken by #16145.
I verified the test fails on that branch.

# https://github.com/facebook/react/pull/16407/commits/3b70481e54882848c4b3a7e9edc4591c84c52053

This is the fix. Again, it doesn't affect master because we don't use `cancelHostCallback` yet. But it fixes the previously added test when combined with #16145. The actual problem isn't related to #16145, we just didn't execute the code path that triggers the bad case until that PR.

The problem itself is that `cancelHostCallback` would clear out the callback. Then in the message loop we would see that it's `null`, and exit early. But we wouldn't schedule another one, so the loop would stop. However, the boolean itself would stay true, so next time we schedule something, we'd think the loop was still running. And fail to schedule it. The fix is to reset the boolean.

The rAF codepath handles this earlier — in `onAnimate`. But we don't have that entry point in the message loop implementation. So we forgot to do it.

# 22a12878b6907bf84f430c5e057802dbe7d0ec50

Just some more tests from #16271 since we're not doing it for now.