### PR TITLE
createElement() decorators.

### DIFF
--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -23,6 +23,8 @@ import {
   cloneElement,
   isValidElement,
   jsx,
+  addCreateElementDecorator,
+  removeCreateElementDecorator,
 } from './ReactElement';
 import {createContext} from './ReactContext';
 import {lazy} from './ReactLazy';
@@ -97,6 +99,13 @@ const React = {
   cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,
   createFactory: __DEV__ ? createFactoryWithValidation : createFactory,
   isValidElement: isValidElement,
+
+  Decorators: {
+    createElement: {
+      add: addCreateElementDecorator,
+      remove: removeCreateElementDecorator,
+    },
+  },
 
   version: ReactVersion,
 


### PR DESCRIPTION
Please, let's consider the following change. So far it's just a proof of concept, I'll do all other necessary steps (tests, typings, docs) if it has a chance to land.

I've seen people monkey-patching `React.createElement()` from their frameworks before. I need to monkey-patch it myself now in order to be able to automatically add some accessibility related attributes (which in my case are needed in the majority of DOM elements, could be added automatically, so adding them manually and teaching every dev on the project to add them is too much of a hustle). Some might suggest using custom jsxFactory in the project's config, which is a semi-option, it requires to import that custom `createElement` in all 100500 tsx files of the project and educate all the devs about it. And it won't help with the components which are built without JSX.

So, I'd like to be able to augment `React.createElement()` in a convenient way (you import a module, call a setup function — and it's working). And monkey-patching currently gives that convenience, but it's a hack and it's not future-proof (`React.createElement` might become read-only in some environment).

I propose to add Decorators API. The example of which is reflected in this PR's code change. The way of defining a decorator is similar to how Python decorators are being defined. Plus a few methods to add/remove them. And the `React.Decorators` namespace could also be extended with some methods like `React.Decorators.disable()` (so that people are able to have that API consumption under their control from the application code).

A code example (inside of my module's setup function):

```js
React.Decorators.createElement.add(function(createElement) {
    // createElement is a reference to the parent createElement
    // (can be already decorated by something else).

    // Should return a function with the same signature as the original createElement().
    return function(type, config, children) {
        if (type === 'h1') {
            arguments[0] = 'h6'; // Instead of all h1's create h6's (just an example).
        }
        return createElement.apply(this, arguments);
    };
});
```

What do you think?