### PR TITLE
Remove wrong copy-paste code in test

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
@@ -474,8 +474,7 @@ describe('ReactDOMFiberAsync', () => {
                 }
                 ref={submitButtonRef}>
                 Submit
-              </button>{' '}
-              : null}
+              </button>
             </div>
           );
         }


### PR DESCRIPTION
Seems this test case copies from the former one which has a `{ this.state.active ? <button</button> : null}`, but this test case doesn't need that