### PR TITLE
[react-events] Fix isTargetWithinNode type

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -158,7 +158,7 @@ const eventResponderContext: ReactDOMResponderContext = {
     return false;
   },
   isTargetWithinNode(
-    childTarget: null | Element | Document,
+    childTarget: Element | Document,
     parentTarget: Element | Document,
   ): boolean {
     validateResponderContext();

--- a/packages/react-events/src/dom/Tap.js
+++ b/packages/react-events/src/dom/Tap.js
@@ -321,22 +321,17 @@ function getHitTarget(
   context: ReactDOMResponderContext,
   state: TapState,
 ): null | Element | Document {
-  if (hasPointerEvents) {
-    return event.target;
-  } else {
-    if (event.pointerType === 'touch') {
-      const doc = context.getActiveDocument();
-      const nativeEvent: any = event.nativeEvent;
-      const touch = getTouchById(nativeEvent, state.activePointerId);
-      if (touch != null) {
-        return doc.elementFromPoint(touch.clientX, touch.clientY);
-      } else {
-        return null;
-      }
+  if (!hasPointerEvents && event.pointerType === 'touch') {
+    const doc = context.getActiveDocument();
+    const nativeEvent: any = event.nativeEvent;
+    const touch = getTouchById(nativeEvent, state.activePointerId);
+    if (touch != null) {
+      return doc.elementFromPoint(touch.clientX, touch.clientY);
     } else {
-      return event.target;
+      return null;
     }
   }
+  return event.target;
 }
 
 function isActivePointer(
@@ -617,6 +612,7 @@ const responderImpl = {
       case 'scroll': {
         if (
           state.isActive &&
+          state.responderTarget != null &&
           // We ignore incoming scroll events when using mouse events
           state.pointerType !== 'mouse' &&
           // If the scroll target is the document or if the pointer target

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -55,7 +55,7 @@ export type ReactDOMResponderContext = {
     eventPriority: EventPriority,
   ) => void,
   isTargetWithinNode: (
-    childTarget: null | Element | Document,
+    childTarget: Element | Document,
     parentTarget: Element | Document,
   ) => boolean,
   isTargetWithinResponder: (null | Element | Document) => boolean,


### PR DESCRIPTION
isTargetWithinNode passes the childTarget to getClosestInstanceFromNode which
does not account for a null value of 'node'.