### PR TITLE
[react-events] Support screen reader virtual clicks

### DIFF
--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -476,6 +476,17 @@ function handleStopPropagation(
   }
 }
 
+// After some investigation work, screen reader virtual
+// clicks (NVDA, Jaws, VoiceOver) do not have co-ords associated with the click
+// event and "detail" is always 0 (where normal clicks are > 0)
+function isScreenReaderVirtualClick(nativeEvent): boolean {
+  return (
+    nativeEvent.detail === 0 &&
+    nativeEvent.screenX === 0 &&
+    nativeEvent.screenY === 0
+  );
+}
+
 function targetIsDocument(target: null | Node): boolean {
   // When target is null, it is the root
   return target === null || target.nodeType === 9;
@@ -616,6 +627,13 @@ const pressResponderImpl = {
       case 'click': {
         if (state.shouldPreventClick) {
           nativeEvent.preventDefault();
+        }
+        const onPress = props.onPress;
+
+        if (isFunction(onPress) && isScreenReaderVirtualClick(nativeEvent)) {
+          state.pointerType = 'keyboard';
+          state.pressTarget = event.responderTarget;
+          dispatchEvent(event, onPress, context, state, 'press', DiscreteEvent);
         }
         break;
       }

--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -483,7 +483,9 @@ function isScreenReaderVirtualClick(nativeEvent): boolean {
   return (
     nativeEvent.detail === 0 &&
     nativeEvent.screenX === 0 &&
-    nativeEvent.screenY === 0
+    nativeEvent.screenY === 0 &&
+    nativeEvent.clientX === 0 &&
+    nativeEvent.clientY === 0
   );
 }
 

--- a/packages/react-events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Press-test.internal.js
@@ -420,6 +420,18 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       innerTarget.pointerup({pointerType: 'mouse'});
       expect(onPress).toBeCalled();
     });
+
+    it('is called once after virtual screen reader "click" event', () => {
+      const target = createEventTarget(ref.current);
+      target.screenReaderClick();
+      expect(onPress).toHaveBeenCalledTimes(1);
+      expect(onPress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pointerType: 'keyboard',
+          type: 'press',
+        }),
+      );
+    });
   });
 
   describe('onPressMove', () => {

--- a/packages/react-events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Press-test.internal.js
@@ -423,7 +423,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
     it('is called once after virtual screen reader "click" event', () => {
       const target = createEventTarget(ref.current);
-      target.screenReaderClick();
+      target.virtualclick();
       expect(onPress).toHaveBeenCalledTimes(1);
       expect(onPress).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/react-events/src/dom/testing-library/domEvents.js
+++ b/packages/react-events/src/dom/testing-library/domEvents.js
@@ -170,65 +170,30 @@ function createMouseEvent(
     x = 0,
     y = 0,
   } = {},
+  virtual = false,
 ) {
   const modifierState = {altKey, ctrlKey, metaKey, shiftKey};
 
   return createEvent(type, {
     altKey,
     buttons,
-    clientX: x,
-    clientY: y,
+    clientX: virtual ? 0 : x,
+    clientY: virtual ? 0 : y,
     ctrlKey,
+    detail: virtual ? 0 : 1,
     getModifierState(keyArg) {
       createGetModifierState(keyArg, modifierState);
     },
     metaKey,
-    movementX,
-    movementY,
-    offsetX,
-    offsetY,
-    pageX: pageX || x,
-    pageY: pageY || y,
+    movementX: virtual ? 0 : movementX,
+    movementY: virtual ? 0 : movementY,
+    offsetX: virtual ? 0 : offsetX,
+    offsetY: virtual ? 0 : offsetY,
+    pageX: virtual ? 0 : pageX || x,
+    pageY: virtual ? 0 : pageY || y,
     preventDefault,
-    screenX: x,
-    screenY: y + defaultBrowserChromeSize,
-    shiftKey,
-  });
-}
-
-function createScreenReaderMouseEvent(
-  type,
-  {
-    altKey = false,
-    buttons = buttonsType.none,
-    ctrlKey = false,
-    metaKey = false,
-    preventDefault = emptyFunction,
-    shiftKey = false,
-  } = {},
-) {
-  const modifierState = {altKey, ctrlKey, metaKey, shiftKey};
-
-  return createEvent(type, {
-    altKey,
-    buttons,
-    clientX: 0,
-    clientY: 0,
-    ctrlKey,
-    detail: 0,
-    getModifierState(keyArg) {
-      createGetModifierState(keyArg, modifierState);
-    },
-    metaKey,
-    movementX: 0,
-    movementY: 0,
-    offsetX: 0,
-    offsetY: 0,
-    pageX: 0,
-    pageY: 0,
-    preventDefault,
-    screenX: 0,
-    screenY: 0,
+    screenX: virtual ? 0 : x,
+    screenY: virtual ? 0 : y + defaultBrowserChromeSize,
     shiftKey,
   });
 }
@@ -288,11 +253,11 @@ export function blur({relatedTarget} = {}) {
 }
 
 export function click(payload) {
-  return createMouseEvent('click', payload);
+  return createMouseEvent('click', payload, false);
 }
 
-export function screenReaderClick(payload) {
-  return createScreenReaderMouseEvent('click', payload);
+export function virtualclick(payload) {
+  return createMouseEvent('click', payload, true);
 }
 
 export function contextmenu(payload) {

--- a/packages/react-events/src/dom/testing-library/domEvents.js
+++ b/packages/react-events/src/dom/testing-library/domEvents.js
@@ -196,6 +196,43 @@ function createMouseEvent(
   });
 }
 
+function createScreenReaderMouseEvent(
+  type,
+  {
+    altKey = false,
+    buttons = buttonsType.none,
+    ctrlKey = false,
+    metaKey = false,
+    preventDefault = emptyFunction,
+    shiftKey = false,
+  } = {},
+) {
+  const modifierState = {altKey, ctrlKey, metaKey, shiftKey};
+
+  return createEvent(type, {
+    altKey,
+    buttons,
+    clientX: 0,
+    clientY: 0,
+    ctrlKey,
+    detail: 0,
+    getModifierState(keyArg) {
+      createGetModifierState(keyArg, modifierState);
+    },
+    metaKey,
+    movementX: 0,
+    movementY: 0,
+    offsetX: 0,
+    offsetY: 0,
+    pageX: 0,
+    pageY: 0,
+    preventDefault,
+    screenX: 0,
+    screenY: 0,
+    shiftKey,
+  });
+}
+
 function createTouchEvent(
   type,
   {
@@ -252,6 +289,10 @@ export function blur({relatedTarget} = {}) {
 
 export function click(payload) {
   return createMouseEvent('click', payload);
+}
+
+export function screenReaderClick(payload) {
+  return createScreenReaderMouseEvent('click', payload);
 }
 
 export function contextmenu(payload) {

--- a/packages/react-events/src/dom/testing-library/index.js
+++ b/packages/react-events/src/dom/testing-library/index.js
@@ -44,6 +44,9 @@ const createEventTarget = node => ({
   keyup(payload) {
     node.dispatchEvent(domEvents.keyup(payload));
   },
+  screenReaderClick(payload) {
+    node.dispatchEvent(domEvents.screenReaderClick(payload));
+  },
   scroll(payload) {
     node.dispatchEvent(domEvents.scroll(payload));
   },

--- a/packages/react-events/src/dom/testing-library/index.js
+++ b/packages/react-events/src/dom/testing-library/index.js
@@ -44,8 +44,8 @@ const createEventTarget = node => ({
   keyup(payload) {
     node.dispatchEvent(domEvents.keyup(payload));
   },
-  screenReaderClick(payload) {
-    node.dispatchEvent(domEvents.screenReaderClick(payload));
+  virtualclick(payload) {
+    node.dispatchEvent(domEvents.virtualclick(payload));
   },
   scroll(payload) {
     node.dispatchEvent(domEvents.scroll(payload));


### PR DESCRIPTION
This PR aims to address issues around using screen reader tooling (VoiceOver, NVDA, JAWS) with the `Press` event responder. We previously relied on "press" events firing when coming from a valid pointer/mouse/touch sequence of events. We also supported "Enter" and "Space" keyboard events. However, we did not take into account that screen reader tooling can also fire virtual `click` events to specific DOM nodes.

Screen reader virtual click events have a pattern that makes them somewhat easy to detect. They seem to also have `0` as the `nativeEvent.detail`, rather than `1` and they also never provide screen co-ordinates (they are all always `0`).

Testing URL: https://m9zxnyvpj9.csb.app/