### PR TITLE
[react-events] Fix Scope listener issue

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1343,7 +1343,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           const prevListeners = oldProps.listeners;
           const nextListeners = newProps.listeners;
           if (prevListeners !== nextListeners) {
-            updateEventListeners(nextListeners, finishedWork);
+            updateEventListeners(nextListeners, finishedWork, null);
           }
         }
       }
@@ -1400,7 +1400,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           const prevListeners = oldProps.listeners;
           const nextListeners = newProps.listeners;
           if (prevListeners !== nextListeners) {
-            updateEventListeners(nextListeners, finishedWork);
+            updateEventListeners(nextListeners, finishedWork, null);
           }
         }
       }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -724,7 +724,11 @@ function completeWork(
           if (enableFlareAPI) {
             const listeners = newProps.listeners;
             if (listeners != null) {
-              updateEventListeners(listeners, workInProgress);
+              updateEventListeners(
+                listeners,
+                workInProgress,
+                rootContainerInstance,
+              );
             }
           }
         } else {
@@ -744,7 +748,11 @@ function completeWork(
           if (enableFlareAPI) {
             const listeners = newProps.listeners;
             if (listeners != null) {
-              updateEventListeners(listeners, workInProgress);
+              updateEventListeners(
+                listeners,
+                workInProgress,
+                rootContainerInstance,
+              );
             }
           }
 
@@ -1233,7 +1241,12 @@ function completeWork(
           if (enableFlareAPI) {
             const listeners = newProps.listeners;
             if (listeners != null) {
-              updateEventListeners(listeners, workInProgress);
+              const rootContainerInstance = getRootHostContainer();
+              updateEventListeners(
+                listeners,
+                workInProgress,
+                rootContainerInstance,
+              );
             }
           }
           if (workInProgress.ref !== null) {

--- a/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
@@ -199,11 +199,11 @@ describe('ReactScope', () => {
     });
 
     it('event responders can be attached to scopes', () => {
+      let onKeyDown = jest.fn();
       const TestScope = React.unstable_createScope((type, props) => true);
-      const onKeyDown = jest.fn();
       const ref = React.createRef();
       const useKeyboard = require('react-events/keyboard').useKeyboard;
-      const Component = () => {
+      let Component = () => {
         const listener = useKeyboard({
           onKeyDown,
         });
@@ -215,7 +215,29 @@ describe('ReactScope', () => {
       };
       ReactDOM.render(<Component />, container);
 
-      const target = createEventTarget(ref.current);
+      let target = createEventTarget(ref.current);
+      target.keydown({key: 'Q'});
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      expect(onKeyDown).toHaveBeenCalledWith(
+        expect.objectContaining({key: 'Q', type: 'keydown'}),
+      );
+
+      onKeyDown = jest.fn();
+      Component = () => {
+        const listener = useKeyboard({
+          onKeyDown,
+        });
+        return (
+          <div>
+            <TestScope listeners={listener}>
+              <div ref={ref} />
+            </TestScope>
+          </div>
+        );
+      };
+      ReactDOM.render(<Component />, container);
+
+      target = createEventTarget(ref.current);
       target.keydown({key: 'Q'});
       expect(onKeyDown).toHaveBeenCalledTimes(1);
       expect(onKeyDown).toHaveBeenCalledWith(


### PR DESCRIPTION
This fixes an issue where event listeners on scopes would fail during the complete phase when a parent fiber was a host component. Added a test case for a regression test.