### PR TITLE
Adds a minimum indentation size for components with extremely long names.

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.css
@@ -11,7 +11,6 @@
 
 .TreeWrapper {
   flex: 0 0 65%;
-  overflow: auto;
 }
 
 .SelectedElementWrapper {

--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -117,7 +117,7 @@ export default function ElementView({data, index, style}: Props) {
         style={{
           // Left offset presents the appearance of a nested tree structure.
           // We must use padding rather than margin/left because of the selected background color.
-          transform: `translateX(calc(${depth} * var(--indentation-size)))`,
+          paddingLeft: `calc(${depth} * var(--indentation-size) + 0.25rem)`,
         }}>
         {ownerID === null ? (
           <ExpandCollapseToggle element={element} store={store} />

--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.css
@@ -8,14 +8,15 @@
 
   /* Default size will be adjusted by Tree after scrolling */
   --indentation-size: 12px;
-}
 
-.List {
-  overflow-x: hidden !important;
+  /* Inner element width will be calculated based on tree element widths */
+  --inner-element-width: 100%;
 }
 
 .InnerElementType {
-  overflow-x: hidden;
+  overflow: hidden;
+  position: relative;
+  width: var(--inner-element-width) !important;
 }
 
 .SearchInput {

--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
@@ -425,6 +425,7 @@ function updateIndentationSizeVar(
   prevListWidthRef.current = listWidth;
 
   let maxIndentationSize: number = indentationSizeRef.current;
+  let innerElementWidth: number = 0;
 
   // eslint-disable-next-line no-for-of-loops/no-for-of-loops
   for (let child of innerDiv.children) {
@@ -446,8 +447,8 @@ function updateIndentationSizeVar(
     }
 
     const remainingWidth = Math.max(0, listWidth - childWidth);
-
     maxIndentationSize = Math.min(maxIndentationSize, remainingWidth / depth);
+    innerElementWidth = Math.max(innerElementWidth, childWidth, listWidth);
   }
 
   // Ensures indentation will not fall below a minimum width..
@@ -459,6 +460,7 @@ function updateIndentationSizeVar(
   indentationSizeRef.current = maxIndentationSize;
 
   list.style.setProperty('--indentation-size', `${maxIndentationSize}px`);
+  list.style.setProperty('--inner-element-width', `${innerElementWidth}px`);
 }
 
 function InnerElementType({children, style, ...rest}) {

--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
@@ -33,7 +33,8 @@ import TreeFocusedContext from './TreeFocusedContext';
 import styles from './Tree.css';
 
 // Never indent more than this number of pixels (even if we have the room).
-const DEFAULT_INDENTATION_SIZE = 12;
+const MAX_INDENTATION_SIZE = 12;
+const MIN_INDENTATION_SIZE = 3;
 
 export type ItemData = {|
   numElements: number,
@@ -419,7 +420,7 @@ function updateIndentationSizeVar(
 
   // Reset the max indentation size if the width of the tree has increased.
   if (listWidth > prevListWidthRef.current) {
-    indentationSizeRef.current = DEFAULT_INDENTATION_SIZE;
+    indentationSizeRef.current = MAX_INDENTATION_SIZE;
   }
   prevListWidthRef.current = listWidth;
 
@@ -449,6 +450,12 @@ function updateIndentationSizeVar(
     maxIndentationSize = Math.min(maxIndentationSize, remainingWidth / depth);
   }
 
+  // Ensures indentation will not fall below a minimum width..
+  maxIndentationSize =
+    maxIndentationSize >= MIN_INDENTATION_SIZE
+      ? maxIndentationSize
+      : MIN_INDENTATION_SIZE;
+
   indentationSizeRef.current = maxIndentationSize;
 
   list.style.setProperty('--indentation-size', `${maxIndentationSize}px`);
@@ -473,7 +480,7 @@ function InnerElementType({children, style, ...rest}) {
   // The user may have resized the window specifically to make more room for DevTools.
   // In either case, this should reset our max indentation size logic.
   // 2. The second is when the user enters or exits an owner tree.
-  const indentationSizeRef = useRef<number>(DEFAULT_INDENTATION_SIZE);
+  const indentationSizeRef = useRef<number>(MAX_INDENTATION_SIZE);
   const prevListWidthRef = useRef<number>(0);
   const prevOwnerIDRef = useRef<number | null>(ownerID);
   const divRef = useRef<HTMLDivElement | null>(null);
@@ -482,7 +489,7 @@ function InnerElementType({children, style, ...rest}) {
   // so when the user opens the "owners tree" view, we should discard the previous width.
   if (ownerID !== prevOwnerIDRef.current) {
     prevOwnerIDRef.current = ownerID;
-    indentationSizeRef.current = DEFAULT_INDENTATION_SIZE;
+    indentationSizeRef.current = MAX_INDENTATION_SIZE;
   }
 
   // When we render new content, measure to see if we need to shrink indentation to fit it.


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/16742

In extreme cases, components with names that exceed the DevTools window width cause the dynamic indentation calculation to equal 0, flattening the entire component hierarchy. When this happens, it is difficult to discern between parent, sibling, and child components. This PR adds a minimum indentation size to ensure the tree is still visually usable in extreme cases, while preserving the regular dynamic indentation functionality under normal circumstances.

**Before:**

![before](https://user-images.githubusercontent.com/1900645/64728237-3032c400-d4a0-11e9-931c-a00c44c88441.PNG)

**After:**

![after](https://user-images.githubusercontent.com/1900645/64728944-c9160f00-d4a1-11e9-911b-5ea1176945cb.PNG)

**Happy Path:**

![normal](https://user-images.githubusercontent.com/1900645/64729070-ffec2500-d4a1-11e9-99f6-075eb70955e5.PNG)



