### PR TITLE
Exclude react-dom when flow checking other builds

### DIFF
--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -13,6 +13,8 @@
 .*/__mocks__/.*
 .*/__tests__/.*
 
+%REACT_RENDERER_FLOW_IGNORES%
+
 [include]
 ../../../node_modules/
 ../../../packages/

--- a/scripts/flow/createFlowConfigs.js
+++ b/scripts/flow/createFlowConfigs.js
@@ -23,16 +23,29 @@ function writeConfig(renderer, isFizzSupported) {
   mkdirp.sync(folder);
 
   const fizzRenderer = isFizzSupported ? renderer : 'custom';
-  const config = configTemplate.replace(
-    '%REACT_RENDERER_FLOW_OPTIONS%',
-    `
+  const config = configTemplate
+    .replace(
+      '%REACT_RENDERER_FLOW_OPTIONS%',
+      `
 module.name_mapper='react-reconciler/inline.${renderer}$$' -> 'react-reconciler/inline-typed'
 module.name_mapper='ReactFiberHostConfig$$' -> 'forks/ReactFiberHostConfig.${renderer}'
 module.name_mapper='react-stream/inline.${renderer}$$' -> 'react-stream/inline-typed'
 module.name_mapper='ReactFizzHostConfig$$' -> 'forks/ReactFizzHostConfig.${fizzRenderer}'
 module.name_mapper='ReactFizzFormatConfig$$' -> 'forks/ReactFizzFormatConfig.${fizzRenderer}'
     `.trim(),
-  );
+    )
+    .replace(
+      '%REACT_RENDERER_FLOW_IGNORES%',
+      renderer === 'dom' || renderer === 'dom-browser'
+        ? ''
+        : // If we're not checking DOM, ignore the DOM package since it
+          // won't be consistent.
+          `
+    .*/packages/react-dom/.*
+    .*/packages/.*/forks/.*.dom.js
+    .*/packages/.*/forks/.*.dom-browser.js
+    `.trim(),
+    );
 
   const disclaimer = `
 # ---------------------------------------------------------------#


### PR DESCRIPTION
_I pulled this commit out of #16725 into a separate PR._

Any given build cannot be self-consistent if we type check all the files that are part of other builds. That's because the HostConfig is swapped out.

Imagine for example a shared method that accepts an `Instance` type:

```
// Reconciler.js
export function render(instance: Instance) {

}
```

And a file specific to ReactDOM might reference this:

```
// ReactDOM.js
import  {render} from "reconciler";
export function renderToId(id: string) {
  render(document.getElementById(id));
}
```

But when we check the native file this won't work.

This is because the HostConfig can't be guaranteed to be consistent with other code such as code that touches the DOM directly.

Ideally we'd have a more systemic solution to this since it will pop up for other packages later too.