### PR TITLE
[react-events] Tap support for virtual click

### DIFF
--- a/packages/react-events/src/dom/shared/index.js
+++ b/packages/react-events/src/dom/shared/index.js
@@ -70,3 +70,16 @@ export function hasModifierKey(event: ReactDOMResponderEvent): boolean {
     altKey === true || ctrlKey === true || metaKey === true || shiftKey === true
   );
 }
+
+// AT-created virtual clicks (e.g., from NVDA, Jaws, VoiceOver) do not include
+// coordinates and "detail" is always 0 (where normal clicks are > 0)
+export function isVirtualClick(event: ReactDOMResponderEvent): boolean {
+  const nativeEvent: any = event.nativeEvent;
+  return (
+    nativeEvent.detail === 0 &&
+    nativeEvent.screenX === 0 &&
+    nativeEvent.screenY === 0 &&
+    nativeEvent.clientX === 0 &&
+    nativeEvent.clientY === 0
+  );
+}


### PR DESCRIPTION
A couple of issues:

1. This implementation can't be used to produce visual feedback as the entire sequence is flushed for the same event. We could wrap the "end" phase in a setTimeout to support this.

2. ~Changing the `targetEventTypes` to use `click` instead of `click_active` results in no `click` event being dispatched to `onRootEvent`, even though `rootEventTypes` contains `click_active`.~