### PR TITLE
Critical bug at [server side render], failure when use [Context.Consumer] in [production] mode only.

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1186,10 +1186,13 @@ class ReactDOMServerRenderer {
                     );
                   }
                 }
-              } else {
-                reactContext = (reactContext: any)._context;
               }
             }
+
+            if ((reactContext: any)._context !== undefined) {
+              reactContext = (reactContext: any)._context;
+            }
+
             const nextProps: any = (nextChild: any).props;
             const threadID = this.threadID;
             validateContextBounds(reactContext, threadID);


### PR DESCRIPTION
Hello everyone!
That fix for server side rendering when you use Context.Consumer.

Issues for example in react:
https://github.com/facebook/react/issues/16848

Issues for example in react-router:
https://github.com/ReactTraining/react-router/issues/6789
https://github.com/ReactTraining/react-router/issues/6704

Issues for example in redux-connect:
https://github.com/makeomatic/redux-connect/issues/137

Issues for example in next.js:
https://github.com/zeit/next.js/issues/7167

Bug was in `ReactDOMServerRenderer.js` since version `16.6.2` and affects.

- `renderToString`
- `renderToStaticMarkup` 
- `renderToNodeStream`
- `renderToStaticNodeStream`

To reproduce, only in `production` mode and total bundle, try

```
const ThemeContext = React.createContext('light');

const Button = () => {
  return (
    <ThemeContext.Provider value="dark">
      <ThemeContext.Consumer>
        {theme => <span>{theme}</span>}
      </ThemeContext.Consumer>
   </ThemeContext.Provider>
  )
}

const appHTML = ReactDomServer.renderToString(<Button />)

console.log(appHTML)
```

And you will see just `<span></span>` instead `<span>dark</span>`
