### PR TITLE
Fix mouseenter handlers fired twice

### DIFF
--- a/fixtures/dom/src/components/fixtures/mouse-events/index.js
+++ b/fixtures/dom/src/components/fixtures/mouse-events/index.js
@@ -1,5 +1,6 @@
 import FixtureSet from '../../FixtureSet';
 import MouseMovement from './mouse-movement';
+import MouseEnter from './mouse-enter';
 
 const React = window.React;
 
@@ -8,6 +9,7 @@ class MouseEvents extends React.Component {
     return (
       <FixtureSet title="Mouse Events">
         <MouseMovement />
+        <MouseEnter />
       </FixtureSet>
     );
   }

--- a/fixtures/dom/src/components/fixtures/mouse-events/mouse-enter.js
+++ b/fixtures/dom/src/components/fixtures/mouse-events/mouse-enter.js
@@ -1,0 +1,73 @@
+import TestCase from '../../TestCase';
+
+const React = window.React;
+const ReactDOM = window.ReactDOM;
+
+const MouseEnter = () => {
+  const containerRef = React.useRef();
+
+  React.useEffect(function() {
+    const hostEl = containerRef.current;
+    ReactDOM.render(<MouseEnterDetect />, hostEl, () => {
+      ReactDOM.render(<MouseEnterDetect />, hostEl.childNodes[1]);
+    });
+  }, []);
+
+  return (
+    <TestCase
+      title="Mouse Enter"
+      description=""
+      affectedBrowsers="Chrome, Safari, Firefox">
+      <TestCase.Steps>
+        <li>Mouse enter the boxes below, from different borders</li>
+      </TestCase.Steps>
+      <TestCase.ExpectedResult>
+        Mouse enter call count should equal to 1; <br />
+        Issue{' '}
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+          href="https://github.com/facebook/react/issues/16763">
+          #16763
+        </a>{' '}
+        should not happen.
+        <br />
+      </TestCase.ExpectedResult>
+      <div ref={containerRef} />
+    </TestCase>
+  );
+};
+
+const MouseEnterDetect = () => {
+  const [log, setLog] = React.useState({});
+  const firstEl = React.useRef();
+  const siblingEl = React.useRef();
+
+  const onMouseEnter = e => {
+    const timeStamp = e.timeStamp;
+    setLog(log => {
+      const callCount = 1 + (log.timeStamp === timeStamp ? log.callCount : 0);
+      return {
+        timeStamp,
+        callCount,
+      };
+    });
+  };
+
+  return (
+    <React.Fragment>
+      <div
+        ref={firstEl}
+        onMouseEnter={onMouseEnter}
+        style={{
+          border: '1px solid #d9d9d9',
+          padding: '20px 20px',
+        }}>
+        Mouse enter call count: {log.callCount || ''}
+      </div>
+      <div ref={siblingEl} />
+    </React.Fragment>
+  );
+};
+
+export default MouseEnter;

--- a/packages/react-dom/src/events/EnterLeaveEventPlugin.js
+++ b/packages/react-dom/src/events/EnterLeaveEventPlugin.js
@@ -146,6 +146,10 @@ const EnterLeaveEventPlugin = {
 
     accumulateEnterLeaveDispatches(leave, enter, from, to);
 
+    if (isOutEvent && from && nativeEventTarget !== fromNode) {
+      return [leave];
+    }
+
     return [leave, enter];
   },
 };


### PR DESCRIPTION
### The bug
mouseenter handler gets fired twice, in a component **ReactDOM.render-ed** in another component.

    ReactDOM.render(<AnotherComponent />, hostEl, () => {
      ReactDOM.render(<AComponentMouseEnterWronglyFiredTwice />, hostEl.childNodes[1]);
    });

    function AComponentMouseEnterWronglyFiredTwice() {
         return (<>
            <div
                onMouseEnter={() => {console.log('You may see this twice');}}
            >
                Move mouse TO here
            </div>
            <div>Move mouse FROM here</div>
         </>)
    }

The bug issue https://github.com/facebook/react/issues/16763
The reproduction demo https://codesandbox.io/s/hungry-field-kgkli

### The cause
For any event happened in **ReactDOM.render-ed** component in another component.
In function handleTopLevel(bookKeeping) {...}, we'll get two ancestors (at least) for bookKeeping.

It's ok for most of the events, but mouseenter is different.
mouseenter is extracted out from mouseout/mouseover.

When mouseout gets dealt twice in `handleTopLevel` in the situation above, mouseenter gets fired twice on the same node.

### The fix

EnterLeaveEventPlugin.js

    extractEvents(...) {
        ...
        if (isOutEvent && from && nativeEventTarget !== fromNode) {
          return [leave];
        }
        return [leave, enter];
    }





