### PR TITLE
Moved backend injection to the content script

### DIFF
--- a/packages/react-devtools-extensions/src/inject.js
+++ b/packages/react-devtools-extensions/src/inject.js
@@ -3,7 +3,7 @@
 export default function inject(scriptName: string, done: ? Function) {
   const source = `
   (function () {
-    window.postMessage({ source: 'react-devtools-inject-backend', type: "FROM_PAGE", text: "Hello from the webpage!" }, "*");
+    window.postMessage({ source: 'react-devtools-inject-script', scriptName: "${scriptName}" }, "*");
   })()
   `;
 

--- a/packages/react-devtools-extensions/src/inject.js
+++ b/packages/react-devtools-extensions/src/inject.js
@@ -2,8 +2,13 @@
 
 export default function inject(scriptName: string, done: ?Function) {
   const source = `
+  // the prototype stuff is in case document.createElement has been modified
   (function () {
-    window.postMessage({ source: 'react-devtools-inject-script', scriptName: "${scriptName}" }, "*");
+    var script = document.constructor.prototype.createElement.call(document, 'script');
+    script.src = "${scriptName}";
+    script.charset = "utf-8";
+    document.documentElement.appendChild(script);
+    script.parentNode.removeChild(script);
   })()
   `;
 

--- a/packages/react-devtools-extensions/src/inject.js
+++ b/packages/react-devtools-extensions/src/inject.js
@@ -1,14 +1,9 @@
 /* global chrome */
 
-export default function inject(scriptName: string, done: ?Function) {
+export default function inject(scriptName: string, done: ? Function) {
   const source = `
-  // the prototype stuff is in case document.createElement has been modified
   (function () {
-    var script = document.constructor.prototype.createElement.call(document, 'script');
-    script.src = "${scriptName}";
-    script.charset = "utf-8";
-    document.documentElement.appendChild(script);
-    script.parentNode.removeChild(script);
+    window.postMessage({ source: 'react-devtools-inject-backend', type: "FROM_PAGE", text: "Hello from the webpage!" }, "*");
   })()
   `;
 

--- a/packages/react-devtools-extensions/src/inject.js
+++ b/packages/react-devtools-extensions/src/inject.js
@@ -1,6 +1,6 @@
 /* global chrome */
 
-export default function inject(scriptName: string, done: ? Function) {
+export default function inject(scriptName: string, done: ?Function) {
   const source = `
   (function () {
     window.postMessage({ source: 'react-devtools-inject-script', scriptName: "${scriptName}" }, "*");

--- a/packages/react-devtools-extensions/src/injectGlobalHook.js
+++ b/packages/react-devtools-extensions/src/injectGlobalHook.js
@@ -32,14 +32,17 @@ window.addEventListener('message', function(evt) {
       };
       chrome.runtime.sendMessage(lastDetectionResult);
 
-    // Inject the backend. This is done in the content script to avoid CSP
-    // and Trusted Types violations, since content scripts can modify the DOM
-    // and are not subject to the page's policies
+      // Inject the backend. This is done in the content script to avoid CSP
+      // and Trusted Types violations, since content scripts can modify the DOM
+      // and are not subject to the page's policies.
     } else if (evt.data.source === 'react-devtools-inject-backend') {
       // the prototype stuff is in case document.createElement has been modified
-      var script = document.constructor.prototype.createElement.call(document, 'script');
+      const script = document.constructor.prototype.createElement.call(
+        document,
+        'script',
+      );
       script.src = chrome.runtime.getURL('build/backend.js');
-      script.charset = "utf-8";
+      script.charset = 'utf-8';
       document.documentElement.appendChild(script);
       script.parentNode.removeChild(script);
     }

--- a/packages/react-devtools-extensions/src/injectGlobalHook.js
+++ b/packages/react-devtools-extensions/src/injectGlobalHook.js
@@ -37,10 +37,10 @@ window.addEventListener('message', function(evt) {
         reactBuildType: evt.data.reactBuildType,
       };
       chrome.runtime.sendMessage(lastDetectionResult);
-    } else if (evt.data.source === 'react-devtools-inject-backend') {
+    } else if (evt.data.source === 'react-devtools-inject-backend' && evt.data.scriptName) {
       //Inject backend
       var script = document.constructor.prototype.createElement.call(document, 'script');
-      script.src = chrome.runtime.getURL('build/backend.js');
+      script.src = evt.data.scriptName;
       script.charset = "utf-8";
       document.documentElement.appendChild(script);
       script.parentNode.removeChild(script);

--- a/packages/react-devtools-extensions/src/injectGlobalHook.js
+++ b/packages/react-devtools-extensions/src/injectGlobalHook.js
@@ -1,15 +1,9 @@
 /* global chrome */
 
 import nullthrows from 'nullthrows';
-import {
-  installHook
-} from 'react-devtools-shared/src/hook';
-import {
-  SESSION_STORAGE_RELOAD_AND_PROFILE_KEY
-} from 'react-devtools-shared/src/constants';
-import {
-  sessionStorageGetItem
-} from 'react-devtools-shared/src/storage';
+import {installHook} from 'react-devtools-shared/src/hook';
+import {SESSION_STORAGE_RELOAD_AND_PROFILE_KEY} from 'react-devtools-shared/src/constants';
+import {sessionStorageGetItem} from 'react-devtools-shared/src/storage';
 
 function injectCode(code) {
   const script = document.createElement('script');

--- a/packages/react-devtools-extensions/src/injectGlobalHook.js
+++ b/packages/react-devtools-extensions/src/injectGlobalHook.js
@@ -31,8 +31,12 @@ window.addEventListener('message', function(evt) {
         reactBuildType: evt.data.reactBuildType,
       };
       chrome.runtime.sendMessage(lastDetectionResult);
+
+    // Inject the backend. This is done in the content script to avoid CSP
+    // and Trusted Types violations, since content scripts can modify the DOM
+    // and are not subject to the page's policies
     } else if (evt.data.source === 'react-devtools-inject-backend') {
-      //Inject the specified script
+      // the prototype stuff is in case document.createElement has been modified
       var script = document.constructor.prototype.createElement.call(document, 'script');
       script.src = chrome.runtime.getURL('build/backend.js');
       script.charset = "utf-8";

--- a/packages/react-devtools-extensions/src/injectGlobalHook.js
+++ b/packages/react-devtools-extensions/src/injectGlobalHook.js
@@ -1,9 +1,15 @@
 /* global chrome */
 
 import nullthrows from 'nullthrows';
-import {installHook} from 'react-devtools-shared/src/hook';
-import {SESSION_STORAGE_RELOAD_AND_PROFILE_KEY} from 'react-devtools-shared/src/constants';
-import {sessionStorageGetItem} from 'react-devtools-shared/src/storage';
+import {
+  installHook
+} from 'react-devtools-shared/src/hook';
+import {
+  SESSION_STORAGE_RELOAD_AND_PROFILE_KEY
+} from 'react-devtools-shared/src/constants';
+import {
+  sessionStorageGetItem
+} from 'react-devtools-shared/src/storage';
 
 function injectCode(code) {
   const script = document.createElement('script');
@@ -24,16 +30,21 @@ let lastDetectionResult;
 // So instead, the hook will use postMessage() to pass message to us here.
 // And when this happens, we'll send a message to the "background page".
 window.addEventListener('message', function(evt) {
-  if (
-    evt.source === window &&
-    evt.data &&
-    evt.data.source === 'react-devtools-detector'
-  ) {
-    lastDetectionResult = {
-      hasDetectedReact: true,
-      reactBuildType: evt.data.reactBuildType,
-    };
-    chrome.runtime.sendMessage(lastDetectionResult);
+  if (evt.source === window && evt.data) {
+    if (evt.data.source === 'react-devtools-detector') {
+      lastDetectionResult = {
+        hasDetectedReact: true,
+        reactBuildType: evt.data.reactBuildType,
+      };
+      chrome.runtime.sendMessage(lastDetectionResult);
+    } else if (evt.data.source === 'react-devtools-inject-backend') {
+      //Inject backend
+      var script = document.constructor.prototype.createElement.call(document, 'script');
+      script.src = chrome.runtime.getURL('build/backend.js');
+      script.charset = "utf-8";
+      document.documentElement.appendChild(script);
+      script.parentNode.removeChild(script);
+    }
   }
 });
 

--- a/packages/react-devtools-extensions/src/injectGlobalHook.js
+++ b/packages/react-devtools-extensions/src/injectGlobalHook.js
@@ -31,10 +31,10 @@ window.addEventListener('message', function(evt) {
         reactBuildType: evt.data.reactBuildType,
       };
       chrome.runtime.sendMessage(lastDetectionResult);
-    } else if (evt.data.source === 'react-devtools-inject-script' && evt.data.scriptName) {
+    } else if (evt.data.source === 'react-devtools-inject-backend') {
       //Inject the specified script
       var script = document.constructor.prototype.createElement.call(document, 'script');
-      script.src = evt.data.scriptName;
+      script.src = chrome.runtime.getURL('build/backend.js');
       script.charset = "utf-8";
       document.documentElement.appendChild(script);
       script.parentNode.removeChild(script);

--- a/packages/react-devtools-extensions/src/injectGlobalHook.js
+++ b/packages/react-devtools-extensions/src/injectGlobalHook.js
@@ -37,8 +37,8 @@ window.addEventListener('message', function(evt) {
         reactBuildType: evt.data.reactBuildType,
       };
       chrome.runtime.sendMessage(lastDetectionResult);
-    } else if (evt.data.source === 'react-devtools-inject-backend' && evt.data.scriptName) {
-      //Inject backend
+    } else if (evt.data.source === 'react-devtools-inject-script' && evt.data.scriptName) {
+      //Inject the specified script
       var script = document.constructor.prototype.createElement.call(document, 'script');
       script.src = evt.data.scriptName;
       script.charset = "utf-8";

--- a/packages/react-devtools-extensions/src/injectGlobalHook.js
+++ b/packages/react-devtools-extensions/src/injectGlobalHook.js
@@ -31,12 +31,10 @@ window.addEventListener('message', function(evt) {
         reactBuildType: evt.data.reactBuildType,
       };
       chrome.runtime.sendMessage(lastDetectionResult);
-
-      // Inject the backend. This is done in the content script to avoid CSP
-      // and Trusted Types violations, since content scripts can modify the DOM
-      // and are not subject to the page's policies.
     } else if (evt.data.source === 'react-devtools-inject-backend') {
-      // the prototype stuff is in case document.createElement has been modified
+      // The backend is injected by the content script to avoid CSP and Trusted Types violations,
+      // since content scripts can modify the DOM and are not subject to the page's policies.
+      // The prototype stuff is in case document.createElement has been modified.
       const script = document.constructor.prototype.createElement.call(
         document,
         'script',

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -138,14 +138,10 @@ function createPanelIfReactLoaded() {
         chrome.devtools.inspectedWindow.eval(
           `window.postMessage({ source: 'react-devtools-inject-backend' });`, 
           function(response, error) {
-          if (error) {
-            console.log(error);
+            if (error) {
+              console.log(error);
+            }
           }
-
-          if (typeof done === 'function') {
-            done();
-          }
-        }
         );
 
         const viewElementSourceFunction = createViewElementSource(

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -135,7 +135,18 @@ function createPanelIfReactLoaded() {
 
         // Initialize the backend only once the Store has been initialized.
         // Otherwise the Store may miss important initial tree op codes.
-        inject(chrome.runtime.getURL('build/backend.js'));
+        chrome.devtools.inspectedWindow.eval(
+          `window.postMessage({ source: 'react-devtools-inject-backend' });`, 
+          function(response, error) {
+          if (error) {
+            console.log(error);
+          }
+
+          if (typeof done === 'function') {
+            done();
+          }
+        }
+        );
 
         const viewElementSourceFunction = createViewElementSource(
           bridge,

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -4,7 +4,6 @@ import {createElement} from 'react';
 import {unstable_createRoot as createRoot, flushSync} from 'react-dom';
 import Bridge from 'react-devtools-shared/src/bridge';
 import Store from 'react-devtools-shared/src/devtools/store';
-import inject from './inject';
 import {
   createViewElementSource,
   getBrowserName,
@@ -136,12 +135,12 @@ function createPanelIfReactLoaded() {
         // Initialize the backend only once the Store has been initialized.
         // Otherwise the Store may miss important initial tree op codes.
         chrome.devtools.inspectedWindow.eval(
-          `window.postMessage({ source: 'react-devtools-inject-backend' });`, 
-          function(response, error) {
-            if (error) {
-              console.log(error);
+          `window.postMessage({ source: 'react-devtools-inject-backend' });`,
+          function(response, evalError) {
+            if (evalError) {
+              console.log(evalError);
             }
-          }
+          },
         );
 
         const viewElementSourceFunction = createViewElementSource(


### PR DESCRIPTION
Moved the backend injection logic to the content script. Previously this was done by using `chrome.devtools.inspectedWindow.eval()`:

```
const source = `
  // the prototype stuff is in case document.createElement has been modified
  (function () {
    var script = document.constructor.prototype.createElement.call(document, 'script');
    script.src = "${scriptName}";
    script.charset = "utf-8";
    document.documentElement.appendChild(script);
    script.parentNode.removeChild(script);
  })()
  `;

  chrome.devtools.inspectedWindow.eval(source, function(response, error)
...
```

Since this code runs in the context of the inspected page, it is subject to the page's CSP restrictions and will cause a [Trusted Types](https://github.com/WICG/trusted-types) violation. Content scripts, however, are not subject to the page's restrictions and can manipulate the DOM. This change will prevent a TrustedScriptURL violation on clients that have Trusted Types support.