### PR TITLE
DevTools shows unsupported renderer version dialog

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -155,7 +155,7 @@ function createPanelIfReactLoaded() {
               overrideTab,
               profilerPortalContainer,
               showTabBar: false,
-              showWelcomeToTheNewDevToolsDialog: true,
+              warnIfUnsupportedVersionDetected: true,
               store,
               viewElementSourceFunction,
             }),

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -474,6 +474,10 @@ export default class Agent extends EventEmitter<{|
     }
   };
 
+  onUnsupportedRenderer(rendererID: number) {
+    this._bridge.send('unsupportedRendererVersion', rendererID);
+  }
+
   _throttledPersistSelection = throttle((rendererID: number, id: number) => {
     // This is throttled, so both renderer and selected ID
     // might not be available by the time we read them.

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -81,7 +81,10 @@ export type ReactRenderer = {
   // Enables DevTools to append owners-only component stack to error messages.
   getCurrentFiber?: () => Fiber | null,
 
-  // <= 15
+  // Uniquely identifies React DOM v15.
+  ComponentTree?: any,
+
+  // Present for React DOM v12 (possibly earlier) through v15.
   Mount?: any,
 };
 

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -83,6 +83,7 @@ type BackendEvents = {|
   stopInspectingNative: [boolean],
   syncSelectionFromNativeElementsPanel: [],
   syncSelectionToNativeElementsPanel: [],
+  unsupportedRendererVersion: [RendererID],
 
   // React Native style editor plug-in.
   isNativeStyleEditorSupported: [

--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -35,6 +35,9 @@ export const PROFILER_EXPORT_VERSION = 4;
 export const CHANGE_LOG_URL =
   'https://github.com/facebook/react/blob/master/packages/react-devtools/CHANGELOG.md';
 
+export const UNSUPPORTED_VERSION_URL =
+  'https://reactjs.org/blog/2019/08/15/new-react-devtools.html#how-do-i-get-the-old-version-back';
+
 // HACK
 //
 // Extracting during build time avoids a temporarily invalid state for the inline target.

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -73,6 +73,7 @@ export default class Store extends EventEmitter<{|
   supportsNativeStyleEditor: [],
   supportsProfiling: [],
   supportsReloadAndProfile: [],
+  unsupportedRendererVersionDetected: [],
 |}> {
   _bridge: FrontendBridge;
 
@@ -124,6 +125,8 @@ export default class Store extends EventEmitter<{|
   _supportsNativeInspection: boolean = true;
   _supportsProfiling: boolean = false;
   _supportsReloadAndProfile: boolean = false;
+
+  _unsupportedRendererVersionDetected: boolean = false;
 
   // Total number of visible elements (within all roots).
   // Used for windowing purposes.
@@ -178,6 +181,10 @@ export default class Store extends EventEmitter<{|
     bridge.addListener(
       'isNativeStyleEditorSupported',
       this.onBridgeNativeStyleEditorSupported,
+    );
+    bridge.addListener(
+      'unsupportedRendererVersion',
+      this.onBridgeUnsupportedRendererVersion,
     );
 
     this._profilerStore = new ProfilerStore(bridge, this, isProfiling);
@@ -335,6 +342,10 @@ export default class Store extends EventEmitter<{|
     // And if so, can the backend use the localStorage API?
     // Both of these are required for the reload-and-profile feature to work.
     return this._supportsReloadAndProfile && this._isBackendStorageAPISupported;
+  }
+
+  get unsupportedRendererVersionDetected(): boolean {
+    return this._unsupportedRendererVersionDetected;
   }
 
   containsElement(id: number): boolean {
@@ -1008,5 +1019,11 @@ export default class Store extends EventEmitter<{|
     this._isBackendStorageAPISupported = isBackendStorageAPISupported;
 
     this.emit('supportsReloadAndProfile');
+  };
+
+  onBridgeUnsupportedRendererVersion = () => {
+    this._unsupportedRendererVersionDetected = true;
+
+    this.emit('unsupportedRendererVersionDetected');
   };
 }

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -24,6 +24,7 @@ import ViewElementSourceContext from './Components/ViewElementSourceContext';
 import {ProfilerContextController} from './Profiler/ProfilerContext';
 import {ModalDialogContextController} from './ModalDialog';
 import ReactLogo from './ReactLogo';
+import UnsupportedVersionDialog from './UnsupportedVersionDialog';
 import WarnIfLegacyBackendDetected from './WarnIfLegacyBackendDetected';
 
 import styles from './DevTools.css';
@@ -51,6 +52,7 @@ export type Props = {|
   showTabBar?: boolean,
   store: Store,
   warnIfLegacyBackendDetected?: boolean,
+  warnIfUnsupportedVersionDetected?: boolean,
   viewElementSourceFunction?: ?ViewElementSource,
 
   // This property is used only by the web extension target.
@@ -92,6 +94,7 @@ export default function DevTools({
   showTabBar = false,
   store,
   warnIfLegacyBackendDetected = false,
+  warnIfUnsupportedVersionDetected = false,
   viewElementSourceFunction,
 }: Props) {
   const [tab, setTab] = useState(defaultTab);
@@ -164,6 +167,7 @@ export default function DevTools({
             </ViewElementSourceContext.Provider>
           </SettingsContextController>
           {warnIfLegacyBackendDetected && <WarnIfLegacyBackendDetected />}
+          {warnIfUnsupportedVersionDetected && <UnsupportedVersionDialog />}
         </ModalDialogContextController>
       </StoreContext.Provider>
     </BridgeContext.Provider>

--- a/packages/react-devtools-shared/src/devtools/views/UnsupportedVersionDialog.css
+++ b/packages/react-devtools-shared/src/devtools/views/UnsupportedVersionDialog.css
@@ -1,0 +1,20 @@
+.Row {  
+  display: flex;  
+  flex-direction: row;  
+  align-items: center;  
+} 
+
+.Column { 
+  display: flex;  
+  flex-direction: column; 
+  align-items: center;  
+} 
+
+.Title {  
+  font-size: var(--font-size-sans-large); 
+  margin-bottom: 0.5rem;  
+} 
+
+.ReleaseNotesLink { 
+  color: var(--color-button-active);  
+}

--- a/packages/react-devtools-shared/src/devtools/views/UnsupportedVersionDialog.js
+++ b/packages/react-devtools-shared/src/devtools/views/UnsupportedVersionDialog.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import React, {Fragment, useContext, useEffect, useState} from 'react';
+import {unstable_batchedUpdates as batchedUpdates} from 'react-dom';
+import {ModalDialogContext} from './ModalDialog';
+import {StoreContext} from './context';
+import {UNSUPPORTED_VERSION_URL} from 'react-devtools-shared/src/constants';
+
+import styles from './UnsupportedVersionDialog.css';
+
+type DAILOG_STATE = 'dialog-not-shown' | 'show-dialog' | 'dialog-shown';
+
+export default function UnsupportedVersionDialog(_: {||}) {
+  const {dispatch} = useContext(ModalDialogContext);
+  const store = useContext(StoreContext);
+  const [state, setState] = useState<DAILOG_STATE>('dialog-not-shown');
+
+  useEffect(
+    () => {
+      if (state === 'dialog-not-shown') {
+        const showDialog = () => {
+          batchedUpdates(() => {
+            setState('show-dialog');
+            dispatch({
+              canBeDismissed: true,
+              type: 'SHOW',
+              content: <DialogContent />,
+            });
+          });
+        };
+
+        if (store.unsupportedRendererVersionDetected) {
+          showDialog();
+        } else {
+          store.addListener('unsupportedRendererVersionDetected', showDialog);
+          return () => {
+            store.removeListener(
+              'unsupportedRendererVersionDetected',
+              showDialog,
+            );
+          };
+        }
+      }
+    },
+    [state, store],
+  );
+
+  return null;
+}
+
+function DialogContent(_: {||}) {
+  return (
+    <Fragment>
+      <div className={styles.Row}>
+        <div>
+          <div className={styles.Title}>Unsupported React version detected</div>
+          <p>
+            This version of React DevTools supports React DOM v15+ and React
+            Native v61+.
+          </p>
+          <p>
+            In order to use DevTools with an older version of React, you'll need
+            to{' '}
+            <a
+              className={styles.ReleaseNotesLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              href={UNSUPPORTED_VERSION_URL}>
+              install an older version of the extension
+            </a>.
+          </p>
+        </div>
+      </div>
+    </Fragment>
+  );
+}

--- a/packages/react-devtools-shell/src/devtools.js
+++ b/packages/react-devtools-shell/src/devtools.js
@@ -57,6 +57,7 @@ inject('dist/app.js', () => {
           browserTheme: 'light',
           showTabBar: true,
           warnIfLegacyBackendDetected: true,
+          warnIfUnsupportedVersionDetected: true,
         }),
       );
     },

--- a/packages/react-devtools/CHANGELOG.md
+++ b/packages/react-devtools/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed bug where Components panel was always empty for certain users. ([bvaughn](https://github.com/bvaughn) in [#16864](https://github.com/facebook/react/pull/16864))
 * Fixed regression in DevTools editable hooks interface that caused primitive values to be shown as `undefined`. ([bvaughn](https://github.com/bvaughn) in [#16867](https://github.com/facebook/react/pull/16867))
 * Fixed bug where DevTools showed stale values in props/state/hooks editing interface. ([bvaughn](https://github.com/bvaughn) in [#16878](https://github.com/facebook/react/pull/16878))
+* Show unsupported version dialog with downgrade instructions. ([bvaughn](https://github.com/bvaughn) in [#16897](https://github.com/facebook/react/pull/16897))
 </details>
 
 ## 4.1.0 (September 19, 2019)


### PR DESCRIPTION
Rather than partially supporting v14, DevTools now shows an unsupported dialog with a link to instructions on how to downgrade DevTools to v3:

![Screen Shot 2019-09-25 at 1 27 17 PM](https://user-images.githubusercontent.com/29597/65637372-ec0feb00-df98-11e9-8d79-223815f3e6d0.png)

I decided on this approach to detecting versions by looking at all v14 and v15 minor releases and by referencing [the old DevTools logic](https://github.com/facebook/react-devtools/blob/d839081f79f681617df7584a8ffd2f4163fa40b9/backend/attachRenderer.js#L24-L76).

I tested all minor release of v15 and v16 to ensure that the dialog didn't get shown. I tested the latest release of v14 and verified that it did.

Resolves #16462