### PR TITLE
[react-events] Keyboard calls preventDefault on 'click' events

### DIFF
--- a/packages/react-events/src/dom/testing-library/domEvents.js
+++ b/packages/react-events/src/dom/testing-library/domEvents.js
@@ -137,6 +137,7 @@ function createKeyboardEvent(
   {
     altKey = false,
     ctrlKey = false,
+    isComposing = false,
     key = '',
     metaKey = false,
     preventDefault = emptyFunction,
@@ -151,6 +152,7 @@ function createKeyboardEvent(
     getModifierState(keyArg) {
       createGetModifierState(keyArg, modifierState);
     },
+    isComposing,
     key,
     metaKey,
     preventDefault,

--- a/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
@@ -220,9 +220,6 @@ describe('ReactScope', () => {
       let target = createEventTarget(ref.current);
       target.keydown({key: 'Q'});
       expect(onKeyDown).toHaveBeenCalledTimes(1);
-      expect(onKeyDown).toHaveBeenCalledWith(
-        expect.objectContaining({key: 'Q', type: 'keydown'}),
-      );
 
       onKeyDown = jest.fn();
       Component = () => {
@@ -242,9 +239,6 @@ describe('ReactScope', () => {
       target = createEventTarget(ref.current);
       target.keydown({key: 'Q'});
       expect(onKeyDown).toHaveBeenCalledTimes(1);
-      expect(onKeyDown).toHaveBeenCalledWith(
-        expect.objectContaining({key: 'Q', type: 'keydown'}),
-      );
     });
   });
 


### PR DESCRIPTION
Make sure to call preventDefault for any 'click' events that follow a 'keydown'
event that matches 'preventKeys'.