### PR TITLE
Remove duplicate character in regex group

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -351,7 +351,7 @@ function getPlugins(
     // Remove 'use strict' from individual source files.
     {
       transform(source) {
-        return source.replace(/['"]use strict['"']/g, '');
+        return source.replace(/['"]use strict["']/g, '');
       },
     },
     // Turn __DEV__ and process.env checks into constants.


### PR DESCRIPTION
Single quote character (`'`) was present 2 times in the same regex group.