### PR TITLE
[react-events] Ensure screen reader virtual clicks support preventDefault

### DIFF
--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -639,7 +639,6 @@ const pressResponderImpl = {
 
           if (preventDefault !== false) {
             nativeEvent.preventDefault();
-            state.shouldPreventClick = true;
           }
           dispatchEvent(event, onPress, context, state, 'press', DiscreteEvent);
         }

--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -635,6 +635,12 @@ const pressResponderImpl = {
         if (isFunction(onPress) && isScreenReaderVirtualClick(nativeEvent)) {
           state.pointerType = 'keyboard';
           state.pressTarget = event.responderTarget;
+          const preventDefault = props.preventDefault;
+
+          if (preventDefault !== false) {
+            nativeEvent.preventDefault();
+            state.shouldPreventClick = true;
+          }
           dispatchEvent(event, onPress, context, state, 'press', DiscreteEvent);
         }
         break;

--- a/packages/react-events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Press-test.internal.js
@@ -423,7 +423,9 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
     it('is called once after virtual screen reader "click" event', () => {
       const target = createEventTarget(ref.current);
-      target.virtualclick();
+      const preventDefault = jest.fn();
+      target.virtualclick({preventDefault});
+      expect(preventDefault).toBeCalled();
       expect(onPress).toHaveBeenCalledTimes(1);
       expect(onPress).toHaveBeenCalledWith(
         expect.objectContaining({


### PR DESCRIPTION
This adds `preventDefault` support to screen reader virtual clicks.