### PR TITLE
[react-devtools] Enable to display Long interaction names(#16736)

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/InteractionListItem.css
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/InteractionListItem.css
@@ -16,8 +16,7 @@
 
 .Name {
   white-space: nowrap;
-  overflow-x: hidden;
-  text-overflow: ellipsis;
+  overflow-x: scroll;
 }
 
 .Timeline {

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarInteractions.css
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarInteractions.css
@@ -16,8 +16,7 @@
 .Name {
   font-size: var(--font-size-sans-large);
   white-space: nowrap;
-  overflow-x: hidden;
-  text-overflow: ellipsis;
+  overflow-x: scroll;
 }
 
 .NothingSelected {


### PR DESCRIPTION
issues: #16736 

fixed long interaction names displayable.
<img width="747" alt="スクリーンショット 2019-09-13 3 44 22" src="https://user-images.githubusercontent.com/32378535/64811789-ebf70f00-d5d8-11e9-9f92-9e276b18f28a.png">