### PR TITLE
[react-events] Refine executeUserEventHandler

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -92,27 +92,29 @@ const eventResponderContext: ReactDOMResponderContext = {
     eventValue: any,
     eventListener: any => void,
     eventPriority: EventPriority,
-  ): any {
+  ): void {
     validateResponderContext();
     validateEventValue(eventValue);
     switch (eventPriority) {
       case DiscreteEvent: {
         flushDiscreteUpdatesIfNeeded(currentTimeStamp);
-        return discreteUpdates(() =>
+        discreteUpdates(() =>
           executeUserEventHandler(eventListener, eventValue),
         );
+        break;
       }
       case UserBlockingEvent: {
         if (enableUserBlockingEvents) {
-          return runWithPriority(UserBlockingPriority, () =>
+          runWithPriority(UserBlockingPriority, () =>
             executeUserEventHandler(eventListener, eventValue),
           );
         } else {
-          return executeUserEventHandler(eventListener, eventValue);
+          executeUserEventHandler(eventListener, eventValue);
         }
+        break;
       }
       case ContinuousEvent: {
-        return executeUserEventHandler(eventListener, eventValue);
+        executeUserEventHandler(eventListener, eventValue);
       }
     }
   },

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -115,6 +115,7 @@ const eventResponderContext: ReactDOMResponderContext = {
       }
       case ContinuousEvent: {
         executeUserEventHandler(eventListener, eventValue);
+        break;
       }
     }
   },

--- a/packages/react-events/src/dom/Keyboard.js
+++ b/packages/react-events/src/dom/Keyboard.js
@@ -173,11 +173,11 @@ function dispatchKeyboardEvent(
     type,
     defaultPrevented,
   );
-  const shouldPropagate = context.dispatchEvent(
-    syntheticEvent,
-    listener,
-    DiscreteEvent,
-  );
+  let shouldPropagate;
+  const listenerWithReturnValue = e => {
+    shouldPropagate = listener(e);
+  };
+  context.dispatchEvent(syntheticEvent, listenerWithReturnValue, DiscreteEvent);
   if (shouldPropagate) {
     context.continuePropagation();
   }

--- a/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
+++ b/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
@@ -106,7 +106,6 @@ const eventResponderContext: ReactNativeResponderContext = {
       }
       case ContinuousEvent: {
         executeUserEventHandler(eventListener, eventValue);
-        break;
       }
     }
   },

--- a/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
+++ b/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
@@ -106,6 +106,7 @@ const eventResponderContext: ReactNativeResponderContext = {
       }
       case ContinuousEvent: {
         executeUserEventHandler(eventListener, eventValue);
+        break;
       }
     }
   },


### PR DESCRIPTION
This is a follow up to #16657 where I wasn't quite happy about losing the usage of `invokeGuardedCallbackAndCatchFirstError`. This reinstates `invokeGuardedCallbackAndCatchFirstError` and works around the problem-space by using an inline function to work out the user callback return value.