### PR TITLE
Only warn in case the fourth argument is a function

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1122,7 +1122,7 @@ function dispatchAction<S, A>(
 
   if (__DEV__) {
     warning(
-      arguments.length <= 3,
+      typeof arguments[3] !== 'function',
       "State updates from the useState() and useReducer() Hooks don't support the " +
         'second callback argument. To execute a side effect after ' +
         'rendering, declare it in the component body with useEffect().',


### PR DESCRIPTION
Ref. #16526.

As per @gaearon 's suggestion, this PR scope down the warning to just the case when second argument is a function.
