### PR TITLE
DevTools: Props editing interface tweaks

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
@@ -16,6 +16,7 @@ import {useEditableValue} from '../hooks';
 type OverrideValueFn = (path: Array<string | number>, value: any) => void;
 
 type EditableValueProps = {|
+  className?: string,
   dataType: string,
   initialValue: any,
   overrideValueFn: OverrideValueFn,
@@ -23,6 +24,7 @@ type EditableValueProps = {|
 |};
 
 export default function EditableValue({
+  className = '',
   dataType,
   initialValue,
   overrideValueFn,
@@ -74,7 +76,7 @@ export default function EditableValue({
     <Fragment>
       <input
         autoComplete="new-password"
-        className={isValid ? styles.Input : styles.Invalid}
+        className={`${isValid ? styles.Input : styles.Invalid} ${className}`}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.css
@@ -53,3 +53,7 @@
   display: flex;
   align-items: center;
 }
+
+.EditableValue {
+  min-width: 1rem;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
@@ -82,7 +82,7 @@ export default function InspectedElementTree({
             </Button>
           )}
         </div>
-        {isEmpty && <div className={styles.Empty}>None</div>}
+        {isEmpty && !canAddEntries && <div className={styles.Empty}>None</div>}
         {!isEmpty &&
           (entries: any).map(([name, value]) => (
             <KeyValue

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
@@ -104,6 +104,7 @@ export default function InspectedElementTree({
             />
             :&nbsp;
             <EditableValue
+              className={styles.EditableValue}
               initialValue={''}
               overrideValueFn={handleNewEntryValue}
               path={[newPropName]}

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
@@ -358,7 +358,7 @@ function InspectedElementView({
         inspectPath={inspectPropsPath}
         overrideValueFn={overridePropsFn}
         showWhenEmpty={true}
-        canAddEntries={true}
+        canAddEntries={typeof overridePropsFn === 'function'}
       />
       {type === ElementTypeSuspense ? (
         <InspectedElementTree


### PR DESCRIPTION
* Fix edge-case value input sizing issue with narrow DevTools UIs.
* Don't allow adding new values unless an `overridePropsFn` function has been provided.
* Don't show the "None" empty label at the same time as the "new prop" input.

![new-edit-Kapture 2019-09-10 at 14 11 17](https://user-images.githubusercontent.com/29597/64651054-72db9a00-d3d5-11e9-9684-486550a498f4.gif)
