### PR TITLE
[Patch Release] v16.10.1

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -659,4 +659,15 @@ describe('ReactDOMServerHydration', () => {
 
     document.body.removeChild(parentContainer);
   });
+
+  it('regression test: Suspense + hydration in legacy mode ', () => {
+    const element = document.createElement('div');
+    element.innerHTML = '<div>Hello World</div>';
+    ReactDOM.hydrate(
+      <React.Suspense>
+        <div>Hello World</div>
+      </React.Suspense>,
+      element,
+    );
+  });
 });

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -404,11 +404,10 @@ function skipPastDehydratedSuspenseInstance(
   let suspenseState: null | SuspenseState = fiber.memoizedState;
   let suspenseInstance: null | SuspenseInstance =
     suspenseState !== null ? suspenseState.dehydrated : null;
-  invariant(
-    suspenseInstance,
-    'Expected to have a hydrated suspense instance. ' +
-      'This error is likely caused by a bug in React. Please file an issue.',
-  );
+  if (suspenseInstance === null) {
+    // This Suspense boundary was hydrated without a match.
+    return nextHydratableInstance;
+  }
   return getNextHydratableInstanceAfterSuspenseInstance(suspenseInstance);
 }
 


### PR DESCRIPTION
Patch release branch for v16.10.1.

## Test Plan

Release candidate version: `0.0.0-d346d9208`

- [X] Confirm that the repro in #16938 is fixed in the RC: https://codesandbox.io/s/rough-frost-dvtbk
- [x] Create Hello World Next app and confirm it works with the latest version Next: https://github.com/zeit/next.js/tree/canary/examples/hello-world
  - [x] Also test `next@9.0.6`, before the bug was addressed downstream.

## Changelog

### React DOM Server

* Fix regression in Next.js apps by allowing Suspense mismatch during hydration to silently proceed ([@sebmarkbage](https://github.com/sebmarkbage) in [#16943](https://github.com/facebook/react/pull/16943))