### PR TITLE
[react-interactions] Add tab handling to FocusList

### DIFF
--- a/packages/react-interactions/accessibility/src/FocusManager.js
+++ b/packages/react-interactions/accessibility/src/FocusManager.js
@@ -64,6 +64,7 @@ const FocusManager = React.forwardRef(
       onBlurWithin: function(event) {
         if (!containFocus) {
           event.continuePropagation();
+          return;
         }
         const lastNode = event.target;
         if (lastNode) {

--- a/packages/react-interactions/accessibility/src/FocusTable.js
+++ b/packages/react-interactions/accessibility/src/FocusTable.js
@@ -31,6 +31,7 @@ type FocusTableProps = {|
     focusTableByID: (id: string) => void,
   ) => void,
   wrap?: boolean,
+  tabScope?: ReactScope,
 |};
 
 const {useRef} = React;

--- a/packages/react-interactions/accessibility/src/__tests__/FocusList-test.internal.js
+++ b/packages/react-interactions/accessibility/src/__tests__/FocusList-test.internal.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
-import {createEventTarget} from 'react-interactions/events/src/dom/testing-library';
+import {
+  createEventTarget,
+  emulateBrowserTab,
+} from 'react-interactions/events/src/dom/testing-library';
 
 let React;
 let ReactFeatureFlags;
@@ -155,6 +158,75 @@ describe('FocusList', () => {
         key: 'ArrowUp',
       });
       expect(document.activeElement.textContent).toBe('Item 3');
+    });
+
+    it('handles keyboard arrow operations mixed with tabbing', () => {
+      const [FocusList, FocusItem] = createFocusList(TabbableScope);
+      const beforeRef = React.createRef();
+      const afterRef = React.createRef();
+
+      function Test() {
+        return (
+          <>
+            <input placeholder="Before" ref={beforeRef} />
+            <FocusList tabScope={TabbableScope} portrait={true}>
+              <ul>
+                <FocusItem>
+                  <li>
+                    <input placeholder="A" />
+                  </li>
+                </FocusItem>
+                <FocusItem>
+                  <li>
+                    <input placeholder="B" />
+                  </li>
+                </FocusItem>
+                <FocusItem>
+                  <li>
+                    <input placeholder="C" />
+                  </li>
+                </FocusItem>
+                <FocusItem>
+                  <li>
+                    <input placeholder="D" />
+                  </li>
+                </FocusItem>
+                <FocusItem>
+                  <li>
+                    <input placeholder="E" />
+                  </li>
+                </FocusItem>
+                <FocusItem>
+                  <li>
+                    <input placeholder="F" />
+                  </li>
+                </FocusItem>
+              </ul>
+            </FocusList>
+            <input placeholder="After" ref={afterRef} />
+          </>
+        );
+      }
+
+      ReactDOM.render(<Test />, container);
+      beforeRef.current.focus();
+
+      expect(document.activeElement.placeholder).toBe('Before');
+      emulateBrowserTab();
+      expect(document.activeElement.placeholder).toBe('A');
+      emulateBrowserTab();
+      expect(document.activeElement.placeholder).toBe('After');
+      emulateBrowserTab(true);
+      expect(document.activeElement.placeholder).toBe('A');
+      const a = createEventTarget(document.activeElement);
+      a.keydown({
+        key: 'ArrowDown',
+      });
+      expect(document.activeElement.placeholder).toBe('B');
+      emulateBrowserTab();
+      expect(document.activeElement.placeholder).toBe('After');
+      emulateBrowserTab(true);
+      expect(document.activeElement.placeholder).toBe('B');
     });
   });
 });

--- a/packages/react-interactions/accessibility/src/__tests__/FocusTable-test.internal.js
+++ b/packages/react-interactions/accessibility/src/__tests__/FocusTable-test.internal.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
-import {createEventTarget} from 'react-interactions/events/src/dom/testing-library';
+import {
+  createEventTarget,
+  emulateBrowserTab,
+} from 'react-interactions/events/src/dom/testing-library';
 
 let React;
 let ReactFeatureFlags;
@@ -28,33 +31,6 @@ describe('FocusTable', () => {
   describe('ReactDOM', () => {
     let ReactDOM;
     let container;
-
-    function emulateBrowserTab(backwards) {
-      const activeElement = document.activeElement;
-      const focusedElem = createEventTarget(activeElement);
-      let defaultPrevented = false;
-      focusedElem.keydown({
-        key: 'Tab',
-        shiftKey: backwards,
-        preventDefault() {
-          defaultPrevented = true;
-        },
-      });
-      if (!defaultPrevented) {
-        // This is not a full spec compliant version, but should be suffice for this test
-        const focusableElems = Array.from(
-          document.querySelectorAll(
-            'input, button, select, textarea, a[href], [tabindex], [contenteditable], iframe, object, embed',
-          ),
-        ).filter(
-          elem => elem.tabIndex > -1 && !elem.disabled && !elem.contentEditable,
-        );
-        const idx = focusableElems.indexOf(activeElement);
-        if (idx !== -1) {
-          focusableElems[backwards ? idx - 1 : idx + 1].focus();
-        }
-      }
-    }
 
     beforeEach(() => {
       ReactDOM = require('react-dom');

--- a/packages/react-interactions/events/src/dom/testing-library/index.js
+++ b/packages/react-interactions/events/src/dom/testing-library/index.js
@@ -158,6 +158,33 @@ function testWithPointerType(message, testFn) {
   });
 }
 
+function emulateBrowserTab(backwards) {
+  const activeElement = document.activeElement;
+  const focusedElem = createEventTarget(activeElement);
+  let defaultPrevented = false;
+  focusedElem.keydown({
+    key: 'Tab',
+    shiftKey: backwards,
+    preventDefault() {
+      defaultPrevented = true;
+    },
+  });
+  if (!defaultPrevented) {
+    // This is not a full spec compliant version, but should be suffice for this test
+    const focusableElems = Array.from(
+      document.querySelectorAll(
+        'input, button, select, textarea, a[href], [tabindex], [contenteditable], iframe, object, embed',
+      ),
+    ).filter(
+      elem => elem.tabIndex > -1 && !elem.disabled && !elem.contentEditable,
+    );
+    const idx = focusableElems.indexOf(activeElement);
+    if (idx !== -1) {
+      focusableElems[backwards ? idx - 1 : idx + 1].focus();
+    }
+  }
+}
+
 export {
   buttonsType,
   createEventTarget,
@@ -166,4 +193,5 @@ export {
   hasPointerEvent,
   setPointerEvent,
   testWithPointerType,
+  emulateBrowserTab,
 };

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -718,6 +718,7 @@ const bundles = [
       'react',
       'react-interactions/events/keyboard',
       'react-interactions/accessibility/tabbable-scope',
+      'react-interactions/accessibility/focus-control',
     ],
   },
 ];


### PR DESCRIPTION
This is a follow up to https://github.com/facebook/react/pull/16922, where we add the same tab keyboard control behavior to `FocusList`