### PR TITLE
Fixing grammatical errors in error message

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -758,8 +758,8 @@ function loopError(hook) {
 function functionError(hook, fn) {
   return {
     message:
-      `React Hook "${hook}" is called in function "${fn}" which is neither ` +
-      'a React function component or a custom React Hook function.',
+      `React Hook "${hook}" is called in function "${fn}" that is neither ` +
+      'a React function component nor a custom React Hook function.',
   };
 }
 

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -428,7 +428,7 @@ export default {
               const message =
                 `React Hook "${context.getSource(hook)}" is called in ` +
                 `function "${context.getSource(codePathFunctionName)}" ` +
-                'which is neither a React function component or a custom ' +
+                'that is neither a React function component nor a custom ' +
                 'React Hook function.';
               context.report({node: hook, message});
             } else if (codePathNode.type === 'Program') {


### PR DESCRIPTION
Fixing a small grammatical error in the error message, neither/nor clause and that/which confusion.
