### PR TITLE
[react-events] Keyboard responder propagation handling

### DIFF
--- a/packages/legacy-events/ReactGenericBatching.js
+++ b/packages/legacy-events/ReactGenericBatching.js
@@ -11,8 +11,6 @@ import {
 } from './ReactControlledComponent';
 import {enableFlareAPI} from 'shared/ReactFeatureFlags';
 
-import {invokeGuardedCallbackAndCatchFirstError} from 'shared/ReactErrorUtils';
-
 // Used as a way to call batchedUpdates when we don't have a reference to
 // the renderer. Such as when we're dispatching events or if third party
 // libraries need to call batchedUpdates. Eventually, this API will go away when

--- a/packages/legacy-events/ReactGenericBatching.js
+++ b/packages/legacy-events/ReactGenericBatching.js
@@ -77,12 +77,12 @@ export function batchedEventUpdates(fn, a, b) {
   }
 }
 
-export function executeUserEventHandler(fn: any => void, value: any) {
+// This is for the React Flare event system
+export function executeUserEventHandler(fn: any => void, value: any): any {
   const previouslyInEventHandler = isInsideEventHandler;
   try {
     isInsideEventHandler = true;
-    const type = typeof value === 'object' && value !== null ? value.type : '';
-    invokeGuardedCallbackAndCatchFirstError(type, fn, undefined, value);
+    return fn(value);
   } finally {
     isInsideEventHandler = previouslyInEventHandler;
   }

--- a/packages/react-events/src/dom/Keyboard.js
+++ b/packages/react-events/src/dom/Keyboard.js
@@ -176,7 +176,14 @@ function dispatchKeyboardEvent(
     target,
     defaultPrevented,
   );
-  context.dispatchEvent(syntheticEvent, listener, DiscreteEvent);
+  const shouldPropagate = context.dispatchEvent(
+    syntheticEvent,
+    listener,
+    DiscreteEvent,
+  );
+  if (shouldPropagate) {
+    context.continuePropagation();
+  }
 }
 
 const keyboardResponderImpl = {

--- a/packages/react-events/src/dom/__tests__/Keyboard-test.internal.js
+++ b/packages/react-events/src/dom/__tests__/Keyboard-test.internal.js
@@ -251,4 +251,88 @@ describe('Keyboard event responder', () => {
       );
     });
   });
+
+  describe('correctly handles responder propagation', () => {
+    describe('onKeyDown', () => {
+      let onKeyDownInner, onKeyDownOuter, ref;
+
+      function renderPropagationTest(propagates) {
+        onKeyDownInner = jest.fn(() => propagates);
+        onKeyDownOuter = jest.fn();
+        ref = React.createRef();
+        const Component = () => {
+          const listenerInner = useKeyboard({
+            onKeyDown: onKeyDownInner,
+          });
+          const listenerOuter = useKeyboard({
+            onKeyDown: onKeyDownOuter,
+          });
+          return (
+            <div listeners={listenerOuter}>
+              <div ref={ref} listeners={listenerInner} />
+            </div>
+          );
+        };
+        ReactDOM.render(<Component />, container);
+      }
+
+      it('propagates when cb returns true', () => {
+        renderPropagationTest(true);
+        const target = createEventTarget(ref.current);
+        target.keydown();
+        expect(onKeyDownInner).toBeCalled();
+        expect(onKeyDownOuter).toBeCalled();
+      });
+
+      it('does not propagate when cb returns false', () => {
+        renderPropagationTest(false);
+        const target = createEventTarget(ref.current);
+        target.keydown();
+        expect(onKeyDownInner).toBeCalled();
+        expect(onKeyDownOuter).not.toBeCalled();
+      });
+    });
+
+    describe('onKeyUp', () => {
+      let onKeyUpInner, onKeyUpOuter, ref;
+
+      function renderPropagationTest(propagates) {
+        onKeyUpInner = jest.fn(() => propagates);
+        onKeyUpOuter = jest.fn();
+        ref = React.createRef();
+        const Component = () => {
+          const listenerInner = useKeyboard({
+            onKeyUp: onKeyUpInner,
+          });
+          const listenerOuter = useKeyboard({
+            onKeyUp: onKeyUpOuter,
+          });
+          return (
+            <div listeners={listenerOuter}>
+              <div ref={ref} listeners={listenerInner} />
+            </div>
+          );
+        };
+        ReactDOM.render(<Component />, container);
+      }
+
+      it('propagates when cb returns true', () => {
+        renderPropagationTest(true);
+        const target = createEventTarget(ref.current);
+        target.keydown();
+        target.keyup();
+        expect(onKeyUpInner).toBeCalled();
+        expect(onKeyUpOuter).toBeCalled();
+      });
+
+      it('does not propagate when cb returns false', () => {
+        renderPropagationTest(false);
+        const target = createEventTarget(ref.current);
+        target.keydown();
+        target.keyup();
+        expect(onKeyUpInner).toBeCalled();
+        expect(onKeyUpOuter).not.toBeCalled();
+      });
+    });
+  });
 });

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -73,6 +73,7 @@ export type ReactDOMResponderContext = {
     target: Element | Document,
     elementType: string,
   ) => boolean,
+  continuePropagation(): void,
   // Used for controller components
   enqueueStateRestore(Element | Document): void,
 };


### PR DESCRIPTION
This adds support for conditional Keyboard responder propagation, for where there are nested keyboard responders. To allow a `onKeyDown` or `onKeyUp` event to propagate the callback is required to return `true` to propagate a single responder level. This is done by providing a new method on context called `continuePropagation` – which tells the responder propagation system to propagate a single level after processing the current responder (of the same responder type).

I also had to remove the usage of `invokeGuardedCallbackAndCatchFirstError` when calling the user-land event callback. This was because the existing `invokeGuardedCallbackAndCatchFirstError` doesn't support returning a value from the callback – which is what we need here. Attempting to change the mechanics of the function seemed far too invasive, so we can test this approach out internally to see if we run into any issues (we shouldn't though).