### PR TITLE
[suspense][error handling] Inline renderRoot and fix error handling bug

### DIFF
--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -342,5 +342,6 @@
   "341": "We just came from a parent so we must have had a parent. This is a bug in React.",
   "342": "A React component suspended while rendering, but no fallback UI was specified.\n\nAdd a <Suspense fallback=...> component higher in the tree to provide a loading indicator or placeholder to display.",
   "343": "ReactDOMServer does not yet support scope components.",
-  "344": "Expected prepareToHydrateHostSuspenseInstance() to never be called. This error is likely caused by a bug in React. Please file an issue."
+  "344": "Expected prepareToHydrateHostSuspenseInstance() to never be called. This error is likely caused by a bug in React. Please file an issue.",
+  "345": "Root did not complete. This is a bug in React."
 }


### PR DESCRIPTION
Follow-up to work loop refactor in #16743.

After the recent changes, the `isSync` argument to `renderRoot` is only used in a single place, to determine whether to call `workLoop` or `workLoopSync`. All other forked behavior was lifted into `performConcurrentWorkOnRoot` and `performSyncWorkOnRoot`. So, this goes one step further and inlines `renderRoot` into its callers.

Most of the changes here are copy-pasting and moving stuff around. The high level flow is essentially the same. I split the work into small commits to help with reviewing.

The final commit is unrelated, but I've included it because it fixes the test I added in #16800. The fix relies on the `handleError` function I extracted as part of this refactor PR. I could also submit a separate fix that's independent of this PR; however, since it's not a super urgent bug, and I was planning to do these refactors regardless, I think it's fine to group these.

Fixes #16800