### PR TITLE
Expose shared/getComponentName as React.getComponentName

### DIFF
--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -13,6 +13,7 @@ import {
   REACT_SUSPENSE_TYPE,
   REACT_SUSPENSE_LIST_TYPE,
 } from 'shared/ReactSymbols';
+import getComponentName from 'shared/getComponentName';
 
 import {Component, PureComponent} from './ReactBaseClasses';
 import {createRef} from './ReactCreateRef';
@@ -99,6 +100,7 @@ const React = {
   cloneElement: __DEV__ ? cloneElementWithValidation : cloneElement,
   createFactory: __DEV__ ? createFactoryWithValidation : createFactory,
   isValidElement: isValidElement,
+  getComponentName,
 
   version: ReactVersion,
 


### PR DESCRIPTION
`getComponentName` is a handy helper function to get a component name for 3rd party libraries and custom renderers.

To get a proper component name, we have to deal with React internals like `shared/getComponentNam` does.
So I think it's beneficial for 3rd party developers to expose the function.
This PR exposes the API as `React.getComponentName` but it's ok to expose the API as an npm package like `react-component-name` instead of adding a function into `React`.

