### PR TITLE
More accurate 'why did this render' wording

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
@@ -167,7 +167,7 @@ function WhatChanged({
   if (changeDescription.didHooksChange) {
     changes.push(
       <div key="hooks" className={styles.WhatChangedItem}>
-        • Hooks changed
+        • Internal state changed
       </div>,
     );
   }
@@ -207,7 +207,7 @@ function WhatChanged({
   if (changes.length === 0) {
     changes.push(
       <div key="nothing" className={styles.WhatChangedItem}>
-        The parent component rendered.
+        The parent component rendered or context changed
       </div>,
     );
   }


### PR DESCRIPTION
After using the new devtools profiler (which is awesome btw!) I discovered that one of my components was rerendering because "the parent component rendered", despite being `React.memo`ed and taking no props, which seemed like an impossibility (see [twitter thread](https://twitter.com/pelotom/status/1182482183769882626?s=20) documenting my confusion). I eventually discovered that it was in fact updating due to context changes, and @bvaughn [helpfully pointed out](https://twitter.com/brian_d_vaughn/status/1182654239627075584?s=20) that the message was a fallback used when the component rerendered due to reasons other than state and props changing.

This PR attempts to make the wording a little more accurate: in addition to adding the "or context changed" caveat, it seems like "Internal state changed" is a more accurate description than "Hooks changed", because updates due to the `useContext` hook don't fall in that category. Ideally in the special case where the component is memoized the message could definitively say the update was due to a context change, but I'm not sure how to detect that situation 🙂