### PR TITLE
Change `trackedTouchCount` console.error to warn

### DIFF
--- a/packages/legacy-events/ResponderEventPlugin.js
+++ b/packages/legacy-events/ResponderEventPlugin.js
@@ -514,7 +514,7 @@ const ResponderEventPlugin = {
       if (trackedTouchCount >= 0) {
         trackedTouchCount -= 1;
       } else {
-        console.error(
+        console.warn(
           'Ended a touch event which was not counted in `trackedTouchCount`.',
         );
         return null;


### PR DESCRIPTION
This is a workaround for an Android OS bug causing errors in React Native.

The very old bug facebook/react-native#15059 is caused by certain Android builds' handling of three-finger screenshots. The OS sends three touchcancel events, but only two touchstart events. This causes unavoidable red box errors. This PR changes the console.error to console.warn. This behaviour is consistent with similar touch event errors. 

