### PR TITLE
[DevTools] Fixed font family issue in Firefox.

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Tooltip.css
+++ b/packages/react-devtools-shared/src/devtools/views/Tooltip.css
@@ -2,6 +2,7 @@
   border: none;
   border-radius: 0.25rem;
   padding: 0.25rem 0.5rem;
+  font-family: var(--font-family-sans);
   font-size: 12px;
   background-color: var(--color-tooltip-background);
   color: var(--color-tooltip-text);


### PR DESCRIPTION
Fixes: #16464 

It appears that we need to explicitly set the `font-family` for FF.

Screenshot:
<img width="201" alt="Screenshot 2019-09-07 at 19 30 13" src="https://user-images.githubusercontent.com/23095052/64478248-0dee2d00-d1a6-11e9-9864-8c0c7750884c.png">

