### PR TITLE
[DevTools] Display RegExp values in props/state

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
@@ -503,6 +503,7 @@ exports[`InspectedElementContext should support complex data types: 1: Inspected
       "1": {}
     },
     "react_element": {},
+    "regexp": {},
     "set": {
       "0": "abc",
       "1": 123

--- a/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
@@ -539,6 +539,7 @@ describe('InspectedElementContext', () => {
           map={mapShallow}
           map_of_maps={mapOfMaps}
           react_element={<span />}
+          regexp={/abc/giu}
           set={setShallow}
           set_of_sets={setOfSets}
           symbol={Symbol('symbol')}
@@ -584,6 +585,7 @@ describe('InspectedElementContext', () => {
       map,
       map_of_maps,
       react_element,
+      regexp,
       set,
       set_of_sets,
       symbol,
@@ -623,6 +625,10 @@ describe('InspectedElementContext', () => {
     expect(react_element[meta.inspectable]).toBe(false);
     expect(react_element[meta.name]).toBe('span');
     expect(react_element[meta.type]).toBe('react_element');
+
+    expect(regexp[meta.inspectable]).toBe(false);
+    expect(regexp[meta.name]).toBe('/abc/giu');
+    expect(regexp[meta.type]).toBe('regexp');
 
     expect(set[meta.inspectable]).toBeUndefined(); // Complex type
     expect(set[meta.name]).toBe('Set');

--- a/packages/react-devtools-shared/src/devtools/views/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/utils.js
@@ -105,6 +105,7 @@ export function getMetaValueLabel(data: Object): string | null {
     case 'object':
       return 'Object';
     case 'date':
+    case 'regexp':
     case 'symbol':
       return name;
     case 'iterator':

--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -81,6 +81,7 @@ type PropType =
   | 'number'
   | 'object'
   | 'react_element'
+  | 'regexp'
   | 'string'
   | 'symbol'
   | 'typed_array'
@@ -128,6 +129,8 @@ function getDataType(data: Object): PropType {
         return 'array_buffer';
       } else if (typeof data[Symbol.iterator] === 'function') {
         return 'iterator';
+      } else if (data instanceof RegExp) {
+        return 'regexp';
       } else if (Object.prototype.toString.call(data) === '[object Date]') {
         return 'date';
       }
@@ -317,6 +320,14 @@ export function dehydrate(
       }
 
     case 'date':
+      cleaned.push(path);
+      return {
+        inspectable: false,
+        name: data.toString(),
+        type,
+      };
+
+    case 'regexp':
       cleaned.push(path);
       return {
         inspectable: false,


### PR DESCRIPTION
Previously, when props/state contained a regexp, it was shown as an
empty object. This commit adds regexps as values in need of special
rehydration (like Symbols or TypedArrays), and display them as a user
might expect.

These values may be editable, but as regexps are not valid JSON it might
depart from the usual editing functionality, which may not be worth the
hassle just to support regexps.

Before:
![image](https://user-images.githubusercontent.com/1144615/66254187-64796780-e762-11e9-9dce-e100178ca344.png)

After:
![image](https://user-images.githubusercontent.com/1144615/66254160-1a908180-e762-11e9-8fb5-645fe129a971.png)
