### PR TITLE
[eslint] strip tailing property in assignments

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -585,6 +585,16 @@ const tests = {
       `,
     },
     {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          let foo = {}
+          useEffect(() => {
+            foo.bar.baz = 43;
+          }, [foo.bar]);
+        }
+      `,
+    },
+    {
       // Valid because we assign ref.current
       // ourselves. Therefore it's likely not
       // a ref managed by React.
@@ -6394,6 +6404,39 @@ const tests = {
       ],
       // Keep this until major IDEs and VS Code FB ESLint plugin support Suggestions API.
       options: [{enableDangerousAutofixThisMayCauseInfiniteLoops: true}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          let foo = {}
+          useEffect(() => {
+            foo.bar.baz = 43;
+            props.foo.bar.baz = 1;
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has missing dependencies: 'foo.bar' and 'props.foo.bar'. " +
+            'Either include them or remove the dependency array.',
+          suggestions: [
+            {
+              desc:
+                'Update the dependencies array to be: [foo.bar, props.foo.bar]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  let foo = {}
+                  useEffect(() => {
+                    foo.bar.baz = 43;
+                    props.foo.bar.baz = 1;
+                  }, [foo.bar, props.foo.bar]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
     },
   ],
 };

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1437,20 +1437,7 @@ function getDependency(node) {
     )
   ) {
     return getDependency(node.parent);
-  } else {
-    return stripTailingPropInAssignment(node);
-  }
-}
-
-/**
- * Assuming () means the passed/returned node:
- * (props) => (props)
- * (props.foo) => (props.foo)
- * (props.foo.bar) = X => (props.foo).bar = X
- * (props.foo.bar.baz) = X => (props.foo.bar).baz
- */
-function stripTailingPropInAssignment(node) {
-  if (
+  } else if (
     node.type === 'MemberExpression' &&
     node.parent &&
     node.parent.type === 'AssignmentExpression'

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1438,6 +1438,25 @@ function getDependency(node) {
   ) {
     return getDependency(node.parent);
   } else {
+    return stripTailingPropInAssignment(node);
+  }
+}
+
+/**
+ * Assuming () means the passed/returned node:
+ * (props) => (props)
+ * (props.foo) => (props.foo)
+ * (props.foo.bar) = X => (props.foo).bar = X
+ * (props.foo.bar.baz) = X => (props.foo.bar).baz
+ */
+function stripTailingPropInAssignment(node) {
+  if (
+    node.type === 'MemberExpression' &&
+    node.parent &&
+    node.parent.type === 'AssignmentExpression'
+  ) {
+    return node.object;
+  } else {
     return node;
   }
 }


### PR DESCRIPTION
closes #15510

>``` 
>let foo = {}
>useEffect(() => {
>   foo.bar.baz = 43;
>}, []);
>```
>This asks you to include foo.bar.baz into deps. But this doesn't make sense, as you write to it. Instead it should ask to include foo.bar into array.