### PR TITLE
Fix typo in ReactSuspenseList-test.internal.js

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -1620,7 +1620,7 @@ describe('ReactSuspenseList', () => {
     );
   });
 
-  it('adding to the middle of committeed tail does not collapse insertions', async () => {
+  it('adding to the middle of committed tail does not collapse insertions', async () => {
     let A = createAsyncText('A');
     let B = createAsyncText('B');
     let C = createAsyncText('C');


### PR DESCRIPTION
Fix typo in the test.
