### PR TITLE
ESLint: exhaustive-deps rule doesn't catch useCallback issue

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -4707,6 +4707,26 @@ const tests = {
           'Either include it or remove the dependency array.',
       ],
     },
+    {
+      code: `
+        import debounce from './debounce'
+
+        function Example({ cb }) {
+          const debouncedCb = useCallback(debounce(cb, {wait: 300}), []);
+        }
+      `,
+      output: `
+        import debounce from './debounce'
+
+        function Example({ cb }) {
+          const debouncedCb = useCallback(debounce(cb, {wait: 300}), [cb]);
+        }
+      `,
+      errors: [
+        "React Hook useCallback has a missing dependency: 'cb'. " +
+          'Either include it or remove the dependency array.',
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
This is a bug report in the form of a PR. I could add the fix, but I just want to make sure that I'm not misunderstanding something. This test fails because the code doesn't give any warnings, but it should.

Specifically this should give a warning:

```javascript
const debouncedCb = useCallback(debounce(cb, {wait: 300}), []);
```

More context: https://twitter.com/kentcdodds/status/1174382572052180992

Let me know if you'd like me to continue with fixing this or if I'm missing something.