### PR TITLE
[React Native] Improve errors for invalid ViewConfig getter functions

### DIFF
--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativeViewConfigRegistry.js
@@ -78,6 +78,12 @@ exports.register = function(name: string, callback: ViewConfigGetter): string {
     'Tried to register two views with the same name %s',
     name,
   );
+  invariant(
+    typeof callback === 'function',
+    'View config getter callback must be a function: %s (received %s)',
+    name,
+    callback === null ? 'null' : typeof callback,
+  );
   viewConfigCallbacks.set(name, callback);
   return name;
 };
@@ -94,8 +100,9 @@ exports.get = function(name: string): ReactNativeBaseComponentViewConfig<> {
     if (typeof callback !== 'function') {
       invariant(
         false,
-        'View config not found for name %s.%s',
+        'View config registration not found for name %s (received %s).%s',
         name,
+        callback === null ? 'null' : typeof callback,
         typeof name[0] === 'string' && /[a-z]/.test(name[0])
           ? ' Make sure to start component names with a capital letter.'
           : '',

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativeViewConfigRegistry.js
@@ -80,7 +80,7 @@ exports.register = function(name: string, callback: ViewConfigGetter): string {
   );
   invariant(
     typeof callback === 'function',
-    'View config getter callback must be a function: %s (received %s)',
+    'View config getter callback for component `%s` must be a function (received `%s`)',
     name,
     callback === null ? 'null' : typeof callback,
   );
@@ -100,7 +100,7 @@ exports.get = function(name: string): ReactNativeBaseComponentViewConfig<> {
     if (typeof callback !== 'function') {
       invariant(
         false,
-        'View config registration not found for name %s (received %s).%s',
+        'View config getter callback for component `%s` must be a function (received `%s`).%s',
         name,
         callback === null ? 'null' : typeof callback,
         typeof name[0] === 'string' && /[a-z]/.test(name[0])

--- a/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
@@ -32,6 +32,17 @@ describe('ReactNativeError', () => {
         .computeComponentStackForErrorReporting;
   });
 
+  it('should throw error if null component registration getter is used', () => {
+    let error;
+    try {
+      createReactNativeComponentClass('View', null);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error.toString()).toBe('Invariant Violation: View config getter callback must be a function: View (received null)');
+  });
+
   it('should be able to extract a component stack from a native view', () => {
     const View = createReactNativeComponentClass('View', () => ({
       validAttributes: {foo: true},

--- a/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
@@ -33,14 +33,15 @@ describe('ReactNativeError', () => {
   });
 
   it('should throw error if null component registration getter is used', () => {
-    let error;
-    try {
-      createReactNativeComponentClass('View', null);
-    } catch (e) {
-      error = e;
-    }
-
-    expect(error.toString()).toBe('Invariant Violation: View config getter callback must be a function: View (received null)');
+    expect(() => {
+      try {
+        createReactNativeComponentClass('View', null);
+      } catch (e) {
+        throw new Error(e.toString());
+      }
+    }).toThrow(
+      'Invariant Violation: View config getter callback for component `View` must be a function (received `null`)',
+    );
   });
 
   it('should be able to extract a component stack from a native view', () => {

--- a/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
+++ b/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
@@ -75,6 +75,12 @@ exports.register = function(name: string, callback: ViewConfigGetter): string {
     'Tried to register two views with the same name %s',
     name,
   );
+  invariant(
+    typeof callback === 'function',
+    'View config getter callback must be a function: %s (received %s)',
+    name,
+    callback === null ? 'null' : typeof callback,
+  );
   viewConfigCallbacks.set(name, callback);
   return name;
 };
@@ -91,8 +97,9 @@ exports.get = function(name: string): ReactNativeBaseComponentViewConfig<> {
     if (typeof callback !== 'function') {
       invariant(
         false,
-        'View config not found for name %s.%s',
+        'View config registration not found for name %s (received %s).%s',
         name,
+        callback === null ? 'null' : typeof callback,
         typeof name[0] === 'string' && /[a-z]/.test(name[0])
           ? ' Make sure to start component names with a capital letter.'
           : '',

--- a/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
+++ b/scripts/rollup/shims/react-native/ReactNativeViewConfigRegistry.js
@@ -77,7 +77,7 @@ exports.register = function(name: string, callback: ViewConfigGetter): string {
   );
   invariant(
     typeof callback === 'function',
-    'View config getter callback must be a function: %s (received %s)',
+    'View config getter callback for component `%s` must be a function (received `%s`)',
     name,
     callback === null ? 'null' : typeof callback,
   );
@@ -97,7 +97,7 @@ exports.get = function(name: string): ReactNativeBaseComponentViewConfig<> {
     if (typeof callback !== 'function') {
       invariant(
         false,
-        'View config registration not found for name %s (received %s).%s',
+        'View config getter callback for component `%s` must be a function (received `%s`).%s',
         name,
         callback === null ? 'null' : typeof callback,
         typeof name[0] === 'string' && /[a-z]/.test(name[0])


### PR DESCRIPTION
# Overview

Improve error messages around invalid ViewConfig getter functions.

# Details

As a followup to #16821, it is unlikely but possible for ViewConfig registry entries to be corrupted. I would like to surface this as early as possible, and include a little more information in exceptions that could be thrown later on.