### PR TITLE
[react-ui] Remove event object warnings

### DIFF
--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -303,6 +303,16 @@ function validateEventValue(eventValue: any): void {
         );
       }
     };
+    eventValue.isDefaultPrevented = () => {
+      if (__DEV__) {
+        showWarning('isDefaultPrevented()');
+      }
+    };
+    eventValue.isPropagationStopped = () => {
+      if (__DEV__) {
+        showWarning('isPropagationStopped()');
+      }
+    };
     // $FlowFixMe: we don't need value, Flow thinks we do
     Object.defineProperty(eventValue, 'nativeEvent', {
       get() {

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -303,26 +303,6 @@ function validateEventValue(eventValue: any): void {
         );
       }
     };
-    eventValue.preventDefault = () => {
-      if (__DEV__) {
-        showWarning('preventDefault()');
-      }
-    };
-    eventValue.stopPropagation = () => {
-      if (__DEV__) {
-        showWarning('stopPropagation()');
-      }
-    };
-    eventValue.isDefaultPrevented = () => {
-      if (__DEV__) {
-        showWarning('isDefaultPrevented()');
-      }
-    };
-    eventValue.isPropagationStopped = () => {
-      if (__DEV__) {
-        showWarning('isPropagationStopped()');
-      }
-    };
     // $FlowFixMe: we don't need value, Flow thinks we do
     Object.defineProperty(eventValue, 'nativeEvent', {
       get() {

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -839,6 +839,30 @@ describe('DOMEventResponderSystem', () => {
     };
     expect(() => {
       handler = event => {
+        event.isDefaultPrevented();
+      };
+      ReactDOM.render(<Test />, container);
+      dispatchClickEvent(buttonRef.current);
+    }).toWarnDev(
+      'Warning: isDefaultPrevented() is not available on event objects created from event responder modules ' +
+        '(React Flare).' +
+        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.isDefaultPrevented() }`',
+      {withoutStack: true},
+    );
+    expect(() => {
+      handler = event => {
+        event.isPropagationStopped();
+      };
+      ReactDOM.render(<Test />, container);
+      dispatchClickEvent(buttonRef.current);
+    }).toWarnDev(
+      'Warning: isPropagationStopped() is not available on event objects created from event responder modules ' +
+        '(React Flare).' +
+        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.isPropagationStopped() }`',
+      {withoutStack: true},
+    );
+    expect(() => {
+      handler = event => {
         return event.nativeEvent;
       };
       ReactDOM.render(<Test />, container);

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -839,54 +839,6 @@ describe('DOMEventResponderSystem', () => {
     };
     expect(() => {
       handler = event => {
-        event.preventDefault();
-      };
-      ReactDOM.render(<Test />, container);
-      dispatchClickEvent(buttonRef.current);
-    }).toWarnDev(
-      'Warning: preventDefault() is not available on event objects created from event responder modules ' +
-        '(React Flare).' +
-        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`',
-      {withoutStack: true},
-    );
-    expect(() => {
-      handler = event => {
-        event.stopPropagation();
-      };
-      ReactDOM.render(<Test />, container);
-      dispatchClickEvent(buttonRef.current);
-    }).toWarnDev(
-      'Warning: stopPropagation() is not available on event objects created from event responder modules ' +
-        '(React Flare).' +
-        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`',
-      {withoutStack: true},
-    );
-    expect(() => {
-      handler = event => {
-        event.isDefaultPrevented();
-      };
-      ReactDOM.render(<Test />, container);
-      dispatchClickEvent(buttonRef.current);
-    }).toWarnDev(
-      'Warning: isDefaultPrevented() is not available on event objects created from event responder modules ' +
-        '(React Flare).' +
-        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.isDefaultPrevented() }`',
-      {withoutStack: true},
-    );
-    expect(() => {
-      handler = event => {
-        event.isPropagationStopped();
-      };
-      ReactDOM.render(<Test />, container);
-      dispatchClickEvent(buttonRef.current);
-    }).toWarnDev(
-      'Warning: isPropagationStopped() is not available on event objects created from event responder modules ' +
-        '(React Flare).' +
-        ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.isPropagationStopped() }`',
-      {withoutStack: true},
-    );
-    expect(() => {
-      handler = event => {
         return event.nativeEvent;
       };
       ReactDOM.render(<Test />, container);


### PR DESCRIPTION
This might be a bit controversial, but one that I've spent the last few weeks considering quite a bit. Today, we don't allow for the new event system to supply methods on the event object to do `preventDefault` and `stopPropagation`. The reasoning for this was based a few important points:

1. Events are used in hooks, and hooks aren't meant to be able to affect if another event hook triggers or doesn't.
2. We want to be able to determine during server-side render what events should be prevented and propagated when it comes to replaying the events during client-side hydration.
3. For RN, the idea is that we can tell the native side this information declaratively ahead of time.

## Propagation

We already have a form of `stopPropagation` in the current event system. The `Keyboard` responder, which has a way of basically doing `stopPropagation` (the return value can allow for propagation). Given that we've not run into that many issues with keyboard, this kind of already means that point 1 above was probably not needed. The hooks themselves still work, it's just their callbacks that are affected, and that doesn't actually invalidate the Rules of Hooks after-all.

## Preventing native behaviour

There is a very important use-cases for where we want to be able to conditionally `preventDefault` at runtime – when handling user focus management.  In the cases where we want to "control" where focus goes using keyboard input, we `preventDefault` on the key that is being pressed so native focus doesn't fire. However, what if we don't want to control the focus? There's no way to conditionally switch of preventing the native event part way through a key press. I also noticed that we end up having all these complex abstractions to try and work around the fact that we have these constraints in place, often ending up generating far more code in the process.

## What about event replaying?

It would be ideal to know ahead of time if something gets prevent defaulted or not, but it feels like we're building all this complex architecture just to handle a bunch of event replaying cases. Keyboard input probably shouldn't even be replayed, and that's one of the main cases where you need conditional propagation and preventing of default behaviour. Pointer events should probably always prevent default, or at least always be declaratively known – so at least they make sense when replaying. Things like scroll should ideally never be prevented, as it leads to a terrible UX.

## What about RN?

Handling of keyboard on RN is another tricky case. I'm not sure of the best way forward here. It gets even more complex because it would be nice in an ideal world for this problem space to be handled in part with Fabric, where we can yield to JS without causing as much of an issue as there is today without Fabric.