### PR TITLE
Fix ESLint hook rules for wrapped components

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -351,6 +351,30 @@ const tests = {
   invalid: [
     {
       code: `
+      // Invalid because it's dangerous and might not warn otherwise.
+      // This *must* be invalid.
+      const Component = wrapperFunction(() => {
+        if (cond) {
+          useConditionalHook();
+        }
+      });
+      `,
+      errors: [conditionalError('useConditionalHook')],
+    },
+    {
+      code: `
+      // Invalid because it's dangerous and might not warn otherwise.
+      // This *must* be invalid.
+      const Component = wrapperFunction(function () {
+        if (cond) {
+          useConditionalHook();
+        }
+      });
+      `,
+      errors: [conditionalError('useConditionalHook')],
+    },
+    {
+      code: `
         // Invalid because it's dangerous and might not warn otherwise.
         // This *must* be invalid.
         function ComponentWithConditionalHook() {

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -499,7 +499,8 @@ function getFunctionName(node) {
     return node.id;
   } else if (
     node.type === 'FunctionExpression' ||
-    node.type === 'ArrowFunctionExpression'
+    node.type === 'ArrowFunctionExpression' ||
+    node.type === 'CallExpression'
   ) {
     if (
       node.parent.type === 'VariableDeclarator' &&
@@ -540,6 +541,13 @@ function getFunctionName(node) {
       // Kinda clowny, but we'd said we'd follow spec convention for
       // `IsAnonymousFunctionDefinition()` usage.
       return node.parent.left;
+    } else if (
+      (node.type === 'ArrowFunctionExpression' ||
+        node.type === 'FunctionExpression') &&
+      node.parent.type === 'CallExpression'
+    ) {
+      // const Component = wrapper(() => useHook());
+      return getFunctionName(node.parent);
     } else {
       return undefined;
     }


### PR DESCRIPTION
This PR fixes the issue that rules like "no hooks in conditional statements" do not work with wrapped functions like you would have with forwardRef. (#14088)

I added new tests for these cases and ensured that the existing tests still pass. Making PR to huge projects is quite new to me, so I hope I did not miss anything.