### PR TITLE
Actually return the fallback fiber

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -1789,7 +1789,7 @@ export function attach(
         // Try our best to find the fallback directly.
         const maybeFallbackFiber = fiber.child && fiber.child.sibling;
         if (maybeFallbackFiber != null) {
-          fiber = maybeFallbackFiber;
+          return maybeFallbackFiber;
         }
       }
       const hostFibers = findAllCurrentHostFibers(id);

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -1777,7 +1777,7 @@ export function attach(
 
   function findNativeNodesForFiberID(id: number) {
     try {
-      let fiber = findCurrentFiberUsingSlowPathById(id);
+      const fiber = findCurrentFiberUsingSlowPathById(id);
       if (fiber === null) {
         return null;
       }


### PR DESCRIPTION
The current behavior of `findNativeNodesForFiberID` for a timed-out Suspense is to attempt to find the fallback fiber, and if not `null`, reassign it to `fiber`. Instead, I believe the proper behavior should be to return this non-null fallback fiber (and not fallback to a host fiber search).

I found this mistake(?) on lgtm.com ([error](https://lgtm.com/projects/g/facebook/react/snapshot/570203d4d133d2b8d8bd56b0834381f9ce54798a/files/packages/react-devtools-shared/src/backend/renderer.js?sort=name&dir=ASC&mode=heatmap#L1795)) so maybe I'm wrong, but I can't see why `fiber` would be assigned a new value if it's never used again.