### PR TITLE
Allow Suspense Mismatch on the Client to Silently Proceed

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -659,4 +659,15 @@ describe('ReactDOMServerHydration', () => {
 
     document.body.removeChild(parentContainer);
   });
+
+  it('regression test: Suspense + hydration in legacy mode ', () => {
+    const element = document.createElement('div');
+    element.innerHTML = '<div>Hello World</div>';
+    ReactDOM.hydrate(
+      <React.Suspense>
+        <div>Hello World</div>
+      </React.Suspense>,
+      element,
+    );
+  });
 });

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -404,11 +404,10 @@ function skipPastDehydratedSuspenseInstance(
   let suspenseState: null | SuspenseState = fiber.memoizedState;
   let suspenseInstance: null | SuspenseInstance =
     suspenseState !== null ? suspenseState.dehydrated : null;
-  invariant(
-    suspenseInstance,
-    'Expected to have a hydrated suspense instance. ' +
-      'This error is likely caused by a bug in React. Please file an issue.',
-  );
+  if (suspenseInstance === null) {
+    // This Suspense boundary was hydrated without a match.
+    return nextHydratableInstance;
+  }
   return getNextHydratableInstanceAfterSuspenseInstance(suspenseInstance);
 }
 


### PR DESCRIPTION
This fixes #16938 but isn't actually the semantics we want for this case.

As described in: https://github.com/facebook/react/issues/16938#issuecomment-536207871

This would silently try to hydrate bad mismatches instead of gracefully regenerate the content on the client. Additionally, the only time the hack makes sense is if you can guarantee that nothing will possibly suspend during hydration. If it does, it opens up a whole new set of issues as the fallback would now try to hydrate.

So it's clear to me that we don't actually want this to be the semantics.

Now the debate is in whether it's ok to change this in a minor. We'd argue that it is because conditional rendering on the server is never considered a public API. E.g. if you conditionally render useLayoutEffect, Context providers or anything else, that's also not a legit usage. So technically we don't consider this a breaking change. Suspense was already erroring if used as intended - unconditionally.

However this is a technicality and it's really about what is the impact of this in practice.