### PR TITLE
Refactored backend renderer to remove most of the recursion

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -1481,9 +1481,7 @@ export function attach(
 
   // Returns whether closest unfiltered fiber parent needs to reset its child list.
   //
-  // TRICKY
-  // Although this method is recursive, refactoring it to be iterative would add a lot of complexity.
-  // Since it is not expected to operate on huge parts of the tree at once, it's probably okay?
+  // TODO Refactor this method to be iterative as well
   function updateFiberRecursively(
     nextFiber: Fiber,
     prevFiber: Fiber,


### PR DESCRIPTION
DevTools doesn't currently handle extremely deep trees (#16491) or extremely wide trees (#16501) very well, due to recursion in the backend interface. This PR removes _most_ of that.

As a sanity test, I confirmed that after this refactor, DevTools was able to handle the following:
```js
const Child = ({ children = null }) => children;

const Deep = () => {
  let children = null;
  for (let i = 0; i < 15000; i++) {
    children = <Child>{children}</Child>;
  }
  return children;
};

const Wide = () => {
  let children = [];
  for (let i = 0; i < 15000; i++) {
    children.push(<Child key={i} />);
  }
  return children;
};
```

Migrated from https://github.com/bvaughn/react-devtools-experimental/pull/385