### PR TITLE
[Fresh] Always remount classes

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHotReloading.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.js
@@ -296,7 +296,11 @@ function scheduleFibersWithFamiliesRecursively(
         if (staleFamilies.has(family)) {
           needsRemount = true;
         } else if (updatedFamilies.has(family)) {
-          needsRender = true;
+          if (tag === ClassComponent) {
+            needsRemount = true;
+          } else {
+            needsRender = true;
+          }
         }
       }
     }

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -1299,6 +1299,53 @@ describe('ReactFreshIntegration', () => {
       }
     });
 
+    it('remounts deprecated factory components', () => {
+      if (__DEV__) {
+        expect(() => {
+          render(`
+            function Parent() {
+              return {
+                render() {
+                  return <Child prop="A" />;
+                }
+              };
+            };
+
+            function Child({prop}) {
+              return <h1>{prop}1</h1>;
+            };
+
+            export default Parent;
+          `);
+        }).toWarnDev(
+          'The <Parent /> component appears to be a function component ' +
+            'that returns a class instance.',
+          {withoutStack: true},
+        );
+        const el = container.firstChild;
+        expect(el.textContent).toBe('A1');
+        patch(`
+          function Parent() {
+            return {
+              render() {
+                return <Child prop="B" />;
+              }
+            };
+          };
+
+          function Child({prop}) {
+            return <h1>{prop}2</h1>;
+          };
+
+          export default Parent;
+        `);
+        // Like classes, factory components always remount.
+        expect(container.firstChild).not.toBe(el);
+        const newEl = container.firstChild;
+        expect(newEl.textContent).toBe('B2');
+      }
+    });
+
     describe('with inline requires', () => {
       beforeEach(() => {
         global.FakeModuleSystem = {};


### PR DESCRIPTION
Class components should never attempt to preserve state.

Normally this was already being handled by the Fresh Runtime. It chooses whether to put type in `updatedFamilies` (re-render) or `staleFamilies` (re-mount) based on whether it has `.prototype && .prototype.isReactComponent`. This is usually sufficient.

There are some corner cases where it isn't sufficient though. Such as recently deprecated factory components. They "look" like functions, but their fibers are tagged as a Class. I just spent an hour debugging a Fast Refresh issue in VR code which was caused by old Relay using factory components and hitting this.

While we don't want to support deprecated components, fixing this is easy and may also help with other corner cases we may encounter in the future. Like a second level of defense.