### PR TITLE
[react-events] Rename hook exports

### DIFF
--- a/packages/react-events/docs/ContextMenu.md
+++ b/packages/react-events/docs/ContextMenu.md
@@ -1,0 +1,54 @@
+# ContextMenu
+
+The `useContextMenu` hooks responds to context-menu events.
+
+```js
+// Example
+const Button = (props) => {
+  const contextmenu = useContextMenu({
+    disabled,
+    onContextMenu,
+    preventDefault
+  });
+
+  return (
+    <div listeners={contextmenu}>
+      {props.children}
+    </div>
+  );
+};
+```
+
+## Types
+
+```js
+type ContextMenuEvent = {
+  altKey: boolean,
+  buttons: 0 | 1 | 2,
+  ctrlKey: boolean,
+  metaKey: boolean,
+  pageX: number,
+  pageY: number,
+  pointerType: PointerType,
+  shiftKey: boolean,
+  target: Element,
+  timeStamp: number,
+  type: 'contextmenu',
+  x: number,
+  y: number,
+}
+```
+
+## Props
+
+### disabled: boolean = false
+
+Disables the responder.
+
+### onContextMenu: (e: ContextMenuEvent) => void
+
+Called when the user performs a gesture to display a context menu.
+
+### preventDefault: boolean = true
+
+Prevents the native behavior (i.e., context menu).

--- a/packages/react-events/docs/Focus.md
+++ b/packages/react-events/docs/Focus.md
@@ -1,29 +1,29 @@
 # Focus
 
-The `Focus` module responds to focus and blur events on its child. Focus events
+The `useFocus` hook responds to focus and blur events on its child. Focus events
 are dispatched for all input types, with the exception of `onFocusVisibleChange`
 which is only dispatched when focusing with a keyboard.
 
-Focus events do not propagate between `Focus` event responders.
+Focus events do not propagate between `useFocus` event responders.
 
 ```js
 // Example
 const Button = (props) => {
-  const [ focusVisible, setFocusVisible ] = useState(false);
+  const [ isFocusVisible, setFocusVisible ] = useState(false);
+  const focus = useFocus({
+    onBlur={props.onBlur}
+    onFocus={props.onFocus}
+    onFocusVisibleChange={setFocusVisible}
+  });
 
   return (
-    <Focus
-      onBlur={props.onBlur}
-      onFocus={props.onFocus}
-      onFocusVisibleChange={setFocusVisible}
+    <button
+      children={props.children}
+      listeners={focus}
+      style={{
+        ...(isFocusVisible && focusVisibleStyles)
+      }}
     >
-      <button
-        children={props.children}
-        style={{
-          ...(focusVisible && focusVisibleStyles)
-        }}
-      >
-    </Focus>
   );
 };
 ```
@@ -33,6 +33,8 @@ const Button = (props) => {
 ```js
 type FocusEvent = {
   target: Element,
+  pointerType: 'mouse' | 'touch' | 'pen' | 'keyboard',
+  timeStamp: number,
   type: 'blur' | 'focus' | 'focuschange' | 'focusvisiblechange'
 }
 ```
@@ -41,7 +43,7 @@ type FocusEvent = {
 
 ### disabled: boolean = false
 
-Disables all `Focus` events.
+Disables the responder.
 
 ### onBlur: (e: FocusEvent) => void
 

--- a/packages/react-events/docs/FocusWithin.md
+++ b/packages/react-events/docs/FocusWithin.md
@@ -1,48 +1,39 @@
 # FocusWithin
 
-The `FocusWithin` module responds to focus and blur events on its child. Focus events
+The `useFocusWithin` hooks responds to focus and blur events on its child. Focus events
 are dispatched for all input types, with the exception of `onFocusVisibleChange`
 which is only dispatched when focusing with a keyboard.
 
-Focus events do not propagate between `FocusWithin` event responders.
+Focus events do not propagate between `useFocusWithin` event responders.
 
 ```js
 // Example
 const Button = (props) => {
-  const [ focusWithin, updateFocusWithin ] = useState(false);
-  const [ focusWithinVisible, updateFocusWithinVisible ] = useState(false);
+  const [ isFocusWithin, updateFocusWithin ] = useState(false);
+  const [ isFocusWithinVisible, updateFocusWithinVisible ] = useState(false);
+  const focusWithin = useFocusWithin({
+    onFocusWithinChange={updateFocusWithin}
+    onFocusWithinVisibleChange={updateFocusWithinVisible}
+  });
 
   return (
-    <FocusWithin
-      onFocusWithinChange={updateFocusWithin}
-      onFocusWithinVisibleChange={updateFocusWithinVisible}
+    <button
+      children={props.children}
+      listeners={focusWithin}
+      style={{
+        ...(isFocusWithin && focusWithinStyles),
+        ...(isFocusWithinVisible && focusWithinVisibleStyles)
+      }}
     >
-      <button
-        children={props.children}
-        style={{
-          ...(focusWithin && focusWithinStyles),
-          ...(focusWithinVisible && focusWithinVisibleStyles)
-        }}
-      >
-    </FocusWithin>
   );
 };
-```
-
-## Types
-
-```js
-type FocusEvent = {
-  target: Element,
-  type: 'focuswithinchange' | 'focuswithinvisiblechange'
-}
 ```
 
 ## Props
 
 ### disabled: boolean = false
 
-Disables all `FocusWithin` events.
+Disables the responder.
 
 ### onFocusWithinChange: boolean => void
 

--- a/packages/react-events/docs/Hover.md
+++ b/packages/react-events/docs/Hover.md
@@ -1,26 +1,29 @@
 # Hover
 
-The `Hover` module responds to hover events on the element it wraps. Hover
+The `useHover` hook responds to hover events on the element it wraps. Hover
 events are only dispatched for `mouse` and `pen` pointer types. Hover begins
 when the pointer enters the element's bounds and ends when the pointer leaves.
 
-Hover events do not propagate between `Hover` event responders.
+Hover events do not propagate between `useHover` event responders.
 
 ```js
 // Example
 const Link = (props) => (
-  const [ hovered, setHovered ] = useState(false);
+  const [ isHovered, setHovered ] = useState(false);
+  const hover = useHover({
+    onHoverChange: setHovered
+  });
+
   return (
-    <Hover onHoverChange={setHovered}>
-      <a
-        {...props}
-        href={props.href}
-        style={{
-          ...props.style,
-          textDecoration: hovered ? 'underline': 'none'
-        }}
-      />
-    </Hover>
+    <a
+      {...props}
+      href={props.href}
+      listeners={hover}
+      style={{
+        ...props.style,
+        textDecoration: isHovered ? 'underline': 'none'
+      }}
+    />
   );
 );
 ```
@@ -28,18 +31,27 @@ const Link = (props) => (
 ## Types
 
 ```js
-type HoverEvent = {
-  pointerType: 'mouse' | 'pen',
+type HoverEventType = 'hoverstart' | 'hoverend' | 'hoverchange' | 'hovermove';
+
+type HoverEvent = {|
+  clientX: number,
+  clientY: number,
+  pageX: number,
+  pageY: number,
+  pointerType: PointerType,
   target: Element,
-  type: 'hoverstart' | 'hoverend' | 'hovermove' | 'hoverchange'
-}
+  timeStamp: number,
+  type: HoverEventType,
+  x: number,
+  y: number,
+|};
 ```
 
 ## Props
 
 ### disabled: boolean
 
-Disables all `Hover` events.
+Disables the responder.
 
 ### onHoverChange: boolean => void
 

--- a/packages/react-events/docs/Press.md
+++ b/packages/react-events/docs/Press.md
@@ -1,33 +1,34 @@
 # Press
 
-The `Press` module responds to press events on the element it wraps. Press
+The `usePress` hook responds to press events on the element it wraps. Press
 events are dispatched for `mouse`, `pen`, `touch`, `trackpad`, and `keyboard`
 pointer types. Press events are only dispatched for keyboards when pressing the
 Enter or Spacebar keys. If `onPress` is not called, this signifies that the
 press ended outside of the element hit bounds (i.e., the user aborted the
 press).
 
-Press events do not propagate between `Press` event responders.
+Press events do not propagate between `usePress` event responders.
 
 ```js
 // Example
 const Button = (props) => (
-  const [ pressed, setPressed ] = useState(false);
+  const [ isPressed, setPressed ] = useState(false);
+  const press = usePress({
+    onPress={props.onPress}
+    onPressChange={setPressed}
+  });
+
   return (
-    <Press
-      onPress={props.onPress}
-      onPressChange={setPressed}
-    >
-      <div
-        {...props}
-        role="button"
-        tabIndex={0}
-        style={
-          ...buttonStyles,
-          ...(pressed && pressedStyles)
-        }}
-      />
-    </Press>
+    <div
+      {...props}
+      listeners={press}
+      role="button"
+      tabIndex={0}
+      style={
+        ...buttonStyles,
+        ...(isPressed && pressedStyles)
+      }}
+    />
   );
 );
 ```
@@ -37,6 +38,7 @@ const Button = (props) => (
 ```js
 type PressEvent = {
   altKey: boolean,
+  buttons: 0 | 1 | 4,
   ctrlKey: boolean,
   defaultPrevented: boolean,
   metaKey: boolean,
@@ -76,7 +78,7 @@ type PressOffset = {
 
 ### disabled: boolean = false
 
-Disables all `Press` events.
+Disables the responder.
 
 ### onPress: (e: PressEvent) => void
 

--- a/packages/react-events/src/dom/ContextMenu.js
+++ b/packages/react-events/src/dom/ContextMenu.js
@@ -120,7 +120,7 @@ export const ContextMenuResponder = React.unstable_createResponder(
   contextMenuImpl,
 );
 
-export function useContextMenuResponder(
+export function useContextMenu(
   props: ContextMenuProps,
 ): ReactEventResponderListener<any, any> {
   return React.unstable_useResponder(ContextMenuResponder, props);

--- a/packages/react-events/src/dom/Drag.js
+++ b/packages/react-events/src/dom/Drag.js
@@ -244,7 +244,7 @@ export const DragResponder = React.unstable_createResponder(
   dragResponderImpl,
 );
 
-export function useDragResponder(
+export function useDrag(
   props: DragProps,
 ): ReactEventResponderListener<any, any> {
   return React.unstable_useResponder(DragResponder, props);

--- a/packages/react-events/src/dom/Focus.js
+++ b/packages/react-events/src/dom/Focus.js
@@ -348,7 +348,7 @@ export const FocusResponder = React.unstable_createResponder(
   focusResponderImpl,
 );
 
-export function useFocusResponder(
+export function useFocus(
   props: FocusProps,
 ): ReactEventResponderListener<any, any> {
   return React.unstable_useResponder(FocusResponder, props);
@@ -485,7 +485,7 @@ export const FocusWithinResponder = React.unstable_createResponder(
   focusWithinResponderImpl,
 );
 
-export function useFocusWithinResponder(
+export function useFocusWithin(
   props: FocusWithinProps,
 ): ReactEventResponderListener<any, any> {
   return React.unstable_useResponder(FocusWithinResponder, props);

--- a/packages/react-events/src/dom/Hover.js
+++ b/packages/react-events/src/dom/Hover.js
@@ -341,7 +341,7 @@ export const HoverResponder = React.unstable_createResponder(
   hasPointerEvents ? hoverResponderImpl : hoverResponderFallbackImpl,
 );
 
-export function useHoverResponder(
+export function useHover(
   props: HoverProps,
 ): ReactEventResponderListener<any, any> {
   return React.unstable_useResponder(HoverResponder, props);

--- a/packages/react-events/src/dom/Input.js
+++ b/packages/react-events/src/dom/Input.js
@@ -215,7 +215,7 @@ export const InputResponder = React.unstable_createResponder(
   inputResponderImpl,
 );
 
-export function useInputResponder(
+export function useInput(
   props: InputResponderProps,
 ): ReactEventResponderListener<any, any> {
   return React.unstable_useResponder(InputResponder, props);

--- a/packages/react-events/src/dom/Keyboard.js
+++ b/packages/react-events/src/dom/Keyboard.js
@@ -209,7 +209,7 @@ export const KeyboardResponder = React.unstable_createResponder(
   keyboardResponderImpl,
 );
 
-export function useKeyboardResponder(
+export function useKeyboard(
   props: KeyboardProps,
 ): ReactEventResponderListener<any, any> {
   return React.unstable_useResponder(KeyboardResponder, props);

--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -854,7 +854,7 @@ export const PressResponder = React.unstable_createResponder(
   pressResponderImpl,
 );
 
-export function usePressResponder(
+export function usePress(
   props: PressProps,
 ): ReactEventResponderListener<any, any> {
   return React.unstable_useResponder(PressResponder, props);

--- a/packages/react-events/src/dom/Scroll.js
+++ b/packages/react-events/src/dom/Scroll.js
@@ -310,7 +310,7 @@ export const ScrollResponder = React.unstable_createResponder(
   scrollResponderImpl,
 );
 
-export function useScrollResponder(
+export function useScroll(
   props: ScrollProps,
 ): ReactEventResponderListener<any, any> {
   return React.unstable_useResponder(ScrollResponder, props);

--- a/packages/react-events/src/dom/Swipe.js
+++ b/packages/react-events/src/dom/Swipe.js
@@ -281,8 +281,8 @@ export const SwipeResponder = React.unstable_createResponder(
   swipeResponderImpl,
 );
 
-export function useSwipeListener(
+export function useSwipe(
   props: SwipeProps,
 ): ReactEventResponderListener<any, any> {
-  return React.unstable_useListener(SwipeResponder, props);
+  return React.unstable_useResponder(SwipeResponder, props);
 }

--- a/packages/react-events/src/dom/__tests__/ContextMenu-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/ContextMenu-test.internal.js
@@ -19,7 +19,7 @@ import {
 let React;
 let ReactFeatureFlags;
 let ReactDOM;
-let useContextMenuResponder;
+let useContextMenu;
 
 function initializeModules(hasPointerEvents) {
   setPointerEvent(hasPointerEvents);
@@ -28,8 +28,7 @@ function initializeModules(hasPointerEvents) {
   ReactFeatureFlags.enableFlareAPI = true;
   React = require('react');
   ReactDOM = require('react-dom');
-  useContextMenuResponder = require('react-events/context-menu')
-    .useContextMenuResponder;
+  useContextMenu = require('react-events/context-menu').useContextMenu;
 }
 
 const forcePointerEvents = true;
@@ -56,7 +55,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       const preventDefault = jest.fn();
       const ref = React.createRef();
       const Component = () => {
-        const listener = useContextMenuResponder({onContextMenu});
+        const listener = useContextMenu({onContextMenu});
         return <div ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
@@ -79,7 +78,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       const preventDefault = jest.fn();
       const ref = React.createRef();
       const Component = () => {
-        const listener = useContextMenuResponder({onContextMenu});
+        const listener = useContextMenu({onContextMenu});
         return <div ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
@@ -101,7 +100,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       const onContextMenu = jest.fn();
       const ref = React.createRef();
       const Component = () => {
-        const listener = useContextMenuResponder({
+        const listener = useContextMenu({
           onContextMenu,
           disabled: true,
         });
@@ -119,7 +118,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       const onContextMenu = jest.fn();
       const ref = React.createRef();
       const Component = () => {
-        const listener = useContextMenuResponder({
+        const listener = useContextMenu({
           onContextMenu,
           preventDefault: false,
         });
@@ -148,7 +147,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       const onContextMenu = jest.fn();
       const ref = React.createRef();
       const Component = () => {
-        const listener = useContextMenuResponder({onContextMenu});
+        const listener = useContextMenu({onContextMenu});
         return <div ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
@@ -180,7 +179,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       const onContextMenu = jest.fn();
       const ref = React.createRef();
       const Component = () => {
-        const listener = useContextMenuResponder({onContextMenu});
+        const listener = useContextMenu({onContextMenu});
         return <div ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);

--- a/packages/react-events/src/dom/__tests__/Drag-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Drag-test.internal.js
@@ -12,7 +12,7 @@
 let React;
 let ReactFeatureFlags;
 let ReactDOM;
-let useDragResponder;
+let useDrag;
 
 describe('Drag event responder', () => {
   let container;
@@ -23,7 +23,7 @@ describe('Drag event responder', () => {
     ReactFeatureFlags.enableFlareAPI = true;
     React = require('react');
     ReactDOM = require('react-dom');
-    useDragResponder = require('react-events/drag').useDragResponder;
+    useDrag = require('react-events/drag').useDrag;
 
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -44,7 +44,7 @@ describe('Drag event responder', () => {
     }
 
     function Component() {
-      const listener = useDragResponder({
+      const listener = useDrag({
         onDragChange: handleOnDrag,
       });
       return (
@@ -100,7 +100,7 @@ describe('Drag event responder', () => {
     }
 
     function Component() {
-      const listener = useDragResponder({
+      const listener = useDrag({
         onDragStart: handleDragStart,
         onDragEnd: handleDragEnd,
       });
@@ -153,7 +153,7 @@ describe('Drag event responder', () => {
     }
 
     function Component() {
-      const listener = useDragResponder({
+      const listener = useDrag({
         onDragMove: handleDragMove,
       });
       return (

--- a/packages/react-events/src/dom/__tests__/Focus-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Focus-test.internal.js
@@ -15,7 +15,7 @@ let React;
 let ReactFeatureFlags;
 let ReactDOM;
 let FocusResponder;
-let useFocusResponder;
+let useFocus;
 
 function initializeModules(hasPointerEvents) {
   setPointerEvent(hasPointerEvents);
@@ -25,7 +25,7 @@ function initializeModules(hasPointerEvents) {
   React = require('react');
   ReactDOM = require('react-dom');
   FocusResponder = require('react-events/focus').FocusResponder;
-  useFocusResponder = require('react-events/focus').useFocusResponder;
+  useFocus = require('react-events/focus').useFocus;
 }
 
 const forcePointerEvents = true;
@@ -54,7 +54,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
       onFocus = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useFocusResponder({
+        const listener = useFocus({
           disabled: true,
           onBlur,
           onFocus,
@@ -80,7 +80,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
       onBlur = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useFocusResponder({
+        const listener = useFocus({
           onBlur,
         });
         return <div ref={ref} listeners={listener} />;
@@ -104,7 +104,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
       ref = React.createRef();
       innerRef = React.createRef();
       const Component = () => {
-        const listener = useFocusResponder({
+        const listener = useFocus({
           onFocus,
         });
         return (
@@ -203,7 +203,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
       ref = React.createRef();
       innerRef = React.createRef();
       const Component = () => {
-        const listener = useFocusResponder({
+        const listener = useFocus({
           onFocusChange,
         });
         return (
@@ -242,7 +242,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
       ref = React.createRef();
       innerRef = React.createRef();
       const Component = () => {
-        const listener = useFocusResponder({
+        const listener = useFocus({
           onFocusVisibleChange,
         });
         return (
@@ -315,7 +315,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
       };
 
       const Inner = () => {
-        const listener = useFocusResponder({
+        const listener = useFocus({
           onBlur: createEventHandler('inner: onBlur'),
           onFocus: createEventHandler('inner: onFocus'),
           onFocusChange: createEventHandler('inner: onFocusChange'),
@@ -324,7 +324,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
       };
 
       const Outer = () => {
-        const listener = useFocusResponder({
+        const listener = useFocus({
           onBlur: createEventHandler('outer: onBlur'),
           onFocus: createEventHandler('outer: onFocus'),
           onFocusChange: createEventHandler('outer: onFocusChange'),

--- a/packages/react-events/src/dom/__tests__/FocusWithin-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/FocusWithin-test.internal.js
@@ -15,7 +15,7 @@ let React;
 let ReactFeatureFlags;
 let ReactDOM;
 let FocusWithinResponder;
-let useFocusWithinResponder;
+let useFocusWithin;
 
 const initializeModules = hasPointerEvents => {
   setPointerEvent(hasPointerEvents);
@@ -25,8 +25,7 @@ const initializeModules = hasPointerEvents => {
   React = require('react');
   ReactDOM = require('react-dom');
   FocusWithinResponder = require('react-events/focus').FocusWithinResponder;
-  useFocusWithinResponder = require('react-events/focus')
-    .useFocusWithinResponder;
+  useFocusWithin = require('react-events/focus').useFocusWithin;
 };
 
 const forcePointerEvents = true;
@@ -55,7 +54,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       onFocusWithinVisibleChange = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useFocusWithinResponder({
+        const listener = useFocusWithin({
           disabled: true,
           onFocusWithinChange,
           onFocusWithinVisibleChange,
@@ -83,7 +82,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       innerRef = React.createRef();
       innerRef2 = React.createRef();
       const Component = () => {
-        const listener = useFocusWithinResponder({
+        const listener = useFocusWithin({
           onFocusWithinChange,
         });
         return (
@@ -151,7 +150,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       innerRef = React.createRef();
       innerRef2 = React.createRef();
       const Component = () => {
-        const listener = useFocusWithinResponder({
+        const listener = useFocusWithin({
           onFocusWithinVisibleChange,
         });
         return (

--- a/packages/react-events/src/dom/__tests__/Hover-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Hover-test.internal.js
@@ -15,7 +15,7 @@ let React;
 let ReactFeatureFlags;
 let ReactDOM;
 let HoverResponder;
-let useHoverResponder;
+let useHover;
 
 function initializeModules(hasPointerEvents) {
   jest.resetModules();
@@ -26,7 +26,7 @@ function initializeModules(hasPointerEvents) {
   React = require('react');
   ReactDOM = require('react-dom');
   HoverResponder = require('react-events/hover').HoverResponder;
-  useHoverResponder = require('react-events/hover').useHoverResponder;
+  useHover = require('react-events/hover').useHover;
 }
 
 const forcePointerEvents = true;
@@ -57,7 +57,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
       onHoverEnd = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useHoverResponder({
+        const listener = useHover({
           disabled: true,
           onHoverChange,
           onHoverStart,
@@ -87,7 +87,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
       onHoverStart = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useHoverResponder({
+        const listener = useHover({
           onHoverStart: onHoverStart,
         });
         return <div ref={ref} listeners={listener} />;
@@ -124,7 +124,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
       onHoverChange = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useHoverResponder({
+        const listener = useHover({
           onHoverChange,
         });
         return <div ref={ref} listeners={listener} />;
@@ -157,7 +157,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
       onHoverEnd = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useHoverResponder({
+        const listener = useHover({
           onHoverEnd,
         });
         return <div ref={ref} listeners={listener} />;
@@ -201,7 +201,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
       const onHoverMove = jest.fn();
       const ref = React.createRef();
       const Component = () => {
-        const listener = useHoverResponder({
+        const listener = useHover({
           onHoverMove,
         });
         return <div ref={ref} listeners={listener} />;
@@ -229,7 +229,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
       };
 
       const Inner = () => {
-        const listener = useHoverResponder({
+        const listener = useHover({
           onHoverStart: createEventHandler('inner: onHoverStart'),
           onHoverEnd: createEventHandler('inner: onHoverEnd'),
           onHoverChange: createEventHandler('inner: onHoverChange'),
@@ -238,7 +238,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
       };
 
       const Outer = () => {
-        const listener = useHoverResponder({
+        const listener = useHover({
           onHoverStart: createEventHandler('outer: onHoverStart'),
           onHoverEnd: createEventHandler('outer: onHoverEnd'),
           onHoverChange: createEventHandler('outer: onHoverChange'),
@@ -305,7 +305,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
       eventLog.push(propertiesWeCareAbout);
     };
     const Component = () => {
-      const listener = useHoverResponder({
+      const listener = useHover({
         onHoverStart: logEvent,
         onHoverEnd: logEvent,
         onHoverMove: logEvent,

--- a/packages/react-events/src/dom/__tests__/Input-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Input-test.internal.js
@@ -13,8 +13,8 @@ let React;
 let ReactFeatureFlags;
 let ReactDOM;
 let InputResponder;
-let useInputResponder;
-let usePressResponder;
+let useInput;
+let usePress;
 let Scheduler;
 
 const setUntrackedChecked = Object.getOwnPropertyDescriptor(
@@ -41,8 +41,8 @@ const modulesInit = () => {
   ReactDOM = require('react-dom');
   Scheduler = require('scheduler');
   InputResponder = require('react-events/input').InputResponder;
-  useInputResponder = require('react-events/input').useInputResponder;
-  usePressResponder = require('react-events/press').usePressResponder;
+  useInput = require('react-events/input').useInput;
+  usePress = require('react-events/press').usePress;
 };
 
 describe('Input event responder', () => {
@@ -70,7 +70,7 @@ describe('Input event responder', () => {
       ref = React.createRef();
 
       function Component() {
-        const listener = useInputResponder({
+        const listener = useInput({
           disabled: true,
           onChange,
           onValueChange,
@@ -117,7 +117,7 @@ describe('Input event responder', () => {
       }
 
       function Component() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange,
           onValueChange,
         });
@@ -157,7 +157,7 @@ describe('Input event responder', () => {
       }
 
       function Component() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange,
           onValueChange,
         });
@@ -200,7 +200,7 @@ describe('Input event responder', () => {
       }
 
       function Component() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange,
           onValueChange,
         });
@@ -242,7 +242,7 @@ describe('Input event responder', () => {
       }
 
       function Component() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange,
           onValueChange,
         });
@@ -283,7 +283,7 @@ describe('Input event responder', () => {
       }
 
       function Component() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange,
           onValueChange,
         });
@@ -345,7 +345,7 @@ describe('Input event responder', () => {
       }
 
       function Component() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange,
           onValueChange,
         });
@@ -385,7 +385,7 @@ describe('Input event responder', () => {
       }
 
       function Component() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange,
           onValueChange,
         });
@@ -438,7 +438,7 @@ describe('Input event responder', () => {
       }
 
       function Component() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange,
           onValueChange,
         });
@@ -483,7 +483,7 @@ describe('Input event responder', () => {
       }
 
       function Radio1() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange: onChange1,
           onValueChange: onValueChange1,
         });
@@ -491,7 +491,7 @@ describe('Input event responder', () => {
       }
 
       function Radio2() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange: onChange2,
           onValueChange: onValueChange2,
         });
@@ -558,7 +558,7 @@ describe('Input event responder', () => {
         onChangeCalled = 0;
         onValueChangeCalled = 0;
         function Component() {
-          const listener = useInputResponder({
+          const listener = useInput({
             onChange,
             onValueChange,
           });
@@ -586,7 +586,7 @@ describe('Input event responder', () => {
         onChangeCalled = 0;
         onValueChangeCalled = 0;
         function Component2() {
-          const listener = useInputResponder({
+          const listener = useInput({
             onChange,
             onValueChange,
           });
@@ -612,7 +612,7 @@ describe('Input event responder', () => {
         onChangeCalled = 0;
         onValueChangeCalled = 0;
         function Component3() {
-          const listener = useInputResponder({
+          const listener = useInput({
             onChange,
             onValueChange,
           });
@@ -652,7 +652,7 @@ describe('Input event responder', () => {
       }
 
       function Component() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange,
           onValueChange,
         });
@@ -689,7 +689,7 @@ describe('Input event responder', () => {
       }
 
       function Component() {
-        const listener = useInputResponder({
+        const listener = useInput({
           onChange,
           onValueChange,
         });
@@ -761,7 +761,7 @@ describe('Input event responder', () => {
         let ops = [];
 
         function Component({innerRef, onChange, controlledValue}) {
-          const listener = useInputResponder({
+          const listener = useInput({
             onChange,
           });
           return (
@@ -821,7 +821,7 @@ describe('Input event responder', () => {
         let ops = [];
 
         function Component({innerRef, onChange, controlledValue}) {
-          const listener = useInputResponder({
+          const listener = useInput({
             onChange,
           });
           return (
@@ -896,7 +896,7 @@ describe('Input event responder', () => {
         let ops = [];
 
         function Component({innerRef, onChange, controlledValue}) {
-          const listener = useInputResponder({
+          const listener = useInput({
             onChange,
           });
           return (
@@ -961,7 +961,7 @@ describe('Input event responder', () => {
           controlledValue,
           pressListener,
         }) {
-          const inputListener = useInputResponder({
+          const inputListener = useInput({
             onChange,
           });
           return (
@@ -975,7 +975,7 @@ describe('Input event responder', () => {
         }
 
         function PressWrapper({innerRef, onPress, onChange, controlledValue}) {
-          const pressListener = usePressResponder({
+          const pressListener = usePress({
             onPress,
           });
           return (

--- a/packages/react-events/src/dom/__tests__/Keyboard-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Keyboard-test.internal.js
@@ -12,7 +12,7 @@
 let React;
 let ReactFeatureFlags;
 let ReactDOM;
-let useKeyboardResponder;
+let useKeyboard;
 
 import {createEventTarget} from '../testing-library';
 
@@ -22,7 +22,7 @@ function initializeModules(hasPointerEvents) {
   ReactFeatureFlags.enableFlareAPI = true;
   React = require('react');
   ReactDOM = require('react-dom');
-  useKeyboardResponder = require('react-events/keyboard').useKeyboardResponder;
+  useKeyboard = require('react-events/keyboard').useKeyboard;
 }
 
 describe('Keyboard event responder', () => {
@@ -48,7 +48,7 @@ describe('Keyboard event responder', () => {
       onKeyUp = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useKeyboardResponder({
+        const listener = useKeyboard({
           disabled: true,
           onKeyDown,
           onKeyUp,
@@ -74,7 +74,7 @@ describe('Keyboard event responder', () => {
       onKeyDown = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useKeyboardResponder({
+        const listener = useKeyboard({
           onKeyDown,
         });
         return <div ref={ref} listeners={listener} />;
@@ -100,7 +100,7 @@ describe('Keyboard event responder', () => {
       onKeyUp = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useKeyboardResponder({
+        const listener = useKeyboard({
           onKeyDown,
           onKeyUp,
         });

--- a/packages/react-events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Press-test.internal.js
@@ -19,7 +19,7 @@ let React;
 let ReactFeatureFlags;
 let ReactDOM;
 let PressResponder;
-let usePressResponder;
+let usePress;
 
 function initializeModules(hasPointerEvents) {
   jest.resetModules();
@@ -29,7 +29,7 @@ function initializeModules(hasPointerEvents) {
   React = require('react');
   ReactDOM = require('react-dom');
   PressResponder = require('react-events/press').PressResponder;
-  usePressResponder = require('react-events/press').usePressResponder;
+  usePress = require('react-events/press').usePress;
 }
 
 function removePressMoveStrings(eventString) {
@@ -68,7 +68,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       onPressEnd = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = usePressResponder({
+        const listener = usePress({
           disabled: true,
           onPressStart,
           onPress,
@@ -97,7 +97,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       onPressStart = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = usePressResponder({
+        const listener = usePress({
           onPressStart,
         });
         return <div ref={ref} listeners={listener} />;
@@ -191,7 +191,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       onPressEnd = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = usePressResponder({
+        const listener = usePress({
           onPressEnd,
         });
         return <div ref={ref} listeners={listener} />;
@@ -286,7 +286,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       onPressChange = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = usePressResponder({
+        const listener = usePress({
           onPressChange,
         });
         return <div ref={ref} listeners={listener} />;
@@ -326,7 +326,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       onPress = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = usePressResponder({
+        const listener = usePress({
           onPress,
         });
         return <div ref={ref} listeners={listener} />;
@@ -374,7 +374,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
     it('is not called after invalid "keyup" event', () => {
       const inputRef = React.createRef();
       const Component = () => {
-        const listener = usePressResponder({onPress});
+        const listener = usePress({onPress});
         return <input ref={inputRef} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
@@ -404,7 +404,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const divRef = React.createRef();
 
       const Component = () => {
-        const listener = usePressResponder({onPress});
+        const listener = usePress({onPress});
         return (
           <div ref={divRef} listeners={listener}>
             <button ref={buttonRef} />
@@ -429,7 +429,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       onPressMove = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = usePressResponder({
+        const listener = usePress({
           onPressMove,
         });
         return <div ref={ref} listeners={listener} />;
@@ -485,7 +485,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         events.push(msg);
       };
       const Component = () => {
-        const listener = usePressResponder({
+        const listener = usePress({
           onPress: createEventHandler('onPress'),
           onPressChange: createEventHandler('onPressChange'),
           onPressMove: createEventHandler('onPressMove'),
@@ -575,7 +575,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         const pressRetentionOffset = {top: 40, bottom: 40, left: 40, right: 40};
 
         const Component = () => {
-          const listener = usePressResponder({
+          const listener = usePress({
             onPress: createEventHandler('onPress'),
             onPressChange: createEventHandler('onPressChange'),
             onPressMove: createEventHandler('onPressMove'),
@@ -719,7 +719,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         };
 
         const Inner = () => {
-          const listener = usePressResponder({
+          const listener = usePress({
             onPress: createEventHandler('inner: onPress'),
             onPressChange: createEventHandler('inner: onPressChange'),
             onPressMove: createEventHandler('inner: onPressMove'),
@@ -740,7 +740,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         };
 
         const Outer = () => {
-          const listener = usePressResponder({
+          const listener = usePress({
             onPress: createEventHandler('outer: onPress'),
             onPressChange: createEventHandler('outer: onPressChange'),
             onPressMove: createEventHandler('outer: onPressMove'),
@@ -777,12 +777,12 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         const onPress = jest.fn();
 
         const Inner = () => {
-          const listener = usePressResponder({onPress});
+          const listener = usePress({onPress});
           return <div ref={ref} listeners={listener} />;
         };
 
         const Outer = () => {
-          const listener = usePressResponder({onPress});
+          const listener = usePress({onPress});
           return (
             <div listeners={listener}>
               <Inner />
@@ -804,12 +804,12 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         const onPressEnd = jest.fn();
 
         const Inner = () => {
-          const listener = usePressResponder({onPressStart, onPressEnd});
+          const listener = usePress({onPressStart, onPressEnd});
           return <div ref={ref} listeners={listener} />;
         };
 
         const Outer = () => {
-          const listener = usePressResponder({onPressStart, onPressEnd});
+          const listener = usePress({onPressStart, onPressEnd});
           return (
             <div listeners={listener}>
               <Inner />
@@ -832,12 +832,12 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         const onPressChange = jest.fn();
 
         const Inner = () => {
-          const listener = usePressResponder({onPressChange});
+          const listener = usePress({onPressChange});
           return <div ref={ref} listeners={listener} />;
         };
 
         const Outer = () => {
-          const listener = usePressResponder({onPressChange});
+          const listener = usePress({onPressChange});
           return (
             <div listeners={listener}>
               <Inner />
@@ -862,7 +862,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const ref = React.createRef();
 
       const Component = () => {
-        const listener = usePressResponder({onPress});
+        const listener = usePress({onPress});
         return <a href="#" ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
@@ -882,7 +882,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const ref = React.createRef();
 
       const Component = () => {
-        const listener = usePressResponder({onPress});
+        const listener = usePress({onPress});
         return <a href="#" ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
@@ -903,7 +903,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const buttonRef = React.createRef();
 
       const Component = () => {
-        const listener = usePressResponder({onPress});
+        const listener = usePress({onPress});
         return (
           <a href="#">
             <button ref={buttonRef} listeners={listener} />
@@ -924,7 +924,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const ref = React.createRef();
 
       const Component = () => {
-        const listener = usePressResponder({onPress});
+        const listener = usePress({onPress});
         return (
           <a href="#" listeners={listener}>
             <div ref={ref} />
@@ -948,7 +948,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const ref = React.createRef();
 
       const Component = () => {
-        const listener = usePressResponder({onPress});
+        const listener = usePress({onPress});
         return <a href="#" ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
@@ -970,7 +970,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const ref = React.createRef();
 
       const Component = () => {
-        const listener = usePressResponder({onPress, preventDefault: false});
+        const listener = usePress({onPress, preventDefault: false});
         return <a href="#" ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
@@ -990,7 +990,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const ref = React.createRef();
 
       const Component = () => {
-        const listener = usePressResponder({onPress, preventDefault: false});
+        const listener = usePress({onPress, preventDefault: false});
         return <a href="#" ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
@@ -1012,7 +1012,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const ref = React.createRef();
 
       const Component = () => {
-        const listener = usePressResponder({onPressEnd});
+        const listener = usePress({onPressEnd});
         return <a href="#" ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
@@ -1029,7 +1029,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
     const ref = React.createRef();
 
     const Component = () => {
-      const listener = usePressResponder({onPressEnd});
+      const listener = usePress({onPressEnd});
       return <a href="#" ref={ref} listeners={listener} />;
     };
     ReactDOM.render(<Component />, container);
@@ -1047,7 +1047,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
     const containerRef = React.createRef();
 
     const Component = () => {
-      const listener = usePressResponder({onPressEnd});
+      const listener = usePress({onPressEnd});
       return (
         <div ref={containerRef}>
           <a ref={ref} listeners={listener} />
@@ -1069,7 +1069,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
     const outsideRef = React.createRef();
 
     const Component = () => {
-      const listener = usePressResponder({onPressEnd});
+      const listener = usePress({onPressEnd});
       return (
         <div>
           <a ref={ref} listeners={listener} />
@@ -1094,7 +1094,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
     const ref = React.createRef();
 
     const Component = () => {
-      const listener = usePressResponder();
+      const listener = usePress();
       return <button ref={ref} listeners={listener} />;
     };
     ReactDOM.render(<Component />, container);
@@ -1128,7 +1128,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
     };
 
     const Component = () => {
-      const listener = usePressResponder({
+      const listener = usePress({
         onPressStart: logEvent,
         onPressEnd: logEvent,
         onPressMove: logEvent,
@@ -1248,7 +1248,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
           updateCounter(count => count + 1);
         }
 
-        const listener = usePressResponder({
+        const listener = usePress({
           onPress: handlePress,
         });
 
@@ -1316,7 +1316,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
           updateCounter(count => count + 1);
         }
 
-        const listener = usePressResponder({
+        const listener = usePress({
           onPress: handlePress,
         });
 
@@ -1398,7 +1398,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
             updatePressesCount(pressesCount + 1);
           }
 
-          const listener = usePressResponder({
+          const listener = usePress({
             onPress: handlePress,
           });
 
@@ -1439,7 +1439,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const pointerDownEvent = jest.fn();
 
       const Component = () => {
-        const listener = usePressResponder({stopPropagation: true});
+        const listener = usePress({stopPropagation: true});
         return <div ref={ref} listeners={listener} />;
       };
 

--- a/packages/react-events/src/dom/__tests__/Scroll-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Scroll-test.internal.js
@@ -14,7 +14,7 @@ import {createEventTarget, setPointerEvent} from '../testing-library';
 let React;
 let ReactFeatureFlags;
 let ReactDOM;
-let useScrollResponder;
+let useScroll;
 
 const forcePointerEvents = true;
 const table = [[forcePointerEvents], [!forcePointerEvents]];
@@ -26,7 +26,7 @@ const initializeModules = hasPointerEvents => {
   ReactFeatureFlags.enableFlareAPI = true;
   React = require('react');
   ReactDOM = require('react-dom');
-  useScrollResponder = require('react-events/scroll').useScrollResponder;
+  useScroll = require('react-events/scroll').useScroll;
 };
 
 describe.each(table)('Scroll responder', hasPointerEvents => {
@@ -51,7 +51,7 @@ describe.each(table)('Scroll responder', hasPointerEvents => {
       onScroll = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useScrollResponder({
+        const listener = useScroll({
           disabled: true,
           onScroll,
         });
@@ -74,7 +74,7 @@ describe.each(table)('Scroll responder', hasPointerEvents => {
       onScroll = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useScrollResponder({
+        const listener = useScroll({
           onScroll,
         });
         return <div ref={ref} listeners={listener} />;
@@ -145,7 +145,7 @@ describe.each(table)('Scroll responder', hasPointerEvents => {
       onScrollDragStart = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useScrollResponder({
+        const listener = useScroll({
           onScrollDragStart,
         });
         return <div ref={ref} listeners={listener} />;
@@ -175,7 +175,7 @@ describe.each(table)('Scroll responder', hasPointerEvents => {
       onScrollDragEnd = jest.fn();
       ref = React.createRef();
       const Component = () => {
-        const listener = useScrollResponder({
+        const listener = useScroll({
           onScrollDragEnd,
         });
         return <div ref={ref} listeners={listener} />;

--- a/packages/react-events/src/rn/Press.js
+++ b/packages/react-events/src/rn/Press.js
@@ -533,7 +533,7 @@ export const PressResponder = React.unstable_createResponder(
   pressResponderImpl,
 );
 
-export function usePressResponder(
+export function usePress(
   props: PressProps,
 ): ReactEventResponderListener<any, any> {
   return React.unstable_useResponder(PressResponder, props);


### PR DESCRIPTION
For example, 'useHoverResponder' becomes 'useHover'