### PR TITLE
[react-devtools-shared] Added string type check for object name prop in getDisplayName function

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -11,48 +11,30 @@ import {getDisplayName} from 'react-devtools-shared/src/utils';
 
 describe('utils', () => {
   describe('getDisplayName', () => {
-    const fallbackName = 'TestFallbackName';
-
-    it('should return default fallback name for empty object', () => {
-      const result = getDisplayName({});
-      expect(result).toEqual('Anonymous');
+    it('should return a function name', () => {
+      function FauxComponent() {}
+      expect(getDisplayName(FauxComponent)).toEqual('FauxComponent');
     });
 
-    it('should return displayName property from object', () => {
-      const obj = {
-        displayName: 'TestDisplayName',
-      };
-      const result = getDisplayName(obj);
-      expect(result).toEqual(obj.displayName);
+    it('should return a displayName name if specified', () => {
+      function FauxComponent() {}
+      FauxComponent.displayName = 'OverrideDisplayName';
+      expect(getDisplayName(FauxComponent)).toEqual('OverrideDisplayName');
     });
 
-    it('should return name property from object', () => {
-      const obj = {
-        name: 'TestName',
-      };
-      const result = getDisplayName(obj);
-      expect(result).toEqual(obj.name);
+    it('should return the fallback for anonymous functions', () => {
+      expect(getDisplayName(() => {}, 'Fallback')).toEqual('Fallback');
     });
 
-    it('should return provided fallback name for empty object', () => {
-      const result = getDisplayName({}, fallbackName);
-      expect(result).toEqual(fallbackName);
+    it('should return Anonymous for anonymous functions without a fallback', () => {
+      expect(getDisplayName(() => {})).toEqual('Anonymous');
     });
 
-    it('should provide fallback name when displayName prop is not a string', () => {
-      const obj = {
-        displayName: {},
-      };
-      const result = getDisplayName(obj, fallbackName);
-      expect(result).toEqual(fallbackName);
-    });
-
-    it('should provide fallback name when name prop is not a string', () => {
-      const obj = {
-        name: {},
-      };
-      const result = getDisplayName(obj, fallbackName);
-      expect(result).toEqual(fallbackName);
+    // Simulate a reported bug:
+    // https://github.com/facebook/react/issues/16685
+    it('should return a fallback when the name prop is not a string', () => {
+      const FauxComponent = {name: {}};
+      expect(getDisplayName(FauxComponent, 'Fallback')).toEqual('Fallback');
     });
   });
 });

--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {getDisplayName} from 'react-devtools-shared/src/utils';
+
+describe('utils', () => {
+  describe('getDisplayName', () => {
+    const fallbackName = 'TestFallbackName';
+
+    it('should return default fallback name for empty object', () => {
+      const result = getDisplayName({});
+      expect(result).toEqual('Anonymous');
+    });
+
+    it('should return displayName property from object', () => {
+      const obj = {
+        displayName: 'TestDisplayName',
+      };
+      const result = getDisplayName(obj);
+      expect(result).toEqual(obj.displayName);
+    });
+
+    it('should return name property from object', () => {
+      const obj = {
+        name: 'TestName',
+      };
+      const result = getDisplayName(obj);
+      expect(result).toEqual(obj.name);
+    });
+
+    it('should return provided fallback name for empty object', () => {
+      const result = getDisplayName({}, fallbackName);
+      expect(result).toEqual(fallbackName);
+    });
+
+    it('should provide fallback name when displayName prop is not a string', () => {
+      const obj = {
+        displayName: {},
+      };
+      const result = getDisplayName(obj, fallbackName);
+      expect(result).toEqual(fallbackName);
+    });
+
+    it('should provide fallback name when name prop is not a string', () => {
+      const obj = {
+        name: {},
+      };
+      const result = getDisplayName(obj, fallbackName);
+      expect(result).toEqual(fallbackName);
+    });
+  });
+});

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -46,17 +46,15 @@ export function getDisplayName(
     return nameFromCache;
   }
 
-  let displayName;
+  let displayName = fallbackName;
 
   // The displayName property is not guaranteed to be a string.
   // It's only safe to use for our purposes if it's a string.
   // github.com/facebook/react-devtools/issues/803
   if (typeof type.displayName === 'string') {
     displayName = type.displayName;
-  }
-
-  if (!displayName) {
-    displayName = type.name || fallbackName;
+  } else if (typeof type.name === 'string') {
+    displayName = type.name;
   }
 
   cachedDisplayNames.set(type, displayName);

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -53,7 +53,7 @@ export function getDisplayName(
   // github.com/facebook/react-devtools/issues/803
   if (typeof type.displayName === 'string') {
     displayName = type.displayName;
-  } else if (typeof type.name === 'string') {
+  } else if (typeof type.name === 'string' && type.name !== '') {
     displayName = type.name;
   }
 


### PR DESCRIPTION
Fixes issue #16685

I've added a small fix in ```getDisplayName``` function from ```utils.js``` file for the case when ```type``` argument doesn't have a ```displayName``` property, but has ```name``` property with incorrect value ex. object. That case means that developer who is using react has in the code something like this: 
```
const Icon = () => {...}
Icon.name = { foo: 'bar' };
```
DevTools relay on displayName/name properties when displaying component names in the tree. 
```getDisplayName``` function requires displayName/name properties to be a string values, otherwise it will use fallback name - 'Anonymous'. 

Tests are included.
You can find longer description of what was wrong in the issue.