### PR TITLE
Document `additionalHooks` option

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -34,6 +34,20 @@ Then add it to your ESLint configuration:
 }
 ```
 
+## Configuration
+
+`exhaustive-deps` can be configured to validate custom hooks via the `additionalHooks` option.
+This option accepts a regex to match the names of custom hooks.
+
+```js
+{
+  "rules": {
+    // ...
+    "react-hooks/exhaustive-deps": ["warn", { "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)" }]
+  }
+}
+```
+
 ## Valid and Invalid Examples
 
 Please refer to the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html) documentation and the [Hooks FAQ](https://reactjs.org/docs/hooks-faq.html#what-exactly-do-the-lint-rules-enforce) to learn more about this rule.


### PR DESCRIPTION
Hi!

I noticed that there doesn't seem to be any documentation about this option for `exhaustive-deps`. Was this a deliberate decision or an oversight? Obviously, feel free to decline this if you don't want to do this or this is the wrong place.

I recently used this for a custom hook at work and it's pretty useful but I'm a little uneasy about using undocumented features.