### PR TITLE
[Hydration Bugfix] Updates to dehydrated content when `disableSchedulerTimeoutBasedOnReactExpirationTime` is enabled

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -2046,8 +2046,16 @@ function updateDehydratedSuspenseComponent(
         // at even higher pri.
         let attemptHydrationAtExpirationTime = renderExpirationTime + 1;
         suspenseState.retryTime = attemptHydrationAtExpirationTime;
+        // TODO: This happens to abort the current render and switch to a
+        // hydration pass, because the priority of the new task is slightly
+        // higher priority, which causes the work loop to cancel the current
+        // Scheduler task via `Scheduler.cancelCallback`. But we should probably
+        // model this entirely within React instead of relying on Scheduler's
+        // semantics for canceling in-progress tasks. I've chosen this approach
+        // for now since it's a fairly non-invasive change and it conceptually
+        // matches how other types of interuptions (e.g. due to input events)
+        // already work.
         scheduleWork(current, attemptHydrationAtExpirationTime);
-        // TODO: Early abort this render.
       } else {
         // We have already tried to ping at a higher priority than we're rendering with
         // so if we got here, we must have failed to hydrate at those levels. We must

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -515,6 +515,9 @@ function scheduleCallbackForRoot(
     // New callback has higher priority than the existing one.
     const existingCallbackNode = root.callbackNode;
     if (existingCallbackNode !== null) {
+      // If this happens during render, this task represents the currently
+      // running task. Canceling has the effect of interrupting the render and
+      // starting over at the higher priority.
       cancelCallback(existingCallbackNode);
     }
     root.callbackExpirationTime = expirationTime;

--- a/scripts/jest/matchers/schedulerTestMatchers.js
+++ b/scripts/jest/matchers/schedulerTestMatchers.js
@@ -57,6 +57,15 @@ function toFlushExpired(Scheduler, expectedYields) {
   });
 }
 
+function toFlushUntilNextPaint(Scheduler, expectedYields) {
+  assertYieldsWereCleared(Scheduler);
+  Scheduler.unstable_flushUntilNextPaint();
+  const actualYields = Scheduler.unstable_clearYields();
+  return captureAssertion(() => {
+    expect(actualYields).toEqual(expectedYields);
+  });
+}
+
 function toHaveYielded(Scheduler, expectedYields) {
   return captureAssertion(() => {
     const actualYields = Scheduler.unstable_clearYields();
@@ -78,6 +87,7 @@ module.exports = {
   toFlushAndYieldThrough,
   toFlushWithoutYielding,
   toFlushExpired,
+  toFlushUntilNextPaint,
   toHaveYielded,
   toFlushAndThrow,
 };


### PR DESCRIPTION
## The Bug

When server rendered content that hasn't finished hydrating yet ("dehydrated" content) receives an update (via props or context), React has a mechanism to force the content to hydrate before applying the update. It does this by increasing the priority of the hydration task from Idle to a level slightly higher than the current render. React will abort the current render, perform the hydration, then try the update again on top of the now-fully-hydrated content.

There are unit tests that cover this case. The bug starts happening when `disableSchedulerTimeoutBasedOnReactExpirationTime` is enabled. It turns out that the mechanism to interrupt the current rendering task depends on the hydration task having a slightly earlier timeout, because Scheduler tasks are sorted by their timeouts. When the hydration task is higher priority, it causes `shouldYield` to flip to true, forcing the render to yield execution and allowing the hydration task to start. (This is similar to how input events can interrupt normal priority renders.)

`disableSchedulerTimeoutBasedOnReactExpirationTime` breaks this mechanism, because when it is enabled, the timeout given to Scheduler is no longer based on React's internal expiration times. Effectively, all rendering tasks within the same priority category are first-in-first-out. So, the hydration task comes *after* the original task in the Scheduler queue, and therefore `shouldYield` will keep returning `false`, and the original task will run to completion. (See https://github.com/facebook/react/pull/16284 for more information on `disableSchedulerTimeoutBasedOnReactExpirationTime`.)

The first commit in this PR adds a regression test for this case.

## The Fix

There are several potential fixes. The one I've chosen is not ideal in the long term, but it's lower risk compared to the complete solution, which will likely require some refactoring of how rendering tasks are scheduled.

The work loop already has some logic to cancel a rendering task in favor of a higher priority one, using `Scheduler.cancelCallback`. It does this by comparing the React expiration times of each task, so it doesn't depend on the ordering of tasks in Scheduler. This works when the high priority task is received during an input event.

However, `Scheduler.cancelCallback` is currently a no-op when given an already-running task. It does not cause the task to stop execution, and if the task does yield with a continuation, then the continuation will run. Which means it won't work if React is already inside the render phase. (Note the distinction between "inside the render phase" versus "in an event that fires in between two chunks of a time sliced task.")

The fix in the second commit addresses both parts: canceling the current task causes `shouldYield` to return `true`, and if the canceled task returns a continuation, the continuation is ignored.

This is sufficient to fix the regression.

## Alternative Fixes

A proper fix would be to model interruptions of in-progress renders in such a way that it does not depend on Scheduler's semantics for canceling and yielding. However, because of the inherent risk involved in changing how rendering tasks are scheduled, I would prefer to land this smaller fix first before attempting a refactor.

(There's already a planned mini-refactor of the work loop, e.g. to optimize how pings and restarts are modeled. We can fold this into that larger change.)