### PR TITLE
Warning system refactoring (part 1)

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -61,7 +61,7 @@ import ReactVersion from 'shared/ReactVersion';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
-import lowPriorityWarning from 'shared/lowPriorityWarning';
+import lowPriorityWarningWithoutStack from 'shared/lowPriorityWarningWithoutStack';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import {enableStableConcurrentModeAPIs} from 'shared/ReactFeatureFlags';
 
@@ -536,7 +536,7 @@ function legacyCreateRootFromDOMContainer(
   if (__DEV__) {
     if (shouldHydrate && !forceHydrate && !warnedAboutHydrateAPI) {
       warnedAboutHydrateAPI = true;
-      lowPriorityWarning(
+      lowPriorityWarningWithoutStack(
         false,
         'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
           'will stop working in React v17. Replace the ReactDOM.render() call ' +
@@ -795,7 +795,7 @@ const ReactDOM: Object = {
   unstable_createPortal(...args) {
     if (!didWarnAboutUnstableCreatePortal) {
       didWarnAboutUnstableCreatePortal = true;
-      lowPriorityWarning(
+      lowPriorityWarningWithoutStack(
         false,
         'The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
           'and will be removed in React 17+. Update your code to use ' +

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -15,7 +15,7 @@ import type {ReactProvider, ReactContext} from 'shared/ReactTypes';
 import React from 'react';
 import invariant from 'shared/invariant';
 import getComponentName from 'shared/getComponentName';
-import lowPriorityWarning from 'shared/lowPriorityWarning';
+import lowPriorityWarningWithoutStack from 'shared/lowPriorityWarningWithoutStack';
 import warning from 'shared/warning';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import describeComponentFrame from 'shared/describeComponentFrame';
@@ -588,7 +588,7 @@ function resolve(
             const componentName = getComponentName(Component) || 'Unknown';
 
             if (!didWarnAboutDeprecatedWillMount[componentName]) {
-              lowPriorityWarning(
+              lowPriorityWarningWithoutStack(
                 false,
                 // keep this warning in sync with ReactStrictModeWarning.js
                 'componentWillMount has been renamed, and is not recommended for use. ' +

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -17,7 +17,7 @@ import {
 } from 'shared/ReactWorkTags';
 import SyntheticEvent from 'legacy-events/SyntheticEvent';
 import invariant from 'shared/invariant';
-import lowPriorityWarning from 'shared/lowPriorityWarning';
+import lowPriorityWarningWithoutStack from 'shared/lowPriorityWarningWithoutStack';
 import {ELEMENT_NODE} from '../shared/HTMLNodeType';
 import * as DOMTopLevelEventTypes from '../events/DOMTopLevelEventTypes';
 import {PLUGIN_EVENT_SYSTEM} from 'legacy-events/EventSystemFlags';
@@ -361,7 +361,7 @@ const ReactTestUtils = {
   mockComponent: function(module, mockTagName) {
     if (!hasWarnedAboutDeprecatedMockComponent) {
       hasWarnedAboutDeprecatedMockComponent = true;
-      lowPriorityWarning(
+      lowPriorityWarningWithoutStack(
         false,
         'ReactTestUtils.mockComponent() is deprecated. ' +
           'Use shallow rendering or jest.mock() instead.\n\n' +

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -25,7 +25,7 @@ import {
   REACT_SUSPENSE_TYPE,
 } from 'shared/ReactSymbols';
 import isValidElementType from 'shared/isValidElementType';
-import lowPriorityWarning from 'shared/lowPriorityWarning';
+import lowPriorityWarningWithoutStack from 'shared/lowPriorityWarningWithoutStack';
 
 export function typeOf(object: any) {
   if (typeof object === 'object' && object !== null) {
@@ -88,7 +88,7 @@ export function isAsyncMode(object: any) {
   if (__DEV__) {
     if (!hasWarnedAboutDeprecatedIsAsyncMode) {
       hasWarnedAboutDeprecatedIsAsyncMode = true;
-      lowPriorityWarning(
+      lowPriorityWarningWithoutStack(
         false,
         'The ReactIs.isAsyncMode() alias has been deprecated, ' +
           'and will be removed in React 17+. Update your code to use ' +

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -13,7 +13,7 @@ import {getStackByFiberInDevAndProd} from './ReactCurrentFiber';
 
 import getComponentName from 'shared/getComponentName';
 import {StrictMode} from './ReactTypeOfMode';
-import lowPriorityWarning from 'shared/lowPriorityWarning';
+import lowPriorityWarningWithoutStack from 'shared/lowPriorityWarningWithoutStack';
 import warningWithoutStack from 'shared/warningWithoutStack';
 
 type FiberArray = Array<Fiber>;
@@ -237,7 +237,7 @@ if (__DEV__) {
     if (componentWillMountUniqueNames.size > 0) {
       const sortedNames = setToSortedString(componentWillMountUniqueNames);
 
-      lowPriorityWarning(
+      lowPriorityWarningWithoutStack(
         false,
         'componentWillMount has been renamed, and is not recommended for use. ' +
           'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
@@ -256,7 +256,7 @@ if (__DEV__) {
         componentWillReceivePropsUniqueNames,
       );
 
-      lowPriorityWarning(
+      lowPriorityWarningWithoutStack(
         false,
         'componentWillReceiveProps has been renamed, and is not recommended for use. ' +
           'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
@@ -276,7 +276,7 @@ if (__DEV__) {
     if (componentWillUpdateUniqueNames.size > 0) {
       const sortedNames = setToSortedString(componentWillUpdateUniqueNames);
 
-      lowPriorityWarning(
+      lowPriorityWarningWithoutStack(
         false,
         'componentWillUpdate has been renamed, and is not recommended for use. ' +
           'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +

--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -6,7 +6,7 @@
  */
 
 import invariant from 'shared/invariant';
-import lowPriorityWarning from 'shared/lowPriorityWarning';
+import lowPriorityWarningWithoutStack from 'shared/lowPriorityWarningWithoutStack';
 
 import ReactNoopUpdateQueue from './ReactNoopUpdateQueue';
 
@@ -105,7 +105,7 @@ if (__DEV__) {
   const defineDeprecationWarning = function(methodName, info) {
     Object.defineProperty(Component.prototype, methodName, {
       get: function() {
-        lowPriorityWarning(
+        lowPriorityWarningWithoutStack(
           false,
           '%s(...) is deprecated in plain JavaScript React classes. %s',
           info[0],

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -12,7 +12,7 @@
  * that support it.
  */
 
-import lowPriorityWarning from 'shared/lowPriorityWarning';
+import lowPriorityWarningWithoutStack from 'shared/lowPriorityWarningWithoutStack';
 import isValidElementType from 'shared/isValidElementType';
 import getComponentName from 'shared/getComponentName';
 import {
@@ -477,7 +477,7 @@ export function createFactoryWithValidation(type) {
     Object.defineProperty(validatedFactory, 'type', {
       enumerable: false,
       get: function() {
-        lowPriorityWarning(
+        lowPriorityWarningWithoutStack(
           false,
           'Factory.type is deprecated. Access the class directly ' +
             'before passing it to createFactory.',

--- a/packages/shared/forks/lowPriorityWarningWithoutStack.www.js
+++ b/packages/shared/forks/lowPriorityWarningWithoutStack.www.js
@@ -5,4 +5,5 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// This "lowPriorityWarning" is an external module
 export default require('lowPriorityWarning');

--- a/packages/shared/lowPriorityWarning.js
+++ b/packages/shared/lowPriorityWarning.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import lowPriorityWarningWithoutStack from 'shared/lowPriorityWarningWithoutStack';
+import ReactSharedInternals from 'shared/ReactSharedInternals';
+
+/**
+ * Similar to invariant but only logs a warning if the condition is not met.
+ * This can be used to log issues in development environments in critical
+ * paths. Removing the logging code for production environments will keep the
+ * same logic and follow the same code paths.
+ */
+
+let lowPriorityWarning = lowPriorityWarningWithoutStack;
+
+if (__DEV__) {
+  lowPriorityWarning = function(condition, format, ...args) {
+    if (condition) {
+      return;
+    }
+    const ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+    const stack = ReactDebugCurrentFrame.getStackAddendum();
+    // eslint-disable-next-line react-internal/warning-and-invariant-args
+    lowPriorityWarningWithoutStack(false, format + '%s', ...args, stack);
+  };
+}
+
+export default lowPriorityWarning;

--- a/packages/shared/lowPriorityWarningWithoutStack.js
+++ b/packages/shared/lowPriorityWarningWithoutStack.js
@@ -19,7 +19,7 @@
  * same logic and follow the same code paths.
  */
 
-let lowPriorityWarning = function() {};
+let lowPriorityWarningWithoutStack = function() {};
 
 if (__DEV__) {
   const printWarning = function(format, ...args) {
@@ -36,10 +36,10 @@ if (__DEV__) {
     } catch (x) {}
   };
 
-  lowPriorityWarning = function(condition, format, ...args) {
+  lowPriorityWarningWithoutStack = function(condition, format, ...args) {
     if (format === undefined) {
       throw new Error(
-        '`lowPriorityWarning(condition, format, ...args)` requires a warning ' +
+        '`lowPriorityWarningWithoutStack(condition, format, ...args)` requires a warning ' +
           'message argument',
       );
     }
@@ -49,4 +49,4 @@ if (__DEV__) {
   };
 }
 
-export default lowPriorityWarning;
+export default lowPriorityWarningWithoutStack;

--- a/scripts/print-warnings/print-warnings.js
+++ b/scripts/print-warnings/print-warnings.js
@@ -53,7 +53,7 @@ function transform(file, enc, cb) {
           if (
             callee.isIdentifier({name: 'warning'}) ||
             callee.isIdentifier({name: 'warningWithoutStack'}) ||
-            callee.isIdentifier({name: 'lowPriorityWarning'})
+            callee.isIdentifier({name: 'lowPriorityWarningWithoutStack'})
           ) {
             const node = astPath.node;
 

--- a/scripts/print-warnings/print-warnings.js
+++ b/scripts/print-warnings/print-warnings.js
@@ -53,6 +53,7 @@ function transform(file, enc, cb) {
           if (
             callee.isIdentifier({name: 'warning'}) ||
             callee.isIdentifier({name: 'warningWithoutStack'}) ||
+            callee.isIdentifier({name: 'lowPriorityWarning'}) ||
             callee.isIdentifier({name: 'lowPriorityWarningWithoutStack'})
           ) {
             const node = astPath.node;
@@ -82,6 +83,7 @@ function transform(file, enc, cb) {
 gs([
   'packages/**/*.js',
   '!packages/shared/warning.js',
+  '!packages/shared/lowPriorityWarning.js',
   '!packages/react-devtools*/**/*.js',
   '!**/__tests__/**/*.js',
   '!**/__mocks__/**/*.js',

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -181,12 +181,12 @@ const forks = Object.freeze({
   },
 
   // This logic is forked on www to ignore some warnings.
-  'shared/lowPriorityWarning': (bundleType, entry) => {
+  'shared/lowPriorityWarningWithoutStack': (bundleType, entry) => {
     switch (bundleType) {
       case FB_WWW_DEV:
       case FB_WWW_PROD:
       case FB_WWW_PROFILING:
-        return 'shared/forks/lowPriorityWarning.www.js';
+        return 'shared/forks/lowPriorityWarningWithoutStack.www.js';
       default:
         return null;
     }


### PR DESCRIPTION
Step 1 of the refactoring proposed in https://github.com/facebook/react/issues/16753

It's pretty much the minimum for now, to make it easier to merge. The `toLowPriorityWarnDev` matcher usage checks still mention the `toWarnDev` name, though. It can be fixed by making the matcher name also an argument to the factory, or the matcher could be forked instead of using a factory.