### PR TITLE
[react-ui] Add preventDefault+ to Keyboard + update a11y components

### DIFF
--- a/packages/react-ui/accessibility/src/FocusTable.js
+++ b/packages/react-ui/accessibility/src/FocusTable.js
@@ -146,7 +146,7 @@ export function createFocusTable(): Array<React.Component> {
   function Cell({children}): FocusCellProps {
     const scopeRef = useRef(null);
     const keyboard = useKeyboard({
-      onKeyDown(event: KeyboardEvent): boolean {
+      onKeyDown(event: KeyboardEvent): void {
         const currentCell = scopeRef.current;
         switch (event.key) {
           case 'UpArrow': {
@@ -162,7 +162,7 @@ export function createFocusTable(): Array<React.Component> {
                 }
               }
             }
-            return false;
+            return;
           }
           case 'DownArrow': {
             const [cells, rowIndex] = getRowCells(currentCell);
@@ -179,7 +179,7 @@ export function createFocusTable(): Array<React.Component> {
                 }
               }
             }
-            return false;
+            return;
           }
           case 'LeftArrow': {
             const [cells, rowIndex] = getRowCells(currentCell);
@@ -190,7 +190,7 @@ export function createFocusTable(): Array<React.Component> {
                 triggerNavigateOut(currentCell, 'left');
               }
             }
-            return false;
+            return;
           }
           case 'RightArrow': {
             const [cells, rowIndex] = getRowCells(currentCell);
@@ -203,10 +203,10 @@ export function createFocusTable(): Array<React.Component> {
                 }
               }
             }
-            return false;
+            return;
           }
         }
-        return true;
+        event.continuePropagation();
       },
     });
     return (

--- a/packages/react-ui/accessibility/src/__tests__/TabFocus-test.internal.js
+++ b/packages/react-ui/accessibility/src/__tests__/TabFocus-test.internal.js
@@ -255,14 +255,14 @@ describe('TabFocusController', () => {
         firstFocusController,
       );
       expect(nextController).toBe(secondFocusController);
-      ReactTabFocus.focusNext(nextController);
+      ReactTabFocus.focusFirst(nextController);
       expect(document.activeElement).toBe(divRef.current);
 
       const previousController = ReactTabFocus.getPreviousController(
         nextController,
       );
       expect(previousController).toBe(firstFocusController);
-      ReactTabFocus.focusNext(previousController);
+      ReactTabFocus.focusFirst(previousController);
       expect(document.activeElement).toBe(buttonRef.current);
     });
   });

--- a/packages/react-ui/events/src/dom/Press.js
+++ b/packages/react-ui/events/src/dom/Press.js
@@ -81,6 +81,13 @@ function isValidKey(e): boolean {
   );
 }
 
+function handlePreventDefault(preventDefault: ?boolean, e: any): void {
+  const key = e.key;
+  if (preventDefault !== false && (key === ' ' || key === 'Enter')) {
+    e.preventDefault();
+  }
+}
+
 /**
  * The lack of built-in composition for gesture responders means we have to
  * selectively ignore callbacks from useKeyboard or useTap if the other is
@@ -142,28 +149,30 @@ export function usePress(props: PressProps) {
 
   const keyboard = useKeyboard({
     disabled: disabled || active === 'tap',
-    preventClick: preventDefault !== false,
-    preventKeys: preventDefault !== false ? [' ', 'Enter'] : [],
     onClick(e) {
+      if (preventDefault !== false) {
+        e.preventDefault();
+      }
       if (active == null && onPress != null) {
         onPress(createGestureState(e, 'press'));
       }
     },
     onKeyDown(e) {
       if (active == null && isValidKey(e)) {
+        handlePreventDefault(preventDefault, e);
         updateActive('keyboard');
+
         if (onPressStart != null) {
           onPressStart(createGestureState(e, 'pressstart'));
         }
         if (onPressChange != null) {
           onPressChange(true);
         }
-        // stop propagation
-        return false;
       }
     },
     onKeyUp(e) {
       if (active === 'keyboard' && isValidKey(e)) {
+        handlePreventDefault(preventDefault, e);
         if (onPressChange != null) {
           onPressChange(false);
         }
@@ -174,8 +183,6 @@ export function usePress(props: PressProps) {
           onPress(createGestureState(e, 'press'));
         }
         updateActive(null);
-        // stop propagation
-        return false;
       }
     },
   });


### PR DESCRIPTION
This PR is a sort of spiritual follow up to https://github.com/facebook/react/pull/16822. Here are the changes outlined in this PR:

- Keyboard responder now provides `preventDefault` and `continuePropagation` to the user event. Keyboard still does not propagate to other keyboard responders by default, but provides a method to allow it to continue and extra level. I had to update tests respectfully, as we previous used the return value from the event (which was a bit confusing).
- Keyboard responder now does not `preventDefault` any events by default. Instead, the user can optionally control this by calling `preventDefault` like already done on the web. The `Press` responder has been updated to ensure that the same standard behavior exists as before.
- The accessibility components have been updated to properly make use of this new functionality.