### PR TITLE
[Fresh] Hash signatures

### DIFF
--- a/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -19,7 +19,14 @@ function transform(input, options = {}) {
       plugins: [
         '@babel/syntax-jsx',
         '@babel/syntax-dynamic-import',
-        [freshPlugin, {skipEnvCheck: true}],
+        [
+          freshPlugin,
+          {
+            skipEnvCheck: true,
+            // To simplify debugging tests:
+            emitFullSignatures: true,
+          },
+        ],
         ...(options.plugins || []),
       ],
     }).code,


### PR DESCRIPTION
Fresh Babel plugin emits "signatures" that are strings containing names of Hooks and call metadata. For example:

```js
export default function App() {
  _s();

  const [foo, setFoo] = useState(0);
  React.useEffect(() => {});
  return <h1>{foo}</h1>;
}

_s(App, "useState{[foo, setFoo](0)}\\nuseEffect{}"); // <-- signature
```

Note the signature contains `[foo, setFoo](0)`. This ensures that if we change the `foo` name, or if we change the initial state (`0`), we force a remount. Including the initial argument source code is a special case for `useState` and `useReducer` since that usually signals an intentional attempt to remount.

Unfortunately, it's not always safe to emit an arbitrary string in some environments. For example, in www we have a transform that replaces `cx("foo")` with some string hash *regardless of whether it's inside a string or not*. It's just a regex. So if an expression like this becomes a part of a signature, www transforms can produce a syntax error.

To fix this, we can default to always emitting hashes for signatures. They're guaranteed to be short, and can't cause these kinds of issues. I left a fallback for ASTExplorer and for our own snapshot tests. (However, our integration tests verify the other branch still works.)