### PR TITLE
[React-DevTools] Support Shift+Enter to go to previous search result

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/SearchInput.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SearchInput.js
@@ -53,9 +53,13 @@ export default function SearchInput(props: Props) {
   );
 
   const handleInputKeyPress = useCallback(
-    ({key}) => {
+    ({key, shiftKey}) => {
       if (key === 'Enter') {
-        dispatch({type: 'GO_TO_NEXT_SEARCH_RESULT'});
+        if (shiftKey) {
+          dispatch({type: 'GO_TO_PREVIOUS_SEARCH_RESULT'});
+        } else {
+          dispatch({type: 'GO_TO_NEXT_SEARCH_RESULT'});
+        }
       }
     },
     [dispatch],


### PR DESCRIPTION
I added support for Shift + Enter while the search bar is in focus in the DevTools, it's a widely used shortcut to go to the previous search results instead of the next one.

As it wasn't a big change, I didn't create an issue, hope that's ok.