### PR TITLE
[React Native] Fix for view config registrations

### DIFF
--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativeViewConfigRegistry.js
@@ -101,10 +101,13 @@ exports.get = function(name: string): ReactNativeBaseComponentViewConfig<> {
           : '',
       );
     }
-    viewConfigCallbacks.set(name, null);
     viewConfig = callback();
     processEventTypes(viewConfig);
     viewConfigs.set(name, viewConfig);
+
+    // Clear the callback after the config is set so that
+    // we don't mask any errors during registration.
+    viewConfigCallbacks.set(name, null);
   } else {
     viewConfig = viewConfigs.get(name);
   }

--- a/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
@@ -75,6 +75,49 @@ beforeEach(() => {
     .ReactNativeViewConfigRegistry.register;
 });
 
+it('fails to register the same event name with different types', () => {
+  const InvalidEvents = createReactNativeComponentClass('InvalidEvents', () => {
+    if (!__DEV__) {
+      // Simulate a registration error in prod.
+      throw new Error('Event cannot be both direct and bubbling: topChange');
+    }
+
+    // This view config has the same bubbling and direct event name
+    // which will fail to register in developement.
+    return {
+      uiViewClassName: 'InvalidEvents',
+      validAttributes: {
+        onChange: true,
+      },
+      bubblingEventTypes: {
+        topChange: {
+          phasedRegistrationNames: {
+            bubbled: 'onChange',
+            captured: 'onChangeCapture',
+          },
+        },
+      },
+      directEventTypes: {
+        topChange: {
+          registrationName: 'onChange',
+        },
+      },
+    };
+  });
+
+  // The first time this renders,
+  // we attempt to register the view config and fail.
+  expect(() => ReactNative.render(<InvalidEvents />, 1)).toThrow(
+    'Event cannot be both direct and bubbling: topChange',
+  );
+
+  // Continue to re-register the config and
+  // fail so that we don't mask the above failure.
+  expect(() => ReactNative.render(<InvalidEvents />, 1)).toThrow(
+    'Event cannot be both direct and bubbling: topChange',
+  );
+});
+
 it('fails if unknown/unsupported event types are dispatched', () => {
   expect(RCTEventEmitter.register).toHaveBeenCalledTimes(1);
   const EventEmitter = RCTEventEmitter.register.mock.calls[0][0];

--- a/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
+++ b/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
@@ -98,10 +98,13 @@ exports.get = function(name: string): ReactNativeBaseComponentViewConfig<> {
           : '',
       );
     }
-    viewConfigCallbacks.set(name, null);
     viewConfig = callback();
     processEventTypes(viewConfig);
     viewConfigs.set(name, viewConfig);
+
+    // Clear the callback after the config is set so that
+    // we don't mask any errors during registration.
+    viewConfigCallbacks.set(name, null);
   } else {
     viewConfig = viewConfigs.get(name);
   }


### PR DESCRIPTION
## Overview
This change fixes a behavior in the React Native view config registry which would hide errors when registering components.

## Details
Before this change, even if we failed to register the view config for any reason (e.g. the events are invalid), we would still clear the callback for the view config.

This means, the next time that a user renders the component and we check for the view config, we would show this error:

> View config not found for name Slider

This error is wrong. The real error is masked (and may never be shown, if the registration happened before error handling is set up), and may be something like:

> Event cannot be both direct and bubbling: topChange

This PR fixes this behavior by clearing the view config callback only after the view config is successfully registered.

## Screen
<img width="756" alt="Screen Shot 2019-09-18 at 2 28 04 PM" src="https://user-images.githubusercontent.com/2440089/65152802-94193780-da20-11e9-84d6-2d8c6e92912f.png">

## Test

- Added test that fails without this change