### PR TITLE
expose isHydrating on host config/ReactDOM

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -39,6 +39,7 @@ import {
   findHostInstanceWithWarning,
   flushPassiveEffects,
   IsThisRendererActing,
+  isHydrating,
 } from 'react-reconciler/inline.dom';
 import {createPortal as createPortalImpl} from 'shared/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
@@ -840,6 +841,7 @@ const ReactDOM: Object = {
       runEventsInBatch,
       flushPassiveEffects,
       IsThisRendererActing,
+      isHydrating,
     ],
   },
 };

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -546,6 +546,8 @@ export function unhideTextInstance(
 //     Hydration
 // -------------------
 
+export const isHydrating = {current: false};
+
 export const supportsHydration = true;
 
 export function canHydrateInstance(

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -43,6 +43,7 @@ const [
   /* eslint-disable no-unused-vars */
   flushPassiveEffects,
   IsThisRendererActing,
+  isHydrating,
   /* eslint-enable no-unused-vars */
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
 

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -33,6 +33,9 @@ const [
   /* eslint-enable no-unused-vars */
   flushPassiveEffects,
   IsThisRendererActing,
+  /* eslint-disable no-unused-vars */
+  isHydrating,
+  /* eslint-enable no-unused-vars */
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
 
 const batchedUpdates = ReactDOM.unstable_batchedUpdates;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -245,6 +245,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
   }
 
   const sharedHostConfig = {
+    isHydrating: {current: false},
     getRootHostContext() {
       return NO_CONTEXT;
     },

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -33,7 +33,7 @@ import invariant from 'shared/invariant';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
-import {getPublicInstance} from './ReactFiberHostConfig';
+import {getPublicInstance, isHydrating} from './ReactFiberHostConfig';
 import {
   findCurrentUnmaskedContext,
   processChildContext,
@@ -345,6 +345,7 @@ export {
   flushSync,
   flushPassiveEffects,
   IsThisRendererActing,
+  isHydrating,
 };
 
 export function getPublicRootInstance(

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -151,3 +151,4 @@ export const didNotFindHydratableTextInstance =
   $$$hostConfig.didNotFindHydratableTextInstance;
 export const didNotFindHydratableSuspenseInstance =
   $$$hostConfig.didNotFindHydratableSuspenseInstance;
+export const isHydrating = $$$hostConfig.isHydrating;

--- a/packages/shared/HostConfigWithNoHydration.js
+++ b/packages/shared/HostConfigWithNoHydration.js
@@ -48,3 +48,6 @@ export const didNotFindHydratableContainerSuspenseInstance = shim;
 export const didNotFindHydratableInstance = shim;
 export const didNotFindHydratableTextInstance = shim;
 export const didNotFindHydratableSuspenseInstance = shim;
+
+// $FlowFixMe We do not want to change the flow signature of isHydrating
+export const isHydrating = null;


### PR DESCRIPTION
As part of an experiment, this PR moves `isHydrating` from ReactFiberHydrationContext to a ref on the host configs that support hydration (ie: react-dom and react-noop). It also exposes the same ref on react-dom's "internal" export. We will remove this export in the near future.