### PR TITLE
Change Babel spread transform from loose -> strict

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -19,7 +19,7 @@ module.exports = {
     '@babel/plugin-transform-shorthand-properties',
     '@babel/plugin-transform-computed-properties',
     '@babel/plugin-transform-for-of',
-    ['@babel/plugin-transform-spread', {loose: true, useBuiltIns: true}],
+    ['@babel/plugin-transform-spread', {loose: false, useBuiltIns: true}],
     '@babel/plugin-transform-parameters',
     ['@babel/plugin-transform-destructuring', {loose: true, useBuiltIns: true}],
     ['@babel/plugin-transform-block-scoping', {throwIfClosureRequired: true}],


### PR DESCRIPTION
The spread syntax should work for typed arrays, e.g.
```js

```

While importing DevTools, I noticed that some of the hydration tests were failing because the spread operator was returning unexpected values.
```js
[...new Uint8Array([1,2,3])]

// rather than this [1, 2, 3]
// it was returning this [[1, 2, 3]]
```

This seems to be because of the way we've configured the `@babel/plugin-transform-spread` "loose" mode. Docs say:
> In loose mode, all iterables are assumed to be arrays.

In the case of DevTools though, we _know_ we are dealing with iterables that aren't necessarily arrays.

Hopefully we can change this transform without negatively impacting the build? Let's compare the output from CI and see if this does anything unexpected.