### PR TITLE
[Fresh] Add skipEnvCheck option to Babel plugin

### DIFF
--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -7,16 +7,16 @@
 
 'use strict';
 
-export default function(babel) {
+export default function(babel, opts) {
   if (typeof babel.getEnv === 'function') {
     // Only available in Babel 7.
     const env = babel.getEnv();
-    if (env !== 'development' && typeof expect !== 'function') {
+    if (env !== 'development' && !opts.skipEnvCheck) {
       throw new Error(
         'React Refresh Babel transform should only be enabled in development environment. ' +
           'Instead, the environment is: "' +
           env +
-          '".',
+          '". If you want to override this check, pass {skipEnvCheck: true} as plugin options.',
       );
     }
   }

--- a/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -19,7 +19,7 @@ function transform(input, options = {}) {
       plugins: [
         '@babel/syntax-jsx',
         '@babel/syntax-dynamic-import',
-        freshPlugin,
+        [freshPlugin, {skipEnvCheck: true}],
         ...(options.plugins || []),
       ],
     }).code,

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -60,7 +60,7 @@ describe('ReactFreshIntegration', () => {
         babelrc: false,
         presets: ['@babel/react'],
         plugins: [
-          freshPlugin,
+          [freshPlugin, {skipEnvCheck: true}],
           '@babel/plugin-transform-modules-commonjs',
           compileDestructuring && '@babel/plugin-transform-destructuring',
         ].filter(Boolean),


### PR DESCRIPTION
This is a first-class way to override the env check in Fresh Babel transform. The check is usually helpful but maybe you want more control. For example, in www we _do_ want to run the transform in tests to ensure it doesn't regress. Same in the React repo.