### PR TITLE
[react-reconciler] Flatten responder listeners array

### DIFF
--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -92,6 +92,18 @@ function mountEventResponder(
   respondersMap.set(responder, responderInstance);
 }
 
+function flatten(array: Array<any>, result: Array<any>): Array<any> {
+  for (let i = 0; i < array.length; i++) {
+    const value = array[i];
+    if (Array.isArray(value)) {
+      flatten(value, result);
+    } else {
+      result.push(value);
+    }
+  }
+  return result;
+}
+
 function updateEventListener(
   listener: ReactEventResponderListener<any, any>,
   fiber: Fiber,
@@ -165,9 +177,11 @@ export function updateEventListeners(
     if (respondersMap === null) {
       respondersMap = new Map();
     }
+
     if (isArray(listeners)) {
-      for (let i = 0, length = listeners.length; i < length; i++) {
-        const listener = listeners[i];
+      const flatListeners = flatten(listeners, []);
+      for (let i = 0, length = flatListeners.length; i < length; i++) {
+        const listener = flatListeners[i];
         updateEventListener(
           listener,
           fiber,


### PR DESCRIPTION
This supports nested arrays of listeners, allowing people to use responder
hooks that combine several other listeners. For example:

```
function usePress(config) {
  const tap = useTap({ ... });
  const keyboard = useKeyboard({ ... });
  // ...
  return [ tap, keyboard ];
}

function MyComponent(props) {
  const press = usePress({ ... });
  return <div listeners={[press]} />
}
```