### PR TITLE
[DevTools] targetOrigin of postMessage needs to be '*' for local files

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -135,7 +135,7 @@ function createPanelIfReactLoaded() {
         // Initialize the backend only once the Store has been initialized.
         // Otherwise the Store may miss important initial tree op codes.
         chrome.devtools.inspectedWindow.eval(
-          `window.postMessage({ source: 'react-devtools-inject-backend' }, window.origin);`,
+          `window.postMessage({ source: 'react-devtools-inject-backend' }, '*');`,
           function(response, evalError) {
             if (evalError) {
               console.error(evalError);


### PR DESCRIPTION
When we (extension) use `postMessage` to send a message to the content script (on the same window) to inject the backend script, the `targetOrigin` was set to `window.origin` here
https://github.com/facebook/react/blob/master/packages/react-devtools-extensions/src/main.js#L138

However, this won't work for local files (`window.origin` is `null`) so I'm changing the `targetOrigin` from `window.origin` to `'*'`. Other existing `postMessage` calls in contentScript.js does so as well.

https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#Using_window.postMessage_in_extensions:
> posting a message to a page at a file: URL currently requires that the targetOrigin argument be "*"

I tested with the local index.html file provided in https://github.com/facebook/react/issues/16952 (but removed `type="text/babel"`) and confirmed that the components tab was empty before this change, and working after this change.
