### PR TITLE
When copying tree to clipboard ensure the full tree is copied

### DIFF
--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -50,6 +50,9 @@ const debug = (methodName, ...args) => {
   }
 };
 
+const invalidRendererWarning = (rendererID: number, id: number) =>
+  `Invalid renderer id "${rendererID}" for element "${id}"`;
+
 type ElementAndRendererID = {|
   id: number,
   rendererID: number,
@@ -227,7 +230,7 @@ export default class Agent extends EventEmitter<{|
   getOwnersList = ({id, rendererID}: ElementAndRendererID) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
-      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+      console.warn(invalidRendererWarning(rendererID, id));
     } else {
       const owners = renderer.getOwnersList(id);
       this._bridge.send('ownersList', ({id, owners}: OwnersList));
@@ -237,7 +240,7 @@ export default class Agent extends EventEmitter<{|
   inspectElement = ({id, path, rendererID}: InspectElementParams) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
-      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+      console.warn(invalidRendererWarning(rendererID, id));
     } else {
       this._bridge.send('inspectedElement', renderer.inspectElement(id, path));
 
@@ -264,7 +267,7 @@ export default class Agent extends EventEmitter<{|
   getDataForCopy = ({id, property, rendererID}: GetDataForCopyParams) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
-      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+      console.warn(invalidRendererWarning(rendererID, id));
     } else {
       const data = renderer.getDataForCopy(id, property);
       if (data !== null) {
@@ -276,7 +279,7 @@ export default class Agent extends EventEmitter<{|
   logElementToConsole = ({id, rendererID}: ElementAndRendererID) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
-      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+      console.warn(invalidRendererWarning(rendererID, id));
     } else {
       renderer.logElementToConsole(id);
     }
@@ -298,7 +301,7 @@ export default class Agent extends EventEmitter<{|
   overrideContext = ({id, path, rendererID, value}: SetInParams) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
-      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+      console.warn(invalidRendererWarning(rendererID, id));
     } else {
       renderer.setInContext(id, path, value);
     }
@@ -313,7 +316,7 @@ export default class Agent extends EventEmitter<{|
   }: OverrideHookParams) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
-      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+      console.warn(invalidRendererWarning(rendererID, id));
     } else {
       renderer.setInHook(id, hookID, path, value);
     }
@@ -322,7 +325,7 @@ export default class Agent extends EventEmitter<{|
   overrideProps = ({id, path, rendererID, value}: SetInParams) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
-      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+      console.warn(invalidRendererWarning(rendererID, id));
     } else {
       renderer.setInProps(id, path, value);
     }
@@ -331,7 +334,7 @@ export default class Agent extends EventEmitter<{|
   overrideState = ({id, path, rendererID, value}: SetInParams) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
-      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+      console.warn(invalidRendererWarning(rendererID, id));
     } else {
       renderer.setInState(id, path, value);
     }
@@ -344,7 +347,7 @@ export default class Agent extends EventEmitter<{|
   }: OverrideSuspenseParams) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
-      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+      console.warn(invalidRendererWarning(rendererID, id));
     } else {
       renderer.overrideSuspense(id, forceFallback);
     }
@@ -452,7 +455,7 @@ export default class Agent extends EventEmitter<{|
   viewElementSource = ({id, rendererID}: ElementAndRendererID) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
-      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+      console.warn(invalidRendererWarning(rendererID, id));
     } else {
       renderer.prepareViewElementSource(id);
     }

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -87,6 +87,12 @@ type PersistedSelection = {|
   path: Array<PathFrame>,
 |};
 
+type GetDataForCopyParams = {|
+  id: number,
+  rendererID: number,
+  property: string,
+|};
+
 export default class Agent extends EventEmitter<{|
   hideNativeHighlight: [],
   showNativeHighlight: [NativeType],
@@ -131,6 +137,7 @@ export default class Agent extends EventEmitter<{|
     bridge.addListener('getOwnersList', this.getOwnersList);
     bridge.addListener('inspectElement', this.inspectElement);
     bridge.addListener('logElementToConsole', this.logElementToConsole);
+    bridge.addListener('getDataForCopy', this.getDataForCopy);
     bridge.addListener('overrideContext', this.overrideContext);
     bridge.addListener('overrideHookState', this.overrideHookState);
     bridge.addListener('overrideProps', this.overrideProps);
@@ -251,6 +258,18 @@ export default class Agent extends EventEmitter<{|
       // For now, it doesn't seem like there is a way to do that:
       // https://github.com/bvaughn/react-devtools-experimental/issues/102
       // (Setting $0 doesn't work, and calling inspect() switches the tab.)
+    }
+  };
+
+  getDataForCopy = ({id, property, rendererID}: GetDataForCopyParams) => {
+    const renderer = this._rendererInterfaces[rendererID];
+    if (renderer == null) {
+      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+    } else {
+      const data = renderer.getDataForCopy(id, property);
+      if (data !== null) {
+        this._bridge.send('dataForCopy', data);
+      }
     }
   };
 

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -15,7 +15,7 @@ import {
   ElementTypeOtherOrUnknown,
 } from 'react-devtools-shared/src/types';
 import {getUID, utfEncodeString, printOperationsArray} from '../../utils';
-import {cleanForBridge, copyWithSet} from '../utils';
+import {cleanForBridge, copyWithSet, sanitizeForCopy} from '../utils';
 import {getDisplayName} from 'react-devtools-shared/src/utils';
 import {
   __DEBUG__,
@@ -695,6 +695,20 @@ export function attach(
     };
   }
 
+  function getDataForCopy(id: number, property: string) {
+    const result = inspectElementRaw(id);
+    if (result === null) {
+      console.warn(`Could not find element with id "${id}"`);
+      return null;
+    }
+
+    if (!result.hasOwnProperty(property)) {
+      return null;
+    }
+
+    return sanitizeForCopy(result[property]);
+  }
+
   function inspectElementRaw(id: number): InspectedElement | null {
     const internalInstance = idToInternalInstanceMap.get(id);
 
@@ -954,5 +968,6 @@ export function attach(
     startProfiling,
     stopProfiling,
     updateComponentFilters,
+    getDataForCopy,
   };
 }

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -33,7 +33,7 @@ import {
   utfEncodeString,
 } from 'react-devtools-shared/src/utils';
 import {sessionStorageGetItem} from 'react-devtools-shared/src/storage';
-import {cleanForBridge, copyWithSet} from './utils';
+import {cleanForBridge, copyWithSet, sanitizeForCopy} from './utils';
 import {
   __DEBUG__,
   SESSION_STORAGE_RELOAD_AND_PROFILE_KEY,
@@ -2560,6 +2560,22 @@ export function attach(
     }
   }
 
+  function getDataForCopy(id: number, property: string) {
+    const result = isMostRecentlyInspectedElementCurrent(id)
+      ? mostRecentlyInspectedElement
+      : inspectElementRaw(id);
+    if (result === null) {
+      console.warn(`Could not find Fiber with id "${id}"`);
+      return null;
+    }
+
+    if (!result.hasOwnProperty(property)) {
+      return null;
+    }
+
+    return sanitizeForCopy(result[property]);
+  }
+
   function logElementToConsole(id) {
     const result = isMostRecentlyInspectedElementCurrent(id)
       ? mostRecentlyInspectedElement
@@ -3131,5 +3147,6 @@ export function attach(
     startProfiling,
     stopProfiling,
     updateComponentFilters,
+    getDataForCopy,
   };
 }

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -257,6 +257,7 @@ export type RendererInterface = {
   startProfiling: (recordChangeDescriptions: boolean) => void,
   stopProfiling: () => void,
   updateComponentFilters: (componentFilters: Array<ComponentFilter>) => void,
+  getDataForCopy: (id: number, property: string) => Object | null,
 };
 
 export type Handler = (data: any) => void;

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -7,9 +7,10 @@
  * @flow
  */
 
-import {dehydrate} from '../hydration';
+import {dehydrate, getDisplayNameForReactElement} from '../hydration';
 
 import type {DehydratedData} from 'react-devtools-shared/src/devtools/views/Components/types';
+import {isElement} from 'react-is';
 
 export function cleanForBridge(
   data: Object | null,
@@ -51,4 +52,47 @@ export function copyWithSet(
   // $FlowFixMe number or string is fine here
   updated[key] = copyWithSet(obj[key], path, value, index + 1);
   return updated;
+}
+
+function getSanitizedValue(value: Object) {
+  if (typeof value === 'function') {
+    return `${value.name}()`;
+  }
+
+  if (isElement(value)) {
+    return `<${getDisplayNameForReactElement(value) || ''} />`;
+  }
+
+  if (typeof HTMLElement !== 'undefined' && value instanceof HTMLElement) {
+    return `<${value.tagName} />`;
+  }
+
+  if (typeof value !== 'object') {
+    return value;
+  }
+
+  return null;
+}
+
+function sanitize(data: Object) {
+  for (const key in data) {
+    const value = data[key];
+    const sanitizedValue = getSanitizedValue(value);
+
+    if (sanitizedValue === null && typeof value === 'object') {
+      sanitize(value);
+    } else {
+      data[key] = sanitizedValue;
+    }
+  }
+}
+
+export function sanitizeForCopy(data: Object) {
+  const clone = Object.assign({}, data);
+  if (clone.hasOwnProperty('children')) {
+    delete clone.children;
+  }
+
+  sanitize(clone);
+  return clone;
 }

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -56,6 +56,11 @@ type InspectElementParams = {|
   path?: Array<string | number>,
 |};
 
+type GetDataForCopyParams = {|
+  ...ElementAndRendererID,
+  property: string,
+|};
+
 type NativeStyleEditor_RenameAttributeParams = {|
   ...ElementAndRendererID,
   oldName: string,
@@ -85,6 +90,7 @@ type BackendEvents = {|
   syncSelectionFromNativeElementsPanel: [],
   syncSelectionToNativeElementsPanel: [],
   unsupportedRendererVersion: [RendererID],
+  dataForCopy: [Object],
 
   // React Native style editor plug-in.
   isNativeStyleEditorSupported: [
@@ -118,6 +124,7 @@ type FrontendEvents = {|
   updateAppendComponentStack: [boolean],
   updateComponentFilters: [Array<ComponentFilter>],
   viewElementSource: [ElementAndRendererID],
+  getDataForCopy: [GetDataForCopyParams],
 
   // React Native style editor plug-in.
   NativeStyleEditor_measure: [ElementAndRendererID],

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
@@ -7,14 +7,13 @@
  * @flow
  */
 
-import {copy} from 'clipboard-js';
 import React, {useCallback, useState} from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import KeyValue from './KeyValue';
 import EditableName from './EditableName';
 import EditableValue from './EditableValue';
-import {alphaSortEntries, serializeDataForCopy} from '../utils';
+import {alphaSortEntries} from '../utils';
 import styles from './InspectedElementTree.css';
 
 import type {InspectPath} from './SelectedElement';
@@ -28,6 +27,7 @@ type Props = {|
   overrideValueFn?: ?OverrideValueFn,
   showWhenEmpty?: boolean,
   canAddEntries?: boolean,
+  copyToClipboard: () => void,
 |};
 
 export default function InspectedElementTree({
@@ -35,6 +35,7 @@ export default function InspectedElementTree({
   inspectPath,
   label,
   overrideValueFn,
+  copyToClipboard,
   canAddEntries = false,
   showWhenEmpty = false,
 }: Props) {
@@ -47,11 +48,6 @@ export default function InspectedElementTree({
   const [newPropName, setNewPropName] = useState<string>('');
 
   const isEmpty = entries === null || entries.length === 0;
-
-  const handleCopy = useCallback(
-    () => copy(serializeDataForCopy(((data: any): Object))),
-    [data],
-  );
 
   const handleNewEntryValue = useCallback(
     (name, value) => {
@@ -77,7 +73,7 @@ export default function InspectedElementTree({
         <div className={styles.HeaderRow}>
           <div className={styles.Header}>{label}</div>
           {!isEmpty && (
-            <Button onClick={handleCopy} title="Copy to clipboard">
+            <Button onClick={copyToClipboard} title="Copy to clipboard">
               <ButtonIcon type="copy" />
             </Button>
           )}


### PR DESCRIPTION
Added a new event - getDataForCopy - that accepts an element id and property as a parameter, gets that property of the element, formats it for copying and returns it in the dataForCopy.

Fixes #16924 