### PR TITLE
Remove canonical check in fiber host component

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -83,15 +83,6 @@ class ReactNativeFiberHostComponent {
       relativeNode = relativeToNativeNode;
     } else if (relativeToNativeNode._nativeTag) {
       relativeNode = relativeToNativeNode._nativeTag;
-    } else if (
-      /* $FlowFixMe canonical doesn't exist on the node.
-       I think this branch is dead and will remove it in a followup */
-      relativeToNativeNode.canonical &&
-      relativeToNativeNode.canonical._nativeTag
-    ) {
-      /* $FlowFixMe canonical doesn't exist on the node.
-       I think this branch is dead and will remove it in a followup */
-      relativeNode = relativeToNativeNode.canonical._nativeTag;
     }
 
     if (relativeNode == null) {


### PR DESCRIPTION
I believe this is a dead branch.

I added this code in https://github.com/facebook/react/pull/15126 and I *think* it has always been wrong. At least, I'm not sure what could trigger it.

I think I was pattern matching from this code in NativeMethodsMixin  https://github.com/facebook/react/blob/master/packages/react-native-renderer/src/NativeMethodsMixin.js#L166-L182

Simplified: 
```
const maybeInstance = findHostInstance(this);
if (maybeInstance == null) {
  return;
}

if (maybeInstance.canonical) {
```

The only thing in the codebase that creates an object with a canonical key is [createInstance in ReactFabricHostConfig](https://github.com/facebook/react/blob/master/packages/react-native-renderer/src/ReactFabricHostConfig.js#L238-L241). `canonical` is only set on Fabric host components, not paper ones.

In order to get that instance, you must call `findHostInstance`. NativeMethodsMixin and ReactNativeComponent both use `findHostInstance` in order to detect whether an instance is created with the paper renderer or the fabric renderer to know which API to call. 

FiberHostComponent only needs to deal with paper components and the FabricHostComponent only needs to deal with the fabric components, so this check for canonical in paper is unnecessary.

When I wrote this code I also added tests for calling this function passing an argument created with all three `NativeMethodsMixin`, `ReactNativeComponent`, and a host component. If I add a `throw` to this if statement, none of the tests fail.
