### PR TITLE
Remove experimental scheduler flags

### DIFF
--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -8,7 +8,5 @@
 
 export const enableSchedulerDebugging = false;
 export const enableIsInputPending = false;
-export const requestIdleCallbackBeforeFirstFrame = false;
-export const requestTimerEventBeforeFirstFrame = false;
 export const enableMessageLoopImplementation = true;
 export const enableProfiling = __PROFILE__;

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
@@ -12,6 +12,4 @@ export const {
 } = require('SchedulerFeatureFlags');
 
 export const enableProfiling = __PROFILE__;
-export const requestIdleCallbackBeforeFirstFrame = false;
-export const requestTimerEventBeforeFirstFrame = false;
 export const enableMessageLoopImplementation = true;


### PR DESCRIPTION
Removes `requestIdleCallbackBeforeFirstFrame` and `requestTimerEventBeforeFirstFrame`.

Both were rAF-specific experiments but we went with MessageLoop instead. We left rAF temporarily in the code but since we never actually used these code paths, I think we should delete them to make the code easier to understand.