### PR TITLE
Remove console.log from copyWithSet

### DIFF
--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -43,7 +43,6 @@ export function copyWithSet(
   value: any,
   index: number = 0,
 ): Object | Array<any> {
-  console.log('[utils] copyWithSet()', obj, path, index, value);
   if (index >= path.length) {
     return value;
   }


### PR DESCRIPTION
This doesn't seem like it's intentional.

See https://fb.workplace.com/groups/2299331103613797/permalink/2425185521028354/ [FB-Only]