### PR TITLE
[Scheduler][www] Put profiling feature behind flag

### DIFF
--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
@@ -9,7 +9,8 @@
 export const {
   enableIsInputPending,
   enableSchedulerDebugging,
+  enableProfiling: enableProfilingFeatureFlag,
 } = require('SchedulerFeatureFlags');
 
-export const enableProfiling = __PROFILE__;
+export const enableProfiling = __PROFILE__ && enableProfilingFeatureFlag;
 export const enableMessageLoopImplementation = true;


### PR DESCRIPTION
Our infra currently doesn't support loading a separate profiling build of Scheduler. Until that's fixed, the recommendation is to load a single build and gate the profiling feature behind a flag.

Alternative to #16659