### PR TITLE
[react-events] Adds preventKeys support to Keyboard responder

### DIFF
--- a/packages/react-events/src/dom/__tests__/Keyboard-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Keyboard-test.internal.js
@@ -92,6 +92,38 @@ describe('Keyboard event responder', () => {
     });
   });
 
+  describe('preventKeys', () => {
+    let onKeyDown, ref;
+
+    beforeEach(() => {
+      onKeyDown = jest.fn();
+      ref = React.createRef();
+      const Component = () => {
+        const listener = useKeyboard({
+          onKeyDown,
+          preventKeys: ['Tab'],
+        });
+        return <div ref={ref} listeners={listener} />;
+      };
+      ReactDOM.render(<Component />, container);
+    });
+
+    it('onKeyDown is default prevented', () => {
+      const preventDefault = jest.fn();
+      const target = createEventTarget(ref.current);
+      target.keydown({key: 'Tab', preventDefault});
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      expect(preventDefault).toBeCalled();
+      expect(onKeyDown).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'Tab',
+          type: 'keydown',
+          defaultPrevented: true,
+        }),
+      );
+    });
+  });
+
   describe('onKeyUp', () => {
     let onKeyDown, onKeyUp, ref;
 

--- a/packages/react-events/src/dom/__tests__/Keyboard-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Keyboard-test.internal.js
@@ -93,11 +93,9 @@ describe('Keyboard event responder', () => {
   });
 
   describe('preventKeys', () => {
-    let onKeyDown, ref;
-
-    beforeEach(() => {
-      onKeyDown = jest.fn();
-      ref = React.createRef();
+    it('onKeyDown is default prevented', () => {
+      const onKeyDown = jest.fn();
+      const ref = React.createRef();
       const Component = () => {
         const listener = useKeyboard({
           onKeyDown,
@@ -106,12 +104,110 @@ describe('Keyboard event responder', () => {
         return <div ref={ref} listeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
-    });
 
-    it('onKeyDown is default prevented', () => {
       const preventDefault = jest.fn();
       const target = createEventTarget(ref.current);
       target.keydown({key: 'Tab', preventDefault});
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      expect(preventDefault).toBeCalled();
+      expect(onKeyDown).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'Tab',
+          type: 'keydown',
+          defaultPrevented: true,
+        }),
+      );
+    });
+
+    it('onKeyDown is default prevented (falsy modifier keys)', () => {
+      let onKeyDown = jest.fn();
+      let ref = React.createRef();
+      let Component = () => {
+        const listener = useKeyboard({
+          onKeyDown,
+          preventKeys: [['Tab', {metaKey: false}]],
+        });
+        return <div ref={ref} listeners={listener} />;
+      };
+      ReactDOM.render(<Component />, container);
+
+      let preventDefault = jest.fn();
+      let target = createEventTarget(ref.current);
+      target.keydown({key: 'Tab', preventDefault, metaKey: true});
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      expect(preventDefault).not.toBeCalled();
+      expect(onKeyDown).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'Tab',
+          type: 'keydown',
+          defaultPrevented: false,
+        }),
+      );
+
+      onKeyDown = jest.fn();
+      ref = React.createRef();
+      Component = () => {
+        const listener = useKeyboard({
+          onKeyDown,
+          preventKeys: [['Tab', {metaKey: true}]],
+        });
+        return <div ref={ref} listeners={listener} />;
+      };
+      ReactDOM.render(<Component />, container);
+
+      preventDefault = jest.fn();
+      target = createEventTarget(ref.current);
+      target.keydown({key: 'Tab', preventDefault, metaKey: false});
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      expect(preventDefault).not.toBeCalled();
+      expect(onKeyDown).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'Tab',
+          type: 'keydown',
+          defaultPrevented: false,
+        }),
+      );
+    });
+
+    it('onKeyDown is default prevented (truthy modifier keys)', () => {
+      let onKeyDown = jest.fn();
+      let ref = React.createRef();
+      let Component = () => {
+        const listener = useKeyboard({
+          onKeyDown,
+          preventKeys: [['Tab', {metaKey: true}]],
+        });
+        return <div ref={ref} listeners={listener} />;
+      };
+      ReactDOM.render(<Component />, container);
+
+      let preventDefault = jest.fn();
+      let target = createEventTarget(ref.current);
+      target.keydown({key: 'Tab', preventDefault, metaKey: true});
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      expect(preventDefault).toBeCalled();
+      expect(onKeyDown).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'Tab',
+          type: 'keydown',
+          defaultPrevented: true,
+        }),
+      );
+
+      onKeyDown = jest.fn();
+      ref = React.createRef();
+      Component = () => {
+        const listener = useKeyboard({
+          onKeyDown,
+          preventKeys: [['Tab', {metaKey: false}]],
+        });
+        return <div ref={ref} listeners={listener} />;
+      };
+      ReactDOM.render(<Component />, container);
+
+      preventDefault = jest.fn();
+      target = createEventTarget(ref.current);
+      target.keydown({key: 'Tab', preventDefault, metaKey: false});
       expect(onKeyDown).toHaveBeenCalledTimes(1);
       expect(preventDefault).toBeCalled();
       expect(onKeyDown).toHaveBeenCalledWith(


### PR DESCRIPTION
This PR adds the functionality to natively `preventDefault` on the Keyboard responder. This is done via a `preventKeys` prop, which takes an array of key strings that should be preventing during the `keydown` event; along with a `defaultPrevented` flag on the callback's event object.