### PR TITLE
[devtools] Add support for React Scope symbol/number

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -82,12 +82,6 @@ type ReactSymbolsType = {
   CONTEXT_CONSUMER_SYMBOL_STRING: string,
   CONTEXT_PROVIDER_NUMBER: number,
   CONTEXT_PROVIDER_SYMBOL_STRING: string,
-  EVENT_COMPONENT_NUMBER: number,
-  EVENT_COMPONENT_STRING: string,
-  EVENT_TARGET_NUMBER: number,
-  EVENT_TARGET_STRING: string,
-  EVENT_TARGET_TOUCH_HIT_NUMBER: number,
-  EVENT_TARGET_TOUCH_HIT_STRING: string,
   FORWARD_REF_NUMBER: number,
   FORWARD_REF_SYMBOL_STRING: string,
   MEMO_NUMBER: number,
@@ -99,6 +93,8 @@ type ReactSymbolsType = {
   SUSPENSE_NUMBER: number,
   SUSPENSE_SYMBOL_STRING: string,
   DEPRECATED_PLACEHOLDER_SYMBOL_STRING: string,
+  SCOPE_NUMBER: number,
+  SCOPE_SYMBOL_STRING: string,
 };
 
 type ReactPriorityLevelsType = {|
@@ -165,12 +161,6 @@ export function getInternalReactConstants(
     CONTEXT_CONSUMER_SYMBOL_STRING: 'Symbol(react.context)',
     CONTEXT_PROVIDER_NUMBER: 0xeacd,
     CONTEXT_PROVIDER_SYMBOL_STRING: 'Symbol(react.provider)',
-    EVENT_COMPONENT_NUMBER: 0xead5,
-    EVENT_COMPONENT_STRING: 'Symbol(react.event_component)',
-    EVENT_TARGET_NUMBER: 0xead6,
-    EVENT_TARGET_STRING: 'Symbol(react.event_target)',
-    EVENT_TARGET_TOUCH_HIT_NUMBER: 0xead7,
-    EVENT_TARGET_TOUCH_HIT_STRING: 'Symbol(react.event_target.touch_hit)',
     FORWARD_REF_NUMBER: 0xead0,
     FORWARD_REF_SYMBOL_STRING: 'Symbol(react.forward_ref)',
     MEMO_NUMBER: 0xead3,
@@ -182,6 +172,8 @@ export function getInternalReactConstants(
     SUSPENSE_NUMBER: 0xead1,
     SUSPENSE_SYMBOL_STRING: 'Symbol(react.suspense)',
     DEPRECATED_PLACEHOLDER_SYMBOL_STRING: 'Symbol(react.placeholder)',
+    SCOPE_NUMBER: 0xead7,
+    SCOPE_SYMBOL_STRING: 'Symbol(react.scope)',
   };
 
   const ReactTypeOfSideEffect: ReactTypeOfSideEffectType = {
@@ -331,6 +323,8 @@ export function getInternalReactConstants(
     DEPRECATED_PLACEHOLDER_SYMBOL_STRING,
     PROFILER_NUMBER,
     PROFILER_SYMBOL_STRING,
+    SCOPE_NUMBER,
+    SCOPE_SYMBOL_STRING,
   } = ReactSymbols;
 
   // NOTICE Keep in sync with shouldFilterFiber() and other get*ForFiber methods
@@ -410,6 +404,9 @@ export function getInternalReactConstants(
           case PROFILER_NUMBER:
           case PROFILER_SYMBOL_STRING:
             return `Profiler(${fiber.memoizedProps.id})`;
+          case SCOPE_NUMBER:
+          case SCOPE_SYMBOL_STRING:
+            return 'Scope';
           default:
             // Unknown element type.
             // This may mean a new element type that has not yet been added to DevTools.


### PR DESCRIPTION
This adds support for displaying `Scope` for the fiber type rather than it being empty in dev tools. Note: scopes are an experimental feature that we're using only internally at FB. I also got rid of the old React Flare symbols that we no longer use anywhere.