### PR TITLE
[Fresh] Don't ignore dependencies for render phase updates

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -428,6 +428,11 @@ export function renderWithHooks(
     do {
       didScheduleRenderPhaseUpdate = false;
       numberOfReRenders += 1;
+      if (__DEV__) {
+        // Even when hot reloading, allow dependencies to stabilize
+        // after first render to prevent infinite render phase updates.
+        ignorePreviousDependencies = false;
+      }
 
       // Start over from the beginning of the list
       nextCurrentHook = current !== null ? current.memoizedState : null;

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -2350,6 +2350,49 @@ describe('ReactFresh', () => {
     }
   });
 
+  // This pattern is inspired by useSubscription and similar mechanisms.
+  it('does not get into infinite loops during render phase updates', () => {
+    if (__DEV__) {
+      render(() => {
+        function Hello() {
+          const source = React.useMemo(() => ({value: 10}), []);
+          const [state, setState] = React.useState({value: null});
+          if (state !== source) {
+            setState(source);
+          }
+          return <p style={{color: 'blue'}}>{state.value}</p>;
+        }
+        $RefreshReg$(Hello, 'Hello');
+        return Hello;
+      });
+
+      const el = container.firstChild;
+      expect(el.textContent).toBe('10');
+      expect(el.style.color).toBe('blue');
+
+      // Perform a hot update.
+      act(() => {
+        patch(() => {
+          function Hello() {
+            const source = React.useMemo(() => ({value: 20}), []);
+            const [state, setState] = React.useState({value: null});
+            if (state !== source) {
+              // This should perform a single render-phase update.
+              setState(source);
+            }
+            return <p style={{color: 'red'}}>{state.value}</p>;
+          }
+          $RefreshReg$(Hello, 'Hello');
+          return Hello;
+        });
+      });
+
+      expect(container.firstChild).toBe(el);
+      expect(el.textContent).toBe('20');
+      expect(el.style.color).toBe('red');
+    }
+  });
+
   it('can hot reload offscreen components', () => {
     if (__DEV__) {
       const AppV1 = prepare(() => {


### PR DESCRIPTION
During a Fresh update, we ignore dependencies. We let the effects re-run, even if deps are `[]`, and free the memo'd values.

This is important because it prevents us from referencing stale code. For example, if we edit top-level `computeExpensive`, we still want `useMemo(() => computeExpensive(), [])` to re-evaluate.

Sometimes this may cause problems, but arguably this points to other flaws in components or Hooks that should be fixed regardless.

---

There is a failure case though. Generally, while components shouldn’t *rely* on `useMemo` for semantics, there is still an expectation that memo chains can “settle”. For example, `useSubscription` does a render-phase update if its arguments differ from its state:

https://github.com/facebook/react/blob/0da7bd0604a5be7f96572b9f75d16fef5674bc5d/packages/use-subscription/src/useSubscription.js#L42-L45

It has to rely on something like `useMemo` in the calling code to keep the source *eventually stable*.

---

The problem with our current approach is that during a Fresh update, dependencies are ignored completely. So even with `useMemo`, things never truly “settle”. This breaks the pattern relied upon by `useSubscription`, and likely, other similar mechanisms.

The fix is to **only ignore dependencies during the first render after the patch**. By that point it has run, all memo'd values have been recreated with fresh code. So it makes sense that we can turn off the cache busting flag for all subsequent render-phase updates of this component, thus letting it settle. This fixes the infinite loop in the regression test I've added.