### PR TITLE
Check for Suspense boundary in a root Container

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -49,12 +49,10 @@ export function getClosestInstanceFromNode(targetNode) {
     // instance. Note that we don't check this field on  the targetNode
     // itself because the fibers are conceptually between the container
     // node and the first child. It isn't surrounding the container node.
-    targetInst = parentNode[internalContainerInstanceKey];
-    if (targetInst) {
-      // If so, we return the HostRoot Fiber.
-      return targetInst;
-    }
-    targetInst = parentNode[internalInstanceKey];
+    // If it's not a container, we check if it's an instance.
+    targetInst =
+      parentNode[internalContainerInstanceKey] ||
+      parentNode[internalInstanceKey];
     if (targetInst) {
       // Since this wasn't the direct target of the event, we might have
       // stepped past dehydrated DOM nodes to get here. However they could


### PR DESCRIPTION
If we find a Container that might mean that we're on a node that is inside
a Suspense boundary that is directly inside the Container root.

Imagine the div is a Container and the span is a dehydrated instance:

```
<div>
  <!--$-->
  <span />
  <!--/$-->
</div>
```

There's no way to tests this yet since I'm not actually utilizing
the return value yet.

The solution is to just use the same path to check for a Suspense boundary
as if we find a parent instance.