### PR TITLE
[react-interactions] Add no-op stopPropagation + preventDefault to Press

### DIFF
--- a/packages/react-interactions/events/src/dom/Press.js
+++ b/packages/react-interactions/events/src/dom/Press.js
@@ -12,6 +12,7 @@ import type {PointerType} from 'shared/ReactDOMTypes';
 import React from 'react';
 import {useTap} from 'react-interactions/events/tap';
 import {useKeyboard} from 'react-interactions/events/keyboard';
+import warning from 'shared/warning';
 
 const emptyObject = {};
 
@@ -48,6 +49,8 @@ type PressEvent = {|
   type: PressEventType,
   x: number,
   y: number,
+  preventDefault: () => void,
+  stopPropagation: () => void,
 |};
 
 function createGestureState(e: any, type: PressEventType): PressEvent {
@@ -67,6 +70,26 @@ function createGestureState(e: any, type: PressEventType): PressEvent {
     type,
     x: e.x,
     y: e.y,
+    preventDefault() {
+      // NO-OP, we should remove this in the future
+      if (__DEV__) {
+        warning(
+          false,
+          'preventDefault is not available on event objects created from event responder modules (React Flare). ' +
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`',
+        );
+      }
+    },
+    stopPropagation() {
+      // NO-OP, we should remove this in the future
+      if (__DEV__) {
+        warning(
+          false,
+          'stopPropagation is not available on event objects created from event responder modules (React Flare). ' +
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`',
+        );
+      }
+    },
   };
 }
 

--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -19,6 +19,7 @@ import type {
 
 import React from 'react';
 import {DiscreteEvent, UserBlockingEvent} from 'shared/ReactTypes';
+import warning from 'shared/warning';
 
 type PressProps = {|
   disabled: boolean,
@@ -93,6 +94,8 @@ type PressEvent = {|
   type: PressEventType,
   x: null | number,
   y: null | number,
+  preventDefault: () => void,
+  stopPropagation: () => void,
 |};
 
 const hasPointerEvents =
@@ -185,6 +188,26 @@ function createPressEvent(
     type,
     x: clientX,
     y: clientY,
+    preventDefault() {
+      // NO-OP, we should remove this in the future
+      if (__DEV__) {
+        warning(
+          false,
+          'preventDefault is not available on event objects created from event responder modules (React Flare). ' +
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`',
+        );
+      }
+    },
+    stopPropagation() {
+      // NO-OP, we should remove this in the future
+      if (__DEV__) {
+        warning(
+          false,
+          'stopPropagation is not available on event objects created from event responder modules (React Flare). ' +
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`',
+        );
+      }
+    },
   };
 }
 


### PR DESCRIPTION
This re-introduces the warning back for `Press` responders for using `preventDefault` and `stopPropagation`. Otherwise the operation on these is a no-op for prod mode.