### PR TITLE
Avoid unnecessary rAFTimeout timer called

### DIFF
--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -214,6 +214,8 @@ if (
   };
 
   const performWorkUntilDeadline = () => {
+    clearTimeout(rAFTimeoutID);
+
     if (enableMessageLoopImplementation) {
       if (scheduledHostCallback !== null) {
         const currentTime = getCurrentTime();
@@ -296,7 +298,6 @@ if (
     // after that.
     isRAFLoopRunning = true;
     requestAnimationFrame(nextRAFTime => {
-      clearTimeout(rAFTimeoutID);
       onAnimationFrame(nextRAFTime);
     });
 


### PR DESCRIPTION
There is a case: we spend more than `frameLength * 3` to execute `performWorkUntilDeadline` when `port.onmessage` be called, so, the `onTimeout` timer will be fired because the cancel(`clearTimeout`) in the rAF will be fired **after** the onTimeout(that's how event loop works) though this won't cause any problem since we do a check in `performWorkUntilDeadline`

So, I want to put the `clearTimeout` in `performWorkUntilDeadline` to avoid this