### PR TITLE
Update useEditableValue hook to sync external value changes

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/useEditableValue-test.js
+++ b/packages/react-devtools-shared/src/__tests__/useEditableValue-test.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+describe('useEditableValue', () => {
+  let act;
+  let React;
+  let ReactDOM;
+  let useEditableValue;
+
+  beforeEach(() => {
+    const utils = require('./utils');
+    act = utils.act;
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+
+    useEditableValue = require('../devtools/views/hooks').useEditableValue;
+  });
+
+  it('should override editable state when external props are updated', () => {
+    let state;
+
+    function Example({value}) {
+      const tuple = useEditableValue(value);
+      state = tuple[0];
+      return null;
+    }
+
+    const container = document.createElement('div');
+    ReactDOM.render(<Example value="foo" />, container);
+    expect(state.editableValue).toEqual('"foo"');
+    expect(state.externalValue).toEqual('foo');
+    expect(state.hasPendingChanges).toBe(false);
+
+    // If there are NO pending changes,
+    // an update to the external prop value should override the local/pending value.
+    ReactDOM.render(<Example value="bar" />, container);
+    expect(state.editableValue).toEqual('"bar"');
+    expect(state.externalValue).toEqual('bar');
+    expect(state.hasPendingChanges).toBe(false);
+  });
+
+  it('should not override editable state when external props are updated if there are pending changes', () => {
+    let dispatch, state;
+
+    function Example({value}) {
+      const tuple = useEditableValue(value);
+      state = tuple[0];
+      dispatch = tuple[1];
+      return null;
+    }
+
+    const container = document.createElement('div');
+    ReactDOM.render(<Example value="foo" />, container);
+    expect(state.editableValue).toEqual('"foo"');
+    expect(state.externalValue).toEqual('foo');
+    expect(state.hasPendingChanges).toBe(false);
+
+    // Update (local) editable state.
+    act(() =>
+      dispatch({
+        type: 'UPDATE',
+        editableValue: 'not-foo',
+        externalValue: 'foo',
+      }),
+    );
+    expect(state.editableValue).toEqual('not-foo');
+    expect(state.externalValue).toEqual('foo');
+    expect(state.hasPendingChanges).toBe(true);
+
+    // If there ARE pending changes,
+    // an update to the external prop value should NOT override the local/pending value.
+    ReactDOM.render(<Example value="bar" />, container);
+    expect(state.editableValue).toEqual('not-foo');
+    expect(state.externalValue).toEqual('bar');
+    expect(state.hasPendingChanges).toBe(true);
+  });
+});

--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React, {Fragment, useCallback, useRef} from 'react';
+import React, {Fragment, useRef} from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import styles from './EditableValue.css';
@@ -17,51 +17,51 @@ type OverrideValueFn = (path: Array<string | number>, value: any) => void;
 
 type EditableValueProps = {|
   className?: string,
-  initialValue: any,
   overrideValueFn: OverrideValueFn,
   path: Array<string | number>,
+  value: any,
 |};
 
 export default function EditableValue({
   className = '',
-  initialValue,
   overrideValueFn,
   path,
+  value,
 }: EditableValueProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const {
-    editableValue,
-    hasPendingChanges,
-    isValid,
-    parsedValue,
-    reset,
-    update,
-  } = useEditableValue(initialValue);
+  const [state, dispatch] = useEditableValue(value);
+  const {editableValue, hasPendingChanges, isValid, parsedValue} = state;
 
-  const handleChange = useCallback(({target}) => update(target.value), [
-    update,
-  ]);
+  const reset = () =>
+    dispatch({
+      type: 'RESET',
+      externalValue: value,
+    });
 
-  const handleKeyDown = useCallback(
-    event => {
-      // Prevent keydown events from e.g. change selected element in the tree
-      event.stopPropagation();
+  const handleChange = ({target}) =>
+    dispatch({
+      type: 'UPDATE',
+      editableValue: target.value,
+      externalValue: value,
+    });
 
-      switch (event.key) {
-        case 'Enter':
-          if (isValid && hasPendingChanges) {
-            overrideValueFn(path, parsedValue);
-          }
-          break;
-        case 'Escape':
-          reset();
-          break;
-        default:
-          break;
-      }
-    },
-    [hasPendingChanges, isValid, overrideValueFn, parsedValue, reset],
-  );
+  const handleKeyDown = event => {
+    // Prevent keydown events from e.g. change selected element in the tree
+    event.stopPropagation();
+
+    switch (event.key) {
+      case 'Enter':
+        if (isValid && hasPendingChanges) {
+          overrideValueFn(path, parsedValue);
+        }
+        break;
+      case 'Escape':
+        reset();
+        break;
+      default:
+        break;
+    }
+  };
 
   let placeholder = '';
   if (editableValue === undefined) {

--- a/packages/react-devtools-shared/src/devtools/views/Components/HooksTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/HooksTree.js
@@ -270,9 +270,9 @@ function HookView({canEditHooks, hook, id, inspectPath, path}: HookViewProps) {
             </span>
             {typeof overrideValueFn === 'function' ? (
               <EditableValue
-                initialValue={value}
                 overrideValueFn={overrideValueFn}
                 path={[]}
+                value={value}
               />
             ) : (
               // $FlowFixMe Cannot create span element because in property children

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
@@ -105,9 +105,9 @@ export default function InspectedElementTree({
             :&nbsp;
             <EditableValue
               className={styles.EditableValue}
-              initialValue={''}
               overrideValueFn={handleNewEntryValue}
               path={[newPropName]}
+              value={''}
             />
           </div>
         )}

--- a/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
@@ -102,9 +102,9 @@ export default function KeyValue({
         </span>
         {isEditable ? (
           <EditableValue
-            initialValue={value}
             overrideValueFn={((overrideValueFn: any): OverrideValueFn)}
             path={path}
+            value={value}
           />
         ) : (
           <span className={styles.Value}>{displayValue}</span>

--- a/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
@@ -619,6 +619,7 @@ type Props = {|
   children: React$Node,
 
   // Used for automated testing
+  defaultInspectedElementID?: ?number,
   defaultOwnerID?: ?number,
   defaultSelectedElementID?: ?number,
   defaultSelectedElementIndex?: ?number,
@@ -627,6 +628,7 @@ type Props = {|
 // TODO Remove TreeContextController wrapper element once global ConsearchText.write API exists.
 function TreeContextController({
   children,
+  defaultInspectedElementID,
   defaultOwnerID,
   defaultSelectedElementID,
   defaultSelectedElementIndex,
@@ -700,7 +702,8 @@ function TreeContextController({
     ownerFlatTree: null,
 
     // Inspection element panel
-    inspectedElementID: null,
+    inspectedElementID:
+      defaultInspectedElementID == null ? null : defaultInspectedElementID,
   });
 
   const dispatchWrapper = useCallback(

--- a/packages/react-devtools/CHANGELOG.md
+++ b/packages/react-devtools/CHANGELOG.md
@@ -7,9 +7,11 @@
   </summary>
   
   <!-- Upcoming changes go here -->
+
 #### Bug fixes
 * Fixed bug where Components panel was always empty for certain users. ([bvaughn](https://github.com/bvaughn) in [#16864](https://github.com/facebook/react/pull/16864))
 * Fixed regression in DevTools editable hooks interface that caused primitive values to be shown as `undefined`. ([bvaughn](https://github.com/bvaughn) in [#16867](https://github.com/facebook/react/pull/16867))
+* Fixed bug where DevTools showed stale values in props/state/hooks editing interface. ([bvaughn](https://github.com/bvaughn) in [#16878](https://github.com/facebook/react/pull/16878))
 </details>
 
 ## 4.1.0 (September 19, 2019)


### PR DESCRIPTION
This PR changes the `useEditableValue` to more intelligently reset the local/editable state value when external value changes.

Previously, the hook initialized local state (in `useState`) to mirror the prop/state value. Updates to the value were ignored though. (Once the state was initialized, it was never updated.) The new hook updates the local/editable state to mirror the external value *unless* there are already pending, local edits being made.

Note that this particular change very closely resembles [one of the derived state anti-patterns](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#anti-pattern-erasing-state-when-props-change) outlined in a previous blog post. I think it might still be an acceptable approach for this specific scenario though.

### Here is a demo of the (broken) behavior before:
![useEditableValue broken before behavior](https://user-images.githubusercontent.com/29597/65546741-f49aef80-decc-11e9-9d21-550c715daf51.gif)

### And here is the behavior after this change:
![useEditableValue fixed after behavior](https://user-images.githubusercontent.com/29597/65546673-d503c700-decc-11e9-9bbe-258a97c59f53.gif)

### Edge case
Because of the way the new hook works, there is a potentially odd edge case, but I think it's acceptable given the way the "reset" button works:
![useEditableValue remaining weird edge case](https://user-images.githubusercontent.com/29597/65546490-7a6a6b00-decc-11e9-8def-83560e5ef566.gif)

Posting this PR for discussion purposes. Let's talk!

Resolves #16843

cc @hristo-kanchev

---

This was also broken for other use cases before. The example above was just one of the most awkward cases, but here is another:

### Before
![useEditableValue before bug](https://user-images.githubusercontent.com/29597/65550502-8fe39300-ded4-11e9-8da3-213a87985f43.gif)

### After
![useEditableValue after](https://user-images.githubusercontent.com/29597/65550513-9540dd80-ded4-11e9-84c8-389a6fa83c70.gif)