### PR TITLE
[ESLint] Forbid top-level use*() calls

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -679,6 +679,24 @@ const tests = {
     },
     {
       code: `
+        // Invalid because it's dangerous and might not warn otherwise.
+        // This *must* be invalid.
+        function useHook({ bar }) {
+          let foo1 = bar && useState();
+          let foo2 = bar || useState();
+          let foo3 = bar ?? useState();
+        }
+      `,
+      errors: [
+        conditionalError('useState'),
+        conditionalError('useState'),
+        // TODO: ideally this *should* warn, but ESLint
+        // doesn't plan full support for ?? until it advances.
+        // conditionalError('useState'),
+      ],
+    },
+    {
+      code: `
         // Invalid because it's dangerous.
         // Normally, this would crash, but not if you use inline requires.
         // This *must* be invalid.

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -432,9 +432,13 @@ export default {
                 'React Hook function.';
               context.report({node: hook, message});
             } else if (codePathNode.type === 'Program') {
-              // For now, ignore if it's in top level scope.
               // We could warn here but there are false positives related
               // configuring libraries like `history`.
+              const message =
+                `React Hook "${context.getSource(hook)}" cannot be called ` +
+                'at the top level. React Hooks must be called in a ' +
+                'React function component or a custom React Hook function.';
+              context.report({node: hook, message});
             } else {
               // Assume in all other cases the user called a hook in some
               // random function callback. This should usually be true for


### PR DESCRIPTION
In the initial release of `eslint-plugin-react-hooks/rules-of-hooks`, we forbid this:

```js
function foo() {
  useState(); // BAD: calling a Hook from a non-Hook
}
```

But we didn't forbid this:

```js
// top-level code

useState(); // ALSO BAD: calling a Hook from top level
```

This PR forbids it in the lint rule.

### Why did it work before?

We didn't ban it at the time for three reasons:

1. We didn't know how Hooks would be received by the community. Taking the whole `use*` prefix seemed dicey and we didn't want to push the convention harder than absolutely necessary.
2. It is a runtime crash anyway, so you find out about this immediately.
3. There's a `history` library whose 2.x versions had an API like this:

```js
const {createHistory, useBasename} = require('history-2.1.2');
const browserHistory = useBasename(createHistory)({
  basename: '/',
});
```

So banning this pattern would create a false positive for it.

### Why ban it now?

If your environment uses "inline requires" (opt-in on React Native), you might not get a crash at all. Instead, **the top level initialization of a module may run as a result of some component's render**, and so Hooks would accidentally "belong" to the parent. That's confusing. While "inline requires" aren't very common on the web, they're a powerful optimization, so it's plausible they will get used more often with time as build systems add support for them.

Even regardless of that risk, we can confidently say Hooks have been a successful rollout now. So whether the bugs themselves are a problem or not, **the `use` convention effectively already strongly implies it's a Hook**. From that perspective, `use*()` at top level is just confusing to look at.

If you run into a false positive, you might want to change that to something like this anyway:

```js
const {createHistory, useBasename: withBasename} = require('history-2.1.2');
const browserHistory = withBasename(createHistory)({
  basename: '/',
});
```
so that your coworkers don't think it's a Hook.

That particular API also doesn't exist in modern versions of `history` anyway. And I haven't found similar APIs in the wild.

### What about `MyLibrary.useFoo()`?

We warn about invalid use of `use*()` and `React.use*()`, but not `MyLibrary.use*()`. This is because initially we saw too many false positives from modules like `MyStore.useNewAnalytics()`.

The new top-level error respects the same rule. For example, it would warn for `useBasename()`, but not for `History.useBasename()`. So that's another escape hatch if you want to suppress it.

In the future, we might consider making it stricter, and banning invalid calls to `MyLibrary.use*()` too. But it's less common in general because the convention is to import Hooks directly without a namespace. It's also much more commonly encountered in open source, like `app.use()` from Express, or `jest.useFakeTimers()`. So maybe it's not worth it.