### PR TITLE
[react-ui/events] Tap responder API changes

### DIFF
--- a/packages/react-ui/events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-ui/events/src/dom/__tests__/Press-test.internal.js
@@ -125,11 +125,13 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
 
     it('is called after middle-button pointer down', () => {
       const target = createEventTarget(ref.current);
-      target.pointerdown({buttons: buttonsType.middle, pointerType: 'mouse'});
+      const pointerType = 'mouse';
+      target.pointerdown({buttons: buttonsType.auxiliary, pointerType});
+      target.pointerup({pointerType});
       expect(onPressStart).toHaveBeenCalledTimes(1);
       expect(onPressStart).toHaveBeenCalledWith(
         expect.objectContaining({
-          buttons: buttonsType.middle,
+          buttons: buttonsType.auxiliary,
           pointerType: 'mouse',
           type: 'pressstart',
         }),
@@ -209,12 +211,15 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
 
     it('is called after middle-button pointer up', () => {
       const target = createEventTarget(ref.current);
-      target.pointerdown({buttons: buttonsType.middle, pointerType: 'mouse'});
+      target.pointerdown({
+        buttons: buttonsType.auxiliary,
+        pointerType: 'mouse',
+      });
       target.pointerup({pointerType: 'mouse'});
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(
         expect.objectContaining({
-          buttons: buttonsType.middle,
+          buttons: buttonsType.auxiliary,
           pointerType: 'mouse',
           type: 'pressend',
         }),
@@ -350,7 +355,10 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
 
     it('is not called after middle-button press', () => {
       const target = createEventTarget(ref.current);
-      target.pointerdown({buttons: buttonsType.middle, pointerType: 'mouse'});
+      target.pointerdown({
+        buttons: buttonsType.auxiliary,
+        pointerType: 'mouse',
+      });
       target.pointerup({pointerType: 'mouse'});
       expect(onPress).not.toHaveBeenCalled();
     });

--- a/packages/react-ui/events/src/dom/__tests__/PressLegacy-test.internal.js
+++ b/packages/react-ui/events/src/dom/__tests__/PressLegacy-test.internal.js
@@ -120,11 +120,14 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
     it('is called after middle-button pointer down', () => {
       const target = createEventTarget(ref.current);
-      target.pointerdown({buttons: buttonsType.middle, pointerType: 'mouse'});
+      target.pointerdown({
+        buttons: buttonsType.auxiliary,
+        pointerType: 'mouse',
+      });
       expect(onPressStart).toHaveBeenCalledTimes(1);
       expect(onPressStart).toHaveBeenCalledWith(
         expect.objectContaining({
-          buttons: buttonsType.middle,
+          buttons: buttonsType.auxiliary,
           pointerType: 'mouse',
           type: 'pressstart',
         }),
@@ -135,7 +138,10 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const node = ref.current;
       const target = createEventTarget(node);
       target.setBoundingClientRect({x: 0, y: 0, width: 100, height: 100});
-      target.pointerdown({buttons: buttonsType.middle, pointerType: 'mouse'});
+      target.pointerdown({
+        buttons: buttonsType.auxiliary,
+        pointerType: 'mouse',
+      });
       target.pointerup({pointerType: 'mouse'});
       target.pointerhover({x: 110, y: 110});
       target.pointerhover({x: 50, y: 50});
@@ -215,12 +221,15 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
     it('is called after middle-button pointer up', () => {
       const target = createEventTarget(ref.current);
-      target.pointerdown({buttons: buttonsType.middle, pointerType: 'mouse'});
+      target.pointerdown({
+        buttons: buttonsType.auxiliary,
+        pointerType: 'mouse',
+      });
       target.pointerup({pointerType: 'mouse'});
       expect(onPressEnd).toHaveBeenCalledTimes(1);
       expect(onPressEnd).toHaveBeenCalledWith(
         expect.objectContaining({
-          buttons: buttonsType.middle,
+          buttons: buttonsType.auxiliary,
           pointerType: 'mouse',
           type: 'pressend',
         }),
@@ -356,7 +365,10 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
     it('is not called after middle-button press', () => {
       const target = createEventTarget(ref.current);
-      target.pointerdown({buttons: buttonsType.middle, pointerType: 'mouse'});
+      target.pointerdown({
+        buttons: buttonsType.auxiliary,
+        pointerType: 'mouse',
+      });
       target.pointerup({pointerType: 'mouse'});
       expect(onPress).not.toHaveBeenCalled();
     });

--- a/packages/react-ui/events/src/dom/shared/index.js
+++ b/packages/react-ui/events/src/dom/shared/index.js
@@ -27,7 +27,7 @@ export const buttonsEnum = {
   none: 0,
   primary: 1,
   secondary: 2,
-  middle: 4,
+  auxiliary: 4,
 };
 
 export function dispatchDiscreteEvent(

--- a/packages/react-ui/events/src/dom/testing-library/domEnvironment.js
+++ b/packages/react-ui/events/src/dom/testing-library/domEnvironment.js
@@ -78,7 +78,7 @@ export const buttonsType = {
   // pen barrel button
   secondary: 2,
   // middle mouse
-  middle: 4,
+  auxiliary: 4,
   // back mouse
   back: 8,
   // forward mouse


### PR DESCRIPTION
This patch limits the `onTap*` callbacks to the primary pointer button. Auxiliary button and modified primary button interactions call `onAuxiliaryTap`, cancel any active tap, and preserve the native behavior.

This makes it easier to use `Tap` for primary pointer interactions while providing a basic way to record auxiliary taps for analytics, etc.