### PR TITLE
Support disabling interaction tracing for suspense promises

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1512,7 +1512,9 @@ function attachSuspenseRetryListeners(finishedWork: Fiber) {
       let retry = resolveRetryThenable.bind(null, finishedWork, thenable);
       if (!retryCache.has(thenable)) {
         if (enableSchedulerTracing) {
-          retry = Schedule_tracing_wrap(retry);
+          if ((thenable: any).__reactDoNotTraceInteractions !== true) {
+            retry = Schedule_tracing_wrap(retry);
+          }
         }
         retryCache.add(thenable);
         thenable.then(retry, retry);

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1512,7 +1512,7 @@ function attachSuspenseRetryListeners(finishedWork: Fiber) {
       let retry = resolveRetryThenable.bind(null, finishedWork, thenable);
       if (!retryCache.has(thenable)) {
         if (enableSchedulerTracing) {
-          if ((thenable: any).__reactDoNotTraceInteractions !== true) {
+          if (thenable.__reactDoNotTraceInteractions !== true) {
             retry = Schedule_tracing_wrap(retry);
           }
         }

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -174,7 +174,7 @@ function attachPingListener(
       renderExpirationTime,
     );
     if (enableSchedulerTracing) {
-      if ((thenable: any).__reactDoNotTraceInteractions !== true) {
+      if (thenable.__reactDoNotTraceInteractions !== true) {
         ping = Schedule_tracing_wrap(ping);
       }
     }

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -174,7 +174,9 @@ function attachPingListener(
       renderExpirationTime,
     );
     if (enableSchedulerTracing) {
-      ping = Schedule_tracing_wrap(ping);
+      if ((thenable: any).__reactDoNotTraceInteractions !== true) {
+        ping = Schedule_tracing_wrap(ping);
+      }
     }
     thenable.then(ping, ping);
   }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -204,6 +204,9 @@ const RootCompleted = 4;
 
 export type Thenable = {
   then(resolve: () => mixed, reject?: () => mixed): Thenable | void,
+
+  // Special flag to opt out of tracing interactions across a Suspense boundary.
+  __reactDoNotTraceInteractions?: boolean,
 };
 
 // Describes where we are in the React execution stack


### PR DESCRIPTION
If a thrown Promise has the `__reactDoNotTraceInteractions` attribute, React will not wrapped its callbacks to continue tracing any current interaction(s).

Example usage:
```js
function SomeComponent() {
  try {
    const value = SomeCache.read(/*...*/);
  } catch (maybePromise) {
    if (typeof value === "object" && typeof value.then === "function") {
      maybePromise.__reactDoNotTraceInteractions = true;
    }
    throw maybePromise;
  }
}
```