### PR TITLE
[EnterLeaveEventPlugin] Fix bug when dealing with unhandled DOM nodes

### DIFF
--- a/packages/react-dom/src/events/EnterLeaveEventPlugin.js
+++ b/packages/react-dom/src/events/EnterLeaveEventPlugin.js
@@ -42,6 +42,12 @@ const eventTypes = {
   },
 };
 
+// We track the lastNativeEvent to ensure that when we encounter
+// cases where we process the same nativeEvent multiple times,
+// which can happen when have multiple ancestors, that we don't
+// duplicate enter
+let lastNativeEvent;
+
 const EnterLeaveEventPlugin = {
   eventTypes: eventTypes,
 
@@ -163,9 +169,11 @@ const EnterLeaveEventPlugin = {
 
     accumulateEnterLeaveDispatches(leave, enter, from, to);
 
-    if (isOutEvent && from && nativeEventTarget !== fromNode) {
+    if (nativeEvent === lastNativeEvent) {
+      lastNativeEvent = null;
       return [leave];
     }
+    lastNativeEvent = nativeEvent;
 
     return [leave, enter];
   },

--- a/packages/react-dom/src/events/__tests__/EnterLeaveEventPlugin-test.js
+++ b/packages/react-dom/src/events/__tests__/EnterLeaveEventPlugin-test.js
@@ -185,4 +185,55 @@ describe('EnterLeaveEventPlugin', () => {
 
     ReactDOM.render(<Parent />, container);
   });
+
+  it('should call mouseEnter when pressing a non tracked React node', done => {
+    const mockFn = jest.fn();
+
+    class Parent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.parentEl = React.createRef();
+      }
+
+      componentDidMount() {
+        ReactDOM.render(<MouseEnterDetect />, this.parentEl.current);
+      }
+
+      render() {
+        return <div ref={this.parentEl} />;
+      }
+    }
+
+    class MouseEnterDetect extends React.Component {
+      constructor(props) {
+        super(props);
+        this.divRef = React.createRef();
+        this.siblingEl = React.createRef();
+      }
+
+      componentDidMount() {
+        const attachedNode = document.createElement('div');
+        this.divRef.current.appendChild(attachedNode);
+        attachedNode.dispatchEvent(
+          new MouseEvent('mouseout', {
+            bubbles: true,
+            cancelable: true,
+            relatedTarget: this.siblingEl.current,
+          }),
+        );
+        expect(mockFn.mock.calls.length).toBe(1);
+        done();
+      }
+
+      render() {
+        return (
+          <div ref={this.divRef}>
+            <div ref={this.siblingEl} onMouseEnter={mockFn} />
+          </div>
+        );
+      }
+    }
+
+    ReactDOM.render(<Parent />, container);
+  });
 });


### PR DESCRIPTION
This PR is a follow up to https://github.com/facebook/react/pull/16928, where that PR fixed one class of bug, but also introduced another issue whilst doing so.

This PR introduces an alternative fix that avoids the issue introduced in that PR. Notably, when a DOM node has not been handled by React (it hasn't got an internal handle to a fiber), then the target fiber ends up not matching 1:1, meaning the logic in https://github.com/facebook/react/pull/16928 is not quite accurate as `nativeEventTarget !== fromNode` is a valid code path. This PR fixes it by tracking the `nativeEvent` between calls to this EnterLeaveEventPlugin – to ensure we don't duplicate enter events for the same native event object.

I've added a test case and validated it fixes the issue internally too.