### PR TITLE
[react-events] Improve mock event object accuracy

### DIFF
--- a/packages/react-events/src/dom/testing-library/domEnvironment.js
+++ b/packages/react-events/src/dom/testing-library/domEnvironment.js
@@ -13,12 +13,17 @@
  * Change environment support for PointerEvent.
  */
 
+const emptyFunction = function() {};
+
 export function hasPointerEvent() {
   return global != null && global.PointerEvent != null;
 }
 
 export function setPointerEvent(bool) {
-  global.PointerEvent = bool ? function() {} : undefined;
+  const mock = bool ? emptyFunction : undefined;
+  global.PointerEvent = mock;
+  global.HTMLElement.prototype.setPointerCapture = mock;
+  global.HTMLElement.prototype.releasePointerCapture = mock;
 }
 
 /**

--- a/packages/react-events/src/dom/testing-library/domEventSequences.js
+++ b/packages/react-events/src/dom/testing-library/domEventSequences.js
@@ -138,12 +138,18 @@ export function pointermove(target, payload) {
   const dispatch = arg => target.dispatchEvent(arg);
   const pointerType = getPointerType(payload);
   if (hasPointerEvent()) {
-    dispatch(domEvents.pointermove(payload));
-  }
-  if (pointerType === 'mouse') {
-    dispatch(domEvents.mousemove(payload));
+    dispatch(
+      domEvents.pointermove({
+        pressure: pointerType === 'touch' ? 1 : 0.5,
+        ...payload,
+      }),
+    );
   } else {
-    dispatch(domEvents.touchmove(payload));
+    if (pointerType === 'mouse') {
+      dispatch(domEvents.mousemove(payload));
+    } else {
+      dispatch(domEvents.touchmove(payload));
+    }
   }
 }
 

--- a/packages/react-events/src/dom/testing-library/index.js
+++ b/packages/react-events/src/dom/testing-library/index.js
@@ -109,10 +109,35 @@ const createEventTarget = node => ({
   },
 });
 
+function describeWithPointerEvent(message, describeFn) {
+  const pointerEvent = 'PointerEvent';
+  const fallback = 'MouseEvent/TouchEvent';
+  describe.each`
+    value    | name
+    ${true}  | ${pointerEvent}
+    ${false} | ${fallback}
+  `(`${message}: $name`, entry => {
+    const hasPointerEvents = entry.value;
+    setPointerEvent(hasPointerEvents);
+    describeFn(hasPointerEvents);
+  });
+}
+
+function testWithPointerType(message, testFn) {
+  const table = hasPointerEvent()
+    ? ['mouse', 'touch', 'pen']
+    : ['mouse', 'touch'];
+  test.each(table)(`${message}: %s`, pointerType => {
+    testFn(pointerType);
+  });
+}
+
 export {
   buttonsType,
   createEventTarget,
+  describeWithPointerEvent,
   platform,
   hasPointerEvent,
   setPointerEvent,
+  testWithPointerType,
 };


### PR DESCRIPTION
* Better simulation for `pointercancel`
* Fix pressure values for different pointers
* Add describe/test helpers for pointer events