### PR TITLE
[react-events] Ensure updateEventListeners updates in commit phase

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -432,7 +432,6 @@ export function mountResponderInstance(
   props: Object,
   state: Object,
   instance: Object,
-  rootContainerInstance: Object,
 ) {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -824,10 +824,9 @@ export function mountResponderInstance(
   responderProps: Object,
   responderState: Object,
   instance: Instance,
-  rootContainerInstance: Container,
 ): ReactDOMEventResponderInstance {
   // Listen to events
-  const doc = rootContainerInstance.ownerDocument;
+  const doc = instance.ownerDocument;
   const documentBody = doc.body || doc;
   const {
     rootEventTypes,

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -12,7 +12,7 @@ import {
   PASSIVE_NOT_SUPPORTED,
 } from 'legacy-events/EventSystemFlags';
 import type {AnyNativeEvent} from 'legacy-events/PluginModuleType';
-import {HostComponent} from 'shared/ReactWorkTags';
+import {HostComponent, SuspenseComponent} from 'shared/ReactWorkTags';
 import type {EventPriority} from 'shared/ReactTypes';
 import type {
   ReactDOMEventResponder,
@@ -32,10 +32,6 @@ import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import warning from 'shared/warning';
 import {enableFlareAPI} from 'shared/ReactFeatureFlags';
 import invariant from 'shared/invariant';
-import {
-  isFiberSuspenseAndTimedOut,
-  getSuspenseFallbackChild,
-} from 'react-reconciler/src/ReactFiberEvents';
 
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
 import {
@@ -628,6 +624,14 @@ function validateResponderContext(): void {
     'An event responder context was used outside of an event cycle. ' +
       'Use context.setTimeout() to use asynchronous responder context outside of event cycle .',
   );
+}
+
+function isFiberSuspenseAndTimedOut(fiber: Fiber): boolean {
+  return fiber.tag === SuspenseComponent && fiber.memoizedState !== null;
+}
+
+function getSuspenseFallbackChild(fiber: Fiber): Fiber | null {
+  return ((((fiber.child: any): Fiber).sibling: any): Fiber).child;
 }
 
 export function dispatchEventForResponderEventSystem(

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -813,8 +813,8 @@ describe('DOMEventResponderSystem', () => {
 
   it('the event responder system should warn on accessing invalid properties', () => {
     const TestResponder = createEventResponder({
-      rootEventTypes: ['click'],
-      onRootEvent: (event, context, props) => {
+      targetEventTypes: ['click'],
+      onEvent: (event, context, props) => {
         const syntheticEvent = {
           target: event.target,
           type: 'click',
@@ -825,19 +825,24 @@ describe('DOMEventResponderSystem', () => {
     });
 
     let handler;
+    let buttonRef = React.createRef();
     const Test = () => {
       const listener = React.unstable_useResponder(TestResponder, {
         onClick: handler,
       });
 
-      return <button listeners={listener}>Click me!</button>;
+      return (
+        <button listeners={listener} ref={buttonRef}>
+          Click me!
+        </button>
+      );
     };
     expect(() => {
       handler = event => {
         event.preventDefault();
       };
       ReactDOM.render(<Test />, container);
-      dispatchClickEvent(document.body);
+      dispatchClickEvent(buttonRef.current);
     }).toWarnDev(
       'Warning: preventDefault() is not available on event objects created from event responder modules ' +
         '(React Flare).' +
@@ -849,7 +854,7 @@ describe('DOMEventResponderSystem', () => {
         event.stopPropagation();
       };
       ReactDOM.render(<Test />, container);
-      dispatchClickEvent(document.body);
+      dispatchClickEvent(buttonRef.current);
     }).toWarnDev(
       'Warning: stopPropagation() is not available on event objects created from event responder modules ' +
         '(React Flare).' +
@@ -861,7 +866,7 @@ describe('DOMEventResponderSystem', () => {
         event.isDefaultPrevented();
       };
       ReactDOM.render(<Test />, container);
-      dispatchClickEvent(document.body);
+      dispatchClickEvent(buttonRef.current);
     }).toWarnDev(
       'Warning: isDefaultPrevented() is not available on event objects created from event responder modules ' +
         '(React Flare).' +
@@ -873,7 +878,7 @@ describe('DOMEventResponderSystem', () => {
         event.isPropagationStopped();
       };
       ReactDOM.render(<Test />, container);
-      dispatchClickEvent(document.body);
+      dispatchClickEvent(buttonRef.current);
     }).toWarnDev(
       'Warning: isPropagationStopped() is not available on event objects created from event responder modules ' +
         '(React Flare).' +
@@ -885,7 +890,7 @@ describe('DOMEventResponderSystem', () => {
         return event.nativeEvent;
       };
       ReactDOM.render(<Test />, container);
-      dispatchClickEvent(document.body);
+      dispatchClickEvent(buttonRef.current);
     }).toWarnDev(
       'Warning: nativeEvent is not available on event objects created from event responder modules ' +
         '(React Flare).' +

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -449,7 +449,6 @@ export function mountResponderInstance(
   props: Object,
   state: Object,
   instance: Instance,
-  rootContainerInstance: Container,
 ) {
   if (enableFlareAPI) {
     const {rootEventTypes} = responder;

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -501,7 +501,6 @@ export function mountResponderInstance(
   props: Object,
   state: Object,
   instance: Instance,
-  rootContainerInstance: Container,
 ) {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -118,6 +118,7 @@ import {
 } from './ReactHookEffectTags';
 import {didWarnAboutReassigningProps} from './ReactFiberBeginWork';
 import {runWithPriority, NormalPriority} from './SchedulerWithReactIntegration';
+import {updateEventListeners} from './ReactFiberEvents';
 
 let didWarnAboutUndefinedSnapshotBeforeUpdate: Set<mixed> | null = null;
 if (__DEV__) {
@@ -1330,6 +1331,13 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
             newProps,
             finishedWork,
           );
+        }
+        if (enableFlareAPI) {
+          const prevListeners = oldProps.listeners;
+          const nextListeners = newProps.listeners;
+          if (prevListeners !== nextListeners) {
+            updateEventListeners(nextListeners, instance, finishedWork);
+          }
         }
       }
       return;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -9,12 +9,7 @@
 
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
-import type {
-  ReactEventResponder,
-  ReactEventResponderInstance,
-  ReactFundamentalComponentInstance,
-  ReactEventResponderListener,
-} from 'shared/ReactTypes';
+import type {ReactFundamentalComponentInstance} from 'shared/ReactTypes';
 import type {FiberRoot} from './ReactFiberRoot';
 import type {
   Instance,
@@ -31,7 +26,6 @@ import type {SuspenseContext} from './ReactFiberSuspenseContext';
 
 import {now} from './SchedulerWithReactIntegration';
 
-import {REACT_RESPONDER_TYPE} from 'shared/ReactSymbols';
 import {
   IndeterminateComponent,
   FunctionComponent,
@@ -79,8 +73,6 @@ import {
   createContainerChildSet,
   appendChildToContainerChildSet,
   finalizeContainerChildren,
-  mountResponderInstance,
-  unmountResponderInstance,
   getFundamentalComponentInstance,
   mountFundamentalComponent,
   cloneFundamentalInstance,
@@ -92,8 +84,6 @@ import {
   getHostContext,
   popHostContainer,
 } from './ReactFiberHostContext';
-import {NoWork} from './ReactFiberExpirationTime';
-import {createResponderInstance} from './ReactFiberEvents';
 import {
   suspenseStackCursor,
   InvisibleParentSuspenseContext,
@@ -133,10 +123,7 @@ import {
 import {createFundamentalStateInstance} from './ReactFiberFundamental';
 import {Never} from './ReactFiberExpirationTime';
 import {resetChildFibers} from './ReactChildFiber';
-import warning from 'shared/warning';
-
-const emptyObject = {};
-const isArray = Array.isArray;
+import {updateEventListeners} from './ReactFiberEvents';
 
 function markUpdate(workInProgress: Fiber) {
   // Tag the fiber with an update effect. This turns a Placement into
@@ -693,14 +680,8 @@ function completeWork(
         if (enableFlareAPI) {
           const prevListeners = current.memoizedProps.listeners;
           const nextListeners = newProps.listeners;
-          const instance = workInProgress.stateNode;
           if (prevListeners !== nextListeners) {
-            updateEventListeners(
-              nextListeners,
-              instance,
-              rootContainerInstance,
-              workInProgress,
-            );
+            markUpdate(workInProgress);
           }
         }
 
@@ -742,12 +723,7 @@ function completeWork(
             const instance = workInProgress.stateNode;
             const listeners = newProps.listeners;
             if (listeners != null) {
-              updateEventListeners(
-                listeners,
-                instance,
-                rootContainerInstance,
-                workInProgress,
-              );
+              updateEventListeners(listeners, instance, workInProgress);
             }
           }
         } else {
@@ -764,12 +740,7 @@ function completeWork(
           if (enableFlareAPI) {
             const listeners = newProps.listeners;
             if (listeners != null) {
-              updateEventListeners(
-                listeners,
-                instance,
-                rootContainerInstance,
-                workInProgress,
-              );
+              updateEventListeners(listeners, instance, workInProgress);
             }
           }
 
@@ -1256,158 +1227,6 @@ function completeWork(
   }
 
   return null;
-}
-
-function mountEventResponder(
-  responder: ReactEventResponder<any, any>,
-  responderProps: Object,
-  instance: Instance,
-  rootContainerInstance: Container,
-  fiber: Fiber,
-  respondersMap: Map<
-    ReactEventResponder<any, any>,
-    ReactEventResponderInstance<any, any>,
-  >,
-) {
-  let responderState = emptyObject;
-  const getInitialState = responder.getInitialState;
-  if (getInitialState !== null) {
-    responderState = getInitialState(responderProps);
-  }
-  const responderInstance = createResponderInstance(
-    responder,
-    responderProps,
-    responderState,
-    instance,
-    fiber,
-  );
-  mountResponderInstance(
-    responder,
-    responderInstance,
-    responderProps,
-    responderState,
-    instance,
-    rootContainerInstance,
-  );
-  respondersMap.set(responder, responderInstance);
-}
-
-function updateEventListener(
-  listener: ReactEventResponderListener<any, any>,
-  fiber: Fiber,
-  visistedResponders: Set<ReactEventResponder<any, any>>,
-  respondersMap: Map<
-    ReactEventResponder<any, any>,
-    ReactEventResponderInstance<any, any>,
-  >,
-  instance: Instance,
-  rootContainerInstance: Container,
-): void {
-  let responder;
-  let props;
-
-  if (listener) {
-    responder = listener.responder;
-    props = listener.props;
-  }
-  invariant(
-    responder && responder.$$typeof === REACT_RESPONDER_TYPE,
-    'An invalid value was used as an event listener. Expect one or many event ' +
-      'listeners created via React.unstable_useResponder().',
-  );
-  const listenerProps = ((props: any): Object);
-  if (visistedResponders.has(responder)) {
-    // show warning
-    if (__DEV__) {
-      warning(
-        false,
-        'Duplicate event responder "%s" found in event listeners. ' +
-          'Event listeners passed to elements cannot use the same event responder more than once.',
-        responder.displayName,
-      );
-    }
-    return;
-  }
-  visistedResponders.add(responder);
-  const responderInstance = respondersMap.get(responder);
-
-  if (responderInstance === undefined) {
-    // Mount
-    mountEventResponder(
-      responder,
-      listenerProps,
-      instance,
-      rootContainerInstance,
-      fiber,
-      respondersMap,
-    );
-  } else {
-    // Update
-    responderInstance.props = listenerProps;
-    responderInstance.fiber = fiber;
-  }
-}
-
-function updateEventListeners(
-  listeners: any,
-  instance: Instance,
-  rootContainerInstance: Container,
-  fiber: Fiber,
-): void {
-  const visistedResponders = new Set();
-  let dependencies = fiber.dependencies;
-  if (listeners != null) {
-    if (dependencies === null) {
-      dependencies = fiber.dependencies = {
-        expirationTime: NoWork,
-        firstContext: null,
-        responders: new Map(),
-      };
-    }
-    let respondersMap = dependencies.responders;
-    if (respondersMap === null) {
-      respondersMap = new Map();
-    }
-    if (isArray(listeners)) {
-      for (let i = 0, length = listeners.length; i < length; i++) {
-        const listener = listeners[i];
-        updateEventListener(
-          listener,
-          fiber,
-          visistedResponders,
-          respondersMap,
-          instance,
-          rootContainerInstance,
-        );
-      }
-    } else {
-      updateEventListener(
-        listeners,
-        fiber,
-        visistedResponders,
-        respondersMap,
-        instance,
-        rootContainerInstance,
-      );
-    }
-  }
-  if (dependencies !== null) {
-    const respondersMap = dependencies.responders;
-    if (respondersMap !== null) {
-      // Unmount
-      const mountedResponders = Array.from(respondersMap.keys());
-      for (let i = 0, length = mountedResponders.length; i < length; i++) {
-        const mountedResponder = mountedResponders[i];
-        if (!visistedResponders.has(mountedResponder)) {
-          const responderInstance = ((respondersMap.get(
-            mountedResponder,
-          ): any): ReactEventResponderInstance<any, any>);
-          unmountResponderInstance(responderInstance);
-          respondersMap.delete(mountedResponder);
-        }
-      }
-    }
-  }
 }
 
 export {completeWork};

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -1,66 +1,24 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @flow
- */
-
 import type {Fiber} from './ReactFiber';
+import type {Instance} from './ReactFiberHostConfig';
 import type {
   ReactEventResponder,
   ReactEventResponderInstance,
   ReactEventResponderListener,
 } from 'shared/ReactTypes';
-import type {Instance} from './ReactFiberHostConfig';
 
-import {SuspenseComponent, Fragment} from 'shared/ReactWorkTags';
+import {
+  mountResponderInstance,
+  unmountResponderInstance,
+} from './ReactFiberHostConfig';
+import {NoWork} from './ReactFiberExpirationTime';
 
-export function createResponderListener(
-  responder: ReactEventResponder<any, any>,
-  props: Object,
-): ReactEventResponderListener<any, any> {
-  const eventResponderListener = {
-    responder,
-    props,
-  };
-  if (__DEV__) {
-    Object.freeze(eventResponderListener);
-  }
-  return eventResponderListener;
-}
+import warning from 'shared/warning';
+import {REACT_RESPONDER_TYPE} from 'shared/ReactSymbols';
 
-export function isFiberSuspenseAndTimedOut(fiber: Fiber): boolean {
-  return fiber.tag === SuspenseComponent && fiber.memoizedState !== null;
-}
+import invariant from 'shared/invariant';
 
-export function getSuspenseFallbackChild(fiber: Fiber): Fiber | null {
-  return ((((fiber.child: any): Fiber).sibling: any): Fiber).child;
-}
-
-export function isFiberSuspenseTimedOutChild(fiber: Fiber | null): boolean {
-  if (fiber === null) {
-    return false;
-  }
-  const parent = fiber.return;
-  if (parent !== null && parent.tag === Fragment) {
-    const grandParent = parent.return;
-
-    if (
-      grandParent !== null &&
-      grandParent.tag === SuspenseComponent &&
-      grandParent.stateNode !== null
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-export function getSuspenseFiberFromTimedOutChild(fiber: Fiber): Fiber {
-  return ((((fiber.return: any): Fiber).return: any): Fiber);
-}
+const emptyObject = {};
+const isArray = Array.isArray;
 
 export function createResponderInstance(
   responder: ReactEventResponder<any, any>,
@@ -77,4 +35,163 @@ export function createResponderInstance(
     state: responderState,
     target,
   };
+}
+
+function mountEventResponder(
+  responder: ReactEventResponder<any, any>,
+  responderProps: Object,
+  instance: Instance,
+  fiber: Fiber,
+  respondersMap: Map<
+    ReactEventResponder<any, any>,
+    ReactEventResponderInstance<any, any>,
+  >,
+) {
+  let responderState = emptyObject;
+  const getInitialState = responder.getInitialState;
+  if (getInitialState !== null) {
+    responderState = getInitialState(responderProps);
+  }
+  const responderInstance = createResponderInstance(
+    responder,
+    responderProps,
+    responderState,
+    instance,
+    fiber,
+  );
+  mountResponderInstance(
+    responder,
+    responderInstance,
+    responderProps,
+    responderState,
+    instance,
+  );
+  respondersMap.set(responder, responderInstance);
+}
+
+function updateEventListener(
+  listener: ReactEventResponderListener<any, any>,
+  fiber: Fiber,
+  visistedResponders: Set<ReactEventResponder<any, any>>,
+  respondersMap: Map<
+    ReactEventResponder<any, any>,
+    ReactEventResponderInstance<any, any>,
+  >,
+  instance: Instance,
+): void {
+  let responder;
+  let props;
+
+  if (listener) {
+    responder = listener.responder;
+    props = listener.props;
+  }
+  invariant(
+    responder && responder.$$typeof === REACT_RESPONDER_TYPE,
+    'An invalid value was used as an event listener. Expect one or many event ' +
+      'listeners created via React.unstable_useResponder().',
+  );
+  const listenerProps = ((props: any): Object);
+  if (visistedResponders.has(responder)) {
+    // show warning
+    if (__DEV__) {
+      warning(
+        false,
+        'Duplicate event responder "%s" found in event listeners. ' +
+          'Event listeners passed to elements cannot use the same event responder more than once.',
+        responder.displayName,
+      );
+    }
+    return;
+  }
+  visistedResponders.add(responder);
+  const responderInstance = respondersMap.get(responder);
+
+  if (responderInstance === undefined) {
+    // Mount (happens in either complete or commit phase)
+    mountEventResponder(
+      responder,
+      listenerProps,
+      instance,
+      fiber,
+      respondersMap,
+    );
+  } else {
+    // Update (happens during commit phase only)
+    responderInstance.props = listenerProps;
+    responderInstance.fiber = fiber;
+  }
+}
+
+export function updateEventListeners(
+  listeners: any,
+  instance: Instance,
+  fiber: Fiber,
+): void {
+  const visistedResponders = new Set();
+  let dependencies = fiber.dependencies;
+  if (listeners != null) {
+    if (dependencies === null) {
+      dependencies = fiber.dependencies = {
+        expirationTime: NoWork,
+        firstContext: null,
+        responders: new Map(),
+      };
+    }
+    let respondersMap = dependencies.responders;
+    if (respondersMap === null) {
+      respondersMap = new Map();
+    }
+    if (isArray(listeners)) {
+      for (let i = 0, length = listeners.length; i < length; i++) {
+        const listener = listeners[i];
+        updateEventListener(
+          listener,
+          fiber,
+          visistedResponders,
+          respondersMap,
+          instance,
+        );
+      }
+    } else {
+      updateEventListener(
+        listeners,
+        fiber,
+        visistedResponders,
+        respondersMap,
+        instance,
+      );
+    }
+  }
+  if (dependencies !== null) {
+    const respondersMap = dependencies.responders;
+    if (respondersMap !== null) {
+      // Unmount
+      const mountedResponders = Array.from(respondersMap.keys());
+      for (let i = 0, length = mountedResponders.length; i < length; i++) {
+        const mountedResponder = mountedResponders[i];
+        if (!visistedResponders.has(mountedResponder)) {
+          const responderInstance = ((respondersMap.get(
+            mountedResponder,
+          ): any): ReactEventResponderInstance<any, any>);
+          unmountResponderInstance(responderInstance);
+          respondersMap.delete(mountedResponder);
+        }
+      }
+    }
+  }
+}
+
+export function createResponderListener(
+  responder: ReactEventResponder<any, any>,
+  props: Object,
+): ReactEventResponderListener<any, any> {
+  const eventResponderListener = {
+    responder,
+    props,
+  };
+  if (__DEV__) {
+    Object.freeze(eventResponderListener);
+  }
+  return eventResponderListener;
 }

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 import type {Fiber} from './ReactFiber';
 import type {Instance} from './ReactFiberHostConfig';
 import type {

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -296,7 +296,6 @@ export function mountResponderInstance(
   props: Object,
   state: Object,
   instance: Instance,
-  rootContainerInstance: Container,
 ) {
   // noop
 }


### PR DESCRIPTION
This is a follow up to the comment @sebmarkbage pointed out in https://github.com/facebook/react/pull/16532#issuecomment-523673963. Notably, we should only be updating EventResponder instances in the commit phase. EventResponder instances should continue to mount in the complete phase.

I also managed to resolve the issue that prevented us from moving the event fiber logic into the `ReactFiberEvents` file, as that logic is now shared between the complete and commit phase files.