### PR TITLE
[scheduler][profiler] Start time of delayed tasks

### DIFF
--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -91,7 +91,7 @@ function advanceTimers(currentTime) {
       timer.sortIndex = timer.expirationTime;
       push(taskQueue, timer);
       if (enableProfiling) {
-        markTaskStart(timer);
+        markTaskStart(timer, currentTime);
         timer.isQueued = true;
       }
     } else {

--- a/packages/scheduler/src/__tests__/SchedulerProfiling-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerProfiling-test.js
@@ -483,6 +483,32 @@ Task 2 [Normal]              │    ░░░░░░░░🡐 canceled
     );
   });
 
+  it('handles delayed tasks', () => {
+    Scheduler.unstable_Profiling.startLoggingProfilingEvents();
+    scheduleCallback(
+      NormalPriority,
+      () => {
+        Scheduler.unstable_advanceTime(1000);
+        Scheduler.unstable_yieldValue('A');
+      },
+      {
+        delay: 1000,
+      },
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+
+    Scheduler.unstable_advanceTime(1000);
+
+    expect(Scheduler).toFlushAndYield(['A']);
+
+    expect(stopProfilingAndPrintFlamegraph()).toEqual(
+      `
+!!! Main thread              │████████████████████░░░░░░░░░░░░░░░░░░░░
+Task 1 [Normal]              │                    ████████████████████
+`,
+    );
+  });
+
   it('handles cancelling a delayed task', () => {
     Scheduler.unstable_Profiling.startLoggingProfilingEvents();
     const task = scheduleCallback(


### PR DESCRIPTION
Fixes a bug in the Scheduler profiler where the start time of a delayed tasks is always 0.