### PR TITLE
[DO NOT MERGE] Prototype showing component errors/warnings within the Components tree

### DIFF
--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -37,7 +37,7 @@ import type {
   RendererID,
   RendererInterface,
 } from './types';
-import type {ComponentFilter} from '../types';
+import type {ComponentFilter, ErrorOrWarning} from '../types';
 
 const debug = (methodName, ...args) => {
   if (__DEBUG__) {
@@ -437,6 +437,10 @@ export default class Agent extends EventEmitter<{|
     } else {
       renderer.prepareViewElementSource(id);
     }
+  };
+
+  onErrorsAndWarnings = (errorsAndWarnings: Array<ErrorOrWarning>) => {
+    this._bridge.send('errorsAndWarnings', errorsAndWarnings);
   };
 
   onTraceUpdates = (nodes: Set<NativeType>) => {

--- a/packages/react-devtools-shared/src/backend/index.js
+++ b/packages/react-devtools-shared/src/backend/index.js
@@ -43,6 +43,7 @@ export function initBackend(
       agent.onUnsupportedRenderer(id);
     }),
 
+    hook.sub('errorsAndWarnings', agent.onErrorsAndWarnings),
     hook.sub('operations', agent.onHookOperations),
     hook.sub('traceUpdates', agent.onTraceUpdates),
 

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -9,7 +9,7 @@
 
 import EventEmitter from 'events';
 
-import type {ComponentFilter, Wall} from './types';
+import type {ComponentFilter, ErrorOrWarning, Wall} from './types';
 import type {
   InspectedElementPayload,
   OwnersList,
@@ -70,6 +70,7 @@ type NativeStyleEditor_SetValueParams = {|
 |};
 
 type BackendEvents = {|
+  errorsAndWarnings: [Array<ErrorOrWarning>],
   extensionBackendInitialized: [],
   inspectedElement: [InspectedElementPayload],
   isBackendStorageAPISupported: [boolean],

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -29,7 +29,7 @@ import {printStore} from './utils';
 import ProfilerStore from './ProfilerStore';
 
 import type {Element} from './views/Components/types';
-import type {ComponentFilter, ElementType} from '../types';
+import type {ComponentFilter, ElementType, ErrorOrWarning} from '../types';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 
 const debug = (methodName, ...args) => {
@@ -174,6 +174,7 @@ export default class Store extends EventEmitter<{|
     }
 
     this._bridge = bridge;
+    bridge.addListener('errorsAndWarnings', this.onBridgeErrorsAndWarnings);
     bridge.addListener('operations', this.onBridgeOperations);
     bridge.addListener(
       'overrideComponentFilters',
@@ -702,6 +703,10 @@ export default class Store extends EventEmitter<{|
     this._nativeStyleEditorValidAttributes = validAttributes || null;
 
     this.emit('supportsNativeStyleEditor');
+  };
+
+  onBridgeErrorsAndWarnings = (errorsAndWarnings: Array<ErrorOrWarning>) => {
+    console.log('onBridgeErrorsAndWarnings', errorsAndWarnings);
   };
 
   onBridgeOperations = (operations: Array<number>) => {

--- a/packages/react-devtools-shared/src/types.js
+++ b/packages/react-devtools-shared/src/types.js
@@ -75,3 +75,8 @@ export type ComponentFilter =
   | BooleanComponentFilter
   | ElementTypeComponentFilter
   | RegExpComponentFilter;
+
+export type ErrorOrWarning = {|
+  id: number,
+  type: 'error' | 'warn',
+|};

--- a/packages/react-devtools-shell/src/app/InlineWarnings/index.js
+++ b/packages/react-devtools-shell/src/app/InlineWarnings/index.js
@@ -1,0 +1,51 @@
+/** @flow */
+
+import React, {Fragment, useEffect, useRef, useState} from 'react';
+
+function WarnDuringRender() {
+  console.warn('This warning fires during every render');
+  return null;
+}
+
+function WarnOnMount() {
+  useEffect(() => {
+    console.warn('This warning fires on initial mount only');
+  }, []);
+  return null;
+}
+
+function WarnOnUpdate() {
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    if (didMountRef.current) {
+      console.warn('This warning fires on every update');
+    } else {
+      didMountRef.current = true;
+    }
+  });
+  return null;
+}
+
+function WarnOnUnmount() {
+  useEffect(() => {
+    return () => {
+      console.warn('This warning fires on unmount');
+    };
+  }, []);
+  return null;
+}
+
+export default function ElementTypes() {
+  const [count, setCount] = useState(0);
+  const handleClick = () => setCount(count + 1);
+  return (
+    <Fragment>
+      <h1>Inline warnings</h1>
+      <button onClick={handleClick}>Update {count > 0 ? count : ''}</button>
+      <WarnDuringRender />
+      <WarnOnMount />
+      <WarnOnUpdate />
+      {count === 0 ? <WarnOnUnmount /> : null}
+    </Fragment>
+  );
+}

--- a/packages/react-devtools-shell/src/app/console.js
+++ b/packages/react-devtools-shell/src/app/console.js
@@ -11,7 +11,12 @@ function ignoreStrings(
   methodName: string,
   stringsToIgnore: Array<string>,
 ): void {
-  const originalMethod = console[methodName];
+  // HACKY In the test harness, DevTools overrides the parent window's console.
+  // Our test app code uses the iframe's console though.
+  // To simulate a more accurate end-ot-end ienvironment,
+  // the shell's console patching should pass through to the parent override methods.
+  const originalMethod = window.parent.console[methodName];
+
   console[methodName] = (...args) => {
     const maybeString = args[0];
     if (typeof maybeString === 'string') {

--- a/packages/react-devtools-shell/src/app/index.js
+++ b/packages/react-devtools-shell/src/app/index.js
@@ -12,6 +12,7 @@ import Iframe from './Iframe';
 import EditableProps from './EditableProps';
 import ElementTypes from './ElementTypes';
 import Hydration from './Hydration';
+import InlineWarnings from './InlineWarnings';
 import InspectableElements from './InspectableElements';
 import InteractionTracing from './InteractionTracing';
 import PriorityLevels from './PriorityLevels';
@@ -31,7 +32,10 @@ ignoreErrors([
   'Warning: Unsafe lifecycle methods',
   'Warning: %s is deprecated in StrictMode.', // findDOMNode
 ]);
-ignoreWarnings(['Warning: componentWillReceiveProps is deprecated']);
+ignoreWarnings([
+  'Warning: componentWillReceiveProps is deprecated',
+  'Warning: componentWillReceiveProps has been renamed',
+]);
 
 const roots = [];
 
@@ -53,6 +57,7 @@ function mountTestApp() {
   mountHelper(Hydration);
   mountHelper(ElementTypes);
   mountHelper(EditableProps);
+  mountHelper(InlineWarnings);
   mountHelper(PriorityLevels);
   mountHelper(ReactNativeWeb);
   mountHelper(Toggle);


### PR DESCRIPTION
Relates to #9189

Last night I played around a bit with the idea of surfacing dev warnings/errors in the Components tree UI:
<img width="792" alt="Screen Shot 2019-10-08 at 9 03 32 PM" src="https://user-images.githubusercontent.com/29597/66509294-9999f880-ea87-11e9-9dfd-9a5e82890110.png">

I'm not sure this is useful or compelling enough to warrant completing, and there are a few significant "TODOs", but I'm pushing in case myself or someone else decides to play with it some more in the future. (I'm not going to follow up with it for the time being.)