### PR TITLE
[react-events] Rely on 'buttons' rather than 'button'

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -481,7 +481,7 @@ function createDOMResponderEvent(
   passive: boolean,
   passiveSupported: boolean,
 ): ReactDOMResponderEvent {
-  const {pointerType} = (nativeEvent: any);
+  const {buttons, pointerType} = (nativeEvent: any);
   let eventPointerType = '';
   let pointerId = null;
 
@@ -490,7 +490,7 @@ function createDOMResponderEvent(
     pointerId = (nativeEvent: any).pointerId;
   } else if (nativeEvent.key !== undefined) {
     eventPointerType = 'keyboard';
-  } else if (nativeEvent.button !== undefined) {
+  } else if (buttons !== undefined) {
     eventPointerType = 'mouse';
   } else if ((nativeEvent: any).changedTouches !== undefined) {
     eventPointerType = 'touch';

--- a/packages/react-events/docs/Press.md
+++ b/packages/react-events/docs/Press.md
@@ -78,11 +78,6 @@ type PressOffset = {
 
 Disables all `Press` events.
 
-### onContextMenu: (e: PressEvent) => void
-
-Called when the context menu is shown. When a press is active, the context menu
-will only be shown (and the press cancelled) if `preventDefault` is `false`.
-
 ### onPress: (e: PressEvent) => void
 
 Called immediately after a press is released, unless the press is released
@@ -114,11 +109,6 @@ element before it is deactivated. Once deactivated, the pointer (still held
 down) can be moved back within the bounds of the element to reactivate it.
 Ensure you pass in a constant to reduce memory allocations. Default is `20` for
 each offset.
-
-### preventContextMenu: boolean = false
-
-Prevents the native context menu from being shown, but `onContextMenu`
-is still called.
 
 ### preventDefault: boolean = true
 

--- a/packages/react-events/src/dom/ContextMenu.js
+++ b/packages/react-events/src/dom/ContextMenu.js
@@ -28,20 +28,19 @@ type ContextMenuState = {
 };
 
 type ContextMenuEvent = {|
-  target: Element | Document,
-  type: 'contextmenu',
-  pointerType: PointerType,
-  timeStamp: number,
-  clientX: null | number,
-  clientY: null | number,
-  pageX: null | number,
-  pageY: null | number,
-  x: null | number,
-  y: null | number,
   altKey: boolean,
+  buttons: 0 | 1 | 2,
   ctrlKey: boolean,
   metaKey: boolean,
+  pageX: null | number,
+  pageY: null | number,
+  pointerType: PointerType,
   shiftKey: boolean,
+  target: Element | Document,
+  timeStamp: number,
+  type: 'contextmenu',
+  x: null | number,
+  y: null | number,
 |};
 
 const hasPointerEvents =
@@ -60,13 +59,13 @@ function dispatchContextMenuEvent(
 
   const gestureState = {
     altKey: nativeEvent.altKey,
-    button: nativeEvent.button === 0 ? 'primary' : 'auxillary',
-    ctrlKey: nativeEvent.altKey,
-    metaKey: nativeEvent.altKey,
-    pageX: nativeEvent.altKey,
-    pageY: nativeEvent.altKey,
+    buttons: nativeEvent.buttons != null ? nativeEvent.buttons : 0,
+    ctrlKey: nativeEvent.ctrlKey,
+    metaKey: nativeEvent.metaKey,
+    pageX: nativeEvent.pageX,
+    pageY: nativeEvent.pageY,
     pointerType,
-    shiftKey: nativeEvent.altKey,
+    shiftKey: nativeEvent.shiftKey,
     target,
     timeStamp,
     type: 'contextmenu',

--- a/packages/react-events/src/dom/Hover.js
+++ b/packages/react-events/src/dom/Hover.js
@@ -37,16 +37,16 @@ type HoverState = {
 type HoverEventType = 'hoverstart' | 'hoverend' | 'hoverchange' | 'hovermove';
 
 type HoverEvent = {|
-  pointerType: PointerType,
-  target: Element | Document,
-  type: HoverEventType,
-  timeStamp: number,
   clientX: null | number,
   clientY: null | number,
   pageX: null | number,
   pageY: null | number,
+  pointerType: PointerType,
   screenX: null | number,
   screenY: null | number,
+  target: Element | Document,
+  timeStamp: number,
+  type: HoverEventType,
   x: null | number,
   y: null | number,
 |};

--- a/packages/react-events/src/dom/__tests__/ContextMenu-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/ContextMenu-test.internal.js
@@ -9,7 +9,12 @@
 
 'use strict';
 
-import {createEventTarget, platform, setPointerEvent} from '../testing-library';
+import {
+  buttonsType,
+  createEventTarget,
+  platform,
+  setPointerEvent,
+} from '../testing-library';
 
 let React;
 let ReactFeatureFlags;
@@ -61,7 +66,11 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       expect(preventDefault).toHaveBeenCalledTimes(1);
       expect(onContextMenu).toHaveBeenCalledTimes(1);
       expect(onContextMenu).toHaveBeenCalledWith(
-        expect.objectContaining({pointerType: 'mouse', type: 'contextmenu'}),
+        expect.objectContaining({
+          buttons: buttonsType.secondary,
+          pointerType: 'mouse',
+          type: 'contextmenu',
+        }),
       );
     });
 
@@ -80,7 +89,11 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       expect(preventDefault).toHaveBeenCalledTimes(1);
       expect(onContextMenu).toHaveBeenCalledTimes(1);
       expect(onContextMenu).toHaveBeenCalledWith(
-        expect.objectContaining({pointerType: 'touch', type: 'contextmenu'}),
+        expect.objectContaining({
+          buttons: buttonsType.none,
+          pointerType: 'touch',
+          type: 'contextmenu',
+        }),
       );
     });
 
@@ -144,7 +157,11 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       target.contextmenu({}, {modified: true});
       expect(onContextMenu).toHaveBeenCalledTimes(1);
       expect(onContextMenu).toHaveBeenCalledWith(
-        expect.objectContaining({pointerType: 'mouse', type: 'contextmenu'}),
+        expect.objectContaining({
+          buttons: buttonsType.primary,
+          pointerType: 'mouse',
+          type: 'contextmenu',
+        }),
       );
     });
   });

--- a/packages/react-events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Press-test.internal.js
@@ -9,7 +9,11 @@
 
 'use strict';
 
-import {createEventTarget, setPointerEvent} from '../testing-library';
+import {
+  buttonsType,
+  createEventTarget,
+  setPointerEvent,
+} from '../testing-library';
 
 let React;
 let ReactFeatureFlags;
@@ -114,36 +118,36 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       },
     );
 
-    it('is called after auxillary-button pointer down', () => {
+    it('is called after middle-button pointer down', () => {
       const target = createEventTarget(ref.current);
-      target.pointerdown({button: 1, pointerType: 'mouse'});
+      target.pointerdown({buttons: buttonsType.middle, pointerType: 'mouse'});
       expect(onPressStart).toHaveBeenCalledTimes(1);
       expect(onPressStart).toHaveBeenCalledWith(
         expect.objectContaining({
-          button: 'auxillary',
+          buttons: buttonsType.middle,
           pointerType: 'mouse',
           type: 'pressstart',
         }),
       );
     });
 
-    it('is not called after pointer move following auxillary-button press', () => {
+    it('is not called after pointer move following middle-button press', () => {
       const node = ref.current;
       const target = createEventTarget(node);
       target.setBoundingClientRect({x: 0, y: 0, width: 100, height: 100});
-      target.pointerdown({button: 1, pointerType: 'mouse'});
-      target.pointerup({button: 1, pointerType: 'mouse'});
+      target.pointerdown({buttons: buttonsType.middle, pointerType: 'mouse'});
+      target.pointerup({buttons: buttonsType.middle, pointerType: 'mouse'});
       target.pointerhover({x: 110, y: 110});
       target.pointerhover({x: 50, y: 50});
       expect(onPressStart).toHaveBeenCalledTimes(1);
     });
 
-    it('ignores any events not caused by primary/auxillary-click or touch/pen contact', () => {
+    it('ignores any events not caused by primary/middle-click or touch/pen contact', () => {
       const target = createEventTarget(ref.current);
-      target.pointerdown({button: 2});
-      target.pointerup({button: 2});
-      target.pointerdown({button: 5});
-      target.pointerup({button: 5});
+      target.pointerdown({buttons: buttonsType.secondary});
+      target.pointerup({buttons: buttonsType.secondary});
+      target.pointerdown({buttons: buttonsType.eraser});
+      target.pointerup({buttons: buttonsType.eraser});
       expect(onPressStart).toHaveBeenCalledTimes(0);
     });
 
@@ -209,14 +213,14 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       },
     );
 
-    it('is called after auxillary-button pointer up', () => {
+    it('is called after middle-button pointer up', () => {
       const target = createEventTarget(ref.current);
-      target.pointerdown({button: 1, pointerType: 'mouse'});
-      target.pointerup({button: 1, pointerType: 'mouse'});
+      target.pointerdown({buttons: buttonsType.middle, pointerType: 'mouse'});
+      target.pointerup({buttons: buttonsType.middle, pointerType: 'mouse'});
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(
         expect.objectContaining({
-          button: 'auxillary',
+          buttons: buttonsType.middle,
           pointerType: 'mouse',
           type: 'pressend',
         }),
@@ -350,10 +354,10 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       },
     );
 
-    it('is not called after auxillary-button press', () => {
+    it('is not called after middle-button press', () => {
       const target = createEventTarget(ref.current);
-      target.pointerdown({button: 1, pointerType: 'mouse'});
-      target.pointerup({button: 1, pointerType: 'mouse'});
+      target.pointerdown({buttons: buttonsType.middle, pointerType: 'mouse'});
+      target.pointerup({buttons: buttonsType.middle, pointerType: 'mouse'});
       expect(onPress).not.toHaveBeenCalled();
     });
 
@@ -460,7 +464,12 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const target = createEventTarget(ref.current);
       target.setBoundingClientRect({x: 0, y: 0, width: 100, height: 100});
       target.keydown({key: 'Enter'});
-      target.pointermove({button: -1, pointerType: 'mouse', x: 10, y: 10});
+      target.pointermove({
+        buttons: buttonsType.none,
+        pointerType: 'mouse',
+        x: 10,
+        y: 10,
+      });
       expect(onPressMove).not.toBeCalled();
     });
   });

--- a/packages/react-events/src/dom/testing-library/domEnvironment.js
+++ b/packages/react-events/src/dom/testing-library/domEnvironment.js
@@ -8,6 +8,7 @@
  */
 
 'use strict';
+
 /**
  * Change environment support for PointerEvent.
  */
@@ -48,4 +49,27 @@ export const platform = {
       }
     }
   },
+};
+
+/**
+ * Buttons bitmask
+ */
+
+export const buttonsType = {
+  none: 0,
+  // left-mouse
+  // touch contact
+  // pen contact
+  primary: 1,
+  // right-mouse
+  // pen barrel button
+  secondary: 2,
+  // middle mouse
+  middle: 4,
+  // back mouse
+  back: 8,
+  // forward mouse
+  forward: 16,
+  // pen eraser
+  eraser: 32,
 };

--- a/packages/react-events/src/dom/testing-library/domEventSequences.js
+++ b/packages/react-events/src/dom/testing-library/domEventSequences.js
@@ -10,7 +10,7 @@
 'use strict';
 
 import * as domEvents from './domEvents';
-import {hasPointerEvent, platform} from './domEnvironment';
+import {buttonsType, hasPointerEvent, platform} from './domEnvironment';
 
 function emptyFunction() {}
 
@@ -29,30 +29,33 @@ export function contextmenu(
 ) {
   const dispatch = arg => target.dispatchEvent(arg);
   if (pointerType === 'touch') {
-    const button = 0;
     if (hasPointerEvent()) {
-      dispatch(domEvents.pointerdown({button, pointerType}));
+      dispatch(
+        domEvents.pointerdown({buttons: buttonsType.primary, pointerType}),
+      );
     }
     dispatch(domEvents.touchstart());
-    dispatch(domEvents.contextmenu({button, preventDefault}));
+    dispatch(
+      domEvents.contextmenu({buttons: buttonsType.none, preventDefault}),
+    );
   } else if (pointerType === 'mouse') {
     if (modified === true) {
-      const button = 0;
+      const buttons = buttonsType.primary;
       const ctrlKey = true;
       if (hasPointerEvent()) {
-        dispatch(domEvents.pointerdown({button, ctrlKey, pointerType}));
+        dispatch(domEvents.pointerdown({buttons, ctrlKey, pointerType}));
       }
-      dispatch(domEvents.mousedown({button, ctrlKey}));
+      dispatch(domEvents.mousedown({buttons, ctrlKey}));
       if (platform.get() === 'mac') {
-        dispatch(domEvents.contextmenu({button, ctrlKey, preventDefault}));
+        dispatch(domEvents.contextmenu({buttons, ctrlKey, preventDefault}));
       }
     } else {
-      const button = 2;
+      const buttons = buttonsType.secondary;
       if (hasPointerEvent()) {
-        dispatch(domEvents.pointerdown({button, pointerType}));
+        dispatch(domEvents.pointerdown({buttons, pointerType}));
       }
-      dispatch(domEvents.mousedown({button}));
-      dispatch(domEvents.contextmenu({button, preventDefault}));
+      dispatch(domEvents.mousedown({buttons}));
+      dispatch(domEvents.contextmenu({buttons, preventDefault}));
     }
   }
 }
@@ -74,7 +77,7 @@ export function pointercancel(target, payload) {
 export function pointerdown(target, defaultPayload) {
   const dispatch = arg => target.dispatchEvent(arg);
   const pointerType = getPointerType(defaultPayload);
-  const payload = {button: 0, buttons: 2, ...defaultPayload};
+  const payload = {buttons: buttonsType.primary, ...defaultPayload};
 
   if (pointerType === 'mouse') {
     if (hasPointerEvent()) {
@@ -147,7 +150,7 @@ export function pointermove(target, payload) {
 export function pointerup(target, defaultPayload) {
   const dispatch = arg => target.dispatchEvent(arg);
   const pointerType = getPointerType(defaultPayload);
-  const payload = {button: 0, buttons: 2, ...defaultPayload};
+  const payload = {buttons: buttonsType.none, ...defaultPayload};
 
   if (pointerType === 'mouse') {
     if (hasPointerEvent()) {

--- a/packages/react-events/src/dom/testing-library/domEvents.js
+++ b/packages/react-events/src/dom/testing-library/domEvents.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+import {buttonsType} from './domEnvironment';
+
 /**
  * Native event object mocks for higher-level events.
  *
@@ -23,6 +25,9 @@
  *
  * 3. PointerEvent and TouchEvent fields are normalized (e.g., 'rotationAngle' -> 'twist')
  */
+
+const defaultPointerSize = 23;
+const defaultBrowserChromeSize = 50;
 
 function emptyFunction() {}
 
@@ -57,8 +62,7 @@ function createPointerEvent(
   type,
   {
     altKey = false,
-    button = -1,
-    buttons = 0,
+    buttons = buttonsType.none,
     ctrlKey = false,
     height,
     metaKey = false,
@@ -86,7 +90,6 @@ function createPointerEvent(
 
   return createEvent(type, {
     altKey,
-    button,
     buttons,
     clientX: x,
     clientY: y,
@@ -94,7 +97,12 @@ function createPointerEvent(
     getModifierState(keyArg) {
       createGetModifierState(keyArg, modifierState);
     },
-    height: pointerType === 'mouse' ? 1 : height != null ? height : 11.5,
+    height:
+      pointerType === 'mouse'
+        ? 1
+        : height != null
+          ? height
+          : defaultPointerSize,
     metaKey,
     movementX,
     movementY,
@@ -107,13 +115,14 @@ function createPointerEvent(
     pressure,
     preventDefault,
     screenX: x,
-    screenY: y + 50, // arbitrary value to emulate browser chrome, etc
+    screenY: y + defaultBrowserChromeSize,
     shiftKey,
     tangentialPressure,
     tiltX,
     tiltY,
     twist,
-    width: pointerType === 'mouse' ? 1 : width != null ? width : 11.5,
+    width:
+      pointerType === 'mouse' ? 1 : width != null ? width : defaultPointerSize,
   });
 }
 
@@ -147,8 +156,7 @@ function createMouseEvent(
   type,
   {
     altKey = false,
-    button = -1,
-    buttons = 0,
+    buttons = buttonsType.none,
     ctrlKey = false,
     metaKey = false,
     movementX = 0,
@@ -167,7 +175,6 @@ function createMouseEvent(
 
   return createEvent(type, {
     altKey,
-    button,
     buttons,
     clientX: x,
     clientY: y,
@@ -184,7 +191,7 @@ function createMouseEvent(
     pageY: pageY || y,
     preventDefault,
     screenX: x,
-    screenY: y + 50, // arbitrary value to emulate browser chrome, etc
+    screenY: y + defaultBrowserChromeSize,
     shiftKey,
   });
 }
@@ -194,7 +201,7 @@ function createTouchEvent(
   {
     altKey = false,
     ctrlKey = false,
-    height = 11.5,
+    height = defaultPointerSize,
     metaKey = false,
     pageX,
     pageY,
@@ -202,7 +209,7 @@ function createTouchEvent(
     preventDefault = emptyFunction,
     shiftKey = false,
     twist = 0,
-    width = 11.5,
+    width = defaultPointerSize,
     x = 0,
     y = 0,
   } = {},
@@ -214,12 +221,14 @@ function createTouchEvent(
     identifier: pointerId,
     pageX: pageX || x,
     pageY: pageY || y,
-    radiusX: width,
-    radiusY: height,
+    radiusX: width / 2,
+    radiusY: height / 2,
     rotationAngle: twist,
     screenX: x,
-    screenY: y + 50, // arbitrary value to emulate browser chrome, etc
+    screenY: y + defaultBrowserChromeSize,
   };
+
+  const activeTouch = type !== 'touchend' ? [touch] : null;
 
   return createEvent(type, {
     altKey,
@@ -228,8 +237,8 @@ function createTouchEvent(
     metaKey,
     preventDefault,
     shiftKey,
-    targetTouches: type !== 'touchend' ? [touch] : null,
-    touches: [touch],
+    targetTouches: activeTouch,
+    touches: activeTouch,
   });
 }
 
@@ -290,7 +299,12 @@ export function pointercancel(payload) {
 }
 
 export function pointerdown(payload) {
-  return createPointerEvent('pointerdown', {button: 0, buttons: 2, ...payload});
+  const isTouch = payload != null && payload.pointerType === 'mouse';
+  return createPointerEvent('pointerdown', {
+    buttons: buttonsType.primary,
+    pressure: isTouch ? 1 : 0.5,
+    ...payload,
+  });
 }
 
 export function pointerenter(payload) {
@@ -314,7 +328,10 @@ export function pointerover(payload) {
 }
 
 export function pointerup(payload) {
-  return createPointerEvent('pointerup', {button: 0, buttons: 2, ...payload});
+  return createPointerEvent('pointerup', {
+    buttons: buttonsType.none,
+    ...payload,
+  });
 }
 
 /**
@@ -322,7 +339,10 @@ export function pointerup(payload) {
  */
 
 export function mousedown(payload) {
-  return createMouseEvent('mousedown', {button: 0, buttons: 2, ...payload});
+  return createMouseEvent('mousedown', {
+    buttons: buttonsType.primary,
+    ...payload,
+  });
 }
 
 export function mouseenter(payload) {
@@ -346,7 +366,10 @@ export function mouseover(payload) {
 }
 
 export function mouseup(payload) {
-  return createMouseEvent('mouseup', {button: 0, buttons: 2, ...payload});
+  return createMouseEvent('mouseup', {
+    buttons: buttonsType.none,
+    ...payload,
+  });
 }
 
 /**

--- a/packages/react-events/src/dom/testing-library/index.js
+++ b/packages/react-events/src/dom/testing-library/index.js
@@ -11,7 +11,12 @@
 
 import * as domEvents from './domEvents';
 import * as domEventSequences from './domEventSequences';
-import {hasPointerEvent, setPointerEvent, platform} from './domEnvironment';
+import {
+  buttonsType,
+  hasPointerEvent,
+  setPointerEvent,
+  platform,
+} from './domEnvironment';
 
 const createEventTarget = node => ({
   node,
@@ -101,4 +106,10 @@ const createEventTarget = node => ({
   },
 });
 
-export {createEventTarget, platform, hasPointerEvent, setPointerEvent};
+export {
+  buttonsType,
+  createEventTarget,
+  platform,
+  hasPointerEvent,
+  setPointerEvent,
+};


### PR DESCRIPTION
The semantics of 'button' on events differs between PointerEvent and
MouseEvent, whereas they are the same for 'buttons'. Furthermore, 'buttons'
allows developers to determine when multiple buttons are pressed as the same
time.

https://w3c.github.io/pointerevents/#the-button-property