### PR TITLE
[react-interactions] Tap cancels on second pointerdown

### DIFF
--- a/packages/react-interactions/events/src/dom/testing-library/domEvents.js
+++ b/packages/react-interactions/events/src/dom/testing-library/domEvents.js
@@ -422,9 +422,14 @@ export function pointerup(payload) {
  */
 
 export function mousedown(payload) {
+  // The value of 'buttons' for 'mousedown' must not be 0
+  const buttons =
+    payload == null || payload.buttons === 0
+      ? buttonsType.primary
+      : payload.buttons;
   return createMouseEvent('mousedown', {
-    buttons: buttonsType.primary,
     ...payload,
+    buttons,
   });
 }
 


### PR DESCRIPTION
This patch causes onTapCancel to be called whenever a second pointer interacts with the responder target.