### PR TITLE
[eslint-plugin-react-hooks] Fix cyclic caching for loops containing a…

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -347,6 +347,18 @@ const tests = {
         useHook();
       }
     `,
+    `
+      // Valid because the neither the condition nor the loop affect the hook call.
+      function App(props) {
+        const someObject = {propA: true};
+        for (const propName in someObject) {
+          if (propName === true) {
+          } else {
+          }
+        }
+        const [myState, setMyState] = useState(null);
+      }
+    `,
   ],
   invalid: [
     {
@@ -558,11 +570,7 @@ const tests = {
       `,
       errors: [
         loopError('useHook1'),
-
-        // NOTE: Small imprecision in error reporting due to caching means we
-        // have a conditional error here instead of a loop error. However,
-        // we will always get an error so this is acceptable.
-        conditionalError('useHook2', true),
+        loopError('useHook2', true),
       ],
     },
     {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -568,10 +568,7 @@ const tests = {
           }
         }
       `,
-      errors: [
-        loopError('useHook1'),
-        loopError('useHook2', true),
-      ],
+      errors: [loopError('useHook1'), loopError('useHook2', true)],
     },
     {
       code: `

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -114,31 +114,33 @@ export default {
          * Populates `cyclic` with cyclic segments.
          */
 
-        function countPathsFromStart(segment) {
+        function countPathsFromStart(segment, pathHistory) {
           const {cache} = countPathsFromStart;
           let paths = cache.get(segment.id);
+          let pathList = new Set(pathHistory);
 
-          // If `paths` is null then we've found a cycle! Add it to `cyclic` and
-          // any other segments which are a part of this cycle.
-          if (paths === null) {
-            if (cyclic.has(segment.id)) {
-              return 0;
-            } else {
-              cyclic.add(segment.id);
-              for (const prevSegment of segment.prevSegments) {
-                countPathsFromStart(prevSegment);
-              }
-              return 0;
+          // If `pathList` includes the current segment then we've found a cycle!
+          // We need to fill `cyclic` with all segments inside cycle
+          if (pathList.has(segment.id)) {
+            const pathArray = [...pathList];
+            const cyclicSegments = pathArray.slice(
+              pathArray.indexOf(segment.id) + 1,
+            );
+            for (const cyclicSegment of cyclicSegments) {
+              cyclic.add(cyclicSegment)
             }
+
+            return 0;
           }
+
+          // add the current segment to pathList
+          pathList.add(segment.id);
 
           // We have a cached `paths`. Return it.
           if (paths !== undefined) {
             return paths;
           }
 
-          // Compute `paths` and cache it. Guarding against cycles.
-          cache.set(segment.id, null);
           if (codePath.thrownSegments.includes(segment)) {
             paths = 0;
           } else if (segment.prevSegments.length === 0) {
@@ -146,7 +148,7 @@ export default {
           } else {
             paths = 0;
             for (const prevSegment of segment.prevSegments) {
-              paths += countPathsFromStart(prevSegment);
+              paths += countPathsFromStart(prevSegment, pathList);
             }
           }
 
@@ -183,31 +185,33 @@ export default {
          * Populates `cyclic` with cyclic segments.
          */
 
-        function countPathsToEnd(segment) {
+        function countPathsToEnd(segment, pathHistory) {
           const {cache} = countPathsToEnd;
           let paths = cache.get(segment.id);
+          let pathList = new Set(pathHistory);
 
-          // If `paths` is null then we've found a cycle! Add it to `cyclic` and
-          // any other segments which are a part of this cycle.
-          if (paths === null) {
-            if (cyclic.has(segment.id)) {
-              return 0;
-            } else {
-              cyclic.add(segment.id);
-              for (const nextSegment of segment.nextSegments) {
-                countPathsToEnd(nextSegment);
-              }
-              return 0;
+          // If `pathList` includes the current segment then we've found a cycle!
+          // We need to fill `cyclic` with all segments inside cycle
+          if (pathList.has(segment.id)) {
+            const pathArray = [...pathList];
+            const cyclicSegments = pathArray.slice(
+              pathArray.indexOf(segment.id) + 1,
+            );
+            for (const cyclicSegment of cyclicSegments) {
+              cyclic.add(cyclicSegment)
             }
+
+            return 0;
           }
+
+          // add the current segment to pathList
+          pathList.add(segment.id);
 
           // We have a cached `paths`. Return it.
           if (paths !== undefined) {
             return paths;
           }
 
-          // Compute `paths` and cache it. Guarding against cycles.
-          cache.set(segment.id, null);
           if (codePath.thrownSegments.includes(segment)) {
             paths = 0;
           } else if (segment.nextSegments.length === 0) {
@@ -215,11 +219,11 @@ export default {
           } else {
             paths = 0;
             for (const nextSegment of segment.nextSegments) {
-              paths += countPathsToEnd(nextSegment);
+              paths += countPathsToEnd(nextSegment, pathList);
             }
           }
-          cache.set(segment.id, paths);
 
+          cache.set(segment.id, paths);
           return paths;
         }
 

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -127,7 +127,7 @@ export default {
               pathArray.indexOf(segment.id) + 1,
             );
             for (const cyclicSegment of cyclicSegments) {
-              cyclic.add(cyclicSegment)
+              cyclic.add(cyclicSegment);
             }
 
             return 0;
@@ -198,7 +198,7 @@ export default {
               pathArray.indexOf(segment.id) + 1,
             );
             for (const cyclicSegment of cyclicSegments) {
-              cyclic.add(cyclicSegment)
+              cyclic.add(cyclicSegment);
             }
 
             return 0;

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -117,7 +117,7 @@ export default {
         function countPathsFromStart(segment, pathHistory) {
           const {cache} = countPathsFromStart;
           let paths = cache.get(segment.id);
-          let pathList = new Set(pathHistory);
+          const pathList = new Set(pathHistory);
 
           // If `pathList` includes the current segment then we've found a cycle!
           // We need to fill `cyclic` with all segments inside cycle

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -193,7 +193,7 @@ export default {
           // If `pathList` includes the current segment then we've found a cycle!
           // We need to fill `cyclic` with all segments inside cycle
           if (pathList.has(segment.id)) {
-            const pathArray = [...pathList];
+            const pathArray = Array.from(pathList);
             const cyclicSegments = pathArray.slice(
               pathArray.indexOf(segment.id) + 1,
             );


### PR DESCRIPTION
This MR Fixes a bug (#16832) in the `eslint-plugin-react-hooks`, where caching of cycles is performed wrong in some cases.

**Example:** https://codesandbox.io/s/exciting-bhabha-mqj7q

**Description**
If the user uses an `if` statement inside a `for ... of obj` statement, and uses a correct hook afterwards, the eslint shows an *error* that:
`React Hook "${hook}" is called conditionally. React Hooks must be called in the exact same order in every component render.`

**Reports**
I guess that it is already known issue because, inside the [ESLintRulesOfHooks.js - L562](https://github.com/facebook/react/blob/master/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js#L562), it is already known that in some cases caching of cyclic paths in code path, might result in the wrong errors.

Also (#16832) reports this case too.

**Reason**
Eslint uses `CodePathSegment` which is similar to doubly linked list. Based on the `CodePathSegment` AST different types of cyclic segments might happen. In the special case of [ForInStatement](https://eslint.org/docs/developer-guide/code-path-analysis#forinstatement) there are two paths from obj identifier to the next segment. In such a graph, in order to traverse all the paths from start to end, we need to not only remember the current segment, but also the whole path. 

The current code uses a simple caching just by name of segments (and not the list of segment history) as a result, whenever it faces a cycle, it breaks the cycle by returning 0. As a result, there might be several conditions, where the segment might have cyclic and not cyclic paths to end. In the current code, if the first path is cyclic all the non-cyclic ones are thrown away. And depending on the starting point and endpoint of AST, we might have different results.

For example for the demo code, the result of  [RulesOfHooks.js - L404](https://github.com/facebook/react/blob/master/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#L291), the value of all `allPathsFromStartToEnd` is calculated as `2` instead of `3`

**Solution**
We need caching of responses and also saving cyclic paths for later logic, In the new code, I added a different caching mechanism, which also remembers the path history too. The effect of the performance is still negligible because even for [the most difficult test](https://github.com/facebook/react/blob/master/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js#L293) including `1099511627776` paths from start to end of the code, it only increases the time about 0.3s on MacBookPro.