### PR TITLE
[react-events] Refactor getCurrentTarget to getResponderNode

### DIFF
--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -1017,7 +1017,7 @@ describe('DOMEventResponderSystem', () => {
         const obj = {
           counter,
           timeStamp: context.getTimeStamp(),
-          target: context.getCurrentTarget(),
+          target: context.getResponderNode(),
           type: 'click-test',
         };
         context.dispatchEvent(obj, props.onClick, DiscreteEvent);

--- a/packages/react-events/src/dom/Focus.js
+++ b/packages/react-events/src/dom/Focus.js
@@ -289,7 +289,7 @@ const focusResponderImpl = {
 
     switch (type) {
       case 'focus': {
-        state.focusTarget = context.getCurrentTarget();
+        state.focusTarget = context.getResponderNode();
         // Limit focus events to the direct child of the event component.
         // Browser focus is not expected to bubble.
         if (!state.isFocused && state.focusTarget === target) {
@@ -427,7 +427,7 @@ const focusWithinResponderImpl = {
 
     switch (type) {
       case 'focus': {
-        state.focusTarget = context.getCurrentTarget();
+        state.focusTarget = context.getResponderNode();
         // Limit focus events to the direct child of the event component.
         // Browser focus is not expected to bubble.
         if (!state.isFocused) {

--- a/packages/react-events/src/dom/Hover.js
+++ b/packages/react-events/src/dom/Hover.js
@@ -235,7 +235,7 @@ const hoverResponderImpl = {
       // START
       case 'pointerover': {
         if (!state.isHovered && pointerType !== 'touch') {
-          state.hoverTarget = context.getCurrentTarget();
+          state.hoverTarget = context.getResponderNode();
           dispatchHoverStartEvents(event, context, props, state);
         }
         break;
@@ -295,7 +295,7 @@ const hoverResponderFallbackImpl = {
       // START
       case 'mouseover': {
         if (!state.isHovered && !state.ignoreEmulatedMouseEvents) {
-          state.hoverTarget = context.getCurrentTarget();
+          state.hoverTarget = context.getResponderNode();
           dispatchHoverStartEvents(event, context, props, state);
         }
         break;

--- a/packages/react-events/src/dom/Input.js
+++ b/packages/react-events/src/dom/Input.js
@@ -184,7 +184,7 @@ const inputResponderImpl = {
     if (props.disabled) {
       return;
     }
-    const currentTarget = context.getCurrentTarget();
+    const currentTarget = context.getResponderNode();
     if (target !== currentTarget || currentTarget === null) {
       return;
     }

--- a/packages/react-events/src/dom/Keyboard.js
+++ b/packages/react-events/src/dom/Keyboard.js
@@ -143,7 +143,6 @@ function createKeyboardEvent(
     repeat,
     shiftKey,
   } = nativeEvent;
-  const target = ((context.getCurrentTarget(): any): Element);
 
   return {
     altKey,
@@ -155,7 +154,7 @@ function createKeyboardEvent(
     metaKey,
     repeat,
     shiftKey,
-    target,
+    target: event.target,
     timeStamp: context.getTimeStamp(),
     type,
   };

--- a/packages/react-events/src/dom/Press.js
+++ b/packages/react-events/src/dom/Press.js
@@ -582,7 +582,7 @@ const pressResponderImpl = {
           // We set these here, before the button check so we have this
           // data around for handling of the context menu
           state.pointerType = pointerType;
-          const pressTarget = (state.pressTarget = context.getCurrentTarget());
+          const pressTarget = (state.pressTarget = context.getResponderNode());
           if (isPointerEvent) {
             state.activePointerId = pointerId;
           } else if (isTouchEvent) {
@@ -634,7 +634,7 @@ const pressResponderImpl = {
 
         if (isFunction(onPress) && isScreenReaderVirtualClick(nativeEvent)) {
           state.pointerType = 'keyboard';
-          state.pressTarget = context.getCurrentTarget();
+          state.pressTarget = context.getResponderNode();
           const preventDefault = props.preventDefault;
 
           if (preventDefault !== false) {

--- a/packages/react-events/src/rn/Press.js
+++ b/packages/react-events/src/rn/Press.js
@@ -412,7 +412,7 @@ const pressResponderImpl = {
     if (type === 'topTouchStart') {
       if (!state.isPressed) {
         state.pointerType = 'touch';
-        const pressTarget = (state.pressTarget = context.getCurrentTarget());
+        const pressTarget = (state.pressTarget = context.getResponderNode());
         const touchEvent = getTouchFromPressEvent(nativeEvent);
         if (touchEvent === null) {
           return;

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -219,7 +219,7 @@ export type ReactNativeResponderContext = {
   setTimeout: (func: () => void, timeout: number) => number,
   clearTimeout: (timerId: number) => void,
   getTimeStamp: () => number,
-  getCurrentTarget(): ReactNativeEventTarget | null,
+  getResponderNode(): ReactNativeEventTarget | null,
 };
 
 export type PointerType =

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -75,5 +75,5 @@ export type ReactDOMResponderContext = {
   continuePropagation(): void,
   // Used for controller components
   enqueueStateRestore(Element | Document): void,
-  getCurrentTarget(): Element | null,
+  getResponderNode(): Element | null,
 };


### PR DESCRIPTION
After discussion with @necolas, the behaviour of `getCurrentTarget` should be the same as the previous `event.responderTarget` – `context.getResponderNode`. This PR changes it so that this is the case.

In the case of scopes, they will always receive `null` for `getResponderNode`.