### PR TITLE
Use www Flag version for warnAboutStringRefs and warnAboutDefaultPropsOnFunctionComponents

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -22,6 +22,8 @@ export const {
   enableUserBlockingEvents,
   disableLegacyContext,
   disableSchedulerTimeoutBasedOnReactExpirationTime,
+  warnAboutStringRefs,
+  warnAboutDefaultPropsOnFunctionComponents,
 } = require('ReactFeatureFlags');
 
 // In www, we have experimental support for gathering data
@@ -80,10 +82,6 @@ export const enableJSXTransformAPI = true;
 export const warnAboutUnmockedScheduler = true;
 
 export const enableSuspenseCallback = true;
-
-export const warnAboutDefaultPropsOnFunctionComponents = false;
-
-export const warnAboutStringRefs = false;
 
 export const flushSuspenseFallbacksInTests = true;
 


### PR DESCRIPTION
Previously, warnAboutStringRefs and warnAboutDefaultPropsOnFunctionComponents were always false. Change these so that their value is dictated by ReactFeatureFlags.js in www instead.