### PR TITLE
[DevTools] Hotfix: Fixed element tree sorting when we have an array of entries.

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
@@ -8,7 +8,7 @@
  */
 
 import {copy} from 'clipboard-js';
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useState, useMemo} from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import KeyValue from './KeyValue';
@@ -38,13 +38,20 @@ export default function InspectedElementTree({
   canAddEntries = false,
   showWhenEmpty = false,
 }: Props) {
-  const entries = data != null ? Object.entries(data) : null;
-  if (entries !== null) {
-    entries.sort(alphaSortEntries);
-  }
-
   const [newPropKey, setNewPropKey] = useState<number>(0);
   const [newPropName, setNewPropName] = useState<string>('');
+  const entries = useMemo(
+    () => {
+      const dataEntries = data != null ? Object.entries(data) : null;
+
+      if (dataEntries !== null) {
+        return dataEntries.sort(alphaSortEntries);
+      }
+
+      return dataEntries;
+    },
+    [data],
+  );
 
   const isEmpty = entries === null || entries.length === 0;
 


### PR DESCRIPTION
Fixes: #16843 

Description:
The bug was caused due to the use of `Object.entries` in the `InspectedElementTree` component.

We aren't taking into account that the `data` prop could change and that the `data` `entries` could be an array.

If we removed the second entry out of three entries in total the index will shift and thus remove the last one which is the incorrect one.

@bvaughn Could you check this out? Thanks!
