### PR TITLE
Remove unnecessary interaction tracing ping wrapper

### DIFF
--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -15,7 +15,6 @@ import type {Update} from './ReactUpdateQueue';
 import type {Thenable} from './ReactFiberWorkLoop';
 import type {SuspenseContext} from './ReactFiberSuspenseContext';
 
-import {unstable_wrap as Schedule_tracing_wrap} from 'scheduler/tracing';
 import getComponentName from 'shared/getComponentName';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {
@@ -31,7 +30,6 @@ import {
   ShouldCapture,
   LifecycleEffectMask,
 } from 'shared/ReactSideEffectTags';
-import {enableSchedulerTracing} from 'shared/ReactFeatureFlags';
 import {NoMode, BatchedMode} from './ReactTypeOfMode';
 import {shouldCaptureSuspense} from './ReactFiberSuspenseComponent';
 
@@ -173,11 +171,6 @@ function attachPingListener(
       thenable,
       renderExpirationTime,
     );
-    if (enableSchedulerTracing) {
-      if (thenable.__reactDoNotTraceInteractions !== true) {
-        ping = Schedule_tracing_wrap(ping);
-      }
-    }
     thenable.then(ping, ping);
   }
 }


### PR DESCRIPTION
Follow up to PR #16776 

Previously we wrapped the call to `pingSuspendedRoot` in `attachPingListener` to restore interactions. Sebastian pointed out that this particular function is only relevant when there is an in progress render (at which point we are already tracking/managing the current interactions in the work loop) so wrapping here would be unnecessary.

Probably no harm in leaving it in place? Opening this PR for discussion purposes though.