### PR TITLE
Enable MessageLoop implementation by default

### DIFF
--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -10,5 +10,5 @@ export const enableSchedulerDebugging = false;
 export const enableIsInputPending = false;
 export const requestIdleCallbackBeforeFirstFrame = false;
 export const requestTimerEventBeforeFirstFrame = false;
-export const enableMessageLoopImplementation = false;
+export const enableMessageLoopImplementation = true;
 export const enableProfiling = __PROFILE__;

--- a/packages/scheduler/src/__tests__/SchedulerRAFOld-test.internal.js
+++ b/packages/scheduler/src/__tests__/SchedulerRAFOld-test.internal.js
@@ -16,7 +16,9 @@ type FrameTimeoutConfigType = {
   timePastFrameDeadline: ?number,
 };
 
-describe('SchedulerDOM', () => {
+// Note: this is testing the implementation that we turned off.
+// enableMessageLoopImplementation is true on master.
+describe('SchedulerRAFOld', () => {
   let rAFCallbacks = [];
   let postMessageCallback;
   let postMessageEvents = [];
@@ -101,6 +103,7 @@ describe('SchedulerDOM', () => {
       ),
     );
 
+    require('scheduler/src/SchedulerFeatureFlags').enableMessageLoopImplementation = false;
     Scheduler = require('scheduler');
   });
 

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
@@ -9,9 +9,9 @@
 export const {
   enableIsInputPending,
   enableSchedulerDebugging,
-  requestIdleCallbackBeforeFirstFrame,
-  requestTimerEventBeforeFirstFrame,
-  enableMessageLoopImplementation,
 } = require('SchedulerFeatureFlags');
 
 export const enableProfiling = __PROFILE__;
+export const requestIdleCallbackBeforeFirstFrame = false;
+export const requestTimerEventBeforeFirstFrame = false;
+export const enableMessageLoopImplementation = true;


### PR DESCRIPTION
This disables the RAF scheduler impl in favor of the MessageLoop one, which we've found better utilizes CPU. Unlike https://github.com/facebook/react/pull/16271, this keeps the RAF implementation for now just in case, but it's only in one specially marked test.

This matches what we already rolled out in www, except the rAF-specific flags (they're true on www but they're dead code in the rAF path anyway — and I didn't want to adjust the test for them).

My previous PR includes most of the extra test coverage for ML scheduler which I picked up from Andrew's earlier PR.