### PR TITLE
Bind rAF and cAF to window (#16606)

### DIFF
--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -83,8 +83,10 @@ if (
   const Date = window.Date;
   const setTimeout = window.setTimeout;
   const clearTimeout = window.clearTimeout;
-  const requestAnimationFrame = window.requestAnimationFrame && window.requestAnimationFrame.bind(window);
-  const cancelAnimationFrame = window.cancelAnimationFrame && window.cancelAnimationFrame.bind(window);
+  const requestAnimationFrame =
+    window.requestAnimationFrame && window.requestAnimationFrame.bind(window);
+  const cancelAnimationFrame =
+    window.cancelAnimationFrame && window.cancelAnimationFrame.bind(window);
 
   if (typeof console !== 'undefined') {
     // TODO: Remove fb.me link

--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -83,8 +83,8 @@ if (
   const Date = window.Date;
   const setTimeout = window.setTimeout;
   const clearTimeout = window.clearTimeout;
-  const requestAnimationFrame = window.requestAnimationFrame;
-  const cancelAnimationFrame = window.cancelAnimationFrame;
+  const requestAnimationFrame = window.requestAnimationFrame && window.requestAnimationFrame.bind(window);
+  const cancelAnimationFrame = window.cancelAnimationFrame && window.cancelAnimationFrame.bind(window);
 
   if (typeof console !== 'undefined') {
     // TODO: Remove fb.me link

--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -83,6 +83,8 @@ if (
   const Date = window.Date;
   const setTimeout = window.setTimeout;
   const clearTimeout = window.clearTimeout;
+  // Explicitly bind local references to `window`, in order to support
+  // environments where the global `this` is not the window (e.g extensions)
   const requestAnimationFrame =
     window.requestAnimationFrame && window.requestAnimationFrame.bind(window);
   const cancelAnimationFrame =

--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -86,9 +86,13 @@ if (
   // Explicitly bind local references to `window`, in order to support
   // environments where the global `this` is not the window (e.g extensions)
   const requestAnimationFrame =
-    window.requestAnimationFrame && window.requestAnimationFrame.bind(window);
+    typeof window.requestAnimationFrame === 'function'
+      ? window.requestAnimationFrame.bind(window)
+      : undefined;
   const cancelAnimationFrame =
-    window.cancelAnimationFrame && window.cancelAnimationFrame.bind(window);
+    typeof window.cancelAnimationFrame === 'function'
+      ? window.cancelAnimationFrame.bind(window)
+      : undefined;
 
   if (typeof console !== 'undefined') {
     // TODO: Remove fb.me link


### PR DESCRIPTION
When capturing local references of requestAnimationFrame and cancelAnimationFrame - bind them to the window object.
Fixes #16606