### PR TITLE
Handle SuspenseListComponent getting retried

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -77,6 +77,7 @@ import {
   HostRoot,
   ClassComponent,
   SuspenseComponent,
+  SuspenseListComponent,
   FunctionComponent,
   ForwardRef,
   MemoComponent,
@@ -2222,6 +2223,9 @@ export function resolveRetryThenable(boundaryFiber: Fiber, thenable: Thenable) {
         if (suspenseState !== null) {
           retryTime = suspenseState.retryTime;
         }
+        break;
+      case SuspenseListComponent:
+        retryCache = boundaryFiber.stateNode;
         break;
       default:
         invariant(

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -11,6 +11,7 @@ describe('ReactSuspenseList', () => {
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
     ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
+    ReactFeatureFlags.enableSuspenseServerRenderer = true;
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');


### PR DESCRIPTION
This happens for example when a deleted boundary transfers its pending promises to the list so that the list can be retried.

This wasn't caught by unit tests because this flag wasn't on in those tests.

This was made worse by the error below getting swallowed by promise handlers.