### PR TITLE
[Scheduler] Add "combined" www build

### DIFF
--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
@@ -12,6 +12,5 @@ export const {
   requestIdleCallbackBeforeFirstFrame,
   requestTimerEventBeforeFirstFrame,
   enableMessageLoopImplementation,
+  enableProfiling,
 } = require('SchedulerFeatureFlags');
-
-export const enableProfiling = __PROFILE__;

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -10,6 +10,7 @@ const bundleTypes = {
   FB_WWW_DEV: 'FB_WWW_DEV',
   FB_WWW_PROD: 'FB_WWW_PROD',
   FB_WWW_PROFILING: 'FB_WWW_PROFILING',
+  FB_WWW_COMBINED: 'FB_WWW_COMBINED',
   RN_OSS_DEV: 'RN_OSS_DEV',
   RN_OSS_PROD: 'RN_OSS_PROD',
   RN_OSS_PROFILING: 'RN_OSS_PROFILING',
@@ -28,6 +29,7 @@ const {
   FB_WWW_DEV,
   FB_WWW_PROD,
   FB_WWW_PROFILING,
+  FB_WWW_COMBINED,
   RN_OSS_DEV,
   RN_OSS_PROD,
   RN_OSS_PROFILING,
@@ -411,13 +413,7 @@ const bundles = [
 
   /******* React Scheduler (experimental) *******/
   {
-    bundleTypes: [
-      NODE_DEV,
-      NODE_PROD,
-      FB_WWW_DEV,
-      FB_WWW_PROD,
-      FB_WWW_PROFILING,
-    ],
+    bundleTypes: [NODE_DEV, NODE_PROD, FB_WWW_COMBINED],
     moduleType: ISOMORPHIC,
     entry: 'scheduler',
     global: 'Scheduler',
@@ -426,14 +422,7 @@ const bundles = [
 
   /******* React Scheduler Mock (experimental) *******/
   {
-    bundleTypes: [
-      UMD_DEV,
-      UMD_PROD,
-      NODE_DEV,
-      NODE_PROD,
-      FB_WWW_DEV,
-      FB_WWW_PROD,
-    ],
+    bundleTypes: [UMD_DEV, UMD_PROD, NODE_DEV, NODE_PROD, FB_WWW_COMBINED],
     moduleType: ISOMORPHIC,
     entry: 'scheduler/unstable_mock',
     global: 'SchedulerMock',

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -10,6 +10,7 @@ const UMD_PROFILING = bundleTypes.UMD_PROFILING;
 const FB_WWW_DEV = bundleTypes.FB_WWW_DEV;
 const FB_WWW_PROD = bundleTypes.FB_WWW_PROD;
 const FB_WWW_PROFILING = bundleTypes.FB_WWW_PROFILING;
+const FB_WWW_COMBINED = bundleTypes.FB_WWW_COMBINED;
 const RN_OSS_DEV = bundleTypes.RN_OSS_DEV;
 const RN_OSS_PROD = bundleTypes.RN_OSS_PROD;
 const RN_OSS_PROFILING = bundleTypes.RN_OSS_PROFILING;
@@ -158,11 +159,7 @@ const forks = Object.freeze({
   },
 
   'scheduler/src/SchedulerFeatureFlags': (bundleType, entry, dependencies) => {
-    if (
-      bundleType === FB_WWW_DEV ||
-      bundleType === FB_WWW_PROD ||
-      bundleType === FB_WWW_PROFILING
-    ) {
+    if (bundleType === FB_WWW_COMBINED) {
       return 'scheduler/src/forks/SchedulerFeatureFlags.www.js';
     }
     return 'scheduler/src/SchedulerFeatureFlags';
@@ -186,6 +183,7 @@ const forks = Object.freeze({
       case FB_WWW_DEV:
       case FB_WWW_PROD:
       case FB_WWW_PROFILING:
+      case FB_WWW_COMBINED:
         return 'shared/forks/lowPriorityWarning.www.js';
       default:
         return null;
@@ -198,6 +196,7 @@ const forks = Object.freeze({
       case FB_WWW_DEV:
       case FB_WWW_PROD:
       case FB_WWW_PROFILING:
+      case FB_WWW_COMBINED:
         return 'shared/forks/warningWithoutStack.www.js';
       default:
         return null;

--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -19,6 +19,7 @@ const {
   FB_WWW_DEV,
   FB_WWW_PROD,
   FB_WWW_PROFILING,
+  FB_WWW_COMBINED,
   RN_OSS_DEV,
   RN_OSS_PROD,
   RN_OSS_PROFILING,
@@ -50,6 +51,7 @@ function getBundleOutputPaths(bundleType, filename, packageName) {
     case FB_WWW_DEV:
     case FB_WWW_PROD:
     case FB_WWW_PROFILING:
+    case FB_WWW_COMBINED:
       return [`build/facebook-www/${filename}`];
     case RN_OSS_DEV:
     case RN_OSS_PROD:

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -12,6 +12,7 @@ const NODE_PROFILING = Bundles.bundleTypes.NODE_PROFILING;
 const FB_WWW_DEV = Bundles.bundleTypes.FB_WWW_DEV;
 const FB_WWW_PROD = Bundles.bundleTypes.FB_WWW_PROD;
 const FB_WWW_PROFILING = Bundles.bundleTypes.FB_WWW_PROFILING;
+const FB_WWW_COMBINED = Bundles.bundleTypes.FB_WWW_COMBINED;
 const RN_OSS_DEV = Bundles.bundleTypes.RN_OSS_DEV;
 const RN_OSS_PROD = Bundles.bundleTypes.RN_OSS_PROD;
 const RN_OSS_PROFILING = Bundles.bundleTypes.RN_OSS_PROFILING;
@@ -159,6 +160,19 @@ ${source}`;
 
   /****************** FB_WWW_PROFILING ******************/
   [FB_WWW_PROFILING](source, globalName, filename, moduleType) {
+    return `/**
+${license}
+ *
+ * @noflow
+ * @preventMunge
+ * @preserve-invariant-messages
+ */
+
+${source}`;
+  },
+
+  /****************** FB_WWW_COMBINED ******************/
+  [FB_WWW_COMBINED](source, globalName, filename, moduleType) {
     return `/**
 ${license}
  *


### PR DESCRIPTION
The Scheduler module in www is loaded before most of our other infra: too early to conditionally load a separate build in production versus development. Which means we're currently sending both a prod and dev bundle to every single user.

We should fix this on the Facebook infra side, but in the meantime, this updates the build script to generate a new type of bundle, `FB_WWW_COMBINED`, which preserves __DEV__ conditions.