### PR TITLE
[react-core] Do not null fiber.sibling in detachFiber

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -904,7 +904,6 @@ function detachFiber(current: Fiber) {
   current.memoizedState = null;
   current.updateQueue = null;
   current.dependencies = null;
-  current.sibling = null;
   current.alternate = null;
   current.firstEffect = null;
   current.lastEffect = null;


### PR DESCRIPTION
We encountered an issue internally when using `findDOMNode` and the changes introduced in https://github.com/facebook/react/pull/16807. Specifically, setting the fiber `sibling` field to `null` is problematic in that it runs into this invariant:

https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberTreeReflection.js#L213-L214

We traverse through the children of the fiber by going from fiber to fiber using `sibling`. Doing this, we encounter a child fiber that has been detatched earlier and thus has no sibling anymore, but the code for `findCurrentFiberUsingSlowPath` expects it should.

We need to revisit this, but for now, let's revert this specific change.